### PR TITLE
feat(web): live-voice client support for mode negotiation and multi-turn frames

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
@@ -143,7 +143,7 @@ function makeClient(connectTimeoutMs = 10_000) {
 /** Connect and return the underlying fake socket once constructed. */
 async function connectAndGetSocket(
   client: LiveVoiceChannelClientType,
-  args: { assistantId: string; conversationId?: string } = {
+  args: Parameters<LiveVoiceChannelClientType["connect"]>[0] = {
     assistantId: "assistant-1",
   },
 ): Promise<FakeWebSocket> {
@@ -214,6 +214,19 @@ describe("connect", () => {
     });
   });
 
+  test("includes mode in the start frame when provided", async () => {
+    const ws = await connectAndGetSocket(makeClient(), {
+      assistantId: "assistant-1",
+      mode: "open-mic",
+    });
+    ws.open();
+    expect(ws.sentJson[0]).toEqual({
+      type: "start",
+      audio: { mimeType: "audio/pcm", sampleRate: 16000, channels: 1 },
+      mode: "open-mic",
+    });
+  });
+
   test("emits error when token minting fails", async () => {
     mintResult = Promise.reject(new Error("mint boom"));
     const client = makeClient();
@@ -272,6 +285,8 @@ describe("server frame dispatch", () => {
     };
     client.on("sttPartial", record("sttPartial"));
     client.on("sttFinal", record("sttFinal"));
+    client.on("turnBoundary", record("turnBoundary"));
+    client.on("interrupted", record("interrupted"));
     client.on("thinking", record("thinking"));
     client.on("assistantTextDelta", record("assistantTextDelta"));
     client.on("ttsAudio", record("ttsAudio"));
@@ -281,6 +296,8 @@ describe("server frame dispatch", () => {
 
     ws.receive({ type: "stt_partial", seq: 2, text: "hel" });
     ws.receive({ type: "stt_final", seq: 3, text: "hello" });
+    ws.receive({ type: "turn_boundary", seq: 10 });
+    ws.receive({ type: "interrupted", seq: 11, turnId: "t1" });
     ws.receive({ type: "thinking", seq: 4, turnId: "t1" });
     ws.receive({ type: "assistant_text_delta", seq: 5, text: "hi" });
     ws.receive({
@@ -309,6 +326,10 @@ describe("server frame dispatch", () => {
 
     expect(got.sttPartial).toEqual([{ type: "stt_partial", seq: 2, text: "hel" }]);
     expect(got.sttFinal).toEqual([{ type: "stt_final", seq: 3, text: "hello" }]);
+    expect(got.turnBoundary).toEqual([{ type: "turn_boundary", seq: 10 }]);
+    expect(got.interrupted).toEqual([
+      { type: "interrupted", seq: 11, turnId: "t1" },
+    ]);
     expect(got.thinking).toEqual([{ type: "thinking", seq: 4, turnId: "t1" }]);
     expect(got.assistantTextDelta).toEqual([
       { type: "assistant_text_delta", seq: 5, text: "hi" },

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
@@ -27,11 +27,14 @@ import {
   type LiveVoiceBusyServerFrame,
   type LiveVoiceClientStartFrame,
   LIVE_VOICE_AUDIO_FORMAT,
+  type LiveVoiceInterruptedServerFrame,
   type LiveVoiceMetricsServerFrame,
   type LiveVoiceReadyServerFrame,
+  type LiveVoiceSessionMode,
   type LiveVoiceSttFinalServerFrame,
   type LiveVoiceSttPartialServerFrame,
   type LiveVoiceThinkingServerFrame,
+  type LiveVoiceTurnBoundaryServerFrame,
   type LiveVoiceTtsAudioServerFrame,
   type LiveVoiceTtsDoneServerFrame,
   parseServerFrame,
@@ -62,6 +65,8 @@ export interface LiveVoiceClientEventMap {
   ready: LiveVoiceReadyServerFrame;
   sttPartial: LiveVoiceSttPartialServerFrame;
   sttFinal: LiveVoiceSttFinalServerFrame;
+  turnBoundary: LiveVoiceTurnBoundaryServerFrame;
+  interrupted: LiveVoiceInterruptedServerFrame;
   thinking: LiveVoiceThinkingServerFrame;
   assistantTextDelta: LiveVoiceAssistantTextDeltaServerFrame;
   ttsAudio: LiveVoiceTtsAudioServerFrame;
@@ -84,6 +89,11 @@ export interface LiveVoiceConnectArgs {
   assistantId: string;
   /** Optional conversation to attach the session to. */
   conversationId?: string;
+  /**
+   * Optional session mode sent in the `start` frame. Omitted for servers that
+   * predate mode negotiation (they default to PTT).
+   */
+  mode?: LiveVoiceSessionMode;
 }
 
 /** Factory so tests can inject a mock WebSocket. Defaults to the global. */
@@ -110,6 +120,7 @@ export class LiveVoiceChannelClient {
   private ws: WebSocket | null = null;
   private connectTimeout: ReturnType<typeof setTimeout> | null = null;
   private conversationId: string | undefined;
+  private mode: LiveVoiceSessionMode | undefined;
 
   private readonly listeners: {
     [E in LiveVoiceClientEventName]: Set<LiveVoiceClientEventHandler<E>>;
@@ -117,6 +128,8 @@ export class LiveVoiceChannelClient {
     ready: new Set(),
     sttPartial: new Set(),
     sttFinal: new Set(),
+    turnBoundary: new Set(),
+    interrupted: new Set(),
     thinking: new Set(),
     assistantTextDelta: new Set(),
     ttsAudio: new Set(),
@@ -165,10 +178,12 @@ export class LiveVoiceChannelClient {
   async connect({
     assistantId,
     conversationId,
+    mode,
   }: LiveVoiceConnectArgs): Promise<void> {
     if (this.state !== "idle") return;
     this.state = "connecting";
     this.conversationId = conversationId;
+    this.mode = mode;
 
     let url: string;
     try {
@@ -249,6 +264,7 @@ export class LiveVoiceChannelClient {
       type: "start",
       audio: LIVE_VOICE_AUDIO_FORMAT,
       ...(this.conversationId ? { conversationId: this.conversationId } : {}),
+      ...(this.mode ? { mode: this.mode } : {}),
     };
     this.trySend(JSON.stringify(startFrame));
   }
@@ -277,6 +293,12 @@ export class LiveVoiceChannelClient {
         return;
       case "stt_final":
         this.emit("sttFinal", frame);
+        return;
+      case "turn_boundary":
+        this.emit("turnBoundary", frame);
+        return;
+      case "interrupted":
+        this.emit("interrupted", frame);
         return;
       case "thinking":
         this.emit("thinking", frame);

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.test.ts
@@ -11,6 +11,8 @@ describe("parseServerFrame", () => {
     { type: "busy", seq: 2, activeSessionId: "s9" },
     { type: "stt_partial", seq: 3, text: "hel" },
     { type: "stt_final", seq: 4, text: "hello" },
+    { type: "turn_boundary", seq: 12 },
+    { type: "interrupted", seq: 13, turnId: "t1" },
     { type: "thinking", seq: 5, turnId: "t1" },
     { type: "assistant_text_delta", seq: 6, text: "hi" },
     {

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.ts
@@ -43,10 +43,15 @@ export const LIVE_VOICE_AUDIO_FORMAT: LiveVoiceAudioConfig = {
   channels: 1,
 };
 
+const _LIVE_VOICE_SESSION_MODES = ["ptt", "open-mic"] as const;
+
+export type LiveVoiceSessionMode = (typeof _LIVE_VOICE_SESSION_MODES)[number];
+
 export interface LiveVoiceClientStartFrame {
   readonly type: "start";
   readonly conversationId?: string;
   readonly audio: LiveVoiceAudioConfig;
+  readonly mode?: LiveVoiceSessionMode;
 }
 
 export interface LiveVoiceClientPttReleaseFrame {
@@ -76,6 +81,8 @@ const LIVE_VOICE_SERVER_FRAME_TYPES = [
   "busy",
   "stt_partial",
   "stt_final",
+  "turn_boundary",
+  "interrupted",
   "thinking",
   "assistant_text_delta",
   "tts_audio",
@@ -111,6 +118,24 @@ export interface LiveVoiceSttPartialServerFrame extends LiveVoiceServerFrameBase
 export interface LiveVoiceSttFinalServerFrame extends LiveVoiceServerFrameBase {
   readonly type: "stt_final";
   readonly text: string;
+}
+
+/**
+ * Server-detected end of user speech; the assistant turn is starting.
+ * Emitted in both modes: in PTT it follows `ptt_release`/final transcript,
+ * in open-mic it is the primary turn signal.
+ */
+export interface LiveVoiceTurnBoundaryServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "turn_boundary";
+}
+
+/**
+ * Barge-in (server-VAD or client `interrupt` frame) was accepted for the
+ * given assistant turn; playback must flush and the session keeps listening.
+ */
+export interface LiveVoiceInterruptedServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "interrupted";
+  readonly turnId: string;
 }
 
 export interface LiveVoiceThinkingServerFrame extends LiveVoiceServerFrameBase {
@@ -170,6 +195,8 @@ export type LiveVoiceServerFrame =
   | LiveVoiceBusyServerFrame
   | LiveVoiceSttPartialServerFrame
   | LiveVoiceSttFinalServerFrame
+  | LiveVoiceTurnBoundaryServerFrame
+  | LiveVoiceInterruptedServerFrame
   | LiveVoiceThinkingServerFrame
   | LiveVoiceAssistantTextDeltaServerFrame
   | LiveVoiceTtsAudioServerFrame


### PR DESCRIPTION
## Summary
- Client protocol port of the server v2 frames: optional mode on start, turn_boundary, interrupted (shapes verified against assistant/src/live-voice/protocol.ts)
- LiveVoiceChannelClient: mode in connect args, turnBoundary/interrupted events dispatched

Part of plan: voice-mode-engine.md (PR 10 of 12)