### PR TITLE
feat(ci): deploy the web SPA to staging/production via the Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1849,10 +1849,15 @@ jobs:
       environment: staging
     secrets: inherit
 
+  # The production SPA deploy is the LAST side effect before the GitHub
+  # Release: it waits on every other release prerequisite (publishes, image
+  # manifests, Electron build + updates), so a release that fails partway
+  # never leaves the prod UI updated, and a failed SPA deploy blocks the
+  # GitHub Release/tag (the `release` job requires this job's success).
   deploy-web-spa-production:
     name: Deploy Web SPA (production)
-    needs: [extract-version, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image]
-    if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging != 'true' && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' }}
+    needs: [extract-version, publish-npm-prod, publish-web-prod, publish-meta-prod, publish-plugin-api-prod, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image, build-electron, upload-electron-updates]
+    if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging != 'true' && needs.publish-npm-prod.result == 'success' && needs.publish-web-prod.result == 'success' && needs.publish-meta-prod.result == 'success' && needs.publish-plugin-api-prod.result == 'success' && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' && needs.build-electron.result == 'success' && needs.upload-electron-updates.result == 'success' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1833,6 +1833,34 @@ jobs:
           fi
           npm publish --tag staging --access public --no-provenance
 
+  # ── Web SPA (staging/production buckets) ──────────────────────────────
+  # The platform SPA (VITE_PLATFORM_MODE=true → GCS) ships with releases:
+  # staging bucket on every staging release, production bucket when a
+  # release goes live. The dev bucket is deployed by dev-release.yaml.
+  deploy-web-spa-staging:
+    name: Deploy Web SPA (staging)
+    needs: [extract-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor]
+    if: ${{ needs.extract-version.outputs.is_staging == 'true' }}
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/deploy-platform-web-spa.yaml
+    with:
+      environment: staging
+    secrets: inherit
+
+  deploy-web-spa-production:
+    name: Deploy Web SPA (production)
+    needs: [extract-version, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image]
+    if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging != 'true' && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' }}
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/deploy-platform-web-spa.yaml
+    with:
+      environment: production
+    secrets: inherit
+
   build-web-prod:
     name: build-npm-prod (web)
     # Build has no side effects; release-ordering gates live on publish-web-prod.
@@ -2330,8 +2358,8 @@ jobs:
           done
 
   release:
-    needs: [extract-version, publish-npm-prod, publish-web-prod, publish-meta-prod, publish-plugin-api-prod, build-electron, upload-electron-updates, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image, build-chrome-extension]
-    if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging != 'true' && needs.extract-version.result == 'success' && needs.publish-npm-prod.result == 'success' && needs.publish-web-prod.result == 'success' && needs.publish-meta-prod.result == 'success' && needs.publish-plugin-api-prod.result == 'success' && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' && needs.build-electron.result == 'success' && needs.upload-electron-updates.result == 'success' }}
+    needs: [extract-version, publish-npm-prod, publish-web-prod, publish-meta-prod, publish-plugin-api-prod, build-electron, upload-electron-updates, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image, build-chrome-extension, deploy-web-spa-production]
+    if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging != 'true' && needs.extract-version.result == 'success' && needs.publish-npm-prod.result == 'success' && needs.publish-web-prod.result == 'success' && needs.publish-meta-prod.result == 'success' && needs.publish-plugin-api-prod.result == 'success' && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' && needs.build-electron.result == 'success' && needs.upload-electron-updates.result == 'success' && needs.deploy-web-spa-production.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -2739,7 +2767,7 @@ jobs:
   notify-release:
     name: Slack Notification (Release)
     if: ${{ always() && !cancelled() }}
-    needs: [extract-version, publish-npm-prod, publish-web-prod, publish-meta-prod, publish-plugin-api-prod, build-electron, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image, register-release, release, merge-release-branch, update-platform, pack-cli, trigger-platform-qa, release-ios, ci-assistant, ci-cli, ci-credential-executor, ci-gateway, build-chrome-extension, publish-chrome-extension]
+    needs: [extract-version, publish-npm-prod, publish-web-prod, publish-meta-prod, publish-plugin-api-prod, build-electron, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image, register-release, release, merge-release-branch, update-platform, pack-cli, trigger-platform-qa, release-ios, ci-assistant, ci-cli, ci-credential-executor, ci-gateway, build-chrome-extension, publish-chrome-extension, deploy-web-spa-staging, deploy-web-spa-production]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: true
@@ -2783,6 +2811,9 @@ jobs:
               STAGING_READY="false"
             fi
             if [ "${{ needs.register-release.result }}" != "success" ]; then
+              STAGING_READY="false"
+            fi
+            if [ "${{ needs.deploy-web-spa-staging.result }}" != "success" ]; then
               STAGING_READY="false"
             fi
           fi


### PR DESCRIPTION
## Summary
- Deploy the platform SPA to the staging GCS bucket on every staging release (gated on the four CI jobs)
- Deploy it to the production bucket on production releases, gated behind the backend image manifests like publish-web-prod
- Make the production SPA deploy a hard dependency of the GitHub Release job and wire both deploys into the release Slack notification

Part of plan: spa-deploy-on-release.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->