### PR TITLE
feat(web): implement the haptic bridge over @capacitor/haptics

### DIFF
--- a/clients/web/src/utils/haptics.test.ts
+++ b/clients/web/src/utils/haptics.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── platform guard ───────────────────────────────────────────────────────────
+//
+// `native-auth` is mocked rather than loaded because its module-load
+// `registerPlugin("NativeAuth")` would fail outside a Capacitor runtime
+// (mirrors push-registration.test.ts).
+
+let isNative = true;
+mock.module("@/runtime/native-auth", () => ({
+  isNativePlatform: () => isNative,
+}));
+
+// ── @capacitor/haptics (lazy-imported plugin Proxy) ──────────────────────────
+
+let pluginError: Error | null = null;
+
+const impactMock = mock(async (_options: { style: string }) => {
+  if (pluginError) {
+    throw pluginError;
+  }
+});
+const notificationMock = mock(async (_options: { type: string }) => {
+  if (pluginError) {
+    throw pluginError;
+  }
+});
+
+mock.module("@capacitor/haptics", () => ({
+  Haptics: {
+    impact: impactMock,
+    notification: notificationMock,
+  },
+  ImpactStyle: {
+    Light: "LIGHT",
+    Medium: "MEDIUM",
+    Heavy: "HEAVY",
+  },
+  NotificationType: {
+    Success: "SUCCESS",
+    Warning: "WARNING",
+    Error: "ERROR",
+  },
+}));
+
+const { haptic } = await import("@/utils/haptics");
+
+beforeEach(() => {
+  isNative = true;
+  pluginError = null;
+  impactMock.mockClear();
+  notificationMock.mockClear();
+});
+
+describe("haptic on native", () => {
+  test("light() fires a Light impact", async () => {
+    await haptic.light();
+
+    expect(impactMock).toHaveBeenCalledTimes(1);
+    expect(impactMock).toHaveBeenCalledWith({ style: "LIGHT" });
+  });
+
+  test("medium() fires a Medium impact", async () => {
+    await haptic.medium();
+
+    expect(impactMock).toHaveBeenCalledTimes(1);
+    expect(impactMock).toHaveBeenCalledWith({ style: "MEDIUM" });
+  });
+
+  test("success() fires a Success notification", async () => {
+    await haptic.success();
+
+    expect(notificationMock).toHaveBeenCalledTimes(1);
+    expect(notificationMock).toHaveBeenCalledWith({ type: "SUCCESS" });
+  });
+
+  test("error() fires an Error notification", async () => {
+    await haptic.error();
+
+    expect(notificationMock).toHaveBeenCalledTimes(1);
+    expect(notificationMock).toHaveBeenCalledWith({ type: "ERROR" });
+  });
+});
+
+describe("haptic on web", () => {
+  test("never touches the plugin", async () => {
+    isNative = false;
+
+    await haptic.light();
+    await haptic.medium();
+    await haptic.success();
+    await haptic.error();
+
+    expect(impactMock).not.toHaveBeenCalled();
+    expect(notificationMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("haptic error handling", () => {
+  test("resolves even when the plugin throws (best-effort)", async () => {
+    pluginError = new Error("haptics unavailable");
+
+    await expect(haptic.light()).resolves.toBeUndefined();
+    await expect(haptic.medium()).resolves.toBeUndefined();
+    await expect(haptic.success()).resolves.toBeUndefined();
+    await expect(haptic.error()).resolves.toBeUndefined();
+
+    expect(impactMock).toHaveBeenCalledTimes(2);
+    expect(notificationMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/clients/web/src/utils/haptics.ts
+++ b/clients/web/src/utils/haptics.ts
@@ -1,3 +1,16 @@
+import { isNativePlatform } from "@/runtime/native-auth";
+
+const runNative = async (fire: () => Promise<void>): Promise<void> => {
+  if (!isNativePlatform()) {
+    return;
+  }
+  try {
+    await fire();
+  } catch {
+    // Best-effort: call sites fire-and-forget and must never see a rejection.
+  }
+};
+
 /**
  * Thin haptic-feedback wrapper. On native Capacitor platforms this delegates
  * to `@capacitor/haptics`; on web it's a no-op. The lazy import ensures the
@@ -5,16 +18,24 @@
  * runtime) never runs in a plain browser context.
  */
 export const haptic = {
-  light: async () => {
-    /* no-op until Capacitor is integrated */
-  },
-  medium: async () => {
-    /* no-op until Capacitor is integrated */
-  },
-  success: async () => {
-    /* no-op until Capacitor is integrated */
-  },
-  error: async () => {
-    /* no-op until Capacitor is integrated */
-  },
+  light: () =>
+    runNative(async () => {
+      const { Haptics, ImpactStyle } = await import("@capacitor/haptics");
+      await Haptics.impact({ style: ImpactStyle.Light });
+    }),
+  medium: () =>
+    runNative(async () => {
+      const { Haptics, ImpactStyle } = await import("@capacitor/haptics");
+      await Haptics.impact({ style: ImpactStyle.Medium });
+    }),
+  success: () =>
+    runNative(async () => {
+      const { Haptics, NotificationType } = await import("@capacitor/haptics");
+      await Haptics.notification({ type: NotificationType.Success });
+    }),
+  error: () =>
+    runNative(async () => {
+      const { Haptics, NotificationType } = await import("@capacitor/haptics");
+      await Haptics.notification({ type: NotificationType.Error });
+    }),
 };


### PR DESCRIPTION
## Summary
- Implement the four no-op haptic stubs (light/medium/success/error) over @capacitor/haptics with the CAPACITOR.md lazy inline-destructure pattern
- 25+ prewired call sites (composer send, conversation actions, pull-to-refresh, edge-swipe) light up with zero call-site changes
- Best-effort: never rejects; no-op off native

Part of plan: mobile-push-deeplink-haptics.md (PR 1 of 4)