### PR TITLE
fix: gate staging/production SPA deploys on web CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1839,7 +1839,7 @@ jobs:
   # release goes live. The dev bucket is deployed by dev-release.yaml.
   deploy-web-spa-staging:
     name: Deploy Web SPA (staging)
-    needs: [extract-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor]
+    needs: [extract-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor, ci-web]
     if: ${{ needs.extract-version.outputs.is_staging == 'true' }}
     permissions:
       contents: read
@@ -1856,8 +1856,8 @@ jobs:
   # GitHub Release/tag (the `release` job requires this job's success).
   deploy-web-spa-production:
     name: Deploy Web SPA (production)
-    needs: [extract-version, publish-npm-prod, publish-web-prod, publish-meta-prod, publish-plugin-api-prod, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image, build-electron, upload-electron-updates]
-    if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging != 'true' && needs.publish-npm-prod.result == 'success' && needs.publish-web-prod.result == 'success' && needs.publish-meta-prod.result == 'success' && needs.publish-plugin-api-prod.result == 'success' && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' && needs.build-electron.result == 'success' && needs.upload-electron-updates.result == 'success' }}
+    needs: [extract-version, publish-npm-prod, publish-web-prod, publish-meta-prod, publish-plugin-api-prod, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image, build-electron, upload-electron-updates, ci-web]
+    if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging != 'true' && needs.publish-npm-prod.result == 'success' && needs.publish-web-prod.result == 'success' && needs.publish-meta-prod.result == 'success' && needs.publish-plugin-api-prod.result == 'success' && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' && needs.build-electron.result == 'success' && needs.upload-electron-updates.result == 'success' && needs.ci-web.result == 'success' }}
     permissions:
       contents: read
       id-token: write
@@ -2768,6 +2768,48 @@ jobs:
       - name: Test
         run: bun run test
         working-directory: credential-executor
+
+  # Gates the staging/production SPA deploys: web lint/typecheck/test must
+  # pass on the release SHA before either bucket is updated.
+  ci-web:
+    needs: extract-version
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
+
+      - name: Install design-library dependencies
+        run: bun install --frozen-lockfile
+        working-directory: packages/design-library
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+        working-directory: clients/web
+
+      - name: Generate API clients
+        run: bun run openapi-ts
+        working-directory: clients/web
+
+      - name: Install shared packages
+        uses: ./.github/actions/install-shared-packages
+        with:
+          packages: packages/environments packages/local-mode
+
+      - name: Lint
+        run: bun run lint
+        working-directory: clients/web
+
+      - name: Typecheck
+        run: bun run typecheck
+        working-directory: clients/web
+
+      - name: Test
+        run: bun run test:ci
+        working-directory: clients/web
 
   notify-release:
     name: Slack Notification (Release)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for spa-deploy-on-release.md.

**Gap:** staging/production SPA deploys not gated on web CI for the deployed SHA
**What was expected:** web lint/typecheck/test pass on the exact SHA before a bucket is updated (as the removed ci-main-web deploy required)
**What was found:** release.yml had no web CI job; SPA deploys gated only on backend CI and release prerequisites
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->