### PR TITLE
fix(web): keep live panels when a deep link targets the active conversation

### DIFF
--- a/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
@@ -116,6 +116,27 @@ describe("deeplink.openThread", () => {
       "abc-123",
     );
   });
+
+  test("same-thread tap keeps live subagent/workflow state — the id doesn't change, so re-seed effects wouldn't re-run", () => {
+    useSubagentStore.setState({ orderedIds: ["sub-1"] });
+    useWorkflowStore.setState({ orderedIds: ["wf-1"] });
+    useConversationStore.setState({ activeConversationId: "abc-123" });
+    useViewerStore.setState({ mainView: "app" });
+    renderHook(() => useGlobalDeepLinkConsumer());
+
+    act(() => {
+      publish("deeplink.openThread", { threadId: "abc-123" });
+    });
+
+    expect(useSubagentStore.getState().orderedIds).toEqual(["sub-1"]);
+    expect(useWorkflowStore.getState().orderedIds).toEqual(["wf-1"]);
+    // Viewer reset + URL sync + window activation still apply.
+    expect(useViewerStore.getState().mainView).toBe("chat");
+    expect(navigateMock).toHaveBeenCalledWith(
+      "/assistant/conversations/abc-123",
+    );
+    expect(ensureMainWindowVisibleMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("deeplink.unknown", () => {

--- a/clients/web/src/hooks/use-global-deep-link-consumer.ts
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.ts
@@ -4,7 +4,9 @@ import { useNavigate } from "react-router";
 
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { ensureMainWindowVisible } from "@/runtime/main-window";
+import { useConversationStore } from "@/stores/conversation-store";
 import { usePendingDeepLinkStore } from "@/stores/pending-deep-link-store";
+import { useViewerStore } from "@/stores/viewer-store";
 import { navigateToConversation } from "@/utils/conversation-navigation";
 import { routes } from "@/utils/routes";
 
@@ -19,7 +21,10 @@ import { routes } from "@/utils/routes";
  * - `deeplink.openThread` → `ensureMainWindowVisible()` +
  *   `navigateToConversation()` — the same shared path as an in-app
  *   conversation switch (viewer reset, subagent/workflow store resets,
- *   active-conversation sync, navigation).
+ *   active-conversation sync, navigation). If the thread is already the
+ *   active conversation, the subagent/workflow resets are skipped — the
+ *   id doesn't change, so the re-seed effects wouldn't re-run and live
+ *   cards would vanish — but the viewer reset and URL sync still apply.
  * - `deeplink.send` → `ensureMainWindowVisible()` + navigate to
  *   `/assistant` + park the message in `usePendingDeepLinkStore`
  *   for `ChatPage`'s composer-domain hook to consume on mount.
@@ -46,6 +51,11 @@ export function useGlobalDeepLinkConsumer(): void {
 
   useBusSubscription("deeplink.openThread", ({ threadId }) => {
     void ensureMainWindowVisible();
+    if (threadId === useConversationStore.getState().activeConversationId) {
+      useViewerStore.getState().setMainView("chat");
+      navigateRef.current(routes.conversation(threadId));
+      return;
+    }
     navigateToConversation(navigateRef.current, threadId);
   });
 


### PR DESCRIPTION
## Summary
Fixes round-2 review gap (codex P2 on #37220) for mobile-push-deeplink-haptics.md.

**Gap:** deeplink.openThread for the already-active conversation reset the subagent/workflow stores without re-seeding (id unchanged), wiping live cards.
**Fix:** same-id taps keep the viewer reset + navigation but skip the store resets; different-id behavior unchanged.