### PR TITLE
feat(web): expose live-voice session context and controls via store

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for the live-voice store's session context and shared controls — the
+ * seam that lets globally mounted surfaces (e.g. the title-bar session pill)
+ * observe and drive a session owned by the composer's `useLiveVoice` instance.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  useLiveVoiceStore,
+  type LiveVoiceSessionControls,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
+
+function makeControls(): LiveVoiceSessionControls {
+  return { stop: mock(() => {}), release: mock(() => {}), interrupt: mock(() => {}) };
+}
+
+beforeEach(() => {
+  useLiveVoiceStore.getState().reset();
+});
+
+describe("useLiveVoiceStore — session context", () => {
+  test("defaults to null assistant/conversation when idle", () => {
+    expect(useLiveVoiceStore.getState().assistantId).toBeNull();
+    expect(useLiveVoiceStore.getState().conversationId).toBeNull();
+  });
+
+  test("setSessionContext records the owning assistant and conversation", () => {
+    useLiveVoiceStore.getState().setSessionContext("assistant-1", "conv-1");
+    expect(useLiveVoiceStore.getState().assistantId).toBe("assistant-1");
+    expect(useLiveVoiceStore.getState().conversationId).toBe("conv-1");
+  });
+
+  test("setSessionContext accepts a null conversation", () => {
+    useLiveVoiceStore.getState().setSessionContext("assistant-1", null);
+    expect(useLiveVoiceStore.getState().assistantId).toBe("assistant-1");
+    expect(useLiveVoiceStore.getState().conversationId).toBeNull();
+  });
+
+  test("reset clears the session context", () => {
+    useLiveVoiceStore.getState().setSessionContext("assistant-1", "conv-1");
+    useLiveVoiceStore.getState().reset();
+    expect(useLiveVoiceStore.getState().assistantId).toBeNull();
+    expect(useLiveVoiceStore.getState().conversationId).toBeNull();
+  });
+});
+
+describe("useLiveVoiceStore — session controls", () => {
+  test("defaults to null controls when idle", () => {
+    expect(useLiveVoiceStore.getState().controls).toBeNull();
+  });
+
+  test("setControls registers the owning controller's controls", () => {
+    const controls = makeControls();
+    useLiveVoiceStore.getState().setControls(controls);
+    expect(useLiveVoiceStore.getState().controls).toBe(controls);
+  });
+
+  test("setControls(null) deregisters controls", () => {
+    useLiveVoiceStore.getState().setControls(makeControls());
+    useLiveVoiceStore.getState().setControls(null);
+    expect(useLiveVoiceStore.getState().controls).toBeNull();
+  });
+
+  test("reset clears registered controls", () => {
+    useLiveVoiceStore.getState().setControls(makeControls());
+    useLiveVoiceStore.getState().reset();
+    expect(useLiveVoiceStore.getState().controls).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -52,9 +52,39 @@ export type LiveVoiceSessionState =
   | "ending"
   | "failed";
 
+/**
+ * Imperative controls for the active session, registered by the
+ * {@link useLiveVoice} controller instance that owns it. Lets a globally
+ * mounted component (e.g. the title-bar session pill) drive a session owned by
+ * the composer's hook instance.
+ */
+export interface LiveVoiceSessionControls {
+  /** End the voice session (release mic, socket, and audio). */
+  stop: () => void;
+  /**
+   * Force-end the current user turn — a manual push-to-talk release, identical
+   * to the automatic silence release (the green ↑ "send now" button). No-op
+   * unless the session is `listening`.
+   */
+  release: () => void;
+  /**
+   * Stop in-flight assistant playback without the user having to speak. V1
+   * behavior: same path as barge-in interrupt, which ends the session (a later
+   * engine revision makes it turn-scoped). No-op unless the session is
+   * `speaking`.
+   */
+  interrupt: () => void;
+}
+
 export interface LiveVoiceState {
   /** Current phase of the session lifecycle. */
   state: LiveVoiceSessionState;
+  /** Assistant the active session was started for, `null` when idle. */
+  assistantId: string | null;
+  /** Conversation the active session is attached to, if any. */
+  conversationId: string | null;
+  /** Controls registered by the owning controller, `null` when no session. */
+  controls: LiveVoiceSessionControls | null;
   /** In-flight partial transcript of the user's current utterance. */
   partialTranscript: string;
   /** Last finalized user transcript. */
@@ -70,6 +100,13 @@ export interface LiveVoiceState {
 export interface LiveVoiceActions {
   /** Replace the session phase. */
   setState: (state: LiveVoiceSessionState) => void;
+  /** Record which assistant/conversation the active session belongs to. */
+  setSessionContext: (
+    assistantId: string,
+    conversationId: string | null,
+  ) => void;
+  /** Register (or clear) the owning controller's session controls. */
+  setControls: (controls: LiveVoiceSessionControls | null) => void;
   setPartialTranscript: (text: string) => void;
   setFinalTranscript: (text: string) => void;
   /** Append a delta to the accumulated assistant transcript. */
@@ -91,6 +128,9 @@ export type LiveVoiceStore = LiveVoiceState & LiveVoiceActions;
 
 const INITIAL_STATE: LiveVoiceState = {
   state: "idle",
+  assistantId: null,
+  conversationId: null,
+  controls: null,
   partialTranscript: "",
   finalTranscript: "",
   assistantTranscript: "",
@@ -102,6 +142,9 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
   ...INITIAL_STATE,
 
   setState: (state) => set({ state }),
+  setSessionContext: (assistantId, conversationId) =>
+    set({ assistantId, conversationId }),
+  setControls: (controls) => set({ controls }),
   setPartialTranscript: (partialTranscript) => set({ partialTranscript }),
   setFinalTranscript: (finalTranscript) => set({ finalTranscript }),
   appendAssistantTranscript: (delta) =>

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -542,6 +542,135 @@ describe("failure", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Session context + shared controls
+// ---------------------------------------------------------------------------
+
+describe("session context and controls", () => {
+  test("start() publishes the session context and controls to the store", async () => {
+    const h = renderController();
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-1");
+    });
+
+    const store = useLiveVoiceStore.getState();
+    expect(store.assistantId).toBe("assistant-1");
+    expect(store.conversationId).toBe("conv-1");
+    expect(store.controls).not.toBeNull();
+  });
+
+  test("start() without a conversation publishes a null conversationId", async () => {
+    const h = renderController();
+    await act(async () => {
+      await h.view.result.current.start("assistant-1");
+    });
+
+    expect(useLiveVoiceStore.getState().assistantId).toBe("assistant-1");
+    expect(useLiveVoiceStore.getState().conversationId).toBeNull();
+  });
+
+  test("release() while listening sends ptt_release and moves to transcribing", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    act(() => {
+      h.view.result.current.release();
+    });
+
+    expect(h.client.pttReleaseCount).toBe(1);
+    expect(h.view.result.current.state).toBe("transcribing");
+  });
+
+  test("release() outside listening is a no-op", async () => {
+    const h = renderController();
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-1");
+    });
+    expect(h.view.result.current.state).toBe("connecting");
+
+    act(() => {
+      h.view.result.current.release();
+    });
+
+    expect(h.client.pttReleaseCount).toBe(0);
+    expect(h.view.result.current.state).toBe("connecting");
+  });
+
+  test("store controls.release drives the manual ptt release", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    act(() => {
+      useLiveVoiceStore.getState().controls?.release();
+    });
+
+    expect(h.client.pttReleaseCount).toBe(1);
+    expect(h.view.result.current.state).toBe("transcribing");
+  });
+
+  test("store controls.interrupt stops playback while speaking and is a no-op otherwise", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    // Not speaking yet: interrupt is a guarded no-op.
+    act(() => {
+      useLiveVoiceStore.getState().controls?.interrupt();
+    });
+    expect(h.client.interruptCount).toBe(0);
+    expect(h.view.result.current.state).toBe("listening");
+
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 3,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+    });
+    expect(h.view.result.current.state).toBe("speaking");
+
+    act(() => {
+      useLiveVoiceStore.getState().controls?.interrupt();
+    });
+
+    // Same path as barge-in: playback stopped, one interrupt, session ends.
+    expect(h.player.isPlaying).toBe(false);
+    expect(h.client.interruptCount).toBe(1);
+    expect(h.view.result.current.state).toBe("idle");
+  });
+
+  test("teardown clears the session context and controls", async () => {
+    const h = renderController();
+    await startListening(h);
+    expect(useLiveVoiceStore.getState().controls).not.toBeNull();
+
+    act(() => {
+      h.view.unmount();
+    });
+
+    const store = useLiveVoiceStore.getState();
+    expect(store.controls).toBeNull();
+    expect(store.assistantId).toBeNull();
+    expect(store.conversationId).toBeNull();
+  });
+
+  test("stop() clears the session context and controls", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    await act(async () => {
+      await h.view.result.current.stop();
+    });
+
+    const store = useLiveVoiceStore.getState();
+    expect(store.controls).toBeNull();
+    expect(store.assistantId).toBeNull();
+    expect(store.conversationId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Teardown
 // ---------------------------------------------------------------------------
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -568,6 +568,28 @@ describe("session context and controls", () => {
     expect(useLiveVoiceStore.getState().conversationId).toBeNull();
   });
 
+  test("ready frame updates a null conversationId with the server-assigned id", async () => {
+    const h = renderController();
+    await act(async () => {
+      await h.view.result.current.start("assistant-1");
+    });
+    expect(useLiveVoiceStore.getState().conversationId).toBeNull();
+
+    await act(async () => {
+      h.client.emit("ready", {
+        type: "ready",
+        seq: 1,
+        sessionId: "s1",
+        conversationId: "conv-server-assigned",
+      });
+      await Promise.resolve();
+    });
+
+    const store = useLiveVoiceStore.getState();
+    expect(store.assistantId).toBe("assistant-1");
+    expect(store.conversationId).toBe("conv-server-assigned");
+  });
+
   test("release() while listening sends ptt_release and moves to transcribing", async () => {
     const h = renderController();
     await startListening(h);

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -105,6 +105,12 @@ export interface UseLiveVoiceResult {
   start: (assistantId: string, conversationId?: string) => Promise<void>;
   /** End the session and release the mic, socket, and audio context. */
   stop: () => Promise<void>;
+  /**
+   * Manually release push-to-talk (the "send now" button) — force-ends the
+   * current user turn exactly like the automatic silence release. No-op unless
+   * the session is `listening`.
+   */
+  release: () => void;
 }
 
 /** Injectable factories so tests can supply mock primitives. */
@@ -226,6 +232,28 @@ export function useLiveVoice(
     useLiveVoiceStore.getState().reset();
   }, []);
 
+  /**
+   * Manual push-to-talk release — same internal path as the automatic silence
+   * release. Guarded to `listening` so a stray click (or the store-registered
+   * control firing late) can't disturb another phase.
+   */
+  const release = useCallback(() => {
+    const session = sessionRef.current;
+    if (!session) return;
+    if (useLiveVoiceStore.getState().state !== "listening") return;
+    releasePushToTalk(session);
+  }, []);
+
+  /**
+   * Stop in-flight assistant playback — the barge-in interrupt path without
+   * the amplitude gate. `interruptIfSpeaking` itself guards to `speaking`.
+   */
+  const interrupt = useCallback(() => {
+    const session = sessionRef.current;
+    if (!session) return;
+    interruptIfSpeaking(session, teardown);
+  }, [teardown]);
+
   const start = useCallback(
     async (assistantId: string, conversationId?: string) => {
       const current = sessionRef.current;
@@ -237,6 +265,11 @@ export function useLiveVoice(
       const store = useLiveVoiceStore.getState();
       store.reset();
       store.setState("connecting");
+      store.setSessionContext(assistantId, conversationId ?? null);
+      // Registered here (not on `ready`) so a globally mounted surface can
+      // drive the session from the moment it exists; cleared by the store
+      // reset in teardown()/stop().
+      store.setControls({ stop: () => void stop(), release, interrupt });
 
       const opts = optionsRef.current;
       const client = (opts.createClient ?? (() => new LiveVoiceChannelClient()))();
@@ -346,7 +379,7 @@ export function useLiveVoice(
 
       await client.connect({ assistantId, conversationId });
     },
-    [teardown],
+    [teardown, stop, release, interrupt],
   );
 
   // Release everything if the consumer unmounts mid-session. teardown() also
@@ -363,6 +396,7 @@ export function useLiveVoice(
     error,
     start,
     stop,
+    release,
   };
 }
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -302,8 +302,15 @@ export function useLiveVoice(
         sessionRef.current === session && session.generation === generation;
 
       session.unsubscribes.push(
-        client.on("ready", () => {
+        client.on("ready", (frame) => {
           if (!live()) return;
+          // When started from a new/empty conversation, `conversationId` was
+          // undefined at start() and the store published `null`. The server
+          // assigns (or confirms) the attached conversation on `ready`, so
+          // republish the context with the authoritative id.
+          useLiveVoiceStore
+            .getState()
+            .setSessionContext(assistantId, frame.conversationId);
           void startCapture(session, teardown);
         }),
         client.on("sttPartial", (frame) => {


### PR DESCRIPTION
## Summary
- live-voice store gains session context (conversationId/assistantId) and a registered controls seam (stop/release/interrupt)
- useLiveVoice exposes release() for manual PTT release; registers/deregisters controls on start/teardown
- Additive only — no state-machine behavior changes; tests added

Part of plan: voice-mode-ui.md (PR 2 of 7)