### PR TITLE
fix(notifications): enrich platform-channel deep links with the conversation id

### DIFF
--- a/assistant/src/__tests__/notification-deep-link.test.ts
+++ b/assistant/src/__tests__/notification-deep-link.test.ts
@@ -4,7 +4,9 @@
  * Validates that the VellumAdapter broadcasts notification_intent with
  * deepLinkMetadata, and that the broadcaster correctly passes deepLinkTarget
  * from the decision through to the adapter payload — regardless of whether
- * the conversation was newly created or reused.
+ * the conversation was newly created or reused. Also covers the platform
+ * (APNs) channel, whose deepLinkTarget must be enriched with the
+ * conversationId so remote-push taps can navigate.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -667,6 +669,171 @@ describe("notification deep-link metadata", () => {
       // Decision did not carry a deepLinkTarget either — the resulting
       // deep link should be undefined or have no conversationId.
       expect(deepLink?.conversationId).toBeUndefined();
+    });
+
+    // ── Platform (APNs) channel deep-link enrichment ──────────────────
+    //
+    // The platform adapter forwards deepLinkTarget verbatim as
+    // deep_link_metadata, so the broadcaster must enrich it with the
+    // conversationId the same way it does for vellum — otherwise remote-push
+    // taps have no routing key and cannot navigate.
+
+    test("broadcaster merges pairing conversationId and messageId into deepLinkTarget for platform", async () => {
+      const platformAdapter = new MockAdapter("platform");
+      const broadcaster = new NotificationBroadcaster([platformAdapter]);
+
+      nextPairingResult = {
+        conversationId: "conv-paired-platform",
+        messageId: "msg-paired-platform",
+        strategy: "start_new_conversation" as const,
+        createdNewConversation: true,
+        conversationFallbackUsed: false,
+      };
+
+      const signal = makeSignal();
+      const decision = makeDecision({
+        selectedChannels: ["platform"],
+        renderedCopy: {
+          platform: { title: "Test Alert", body: "Something happened" },
+        },
+      });
+
+      await broadcaster.broadcastDecision(signal, decision);
+
+      expect(platformAdapter.sent).toHaveLength(1);
+      const deepLink = platformAdapter.sent[0].deepLinkTarget;
+      expect(deepLink).toBeDefined();
+      expect(deepLink!.conversationId).toBe("conv-paired-platform");
+      expect(deepLink!.messageId).toBe("msg-paired-platform");
+    });
+
+    test("platform deep link falls back to signal.sourceContextId when pairing returns no conversation", async () => {
+      const platformAdapter = new MockAdapter("platform");
+      const broadcaster = new NotificationBroadcaster([platformAdapter]);
+
+      // Production platform pairing: push_only strategy pairs no conversation.
+      nextPairingResult = {
+        conversationId: null,
+        messageId: null,
+        strategy: "push_only" as const,
+        createdNewConversation: false,
+        conversationFallbackUsed: false,
+      };
+
+      const originConvId = "conv-origin-of-push";
+      mockExistingConversations[originConvId] = { id: originConvId };
+
+      const signal = makeSignal({ sourceContextId: originConvId });
+      const decision = makeDecision({
+        selectedChannels: ["platform"],
+        renderedCopy: {
+          platform: { title: "Turn done", body: "Your task finished" },
+        },
+      });
+
+      await broadcaster.broadcastDecision(signal, decision);
+
+      expect(platformAdapter.sent).toHaveLength(1);
+      const deepLink = platformAdapter.sent[0].deepLinkTarget;
+      expect(deepLink).toBeDefined();
+      expect(deepLink!.conversationId).toBe(originConvId);
+    });
+
+    test("platform deep link omits conversationId when sourceContextId is a sentinel", async () => {
+      const platformAdapter = new MockAdapter("platform");
+      const broadcaster = new NotificationBroadcaster([platformAdapter]);
+
+      nextPairingResult = {
+        conversationId: null,
+        messageId: null,
+        strategy: "push_only" as const,
+        createdNewConversation: false,
+        conversationFallbackUsed: false,
+      };
+
+      const signal = makeSignal({ sourceContextId: "job-sentinel-123" });
+      const decision = makeDecision({
+        selectedChannels: ["platform"],
+        renderedCopy: {
+          platform: { title: "Alert", body: "Body" },
+        },
+      });
+
+      await broadcaster.broadcastDecision(signal, decision);
+
+      expect(platformAdapter.sent).toHaveLength(1);
+      expect(
+        platformAdapter.sent[0].deepLinkTarget?.conversationId,
+      ).toBeUndefined();
+    });
+
+    test("vellum and platform each receive deep-link enrichment in the same broadcast", async () => {
+      const vellumAdapter = new MockAdapter("vellum");
+      const platformAdapter = new MockAdapter("platform");
+      const broadcaster = new NotificationBroadcaster([
+        vellumAdapter,
+        platformAdapter,
+      ]);
+
+      // Vellum is ordered first and consumes the queued pairing result;
+      // the platform pairing call then receives the mock's auto-generated
+      // conversation, so each channel is enriched from its own pairing.
+      nextPairingResult = {
+        conversationId: "conv-vellum-paired",
+        messageId: "msg-vellum-paired",
+        strategy: "start_new_conversation" as const,
+        createdNewConversation: true,
+        conversationFallbackUsed: false,
+      };
+
+      const signal = makeSignal();
+      const decision = makeDecision({
+        selectedChannels: ["platform", "vellum"],
+        renderedCopy: {
+          vellum: { title: "Test Alert", body: "Something happened" },
+          platform: { title: "Test Alert", body: "Something happened" },
+        },
+      });
+
+      await broadcaster.broadcastDecision(signal, decision);
+
+      // Vellum behavior unchanged: paired conversation wins.
+      expect(vellumAdapter.sent).toHaveLength(1);
+      expect(vellumAdapter.sent[0].deepLinkTarget?.conversationId).toBe(
+        "conv-vellum-paired",
+      );
+
+      // Platform enriched independently from its own pairing call.
+      expect(platformAdapter.sent).toHaveLength(1);
+      const platformConvId =
+        platformAdapter.sent[0].deepLinkTarget?.conversationId;
+      expect(String(platformConvId)).toStartWith("mock-conv-");
+    });
+
+    test("channels other than vellum and platform do not receive deterministic enrichment", async () => {
+      const telegramAdapter = new MockAdapter("telegram");
+      const broadcaster = new NotificationBroadcaster([telegramAdapter]);
+
+      nextPairingResult = {
+        conversationId: "conv-telegram-paired",
+        messageId: "msg-telegram-paired",
+        strategy: "continue_existing_conversation" as const,
+        createdNewConversation: true,
+        conversationFallbackUsed: false,
+      };
+
+      const signal = makeSignal();
+      const decision = makeDecision({
+        selectedChannels: ["telegram"],
+        renderedCopy: {
+          telegram: { title: "Alert", body: "Body" },
+        },
+      });
+
+      await broadcaster.broadcastDecision(signal, decision);
+
+      expect(telegramAdapter.sent).toHaveLength(1);
+      expect(telegramAdapter.sent[0].deepLinkTarget).toBeUndefined();
     });
   });
 });

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -335,15 +335,17 @@ export class NotificationBroadcaster {
         { conversationAction, bindingContext: destination.bindingContext },
       );
 
