### PR TITLE
fix: update deploy-platform-web-spa header for the new single-environment callers

### DIFF
--- a/.github/workflows/deploy-platform-web-spa.yaml
+++ b/.github/workflows/deploy-platform-web-spa.yaml
@@ -11,10 +11,13 @@ name: Deploy Web SPA (reusable)
 # a $GITHUB_ENV/$GITHUB_PATH/BASH_ENV hook (or a fake `gcloud`) that would fire
 # in the post-auth publish step and exfiltrate the short-lived GCP credentials.
 #
-# The caller matrixes over environments (fail-fast: false), so each environment
-# is an independent instance of this workflow — a failure building `dev` never
-# blocks `staging`/`production`. `production` gates at `build-and-package` if it
-# has required reviewers; `deploy` then inherits the gate via `needs`.
+# Three single-environment callers, one per environment: `deploy-web-spa` in
+# dev-release.yaml deploys `dev` on every hourly dev release (gated on ci-web +
+# register-release); release.yml's `deploy-web-spa-staging` deploys `staging`
+# on staging releases and `deploy-web-spa-production` deploys `production` when
+# a release goes live — gated on all other release prerequisites and required
+# by the GitHub Release job. The `environment:` binding only resolves each
+# environment's secrets/vars; no environment gates on required reviewers.
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for spa-deploy-on-release.md.

**Gap:** Stale matrix-caller header in deploy-platform-web-spa.yaml
**What was expected:** header describes the actual callers
**What was found:** header still documented the deleted ci-main-web matrix caller and a nonexistent required-reviewers gate
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->