### PR TITLE
feat(web): multi-turn live-voice sessions with seamless barge-in

### DIFF
--- a/clients/web/src/domains/chat/components/live-voice-button.tsx
+++ b/clients/web/src/domains/chat/components/live-voice-button.tsx
@@ -13,8 +13,6 @@
  *   - any other (active)  → stop-circle icon, click to stop; the live
  *                           `inputAmplitude` drives a subtle pulse so the user
  *                           sees the mic is hearing them.
- *
- * Wiring into the composer happens in a later PR; this is the standalone control.
  */
 
 import { Loader2, Mic, StopCircle } from "lucide-react";

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -4,9 +4,9 @@
  * The three merged primitives — client, capture, player — are replaced with
  * hand-rolled fakes injected through `useLiveVoice`'s factory options, so no
  * WebSocket, microphone, or AudioContext is touched. The fakes expose drivers
- * (`emit`, `pushChunk`, `pushAmplitude`) so a test can drive a full turn and
- * assert the state-machine transitions, barge-in, automatic ptt_release, and
- * teardown.
+ * (`emit`, `pushChunk`, `pushAmplitude`) so a test can drive multi-turn
+ * sessions and assert the state-machine transitions, barge-in, automatic
+ * ptt_release, and teardown.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -245,11 +245,11 @@ afterEach(() => {
 });
 
 // ---------------------------------------------------------------------------
-// Full turn
+// Multi-turn session
 // ---------------------------------------------------------------------------
 
