### PR TITLE
feat(web): per-org low-balance alert threshold control

### DIFF
--- a/clients/web/src/domains/settings/components/billing-panel.tsx
+++ b/clients/web/src/domains/settings/components/billing-panel.tsx
@@ -5,6 +5,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { AddCreditsModal } from "@/components/add-credits-modal";
 import { AutoTopUpCard } from "@/domains/settings/components/auto-top-up-card";
+import { LowBalanceAlertCard } from "@/domains/settings/components/low-balance-alert-card";
 import {
     organizationsBillingSummaryRetrieveOptions,
     organizationsBillingSummaryRetrieveQueryKey,
@@ -244,6 +245,9 @@ export function BillingPanel() {
         {renderBalanceBody()}
         <div className="mt-6 border-t border-[var(--border-base)] pt-6">
           <AutoTopUpCard />
+        </div>
+        <div className="mt-6 border-t border-[var(--border-base)] pt-6">
+          <LowBalanceAlertCard />
         </div>
       </Card>
 

--- a/clients/web/src/domains/settings/components/low-balance-alert-card.test.tsx
+++ b/clients/web/src/domains/settings/components/low-balance-alert-card.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Tests for LowBalanceAlertCard:
+ *  - renders the current per-org override in the input
+ *  - saving a new value PUTs the two-decimal threshold body
+ *  - "Reset to default" PUTs `threshold_usd: null` to clear the override
+ *  - out-of-bounds input shows an inline error and does NOT call the API
+ *
+ * The GET is seeded directly into the React Query cache so `useQuery` resolves
+ * synchronously; the PUT SDK function is mocked to capture the request body.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+
+import * as sdkGen from "@/generated/api/sdk.gen";
+
+let updateCalls: Array<Record<string, unknown>> = [];
+
+mock.module("@/generated/api/sdk.gen", () => ({
+  ...sdkGen,
+  organizationsBillingLowBalanceAlertUpdate: (opts: Record<string, unknown>) => {
+    updateCalls.push(opts);
+    const body = (opts.body ?? {}) as { threshold_usd: string | null };
+    return Promise.resolve({
+      data: {
+        threshold_usd: body.threshold_usd,
+        effective_threshold_usd: body.threshold_usd ?? "5.00",
+        default_threshold_usd: "5.00",
+      },
+      response: { ok: true },
+    });
+  },
+}));
+
+import { organizationsBillingLowBalanceAlertRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+import type { LowBalanceAlertResponse } from "@/generated/api/types.gen";
+
+const { LowBalanceAlertCard } = await import("./low-balance-alert-card");
+
+function makeClient(config: LowBalanceAlertResponse): QueryClient {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  client.setQueryData(
+    organizationsBillingLowBalanceAlertRetrieveQueryKey(),
+    config,
+  );
+  return client;
+}
+
+function renderCard(config: LowBalanceAlertResponse): ReturnType<typeof render> {
+  return render(
+    <QueryClientProvider client={makeClient(config)}>
+      <LowBalanceAlertCard />
+    </QueryClientProvider>,
+  );
+}
+
+const UNSET: LowBalanceAlertResponse = {
+  threshold_usd: null,
+  effective_threshold_usd: "5.00",
+  default_threshold_usd: "5.00",
+};
+
+beforeEach(() => {
+  updateCalls = [];
+});
+
+afterEach(cleanup);
+
+describe("LowBalanceAlertCard", () => {
+  test("renders the current override in the input", () => {
+    const { getByTestId } = renderCard({ ...UNSET, threshold_usd: "25.00" });
+    const input = getByTestId("low-balance-alert-input") as HTMLInputElement;
+    expect(input.value).toBe("25.00");
+  });
+
+  test("saving a new value PUTs the two-decimal threshold", async () => {
+    const { getByTestId } = renderCard(UNSET);
+    fireEvent.change(getByTestId("low-balance-alert-input"), {
+      target: { value: "50" },
+    });
+    fireEvent.click(getByTestId("low-balance-alert-save-button"));
+
+    await waitFor(() => {
+      if (updateCalls.length === 0) throw new Error("PUT not called");
+    });
+    expect(updateCalls[0]!.body).toEqual({ threshold_usd: "50.00" });
+  });
+
+  test("Reset to default PUTs threshold_usd: null", async () => {
+    const { getByTestId } = renderCard({ ...UNSET, threshold_usd: "25.00" });
+    fireEvent.click(getByTestId("low-balance-alert-reset-button"));
+
+    await waitFor(() => {
+      if (updateCalls.length === 0) throw new Error("PUT not called");
+    });
+    expect(updateCalls[0]!.body).toEqual({ threshold_usd: null });
+  });
+
+  test("out-of-bounds input shows an error and does not call the API", () => {
+    const { getByTestId, container } = renderCard(UNSET);
+    fireEvent.change(getByTestId("low-balance-alert-input"), {
+      target: { value: "2000" },
+    });
+    fireEvent.click(getByTestId("low-balance-alert-save-button"));
+
+    expect(container.textContent).toContain("Must be between $1 and $1,000");
+    expect(updateCalls.length).toBe(0);
+  });
+});

--- a/clients/web/src/domains/settings/components/low-balance-alert-card.test.tsx
+++ b/clients/web/src/domains/settings/components/low-balance-alert-card.test.tsx
@@ -84,7 +84,9 @@ describe("LowBalanceAlertCard", () => {
     fireEvent.click(getByTestId("low-balance-alert-save-button"));
 
     await waitFor(() => {
-      if (updateCalls.length === 0) throw new Error("PUT not called");
+      if (updateCalls.length === 0) {
+        throw new Error("PUT not called");
+      }
     });
     expect(updateCalls[0]!.body).toEqual({ threshold_usd: "50.00" });
   });
@@ -94,7 +96,9 @@ describe("LowBalanceAlertCard", () => {
     fireEvent.click(getByTestId("low-balance-alert-reset-button"));
 
     await waitFor(() => {
-      if (updateCalls.length === 0) throw new Error("PUT not called");
+      if (updateCalls.length === 0) {
+        throw new Error("PUT not called");
+      }
     });
     expect(updateCalls[0]!.body).toEqual({ threshold_usd: null });
   });

--- a/clients/web/src/domains/settings/components/low-balance-alert-card.tsx
+++ b/clients/web/src/domains/settings/components/low-balance-alert-card.tsx
@@ -1,0 +1,181 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState, type ChangeEvent } from "react";
+
+import {
+    organizationsBillingLowBalanceAlertRetrieveOptions,
+    organizationsBillingLowBalanceAlertRetrieveQueryKey,
+    organizationsBillingLowBalanceAlertRetrieveSetQueryData,
+    organizationsBillingLowBalanceAlertUpdateMutation,
+} from "@/generated/api/@tanstack/react-query.gen";
+import { Button } from "@vellumai/design-library/components/button";
+import { Input } from "@vellumai/design-library/components/input";
+import { Notice } from "@vellumai/design-library/components/notice";
+
+/** Format a USD decimal string ("5.00") as "$5.00" for display copy. */
+function formatUsd(value: string): string {
+  const n = parseFloat(value);
+  return Number.isFinite(n) ? `$${n.toFixed(2)}` : `$${value}`;
+}
+
+/**
+ * Validate the threshold input against the same bounds the backend enforces
+ * ($1..$1000, two decimal places). Exported so unit tests can exercise it
+ * without rendering the card. Empty string is valid here — it means "clear
+ * the override" and is sent to the API as `null`.
+ */
+export function validateThreshold(raw: string): string | undefined {
+  if (raw.trim() === "") return undefined;
+  const n = parseFloat(raw);
+  if (!Number.isFinite(n) || n < 1 || n > 1000) {
+    return "Must be between $1 and $1,000";
+  }
+  // Reject more than two decimal places (backend requires exactly two; we
+  // pad on save, but can't silently round away cents the user typed).
+  if (!/^\d+(\.\d{1,2})?$/.test(raw.trim())) {
+    return "Use at most two decimal places";
+  }
+  return undefined;
+}
+
+/**
+ * Settings → Billing low-balance alert control. Embedded directly inside the
+ * Credit Balance card by `BillingPanel.tsx` (under a divider, after the
+ * auto-reload section). A single always-visible input sets "alert me when my
+ * balance drops below $X"; clearing it (or Reset to default) reverts to the
+ * global default threshold.
+ */
+export function LowBalanceAlertCard() {
+  const queryClient = useQueryClient();
+  const alertQuery = useQuery(
+    organizationsBillingLowBalanceAlertRetrieveOptions(),
+  );
+  const updateMutation = useMutation(
+    organizationsBillingLowBalanceAlertUpdateMutation(),
+  );
+
+  // `undefined` means "not yet edited" — seed from the query below once it
+  // loads. Tracking the edited value separately keeps the input controlled
+  // without an effect that copies server state into local state.
+  const [draft, setDraft] = useState<string | null>(null);
+  const [touched, setTouched] = useState(false);
+
+  if (alertQuery.isLoading) {
+    return (
+      <div data-testid="low-balance-alert-card">
+        <p className="text-body-medium-lighter text-[var(--content-tertiary)]">
+          Loading…
+        </p>
+      </div>
+    );
+  }
+  if (alertQuery.isError || !alertQuery.data) {
+    return (
+      <div data-testid="low-balance-alert-card">
+        <Notice tone="error">Failed to load low-balance alert settings.</Notice>
+      </div>
+    );
+  }
+
+  const config = alertQuery.data;
+  // `draft === null` → user hasn't edited; show the current override (or empty
+  // when unset so the placeholder/default copy shows through).
+  const value = draft ?? (config.threshold_usd ?? "");
+  const clientError = validateThreshold(value);
+
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setDraft(e.target.value);
+  };
+
+  const persist = (threshold_usd: string | null) => {
+    updateMutation.mutate(
+      { body: { threshold_usd } },
+      {
+        onSuccess: (data) => {
+          organizationsBillingLowBalanceAlertRetrieveSetQueryData(
+            queryClient,
+            undefined,
+            data,
+          );
+          void queryClient.invalidateQueries({
+            queryKey: organizationsBillingLowBalanceAlertRetrieveQueryKey(),
+          });
+          setDraft(null);
+          setTouched(false);
+        },
+      },
+    );
+  };
+
+  const handleSave = () => {
+    setTouched(true);
+    if (clientError) return;
+    // Empty input clears the override (revert to the global default).
+    const trimmed = value.trim();
+    persist(trimmed === "" ? null : parseFloat(trimmed).toFixed(2));
+  };
+
+  const handleReset = () => {
+    setDraft("");
+    setTouched(false);
+    persist(null);
+  };
+
+  const showGenericError = updateMutation.isError;
+  const visibleError = touched ? clientError : undefined;
+
+  return (
+    <div data-testid="low-balance-alert-card">
+      <div className="flex flex-wrap items-start gap-3">
+        <div className="min-w-[12rem] flex-1">
+          <Input
+            type="number"
+            step="0.01"
+            label="Alert me when my balance drops below"
+            helperText={`Default is ${formatUsd(config.default_threshold_usd)} when unset`}
+            placeholder={config.effective_threshold_usd}
+            value={value}
+            onChange={onChange}
+            onBlur={() => setTouched(true)}
+            errorText={visibleError}
+            data-testid="low-balance-alert-input"
+            fullWidth
+          />
+        </div>
+        {/*
+         * `pt-[18px]` aligns the buttons with the input box (12px label +
+         * 6px gap before the input starts), matching AutoTopUpForm's row.
+         */}
+        <div className="flex shrink-0 items-center gap-2 pt-[18px]">
+          {config.threshold_usd != null && (
+            <Button
+              variant="outlined"
+              onClick={handleReset}
+              disabled={updateMutation.isPending}
+              data-testid="low-balance-alert-reset-button"
+            >
+              Reset to default
+            </Button>
+          )}
+          <Button
+            variant="primary"
+            onClick={handleSave}
+            disabled={updateMutation.isPending}
+            data-testid="low-balance-alert-save-button"
+          >
+            Save
+          </Button>
+        </div>
+      </div>
+
+      {showGenericError && (
+        <Notice
+          tone="error"
+          className="mt-4"
+          data-testid="low-balance-alert-update-error"
+        >
+          Failed to save low-balance alert. Please try again.
+        </Notice>
+      )}
+    </div>
+  );
+}

--- a/clients/web/src/domains/settings/components/low-balance-alert-card.tsx
+++ b/clients/web/src/domains/settings/components/low-balance-alert-card.tsx
@@ -24,7 +24,9 @@ function formatUsd(value: string): string {
  * the override" and is sent to the API as `null`.
  */
 export function validateThreshold(raw: string): string | undefined {
-  if (raw.trim() === "") return undefined;
+  if (raw.trim() === "") {
+    return undefined;
+  }
   const n = parseFloat(raw);
   if (!Number.isFinite(n) || n < 1 || n > 1000) {
     return "Must be between $1 and $1,000";
@@ -108,7 +110,9 @@ export function LowBalanceAlertCard() {
 
   const handleSave = () => {
     setTouched(true);
-    if (clientError) return;
+    if (clientError) {
+      return;
+    }
     // Empty input clears the override (revert to the global default).
     const trimmed = value.trim();
     persist(trimmed === "" ? null : parseFloat(trimmed).toFixed(2));


### PR DESCRIPTION
## What

Adds an always-visible control on the Billing → **Credit Balance** card so a user can set *"alert me when my balance drops below \$X."* This drives the low-balance warning email threshold, independent of auto-top-up (it matters most for users without auto-reload).

Backs onto the platform endpoint added in vellum-assistant-platform#8854:
`GET`/`PUT /v1/organizations/billing/low-balance-alert/` → `{ threshold_usd, effective_threshold_usd, default_threshold_usd }`.

## Changes

- **`low-balance-alert-card.tsx`** — new card, modeled on `AutoTopUpCard` but with a single field:
  - `useQuery(organizationsBillingLowBalanceAlertRetrieveOptions())` to read the current override.
  - One `<Input type="number">` prefilled with `threshold_usd`; placeholder from `effective_threshold_usd`, helper `"Default is $5.00 when unset"` from `default_threshold_usd`.
  - Save → `useMutation(organizationsBillingLowBalanceAlertUpdateMutation())` with `.mutate({ body: { threshold_usd } })`; on success does the optimistic `...SetQueryData` + `invalidateQueries` pattern.
  - **Reset to default** (shown only when an override exists) and clearing the input both PUT `threshold_usd: null`.
  - Client-side bounds validation (\$1–\$1000, ≤2 decimals) with an inline error, mirroring `validateAutoTopUpValues`; two-decimal normalization at the API boundary.
- **`billing-panel.tsx`** — renders `<LowBalanceAlertCard />` under a divider after `<AutoTopUpCard />`.
- **`low-balance-alert-card.test.tsx`** — covers: renders current override, saves a new value (PUT body assertion), clears via `null` (Reset to default), and shows a validation error for out-of-bounds input.

The OpenAPI schema + generated client for this endpoint already landed on `main` via the automated platform sync (#37159), so this PR is the UI only.

## Notes

- Single always-visible field, so — unlike `AutoTopUpCard` — there's no separate form component or view/form mode; it's one file.
- The `curly` lint warnings are the repo-wide house style (present on the neighboring `auto-top-up-card` / `billing-panel` too), not new to this change.

## Test plan

- `bunx tsc --noEmit` — clean
- `bun test src/domains/settings/components/low-balance-alert-card.test.tsx` — 4 pass
- `eslint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->