### PR TITLE
Bump plugin UI backwards-compat gates to 0.11.0

### DIFF
--- a/clients/web/src/lib/backwards-compat/use-supports-inchat-plugin-edit.test.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-inchat-plugin-edit.test.ts
@@ -20,24 +20,24 @@ afterEach(() => {
 });
 
 // Exhaustive semver truth-table lives in `utils.test.ts`. Here we verify the
-// boundary on each side of MIN_VERSION (0.10.7 — the manage-plugins surface is
-// held back until it is ready) plus the conservative-on-unknown policy,
+// boundary on each side of MIN_VERSION (0.11.0 — the release that ships the
+// manage-plugins surface) plus the conservative-on-unknown policy,
 // exercised through the public hook.
 describe("useSupportsInchatPluginEdit", () => {
   test("reads false when the version is unknown", () => {
     expect(readGate(null)).toBe(false);
   });
 
-  test("reads false below 0.10.7 (incl. 0.10.5, 0.10.6)", () => {
+  test("reads false below 0.11.0 (incl. 0.10.7, 0.10.9)", () => {
+    expect(readGate("0.10.9")).toBe(false);
+    expect(readGate("0.10.7")).toBe(false);
     expect(readGate("0.10.6")).toBe(false);
-    expect(readGate("0.10.5")).toBe(false);
-    expect(readGate("0.10.4")).toBe(false);
     expect(readGate("0.9.0")).toBe(false);
   });
 
-  test("reads true for assistants on 0.10.7+", () => {
-    expect(readGate("0.10.7")).toBe(true);
+  test("reads true for assistants on 0.11.0+", () => {
     expect(readGate("0.11.0")).toBe(true);
+    expect(readGate("0.11.1")).toBe(true);
     expect(readGate("1.0.0")).toBe(true);
   });
 

--- a/clients/web/src/lib/backwards-compat/use-supports-inchat-plugin-edit.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-inchat-plugin-edit.ts
@@ -10,14 +10,14 @@
  * so the pill would misrepresent per-chat state — keep it hidden until the
  * active assistant is known to support it. Conservative on unknown.
  *
- * MIN_VERSION targets 0.10.7 — the manage-plugins surface (this in-chat pill
- * plus the new-chat plugin picker) is not ready for release, so the gate holds
- * at a version the monorepo has not yet cut, keeping the pill hidden on every
- * shipped assistant until the surface lands.
+ * MIN_VERSION targets 0.11.0 — the manage-plugins surface (this in-chat pill
+ * plus the new-chat plugin picker) ships in that release, so the gate holds
+ * until the active assistant is on 0.11.0 or newer, keeping the pill hidden on
+ * every older assistant until the surface lands.
  */
 import { useAssistantSupports } from "./utils";
 
-export const MIN_VERSION = "0.10.7";
+export const MIN_VERSION = "0.11.0";
 
 /**
  * Returns `true` when the active assistant exposes the standalone

--- a/clients/web/src/lib/backwards-compat/use-supports-new-chat-plugins.test.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-new-chat-plugins.test.ts
@@ -27,7 +27,7 @@ afterEach(() => {
 });
 
 // Exhaustive truth-table for the underlying semver gate lives in
-// `utils.test.ts`. Here we verify the boundary on each side of 0.10.7
+// `utils.test.ts`. Here we verify the boundary on each side of 0.11.0
 // plus the conservative-on-unknown policy, exercised through the public
 // hook and the awaiting send-path variant. (The snapshot read is a
 // private helper; it is covered via these exported entry points.)
@@ -36,16 +36,16 @@ describe("useSupportsNewChatPlugins", () => {
     expect(readGateViaHook(null)).toBe(false);
   });
 
-  test("reads false for assistants below 0.10.7 (incl. 0.10.5, 0.10.6)", () => {
+  test("reads false for assistants below 0.11.0 (incl. 0.10.7, 0.10.9)", () => {
+    expect(readGateViaHook("0.10.9")).toBe(false);
+    expect(readGateViaHook("0.10.7")).toBe(false);
     expect(readGateViaHook("0.10.6")).toBe(false);
-    expect(readGateViaHook("0.10.5")).toBe(false);
-    expect(readGateViaHook("0.10.4")).toBe(false);
     expect(readGateViaHook("0.9.0")).toBe(false);
   });
 
-  test("reads true for assistants on 0.10.7+", () => {
-    expect(readGateViaHook("0.10.7")).toBe(true);
+  test("reads true for assistants on 0.11.0+", () => {
     expect(readGateViaHook("0.11.0")).toBe(true);
+    expect(readGateViaHook("0.11.1")).toBe(true);
     expect(readGateViaHook("1.0.0")).toBe(true);
   });
 
@@ -62,7 +62,7 @@ describe("resolveSupportsNewChatPlugins", () => {
   });
 
   test("resolves true for a supported daemon once the version is known", async () => {
-    setVersion("0.10.7");
+    setVersion("0.11.0");
     expect(await resolveSupportsNewChatPlugins()).toBe(true);
   });
 });

--- a/clients/web/src/lib/backwards-compat/use-supports-new-chat-plugins.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-new-chat-plugins.ts
@@ -19,10 +19,10 @@
  * on the send path so the decision awaits version hydration rather than
  * optimistically assuming support.
  *
- * MIN_VERSION targets 0.10.7 — the manage-plugins surface (this new-chat
- * picker plus the in-chat plugin pill) is not ready for release, so the
- * gate holds at a version the monorepo has not yet cut. That keeps the
- * picker and send-path inclusion hidden on every shipped assistant until
+ * MIN_VERSION targets 0.11.0 — the manage-plugins surface (this new-chat
+ * picker plus the in-chat plugin pill) ships in that release, so the gate
+ * holds until the active assistant is on 0.11.0 or newer. That keeps the
+ * picker and send-path inclusion hidden on every older assistant until
  * the surface lands; bump MIN_VERSION to the release that finalizes
  * per-chat plugin selection when it is ready.
  */
@@ -32,7 +32,7 @@ import {
   whenAssistantVersionKnown,
 } from "./utils";
 
-export const MIN_VERSION = "0.10.7";
+export const MIN_VERSION = "0.11.0";
 
 /**
  * Returns `true` when the active assistant accepts the per-chat plugin


### PR DESCRIPTION
## Why

The web app version-gates the manage-plugins surface (the new-chat plugin picker and the in-chat plugin pill) against the locally-installed assistant. Both gates were held at `MIN_VERSION = "0.10.7"` — a version the monorepo had not yet cut — as a way to keep the surface hidden on every shipped assistant while it wasn't ready.

That surface ships in **0.11.0**, so this bumps both gates to point at the release that actually finalizes per-chat plugin selection.

## What changed

- `use-supports-new-chat-plugins.ts` — `MIN_VERSION` `0.10.7` → `0.11.0` (plus docstring)
- `use-supports-inchat-plugin-edit.ts` — `MIN_VERSION` `0.10.7` → `0.11.0` (plus docstring)
- Updated both test files so the boundary cases straddle `0.11.0`: `0.10.7`/`0.10.9` now assert `false` (below the gate), `0.11.0`/`0.11.1` assert `true`.

## Testing

`bun test` on both gate test files — 10 pass, 0 fail.


---
_Generated by [Claude Code](https://claude.ai/code/session_016EdwKTEQeYk2AhYfJU26uv)_