### PR TITLE
feat(web): deep-link into the conversation from APNs remote-push taps

### DIFF
--- a/clients/web/src/runtime/push-registration.test.ts
+++ b/clients/web/src/runtime/push-registration.test.ts
@@ -1,4 +1,6 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { subscribe } from "@/lib/event-bus";
 
 // ── platform guards ──────────────────────────────────────────────────────────
 //
@@ -22,17 +24,27 @@ mock.module("@capacitor/core", () => ({
 
 type RegistrationHandler = (token: { value: string }) => void;
 type ErrorHandler = (error: { error: string }) => void;
+type ActionPerformedHandler = (action: {
+  actionId: string;
+  notification: { data?: unknown };
+}) => void;
 
 let registrationHandler: RegistrationHandler | null = null;
 let registrationErrorHandler: ErrorHandler | null = null;
+let actionPerformedHandler: ActionPerformedHandler | null = null;
 let permissionState: "granted" | "denied" | "prompt" = "granted";
 
 const addListenerMock = mock(
-  async (event: string, handler: RegistrationHandler | ErrorHandler) => {
+  async (
+    event: string,
+    handler: RegistrationHandler | ErrorHandler | ActionPerformedHandler,
+  ) => {
     if (event === "registration") {
       registrationHandler = handler as RegistrationHandler;
     } else if (event === "registrationError") {
       registrationErrorHandler = handler as ErrorHandler;
+    } else if (event === "pushNotificationActionPerformed") {
+      actionPerformedHandler = handler as ActionPerformedHandler;
     }
     return { remove: async () => {} };
   },
@@ -113,6 +125,7 @@ mock.module("@/lib/sentry/capture-error", () => ({
 }));
 
 const {
+  extractPushConversationId,
   isRemotePushSupported,
   registerForRemotePush,
   unregisterFromRemotePush,
@@ -128,6 +141,22 @@ const flushMicrotasks = async (rounds = 10) => {
   }
 };
 
+// Bus subscriptions made by a test; unsubscribed in afterEach so cases
+// stay isolated.
+const busUnsubscribes: Array<() => void> = [];
+const subscribeForTest: typeof subscribe = (event, handler) => {
+  const unsubscribe = subscribe(event, handler);
+  busUnsubscribes.push(unsubscribe);
+  return unsubscribe;
+};
+
+afterEach(() => {
+  for (const unsubscribe of busUnsubscribes) {
+    unsubscribe();
+  }
+  busUnsubscribes.length = 0;
+});
+
 beforeEach(() => {
   isNative = true;
   platform = "ios";
@@ -135,6 +164,7 @@ beforeEach(() => {
   bundleId = "ai.vocify-inc.vellum-assistant-ios";
   registrationHandler = null;
   registrationErrorHandler = null;
+  actionPerformedHandler = null;
   lastUpsertArg = null;
   lastDeleteArg = null;
   upsertError = undefined;
@@ -234,6 +264,92 @@ describe("registerForRemotePush", () => {
 
     expect(captureErrorMock).toHaveBeenCalledTimes(1);
     expect(upsertMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("pushNotificationActionPerformed tap routing", () => {
+  const tap = (data?: unknown) => {
+    actionPerformedHandler?.({ actionId: "tap", notification: { data } });
+  };
+
+  let published: Array<{ threadId: string }> = [];
+  beforeEach(() => {
+    published = [];
+    subscribeForTest("deeplink.openThread", (payload) => {
+      published.push(payload);
+    });
+  });
+
+  test("publishes deeplink.openThread from data.deep_link.conversationId", async () => {
+    await registerForRemotePush("assistant-1");
+    tap({ deep_link: { conversationId: "conv-123" } });
+
+    expect(published).toEqual([{ threadId: "conv-123" }]);
+  });
+
+  test("falls back to a top-level data.conversationId", async () => {
+    await registerForRemotePush("assistant-1");
+    tap({ conversationId: "conv-456" });
+
+    expect(published).toEqual([{ threadId: "conv-456" }]);
+  });
+
+  test("publishes nothing for absent or malformed data", async () => {
+    await registerForRemotePush("assistant-1");
+    tap(undefined);
+    tap(null);
+    tap("not-an-object");
+    tap({});
+    tap({ deep_link: "not-an-object" });
+    tap({ deep_link: { conversationId: 42 } });
+    tap({ conversationId: { nested: true } });
+
+    expect(published).toEqual([]);
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("extractPushConversationId", () => {
+  test("reads data.deep_link.conversationId", () => {
+    expect(
+      extractPushConversationId({ deep_link: { conversationId: "conv-1" } }),
+    ).toBe("conv-1");
+  });
+
+  test("falls back to a top-level conversationId", () => {
+    expect(extractPushConversationId({ conversationId: "conv-2" })).toBe(
+      "conv-2",
+    );
+  });
+
+  test("prefers deep_link over a top-level conversationId", () => {
+    expect(
+      extractPushConversationId({
+        deep_link: { conversationId: "conv-deep" },
+        conversationId: "conv-top",
+      }),
+    ).toBe("conv-deep");
+  });
+
+  test("falls back to top-level when deep_link.conversationId is malformed", () => {
+    expect(
+      extractPushConversationId({
+        deep_link: { conversationId: 42 },
+        conversationId: "conv-top",
+      }),
+    ).toBe("conv-top");
+  });
+
+  test("returns undefined for non-object, absent, and malformed shapes", () => {
+    expect(extractPushConversationId(undefined)).toBeUndefined();
+    expect(extractPushConversationId(null)).toBeUndefined();
+    expect(extractPushConversationId("conv-1")).toBeUndefined();
+    expect(extractPushConversationId(42)).toBeUndefined();
+    expect(extractPushConversationId([])).toBeUndefined();
+    expect(extractPushConversationId({})).toBeUndefined();
+    expect(extractPushConversationId({ deep_link: null })).toBeUndefined();
+    expect(extractPushConversationId({ deep_link: {} })).toBeUndefined();
+    expect(extractPushConversationId({ conversationId: 42 })).toBeUndefined();
   });
 });
 

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -1,5 +1,6 @@
 /**
- * APNs remote-push device-token registration for the Capacitor iOS app.
+ * APNs remote-push device-token registration and tap routing for the
+ * Capacitor iOS app.
  *
  * The daemon's `platform` notification channel POSTs background notifications
  * (reminders, activity completions, etc.) to the Vellum platform's
@@ -22,6 +23,11 @@
  *   - {@link unregisterFromRemotePush} — call from the logout path BEFORE the
  *     session cookie is cleared (see `stores/auth-store.ts`) so the platform
  *     delete is authenticated. Removes the token for the bound assistant.
+ *   - Tap routing — alongside the token listeners, a
+ *     `pushNotificationActionPerformed` listener publishes
+ *     `deeplink.openThread` on the event bus when a tapped notification
+ *     carries a conversation id, so `useGlobalDeepLinkConsumer` (mounted in
+ *     `RootLayout`) navigates to the conversation.
  *
  * iOS-only and best-effort: no-ops on Electron, desktop browsers, and Android
  * (no native Capacitor Android shell ships today); registration/delete failures
@@ -39,6 +45,7 @@ import {
   assistantsPushTokensUpsert,
 } from "@/generated/api/sdk.gen";
 import type { ApnsEnvironmentEnum } from "@/generated/api/types.gen";
+import { publish } from "@/lib/event-bus";
 import { captureError } from "@/lib/sentry/capture-error";
 import { isNativePlatform } from "@/runtime/native-auth";
 import { createStorageAccessor } from "@/utils/typed-storage";
@@ -68,7 +75,11 @@ function parseRegisteredToken(raw: string): RegisteredToken | null {
     typeof value.bundleId === "string" &&
     typeof value.assistantId === "string"
   ) {
-    return { token: value.token, bundleId: value.bundleId, assistantId: value.assistantId };
+    return {
+      token: value.token,
+      bundleId: value.bundleId,
+      assistantId: value.assistantId,
+    };
   }
   return null;
 }
@@ -179,10 +190,38 @@ async function upsertToken(token: string, assistantId: string): Promise<void> {
 }
 
 /**
- * Register the APNs `registration` / `registrationError` listeners exactly
- * once. The `registration` handler upserts the token under whichever assistant
- * is current when iOS delivers it (iOS may emit the token asynchronously, and
- * re-emits the cached token on subsequent `register()` calls).
+ * Extract the conversation id a tapped push notification routes to.
+ *
+ * APNs custom keys arrive as `notification.data`. The daemon's
+ * `deep_link_metadata` reaches us as `data.deep_link.conversationId` (the
+ * platform forwards it into the APNs payload); producers that embed routing
+ * directly in `context_payload` put `conversationId` at the top level, so
+ * that is the fallback. Returns `undefined` for absent or malformed shapes —
+ * never throws.
+ */
+export function extractPushConversationId(data: unknown): string | undefined {
+  if (typeof data !== "object" || data === null) {
+    return undefined;
+  }
+  const record = data as Record<string, unknown>;
+  const deepLink = record.deep_link;
+  if (typeof deepLink === "object" && deepLink !== null) {
+    const conversationId = (deepLink as Record<string, unknown>).conversationId;
+    if (typeof conversationId === "string") {
+      return conversationId;
+    }
+  }
+  return typeof record.conversationId === "string"
+    ? record.conversationId
+    : undefined;
+}
+
+/**
+ * Register the APNs `registration` / `registrationError` / tap listeners
+ * exactly once. The `registration` handler upserts the token under whichever
+ * assistant is current when iOS delivers it (iOS may emit the token
+ * asynchronously, and re-emits the cached token on subsequent `register()`
+ * calls).
  */
 async function ensureListeners(): Promise<void> {
   if (listenersRegistered) return;
@@ -200,6 +239,20 @@ async function ensureListeners(): Promise<void> {
         level: "warning",
       });
     });
+    await PushNotifications.addListener(
+      "pushNotificationActionPerformed",
+      (action) => {
+        // Pushes dispatched by a platform that does not yet forward the
+        // daemon's `deep_link_metadata` carry no routing keys — the tap
+        // foregrounds the app without navigating.
+        const conversationId = extractPushConversationId(
+          action.notification.data,
+        );
+        if (conversationId) {
+          publish("deeplink.openThread", { threadId: conversationId });
+        }
+      },
+    );
   } catch (err) {
     // Allow a later call to retry listener registration.
     listenersRegistered = false;
@@ -220,7 +273,9 @@ async function ensureListeners(): Promise<void> {
  * authorization backs the local-notification path, so this does not introduce a
  * second OS prompt.
  */
-export async function registerForRemotePush(assistantId: string): Promise<void> {
+export async function registerForRemotePush(
+  assistantId: string,
+): Promise<void> {
   if (!isRemotePushSupported()) return;
   currentAssistantId = assistantId;
 


### PR DESCRIPTION
## Summary
- Adds a pushNotificationActionPerformed listener so tapping an APNs remote push publishes deeplink.openThread and navigates to the conversation
- Reads notification.data.deep_link.conversationId (forwarded by a companion vellum-assistant-platform PR) with a top-level conversationId fallback
- Degrades gracefully (no-op, no error) while the platform half is not yet deployed

Part of plan: mobile-push-deeplink-haptics.md (PR 4 of 4)