### PR TITLE
fix(channels): only hide the <no_response/> sentinel, never the reply around it

### DIFF
--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -572,6 +572,71 @@ describe("channel-reply-delivery", () => {
     expect(deliveryCalls[0].payload.text).toBe("current answer");
   });
 
+  // A bare-sentinel row never delivers its attachments (marker rows suppress
+  // attachment delivery), so attachments alone must not make the row count
+  // as the turn's real reply and stop the fall-through.
+  it("falls through a bare no_response row with attachments to the turn's real reply", async () => {
+    conversationMessages.push(
+      { id: "msg-current-user", role: "user", content: "current prompt" },
+      {
+        id: "msg-current-text",
+        role: "assistant",
+        content: '[{"type":"text","text":"current answer"}]',
+      },
+      {
+        id: "msg-current-silent",
+        role: "assistant",
+        content: '[{"type":"text","text":"<no_response/>"}]',
+      },
+    );
+    attachmentsByMessageId.set("msg-current-silent", [
+      {
+        id: "att-silent",
+        originalFilename: "chart.png",
+        mimeType: "image/png",
+        sizeBytes: 10,
+        kind: "generated",
+      },
+    ]);
+    const silentStub = {
+      text: "<no_response/>",
+      textSegments: ["<no_response/>"],
+      toolCalls: [],
+      toolCallsBeforeText: false,
+      contentOrder: ["text:0"],
+      surfaces: [],
+      thinkingSegments: [],
+    };
+    const answerStub = {
+      text: "current answer",
+      textSegments: ["current answer"],
+      toolCalls: [],
+      toolCallsBeforeText: false,
+      contentOrder: ["text:0"],
+      surfaces: [],
+      thinkingSegments: [],
+    };
+    // messageId branch reads the targeted silent row, the turn scan reads
+    // the silent row then the text row, and delivery re-reads the text row.
+    renderedHistoryContentQueue.push(
+      silentStub,
+      silentStub,
+      answerStub,
+      answerStub,
+    );
+
+    await deliverReplyViaCallback(
+      "conv-1",
+      "chat-current",
+      "http://gateway/deliver/slack",
+      "assistant-current",
+      { messageId: "msg-current-silent", sinceMessageId: "msg-current-user" },
+    );
+
+    expect(deliveryCalls).toHaveLength(1);
+    expect(deliveryCalls[0].payload.text).toBe("current answer");
+  });
+
   it("skips already-delivered segments when startFromSegment is set", async () => {
     await deliverRenderedReplyViaCallback({
       callbackUrl: "http://gateway/deliver/telegram",

--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -435,7 +435,10 @@ describe("channel-reply-delivery", () => {
     expect(deliveryCalls).toHaveLength(0);
   });
 
-  it("treats a current-turn no_response marker as terminal instead of falling back", async () => {
+  // Silence means the turn produced no real reply text anywhere — not "the
+  // last row was a sentinel". A trailing bare <no_response/> row must not
+  // swallow the real reply written earlier in the same turn.
+  it("delivers the earlier real reply when the turn ends with a bare no_response row", async () => {
     conversationMessages.push(
       { id: "msg-current-user", role: "user", content: "current prompt" },
       {
@@ -449,7 +452,7 @@ describe("channel-reply-delivery", () => {
         content: '[{"type":"text","text":"<no_response/>"}]',
       },
     );
-    renderedHistoryContentQueue.push({
+    const silentStub = {
       text: "<no_response/>",
       textSegments: ["<no_response/>"],
       toolCalls: [],
@@ -457,8 +460,42 @@ describe("channel-reply-delivery", () => {
       contentOrder: ["text:0"],
       surfaces: [],
       thinkingSegments: [],
-    });
-    renderedHistoryContentQueue.push({
+    };
+    const answerStub = {
+      text: "current answer",
+      textSegments: ["current answer"],
+      toolCalls: [],
+      toolCallsBeforeText: false,
+      contentOrder: ["text:0"],
+      surfaces: [],
+      thinkingSegments: [],
+    };
+    // Turn scan reads the silent row then the text row; delivery re-reads
+    // the chosen text row.
+    renderedHistoryContentQueue.push(silentStub, answerStub, answerStub);
+
+    await deliverReplyViaCallback(
+      "conv-1",
+      "chat-current",
+      "http://gateway/deliver/slack",
+      "assistant-current",
+      { sinceMessageId: "msg-current-user" },
+    );
+
+    expect(deliveryCalls).toHaveLength(1);
+    expect(deliveryCalls[0].payload.text).toBe("current answer");
+  });
+
+  it("stays silent when a no_response turn has no real reply text anywhere", async () => {
+    conversationMessages.push(
+      { id: "msg-current-user", role: "user", content: "current prompt" },
+      {
+        id: "msg-current-silent",
+        role: "assistant",
+        content: '[{"type":"text","text":"<no_response/>"}]',
+      },
+    );
+    const silentStub = {
       text: "<no_response/>",
       textSegments: ["<no_response/>"],
       toolCalls: [],
@@ -466,7 +503,10 @@ describe("channel-reply-delivery", () => {
       contentOrder: ["text:0"],
       surfaces: [],
       thinkingSegments: [],
-    });
+    };
+    // Turn scan reads the silent row; delivery re-reads it as the terminal
+    // deliberate-silence target.
+    renderedHistoryContentQueue.push(silentStub, silentStub);
 
     await deliverReplyViaCallback(
       "conv-1",
@@ -477,6 +517,59 @@ describe("channel-reply-delivery", () => {
     );
 
     expect(deliveryCalls).toHaveLength(0);
+  });
+
+  it("falls through a messageId-targeted bare no_response row to the turn's real reply", async () => {
+    conversationMessages.push(
+      { id: "msg-current-user", role: "user", content: "current prompt" },
+      {
+        id: "msg-current-text",
+        role: "assistant",
+        content: '[{"type":"text","text":"current answer"}]',
+      },
+      {
+        id: "msg-current-silent",
+        role: "assistant",
+        content: '[{"type":"text","text":"<no_response/>"}]',
+      },
+    );
+    const silentStub = {
+      text: "<no_response/>",
+      textSegments: ["<no_response/>"],
+      toolCalls: [],
+      toolCallsBeforeText: false,
+      contentOrder: ["text:0"],
+      surfaces: [],
+      thinkingSegments: [],
+    };
+    const answerStub = {
+      text: "current answer",
+      textSegments: ["current answer"],
+      toolCalls: [],
+      toolCallsBeforeText: false,
+      contentOrder: ["text:0"],
+      surfaces: [],
+      thinkingSegments: [],
+    };
+    // messageId branch reads the targeted silent row, the turn scan reads
+    // the silent row then the text row, and delivery re-reads the text row.
+    renderedHistoryContentQueue.push(
+      silentStub,
+      silentStub,
+      answerStub,
+      answerStub,
+    );
+
+    await deliverReplyViaCallback(
+      "conv-1",
+      "chat-current",
+      "http://gateway/deliver/slack",
+      "assistant-current",
+      { messageId: "msg-current-silent", sinceMessageId: "msg-current-user" },
+    );
+
+    expect(deliveryCalls).toHaveLength(1);
+    expect(deliveryCalls[0].payload.text).toBe("current answer");
   });
 
   it("skips already-delivered segments when startFromSegment is set", async () => {
@@ -701,6 +794,57 @@ describe("channel-reply-delivery", () => {
 
     expect(deliveryCalls).toHaveLength(1);
     expect(deliveryCalls[0].payload.text).toBe("Real response.");
+  });
+
+  it("strips a prefixed inline <no_response/> and delivers the rest of the segment", async () => {
+    await deliverRenderedReplyViaCallback({
+      callbackUrl: "http://gateway/deliver/telegram",
+      chatId: "chat-inline-prefix",
+      textSegments: ["<no_response/>\n\nReal reply."],
+      interSegmentDelayMs: 0,
+    });
+
+    expect(deliveryCalls).toHaveLength(1);
+    expect(deliveryCalls[0].payload.text).toBe("Real reply.");
+  });
+
+  it("strips a trailing inline <no_response/> and delivers the rest of the segment", async () => {
+    await deliverRenderedReplyViaCallback({
+      callbackUrl: "http://gateway/deliver/telegram",
+      chatId: "chat-inline-trailing",
+      textSegments: ["Real reply.\n\n<no_response/>"],
+      interSegmentDelayMs: 0,
+    });
+
+    expect(deliveryCalls).toHaveLength(1);
+    expect(deliveryCalls[0].payload.text).toBe("Real reply.");
+  });
+
+  it("never leaks the sentinel into delivered text, including the fallback path", async () => {
+    await deliverRenderedReplyViaCallback({
+      callbackUrl: "http://gateway/deliver/telegram",
+      chatId: "chat-fallback-strip",
+      textSegments: [],
+      fallbackText: "Fallback reply. <no_response/>",
+      interSegmentDelayMs: 0,
+    });
+
+    expect(deliveryCalls).toHaveLength(1);
+    expect(deliveryCalls[0].payload.text).toBe("Fallback reply.");
+    for (const call of deliveryCalls) {
+      expect(String(call.payload.text)).not.toContain("<no_response");
+    }
+  });
+
+  it("suppresses delivery for a case-insensitive bare sentinel", async () => {
+    await deliverRenderedReplyViaCallback({
+      callbackUrl: "http://gateway/deliver/slack",
+      chatId: "chat-silent-case",
+      textSegments: ["<NO_RESPONSE/>"],
+      interSegmentDelayMs: 0,
+    });
+
+    expect(deliveryCalls).toHaveLength(0);
   });
 
   it("passes startFromSegment through deliverReplyViaCallback options", async () => {

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -88,16 +88,21 @@ function toDeliverableTextSegments(
 
 /**
  * A reply worth delivering on its own merits: real text after sentinel
- * stripping, or attachments. A bare `<no_response/>` row does NOT count.
+ * stripping, or attachments. A bare `<no_response/>` row does NOT count —
+ * even when it carries attachments, since `deliverRenderedReplyViaCallback`
+ * suppresses attachment delivery for marker rows; counting such a row as
+ * real would stop the turn scan on a row that delivers nothing.
  */
 function hasRealDeliverableReply(
   rendered: RenderedHistoryContent,
   attachments: RuntimeAttachmentMetadata[],
 ): boolean {
-  return (
-    toDeliverableTextSegments(rendered.textSegments, rendered.text).length >
-      0 || attachments.length > 0
-  );
+  if (
+    toDeliverableTextSegments(rendered.textSegments, rendered.text).length > 0
+  ) {
+    return true;
+  }
+  return attachments.length > 0 && !hasNoResponseMarker(rendered.textSegments);
 }
 
 /**

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -12,6 +12,10 @@ import { getLogger } from "../util/logger.js";
 import type { ChannelDeliveryResult } from "./gateway-client.js";
 import { deliverChannelReply } from "./gateway-client.js";
 import type { RuntimeAttachmentMetadata } from "./http-types.js";
+import {
+  containsNoResponseMarker,
+  stripNoResponseMarkers,
+} from "./no-response.js";
 
 const log = getLogger("channel-reply-delivery");
 
@@ -50,40 +54,64 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-const NO_RESPONSE_RE = /^\s*<no_response\s*\/?>\s*$/;
-
-/** Returns true when any segment is a `<no_response/>` sentinel. */
+/** Returns true when any segment carries a `<no_response/>` sentinel. */
 function hasNoResponseMarker(textSegments: string[]): boolean {
-  return textSegments.some((s) => NO_RESPONSE_RE.test(s));
+  return textSegments.some(containsNoResponseMarker);
 }
 
 function toDeliverableTextSegments(
   textSegments: string[],
   fallbackText?: string,
 ): string[] {
+  // Hide the sentinel itself, never the content around it: strip every
+  // occurrence from mixed segments so a reply the model wrapped around a
+  // stray <no_response/> still reaches the user, and the raw sentinel never
+  // leaks into the channel as visible text.
   const nonEmptySegments = textSegments
-    .map(stripVellumLinks)
-    .filter(
-      (segment) => segment.trim().length > 0 && !NO_RESPONSE_RE.test(segment),
-    );
+    .map((segment) => {
+      const stripped = stripVellumLinks(segment);
+      return containsNoResponseMarker(stripped)
+        ? stripNoResponseMarkers(stripped)
+        : stripped;
+    })
+    .filter((segment) => segment.trim().length > 0);
   if (nonEmptySegments.length > 0) return nonEmptySegments;
   // If the only text was <no_response/>, treat as intentional silence —
   // do not fall back to fallbackText.
   if (hasNoResponseMarker(textSegments)) return [];
-  if (typeof fallbackText === "string" && fallbackText.trim().length > 0) {
-    return [fallbackText];
+  if (typeof fallbackText === "string") {
+    const fallback = stripNoResponseMarkers(fallbackText);
+    if (fallback.length > 0) return [fallback];
   }
   return [];
 }
 
-function hasDeliverableReply(
+/**
+ * A reply worth delivering on its own merits: real text after sentinel
+ * stripping, or attachments. A bare `<no_response/>` row does NOT count.
+ */
+function hasRealDeliverableReply(
   rendered: RenderedHistoryContent,
   attachments: RuntimeAttachmentMetadata[],
 ): boolean {
   return (
     toDeliverableTextSegments(rendered.textSegments, rendered.text).length >
-      0 ||
-    attachments.length > 0 ||
+      0 || attachments.length > 0
+  );
+}
+
+/**
+ * A reply whose delivery is a terminal outcome: real content, or a bare
+ * `<no_response/>` sentinel whose "delivery" is deliberate silence. The
+ * unbounded fallback scan stops at either so a silence marker can never be
+ * skipped in favor of re-delivering an older turn's reply.
+ */
+function hasDeliverableReply(
+  rendered: RenderedHistoryContent,
+  attachments: RuntimeAttachmentMetadata[],
+): boolean {
+  return (
+    hasRealDeliverableReply(rendered, attachments) ||
     hasNoResponseMarker(rendered.textSegments)
   );
 }
@@ -284,16 +312,27 @@ export function findAssistantReplyMessageIdForTurn(
     }
   }
 
+  let sentinelRowId: string | undefined;
   for (let i = turnEndIndex - 1; i > userIndex; i--) {
     const msg = msgs[i];
     if (msg.role === "assistant") {
       const { rendered, replyAttachments } = readPersistedAssistantReply(msg);
-      if (hasDeliverableReply(rendered, replyAttachments)) {
+      if (hasRealDeliverableReply(rendered, replyAttachments)) {
         return msg.id;
+      }
+      if (
+        sentinelRowId === undefined &&
+        hasNoResponseMarker(rendered.textSegments)
+      ) {
+        sentinelRowId = msg.id;
       }
     }
   }
-  return undefined;
+  // Silence means the turn produced no real reply text anywhere — not "the
+  // last row was a sentinel". Only when no row in the turn carries real
+  // content does the bare <no_response/> row become the reply; delivering it
+  // suppresses all output as deliberate silence.
+  return sentinelRowId;
 }
 
 async function deliverPersistedAssistantMessageViaCallback(
@@ -302,8 +341,10 @@ async function deliverPersistedAssistantMessageViaCallback(
   callbackUrl: string,
   assistantId: string | undefined,
   options: DeliverReplyOptions | undefined,
+  preRead?: ReturnType<typeof readPersistedAssistantReply>,
 ): Promise<boolean> {
-  const { rendered, replyAttachments } = readPersistedAssistantReply(msg);
+  const { rendered, replyAttachments } =
+    preRead ?? readPersistedAssistantReply(msg);
   if (!hasDeliverableReply(rendered, replyAttachments)) {
     return false;
   }
@@ -355,14 +396,27 @@ export async function deliverReplyViaCallback(
         `Target assistant reply message not found: ${options.messageId}`,
       );
     }
-    await deliverPersistedAssistantMessageViaCallback(
-      msg,
-      externalChatId,
-      callbackUrl,
-      assistantId,
-      options,
-    );
-    return;
+    // The targeted row is usually the turn's final assistant row, but a bare
+    // <no_response/> or tool-only final row is not necessarily the turn's
+    // reply — the model may have written the real reply in an earlier row of
+    // the same turn. When the turn boundary is known, defer to the turn scan
+    // below; it returns this same sentinel row (deliberate silence) only when
+    // no row in the turn carries real content.
+    const preRead = readPersistedAssistantReply(msg);
+    if (
+      hasRealDeliverableReply(preRead.rendered, preRead.replyAttachments) ||
+      !options.sinceMessageId
+    ) {
+      await deliverPersistedAssistantMessageViaCallback(
+        msg,
+        externalChatId,
+        callbackUrl,
+        assistantId,
+        options,
+        preRead,
+      );
+      return;
+    }
   }
 
   if (options?.sinceMessageId) {

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -436,6 +436,10 @@ export async function sweepFailedEvents(
         assistantId,
         {
           messageId: replyMessageId,
+          // The stored reply id may point at a bare <no_response/> row from
+          // the turn's final message; the turn boundary lets delivery fall
+          // through to the real reply written earlier in the same turn.
+          ...(event.messageId ? { sinceMessageId: event.messageId } : {}),
           startFromSegment: event.deliveredSegmentCount,
           ...(priorStreamMessageTs ? { messageTs: priorStreamMessageTs } : {}),
           onSegmentDelivered: (count) =>

--- a/assistant/src/runtime/no-response.ts
+++ b/assistant/src/runtime/no-response.ts
@@ -1,10 +1,12 @@
 /**
  * The assistant emits a `<no_response/>` sentinel to signal that a turn should
- * produce no user-visible reply. Slack surfaces that begin work on the first
- * deliverable text (the thinking-status indicator and native reply streaming)
- * must not act on a partially-arrived sentinel: a slow stream can surface just
- * `<` or `<no_resp` before the rest lands, and starting on that leaks a stray
- * message that later resolves to empty.
+ * produce no user-visible reply. Channel delivery must hide the sentinel
+ * itself without hiding real content it happens to coexist with. Slack
+ * surfaces that begin work on the first deliverable text (the thinking-status
+ * indicator and native reply streaming) additionally must not act on a
+ * partially-arrived sentinel: a slow stream can surface just `<` or `<no_resp`
+ * before the rest lands, and starting on that leaks a stray message that
+ * later resolves to empty.
  */
 
 /** Matches a message whose entire content is the sentinel. */
@@ -12,6 +14,24 @@ const NO_RESPONSE_ONLY_RE = /^\s*<no_response\s*\/?>\s*$/i;
 
 /** Matches every sentinel occurrence for stripping it out of mixed content. */
 export const NO_RESPONSE_INLINE_RE = /<no_response\s*\/?>/gi;
+
+/**
+ * Detection variant without the `g` flag: a `g`-flagged regex is stateful
+ * under `.test()` (it resumes from `lastIndex`), so reusing
+ * {@link NO_RESPONSE_INLINE_RE} for detection would alternate between
+ * matches and misses across calls.
+ */
+const NO_RESPONSE_MARKER_RE = new RegExp(NO_RESPONSE_INLINE_RE.source, "i");
+
+/** Whether `text` contains the sentinel anywhere. */
+export function containsNoResponseMarker(text: string): boolean {
+  return NO_RESPONSE_MARKER_RE.test(text);
+}
+
+/** Removes every sentinel occurrence, trimming the leftover whitespace. */
+export function stripNoResponseMarkers(text: string): string {
+  return text.replace(NO_RESPONSE_INLINE_RE, "").trim();
+}
 
 const NO_RESPONSE_SENTINEL_FORMS = [
   "<no_response/>",
@@ -43,5 +63,5 @@ export function hasDeliverableAssistantText(text: string): boolean {
   if (trimmed.length === 0) return false;
   if (NO_RESPONSE_ONLY_RE.test(trimmed)) return false;
   if (isPotentialNoResponsePrefix(trimmed)) return false;
-  return trimmed.replace(NO_RESPONSE_INLINE_RE, "").trim().length > 0;
+  return stripNoResponseMarkers(trimmed).length > 0;
 }

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -46,7 +46,7 @@ import type {
   MessageProcessor,
   SlackInboundMessageMetadata,
 } from "../../http-types.js";
-import { hasDeliverableAssistantText } from "../../slack-no-response.js";
+import { hasDeliverableAssistantText } from "../../no-response.js";
 import { createSlackReplySession } from "../../slack-reply-session.js";
 import type { TaskProgressData } from "../../slack-task-progress.js";
 import {

--- a/assistant/src/runtime/slack-reply-session.ts
+++ b/assistant/src/runtime/slack-reply-session.ts
@@ -18,7 +18,7 @@ import { deliverChannelReply } from "./gateway-client.js";
 import {
   hasDeliverableAssistantText,
   NO_RESPONSE_INLINE_RE,
-} from "./slack-no-response.js";
+} from "./no-response.js";
 import type { TaskProgressData } from "./slack-task-progress.js";
 import {
   getTaskProgressDataFromSurfaceData,


### PR DESCRIPTION
## Summary
- Strip inline `<no_response/>` occurrences from delivered text segments (and the fallback text) instead of only dropping whole-sentinel segments, so `<no_response/>` + real content delivers the content and the raw sentinel never leaks to the channel.
- Redefine turn-level silence in `channel-reply-delivery.ts`: a turn is silent only when **no** assistant row in it carries real reply text. A trailing bare-sentinel row no longer swallows the real reply written earlier in the same turn — the `messageId`-targeted delivery falls through to the turn-bounded scan, which prefers real-content rows and returns the sentinel row (deliberate silence) only when nothing real exists. The unbounded fallback scan keeps sentinel-terminal semantics so deliberate silence can never re-deliver an older turn's reply. The retry sweep now passes the turn boundary (`sinceMessageId`) so retries get the same behavior.
- Promote `slack-no-response.ts` → `no-response.ts` (channel-neutral) with a non-global, case-insensitive detection helper (`/g` regexes are stateful under `.test()`), fixing the case-sensitivity drift between the Slack path and the generic channel delivery path.

## Original prompt
A transcript-dataset review found three Telegram turns where the assistant wrote a full reply but nothing was delivered because the turn also carried the `<no_response/>` sentinel (once prefixed inside the content, twice trailing); the user repeatedly concluded the assistant was broken. The other 12 bare sentinels in the dataset were legitimate deliberate silences and must stay silent. DoD: only hide the `<no_response/>` sentinel itself — never remove the rest of the message. The fix is delivery-side only; the turn-context prompt wording is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)