-describe("full turn", () => {
-  test("drives idle → connecting → listening → thinking → speaking → idle (session ends after the turn)", async () => {
+describe("multi-turn session", () => {
+  test("drives two turns over one socket: … → speaking → listening → speaking → listening", async () => {
     const h = renderController();
 
     expect(h.view.result.current.state).toBe("idle");
@@ -327,16 +327,59 @@ describe("full turn", () => {
     expect(h.view.result.current.state).toBe("speaking");
     expect(h.player.enqueued).toHaveLength(1);
 
-    // tts_done awaits playback drain, then ends the session (single-utterance):
-    // the socket is closed and the mic is shut down, returning to idle.
+    // tts_done awaits playback drain, then resumes listening on the same
+    // socket and mic — the session is multi-turn, so nothing is torn down.
     await act(async () => {
       h.client.emit("ttsDone", { type: "tts_done", seq: 8, turnId: "t1" });
       h.player.finishPlayback();
       await Promise.resolve();
     });
-    expect(h.view.result.current.state).toBe("idle");
-    expect(h.client.closed).toBe(true);
-    expect(h.getCapture().shutdownCount).toBe(1);
+    expect(h.view.result.current.state).toBe("listening");
+    expect(h.client.closed).toBe(false);
+    expect(h.client.ended).toBe(false);
+    expect(h.getCapture().shutdownCount).toBe(0);
+    // No mic re-acquisition: the original capture graph spans both turns.
+    expect(h.getCapture().startCount).toBe(1);
+
+    // Second turn: forwarding re-opened, so captured audio streams again.
+    act(() => {
+      h.getCapture().pushAmplitude(0.1);
+      h.getCapture().pushChunk(pcmChunk(20));
+    });
+    expect(h.client.sentAudio).toHaveLength(2);
+
+    act(() => {
+      h.client.emit("sttFinal", { type: "stt_final", seq: 9, text: "again" });
+    });
+    expect(h.view.result.current.finalTranscript).toBe("again");
+
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 10, turnId: "t2" });
+    });
+    // The per-turn assistant transcript resets for the new response.
+    expect(h.view.result.current.assistantTranscript).toBe("");
+    expect(h.view.result.current.state).toBe("thinking");
+
+    act(() => {
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 11,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+    });
+    expect(h.view.result.current.state).toBe("speaking");
+    expect(h.player.enqueued).toHaveLength(2);
+
+    await act(async () => {
+      h.client.emit("ttsDone", { type: "tts_done", seq: 12, turnId: "t2" });
+      h.player.finishPlayback();
+      await Promise.resolve();
+    });
+    expect(h.view.result.current.state).toBe("listening");
+    expect(h.client.closed).toBe(false);
+    expect(h.getCapture().shutdownCount).toBe(0);
   });
 });
 
@@ -345,7 +388,7 @@ describe("full turn", () => {
 // ---------------------------------------------------------------------------
 
 describe("barge-in", () => {
-  test("amplitude over threshold while speaking stops playback, interrupts, and ends the session", async () => {
+  test("amplitude over threshold while speaking stops playback and interrupts; the interrupted frame resumes listening on the same socket", async () => {
     const h = renderController();
     await startListening(h);
 
@@ -366,13 +409,63 @@ describe("barge-in", () => {
       h.getCapture().pushAmplitude(0.2); // over BARGE_IN_AMPLITUDE_THRESHOLD
     });
 
-    // Playback is stopped and a single interrupt is sent; the (now terminal)
-    // session is then torn down → idle (mic shut down, socket closed).
+    // Playback is stopped and a single interrupt is sent; the session stays
+    // open awaiting the server's `interrupted` confirmation.
     expect(h.player.isPlaying).toBe(false);
     expect(h.client.interruptCount).toBe(1);
-    expect(h.view.result.current.state).toBe("idle");
-    expect(h.client.closed).toBe(true);
-    expect(h.getCapture().shutdownCount).toBe(1);
+    expect(h.client.closed).toBe(false);
+    expect(h.view.result.current.state).toBe("speaking");
+
+    act(() => {
+      h.client.emit("interrupted", {
+        type: "interrupted",
+        seq: 4,
+        turnId: "t1",
+      });
+    });
+    expect(h.view.result.current.state).toBe("listening");
+    expect(h.client.closed).toBe(false);
+    expect(h.getCapture().shutdownCount).toBe(0);
+
+    // Forwarding re-opened: the next utterance streams on the same socket.
+    act(() => {
+      h.getCapture().pushAmplitude(0.1);
+      h.getCapture().pushChunk(pcmChunk(20));
+    });
+    expect(h.client.sentAudio).toHaveLength(1);
+  });
+
+  test("server-initiated interrupted (no local threshold crossing) flushes playback and resumes listening", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 3,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+    });
+    expect(h.player.isPlaying).toBe(true);
+
+    act(() => {
+      h.client.emit("interrupted", {
+        type: "interrupted",
+        seq: 4,
+        turnId: "t1",
+      });
+    });
+
+    // The client never initiated the barge-in, yet playback is flushed and
+    // the session resumes listening.
+    expect(h.client.interruptCount).toBe(0);
+    expect(h.player.isPlaying).toBe(false);
+    expect(h.view.result.current.state).toBe("listening");
+    expect(h.client.closed).toBe(false);
+    expect(h.getCapture().shutdownCount).toBe(0);
   });
 
   test("interrupt is sent at most once per response", async () => {
@@ -395,7 +488,7 @@ describe("barge-in", () => {
     expect(h.client.interruptCount).toBe(1);
   });
 
-  test("realistic turn: auto-release → speaking → barge-in ends the session", async () => {
+  test("realistic turn: auto-release → speaking → barge-in resumes listening for the next turn", async () => {
     const h = renderController();
     await startListening(h);
     const capture = h.getCapture();
@@ -424,14 +517,35 @@ describe("barge-in", () => {
     expect(h.view.result.current.state).toBe("speaking");
 
     // The mic never stopped, so amplitude still flows while the assistant
-    // speaks: a loud reading interrupts (barge-in), which ends the session.
+    // speaks: a loud reading interrupts (barge-in); the server's `interrupted`
+    // confirmation resumes listening without tearing anything down.
     act(() => {
       capture.pushAmplitude(0.3); // over BARGE_IN_AMPLITUDE_THRESHOLD
     });
     expect(h.client.interruptCount).toBe(1);
     expect(h.player.isPlaying).toBe(false);
-    expect(h.view.result.current.state).toBe("idle");
-    expect(capture.shutdownCount).toBe(1);
+
+    act(() => {
+      h.client.emit("interrupted", {
+        type: "interrupted",
+        seq: 6,
+        turnId: "t1",
+      });
+    });
+    expect(h.view.result.current.state).toBe("listening");
+    expect(capture.shutdownCount).toBe(0);
+    expect(h.client.closed).toBe(false);
+
+    // The next utterance auto-releases again on the same session (the
+    // per-turn release/speech flags were reset by the resume).
+    act(() => {
+      capture.pushAmplitude(0.1);
+      capture.pushChunk(pcmChunk(200));
+      capture.pushAmplitude(0.0);
+      capture.pushChunk(pcmChunk(1000));
+    });
+    expect(h.client.pttReleaseCount).toBe(2);
+    expect(h.view.result.current.state).toBe("transcribing");
   });
 });
 
@@ -472,6 +586,37 @@ describe("automatic ptt_release", () => {
 
     expect(h.client.pttReleaseCount).toBe(0);
     expect(h.view.result.current.state).toBe("listening");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Server turn boundary
+// ---------------------------------------------------------------------------
+
+describe("turn_boundary", () => {
+  test("while listening moves to transcribing (server segmented the turn)", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    act(() => {
+      h.client.emit("turnBoundary", { type: "turn_boundary", seq: 2 });
+    });
+
+    expect(h.view.result.current.state).toBe("transcribing");
+    // The transition is UI-only: no client-side ptt_release is sent.
+    expect(h.client.pttReleaseCount).toBe(0);
+  });
+
+  test("outside listening leaves the state alone", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+      h.client.emit("turnBoundary", { type: "turn_boundary", seq: 3 });
+    });
+
+    expect(h.view.result.current.state).toBe("thinking");
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -12,36 +12,33 @@
  * controller instance drives at most one session at a time; `start()` while a
  * session is live is a no-op.
  *
- * ## Single-utterance sessions
- * A live-voice session handles exactly one utterance → one response. The runtime
- * (and the macOS reference) treat `ptt_release` as terminal: once released, the
- * session never re-accepts audio (sending more yields `invalid_audio_payload`).
- * So this controller does NOT keep one socket open across turns — after the
- * assistant finishes speaking it ends the session (→ idle), and the user starts
- * a fresh one for the next turn. Barge-in is the one case that reconnects
- * automatically (see below).
+ * ## Multi-turn sessions
+ * One session spans many turns over a single socket and a single mic
+ * acquisition: after the assistant's response finishes playing (or is
+ * interrupted), the controller re-opens audio forwarding and returns to
+ * `listening` for the next utterance. The session ends only via `stop()`
+ * (user), a server/socket `closed`, `busy`, or an error.
  *
- * ## State transitions (one session = one turn)
+ * ## State transitions
  * `idle → connecting` (start) → `listening` (ready + capture started) →
- * `transcribing` (ptt released) → `thinking` (server response) → `speaking`
- * (tts_audio) → `idle` (tts_done drained → session ended). The mic keeps
- * capturing for the whole session; `stop()`, teardown, an error, a server
- * `archived`/`closed`, or end-of-response returns to `idle`/`failed`.
+ * `transcribing` (ptt released / server turn boundary) → `thinking` (server
+ * response) → `speaking` (tts_audio) → `listening` (tts_done drained, or
+ * barge-in confirmed via `interrupted`) → … repeating until `stop()`, an
+ * error, or a server `closed` returns to `idle`/`failed`.
  *
  * ## Mic forwarding
  * The mic capture graph runs for the entire active session so amplitude keeps
  * flowing for barge-in even while the assistant is thinking/speaking. Audio
  * *forwarding* (`session.forwardingAudio`) is gated to the user's turn: captured
  * PCM is streamed only while forwarding is on. Push-to-talk release flips
- * forwarding off (without stopping the mic); it is not re-opened within a
- * session (the session is single-utterance — see above).
+ * forwarding off (without stopping the mic); resuming listening for the next
+ * turn re-opens it.
  *
  * ## Barge-in
  * While `speaking`, a captured amplitude over {@link BARGE_IN_AMPLITUDE_THRESHOLD}
- * stops playback, sends `interrupt` (once per response), and ends the session
- * (→ idle) — the interrupted session is terminal on the runtime, so the user
- * starts a fresh session to respond. (Seamless reconnect-on-barge-in is a
- * follow-up.)
+ * stops playback and sends `interrupt` (once per response). The server confirms
+ * with an `interrupted` frame — which also arrives unprompted on server-VAD
+ * barge-in — flushing playback and resuming `listening` on the same socket.
  *
  * ## Automatic push-to-talk release
  * While `listening`, sustained speech (≥ {@link MINIMUM_SPEECH_DURATION_BEFORE_RELEASE_MS})
@@ -132,12 +129,10 @@ interface SessionContext {
   captureRunning: boolean;
   /**
    * Whether captured PCM is currently streamed to the server. On while the user
-   * is speaking (`listening`); turned off after an automatic push-to-talk
-   * release. A live-voice session is single-utterance (the runtime treats
-   * `ptt_release` as terminal — it never re-accepts audio), so forwarding is not
-   * re-opened within a session: the session ends after the response, and a fresh
-   * session is started for the next turn. Amplitude keeps flowing regardless so
-   * barge-in works while not forwarding.
+   * is speaking (`listening`); turned off by push-to-talk release and while the
+   * assistant response plays, then re-opened by {@link resumeListening} for the
+   * next turn. Amplitude keeps flowing regardless so barge-in works while not
+   * forwarding.
    */
   forwardingAudio: boolean;
   /** Whether the assistant has sent any TTS audio for the current response. */
@@ -259,7 +254,7 @@ export function useLiveVoice(
 
       const capture = (opts.createCapture ?? ((o) => new LiveVoiceAudioCapture(o)))({
         onChunk: (buf) => handleChunk(session, buf),
-        onAmplitude: (amplitude) => handleAmplitude(session, amplitude, teardown),
+        onAmplitude: (amplitude) => handleAmplitude(session, amplitude),
       });
       session.capture = capture;
       sessionRef.current = session;
@@ -321,7 +316,25 @@ export function useLiveVoice(
         }),
         client.on("ttsDone", () => {
           if (!live()) return;
-          void finishResponseAfterPlayback(session, teardown);
+          void finishResponseAfterPlayback(session);
+        }),
+        client.on("turnBoundary", () => {
+          if (!live()) return;
+          // The server segmented the user's turn; mirror the local auto-release
+          // UI transition. Under PTT this follows our own ptt_release (state
+          // already advanced); in open-mic it is the primary end-of-turn signal.
+          const s = useLiveVoiceStore.getState();
+          if (s.state === "listening") s.setState("transcribing");
+        }),
+        client.on("interrupted", () => {
+          if (!live()) return;
+          // Barge-in accepted (locally initiated or server-VAD). Flush playback
+          // — idempotent when a local barge-in already stopped the player — and
+          // go back to listening unless the drain path already resumed.
+          session.player.stop();
+          if (useLiveVoiceStore.getState().state !== "listening") {
+            resumeListening(session);
+          }
         }),
         client.on("archived", () => {
           if (!live()) return;
@@ -411,15 +424,11 @@ function handleChunk(session: SessionContext, buf: ArrayBuffer): void {
  * Runs whenever the mic is open — including while not forwarding — so a loud
  * amplitude can interrupt the assistant mid-response (barge-in).
  */
-function handleAmplitude(
-  session: SessionContext,
-  amplitude: number,
-  teardown: () => void,
-): void {
+function handleAmplitude(session: SessionContext, amplitude: number): void {
   if (!session.captureRunning) return;
   useLiveVoiceStore.getState().setInputAmplitude(amplitude);
   if (amplitude >= BARGE_IN_AMPLITUDE_THRESHOLD) {
-    interruptIfSpeaking(session, teardown);
+    interruptIfSpeaking(session);
   }
 }
 
@@ -468,24 +477,32 @@ function releasePushToTalk(session: SessionContext): void {
 /**
  * Resume listening for the next utterance: re-open the forwarding gate, clear
  * the per-utterance counters/flags, and move to `listening`. The mic is already
- * running (continuous capture), so there is nothing to restart here.
+ * running (continuous capture) and the socket stays open, so there is nothing
+ * to restart here.
  */
+function resumeListening(session: SessionContext): void {
+  session.forwardingAudio = true;
+  session.interruptSent = false;
+  session.responseAudioStarted = false;
+  session.releaseInFlight = false;
+  session.speechMs = 0;
+  session.silenceMs = 0;
+  const s = useLiveVoiceStore.getState();
+  s.setPartialTranscript("");
+  s.setState("listening");
+}
+
 /**
- * Barge-in: stop playback and interrupt the server once per response, then end
- * the session (→ idle). The interrupted session is terminal on the runtime — it
- * won't accept more audio — so we can't keep forwarding on it; the user starts a
- * fresh session to respond. (Seamless reconnect-on-barge-in is a follow-up.)
+ * Barge-in: stop playback and interrupt the server once per response. The
+ * session stays open — the server confirms with an `interrupted` frame, which
+ * flushes any straggler audio and resumes `listening` for the next utterance.
  */
-function interruptIfSpeaking(
-  session: SessionContext,
-  teardown: () => void,
-): void {
+function interruptIfSpeaking(session: SessionContext): void {
   if (useLiveVoiceStore.getState().state !== "speaking") return;
   if (!session.player.isPlaying || session.interruptSent) return;
   session.interruptSent = true;
   session.player.stop();
   session.client.interrupt();
-  teardown();
 }
 
 /** First TTS frame of a response: reset playback flags for the new utterance. */
@@ -496,20 +513,14 @@ function beginAssistantAudioIfNeeded(session: SessionContext): void {
 }
 
 /**
- * After `tts_done`, await playback drain, then end the session (→ idle).
- *
- * A live-voice session is single-utterance: once `ptt_release` fires the runtime
- * won't accept more audio on it, so we don't resume listening on the same
- * socket — we tear the session down and the user starts a fresh one for the next
- * turn (mirrors the macOS `closeCompletedUtteranceSessionAfterPlayback`).
- * Forwarding is suspended during the drain so playback audio captured by the
- * (still-open) mic isn't streamed back. A barge-in during the drain already
- * tore this session down and reconnected (generation bumped / state no longer
- * `speaking`), so we leave that fresh session alone.
+ * After `tts_done`, await playback drain, then resume listening for the next
+ * turn on the same socket. Forwarding is suspended during the drain so playback
+ * audio captured by the (still-open) mic isn't streamed back. If an
+ * `interrupted` frame resumed listening while we drained, leave the new turn
+ * alone — resuming again would clear its in-flight counters/transcript.
  */
 async function finishResponseAfterPlayback(
   session: SessionContext,
-  teardown: () => void,
 ): Promise<void> {
   const generation = session.generation;
   session.responseAudioStarted = false;
@@ -517,10 +528,8 @@ async function finishResponseAfterPlayback(
 
   await session.player.waitUntilDrained();
   if (session.generation !== generation) return;
-
-  // A barge-in mid-drain already reconnected a fresh session; don't tear it down.
-  if (useLiveVoiceStore.getState().state !== "speaking") return;
-  teardown();
+  if (useLiveVoiceStore.getState().state === "listening") return;
+  resumeListening(session);
 }
 
 /** Fail the session: tear down primitives and surface the message. */

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -374,17 +374,17 @@
       "id": "research-onboarding",
       "scope": "client",
       "key": "research-onboarding",
-      "label": "Research onboarding (spike)",
-      "description": "Spike: replace pre-chat onboarding with a web-research \"here's what I know about you\" flow, including a Google Calendar \"Let's chat tomorrow\" step shown over the streaming research. Gates the /assistant/onboarding/research route and the research mock harness. Off by default; enable locally via the feature-flags panel.",
-      "defaultEnabled": false
+      "label": "Research onboarding",
+      "description": "Replace pre-chat onboarding with a web-research \"here's what I know about you\" flow, including the \"Create my personality\" step and a Google Calendar \"Let's chat tomorrow\" step shown over the streaming research. Gates the /assistant/onboarding/research route and the research mock harness. On by default (GA); after consent, new web users (non-native, non-local-mode) are routed into this flow instead of the standard hatching path.",
+      "defaultEnabled": true
     },
     {
       "id": "personality-onboarding",
       "scope": "client",
       "key": "personality-onboarding",
-      "label": "Personality onboarding step (spike)",
-      "description": "Spike: show the \"Create my personality\" trait-slider step in the research-onboarding flow (between the pitch and the integration step). On continue it applies the sliders to the assistant's persona on a throwaway side conversation. When off, the step is skipped entirely. Off by default; enable locally via the feature-flags panel.",
-      "defaultEnabled": false
+      "label": "Personality onboarding step",
+      "description": "Show the \"Create my personality\" trait-slider step in the research-onboarding flow (between the pitch and the integration step). On continue it applies the sliders to the assistant's persona on a throwaway side conversation. When off, the step is skipped entirely. On by default (GA); only takes effect where the research-onboarding flow itself is enabled.",
+      "defaultEnabled": true
     },
     {
       "id": "channel-trust-floors",

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -374,17 +374,17 @@
       "id": "research-onboarding",
       "scope": "client",
       "key": "research-onboarding",
-      "label": "Research onboarding",
-      "description": "Replace pre-chat onboarding with a web-research \"here's what I know about you\" flow, including the \"Create my personality\" step and a Google Calendar \"Let's chat tomorrow\" step shown over the streaming research. Gates the /assistant/onboarding/research route and the research mock harness. On by default (GA); after consent, new web users (non-native, non-local-mode) are routed into this flow instead of the standard hatching path.",
-      "defaultEnabled": true
+      "label": "Research onboarding (spike)",
+      "description": "Spike: replace pre-chat onboarding with a web-research \"here's what I know about you\" flow, including a Google Calendar \"Let's chat tomorrow\" step shown over the streaming research. Gates the /assistant/onboarding/research route and the research mock harness. Off by default; enable locally via the feature-flags panel.",
+      "defaultEnabled": false
     },
     {
       "id": "personality-onboarding",
       "scope": "client",
       "key": "personality-onboarding",
-      "label": "Personality onboarding step",
-      "description": "Show the \"Create my personality\" trait-slider step in the research-onboarding flow (between the pitch and the integration step). On continue it applies the sliders to the assistant's persona on a throwaway side conversation. When off, the step is skipped entirely. On by default (GA); only takes effect where the research-onboarding flow itself is enabled.",
-      "defaultEnabled": true
+      "label": "Personality onboarding step (spike)",
+      "description": "Spike: show the \"Create my personality\" trait-slider step in the research-onboarding flow (between the pitch and the integration step). On continue it applies the sliders to the assistant's persona on a throwaway side conversation. When off, the step is skipped entirely. Off by default; enable locally via the feature-flags panel.",
+      "defaultEnabled": false
     },
     {
       "id": "channel-trust-floors",


### PR DESCRIPTION
## Summary
- Session loop: after tts_done drain the client returns to listening on the same socket/mic (resumeListening) instead of tearing down
- Barge-in keeps the session alive: local interrupt + server interrupted event both flush playback and resume listening
- turn_boundary drives the transcribing transition; stale single-utterance comments removed

Part of plan: voice-mode-engine.md (PR 11 of 12)