### PR TITLE
feat(live-voice): CallTransport implementation streaming TTS over the session socket

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-segments.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-segments.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  extractSpeakableSegments,
+  findSpeakableBoundary,
+  LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD,
+} from "../live-voice-segments.js";
+
+describe("extractSpeakableSegments", () => {
+  test("extracts a sentence at a punctuation boundary and keeps the remainder", () => {
+    const { segments, remainder } = extractSpeakableSegments(
+      "Hello there. Still stream",
+      false,
+    );
+
+    expect(segments).toEqual(["Hello there."]);
+    expect(remainder).toBe(" Still stream");
+  });
+
+  test("extracts multiple complete sentences in order", () => {
+    const { segments, remainder } = extractSpeakableSegments(
+      "First one. Second one! Third one? tail",
+      false,
+    );
+
+    expect(segments).toEqual(["First one.", "Second one!", "Third one?"]);
+    expect(remainder).toBe(" tail");
+  });
+
+  test("splits at newlines even without sentence punctuation", () => {
+    const { segments, remainder } = extractSpeakableSegments(
+      "line one\nline two",
+      false,
+    );
+
+    expect(segments).toEqual(["line one"]);
+    expect(remainder).toBe("line two");
+  });
+
+  test("includes trailing quote punctuation in the segment", () => {
+    const { segments, remainder } = extractSpeakableSegments(
+      'She said "stop." Then left',
+      false,
+    );
+
+    expect(segments).toEqual(['She said "stop."']);
+    expect(remainder).toBe(" Then left");
+  });
+
+  test("does not split on punctuation inside a word", () => {
+    const { segments, remainder } = extractSpeakableSegments(
+      "pi is 3.14159 give or take",
+      false,
+    );
+
+    expect(segments).toEqual([]);
+    expect(remainder).toBe("pi is 3.14159 give or take");
+  });
+
+  test("buffers short text without a boundary", () => {
+    const { segments, remainder } = extractSpeakableSegments(
+      "Still listening",
+      false,
+    );
+
+    expect(segments).toEqual([]);
+    expect(remainder).toBe("Still listening");
+  });
+
+  test("force flush emits the trimmed remainder as a final segment", () => {
+    const { segments, remainder } = extractSpeakableSegments(
+      "Hello there. Still listening ",
+      true,
+    );
+
+    expect(segments).toEqual(["Hello there.", "Still listening"]);
+    expect(remainder).toBe("");
+  });
+
+  test("force flush of whitespace-only text yields no segments", () => {
+    const { segments, remainder } = extractSpeakableSegments("   \n  ", true);
+
+    expect(segments).toEqual([]);
+    expect(remainder).toBe("");
+  });
+
+  test("splits long unpunctuated text conservatively at a whitespace boundary", () => {
+    const text = "steady ".repeat(32);
+    const { segments, remainder } = extractSpeakableSegments(text, false);
+
+    expect(segments).toHaveLength(1);
+    const segment = segments[0] ?? "";
+    expect(segment.length).toBeGreaterThan(100);
+    expect(segment.length).toBeLessThanOrEqual(
+      LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD + 1,
+    );
+    expect(segment.endsWith("steady")).toBe(true);
+    expect(text.startsWith(segment)).toBe(true);
+    expect(remainder.length).toBeGreaterThan(0);
+  });
+
+  test("splits long text without whitespace at the hard threshold", () => {
+    const text = "x".repeat(LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD + 40);
+    const { segments, remainder } = extractSpeakableSegments(text, false);
+
+    expect(segments).toEqual([
+      "x".repeat(LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD),
+    ]);
+    expect(remainder).toBe("x".repeat(40));
+  });
+});
+
+describe("findSpeakableBoundary", () => {
+  test("returns the index just past sentence punctuation at end of text", () => {
+    expect(findSpeakableBoundary("Done.")).toBe(5);
+  });
+
+  test("returns the index just past punctuation followed by whitespace", () => {
+    expect(findSpeakableBoundary("Done. More")).toBe(5);
+  });
+
+  test("extends past trailing bracket punctuation", () => {
+    expect(findSpeakableBoundary("(Done.) More")).toBe(7);
+  });
+
+  test("returns null for short text without a boundary", () => {
+    expect(findSpeakableBoundary("no boundary here")).toBeNull();
+  });
+
+  test("returns the newline boundary before later punctuation", () => {
+    expect(findSpeakableBoundary("ab\ncd.")).toBe(3);
+  });
+});

