### PR TITLE
feat(web): register the Capacitor appUrlOpen deep-link event source

### DIFF
--- a/clients/web/src/hooks/use-event-bus-init.ts
+++ b/clients/web/src/hooks/use-event-bus-init.ts
@@ -5,8 +5,9 @@
  *
  * 1. **Signal sources.** Wires each `runtime/event-sources/*` helper
  *    once at mount so DOM visibility, network online/offline,
- *    Capacitor app state, Electron `powerMonitor`, and Electron
- *    deep-link events flow into the bus. The lifecycle diagnostics
+ *    Capacitor app state, Capacitor deep links, Electron
+ *    `powerMonitor`, and Electron deep-link events flow into the bus.
+ *    The lifecycle diagnostics
  *    recorder is attached in the same effect so those signals are
  *    captured for support bundles.
  *
@@ -27,6 +28,7 @@ import { sseService } from "@/assistant/sse-service";
 import { subscribeLifecycleDiagnostics } from "@/lib/lifecycle-diagnostics";
 import { setupQueryFocusManager } from "@/lib/query-focus-manager";
 import { publishCapacitorAppStateSource } from "@/runtime/event-sources/capacitor-app-state";
+import { publishCapacitorDeepLinksSource } from "@/runtime/event-sources/capacitor-deep-links";
 import { publishVisibilitySource } from "@/runtime/event-sources/dom-visibility";
 import { publishElectronConnectivitySource } from "@/runtime/event-sources/electron-connectivity";
 import { publishElectronDeepLinksSource } from "@/runtime/event-sources/electron-deep-links";
