### PR TITLE
feat(assistant): enable schedule worker and memory worker by default

### DIFF
--- a/assistant/src/__tests__/schedule-retry.test.ts
+++ b/assistant/src/__tests__/schedule-retry.test.ts
@@ -64,6 +64,7 @@ mock.module("../notifications/emit-signal.js", () => ({
     emitNotificationSignalImpl(payload),
 }));
 
+import { loadRawConfig, saveRawConfig } from "../config/loader.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { applyRetryDecision, decideRetry } from "../schedule/retry-policy.js";
@@ -103,6 +104,13 @@ function startScheduler(
 }
 
 await initializeDb();
+
+// The schedule worker is on by default, which stands the daemon's in-process
+// scheduler down. These tests exercise that in-process execution path directly,
+// so pin the worker flag off for this test process.
+const rawConfig = loadRawConfig();
+rawConfig.schedules = { worker: { enabled: false } };
+saveRawConfig(rawConfig);
 
 /** Access the underlying bun:sqlite Database for raw parameterized queries. */
 function getRawDb(): import("bun:sqlite").Database {

--- a/assistant/src/__tests__/scheduler-recurrence.test.ts
+++ b/assistant/src/__tests__/scheduler-recurrence.test.ts
@@ -69,6 +69,7 @@ mock.module("../notifications/emit-signal.js", () => ({
   },
 }));
 
+import { loadRawConfig, saveRawConfig } from "../config/loader.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import {
@@ -80,6 +81,13 @@ import { startScheduler } from "../schedule/scheduler.js";
 import { createTask } from "../tasks/task-store.js";
 
 await initializeDb();