--- a/assistant/src/live-voice/__tests__/live-voice-transport.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-transport.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type { LiveVoiceTtsStreamer } from "../live-voice-session.js";
+import { LiveVoiceCallTransport } from "../live-voice-transport.js";
+import type {
+  LiveVoiceTtsAudioChunk,
+  LiveVoiceTtsOptions,
+  LiveVoiceTtsResult,
+} from "../live-voice-tts.js";
+import type { LiveVoiceServerFramePayload } from "../protocol.js";
+
+function makeTtsChunk(
+  text: string,
+  contentType = "audio/pcm",
+): LiveVoiceTtsAudioChunk {
+  return {
+    type: "tts_audio",
+    contentType,
+    sampleRate: 24_000,
+    dataBase64: Buffer.from(text).toString("base64"),
+  };
+}
+
+function makeTtsResult(
+  text: string,
+  contentType = "audio/pcm",
+): LiveVoiceTtsResult {
+  return {
+    provider: "fish-audio",
+    contentType,
+    sampleRate: 24_000,
+    chunks: 1,
+    bytes: Buffer.byteLength(text),
+  };
+}
+
+function createEchoStreamer(ttsTexts: string[]): LiveVoiceTtsStreamer {
+  return mock(async (options: LiveVoiceTtsOptions) => {
+    ttsTexts.push(options.text);
+    options.onAudioChunk(makeTtsChunk(`audio:${options.text}`));
+    return makeTtsResult(options.text);
+  });
+}
+
+function createHarness(streamTtsAudio: LiveVoiceTtsStreamer) {
+  const frames: LiveVoiceServerFramePayload[] = [];
+  const sendFrame = mock(async (payload: LiveVoiceServerFramePayload) => {
+    frames.push(payload);
+  });
+  const onSessionEnd = mock((_reason?: string) => {});
+  const transport = new LiveVoiceCallTransport({
+    sendFrame,
+    streamTtsAudio,
+    sampleRate: 24_000,
+    turnId: () => "turn-1",
+    onSessionEnd,
+  });
+
+  return { frames, onSessionEnd, sendFrame, transport };
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message = "Timed out waiting for live voice transport test condition",
+): Promise<void> {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(message);
+}
+
+async function flushAsyncCallbacks(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("LiveVoiceCallTransport", () => {
+  test("streams token segments as ordered tts_audio frames ending in tts_done", async () => {
+    const ttsTexts: string[] = [];
+    const { frames, transport } = createHarness(createEchoStreamer(ttsTexts));
+
+    transport.sendTextToken("Hello ", false);
+    transport.sendTextToken("there. And", false);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
+    expect(frames.some((frame) => frame.type === "tts_done")).toBe(false);
+
+    transport.sendTextToken(" more", true);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(ttsTexts).toEqual(["Hello there.", "And more"]);
+    expect(frames.map((frame) => frame.type)).toEqual([
+      "tts_audio",
+      "tts_audio",
+      "tts_done",
+    ]);
+    expect(frames[0]).toMatchObject({
+      type: "tts_audio",
+      mimeType: "audio/pcm",
+      sampleRate: 24_000,
+      dataBase64: Buffer.from("audio:Hello there.").toString("base64"),
+    });
+    expect(frames[1]).toMatchObject({
+      dataBase64: Buffer.from("audio:And more").toString("base64"),
+    });
+    expect(frames.at(-1)).toEqual({ type: "tts_done", turnId: "turn-1" });
+  });
+
+  test("forwards non-PCM TTS chunk content type unchanged", async () => {
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk("wav audio", "audio/wav"));
+      return makeTtsResult("wav audio", "audio/wav");
+    });
+    const { frames, transport } = createHarness(streamTtsAudio);
+
+    transport.sendTextToken("Hello there.", true);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
+
+    expect(frames.find((frame) => frame.type === "tts_audio")).toMatchObject({
+      mimeType: "audio/wav",
+      dataBase64: Buffer.from("wav audio").toString("base64"),
+    });
+  });
+
+  test("synthesizes segments serially, not concurrently", async () => {
+    const started: string[] = [];
+    const resolvers: Array<(result: LiveVoiceTtsResult) => void> = [];
+    const streamTtsAudio = mock(
+      (options: LiveVoiceTtsOptions) =>
+        new Promise<LiveVoiceTtsResult>((resolve) => {
+          started.push(options.text);
+          resolvers.push(resolve);
+        }),
+    );
+    const { frames, transport } = createHarness(streamTtsAudio);
+
+    transport.sendTextToken("One. Two.", true);
+    await waitFor(() => started.length === 1);
+    await flushAsyncCallbacks();
+
+    expect(started).toEqual(["One."]);
+
+    resolvers[0]?.(makeTtsResult("One."));
+    await waitFor(() => started.length === 2);
+    expect(started).toEqual(["One.", "Two."]);
+
+    resolvers[1]?.(makeTtsResult("Two."));
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+  });
+
+  test("fires the armed audio-start callback exactly once on the first chunk", async () => {
+    const ttsTexts: string[] = [];
+    const { frames, transport } = createHarness(createEchoStreamer(ttsTexts));
+    const audioStart = mock(() => {});
+    transport.setAudioStartCallback(audioStart);
+
+    transport.sendTextToken("First one. Second one.", true);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(
+      frames.filter((frame) => frame.type === "tts_audio").length,
+    ).toBeGreaterThan(1);
+    expect(audioStart).toHaveBeenCalledTimes(1);
+  });
+
+  test("re-arming the audio-start callback fires it for the next turn's audio", async () => {
+    const ttsTexts: string[] = [];
+    const { frames, transport } = createHarness(createEchoStreamer(ttsTexts));
+    const firstTurnAudioStart = mock(() => {});
+    transport.setAudioStartCallback(firstTurnAudioStart);
+
+    transport.sendTextToken("Turn one.", true);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    expect(firstTurnAudioStart).toHaveBeenCalledTimes(1);
+
+    const secondTurnAudioStart = mock(() => {});
+    transport.setAudioStartCallback(secondTurnAudioStart);
+    transport.sendTextToken("Turn two.", true);
+    await waitFor(
+      () => frames.filter((frame) => frame.type === "tts_done").length === 2,
+    );
+
+    expect(firstTurnAudioStart).toHaveBeenCalledTimes(1);
+    expect(secondTurnAudioStart).toHaveBeenCalledTimes(1);
+  });
+
+  test("passing null disarms the audio-start callback", async () => {
+    const ttsTexts: string[] = [];
+    const { frames, transport } = createHarness(createEchoStreamer(ttsTexts));
+    const audioStart = mock(() => {});
+    transport.setAudioStartCallback(audioStart);
+    transport.setAudioStartCallback(null);
+
+    transport.sendTextToken("Hello there.", true);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(audioStart).not.toHaveBeenCalled();
+  });
+
+  test("discardPendingText aborts in-flight synthesis and drops queued segments", async () => {
+    let activeOptions: LiveVoiceTtsOptions | undefined;
+    let resolveActive: ((result: LiveVoiceTtsResult) => void) | undefined;
+    const streamTtsAudio = mock(
+      (options: LiveVoiceTtsOptions) =>
+        new Promise<LiveVoiceTtsResult>((resolve) => {
+          activeOptions = options;
+          resolveActive = resolve;
+        }),
+    );
+    const { frames, transport } = createHarness(streamTtsAudio);
+    const audioStart = mock(() => {});
+    transport.setAudioStartCallback(audioStart);
+
+    transport.sendTextToken("One. Two.", false);
+    transport.sendTextToken(" buffered tail", false);
+    await waitFor(() => activeOptions !== undefined);
+
+    transport.discardPendingText();
+
+    expect(activeOptions?.signal?.aborted).toBe(true);
+    activeOptions?.onAudioChunk(makeTtsChunk("late audio"));
+    resolveActive?.(makeTtsResult("late audio"));
+    await flushAsyncCallbacks();
+
+    expect(streamTtsAudio).toHaveBeenCalledTimes(1);
+    expect(frames).toEqual([]);
+    expect(audioStart).not.toHaveBeenCalled();
+    expect(transport.collectAssistantAudio()).toEqual([]);
+
+    // The queue stays usable: a later end-of-turn signal only emits
+    // tts_done — the discarded buffered tail never synthesizes.
+    transport.sendTextToken("", true);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    expect(streamTtsAudio).toHaveBeenCalledTimes(1);
+    expect(frames).toEqual([{ type: "tts_done", turnId: "turn-1" }]);
+  });
+
+  test("empty end-of-turn token emits only tts_done", async () => {
+    const ttsTexts: string[] = [];
+    const streamTtsAudio = createEchoStreamer(ttsTexts);
+    const { frames, transport } = createHarness(streamTtsAudio);
+
+    transport.sendTextToken("", true);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(streamTtsAudio).not.toHaveBeenCalled();
+    expect(frames).toEqual([{ type: "tts_done", turnId: "turn-1" }]);
+  });
+
+  test("TTS failure emits an error frame and still reaches tts_done", async () => {
+    const streamTtsAudio = mock(async () => {
+      throw new Error("provider unavailable");
+    });
+    const { frames, transport } = createHarness(streamTtsAudio);
+
+    transport.sendTextToken("This fails.", true);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(frames.find((frame) => frame.type === "error")).toMatchObject({
+      type: "error",
+      message: expect.stringContaining("provider unavailable"),
+    });
+    expect(frames.at(-1)).toEqual({ type: "tts_done", turnId: "turn-1" });
+  });
+
+  test("collectAssistantAudio returns emitted chunks once and resets", async () => {
+    const ttsTexts: string[] = [];
+    const { frames, transport } = createHarness(createEchoStreamer(ttsTexts));
+
+    transport.sendTextToken("First one. Second one.", true);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    const collected = transport.collectAssistantAudio();
+    expect(collected.map((chunk) => chunk.toString())).toEqual([
+      "audio:First one.",
+      "audio:Second one.",
+    ]);
+    expect(transport.collectAssistantAudio()).toEqual([]);
+  });
+
+  test("endSession invokes onSessionEnd with the reason", () => {
+    const { onSessionEnd, transport } = createHarness(createEchoStreamer([]));
+
+    transport.endSession("Maximum call duration reached");
+
+    expect(onSessionEnd).toHaveBeenCalledTimes(1);
+    expect(onSessionEnd).toHaveBeenCalledWith("Maximum call duration reached");
+  });
+
+  test("sendPlayUrl is a no-op that does not throw", () => {
+    const { frames, transport } = createHarness(createEchoStreamer([]));
+
+    expect(() => {
+      transport.sendPlayUrl("https://example.com/audio.wav");
+    }).not.toThrow();
+    expect(frames).toEqual([]);
+  });
+});

