### PR TITLE
docs: voice-mode duplex engine architecture and proposal papertrail

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -721,13 +721,32 @@ The local live voice channel uses a single gateway-authenticated WebSocket at `/
 
 The assistant runtime route lives in `src/runtime/http-server.ts`. It mirrors the STT streaming security posture: direct access must come from private-network peers/origins, and authenticated deployments require the gateway service token. The runtime parses JSON frames with `parseLiveVoiceClientTextFrame()`, parses binary frames with `parseLiveVoiceBinaryAudioFrame()`, and routes accepted sessions through `LiveVoiceSessionManager`. The manager owns a single-active-session lock and returns a `busy` frame for concurrent sessions.
 
-Sessions are full-duplex and multi-turn: one WebSocket spans the whole conversation, the client mic streams continuously (audio frames are accepted in every non-closed state), and turn-taking is owned by the phone stack's `CallController` running under the in-app `VoiceControllerProfile` (`src/calls/voice-session-source.ts` — no `call_sessions` row, lifecycle writes are no-ops, guardian dispatch disabled, token-stream speech output). `LiveVoiceSession` is a composition root that wires three collaborators:
+Sessions are full-duplex and multi-turn: one WebSocket spans the whole conversation, the client mic streams continuously (audio frames are accepted in every non-closed state), and turn-taking is owned by the phone stack's `CallController` running under the in-app `VoiceControllerProfile` built by `createInAppVoiceControllerProfile()` (`src/calls/voice-session-source.ts` — no `call_sessions` row, lifecycle writes are no-ops, guardian dispatch disabled, token-stream speech output, and an in-app control prompt from `buildLiveVoiceControlPrompt()` instead of the phone-call prompt). `LiveVoiceSession` is a composition root that wires three collaborators:
 
-- `LiveVoiceIngest` — inbound PCM16 audio: energy VAD (`pcm-speech-activity.ts`), turn segmentation (`MediaTurnDetector`), and streaming STT with per-turn batch fallback. Sessions negotiate a mic mode on the `start` frame (`ptt` default, `open-mic`); server-side VAD runs in both modes.
+- `LiveVoiceIngest` — inbound PCM16 audio: energy VAD (`pcm-speech-activity.ts`), turn segmentation (`MediaTurnDetector`), and streaming STT with per-turn batch fallback.
 - `CallController` — turn state (`idle|processing|speaking`), barge-in gating (accepted only while speaking), control markers (`[END_CALL]` ends the session via the transport), and voice turns through `voice-session-bridge`.
 - `LiveVoiceCallTransport` — consumes the controller's token stream, runs segmented streaming TTS, and emits `tts_audio`/`tts_done` frames.
 
-Server-VAD speech onset (or a client `interrupt` frame) during assistant speech is a barge-in: the controller aborts the in-flight turn, the transport flushes pending synthesis, and the session emits an `interrupted` frame with the aborted turn id, then keeps listening. `ptt_release` is a manual end-of-turn signal (authoritative in PTT, a hint in open-mic; the ingest emits `turn_boundary` when the local detector ends a turn). Session startup is gated by `resolveLiveVoiceCredentialReadiness()` — a missing STT or TTS credential fails the `start` frame with a `credentials_missing` error instead of failing mid-conversation. The session-wide duration limit (`liveVoice.maxSessionDurationSeconds`) is enforced by the controller's in-app timers.
+```
+client mic ── binary PCM16 frames ──> LiveVoiceIngest
+                                        (energy VAD → MediaTurnDetector → streaming STT)
+                                            │ speech-start / transcript finals
+                                            v
+                                      CallController
+                                        (in-app VoiceControllerProfile:
+                                         turn state, barge-in, timers, control markers)
+                                            │ voice turns via voice-session-bridge;
+                                            │ response token stream
+                                            v
+                                      LiveVoiceCallTransport
+                                        (speakable segments → streaming TTS)
+                                            │
+client playback <── tts_audio / tts_done ───┘
+```
+
+Each session runs in one of two mic modes, negotiated on the `start` frame and defaulting to `liveVoice.mode` (`ptt`) when the frame omits it. In `ptt` the client's `ptt_release` frame is the authoritative end-of-turn signal; in `open-mic` the server segments turns itself (VAD + `MediaTurnDetector`) and `ptt_release` is only a hint. Server-side VAD runs in both modes so barge-in works during assistant playback regardless of mode.
+
+Server-VAD speech onset (or a client `interrupt` frame) during assistant speech is a barge-in: the controller aborts the in-flight turn, the transport flushes pending synthesis, and the session emits an `interrupted` frame with the aborted turn id, then keeps listening. When the server-side detector ends a user turn, the ingest emits a `turn_boundary` frame so the client can render the transition. Session startup is gated by `resolveLiveVoiceCredentialReadiness()` — a missing STT or TTS credential fails the `start` frame with a `credentials_missing` error instead of failing mid-conversation. The session-wide duration limit (`liveVoice.maxSessionDurationSeconds`) is enforced by the controller's in-app timers.
 
 The assistant-side live voice module is intentionally bounded under `src/live-voice/`:
 
@@ -749,7 +768,17 @@ Live voice STT uses the same `resolveStreamingTranscriber()` path as conversatio
 
 Live voice TTS uses `streamLiveVoiceTtsAudio()` and the configured `services.tts.provider`. The selected provider must be registered, catalog-compatible, and expose `capabilities.supportsStreaming` plus `synthesizeStream()`. Fish Audio is the current catalog provider with streaming synthesis support; non-streaming providers remain available for buffered message playback or other supported surfaces, but live voice fails the credential preflight instead of silently falling back to buffered playback.
 
-Live voice is local/gateway-scoped. Managed/cloud WebSocket proxy support, cross-region routing, and p50/p95 latency guarantees are out of scope. Metrics frames expose timing data for measurement, but the architecture does not promise a hard latency SLO. VAD thresholds, mic-mode default, and the session duration cap live under the `liveVoice` config namespace (`src/config/schemas/live-voice.ts`).
+Live voice is local/gateway-scoped. Managed/cloud WebSocket proxy support, cross-region routing, and p50/p95 latency guarantees are out of scope. Metrics frames expose timing data for measurement, but the architecture does not promise a hard latency SLO.
+
+Engine tuning lives under the `liveVoice` config namespace (`src/config/schemas/live-voice.ts`):
+
+| Key                                   | Default | Purpose                                                                                |
+| ------------------------------------- | ------- | -------------------------------------------------------------------------------------- |
+| `liveVoice.mode`                      | `ptt`   | Default mic mode (`ptt` or `open-mic`) when the `start` frame does not negotiate one   |
+| `liveVoice.vad.speechEnergyThreshold` | `800`   | Mean absolute amplitude (16-bit linear scale) above which a PCM frame counts as speech |
+| `liveVoice.vad.silenceThresholdMs`    | `800`   | Trailing silence (ms) after speech that ends the user's turn                           |
+| `liveVoice.vad.maxTurnDurationMs`     | `30000` | Maximum duration (ms) of a single user turn before it is force-ended                   |
+| `liveVoice.maxSessionDurationSeconds` | `1800`  | Session-wide duration cap, enforced by the controller's in-app timers                  |
 
 **Client service-first boundary:**
 

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
@@ -15,9 +15,9 @@
  * - Every inbound server frame is JSON text and is parsed via
  *   {@link parseServerFrame}.
  *
- * Connection handshake mirrors the macOS client: a ~10s connect timeout fails
- * the session if no `ready` frame arrives, and a server `busy` frame is handled
- * distinctly from `error`.
+ * Connection handshake: a ~10s connect timeout fails the session if no
+ * `ready` frame arrives, and a server `busy` frame is handled distinctly
+ * from `error`.
  */
 
 import { resolveLiveVoiceWsUrl } from "@/domains/chat/voice/live-voice/connection";

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -30,13 +30,13 @@ import { createSelectors } from "@/utils/create-selectors";
 // ---------------------------------------------------------------------------
 
 /**
- * Phase of the live-voice session. Mirrors the macOS
- * `LiveVoiceChannelManager.State` enum 1:1.
+ * Phase of the live-voice session.
  *
  * - `idle` — no session (or a finished one cleaned up).
  * - `connecting` — minting a token / opening the socket, before `ready`.
  * - `listening` — mic is capturing and streaming PCM to the server.
- * - `transcribing` — push-to-talk released; waiting on the final transcript.
+ * - `transcribing` — user turn ended (push-to-talk released or server turn
+ *   boundary); waiting on the final transcript.
  * - `thinking` — server is generating the assistant response.
  * - `speaking` — TTS audio is queued/playing.
  * - `ending` — graceful teardown in progress.

--- a/clients/web/src/domains/chat/voice/live-voice/pcm-capture.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/pcm-capture.ts
@@ -39,7 +39,7 @@ import { getVoiceInputMediaStream } from "@/utils/voice-input-device";
 // to reach into the protocol module. Canonical definition lives in protocol.ts.
 export { LIVE_VOICE_AUDIO_FORMAT };
 
-// Matches `use-audio-amplitude.ts` (and the macOS AudioEngineController):
+// Matches `use-audio-amplitude.ts`:
 // EMA with alpha 0.5, scaled by 14 and clamped to 1.0.
 const AMPLITUDE_SMOOTHING = 0.5;
 const AMPLITUDE_SCALE = 14.0;

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -66,7 +66,7 @@ import {
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 
 // ---------------------------------------------------------------------------
-// Thresholds (mirror the macOS LiveVoiceChannelManager defaults)
+// Client-side amplitude/timing thresholds
 // ---------------------------------------------------------------------------
 
 /** Mic amplitude (in [0, 1]) above which barge-in interrupts assistant speech. */

--- a/docs/proposals/live-voice-channel.md
+++ b/docs/proposals/live-voice-channel.md
@@ -1,8 +1,11 @@
 # Live Voice Channel Integration Plan
 
-> **Implementation status:** V1 now uses `/v1/live-voice` as a gateway-authenticated WebSocket route. The gateway handler is `gateway/src/http/routes/live-voice-websocket.ts`; the assistant runtime upgrade and protocol shell live in `assistant/src/runtime/http-server.ts`; and the assistant-side module boundaries are under `assistant/src/live-voice/`. Treat the proposal below (including its references to the removed Swift macOS client) as historical design context; the durable architecture reference is `assistant/ARCHITECTURE.md`.
+> **SUPERSEDED — do not use for new planning.** This document was the V1 plan; V1 shipped (push-to-talk live voice at `/v1/live-voice`, web client behind the `voice-mode` flag). It is now stale in two load-bearing ways:
 >
-> V1 requires a configured streaming STT provider for live partial/final transcripts and a streaming-capable TTS provider for streamed assistant audio. Managed/cloud WebSocket proxy support, cross-region routing, and hard p50/p95 latency guarantees are explicitly out of scope for this version.
+> 1. It predates **PR #37047** (JARVIS-1111, merged 2026-07-02), which removed Twilio ConversationRelay and moved all phone-call STT/TTS into the daemon over a transport-agnostic pipeline. The reuse assessments below — in particular "do not reuse `CallController`", "`media-stream-stt-session.ts` mostly not reusable", and the explicit-interrupt-only barge-in recommendation — no longer reflect the codebase.
+> 2. It references the removed Swift macOS client (`VoiceInputManager.swift`, `AudioEngineController.swift`, etc.). The macOS app is now an Electron shell around the web client; the only live-voice client implementation is `clients/web/src/domains/chat/voice/live-voice/`.
+>
+> The current design doc for the voice mode project (full-duplex in-app voice) is **[`voice-mode.md`](./voice-mode.md)**. The durable architecture reference is `assistant/ARCHITECTURE.md`. The proposal below is preserved as historical design context only.
 
 ## 1. Existing Infrastructure Map
 

--- a/docs/proposals/voice-mode.md
+++ b/docs/proposals/voice-mode.md
@@ -1,0 +1,140 @@
+# Voice Mode: Full-Duplex In-App Voice
+
+> **Status:** Proposal (kickoff draft, 2026-07-06). Supersedes [`live-voice-channel.md`](./live-voice-channel.md), whose V1 plan shipped and whose reuse assessments predate the phone-pipeline migration (PR #37047). Durable architecture reference: `assistant/ARCHITECTURE.md`.
+>
+> **Implementation update (2026-07-06):** the duplex engine described in §3 — server duplex integration plus the multi-turn protocol and web client (workstreams 1–2 of §4) — has landed on the `voice-mode-engine` feature branch via the voice-mode-engine plan. Product UX, session policy revisits, cloud rollout, and synthesis consolidation (workstreams 3–6) remain open.
+>
+> **Goal:** bring the phone-call conversation experience into the app itself — a full-duplex, multi-turn, barge-in-capable voice conversation with the assistant, replacing the shipped V1's push-to-talk single-utterance model.
+
+## 1. Where we are
+
+Two voice front-ends exist on `main` today, both driving the same brain — `startVoiceTurn()` in `assistant/src/calls/voice-session-bridge.ts`, which runs a voice turn through the normal agent loop (same LLM, tools, memory, skills, approvals, persistence). Voice mode is a transport and turn-taking project, not a new inference path.
+
+| | Phone calls (`assistant/src/calls/`) | Live voice V1 (`assistant/src/live-voice/`) |
+| --- | --- | --- |
+| Transport | Twilio Media Streams WS at `/v1/calls/media-stream` (μ-law 8 kHz) | Client WS at `/v1/live-voice` (PCM16 16 kHz in, streamed TTS out) |
+| Turn-taking | Full-duplex: energy-VAD barge-in, silence/turn detection, silence nudge, END_CALL listen window, duration limits (`CallController`) | Half-duplex push-to-talk; manual `interrupt` frame; single utterance per socket |
+| STT | Streaming with catalog gating + batch fallback + startup buffering (`MediaStreamSttSession`) | Bare `resolveStreamingTranscriber()` call, no fallback/resilience |
+| Sessions | `call_sessions`/`call_events`, multi-turn until hangup | In-memory, single active session per daemon (`live-voice-session-manager.ts`) |
+| Clients | PSTN caller | Web client (`clients/web/src/domains/chat/voice/live-voice/`), composer-wired, dark behind the `voice-mode` flag. macOS is an Electron shell around the same web code; there is no other client. |
+
+### What PR #37047 changed (why the V1 plan is superseded)
+
+Until 2026-07-02, phone calls ran on Twilio ConversationRelay — **Twilio owned STT and TTS**, so the phone stack's speech handling was structurally unreusable for in-app voice, and the V1 plan correctly said so. #37047 (JARVIS-1111) removed ConversationRelay entirely and moved the whole speech pipeline into the daemon:
+
+- **`CallController` is transport-decoupled.** It takes a `CallTransport` (`assistant/src/calls/call-transport.ts`), an interface written explicitly so "alternative transports can be introduced without modifying controller logic." Constructor surface: `(callSessionId, transport, task, opts)`.
+- **`MediaStreamSttSession` is transport-neutral** (callback hooks: `onSpeechStart`, `onTranscriptFinal`, `onDtmf`, `onStop`) and carries production hardening: catalog-gated streaming vs per-turn batch (Deepgram realtime with utterance-boundary finals; whisper/gemini/xai batch), batch fallback when the streaming socket dies mid-session, bounded startup buffering (~10 s of frames), and barge-in driven by a local energy VAD — never by transcriber partials.
+- **`MediaTurnDetector`** (`media-turn-detector.ts`) is integration-neutral by design: the caller supplies per-chunk speech classification; it emits turn-start/turn-end callbacks on silence-threshold (800 ms default) and max-duration boundaries.
+- **Credential preflight** (`telephony-credential-preflight.ts`): calls fail before dialing when STT/TTS keys are missing, instead of erroring mid-conversation.
+- The controller inherits the JARVIS-1232 barge-in race fixes and exactly-once call finalization.
+
+Net: the phone stack went from "Twilio does the speech" to "the daemon does the speech over an abstract transport." That collapses most of the server-side work for voice mode into integration.
+
+## 2. Revised reuse map
+
+Replaces §1–2 of the superseded doc.
+
+| Component | Verdict | Notes |
+| --- | --- | --- |
+| `voice-session-bridge.ts` / `startVoiceTurn()` | **Reuse as-is** | Already shared by both stacks; `approvalMode: "local-live-voice"` path exists. |
+| `CallController` (`call-controller.ts`) | **Adopt via a new `CallTransport` impl** | Buys the idle→processing→speaking state machine, barge-in, silence nudge, END_CALL listen window + re-engagement cap, duration timers, guardian consultation, control-marker protocol. See §3 for the coupling caveats. |
+| `CallTransport` (`call-transport.ts`) | **Implement for live voice** | `sendTextToken`, `sendPlayUrl`, `endSession`; optional `setAudioStartCallback`, `discardPendingText`. Set `requiresWavAudio: false` — no μ-law transcoder, so compressed TTS formats are fine. |
+| `MediaTurnDetector` (`media-turn-detector.ts`) | **Reuse directly** | Server-side open-mic turn detection. Replaces the web client's fragile client-side auto-release heuristic (120 ms speech + 1 s silence). |
+| `MediaStreamSttSession` (`media-stream-stt-session.ts`) | **Lift the patterns; port the VAD** | The resilience patterns (catalog gating, batch fallback, startup buffering, VAD-driven barge-in) belong in the live-voice ingest path. The energy heuristic itself is μ-law-specific (`media-stream-stt-session.ts:710`); write the trivial PCM16 equivalent. Ingest framing (Twilio frame parsing, μ-law decode) stays telephony-only — note it already normalizes to 16 kHz PCM16, the exact format the live-voice client sends, so everything downstream of decode is format-compatible. |
+| STT resolver + provider catalog | **Reuse (already shared)** | `resolveStreamingTranscriber()` hardening from #37047 benefits live voice for free. Streaming requires `conversationStreamingMode: "realtime-ws"` (deepgram, google-gemini, xai). |
+| TTS stack (`assistant/src/tts/`) | **Reuse (already shared)** | Streaming requires `synthesizeStream()` — Fish Audio only today; single point of failure to track. |
+| `telephony-credential-preflight.ts` | **Adopt the pattern** | Preflight STT/TTS keys at `start`-frame time; reject the session with a clear error instead of dying on the first turn. |
+| `CallSetupFlow` + `GuardianWaitController` | Available, likely unneeded | Now transport-agnostic, but in-app users are already authenticated; no admission/verification flow needed. |
+| `live-voice/` V1 module | **Keep transport + protocol; replace orchestration** | `protocol.ts`, session manager shell, archive, metrics survive. `LiveVoiceSession`'s STT→turn→TTS orchestration is what `CallController` replaces. |
+| Web client (`clients/web/.../live-voice/`) | **Keep; extend** | Capture, playback, store, connection/auth all stand. Needs multi-turn protocol support and continuous-mic UX (§4). |
+| ConversationRelay anything | **Gone** | `relay-server.ts`, `/v1/calls/relay`, gateway relay proxy, `telephony-stt-routing.ts` were deleted. Ignore references in older docs/plans. |
+| Native-twilio TTS subsystem (`resolveVoiceQualityProfile`, voice-spec registry, `callMode`) | **Do not touch** | Flagged dead / pending removal in #37047's deferred follow-ups. |
+
+## 3. Proposed architecture
+
+Adopt `CallController` over the live-voice WebSocket, rather than growing duplex logic inside `LiveVoiceSession`:
+
+```text
+clients/web  live-voice module (capture: 16 kHz PCM16 worklet; playback: gapless Web Audio)
+      | WS /v1/live-voice  (cloud: browser → velay → gateway tunnel/loopback → runtime;
+      |                     self-hosted: browser → gateway → runtime)
+      v
+assistant/src/live-voice/
+  LiveVoiceSessionManager        (session lifecycle, single-session policy, metrics, archive)
+  LiveVoiceIngest                (PCM frames → energy VAD → MediaTurnDetector
+                                  → streaming STT w/ batch fallback + startup buffer)
+  LiveVoiceTransport : CallTransport
+                                 (assistant text tokens → streaming TTS → tts_audio frames;
+                                  requiresWavAudio=false; discardPendingText on barge-in)
+      v
+assistant/src/calls/CallController   (state machine, barge-in, timers, markers, guardian consult)
+      v
+voice-session-bridge.startVoiceTurn() → conversation.runAgentLoop()
+```
+
+The ingest side mirrors what `media-stream-server.ts` does for Twilio: VAD classifies each PCM chunk, `MediaTurnDetector` segments turns, speech-start during `speaking` state triggers `CallController.handleBargeIn()` (abort in-flight turn, flush queued TTS), transcript finals drive turns.
+
+### Controller coupling to resolve
+
+_Resolved as shipped: `VoiceSessionSource` abstracts session reads and `VoiceControllerProfile` (with `createInAppVoiceControllerProfile()`) carries the per-flavor behavior below (`assistant/src/calls/voice-session-source.ts`)._
+
+**Decided (2026-07-06): no session-record concept for in-app voice.** Live-voice sessions are just conversations — user and assistant turns persist as normal messages in the conversation (which is what V1 already does). `CallController`'s session lookup gets abstracted behind a session-source interface; `call_sessions`/`call_events` stay phone-only. Known couplings to break:
+
+- `getCallSession(callSessionId)` in the constructor for `conversationId`/`skipDisclosure` (`call-controller.ts:184`) — replace with an injected session source; live voice supplies `conversationId` directly and has no disclosure concept.
+- Disclosure announcement, inbound-verification behavior, and the phone-shaped control-marker prompt (`buildVoiceCallControlPrompt`) need an in-app variant: no disclosure, no callee verification, guardian consultation becomes a normal in-app approval, `[END_CALL]` maps to session end.
+- Phone approval policy (auto-deny side-effect tools) must not apply; live voice already has the interactive `local-live-voice` approval mode.
+- Call-event recording (`recordCallEvent`) and pointer/completion messages are phone-only; live voice keeps its existing archive path (`live-voice-archive.ts`).
+
+### Protocol changes (`live-voice/protocol.ts`)
+
+V1's frames mostly survive. Deltas:
+
+- **Multi-turn:** drop single-utterance-per-socket. `ptt_release` becomes optional (retained for a PTT mode); in open-mic mode the server segments turns itself and emits a new `turn_boundary`/`listening` signal so the client can render state.
+- **Barge-in:** server-detected; `interrupt` frame retained as a manual override. Server emits an explicit `interrupted` frame so playback flushes deterministically (the client already supports generation-token flush in `tts-playback.ts`).
+- **Mode negotiation in `start`:** `mode: "open-mic" | "ptt"`.
+
+### Configuration
+
+Add a `liveVoice.*` config namespace mirroring `calls.voice.*`: mode default (open-mic vs PTT), VAD sensitivity / silence threshold, max session duration. Continue sourcing providers from `services.stt` / `services.tts` — no live-voice-specific provider config.
+
+## 4. Gap list → workstreams
+
+1. **Server: duplex integration** — `LiveVoiceTransport`, PCM16 energy VAD, `MediaTurnDetector` wiring, controller session-source abstraction, in-app control prompt, credential preflight at `start`. Mostly integration of #37047 components. _Shipped (voice-mode-engine plan; the transport landed as `LiveVoiceCallTransport`, the session-source abstraction as `VoiceSessionSource` + `VoiceControllerProfile`)._
+2. **Protocol + client: multi-turn sessions** — protocol deltas above; web client state machine (`use-live-voice.ts`) moves from single-utterance to continuous session with server-driven turn boundaries; seamless barge-in without socket teardown. _Shipped (voice-mode-engine plan)._
+3. **Product UX** — today the UI is one composer button + amplitude. Define the in-conversation voice surface (overlay/screen, transcript display, interrupt affordance, session end).
+4. **Session policy** — revisit the single-active-session lock (`live-voice-session-manager.ts`) for multi-tab/multi-device; V1's `busy` frame is the fallback.
+5. **Cloud rollout** — verify the Django `POST /v1/auth/live-voice-token/` mint endpoint is live platform-side (the client assumes it in `connection.ts`); measure the 3-hop cloud path (browser→velay→gateway→runtime) with the existing per-turn `metrics` frames before considering transport changes; `voice-mode` flag targeting (LaunchDarkly, platform repo terraform + dashboard).
+6. **Synthesis consolidation** (optional, pre-blessed) — #37047 explicitly deferred consolidating the three copied provider-synthesis paths (phone `call-speech-output.ts`/`tts-call-strategy.ts`, `live-voice-tts.ts`, message-TTS). Natural to absorb if phone and in-app unify on one controller.
+
+## 5. Decisions superseding the old doc's open questions
+
+| Old question | Old answer (V1) | Voice-mode answer |
+| --- | --- | --- |
+| Share `CallController`? | No — new controller | **Yes, via `CallTransport`** — the interface now exists for this; rebuilding duplex turn-taking would duplicate a production-hardened engine. |
+| Barge-in strategy | Explicit interrupt only | **Server-side VAD barge-in** (phone parity); manual interrupt retained. |
+| `/v1/live-voice` vs `/v1/calls` | `/v1/live-voice` | Unchanged — keep `/v1/live-voice`. |
+| One socket vs STT socket + control socket | One socket | Unchanged. |
+| TTS use case `"phone-call"` vs `"live-voice"` | Reuse `"phone-call"` | Revisit during synthesis consolidation; not a blocker. |
+| macOS client location | New Swift `LiveVoiceChannelManager` | **Obsolete** — macOS is Electron around the web client; the web module is the only client. |
+| OpenAI Realtime | Defer | Still deferred; re-evaluate only if measured cloud latency (via `metrics` frames) misses target. |
+
+## 6. Decisions and remaining open questions
+
+Decided 2026-07-06:
+
+- **Session records:** none — conversations only (§3).
+- **Mode default: PTT.** Open-mic ships as a mode behind the same engine (the server-side VAD/turn-detection path must still be built so barge-in works during assistant playback), but PTT is the default; open-mic may land Electron-first later.
+- **Echo handling: deferred.** With PTT default the mic isn't streaming during playback, so it's moot for launch; revisit when open-mic becomes a default anywhere.
+- **Multi-tab: keep V1 behavior** — single active session per daemon; a second concurrent session gets the `busy` frame.
+
+Still open:
+
+- **Latency budget:** what p50/p95 turn latency is acceptable on the cloud path before transport work (e.g. WebRTC — currently zero in-repo infrastructure) enters scope?
+
+## 7. Out of scope
+
+- Wake words / always-on ambient listening (open-mic applies only within an explicit voice session).
+- Changes to the PSTN phone path beyond shared-code refactors.
+- WebRTC or any new transport infrastructure (measure first; see §6).
+- New STT/TTS providers, except unblocking a second streaming-TTS provider if Fish Audio's `synthesizeStream()` exclusivity becomes a launch risk.
+- Voice cloning, avatars, visual embodiment.

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -44,11 +44,11 @@ The request carries base64-encoded WAV audio and a MIME type. The daemon resolve
 
 **Key source files:**
 
-| File                                             | Purpose                                                                   |
-| ------------------------------------------------ | ------------------------------------------------------------------------- |
-| `gateway/src/http/routes/runtime-proxy.ts`       | Assistant-scoped path rewriting (`/v1/assistants/:id/...` → `/v1/...`)    |
-| `assistant/src/runtime/routes/stt-routes.ts`     | Daemon HTTP endpoint: validates audio, resolves transcriber, returns text |
-| `clients/web/src/domains/chat/voice/stt-api.ts`     | Web client: POSTs audio to the gateway, returns a typed result            |
+| File                                            | Purpose                                                                   |
+| ----------------------------------------------- | ------------------------------------------------------------------------- |
+| `gateway/src/http/routes/runtime-proxy.ts`      | Assistant-scoped path rewriting (`/v1/assistants/:id/...` → `/v1/...`)    |
+| `assistant/src/runtime/routes/stt-routes.ts`    | Daemon HTTP endpoint: validates audio, resolves transcriber, returns text |
+| `clients/web/src/domains/chat/voice/stt-api.ts` | Web client: POSTs audio to the gateway, returns a typed result            |
 
 ### STT Streaming WebSocket Proxy
 
@@ -73,13 +73,13 @@ Clients open WebSocket connections through the gateway to the daemon's real-time
 
 **Key source files:**
 
-| File                                              | Purpose                                                                                                            |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `gateway/src/http/routes/stt-stream-websocket.ts` | WebSocket upgrade handler (`createSttStreamWebsocketHandler`) and proxy handlers (`getSttStreamWebsocketHandlers`) |
-| `gateway/src/index.ts`                            | Route registration: wires upgrade handler to the gateway's Bun HTTP server                                         |
-| `assistant/src/runtime/http-server.ts`            | Daemon-side WebSocket upgrade at `/v1/stt/stream`, session creation and registry                                   |
-| `assistant/src/stt/stt-stream-session.ts`         | Runtime session orchestrator: drives the `StreamingTranscriber` from the WebSocket                                 |
-| `clients/web/src/domains/chat/voice/dictation-stream.ts` | Web client: opens the gateway WebSocket, parses transcript events, reports failures                            |
+| File                                                     | Purpose                                                                                                            |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `gateway/src/http/routes/stt-stream-websocket.ts`        | WebSocket upgrade handler (`createSttStreamWebsocketHandler`) and proxy handlers (`getSttStreamWebsocketHandlers`) |
+| `gateway/src/index.ts`                                   | Route registration: wires upgrade handler to the gateway's Bun HTTP server                                         |
+| `assistant/src/runtime/http-server.ts`                   | Daemon-side WebSocket upgrade at `/v1/stt/stream`, session creation and registry                                   |
+| `assistant/src/stt/stt-stream-session.ts`                | Runtime session orchestrator: drives the `StreamingTranscriber` from the WebSocket                                 |
+| `clients/web/src/domains/chat/voice/dictation-stream.ts` | Web client: opens the gateway WebSocket, parses transcript events, reports failures                                |
 
 ### Assistant Feature Flags API
 
@@ -636,17 +636,17 @@ If no guardian binding exists for the channel, escalation fails closed -- the me
 
 **Assistant DB** (`assistant.db` — current owner of contact info, migrating to gateway):
 
-| Table              | Purpose                                                                |
-| ------------------ | ---------------------------------------------------------------------- |
-| `contacts`         | Contact records with role, relationship, and per-contact metadata      |
-| `contact_channels` | Channel bindings per contact with access policy (allow/deny/escalate)  |
+| Table              | Purpose                                                               |
+| ------------------ | --------------------------------------------------------------------- |
+| `contacts`         | Contact records with role, relationship, and per-contact metadata     |
+| `contact_channels` | Channel bindings per contact with access policy (allow/deny/escalate) |
 
 **Gateway DB** (`gateway.sqlite` — canonical owner of invites, future owner of auth/authz):
 
-| Table              | Purpose                                                                 |
-| ------------------ | ----------------------------------------------------------------------- |
-| `contacts`         | Contact auth/authz: id, display_name, role, principal_id                |
-| `contact_channels` | Channel bindings with policy, status, external IDs, verification state  |
+| Table              | Purpose                                                                              |
+| ------------------ | ------------------------------------------------------------------------------------ |
+| `contacts`         | Contact auth/authz: id, display_name, role, principal_id                             |
+| `contact_channels` | Channel bindings with policy, status, external IDs, verification state               |
 | `ingress_invites`  | Canonical invite store — token/code hashes, expiry, use counts, voice/display fields |
 
 The gateway's `ingress_invites` table is the sole invite store: mint, list, revoke, and redemption all run gateway-natively, and the daemon relays its invite surfaces here over IPC. The gateway data migrations `m0007`/`m0009` reference `assistant_ingress_invites` — a legacy assistant table absent from the current assistant schema — only as a one-time backfill source.
@@ -655,17 +655,17 @@ The gateway declares `contacts` and `contact_channels` tables and exposes them v
 
 #### Key Modules
 
-| Module                                                    | Purpose                                                                    |
-| --------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Module                                                    | Purpose                                                                             |
+| --------------------------------------------------------- | ----------------------------------------------------------------------------------- |
 | `gateway/src/http/routes/contacts-control-plane-proxy.ts` | Gateway-native invite lifecycle (mint, list, revoke, redeem) shared by HTTP and IPC |
-| `gateway/src/ipc/invite-handlers.ts`                      | IPC routes relaying the daemon's invite surfaces to the native functions   |
-| `gateway/src/verification/invite-redemption.ts`           | Redemption engine — validation, atomic claim, ACL activation               |
-| `assistant/src/contacts/contact-store.ts`                 | Contact and channel lookups (findContactChannel, guardian bindings)        |
-| `assistant/src/contacts/contacts-write.ts`                | Contact and channel writes (upsert, policy changes, redemption info mirror) |
-| `assistant/src/ipc/routes/invite-ipc-routes.ts`           | `invite_redeemed` info mirror — local contact/channel identity upsert      |
-| `assistant/src/runtime/routes/inbound-message-handler.ts` | ACL enforcement point -- member lookup, policy check, escalation creation  |
-| `gateway/src/db/contact-store.ts`                         | Gateway-side ContactStore — contact/channel reads and invite CRUD          |
-| `gateway/src/ipc/contact-handlers.ts`                     | IPC route handlers for contact reads                                       |
+| `gateway/src/ipc/invite-handlers.ts`                      | IPC routes relaying the daemon's invite surfaces to the native functions            |
+| `gateway/src/verification/invite-redemption.ts`           | Redemption engine — validation, atomic claim, ACL activation                        |
+| `assistant/src/contacts/contact-store.ts`                 | Contact and channel lookups (findContactChannel, guardian bindings)                 |
+| `assistant/src/contacts/contacts-write.ts`                | Contact and channel writes (upsert, policy changes, redemption info mirror)         |
+| `assistant/src/ipc/routes/invite-ipc-routes.ts`           | `invite_redeemed` info mirror — local contact/channel identity upsert               |
+| `assistant/src/runtime/routes/inbound-message-handler.ts` | ACL enforcement point -- member lookup, policy check, escalation creation           |
+| `gateway/src/db/contact-store.ts`                         | Gateway-side ContactStore — contact/channel reads and invite CRUD                   |
+| `gateway/src/ipc/contact-handlers.ts`                     | IPC route handlers for contact reads                                                |
 
 ### Telegram Credential Flow
 
@@ -980,36 +980,36 @@ sequenceDiagram
 
 ### Key Components
 
-| File                                                             | Role                                                                                                                                                                                                                   |
-| ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `assistant/src/calls/call-store.ts`                              | CRUD operations for call sessions, call events, and pending questions in SQLite via Drizzle ORM                                                                                                                        |
-| `assistant/src/calls/call-domain.ts`                             | Shared domain functions (`startCall`, `getCallStatus`, `cancelCall`, `answerCall`, `relayInstruction`) used by both tools and HTTP routes                                                                              |
-| `assistant/src/calls/guardian-dispatch.ts`                       | Cross-channel dispatch engine: fans out ASK_GUARDIAN questions to mac/telegram, creates server-side guardian conversations, manages deliveries                                                                         |
-| `assistant/src/memory/guardian-action-store.ts`                  | CRUD for guardian action requests and deliveries; first-writer-wins resolution via atomic status check                                                                                                                 |
-| `assistant/src/calls/guardian-action-sweep.ts`                   | Periodic 60s sweep for expired guardian action requests; sends expiry notices to all delivery channels                                                                                                                 |
-| `assistant/src/calls/call-domain.ts:createInboundVoiceSession()` | Creates or reuses a voice session for an inbound call keyed by CallSid (idempotent replay protection)                                                                                                                  |
-| `assistant/src/runtime/channel-verification-service.ts`          | Channel verification session lifecycle: create session with six-digit code, find pending sessions, validate and consume on match                                                                                       |
-| `assistant/src/calls/call-state-machine.ts`                      | Deterministic state transition validator with allowed-transition table and terminal-state enforcement                                                                                                                  |
-| `assistant/src/calls/call-recovery.ts`                           | Startup reconciliation of non-terminal calls: fetches provider status and transitions stale sessions                                                                                                                   |
-| `assistant/src/calls/twilio-provider.ts`                         | Twilio Voice REST API integration (initiateCall, endCall, getCallStatus) using direct fetch — no Twilio SDK dependency                                                                                                 |
-| `assistant/src/calls/twilio-routes.ts`                           | HTTP webhook handlers: voice webhook (returns `<Connect><Stream>` TwiML, enforces the credential preflight with `<Say>` + `<Hangup/>` when not ready), status callback                                                 |
-| `assistant/src/calls/media-stream-server.ts`                     | WebSocket handler for Twilio Media Streams; manages one MediaStreamCallSession per call, runs `routeSetup`, and drives interactive setup outcomes through `CallSetupFlow`                                              |
-| `assistant/src/calls/call-setup-flow.ts`                         | Transport-agnostic call setup flow: verification, invite-redemption, name-capture, and unverified-caller sub-flows over DTMF/spoken input                                                                              |
-| `assistant/src/calls/guardian-wait-controller.ts`                | Guardian access-request wait orchestration: hold messaging, heartbeats, status polling, consultation timeout, callback handoff                                                                                         |
-| `assistant/src/calls/media-stream-stt-session.ts`                | Daemon-side STT for media-stream audio: streaming transcriber (utterance-boundary finals) with batch + VAD turn-detection fallback                                                                                     |
-| `assistant/src/calls/telephony-credential-preflight.ts`          | Combined STT + TTS credential-readiness resolver gating inbound TwiML and outbound call placement                                                                                                                      |
-| `assistant/src/calls/speaker-identification.ts`                  | Reusable speaker recognition primitive for voice prompts: extracts provider speaker metadata (top-level and nested fields), resolves stable per-call speaker identities, and emits speaker context for personalization |
-| `assistant/src/calls/call-controller.ts`                         | Session-backed voice controller: routes voice turns through the daemon session pipeline via voice-session-bridge, detects ASK_GUARDIAN and END_CALL control markers                                                    |
-| `assistant/src/calls/voice-session-bridge.ts`                    | Bridge between the voice call controller and the daemon session/run pipeline: wraps RunOrchestrator.startRun() with voice-specific defaults, translating agent-loop events into callbacks for real-time TTS streaming  |
-| `assistant/src/calls/call-state.ts`                              | Notifier pattern (Maps with register/unregister/fire helpers) for cross-component communication: question notifiers, completion notifiers, and controller registry                                                     |
-| `assistant/src/calls/call-constants.ts`                          | Config-backed constants: max call duration, user consultation timeout, silence timeout, denied emergency numbers                                                                                                       |
-| `assistant/src/calls/voice-provider.ts`                          | Abstract VoiceProvider interface for provider-agnostic call initiation                                                                                                                                                 |
-| `assistant/src/calls/twilio-config.ts`                           | Twilio credential and configuration resolution from secure key store and environment                                                                                                                                   |
-| `assistant/src/calls/types.ts`                                   | TypeScript type definitions: CallSession, CallEvent, CallPendingQuestion, CallStatus, CallEventType                                                                                                                    |
-| `gateway/src/http/routes/twilio-voice-webhook.ts`                | Gateway route: validates Twilio signature, forwards voice webhook to runtime                                                                                                                                           |
-| `gateway/src/http/routes/twilio-status-webhook.ts`               | Gateway route: validates Twilio signature, forwards status callback to runtime                                                                                                                                         |
-| `gateway/src/http/routes/twilio-media-websocket.ts`              | Gateway route: WebSocket proxy for Media Streams frames between Twilio and runtime (all calls)                                                                                                                         |
-| `gateway/src/twilio/validate-webhook.ts`                         | Twilio webhook validation: HMAC-SHA1 signature verification, payload size limits, fail-closed when auth token missing                                                                                                  |
+| File                                                             | Role                                                                                                                                                                                                                                                                                             |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `assistant/src/calls/call-store.ts`                              | CRUD operations for call sessions, call events, and pending questions in SQLite via Drizzle ORM                                                                                                                                                                                                  |
+| `assistant/src/calls/call-domain.ts`                             | Shared domain functions (`startCall`, `getCallStatus`, `cancelCall`, `answerCall`, `relayInstruction`) used by both tools and HTTP routes                                                                                                                                                        |
+| `assistant/src/calls/guardian-dispatch.ts`                       | Cross-channel dispatch engine: fans out ASK_GUARDIAN questions to mac/telegram, creates server-side guardian conversations, manages deliveries                                                                                                                                                   |
+| `assistant/src/memory/guardian-action-store.ts`                  | CRUD for guardian action requests and deliveries; first-writer-wins resolution via atomic status check                                                                                                                                                                                           |
+| `assistant/src/calls/guardian-action-sweep.ts`                   | Periodic 60s sweep for expired guardian action requests; sends expiry notices to all delivery channels                                                                                                                                                                                           |
+| `assistant/src/calls/call-domain.ts:createInboundVoiceSession()` | Creates or reuses a voice session for an inbound call keyed by CallSid (idempotent replay protection)                                                                                                                                                                                            |
+| `assistant/src/runtime/channel-verification-service.ts`          | Channel verification session lifecycle: create session with six-digit code, find pending sessions, validate and consume on match                                                                                                                                                                 |
+| `assistant/src/calls/call-state-machine.ts`                      | Deterministic state transition validator with allowed-transition table and terminal-state enforcement                                                                                                                                                                                            |
+| `assistant/src/calls/call-recovery.ts`                           | Startup reconciliation of non-terminal calls: fetches provider status and transitions stale sessions                                                                                                                                                                                             |
+| `assistant/src/calls/twilio-provider.ts`                         | Twilio Voice REST API integration (initiateCall, endCall, getCallStatus) using direct fetch — no Twilio SDK dependency                                                                                                                                                                           |
+| `assistant/src/calls/twilio-routes.ts`                           | HTTP webhook handlers: voice webhook (returns `<Connect><Stream>` TwiML, enforces the credential preflight with `<Say>` + `<Hangup/>` when not ready), status callback                                                                                                                           |
+| `assistant/src/calls/media-stream-server.ts`                     | WebSocket handler for Twilio Media Streams; manages one MediaStreamCallSession per call, runs `routeSetup`, and drives interactive setup outcomes through `CallSetupFlow`                                                                                                                        |
+| `assistant/src/calls/call-setup-flow.ts`                         | Transport-agnostic call setup flow: verification, invite-redemption, name-capture, and unverified-caller sub-flows over DTMF/spoken input                                                                                                                                                        |
+| `assistant/src/calls/guardian-wait-controller.ts`                | Guardian access-request wait orchestration: hold messaging, heartbeats, status polling, consultation timeout, callback handoff                                                                                                                                                                   |
+| `assistant/src/calls/media-stream-stt-session.ts`                | Daemon-side STT for media-stream audio: streaming transcriber (utterance-boundary finals) with batch + VAD turn-detection fallback                                                                                                                                                               |
+| `assistant/src/calls/telephony-credential-preflight.ts`          | Combined STT + TTS credential-readiness resolver gating inbound TwiML and outbound call placement                                                                                                                                                                                                |
+| `assistant/src/calls/speaker-identification.ts`                  | Reusable speaker recognition primitive for voice prompts: extracts provider speaker metadata (top-level and nested fields), resolves stable per-call speaker identities, and emits speaker context for personalization                                                                           |
+| `assistant/src/calls/call-controller.ts`                         | Voice turn controller shared by phone calls and in-app live voice (session reads via `VoiceSessionSource`, per-flavor behavior via `VoiceControllerProfile`): routes voice turns through the daemon session pipeline via voice-session-bridge, detects ASK_GUARDIAN and END_CALL control markers |
+| `assistant/src/calls/voice-session-bridge.ts`                    | Bridge between the voice call controller and the daemon session/run pipeline: wraps RunOrchestrator.startRun() with voice-specific defaults, translating agent-loop events into callbacks for real-time TTS streaming                                                                            |
+| `assistant/src/calls/call-state.ts`                              | Notifier pattern (Maps with register/unregister/fire helpers) for cross-component communication: question notifiers, completion notifiers, and controller registry                                                                                                                               |
+| `assistant/src/calls/call-constants.ts`                          | Config-backed constants: max call duration, user consultation timeout, silence timeout, denied emergency numbers                                                                                                                                                                                 |
+| `assistant/src/calls/voice-provider.ts`                          | Abstract VoiceProvider interface for provider-agnostic call initiation                                                                                                                                                                                                                           |
+| `assistant/src/calls/twilio-config.ts`                           | Twilio credential and configuration resolution from secure key store and environment                                                                                                                                                                                                             |
+| `assistant/src/calls/types.ts`                                   | TypeScript type definitions: CallSession, CallEvent, CallPendingQuestion, CallStatus, CallEventType                                                                                                                                                                                              |
+| `gateway/src/http/routes/twilio-voice-webhook.ts`                | Gateway route: validates Twilio signature, forwards voice webhook to runtime                                                                                                                                                                                                                     |
+| `gateway/src/http/routes/twilio-status-webhook.ts`               | Gateway route: validates Twilio signature, forwards status callback to runtime                                                                                                                                                                                                                   |
+| `gateway/src/http/routes/twilio-media-websocket.ts`              | Gateway route: WebSocket proxy for Media Streams frames between Twilio and runtime (all calls)                                                                                                                                                                                                   |
+| `gateway/src/twilio/validate-webhook.ts`                         | Twilio webhook validation: HMAC-SHA1 signature verification, payload size limits, fail-closed when auth token missing                                                                                                                                                                            |
 
 ### Call State Machine
 
@@ -1154,20 +1154,20 @@ Malformed or unprocessable provider callback payloads are logged as dead-letter 
 
 Call behavior is controlled via the `calls` config block in the assistant configuration (`config/schema.ts`). All values have sensible defaults and are validated via Zod:
 
-| Field                             | Type     | Default                                       | Description                                                                                                                                                                                     |
-| --------------------------------- | -------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `calls.enabled`                   | boolean  | `true`                                        | Master toggle for the calls feature. When `false`, call routes return 403 and tools return errors.                                                                                              |
-| `calls.provider`                  | enum     | `'twilio'`                                    | Voice provider to use (currently only Twilio is supported).                                                                                                                                     |
-| `calls.maxDurationSeconds`        | int      | `3600`                                        | Maximum allowed duration per call.                                                                                                                                                              |
-| `calls.userConsultTimeoutSeconds` | int      | `120`                                         | How long to wait for a user answer before timing out a pending question.                                                                                                                        |
-| `calls.disclosure.enabled`        | boolean  | `true`                                        | Whether the AI should disclose it is an AI at the start of the call.                                                                                                                            |
-| `calls.disclosure.text`           | string   | _(default disclosure prompt)_                 | The disclosure instruction included in the system prompt.                                                                                                                                       |
-| `calls.safety.denyCategories`     | string[] | `[]`                                          | Categories of calls to deny (e.g., emergency numbers are always denied regardless of this setting).                                                                                             |
-| `llm.callSites.callAgent.model`   | string   | _(unset — falls back to `llm.default.model`)_ | Optional override for the LLM model used in voice call conversations.                                                                                                                           |
-| `calls.voice.language`            | string   | `'en-US'`                                     | Language code for TTS and transcription.                                                                                                                                                        |
-| `services.stt.provider`           | enum     | `'deepgram'`                                  | STT provider for all boundaries including telephony. The daemon transcribes media-stream call audio with this provider (streaming when supported, batch otherwise).                             |
-| `services.tts.provider`           | enum     | `'elevenlabs'`                                | Active TTS provider for speech synthesis (catalog-driven; see [TTS Provider Abstraction](../assistant/ARCHITECTURE.md#tts-provider-abstraction-servicestts)).                                   |
-| `services.tts.providers.<id>.*`   | object   | _(per-provider defaults)_                     | Provider-specific settings block. One block per catalog entry (e.g. `elevenlabs`, `fish-audio`).                                                                                                |
+| Field                             | Type     | Default                                       | Description                                                                                                                                                         |
+| --------------------------------- | -------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `calls.enabled`                   | boolean  | `true`                                        | Master toggle for the calls feature. When `false`, call routes return 403 and tools return errors.                                                                  |
+| `calls.provider`                  | enum     | `'twilio'`                                    | Voice provider to use (currently only Twilio is supported).                                                                                                         |
+| `calls.maxDurationSeconds`        | int      | `3600`                                        | Maximum allowed duration per call.                                                                                                                                  |
+| `calls.userConsultTimeoutSeconds` | int      | `120`                                         | How long to wait for a user answer before timing out a pending question.                                                                                            |
+| `calls.disclosure.enabled`        | boolean  | `true`                                        | Whether the AI should disclose it is an AI at the start of the call.                                                                                                |
+| `calls.disclosure.text`           | string   | _(default disclosure prompt)_                 | The disclosure instruction included in the system prompt.                                                                                                           |
+| `calls.safety.denyCategories`     | string[] | `[]`                                          | Categories of calls to deny (e.g., emergency numbers are always denied regardless of this setting).                                                                 |
+| `llm.callSites.callAgent.model`   | string   | _(unset — falls back to `llm.default.model`)_ | Optional override for the LLM model used in voice call conversations.                                                                                               |
+| `calls.voice.language`            | string   | `'en-US'`                                     | Language code for TTS and transcription.                                                                                                                            |
+| `services.stt.provider`           | enum     | `'deepgram'`                                  | STT provider for all boundaries including telephony. The daemon transcribes media-stream call audio with this provider (streaming when supported, batch otherwise). |
+| `services.tts.provider`           | enum     | `'elevenlabs'`                                | Active TTS provider for speech synthesis (catalog-driven; see [TTS Provider Abstraction](../assistant/ARCHITECTURE.md#tts-provider-abstraction-servicestts)).       |
+| `services.tts.providers.<id>.*`   | object   | _(per-provider defaults)_                     | Provider-specific settings block. One block per catalog entry (e.g. `elevenlabs`, `fish-audio`).                                                                    |
 
 ### Caller Identity Resolution
 


### PR DESCRIPTION
## Summary
- Commits the voice-mode design doc and the SUPERSEDED banner on the V1 live-voice proposal
- Finalizes assistant/ARCHITECTURE.md duplex live-voice section (+ liveVoice config table)
- Sweeps stale single-utterance/half-duplex comments left outside the rewritten files

Part of plan: voice-mode-engine.md (PR 12 of 12)