### PR TITLE
fix(search): use X-Client-Name for Tavily integration attribution

### DIFF
--- a/assistant/src/__tests__/web-search.test.ts
+++ b/assistant/src/__tests__/web-search.test.ts
@@ -990,7 +990,7 @@ async function executeTavilySearchHelper(
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${apiKey}`,
-          "X-Client-Source": "vellum-assistant",
+          "X-Client-Name": "vellum-assistant",
         },
         body: JSON.stringify(body),
       });

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -892,7 +892,7 @@ async function executeTavilySearch(
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${apiKey}`,
-          "X-Client-Source": "vellum-assistant",
+          "X-Client-Name": "vellum-assistant",
         },
         body: JSON.stringify(body),
         signal,


### PR DESCRIPTION
## Summary
- Renames `X-Client-Source` → `X-Client-Name` on Tavily search requests so the integration is attributed correctly in Tavily analytics

Part of FDE-557

## Test plan
- [x] `cd assistant && bun test src/__tests__/web-search.test.ts --grep "Tavily"`


Made with [Cursor](https://cursor.com)