### PR TITLE
test(web): consolidate Capacitor listener contract tests in the helper suite

### DIFF
--- a/clients/web/src/runtime/event-sources/capacitor-app-state.test.ts
+++ b/clients/web/src/runtime/event-sources/capacitor-app-state.test.ts
@@ -3,29 +3,15 @@ import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 type AppStatePayload = { isActive: boolean };
 type AppStateHandler = (payload: AppStatePayload) => void;
 
-let isNative = true;
-const isNativePlatformMock = mock(() => isNative);
 mock.module("@/runtime/native-auth", () => ({
-  isNativePlatform: isNativePlatformMock,
+  isNativePlatform: () => true,
 }));
 
 let activeHandler: AppStateHandler | null = null;
-const handleRemoveMock = mock(async () => {});
-let addListenerResolver: ((value: { remove: typeof handleRemoveMock }) => void) | null = null;
-let addListenerRejecter: ((err: Error) => void) | null = null;
-let pendingAddListenerPromise: Promise<{ remove: typeof handleRemoveMock }> | null =
-  null;
-
 const addListenerMock = mock(
   (_event: "appStateChange", handler: AppStateHandler) => {
     activeHandler = handler;
-    pendingAddListenerPromise = new Promise<{ remove: typeof handleRemoveMock }>(
-      (resolve, reject) => {
-        addListenerResolver = resolve;
-        addListenerRejecter = reject;
-      },
-    );
-    return pendingAddListenerPromise;
+    return Promise.resolve({ remove: async () => {} });
   },
 );
 
@@ -35,72 +21,47 @@ mock.module("@capacitor/app", () => ({
   },
 }));
 
-const captureExceptionMock = mock(() => {});
-// Full Sentry surface — `mock.module` is process-global in bun, so a
-// partial shape would shadow `addBreadcrumb` (used by other modules
-// transitively loaded in this run) for every later test file. Both
-// methods are kept here so the mock can satisfy any consumer that
-// happens to load Sentry through our module under test.
-mock.module("@sentry/browser", () => ({
-  captureException: captureExceptionMock,
-  addBreadcrumb: () => {},
-  setContext: () => {},
-}));
-mock.module("@sentry/react", () => ({
-  captureException: captureExceptionMock,
-  addBreadcrumb: () => {},
-  setContext: () => {},
+// Warm the module cache so the source's lazy `import("@capacitor/app")`
+// resolves within microtasks instead of a full loader turn.
+await import("@capacitor/app");
+
+const captureErrorMock = mock(() => {});
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: captureErrorMock,
 }));
 
 import * as eventBus from "@/lib/event-bus";
 
 const publishSpy = spyOn(eventBus, "publish");
 
-const { publishCapacitorAppStateSource } = await import(
-  "@/runtime/event-sources/capacitor-app-state"
-);
+const { publishCapacitorAppStateSource } =
+  await import("@/runtime/event-sources/capacitor-app-state");
 
+// The dynamic `import("@capacitor/app")` and its `.then` chain each
+// queue a microtask, so listener registration lags synchronous test
+// code — flush before driving the captured handler.
 const flushMicrotasks = async (rounds = 4) => {
-  for (let i = 0; i < rounds; i++) await Promise.resolve();
-};
-const resolveAddListener = async () => {
-  // The dynamic `import("@capacitor/app")` and its `.then` chain each
-  // queue a microtask, so the source's `addListenerMock` call lags
-  // synchronous test code. Flush before resolving the pending promise,
-  // then flush again so the `.then` that stores the `handle` runs.
-  await flushMicrotasks();
-  addListenerResolver?.({ remove: handleRemoveMock });
-  await flushMicrotasks();
+  for (let i = 0; i < rounds; i++) {
+    await Promise.resolve();
+  }
 };
 
 beforeEach(() => {
-  isNative = true;
   activeHandler = null;
-  addListenerResolver = null;
-  addListenerRejecter = null;
-  pendingAddListenerPromise = null;
-  isNativePlatformMock.mockClear();
   addListenerMock.mockClear();
-  handleRemoveMock.mockClear();
-  captureExceptionMock.mockClear();
+  captureErrorMock.mockClear();
   publishSpy.mockClear();
 });
 
