### PR TITLE
feat(web): voice session title-bar pill component

### DIFF
--- a/clients/web/src/domains/chat/components/voice-session-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * Tests for `VoiceSessionPill`.
+ *
+ * The pill is purely presentational, so tests drive it directly through
+ * props. The embedded `VoiceTimelineWaveform` renders a real canvas —
+ * happy-dom's `getContext("2d")` returns `null`, which that component treats
+ * as "don't start the draw loop", so no canvas harness is needed here (its
+ * own test file covers the drawing behavior).
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import type { LiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live-voice-store";
+import {
+  VoiceSessionPill,
+  type VoiceSessionPillProps,
+} from "@/domains/chat/components/voice-session-pill";
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderPill(overrides: Partial<VoiceSessionPillProps> = {}) {
+  const handlers = {
+    onStop: mock(() => {}),
+    onEnd: mock(() => {}),
+    onSend: mock(() => {}),
+    onNavigate: mock(() => {}),
+  };
+  render(
+    <VoiceSessionPill
+      primaryLabel="Working on App…"
+      secondaryLabel="Thread name here"
+      state="listening"
+      getAmplitude={() => 0.5}
+      {...handlers}
+      {...overrides}
+    />,
+  );
+  return handlers;
+}
+
+const stopButton = () => screen.queryByRole("button", { name: "Stop assistant response" });
+const endButton = () => screen.getByRole("button", { name: "End voice session" });
+const sendButton = () => screen.getByRole("button", { name: "Send now" });
+const labelButton = () => screen.queryByRole("button", { name: "Go to voice session thread" });
+
+describe("VoiceSessionPill — labels", () => {
+  test("renders both label lines with truncation", () => {
+    renderPill();
+    const primary = screen.getByText("Working on App…");
+    const secondary = screen.getByText("Thread name here");
+    expect(primary.className).toContain("truncate");
+    expect(secondary.className).toContain("truncate");
+  });
+
+  test("omits the secondary line when not provided", () => {
+    renderPill({ secondaryLabel: undefined });
+    expect(screen.getByText("Working on App…")).toBeTruthy();
+    expect(screen.queryByText("Thread name here")).toBeNull();
+  });
+
+  test("label area is a plain (non-interactive) element without onNavigate", () => {
+    renderPill({ onNavigate: undefined });
+    expect(labelButton()).toBeNull();
+    expect(screen.getByText("Working on App…")).toBeTruthy();
+  });
+});
+
+describe("VoiceSessionPill — title-bar constraints", () => {
+  test("root is a no-drag group capped to the header control height", () => {
+    renderPill();
+    const root = screen.getByRole("group", { name: "Voice session" });
+    expect(root.className).toContain("[-webkit-app-region:no-drag]");
+    expect(root.className).toContain("h-8");
+  });
+});
+
+describe("VoiceSessionPill — stop control", () => {
+  test("hidden outside the speaking state", () => {
+    for (const state of [
+      "connecting",
+      "listening",
+      "transcribing",
+      "thinking",
+      "ending",
+    ] as LiveVoiceSessionState[]) {
+      renderPill({ state });
+      expect(stopButton()).toBeNull();
+      cleanup();
+    }
+  });
+
+  test("shown while speaking and fires onStop", () => {
+    const { onStop, onNavigate } = renderPill({ state: "speaking" });
+    fireEvent.click(stopButton()!);
+    expect(onStop).toHaveBeenCalledTimes(1);
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+});
+
+describe("VoiceSessionPill — send control", () => {
+  test("enabled while listening and fires onSend", () => {
+    const { onSend, onNavigate } = renderPill({ state: "listening" });
+    const send = sendButton();
+    expect(send.hasAttribute("disabled")).toBe(false);
+    fireEvent.click(send);
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  test("disabled in every non-listening state", () => {
+    for (const state of [
+      "connecting",
+      "transcribing",
+      "thinking",
+      "speaking",
+      "ending",
+    ] as LiveVoiceSessionState[]) {
+      const { onSend } = renderPill({ state });
+      const send = sendButton();
+      expect(send.hasAttribute("disabled")).toBe(true);
+      fireEvent.click(send);
+      expect(onSend).not.toHaveBeenCalled();
+      cleanup();
+    }
+  });
+});
+
+describe("VoiceSessionPill — end control", () => {
+  test("always enabled and fires onEnd", () => {
+    const { onEnd, onNavigate } = renderPill({ state: "thinking" });
+    const end = endButton();
+    expect(end.hasAttribute("disabled")).toBe(false);
+    fireEvent.click(end);
+    expect(onEnd).toHaveBeenCalledTimes(1);
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+});
+
+describe("VoiceSessionPill — navigation", () => {
+  test("clicking the label area fires onNavigate only", () => {
+    const { onNavigate, onStop, onEnd, onSend } = renderPill();
+    fireEvent.click(labelButton()!);
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+    expect(onStop).not.toHaveBeenCalled();
+    expect(onEnd).not.toHaveBeenCalled();
+    expect(onSend).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/domains/chat/components/voice-session-pill.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.tsx
@@ -1,6 +1,6 @@
 /**
  * Title-bar pill for an active live-voice session (Light 54's right cluster).
- * Presentational — the host (PR 7) owns store wiring and visibility rules.
+ * Presentational — the mounting host owns store wiring and visibility rules.
  *
  * Layout, left → right: two-line context label (primary action text over the
  * owning thread's name), circular stop control (only while the assistant is

--- a/clients/web/src/domains/chat/components/voice-session-pill.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.tsx
@@ -1,0 +1,152 @@
+/**
+ * Title-bar pill for an active live-voice session (Light 54's right cluster).
+ * Presentational — the host (PR 7) owns store wiring and visibility rules.
+ *
+ * Layout, left → right: two-line context label (primary action text over the
+ * owning thread's name), circular stop control (only while the assistant is
+ * `speaking`), mic glyph + compact timeline waveform, red ✕ (end session),
+ * green ↑ (manual turn release — enabled only while `listening`).
+ *
+ * The pill lives inside `ChatLayoutHeader`, which doubles as the Electron
+ * macOS title bar (`-webkit-app-region: drag`). The root opts the whole
+ * cluster out via `no-drag` so every child — including the non-`button`
+ * canvas/label area — stays clickable, matching the header's own treatment of
+ * its interactive children.
+ *
+ * Height is capped at `h-8` (32px): the header's Electron title-bar row is
+ * 44px min-height with 32px controls, so the pill must never stretch it.
+ */
+
+import { ArrowUp, Mic, Square, X } from "lucide-react";
+
+import { Button, Typography, cn } from "@vellumai/design-library";
+
+import type { LiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { VoiceTimelineWaveform } from "@/domains/chat/voice/voice-timeline-waveform";
+
+/**
+ * States in which the mic is live and the waveform should keep scrolling in
+ * new amplitude samples. Outside these (connecting/ending/terminal states) the
+ * bars freeze in place.
+ */
+const WAVEFORM_ACTIVE_STATES: ReadonlySet<LiveVoiceSessionState> = new Set([
+  "listening",
+  "transcribing",
+  "thinking",
+  "speaking",
+]);
+
+export interface VoiceSessionPillProps {
+  /** Line 1: what the assistant is doing (e.g. "Working on App…"). */
+  primaryLabel: string;
+  /** Line 2: the owning thread's name. */
+  secondaryLabel?: string;
+  state: LiveVoiceSessionState;
+  /** Polled by the waveform at ~30 Hz; must not force parent re-renders. */
+  getAmplitude: () => number;
+  /** Stop the in-flight assistant response without ending the session. */
+  onStop: () => void;
+  /** End the voice session. */
+  onEnd: () => void;
+  /** Manual turn release ("send now") while listening. */
+  onSend: () => void;
+  /** Invoked when the label area is clicked (navigate to the owning thread). */
+  onNavigate?: () => void;
+}
+
+export function VoiceSessionPill({
+  primaryLabel,
+  secondaryLabel,
+  state,
+  getAmplitude,
+  onStop,
+  onEnd,
+  onSend,
+  onNavigate,
+}: VoiceSessionPillProps) {
+  const labelContent = (
+    <>
+      <Typography
+        as="p"
+        variant="body-medium-default"
+        className="truncate text-[var(--content-default)]"
+      >
+        {primaryLabel}
+      </Typography>
+      {secondaryLabel ? (
+        <Typography
+          as="p"
+          variant="label-medium-default"
+          className="truncate text-[var(--content-tertiary)]"
+        >
+          {secondaryLabel}
+        </Typography>
+      ) : null}
+    </>
+  );
+
+  // Right-aligned per Light 54: both lines rag toward the stop control.
+  const labelClass = "flex h-8 min-w-0 max-w-40 flex-col justify-center gap-0.5 text-right";
+
+  return (
+    <div
+      role="group"
+      aria-label="Voice session"
+      className="flex h-8 items-center gap-2 [-webkit-app-region:no-drag]"
+    >
+      {onNavigate ? (
+        <button
+          type="button"
+          onClick={onNavigate}
+          aria-label="Go to voice session thread"
+          className={cn(labelClass, "cursor-pointer")}
+        >
+          {labelContent}
+        </button>
+      ) : (
+        <div className={labelClass}>{labelContent}</div>
+      )}
+      {state === "speaking" ? (
+        <Button
+          variant="primary"
+          iconOnly={<Square fill="currentColor" />}
+          className="rounded-full"
+          // Compact title-bar affordance: keep desktop sizing so the pill
+          // never exceeds the header row height on touch-mobile web.
+          expandOnMobile={false}
+          aria-label="Stop assistant response"
+          tooltip="Stop assistant response"
+          onClick={onStop}
+        />
+      ) : null}
+      <div className="flex items-center gap-1">
+        <Mic aria-hidden className="size-3.5 shrink-0 text-[var(--content-default)]" />
+        <VoiceTimelineWaveform
+          compact
+          active={WAVEFORM_ACTIVE_STATES.has(state)}
+          getAmplitude={getAmplitude}
+          className="w-24"
+        />
+      </div>
+      <Button
+        variant="danger"
+        iconOnly={<X strokeWidth={2.5} />}
+        className="rounded-full"
+        expandOnMobile={false}
+        aria-label="End voice session"
+        tooltip="End voice session"
+        onClick={onEnd}
+      />
+      <Button
+        variant="primary"
+        iconOnly={<ArrowUp strokeWidth={2.5} />}
+        className="rounded-full"
+        expandOnMobile={false}
+        disabled={state !== "listening"}
+        aria-label="Send now"
+        tooltip="Send now"
+        onClick={onSend}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New VoiceSessionPill presentational component (context labels + stop/waveform/end/send cluster) per Light 54 design
- Electron title-bar no-drag safe; height-constrained to the header row
- Unit tests

### Design deviations (Light 54)
- The ↑ send control uses the design-library `primary` variant (near-black in light theme, near-white in dark) rather than the mock's green, and ✕ uses the `danger` token red rather than the mock's orange-red — per plan, variants match the composer bar for consistency.
- Controls are `rounded-full` to match the circular buttons in the title-bar mock (the composer's are default rounded-md).

Part of plan: voice-mode-ui.md (PR 6 of 7)