--- a/assistant/src/live-voice/live-voice-segments.ts
+++ b/assistant/src/live-voice/live-voice-segments.ts
@@ -1,0 +1,104 @@
+/**
+ * Speakable-segment extraction for streaming TTS.
+ *
+ * Incoming assistant text is buffered until a natural speech boundary
+ * (sentence-ending punctuation followed by whitespace, or a newline) is
+ * found, so TTS synthesis can start before the full message arrives
+ * without splitting mid-sentence. Buffers that grow past
+ * {@link LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD} without a natural
+ * boundary are split conservatively at a trailing whitespace position.
+ */
+
+export const LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD = 180;
+export const SENTENCE_ENDING_PUNCTUATION = new Set([".", "!", "?"]);
+const TRAILING_SENTENCE_PUNCTUATION = new Set(['"', "'", ")", "]"]);
+
+/**
+ * Split `text` into speakable segments plus an unconsumed remainder.
+ * When `force` is true the remainder is flushed as a final segment.
+ */
+export function extractSpeakableSegments(
+  text: string,
+  force: boolean,
+): { segments: string[]; remainder: string } {
+  const segments: string[] = [];
+  let remainder = text;
+
+  while (remainder.length > 0) {
+    const boundary = findSpeakableBoundary(remainder);
+    if (boundary === null) {
+      break;
+    }
+
+    const segment = remainder.slice(0, boundary).trim();
+    if (segment.length > 0) {
+      segments.push(segment);
+    }
+    remainder = remainder.slice(boundary);
+  }
+
+  if (force) {
+    const segment = remainder.trim();
+    if (segment.length > 0) {
+      segments.push(segment);
+    }
+    remainder = "";
+  }
+
+  return { segments, remainder };
+}
+
+/**
+ * Find the first index one past a speakable boundary in `text`, or null
+ * when no boundary exists yet and the text is still under the segment
+ * threshold.
+ */
+export function findSpeakableBoundary(text: string): number | null {
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (char === "\n") {
+      return index + 1;
+    }
+    if (!char || !SENTENCE_ENDING_PUNCTUATION.has(char)) {
+      continue;
+    }
+
+    let boundary = index + 1;
+    while (
+      boundary < text.length &&
+      TRAILING_SENTENCE_PUNCTUATION.has(text[boundary] ?? "")
+    ) {
+      boundary += 1;
+    }
+
+    if (boundary === text.length || isWhitespace(text[boundary] ?? "")) {
+      return boundary;
+    }
+  }
+
+  if (text.length < LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD) {
+    return null;
+  }
+
+  const preferredBoundary = findLastWhitespaceBoundary(
+    text,
+    LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD,
+  );
+  return preferredBoundary ?? LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD;
+}
+
+function findLastWhitespaceBoundary(
+  text: string,
+  maxLength: number,
+): number | null {
+  for (let index = maxLength; index > Math.floor(maxLength * 0.6); index -= 1) {
+    if (isWhitespace(text[index] ?? "")) {
+      return index + 1;
+    }
+  }
+  return null;
+}
+
+function isWhitespace(value: string): boolean {
+  return /\s/.test(value);
+}

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -24,6 +24,7 @@ import {
   LiveVoiceMetricsCollector,
   type LiveVoiceMetricsEvent,
 } from "./live-voice-metrics.js";
