### PR TITLE
refactor(calls): abstract CallController session reads behind a VoiceSessionSource

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -265,6 +265,7 @@ import {
 } from "../calls/call-store.js";
 import type { CallTransport } from "../calls/call-transport.js";
 import { resolveCallTtsProvider } from "../calls/resolve-call-tts-provider.js";
+import type { VoiceSessionSource } from "../calls/voice-session-source.js";
 import { loadConfig } from "../config/loader.js";
 import {
   getCanonicalGuardianRequest,
@@ -3495,5 +3496,42 @@ describe("call-controller", () => {
       controller.destroy();
       await turnPromise.catch(() => {});
     });
+  });
+
+  // ── Injected VoiceSessionSource ─────────────────────────────────────
+
+  test("injected session source: constructor resolves conversationId without a call_sessions row", async () => {
+    ensureConversation("conv-injected-source");
+    const sessionSource: VoiceSessionSource = {
+      conversationId: "conv-injected-source",
+      skipDisclosure: true,
+      getSnapshot: () => ({
+        status: "in_progress",
+        conversationId: "conv-injected-source",
+        initiatedFromConversationId: null,
+        startedAt: Date.now(),
+        toNumber: "+15555550100",
+      }),
+    };
+    const transport = createMockTransport();
+    const controller = new CallController(
+      "call-session-without-row",
+      transport,
+      null,
+      { sessionSource },
+    );
+
+    mockStartVoiceTurn.mockClear();
+    await controller.handleCallerUtterance("Hello");
+
+    expect(mockStartVoiceTurn).toHaveBeenCalledTimes(1);
+    const turnOpts = mockStartVoiceTurn.mock.calls[0][0] as {
+      conversationId: string;
+      skipDisclosure: boolean;
+    };
+    expect(turnOpts.conversationId).toBe("conv-injected-source");
+    expect(turnOpts.skipDisclosure).toBe(true);
+
+    controller.destroy();
   });
 });

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -45,7 +45,6 @@ import { isTerminalState } from "./call-state-machine.js";
 import {
   createPendingQuestion,
   expirePendingQuestions,
-  getCallSession,
   recordCallEvent,
   updateCallSession,
 } from "./call-store.js";
@@ -70,6 +69,10 @@ import {
   startVoiceTurn,
   type VoiceTurnHandle,
 } from "./voice-session-bridge.js";
+import {
+  createPhoneVoiceSessionSource,
+  type VoiceSessionSource,
+} from "./voice-session-source.js";
 
 const log = getLogger("call-controller");
 