+// The platform guard, unsubscribe races, and failure reporting are the
+// `subscribeCapacitorListener` contract, covered by
+// `runtime/capacitor-listener.test.ts`. This suite covers only this
+// source's wiring: what it publishes and its error context.
 describe("publishCapacitorAppStateSource", () => {
-  test("is a no-op off Capacitor iOS (returns a no-op unsubscribe, never imports the plugin)", () => {
-    isNative = false;
-
-    const unsubscribe = publishCapacitorAppStateSource();
-    unsubscribe();
-
-    expect(addListenerMock).not.toHaveBeenCalled();
-    expect(publishSpy).not.toHaveBeenCalled();
-  });
-
   test("publishes app.resume(signal:'app_state') when isActive flips true", async () => {
     publishCapacitorAppStateSource();
+    await flushMicrotasks();
 
-    await resolveAddListener();
     activeHandler!({ isActive: true });
 
     expect(publishSpy).toHaveBeenCalledWith("app.resume", {
@@ -110,8 +71,8 @@ describe("publishCapacitorAppStateSource", () => {
 
   test("publishes app.hidden(signal:'app_state') when isActive flips false", async () => {
     publishCapacitorAppStateSource();
+    await flushMicrotasks();
 
-    await resolveAddListener();
     activeHandler!({ isActive: false });
 
     expect(publishSpy).toHaveBeenCalledWith("app.hidden", {
@@ -119,38 +80,16 @@ describe("publishCapacitorAppStateSource", () => {
     });
   });
 
-  test("returned unsubscribe removes the listener once it resolves", async () => {
-    const unsubscribe = publishCapacitorAppStateSource();
-
-    await resolveAddListener();
-    expect(handleRemoveMock).not.toHaveBeenCalled();
-
-    unsubscribe();
-    expect(handleRemoveMock).toHaveBeenCalledTimes(1);
-  });
-
-  test("unsubscribe BEFORE the lazy import resolves still removes the just-registered listener", async () => {
-    const unsubscribe = publishCapacitorAppStateSource();
-
-    // Unsubscribe is called first — internal `cancelled` flag must
-    // catch the late `.then` and remove the listener.
-    unsubscribe();
-    await resolveAddListener();
-
-    expect(handleRemoveMock).toHaveBeenCalledTimes(1);
-  });
-
-  test("reports a lazy-import failure to Sentry instead of throwing", async () => {
-    publishCapacitorAppStateSource();
-
-    await flushMicrotasks();
+  test("reports listener-registration failures under the 'event_bus_capacitor_init' context", async () => {
     const err = new Error("plugin missing");
-    addListenerRejecter?.(err);
+    addListenerMock.mockImplementationOnce(() => Promise.reject(err));
+
+    publishCapacitorAppStateSource();
     await flushMicrotasks();
 
-    expect(captureExceptionMock).toHaveBeenCalledWith(err, {
+    expect(captureErrorMock).toHaveBeenCalledWith(err, {
+      context: "event_bus_capacitor_init",
       level: "warning",
-      tags: { context: "event_bus_capacitor_init" },
     });
   });
 });

--- a/clients/web/src/runtime/event-sources/capacitor-app-state.ts
+++ b/clients/web/src/runtime/event-sources/capacitor-app-state.ts
@@ -9,10 +9,7 @@ import { subscribeCapacitorListener } from "@/runtime/capacitor-listener";
  * `publishVisibilitySource` / `publishWindowOnlineSource`
  * / `publishElectronPowerSource` instead.
  *
- * `subscribeCapacitorListener` owns the platform guard, the
- * unsubscribe-before-import-resolves race, and failure reporting; the
- * `@capacitor/app` import stays lazy and inline here per CAPACITOR.md's
- * "lazy-import rule".
+ * Lazy inline `@capacitor/app` import per CAPACITOR.md's "lazy-import rule".
  */
 export function publishCapacitorAppStateSource(): () => void {
   return subscribeCapacitorListener("event_bus_capacitor_init", async () => {

--- a/clients/web/src/runtime/event-sources/capacitor-deep-links.test.ts
+++ b/clients/web/src/runtime/event-sources/capacitor-deep-links.test.ts
@@ -2,27 +2,15 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 type AppUrlOpenHandler = (payload: { url: string }) => void;
 
-let isNative = true;
-const isNativePlatformMock = mock(() => isNative);
 mock.module("@/runtime/native-auth", () => ({
-  isNativePlatform: isNativePlatformMock,
+  isNativePlatform: () => true,
 }));
 
 let urlOpenHandler: AppUrlOpenHandler | null = null;
-const handleRemoveMock = mock(async () => {});
-let addListenerResolver:
-  ((value: { remove: typeof handleRemoveMock }) => void) | null = null;
-let addListenerRejecter: ((err: Error) => void) | null = null;
-
 const addListenerMock = mock(
   (_event: "appUrlOpen", handler: AppUrlOpenHandler) => {
     urlOpenHandler = handler;
-    return new Promise<{ remove: typeof handleRemoveMock }>(
-      (resolve, reject) => {
-        addListenerResolver = resolve;
-        addListenerRejecter = reject;
-      },
-    );
+    return Promise.resolve({ remove: async () => {} });
   },
 );
 
@@ -31,6 +19,10 @@ mock.module("@capacitor/app", () => ({
     addListener: addListenerMock,
   },
 }));
+
+// Warm the module cache so the source's lazy `import("@capacitor/app")`
+// resolves within microtasks instead of a full loader turn.
+await import("@capacitor/app");
 
 const captureErrorMock = mock(() => {});
 mock.module("@/lib/sentry/capture-error", () => ({
@@ -47,40 +39,26 @@ import {
 const { publishCapacitorDeepLinksSource } =
   await import("@/runtime/event-sources/capacitor-deep-links");
 
+// The dynamic `import("@capacitor/app")` and its `.then` chain each
+// queue a microtask, so listener registration lags synchronous test
+// code — flush before driving the captured handler.
 const flushMicrotasks = async (rounds = 4) => {
-  for (let i = 0; i < rounds; i++) await Promise.resolve();
-};
-const resolveAddListener = async () => {
-  // The dynamic `import("@capacitor/app")` and its `.then` chain each
-  // queue a microtask, so the source's `addListenerMock` call lags
-  // synchronous test code. Flush before resolving the pending promise,
-  // then flush again so the `.then` that stores the `handle` runs.
-  await flushMicrotasks();
-  addListenerResolver?.({ remove: handleRemoveMock });
-  await flushMicrotasks();
+  for (let i = 0; i < rounds; i++) {
+    await Promise.resolve();
+  }
 };
 
 beforeEach(() => {
-  isNative = true;
   urlOpenHandler = null;
-  addListenerResolver = null;
-  addListenerRejecter = null;
-  isNativePlatformMock.mockClear();
   addListenerMock.mockClear();
-  handleRemoveMock.mockClear();
   captureErrorMock.mockClear();
 });
 
+// The platform guard, unsubscribe races, and failure reporting are the
+// `subscribeCapacitorListener` contract, covered by
+// `runtime/capacitor-listener.test.ts`. This suite covers only this
+// source's wiring: URL routing and its error context.
 describe("publishCapacitorDeepLinksSource", () => {
-  test("is a no-op off Capacitor iOS (returns a no-op unsubscribe, never imports the plugin)", () => {
-    isNative = false;
-
-    const unsubscribe = publishCapacitorDeepLinksSource();
-    unsubscribe();
-
-    expect(addListenerMock).not.toHaveBeenCalled();
-  });
-
   test("dispatches the OAuth-complete window CustomEvent for an oauth-complete deep link", async () => {
     const received: OAuthCompleteDeepLinkPayload[] = [];
     const windowListener = (
@@ -91,8 +69,8 @@ describe("publishCapacitorDeepLinksSource", () => {
     window.addEventListener(OAUTH_COMPLETE_DEEP_LINK_EVENT, windowListener);
 
     try {
-      const unsubscribe = publishCapacitorDeepLinksSource();
-      await resolveAddListener();
+      publishCapacitorDeepLinksSource();
+      await flushMicrotasks();
 
       const payload: OAuthCompleteDeepLinkPayload = {
         requestId: "req-123",
@@ -105,7 +83,6 @@ describe("publishCapacitorDeepLinksSource", () => {
       });
 
       expect(received).toEqual([payload]);
-      unsubscribe();
     } finally {
       window.removeEventListener(
         OAUTH_COMPLETE_DEEP_LINK_EVENT,
@@ -121,45 +98,24 @@ describe("publishCapacitorDeepLinksSource", () => {
     });
 
     try {
-      const unsubscribe = publishCapacitorDeepLinksSource();
-      await resolveAddListener();
+      publishCapacitorDeepLinksSource();
+      await flushMicrotasks();
 
       urlOpenHandler!({ url: "vellum-assistant://some-future-link?x=1" });
 
       expect(received).toEqual([
         { url: "vellum-assistant://some-future-link?x=1" },
       ]);
-      unsubscribe();
     } finally {
       unsubscribeBus();
     }
   });
 
-  test("returned unsubscribe removes the listener once it resolves", async () => {
-    const unsubscribe = publishCapacitorDeepLinksSource();
-
-    await resolveAddListener();
-    expect(handleRemoveMock).not.toHaveBeenCalled();
-
-    unsubscribe();
-    expect(handleRemoveMock).toHaveBeenCalledTimes(1);
-  });
-
-  test("unsubscribe BEFORE the lazy import resolves still removes the just-registered listener", async () => {
-    const unsubscribe = publishCapacitorDeepLinksSource();
-
-    unsubscribe();
-    await resolveAddListener();
-
-    expect(handleRemoveMock).toHaveBeenCalledTimes(1);
-  });
-
-  test("reports a lazy-import failure instead of throwing", async () => {
-    publishCapacitorDeepLinksSource();
-
-    await flushMicrotasks();
+  test("reports listener-registration failures under the 'capacitor_deep_links' context", async () => {
     const err = new Error("plugin missing");
-    addListenerRejecter?.(err);
+    addListenerMock.mockImplementationOnce(() => Promise.reject(err));
+
+    publishCapacitorDeepLinksSource();
     await flushMicrotasks();
 
     expect(captureErrorMock).toHaveBeenCalledWith(err, {

--- a/clients/web/src/runtime/event-sources/capacitor-deep-links.ts
+++ b/clients/web/src/runtime/event-sources/capacitor-deep-links.ts
@@ -20,10 +20,7 @@ import {
  * Off Capacitor iOS the function is a no-op — Electron deep links flow
  * through `publishElectronDeepLinksSource` instead.
  *
- * `subscribeCapacitorListener` owns the platform guard, the
- * unsubscribe-before-import-resolves race, and failure reporting; the
- * `@capacitor/app` import stays lazy and inline here per CAPACITOR.md's
- * "lazy-import rule".
+ * Lazy inline `@capacitor/app` import per CAPACITOR.md's "lazy-import rule".
  */
 export function publishCapacitorDeepLinksSource(): () => void {
   return subscribeCapacitorListener("capacitor_deep_links", async () => {


### PR DESCRIPTION
## Summary
Fixes round-2 review gap (slop audit) for mobile-push-deeplink-haptics.md.

**Gap:** the subscribeCapacitorListener contract (race/guard/error behaviors) was tested in triplicate with duplicated pending-promise scaffolding; both adopters pasted the same doc paragraph.
**Fix:** helper suite owns the contract tests; event-source suites keep source-specific behavior + one wiring sanity test; doc paragraph trimmed.