-      // For the vellum channel, merge the conversationId into deep-link metadata
-      // so the macOS client can navigate directly to the conversation. Prefer
-      // the paired conversation (interactive opt-in flows); otherwise fall back
+      // For the vellum and platform channels, merge the conversationId into
+      // deep-link metadata so clients can navigate directly to the conversation
+      // (macOS reads it from notification_intent; the platform relays it to
+      // iOS inside the APNs payload as deep_link). Prefer the
+      // paired conversation (interactive opt-in flows); otherwise fall back
       // to the originating conversation referenced by `sourceContextId` when it
       // resolves to a real row. Sentinel context ids (job IDs, call session IDs,
       // access-req-* strings) leave the deep link without a conversation, and
-      // the macOS handler opens the app to its default landing.
+      // the client opens the app to its default landing.
       let deepLinkTarget = decision.deepLinkTarget;
-      if (channel === "vellum") {
+      if (channel === "vellum" || channel === "platform") {
         const deepLinkConversationId =
           pairing.conversationId ??
           resolveSourceConversationId(signal.sourceContextId);
@@ -359,68 +361,68 @@ export class NotificationBroadcaster {
             };
           }
         }
+      }
 
-        if (pairing.conversationId) {
-          // Resolve guardian scoping for conversation-created events so clients
-          // can filter guardian-sensitive conversations the same way they filter
-          // guardian-sensitive notification intents.
-          const guardianPrincipalId =
-            typeof destination.metadata?.guardianPrincipalId === "string"
-              ? destination.metadata.guardianPrincipalId
-              : undefined;
-          const targetGuardianPrincipalId =
-            guardianPrincipalId &&
-            isGuardianSensitiveEvent(signal.sourceEventName)
-              ? guardianPrincipalId
-              : undefined;
+      if (channel === "vellum" && pairing.conversationId) {
+        // Resolve guardian scoping for conversation-created events so clients
+        // can filter guardian-sensitive conversations the same way they filter
+        // guardian-sensitive notification intents.
+        const guardianPrincipalId =
+          typeof destination.metadata?.guardianPrincipalId === "string"
+            ? destination.metadata.guardianPrincipalId
+            : undefined;
+        const targetGuardianPrincipalId =
+          guardianPrincipalId &&
+          isGuardianSensitiveEvent(signal.sourceEventName)
+            ? guardianPrincipalId
+            : undefined;
 
-          const conversationTitle =
-            copy.conversationTitle ?? copy.title ?? signal.sourceEventName;
-          const conversationSilent =
-            signal.attentionHints.urgency !== "high" &&
-            signal.attentionHints.urgency !== "critical";
-          const info: ConversationCreatedInfo = {
-            conversationId: pairing.conversationId,
-            title: conversationTitle,
-            sourceEventName: signal.sourceEventName,
-            targetGuardianPrincipalId,
-            groupId: signal.conversationMetadata?.groupId,
-            source: signal.conversationMetadata?.source,
-            silent: conversationSilent,
-          };
+        const conversationTitle =
+          copy.conversationTitle ?? copy.title ?? signal.sourceEventName;
+        const conversationSilent =
+          signal.attentionHints.urgency !== "high" &&
+          signal.attentionHints.urgency !== "critical";
+        const info: ConversationCreatedInfo = {
+          conversationId: pairing.conversationId,
+          title: conversationTitle,
+          sourceEventName: signal.sourceEventName,
+          targetGuardianPrincipalId,
+          groupId: signal.conversationMetadata?.groupId,
+          source: signal.conversationMetadata?.source,
+          silent: conversationSilent,
+        };
 
-          // The per-dispatch onConversationCreated callback fires whenever a vellum
-          // conversation is paired (new or reused) because callers like
-          // dispatchGuardianQuestion rely on it to create delivery bookkeeping
-          // rows before emitNotificationSignal() returns.
-          if (options?.onConversationCreated) {
+        // The per-dispatch onConversationCreated callback fires whenever a vellum
+        // conversation is paired (new or reused) because callers like
+        // dispatchGuardianQuestion rely on it to create delivery bookkeeping
+        // rows before emitNotificationSignal() returns.
+        if (options?.onConversationCreated) {
+          try {
+            options.onConversationCreated(info);
+          } catch (err) {
+            log.error(
+              { err, signalId: signal.signalId },
+              "per-dispatch onConversationCreated callback failed — continuing broadcast",
+            );
+          }
+        }
+
+        // Emit notification_conversation_created event only when a NEW
+        // conversation was actually created. Reusing an existing conversation
+        // should not fire the event — the client already knows about the
+        // conversation.
+        if (
+          pairing.createdNewConversation &&
+          pairing.strategy === "start_new_conversation"
+        ) {
+          if (this.onConversationCreated) {
             try {
-              options.onConversationCreated(info);
+              this.onConversationCreated(info);
             } catch (err) {
               log.error(
                 { err, signalId: signal.signalId },
-                "per-dispatch onConversationCreated callback failed — continuing broadcast",
+                "onConversationCreated callback failed — continuing broadcast",
               );
-            }
-          }
-
-          // Emit notification_conversation_created event only when a NEW
-          // conversation was actually created. Reusing an existing conversation
-          // should not fire the event — the client already knows about the
-          // conversation.
-          if (
-            pairing.createdNewConversation &&
-            pairing.strategy === "start_new_conversation"
-          ) {
-            if (this.onConversationCreated) {
-              try {
-                this.onConversationCreated(info);
-              } catch (err) {
-                log.error(
-                  { err, signalId: signal.signalId },
-                  "onConversationCreated callback failed — continuing broadcast",
-                );
-              }
             }
           }
         }

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -192,12 +192,16 @@ async function upsertToken(token: string, assistantId: string): Promise<void> {
 /**
  * Extract the conversation id a tapped push notification routes to.
  *
- * APNs custom keys arrive as `notification.data`. The daemon's
- * `deep_link_metadata` reaches us as `data.deep_link.conversationId` (the
- * platform forwards it into the APNs payload); producers that embed routing
- * directly in `context_payload` put `conversationId` at the top level, so
- * that is the fallback. Returns `undefined` for absent or malformed shapes —
- * never throws.
+ * APNs custom keys arrive as `notification.data`. The intended contract is
+ * daemon → platform → client: the daemon's `platform` channel sends
+ * `deep_link_metadata` with the dispatch, the platform forwards it into the
+ * APNs payload as `deep_link`, and this reads `data.deep_link.conversationId`.
+ * Producers that embed routing directly in `context_payload` put
+ * `conversationId` at the top level, so that is the fallback. Pushes whose
+ * payload carries no routing keys (a hop of the contract not yet deployed)
+ * gracefully yield `undefined` — the tap foregrounds the app without
+ * navigating. Returns `undefined` for absent or malformed shapes; never
+ * throws.
  */
 export function extractPushConversationId(data: unknown): string | undefined {
   if (typeof data !== "object" || data === null) {
@@ -242,9 +246,9 @@ async function ensureListeners(): Promise<void> {
     await PushNotifications.addListener(
       "pushNotificationActionPerformed",
       (action) => {
-        // Pushes dispatched by a platform that does not yet forward the
-        // daemon's `deep_link_metadata` carry no routing keys — the tap
-        // foregrounds the app without navigating.
+        // A payload without routing keys is a graceful no-op: the tap
+        // foregrounds the app without navigating (see
+        // extractPushConversationId for the deep-link contract).
         const conversationId = extractPushConversationId(
           action.notification.data,
         );


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for mobile-push-deeplink-haptics.md.

**Gap:** APNs pushes carried no conversationId — the broadcaster's deep-link enrichment was gated to the vellum channel, so remote-push taps could never deep-link even after the platform forwards deep_link_metadata.
**Fix:** extend the deterministic conversationId/messageId enrichment to the platform channel; soften the web reader's JSDoc to describe the contract rather than assert it.