### PR TITLE
feat(web): navigate to the conversation when a notification is tapped

### DIFF
--- a/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
@@ -1,14 +1,12 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, renderHook, act } from "@testing-library/react";
 
-import {
-  __resetForTesting,
-  publish,
-} from "@/lib/event-bus";
+import { __resetForTesting, publish } from "@/lib/event-bus";
 import {
   __resetPendingDeepLinkForTesting,
   usePendingDeepLinkStore,
 } from "@/stores/pending-deep-link-store";
+import { useViewerStore } from "@/stores/viewer-store";
 
 const navigateMock = mock((_to: string) => undefined);
 mock.module("react-router", () => ({
@@ -29,9 +27,8 @@ mock.module("@sentry/react", () => ({
   captureException: () => {},
 }));
 
-const { useGlobalDeepLinkConsumer } = await import(
-  "./use-global-deep-link-consumer"
-);
+const { useGlobalDeepLinkConsumer } =
+  await import("./use-global-deep-link-consumer");
 
 beforeEach(() => {
   __resetForTesting();
@@ -39,12 +36,14 @@ beforeEach(() => {
   navigateMock.mockClear();
   ensureMainWindowVisibleMock.mockClear();
   sentryBreadcrumbMock.mockClear();
+  useViewerStore.setState({ mainView: "chat" });
 });
 
 afterEach(() => {
   cleanup();
   __resetForTesting();
   __resetPendingDeepLinkForTesting();
+  useViewerStore.setState({ mainView: "chat" });
 });
 
 describe("deeplink.send", () => {
@@ -75,6 +74,20 @@ describe("deeplink.openThread", () => {
       "/assistant/conversations/abc-123",
     );
     expect(ensureMainWindowVisibleMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("resets the main view to chat so the thread isn't hidden behind the app viewer", () => {
+    useViewerStore.setState({ mainView: "app" });
+    renderHook(() => useGlobalDeepLinkConsumer());
+
+    act(() => {
+      publish("deeplink.openThread", { threadId: "abc-123" });
+    });
+
+    expect(useViewerStore.getState().mainView).toBe("chat");
+    expect(navigateMock).toHaveBeenCalledWith(
+      "/assistant/conversations/abc-123",
+    );
   });
 });
 

--- a/clients/web/src/hooks/use-global-deep-link-consumer.ts
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.ts
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { ensureMainWindowVisible } from "@/runtime/main-window";
 import { usePendingDeepLinkStore } from "@/stores/pending-deep-link-store";
+import { useViewerStore } from "@/stores/viewer-store";
 import { routes } from "@/utils/routes";
 
 /**
@@ -15,7 +16,8 @@ import { routes } from "@/utils/routes";
  *
  * Responsibilities:
  *
- * - `deeplink.openThread` → `ensureMainWindowVisible()` +
+ * - `deeplink.openThread` → `ensureMainWindowVisible()` + reset the
+ *   viewer to chat (dismisses a full-width app viewer) +
  *   `navigate(routes.conversation(threadId))`.
  * - `deeplink.send` → `ensureMainWindowVisible()` + navigate to
  *   `/assistant` + park the message in `usePendingDeepLinkStore`
@@ -42,6 +44,9 @@ export function useGlobalDeepLinkConsumer(): void {
 
   useBusSubscription("deeplink.openThread", ({ threadId }) => {
     void ensureMainWindowVisible();
+    // Mirror the normal conversation-switch path: dismiss the full-width
+    // app viewer so the navigated-to thread is actually visible.
+    useViewerStore.getState().setMainView("chat");
     navigateRef.current(routes.conversation(threadId));
   });
 

--- a/clients/web/src/hooks/use-notification-tap-navigation.test.tsx
+++ b/clients/web/src/hooks/use-notification-tap-navigation.test.tsx
@@ -31,11 +31,13 @@ beforeEach(() => {
   capturedHandler = null;
   setNotificationTapHandlerMock.mockClear();
   sentryBreadcrumbMock.mockClear();
+  window.history.pushState(null, "", "/");
 });
 
 afterEach(() => {
   cleanup();
   __resetForTesting();
+  window.history.pushState(null, "", "/");
 });
 
 describe("useNotificationTapNavigation", () => {
@@ -44,6 +46,15 @@ describe("useNotificationTapNavigation", () => {
 
     expect(setNotificationTapHandlerMock).toHaveBeenCalledTimes(1);
     expect(capturedHandler).not.toBeNull();
+  });
+
+  test("a pop-out window registers no tap handler", () => {
+    window.history.pushState(null, "", "/?popout=1");
+
+    renderHook(() => useNotificationTapNavigation());
+
+    expect(setNotificationTapHandlerMock).not.toHaveBeenCalled();
+    expect(capturedHandler).toBeNull();
   });
 
   test("a tap with a conversationId publishes deeplink.openThread", () => {

--- a/clients/web/src/hooks/use-notification-tap-navigation.test.tsx
+++ b/clients/web/src/hooks/use-notification-tap-navigation.test.tsx
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook, act } from "@testing-library/react";
+
+import { __resetForTesting, subscribe } from "@/lib/event-bus";
+import type { NotificationTapPayload } from "@/runtime/notifications";
+
+let capturedHandler: ((payload: NotificationTapPayload) => void) | null = null;
+const setNotificationTapHandlerMock = mock(
+  (handler: (payload: NotificationTapPayload) => void) => {
+    capturedHandler = handler;
+  },
+);
+mock.module("@/runtime/notifications", () => ({
+  setNotificationTapHandler: setNotificationTapHandlerMock,
+}));
+
+const sentryBreadcrumbMock = mock((_args: unknown) => undefined);
+// Full Sentry surface — `mock.module` is process-global in bun, so a
+// partial mock would shadow `captureException` (used by `runtime/event-sources/*`
+// and `sse-service`) for every later test file in the run.
+mock.module("@sentry/react", () => ({
+  addBreadcrumb: sentryBreadcrumbMock,
+  captureException: () => {},
+}));
+
+const { useNotificationTapNavigation } =
+  await import("./use-notification-tap-navigation");
+
+beforeEach(() => {
+  __resetForTesting();
+  capturedHandler = null;
+  setNotificationTapHandlerMock.mockClear();
+  sentryBreadcrumbMock.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+  __resetForTesting();
+});
+
+describe("useNotificationTapNavigation", () => {
+  test("mounting registers a tap handler", () => {
+    renderHook(() => useNotificationTapNavigation());
+
+    expect(setNotificationTapHandlerMock).toHaveBeenCalledTimes(1);
+    expect(capturedHandler).not.toBeNull();
+  });
+
+  test("a tap with a conversationId publishes deeplink.openThread", () => {
+    renderHook(() => useNotificationTapNavigation());
+
+    const received: Array<{ threadId: string }> = [];
+    subscribe("deeplink.openThread", (payload) => {
+      received.push(payload);
+    });
+
+    act(() => {
+      capturedHandler?.({ conversationId: "abc", sourceEventName: "x" });
+    });
+
+    expect(received).toEqual([{ threadId: "abc" }]);
+    expect(sentryBreadcrumbMock).not.toHaveBeenCalled();
+  });
+
+  test("a tap without a conversationId publishes nothing", () => {
+    renderHook(() => useNotificationTapNavigation());
+
+    const received: Array<{ threadId: string }> = [];
+    subscribe("deeplink.openThread", (payload) => {
+      received.push(payload);
+    });
+
+    act(() => {
+      capturedHandler?.({ sourceEventName: "x" });
+    });
+
+    expect(received).toEqual([]);
+    expect(sentryBreadcrumbMock).toHaveBeenCalledTimes(1);
+    const args = sentryBreadcrumbMock.mock.calls[0]?.[0] as {
+      category?: string;
+      message?: string;
+      data?: { sourceEventName?: string };
+    };
+    expect(args.category).toBe("notification");
+    expect(args.message).toBe("tap_without_conversation");
+    expect(args.data?.sourceEventName).toBe("x");
+  });
+});

--- a/clients/web/src/hooks/use-notification-tap-navigation.ts
+++ b/clients/web/src/hooks/use-notification-tap-navigation.ts
@@ -1,0 +1,39 @@
+import { useEffect } from "react";
+import * as Sentry from "@sentry/react";
+
+import { publish } from "@/lib/event-bus";
+import { setNotificationTapHandler } from "@/runtime/notifications";
+
+/**
+ * Routes notification taps to the originating conversation. Mounted at
+ * `RootLayout` so a tap arriving on any authenticated route navigates.
+ *
+ * The handler publishes `deeplink.openThread` on the event bus rather
+ * than navigating directly — `useGlobalDeepLinkConsumer` (also mounted
+ * at `RootLayout`) turns that into `ensureMainWindowVisible()` +
+ * `navigate(routes.conversation(threadId))`, so notification taps get
+ * identical behavior to `vellum://thread/...` deep links. One wiring
+ * covers all three tap paths in `runtime/notifications.ts`: Capacitor
+ * `localNotificationActionPerformed`, Electron notification actions,
+ * and browser `Notification.onclick`.
+ *
+ * No effect cleanup: `setNotificationTapHandler` swaps the handler
+ * reference in place and registers the platform listeners only once
+ * for the app's lifetime, so there is nothing to tear down.
+ */
+export function useNotificationTapNavigation(): void {
+  useEffect(() => {
+    setNotificationTapHandler((payload) => {
+      if (payload.conversationId) {
+        publish("deeplink.openThread", { threadId: payload.conversationId });
+        return;
+      }
+      Sentry.addBreadcrumb({
+        category: "notification",
+        level: "info",
+        message: "tap_without_conversation",
+        data: { sourceEventName: payload.sourceEventName },
+      });
+    });
+  }, []);
+}

--- a/clients/web/src/hooks/use-notification-tap-navigation.ts
+++ b/clients/web/src/hooks/use-notification-tap-navigation.ts
@@ -23,6 +23,13 @@ import { setNotificationTapHandler } from "@/runtime/notifications";
  */
 export function useNotificationTapNavigation(): void {
   useEffect(() => {
+    // Electron pop-out windows (`?popout=1`) mount `RootLayout` too, and
+    // the macOS notification bridge broadcasts each action to every
+    // BrowserWindow. Only the main window may handle taps — a pop-out
+    // navigating would replace the conversation it exists to keep open.
+    if (window.location.search.includes("popout=1")) {
+      return;
+    }
     setNotificationTapHandler((payload) => {
       if (payload.conversationId) {
         publish("deeplink.openThread", { threadId: payload.conversationId });

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -28,6 +28,7 @@ import { useAssistantResourceSync } from "@/hooks/use-assistant-resource-sync";
 import { useDocumentEditorSync } from "@/hooks/use-document-editor-sync";
 import { useBookmarksSync } from "@/hooks/use-bookmarks-sync";
 import { useNotificationIntentSync } from "@/hooks/use-notification-intent-sync";
+import { useNotificationTapNavigation } from "@/hooks/use-notification-tap-navigation";
 import { usePushRegistration } from "@/hooks/use-push-registration";
 import { useSoundEffects } from "@/hooks/use-sound-effects";
 import { useOnboardingWindowSize } from "@/hooks/use-onboarding-window-size";
@@ -138,6 +139,7 @@ export function RootLayout() {
   useFeatureFlagBusSync(assistantId, isAssistantActive);
   useNotificationIntentSync(assistantId);
   usePushRegistration(assistantId);
+  useNotificationTapNavigation();
   useSoundEffects(assistantId, isAssistantActive);
   useDocumentEditorSync();
   useBookmarksSync();
@@ -304,7 +306,8 @@ export function RootLayout() {
           keyboardOpen && visibleViewport
             ? `${visibleViewport.height + keyboardOffsetTop}px`
             : "100dvh",
-        paddingTop: keyboardOffsetTop > 0 ? `${keyboardOffsetTop}px` : undefined,
+        paddingTop:
+          keyboardOffsetTop > 0 ? `${keyboardOffsetTop}px` : undefined,
         paddingBottom: keyboardOpen
           ? "0px"
           : "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))",
@@ -321,7 +324,10 @@ export function RootLayout() {
       {!electron && !isPopout && !suppressStatusBanner ? (
         <StatusBanner placement="web" reserveTopSafeArea />
       ) : null}
-      <div className="flex min-w-0 flex-col overflow-hidden w-full" style={{ flex: "1 1 0%", minHeight: 0 }}>
+      <div
+        className="flex min-w-0 flex-col overflow-hidden w-full"
+        style={{ flex: "1 1 0%", minHeight: 0 }}
+      >
         <Outlet />
       </div>
 


### PR DESCRIPTION
## Summary
- Mounts the previously-orphaned setNotificationTapHandler via a new useNotificationTapNavigation hook in RootLayout
- Taps publish the existing deeplink.openThread bus event; useGlobalDeepLinkConsumer handles navigation to the conversation
- Fixes tap dead-ends on Capacitor iOS local notifications, Electron notification actions, AND desktop-browser notifications

Part of plan: mobile-push-deeplink-haptics.md (PR 3 of 4)