### PR TITLE
fix(web): stop bouncing onboarded users back into the onboarding funnel

### DIFF
--- a/clients/web/src/domains/onboarding/onboarding-store.ts
+++ b/clients/web/src/domains/onboarding/onboarding-store.ts
@@ -10,7 +10,10 @@
  * are populated on session sync (e.g. `restoreConsentForUser`, called from
  * the auth store once the user id is known). Persistence to durable per-user
  * device keys is handled by `persistConsentForUser` in
- * `onboarding-cleanup.ts`.
+ * `onboarding-cleanup.ts`. `consentHydrated` (also in-memory-only) records
+ * that a session sync — or an explicit user acceptance — has populated those
+ * flags, so route guards can distinguish "not yet loaded" from a genuine
+ * `false`.
  *
  * Reference: {@link https://zustand.docs.pmnd.rs/}
  */
@@ -43,6 +46,11 @@ export interface OnboardingState {
   privacyConsent: boolean;
   analyticsConsentCurrent: boolean;
   diagnosticsConsentCurrent: boolean;
+  /**
+   * Whether the consent flags above reflect a completed session sync (or an
+   * explicit user acceptance) rather than their unhydrated boot defaults.
+   */
+  consentHydrated: boolean;
 }
 
 export interface OnboardingActions {
@@ -52,6 +60,7 @@ export interface OnboardingActions {
   setPrivacyConsent: (value: boolean) => void;
   setAnalyticsConsentCurrent: (value: boolean) => void;
   setDiagnosticsConsentCurrent: (value: boolean) => void;
+  setConsentHydrated: (value: boolean) => void;
 }
 
 export type OnboardingStore = OnboardingState & OnboardingActions;
@@ -67,6 +76,7 @@ const useOnboardingStoreBase = create<OnboardingStore>()((set) => ({
   privacyConsent: false,
   analyticsConsentCurrent: false,
   diagnosticsConsentCurrent: false,
+  consentHydrated: false,
 
   setShareAnalytics: (value) => {
     set({ shareAnalytics: value });
@@ -91,6 +101,9 @@ const useOnboardingStoreBase = create<OnboardingStore>()((set) => ({
   },
   setDiagnosticsConsentCurrent: (value) => {
     set({ diagnosticsConsentCurrent: value });
+  },
+  setConsentHydrated: (value) => {
+    set({ consentHydrated: value });
   },
 }));
 

--- a/clients/web/src/domains/onboarding/prefs.ts
+++ b/clients/web/src/domains/onboarding/prefs.ts
@@ -157,6 +157,16 @@ export function readDiagnosticsConsentCurrent(): boolean {
 }
 
 /**
+ * SSR-safe, non-hook read of whether the consent flags reflect a completed
+ * session sync (or an explicit user acceptance). Used by the navigation guard
+ * to defer consent-based redirects until the flags are trustworthy — the
+ * flags boot `false` and only reflect reality once hydration lands.
+ */
+export function readConsentHydrated(): boolean {
+  return useOnboardingStore.getState().consentHydrated;
+}
+
+/**
  * SSR-safe, non-hook read for telemetry emitters.
  *
  * Unlike the onboarding UI, this treats an absent preference as no consent:

--- a/clients/web/src/lib/auth/auth-middleware.test.ts
+++ b/clients/web/src/lib/auth/auth-middleware.test.ts
@@ -45,8 +45,27 @@ mock.module("@/domains/onboarding/prefs", () => ({
   readDiagnosticsConsentCurrent: () => true,
 }));
 
+// Clamp whenStoreState timeouts so hydration-timeout paths are testable
+// without real 5s waits; untimed waits and predicate semantics are the real
+// implementation's. Bind the real function BEFORE registering the mock —
+// mock.module patches the imported namespace object in place, so a call-time
+// `actual.whenStoreState` lookup would resolve to this wrapper and recurse.
+const WAIT_TIMEOUT_CLAMP_MS = 100;
+const whenStoreStateReal = (await import("@/utils/when-store-state"))
+  .whenStoreState;
+mock.module("@/utils/when-store-state", () => ({
+  whenStoreState: ((store, predicate, options) =>
+    whenStoreStateReal(store, predicate, {
+      ...options,
+      ...(options?.timeoutMs !== undefined
+        ? { timeoutMs: Math.min(options.timeoutMs, WAIT_TIMEOUT_CLAMP_MS) }
+        : {}),
+    })) as typeof whenStoreStateReal,
+}));
+
 import { authMiddleware } from "./auth-middleware";
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
+import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { useAuthStore, type AuthUser } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
@@ -79,7 +98,9 @@ async function runMiddlewareOutcome(
     await authMiddleware(args, next);
     return { admitted: true };
   } catch (thrown) {
-    if (thrown instanceof Response) return { admitted: false, response: thrown };
+    if (thrown instanceof Response) {
+      return { admitted: false, response: thrown };
+    }
     throw thrown;
   }
 }
@@ -97,7 +118,9 @@ async function runMiddleware(pathname: string): Promise<Response> {
   try {
     await authMiddleware(args, next);
   } catch (thrown) {
-    if (thrown instanceof Response) return thrown;
+    if (thrown instanceof Response) {
+      return thrown;
+    }
     throw thrown;
   }
   throw new Error("expected a redirect to be thrown");
@@ -241,6 +264,42 @@ describe("authMiddleware — app-access admit gate", () => {
       expect(outcome.response.headers.get("Location")).toBe(
         `${routes.account.login}?returnTo=${encodeURIComponent("/assistant/home")}`,
       );
+    }
+  });
+});
+
+describe("authMiddleware — hydration timeout", () => {
+  test("a hung hydration degrades to a decision instead of re-entering the wait", async () => {
+    isLocalModeMock.mockImplementation(() => false);
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      user: fakeUser,
+      platformSession: "present",
+    });
+    // Simulate consent/assistants fetches that hang: neither store ever
+    // reports hydration, so both waits run out their (clamped) timeouts.
+    const priorConsentHydrated = useOnboardingStore.getState().consentHydrated;
+    const priorAssistantsHydrated =
+      useResolvedAssistantsStore.getState().assistantsHydrated;
+    useOnboardingStore.setState({ consentHydrated: false });
+    useResolvedAssistantsStore.setState({
+      assistants: [],
+      assistantsHydrated: false,
+    });
+
+    try {
+      // Must settle (the consent prefs are pinned current above, so with the
+      // hydration flags forced after the timeout, requireAssistant lands on
+      // the consented no-assistant branch) — pre-guard this recursed into the
+      // identical wait forever.
+      const res = await runMiddleware(routes.home);
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe(routes.onboarding.hatching);
+    } finally {
+      useOnboardingStore.setState({ consentHydrated: priorConsentHydrated });
+      useResolvedAssistantsStore.setState({
+        assistantsHydrated: priorAssistantsHydrated,
+      });
     }
   });
 });

--- a/clients/web/src/lib/auth/auth-middleware.ts
+++ b/clients/web/src/lib/auth/auth-middleware.ts
@@ -18,10 +18,25 @@ export const authUserContext = createRouterContext<AuthUser | null>(null);
 const PLATFORM_SESSION_PROBE_TIMEOUT_MS = 5_000;
 const STATE_HYDRATION_TIMEOUT_MS = 5_000;
 
-export const authMiddleware: MiddlewareFunction = async ({ request, context }, next) => {
+export const authMiddleware: MiddlewareFunction = (args, next) =>
+  resolveWithGuard(args, next, false);
+
+const resolveWithGuard = async (
+  { request, context }: Parameters<MiddlewareFunction>[0],
+  next: Parameters<MiddlewareFunction>[1],
+  hydrationTimedOut: boolean,
+): Promise<Awaited<ReturnType<MiddlewareFunction>>> => {
   const url = new URL(request.url);
 
-  const state = buildNavigationState();
+  // After a timed-out hydration wait, force the hydration flags so the
+  // resolver decides on whatever state exists instead of returning another
+  // "wait" — a fetch that hangs (never reaching any settle path) must degrade
+  // to a decision, not loop navigation in timeout-sized chunks.
+  const state = buildNavigationState(
+    hydrationTimedOut
+      ? { consentHydrated: true, assistantsHydrated: true }
+      : undefined,
+  );
 
   const decision = resolveNavigation(state, {
     kind: "route-guard",
@@ -40,12 +55,13 @@ export const authMiddleware: MiddlewareFunction = async ({ request, context }, n
     // Platform mode also waits for consent and the assistants list to hydrate
     // — the resolver defers to them, and deciding on their boot defaults would
     // misroute an established user into onboarding. Both resolve immediately
-    // when already hydrated; on timeout, re-resolve with whatever state exists
-    // rather than hanging navigation. Scoped to sessions that can actually
-    // hydrate: local mode's resolver steps never wait on hydration
-    // (lockfile-driven), and an unauthenticated session never populates
-    // either store, so waiting in those cases would only stall boot.
+    // when already hydrated. Scoped to sessions that can actually hydrate:
+    // local mode's resolver steps never wait on hydration (lockfile-driven),
+    // and an unauthenticated session never populates either store, so waiting
+    // in those cases would only stall boot.
+    let hydrationStillPending = false;
     if (
+      !hydrationTimedOut &&
       !isLocalMode() &&
       isAuthenticated(useAuthStore.getState().sessionStatus)
     ) {
@@ -57,8 +73,15 @@ export const authMiddleware: MiddlewareFunction = async ({ request, context }, n
         (s) => s.assistantsHydrated,
         { timeoutMs: STATE_HYDRATION_TIMEOUT_MS },
       );
+      hydrationStillPending =
+        !useOnboardingStore.getState().consentHydrated ||
+        !useResolvedAssistantsStore.getState().assistantsHydrated;
     }
-    return authMiddleware({ request, context } as Parameters<MiddlewareFunction>[0], next);
+    return resolveWithGuard(
+      { request, context } as Parameters<MiddlewareFunction>[0],
+      next,
+      hydrationTimedOut || hydrationStillPending,
+    );
   }
 
   if (decision.action === "redirect") {

--- a/clients/web/src/lib/auth/auth-middleware.ts
+++ b/clients/web/src/lib/auth/auth-middleware.ts
@@ -5,15 +5,18 @@ import {
 } from "react-router";
 
 import { useAuthStore, type AuthUser } from "@/stores/auth-store";
-import { isSessionSettled } from "@/stores/session-status";
+import { isAuthenticated, isSessionSettled } from "@/stores/session-status";
 import { isLocalMode, hasAssistants } from "@/lib/local-mode";
 import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
 import { buildNavigationState } from "@/lib/navigation/build-state";
+import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { whenStoreState } from "@/utils/when-store-state";
 
 export const authUserContext = createRouterContext<AuthUser | null>(null);
 
 const PLATFORM_SESSION_PROBE_TIMEOUT_MS = 5_000;
+const STATE_HYDRATION_TIMEOUT_MS = 5_000;
 
 export const authMiddleware: MiddlewareFunction = async ({ request, context }, next) => {
   const url = new URL(request.url);
@@ -32,6 +35,27 @@ export const authMiddleware: MiddlewareFunction = async ({ request, context }, n
         useAuthStore,
         (s) => s.platformSession !== "unknown",
         { timeoutMs: PLATFORM_SESSION_PROBE_TIMEOUT_MS },
+      );
+    }
+    // Platform mode also waits for consent and the assistants list to hydrate
+    // — the resolver defers to them, and deciding on their boot defaults would
+    // misroute an established user into onboarding. Both resolve immediately
+    // when already hydrated; on timeout, re-resolve with whatever state exists
+    // rather than hanging navigation. Scoped to sessions that can actually
+    // hydrate: local mode's resolver steps never wait on hydration
+    // (lockfile-driven), and an unauthenticated session never populates
+    // either store, so waiting in those cases would only stall boot.
+    if (
+      !isLocalMode() &&
+      isAuthenticated(useAuthStore.getState().sessionStatus)
+    ) {
+      await whenStoreState(useOnboardingStore, (s) => s.consentHydrated, {
+        timeoutMs: STATE_HYDRATION_TIMEOUT_MS,
+      });
+      await whenStoreState(
+        useResolvedAssistantsStore,
+        (s) => s.assistantsHydrated,
+        { timeoutMs: STATE_HYDRATION_TIMEOUT_MS },
       );
     }
     return authMiddleware({ request, context } as Parameters<MiddlewareFunction>[0], next);

--- a/clients/web/src/lib/navigation/build-state.test.ts
+++ b/clients/web/src/lib/navigation/build-state.test.ts
@@ -25,6 +25,7 @@ mock.module("@/domains/onboarding/prefs", () => ({
   readPrivacyConsent: () => true,
   readAnalyticsConsentCurrent: () => true,
   readDiagnosticsConsentCurrent: () => true,
+  readConsentHydrated: () => true,
 }));
 
 const { buildNavigationState } = await import("./build-state");

--- a/clients/web/src/lib/navigation/build-state.ts
+++ b/clients/web/src/lib/navigation/build-state.ts
@@ -12,6 +12,7 @@ import {
   readPrivacyConsent,
   readAnalyticsConsentCurrent,
   readDiagnosticsConsentCurrent,
+  readConsentHydrated,
 } from "@/domains/onboarding/prefs";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import type { NavigationState } from "./navigation-resolver";
@@ -20,6 +21,8 @@ export function buildNavigationState(
   overrides?: Partial<NavigationState>,
 ): NavigationState {
   const { sessionStatus, platformSession } = useAuthStore.getState();
+  const { assistants, assistantsHydrated } =
+    useResolvedAssistantsStore.getState();
   const isRemoteGateway = isRemoteGatewayMode();
   return {
     isLocalMode: isLocalMode(),
@@ -29,7 +32,7 @@ export function buildNavigationState(
       ? remoteGatewayPublicPathPrefix()
       : "",
     isGatewayAuth: isGatewayAuthMode(),
-    hasAssistants: useResolvedAssistantsStore.getState().assistants.length > 0,
+    hasAssistants: assistants.length > 0,
     sessionSettled: isSessionSettled(sessionStatus),
     // `isAuthenticated` mirrors `sessionStatus`. The local gateway is the sole
     // session authority (#35152), so a reachable local user is already
@@ -42,6 +45,8 @@ export function buildNavigationState(
     privacyConsent: readPrivacyConsent(),
     analyticsConsentCurrent: readAnalyticsConsentCurrent(),
     diagnosticsConsentCurrent: readDiagnosticsConsentCurrent(),
+    consentHydrated: readConsentHydrated(),
+    assistantsHydrated,
     ...overrides,
   };
 }

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -21,6 +21,10 @@ const base: NavigationState = {
   privacyConsent: true,
   analyticsConsentCurrent: true,
   diagnosticsConsentCurrent: true,
+  // Hydrated by default so the cases below describe settled-state behavior;
+  // the hydration-gating cases override these explicitly.
+  consentHydrated: true,
+  assistantsHydrated: true,
 };
 
 function s(overrides: Partial<NavigationState>): NavigationState {
@@ -304,6 +308,107 @@ describe("resolveNavigation", () => {
       expect(
         guard(s({ isLocalMode: false, tosAccepted: false, privacyConsent: false, hasAssistants: false })),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
+    });
+
+    // -- hydration gating ---------------------------------------------------
+
+    test("waits (not privacy) for a platform user when the assistants list has not hydrated", () => {
+      // Boot race: assistants and consent both start empty/false. Deciding
+      // here would dump an established user into the onboarding funnel.
+      expect(
+        guard(
+          s({
+            hasAssistants: false,
+            tosAccepted: false,
+            privacyConsent: false,
+            analyticsConsentCurrent: false,
+            diagnosticsConsentCurrent: false,
+            assistantsHydrated: false,
+            consentHydrated: false,
+          }),
+        ),
+      ).toEqual(WAIT);
+    });
+
+    test("waits for a platform user when assistants hydrated but consent has not", () => {
+      expect(
+        guard(
+          s({
+            hasAssistants: false,
+            tosAccepted: false,
+            privacyConsent: false,
+            assistantsHydrated: true,
+            consentHydrated: false,
+          }),
+        ),
+      ).toEqual(WAIT);
+    });
+
+    test("redirects to privacy once both hydrated and consent is genuinely false", () => {
+      expect(
+        guard(
+          s({
+            hasAssistants: false,
+            tosAccepted: false,
+            privacyConsent: false,
+            assistantsHydrated: true,
+            consentHydrated: true,
+          }),
+        ),
+      ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
+    });
+
+    test("waits (not review-terms) when consent looks stale but has not hydrated", () => {
+      expect(
+        guard(
+          s({
+            hasAssistants: true,
+            analyticsConsentCurrent: false,
+            consentHydrated: false,
+          }),
+        ),
+      ).toEqual(WAIT);
+    });
+
+    test("redirects to review-terms once hydrated consent is genuinely stale", () => {
+      expect(
+        guard(
+          s({
+            hasAssistants: true,
+            analyticsConsentCurrent: false,
+            consentHydrated: true,
+          }),
+        ),
+      ).toEqual({ action: "redirect", to: "/assistant/review-terms?returnTo=%2Fassistant" });
+    });
+
+    test("local mode ignores hydration flags (lockfile-driven list, sync consent)", () => {
+      // The no-assistants fork keys off the platform probe, not hydration...
+      expect(
+        guard(
+          s({
+            isLocalMode: true,
+            hasAssistants: false,
+            platformSession: "absent",
+            assistantsHydrated: false,
+            consentHydrated: false,
+          }),
+        ),
+      ).toEqual({ action: "redirect", to: "/assistant/welcome" });
+      // ...and stale-consent enforcement decides immediately: the local paths
+      // that enforce consent hydrate synchronously during session init.
+      expect(
+        guard(
+          s({
+            isLocalMode: true,
+            hasAssistants: true,
+            platformSession: "present",
+            tosAccepted: false,
+            privacyConsent: false,
+            consentHydrated: false,
+          }),
+        ),
+      ).toEqual({ action: "redirect", to: "/assistant/review-terms?returnTo=%2Fassistant" });
     });
 
     // -- stale consent toggles --------------------------------------------

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -20,6 +20,14 @@ export interface NavigationState {
   privacyConsent: boolean;
   analyticsConsentCurrent: boolean;
   diagnosticsConsentCurrent: boolean;
+  /**
+   * Whether the consent flags above reflect a completed session sync (or an
+   * explicit acceptance). They boot `false`, so acting on them before
+   * hydration would misread an established user as un-onboarded.
+   */
+  consentHydrated: boolean;
+  /** Whether the resolved assistants list reflects at least one authoritative load. */
+  assistantsHydrated: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -303,6 +311,14 @@ function requireAssistant(
     return { action: "redirect", to: routes.welcome };
   }
 
+  // Platform boot populates the assistants list and the consent flags
+  // asynchronously; both boot empty/false. Deciding before they hydrate would
+  // read an established user as brand-new and funnel them into onboarding.
+  // (Local mode is excluded above — its list is lockfile-driven.)
+  if (!state.assistantsHydrated || !state.consentHydrated) {
+    return { action: "wait" };
+  }
+
   if (!hasCompletedOnboarding(state)) {
     return { action: "redirect", to: routes.onboarding.privacy };
   }
@@ -331,6 +347,15 @@ function requireConsent(
     consentIsCurrent(state)
   ) {
     return null;
+  }
+
+  // The flags boot false and hydrate asynchronously — a redirect decided
+  // before hydration would bounce a fully consented user to review-terms.
+  // Local mode decides immediately: its platform-session paths that enforce
+  // consent hydrate synchronously during session init, and the gateway-probe
+  // path never hydrates, so waiting there would hang navigation.
+  if (!state.consentHydrated && !state.isLocalMode) {
+    return { action: "wait" };
   }
 
   const returnTo = encodeURIComponent(pathnameWithSearch);

--- a/clients/web/src/lib/onboarding-middleware.ts
+++ b/clients/web/src/lib/onboarding-middleware.ts
@@ -50,6 +50,9 @@ export const onboardingCompletedMiddleware: MiddlewareFunction = async (
     buildNavigationState({ sessionSettled: true, isAuthenticated: true }),
     { kind: "route-guard", pathname: url.pathname },
   );
+  // A "wait" decision (still-hydrating state) falls through to next(): the
+  // parent auth middleware owns hydration waits, so rendering is the safe
+  // fallback here.
   if (decision.action === "redirect") throw redirect(decision.to);
   return next();
 };

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -228,10 +228,13 @@ mock.module("@/utils/onboarding-cleanup", () => ({
   DIAGNOSTICS_CONSENT_VERSION: "2026-06-08",
 }));
 
+const setTosAcceptedMock = mock((_value: boolean) => {});
+const setPrivacyConsentMock = mock((_value: boolean) => {});
 const setAnalyticsConsentCurrentMock = mock((_value: boolean) => {});
 const setDiagnosticsConsentCurrentMock = mock((_value: boolean) => {});
 const setShareAnalyticsMock = mock((_value: boolean) => {});
 const setShareDiagnosticsMock = mock((_value: boolean) => {});
+const setConsentHydratedMock = mock((_value: boolean) => {});
 // Mirror the store's device-initialized share values; the backfill reads these
 // to send the device opt-out value alongside the accepted version.
 let mockStoreShareAnalytics = true;
@@ -240,12 +243,13 @@ let mockStoreShareDiagnostics = true;
 mock.module("@/domains/onboarding/onboarding-store", () => ({
   useOnboardingStore: {
     getState: () => ({
-      setTosAccepted: () => {},
-      setPrivacyConsent: () => {},
+      setTosAccepted: setTosAcceptedMock,
+      setPrivacyConsent: setPrivacyConsentMock,
       setShareAnalytics: setShareAnalyticsMock,
       setShareDiagnostics: setShareDiagnosticsMock,
       setAnalyticsConsentCurrent: setAnalyticsConsentCurrentMock,
       setDiagnosticsConsentCurrent: setDiagnosticsConsentCurrentMock,
+      setConsentHydrated: setConsentHydratedMock,
       shareAnalytics: mockStoreShareAnalytics,
       shareDiagnostics: mockStoreShareDiagnostics,
     }),
@@ -361,10 +365,13 @@ beforeEach(() => {
   persistConsentForUserMock.mockClear();
   persistToggleConsentMock.mockClear();
   resolveServerConsentMock.mockClear();
+  setTosAcceptedMock.mockClear();
+  setPrivacyConsentMock.mockClear();
   setAnalyticsConsentCurrentMock.mockClear();
   setDiagnosticsConsentCurrentMock.mockClear();
   setShareAnalyticsMock.mockClear();
   setShareDiagnosticsMock.mockClear();
+  setConsentHydratedMock.mockClear();
   mockStoreShareAnalytics = true;
   mockStoreShareDiagnostics = true;
   fetchConsentMock.mockClear();
@@ -690,10 +697,11 @@ describe("auth store onboarding flag reconciliation", () => {
     mockStoreShareDiagnostics = true;
   });
 
-  test("stale-but-real record keeps server share values and skips the device fallback", async () => {
+  test("stale-but-real record keeps server share values authoritative", async () => {
     // hasServerRecord=true but legal consent is stale (tos=false). The server's
-    // share opt-out is authoritative and must be applied; the device fallback
-    // must NOT run (its values are not authoritative for a real record).
+    // share opt-out is authoritative and must be applied. The device keys are
+    // consulted for the stale version flags, but attest nothing here, so the
+    // stale flags stand and no backfill fires.
     sessionUser = { id: "user-1", email: "user@example.com" };
     resolveServerConsentMock.mockReturnValueOnce({
       tos: false,
@@ -708,7 +716,166 @@ describe("auth store onboarding flag reconciliation", () => {
     await useAuthStore.getState().initSession();
 
     expect(setShareAnalyticsMock).toHaveBeenCalledWith(false);
+    expect(restoreConsentForUserMock).toHaveBeenCalledWith("user-1");
+    expect(setTosAcceptedMock).toHaveBeenCalledWith(false);
+    expect(setPrivacyConsentMock).toHaveBeenCalledWith(false);
+    expect(patchConsentMock).not.toHaveBeenCalled();
+  });
+
+  test("a fully current server record does not consult the device keys", async () => {
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    resolveServerConsentMock.mockReturnValueOnce({
+      tos: true,
+      privacy: true,
+      shareAnalytics: true,
+      shareDiagnostics: true,
+      analyticsCurrent: true,
+      diagnosticsCurrent: true,
+      hasServerRecord: true,
+    });
+
+    await useAuthStore.getState().initSession();
+
     expect(restoreConsentForUserMock).not.toHaveBeenCalled();
+  });
+
+  test("a stale server record is overridden by current-version device acks, and the backfill re-fires", async () => {
+    // The device ack keys are version-stamped, so a true key attests
+    // acceptance of the CURRENT terms — the stale server record just means
+    // the fire-and-forget backfill write never landed. The in-memory flags
+    // must stay true (no bounce into onboarding/review-terms) and the
+    // backfill must be re-sent.
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    resolveServerConsentMock.mockReturnValueOnce({
+      tos: false,
+      privacy: false,
+      shareAnalytics: true,
+      shareDiagnostics: true,
+      analyticsCurrent: false,
+      diagnosticsCurrent: false,
+      hasServerRecord: true,
+    });
+    restoreConsentForUserMock.mockReturnValueOnce({
+      tos: true,
+      privacy: true,
+      analyticsCurrent: true,
+      diagnosticsCurrent: true,
+    });
+
+    await useAuthStore.getState().initSession();
+
+    expect(setTosAcceptedMock).toHaveBeenCalledWith(true);
+    expect(setPrivacyConsentMock).toHaveBeenCalledWith(true);
+    expect(setAnalyticsConsentCurrentMock).toHaveBeenCalledWith(true);
+    expect(setDiagnosticsConsentCurrentMock).toHaveBeenCalledWith(true);
+    expect(persistConsentForUserMock).toHaveBeenLastCalledWith(
+      "user-1",
+      true,
+      true,
+    );
+    // The backfill stamps every stale-but-attested version…
+    expect(patchConsentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tos_accepted_version: expect.any(String),
+        privacy_policy_accepted_version: expect.any(String),
+        ai_data_sharing_accepted_version: expect.any(String),
+        share_analytics_accepted_version: expect.any(String),
+        share_diagnostics_accepted_version: expect.any(String),
+      }),
+    );
+    // …but never the share booleans: a real record's values are authoritative.
+    const body = patchConsentMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(body).not.toContainKey("share_analytics");
+    expect(body).not.toContainKey("share_diagnostics");
+  });
+
+  test("device acks override only the stale axes of a partially stale record", async () => {
+    // ToS is current on the server; only privacy is stale. The device attests
+    // privacy, so the backfill patches the privacy artifacts alone.
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    resolveServerConsentMock.mockReturnValueOnce({
+      tos: true,
+      privacy: false,
+      shareAnalytics: true,
+      shareDiagnostics: true,
+      analyticsCurrent: true,
+      diagnosticsCurrent: true,
+      hasServerRecord: true,
+    });
+    restoreConsentForUserMock.mockReturnValueOnce({
+      tos: true,
+      privacy: true,
+      analyticsCurrent: true,
+      diagnosticsCurrent: true,
+    });
+
+    await useAuthStore.getState().initSession();
+
+    expect(setTosAcceptedMock).toHaveBeenCalledWith(true);
+    expect(setPrivacyConsentMock).toHaveBeenCalledWith(true);
+    const body = patchConsentMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(body).toContainKey("privacy_policy_accepted_version");
+    expect(body).toContainKey("ai_data_sharing_accepted_version");
+    expect(body).not.toContainKey("tos_accepted_version");
+    expect(body).not.toContainKey("share_analytics_accepted_version");
+    expect(body).not.toContainKey("share_diagnostics_accepted_version");
+  });
+
+  test("stale axes without device attestation stay stale (no override, no backfill)", async () => {
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    resolveServerConsentMock.mockReturnValueOnce({
+      tos: false,
+      privacy: false,
+      shareAnalytics: true,
+      shareDiagnostics: true,
+      analyticsCurrent: false,
+      diagnosticsCurrent: false,
+      hasServerRecord: true,
+    });
+    restoreConsentForUserMock.mockReturnValueOnce({
+      tos: false,
+      privacy: false,
+      analyticsCurrent: false,
+      diagnosticsCurrent: false,
+    });
+
+    await useAuthStore.getState().initSession();
+
+    expect(setTosAcceptedMock).toHaveBeenCalledWith(false);
+    expect(setPrivacyConsentMock).toHaveBeenCalledWith(false);
+    expect(patchConsentMock).not.toHaveBeenCalled();
+  });
+
+  test("syncUserScopedState marks consent hydrated on every settle path", async () => {
+    // Success path (server record).
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    await useAuthStore.getState().initSession();
+    expect(setConsentHydratedMock).toHaveBeenCalledWith(true);
+
+    // Server-fetch-failure fallback path.
+    setConsentHydratedMock.mockClear();
+    mockFetchConsentError = new Error("Network error");
+    await useAuthStore.getState().refreshSession();
+    expect(setConsentHydratedMock).toHaveBeenCalledWith(true);
+
+    // Null-user path (settled unauthenticated).
+    setConsentHydratedMock.mockClear();
+    mockFetchConsentError = null;
+    sessionUser = null;
+    await useAuthStore.getState().initSession();
+    expect(setConsentHydratedMock).toHaveBeenCalledWith(true);
+  });
+
+  test("initSession marks the assistants list hydrated even when the platform fetch fails", async () => {
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    useResolvedAssistantsStore.setState({ assistantsHydrated: false });
+    listAssistantsMock.mockImplementationOnce(async () => {
+      throw new Error("Network error");
+    });
+
+    await useAuthStore.getState().initSession();
+
+    expect(useResolvedAssistantsStore.getState().assistantsHydrated).toBe(true);
   });
 
   test("initSession falls back to device keys when fetchConsent fails", async () => {

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -56,7 +56,11 @@ import { listAssistants } from "@/assistant/api";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { deleteBiometricToken } from "@/runtime/native-biometric";
 import { unregisterFromRemotePush } from "@/runtime/push-registration";
-import { fetchConsent, patchConsent } from "@/domains/account/profile";
+import {
+  fetchConsent,
+  patchConsent,
+  type ConsentPatch,
+} from "@/domains/account/profile";
 import {
   restoreConsentForUser,
   persistConsentForUser,
@@ -272,6 +276,50 @@ function broadcastAuthChange(): void {
   broadcastChannel?.postMessage("auth-changed");
 }
 
+/**
+ * Payload for the fire-and-forget server backfill of device-attested consent.
+ * Each axis contributes its current version stamp only when the device ack
+ * attests it (device ack keys are version-stamped, so a true key proves
+ * acceptance of the CURRENT version). Share boolean values ride along only
+ * when `shareValues` is passed — appropriate for a truly empty server record,
+ * where the API default would otherwise overwrite a device opt-out on the
+ * next fetch. A real server record's share booleans are authoritative and
+ * must not be patched from the device.
+ */
+function buildDeviceConsentBackfill(axes: {
+  tos: boolean;
+  privacy: boolean;
+  analytics: boolean;
+  diagnostics: boolean;
+  shareValues?: { analytics: boolean; diagnostics: boolean };
+}): ConsentPatch {
+  return {
+    ...(axes.tos ? { tos_accepted_version: TOS_CONSENT_VERSION } : {}),
+    ...(axes.privacy
+      ? {
+          privacy_policy_accepted_version: PRIVACY_CONSENT_VERSION,
+          ai_data_sharing_accepted_version: PRIVACY_CONSENT_VERSION,
+        }
+      : {}),
+    ...(axes.analytics
+      ? {
+          share_analytics_accepted_version: ANALYTICS_CONSENT_VERSION,
+          ...(axes.shareValues
+            ? { share_analytics: axes.shareValues.analytics }
+            : {}),
+        }
+      : {}),
+    ...(axes.diagnostics
+      ? {
+          share_diagnostics_accepted_version: DIAGNOSTICS_CONSENT_VERSION,
+          ...(axes.shareValues
+            ? { share_diagnostics: axes.shareValues.diagnostics }
+            : {}),
+        }
+      : {}),
+  };
+}
+
 async function syncUserScopedState(nextUserId: string | null): Promise<void> {
   if (nextUserId) {
     try {
@@ -311,9 +359,9 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       let analyticsCurrent = resolved.analyticsCurrent;
       let diagnosticsCurrent = resolved.diagnosticsCurrent;
 
-      // Only fall back to device keys for a TRULY empty record. A stale-but-real
-      // record's server values are authoritative and must not be overwritten;
-      // the nav layer routes the user to review-terms for the stale legal consent.
+      // Fall back to device keys for a TRULY empty record: the device ack
+      // keys are the only consent evidence, so they drive all four axes and
+      // seed the server via the backfill.
       if (!resolved.hasServerRecord) {
         const deviceConsent = restoreConsentForUser(nextUserId);
         analyticsCurrent = deviceConsent.analyticsCurrent;
@@ -332,23 +380,71 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
           // Backfill the server from the device acks. Stamp any toggle version
           // whose device ack is current AND send the device share value so the
           // next fetch can't overwrite a device opt-out with the API default.
-          void patchConsent({
-            tos_accepted_version: TOS_CONSENT_VERSION,
-            privacy_policy_accepted_version: PRIVACY_CONSENT_VERSION,
-            ai_data_sharing_accepted_version: PRIVACY_CONSENT_VERSION,
-            ...(analyticsCurrent
-              ? {
-                  share_analytics_accepted_version: ANALYTICS_CONSENT_VERSION,
-                  share_analytics: store.shareAnalytics,
-                }
-              : {}),
-            ...(diagnosticsCurrent
-              ? {
-                  share_diagnostics_accepted_version: DIAGNOSTICS_CONSENT_VERSION,
-                  share_diagnostics: store.shareDiagnostics,
-                }
-              : {}),
-          }).catch(() => {});
+          void patchConsent(
+            buildDeviceConsentBackfill({
+              tos: true,
+              privacy: true,
+              analytics: analyticsCurrent,
+              diagnostics: diagnosticsCurrent,
+              shareValues: {
+                analytics: store.shareAnalytics,
+                diagnostics: store.shareDiagnostics,
+              },
+            }),
+          ).catch(() => {});
+        }
+      } else if (!tos || !privacy || !analyticsCurrent || !diagnosticsCurrent) {
+        // A real record with stale/false version-derived flags. The device ack
+        // keys are version-stamped, so a true key attests acceptance of the
+        // CURRENT version — a stale server version alongside a current device
+        // ack means only the fire-and-forget backfill write hasn't landed.
+        // Prefer the device attestation for those axes and re-send the
+        // backfill, so an established user isn't bounced into onboarding by a
+        // record their own acceptance is still in flight to. Axes the server
+        // records as current stay server-authoritative, as do the share
+        // boolean values (adopted above).
+        const deviceConsent = restoreConsentForUser(nextUserId);
+        const tosFromDevice = !tos && deviceConsent.tos;
+        const privacyFromDevice = !privacy && deviceConsent.privacy;
+        const analyticsFromDevice =
+          !analyticsCurrent && deviceConsent.analyticsCurrent;
+        const diagnosticsFromDevice =
+          !diagnosticsCurrent && deviceConsent.diagnosticsCurrent;
+        if (tosFromDevice) {
+          tos = true;
+        }
+        if (privacyFromDevice) {
+          privacy = true;
+        }
+        if (analyticsFromDevice) {
+          analyticsCurrent = true;
+        }
+        if (diagnosticsFromDevice) {
+          diagnosticsCurrent = true;
+          // Diagnostics currency comes from the device ack, so reopen the
+          // reporting gate the chokepoint closed for the stale server version
+          // — same `preference && currency` rule as the no-record branch.
+          // Re-read the preference: the server's authoritative share value
+          // was written to the store above.
+          setDiagnosticsReportingGate(
+            useOnboardingStore.getState().shareDiagnostics &&
+              diagnosticsCurrent,
+          );
+        }
+        if (
+          tosFromDevice ||
+          privacyFromDevice ||
+          analyticsFromDevice ||
+          diagnosticsFromDevice
+        ) {
+          void patchConsent(
+            buildDeviceConsentBackfill({
+              tos: tosFromDevice,
+              privacy: privacyFromDevice,
+              analytics: analyticsFromDevice,
+              diagnostics: diagnosticsFromDevice,
+            }),
+          ).catch(() => {});
         }
       }
 
@@ -362,6 +458,7 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
         diagnosticsCurrent,
       });
       syncOrganizationState(nextUserId);
+      store.setConsentHydrated(true);
       return;
     } catch {
       // Server fetch failed — fall through to device keys
@@ -375,6 +472,7 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
   store.setAnalyticsConsentCurrent(consent.analyticsCurrent);
   store.setDiagnosticsConsentCurrent(consent.diagnosticsCurrent);
   syncOrganizationState(nextUserId);
+  store.setConsentHydrated(true);
 }
 
 // Monotonic id stamped on each platform-session probe. Probes can overlap
@@ -653,9 +751,14 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
             useResolvedAssistantsStore
               .getState()
               .setFromApi(apiAssistants.data);
+          } else {
+            useResolvedAssistantsStore.getState().markHydrated();
           }
         } catch {
-          /* best effort */
+          // Best effort — but the route guard gates on hydration, so a failed
+          // fetch must still mark the list settled or navigation would stall
+          // against its hydration timeout on every route change.
+          useResolvedAssistantsStore.getState().markHydrated();
         }
         set(authenticatedPlatformUser(user));
         return;
@@ -691,9 +794,13 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
                 useResolvedAssistantsStore
                   .getState()
                   .setFromApi(apiAssistants.data);
+              } else {
+                useResolvedAssistantsStore.getState().markHydrated();
               }
             } catch {
-              /* best effort */
+              // Best effort — a failed fetch still marks the list settled so
+              // the route guard's hydration wait can't stall navigation.
+              useResolvedAssistantsStore.getState().markHydrated();
             }
             set(authenticatedPlatformUser(user));
             return;

--- a/clients/web/src/stores/resolved-assistants-store.ts
+++ b/clients/web/src/stores/resolved-assistants-store.ts
@@ -91,6 +91,12 @@ interface ResolvedAssistantsState {
 interface ResolvedAssistantsActions {
   setFromLockfile: (lockfile: Lockfile) => void;
   setFromApi: (assistants: Assistant[]) => void;
+  /**
+   * Mark the list hydrated without replacing it. For load paths that settle
+   * with no authoritative data (a failed platform assistants fetch), so guards
+   * awaiting hydration don't wait forever on a list that isn't coming.
+   */
+  markHydrated: () => void;
   upsertFromApi: (assistant: Assistant) => void;
   remove: (assistantId: string) => void;
   clear: () => void;
@@ -160,6 +166,8 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
           };
         }),
       }),
+
+    markHydrated: () => set({ assistantsHydrated: true }),
 
     upsertFromApi: (assistant) =>
       set((state) => {

--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -29,6 +29,7 @@ const storeState = {
   setShareDiagnostics: mock(() => {}),
   setAnalyticsConsentCurrent: mock(() => {}),
   setDiagnosticsConsentCurrent: mock(() => {}),
+  setConsentHydrated: mock(() => {}),
 };
 mock.module("@/domains/onboarding/onboarding-store", () => ({
   useOnboardingStore: { getState: () => storeState },
@@ -91,6 +92,7 @@ beforeEach(() => {
   storeState.setShareDiagnostics.mockReset();
   storeState.setAnalyticsConsentCurrent.mockReset();
   storeState.setDiagnosticsConsentCurrent.mockReset();
+  storeState.setConsentHydrated.mockReset();
   patchConsentMock.mockReset();
   patchConsentMock.mockImplementation(async () => {});
   setDeviceBoolMock.mockReset();
@@ -474,6 +476,18 @@ describe("saveConsent", () => {
     expect(storeState.setDiagnosticsConsentCurrent).toHaveBeenCalledWith(true);
     expect(localStorage.getItem(analyticsKey("user-1"))).toBe("true");
     expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe("true");
+  });
+
+  test("marks consent hydrated — an explicit acceptance is authoritative", () => {
+    saveConsent({
+      userId: "user-1",
+      tos: true,
+      privacy: true,
+      shareAnalytics: true,
+      shareDiagnostics: true,
+      hasPlatformSession: false,
+    });
+    expect(storeState.setConsentHydrated).toHaveBeenCalledWith(true);
   });
 });
 

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -257,6 +257,9 @@ export function saveConsent(opts: {
   store.setShareDiagnostics(opts.shareDiagnostics);
   store.setAnalyticsConsentCurrent(true);
   store.setDiagnosticsConsentCurrent(true);
+  // An explicit user acceptance is authoritative hydration — route guards may
+  // trust the flags without waiting for a session sync.
+  store.setConsentHydrated(true);
   // Version is current by construction here, so the gate equals the preference.
   setDiagnosticsReportingGate(opts.shareDiagnostics);
 


### PR DESCRIPTION
## Problem

LogRocket shows established platform users being spontaneously redirected from an active conversation (`/assistant/conversations/:id`) to `/assistant/onboarding/privacy` — no click, no reload, tab in the foreground. Since research-onboarding went GA (#36985), re-accepting on the privacy screen drops them into the full research onboarding flow, where they re-do onboarding and trigger another hatch. In one replayed session this happened **twice** to the same user in 14 minutes.

## Root cause

Two independent defects have to combine, and both are client-side state-lifecycle bugs:

**1. A consent re-sync can flip in-memory consent flags `true → false` mid-session.**
`saveConsent` writes the server consent record fire-and-forget (`void patchConsent(...).catch(() => {})`). If that PUT fails, the server keeps a stale record while the device holds version-stamped ack keys proving current acceptance. On the next `refreshSession` (app resume / `online` event), `syncUserScopedState` saw `hasServerRecord === true`, treated the stale record as authoritative, and overwrote `tosAccepted`/`privacyConsent` to `false` — the device-key fallback only ran for a *truly empty* record. Session replay confirms a `/v1/user/consent/` fetch ~2s before each redirect.

**2. The navigation guard acts on unhydrated boot defaults.**
`authMiddleware` runs the route-guard resolver on *every* navigation, including background programmatic ones (the draft→real conversation URL swap after the auto-greet lands, and the conversation-list bootstrap `navigate(..., {replace: true})` that re-fires on any list refetch). `hasAssistants` and the consent flags both boot false/empty and hydrate asynchronously; `initSession`'s assistants fetch failure path silently skipped `setFromApi`, leaving the list empty for the whole session. When the guard evaluates in that window, `requireAssistant` reads an established user as brand-new and throws a redirect to the privacy screen.

## Fix

- **Consent**: for a real-but-stale server record, `syncUserScopedState` now prefers the version-stamped device attestation for exactly the stale axes and re-fires the backfill PUT (extracted a shared `buildDeviceConsentBackfill` used by both the empty-record and stale-record paths). Current server records — including the share booleans — remain fully authoritative. A future consent-version bump still forces re-review: device ack keys embed the version in the key name, so old acks can't attest a new version.
- **Hydration gating**: `NavigationState` gains `consentHydrated` / `assistantsHydrated`. `requireAssistant` and `requireConsent` return a `wait` decision instead of redirecting while state is unhydrated (platform mode only; local mode is lockfile-driven and keeps existing behavior). `authMiddleware` awaits both hydration flags with a bounded 5s timeout, then re-resolves — navigation can never hang. All settle paths now mark hydration, including `syncUserScopedState`'s failure/null paths and `initSession`'s assistants-fetch failure paths (new `markHydrated()` store action).

## Testing

- `bunx tsc --noEmit` clean; ESLint 0 errors, no new warnings.
- `navigation-resolver.test.ts` (83), `auth-store.test.ts` (60), `build-state.test.ts`, `onboarding-cleanup.test.ts`, `src/lib/auth` suites (37) — all pass. New cases cover: unhydrated → wait (both axes), hydrated + genuinely unconsented → privacy redirect preserved, stale-record + device acks → flags stay true + backfill re-fires with version stamps only, partial-stale records patch only stale axes, hydration marked on every settle path.

## Repro (staging/dev)

1. Onboard normally and sit in a conversation.
2. Stub `GET /v1/user/consent/` to return a record with stale versions (e.g. `tos_accepted_version: "2020-01-01"`), then hide+reshow the tab (fires `app.resume` → `refreshSession`) — pre-fix, the in-memory flags flip false.
3. Empty the resolved-assistants store (pre-fix this happens organically when `initSession`'s org/assistants fetch fails at boot; simulate via `useResolvedAssistantsStore.getState().clear()` in the console).
4. Send a message or invalidate the conversation-list query so a programmatic `navigate()` fires → pre-fix you're bounced to `/assistant/onboarding/privacy`; post-fix the guard waits for hydration and honors device-attested consent.

## Follow-ups (not in this PR)

- The replayed sessions also show the *platform* serving 404s on just-created conversations/workspace files and a degraded `operational/status/` shortly after hatch — worth a separate platform-side investigation (that instability is what triggers the resyncs/renavigations that expose this bug).
- `saveConsent`'s PUT is still fire-and-forget; a retry-with-backoff would shrink the stale-record window further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->