### PR TITLE
feat(web): handle live-voice speech_started / utterance_end / turn_cancelled frames

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
@@ -143,9 +143,11 @@ function makeClient(connectTimeoutMs = 10_000) {
 /** Connect and return the underlying fake socket once constructed. */
 async function connectAndGetSocket(
   client: LiveVoiceChannelClientType,
-  args: { assistantId: string; conversationId?: string } = {
-    assistantId: "assistant-1",
-  },
+  args: {
+    assistantId: string;
+    conversationId?: string;
+    turnDetection?: "manual" | "server_vad";
+  } = { assistantId: "assistant-1" },
 ): Promise<FakeWebSocket> {
   await client.connect(args);
   const ws = FakeWebSocket.instances.at(-1);
@@ -205,13 +207,28 @@ describe("connect", () => {
     expect(ws.sentBinary).toHaveLength(0);
   });
 
-  test("omits conversationId from the start frame when not provided", async () => {
+  test("omits conversationId and turnDetection from the start frame when not provided", async () => {
     const ws = await connectAndGetSocket(makeClient());
     ws.open();
     expect(ws.sentJson[0]).toEqual({
       type: "start",
       audio: { mimeType: "audio/pcm", sampleRate: 16000, channels: 1 },
     });
+  });
+
+  test("includes turnDetection in the start frame when provided", async () => {
+    const ws = await connectAndGetSocket(makeClient(), {
+      assistantId: "assistant-1",
+      turnDetection: "server_vad",
+    });
+    ws.open();
+    expect(ws.sentJson).toEqual([
+      {
+        type: "start",
+        audio: { mimeType: "audio/pcm", sampleRate: 16000, channels: 1 },
+        turnDetection: "server_vad",
+      },
+    ]);
   });
 
   test("emits error when token minting fails", async () => {
@@ -263,13 +280,19 @@ describe("server frame dispatch", () => {
     ]);
   });
 
-  test("dispatches each transcript/text/tts/metrics/archived frame to its event", async () => {
-    const { client, ws } = await ready();
-
+  /** Per-test event recorder: `record(name)` handlers append into `got[name]`. */
+  function makeRecorder() {
     const got: Record<string, unknown[]> = {};
     const record = (name: string) => (f: unknown) => {
       (got[name] ??= []).push(f);
     };
+    return { got, record };
+  }
+
+  test("dispatches each transcript/text/tts/metrics/archived frame to its event", async () => {
+    const { client, ws } = await ready();
+
+    const { got, record } = makeRecorder();
     client.on("sttPartial", record("sttPartial"));
     client.on("sttFinal", record("sttFinal"));
     client.on("thinking", record("thinking"));
@@ -317,6 +340,49 @@ describe("server frame dispatch", () => {
     expect(got.ttsDone).toEqual([{ type: "tts_done", seq: 7, turnId: "t1" }]);
     expect(got.metrics).toHaveLength(1);
     expect(got.archived).toHaveLength(1);
+  });
+
+  test("dispatches speech_started / utterance_end / turn_cancelled to their events", async () => {
+    const { client, ws } = await ready();
+
+    const { got, record } = makeRecorder();
+    client.on("speechStarted", record("speechStarted"));
+    client.on("utteranceEnd", record("utteranceEnd"));
+    client.on("turnCancelled", record("turnCancelled"));
+
+    ws.receive({ type: "speech_started", seq: 2 });
+    ws.receive({ type: "utterance_end", seq: 3, reason: "silence" });
+    ws.receive({ type: "utterance_end", seq: 4, reason: "max-duration" });
+    ws.receive({ type: "turn_cancelled", seq: 5, turnId: "t1" });
+
+    expect(got.speechStarted).toEqual([{ type: "speech_started", seq: 2 }]);
+    expect(got.utteranceEnd).toEqual([
+      { type: "utterance_end", seq: 3, reason: "silence" },
+      { type: "utterance_end", seq: 4, reason: "max-duration" },
+    ]);
+    expect(got.turnCancelled).toEqual([
+      { type: "turn_cancelled", seq: 5, turnId: "t1" },
+    ]);
+  });
+
+  test("ignores unknown server frame types without failing the session", async () => {
+    const { client, ws } = await ready();
+    const errors: unknown[] = [];
+    let closedCount = 0;
+    client.on("error", (e) => errors.push(e));
+    client.on("closed", () => closedCount++);
+
+    ws.receive({ type: "frame_from_the_future", seq: 2 });
+
+    expect(errors).toHaveLength(0);
+    expect(closedCount).toBe(0);
+    expect(ws.closed).toBe(false);
+
+    // The session stays live: later known frames still dispatch.
+    const seen: unknown[] = [];
+    client.on("sttPartial", (f) => seen.push(f));
+    ws.receive({ type: "stt_partial", seq: 3, text: "still here" });
+    expect(seen).toEqual([{ type: "stt_partial", seq: 3, text: "still here" }]);
   });
 
   test("server error frame emits a protocol-error and closes", async () => {

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
@@ -29,11 +29,15 @@ import {
   LIVE_VOICE_AUDIO_FORMAT,
   type LiveVoiceMetricsServerFrame,
   type LiveVoiceReadyServerFrame,
+  type LiveVoiceSpeechStartedServerFrame,
   type LiveVoiceSttFinalServerFrame,
   type LiveVoiceSttPartialServerFrame,
   type LiveVoiceThinkingServerFrame,
   type LiveVoiceTtsAudioServerFrame,
   type LiveVoiceTtsDoneServerFrame,
+  type LiveVoiceTurnCancelledServerFrame,
+  type LiveVoiceTurnDetectionMode,
+  type LiveVoiceUtteranceEndServerFrame,
   parseServerFrame,
 } from "@/domains/chat/voice/live-voice/protocol";
 
@@ -60,12 +64,18 @@ export interface LiveVoiceClientError {
  */
 export interface LiveVoiceClientEventMap {
   ready: LiveVoiceReadyServerFrame;
+  /** Server VAD detected user speech — stop local TTS playback immediately. */
+  speechStarted: LiveVoiceSpeechStartedServerFrame;
+  /** Server VAD closed the utterance; transcription begins. */
+  utteranceEnd: LiveVoiceUtteranceEndServerFrame;
   sttPartial: LiveVoiceSttPartialServerFrame;
   sttFinal: LiveVoiceSttFinalServerFrame;
   thinking: LiveVoiceThinkingServerFrame;
   assistantTextDelta: LiveVoiceAssistantTextDeltaServerFrame;
   ttsAudio: LiveVoiceTtsAudioServerFrame;
   ttsDone: LiveVoiceTtsDoneServerFrame;
+  /** Barge-in aborted the turn — drop buffered tts_audio; no tts_done follows. */
+  turnCancelled: LiveVoiceTurnCancelledServerFrame;
   metrics: LiveVoiceMetricsServerFrame;
   archived: LiveVoiceArchivedServerFrame;
   busy: LiveVoiceBusyServerFrame;
@@ -84,6 +94,11 @@ export interface LiveVoiceConnectArgs {
   assistantId: string;
   /** Optional conversation to attach the session to. */
   conversationId?: string;
+  /**
+   * Turn-detection mode sent on the `start` frame. Omitted means "manual"
+   * (push-to-talk).
+   */
+  turnDetection?: LiveVoiceTurnDetectionMode;
 }
 
 /** Factory so tests can inject a mock WebSocket. Defaults to the global. */
@@ -110,17 +125,21 @@ export class LiveVoiceChannelClient {
   private ws: WebSocket | null = null;
   private connectTimeout: ReturnType<typeof setTimeout> | null = null;
   private conversationId: string | undefined;
+  private turnDetection: LiveVoiceTurnDetectionMode | undefined;
 
   private readonly listeners: {
     [E in LiveVoiceClientEventName]: Set<LiveVoiceClientEventHandler<E>>;
   } = {
     ready: new Set(),
+    speechStarted: new Set(),
+    utteranceEnd: new Set(),
     sttPartial: new Set(),
     sttFinal: new Set(),
     thinking: new Set(),
     assistantTextDelta: new Set(),
     ttsAudio: new Set(),
     ttsDone: new Set(),
+    turnCancelled: new Set(),
     metrics: new Set(),
     archived: new Set(),
     busy: new Set(),
@@ -165,10 +184,12 @@ export class LiveVoiceChannelClient {
   async connect({
     assistantId,
     conversationId,
+    turnDetection,
   }: LiveVoiceConnectArgs): Promise<void> {
     if (this.state !== "idle") return;
     this.state = "connecting";
     this.conversationId = conversationId;
+    this.turnDetection = turnDetection;
 
     let url: string;
     try {
@@ -249,6 +270,7 @@ export class LiveVoiceChannelClient {
       type: "start",
       audio: LIVE_VOICE_AUDIO_FORMAT,
       ...(this.conversationId ? { conversationId: this.conversationId } : {}),
+      ...(this.turnDetection ? { turnDetection: this.turnDetection } : {}),
     };
     this.trySend(JSON.stringify(startFrame));
   }
@@ -272,6 +294,12 @@ export class LiveVoiceChannelClient {
         this.emit("busy", frame);
         this.close();
         return;
+      case "speech_started":
+        this.emit("speechStarted", frame);
+        return;
+      case "utterance_end":
+        this.emit("utteranceEnd", frame);
+        return;
       case "stt_partial":
         this.emit("sttPartial", frame);
         return;
@@ -290,6 +318,9 @@ export class LiveVoiceChannelClient {
       case "tts_done":
         this.emit("ttsDone", frame);
         return;
+      case "turn_cancelled":
+        this.emit("turnCancelled", frame);
+        return;
       case "metrics":
         this.emit("metrics", frame);
         return;
@@ -298,6 +329,13 @@ export class LiveVoiceChannelClient {
         return;
       case "error":
         this.fail("protocol-error", frame.message, frame.code);
+        return;
+      case "unknown_frame":
+        // Frame types from a newer server than this client. Ignore so
+        // protocol additions never kill older clients.
+        console.warn(
+          `live-voice: ignoring unknown server frame type "${frame.frameType}"`,
+        );
         return;
     }
   }

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.test.ts
@@ -9,6 +9,9 @@ describe("parseServerFrame", () => {
   const frames: LiveVoiceServerFrame[] = [
     { type: "ready", seq: 1, sessionId: "s1", conversationId: "c1" },
     { type: "busy", seq: 2, activeSessionId: "s9" },
+    { type: "speech_started", seq: 12 },
+    { type: "utterance_end", seq: 13, reason: "silence" },
+    { type: "turn_cancelled", seq: 14, turnId: "t2" },
     { type: "stt_partial", seq: 3, text: "hel" },
     { type: "stt_final", seq: 4, text: "hello" },
     { type: "thinking", seq: 5, turnId: "t1" },
@@ -70,15 +73,11 @@ describe("parseServerFrame", () => {
     }
   });
 
-  test("returns invalid_json for unknown frame type", () => {
+  test("returns unknown_frame for an unrecognized frame type", () => {
     const result = parseServerFrame(
       JSON.stringify({ type: "made_up", seq: 1 }),
     );
-    expect(result).toEqual({
-      type: "error",
-      code: "invalid_json",
-      message: expect.any(String),
-    });
+    expect(result).toEqual({ type: "unknown_frame", frameType: "made_up" });
   });
 
   test("returns invalid_json for missing type", () => {
@@ -88,5 +87,23 @@ describe("parseServerFrame", () => {
       code: "invalid_json",
       message: expect.any(String),
     });
+  });
+
+  test("returns invalid_json for a non-string type", () => {
+    const result = parseServerFrame(JSON.stringify({ type: 42, seq: 1 }));
+    expect(result).toEqual({
+      type: "error",
+      code: "invalid_json",
+      message: expect.any(String),
+    });
+  });
+
+  test("round-trips utterance_end with a max-duration reason", () => {
+    const frame: LiveVoiceServerFrame = {
+      type: "utterance_end",
+      seq: 15,
+      reason: "max-duration",
+    };
+    expect(parseServerFrame(JSON.stringify(frame))).toEqual(frame);
   });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.ts
@@ -43,10 +43,18 @@ export const LIVE_VOICE_AUDIO_FORMAT: LiveVoiceAudioConfig = {
   channels: 1,
 };
 
+export type LiveVoiceTurnDetectionMode = "manual" | "server_vad";
+
 export interface LiveVoiceClientStartFrame {
   readonly type: "start";
   readonly conversationId?: string;
   readonly audio: LiveVoiceAudioConfig;
+  /**
+   * Turn-detection mode for the session. Absent means "manual" (push-to-talk).
+   * "server_vad" also implies a multi-turn session: the server detects
+   * utterance boundaries and runs repeated utterance→turn cycles.
+   */
+  readonly turnDetection?: LiveVoiceTurnDetectionMode;
 }
 
 export interface LiveVoiceClientPttReleaseFrame {
@@ -74,12 +82,15 @@ export type LiveVoiceClientFrame =
 const LIVE_VOICE_SERVER_FRAME_TYPES = [
   "ready",
   "busy",
+  "speech_started",
+  "utterance_end",
   "stt_partial",
   "stt_final",
   "thinking",
   "assistant_text_delta",
   "tts_audio",
   "tts_done",
+  "turn_cancelled",
   "metrics",
   "archived",
   "error",
@@ -101,6 +112,24 @@ export interface LiveVoiceReadyServerFrame extends LiveVoiceServerFrameBase {
 export interface LiveVoiceBusyServerFrame extends LiveVoiceServerFrameBase {
   readonly type: "busy";
   readonly activeSessionId: string;
+}
+
+/**
+ * Emitted when the server VAD detects user speech. The client MUST
+ * immediately stop local TTS playback — this doubles as the flush-tail-audio
+ * signal.
+ */
+export interface LiveVoiceSpeechStartedServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "speech_started";
+}
+
+/**
+ * Emitted when the server VAD closes the utterance and the turn's
+ * transcription begins (plays the role ptt_release plays in manual mode).
+ */
+export interface LiveVoiceUtteranceEndServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "utterance_end";
+  readonly reason: "silence" | "max-duration";
 }
 
 export interface LiveVoiceSttPartialServerFrame extends LiveVoiceServerFrameBase {
@@ -136,6 +165,15 @@ export interface LiveVoiceTtsDoneServerFrame extends LiveVoiceServerFrameBase {
   readonly turnId: string;
 }
 
+/**
+ * Emitted when an in-flight assistant turn is aborted by barge-in. The client
+ * must drop any buffered tts_audio for that turn; no tts_done will follow.
+ */
+export interface LiveVoiceTurnCancelledServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "turn_cancelled";
+  readonly turnId: string;
+}
+
 export interface LiveVoiceMetricsServerFrame extends LiveVoiceServerFrameBase {
   readonly type: "metrics";
   readonly turnId: string;
@@ -168,24 +206,39 @@ export interface LiveVoiceErrorServerFrame extends LiveVoiceServerFrameBase {
 export type LiveVoiceServerFrame =
   | LiveVoiceReadyServerFrame
   | LiveVoiceBusyServerFrame
+  | LiveVoiceSpeechStartedServerFrame
+  | LiveVoiceUtteranceEndServerFrame
   | LiveVoiceSttPartialServerFrame
   | LiveVoiceSttFinalServerFrame
   | LiveVoiceThinkingServerFrame
   | LiveVoiceAssistantTextDeltaServerFrame
   | LiveVoiceTtsAudioServerFrame
   | LiveVoiceTtsDoneServerFrame
+  | LiveVoiceTurnCancelledServerFrame
   | LiveVoiceMetricsServerFrame
   | LiveVoiceArchivedServerFrame
   | LiveVoiceErrorServerFrame;
 
 /**
  * Error frame returned by {@link parseServerFrame} when the raw payload cannot
- * be JSON-parsed or lacks a recognized `type` discriminator.
+ * be JSON-parsed or lacks a `type` discriminator.
  */
 export interface LiveVoiceInvalidJsonFrame {
   readonly type: "error";
   readonly code: "invalid_json";
   readonly message: string;
+}
+
+/**
+ * Result returned by {@link parseServerFrame} for a structurally valid frame
+ * whose `type` is not in this client's allowlist. Newer servers may emit frame
+ * types this client version does not know; callers must ignore these rather
+ * than treat them as protocol errors.
+ */
+export interface LiveVoiceUnknownServerFrame {
+  readonly type: "unknown_frame";
+  /** The wire `type` this client does not recognize. */
+  readonly frameType: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -206,12 +259,14 @@ function isLiveVoiceServerFrameType(
  * {@link LiveVoiceServerFrame}.
  *
  * Returns a {@link LiveVoiceInvalidJsonFrame} (`code: "invalid_json"`) when the
- * payload is not valid JSON, is not an object, or carries an unknown/missing
- * `type` discriminator.
+ * payload is not valid JSON, is not an object, or lacks a string `type`
+ * discriminator. A well-formed frame whose `type` is not in this client's
+ * allowlist parses to a {@link LiveVoiceUnknownServerFrame} instead, so future
+ * protocol additions are ignorable rather than session-fatal.
  */
 export function parseServerFrame(
   raw: string,
-): LiveVoiceServerFrame | LiveVoiceInvalidJsonFrame {
+): LiveVoiceServerFrame | LiveVoiceInvalidJsonFrame | LiveVoiceUnknownServerFrame {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
@@ -223,17 +278,20 @@ export function parseServerFrame(
     };
   }
 
-  if (
-    parsed === null ||
-    typeof parsed !== "object" ||
-    Array.isArray(parsed) ||
-    !isLiveVoiceServerFrameType((parsed as { type?: unknown }).type)
-  ) {
+  const frameType =
+    parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as { type?: unknown }).type
+      : undefined;
+  if (typeof frameType !== "string") {
     return {
       type: "error",
       code: "invalid_json",
-      message: "Live voice server frame has missing or unknown type",
+      message: "Live voice server frame has a missing or non-string type",
     };
+  }
+
+  if (!isLiveVoiceServerFrameType(frameType)) {
+    return { type: "unknown_frame", frameType };
   }
 
   return parsed as LiveVoiceServerFrame;


### PR DESCRIPTION
## Summary
- Mirrors the daemon's live-voice VAD protocol additions in the web client: three new server frames routed to client events, and turnDetection on the start frame (sent only when provided).
- Unknown server frame types are now ignored with a warning instead of failing the session, so future protocol additions don't kill older clients.
- UI wiring (playback stop on speech_started, hands-free session flow) lands in the follow-up PR.

Part of plan: live-voice-server-barge-in.md (PR 10 of 11)