### PR TITLE
feat(calls): in-app controller profile with live-voice control prompt

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -38,6 +38,15 @@ mock.module("../config/loader.js", () => {
     },
     memory: { enabled: false },
     notifications: {},
+    liveVoice: {
+      mode: "ptt",
+      vad: {
+        speechEnergyThreshold: 800,
+        silenceThresholdMs: 800,
+        maxTurnDurationMs: 30_000,
+      },
+      maxSessionDurationSeconds: 1800,
+    },
     ingress: {
       enabled: true,
       publicBaseUrl: "https://generic.example.com",
@@ -187,10 +196,14 @@ mock.module("../contacts/guardian-delivery-reader.js", () => ({
   anyGuardian: (list: unknown[]) => list[0],
 }));
 
+const MOCK_LIVE_VOICE_PROMPT =
+  "<voice_call_control>mock live-voice prompt</voice_call_control>";
+
 mock.module("../calls/voice-session-bridge.js", () => {
   mockStartVoiceTurn = mock(createMockVoiceTurn(["Hello", " there"]));
   return {
     startVoiceTurn: (...args: unknown[]) => mockStartVoiceTurn(...args),
+    buildLiveVoiceControlPrompt: () => MOCK_LIVE_VOICE_PROMPT,
   };
 });
 
@@ -265,7 +278,10 @@ import {
 } from "../calls/call-store.js";
 import type { CallTransport } from "../calls/call-transport.js";
 import { resolveCallTtsProvider } from "../calls/resolve-call-tts-provider.js";
-import type { VoiceSessionSource } from "../calls/voice-session-source.js";
+import {
+  createInAppVoiceControllerProfile,
+  type VoiceSessionSource,
+} from "../calls/voice-session-source.js";
 import { loadConfig } from "../config/loader.js";
 import {
   getCanonicalGuardianRequest,
@@ -3533,5 +3549,190 @@ describe("call-controller", () => {
     expect(turnOpts.skipDisclosure).toBe(true);
 
     controller.destroy();
+  });
+
+  // ── In-app controller profile ───────────────────────────────────────
+
+  describe("in-app controller profile", () => {
+    const IN_APP_SESSION_ID = "live-voice-session-no-row";
+
+    /**
+     * Controller wired like an in-app live-voice session: injected session
+     * source (no call_sessions row exists) plus the in-app profile.
+     */
+    function setupInAppController() {
+      ensureConversation("conv-inapp-test");
+      const sessionSource: VoiceSessionSource = {
+        conversationId: "conv-inapp-test",
+        skipDisclosure: true,
+        getSnapshot: () => ({
+          status: "in_progress",
+          conversationId: "conv-inapp-test",
+          initiatedFromConversationId: null,
+          startedAt: Date.now(),
+          toNumber: "",
+        }),
+      };
+      const transport = createMockTransport();
+      const controller = new CallController(
+        IN_APP_SESSION_ID,
+        transport,
+        null,
+        { sessionSource, profile: createInAppVoiceControllerProfile() },
+      );
+      return { relay: transport, controller };
+    }
+
+    test("recordEvent is a no-op: turns and instructions write no call_events rows", async () => {
+      const { controller } = setupInAppController();
+
+      await controller.handleCallerUtterance("Hello");
+      await controller.handleUserInstruction("Be brief");
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(getCallEvents(IN_APP_SESSION_ID)).toEqual([]);
+
+      controller.destroy();
+    });
+
+    test("[END_CALL] ends the transport session without phone finalization", async () => {
+      mockStartVoiceTurn.mockImplementation(
+        createMockVoiceTurn(["Goodbye! ", "[END_CALL]"]),
+      );
+      const { relay, controller } = setupInAppController();
+
+      await controller.handleCallerUtterance("That's all, bye");
+      // In-app profile has no END_CALL listen window — the session ends
+      // synchronously. Give fire-and-forget finalization (if it were wired)
+      // a tick to surface before asserting nothing happened.
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(relay.endCalled).toBe(true);
+      const allText = relay.sentTokens.map((t) => t.token).join("");
+      expect(allText).not.toContain("[END_CALL]");
+
+      // No phone-call finalization: no call_sessions/call_events rows are
+      // created, and finalizeCall's completion message never lands in the
+      // session conversation.
+      expect(getCallSession(IN_APP_SESSION_ID)).toBeNull();
+      expect(getCallEvents(IN_APP_SESSION_ID)).toEqual([]);
+      expect(getMessages("conv-inapp-test")).toEqual([]);
+
+      controller.destroy();
+    });
+
+    test("ASK_GUARDIAN marker is stripped and no consultation is dispatched", async () => {
+      mockStartVoiceTurn.mockImplementation(
+        createMockVoiceTurn([
+          "Let me check. ",
+          "[ASK_GUARDIAN: Is this okay?]",
+        ]),
+      );
+      const { relay, controller } = setupInAppController();
+
+      await controller.handleCallerUtterance("Do the thing");
+      // Give any (unexpected) fire-and-forget dispatch a tick to surface.
+      await new Promise((r) => setTimeout(r, 10));
+
+      const allText = relay.sentTokens.map((t) => t.token).join("");
+      expect(allText).toContain("Let me check.");
+      expect(allText).not.toContain("ASK_GUARDIAN");
+
+      expect(controller.getPendingConsultationQuestionId()).toBeNull();
+      expect(getPendingQuestion(IN_APP_SESSION_ID)).toBeNull();
+      expect(
+        getPendingCanonicalRequestByCallSessionId(IN_APP_SESSION_ID),
+      ).toBeNull();
+      expect(controller.getState()).toBe("idle");
+
+      controller.destroy();
+    });
+
+    test("startVoiceTurn receives the live-voice turn context", async () => {
+      let captured: Record<string, unknown> | undefined;
+      mockStartVoiceTurn.mockImplementation(
+        async (opts: {
+          onTextDelta: (t: string) => void;
+          onComplete: () => void;
+        }) => {
+          captured = opts as unknown as Record<string, unknown>;
+          opts.onTextDelta("Hi.");
+          opts.onComplete();
+          return { turnId: "run-inapp", abort: () => {} };
+        },
+      );
+      const { controller } = setupInAppController();
+
+      await controller.handleCallerUtterance("Hello");
+
+      expect(captured).toMatchObject({
+        conversationId: "conv-inapp-test",
+        skipDisclosure: true,
+        approvalMode: "local-live-voice",
+        userMessageChannel: "vellum",
+        assistantMessageChannel: "vellum",
+        userMessageInterface: "macos",
+        assistantMessageInterface: "macos",
+        voiceControlPrompt: MOCK_LIVE_VOICE_PROMPT,
+      });
+
+      controller.destroy();
+    });
+
+    test("token-stream speech output: tokens flow through sendTextToken, synthesized-play path skipped", async () => {
+      // Configure a synthesized-play provider (fish-audio streaming) that
+      // would emit a play URL on the auto path. Under token-stream the
+      // provider must never be invoked and no play URL may be sent.
+      const cfg = loadConfig();
+      cfg.services.tts.provider = "fish-audio";
+      cfg.services.tts.providers["fish-audio"].referenceId = "fish-ref-123";
+
+      let synthesizeStreamCalled = false;
+      const fishAudioStreaming: TtsProvider = {
+        id: "fish-audio",
+        capabilities: {
+          supportsStreaming: true,
+          supportedFormats: ["mp3", "wav", "opus"],
+        },
+        async synthesize() {
+          return { audio: Buffer.from("x"), contentType: "audio/mpeg" };
+        },
+        async synthesizeStream(_request, onChunk) {
+          synthesizeStreamCalled = true;
+          onChunk(Buffer.from("fish-audio-stream"));
+          return {
+            audio: Buffer.from("fish-audio-stream"),
+            contentType: "audio/mpeg",
+          };
+        },
+      };
+      _setTtsProviderForTests(fishAudioStreaming);
+
+      mockStartVoiceTurn.mockImplementation(
+        createMockVoiceTurn(["Hello from the live voice path."]),
+      );
+      const { relay, controller } = setupInAppController();
+
+      await controller.handleCallerUtterance("Hi");
+
+      expect(synthesizeStreamCalled).toBe(false);
+      expect(relay.sentPlayUrls).toEqual([]);
+      const allText = relay.sentTokens.map((t) => t.token).join("");
+      expect(allText).toContain("Hello from the live voice path.");
+      const lastToken = relay.sentTokens[relay.sentTokens.length - 1];
+      expect(lastToken.last).toBe(true);
+
+      controller.destroy();
+    });
+
+    test("profile knobs: liveVoice max duration, no end-call listen window, guardian disabled", () => {
+      const profile = createInAppVoiceControllerProfile();
+
+      expect(profile.timers.maxDurationMs()).toBe(1800 * 1000);
+      expect(profile.timers.endCallListenWindowMs()).toBe(0);
+      expect(profile.timers.silenceTimeoutMs()).toBe(30_000);
+      expect(profile.guardianConsultation.mode).toBe("disabled");
+      expect(profile.speechOutput).toBe("token-stream");
+    });
   });
 });

--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -45,7 +45,10 @@ mock.module("../daemon/conversation-store.js", () => ({
   },
 }));
 
