### PR TITLE
docs: align the /release skill and internal reference with the dispatch-only release workflow

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -6,7 +6,7 @@ description: >
 
 Cut a new release by triggering the Release workflow via GitHub Actions workflow dispatch.
 
-The user may pass `$ARGUMENTS` as the bump type: `patch`, `minor`, or `major`. If not provided, default to `patch`.
+The workflow computes the version itself: a dispatch from `main` takes the latest `v<major>.<minor>.<patch>` tag and increments the patch number. There is no bump-type input — minor/major bumps land by changing the version on `main` first, not through this command.
 
 ## Steps
 
@@ -16,32 +16,31 @@ The user may pass `$ARGUMENTS` as the bump type: `patch`, `minor`, or `major`. I
 git checkout main && git pull
 ```
 
-### 2. Determine the bump type
+The dispatch builds whatever is on `origin/main` — pulling first is so the release you announce matches what you can see locally.
 
-If the user provided `$ARGUMENTS`, treat it as the bump type (`patch`, `minor`, or `major`). Otherwise default to `patch`.
+### 2. Confirm the payload
 
-Validate + show what you're about to do and ask for confirmation before proceeding:
+Show the latest tag and the commits since it, so it's clear what the release will carry:
 
 ```bash
-BUMP_TYPE="${ARGUMENTS:-patch}"
-case "$BUMP_TYPE" in
-  patch|minor|major) ;;
-  *) echo "Invalid bump type: $BUMP_TYPE (expected patch|minor|major)"; exit 1 ;;
-esac
-
-echo "About to trigger a $BUMP_TYPE release bump"
+git describe --tags --abbrev=0
+git log --oneline "$(git describe --tags --abbrev=0)"..origin/main | head -20
 ```
+
+Confirm with the user before dispatching unless they already asked for the release explicitly.
 
 ### 3. Trigger the Release workflow
 
 ```bash
 gh workflow run release.yml \
   --repo vellum-ai/vellum-assistant \
-  --ref main \
-  --field bump=<patch|minor|major>
+  --ref main
 ```
 
-This triggers the unified Release workflow which automatically handles:
+The only dispatch input is the optional `slack_user_id` (`--field slack_user_id=U…`), used to attribute the release notification; omit it when unknown.
+
+The unified Release workflow automatically handles:
+- Computing the next patch version from the latest tag
 - Version bumping across all packages
 - Creating a release branch, PR, and merging it
 - Tagging the release
@@ -50,17 +49,17 @@ This triggers the unified Release workflow which automatically handles:
 - Creating GitHub Releases on `vellum-ai/vellum-assistant`
 - Updating the `vellum-assistant-platform` dependency
 
-### 4. Verify the workflow started
+### 4. Verify the workflow started and read the version
 
 ```bash
 gh run list --repo vellum-ai/vellum-assistant --workflow="Release" --limit 1
 ```
 
-Confirm the workflow was triggered.
+The computed version appears in the `extract-version` job log as `BASE_VERSION: <x.y.z>`.
 
 ### 5. Report
 
 Output:
-- The version number (from the workflow output)
+- The version number (from the `extract-version` job)
 - A link to the running workflow
 - Remind the user that the full release pipeline takes ~15-20 minutes and will auto-publish everything when done

--- a/docs/internal-reference.md
+++ b/docs/internal-reference.md
@@ -584,7 +584,7 @@ Multiple plans can run in parallel — just specify the plan name to disambiguat
 | Command | Purpose |
 |---------|---------|
 | `/plan-html <topic\|plan-name>` | Create or refresh a rollout plan in `.private/plans/` with both markdown and a polished, review-friendly HTML view (including per-PR file lists). |
-| `/release [version]` | Cut a release: pull main, determine/create version tag, generate release notes, publish GitHub Release, and verify CI trigger. |
+| `/release` | Cut a release: pull main, then dispatch the unified Release workflow, which computes the next patch version from the latest tag and handles version bumps, tagging, npm, DMG, and GitHub Release publishing. |
 | `/triage [user\|assistant\|device]` | Search Sentry for recent errors and log reports by user, assistant, or device in the `vellum-assistant-brain` project, then cross-reference with Linear issues to produce a triage summary. |
 | `/update` | Pull latest from `main`, kill stale processes, rebuild and launch the macOS app. The app manages its own assistant and gateway lifecycle (hatching on first launch). Prints a startup summary. |
 
@@ -611,16 +611,17 @@ All workflows use squash-merge (no merge commits), worktree isolation for parall
 
 ### Release Management
 
-Releases are cut using the `/release` Claude Code command and follow a fully automated pipeline from tag to client update.
+Releases are cut using the `/release` Claude Code command and follow a fully automated pipeline from workflow dispatch to client update.
 
 #### Cutting a release
 
-Run `/release [version]` in Claude Code. If no version is provided, the patch version is auto-incremented from the latest git tag (e.g. `v0.1.5` becomes `v0.1.6`). The command:
+Run `/release` in Claude Code. The command:
 
-1. Pulls the latest `main` branch
-2. Generates release notes from commits since the last tag, grouped into Features, Fixes, and Infrastructure
-3. Creates a GitHub Release with the corresponding git tag
-4. Confirms the CI build was triggered
+1. Pulls the latest `main` branch and shows the commits the release will carry
+2. Dispatches the `release.yml` workflow on `main` (`gh workflow run release.yml`); the only input is an optional `slack_user_id` for attribution
+3. Confirms the workflow started and reads the computed version from the `extract-version` job (`BASE_VERSION`)
+
+The workflow computes the next patch version from the latest `v<major>.<minor>.<patch>` tag — there is no bump-type input — then bumps versions across packages, creates and merges a release branch PR, tags the release, publishes npm packages, builds/signs/notarizes the macOS DMG, creates the GitHub Release, and updates the `vellum-assistant-platform` dependency.
 
 #### What happens after a release is created
 


### PR DESCRIPTION
The `/release` skill instructed `gh workflow run release.yml --field bump=<patch|minor|major>`, which fails with **HTTP 422: Unexpected inputs** — `release.yml`'s only `workflow_dispatch` input is the optional `slack_user_id`, and a main dispatch computes the next patch version from the latest tag itself (hit this live while cutting v0.10.6). The internal-reference release section likewise described a tag-creation/release-notes flow the unified workflow replaced.

Rewrites both to the actual sequence: pull main → show the commits the release will carry → dispatch with no version input → verify + read `BASE_VERSION` from the `extract-version` job. Per the repo rule, `docs/internal-reference.md`'s Claude Code Workflow section is updated in the same PR as the skill change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)