### PR TITLE
test(heartbeat): spread the real platform module in the heartbeat-service mock

### DIFF
--- a/assistant/src/heartbeat/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-service.test.ts
@@ -29,8 +29,14 @@ mock.module("../../runtime/assistant-event-hub.js", () => ({
 // Stub workspace prompt reads so the heartbeat service doesn't try to
 // read real workspace files. Use a fallback for early module-load calls
 // (e.g. AuthSessionCache constructor) before beforeEach sets workspaceDir.
+// The mock spreads the real module so exports it doesn't override (imported
+// by transitive dependencies of the service under test) keep their real,
+// preload-temp-dir-scoped implementations instead of vanishing — a missing
+// export is an import-time SyntaxError for the whole test file.
+const realPlatform = await import("../../util/platform.js");
 const fallbackDir = join(tmpdir(), "vellum-hb-svc-fallback");
 mock.module("../../util/platform.js", () => ({
+  ...realPlatform,
   getWorkspaceDir: () => workspaceDir ?? fallbackDir,
   getWorkspacePromptPath: (name: string) =>
     join(workspaceDir ?? fallbackDir, name),


### PR DESCRIPTION
Main is red: `heartbeat-service.test.ts` fails at import with `SyntaxError: Export named 'getMonitoringDataDir' not found` (also failed the release/v0.10.6 staging bake).

**Cause** (bisected locally: green at `fada8d5089`, red at `1a9183d7e1`): the test's `mock.module("../../util/platform.js", …)` returns a hand-enumerated export map. #37175 routed hook dispatch through the resource-monitor sentinel, pulling `monitoring/*` — which imports `getMonitoringDataDir` from `util/platform` — into the heartbeat service's import graph. `mock.module` replaces the module wholesale, so the un-enumerated export is an import-time SyntaxError before any test runs.

**Fix**: spread the real module under the overrides (`{ ...realPlatform, <overrides> }`) so un-redirected exports keep their real, preload-temp-scoped implementations. Robust to the next transitive import instead of whack-a-mole on export names. 13/13 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)