@@ -57,6 +59,7 @@ export function useEventBusInit({
       publishVisibilitySource(),
       publishWindowOnlineSource(),
       publishCapacitorAppStateSource(),
+      publishCapacitorDeepLinksSource(),
       publishElectronPowerSource(),
       publishElectronDeepLinksSource(),
       publishElectronConnectivitySource(),

--- a/clients/web/src/runtime/event-sources/capacitor-deep-links.test.ts
+++ b/clients/web/src/runtime/event-sources/capacitor-deep-links.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+type AppUrlOpenHandler = (payload: { url: string }) => void;
+
+let isNative = true;
+const isNativePlatformMock = mock(() => isNative);
+mock.module("@/runtime/native-auth", () => ({
+  isNativePlatform: isNativePlatformMock,
+}));
+
+let urlOpenHandler: AppUrlOpenHandler | null = null;
+const handleRemoveMock = mock(async () => {});
+let addListenerResolver:
+  ((value: { remove: typeof handleRemoveMock }) => void) | null = null;
+let addListenerRejecter: ((err: Error) => void) | null = null;
+
+const addListenerMock = mock(
+  (_event: "appUrlOpen", handler: AppUrlOpenHandler) => {
+    urlOpenHandler = handler;
+    return new Promise<{ remove: typeof handleRemoveMock }>(
+      (resolve, reject) => {
+        addListenerResolver = resolve;
+        addListenerRejecter = reject;
+      },
+    );
+  },
+);
+
+mock.module("@capacitor/app", () => ({
+  App: {
+    addListener: addListenerMock,
+  },
+}));
+
+const captureErrorMock = mock(() => {});
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: captureErrorMock,
+}));
+
+import { subscribe } from "@/lib/event-bus";
+import {
+  buildOAuthCompleteDeepLink,
+  OAUTH_COMPLETE_DEEP_LINK_EVENT,
+  type OAuthCompleteDeepLinkPayload,
+} from "@/runtime/native-deep-link";
+
+const { publishCapacitorDeepLinksSource } =
+  await import("@/runtime/event-sources/capacitor-deep-links");
+
+const flushMicrotasks = async (rounds = 4) => {
+  for (let i = 0; i < rounds; i++) await Promise.resolve();
+};
+const resolveAddListener = async () => {
+  // The dynamic `import("@capacitor/app")` and its `.then` chain each
+  // queue a microtask, so the source's `addListenerMock` call lags
+  // synchronous test code. Flush before resolving the pending promise,
+  // then flush again so the `.then` that stores the `handle` runs.
+  await flushMicrotasks();
+  addListenerResolver?.({ remove: handleRemoveMock });
+  await flushMicrotasks();
+};
+
+beforeEach(() => {
+  isNative = true;
+  urlOpenHandler = null;
+  addListenerResolver = null;
+  addListenerRejecter = null;
+  isNativePlatformMock.mockClear();
+  addListenerMock.mockClear();
+  handleRemoveMock.mockClear();
+  captureErrorMock.mockClear();
+});
+
+describe("publishCapacitorDeepLinksSource", () => {
+  test("is a no-op off Capacitor iOS (returns a no-op unsubscribe, never imports the plugin)", () => {
+    isNative = false;
+
+    const unsubscribe = publishCapacitorDeepLinksSource();
+    unsubscribe();
+
+    expect(addListenerMock).not.toHaveBeenCalled();
+  });
+
+  test("dispatches the OAuth-complete window CustomEvent for an oauth-complete deep link", async () => {
+    const received: OAuthCompleteDeepLinkPayload[] = [];
+    const windowListener = (
+      event: CustomEvent<OAuthCompleteDeepLinkPayload>,
+    ) => {
+      received.push(event.detail);
+    };
+    window.addEventListener(OAUTH_COMPLETE_DEEP_LINK_EVENT, windowListener);
+
+    try {
+      const unsubscribe = publishCapacitorDeepLinksSource();
+      await resolveAddListener();
+
+      const payload: OAuthCompleteDeepLinkPayload = {
+        requestId: "req-123",
+        oauthStatus: "success",
+        oauthProvider: "google",
+        oauthCode: "code-abc",
+      };
+      urlOpenHandler!({
+        url: buildOAuthCompleteDeepLink("vellum-assistant", payload),
+      });
+
+      expect(received).toEqual([payload]);
+      unsubscribe();
+    } finally {
+      window.removeEventListener(
+        OAUTH_COMPLETE_DEEP_LINK_EVENT,
+        windowListener,
+      );
+    }
+  });
+
+  test("publishes deeplink.unknown on the bus for a non-OAuth URL", async () => {
+    const received: { url: string }[] = [];
+    const unsubscribeBus = subscribe("deeplink.unknown", (payload) => {
+      received.push(payload);
+    });
+
+    try {
+      const unsubscribe = publishCapacitorDeepLinksSource();
+      await resolveAddListener();
+
+      urlOpenHandler!({ url: "vellum-assistant://some-future-link?x=1" });
+
+      expect(received).toEqual([
+        { url: "vellum-assistant://some-future-link?x=1" },
+      ]);
+      unsubscribe();
+    } finally {
+      unsubscribeBus();
+    }
+  });
+
+  test("returned unsubscribe removes the listener once it resolves", async () => {
+    const unsubscribe = publishCapacitorDeepLinksSource();
+
+    await resolveAddListener();
+    expect(handleRemoveMock).not.toHaveBeenCalled();
+
+    unsubscribe();
+    expect(handleRemoveMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("unsubscribe BEFORE the lazy import resolves still removes the just-registered listener", async () => {
+    const unsubscribe = publishCapacitorDeepLinksSource();
+
+    unsubscribe();
+    await resolveAddListener();
+
+    expect(handleRemoveMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("reports a lazy-import failure instead of throwing", async () => {
+    publishCapacitorDeepLinksSource();
+
+    await flushMicrotasks();
+    const err = new Error("plugin missing");
+    addListenerRejecter?.(err);
+    await flushMicrotasks();
+
+    expect(captureErrorMock).toHaveBeenCalledWith(err, {
+      context: "capacitor_deep_links",
+      level: "warning",
+    });
+  });
+});

--- a/clients/web/src/runtime/event-sources/capacitor-deep-links.ts
+++ b/clients/web/src/runtime/event-sources/capacitor-deep-links.ts
@@ -1,0 +1,68 @@
+import { captureError } from "@/lib/sentry/capture-error";
+import type { PluginListenerHandle } from "@capacitor/core";
+
+import { publish } from "@/lib/event-bus";
+import { isNativePlatform } from "@/runtime/native-auth";
+import {
+  OAUTH_COMPLETE_DEEP_LINK_EVENT,
+  parseOAuthCompleteDeepLink,
+} from "@/runtime/native-deep-link";
+
+/**
+ * Capacitor iOS shell's `App.appUrlOpen` → deep-link routing.
+ *
+ * OAuth-complete URLs (`vellum-assistant://oauth-complete?…`) dispatch
+ * the `OAUTH_COMPLETE_DEEP_LINK_EVENT` window CustomEvent that
+ * `useOAuthCompleteDeepLinkListener` already consumes, making OAuth
+ * completion event-driven instead of relying only on the
+ * `browserFinished` poll fallback in `runtime/browser.ts` (which stays
+ * in place as a safety net). Any other URL publishes
+ * `deeplink.unknown { url }` on the bus — future URL kinds
+ * (conversation universal links, quick actions) branch here.
+ *
+ * Off Capacitor iOS the function is a no-op (`isNativePlatform()`
+ * returns false) — Electron deep links flow through
+ * `publishElectronDeepLinksSource` instead.
+ *
+ * The `@capacitor/app` plugin import is lazy (per CAPACITOR.md's
+ * "lazy-import rule"), and the sync return + internal `cancelled` flag
+ * covers unsubscribing before the import resolves — both mirror
+ * `publishCapacitorAppStateSource`.
+ */
+export function publishCapacitorDeepLinksSource(): () => void {
+  if (!isNativePlatform()) return () => undefined;
+
+  let handle: PluginListenerHandle | null = null;
+  let cancelled = false;
+
+  import("@capacitor/app")
+    .then(({ App }) =>
+      App.addListener("appUrlOpen", ({ url }) => handleUrl(url)),
+    )
+    .then((registered) => {
+      if (cancelled) {
+        void registered.remove();
+        return;
+      }
+      handle = registered;
+    })
+    .catch((err) => {
+      captureError(err, { context: "capacitor_deep_links", level: "warning" });
+    });
+
+  return () => {
+    cancelled = true;
+    void handle?.remove();
+  };
+}
+
+function handleUrl(url: string): void {
+  const payload = parseOAuthCompleteDeepLink(url);
+  if (payload !== null) {
+    window.dispatchEvent(
+      new CustomEvent(OAUTH_COMPLETE_DEEP_LINK_EVENT, { detail: payload }),
+    );
+    return;
+  }
+  publish("deeplink.unknown", { url });
+}


### PR DESCRIPTION
## Summary
- New capacitor-deep-links event source registers the previously-missing App.addListener("appUrlOpen") on native iOS
- OAuth-complete deep links now dispatch the existing OAUTH_COMPLETE_DEEP_LINK_EVENT contract (event-driven instead of poll-only); unknown URLs publish deeplink.unknown
- Registered in useEventBusInit alongside the other runtime event sources

Part of plan: mobile-push-deeplink-haptics.md (PR 2 of 4)