### PR TITLE
docs: document the real two-step release process

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,65 +1,73 @@
 ---
 name: release
 description: >
-  Cut a new release by triggering the Release workflow via GitHub Actions workflow dispatch.
+  Cut a new release: create the release branch (staging bake), then dispatch the
+  production Release run on that branch.
 ---
 
-Cut a new release by triggering the Release workflow via GitHub Actions workflow dispatch.
+Cut a new release. Releases are a **two-step** process:
 
-The workflow computes the version itself: a dispatch from `main` takes the latest `v<major>.<minor>.<patch>` tag and increments the patch number. There is no bump-type input — minor/major bumps land by changing the version on `main` first, not through this command.
+1. **Branch cut → staging bake**: `create-release-branch.yml` computes the version from the bump type, deletes any stale `release/v<X.Y.Z>` branch, cuts a fresh one from `main` HEAD with the version-bump commit, and pushes it. That push triggers a `Release` run on the branch which is a **staging** deploy (push-triggered and main-dispatched `Release` runs are always staging).
+2. **Production**: dispatching `release.yml` **on the `release/v<X.Y.Z>` branch** runs the full production release — tag, GitHub Release, DMG sign/notarize/publish, npm packages, Docker Hub images, iOS TestFlight, platform dependency bump, and the merge-back of the release branch to `main`.
+
+The scheduled Tue/Fri 9am ET cut performs step 1 automatically; a human performs step 2 after the staging bake is green. A `release/v<X.Y.Z>` branch with no corresponding GitHub Release means a cut was never promoted — re-running step 1 refreshes it from current `main`.
+
+The user may pass `$ARGUMENTS` as the bump type for step 1: `patch`, `minor`, `major`, or `hotfix` (patch cut from the latest release tag's commit instead of `main`, pushed `[skip ci]` for manual cherry-picks). Default to `patch`.
 
 ## Steps
 
-### 1. Pull latest main
+### 1. Pull latest main and show the payload
 
 ```bash
 git checkout main && git pull
-```
-
-The dispatch builds whatever is on `origin/main` — pulling first is so the release you announce matches what you can see locally.
-
-### 2. Confirm the payload
-
-Show the latest tag and the commits since it, so it's clear what the release will carry:
-
-```bash
 git describe --tags --abbrev=0
 git log --oneline "$(git describe --tags --abbrev=0)"..origin/main | head -20
 ```
 
-Confirm with the user before dispatching unless they already asked for the release explicitly.
+Confirm with the user before proceeding unless they already asked for the release explicitly.
 
-### 3. Trigger the Release workflow
+### 2. Cut the release branch (staging bake)
+
+```bash
+gh workflow run create-release-branch.yml \
+  --repo vellum-ai/vellum-assistant \
+  --ref main \
+  --field bump=<patch|minor|major|hotfix>
+```
+
+Then wait for the branch cut and find the staging `Release` run its push triggered:
+
+```bash
+gh run list --workflow="Create Release Branch" --limit 1
+gh run list --workflow=Release --branch "release/v<X.Y.Z>" --limit 1
+```
+
+The version appears in the branch name; the staging run takes ~15-20 minutes. **Wait for it to succeed** — it is the CI bake for the exact release payload. If it fails, fix `main` and re-run this step (it recuts the branch from `main` HEAD).
+
+### 3. Dispatch the production release
 
 ```bash
 gh workflow run release.yml \
   --repo vellum-ai/vellum-assistant \
-  --ref main
+  --ref "release/v<X.Y.Z>"
 ```
 
-The only dispatch input is the optional `slack_user_id` (`--field slack_user_id=U…`), used to attribute the release notification; omit it when unknown.
+The only dispatch input is the optional `slack_user_id` (`--field slack_user_id=U…`) for the release notification; omit it when unknown.
 
-The unified Release workflow automatically handles:
-- Computing the next patch version from the latest tag
-- Version bumping across all packages
-- Creating a release branch, PR, and merging it
-- Tagging the release
-- Publishing npm packages
-- Building, signing, notarizing, and publishing the macOS DMG
-- Creating GitHub Releases on `vellum-ai/vellum-assistant`
-- Updating the `vellum-assistant-platform` dependency
+### 4. Verify
 
-### 4. Verify the workflow started and read the version
+The production run takes ~20 minutes. When it completes:
 
 ```bash
-gh run list --repo vellum-ai/vellum-assistant --workflow="Release" --limit 1
+gh release list --limit 1        # v<X.Y.Z> should be Latest
+git fetch --tags && git tag -l "v<X.Y.Z>"
+git log --oneline origin/main -1 # merge-back commit "Release v<X.Y.Z>"
 ```
 
-The computed version appears in the `extract-version` job log as `BASE_VERSION: <x.y.z>`.
+If the merge-back to main failed, the run's Slack notification includes the manual-merge command.
 
 ### 5. Report
 
 Output:
-- The version number (from the `extract-version` job)
-- A link to the running workflow
-- Remind the user that the full release pipeline takes ~15-20 minutes and will auto-publish everything when done
+- The version number and a link to the production run
+- Confirmation that the GitHub Release, tag, and merge-back all landed

--- a/docs/internal-reference.md
+++ b/docs/internal-reference.md
@@ -584,7 +584,7 @@ Multiple plans can run in parallel — just specify the plan name to disambiguat
 | Command | Purpose |
 |---------|---------|
 | `/plan-html <topic\|plan-name>` | Create or refresh a rollout plan in `.private/plans/` with both markdown and a polished, review-friendly HTML view (including per-PR file lists). |
-| `/release` | Cut a release: pull main, then dispatch the unified Release workflow, which computes the next patch version from the latest tag and handles version bumps, tagging, npm, DMG, and GitHub Release publishing. |
+| `/release [bump]` | Cut a release in two steps: dispatch `create-release-branch.yml` (cuts `release/vX.Y.Z` from main → staging bake), then after the bake is green dispatch `release.yml` on the release branch for the full production release. |
 | `/triage [user\|assistant\|device]` | Search Sentry for recent errors and log reports by user, assistant, or device in the `vellum-assistant-brain` project, then cross-reference with Linear issues to produce a triage summary. |
 | `/update` | Pull latest from `main`, kill stale processes, rebuild and launch the macOS app. The app manages its own assistant and gateway lifecycle (hatching on first launch). Prints a startup summary. |
 
@@ -611,17 +611,18 @@ All workflows use squash-merge (no merge commits), worktree isolation for parall
 
 ### Release Management
 
-Releases are cut using the `/release` Claude Code command and follow a fully automated pipeline from workflow dispatch to client update.
+Releases are cut using the `/release` Claude Code command and follow a two-step pipeline: a branch cut with a staging bake, then a production dispatch on the release branch.
 
 #### Cutting a release
 
-Run `/release` in Claude Code. The command:
+Run `/release [patch|minor|major|hotfix]` in Claude Code. The command:
 
 1. Pulls the latest `main` branch and shows the commits the release will carry
-2. Dispatches the `release.yml` workflow on `main` (`gh workflow run release.yml`); the only input is an optional `slack_user_id` for attribution
-3. Confirms the workflow started and reads the computed version from the `extract-version` job (`BASE_VERSION`)
+2. Dispatches `create-release-branch.yml` with the bump type. The workflow computes the version from the latest tag, deletes any stale `release/vX.Y.Z` branch, cuts a fresh one from `main` HEAD with the version-bump commit ("Release vX.Y.Z"), and pushes it — which triggers a **staging** `Release` run on the branch (push-triggered and main-dispatched `Release` runs are always staging; the scheduled Tue/Fri 9am ET cut is this same step)
+3. Waits for the staging bake to succeed — it is the CI bake for the exact release payload; a failure means fixing `main` and re-cutting
+4. Dispatches `release.yml` on `release/vX.Y.Z` — "manual dispatch on a release branch" is the **full production release**: tags `vX.Y.Z`, publishes npm packages, builds/signs/notarizes and publishes the macOS DMG, pushes Docker Hub images, uploads iOS to TestFlight, creates the GitHub Release, updates the `vellum-assistant-platform` dependency, and merges the release branch back to `main`
 
-The workflow computes the next patch version from the latest `v<major>.<minor>.<patch>` tag — there is no bump-type input — then bumps versions across packages, creates and merges a release branch PR, tags the release, publishes npm packages, builds/signs/notarizes the macOS DMG, creates the GitHub Release, and updates the `vellum-assistant-platform` dependency.
+A lingering `release/vX.Y.Z` branch with no matching GitHub Release means a scheduled cut was never promoted to production; re-running step 2 refreshes it from current `main`.
 
 #### What happens after a release is created
 


### PR DESCRIPTION
Corrects #37199 — which documented `gh workflow run release.yml --ref main` as the release. Shipping v0.10.6 today revealed that path is a **staging** deploy (`is_staging=true` for main dispatches and branch pushes). The real process:

1. **`create-release-branch.yml`** (manual with `bump=patch|minor|major|hotfix`, or the scheduled Tue/Fri 9am ET cut): deletes any stale `release/vX.Y.Z`, cuts fresh from main HEAD with the version-bump commit, pushes → the push triggers a **staging bake** `Release` run on the branch.
2. **`release.yml` dispatched on `release/vX.Y.Z`** = full production release: tag, GitHub Release, DMG, npm, Docker Hub, TestFlight, platform dependency bump, merge-back to main.

Also documents the stale-branch tell (a `release/vX.Y.Z` branch with no matching GitHub Release = an unpromoted cut — exactly the state v0.10.6 sat in since the July 3 scheduled cut) and the `hotfix` bump type. `docs/internal-reference.md` updated in the same PR per the repo rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)