### PR TITLE
feat(live-voice): session-start credential preflight for STT/TTS providers

### DIFF
--- a/assistant/src/calls/telephony-tts-capability.ts
+++ b/assistant/src/calls/telephony-tts-capability.ts
@@ -103,7 +103,7 @@ export async function evaluateTelephonyTtsPlayability(
   }
 
   for (const secret of entry.secretRequirements) {
-    if (!(await secretResolves(secret.credentialStoreKey))) {
+    if (!(await ttsSecretResolves(secret.credentialStoreKey))) {
       return {
         status: "not-playable",
         providerId: entry.id,
@@ -159,18 +159,18 @@ export function fishAudioReferenceIdConfigured(): boolean {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
 /**
- * Check whether a catalog `credentialStoreKey` resolves to a value.
+ * Check whether a TTS catalog `credentialStoreKey` resolves to a value.
  *
  * API keys (`credential/{service}/api_key` or a bare service name) go
  * through `getProviderKeyAsync` so env-var-only setups are honoured;
- * other namespaced fields are looked up verbatim.
+ * other namespaced fields are looked up verbatim. Shared by
+ * {@link evaluateTelephonyTtsPlayability} and the live-voice credential
+ * preflight.
  */
-async function secretResolves(credentialStoreKey: string): Promise<boolean> {
+export async function ttsSecretResolves(
+  credentialStoreKey: string,
+): Promise<boolean> {
   const parts = credentialStoreKey.split("/");
   if (parts.length === 1) {
     return Boolean(await getProviderKeyAsync(credentialStoreKey));

--- a/assistant/src/live-voice/__tests__/live-voice-credential-preflight.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-credential-preflight.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Tests for the live-voice credential-readiness preflight resolver.
+ *
+ * The STT transcriber resolvers, secure-keys lookups, and config loader are
+ * mocked so the readiness combination logic is exercised in isolation (the
+ * real TTS provider catalog is used — provider ids like "fish-audio" and
+ * "elevenlabs" carry their real streaming capabilities). `mock.module` is
+ * process-global in Bun and leaks into sibling files that run later in the
+ * same `bun test` invocation, so each stub delegates to the real
+ * implementation unless this file's tests are active
+ * (`preflightMocksActive`, toggled in beforeAll/afterAll). The real exports
+ * are snapshotted into plain objects NOW, before the stubs register — a
+ * module namespace is a live view, so reading the real export after the
+ * stub installs would resolve back to the stub (infinite recursion).
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+let preflightMocksActive = false;
+
+const realSttResolveModule = {
+  ...(await import("../../providers/speech-to-text/resolve.js")),
+};
+const realSecureKeysModule = {
+  ...(await import("../../security/secure-keys.js")),
+};
+const realConfigLoaderModule = {
+  ...(await import("../../config/loader.js")),
+};
+
+// -- Mutable stub state --------------------------------------------------------
+
+import type {
+  BatchTranscriber,
+  StreamingTranscriber,
+} from "../../stt/types.js";
+
+let streamingTranscriber: StreamingTranscriber | null;
+let batchTranscriber: BatchTranscriber | null;
+let providerKeys: Record<string, string>;
+let sttProvider: string;
+let ttsProvider: string;
+
+mock.module("../../providers/speech-to-text/resolve.js", () => ({
+  ...realSttResolveModule,
+  resolveStreamingTranscriber: async () =>
+    preflightMocksActive
+      ? streamingTranscriber
+      : realSttResolveModule.resolveStreamingTranscriber(),
+  resolveBatchTranscriber: async () =>
+    preflightMocksActive
+      ? batchTranscriber
+      : realSttResolveModule.resolveBatchTranscriber(),
+}));
+
+mock.module("../../security/secure-keys.js", () => ({
+  ...realSecureKeysModule,
+  getProviderKeyAsync: async (provider: string) =>
+    preflightMocksActive
+      ? providerKeys[provider]
+      : realSecureKeysModule.getProviderKeyAsync(provider),
+  getSecureKeyAsync: async (account: string) =>
+    preflightMocksActive
+      ? undefined
+      : realSecureKeysModule.getSecureKeyAsync(account),
+}));
+
+mock.module("../../config/loader.js", () => ({
+  ...realConfigLoaderModule,
+  getConfig: () =>
+    preflightMocksActive
+      ? ({
+          services: {
+            stt: { provider: sttProvider },
+            tts: { provider: ttsProvider, providers: {} },
+          },
+        } as unknown as ReturnType<typeof realConfigLoaderModule.getConfig>)
+      : realConfigLoaderModule.getConfig(),
+}));
+
+import { resolveLiveVoiceCredentialReadiness } from "../live-voice-credential-preflight.js";
+
+beforeAll(() => {
+  preflightMocksActive = true;
+});
+
+afterAll(() => {
+  preflightMocksActive = false;
+});
+
+beforeEach(() => {
+  // Baseline: everything ready — a streaming STT transcriber resolves and
+  // the streaming-capable fish-audio TTS provider has credentials.
+  streamingTranscriber = {} as StreamingTranscriber;
+  batchTranscriber = null;
+  providerKeys = { deepgram: "test-key", "fish-audio": "test-key" };
+  sttProvider = "deepgram";
+  ttsProvider = "fish-audio";
+});
+
+function expectNotReady(
+  readiness: Awaited<ReturnType<typeof resolveLiveVoiceCredentialReadiness>>,
+) {
+  expect(readiness.status).toBe("not-ready");
+  if (readiness.status !== "not-ready") {
+    throw new Error("expected not-ready");
+  }
+  return readiness;
+}
+
+describe("resolveLiveVoiceCredentialReadiness", () => {
+  test("streaming STT + streaming TTS with credentials → ready", async () => {
+    const readiness = await resolveLiveVoiceCredentialReadiness();
+    expect(readiness).toEqual({ status: "ready" });
+  });
+
+  test("no streaming STT but a batch transcriber resolves (fallback mode) → still ready", async () => {
+    streamingTranscriber = null;
+    batchTranscriber = {} as BatchTranscriber;
+
+    const readiness = await resolveLiveVoiceCredentialReadiness();
+    expect(readiness).toEqual({ status: "ready" });
+  });
+
+  test("STT credentials missing → not-ready with an stt entry naming the credential provider", async () => {
+    streamingTranscriber = null;
+    batchTranscriber = null;
+    delete providerKeys.deepgram;
+
+    const readiness = expectNotReady(
+      await resolveLiveVoiceCredentialReadiness(),
+    );
+    expect(readiness.missing).toEqual([
+      {
+        kind: "stt",
+        providerId: "deepgram",
+        reason: 'No API key configured for credential provider "deepgram"',
+      },
+    ]);
+    expect(readiness.userMessage).toContain('"deepgram"');
+    expect(readiness.userMessage).toContain("speech-to-text");
+  });
+
+  test("unknown STT provider → not-ready with a catalog gap naming the configured id", async () => {
+    streamingTranscriber = null;
+    batchTranscriber = null;
+    sttProvider = "acme-stt";
+
+    const readiness = expectNotReady(
+      await resolveLiveVoiceCredentialReadiness(),
+    );
+    expect(readiness.missing).toEqual([
+      {
+        kind: "stt",
+        providerId: "acme-stt",
+        reason: 'STT provider "acme-stt" is not in the provider catalog',
+      },
+    ]);
+    expect(readiness.userMessage).toContain('"acme-stt"');
+  });
+
+  test("keyed STT provider that resolves neither transcriber → not-ready with a capability gap", async () => {
+    streamingTranscriber = null;
+    batchTranscriber = null;
+
+    const readiness = expectNotReady(
+      await resolveLiveVoiceCredentialReadiness(),
+    );
+    expect(readiness.missing).toEqual([
+      {
+        kind: "stt",
+        providerId: "deepgram",
+        reason:
+          'STT provider "deepgram" supports neither streaming nor batch transcription',
+      },
+    ]);
+    expect(readiness.userMessage).toContain("live transcription");
+  });
+
+  test("non-streaming TTS provider → not-ready with a tts entry naming the provider", async () => {
+    ttsProvider = "elevenlabs";
+    providerKeys.elevenlabs = "test-key";
+
+    const readiness = expectNotReady(
+      await resolveLiveVoiceCredentialReadiness(),
+    );
+    expect(readiness.missing).toEqual([
+      {
+        kind: "tts",
+        providerId: "elevenlabs",
+        reason:
+          'TTS provider "elevenlabs" does not support streaming synthesis',
+      },
+    ]);
+    expect(readiness.userMessage).toContain('"elevenlabs"');
+    expect(readiness.userMessage).toContain("streaming synthesis");
+  });
+
+  test("streaming TTS provider missing credentials → not-ready naming the missing key", async () => {
+    delete providerKeys["fish-audio"];
+
+    const readiness = expectNotReady(
+      await resolveLiveVoiceCredentialReadiness(),
+    );
+    expect(readiness.missing).toEqual([
+      {
+        kind: "tts",
+        providerId: "fish-audio",
+        reason:
+          'TTS provider "fish-audio" is missing credentials (Fish Audio API Key)',
+      },
+    ]);
+    expect(readiness.userMessage).toContain('"fish-audio"');
+    expect(readiness.userMessage).toContain("text-to-speech");
+    expect(readiness.userMessage).toContain("Fish Audio API Key");
+  });
+
+  test("unknown TTS provider → not-ready with a catalog gap naming the configured id", async () => {
+    ttsProvider = "acme-tts";
+
+    const readiness = expectNotReady(
+      await resolveLiveVoiceCredentialReadiness(),
+    );
+    expect(readiness.missing).toEqual([
+      {
+        kind: "tts",
+        providerId: "acme-tts",
+        reason: 'TTS provider "acme-tts" is not in the provider catalog',
+      },
+    ]);
+    expect(readiness.userMessage).toContain('"acme-tts"');
+  });
+
+  test("both STT and TTS missing → both entries, message names both providers", async () => {
+    streamingTranscriber = null;
+    batchTranscriber = null;
+    delete providerKeys.deepgram;
+    delete providerKeys["fish-audio"];
+
+    const readiness = expectNotReady(
+      await resolveLiveVoiceCredentialReadiness(),
+    );
+    expect(readiness.missing.map((gap) => gap.kind)).toEqual(["stt", "tts"]);
+    expect(readiness.userMessage).toContain('"deepgram"');
+    expect(readiness.userMessage).toContain('"fish-audio"');
+    // Single sentence: suitable for the client `error` frame.
+    expect(readiness.userMessage).not.toContain("\n");
+    expect(readiness.userMessage.endsWith(".")).toBe(true);
+  });
+});

--- a/assistant/src/live-voice/live-voice-credential-preflight.ts
+++ b/assistant/src/live-voice/live-voice-credential-preflight.ts
@@ -1,0 +1,193 @@
+/**
+ * Live-voice credential-readiness preflight.
+ *
+ * A live voice session needs the daemon to run both audio legs: streaming
+ * (or per-turn batch fallback) speech-to-text for caller audio, and
+ * streaming text-to-speech for assistant audio. This resolver combines the
+ * two checks into a single ready / not-ready verdict with a user-facing
+ * message suitable for the client `error` frame, so a session fails at
+ * start instead of mid-conversation. It opens no live connections and
+ * performs no session wiring — the session composition root gates startup
+ * on the verdict. Mirrors `calls/telephony-credential-preflight.ts` for
+ * the phone-call transport.
+ */
+
+import { ttsSecretResolves } from "../calls/telephony-tts-capability.js";
+import { getConfig } from "../config/loader.js";
+import { getProviderEntry } from "../providers/speech-to-text/provider-catalog.js";
+import {
+  resolveBatchTranscriber,
+  resolveStreamingTranscriber,
+} from "../providers/speech-to-text/resolve.js";
+import { getProviderKeyAsync } from "../security/secure-keys.js";
+import type { SttProviderId } from "../stt/types.js";
+import type { TtsProviderCatalogEntry } from "../tts/provider-catalog.js";
+import { getCatalogProvider, getTtsProvider } from "../tts/provider-catalog.js";
+import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** A single credential/capability gap blocking live-voice readiness. */
+export interface LiveVoiceCredentialGap {
+  kind: "stt" | "tts";
+  providerId: string;
+  reason: string;
+}
+
+/** Result of resolving whether live-voice STT+TTS credentials are in order. */
+export type LiveVoiceCredentialReadiness =
+  | { status: "ready" }
+  | {
+      status: "not-ready";
+      missing: LiveVoiceCredentialGap[];
+      /**
+       * A single human-readable sentence naming the offending provider(s)
+       * and missing credential(s), suitable for the client `error` frame.
+       */
+      userMessage: string;
+    };
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve whether the daemon can run both audio legs of a live voice
+ * session.
+ *
+ * Readiness requires:
+ * - STT: the configured `services.stt.provider` resolves a streaming
+ *   transcriber, or — acceptable fallback mode — a batch transcriber.
+ * - TTS: the configured `services.tts.provider` supports streaming
+ *   synthesis (`synthesizeStream`) and all of its required secrets resolve.
+ */
+export async function resolveLiveVoiceCredentialReadiness(): Promise<LiveVoiceCredentialReadiness> {
+  const gaps = (await Promise.all([resolveSttGap(), resolveTtsGap()])).filter(
+    (gap) => gap !== null,
+  );
+
+  if (gaps.length === 0) {
+    return { status: "ready" };
+  }
+
+  return {
+    status: "not-ready",
+    missing: gaps.map(({ gap }) => gap),
+    userMessage: `Live voice is unavailable because it requires ${gaps
+      .map(({ clause }) => clause)
+      .join(" and ")}.`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** A gap entry plus its user-message clause. */
+interface GapWithClause {
+  gap: LiveVoiceCredentialGap;
+  clause: string;
+}
+
+/**
+ * Resolve the STT leg: no gap when the configured provider yields a
+ * streaming transcriber or (batch-fallback mode) a batch transcriber.
+ * When neither resolves, classify why so the gap names the missing piece.
+ */
+async function resolveSttGap(): Promise<GapWithClause | null> {
+  if ((await resolveStreamingTranscriber()) !== null) {
+    return null;
+  }
+  if ((await resolveBatchTranscriber()) !== null) {
+    return null;
+  }
+
+  const providerId = getConfig().services.stt.provider;
+  const entry = getProviderEntry(providerId as SttProviderId);
+  if (!entry) {
+    return {
+      gap: {
+        kind: "stt",
+        providerId,
+        reason: `STT provider "${providerId}" is not in the provider catalog`,
+      },
+      clause: `a recognized speech-to-text provider (the configured "${providerId}" is not in the provider catalog)`,
+    };
+  }
+
+  const apiKey = await getProviderKeyAsync(entry.credentialProvider);
+  if (!apiKey) {
+    return {
+      gap: {
+        kind: "stt",
+        providerId: entry.id,
+        reason: `No API key configured for credential provider "${entry.credentialProvider}"`,
+      },
+      clause: `an API key for the speech-to-text provider "${entry.id}"`,
+    };
+  }
+
+  return {
+    gap: {
+      kind: "stt",
+      providerId: entry.id,
+      reason: `STT provider "${entry.id}" supports neither streaming nor batch transcription`,
+    },
+    clause: `a speech-to-text provider that supports live transcription (the configured "${entry.id}" does not)`,
+  };
+}
+
+/**
+ * Resolve the TTS leg: no gap when the configured provider supports
+ * streaming synthesis and every secret its catalog entry requires
+ * resolves to a value.
+ */
+async function resolveTtsGap(): Promise<GapWithClause | null> {
+  const { provider: providerId } = resolveTtsConfig(getConfig());
+
+  let entry: TtsProviderCatalogEntry;
+  try {
+    entry = getCatalogProvider(providerId);
+  } catch {
+    return {
+      gap: {
+        kind: "tts",
+        providerId,
+        reason: `TTS provider "${providerId}" is not in the provider catalog`,
+      },
+      clause: `a recognized text-to-speech provider (the configured "${providerId}" is not in the provider catalog)`,
+    };
+  }
+
+  const adapter = getTtsProvider(entry.id);
+  if (
+    !adapter.capabilities.supportsStreaming ||
+    typeof adapter.synthesizeStream !== "function"
+  ) {
+    return {
+      gap: {
+        kind: "tts",
+        providerId: entry.id,
+        reason: `TTS provider "${entry.id}" does not support streaming synthesis`,
+      },
+      clause: `a text-to-speech provider that supports streaming synthesis (the configured "${entry.id}" does not)`,
+    };
+  }
+
+  for (const secret of entry.secretRequirements) {
+    if (!(await ttsSecretResolves(secret.credentialStoreKey))) {
+      return {
+        gap: {
+          kind: "tts",
+          providerId: entry.id,
+          reason: `TTS provider "${entry.id}" is missing credentials (${secret.displayName})`,
+        },
+        clause: `an API key for the text-to-speech provider "${entry.id}" (${secret.displayName})`,
+      };
+    }
+  }
+
+  return null;
+}

--- a/assistant/src/live-voice/live-voice-credential-preflight.ts
+++ b/assistant/src/live-voice/live-voice-credential-preflight.ts
@@ -18,8 +18,8 @@ import { getProviderEntry } from "../providers/speech-to-text/provider-catalog.j
 import {
   resolveBatchTranscriber,
   resolveStreamingTranscriber,
+  sttProviderKeyResolves,
 } from "../providers/speech-to-text/resolve.js";
-import { getProviderKeyAsync } from "../security/secure-keys.js";
 import type { SttProviderId } from "../stt/types.js";
 import type { TtsProviderCatalogEntry } from "../tts/provider-catalog.js";
 import { getCatalogProvider, getTtsProvider } from "../tts/provider-catalog.js";
@@ -117,8 +117,7 @@ async function resolveSttGap(): Promise<GapWithClause | null> {
     };
   }
 
-  const apiKey = await getProviderKeyAsync(entry.credentialProvider);
-  if (!apiKey) {
+  if (!(await sttProviderKeyResolves(entry.credentialProvider))) {
     return {
       gap: {
         kind: "stt",

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -449,3 +449,15 @@ async function createStreamingTranscriber(
     }
   }
 }
+
+/**
+ * True when an API key resolves for the given credential provider name.
+ *
+ * Centralized here (an authorized secure-keys importer) so callers that only
+ * need a key-existence check don't import secure-keys directly.
+ */
+export async function sttProviderKeyResolves(
+  credentialProviderName: string,
+): Promise<boolean> {
+  return (await getProviderKeyAsync(credentialProviderName)) !== undefined;
+}


### PR DESCRIPTION
## Summary
- resolveLiveVoiceCredentialReadiness: fail-before-session preflight mirroring the telephony credential preflight
- STT ready via streaming transcriber or batch fallback; TTS requires a streaming-capable (synthesizeStream) provider with credentials
- Exports the shared TTS secret-resolution helper (ttsSecretResolves) from telephony-tts-capability instead of duplicating it
- Standalone module; session wire-in lands in the duplex session PR

Part of plan: voice-mode-engine.md (PR 9 of 12)