+
+// The schedule worker is on by default, which stands the daemon's in-process
+// scheduler down. These tests exercise that in-process execution path directly,
+// so pin the worker flag off for this test process.
+const rawConfig = loadRawConfig();
+rawConfig.schedules = { worker: { enabled: false } };
+saveRawConfig(rawConfig);
 
 /** Access the underlying bun:sqlite Database for raw parameterized queries. */
 function getRawDb(): import("bun:sqlite").Database {

--- a/assistant/src/__tests__/scheduler-reuse-conversation.test.ts
+++ b/assistant/src/__tests__/scheduler-reuse-conversation.test.ts
@@ -104,6 +104,7 @@ mock.module("../daemon/process-message.js", () => ({
     processMessageImpl(conversationId, message),
 }));
 
+import { loadRawConfig, saveRawConfig } from "../config/loader.js";
 import { deleteConversation } from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
@@ -112,6 +113,13 @@ import { createSchedule, getScheduleRuns } from "../schedule/schedule-store.js";
 import { startScheduler } from "../schedule/scheduler.js";
 
 await initializeDb();
+
+// The schedule worker is on by default, which stands the daemon's in-process
+// scheduler down. These tests exercise that in-process execution path directly,
+// so pin the worker flag off for this test process.
+const rawConfig = loadRawConfig();
+rawConfig.schedules = { worker: { enabled: false } };
+saveRawConfig(rawConfig);
 
 /** Access the underlying bun:sqlite Database for raw parameterized queries. */
 function getRawDb(): import("bun:sqlite").Database {

--- a/assistant/src/__tests__/scheduler-wake.test.ts
+++ b/assistant/src/__tests__/scheduler-wake.test.ts
@@ -32,12 +32,20 @@ mock.module("../daemon/process-message.js", () => ({
   processMessage: mockProcessMessage,
 }));
 
+import { loadRawConfig, saveRawConfig } from "../config/loader.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { createSchedule } from "../schedule/schedule-store.js";
 import { startScheduler } from "../schedule/scheduler.js";
 
 await initializeDb();
+
+// The schedule worker is on by default, which stands the daemon's in-process
+// scheduler down. These tests exercise that in-process execution path directly,
+// so pin the worker flag off for this test process.
+const rawConfig = loadRawConfig();
+rawConfig.schedules = { worker: { enabled: false } };
+saveRawConfig(rawConfig);
 
 /** Access the underlying bun:sqlite Database for raw parameterized queries. */
 function getRawDb(): import("bun:sqlite").Database {

--- a/assistant/src/__tests__/task-scheduler.test.ts
+++ b/assistant/src/__tests__/task-scheduler.test.ts
@@ -102,6 +102,7 @@ mock.module("../daemon/process-message.js", () => ({
   ) => processMessageImpl(conversationId, message, options),
 }));
 
+import { loadRawConfig, saveRawConfig } from "../config/loader.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { recordUsageEvent } from "../persistence/llm-usage-store.js";
@@ -120,6 +121,13 @@ import { scheduleTask } from "../tasks/task-scheduler.js";
 import { createTask } from "../tasks/task-store.js";
 
 await initializeDb();
+
+// The schedule worker is on by default, which stands the daemon's in-process
+// scheduler down. These tests exercise that in-process execution path directly
+// (runScheduleDueWorkOnce), so pin the worker flag off for this test process.
+const rawConfig = loadRawConfig();
+rawConfig.schedules = { worker: { enabled: false } };
+saveRawConfig(rawConfig);
 
 /** Access the underlying bun:sqlite Database for raw parameterized queries. */
 function getRawDb(): import("bun:sqlite").Database {

--- a/assistant/src/config/schemas/memory-lifecycle.ts
+++ b/assistant/src/config/schemas/memory-lifecycle.ts
@@ -82,9 +82,9 @@ export const MemoryWorkerConfigSchema = z
   .object({
     enabled: z
       .boolean({ error: "memory.worker.enabled must be a boolean" })
-      .default(false)
+      .default(true)
       .describe(
-        "Whether the memory jobs worker runs as a separate OS process instead of the assistant's synchronous in-process runner. The assistant's worker supervisor re-reads this flag on every poll: while it is set, the in-process runner stands down (the out-of-process worker, spawned at startup when set, owns the queue); while it is unset, the in-process runner drains the queue. `assistant memory worker start`/`stop` flip the flag (and spawn/stop the worker process) to switch modes at runtime without a restart.",
+        "Whether the memory jobs worker runs as a separate OS process instead of the assistant's synchronous in-process runner. The assistant's worker supervisor re-reads this flag on every poll: while it is set (the default), the in-process runner stands down (the out-of-process worker, spawned at startup when set, owns the queue); while it is unset, the in-process runner drains the queue. `assistant memory worker start`/`stop` flip the flag (and spawn/stop the worker process) to switch modes at runtime without a restart.",
       ),
   })
   .describe("Memory jobs worker process configuration");

--- a/assistant/src/config/schemas/schedules.ts
+++ b/assistant/src/config/schemas/schedules.ts
@@ -17,9 +17,9 @@ export const ScheduleWorkerConfigSchema = z
   .object({
     enabled: z
       .boolean({ error: "schedules.worker.enabled must be a boolean" })
-      .default(false)
+      .default(true)
       .describe(
-        "Whether scheduled jobs run in a separate schedule worker OS process instead of the assistant's in-process scheduler. When set, the assistant spawns the worker at startup and its own scheduler stands down from executing schedules. `assistant schedules worker start`/`stop` flip this flag at runtime.",
+        "Whether scheduled jobs run in a separate schedule worker OS process instead of the assistant's in-process scheduler. When set (the default), the assistant spawns the worker at startup and its own scheduler stands down from executing schedules. `assistant schedules worker start`/`stop` flip this flag at runtime.",
       ),
   })
   .describe("Schedule worker process configuration");

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -152,8 +152,9 @@ let instance: MemoryJobsWorker | null = null;
  * supervisor owns the synchronous in-process runner and reconciles to
  * `memory.worker.enabled` on every poll, re-reading the flag from disk so a
  * runtime change takes effect without a restart:
- *   - flag off (default): drain the queue in-process (the synchronous runner).
- *   - flag on: stand down (the out-of-process worker owns the queue).
+ *   - flag off: drain the queue in-process (the synchronous runner).
+ *   - flag on (the default): stand down (the out-of-process worker owns the
+ *     queue).
  * Gating on the flag — rather than on the worker process actually being present
  * — keeps exactly one drainer active and avoids a boot race: when the flag is
  * on the supervisor never processes, so it can't claim jobs that the spawning


### PR DESCRIPTION
## Prompt / plan

"We are ready to default schedule worker and memory worker as default on." Both out-of-process workers have been opt-in via `assistant schedules worker start` / `assistant memory worker start`; this flips the config defaults so they are on for fresh installs and for any config that never set the flags explicitly.

- `schedules.worker.enabled`: `false` → `true` (`assistant/src/config/schemas/schedules.ts`)
- `memory.worker.enabled`: `false` → `true` (`assistant/src/config/schemas/memory-lifecycle.ts`)

At daemon boot the existing lifecycle code (`startScheduleWorkerIfEnabled`, `startMemoryJobsWorker`) now spawns both worker processes by default, and the in-process scheduler / synchronous memory-jobs runner stand down. Explicit opt-outs persisted by `worker stop` (or hand-edited configs) still win — the flip only changes what an *absent* key means. Also updated the schema `.describe()` strings and the stale "flag off (default)" comment in `jobs-worker.ts` to match.

## Test plan

- `bun test` on the worker suites in isolation: `config/schemas/__tests__/memory-lifecycle`, `__tests__/scheduler-worker-standdown`, `runtime/routes/__tests__/schedule-worker-routes`, `runtime/routes/__tests__/memory-worker-routes`, `schedule/__tests__/worker-control`, `persistence/__tests__/worker-control` — all pass. (Running some of these files combined in one bun process fails identically with and without this change — pre-existing cross-file mock interference, not introduced here.)
- Direct default check: parsing `{}` through `SchedulesConfigSchema` / `MemoryWorkerConfigSchema` now yields `enabled: true` for both.
- `bun run typecheck` clean; `bun run generate:openapi` produces no diff (the spec doesn't embed these config defaults).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NYBSsfhXV4Aocgah7gQBgy

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYBSsfhXV4Aocgah7gQBgy)_