-import { startVoiceTurn } from "../calls/voice-session-bridge.js";
+import {
+  buildLiveVoiceControlPrompt,
+  startVoiceTurn,
+} from "../calls/voice-session-bridge.js";
 import {
   createConversation,
   getMessages,
@@ -1449,5 +1452,32 @@ describe("voice-session-bridge", () => {
     });
 
     expect(abortCalled).toBe(true);
+  });
+
+  describe("buildLiveVoiceControlPrompt", () => {
+    test("contains the brevity, END_CALL, and plain-speech rules", () => {
+      const prompt = buildLiveVoiceControlPrompt();
+
+      expect(prompt).toContain("<voice_call_control>");
+      expect(prompt).toContain("</voice_call_control>");
+      expect(prompt).toContain("Be concise — keep responses to 1-3 sentences.");
+      expect(prompt).toContain("[END_CALL]");
+      expect(prompt).toContain("ends the voice session");
+      expect(prompt).toContain(
+        "Your text is sent directly to a text-to-speech engine.",
+      );
+      expect(prompt).toContain("Never use markdown formatting");
+    });
+
+    test("omits phone-only rules: disclosure, guardian consultation, speaker/verification markers", () => {
+      const prompt = buildLiveVoiceControlPrompt();
+
+      expect(prompt).not.toContain("ASK_GUARDIAN");
+      expect(prompt).not.toContain("[SPEAKER");
+      expect(prompt).not.toContain("disclosure");
+      expect(prompt).not.toContain("Begin the conversation naturally");
+      expect(prompt).not.toContain("CALL_OPENING");
+      expect(prompt).not.toContain("verification");
+    });
   });
 });

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -26,30 +26,13 @@ import type { TtsProvider, TtsProviderId } from "../tts/types.js";
 import { getLogger } from "../util/logger.js";
 import { createStreamingEntry } from "./audio-store.js";
 import {
-  getEndCallListenWindowMs,
-  getMaxCallDurationMs,
-  getSilenceTimeoutMs,
-  getUserConsultationTimeoutMs,
-} from "./call-constants.js";
-import {
-  formatDuration,
-  postPointerMessageSafe,
-} from "./call-pointer-messages.js";
-import {
   fireCallQuestionNotifier,
   fireCallTranscriptNotifier,
   registerCallController,
   unregisterCallController,
 } from "./call-state.js";
 import { isTerminalState } from "./call-state-machine.js";
