### PR TITLE
feat(web): voice composer bar component

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * Tests for `VoiceComposerBar`.
+ *
+ * The bar is purely presentational, so tests drive it prop-by-prop: state
+ * label mapping, send-button enablement, callback wiring, and accessibility
+ * attributes. The embedded `VoiceTimelineWaveform` renders a real canvas —
+ * happy-dom's `getContext("2d")` returns `null`, which that component
+ * handles by skipping its draw loop, so no canvas/rAF harness is needed
+ * here (its rendering behavior is covered by its own test file).
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { VoiceComposerBar } from "@/domains/chat/components/chat-composer/voice-composer-bar";
+import type { LiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live-voice-store";
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderBar(state: LiveVoiceSessionState, overrides?: {
+  onEnd?: () => void;
+  onSend?: () => void;
+}) {
+  return render(
+    <VoiceComposerBar
+      state={state}
+      getAmplitude={() => 0.5}
+      onEnd={overrides?.onEnd ?? (() => {})}
+      onSend={overrides?.onSend ?? (() => {})}
+    />,
+  );
+}
+
+describe("VoiceComposerBar — state label", () => {
+  const labels: Array<[LiveVoiceSessionState, string]> = [
+    ["connecting", "Connecting…"],
+    ["listening", "Listening…"],
+    ["transcribing", "Transcribing…"],
+    ["thinking", "Thinking…"],
+    ["speaking", "Speaking…"],
+    ["ending", "Ending…"],
+  ];
+
+  for (const [state, label] of labels) {
+    test(`renders "${label}" for the ${state} state`, () => {
+      renderBar(state);
+      expect(screen.getByText(label)).toBeTruthy();
+    });
+  }
+
+  test("announces state changes via an aria-live region", () => {
+    renderBar("listening");
+    const label = screen.getByText("Listening…");
+    expect(label.getAttribute("aria-live")).toBe("polite");
+  });
+});
+
+describe("VoiceComposerBar — send enablement", () => {
+  test("send is enabled while listening", () => {
+    renderBar("listening");
+    const send = screen.getByRole("button", { name: "Send now" });
+    expect((send as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  const nonListening: LiveVoiceSessionState[] = [
+    "connecting",
+    "transcribing",
+    "thinking",
+    "speaking",
+    "ending",
+  ];
+
+  for (const state of nonListening) {
+    test(`send is disabled while ${state}`, () => {
+      renderBar(state);
+      const send = screen.getByRole("button", { name: "Send now" });
+      expect((send as HTMLButtonElement).disabled).toBe(true);
+    });
+  }
+
+  test("end stays enabled in every session state", () => {
+    for (const state of ["connecting", "listening", "speaking", "ending"] as const) {
+      const { unmount } = renderBar(state);
+      const end = screen.getByRole("button", { name: "End voice session" });
+      expect((end as HTMLButtonElement).disabled).toBe(false);
+      unmount();
+    }
+  });
+});
+
+describe("VoiceComposerBar — callbacks", () => {
+  test("clicking end fires onEnd", () => {
+    const onEnd = mock(() => {});
+    renderBar("speaking", { onEnd });
+    fireEvent.click(screen.getByRole("button", { name: "End voice session" }));
+    expect(onEnd).toHaveBeenCalledTimes(1);
+  });
+
+  test("clicking send while listening fires onSend", () => {
+    const onSend = mock(() => {});
+    renderBar("listening", { onSend });
+    fireEvent.click(screen.getByRole("button", { name: "Send now" }));
+    expect(onSend).toHaveBeenCalledTimes(1);
+  });
+
+  test("clicking send while disabled does not fire onSend", () => {
+    const onSend = mock(() => {});
+    renderBar("thinking", { onSend });
+    fireEvent.click(screen.getByRole("button", { name: "Send now" }));
+    expect(onSend).not.toHaveBeenCalled();
+  });
+});
+
+describe("VoiceComposerBar — structure and accessibility", () => {
+  test("bar container is a labelled group", () => {
+    renderBar("listening");
+    const group = screen.getByRole("group", { name: "Voice session" });
+    expect(group).toBeTruthy();
+  });
+
+  test("renders the timeline waveform canvas", () => {
+    const { container } = renderBar("listening");
+    expect(container.querySelector("canvas")).toBeTruthy();
+  });
+
+  test("both control buttons carry aria labels", () => {
+    renderBar("listening");
+    expect(
+      screen.getByRole("button", { name: "End voice session" }),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Send now" })).toBeTruthy();
+  });
+});

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
@@ -1,0 +1,100 @@
+/**
+ * Voice-session composer bar (Light 53): while a live-voice session is
+ * active the composer's action row is replaced by this bar — a small mic
+ * glyph and muted state label on the left, the dotted timeline waveform
+ * filling the middle, and end (✕) / send-now (↑) controls on the right.
+ *
+ * Purely presentational: the parent owns the `useLiveVoice` session and
+ * wires `state`, an amplitude poll function, and the two callbacks. The
+ * green ↑ is a manual "send now" (push-to-talk release) and is only
+ * meaningful while the session is listening; the red ✕ ends the session
+ * and is always available.
+ *
+ * Layout mirrors the composer's bottom action row (`px-2 pb-2`, regular
+ * `h-8` icon buttons) so swapping the rows in during a session causes no
+ * layout shift.
+ */
+
+import { ArrowUp, Mic, X } from "lucide-react";
+
+import { Button } from "@vellumai/design-library";
+
+import type { LiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { VoiceTimelineWaveform } from "@/domains/chat/voice/voice-timeline-waveform";
+
+/**
+ * Deliberately minimal state treatment (decided 2026-07-06): assistant
+ * output streams into the thread transcript like text chat, so the bar
+ * only carries a small label. `idle`/`failed` map to an empty label —
+ * the parent unmounts the bar in those states.
+ */
+const STATE_LABELS: Record<LiveVoiceSessionState, string> = {
+  idle: "",
+  connecting: "Connecting…",
+  listening: "Listening…",
+  transcribing: "Transcribing…",
+  thinking: "Thinking…",
+  speaking: "Speaking…",
+  ending: "Ending…",
+  failed: "",
+};
+
+export interface VoiceComposerBarProps {
+  state: LiveVoiceSessionState;
+  /** Polled ~30 Hz by the waveform's draw loop — no re-render per sample. */
+  getAmplitude: () => number;
+  /** Red ✕ — end the voice session. */
+  onEnd: () => void;
+  /** Green ↑ — manually release the current turn (send now). */
+  onSend: () => void;
+}
+
+export function VoiceComposerBar({
+  state,
+  getAmplitude,
+  onEnd,
+  onSend,
+}: VoiceComposerBarProps) {
+  return (
+    <div
+      role="group"
+      aria-label="Voice session"
+      className="flex items-center gap-3 px-2 pb-2"
+    >
+      {/* pl-2 lines the mic up with the textarea's px-4 text inset. */}
+      <div className="flex shrink-0 items-center gap-2 pl-2">
+        <Mic
+          aria-hidden
+          className="h-4 w-4 text-[var(--content-secondary)]"
+        />
+        {/* Muted placeholder styling — matches the textarea's placeholder. */}
+        <span
+          aria-live="polite"
+          className="text-chat text-[var(--content-disabled)]"
+        >
+          {STATE_LABELS[state]}
+        </span>
+      </div>
+      <VoiceTimelineWaveform
+        getAmplitude={getAmplitude}
+        active={state === "listening"}
+        className="min-w-0 flex-1"
+      />
+      <div className="flex shrink-0 items-center gap-1">
+        <Button
+          variant="danger"
+          iconOnly={<X className="h-4 w-4" strokeWidth={2.5} />}
+          onClick={onEnd}
+          aria-label="End voice session"
+        />
+        <Button
+          variant="primary"
+          iconOnly={<ArrowUp className="h-4 w-4" strokeWidth={2.5} />}
+          onClick={onSend}
+          disabled={state !== "listening"}
+          aria-label="Send now"
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New VoiceComposerBar presentational component (mic + state label + timeline waveform + end/send controls) per Light 53 design
- Props-driven; send enabled only while listening; a11y labels + aria-live state
- Both control buttons use stock design-library variants (danger for end, primary for send) — no custom classes needed
- Unit tests

Part of plan: voice-mode-ui.md (PR 3 of 7)