### PR TITLE
feat(ci): deploy the web SPA to dev as part of the hourly dev release

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -808,9 +808,12 @@ jobs:
   # ── Web SPA (dev bucket) ─────────────────────────────────────────────
   # The platform SPA ships to the dev GCS bucket with every dev release,
   # not on merge to main; staging/production deploys live in release.yml.
+  # Gated on register-release so the dev bucket only updates when the dev
+  # backend release actually registered with the platform — if register-release
+  # fails or is skipped, this job is skipped too.
   deploy-web-spa:
     name: Deploy Web SPA (dev)
-    needs: [ci-web]
+    needs: [ci-web, register-release]
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -266,6 +266,47 @@ jobs:
         run: bun run typecheck
         working-directory: cli
 
+  ci-web:
+    needs: [check-for-new-commits]
+    if: ${{ needs.check-for-new-commits.outputs.has_new_commits == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
+
+      - name: Install design-library dependencies
+        run: bun install --frozen-lockfile
+        working-directory: packages/design-library
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+        working-directory: clients/web
+
+      - name: Generate API clients
+        run: bun run openapi-ts
+        working-directory: clients/web
+
+      - name: Install shared packages
+        uses: ./.github/actions/install-shared-packages
+        with:
+          packages: packages/environments packages/local-mode
+
+      - name: Lint
+        run: bun run lint
+        working-directory: clients/web
+
+      - name: Typecheck
+        run: bun run typecheck
+        working-directory: clients/web
+
+      - name: Test
+        run: bun run test:ci
+        working-directory: clients/web
+
   # ── Docker Images ──────────────────────────────────────────────────────
 
   push-assistant-image:
@@ -764,6 +805,20 @@ jobs:
           path: /tmp/manifest-digest/*
           retention-days: 1
 
+  # ── Web SPA (dev bucket) ─────────────────────────────────────────────
+  # The platform SPA ships to the dev GCS bucket with every dev release,
+  # not on merge to main; staging/production deploys live in release.yml.
+  deploy-web-spa:
+    name: Deploy Web SPA (dev)
+    needs: [ci-web]
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/deploy-platform-web-spa.yaml
+    with:
+      environment: dev
+    secrets: inherit
+
   publish-production-preview-image-tags:
     needs: [compute-version, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest]
     if: ${{ always() && !cancelled() && github.ref_name == 'main' && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' }}
@@ -1234,7 +1289,7 @@ jobs:
   # SLACK_RELEASES_WEBHOOK_URL (releases). The job no-ops if the secret is unset.
 
   notify-dev-release:
-    needs: [compute-version, register-release, register-preview-release, build-electron, upload-electron-updates]
+    needs: [compute-version, register-release, register-preview-release, build-electron, upload-electron-updates, deploy-web-spa]
     # Run on success and failure alike, but not when the run was cancelled
     # (e.g. superseded by a newer hourly run via cancel-in-progress) — a
     # cancelled run is not a real failure and should not alert the channel.
@@ -1267,6 +1322,7 @@ jobs:
           # failure downstream of register-release still posts the changelog.
           RELEASE_RESULT: ${{ needs.register-release.result }}
           ELECTRON_RESULT: ${{ needs.build-electron.result }}
+          SPA_RESULT: ${{ needs.deploy-web-spa.result }}
         run: |
           set -euo pipefail
 
@@ -1371,17 +1427,25 @@ jobs:
           # Top-level blocks: header, "N commits since last dev release", buttons.
           # Commit list lives in an attachment so Slack auto-collapses it behind
           # a "show more" toggle (see Slack docs on attachments truncation).
-          # When the release registered but the Electron build failed,
-          # swap the header emoji and append a warning so the notification
-          # surfaces the failure instead of looking fully green.
+          # When the release registered but the Electron build or the web SPA
+          # deploy failed, swap the header emoji and append a warning so the
+          # notification surfaces the failure instead of looking fully green.
+          # The warnings are independent — either or both can fire.
+          HEADER_EMOJI="🚀"
           if [ "${ELECTRON_RESULT}" != "success" ]; then
             HEADER_EMOJI="⚠️"
             # Build with jq so the value is real JSON — --argjson rejects
             # jq-program syntax like unquoted object keys.
             ELECTRON_WARNING=$(jq -n '{ type: "section", text: { type: "mrkdwn", text: "⚠️ *Electron build failed* — the release was published but the desktop app was not built. See the workflow run for details." } }')
           else
-            HEADER_EMOJI="🚀"
             ELECTRON_WARNING=""
+          fi
+
+          if [ "${SPA_RESULT}" != "success" ]; then
+            HEADER_EMOJI="⚠️"
+            SPA_WARNING=$(jq -n '{ type: "section", text: { type: "mrkdwn", text: "⚠️ *Web SPA deploy failed* — the release was published but the dev web UI was not updated. See the workflow run for details." } }')
+          else
+            SPA_WARNING=""
           fi
 
           BLOCKS=$(jq -n \
@@ -1401,6 +1465,10 @@ jobs:
 
           if [ -n "$ELECTRON_WARNING" ]; then
             BLOCKS=$(echo "$BLOCKS" | jq --argjson warn "$ELECTRON_WARNING" '. += [$warn]')
+          fi
+
+          if [ -n "$SPA_WARNING" ]; then
+            BLOCKS=$(echo "$BLOCKS" | jq --argjson warn "$SPA_WARNING" '. += [$warn]')
           fi
 
           # Attachment blocks: the actual commit list, chunked into sections to

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -2058,7 +2058,7 @@ jobs:
           npm publish /tmp/npm-dist/package.tgz --tag dev --access public --no-provenance
 
   build-web-dev:
-    needs: [compute-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor]
+    needs: [compute-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor, ci-web]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
## Summary
- Add a ci-web job (lint/typecheck/test for clients/web) to the hourly dev release, mirroring ci-main-web coverage
- Deploy the platform SPA to the dev GCS bucket via the deploy-platform-web-spa reusable workflow, gated on ci-web
- Surface SPA deploy failures in the #dev-releases Slack notification alongside the existing Electron warning

Part of plan: spa-deploy-on-release.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->