-import {
-  createPendingQuestion,
-  expirePendingQuestions,
-  recordCallEvent,
-  updateCallSession,
-} from "./call-store.js";
 import type { CallTransport } from "./call-transport.js";
-import { finalizeCall } from "./finalize-call.js";
 import { sendGuardianExpiryNotices } from "./guardian-action-sweep.js";
 import { dispatchGuardianQuestion } from "./guardian-dispatch.js";
 import { resolveCallTtsProvider } from "./resolve-call-tts-provider.js";
@@ -70,7 +53,10 @@ import {
   type VoiceTurnHandle,
 } from "./voice-session-bridge.js";
 import {
+  createPhoneVoiceControllerProfile,
   createPhoneVoiceSessionSource,
+  type PhoneDispatchGuardianConsultation,
+  type VoiceControllerProfile,
   type VoiceSessionSource,
 } from "./voice-session-source.js";
 
@@ -166,6 +152,8 @@ export class CallController {
   private activeSynthesisAbort: AbortController | null = null;
   /** Source of session state reads (conversation binding, lifecycle fields). */
   private sessionSource: VoiceSessionSource;
+  /** Behavioral profile (lifecycle writes, guardian gating, turn context, timers). */
+  private profile: VoiceControllerProfile;
 
   constructor(
     callSessionId: string,
@@ -176,6 +164,7 @@ export class CallController {
       assistantId?: string;
       trustContext?: TrustContext;
       sessionSource?: VoiceSessionSource;
+      profile?: VoiceControllerProfile;
     },
   ) {
     this.callSessionId = callSessionId;
@@ -185,6 +174,8 @@ export class CallController {
     this.broadcast = opts?.broadcast;
     this.assistantId = opts?.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
     this.trustContext = opts?.trustContext ?? null;
+    this.profile =
+      opts?.profile ?? createPhoneVoiceControllerProfile(callSessionId);
 
     // Resolve the conversation ID and skipDisclosure from the session source
     this.sessionSource =
@@ -337,7 +328,7 @@ export class CallController {
     clearTimeout(this.pendingGuardianInput.timer);
     this.pendingGuardianInput = null;
 
-    updateCallSession(this.callSessionId, { status: "in_progress" });
+    this.profile.updateStatus({ status: "in_progress" });
 
     // Inject the answer as a queued instruction so it merges into the
     // next turn naturally, respecting role-alternation. If the controller
@@ -366,7 +357,7 @@ export class CallController {
   async handleUserInstruction(instructionText: string): Promise<void> {
     this.cancelPendingEndCall();
 
-    recordCallEvent(this.callSessionId, "user_instruction_relayed", {
+    this.profile.recordEvent("user_instruction_relayed", {
       instruction: instructionText,
     });
 
@@ -652,10 +643,20 @@ export class CallController {
     // When the transport requires WAV (media-stream), request WAV so
     // the audio store entry and any downstream fetch/transcode receives
     // PCM that audioBufferToFrames can convert to mu-law.
+    //
+    // Token-stream profiles (in-app live voice) skip provider resolution
+    // entirely: the transport owns synthesis, so every token flows through
+    // sendTextToken and the synthesized-play path is never taken.
     const { provider, useSynthesizedPath, audioFormat } =
-      await resolveCallTtsProvider({
-        preferWav: this.transport.requiresWavAudio,
-      });
+      this.profile.speechOutput === "token-stream"
+        ? {
+            provider: null,
+            useSynthesizedPath: false,
+            audioFormat: "mp3" as const,
+          }
+        : await resolveCallTtsProvider({
+            preferWav: this.transport.requiresWavAudio,
+          });
 
     // Buffer incoming tokens so we can strip control markers ([ASK_GUARDIAN:...], [END_CALL])
     // before they reach TTS. We hold text whenever an unmatched '[' appears, since it
@@ -733,7 +734,10 @@ export class CallController {
         reject(new Error(message));
       };
 
-      // Start the voice turn through the session bridge
+      // Start the voice turn through the session bridge. The profile
+      // supplies the approval mode, channel/interface context, and control
+      // prompt (phone defaults, or the live-voice context for in-app
+      // sessions).
       startVoiceTurn({
         conversationId: this.conversationId,
         callSessionId: this.callSessionId,
@@ -743,6 +747,7 @@ export class CallController {
         isInbound: this.isInbound,
         task: this.task,
         skipDisclosure: this.skipDisclosure,
+        ...this.profile.voiceTurn,
         onTextDelta,
         onComplete,
         onError,
@@ -980,7 +985,7 @@ export class CallController {
     const responseText = fullResponseText;
 
     // Record the assistant response event
-    recordCallEvent(this.callSessionId, "assistant_spoke", {
+    this.profile.recordEvent("assistant_spoke", {
       text: responseText,
     });
     const spokenText = sanitizeForTts(
@@ -1041,8 +1046,19 @@ export class CallController {
     const questionText =
       toolApprovalMeta?.question ?? (askMatch ? askMatch[1] : null);
 
+    const guardianConsultation = this.profile.guardianConsultation;
     if (questionText) {
-      if (this.isCallerGuardian()) {
+      if (guardianConsultation.mode === "disabled") {
+        // Defensive: the in-app control prompt omits the guardian markers
+        // entirely, so a marker here is a model deviation. It never reaches
+        // the spoken output (control markers are stripped before TTS) —
+        // just log and continue the turn without dispatching.
+        log.warn(
+          { callSessionId: this.callSessionId },
+          "Ignoring guardian consultation marker — guardian dispatch disabled for this session",
+        );
+        // Fall through to normal turn completion (idle + flushPendingInstructions)
+      } else if (this.isCallerGuardian()) {
         // Caller IS the guardian — don't dispatch cross-channel.
         // Queue an instruction so the next turn asks them directly.
         log.info(
@@ -1061,7 +1077,7 @@ export class CallController {
           { callSessionId: this.callSessionId },
           "Guardian unavailable for call — skipping ASK_GUARDIAN wait",
         );
-        recordCallEvent(this.callSessionId, "guardian_unavailable_skipped", {
+        this.profile.recordEvent("guardian_unavailable_skipped", {
           question: questionText,
         });
         this.pendingInstructions.push(
@@ -1087,7 +1103,7 @@ export class CallController {
           { callSessionId: this.callSessionId },
           "Deferring ASK_GUARDIAN — queued USER_ANSWERED pending",
         );
-        recordCallEvent(this.callSessionId, "guardian_consult_deferred", {
+        this.profile.recordEvent("guardian_consult_deferred", {
           question: questionText,
         });
         // Fall through to normal turn completion (idle + flushPendingInstructions)
@@ -1125,7 +1141,7 @@ export class CallController {
               },
               "Coalescing repeated ASK_GUARDIAN — same tool/action already pending",
             );
-            recordCallEvent(this.callSessionId, "guardian_consult_coalesced", {
+            this.profile.recordEvent("guardian_consult_coalesced", {
               question: questionText,
             });
             // Fall through to normal turn completion (idle + flushPendingInstructions)
@@ -1135,7 +1151,7 @@ export class CallController {
 
             // Expire the previous consultation's storage records so stale
             // guardian answers cannot match the old request.
-            expirePendingQuestions(this.callSessionId);
+            guardianConsultation.expirePendingQuestions();
             const previousRequest = getPendingCanonicalRequestByCallSessionId(
               this.callSessionId,
             );
@@ -1159,6 +1175,7 @@ export class CallController {
             // can backfill supersession chain metadata (superseded_by_request_id)
             // once the new request has been created.
             this.dispatchNewConsultation(
+              guardianConsultation,
               questionText,
               effectiveToolMeta,
               previousRequest?.id ?? null,
@@ -1166,7 +1183,12 @@ export class CallController {
           }
         } else {
           // No prior consultation — dispatch fresh
-          this.dispatchNewConsultation(questionText, effectiveToolMeta, null);
+          this.dispatchNewConsultation(
+            guardianConsultation,
+            questionText,
+            effectiveToolMeta,
+            null,
+          );
         }
       }
     }
@@ -1203,7 +1225,7 @@ export class CallController {
       this.endCallListenTimer = null;
     }
 
-    const listenWindowMs = getEndCallListenWindowMs();
+    const listenWindowMs = this.profile.timers.endCallListenWindowMs();
     // After the caller has re-engaged once post-END_CALL, complete
     // immediately on the next END_CALL. The first deferral gets a
     // listen window (caller might say "wait, one more thing"); a
@@ -1214,7 +1236,7 @@ export class CallController {
     const callContinues =
       this.pendingInstructions.length > 0 || effectiveListenWindowMs > 0;
     if (clearedPendingGuardianInput && callContinues) {
-      updateCallSession(this.callSessionId, { status: "in_progress" });
+      this.profile.updateStatus({ status: "in_progress" });
     }
 
     if (this.pendingInstructions.length > 0) {
@@ -1248,7 +1270,10 @@ export class CallController {
     // Expire store-side consultation records so clients don't observe
     // a completed call with a dangling pendingQuestion, and guardian
     // replies are cleanly rejected instead of hitting answerCall failures.
-    expirePendingQuestions(this.callSessionId);
+    // Pending consultations only exist under phone-dispatch mode.
+    if (this.profile.guardianConsultation.mode === "phone-dispatch") {
+      this.profile.guardianConsultation.expirePendingQuestions();
+    }
     const previousRequest = getPendingCanonicalRequestByCallSessionId(
       this.callSessionId,
     );
@@ -1269,35 +1294,19 @@ export class CallController {
       return;
     }
 
-    const shouldNotifyCompletion = !!currentSession;
-
     this.transport.endSession("Call completed");
-    updateCallSession(this.callSessionId, {
+    this.profile.updateStatus({
       status: "completed",
       endedAt: Date.now(),
     });
-    recordCallEvent(this.callSessionId, "call_ended", {
+    this.profile.recordEvent("call_ended", {
       reason: "completed",
     });
 
-    // Notify the voice conversation
-    if (shouldNotifyCompletion && currentSession) {
-      finalizeCall(this.callSessionId, currentSession.conversationId);
-    }
-
-    // Post a pointer message in the initiating conversation
-    if (currentSession?.initiatedFromConversationId) {
-      const durationMs = currentSession.startedAt
-        ? Date.now() - currentSession.startedAt
-        : 0;
-      postPointerMessageSafe(
-        currentSession.initiatedFromConversationId,
-        "completed",
-        currentSession.toNumber,
-        {
-          duration: durationMs > 0 ? formatDuration(durationMs) : undefined,
-        },
-      );
+    // Notify the voice conversation and post a pointer message in the
+    // initiating conversation.
+    if (currentSession) {
+      this.profile.finalize(currentSession, { notifyCompletion: true });
     }
     this.state = "idle";
   }
@@ -1371,16 +1380,14 @@ export class CallController {
    * chain after the new request is created.
    */
   private dispatchNewConsultation(
+    consultation: PhoneDispatchGuardianConsultation,
     questionText: string,
     effectiveToolMeta: { toolName: string; inputDigest: string } | null,
     supersededRequestId: string | null,
   ): void {
-    const pendingQuestion = createPendingQuestion(
-      this.callSessionId,
-      questionText,
-    );
-    updateCallSession(this.callSessionId, { status: "waiting_on_user" });
-    recordCallEvent(this.callSessionId, "user_question_asked", {
+    const pendingQuestion = consultation.createPendingQuestion(questionText);
+    this.profile.updateStatus({ status: "waiting_on_user" });
+    this.profile.recordEvent("user_question_asked", {
       question: questionText,
     });
 
@@ -1480,11 +1487,11 @@ export class CallController {
       }
 
       // Expire pending questions and update call state
-      expirePendingQuestions(this.callSessionId);
+      consultation.expirePendingQuestions();
       this.pendingGuardianInput = null;
-      updateCallSession(this.callSessionId, { status: "in_progress" });
+      this.profile.updateStatus({ status: "in_progress" });
       this.guardianUnavailableForCall = true;
-      recordCallEvent(this.callSessionId, "guardian_consultation_timed_out", {
+      this.profile.recordEvent("guardian_consultation_timed_out", {
         question: questionText,
       });
 
@@ -1503,7 +1510,7 @@ export class CallController {
         this.resetSilenceTimer();
         this.flushPendingInstructions();
       }
-    }, getUserConsultationTimeoutMs());
+    }, this.profile.timers.consultTimeoutMs());
 
     this.pendingGuardianInput = {
       questionText,
@@ -1539,7 +1546,7 @@ export class CallController {
   }
 
   private startDurationTimer(): void {
-    const maxDurationMs = getMaxCallDurationMs();
+    const maxDurationMs = this.profile.timers.maxDurationMs();
     const warningMs = maxDurationMs - 2 * 60 * 1000; // 2 minutes before max
 
     if (warningMs > 0) {
@@ -1574,30 +1581,19 @@ export class CallController {
           : false;
 
         this.transport.endSession("Maximum call duration reached");
-        updateCallSession(this.callSessionId, {
+        this.profile.updateStatus({
           status: "completed",
           endedAt: Date.now(),
         });
-        recordCallEvent(this.callSessionId, "call_ended", {
+        this.profile.recordEvent("call_ended", {
           reason: "max_duration",
         });
-        if (shouldNotifyCompletion && currentSession) {
-          finalizeCall(this.callSessionId, currentSession.conversationId);
-        }
-
-        // Post a pointer message in the initiating conversation
-        if (currentSession?.initiatedFromConversationId) {
-          const durationMs = currentSession.startedAt
-            ? Date.now() - currentSession.startedAt
-            : 0;
-          postPointerMessageSafe(
-            currentSession.initiatedFromConversationId,
-            "completed",
-            currentSession.toNumber,
-            {
-              duration: durationMs > 0 ? formatDuration(durationMs) : undefined,
-            },
-          );
+        // Notify the voice conversation (unless already terminal) and post
+        // a pointer message in the initiating conversation.
+        if (currentSession) {
+          this.profile.finalize(currentSession, {
+            notifyCompletion: shouldNotifyCompletion,
+          });
         }
       }, 3000);
     }, maxDurationMs);
@@ -1622,6 +1618,6 @@ export class CallController {
         "Silence timeout triggered",
       );
       this.transport.sendTextToken("Are you still there?", true);
-    }, getSilenceTimeoutMs());
+    }, this.profile.timers.silenceTimeoutMs());
   }
 }

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -28,6 +28,7 @@ import { getLogger } from "../util/logger.js";
 import {
   CALL_OPENING_MARKER,
   CALL_VERIFICATION_COMPLETE_MARKER,
+  END_CALL_MARKER,
 } from "./voice-control-protocol.js";
 
 const log = getLogger("voice-session-bridge");
@@ -135,8 +136,20 @@ export interface VoiceTurnHandle {
 }
 
 // ---------------------------------------------------------------------------
-// Call-control protocol prompt builder
+// Call-control protocol prompt builders
 // ---------------------------------------------------------------------------
+
+/** Brevity rule body shared by the phone and live-voice control prompts. */
+const CONCISENESS_RULE = "Be concise — keep responses to 1-3 sentences.";
+
+/**
+ * Plain-text-for-TTS rule body shared by the phone and live-voice control
+ * prompts. `markerExamples` names the protocol markers that remain valid
+ * (non-spoken) output in the given context.
+ */
+function plainSpeechRule(markerExamples: string): string {
+  return `Your text is sent directly to a text-to-speech engine. Never use markdown formatting (asterisks, headers, backticks, links) or emojis in your spoken responses. Write plain conversational text only. Protocol markers like ${markerExamples} are not spoken text and should still be used normally.`;
+}
 
 /**
  * Build the call-control protocol prompt injected into each voice turn.
@@ -173,7 +186,7 @@ function buildVoiceCallControlPrompt(opts: {
   lines.push(
     "CALL PROTOCOL RULES:",
     disclosureRule,
-    "1. Be concise — keep responses to 1-3 sentences. Phone conversations should be brief and natural.",
+    `1. ${CONCISENESS_RULE} Phone conversations should be brief and natural.`,
     ...(opts.isCallerGuardian
       ? [
           "2. You are speaking directly with your guardian (your user). Do NOT use [ASK_GUARDIAN:]. If you need permission, information, or confirmation, ask them directly in the conversation. They can answer you right now.",
@@ -234,11 +247,33 @@ function buildVoiceCallControlPrompt(opts: {
   lines.push(
     "9. After the opening greeting turn, treat the Task field as background context only — do not re-execute its instructions on subsequent turns.",
     '10. Do not make up information. If you are unsure, use [ASK_GUARDIAN: your question] to consult your guardian. For tool permission requests, use [ASK_GUARDIAN_APPROVAL: {"question":"...","toolName":"...","input":{...}}].',
-    `11. Your text is sent directly to a text-to-speech engine. Never use markdown formatting (asterisks, headers, backticks, links) or emojis in your spoken responses. Write plain conversational text only. Protocol markers like ${opts.isCallerGuardian ? "[END_CALL]" : "[ASK_GUARDIAN: ...] and [END_CALL]"} are not spoken text and should still be used normally.`,
+    `11. ${plainSpeechRule(opts.isCallerGuardian ? "[END_CALL]" : "[ASK_GUARDIAN: ...] and [END_CALL]")}`,
     "</voice_call_control>",
   );
 
   return lines.join("\n");
+}
+
+/**
+ * Build the control prompt injected into each in-app live-voice turn.
+ *
+ * Contains only the marker rules that apply in-app: brevity, [END_CALL]
+ * (ends the voice session), and plain-text-for-TTS. Phone-only rules are
+ * intentionally absent — no disclosure (the user launched the session
+ * themselves), no [ASK_GUARDIAN]/[ASK_GUARDIAN_APPROVAL] (approvals surface
+ * interactively via the local-live-voice approval mode), and no
+ * [SPEAKER]/verification markers.
+ */
+export function buildLiveVoiceControlPrompt(): string {
+  return [
+    "<voice_call_control>",
+    "VOICE SESSION RULES:",
+    `1. ${CONCISENESS_RULE} Voice conversations should be brief and natural.`,
+    "2. You are speaking directly with your user in a live voice session. If you need permission, information, or confirmation, ask them directly — they can answer you right now.",
+    `3. When the user indicates they are done or the conversation reaches a natural conclusion, include ${END_CALL_MARKER} in your response along with a brief goodbye. ${END_CALL_MARKER} ends the voice session.`,
+    `4. ${plainSpeechRule(END_CALL_MARKER)}`,
+    "</voice_call_control>",
+  ].join("\n");
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/calls/voice-session-source.ts
+++ b/assistant/src/calls/voice-session-source.ts
@@ -1,15 +1,41 @@
 /**
- * Session-source abstraction for CallController.
+ * Session-source and controller-profile abstractions for CallController.
  *
  * CallController reads session state (conversation binding at construction,
- * lifecycle fields during the call) through a VoiceSessionSource rather than
- * directly from the call_sessions store. Phone calls use the store-backed
- * source below; non-phone voice sessions can inject a source that has no
- * call_sessions row at all.
+ * lifecycle fields during the call) through a VoiceSessionSource, and routes
+ * behavior that differs between phone calls and in-app live-voice sessions
+ * through a VoiceControllerProfile. Phone calls use the store-backed
+ * implementations below; in-app voice sessions have no call_sessions row at
+ * all, so their profile turns every store write into a no-op and lets the
+ * live-voice session own teardown, approvals, and TTS synthesis.
  */
 
-import { getCallSession } from "./call-store.js";
-import type { CallStatus } from "./types.js";
+import type { ChannelId, InterfaceId } from "../channels/types.js";
+import { getConfig } from "../config/loader.js";
+import {
+  getEndCallListenWindowMs,
+  getMaxCallDurationMs,
+  getSilenceTimeoutMs,
+  getUserConsultationTimeoutMs,
+} from "./call-constants.js";
+import {
+  formatDuration,
+  postPointerMessageSafe,
+} from "./call-pointer-messages.js";
+import {
+  createPendingQuestion,
+  expirePendingQuestions,
+  getCallSession,
+  recordCallEvent,
+  updateCallSession,
+} from "./call-store.js";
+import { finalizeCall } from "./finalize-call.js";
+import type {
+  CallEventType,
+  CallPendingQuestion,
+  CallStatus,
+} from "./types.js";
+import { buildLiveVoiceControlPrompt } from "./voice-session-bridge.js";
 
 /** Point-in-time view of the session lifecycle fields CallController reads. */
 export interface VoiceSessionSnapshot {
@@ -54,5 +80,172 @@ export function createPhoneVoiceSessionSource(
         toNumber: current.toNumber,
       };
     },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Controller profile
+// ---------------------------------------------------------------------------
+
+/** Per-turn context CallController merges into each startVoiceTurn call. */
+export interface VoiceTurnProfileContext {
+  approvalMode: "phone-call" | "local-live-voice";
+  userMessageChannel: ChannelId;
+  assistantMessageChannel: ChannelId;
+  userMessageInterface: InterfaceId;
+  assistantMessageInterface: InterfaceId;
+  /** Per-turn control prompt. Undefined builds the phone prompt; null disables it. */
+  voiceControlPrompt: string | null | undefined;
+}
+
+/**
+ * Guardian consultation surface for the phone flow: the controller persists
+ * a pending question and dispatches the consultation cross-channel.
+ */
+export interface PhoneDispatchGuardianConsultation {
+  mode: "phone-dispatch";
+  createPendingQuestion(questionText: string): CallPendingQuestion;
+  expirePendingQuestions(): void;
+}
+
+/**
+ * Guardian consultation is disabled: an ASK_GUARDIAN marker in model output
+ * is stripped and logged instead of dispatched (approvals surface
+ * interactively through the client under local-live-voice).
+ */
+export interface DisabledGuardianConsultation {
+  mode: "disabled";
+}
+
+export type GuardianConsultationProfile =
+  | PhoneDispatchGuardianConsultation
+  | DisabledGuardianConsultation;
+
+/** Timer budgets, read lazily each time the controller arms a timer. */
+export interface VoiceControllerTimers {
+  maxDurationMs(): number;
+  silenceTimeoutMs(): number;
+  endCallListenWindowMs(): number;
+  consultTimeoutMs(): number;
+}
+
+/**
+ * Behavioral knobs for CallController that differ between phone calls and
+ * in-app live-voice sessions. The phone profile delegates to the call
+ * store / finalization modules; the in-app profile turns lifecycle writes
+ * into no-ops because no call_sessions row exists for those sessions.
+ */
+export interface VoiceControllerProfile {
+  /** Record a call lifecycle event. Phone: call_events row; in-app: no-op. */
+  recordEvent(type: CallEventType, payload?: Record<string, unknown>): void;
+  /** Update session lifecycle fields. Phone: call_sessions row; in-app: no-op. */
+  updateStatus(updates: { status: CallStatus; endedAt?: number }): void;
+  /**
+   * Post-completion side effects. Phone: voice-conversation completion
+   * (when notifyCompletion) plus a pointer message in the initiating
+   * conversation; in-app: no-op (transport endSession closes the session).
+   */
+  finalize(
+    session: VoiceSessionSnapshot,
+    opts: { notifyCompletion: boolean },
+  ): void;
+  guardianConsultation: GuardianConsultationProfile;
+  /** Turn context merged into the controller's startVoiceTurn calls. */
+  voiceTurn: VoiceTurnProfileContext;
+  timers: VoiceControllerTimers;
+  /**
+   * "auto": resolve the call TTS provider per turn (synthesized-play vs
+   * native token streaming). "token-stream": always stream tokens through
+   * the transport — the transport owns synthesis and sendPlayUrl is never
+   * used.
+   */
+  speechOutput: "auto" | "token-stream";
+}
+
+/** Store-backed profile for phone calls. */
+export function createPhoneVoiceControllerProfile(
+  callSessionId: string,
+): VoiceControllerProfile {
+  return {
+    recordEvent(type, payload) {
+      recordCallEvent(callSessionId, type, payload);
+    },
+    updateStatus(updates) {
+      updateCallSession(callSessionId, updates);
+    },
+    finalize(session, opts) {
+      if (opts.notifyCompletion) {
+        finalizeCall(callSessionId, session.conversationId);
+      }
+      if (session.initiatedFromConversationId) {
+        const durationMs = session.startedAt
+          ? Date.now() - session.startedAt
+          : 0;
+        postPointerMessageSafe(
+          session.initiatedFromConversationId,
+          "completed",
+          session.toNumber,
+          {
+            duration: durationMs > 0 ? formatDuration(durationMs) : undefined,
+          },
+        );
+      }
+    },
+    guardianConsultation: {
+      mode: "phone-dispatch",
+      createPendingQuestion: (questionText) =>
+        createPendingQuestion(callSessionId, questionText),
+      expirePendingQuestions: () => expirePendingQuestions(callSessionId),
+    },
+    voiceTurn: {
+      approvalMode: "phone-call",
+      userMessageChannel: "phone",
+      assistantMessageChannel: "phone",
+      userMessageInterface: "phone",
+      assistantMessageInterface: "phone",
+      voiceControlPrompt: undefined,
+    },
+    timers: {
+      maxDurationMs: getMaxCallDurationMs,
+      silenceTimeoutMs: getSilenceTimeoutMs,
+      endCallListenWindowMs: getEndCallListenWindowMs,
+      consultTimeoutMs: getUserConsultationTimeoutMs,
+    },
+    speechOutput: "auto",
+  };
+}
+
+/**
+ * Profile for in-app live-voice sessions. No call_sessions row exists, so
+ * lifecycle writes are no-ops; teardown is owned by the live-voice session
+ * (via transport endSession); guardian consultation is disabled because
+ * approvals surface interactively through the client; and the transport
+ * owns TTS synthesis (token-stream).
+ */
+export function createInAppVoiceControllerProfile(): VoiceControllerProfile {
+  return {
+    recordEvent() {},
+    updateStatus() {},
+    finalize() {},
+    guardianConsultation: { mode: "disabled" },
+    voiceTurn: {
+      approvalMode: "local-live-voice",
+      userMessageChannel: "vellum",
+      assistantMessageChannel: "vellum",
+      userMessageInterface: "macos",
+      assistantMessageInterface: "macos",
+      voiceControlPrompt: buildLiveVoiceControlPrompt(),
+    },
+    timers: {
+      maxDurationMs: () =>
+        getConfig().liveVoice.maxSessionDurationSeconds * 1000,
+      silenceTimeoutMs: getSilenceTimeoutMs,
+      // In-app END_CALL ends the session immediately — no telephony
+      // "wait, one more thing" listen window.
+      endCallListenWindowMs: () => 0,
+      // Unreachable while guardian consultation is disabled.
+      consultTimeoutMs: getUserConsultationTimeoutMs,
+    },
+    speechOutput: "token-stream",
   };
 }


### PR DESCRIPTION
## Summary
- CallController lifecycle side-effects (recordEvent/updateStatus/finalize), guardian gating, startVoiceTurn context, timers, and speech-output strategy now flow through an injectable profile; phone defaults byte-identical
- New buildLiveVoiceControlPrompt: brevity + END_CALL + plaintext rules, no disclosure/guardian/verification markers
- token-stream speech mode: all output via sendTextToken, synthesized-play path skipped

Part of plan: voice-mode-engine.md (PR 5 of 12)