### PR TITLE
feat(live-voice): server-side VAD turn detection and barge-in

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-metrics.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-metrics.test.ts
@@ -155,6 +155,55 @@ describe("LiveVoiceMetricsCollector", () => {
     expect(turn.durations.totalTurnDurationMs).toBe(350);
   });
 
+  test("startTurn seeds stashed marks and backdates the turn start", () => {
+    const clock = makeClock(1_000);
+    const collector = new LiveVoiceMetricsCollector({
+      sessionId: "session-5",
+      clock: clock.now,
+    });
+
+    clock.advance(500);
+    const turn = collector.startTurn("turn-seeded", {
+      firstAudioAtMs: 1_100,
+      speechStartAtMs: 1_150,
+      utteranceEndAtMs: 1_300,
+      finalTranscriptAtMs: 1_400,
+    });
+
+    expect(turn.timestamps.startedAtMs).toBe(1_100);
+    expect(turn.timestamps.firstAudioAtMs).toBe(1_100);
+    expect(turn.timestamps.speechStartAtMs).toBe(1_150);
+    expect(turn.timestamps.utteranceEndAtMs).toBe(1_300);
+    expect(turn.timestamps.finalTranscriptAtMs).toBe(1_400);
+    expect(turn.durations.utteranceEndToFinalTranscriptMs).toBe(100);
+
+    // A live mark never overwrites a seeded mark (first timestamp wins).
+    clock.advance(100);
+    collector.markFinalTranscript("turn-seeded");
+    expect(
+      collector.getSnapshot().activeTurn?.timestamps.finalTranscriptAtMs,
+    ).toBe(1_400);
+
+    clock.advance(100);
+    const completed = collector.completeTurn("turn-seeded");
+    expect(completed.durations.totalTurnDurationMs).toBe(600);
+  });
+
+  test("seed marks ahead of the turn start are clamped to it", () => {
+    const clock = makeClock(2_000);
+    const collector = new LiveVoiceMetricsCollector({
+      sessionId: "session-6",
+      clock: clock.now,
+    });
+
+    const turn = collector.startTurn("turn-clamped", {
+      utteranceEndAtMs: 5_000,
+    });
+
+    expect(turn.timestamps.startedAtMs).toBe(2_000);
+    expect(turn.timestamps.utteranceEndAtMs).toBe(2_000);
+  });
+
   test("records only the first timestamp for first-phase metrics", () => {
     const clock = makeClock(10_000);
     const collector = new LiveVoiceMetricsCollector({

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -93,6 +93,11 @@ function createHarness(options: {
   turnDetectorConfig?: TurnDetectorConfig;
   emitMetrics?: boolean;
   metricsClock?: () => number;
+  // Return a promise to hold a frame's transport write open (a backed-up
+  // outbound queue); return null to write immediately.
+  holdSendFrame?: (
+    payload: Parameters<LiveVoiceSessionFactoryContext["sendFrame"]>[0],
+  ) => Promise<void> | null;
 }) {
   const sequencer = createLiveVoiceServerFrameSequencer();
   const frames: LiveVoiceServerFrame[] = [];
@@ -100,6 +105,7 @@ function createHarness(options: {
     sessionId: "session-123",
     startFrame: options.startFrame ?? VAD_START_FRAME,
     sendFrame: mock(async (payload) => {
+      await options.holdSendFrame?.(payload);
       const frame = sequencer.next(payload);
       frames.push(frame);
       return frame;
@@ -318,6 +324,70 @@ describe("LiveVoiceSession server VAD", () => {
       content: "actually never mind",
     });
     expect(countType(frames, "utterance_end")).toBe(2);
+  });
+
+  test("speech while the first tts_audio send is stuck in the queue does not cancel; barge-in works once it lands", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const abort = mock();
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks ??= options.callbacks;
+      return { turnId: "bridge-turn", abort };
+    });
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk("assistant audio"));
+      return makeTtsResult("assistant audio");
+    });
+    let releaseDeltaSend: (() => void) | undefined;
+    const { frames, session } = createHarness({
+      finals: ["what's the weather", "wait actually", "stop please"],
+      startVoiceTurn,
+      streamTtsAudio,
+      // Hold the assistant_text_delta write open so the queued tts_audio
+      // frame sits behind it, unsent.
+      holdSendFrame: (payload) => {
+        if (payload.type !== "assistant_text_delta" || releaseDeltaSend) {
+          return null;
+        }
+        return new Promise<void>((resolve) => {
+          releaseDeltaSend = resolve;
+        });
+      },
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+    callbacks?.assistant_text_delta?.(makeTextDelta("It is sunny today."));
+    await waitFor(() => releaseDeltaSend !== undefined);
+    await waitFor(() => streamTtsAudio.mock.calls.length === 1);
+
+    // User speaks while the tts_audio frame is queued but unsent: no audio
+    // has reached the client, so the turn must not be treated as audible.
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await flushAsyncCallbacks();
+    expect(countType(frames, "turn_cancelled")).toBe(0);
+    expect(abort).not.toHaveBeenCalled();
+
+    // Unblock the queue: the reply's audio is actually delivered.
+    releaseDeltaSend?.();
+    await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
+    expect(countType(frames, "turn_cancelled")).toBe(0);
+    expect(abort).not.toHaveBeenCalled();
+
+    // Once audio has genuinely gone out, a new speech onset barge-ins.
+    await waitFor(() => countType(frames, "utterance_end") === 2);
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "turn_cancelled"),
+    );
+    expect(
+      frames.find((frame) => frame.type === "turn_cancelled"),
+    ).toMatchObject({
+      type: "turn_cancelled",
+      turnId: "live-turn-1",
+    });
+    await waitFor(() => abort.mock.calls.length === 1);
   });
 
   test("speech while the turn is still thinking emits speech_started but does not cancel", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -9,8 +9,10 @@ import type {
   StreamingTranscriber,
   SttStreamServerEvent,
 } from "../../stt/types.js";
+import type { LiveVoiceAudioArchiveResult } from "../live-voice-archive.js";
 import {
   LiveVoiceSession,
+  type LiveVoiceSessionAudioArchiver,
   type LiveVoiceTtsStreamer,
   type LiveVoiceTurnStarter,
 } from "../live-voice-session.js";
@@ -87,6 +89,7 @@ function createHarness(options: {
   finals?: string[];
   startVoiceTurn?: LiveVoiceTurnStarter;
   streamTtsAudio?: LiveVoiceTtsStreamer | null;
+  archiveAudio?: LiveVoiceSessionAudioArchiver;
   turnDetectorConfig?: TurnDetectorConfig;
   emitMetrics?: boolean;
   metricsClock?: () => number;
@@ -123,6 +126,7 @@ function createHarness(options: {
       options.startVoiceTurn ??
       mock(async () => ({ turnId: "bridge-turn", abort: mock() })),
     streamTtsAudio: options.streamTtsAudio ?? null,
+    archiveAudio: options.archiveAudio ?? null,
     emitMetrics: options.emitMetrics ?? false,
     ...(options.metricsClock ? { metricsClock: options.metricsClock } : {}),
     createTurnId: () => {
@@ -443,6 +447,125 @@ describe("LiveVoiceSession server VAD", () => {
       turnId: "live-turn-1",
       sttMs: 10,
     });
+  });
+
+  test("idle silence is skipped and a bounded pre-roll flushes on speech onset", async () => {
+    const archivedUserAudio: Buffer[] = [];
+    const archiveAudio: LiveVoiceSessionAudioArchiver = async (input) => {
+      if (input.role === "user") {
+        archivedUserAudio.push(Buffer.from(input.audio.dataBase64, "base64"));
+      }
+      const result: LiveVoiceAudioArchiveResult = {
+        type: "warning",
+        warning: { code: "archive_failed", message: "not archived in test" },
+      };
+      return result;
+    };
+    const { frames, session, transcribers } = createHarness({
+      finals: ["hello there"],
+      startVoiceTurn: makeAutoCompletingTurnStarter(["Hi."]).startVoiceTurn,
+      archiveAudio,
+    });
+
+    await session.start();
+    const transcriber = transcribers[0];
+    for (let index = 0; index < 40; index += 1) {
+      await session.handleBinaryAudio(SILENT_CHUNK);
+    }
+
+    // An open idle mic never reaches the transcriber or the archive buffer.
+    expect(transcriber?.received).toHaveLength(0);
+    expect(frameTypes(frames)).toEqual(["ready"]);
+
+    await session.handleBinaryAudio(LOUD_CHUNK);
+
+    // Speech onset flushes the capped pre-roll ahead of the speech chunk.
+    const silent = Buffer.from(SILENT_CHUNK);
+    const loud = Buffer.from(LOUD_CHUNK);
+    expect(transcriber?.received).toHaveLength(26);
+    expect(
+      transcriber?.received.slice(0, 25).every((chunk) => chunk.equals(silent)),
+    ).toBe(true);
+    expect(transcriber?.received.at(-1)?.equals(loud)).toBe(true);
+
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    await waitFor(() => archivedUserAudio.length === 1);
+    // Archived user audio covers pre-roll + speech, not the idle stretch.
+    expect(archivedUserAudio[0]?.byteLength).toBe(
+      26 * SILENT_CHUNK.byteLength,
+    );
+  });
+
+  test("an utterance captured during an open turn seeds its metrics marks", async () => {
+    let now = 0;
+    const turnCallbacks: VoiceTurnCallbacks[] = [];
+    const startVoiceTurn: LiveVoiceTurnStarter = async (options) => {
+      turnCallbacks.push(options.callbacks ?? {});
+      return { turnId: `bridge-turn-${turnCallbacks.length}`, abort: mock() };
+    };
+    const { frames, session } = createHarness({
+      finals: ["first question", "second question"],
+      startVoiceTurn,
+      emitMetrics: true,
+      metricsClock: () => {
+        now += 10;
+        return now;
+      },
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+    // The second utterance runs its full VAD cycle while turn 1 is still
+    // thinking, so its early marks land before its metrics turn can open.
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => countType(frames, "utterance_end") === 2);
+    await waitFor(() => countType(frames, "stt_final") === 2);
+
+    turnCallbacks[0]?.assistant_text_delta?.(makeTextDelta("First answer."));
+    turnCallbacks[0]?.message_complete?.(makeMessageComplete());
+    await waitFor(() => turnCallbacks.length === 2);
+    turnCallbacks[1]?.assistant_text_delta?.(makeTextDelta("Second answer."));
+    turnCallbacks[1]?.message_complete?.(makeMessageComplete());
+
+    await waitFor(() =>
+      frames.some(
+        (frame) =>
+          frame.type === "metrics" &&
+          frame.event === "turn_completed" &&
+          frame.turnId === "live-turn-2",
+      ),
+    );
+    const completedMetrics = frames.find(
+      (frame) =>
+        frame.type === "metrics" &&
+        frame.event === "turn_completed" &&
+        frame.turnId === "live-turn-2",
+    );
+    if (completedMetrics?.type !== "metrics") {
+      throw new Error("Expected a turn_completed metrics frame for turn 2.");
+    }
+
+    // sttMs spans the stashed utterance_end → final_transcript marks.
+    expect(completedMetrics.sttMs).toBe(10);
+    expect(completedMetrics.llmFirstDeltaMs).not.toBeNull();
+    expect(completedMetrics.totalMs).toBeGreaterThan(0);
+
+    const snapshot = completedMetrics.metrics as {
+      recentTurns: Array<{
+        turnId: string;
+        timestamps: {
+          speechStartAtMs: number | null;
+          utteranceEndAtMs: number | null;
+        };
+      }>;
+    };
+    const turn = snapshot.recentTurns.find(
+      (recent) => recent.turnId === "live-turn-2",
+    );
+    expect(turn?.timestamps.speechStartAtMs).not.toBeNull();
+    expect(turn?.timestamps.utteranceEndAtMs).not.toBeNull();
   });
 
   test("manual mode emits none of the VAD frames", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -1,0 +1,468 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type { TurnDetectorConfig } from "../../calls/media-turn-detector.js";
+import type {
+  VoiceTurnCallbacks,
+  VoiceTurnOptions,
+} from "../../calls/voice-session-bridge.js";
+import type {
+  StreamingTranscriber,
+  SttStreamServerEvent,
+} from "../../stt/types.js";
+import {
+  LiveVoiceSession,
+  type LiveVoiceTtsStreamer,
+  type LiveVoiceTurnStarter,
+} from "../live-voice-session.js";
+import type { LiveVoiceSessionFactoryContext } from "../live-voice-session-manager.js";
+import type {
+  LiveVoiceTtsAudioChunk,
+  LiveVoiceTtsOptions,
+  LiveVoiceTtsResult,
+} from "../live-voice-tts.js";
+import {
+  createLiveVoiceServerFrameSequencer,
+  type LiveVoiceClientStartFrame,
+  type LiveVoiceServerFrame,
+} from "../protocol.js";
+
+const SAMPLE_RATE = 24_000;
+
+const VAD_START_FRAME = {
+  type: "start",
+  conversationId: "conversation-123",
+  turnDetection: "server_vad",
+  audio: {
+    mimeType: "audio/pcm",
+    sampleRate: SAMPLE_RATE,
+    channels: 1,
+  },
+} as const satisfies LiveVoiceClientStartFrame;
+
+const MANUAL_START_FRAME = {
+  type: "start",
+  conversationId: "conversation-123",
+  audio: VAD_START_FRAME.audio,
+} as const satisfies LiveVoiceClientStartFrame;
+
+function pcm(amplitude: number, sampleCount = 240): Uint8Array {
+  const buffer = Buffer.alloc(sampleCount * 2);
+  for (let index = 0; index < sampleCount; index += 1) {
+    buffer.writeInt16LE(amplitude, index * 2);
+  }
+  return new Uint8Array(buffer);
+}
+
+const LOUD_CHUNK = pcm(8_000);
+const SILENT_CHUNK = pcm(0);
+
+class MockStreamingTranscriber implements StreamingTranscriber {
+  readonly providerId = "deepgram" as const;
+  readonly boundaryId = "daemon-streaming" as const;
+  readonly received: Buffer[] = [];
+  stopped = false;
+  private onEvent: ((event: SttStreamServerEvent) => void) | null = null;
+
+  constructor(private readonly stopEvents: SttStreamServerEvent[]) {}
+
+  async start(onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
+    this.onEvent = onEvent;
+  }
+
+  sendAudio(chunk: Buffer): void {
+    this.received.push(Buffer.from(chunk));
+  }
+
+  stop(): void {
+    if (this.stopped) return;
+    this.stopped = true;
+    for (const event of this.stopEvents) {
+      this.onEvent?.(event);
+    }
+  }
+}
+
+function createHarness(options: {
+  startFrame?: LiveVoiceClientStartFrame;
+  finals?: string[];
+  startVoiceTurn?: LiveVoiceTurnStarter;
+  streamTtsAudio?: LiveVoiceTtsStreamer | null;
+  turnDetectorConfig?: TurnDetectorConfig;
+  emitMetrics?: boolean;
+  metricsClock?: () => number;
+}) {
+  const sequencer = createLiveVoiceServerFrameSequencer();
+  const frames: LiveVoiceServerFrame[] = [];
+  const context: LiveVoiceSessionFactoryContext = {
+    sessionId: "session-123",
+    startFrame: options.startFrame ?? VAD_START_FRAME,
+    sendFrame: mock(async (payload) => {
+      const frame = sequencer.next(payload);
+      frames.push(frame);
+      return frame;
+    }),
+  };
+
+  const finals = options.finals ?? ["hello world"];
+  const transcribers: MockStreamingTranscriber[] = [];
+  const resolveTranscriber = mock(async () => {
+    const text =
+      finals[transcribers.length] ?? `utterance ${transcribers.length + 1}`;
+    const transcriber = new MockStreamingTranscriber([
+      { type: "final", text },
+      { type: "closed" },
+    ]);
+    transcribers.push(transcriber);
+    return transcriber;
+  });
+
+  let turnNumber = 0;
+  const session = new LiveVoiceSession(context, {
+    resolveTranscriber,
+    startVoiceTurn:
+      options.startVoiceTurn ??
+      mock(async () => ({ turnId: "bridge-turn", abort: mock() })),
+    streamTtsAudio: options.streamTtsAudio ?? null,
+    emitMetrics: options.emitMetrics ?? false,
+    ...(options.metricsClock ? { metricsClock: options.metricsClock } : {}),
+    createTurnId: () => {
+      turnNumber += 1;
+      return `live-turn-${turnNumber}`;
+    },
+    turnDetectorConfig: options.turnDetectorConfig ?? {
+      silenceThresholdMs: 40,
+    },
+  });
+
+  return { frames, session, transcribers };
+}
+
+function frameTypes(frames: LiveVoiceServerFrame[]): string[] {
+  return frames.map((frame) => frame.type);
+}
+
+function countType(frames: LiveVoiceServerFrame[], type: string): number {
+  return frames.filter((frame) => frame.type === type).length;
+}
+
+function makeTtsChunk(text: string): LiveVoiceTtsAudioChunk {
+  return {
+    type: "tts_audio",
+    contentType: "audio/pcm",
+    sampleRate: SAMPLE_RATE,
+    dataBase64: Buffer.from(text).toString("base64"),
+  };
+}
+
+function makeTtsResult(text: string): LiveVoiceTtsResult {
+  return {
+    provider: "fish-audio",
+    contentType: "audio/pcm",
+    sampleRate: SAMPLE_RATE,
+    chunks: 1,
+    bytes: Buffer.byteLength(text),
+  };
+}
+
+function makeTextDelta(
+  text: string,
+): Parameters<NonNullable<VoiceTurnCallbacks["assistant_text_delta"]>>[0] {
+  return {
+    type: "assistant_text_delta",
+    text,
+    conversationId: "conversation-123",
+  };
+}
+
+function makeMessageComplete(): Parameters<
+  NonNullable<VoiceTurnCallbacks["message_complete"]>
+>[0] {
+  return {
+    type: "message_complete",
+    conversationId: "conversation-123",
+    messageId: "assistant-message-123",
+  };
+}
+
+// Completes each turn immediately: one text delta, then message_complete.
+function makeAutoCompletingTurnStarter(replies: string[]): {
+  startVoiceTurn: LiveVoiceTurnStarter;
+  calls: VoiceTurnOptions[];
+} {
+  const calls: VoiceTurnOptions[] = [];
+  const startVoiceTurn: LiveVoiceTurnStarter = async (options) => {
+    calls.push(options);
+    const reply = replies[calls.length - 1] ?? "Okay.";
+    options.callbacks?.assistant_text_delta?.(makeTextDelta(reply));
+    options.callbacks?.message_complete?.(makeMessageComplete());
+    return { turnId: `bridge-turn-${calls.length}`, abort: mock() };
+  };
+  return { startVoiceTurn, calls };
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message = "Timed out waiting for live voice VAD test condition",
+): Promise<void> {
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(message);
+}
+
+async function flushAsyncCallbacks(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+
+describe("LiveVoiceSession server VAD", () => {
+  test("silence then speech then silence emits speech_started, utterance_end, and runs a turn", async () => {
+    const { frames, session } = createHarness({
+      finals: ["hello world"],
+      startVoiceTurn: makeAutoCompletingTurnStarter(["Hi there."])
+        .startVoiceTurn,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(SILENT_CHUNK);
+    expect(frameTypes(frames)).toEqual(["ready"]);
+
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(frameTypes(frames)).toEqual([
+      "ready",
+      "speech_started",
+      "utterance_end",
+      "stt_final",
+      "thinking",
+      "assistant_text_delta",
+      "tts_done",
+    ]);
+    expect(
+      frames.find((frame) => frame.type === "utterance_end"),
+    ).toMatchObject({
+      type: "utterance_end",
+      reason: "silence",
+    });
+    expect(frames.find((frame) => frame.type === "thinking")).toMatchObject({
+      type: "thinking",
+      turnId: "live-turn-1",
+    });
+  });
+
+  test("barge-in during TTS emits speech_started before turn_cancelled and aborts the turn", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    let lateTtsChunk: ((chunk: LiveVoiceTtsAudioChunk) => void) | undefined;
+    const abort = mock();
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks ??= options.callbacks;
+      return { turnId: "bridge-turn", abort };
+    });
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      lateTtsChunk = options.onAudioChunk;
+      options.onAudioChunk(makeTtsChunk("assistant audio"));
+      return makeTtsResult("assistant audio");
+    });
+    const { frames, session, transcribers } = createHarness({
+      finals: ["what's the weather", "actually never mind"],
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+    callbacks?.assistant_text_delta?.(makeTextDelta("It is sunny today."));
+    await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
+
+    // User speaks over the assistant's audio.
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "turn_cancelled"),
+    );
+
+    const types = frameTypes(frames);
+    const bargeInSpeechStartedIndex = types.lastIndexOf("speech_started");
+    const turnCancelledIndex = types.indexOf("turn_cancelled");
+    expect(bargeInSpeechStartedIndex).toBeGreaterThan(-1);
+    expect(bargeInSpeechStartedIndex).toBeLessThan(turnCancelledIndex);
+    expect(frames[turnCancelledIndex]).toMatchObject({
+      type: "turn_cancelled",
+      turnId: "live-turn-1",
+    });
+    await waitFor(() => abort.mock.calls.length === 1);
+
+    // A late TTS chunk for the cancelled turn is suppressed.
+    lateTtsChunk?.(makeTtsChunk("late audio"));
+    await flushAsyncCallbacks();
+    expect(frameTypes(frames).lastIndexOf("tts_audio")).toBeLessThan(
+      turnCancelledIndex,
+    );
+    expect(
+      frames.some(
+        (frame) => frame.type === "tts_done" && frame.turnId === "live-turn-1",
+      ),
+    ).toBe(false);
+
+    // The barge-in speech was captured from onset into the next utterance.
+    await waitFor(() => transcribers.length === 2);
+    await waitFor(() => (transcribers[1]?.received.length ?? 0) > 0);
+    await waitFor(() => startVoiceTurn.mock.calls.length === 2);
+    expect(startVoiceTurn.mock.calls[1]?.[0]).toMatchObject({
+      content: "actually never mind",
+    });
+    expect(countType(frames, "utterance_end")).toBe(2);
+  });
+
+  test("speech while the turn is still thinking emits speech_started but does not cancel", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const abort = mock();
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks ??= options.callbacks;
+      return { turnId: "bridge-turn", abort };
+    });
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk("assistant audio"));
+      return makeTtsResult("assistant audio");
+    });
+    const { frames, session } = createHarness({
+      finals: ["first question", "second question"],
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+    // No TTS audio has been forwarded yet — the turn is still "thinking".
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await flushAsyncCallbacks();
+
+    expect(countType(frames, "speech_started")).toBe(2);
+    expect(countType(frames, "turn_cancelled")).toBe(0);
+    expect(abort).not.toHaveBeenCalled();
+
+    // The unspoken reply still completes normally.
+    callbacks?.assistant_text_delta?.(makeTextDelta("Here is the answer."));
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() =>
+      frames.some(
+        (frame) => frame.type === "tts_done" && frame.turnId === "live-turn-1",
+      ),
+    );
+    expect(countType(frames, "turn_cancelled")).toBe(0);
+  });
+
+  test("runs two VAD turns back-to-back on one session", async () => {
+    const { startVoiceTurn, calls } = makeAutoCompletingTurnStarter([
+      "First reply.",
+      "Second reply.",
+    ]);
+    const { frames, session } = createHarness({
+      finals: ["turn one", "turn two"],
+      startVoiceTurn,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => countType(frames, "tts_done") === 1);
+
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => countType(frames, "tts_done") === 2);
+
+    expect(countType(frames, "speech_started")).toBe(2);
+    expect(countType(frames, "utterance_end")).toBe(2);
+    const thinkingTurnIds = frames.flatMap((frame) =>
+      frame.type === "thinking" ? [frame.turnId] : [],
+    );
+    expect(thinkingTurnIds).toEqual(["live-turn-1", "live-turn-2"]);
+    expect(calls.map((options) => options.content)).toEqual([
+      "turn one",
+      "turn two",
+    ]);
+  });
+
+  test("ptt_release acts as a manual utterance override in server_vad mode", async () => {
+    const { frames, session } = createHarness({
+      finals: ["cut me off"],
+      startVoiceTurn: makeAutoCompletingTurnStarter(["Done."]).startVoiceTurn,
+      // A long silence threshold proves the release came from the client
+      // frame, not the silence timer.
+      turnDetectorConfig: { silenceThresholdMs: 5_000 },
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "speech_started"),
+    );
+
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(frameTypes(frames)).toEqual([
+      "ready",
+      "speech_started",
+      "utterance_end",
+      "stt_final",
+      "thinking",
+      "assistant_text_delta",
+      "tts_done",
+    ]);
+  });
+
+  test("VAD turns report sttMs from the utterance_end boundary", async () => {
+    let now = 1_000;
+    const { frames, session } = createHarness({
+      finals: ["measure me"],
+      startVoiceTurn: makeAutoCompletingTurnStarter(["Measured."])
+        .startVoiceTurn,
+      emitMetrics: true,
+      metricsClock: () => {
+        now += 10;
+        return now;
+      },
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() =>
+      frames.some(
+        (frame) => frame.type === "metrics" && frame.event === "turn_completed",
+      ),
+    );
+
+    const completedMetrics = frames.find(
+      (frame) => frame.type === "metrics" && frame.event === "turn_completed",
+    );
+    expect(completedMetrics).toMatchObject({
+      type: "metrics",
+      turnId: "live-turn-1",
+      sttMs: 10,
+    });
+  });
+
+  test("manual mode emits none of the VAD frames", async () => {
+    const { frames, session } = createHarness({
+      startFrame: MANUAL_START_FRAME,
+      finals: ["hello world"],
+      startVoiceTurn: makeAutoCompletingTurnStarter(["Hi."]).startVoiceTurn,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(frameTypes(frames)).toEqual([
+      "ready",
+      "stt_final",
+      "thinking",
+      "assistant_text_delta",
+      "tts_done",
+    ]);
+  });
+});

--- a/assistant/src/live-voice/__tests__/protocol.test.ts
+++ b/assistant/src/live-voice/__tests__/protocol.test.ts
@@ -192,7 +192,7 @@ describe("parseLiveVoiceClientTextFrame", () => {
     });
   });
 
-  test("rejects turnDetection server_vad until its session lifecycle is implemented", () => {
+  test("parses start frames with turnDetection server_vad", () => {
     const result = parseLiveVoiceClientTextFrame(
       JSON.stringify({
         type: "start",
@@ -205,16 +205,19 @@ describe("parseLiveVoiceClientTextFrame", () => {
       }),
     );
 
-    expect(result.ok).toBe(false);
-    if (result.ok) {
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
       return;
     }
 
-    expect(result.error).toMatchObject({
-      code: "invalid_field",
-      field: "turnDetection",
-      frameType: "start",
-      message: "start frame field turnDetection: server_vad is not yet supported",
+    expect(result.frame).toEqual({
+      type: "start",
+      turnDetection: "server_vad",
+      audio: {
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        channels: 1,
+      },
     });
   });
 
@@ -410,7 +413,11 @@ describe("LiveVoiceServerFrameSequencer", () => {
       reason: "max-duration",
     });
 
-    expect(silence).toEqual({ type: "utterance_end", reason: "silence", seq: 1 });
+    expect(silence).toEqual({
+      type: "utterance_end",
+      reason: "silence",
+      seq: 1,
+    });
     expect(maxDuration).toEqual({
       type: "utterance_end",
       reason: "max-duration",

--- a/assistant/src/live-voice/live-voice-metrics.ts
+++ b/assistant/src/live-voice/live-voice-metrics.ts
@@ -35,6 +35,24 @@ interface LiveVoiceSessionMetrics {
   startToReadyMs: number | null;
 }
 
+// Marks captured before a turn opened in the collector (server-VAD overlap);
+// passed to startTurn to backfill the new turn's timestamps.
+export interface LiveVoiceTurnSeedMarks {
+  firstAudioAtMs?: number;
+  firstPartialAtMs?: number;
+  speechStartAtMs?: number;
+  utteranceEndAtMs?: number;
+  finalTranscriptAtMs?: number;
+}
+
+const SEEDABLE_MARK_FIELDS = [
+  "firstAudioAtMs",
+  "firstPartialAtMs",
+  "speechStartAtMs",
+  "utteranceEndAtMs",
+  "finalTranscriptAtMs",
+] as const satisfies ReadonlyArray<keyof LiveVoiceTurnSeedMarks>;
+
 interface LiveVoiceTurnTimestamps {
   startedAtMs: number;
   firstAudioAtMs: number | null;
@@ -149,7 +167,10 @@ export class LiveVoiceMetricsCollector {
     return this.emit("session_ready");
   }
 
-  startTurn(turnId = this.createTurnId()): LiveVoiceTurnMetrics {
+  startTurn(
+    turnId = this.createTurnId(),
+    seedMarks: LiveVoiceTurnSeedMarks = {},
+  ): LiveVoiceTurnMetrics {
     if (this.activeTurn !== null) {
       this.cancelTurn("superseded");
     }
@@ -172,8 +193,30 @@ export class LiveVoiceMetricsCollector {
         cancelledAtMs: null,
       },
     };
+    this.applySeedMarks(this.activeTurn, seedMarks);
     this.emit("turn_started", turnId);
     return snapshotTurn(this.activeTurn);
+  }
+
+  // Backfills marks stashed before this turn opened. Seeds never overwrite
+  // an existing mark (first timestamp wins) and are clamped to the turn's
+  // start timestamp; the earliest seed becomes the turn start so total
+  // durations cover the stashed span.
+  private applySeedMarks(
+    turn: MutableTurn,
+    seeds: LiveVoiceTurnSeedMarks,
+  ): void {
+    const startedAtMs = turn.timestamps.startedAtMs;
+    let earliestMs = startedAtMs;
+    for (const field of SEEDABLE_MARK_FIELDS) {
+      const value = seeds[field];
+      if (value === undefined || !Number.isFinite(value)) continue;
+      if (turn.timestamps[field] !== null) continue;
+      const seededMs = Math.min(value, startedAtMs);
+      turn.timestamps[field] = seededMs;
+      earliestMs = Math.min(earliestMs, seededMs);
+    }
+    turn.timestamps.startedAtMs = earliestMs;
   }
 
   markFirstAudio(turnId?: string): LiveVoiceMetricsFrame {

--- a/assistant/src/live-voice/live-voice-metrics.ts
+++ b/assistant/src/live-voice/live-voice-metrics.ts
@@ -6,7 +6,10 @@ export type LiveVoiceMetricsEvent =
   | "turn_started"
   | "first_audio"
   | "first_partial"
+  | "vad_speech_start"
   | "ptt_release"
+  | "utterance_end"
+  | "barge_in"
   | "final_transcript"
   | "first_assistant_delta"
   | "first_tts_audio"
@@ -36,7 +39,9 @@ interface LiveVoiceTurnTimestamps {
   startedAtMs: number;
   firstAudioAtMs: number | null;
   firstPartialAtMs: number | null;
+  speechStartAtMs: number | null;
   pttReleaseAtMs: number | null;
+  utteranceEndAtMs: number | null;
   finalTranscriptAtMs: number | null;
   firstAssistantDeltaAtMs: number | null;
   firstTtsAudioAtMs: number | null;
@@ -47,6 +52,7 @@ interface LiveVoiceTurnTimestamps {
 interface LiveVoiceTurnDurations {
   firstAudioToFirstPartialMs: number | null;
   pttReleaseToFinalTranscriptMs: number | null;
+  utteranceEndToFinalTranscriptMs: number | null;
   finalTranscriptToFirstAssistantDeltaMs: number | null;
   firstAssistantDeltaToFirstTtsAudioMs: number | null;
   totalTurnDurationMs: number | null;
@@ -73,6 +79,7 @@ interface LiveVoiceMetricsSummary {
   durations: {
     firstAudioToFirstPartialMs: LiveVoiceDurationSummary;
     pttReleaseToFinalTranscriptMs: LiveVoiceDurationSummary;
+    utteranceEndToFinalTranscriptMs: LiveVoiceDurationSummary;
     finalTranscriptToFirstAssistantDeltaMs: LiveVoiceDurationSummary;
     firstAssistantDeltaToFirstTtsAudioMs: LiveVoiceDurationSummary;
     totalTurnDurationMs: LiveVoiceDurationSummary;
@@ -155,7 +162,9 @@ export class LiveVoiceMetricsCollector {
         startedAtMs: this.timestamp(),
         firstAudioAtMs: null,
         firstPartialAtMs: null,
+        speechStartAtMs: null,
         pttReleaseAtMs: null,
+        utteranceEndAtMs: null,
         finalTranscriptAtMs: null,
         firstAssistantDeltaAtMs: null,
         firstTtsAudioAtMs: null,
@@ -183,12 +192,32 @@ export class LiveVoiceMetricsCollector {
     return this.emit("first_partial", turn.turnId);
   }
 
+  markSpeechStart(turnId?: string): LiveVoiceMetricsFrame {
+    const turn = this.ensureActiveTurn(turnId);
+    if (turn.timestamps.speechStartAtMs === null) {
+      turn.timestamps.speechStartAtMs = this.timestamp();
+    }
+    return this.emit("vad_speech_start", turn.turnId);
+  }
+
   markPushToTalkRelease(turnId?: string): LiveVoiceMetricsFrame {
     const turn = this.ensureActiveTurn(turnId);
     if (turn.timestamps.pttReleaseAtMs === null) {
       turn.timestamps.pttReleaseAtMs = this.timestamp();
     }
     return this.emit("ptt_release", turn.turnId);
+  }
+
+  markUtteranceEnd(turnId?: string): LiveVoiceMetricsFrame {
+    const turn = this.ensureActiveTurn(turnId);
+    if (turn.timestamps.utteranceEndAtMs === null) {
+      turn.timestamps.utteranceEndAtMs = this.timestamp();
+    }
+    return this.emit("utterance_end", turn.turnId);
+  }
+
+  markBargeIn(turnId?: string): LiveVoiceMetricsFrame {
+    return this.emit("barge_in", turnId ?? this.activeTurn?.turnId);
   }
 
   markFinalTranscript(turnId?: string): LiveVoiceMetricsFrame {
@@ -340,7 +369,11 @@ export function getLiveVoiceMetricsAggregateFields(
   }
 
   return {
-    sttMs: turn.durations.pttReleaseToFinalTranscriptMs,
+    // Manual mode stamps ptt_release; server-VAD sessions stamp utterance_end
+    // instead, so the VAD boundary plays the sttMs role there.
+    sttMs:
+      turn.durations.pttReleaseToFinalTranscriptMs ??
+      turn.durations.utteranceEndToFinalTranscriptMs,
     llmFirstDeltaMs: turn.durations.finalTranscriptToFirstAssistantDeltaMs,
     ttsFirstAudioMs: turn.durations.firstAssistantDeltaToFirstTtsAudioMs,
     totalMs: turn.durations.totalTurnDurationMs,
@@ -397,6 +430,10 @@ function snapshotTurn(turn: MutableTurn): LiveVoiceTurnMetrics {
         timestamps.pttReleaseAtMs,
         timestamps.finalTranscriptAtMs,
       ),
+      utteranceEndToFinalTranscriptMs: duration(
+        timestamps.utteranceEndAtMs,
+        timestamps.finalTranscriptAtMs,
+      ),
       finalTranscriptToFirstAssistantDeltaMs: duration(
         timestamps.finalTranscriptAtMs,
         timestamps.firstAssistantDeltaAtMs,
@@ -429,6 +466,9 @@ function summarizeTurns(turns: MutableTurn[]): LiveVoiceMetricsSummary {
       ),
       pttReleaseToFinalTranscriptMs: summarizeDuration(
         durations.map((value) => value.pttReleaseToFinalTranscriptMs),
+      ),
+      utteranceEndToFinalTranscriptMs: summarizeDuration(
+        durations.map((value) => value.utteranceEndToFinalTranscriptMs),
       ),
       finalTranscriptToFirstAssistantDeltaMs: summarizeDuration(
         durations.map((value) => value.finalTranscriptToFirstAssistantDeltaMs),

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -28,6 +28,7 @@ import {
   type LiveVoiceMetricsClock,
   LiveVoiceMetricsCollector,
   type LiveVoiceMetricsEvent,
+  type LiveVoiceTurnSeedMarks,
 } from "./live-voice-metrics.js";
 import {
   type LiveVoiceSession as LiveVoiceSessionContract,
@@ -60,6 +61,10 @@ const TRAILING_SENTENCE_PUNCTUATION = new Set(['"', "'", ")", "]"]);
 // Cap on audio buffered while a server-VAD utterance waits for its
 // transcriber (PCM16 mono seconds; oldest chunks are dropped past the cap).
 const SERVER_VAD_PENDING_AUDIO_MAX_SECONDS = 10;
+// Idle-mic chunks retained while the VAD detector is idle; flushed on speech
+// onset so the transcriber gets leading context without streaming an open
+// quiet mic.
+const SERVER_VAD_PRE_ROLL_MAX_CHUNKS = 25;
 
 export type LiveVoiceStreamingTranscriberResolver = (
   options: ResolveStreamingTranscriberOptions,
@@ -128,6 +133,18 @@ interface UtteranceCycle {
   userAudioChunks: Buffer[];
   metricsTurnStarted: boolean;
   metricsTurnFinished: boolean;
+  // Marks captured while the previous cycle's metrics turn was still open
+  // (server_vad overlap); seeded into the collector when this cycle's
+  // metrics turn starts.
+  stashedMetricsMarks: StashedMetricsMarks;
+}
+
+interface StashedMetricsMarks {
+  firstAudioAtMs: number | null;
+  firstPartialAtMs: number | null;
+  speechStartAtMs: number | null;
+  utteranceEndAtMs: number | null;
+  finalTranscriptAtMs: number | null;
 }
 
 type UtteranceStartResult =
@@ -177,6 +194,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // Set on VAD speech onset; consumed when the first speech chunk is routed
   // to an utterance so the metric lands on the right turn.
   private vadSpeechStartPending = false;
+  // Bounded ring of idle-mic chunks skipped while the VAD detector is idle;
+  // flushed ahead of the first routed chunk on speech onset.
+  private vadPreRollChunks: Buffer[] = [];
+  private readonly metricsClock: LiveVoiceMetricsClock;
 
   constructor(
     context: LiveVoiceSessionFactoryContext,
@@ -192,6 +213,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.createTurnId = options.createTurnId ?? randomUUID;
     this.conversationId =
       context.startFrame.conversationId ?? context.sessionId;
+    this.metricsClock = options.metricsClock ?? Date.now;
     this.metrics = new LiveVoiceMetricsCollector({
       sessionId: context.sessionId,
       conversationId: this.conversationId,
@@ -295,6 +317,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       userAudioChunks: [],
       metricsTurnStarted: false,
       metricsTurnFinished: false,
+      stashedMetricsMarks: {
+        firstAudioAtMs: null,
+        firstPartialAtMs: null,
+        speechStartAtMs: null,
+        utteranceEndAtMs: null,
+        finalTranscriptAtMs: null,
+      },
     };
     this.currentUtterance = utterance;
 
@@ -431,6 +460,17 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     const hasSpeech = detectPcm16SpeechActivity(chunk);
     detector.onMediaChunk(hasSpeech);
 
+    // Idle mic: hold silent chunks in the bounded pre-roll instead of
+    // collecting or streaming them; flushed on speech onset so the
+    // transcriber still gets leading context ahead of the first syllable.
+    if (!hasSpeech && !detector.isActive) {
+      this.vadPreRollChunks.push(Buffer.from(chunk));
+      while (this.vadPreRollChunks.length > SERVER_VAD_PRE_ROLL_MAX_CHUNKS) {
+        this.vadPreRollChunks.shift();
+      }
+      return;
+    }
+
     let utterance = this.currentUtterance;
     if (!utterance) return;
     if (utterance.released || utterance.completed) {
@@ -442,6 +482,16 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       if (!utterance || utterance.released || utterance.completed) return;
     }
 
+    for (const preRollChunk of this.vadPreRollChunks.splice(0)) {
+      await this.routeVadAudio(utterance, preRollChunk);
+    }
+    await this.routeVadAudio(utterance, chunk);
+  }
+
+  private async routeVadAudio(
+    utterance: UtteranceCycle,
+    chunk: Buffer,
+  ): Promise<void> {
     this.collectUserAudio(utterance, chunk);
     if (this.vadSpeechStartPending) {
       this.vadSpeechStartPending = false;
@@ -1024,40 +1074,62 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   private collectUserAudio(utterance: UtteranceCycle, chunk: Buffer): void {
-    const turnId = this.ensureTurnId(utterance);
     utterance.userAudioChunks.push(Buffer.from(chunk));
-    if (!this.startMetricsTurnIfNeeded(utterance, turnId)) return;
-    this.metrics.markFirstAudio(turnId);
+    this.markUtteranceMetric(utterance, "firstAudioAtMs", (turnId) =>
+      this.metrics.markFirstAudio(turnId),
+    );
   }
 
   private markSpeechStart(utterance: UtteranceCycle): void {
-    const turnId = this.ensureTurnId(utterance);
-    if (!this.startMetricsTurnIfNeeded(utterance, turnId)) return;
-    this.metrics.markSpeechStart(turnId);
+    this.markUtteranceMetric(utterance, "speechStartAtMs", (turnId) =>
+      this.metrics.markSpeechStart(turnId),
+    );
   }
 
   // Manual mode stamps the PTT release; server_vad stamps the utterance-end
   // boundary instead (utteranceEndToFinalTranscript plays the sttMs role).
   private markUtteranceReleased(utterance: UtteranceCycle): void {
+    if (this.turnDetector) {
+      this.markUtteranceMetric(utterance, "utteranceEndAtMs", (turnId) =>
+        this.metrics.markUtteranceEnd(turnId),
+      );
+      return;
+    }
     const turnId = this.ensureTurnId(utterance);
     if (!this.startMetricsTurnIfNeeded(utterance, turnId)) return;
-    if (this.turnDetector) {
-      this.metrics.markUtteranceEnd(turnId);
-    } else {
-      this.metrics.markPushToTalkRelease(turnId);
-    }
+    this.metrics.markPushToTalkRelease(turnId);
   }
 
   private markFirstPartial(utterance: UtteranceCycle): void {
-    const turnId = this.ensureTurnId(utterance);
-    if (!this.startMetricsTurnIfNeeded(utterance, turnId)) return;
-    this.metrics.markFirstPartial(turnId);
+    this.markUtteranceMetric(utterance, "firstPartialAtMs", (turnId) =>
+      this.metrics.markFirstPartial(turnId),
+    );
   }
 
   private markFinalTranscript(utterance: UtteranceCycle): void {
+    this.markUtteranceMetric(utterance, "finalTranscriptAtMs", (turnId) =>
+      this.metrics.markFinalTranscript(turnId),
+    );
+  }
+
+  // Records the mark on the utterance's metrics turn, or — while a previous
+  // cycle's still-open turn blocks the collector — stashes the timestamp on
+  // the utterance (first timestamp wins) so startMetricsTurnIfNeeded can
+  // seed it when this cycle's turn starts.
+  private markUtteranceMetric(
+    utterance: UtteranceCycle,
+    field: keyof StashedMetricsMarks,
+    mark: (turnId: string) => void,
+  ): void {
     const turnId = this.ensureTurnId(utterance);
-    if (!this.startMetricsTurnIfNeeded(utterance, turnId)) return;
-    this.metrics.markFinalTranscript(turnId);
+    if (this.startMetricsTurnIfNeeded(utterance, turnId)) {
+      mark(turnId);
+      return;
+    }
+    if (utterance.metricsTurnFinished) return;
+    if (utterance.stashedMetricsMarks[field] === null) {
+      utterance.stashedMetricsMarks[field] = this.metricsClock();
+    }
   }
 
   private markFirstAssistantDelta(
@@ -1083,7 +1155,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (utterance.metricsTurnFinished) return false;
     if (utterance.metricsTurnStarted) return true;
     if (this.hasBlockingMetricsTurn(utterance)) return false;
-    this.metrics.startTurn(turnId);
+    this.metrics.startTurn(turnId, toSeedMarks(utterance.stashedMetricsMarks));
     utterance.metricsTurnStarted = true;
     return true;
   }
@@ -1480,6 +1552,26 @@ function findLastWhitespaceBoundary(
 
 function isWhitespace(value: string): boolean {
   return /\s/.test(value);
+}
+
+function toSeedMarks(stashed: StashedMetricsMarks): LiveVoiceTurnSeedMarks {
+  return {
+    ...(stashed.firstAudioAtMs !== null
+      ? { firstAudioAtMs: stashed.firstAudioAtMs }
+      : {}),
+    ...(stashed.firstPartialAtMs !== null
+      ? { firstPartialAtMs: stashed.firstPartialAtMs }
+      : {}),
+    ...(stashed.speechStartAtMs !== null
+      ? { speechStartAtMs: stashed.speechStartAtMs }
+      : {}),
+    ...(stashed.utteranceEndAtMs !== null
+      ? { utteranceEndAtMs: stashed.utteranceEndAtMs }
+      : {}),
+    ...(stashed.finalTranscriptAtMs !== null
+      ? { finalTranscriptAtMs: stashed.finalTranscriptAtMs }
+      : {}),
+  };
 }
 
 function takeBufferedAudio(chunks: Buffer[]): Buffer | null {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1,6 +1,10 @@
 import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
 
+import {
+  MediaTurnDetector,
+  type TurnDetectorConfig,
+} from "../calls/media-turn-detector.js";
 import type {
   VoiceTurnHandle,
   VoiceTurnOptions,
@@ -10,6 +14,7 @@ import {
   supportsBoundary,
 } from "../providers/speech-to-text/provider-catalog.js";
 import type { ResolveStreamingTranscriberOptions } from "../providers/speech-to-text/resolve.js";
+import { detectPcm16SpeechActivity } from "../stt/speech-energy.js";
 import type {
   StreamingTranscriber,
   SttStreamServerEvent,
@@ -52,6 +57,9 @@ type LiveVoiceSessionState =
 const LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD = 180;
 const SENTENCE_ENDING_PUNCTUATION = new Set([".", "!", "?"]);
 const TRAILING_SENTENCE_PUNCTUATION = new Set(['"', "'", ")", "]"]);
+// Cap on audio buffered while a server-VAD utterance waits for its
+// transcriber (PCM16 mono seconds; oldest chunks are dropped past the cap).
+const SERVER_VAD_PENDING_AUDIO_MAX_SECONDS = 10;
 
 export type LiveVoiceStreamingTranscriberResolver = (
   options: ResolveStreamingTranscriberOptions,
@@ -91,6 +99,8 @@ export interface LiveVoiceSessionOptions {
   emitMetrics?: boolean;
   metricsClock?: LiveVoiceMetricsClock;
   createTurnId?: () => string;
+  /** Overrides the server-VAD turn detector thresholds (tests). */
+  turnDetectorConfig?: TurnDetectorConfig;
 }
 
 type LiveVoiceUtterancePhase =
@@ -106,8 +116,12 @@ interface UtteranceCycle {
   phase: LiveVoiceUtterancePhase;
   released: boolean;
   assistantTurnStarted: boolean;
+  // The whole cycle (turn included) finalized; the record can no longer
+  // accept audio and the session may re-arm over it.
+  completed: boolean;
   transcriber: StreamingTranscriber | null;
   pendingAudioChunks: Buffer[];
+  pendingAudioBytes: number;
   finalTranscriptSegments: string[];
   turnId: string | null;
   userMessageId: string | null;
@@ -130,6 +144,9 @@ interface ActiveAssistantTurn {
   handle: VoiceTurnHandle | null;
   assistantCompleted: boolean;
   ttsDone: boolean;
+  // First tts_audio chunk forwarded to the client — the barge-in gate:
+  // speech only cancels a turn that has audibly started speaking.
+  ttsAudioStarted: boolean;
   finalized: boolean;
   ttsBuffer: string;
   ttsQueue: Promise<void>;
@@ -154,6 +171,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private outboundFrames: Promise<void> = Promise.resolve();
   private activeAssistantTurn: ActiveAssistantTurn | null = null;
   private sessionEndMetricsEmitted = false;
+  // Non-null iff the start frame requested turnDetection "server_vad".
+  private readonly turnDetector: MediaTurnDetector | null;
+  private readonly maxPendingAudioBytes: number;
+  // Set on VAD speech onset; consumed when the first speech chunk is routed
+  // to an utterance so the metric lands on the right turn.
+  private vadSpeechStartPending = false;
 
   constructor(
     context: LiveVoiceSessionFactoryContext,
@@ -174,6 +197,17 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       conversationId: this.conversationId,
       ...(options.metricsClock ? { clock: options.metricsClock } : {}),
     });
+    this.turnDetector =
+      context.startFrame.turnDetection === "server_vad"
+        ? new MediaTurnDetector(options.turnDetectorConfig ?? {}, {
+            onTurnStart: () => this.handleVadSpeechStart(),
+            onTurnEnd: (reason) => this.handleVadUtteranceEnd(reason),
+          })
+        : null;
+    this.maxPendingAudioBytes =
+      context.startFrame.audio.sampleRate *
+      2 *
+      SERVER_VAD_PENDING_AUDIO_MAX_SECONDS;
   }
 
   get finalTranscriptText(): string {
@@ -208,7 +242,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         await this.handleAudio(Buffer.from(frame.dataBase64, "base64"));
         return;
       case "ptt_release":
-        await this.releaseUtterance();
+        await this.releaseFromClient();
         return;
       case "interrupt":
         await this.interrupt();
@@ -229,6 +263,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     const shouldEmitSessionEndMetrics = this.state !== "failed";
     this.state = "closed";
+    this.turnDetector?.dispose();
     const utterance = this.currentUtterance;
     if (utterance) {
       stopTranscriberBestEffort(utterance.transcriber);
@@ -250,8 +285,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       phase: "pending",
       released: false,
       assistantTurnStarted: false,
+      completed: false,
       transcriber: null,
       pendingAudioChunks: [],
+      pendingAudioBytes: 0,
       finalTranscriptSegments: [],
       turnId: null,
       userMessageId: null,
@@ -329,6 +366,17 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private async rearmAfterTurn(): Promise<void> {
     if (this.isClosed || this.state === "failed") return;
 
+    const current = this.currentUtterance;
+    if (current && !current.completed) {
+      // server_vad armed the next utterance during the finished turn; it may
+      // already be released and waiting to start its own turn.
+      await this.startAssistantTurnIfReady();
+      return;
+    }
+    await this.armUtterance();
+  }
+
+  private async armUtterance(): Promise<void> {
     const result = await this.beginUtterance();
     if (result.status === "started" || result.status === "stale") return;
 
@@ -341,6 +389,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   private async handleAudio(chunk: Buffer): Promise<void> {
+    if (this.turnDetector) {
+      await this.handleServerVadAudio(this.turnDetector, chunk);
+      return;
+    }
+
     const utterance = this.currentUtterance;
     if (!utterance || this.isClosed || this.state === "failed") return;
 
@@ -357,6 +410,71 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return;
     }
     await this.forwardAudioToTranscriber(utterance, chunk);
+  }
+
+  // server_vad ingress: every chunk feeds the energy VAD (never an error
+  // frame — audio is accepted in every non-closed state). Chunks route to
+  // the current utterance; once that cycle is spent, speech lazily arms the
+  // next utterance so barge-in speech is captured from its onset.
+  private async handleServerVadAudio(
+    detector: MediaTurnDetector,
+    chunk: Buffer,
+  ): Promise<void> {
+    if (
+      this.isClosed ||
+      this.state === "failed" ||
+      this.state === "initializing"
+    ) {
+      return;
+    }
+
+    const hasSpeech = detectPcm16SpeechActivity(chunk);
+    detector.onMediaChunk(hasSpeech);
+
+    let utterance = this.currentUtterance;
+    if (!utterance) return;
+    if (utterance.released || utterance.completed) {
+      if (!hasSpeech || !this.canArmNextUtterance(utterance)) return;
+      // Sets currentUtterance synchronously; the transcriber resolves async
+      // while this chunk lands in the new utterance's pending buffer.
+      void this.armUtterance();
+      utterance = this.currentUtterance;
+      if (!utterance || utterance.released || utterance.completed) return;
+    }
+
+    this.collectUserAudio(utterance, chunk);
+    if (this.vadSpeechStartPending) {
+      this.vadSpeechStartPending = false;
+      this.markSpeechStart(utterance);
+    }
+    if (utterance.phase === "pending") {
+      this.bufferPendingUtteranceAudio(utterance, chunk);
+      return;
+    }
+    await this.forwardAudioToTranscriber(utterance, chunk);
+  }
+
+  // A released utterance's transcription pipeline still reads
+  // currentUtterance; replacing it is only safe once its assistant turn has
+  // started (or the cycle fully finalized). Speech in the short
+  // release→turn-start window is not captured.
+  private canArmNextUtterance(utterance: UtteranceCycle): boolean {
+    return utterance.completed || utterance.assistantTurnStarted;
+  }
+
+  private bufferPendingUtteranceAudio(
+    utterance: UtteranceCycle,
+    chunk: Buffer,
+  ): void {
+    utterance.pendingAudioChunks.push(Buffer.from(chunk));
+    utterance.pendingAudioBytes += chunk.byteLength;
+    while (
+      utterance.pendingAudioBytes > this.maxPendingAudioBytes &&
+      utterance.pendingAudioChunks.length > 1
+    ) {
+      const dropped = utterance.pendingAudioChunks.shift();
+      utterance.pendingAudioBytes -= dropped?.byteLength ?? 0;
+    }
   }
 
   private async forwardAudioToTranscriber(
@@ -385,9 +503,70 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     utterance: UtteranceCycle,
   ): Promise<void> {
     const chunks = utterance.pendingAudioChunks.splice(0);
+    utterance.pendingAudioBytes = 0;
     for (const chunk of chunks) {
       await this.forwardAudioToTranscriber(utterance, chunk);
     }
+  }
+
+  // VAD speech onset. Contract: speech_started always goes out (the client
+  // flushes tail playback immediately); barge-in then cancels the active
+  // turn only once its first tts_audio chunk was forwarded — speech during
+  // a pre-TTS "thinking" turn never kills the unspoken reply.
+  private handleVadSpeechStart(): void {
+    if (this.isClosed || this.state === "failed") return;
+
+    void this.sendFrame({ type: "speech_started" });
+    this.vadSpeechStartPending = true;
+
+    const turn = this.activeAssistantTurn;
+    if (turn && !turn.finalized && turn.ttsAudioStarted) {
+      this.bargeIn(turn);
+    }
+  }
+
+  private bargeIn(turn: ActiveAssistantTurn): void {
+    // Abort synchronously so no tts_audio frame can follow turn_cancelled,
+    // and settle the cancelled turn's metrics so the next utterance's marks
+    // do not collide with it in the collector.
+    turn.abortController.abort();
+    this.metrics.markBargeIn(turn.turnId);
+    void (async () => {
+      await this.finishMetricsTurn(
+        turn.utterance,
+        "cancelled",
+        "barge_in",
+        turn.turnId,
+      );
+      await this.sendFrame({ type: "turn_cancelled", turnId: turn.turnId });
+      await this.cancelAssistantTurn("barge_in");
+    })().catch(() => {});
+  }
+
+  // VAD closed the utterance — the analog of ptt_release: emit
+  // utterance_end, then run the standard release path.
+  private handleVadUtteranceEnd(reason: "silence" | "max-duration"): void {
+    void (async () => {
+      if (this.isClosed || this.state === "failed") return;
+      this.vadSpeechStartPending = false;
+      const utterance = this.currentUtterance;
+      if (!utterance || utterance.released || utterance.completed) return;
+      await this.sendFrame({ type: "utterance_end", reason });
+      await this.releaseUtterance();
+    })().catch(() => {});
+  }
+
+  // In server_vad mode a client ptt_release still works as a manual
+  // override: force the detector's utterance boundary so the release runs
+  // the same utterance_end path; without an open detector turn, fall back
+  // to a plain release.
+  private async releaseFromClient(): Promise<void> {
+    if (this.turnDetector?.isActive) {
+      this.turnDetector.forceEnd();
+      await this.drainOutboundFrames();
+      return;
+    }
+    await this.releaseUtterance();
   }
 
   private async releaseUtterance(): Promise<void> {
@@ -396,7 +575,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     if (utterance.phase === "transcriber_closed") {
       utterance.released = true;
-      this.markPushToTalkReleased(utterance);
+      this.markUtteranceReleased(utterance);
       await this.startAssistantTurnIfReady();
       await this.drainOutboundFrames();
       return;
@@ -405,7 +584,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (utterance.released) return;
 
     utterance.released = true;
-    this.markPushToTalkReleased(utterance);
+    this.markUtteranceReleased(utterance);
 
     if (utterance.phase === "pending") {
       // The transcriber is still starting; beginUtterance completes the release.
@@ -493,6 +672,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (utterance) {
       stopTranscriberBestEffort(utterance.transcriber);
       utterance.transcriber = null;
+      // In server_vad mode the current utterance may be the lazily armed
+      // next cycle, distinct from the in-flight turn's — finalize it too so
+      // the post-turn re-arm can replace it.
+      const turn = this.activeAssistantTurn;
+      if (turn && turn.utterance !== utterance) {
+        await this.finalizePendingUtterance(utterance, "interrupt");
+      }
     }
     await this.cancelAssistantTurn("interrupt");
     await this.drainOutboundFrames();
@@ -509,6 +695,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     ) {
       return;
     }
+    // One assistant turn at a time: a server_vad utterance that closes while
+    // the previous turn is still speaking waits; rearmAfterTurn retries it.
+    if (this.activeAssistantTurn) return;
     if (utterance.phase !== "transcriber_closed") {
       return;
     }
@@ -535,6 +724,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       handle: null,
       assistantCompleted: false,
       ttsDone: false,
+      ttsAudioStarted: false,
       finalized: false,
       ttsBuffer: "",
       ttsQueue: Promise.resolve(),
@@ -803,6 +993,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
               );
               activeTurn.assistantAudioMimeType = chunk.contentType;
               activeTurn.assistantAudioSampleRate = chunk.sampleRate;
+              activeTurn.ttsAudioStarted = true;
               this.metrics.markFirstTtsAudio(activeTurn.turnId);
               ttsAudioFrames = ttsAudioFrames.then(() =>
                 this.sendFrame(
@@ -835,25 +1026,37 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private collectUserAudio(utterance: UtteranceCycle, chunk: Buffer): void {
     const turnId = this.ensureTurnId(utterance);
     utterance.userAudioChunks.push(Buffer.from(chunk));
-    this.startMetricsTurnIfNeeded(utterance, turnId);
+    if (!this.startMetricsTurnIfNeeded(utterance, turnId)) return;
     this.metrics.markFirstAudio(turnId);
   }
 
-  private markPushToTalkReleased(utterance: UtteranceCycle): void {
+  private markSpeechStart(utterance: UtteranceCycle): void {
     const turnId = this.ensureTurnId(utterance);
-    this.startMetricsTurnIfNeeded(utterance, turnId);
-    this.metrics.markPushToTalkRelease(turnId);
+    if (!this.startMetricsTurnIfNeeded(utterance, turnId)) return;
+    this.metrics.markSpeechStart(turnId);
+  }
+
+  // Manual mode stamps the PTT release; server_vad stamps the utterance-end
+  // boundary instead (utteranceEndToFinalTranscript plays the sttMs role).
+  private markUtteranceReleased(utterance: UtteranceCycle): void {
+    const turnId = this.ensureTurnId(utterance);
+    if (!this.startMetricsTurnIfNeeded(utterance, turnId)) return;
+    if (this.turnDetector) {
+      this.metrics.markUtteranceEnd(turnId);
+    } else {
+      this.metrics.markPushToTalkRelease(turnId);
+    }
   }
 
   private markFirstPartial(utterance: UtteranceCycle): void {
     const turnId = this.ensureTurnId(utterance);
-    this.startMetricsTurnIfNeeded(utterance, turnId);
+    if (!this.startMetricsTurnIfNeeded(utterance, turnId)) return;
     this.metrics.markFirstPartial(turnId);
   }
 
   private markFinalTranscript(utterance: UtteranceCycle): void {
     const turnId = this.ensureTurnId(utterance);
-    this.startMetricsTurnIfNeeded(utterance, turnId);
+    if (!this.startMetricsTurnIfNeeded(utterance, turnId)) return;
     this.metrics.markFinalTranscript(turnId);
   }
 
@@ -861,7 +1064,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     utterance: UtteranceCycle,
     turnId: string,
   ): void {
-    this.startMetricsTurnIfNeeded(utterance, turnId);
+    if (!this.startMetricsTurnIfNeeded(utterance, turnId)) return;
     this.metrics.markFirstAssistantDelta(turnId);
   }
 
@@ -872,19 +1075,37 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     return utterance.turnId;
   }
 
+  // Returns whether marks may be recorded for this utterance's metrics turn.
   private startMetricsTurnIfNeeded(
     utterance: UtteranceCycle,
     turnId: string,
-  ): void {
-    if (utterance.metricsTurnStarted || utterance.metricsTurnFinished) return;
+  ): boolean {
+    if (utterance.metricsTurnFinished) return false;
+    if (utterance.metricsTurnStarted) return true;
+    if (this.hasBlockingMetricsTurn(utterance)) return false;
     this.metrics.startTurn(turnId);
     utterance.metricsTurnStarted = true;
+    return true;
+  }
+
+  // The collector tracks one turn at a time; while the previous cycle's
+  // metrics turn is still open (server_vad overlap), the next utterance's
+  // marks wait rather than superseding the in-flight turn.
+  private hasBlockingMetricsTurn(utterance: UtteranceCycle): boolean {
+    const turn = this.activeAssistantTurn;
+    return (
+      turn !== null &&
+      turn.utterance !== utterance &&
+      turn.utterance.metricsTurnStarted &&
+      !turn.utterance.metricsTurnFinished
+    );
   }
 
   private async finalizePendingUtterance(
     utterance: UtteranceCycle,
     reason: string,
   ): Promise<void> {
+    utterance.completed = true;
     const turnId = utterance.turnId;
     if (!turnId) return;
 
@@ -908,6 +1129,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (turn.finalized) return;
 
     turn.finalized = true;
+    turn.utterance.completed = true;
     await this.archiveBufferedAudio({
       turnId: turn.turnId,
       userMessageId: turn.utterance.userMessageId,

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -161,7 +161,7 @@ interface ActiveAssistantTurn {
   handle: VoiceTurnHandle | null;
   assistantCompleted: boolean;
   ttsDone: boolean;
-  // First tts_audio chunk forwarded to the client — the barge-in gate:
+  // A tts_audio frame actually went out to the client — the barge-in gate:
   // speech only cancels a turn that has audibly started speaking.
   ttsAudioStarted: boolean;
   finalized: boolean;
@@ -1043,10 +1043,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
               );
               activeTurn.assistantAudioMimeType = chunk.contentType;
               activeTurn.assistantAudioSampleRate = chunk.sampleRate;
-              activeTurn.ttsAudioStarted = true;
-              this.metrics.markFirstTtsAudio(activeTurn.turnId);
-              ttsAudioFrames = ttsAudioFrames.then(() =>
-                this.sendFrame(
+              ttsAudioFrames = ttsAudioFrames.then(async () => {
+                const sent = await this.sendFrame(
                   {
                     type: "tts_audio",
                     mimeType: chunk.contentType,
@@ -1054,8 +1052,22 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
                     dataBase64: chunk.dataBase64,
                   },
                   () => this.isForwardingTts(token),
-                ),
-              );
+                );
+                // Arm the barge-in gate only once a tts_audio frame was
+                // actually written — a backed-up outbound queue must not
+                // let speech cancel a still-unspoken reply. Token match
+                // keeps a stale turn's late send from arming a newer turn.
+                if (!sent) return;
+                const turnAfterSend = this.activeAssistantTurn;
+                if (
+                  turnAfterSend?.token !== token ||
+                  turnAfterSend.ttsAudioStarted
+                ) {
+                  return;
+                }
+                turnAfterSend.ttsAudioStarted = true;
+                this.metrics.markFirstTtsAudio(turnAfterSend.turnId);
+              });
             },
           });
           await ttsAudioFrames;
@@ -1400,21 +1412,25 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     });
   }
 
+  // Resolves true only if the frame passed shouldSend and was written.
   private async sendFrame(
     frame: LiveVoiceServerFramePayload,
     shouldSend: () => boolean = () => true,
-  ): Promise<void> {
+  ): Promise<boolean> {
+    let sent = false;
     this.outboundFrames = this.outboundFrames
       .catch(() => {})
       .then(async () => {
         if (!shouldSend()) return;
         await this.context.sendFrame(frame);
+        sent = true;
       })
       .catch(() => {
         // Transport failures are handled by the WebSocket/session owner.
       });
 
     await this.outboundFrames;
+    return sent;
   }
 
   private async drainOutboundFrames(): Promise<void> {

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -404,21 +404,13 @@ function validateStartFrame(
     );
   }
 
-  if ("turnDetection" in value && !isLiveVoiceTurnDetectionMode(value.turnDetection)) {
+  if (
+    "turnDetection" in value &&
+    !isLiveVoiceTurnDetectionMode(value.turnDetection)
+  ) {
     return protocolError(
       "invalid_field",
       "start frame field turnDetection must be manual or server_vad",
-      "turnDetection",
-      "start",
-    );
-  }
-
-  // Temporary: server_vad is declared in the contract but not yet accepted;
-  // the session lifecycle for it is not implemented.
-  if (value.turnDetection === "server_vad") {
-    return protocolError(
-      "invalid_field",
-      "start frame field turnDetection: server_vad is not yet supported",
       "turnDetection",
       "start",
     );


### PR DESCRIPTION
## Summary
- turnDetection: server_vad now works end-to-end in LiveVoiceSession: a MediaTurnDetector fed by detectPcm16SpeechActivity detects utterance boundaries (utterance_end replaces ptt_release) and speech starts (speech_started frame, client flushes tail playback).
- Barge-in mirrors the phone stack's #37061 semantics: cancels the active turn only once its first tts_audio was forwarded (turn_cancelled frame; speech during thinking never kills an unspoken reply); barge-in speech is captured from onset into the next utterance.
- Lifts the temporary protocol rejection of server_vad; adds vad_speech_start/utterance_end/barge_in metrics. Manual/PTT sessions are wire-identical.

Part of plan: live-voice-server-barge-in.md (PR 8 of 11)