### PR TITLE
docs(web): correct deeplink.* event publisher docs

### DIFF
--- a/clients/web/docs/EVENT_BUS.md
+++ b/clients/web/docs/EVENT_BUS.md
@@ -57,6 +57,7 @@ Every event name in `BusEventMap` has a typed payload. Producers:
 - `runtime/event-sources/*` for host-environment signals (`app.*`, `power.*`, `deeplink.*`).
 - `assistant/sse-service.ts` for SSE-derived signals (`sse.*`).
 - `use-event-stream.ts`'s burst-limited reachability retry for `reachability.retry-requested`.
+- `hooks/use-notification-tap-navigation.ts` and `runtime/push-registration.ts` for notification-tap `deeplink.openThread`.
 
 | Event | Payload | Produced when |
 |---|---|---|
@@ -73,9 +74,9 @@ Every event name in `BusEventMap` has a typed payload. Producers:
 | `power.lock` | `{}` | Electron host: screen locked. No bus-owned action today. Off Electron never fires. |
 | `power.unlock` | `{}` | Electron host: screen unlocked. Bus bounces its SSE (same shape as `power.resume`). Off Electron never fires. |
 | `power.active` | `{}` | Electron host: `user-did-become-active` after idle. No bus-owned action today; future ticket may nudge stale state. Off Electron never fires. |
-| `deeplink.send` | `{ message }` | Electron host: inbound `vellum://send?message=…` URL routed by Launch Services. Chat domain consumes to pre-fill the composer. |
-| `deeplink.openThread` | `{ threadId }` | Electron host: inbound `vellum://thread/<id>` URL. Chat domain consumes to navigate. |
-| `deeplink.unknown` | `{ url }` | Parser fallback for foreign schemes / malformed URLs. Consumers typically log + drop; exists so the bridge surface is exhaustive. |
+| `deeplink.send` | `{ message }` | Electron host only: inbound `vellum://send?message=…` URL routed by Launch Services. Chat domain consumes to pre-fill the composer. |
+| `deeplink.openThread` | `{ threadId }` | Electron host: inbound `vellum://thread/<id>` URL. Also published by the notification-tap handler (`hooks/use-notification-tap-navigation.ts`) on every platform — Capacitor local notifications, Electron notification actions, browser `Notification.onclick` — and by APNs remote-push taps on Capacitor iOS (`runtime/push-registration.ts`). Chat domain consumes to navigate. |
+| `deeplink.unknown` | `{ url }` | Parser fallback for foreign schemes / malformed URLs — from the Electron deep-link path and from Capacitor iOS `App.appUrlOpen` URLs no handler claims (`runtime/event-sources/capacitor-deep-links.ts`). Consumers typically log + drop; exists so the bridge surface is exhaustive. |
 
 ## Subscribing
 
@@ -110,8 +111,11 @@ const unsubscribeResume = subscribe("app.resume", () => {
 
 Publishing is reserved for the bus's owner files (`sseService`,
 `runtime/event-sources/*`) and the narrow surfaces that need to ask
-the bus to do something — today only `reachability.retry-requested`.
-Don't add new producers without a documented reason.
+the bus to do something — today `reachability.retry-requested` and
+the notification-tap `deeplink.openThread` publishers
+(`hooks/use-notification-tap-navigation.ts`,
+`runtime/push-registration.ts`). Don't add new producers without a
+documented reason.
 
 ```ts
 import { publish } from "@/lib/event-bus";

--- a/clients/web/src/lib/event-bus.ts
+++ b/clients/web/src/lib/event-bus.ts
@@ -16,6 +16,9 @@
  *   - `assistant/sse-service.ts` for SSE-derived signals
  *   - `domains/chat/hooks/use-event-stream.ts` for
  *     `reachability.retry-requested`
+ *   - `hooks/use-notification-tap-navigation.ts` and
+ *     `runtime/push-registration.ts` for notification-tap
+ *     `deeplink.openThread`
  *
  * Consumers: `useBusSubscription` (React) or `subscribe` directly
  * (non-React).
@@ -125,18 +128,30 @@ export interface BusEventMap {
   "power.unlock": Record<string, never>;
   "power.active": Record<string, never>;
   /**
-   * Inbound deep links from the Electron host — `vellum://` and
-   * `vellum-assistant://` URL schemes the OS routed to us. Parsed
-   * into discriminated payloads in `clients/macos/src/main/deep-links.ts`.
-   * Domain consumers (chat composer, conversation router) subscribe
-   * here to take action.
+   * Inbound deep links — `vellum://` / `vellum-assistant://` URLs
+   * the OS routed to us, plus notification taps that resolve to a
+   * conversation. Domain consumers (chat composer, conversation
+   * router) subscribe here to take action.
    *
-   * `deeplink.unknown` covers parser fallbacks — foreign schemes,
-   * malformed URLs, unrecognized hosts. Consumers typically log
-   * and drop these; useful as a no-action signal so the bridge
-   * surface is exhaustive.
-   *
-   * Off Electron these never fire.
+   * Publishers per event:
+   *   - `deeplink.send`: Electron host only —
+   *     `vellum://send?message=…` URLs parsed into discriminated
+   *     payloads in `clients/macos/src/main/deep-links.ts` and
+   *     re-published by
+   *     `runtime/event-sources/electron-deep-links.ts`.
+   *   - `deeplink.openThread`: Electron `vellum://thread/<id>` URLs
+   *     (same path as above); notification taps carrying a
+   *     conversation id on every platform via
+   *     `hooks/use-notification-tap-navigation.ts` (Capacitor local
+   *     notifications, Electron notification actions, browser
+   *     `Notification.onclick`); and APNs remote-push taps on
+   *     Capacitor iOS via `runtime/push-registration.ts`.
+   *   - `deeplink.unknown`: parser fallbacks — foreign schemes,
+   *     malformed URLs, unrecognized hosts — from the Electron path
+   *     and from Capacitor iOS `App.appUrlOpen` URLs no handler
+   *     claims (`runtime/event-sources/capacitor-deep-links.ts`).
+   *     Consumers typically log and drop these; useful as a
+   *     no-action signal so the bridge surface is exhaustive.
    */
   "deeplink.send": { message: string };
   "deeplink.openThread": { threadId: string };


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for mobile-push-deeplink-haptics.md.

**Gap:** event-bus.ts and EVENT_BUS.md still said deeplink.* events never fire off Electron; they now fire on Capacitor iOS (appUrlOpen, push taps) and via the cross-platform notification tap handler.
**Fix:** documentation updated to list the actual publishers per event; deeplink.send noted as still Electron-only.