### PR TITLE
feat(web): voice timeline waveform component

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-timeline-waveform.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-timeline-waveform.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * Tests for `VoiceTimelineWaveform`.
+ *
+ * happy-dom's `canvas.getContext("2d")` returns `null`, so a minimal fake 2D
+ * context is installed on `HTMLCanvasElement.prototype` to let the draw loop
+ * run. `requestAnimationFrame` is monkey-patched to capture callbacks so
+ * frames are driven manually with controlled timestamps (same approach as the
+ * `setTimeout` harness in `website-carousel.test.tsx`).
+ *
+ * The reduced-motion branch is verified by stubbing `motion/react` so
+ * `useReducedMotion()` returns `true` and asserting the animation loop never
+ * starts — mirroring the reduced-motion pattern in
+ * `website-carousel.test.tsx`.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, render } from "@testing-library/react";
+
+import { VoiceTimelineWaveform } from "@/domains/chat/voice/voice-timeline-waveform";
+
+// ---------------------------------------------------------------------------
+// requestAnimationFrame harness
+// ---------------------------------------------------------------------------
+
+let rafCallbacks: Map<number, FrameRequestCallback>;
+let nextRafId = 1;
+let rafCallCount = 0;
+let canceledRafIds: number[];
+let originalRaf: typeof globalThis.requestAnimationFrame;
+let originalCancelRaf: typeof globalThis.cancelAnimationFrame;
+
+/** Fire every pending rAF callback once with the given timestamp. */
+function fireFrame(ts: number) {
+  const callbacks = [...rafCallbacks.values()];
+  rafCallbacks.clear();
+  for (const cb of callbacks) {
+    cb(ts);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fake 2D context — happy-dom has no canvas implementation.
+// ---------------------------------------------------------------------------
+
+function makeFakeContext() {
+  return {
+    fillStyle: "",
+    setTransform: mock(() => {}),
+    clearRect: mock(() => {}),
+    beginPath: mock(() => {}),
+    roundRect: mock(() => {}),
+    fill: mock(() => {}),
+  };
+}
+
+let fakeCtx: ReturnType<typeof makeFakeContext>;
+let originalGetContext: typeof HTMLCanvasElement.prototype.getContext;
+
+beforeEach(() => {
+  rafCallbacks = new Map();
+  nextRafId = 1;
+  rafCallCount = 0;
+  canceledRafIds = [];
+  originalRaf = globalThis.requestAnimationFrame;
+  originalCancelRaf = globalThis.cancelAnimationFrame;
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+    rafCallCount += 1;
+    const id = nextRafId++;
+    rafCallbacks.set(id, cb);
+    return id;
+  }) as typeof globalThis.requestAnimationFrame;
+  globalThis.cancelAnimationFrame = ((id: number) => {
+    canceledRafIds.push(id);
+    rafCallbacks.delete(id);
+  }) as typeof globalThis.cancelAnimationFrame;
+
+  fakeCtx = makeFakeContext();
+  originalGetContext = HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = ((type: string) =>
+    type === "2d" ? fakeCtx : null) as typeof HTMLCanvasElement.prototype.getContext;
+});
+
+afterEach(() => {
+  globalThis.requestAnimationFrame = originalRaf;
+  globalThis.cancelAnimationFrame = originalCancelRaf;
+  HTMLCanvasElement.prototype.getContext = originalGetContext;
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("VoiceTimelineWaveform — rendering", () => {
+  test("renders an aria-hidden canvas", () => {
+    const { container } = render(<VoiceTimelineWaveform active getAmplitude={() => 0.5} />);
+    const canvas = container.querySelector("canvas");
+    expect(canvas).toBeTruthy();
+    expect(canvas!.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  test("default sizing uses the full-height canvas class", () => {
+    const { container } = render(<VoiceTimelineWaveform active />);
+    const canvas = container.querySelector("canvas")!;
+    expect(canvas.className).toContain("h-6");
+    expect(canvas.className).toContain("w-full");
+  });
+
+  test("compact sizing uses the shorter canvas class", () => {
+    const { container } = render(<VoiceTimelineWaveform active compact />);
+    const canvas = container.querySelector("canvas")!;
+    expect(canvas.className).toContain("h-4");
+    expect(canvas.className).not.toContain("h-6");
+  });
+
+  test("merges a caller-supplied className", () => {
+    const { container } = render(<VoiceTimelineWaveform active className="flex-1" />);
+    expect(container.querySelector("canvas")!.className).toContain("flex-1");
+  });
+});
+
+describe("VoiceTimelineWaveform — animation loop", () => {
+  test("starts the rAF loop and reschedules each frame", () => {
+    render(<VoiceTimelineWaveform active getAmplitude={() => 0.5} />);
+    expect(rafCallCount).toBe(1);
+    fireFrame(100);
+    expect(rafCallCount).toBe(2);
+    fireFrame(200);
+    expect(rafCallCount).toBe(3);
+  });
+
+  test("polls getAmplitude while active", () => {
+    const getAmplitude = mock(() => 0.5);
+    render(<VoiceTimelineWaveform active getAmplitude={getAmplitude} />);
+    fireFrame(100);
+    fireFrame(200);
+    expect(getAmplitude.mock.calls.length).toBe(2);
+  });
+
+  test("stops sampling (but keeps drawing) when not active", () => {
+    const getAmplitude = mock(() => 0.5);
+    render(<VoiceTimelineWaveform active={false} getAmplitude={getAmplitude} />);
+    fireFrame(100);
+    fireFrame(200);
+    expect(getAmplitude.mock.calls.length).toBe(0);
+    expect(fakeCtx.clearRect.mock.calls.length).toBe(2);
+  });
+
+  test("cancels the pending frame on unmount and a late frame does not throw", () => {
+    const { unmount } = render(<VoiceTimelineWaveform active getAmplitude={() => 0.5} />);
+    // Capture the pending callback before unmount cancels it, simulating a
+    // frame already dispatched when cleanup runs.
+    const pending = [...rafCallbacks.values()];
+    expect(pending).toHaveLength(1);
+    unmount();
+    expect(canceledRafIds).toHaveLength(1);
+    expect(rafCallbacks.size).toBe(0);
+    expect(() => pending[0]!(300)).not.toThrow();
+  });
+
+  test("does not start a loop when the 2d context is unavailable", () => {
+    HTMLCanvasElement.prototype.getContext = (() =>
+      null) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+    const { unmount } = render(<VoiceTimelineWaveform active />);
+    expect(rafCallCount).toBe(0);
+    expect(() => unmount()).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reduced-motion path — verified by stubbing `motion/react`.
+// ---------------------------------------------------------------------------
+
+describe("VoiceTimelineWaveform — reduced motion", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("renders a static frame without starting the animation loop", async () => {
+    mock.module("motion/react", () => ({
+      useReducedMotion: () => true,
+    }));
+
+    const { VoiceTimelineWaveform: ReducedWaveform } = await import(
+      "./voice-timeline-waveform"
+    );
+    const { container, unmount } = render(
+      <ReducedWaveform active getAmplitude={() => 0.5} />,
+    );
+
+    expect(container.querySelector("canvas")).toBeTruthy();
+    // No animation loop — the static branch draws once, synchronously.
+    expect(rafCallCount).toBe(0);
+    expect(fakeCtx.clearRect.mock.calls.length).toBe(1);
+    expect(() => unmount()).not.toThrow();
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-timeline-waveform.tsx
+++ b/clients/web/src/domains/chat/voice/voice-timeline-waveform.tsx
@@ -1,0 +1,231 @@
+/**
+ * Voice-session timeline waveform: a dotted hairline baseline spanning the
+ * full width, with a live amplitude-bar cluster drawn over a bounded segment
+ * of the line (right of center). Presentational — the parent owns the voice
+ * session and supplies an amplitude source.
+ *
+ * Rendering mirrors the composer's `StreamingWaveform` (dense 2×2px bars,
+ * ~30 Hz sampling, right→left history, DPR-scaled canvas) but is a separate
+ * component because the visual — dotted baseline + bounded bar segment — is
+ * distinct from that component's full-width bar field.
+ *
+ * Amplitude is preferably supplied via `getAmplitude` so the parent can poll
+ * a store/analyser without re-rendering per sample; a plain `amplitude` prop
+ * is the fallback. Colors resolve from CSS var tokens at draw time so all
+ * themes (including runtime `data-theme` switches) render correctly. Under
+ * reduced motion the component draws a single static, amplitude-independent
+ * frame and never starts the animation loop.
+ */
+
+import { useReducedMotion } from "motion/react";
+import { useEffect, useLayoutEffect, useRef } from "react";
+
+import { cn } from "@vellumai/design-library";
+
+// ---------------------------------------------------------------------------
+// Visual constants — bar metrics match StreamingWaveform.
+// ---------------------------------------------------------------------------
+const BAR_W = 2; // px width of each amplitude bar
+const BAR_GAP = 2; // px gap between bars
+const STEP = BAR_W + BAR_GAP;
+const MIN_BAR_H_PX = 2; // silent bars render as baseline dots
+const MAX_H_RATIO = 0.85; // max bar is 85% of canvas height
+const SAMPLE_MS = 33; // ~30 Hz sampling cadence
+
+const DOT_SIZE = 1.5; // px square of each baseline dot
+const DOT_STEP = 5; // px between dot starts
+const SEGMENT_CENTER_RATIO = 0.7; // bar segment centers right of the midline
+const SEGMENT_W = 120; // px width of the bar segment
+const SEGMENT_W_COMPACT = 72; // narrower segment for the title-bar pill
+
+// Fallbacks mirror the light-theme values in design-library tokens.css; they
+// only apply when the CSS vars fail to resolve (e.g. headless tests).
+const FALLBACK_LINE_COLOR = "#71808E";
+const FALLBACK_BAR_COLOR = "#24292E";
+
+function clamp01(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+/** Deterministic, amplitude-independent bar heights for the static render. */
+function staticBarLevel(index: number): number {
+  return 0.2 + 0.6 * Math.abs(Math.sin((index + 1) * 2.4));
+}
+
+function resolveColors(): { line: string; bar: string } {
+  const style = getComputedStyle(document.documentElement);
+  return {
+    line: style.getPropertyValue("--content-tertiary").trim() || FALLBACK_LINE_COLOR,
+    bar: style.getPropertyValue("--content-default").trim() || FALLBACK_BAR_COLOR,
+  };
+}
+
+/** Resize the backing store to CSS size × DPR and return the CSS-px size. */
+function syncCanvasSize(
+  canvas: HTMLCanvasElement,
+  ctx: CanvasRenderingContext2D,
+): { w: number; h: number } {
+  const dpr = window.devicePixelRatio ?? 1;
+  const w = canvas.offsetWidth;
+  const h = canvas.offsetHeight;
+  if (canvas.width !== Math.round(w * dpr) || canvas.height !== Math.round(h * dpr)) {
+    canvas.width = Math.round(w * dpr);
+    canvas.height = Math.round(h * dpr);
+  }
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  return { w, h };
+}
+
+/** Draw the dotted baseline plus the bar segment. */
+function drawTimeline(
+  ctx: CanvasRenderingContext2D,
+  w: number,
+  h: number,
+  segmentWidth: number,
+  barLevelAt: (barIndex: number, numBars: number) => number,
+): void {
+  ctx.clearRect(0, 0, w, h);
+  if (w <= 0 || h <= 0) {
+    return;
+  }
+
+  const { line, bar } = resolveColors();
+  const midY = h / 2;
+  const segW = Math.min(segmentWidth, w);
+  const segLeft = Math.min(Math.max(w * SEGMENT_CENTER_RATIO - segW / 2, 0), w - segW);
+
+  // Dotted hairline across the full width, skipping the bar segment.
+  ctx.fillStyle = line;
+  for (let x = 0; x + DOT_SIZE <= w; x += DOT_STEP) {
+    if (x >= segLeft - DOT_SIZE && x < segLeft + segW) {
+      continue;
+    }
+    ctx.beginPath();
+    ctx.roundRect(x, midY - DOT_SIZE / 2, DOT_SIZE, DOT_SIZE, DOT_SIZE / 2);
+    ctx.fill();
+  }
+
+  // Amplitude bars over the segment; newest sample → rightmost bar.
+  ctx.fillStyle = bar;
+  const numBars = Math.floor(segW / STEP);
+  const maxBarH = h * MAX_H_RATIO;
+  for (let i = 0; i < numBars; i++) {
+    const bh = Math.max(MIN_BAR_H_PX, barLevelAt(i, numBars) * maxBarH);
+    ctx.beginPath();
+    ctx.roundRect(segLeft + i * STEP, midY - bh / 2, BAR_W, bh, BAR_W / 2);
+    ctx.fill();
+  }
+}
+
+export interface VoiceTimelineWaveformProps {
+  /**
+   * Preferred amplitude source (0–1), polled at ~30 Hz inside the draw loop
+   * so the parent never re-renders per sample.
+   */
+  getAmplitude?: () => number;
+  /** Plain amplitude fallback (0–1) when no poll function is supplied. */
+  amplitude?: number;
+  /** While true new samples scroll in; when false the bars freeze in place. */
+  active: boolean;
+  /** Title-bar pill sizing: shorter canvas and a narrower bar segment. */
+  compact?: boolean;
+  className?: string;
+}
+
+export function VoiceTimelineWaveform({
+  getAmplitude,
+  amplitude = 0,
+  active,
+  compact = false,
+  className,
+}: VoiceTimelineWaveformProps) {
+  const reducedMotion = useReducedMotion();
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  // Refs let the rAF loop read the latest inputs without re-initializing.
+  const getAmplitudeRef = useRef(getAmplitude);
+  const amplitudeRef = useRef(amplitude);
+  const activeRef = useRef(active);
+  const samplesRef = useRef<number[]>([]);
+
+  useLayoutEffect(() => {
+    getAmplitudeRef.current = getAmplitude;
+  }, [getAmplitude]);
+
+  useLayoutEffect(() => {
+    amplitudeRef.current = amplitude;
+  }, [amplitude]);
+
+  useLayoutEffect(() => {
+    activeRef.current = active;
+  }, [active]);
+
+  const segmentWidth = compact ? SEGMENT_W_COMPACT : SEGMENT_W;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      return;
+    }
+
+    if (reducedMotion) {
+      // Static frame: dotted line + fixed bar cluster, no animation loop.
+      const drawStatic = () => {
+        const { w, h } = syncCanvasSize(canvas, ctx);
+        drawTimeline(ctx, w, h, segmentWidth, staticBarLevel);
+      };
+      drawStatic();
+      if (typeof ResizeObserver === "undefined") {
+        return;
+      }
+      const observer = new ResizeObserver(drawStatic);
+      observer.observe(canvas);
+      return () => {
+        observer.disconnect();
+      };
+    }
+
+    let rafId: ReturnType<typeof requestAnimationFrame>;
+    let lastSampleTs = 0;
+
+    const tick = (ts: number) => {
+      if (activeRef.current && ts - lastSampleTs >= SAMPLE_MS) {
+        lastSampleTs = ts;
+        const raw = getAmplitudeRef.current
+          ? getAmplitudeRef.current()
+          : amplitudeRef.current;
+        samplesRef.current.push(clamp01(raw));
+        const maxBars = Math.floor(segmentWidth / STEP);
+        if (samplesRef.current.length > maxBars * 2) {
+          samplesRef.current = samplesRef.current.slice(-maxBars);
+        }
+      }
+
+      const { w, h } = syncCanvasSize(canvas, ctx);
+      const samples = samplesRef.current;
+      drawTimeline(ctx, w, h, segmentWidth, (i, numBars) => {
+        const si = samples.length - numBars + i;
+        return si >= 0 ? (samples[si] ?? 0) : 0;
+      });
+
+      rafId = requestAnimationFrame(tick);
+    };
+
+    rafId = requestAnimationFrame(tick);
+    return () => {
+      cancelAnimationFrame(rafId);
+    };
+  }, [reducedMotion, segmentWidth]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden
+      // width/height backing store is set by the draw code; CSS drives layout.
+      className={cn("block w-full", compact ? "h-4" : "h-6", className)}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- New VoiceTimelineWaveform canvas primitive: dotted baseline + live amplitude-bar segment (compact variant for the title bar)
- Theme-aware via CSS-var token colors; reduced-motion renders static
- Unit tests

Part of plan: voice-mode-ui.md (PR 1 of 7)

## Visual verification note
No in-app mount exists yet (PR 3/6 integrate this component), so the Light 53 match was verified numerically with a synthetic amplitude signal: dotted hairline spans the full width, dots skip the bar segment, the 30-bar cluster centers at ~0.70 of the width (design measures ~0.68), newest sample renders tallest at the right edge with a 2px silent-bar floor. Colors resolve from `--content-tertiary`/`--content-default` at draw time, so light/dark/velvet and runtime `data-theme` switches all render from tokens; raw hex appears only as CSS-var fallbacks per the style guide.