### PR TITLE
refactor(web): extract shared Capacitor listener subscription helper

### DIFF
--- a/clients/web/src/runtime/browser.ts
+++ b/clients/web/src/runtime/browser.ts
@@ -1,5 +1,6 @@
 import { Capacitor } from "@capacitor/core";
 
+import { subscribeCapacitorListener } from "@/runtime/capacitor-listener";
 import { isElectron } from "@/runtime/is-electron";
 
 /**
@@ -42,20 +43,8 @@ export const openUrl = async (url: string): Promise<void> => {
  * Usage:
  *   useEffect(() => openUrlFinishedListener(() => { refetch(); onClose(); }), []);
  */
-export const openUrlFinishedListener = (
-  callback: () => void,
-): (() => void) => {
-  if (!Capacitor.isNativePlatform()) return () => {};
-
-  let handle: { remove: () => void } | null = null;
-
-  void import("@capacitor/browser").then(({ Browser }) => {
-    void Browser.addListener("browserFinished", callback).then((h) => {
-      handle = h;
-    });
+export const openUrlFinishedListener = (callback: () => void): (() => void) =>
+  subscribeCapacitorListener("capacitor_browser_finished", async () => {
+    const { Browser } = await import("@capacitor/browser");
+    return Browser.addListener("browserFinished", callback);
   });
-
-  return () => {
-    handle?.remove();
-  };
-};

--- a/clients/web/src/runtime/capacitor-listener.test.ts
+++ b/clients/web/src/runtime/capacitor-listener.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { PluginListenerHandle } from "@capacitor/core";
+
+let isNative = true;
+const isNativePlatformMock = mock(() => isNative);
+mock.module("@/runtime/native-auth", () => ({
+  isNativePlatform: isNativePlatformMock,
+}));
+
+const captureErrorMock = mock(() => {});
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: captureErrorMock,
+}));
+
+const { subscribeCapacitorListener } =
+  await import("@/runtime/capacitor-listener");
+
+const handleRemoveMock = mock(async () => {});
+let subscribeResolver: ((handle: PluginListenerHandle) => void) | null = null;
+let subscribeRejecter: ((err: Error) => void) | null = null;
+
+const subscribeMock = mock(
+  () =>
+    new Promise<PluginListenerHandle>((resolve, reject) => {
+      subscribeResolver = resolve;
+      subscribeRejecter = reject;
+    }),
+);
+
+const flushMicrotasks = async (rounds = 4) => {
+  for (let i = 0; i < rounds; i++) {
+    await Promise.resolve();
+  }
+};
+
+beforeEach(() => {
+  isNative = true;
+  subscribeResolver = null;
+  subscribeRejecter = null;
+  isNativePlatformMock.mockClear();
+  subscribeMock.mockClear();
+  handleRemoveMock.mockClear();
+  captureErrorMock.mockClear();
+});
+
+describe("subscribeCapacitorListener", () => {
+  test("is a no-op off Capacitor iOS (returns a no-op unsubscribe, never calls subscribe)", () => {
+    isNative = false;
+
+    const unsubscribe = subscribeCapacitorListener("ctx", subscribeMock);
+    unsubscribe();
+
+    expect(subscribeMock).not.toHaveBeenCalled();
+  });
+
+  test("returned unsubscribe removes the listener once subscribe resolves", async () => {
+    const unsubscribe = subscribeCapacitorListener("ctx", subscribeMock);
+
+    subscribeResolver?.({ remove: handleRemoveMock });
+    await flushMicrotasks();
+    expect(handleRemoveMock).not.toHaveBeenCalled();
+
+    unsubscribe();
+    expect(handleRemoveMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("unsubscribe BEFORE subscribe resolves still removes the just-registered listener", async () => {
+    const unsubscribe = subscribeCapacitorListener("ctx", subscribeMock);
+
+    // Unsubscribe first — the internal `cancelled` flag must catch the
+    // late resolution and remove the listener.
+    unsubscribe();
+    subscribeResolver?.({ remove: handleRemoveMock });
+    await flushMicrotasks();
+
+    expect(handleRemoveMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("reports a subscribe failure under the given context instead of throwing", async () => {
+    subscribeCapacitorListener("my_context", subscribeMock);
+
+    const err = new Error("plugin missing");
+    subscribeRejecter?.(err);
+    await flushMicrotasks();
+
+    expect(captureErrorMock).toHaveBeenCalledWith(err, {
+      context: "my_context",
+      level: "warning",
+    });
+  });
+});

--- a/clients/web/src/runtime/capacitor-listener.ts
+++ b/clients/web/src/runtime/capacitor-listener.ts
@@ -1,0 +1,60 @@
+import { captureError } from "@/lib/sentry/capture-error";
+import type { PluginListenerHandle } from "@capacitor/core";
+
+import { isNativePlatform } from "@/runtime/native-auth";
+
+/**
+ * Shared subscription scaffold for Capacitor plugin event listeners.
+ * Owns the pieces every native listener source needs:
+ *
+ * - The `isNativePlatform()` guard — off Capacitor iOS this returns a
+ *   no-op unsubscribe without ever invoking `subscribe` (so the plugin
+ *   is never loaded).
+ * - The unsubscribe-before-registration race: `subscribe()` resolves
+ *   asynchronously (lazy plugin import), so an unsubscribe that runs
+ *   first sets the internal `cancelled` flag and the resolution path
+ *   removes the just-registered listener instead of leaking it.
+ * - Failure reporting: a rejected `subscribe()` is captured under
+ *   `errorContext` at warning level instead of surfacing as an
+ *   unhandled rejection.
+ *
+ * `subscribe` must lazy-import the plugin and call `addListener`
+ * inline, per CAPACITOR.md's "lazy-import rule" — the plugin Proxy
+ * must never cross a Promise-resolution context, so it stays inside
+ * the caller's closure and only the listener handle escapes:
+ *
+ * ```ts
+ * subscribeCapacitorListener("my_context", async () => {
+ *   const { App } = await import("@capacitor/app");
+ *   return App.addListener("appStateChange", handler);
+ * });
+ * ```
+ */
+export function subscribeCapacitorListener(
+  errorContext: string,
+  subscribe: () => Promise<PluginListenerHandle>,
+): () => void {
+  if (!isNativePlatform()) {
+    return () => undefined;
+  }
+
+  let handle: PluginListenerHandle | null = null;
+  let cancelled = false;
+
+  subscribe()
+    .then((registered) => {
+      if (cancelled) {
+        void registered.remove();
+        return;
+      }
+      handle = registered;
+    })
+    .catch((err) => {
+      captureError(err, { context: errorContext, level: "warning" });
+    });
+
+  return () => {
+    cancelled = true;
+    void handle?.remove();
+  };
+}

--- a/clients/web/src/runtime/event-sources/capacitor-app-state.ts
+++ b/clients/web/src/runtime/event-sources/capacitor-app-state.ts
@@ -1,57 +1,28 @@
-import { captureError } from "@/lib/sentry/capture-error";
-import type { PluginListenerHandle } from "@capacitor/core";
-
 import { publish } from "@/lib/event-bus";
-import { isNativePlatform } from "@/runtime/native-auth";
+import { subscribeCapacitorListener } from "@/runtime/capacitor-listener";
 
 /**
  * Capacitor iOS shell's `App.appStateChange` →
  * `app.resume(signal: "app_state")` on active, `app.hidden(signal:
  * "app_state")` on inactive. Off Capacitor iOS the function is a no-op
- * (`isNativePlatform()` returns false) — web and Electron get their
- * lifecycle signals from `publishVisibilitySource` / `publishWindowOnlineSource`
+ * — web and Electron get their lifecycle signals from
+ * `publishVisibilitySource` / `publishWindowOnlineSource`
  * / `publishElectronPowerSource` instead.
  *
- * The `@capacitor/app` plugin import is lazy (per CAPACITOR.md's
- * "lazy-import rule"): Capacitor plugins are Proxy objects whose
- * `.then` trap hangs an outer `await` indefinitely if the Proxy
- * crosses a Promise-resolution context. The dynamic import inside
- * the helper keeps the Proxy out of any async return.
- *
- * The sync return + internal `cancelled` flag covers the case where
- * the caller unsubscribes before the import resolves: we mark
- * cancelled, the import-resolution path checks it and removes the
- * just-registered listener.
+ * `subscribeCapacitorListener` owns the platform guard, the
+ * unsubscribe-before-import-resolves race, and failure reporting; the
+ * `@capacitor/app` import stays lazy and inline here per CAPACITOR.md's
+ * "lazy-import rule".
  */
 export function publishCapacitorAppStateSource(): () => void {
-  if (!isNativePlatform()) return () => undefined;
-
-  let handle: PluginListenerHandle | null = null;
-  let cancelled = false;
-
-  import("@capacitor/app")
-    .then(({ App }) =>
-      App.addListener("appStateChange", ({ isActive }) => {
-        if (isActive) {
-          publish("app.resume", { signal: "app_state" });
-        } else {
-          publish("app.hidden", { signal: "app_state" });
-        }
-      }),
-    )
-    .then((registered) => {
-      if (cancelled) {
-        void registered.remove();
-        return;
+  return subscribeCapacitorListener("event_bus_capacitor_init", async () => {
+    const { App } = await import("@capacitor/app");
+    return App.addListener("appStateChange", ({ isActive }) => {
+      if (isActive) {
+        publish("app.resume", { signal: "app_state" });
+      } else {
+        publish("app.hidden", { signal: "app_state" });
       }
-      handle = registered;
-    })
-    .catch((err) => {
-      captureError(err, { context: "event_bus_capacitor_init", level: "warning" });
     });
-
-  return () => {
-    cancelled = true;
-    void handle?.remove();
-  };
+  });
 }

--- a/clients/web/src/runtime/event-sources/capacitor-deep-links.ts
+++ b/clients/web/src/runtime/event-sources/capacitor-deep-links.ts
@@ -1,8 +1,5 @@
-import { captureError } from "@/lib/sentry/capture-error";
-import type { PluginListenerHandle } from "@capacitor/core";
-
 import { publish } from "@/lib/event-bus";
-import { isNativePlatform } from "@/runtime/native-auth";
+import { subscribeCapacitorListener } from "@/runtime/capacitor-listener";
 import {
   OAUTH_COMPLETE_DEEP_LINK_EVENT,
   parseOAuthCompleteDeepLink,
@@ -20,40 +17,19 @@ import {
  * `deeplink.unknown { url }` on the bus — future URL kinds
  * (conversation universal links, quick actions) branch here.
  *
- * Off Capacitor iOS the function is a no-op (`isNativePlatform()`
- * returns false) — Electron deep links flow through
- * `publishElectronDeepLinksSource` instead.
+ * Off Capacitor iOS the function is a no-op — Electron deep links flow
+ * through `publishElectronDeepLinksSource` instead.
  *
- * The `@capacitor/app` plugin import is lazy (per CAPACITOR.md's
- * "lazy-import rule"), and the sync return + internal `cancelled` flag
- * covers unsubscribing before the import resolves — both mirror
- * `publishCapacitorAppStateSource`.
+ * `subscribeCapacitorListener` owns the platform guard, the
+ * unsubscribe-before-import-resolves race, and failure reporting; the
+ * `@capacitor/app` import stays lazy and inline here per CAPACITOR.md's
+ * "lazy-import rule".
  */
 export function publishCapacitorDeepLinksSource(): () => void {
-  if (!isNativePlatform()) return () => undefined;
-
-  let handle: PluginListenerHandle | null = null;
-  let cancelled = false;
-
-  import("@capacitor/app")
-    .then(({ App }) =>
-      App.addListener("appUrlOpen", ({ url }) => handleUrl(url)),
-    )
-    .then((registered) => {
-      if (cancelled) {
-        void registered.remove();
-        return;
-      }
-      handle = registered;
-    })
-    .catch((err) => {
-      captureError(err, { context: "capacitor_deep_links", level: "warning" });
-    });
-
-  return () => {
-    cancelled = true;
-    void handle?.remove();
-  };
+  return subscribeCapacitorListener("capacitor_deep_links", async () => {
+    const { App } = await import("@capacitor/app");
+    return App.addListener("appUrlOpen", ({ url }) => handleUrl(url));
+  });
 }
 
 function handleUrl(url: string): void {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for mobile-push-deeplink-haptics.md.

**Gap:** the lazy-Capacitor-listener + cancelled-flag race scaffold was duplicated across capacitor-deep-links and capacitor-app-state (with a third unguarded variant in browser.ts).
**Fix:** one plugin-agnostic helper owns the race logic; both event sources adopt it (browser.ts migrated only if drop-in clean).