### PR TITLE
fix(web): route deeplink.openThread through navigateToConversation

### DIFF
--- a/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, renderHook, act } from "@testing-library/react";
 
+import { useSubagentStore } from "@/domains/chat/subagent-store";
+import { useWorkflowStore } from "@/domains/chat/workflow-store";
 import { __resetForTesting, publish } from "@/lib/event-bus";
+import { useConversationStore } from "@/stores/conversation-store";
 import {
   __resetPendingDeepLinkForTesting,
   usePendingDeepLinkStore,
@@ -30,20 +33,27 @@ mock.module("@sentry/react", () => ({
 const { useGlobalDeepLinkConsumer } =
   await import("./use-global-deep-link-consumer");
 
+const resetStores = () => {
+  useViewerStore.setState({ mainView: "chat" });
+  useSubagentStore.getState().reset();
+  useWorkflowStore.getState().reset();
+  useConversationStore.getState().reset();
+};
+
 beforeEach(() => {
   __resetForTesting();
   __resetPendingDeepLinkForTesting();
   navigateMock.mockClear();
   ensureMainWindowVisibleMock.mockClear();
   sentryBreadcrumbMock.mockClear();
-  useViewerStore.setState({ mainView: "chat" });
+  resetStores();
 });
 
 afterEach(() => {
   cleanup();
   __resetForTesting();
   __resetPendingDeepLinkForTesting();
-  useViewerStore.setState({ mainView: "chat" });
+  resetStores();
 });
 
 describe("deeplink.send", () => {
@@ -87,6 +97,23 @@ describe("deeplink.openThread", () => {
     expect(useViewerStore.getState().mainView).toBe("chat");
     expect(navigateMock).toHaveBeenCalledWith(
       "/assistant/conversations/abc-123",
+    );
+  });
+
+  test("runs the full conversation-switch path — subagent/workflow resets + active id sync", () => {
+    useSubagentStore.setState({ orderedIds: ["sub-1"] });
+    useWorkflowStore.setState({ orderedIds: ["wf-1"] });
+    useConversationStore.setState({ activeConversationId: "old-conversation" });
+    renderHook(() => useGlobalDeepLinkConsumer());
+
+    act(() => {
+      publish("deeplink.openThread", { threadId: "abc-123" });
+    });
+
+    expect(useSubagentStore.getState().orderedIds).toEqual([]);
+    expect(useWorkflowStore.getState().orderedIds).toEqual([]);
+    expect(useConversationStore.getState().activeConversationId).toBe(
+      "abc-123",
     );
   });
 });

--- a/clients/web/src/hooks/use-global-deep-link-consumer.ts
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.ts
@@ -5,7 +5,7 @@ import { useNavigate } from "react-router";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { ensureMainWindowVisible } from "@/runtime/main-window";
 import { usePendingDeepLinkStore } from "@/stores/pending-deep-link-store";
-import { useViewerStore } from "@/stores/viewer-store";
+import { navigateToConversation } from "@/utils/conversation-navigation";
 import { routes } from "@/utils/routes";
 
 /**
@@ -16,17 +16,19 @@ import { routes } from "@/utils/routes";
  *
  * Responsibilities:
  *
- * - `deeplink.openThread` → `ensureMainWindowVisible()` + reset the
- *   viewer to chat (dismisses a full-width app viewer) +
- *   `navigate(routes.conversation(threadId))`.
+ * - `deeplink.openThread` → `ensureMainWindowVisible()` +
+ *   `navigateToConversation()` — the same shared path as an in-app
+ *   conversation switch (viewer reset, subagent/workflow store resets,
+ *   active-conversation sync, navigation).
  * - `deeplink.send` → `ensureMainWindowVisible()` + navigate to
  *   `/assistant` + park the message in `usePendingDeepLinkStore`
  *   for `ChatPage`'s composer-domain hook to consume on mount.
  * - `deeplink.unknown` → Sentry breadcrumb.
  *
  * The composer pre-fill itself stays in the chat domain
- * (`useDeepLinkConsumer`) because it owns `setInput`. This hook is
- * intentionally generic — it doesn't import chat-specific state.
+ * (`useDeepLinkConsumer`) because it owns `setInput`. This hook stays
+ * generic — chat-specific store handling lives in the shared
+ * `navigateToConversation` util.
  */
 
 export function useGlobalDeepLinkConsumer(): void {
@@ -44,10 +46,7 @@ export function useGlobalDeepLinkConsumer(): void {
 
   useBusSubscription("deeplink.openThread", ({ threadId }) => {
     void ensureMainWindowVisible();
-    // Mirror the normal conversation-switch path: dismiss the full-width
-    // app viewer so the navigated-to thread is actually visible.
-    useViewerStore.getState().setMainView("chat");
-    navigateRef.current(routes.conversation(threadId));
+    navigateToConversation(navigateRef.current, threadId);
   });
 
   useBusSubscription("deeplink.unknown", ({ url }) => {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for mobile-push-deeplink-haptics.md.

**Gap:** the deep-link consumer hand-copied 2 of navigateToConversation's 5 steps, so notification-tap navigation skipped the subagent/workflow store resets and activeConversationId sync (stale subagent panel possible).
**Fix:** call the shared navigateToConversation util; tests extended for the previously-skipped resets.