@@ -161,6 +164,8 @@ export class CallController {
   private guardianUnavailableForCall = false;
   /** Active synthesized-TTS session — tracked so interrupt handling can close it. */
   private activeSynthesisAbort: AbortController | null = null;
+  /** Source of session state reads (conversation binding, lifecycle fields). */
+  private sessionSource: VoiceSessionSource;
 
   constructor(
     callSessionId: string,
@@ -170,6 +175,7 @@ export class CallController {
       broadcast?: (msg: ServerMessage) => void;
       assistantId?: string;
       trustContext?: TrustContext;
+      sessionSource?: VoiceSessionSource;
     },
   ) {
     this.callSessionId = callSessionId;
@@ -180,10 +186,11 @@ export class CallController {
     this.assistantId = opts?.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
     this.trustContext = opts?.trustContext ?? null;
 
-    // Resolve the conversation ID and skipDisclosure from the call session
-    const session = getCallSession(callSessionId);
-    this.conversationId = session?.conversationId ?? callSessionId;
-    this.skipDisclosure = session?.skipDisclosure ?? false;
+    // Resolve the conversation ID and skipDisclosure from the session source
+    this.sessionSource =
+      opts?.sessionSource ?? createPhoneVoiceSessionSource(callSessionId);
+    this.conversationId = this.sessionSource.conversationId;
+    this.skipDisclosure = this.sessionSource.skipDisclosure;
 
     this.startDurationTimer();
     this.resetSilenceTimer();
@@ -980,7 +987,7 @@ export class CallController {
       stripInternalSpeechMarkers(responseText),
     ).trim();
     if (spokenText.length > 0) {
-      const session = getCallSession(this.callSessionId);
+      const session = this.sessionSource.getSnapshot();
       if (session) {
         fireCallTranscriptNotifier(
           session.conversationId,
@@ -1179,7 +1186,7 @@ export class CallController {
   }
 
   private scheduleEndCallAfterListenWindow(): void {
-    const currentSession = getCallSession(this.callSessionId);
+    const currentSession = this.sessionSource.getSnapshot();
     if (currentSession && isTerminalState(currentSession.status)) {
       this.state = "idle";
       this.currentTurnHandle = null;
@@ -1256,7 +1263,7 @@ export class CallController {
   private completeCallFromEndMarker(): void {
     if (this.destroyed) return;
 
-    const currentSession = getCallSession(this.callSessionId);
+    const currentSession = this.sessionSource.getSnapshot();
     if (currentSession && isTerminalState(currentSession.status)) {
       this.state = "idle";
       return;
@@ -1378,7 +1385,7 @@ export class CallController {
     });
 
     // Notify the conversation that a question was asked
-    const session = getCallSession(this.callSessionId);
+    const session = this.sessionSource.getSnapshot();
     if (session) {
       fireCallQuestionNotifier(
         session.conversationId,
@@ -1559,7 +1566,7 @@ export class CallController {
       );
       // Give TTS a moment to play, then end
       this.durationEndTimer = setTimeout(() => {
-        const currentSession = getCallSession(this.callSessionId);
+        const currentSession = this.sessionSource.getSnapshot();
         const shouldNotifyCompletion = currentSession
           ? currentSession.status !== "completed" &&
             currentSession.status !== "failed" &&

--- a/assistant/src/calls/voice-session-source.ts
+++ b/assistant/src/calls/voice-session-source.ts
@@ -1,0 +1,58 @@
+/**
+ * Session-source abstraction for CallController.
+ *
+ * CallController reads session state (conversation binding at construction,
+ * lifecycle fields during the call) through a VoiceSessionSource rather than
+ * directly from the call_sessions store. Phone calls use the store-backed
+ * source below; non-phone voice sessions can inject a source that has no
+ * call_sessions row at all.
+ */
+
+import { getCallSession } from "./call-store.js";
+import type { CallStatus } from "./types.js";
+
+/** Point-in-time view of the session lifecycle fields CallController reads. */
+export interface VoiceSessionSnapshot {
+  status: CallStatus;
+  conversationId: string;
+  initiatedFromConversationId: string | null;
+  startedAt: number | null;
+  toNumber: string;
+}
+
+export interface VoiceSessionSource {
+  /** Conversation the voice session is bound to. */
+  readonly conversationId: string;
+  /** When true, the disclosure announcement is skipped for this call. */
+  readonly skipDisclosure: boolean;
+  /**
+   * Current session lifecycle state, re-read on each call. Returns null when
+   * the underlying session no longer exists (e.g. the row was deleted).
+   */
+  getSnapshot(): VoiceSessionSnapshot | null;
+}
+
+/** Store-backed source for phone calls: wraps getCallSession(callSessionId). */
+export function createPhoneVoiceSessionSource(
+  callSessionId: string,
+): VoiceSessionSource {
+  const session = getCallSession(callSessionId);
+  return {
+    conversationId: session?.conversationId ?? callSessionId,
+    skipDisclosure: session?.skipDisclosure ?? false,
+    getSnapshot(): VoiceSessionSnapshot | null {
+      const current = getCallSession(callSessionId);
+      if (!current) {
+        return null;
+      }
+      return {
+        status: current.status,
+        conversationId: current.conversationId,
+        initiatedFromConversationId:
+          current.initiatedFromConversationId ?? null,
+        startedAt: current.startedAt,
+        toNumber: current.toNumber,
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- New VoiceSessionSource interface + createPhoneVoiceSessionSource default (wraps getCallSession)
- CallController's six direct getCallSession reads now go through the injected source; phone behavior byte-identical
- Enables non-phone voice sessions (in-app live voice) to drive the controller without call_sessions rows

Part of plan: voice-mode-engine.md (PR 4 of 12)