+import { extractSpeakableSegments } from "./live-voice-segments.js";
 import {
   type LiveVoiceSession as LiveVoiceSessionContract,
   type LiveVoiceSessionCloseReason,
@@ -48,10 +49,6 @@ type LiveVoiceSessionState =
   | "interrupted"
   | "failed"
   | "closed";
-
-const LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD = 180;
-const SENTENCE_ENDING_PUNCTUATION = new Set([".", "!", "?"]);
-const TRAILING_SENTENCE_PUNCTUATION = new Set(['"', "'", ")", "]"]);
 
 export type LiveVoiceStreamingTranscriberResolver = (
   options: ResolveStreamingTranscriberOptions,
@@ -1023,81 +1020,6 @@ async function defaultArchiveLiveVoiceAudio(
   return input.role === "user"
     ? linkLiveVoiceUserUtteranceAudioToMessage(input)
     : linkLiveVoiceAssistantResponseAudioToMessage(input);
-}
-
-function extractSpeakableSegments(
-  text: string,
-  force: boolean,
-): { segments: string[]; remainder: string } {
-  const segments: string[] = [];
-  let remainder = text;
-
-  while (remainder.length > 0) {
-    const boundary = findSpeakableBoundary(remainder);
-    if (boundary === null) break;
-
-    const segment = remainder.slice(0, boundary).trim();
-    if (segment.length > 0) {
-      segments.push(segment);
-    }
-    remainder = remainder.slice(boundary);
-  }
-
-  if (force) {
-    const segment = remainder.trim();
-    if (segment.length > 0) {
-      segments.push(segment);
-    }
-    remainder = "";
-  }
-
-  return { segments, remainder };
-}
-
-function findSpeakableBoundary(text: string): number | null {
-  for (let index = 0; index < text.length; index += 1) {
-    const char = text[index];
-    if (char === "\n") return index + 1;
-    if (!char || !SENTENCE_ENDING_PUNCTUATION.has(char)) continue;
-
-    let boundary = index + 1;
-    while (
-      boundary < text.length &&
-      TRAILING_SENTENCE_PUNCTUATION.has(text[boundary] ?? "")
-    ) {
-      boundary += 1;
-    }
-
-    if (boundary === text.length || isWhitespace(text[boundary] ?? "")) {
-      return boundary;
-    }
-  }
-
-  if (text.length < LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD) {
-    return null;
-  }
-
-  const preferredBoundary = findLastWhitespaceBoundary(
-    text,
-    LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD,
-  );
-  return preferredBoundary ?? LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD;
-}
-
-function findLastWhitespaceBoundary(
-  text: string,
-  maxLength: number,
-): number | null {
-  for (let index = maxLength; index > Math.floor(maxLength * 0.6); index -= 1) {
-    if (isWhitespace(text[index] ?? "")) {
-      return index + 1;
-    }
-  }
-  return null;
-}
-
-function isWhitespace(value: string): boolean {
-  return /\s/.test(value);
 }
 
 function takeBufferedAudio(chunks: Buffer[]): Buffer | null {

--- a/assistant/src/live-voice/live-voice-transport.ts
+++ b/assistant/src/live-voice/live-voice-transport.ts
@@ -1,0 +1,220 @@
+import { Buffer } from "node:buffer";
+
+import type { CallTransport } from "../calls/call-transport.js";
+import { getLogger } from "../util/logger.js";
+import { extractSpeakableSegments } from "./live-voice-segments.js";
+import type { LiveVoiceTtsStreamer } from "./live-voice-session.js";
+import {
+  LiveVoiceProtocolErrorCode,
+  type LiveVoiceServerFramePayload,
+} from "./protocol.js";
+
+const log = getLogger("live-voice-transport");
+
+export interface LiveVoiceCallTransportDeps {
+  /**
+   * Outbound frame sink. The session owns frame ordering (sequencer +
+   * serialized socket writes); the transport only guarantees it calls
+   * this in playback order.
+   */
+  sendFrame: (payload: LiveVoiceServerFramePayload) => Promise<unknown>;
+  streamTtsAudio: LiveVoiceTtsStreamer;
+  /** PCM sample rate requested from TTS and stamped on audio frames. */
+  sampleRate: number;
+  /** Returns the current assistant turn id, stamped on `tts_done`. */
+  turnId: () => string;
+  /** Invoked when the controller ends the session ([END_CALL], timers). */
+  onSessionEnd: (reason?: string) => void;
+}
+
+/**
+ * `CallTransport` implementation for in-app live-voice sessions.
+ *
+ * Consumes the call controller's token stream (`sendTextToken`), splits it
+ * into speakable segments, and runs streaming TTS per segment on a
+ * serialized queue — audio for segment N is fully emitted as `tts_audio`
+ * frames before segment N+1 synthesis starts. An end-of-turn token
+ * (`last: true`) force-flushes the remainder and emits `tts_done` after
+ * the queue drains.
+ *
+ * Barge-in: `discardPendingText()` drops buffered text and aborts the
+ * active and queued synthesis jobs so no further `tts_audio` frames from
+ * the aborted turn reach the socket.
+ */
+export class LiveVoiceCallTransport implements CallTransport {
+  private readonly deps: LiveVoiceCallTransportDeps;
+
+  /** Accumulated token text awaiting a speakable segment boundary. */
+  private textBuffer = "";
+
+  /** Serialized TTS job chain — one segment synthesizes at a time. */
+  private ttsQueue: Promise<void> = Promise.resolve();
+
+  /** Abort handles for the active + queued jobs, cleared on barge-in. */
+  private readonly pendingJobAborts = new Set<AbortController>();
+
+  /**
+   * One-shot audio-start signal armed by the call controller so it can
+   * flip to `speaking` when real audio goes out (see
+   * CallTransport.setAudioStartCallback). Fires on the first emitted
+   * chunk, then disarms; the controller re-arms it as it streams tokens.
+   */
+  private audioStartCallback: (() => void) | null = null;
+
+  /** Emitted assistant audio retained for per-turn archiving. */
+  private assistantAudioChunks: Buffer[] = [];
+
+  constructor(deps: LiveVoiceCallTransportDeps) {
+    this.deps = deps;
+  }
+
+  // ── CallTransport interface ─────────────────────────────────────────
+
+  sendTextToken(token: string, last: boolean): void {
+    this.textBuffer += token;
+
+    const { segments, remainder } = extractSpeakableSegments(
+      this.textBuffer,
+      last,
+    );
+    this.textBuffer = remainder;
+
+    for (const segment of segments) {
+      this.enqueueTtsSegment(segment);
+    }
+
+    if (last) {
+      this.enqueueTtsDone(this.deps.turnId());
+    }
+  }
+
+  sendPlayUrl(url: string): void {
+    // Unreachable under the token-stream speech strategy: live-voice
+    // sessions never resolve a synthesized-play TTS provider, so the
+    // controller only speaks via sendTextToken. Kept to satisfy the
+    // CallTransport interface.
+    log.warn({ url }, "Live voice transport ignoring unexpected play URL");
+  }
+
+  endSession(reason?: string): void {
+    this.deps.onSessionEnd(reason);
+  }
+
+  setAudioStartCallback(cb: (() => void) | null): void {
+    this.audioStartCallback = cb;
+  }
+
+  discardPendingText(): void {
+    this.textBuffer = "";
+    const aborts = [...this.pendingJobAborts];
+    this.pendingJobAborts.clear();
+    for (const abort of aborts) {
+      abort.abort();
+    }
+  }
+
+  // ── Session surface ─────────────────────────────────────────────────
+
+  /**
+   * Drain the assistant audio emitted since the previous call. The
+   * session consumes this once per turn for archiving.
+   */
+  collectAssistantAudio(): Buffer[] {
+    const chunks = this.assistantAudioChunks;
+    this.assistantAudioChunks = [];
+    return chunks;
+  }
+
+  // ── TTS queue ───────────────────────────────────────────────────────
+
+  private enqueueTtsSegment(segment: string): void {
+    const abort = this.registerJobAbort();
+    this.enqueueJob(async () => {
+      if (abort.signal.aborted) {
+        return;
+      }
+
+      try {
+        // sendFrame calls are chained so the job only completes after
+        // every chunk frame for this segment has been handed to the
+        // socket, keeping tts_done ordered behind the audio.
+        let frameChain: Promise<unknown> = Promise.resolve();
+        await this.deps.streamTtsAudio({
+          text: segment,
+          signal: abort.signal,
+          outputFormat: "pcm",
+          sampleRate: this.deps.sampleRate,
+          onAudioChunk: (chunk) => {
+            if (abort.signal.aborted) {
+              return;
+            }
+            this.assistantAudioChunks.push(
+              Buffer.from(chunk.dataBase64, "base64"),
+            );
+            this.fireAudioStartCallback();
+            frameChain = frameChain.then(() =>
+              this.deps.sendFrame({
+                type: "tts_audio",
+                mimeType: chunk.contentType,
+                sampleRate: chunk.sampleRate,
+                dataBase64: chunk.dataBase64,
+              }),
+            );
+          },
+        });
+        await frameChain;
+      } catch (err) {
+        if (abort.signal.aborted) {
+          return;
+        }
+        await this.deps.sendFrame({
+          type: "error",
+          code: LiveVoiceProtocolErrorCode.InvalidField,
+          message: `Live voice TTS failed: ${errorMessage(err)}`,
+        });
+      } finally {
+        this.pendingJobAborts.delete(abort);
+      }
+    });
+  }
+
+  private enqueueTtsDone(turnId: string): void {
+    const abort = this.registerJobAbort();
+    this.enqueueJob(async () => {
+      try {
+        if (abort.signal.aborted) {
+          return;
+        }
+        await this.deps.sendFrame({ type: "tts_done", turnId });
+      } finally {
+        this.pendingJobAborts.delete(abort);
+      }
+    });
+  }
+
+  private registerJobAbort(): AbortController {
+    const abort = new AbortController();
+    this.pendingJobAborts.add(abort);
+    return abort;
+  }
+
+  private enqueueJob(job: () => Promise<void>): void {
+    this.ttsQueue = this.ttsQueue.then(job).catch(() => {
+      // Job failures are reported as error frames inside the job;
+      // transport failures are owned by the session. Keep draining.
+    });
+  }
+
+  private fireAudioStartCallback(): void {
+    const callback = this.audioStartCallback;
+    if (!callback) {
+      return;
+    }
+    this.audioStartCallback = null;
+    callback();
+  }
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}


### PR DESCRIPTION
## Summary
- LiveVoiceCallTransport: CallController's token stream -> speakable segments -> serialized streaming TTS -> tts_audio/tts_done frames; barge-in flush via discardPendingText; audio-start signal for the speaking transition
- extractSpeakableSegments extracted to live-voice-segments.ts (shared with the V1 session until the duplex rewrite)

Part of plan: voice-mode-engine.md (PR 7 of 12)