### PR TITLE
fix(contacts): call the contacts control plane through the generated gateway SDK

### DIFF
--- a/clients/web/src/domains/chat/api/interactions.ts
+++ b/clients/web/src/domains/chat/api/interactions.ts
@@ -14,6 +14,7 @@ import {
   questionresponsePost,
   secretPost,
 } from "@/generated/daemon/sdk.gen";
+import { assistantContactsPromptSubmit } from "@/generated/gateway/sdk.gen";
 import type {
   PendinginteractionsGetResponse,
   QuestionresponsePostData,
@@ -183,8 +184,7 @@ export async function submitContactPrompt(
   displayName?: string,
 ): Promise<SubmitSecretResponseResult> {
   try {
-    const { error, response } = await client.post<unknown, unknown>({
-      url: "/v1/assistants/{assistant_id}/contacts/prompt/submit/",
+    const { error, response } = await assistantContactsPromptSubmit({
       path: { assistant_id: assistantId },
       body: { requestId, address, channelType, role, displayName },
       throwOnError: false,

--- a/clients/web/src/domains/contacts/contacts-gateway.ts
+++ b/clients/web/src/domains/contacts/contacts-gateway.ts
@@ -2,12 +2,20 @@
  * Gateway-native contact operations.
  *
  * These endpoints are handled directly by the gateway control plane
- * (contacts-control-plane-proxy.ts), not the daemon, so they don't
- * appear in the generated daemon SDK. They use the platform client
- * which routes through the gateway proxy.
+ * (contacts-control-plane-proxy.ts), not the daemon, so they live in the
+ * generated gateway SDK rather than the daemon SDK. The gateway client's
+ * interceptor forwards them to the self-hosted gateway in local /
+ * self-hosted mode and falls through to the platform proxy for
+ * platform-hosted assistants.
  */
 
 import { client } from "@/generated/api/client.gen";
+import {
+  assistantContactDelete,
+  assistantContactsUpsert,
+  assistantContactChannelVerify,
+} from "@/generated/gateway/sdk.gen";
+import type { AssistantContactsUpsertData } from "@/generated/gateway/types.gen";
 import {
   ApiError,
   assertHasResponse,
@@ -19,16 +27,11 @@ type Contact = ContactsGetResponse["contacts"][number];
 
 export async function upsertContact(
   assistantId: string,
-  body: Record<string, unknown>,
+  body: AssistantContactsUpsertData["body"],
 ): Promise<Contact> {
-  const { data, error, response } = await client.post<
-    { 200: { ok?: boolean; contact?: Contact } },
-    unknown
-  >({
-    url: "/v1/assistants/{assistant_id}/contacts/",
+  const { data, error, response } = await assistantContactsUpsert({
     path: { assistant_id: assistantId },
     body,
-    headers: { "Content-Type": "application/json" },
     throwOnError: false,
   });
   assertHasResponse(response, error, "Failed to save contact");
@@ -38,15 +41,16 @@ export async function upsertContact(
       extractErrorMessage(error, response, "Failed to save contact"),
     );
   }
-  return data.contact;
+  // The gateway's ContactPayload matches the daemon contact wire shape the
+  // contacts list is typed with (see toContactPayload in the gateway).
+  return data.contact as Contact;
 }
 
 export async function deleteContact(
   assistantId: string,
   contactId: string,
 ): Promise<void> {
-  const { error, response } = await client.delete<unknown, unknown>({
-    url: "/v1/assistants/{assistant_id}/contacts/{contact_id}/",
+  const { error, response } = await assistantContactDelete({
     path: { assistant_id: assistantId, contact_id: contactId },
     throwOnError: false,
   });
@@ -63,8 +67,7 @@ export async function verifyContactChannel(
   assistantId: string,
   channelId: string,
 ): Promise<void> {
-  const { error, response } = await client.post<unknown, unknown>({
-    url: "/v1/assistants/{assistant_id}/contact-channels/{channel_id}/verify/",
+  const { error, response } = await assistantContactChannelVerify({
     path: { assistant_id: assistantId, channel_id: channelId },
     throwOnError: false,
   });


### PR DESCRIPTION
## Prompt / plan

Part 2 of 2 for [LUM-2705](https://linear.app/vellum/issue/LUM-2705/fixcontacts-delete-contact-returns-not-found-toast-for-pre-migration) — **stacked on #37212** (the foundational PR that adds the gateway's assistant-scoped contacts routes and publishes them in the generated OpenAPI spec / gateway SDK). This PR is the one that actually fixes the bug.

Migrates the four hand-rolled contacts control-plane calls from raw platform-client requests to the generated gateway SDK:

- `contacts-gateway.ts`: `upsertContact` → `assistantContactsUpsert`, `deleteContact` → `assistantContactDelete`, `verifyContactChannel` → `assistantContactChannelVerify`
- `interactions.ts`: `submitContactPrompt` → `assistantContactsPromptSubmit`

**Why this fixes LUM-2705**: the platform client only rewrites assistant-scoped requests to the self-hosted gateway when the first path segment is in `RUNTIME_PROXIED_FIRST_SEGMENTS`, and `contacts`/`contact-channels` are not — so in local/self-hosted mode the DELETE fell through to the platform, whose 404 surfaced as the red "Not Found" toast while the contact stayed put. The gateway SDK client forwards **all** assistant-scoped requests to the self-hosted gateway (no segment allowlist), where the routes from #37212 serve them natively. Platform-hosted assistants are unchanged (no ingress registered → requests keep flowing through the platform proxy, same as feature flags on this client today).

Deliberately **not** grown: `RUNTIME_PROXIED_FIRST_SEGMENTS` — per its own comments that list should shrink toward deletion as call sites move onto the generated SDKs, not accumulate more segments.

Also: the upsert body is now typed by the generated request schema instead of `Record<string, unknown>`; exported function signatures are unchanged so no consumer churn. `redeemA2AInvite` stays on the platform client (platform broker endpoint).

Fixes LUM-2705.

## Test plan

- `bunx tsc --noEmit` clean (includes regenerating the SDK from the stacked spec).
- `contacts-page.test.tsx` and `api-interceptors.test.ts` (62) pass; eslint clean on both migrated files.
- Routing verified end-to-end in part 1: the SDK's URL shapes match the gateway's assistant-scoped route regexes, and the gateway handlers behind them are covered by `contacts-control-plane-proxy.test.ts` (98) / `contact-prompt-submit.test.ts` (17).

## CLI verb checklist

No new routes — web client call-site migration only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQukmCcA8NK2y9wqFVCdjc

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQukmCcA8NK2y9wqFVCdjc)_