### PR TITLE
feat(web): show live-voice session pill when away from the owning thread

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -61,6 +61,7 @@ import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { ResearchResultsOverlay } from "@/domains/chat/onboarding-research/research-results-overlay";
 import { OnboardingCheckinOverlay } from "@/components/onboarding-checkin-overlay";
 import { OnboardingAvatarApplier } from "@/components/onboarding-avatar-applier";
+import { VoiceSessionPillHost } from "@/domains/chat/components/voice-session-pill-host";
 import { ChatConversationHeader } from "./chat-conversation-header";
 import { ChatLayoutHeader } from "./chat-layout-header";
 import { RenameDialogFromStore } from "./rename-dialog-from-store";
@@ -622,7 +623,18 @@ export function ChatLayout() {
           sidebarWidth={sidebarWidth}
           toggleSidebar={toggleSidebar}
           topBarCenter={topBarCenter}
-          topBarRightSlot={topBarRightSlot}
+          // The voice-session pill is composed here — NOT registered through
+          // useChatLayoutSlotsStore — because slot registration is owned by
+          // per-route hooks that unmount on navigation, exactly when the pill
+          // must persist. The host renders null when no session is active (or
+          // while viewing the owning thread's composer), so the header is
+          // unaffected otherwise.
+          topBarRightSlot={
+            <>
+              {topBarRightSlot}
+              <VoiceSessionPillHost />
+            </>
+          }
           canGoBack={canGoBack}
           canGoForward={canGoForward}
           onGoBack={handleGoBack}

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
@@ -27,8 +27,12 @@ import { VoiceTimelineWaveform } from "@/domains/chat/voice/voice-timeline-wavef
  * output streams into the thread transcript like text chat, so the bar
  * only carries a small label. `idle`/`failed` map to an empty label —
  * the parent unmounts the bar in those states.
+ *
+ * Exported for the title-bar session pill (`voice-session-pill-host.tsx`),
+ * which shows the same activity label while the user is away from the
+ * owning thread.
  */
-const STATE_LABELS: Record<LiveVoiceSessionState, string> = {
+export const STATE_LABELS: Record<LiveVoiceSessionState, string> = {
   idle: "",
   connecting: "Connecting…",
   listening: "Listening…",

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.test.tsx
@@ -1,0 +1,256 @@
+/**
+ * Tests for `VoiceSessionPillHost`.
+ *
+ * The host wires real Zustand stores (live-voice, conversation) to the
+ * presentational `VoiceSessionPill`, so tests drive those stores directly and
+ * mock only the modules with heavy dependency graphs: router hooks (mutable
+ * pathname + navigate spy), `useActiveConversation` (TanStack Query), the
+ * viewer store (generated SDK imports), and the imperative
+ * `navigateToConversation` util (haptics/sounds).
+ *
+ * The embedded `VoiceTimelineWaveform` renders a real canvas — happy-dom's
+ * `getContext("2d")` returns `null`, which that component treats as "don't
+ * start the draw loop", so no canvas harness is needed.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import type { MainView } from "@/stores/viewer-store";
+import type { Conversation } from "@/types/conversation-types";
+import { routes } from "@/utils/routes";
+
+import {
+  useLiveVoiceStore,
+  type LiveVoiceSessionState,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
+import { useConversationStore } from "@/stores/conversation-store";
+
+const OWNING_CONVERSATION_ID = "conv-owning";
+const OTHER_CONVERSATION_ID = "conv-other";
+const ASSISTANT_ID = "assistant-1";
+
+let mockPathname = routes.conversation(OTHER_CONVERSATION_ID);
+const navigateFn = mock(() => {});
+mock.module("react-router", () => ({
+  useLocation: () => ({ pathname: mockPathname }),
+  useNavigate: () => navigateFn,
+}));
+
+let mockOwningConversation: Conversation | undefined;
+const useActiveConversationSpy = mock(
+  (_assistantId: string | null, _conversationId: string | null | undefined, _enabled: boolean) =>
+    mockOwningConversation,
+);
+mock.module("@/domains/chat/hooks/use-active-conversation", () => ({
+  useActiveConversation: useActiveConversationSpy,
+}));
+
+let mockMainView: MainView = "chat";
+mock.module("@/stores/viewer-store", () => ({
+  useViewerStore: {
+    use: {
+      mainView: () => mockMainView,
+    },
+  },
+}));
+
+const navigateToConversationSpy = mock(
+  (_navigate: unknown, _conversationId: string) => {},
+);
+mock.module("@/utils/conversation-navigation", () => ({
+  navigateToConversation: navigateToConversationSpy,
+}));
+
+// Imported after the mocks so the host picks up the mocked modules.
+const { VoiceSessionPillHost } = await import(
+  "@/domains/chat/components/voice-session-pill-host"
+);
+
+const controls = {
+  stop: mock(() => {}),
+  release: mock(() => {}),
+  interrupt: mock(() => {}),
+};
+
+/** Put the live-voice store into an active session owned by `conversationId`. */
+function startSession(
+  state: LiveVoiceSessionState = "listening",
+  conversationId: string | null = OWNING_CONVERSATION_ID,
+) {
+  const store = useLiveVoiceStore.getState();
+  store.setSessionContext(ASSISTANT_ID, conversationId);
+  store.setControls(controls);
+  store.setState(state);
+}
+
+beforeEach(() => {
+  mockPathname = routes.conversation(OTHER_CONVERSATION_ID);
+  mockMainView = "chat";
+  mockOwningConversation = {
+    conversationId: OWNING_CONVERSATION_ID,
+    title: "Owning thread",
+  };
+  navigateFn.mockClear();
+  navigateToConversationSpy.mockClear();
+  useActiveConversationSpy.mockClear();
+  controls.stop.mockClear();
+  controls.release.mockClear();
+  controls.interrupt.mockClear();
+  useLiveVoiceStore.getState().reset();
+  useConversationStore
+    .getState()
+    .setActiveConversationId(OTHER_CONVERSATION_ID);
+});
+
+afterEach(() => {
+  cleanup();
+  useLiveVoiceStore.getState().reset();
+  useConversationStore.getState().reset();
+});
+
+const pill = () => screen.queryByRole("group", { name: "Voice session" });
+
+describe("VoiceSessionPillHost — visibility", () => {
+  test("renders nothing when no session is active", () => {
+    const { container } = render(<VoiceSessionPillHost />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders the pill while viewing a different conversation", () => {
+    startSession("listening");
+    render(<VoiceSessionPillHost />);
+    expect(pill()).not.toBeNull();
+    expect(screen.getByText("Listening…")).toBeTruthy();
+    expect(screen.getByText("Owning thread")).toBeTruthy();
+  });
+
+  test("hides the pill while viewing the owning conversation's composer", () => {
+    startSession("listening");
+    useConversationStore
+      .getState()
+      .setActiveConversationId(OWNING_CONVERSATION_ID);
+    mockPathname = routes.conversation(OWNING_CONVERSATION_ID);
+    const { container } = render(<VoiceSessionPillHost />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("shows the pill over the fullscreen app viewer even in the owning conversation", () => {
+    startSession("listening");
+    useConversationStore
+      .getState()
+      .setActiveConversationId(OWNING_CONVERSATION_ID);
+    mockPathname = routes.conversation(OWNING_CONVERSATION_ID);
+    mockMainView = "app";
+    render(<VoiceSessionPillHost />);
+    expect(pill()).not.toBeNull();
+  });
+
+  test("shows the pill on a non-conversation route even when the owning id is still active", () => {
+    // `activeConversationId` deliberately persists across route changes, so
+    // the id comparison alone can't detect that the composer left the screen.
+    startSession("listening");
+    useConversationStore
+      .getState()
+      .setActiveConversationId(OWNING_CONVERSATION_ID);
+    mockPathname = routes.home;
+    render(<VoiceSessionPillHost />);
+    expect(pill()).not.toBeNull();
+  });
+
+  test("hides the pill for a session with no owning conversation", () => {
+    startSession("listening", null);
+    const { container } = render(<VoiceSessionPillHost />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders nothing after the session fails", () => {
+    startSession("listening");
+    useLiveVoiceStore.getState().fail("boom");
+    const { container } = render(<VoiceSessionPillHost />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("VoiceSessionPillHost — labels", () => {
+  test("omits the thread name while the owning row is still loading", () => {
+    mockOwningConversation = undefined;
+    startSession("thinking");
+    render(<VoiceSessionPillHost />);
+    expect(screen.getByText("Thinking…")).toBeTruthy();
+    expect(screen.queryByText("Owning thread")).toBeNull();
+  });
+
+  test("falls back to Untitled for an owning row without a title", () => {
+    mockOwningConversation = { conversationId: OWNING_CONVERSATION_ID };
+    startSession("listening");
+    render(<VoiceSessionPillHost />);
+    expect(screen.getByText("Untitled")).toBeTruthy();
+  });
+
+  test("resolves the owning row only while visible", () => {
+    startSession("listening");
+    render(<VoiceSessionPillHost />);
+    expect(useActiveConversationSpy).toHaveBeenCalledWith(
+      ASSISTANT_ID,
+      OWNING_CONVERSATION_ID,
+      true,
+    );
+  });
+});
+
+describe("VoiceSessionPillHost — controls", () => {
+  test("✕ ends the session via controls.stop", () => {
+    startSession("listening");
+    render(<VoiceSessionPillHost />);
+    fireEvent.click(screen.getByRole("button", { name: "End voice session" }));
+    expect(controls.stop).toHaveBeenCalledTimes(1);
+    expect(controls.release).not.toHaveBeenCalled();
+    expect(controls.interrupt).not.toHaveBeenCalled();
+  });
+
+  test("↑ releases the current turn via controls.release", () => {
+    startSession("listening");
+    render(<VoiceSessionPillHost />);
+    fireEvent.click(screen.getByRole("button", { name: "Send now" }));
+    expect(controls.release).toHaveBeenCalledTimes(1);
+    expect(controls.stop).not.toHaveBeenCalled();
+  });
+
+  test("■ interrupts the assistant via controls.interrupt while speaking", () => {
+    startSession("speaking");
+    render(<VoiceSessionPillHost />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Stop assistant response" }),
+    );
+    expect(controls.interrupt).toHaveBeenCalledTimes(1);
+    expect(controls.stop).not.toHaveBeenCalled();
+  });
+
+  test("controls are no-ops when none are registered", () => {
+    startSession("listening");
+    useLiveVoiceStore.getState().setControls(null);
+    render(<VoiceSessionPillHost />);
+    expect(() => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "End voice session" }),
+      );
+    }).not.toThrow();
+  });
+});
+
+describe("VoiceSessionPillHost — navigation", () => {
+  test("clicking the label navigates to the owning conversation", () => {
+    startSession("listening");
+    render(<VoiceSessionPillHost />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Go to voice session thread" }),
+    );
+    expect(navigateToConversationSpy).toHaveBeenCalledTimes(1);
+    expect(navigateToConversationSpy).toHaveBeenCalledWith(
+      navigateFn,
+      OWNING_CONVERSATION_ID,
+    );
+  });
+});

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
@@ -1,0 +1,113 @@
+/**
+ * Store-wiring host for the title-bar voice-session pill (Light 54).
+ *
+ * Mounted once by `ChatLayout` — composed directly with the header's
+ * `topBarRightSlot` content rather than registered through
+ * `useChatLayoutSlotsStore`, because slot registration is owned by per-route
+ * hooks that unmount on navigation, which is exactly when the pill must
+ * persist.
+ *
+ * Renders `VoiceSessionPill` only while a live-voice session is active AND
+ * the owning conversation's composer is not the current surface, i.e. when
+ * any of these hold:
+ *
+ * - the user is viewing a different conversation,
+ * - the user is off the conversation routes entirely (Home, Library, …) —
+ *   `activeConversationId` deliberately persists across route changes (see
+ *   `chat-layout.tsx`), so the id comparison alone can't detect this,
+ * - the fullscreen app viewer covers the thread (`mainView === "app"`).
+ *   `app-editing` (split view) and the right-drawer detail panels keep the
+ *   composer visible, so they don't count.
+ *
+ * A session with no owning conversation (started from an unsent draft) has
+ * no thread to return to, so the pill stays hidden for it.
+ */
+
+import { useCallback } from "react";
+import { useLocation, useNavigate } from "react-router";
+
+import { navigateToConversation } from "@/utils/conversation-navigation";
+import { routes } from "@/utils/routes";
+
+import { STATE_LABELS } from "@/domains/chat/components/chat-composer/voice-composer-bar";
+import { VoiceSessionPill } from "@/domains/chat/components/voice-session-pill";
+import { useActiveConversation } from "@/domains/chat/hooks/use-active-conversation";
+import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { useConversationStore } from "@/stores/conversation-store";
+import { useViewerStore } from "@/stores/viewer-store";
+
+/** Routes where ChatPage mounts the active conversation's composer. */
+function isConversationRoute(pathname: string): boolean {
+  return (
+    pathname === routes.assistant ||
+    pathname === `${routes.assistant}/` ||
+    pathname.startsWith(`${routes.conversations}/`)
+  );
+}
+
+export function VoiceSessionPillHost() {
+  const state = useLiveVoiceStore.use.state();
+  const sessionAssistantId = useLiveVoiceStore.use.assistantId();
+  const sessionConversationId = useLiveVoiceStore.use.conversationId();
+  const controls = useLiveVoiceStore.use.controls();
+
+  const activeConversationId = useConversationStore.use.activeConversationId();
+  const mainView = useViewerStore.use.mainView();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const sessionActive = state !== "idle" && state !== "failed";
+  const viewingOwningComposer =
+    sessionConversationId !== null &&
+    sessionConversationId === activeConversationId &&
+    isConversationRoute(location.pathname) &&
+    mainView !== "app";
+  const visible =
+    sessionActive && sessionConversationId !== null && !viewingOwningComposer;
+
+  // Resolves the owning row from whichever list cache holds it, fetching the
+  // single row when absent. Enabled only while the pill is shown so hidden
+  // states cost nothing.
+  const owningConversation = useActiveConversation(
+    sessionAssistantId,
+    sessionConversationId,
+    visible,
+  );
+
+  // Stable poll function — the waveform samples ~30 Hz via its draw loop, so
+  // amplitude must not flow through props/re-renders (same pattern as the
+  // composer's voice bar wiring).
+  const getAmplitude = useCallback(
+    () => useLiveVoiceStore.getState().inputAmplitude,
+    [],
+  );
+
+  const handleNavigate = useCallback(() => {
+    if (sessionConversationId) {
+      navigateToConversation(navigate, sessionConversationId);
+    }
+  }, [navigate, sessionConversationId]);
+
+  const handleStop = useCallback(() => controls?.interrupt(), [controls]);
+  const handleEnd = useCallback(() => controls?.stop(), [controls]);
+  const handleSend = useCallback(() => controls?.release(), [controls]);
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <VoiceSessionPill
+      primaryLabel={STATE_LABELS[state]}
+      secondaryLabel={
+        owningConversation ? (owningConversation.title ?? "Untitled") : undefined
+      }
+      state={state}
+      getAmplitude={getAmplitude}
+      onStop={handleStop}
+      onEnd={handleEnd}
+      onSend={handleSend}
+      onNavigate={handleNavigate}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- New VoiceSessionPillHost wires the session pill to the live-voice store and mounts it in the chat layout header's right cluster
- Shows only when a session is active and the user is away from the owning conversation; label navigates back; controls drive the session via the store seam
- Tests for visibility rules and control delegation

## Visibility rule
The pill shows while a session is active and the owning conversation's composer is not the current surface:
- viewing a different conversation, or
- off the conversation routes entirely (Home, Library, …) — `activeConversationId` persists across route changes so the id comparison alone can't detect this, or
- the fullscreen app viewer covers the thread (`useViewerStore.mainView === "app"` — the app-overlay condition from the plan, wired via existing state; `app-editing` split view and the right-drawer detail panels keep the composer visible so they don't count).

Sessions with no owning conversation (unsent draft) keep the pill hidden — there is no thread to return to.

## Notes for reviewers
- The host is composed directly with `topBarRightSlot` content in `ChatLayout` (not registered through `useChatLayoutSlotsStore`) because slot registration is owned by per-route hooks that unmount on navigation — exactly when the pill must persist.
- `STATE_LABELS` is now exported from `voice-composer-bar.tsx` and reused for the pill's line-1 activity label (single source for the state → label mapping).
- **Manual check needed in the desktop shell:** Electron drag-region behavior (the pill root opts out via `no-drag`, matching the header's treatment) should be verified in the macOS Electron title bar.

Part of plan: voice-mode-ui.md (PR 7 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)