### PR TITLE
feat(web): swap composer to voice bar during live-voice sessions

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -38,14 +38,13 @@ mock.module("@/runtime/is-electron", () => ({
   isElectron: () => mockIsElectron,
 }));
 
-// Live-voice integration mocks. The composer mounts `LiveVoiceButton` (which
-// self-gates on `voice-mode`) and reads live-voice session state via the
-// `useLiveVoiceStore` per-field selectors for the transcript surface +
-// dictation mutual-exclusion. Both are mocked so the composer renders in
+// Live-voice integration mocks. The composer owns the single `useLiveVoice()`
+// controller (it must outlive the `LiveVoiceButton`, which is swapped out with
+// the rest of the action row during a session) and polls amplitude through
+// `useLiveVoiceStore.getState()`. Both are mocked so the composer renders in
 // isolation: the flag via a mutable `mockVoiceMode`, and the session via a
-// mutable state + transcript bag exposed through the store's `.use.*`
-// selectors. Defaults (flag off, idle, empty) keep the existing HTML-surface
-// assertions unchanged.
+// mutable state/error bag exposed through the mocked hook. Defaults (flag
+// off, idle, no error) keep the existing HTML-surface assertions unchanged.
 let mockVoiceMode = false;
 mock.module("@/stores/assistant-feature-flag-store", () => ({
   useAssistantFeatureFlagStore: {
@@ -59,40 +58,38 @@ mock.module("@/stores/assistant-feature-flag-store", () => ({
 // narrow union (not an import from the `voice` domain) so the `chat` test stays
 // free of cross-domain coupling — the composer only ever distinguishes idle
 // from non-idle, so the precise phase taxonomy is irrelevant here.
-type MockLiveVoiceState = "idle" | "connecting" | "listening" | "failed";
+type MockLiveVoiceState = "idle" | "listening" | "failed";
 
 let mockLiveVoiceState: MockLiveVoiceState = "idle";
-let mockLivePartial = "";
-let mockLiveFinal = "";
-let mockLiveAssistant = "";
+let mockLiveVoiceError: string | null = null;
 const liveStartSpy = mock(
   async (_assistantId: string, _conversationId?: string) => {},
 );
 const liveStopSpy = mock(async () => {});
-// The composer reads session state through the store's per-field selectors
-// (`useLiveVoiceStore.use.state()` etc.), so mock the store rather than the
-// `useLiveVoice` controller. `LiveVoiceButton` is the only `useLiveVoice`
-// consumer, and it is mocked separately below.
+const liveReleaseSpy = mock(() => {});
+const liveResetSpy = mock(() => {});
+// The composer only touches the store imperatively (`getState()` for the voice
+// bar's amplitude poll and for resetting a failed session from the error
+// notice); reactive session state flows through the mocked hook below.
 mock.module("@/domains/chat/voice/live-voice/live-voice-store", () => ({
   useLiveVoiceStore: {
-    use: {
-      state: () => mockLiveVoiceState,
-      partialTranscript: () => mockLivePartial,
-      finalTranscript: () => mockLiveFinal,
-      assistantTranscript: () => mockLiveAssistant,
-    },
+    getState: () => ({
+      inputAmplitude: 0,
+      reset: liveResetSpy,
+    }),
   },
 }));
 mock.module("@/domains/chat/voice/live-voice/use-live-voice", () => ({
   useLiveVoice: () => ({
     state: mockLiveVoiceState,
-    partialTranscript: mockLivePartial,
-    finalTranscript: mockLiveFinal,
-    assistantTranscript: mockLiveAssistant,
+    partialTranscript: "",
+    finalTranscript: "",
+    assistantTranscript: "",
     inputAmplitude: 0,
-    error: null,
+    error: mockLiveVoiceError,
     start: liveStartSpy,
     stop: liveStopSpy,
+    release: liveReleaseSpy,
   }),
 }));
 
@@ -131,13 +128,13 @@ function resetLiveVoiceMocks() {
   mockIsElectron = false;
   mockVoiceMode = false;
   mockLiveVoiceState = "idle";
-  mockLivePartial = "";
-  mockLiveFinal = "";
-  mockLiveAssistant = "";
+  mockLiveVoiceError = null;
   mockVoicePhase = "idle";
   setAudioLevelSpy.mockClear();
   liveStartSpy.mockClear();
   liveStopSpy.mockClear();
+  liveReleaseSpy.mockClear();
+  liveResetSpy.mockClear();
 }
 
 // Imported after the mocks so the component (and its transitive flag-store /
@@ -768,7 +765,6 @@ describe("ChatComposer — live-voice integration", () => {
 
     // THEN the live-voice control is absent and dictation is unaffected
     expect(queryByLabelText("Start voice mode")).toBeNull();
-    expect(queryByLabelText("Stop voice mode")).toBeNull();
     const dictation = queryByLabelText(
       "Start voice input",
     ) as HTMLButtonElement | null;
@@ -776,59 +772,78 @@ describe("ChatComposer — live-voice integration", () => {
     expect(dictation?.disabled).toBe(false);
   });
 
-  test("flag ON, idle: live-voice button present, dictation still enabled", () => {
+  test("flag ON, idle: live-voice button present, normal row, no voice bar", () => {
     // GIVEN the flag is on with no active session
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
     mockLiveVoiceState = "idle";
 
     // WHEN the composer renders
-    const { getByLabelText, queryByLabelText } = renderVoiceComposer();
+    const { getByLabelText, queryByLabelText, queryByRole } =
+      renderVoiceComposer();
 
-    // THEN both mics are available and neither is forced disabled
+    // THEN both mics are available, neither is forced disabled, and the
+    // action row is the normal composer row (no voice bar)
     expect(getByLabelText("Start voice mode")).toBeTruthy();
     const dictation = queryByLabelText(
       "Start voice input",
     ) as HTMLButtonElement | null;
     expect(dictation?.disabled).toBe(false);
+    expect(queryByRole("group", { name: "Voice session" })).toBeNull();
+    expect(getByLabelText("Send message")).toBeTruthy();
   });
 
-  test("active session disables dictation (mutual exclusion)", () => {
+  test("clicking the live-voice button starts a session for the conversation", () => {
+    // GIVEN the flag is on with no active session
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockLiveVoiceState = "idle";
+
+    // WHEN the user clicks the entry-point mic
+    const { getByLabelText } = renderVoiceComposer();
+    fireEvent.click(getByLabelText("Start voice mode"));
+
+    // THEN the composer-owned controller starts with the bound context
+    expect(liveStartSpy).toHaveBeenCalledTimes(1);
+    expect(liveStartSpy).toHaveBeenCalledWith("asst_test", "conv_test");
+  });
+
+  test("active session swaps the action row for the voice bar (mutual exclusion by absence)", () => {
     // GIVEN a live-voice session is listening
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
     mockLiveVoiceState = "listening";
 
     // WHEN the composer renders
-    const { getByLabelText } = renderVoiceComposer();
+    const { getByRole, queryByLabelText } = renderVoiceComposer();
 
-    // THEN the live-voice control is a stop affordance and the dictation
-    // mic is disabled so the two capture flows can't run together
-    expect(getByLabelText("Stop voice mode")).toBeTruthy();
-    const dictation = getByLabelText(
-      "Start voice input",
-    ) as HTMLButtonElement;
-    expect(dictation.disabled).toBe(true);
+    // THEN the voice bar replaces the whole action row — attach, both mic
+    // buttons, and send are gone, so the two capture flows can't coexist
+    expect(getByRole("group", { name: "Voice session" })).toBeTruthy();
+    expect(queryByLabelText("Start voice mode")).toBeNull();
+    expect(queryByLabelText("Start voice input")).toBeNull();
+    expect(queryByLabelText("Send message")).toBeNull();
+    // ...and the old inline transcript strip is gone for good
+    expect(queryByLabelText("Live voice transcript")).toBeNull();
   });
 
-  test("active session surfaces user + assistant transcripts", () => {
-    // GIVEN a listening session with partial speech and a streaming reply
+  test("active session keeps the textarea mounted but inert", () => {
+    // GIVEN a live-voice session is listening
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
     mockLiveVoiceState = "listening";
-    mockLivePartial = "what is the";
-    mockLiveAssistant = "Let me check";
 
     // WHEN the composer renders
-    const { getByLabelText } = renderVoiceComposer();
+    const { container } = renderVoiceComposer();
 
-    // THEN the transcript surface shows both sides of the turn
-    const surface = getByLabelText("Live voice transcript");
-    expect(surface.textContent).toContain("what is the");
-    expect(surface.textContent).toContain("Let me check");
+    // THEN the textarea stays (a later PR streams the transcript into it)
+    // but is disabled so focus/typing can't fight the session
+    const textarea = container.querySelector("textarea");
+    expect(textarea).not.toBeNull();
+    expect((textarea as HTMLTextAreaElement).disabled).toBe(true);
   });
 
-  test("active session stays stoppable even when the composer is busy", () => {
+  test("voice bar ✕ ends the session even when the composer is busy", () => {
     // GIVEN a live session AND the composer is otherwise disabled
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
@@ -837,24 +852,26 @@ describe("ChatComposer — live-voice integration", () => {
     // WHEN the composer renders with typingDisabled raised
     const { getByLabelText } = renderVoiceComposer({ typingDisabled: true });
 
-    // THEN the stop control is still actionable and clicking it stops
-    const stop = getByLabelText("Stop voice mode") as HTMLButtonElement;
-    expect(stop.disabled).toBe(false);
-    fireEvent.click(stop);
+    // THEN the end control is still actionable and clicking it stops
+    const end = getByLabelText("End voice session") as HTMLButtonElement;
+    expect(end.disabled).toBe(false);
+    fireEvent.click(end);
     expect(liveStopSpy).toHaveBeenCalledTimes(1);
   });
 
-  test("flag ON but no transcript content: surface stays empty when idle", () => {
-    // GIVEN the flag is on but the session is idle
+  test("voice bar ↑ manually releases the turn while listening", () => {
+    // GIVEN a listening session
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "idle";
+    mockLiveVoiceState = "listening";
 
-    // WHEN the composer renders
-    const { queryByLabelText } = renderVoiceComposer();
+    // WHEN the user clicks send-now
+    const { getByLabelText } = renderVoiceComposer();
+    fireEvent.click(getByLabelText("Send now"));
 
-    // THEN no transcript surface is rendered (idle = nothing to show)
-    expect(queryByLabelText("Live voice transcript")).toBeNull();
+    // THEN the composer-owned controller releases the turn
+    expect(liveReleaseSpy).toHaveBeenCalledTimes(1);
+    expect(liveStopSpy).not.toHaveBeenCalled();
   });
 
   test("dictation active disables the live-voice button (reverse mutual exclusion)", () => {
@@ -896,21 +913,56 @@ describe("ChatComposer — live-voice integration", () => {
     expect(liveVoice.disabled).toBe(true);
   });
 
-  test("failed live-voice state is inactive: dictation re-enabled, no transcript surface", () => {
-    // GIVEN the flag is on and a live-voice start attempt has failed
+  test("failed live-voice state is inactive: normal row restored, dictation re-enabled", () => {
+    // GIVEN the flag is on and a live-voice session has failed
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
     mockLiveVoiceState = "failed";
 
     // WHEN the composer renders (dictation idle)
-    const { getByLabelText, queryByLabelText } = renderVoiceComposer();
+    const { getByLabelText, queryByRole } = renderVoiceComposer();
 
-    // THEN dictation is treated as available again (failed = inactive)...
+    // THEN the voice bar is unmounted and the normal row is back...
+    expect(queryByRole("group", { name: "Voice session" })).toBeNull();
+    expect(getByLabelText("Send message")).toBeTruthy();
+    // ...with dictation treated as available again (failed = inactive)
     const dictation = getByLabelText(
       "Start voice input",
     ) as HTMLButtonElement;
     expect(dictation.disabled).toBe(false);
-    // ...and the transcript surface is unmounted rather than left hanging
-    expect(queryByLabelText("Live voice transcript")).toBeNull();
+  });
+
+  test("failed session surfaces the hook error as a dismissible notice", () => {
+    // GIVEN a failed session carrying an error message
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockLiveVoiceState = "failed";
+    mockLiveVoiceError = "Microphone capture could not start.";
+
+    // WHEN the composer renders
+    const { getByText, getByLabelText } = renderVoiceComposer();
+
+    // THEN the error notice is visible with the hook's message
+    expect(getByText("Microphone capture could not start.")).toBeTruthy();
+
+    // WHEN the user dismisses it
+    fireEvent.click(getByLabelText("Dismiss"));
+
+    // THEN the store is reset back to idle (which clears the error)
+    expect(liveResetSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("no live-voice error notice while idle or without an error", () => {
+    // GIVEN the flag is on with an idle session and no error
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockLiveVoiceState = "idle";
+    mockLiveVoiceError = null;
+
+    // WHEN the composer renders
+    const { queryByLabelText } = renderVoiceComposer();
+
+    // THEN no dismissible notice is mounted
+    expect(queryByLabelText("Dismiss")).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -42,9 +42,10 @@ mock.module("@/runtime/is-electron", () => ({
 // controller (it must outlive the `LiveVoiceButton`, which is swapped out with
 // the rest of the action row during a session) and polls amplitude through
 // `useLiveVoiceStore.getState()`. Both are mocked so the composer renders in
-// isolation: the flag via a mutable `mockVoiceMode`, and the session via a
-// mutable state/error bag exposed through the mocked hook. Defaults (flag
-// off, idle, no error) keep the existing HTML-surface assertions unchanged.
+// isolation: the flag via a mutable `mockVoiceMode` (consumed by the real
+// `LiveVoiceButton`, which self-gates on it), and the session via a mutable
+// state/error bag exposed through the mocked hook. Defaults (flag off, idle,
+// no error) keep the existing HTML-surface assertions unchanged.
 let mockVoiceMode = false;
 mock.module("@/stores/assistant-feature-flag-store", () => ({
   useAssistantFeatureFlagStore: {
@@ -79,18 +80,23 @@ mock.module("@/domains/chat/voice/live-voice/live-voice-store", () => ({
     }),
   },
 }));
+// Spy wrapper so tests can assert the composer opts out of the hook's
+// high-frequency audio-state subscription (`observeAudioState: false`) —
+// the guard that keeps per-mic-sample amplitude updates from re-rendering
+// the whole composer (the voice bar polls amplitude via `getState()`).
+const useLiveVoiceSpy = mock((_options?: { observeAudioState?: boolean }) => ({
+  state: mockLiveVoiceState,
+  partialTranscript: "",
+  finalTranscript: "",
+  assistantTranscript: "",
+  inputAmplitude: 0,
+  error: mockLiveVoiceError,
+  start: liveStartSpy,
+  stop: liveStopSpy,
+  release: liveReleaseSpy,
+}));
 mock.module("@/domains/chat/voice/live-voice/use-live-voice", () => ({
-  useLiveVoice: () => ({
-    state: mockLiveVoiceState,
-    partialTranscript: "",
-    finalTranscript: "",
-    assistantTranscript: "",
-    inputAmplitude: 0,
-    error: mockLiveVoiceError,
-    start: liveStartSpy,
-    stop: liveStopSpy,
-    release: liveReleaseSpy,
-  }),
+  useLiveVoice: useLiveVoiceSpy,
 }));
 
 // The real `VoiceInputButton` self-suppresses (returns null) unless the test
@@ -135,6 +141,7 @@ function resetLiveVoiceMocks() {
   liveStopSpy.mockClear();
   liveReleaseSpy.mockClear();
   liveResetSpy.mockClear();
+  useLiveVoiceSpy.mockClear();
 }
 
 // Imported after the mocks so the component (and its transitive flag-store /
@@ -964,5 +971,92 @@ describe("ChatComposer — live-voice integration", () => {
 
     // THEN no dismissible notice is mounted
     expect(queryByLabelText("Dismiss")).toBeNull();
+  });
+
+  test("composer opts out of the hook's high-frequency audio state (observeAudioState: false)", () => {
+    // GIVEN a voice-enabled composer
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+
+    // WHEN it renders
+    renderVoiceComposer();
+
+    // THEN it consumes only the low-frequency session state + actions —
+    // amplitude ticks and transcript deltas must not re-render the whole
+    // composer (the voice bar polls amplitude via getState() instead)
+    expect(useLiveVoiceSpy).toHaveBeenCalled();
+    for (const call of useLiveVoiceSpy.mock.calls) {
+      expect(call[0]).toEqual({ observeAudioState: false });
+    }
+  });
+
+  test("voice bar persists when the flag flips off mid-session (no stranded session)", () => {
+    // GIVEN an active session but the voice-mode flag has since flipped off
+    // while the composer (and its session-owning controller) stayed mounted
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = false;
+    mockLiveVoiceState = "listening";
+
+    // WHEN the composer renders
+    const { getByRole, getByLabelText, queryByLabelText } =
+      renderVoiceComposer();
+
+    // THEN the active-UI swap follows the session state, not eligibility:
+    // the bar (and its ✕ stop control) stays until teardown completes...
+    expect(getByRole("group", { name: "Voice session" })).toBeTruthy();
+    const end = getByLabelText("End voice session") as HTMLButtonElement;
+    expect(end.disabled).toBe(false);
+    // ...while the entry-point button stays flag-gated off
+    expect(queryByLabelText("Start voice mode")).toBeNull();
+
+    // AND the ✕ still ends the live session
+    fireEvent.click(end);
+    expect(liveStopSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("voice bar persists when assistantId is transiently cleared mid-session", () => {
+    // GIVEN an active session whose assistantId has been cleared from props
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockLiveVoiceState = "listening";
+
+    // WHEN the composer renders without an assistant id
+    const { getByRole, getByLabelText } = renderVoiceComposer({
+      assistantId: null,
+    });
+
+    // THEN the stop control remains available for the live mic/socket
+    expect(getByRole("group", { name: "Voice session" })).toBeTruthy();
+    fireEvent.click(getByLabelText("End voice session"));
+    expect(liveStopSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("failure after an eligibility drop still surfaces the error notice", () => {
+    // GIVEN a session that failed right after the flag flipped off
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = false;
+    mockLiveVoiceState = "failed";
+    mockLiveVoiceError = "Connection lost.";
+
+    // WHEN the composer renders
+    const { getByText } = renderVoiceComposer();
+
+    // THEN the user still learns why voice stopped
+    expect(getByText("Connection lost.")).toBeTruthy();
+  });
+
+  test("no-voice variant (app-editing) never swaps its row for a session it doesn't own", () => {
+    // GIVEN a live session exists in the global store (owned by another
+    // composer instance) and this variant has no voice props
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockLiveVoiceState = "listening";
+
+    // WHEN the app-editing variant renders (no voiceInputRef/onVoiceTranscript)
+    const html = renderComposer();
+
+    // THEN its action row is untouched — no voice bar, normal send button
+    expect(html).not.toContain('aria-label="Voice session"');
+    expect(html).toContain('aria-label="Send message"');
   });
 });

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -39,7 +39,6 @@ import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-sto
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { isElectron } from "@/runtime/is-electron";
 import { useIsNativePlatform } from "@/runtime/native-auth";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { isPointerCoarse } from "@/utils/pointer";
 import { Button, Notice, Popover } from "@vellumai/design-library";
 
@@ -212,33 +211,48 @@ export function ChatComposer({
     voiceInputRef !== undefined && onVoiceTranscript !== undefined;
 
   // ---- Live voice (full-duplex conversation) ----------------------------
-  // Coexists with dictation: `LiveVoiceButton` self-gates on the `voice-mode`
-  // flag, but the row swap and the mutual-exclusion wiring below must also
-  // no-op when the flag is off so the composer is byte-identical for users
-  // without the flag. The live-voice button only appears alongside the
-  // dictation button (same `showVoiceInput` precondition + a non-null id).
-  const voiceMode = useAssistantFeatureFlagStore.use.voiceMode();
-  const liveVoiceEligible = voiceMode && showVoiceInput && !!assistantId;
+  // Coexists with dictation: entry is gated on eligibility — `LiveVoiceButton`
+  // self-gates on the `voice-mode` flag and only renders alongside the
+  // dictation button (`showVoiceInput` + a non-null assistant id) — so with
+  // the flag off no session can ever start and the session state below stays
+  // `idle`, keeping the composer byte-identical for users without the flag.
   // The composer owns the single `useLiveVoice()` controller instance. It has
   // to live here (not in `LiveVoiceButton`): while a session is active the
   // action row that hosts the button is swapped out for `VoiceComposerBar`,
   // and the hook tears the session down when its owner unmounts — a
   // button-owned controller would kill the session the moment it started.
   // The button is purely the presentational entry point (see its docs).
+  //
+  // `observeAudioState: false` — the composer only needs the low-frequency
+  // session phase + error + actions. Without it the hook would subscribe this
+  // whole component to `inputAmplitude` (updated per mic sample) and the
+  // transcript fields, re-rendering the entire composer on every mic-level
+  // tick; the voice bar's waveform instead polls amplitude via `getState()`
+  // in its canvas draw loop (see `getLiveVoiceAmplitude` below).
   const {
     state: liveVoiceState,
     error: liveVoiceError,
     start: liveVoiceStart,
     stop: liveVoiceStop,
     release: liveVoiceRelease,
-  } = useLiveVoice();
+  } = useLiveVoice({ observeAudioState: false });
   // Anything but idle/failed counts as an active session; while active the
   // whole action row (including both mic buttons) is replaced by the voice
   // bar, so the two capture flows can never run at once. `failed` is a
   // retryable/inactive state, so it must fall back to the normal row —
   // otherwise dictation would stay unavailable after a failed start.
+  //
+  // Deliberately based on the session state alone — NOT on the entry-point
+  // eligibility (the `voice-mode` flag / a non-null `assistantId`) — so a
+  // mid-session eligibility drop (flag flip, `assistantId` transiently
+  // cleared) can't unmount the voice bar while the still-mounted controller
+  // keeps the mic/socket live: the bar's ✕ stays available until teardown
+  // completes and the state returns to `idle`. `showVoiceInput` (static per
+  // variant) scopes the swap to the voice-enabled composer — the app-editing
+  // variant shares the global live-voice store but must never swap its row
+  // for a session it doesn't own.
   const isLiveVoiceActive =
-    liveVoiceEligible &&
+    showVoiceInput &&
     liveVoiceState !== "idle" &&
     liveVoiceState !== "failed";
   // Amplitude is polled by the voice bar's canvas draw loop straight from the
@@ -364,8 +378,11 @@ export function ChatComposer({
       <ComposerDraftNotices />
       {/* Live-voice failure notice — composer-owned (the session controller
           lives here), mirroring the dictation `voiceError` Notice rendered by
-          `ComposerNotices` in the orchestration stack below. */}
-      {liveVoiceEligible && liveVoiceState === "failed" && liveVoiceError && (
+          `ComposerNotices` in the orchestration stack below. Keyed on the
+          session state (not entry eligibility) for the same reason as
+          `isLiveVoiceActive`: a session that fails right after an eligibility
+          drop must still surface its error. */}
+      {showVoiceInput && liveVoiceState === "failed" && liveVoiceError && (
         <div className="mb-2">
           <Notice tone="error" onDismiss={dismissLiveVoiceError}>
             {liveVoiceError}

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -25,6 +25,7 @@ import {
 import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 import { ComposerDraftNotices } from "@/domains/chat/components/composer-draft-notices";
 import { StreamingWaveform } from "@/domains/chat/components/chat-composer/streaming-waveform";
+import { VoiceComposerBar } from "@/domains/chat/components/chat-composer/voice-composer-bar";
 import { LiveVoiceButton } from "@/domains/chat/components/live-voice-button";
 import {
     VoiceInputButton,
@@ -32,6 +33,7 @@ import {
 } from "@/domains/chat/components/voice-input-button";
 import { type TurnPhase, useTurnStore } from "@/domains/chat/turn-store";
 import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { useLiveVoice } from "@/domains/chat/voice/live-voice/use-live-voice";
 import { useAudioAmplitude } from "@/domains/chat/voice/use-audio-amplitude";
 import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
 import { useIsMobile } from "@/hooks/use-is-mobile";
@@ -39,7 +41,7 @@ import { isElectron } from "@/runtime/is-electron";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { isPointerCoarse } from "@/utils/pointer";
-import { Button, Popover } from "@vellumai/design-library";
+import { Button, Notice, Popover } from "@vellumai/design-library";
 
 import {
     computeGhostSuffix,
@@ -211,31 +213,52 @@ export function ChatComposer({
 
   // ---- Live voice (full-duplex conversation) ----------------------------
   // Coexists with dictation: `LiveVoiceButton` self-gates on the `voice-mode`
-  // flag, but the transcript surface and the mutual-exclusion wiring below
-  // must also no-op when the flag is off so the composer is byte-identical for
-  // users without the flag. The live-voice button only appears alongside the
+  // flag, but the row swap and the mutual-exclusion wiring below must also
+  // no-op when the flag is off so the composer is byte-identical for users
+  // without the flag. The live-voice button only appears alongside the
   // dictation button (same `showVoiceInput` precondition + a non-null id).
   const voiceMode = useAssistantFeatureFlagStore.use.voiceMode();
   const liveVoiceEligible = voiceMode && showVoiceInput && !!assistantId;
-  // Read session state via the store's per-field selectors rather than mounting
-  // a second `useLiveVoice()` controller. The single controller instance lives
-  // in `LiveVoiceButton` (which drives start/stop + owns the unmount-teardown
-  // effect); the composer only ever *reads* the projected state, so two
-  // controllers with competing teardown effects on the same store would be a
-  // footgun. These atomic selectors re-render only on the fields they read.
-  const liveVoiceState = useLiveVoiceStore.use.state();
-  const liveVoicePartial = useLiveVoiceStore.use.partialTranscript();
-  const liveVoiceFinal = useLiveVoiceStore.use.finalTranscript();
-  const liveVoiceAssistant = useLiveVoiceStore.use.assistantTranscript();
+  // The composer owns the single `useLiveVoice()` controller instance. It has
+  // to live here (not in `LiveVoiceButton`): while a session is active the
+  // action row that hosts the button is swapped out for `VoiceComposerBar`,
+  // and the hook tears the session down when its owner unmounts — a
+  // button-owned controller would kill the session the moment it started.
+  // The button is purely the presentational entry point (see its docs).
+  const {
+    state: liveVoiceState,
+    error: liveVoiceError,
+    start: liveVoiceStart,
+    stop: liveVoiceStop,
+    release: liveVoiceRelease,
+  } = useLiveVoice();
   // Anything but idle/failed counts as an active session; while active the
-  // dictation mic is disabled so the two capture flows never run at once.
-  // `failed` is a retryable/inactive state in `useLiveVoice`/`LiveVoiceButton`,
-  // so we must treat it as inactive — otherwise dictation stays disabled and
-  // the (empty) transcript surface stays mounted after a failed start.
+  // whole action row (including both mic buttons) is replaced by the voice
+  // bar, so the two capture flows can never run at once. `failed` is a
+  // retryable/inactive state, so it must fall back to the normal row —
+  // otherwise dictation would stay unavailable after a failed start.
   const isLiveVoiceActive =
     liveVoiceEligible &&
     liveVoiceState !== "idle" &&
     liveVoiceState !== "failed";
+  // Amplitude is polled by the voice bar's canvas draw loop straight from the
+  // store (~30 Hz), so per-sample updates never flow through props.
+  const getLiveVoiceAmplitude = useCallback(
+    () => useLiveVoiceStore.getState().inputAmplitude,
+    [],
+  );
+  const handleLiveVoiceStart = useCallback(() => {
+    if (!assistantId) return;
+    void liveVoiceStart(assistantId, conversationId ?? undefined);
+  }, [assistantId, conversationId, liveVoiceStart]);
+  const handleLiveVoiceEnd = useCallback(() => {
+    void liveVoiceStop();
+  }, [liveVoiceStop]);
+  // Dismissing the failure notice resets the store back to idle — `failed` is
+  // terminal for the session, so this only clears the surfaced error.
+  const dismissLiveVoiceError = useCallback(() => {
+    useLiveVoiceStore.getState().reset();
+  }, []);
 
   const pointerCoarse = useMemo(() => isPointerCoarse(), []);
   const isMobile = useIsMobile();
@@ -339,6 +362,16 @@ export function ChatComposer({
       {/* Composer-owned draft/attachment notices (self-sourced), above the
           orchestration banner stack. */}
       <ComposerDraftNotices />
+      {/* Live-voice failure notice — composer-owned (the session controller
+          lives here), mirroring the dictation `voiceError` Notice rendered by
+          `ComposerNotices` in the orchestration stack below. */}
+      {liveVoiceEligible && liveVoiceState === "failed" && liveVoiceError && (
+        <div className="mb-2">
+          <Notice tone="error" onDismiss={dismissLiveVoiceError}>
+            {liveVoiceError}
+          </Notice>
+        </div>
+      )}
       {noticesAboveFormSlot}
       <Popover.Root open={emoji.show || slash.show}>
         <Popover.Anchor asChild>
@@ -538,7 +571,10 @@ export function ChatComposer({
                   }
                 }}
                 placeholder={ghostSuffix ? "" : placeholder}
-                disabled={typingDisabled}
+                // Inert during a live-voice session so focus/typing can't
+                // fight the session (a later PR streams the live transcript
+                // into this region). The grid mirror keeps the height stable.
+                disabled={typingDisabled || isLiveVoiceActive}
                 rows={1}
                 className="col-start-1 row-start-1 w-full resize-none overflow-y-auto border-none bg-transparent px-4 pt-3 pb-2 text-chat text-[var(--content-default)] placeholder:text-[var(--content-disabled)] focus:outline-none disabled:opacity-50"
                 style={{ maxHeight: `${textareaMaxHeightPx}px` }}
@@ -573,139 +609,130 @@ export function ChatComposer({
                 )}
               </div>
             )}
-            {isLiveVoiceActive && (
-              // Live-voice transcript surface — distinct from the dictation
-              // interim preview above, which only exists while the dictation
-              // recorder is running. Shows the user's partial/final speech and
-              // the streaming assistant reply for the in-flight turn.
-              <div
-                className="px-4 pb-1 space-y-0.5"
-                aria-label="Live voice transcript"
-                aria-live="polite"
-              >
-                {(liveVoicePartial || liveVoiceFinal) && (
-                  <p className="truncate text-[11px] text-[var(--content-secondary)]">
-                    {liveVoicePartial || liveVoiceFinal}
-                  </p>
-                )}
-                {liveVoiceAssistant && (
-                  <p className="truncate text-[11px] italic text-[var(--content-tertiary)]">
-                    {liveVoiceAssistant}
-                  </p>
-                )}
+            {isLiveVoiceActive ? (
+              // Voice session bar (Light 53): the whole action row — slots,
+              // attach, both mic buttons, and send — is replaced by the bar
+              // for the duration of the session. ✕ ends the session (the
+              // normal row returns via `isLiveVoiceActive` flipping false);
+              // green ↑ manually releases the current turn while listening.
+              <VoiceComposerBar
+                state={liveVoiceState}
+                getAmplitude={getLiveVoiceAmplitude}
+                onEnd={handleLiveVoiceEnd}
+                onSend={liveVoiceRelease}
+              />
+            ) : (
+              <div className="flex items-center justify-between px-2 pb-2">
+                <div className="flex items-center gap-1">
+                  {thresholdPickerSlot}
+                  {contextWindowIndicatorSlot}
+                </div>
+                <div className="flex items-center gap-1">
+                  {canStopGenerating ? (
+                    <>
+                      {/* Desktop: always show stop. Mobile: show stop only when there is no sendable content. */}
+                      {(!isMobile || !canSendMessageContent) && (
+                        <Button
+                          variant="primary"
+                          iconOnly={
+                            <Square className="h-3 w-3" fill="currentColor" />
+                          }
+                          onClick={onStopGenerating}
+                          aria-label="Stop generating"
+                        />
+                      )}
+                      {/* Mobile: show send instead of stop when content can be queued. */}
+                      {isMobile && canSendMessageContent && (
+                        <Button
+                          variant="primary"
+                          iconOnly={
+                            <ArrowUp className="h-4 w-4" strokeWidth={2.5} />
+                          }
+                          type="submit"
+                          disabled={sendDisabled || attachmentsUploadingCount > 0}
+                          title={
+                            sendDisabled
+                              ? "Type a message to send"
+                              : attachmentsUploadingCount > 0
+                                ? "Uploading attachments…"
+                                : "Send message"
+                          }
+                          aria-label="Send message"
+                        />
+                      )}
+                    </>
+                  ) : (
+                    <>
+                      <AttachFileButton
+                        disabled={typingDisabled || !assistantId}
+                        onFilesSelected={onAddAttachmentFiles}
+                      />
+                      {showVoiceInput && (
+                        <VoiceInputButton
+                          ref={voiceInputRef}
+                          assistantId={assistantId}
+                          // Mutual exclusion: an active live-voice session
+                          // replaces this whole row with the voice bar, so the
+                          // two capture flows never run simultaneously; the
+                          // `isLiveVoiceActive` term is defense-in-depth for
+                          // that structural guarantee.
+                          disabled={typingDisabled || isLiveVoiceActive}
+                          onTranscript={onVoiceTranscript}
+                          onInterimTranscript={onVoiceInterimTranscript}
+                          onError={onVoiceError}
+                          onBeforeStart={onVoiceBeforeStart}
+                          onStreamReady={(stream: MediaStream | null) => {
+                            voiceStreamRef.current = stream;
+                            setVoiceStream(stream);
+                          }}
+                        />
+                      )}
+                      {showVoiceInput && assistantId && (
+                        // Self-gates on the `voice-mode` flag (renders null when
+                        // off — no layout shift). Purely the session entry
+                        // point: once a session starts, this row (button
+                        // included) is swapped for `VoiceComposerBar`, whose ✕
+                        // owns stopping.
+                        //
+                        // Mutual exclusion (reverse direction): while dictation
+                        // is active (`isVoiceActive`) live voice is disabled so
+                        // it can't start a second mic/voice session alongside
+                        // the recorder.
+                        <LiveVoiceButton
+                          onStart={handleLiveVoiceStart}
+                          disabled={typingDisabled || isVoiceActive}
+                        />
+                      )}
+                      {/* macOS parity: the send button is hidden during recording
+                      and while transcription is being processed. Only the voice
+                      button (mic / stop / spinner) is shown. */}
+                      {!isVoiceActive && (
+                        <Button
+                          variant="primary"
+                          iconOnly={
+                            <ArrowUp className="h-4 w-4" strokeWidth={2.5} />
+                          }
+                          type="submit"
+                          disabled={
+                            sendDisabled ||
+                            attachmentsUploadingCount > 0 ||
+                            !canSendMessageContent
+                          }
+                          title={
+                            sendDisabled || !canSendMessageContent
+                              ? "Type a message to send"
+                              : attachmentsUploadingCount > 0
+                                ? "Uploading attachments…"
+                                : "Send message"
+                          }
+                          aria-label="Send message"
+                        />
+                      )}
+                    </>
+                  )}
+                </div>
               </div>
             )}
-            <div className="flex items-center justify-between px-2 pb-2">
-              <div className="flex items-center gap-1">
-                {thresholdPickerSlot}
-                {contextWindowIndicatorSlot}
-              </div>
-              <div className="flex items-center gap-1">
-                {canStopGenerating ? (
-                  <>
-                    {/* Desktop: always show stop. Mobile: show stop only when there is no sendable content. */}
-                    {(!isMobile || !canSendMessageContent) && (
-                      <Button
-                        variant="primary"
-                        iconOnly={
-                          <Square className="h-3 w-3" fill="currentColor" />
-                        }
-                        onClick={onStopGenerating}
-                        aria-label="Stop generating"
-                      />
-                    )}
-                    {/* Mobile: show send instead of stop when content can be queued. */}
-                    {isMobile && canSendMessageContent && (
-                      <Button
-                        variant="primary"
-                        iconOnly={
-                          <ArrowUp className="h-4 w-4" strokeWidth={2.5} />
-                        }
-                        type="submit"
-                        disabled={sendDisabled || attachmentsUploadingCount > 0}
-                        title={
-                          sendDisabled
-                            ? "Type a message to send"
-                            : attachmentsUploadingCount > 0
-                              ? "Uploading attachments…"
-                              : "Send message"
-                        }
-                        aria-label="Send message"
-                      />
-                    )}
-                  </>
-                ) : (
-                  <>
-                    <AttachFileButton
-                      disabled={typingDisabled || !assistantId}
-                      onFilesSelected={onAddAttachmentFiles}
-                    />
-                    {showVoiceInput && (
-                      <VoiceInputButton
-                        ref={voiceInputRef}
-                        assistantId={assistantId}
-                        // Mutual exclusion: an active live-voice session
-                        // disables the dictation mic so the two capture flows
-                        // never run simultaneously.
-                        disabled={typingDisabled || isLiveVoiceActive}
-                        onTranscript={onVoiceTranscript}
-                        onInterimTranscript={onVoiceInterimTranscript}
-                        onError={onVoiceError}
-                        onBeforeStart={onVoiceBeforeStart}
-                        onStreamReady={(stream: MediaStream | null) => {
-                          voiceStreamRef.current = stream;
-                          setVoiceStream(stream);
-                        }}
-                      />
-                    )}
-                    {showVoiceInput && assistantId && (
-                      // Self-gates on the `voice-mode` flag (renders null when
-                      // off — no layout shift). The composer's busy/disabled
-                      // signal only gates the START path; an active session
-                      // stays stoppable even while the composer is otherwise
-                      // busy (see LiveVoiceButton).
-                      //
-                      // Mutual exclusion (reverse direction): while dictation is
-                      // active (`isVoiceActive`) we disable live voice so it
-                      // can't START a second mic/voice session alongside the
-                      // recorder. `LiveVoiceButton` only applies external
-                      // `disabled` to its START path, so an in-flight live-voice
-                      // session is never trapped by this.
-                      <LiveVoiceButton
-                        assistantId={assistantId}
-                        conversationId={conversationId ?? undefined}
-                        disabled={typingDisabled || isVoiceActive}
-                      />
-                    )}
-                    {/* macOS parity: the send button is hidden during recording
-                    and while transcription is being processed. Only the voice
-                    button (mic / stop / spinner) is shown. */}
-                    {!isVoiceActive && (
-                      <Button
-                        variant="primary"
-                        iconOnly={
-                          <ArrowUp className="h-4 w-4" strokeWidth={2.5} />
-                        }
-                        type="submit"
-                        disabled={
-                          sendDisabled ||
-                          attachmentsUploadingCount > 0 ||
-                          !canSendMessageContent
-                        }
-                        title={
-                          sendDisabled || !canSendMessageContent
-                            ? "Type a message to send"
-                            : attachmentsUploadingCount > 0
-                              ? "Uploading attachments…"
-                              : "Send message"
-                        }
-                        aria-label="Send message"
-                      />
-                    )}
-                  </>
-                )}
-              </div>
-            </div>
           </form>
         </Popover.Anchor>
         <Popover.Content

--- a/clients/web/src/domains/chat/components/live-voice-button.test.tsx
+++ b/clients/web/src/domains/chat/components/live-voice-button.test.tsx
@@ -1,10 +1,10 @@
 /**
  * Tests for `LiveVoiceButton`.
  *
- * The button is gated behind the `voice-mode` assistant flag and toggles a
- * {@link useLiveVoice} session. We mock both so the component renders in
- * isolation: the flag store via a mutable `mockVoiceMode`, and `useLiveVoice`
- * via spies for `start`/`stop` plus a mutable `mockState`/`mockInputAmplitude`.
+ * The button is a purely presentational entry point: it self-gates on the
+ * `voice-mode` assistant flag (mocked via a mutable `mockVoiceMode`) and
+ * forwards clicks to the composer-bound `onStart`. Session lifecycle lives in
+ * the composer's `useLiveVoice` controller, so there is nothing else to mock.
  *
  * Uses happy-dom via the bun:test preload configured in `web/bunfig.toml`.
  */
@@ -19,8 +19,6 @@ import {
 } from "bun:test";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
-import type { LiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live-voice-store";
-
 let mockVoiceMode = false;
 mock.module("@/stores/assistant-feature-flag-store", () => ({
   useAssistantFeatureFlagStore: {
@@ -30,34 +28,16 @@ mock.module("@/stores/assistant-feature-flag-store", () => ({
   },
 }));
 
-const startSpy = mock(async (_assistantId: string, _conversationId?: string) => {});
-const stopSpy = mock(async () => {});
-let mockState: LiveVoiceSessionState = "idle";
-let mockInputAmplitude = 0;
-mock.module("@/domains/chat/voice/live-voice/use-live-voice", () => ({
-  useLiveVoice: () => ({
-    state: mockState,
-    partialTranscript: "",
-    finalTranscript: "",
-    assistantTranscript: "",
-    inputAmplitude: mockInputAmplitude,
-    error: null,
-    start: startSpy,
-    stop: stopSpy,
-  }),
-}));
-
 // Imported after the mocks so the component picks up the mocked modules.
 const { LiveVoiceButton } = await import(
   "@/domains/chat/components/live-voice-button"
 );
 
+const onStartSpy = mock(() => {});
+
 beforeEach(() => {
   mockVoiceMode = false;
-  mockState = "idle";
-  mockInputAmplitude = 0;
-  startSpy.mockClear();
-  stopSpy.mockClear();
+  onStartSpy.mockClear();
 });
 
 afterEach(() => {
@@ -70,102 +50,40 @@ describe("LiveVoiceButton", () => {
     mockVoiceMode = false;
 
     // WHEN the button renders
-    const { container } = render(<LiveVoiceButton assistantId="a1" />);
+    const { container } = render(<LiveVoiceButton onStart={onStartSpy} />);
 
     // THEN nothing is painted
     expect(container.firstChild).toBeNull();
   });
 
-  test("renders a start control when the flag is on and idle", () => {
-    // GIVEN the flag is enabled and no session is active
+  test("renders a start control when the flag is on", () => {
+    // GIVEN the flag is enabled
     mockVoiceMode = true;
-    mockState = "idle";
 
     // WHEN the button renders
-    const { getByLabelText } = render(<LiveVoiceButton assistantId="a1" />);
+    const { getByLabelText } = render(<LiveVoiceButton onStart={onStartSpy} />);
 
-    // THEN it offers to start voice mode and is not pressed
-    const button = getByLabelText("Start voice mode");
-    expect(button).toBeTruthy();
-    expect(button.getAttribute("aria-pressed")).toBe("false");
+    // THEN it offers to start voice mode
+    expect(getByLabelText("Start voice mode")).toBeTruthy();
   });
 
-  test("starts a session on click when idle", () => {
-    // GIVEN an idle, flag-enabled button with a conversation
+  test("fires onStart on click", () => {
+    // GIVEN a flag-enabled button
     mockVoiceMode = true;
-    mockState = "idle";
-    const { getByLabelText } = render(
-      <LiveVoiceButton assistantId="a1" conversationId="c1" />,
-    );
+    const { getByLabelText } = render(<LiveVoiceButton onStart={onStartSpy} />);
 
     // WHEN the user clicks it
     fireEvent.click(getByLabelText("Start voice mode"));
 
-    // THEN it starts a live-voice session for the assistant + conversation
-    expect(startSpy).toHaveBeenCalledTimes(1);
-    expect(startSpy).toHaveBeenCalledWith("a1", "c1");
-    expect(stopSpy).not.toHaveBeenCalled();
+    // THEN the composer-bound start callback fires once
+    expect(onStartSpy).toHaveBeenCalledTimes(1);
   });
 
-  test("stops the session on click when active", () => {
-    // GIVEN an active session (listening)
+  test("prevents starting a session when disabled", () => {
+    // GIVEN a flag-enabled button that the parent has disabled
     mockVoiceMode = true;
-    mockState = "listening";
-    const { getByLabelText } = render(<LiveVoiceButton assistantId="a1" />);
-
-    // THEN the control reflects the live session
-    const button = getByLabelText("Stop voice mode");
-    expect(button.getAttribute("aria-pressed")).toBe("true");
-
-    // WHEN the user clicks it
-    fireEvent.click(button);
-
-    // THEN it stops the session
-    expect(stopSpy).toHaveBeenCalledTimes(1);
-    expect(startSpy).not.toHaveBeenCalled();
-  });
-
-  test("reflects connecting as a busy, non-toggling state", () => {
-    // GIVEN a session that is still connecting
-    mockVoiceMode = true;
-    mockState = "connecting";
-    const { getByLabelText } = render(<LiveVoiceButton assistantId="a1" />);
-
-    // THEN the control is busy and disabled
-    const button = getByLabelText("Connecting live voice") as HTMLButtonElement;
-    expect(button.getAttribute("aria-busy")).toBe("true");
-    expect(button.disabled).toBe(true);
-
-    // WHEN the user clicks it, neither start nor stop fire
-    fireEvent.click(button);
-    expect(startSpy).not.toHaveBeenCalled();
-    expect(stopSpy).not.toHaveBeenCalled();
-  });
-
-  test("stays stoppable when disabled while a session is active", () => {
-    // GIVEN an active session and a parent that has raised `disabled`
-    mockVoiceMode = true;
-    mockState = "listening";
     const { getByLabelText } = render(
-      <LiveVoiceButton assistantId="a1" disabled />,
-    );
-
-    // THEN the stop control remains enabled despite the external disabled prop
-    const button = getByLabelText("Stop voice mode") as HTMLButtonElement;
-    expect(button.disabled).toBe(false);
-
-    // WHEN the user clicks it, the session is stopped
-    fireEvent.click(button);
-    expect(stopSpy).toHaveBeenCalledTimes(1);
-    expect(startSpy).not.toHaveBeenCalled();
-  });
-
-  test("prevents starting a session when disabled while idle", () => {
-    // GIVEN an idle, flag-enabled button that the parent has disabled
-    mockVoiceMode = true;
-    mockState = "idle";
-    const { getByLabelText } = render(
-      <LiveVoiceButton assistantId="a1" disabled />,
+      <LiveVoiceButton onStart={onStartSpy} disabled />,
     );
 
     // THEN the start control is disabled
@@ -174,19 +92,6 @@ describe("LiveVoiceButton", () => {
 
     // WHEN the user clicks it, no session is started
     fireEvent.click(button);
-    expect(startSpy).not.toHaveBeenCalled();
-    expect(stopSpy).not.toHaveBeenCalled();
-  });
-
-  test("scales the icon with live amplitude while active", () => {
-    // GIVEN an active session with non-zero mic amplitude
-    mockVoiceMode = true;
-    mockState = "listening";
-    mockInputAmplitude = 1;
-    const { getByLabelText } = render(<LiveVoiceButton assistantId="a1" />);
-
-    // THEN the control carries an amplitude-driven transform
-    const button = getByLabelText("Stop voice mode");
-    expect(button.style.transform).toContain("scale(");
+    expect(onStartSpy).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/chat/components/live-voice-button.tsx
+++ b/clients/web/src/domains/chat/components/live-voice-button.tsx
@@ -1,103 +1,49 @@
 /**
- * `LiveVoiceButton` — composer control that toggles a live-voice conversation.
+ * `LiveVoiceButton` — composer entry point for a live-voice conversation.
  *
  * Distinct from the dictation {@link import("./voice-input-button").VoiceInputButton}:
  * that one records a single utterance and drops a transcript into the composer,
- * while this one opens a full-duplex live-voice session via {@link useLiveVoice}
- * (mic streaming + TTS playback + barge-in). The button is gated behind the
- * `voice-mode` assistant flag and renders nothing when the flag is off.
+ * while this one starts a full-duplex live-voice session (mic streaming + TTS
+ * playback + barge-in). The button is gated behind the `voice-mode` assistant
+ * flag and renders nothing when the flag is off.
  *
- * Appearance reflects the {@link useLiveVoice} session phase:
- *   - `idle`/`failed`     → mic icon, click to start
- *   - `connecting`        → spinning loader, disabled (token mint / socket open)
- *   - any other (active)  → stop-circle icon, click to stop; the live
- *                           `inputAmplitude` drives a subtle pulse so the user
- *                           sees the mic is hearing them.
- *
- * Wiring into the composer happens in a later PR; this is the standalone control.
+ * Purely presentational: the `useLiveVoice` controller lives in the composer
+ * (which binds the assistant/conversation into `onStart`). While a session is
+ * active the composer swaps its whole action row — this button included — for
+ * the `VoiceComposerBar`, whose ✕ owns ending the session; so this control only
+ * ever renders while no session is active and never needs a stop affordance.
  */
 
-import { Loader2, Mic, StopCircle } from "lucide-react";
-import { useCallback } from "react";
+import { Mic } from "lucide-react";
 
 import { Button } from "@vellumai/design-library";
 
-import { useLiveVoice } from "@/domains/chat/voice/live-voice/use-live-voice";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 interface LiveVoiceButtonProps {
-  /** Assistant whose live-voice channel the session attaches to. */
-  assistantId: string;
-  /** Optional conversation to continue inside the session. */
-  conversationId?: string;
-  /** Disable the control (e.g. while the composer is otherwise busy). */
+  /** Start a live-voice session (the composer binds assistant + conversation). */
+  onStart: () => void;
+  /** Disable the control (e.g. while dictation is recording). */
   disabled?: boolean;
 }
 
 export function LiveVoiceButton({
-  assistantId,
-  conversationId,
+  onStart,
   disabled = false,
 }: LiveVoiceButtonProps) {
   const voiceMode = useAssistantFeatureFlagStore.use.voiceMode();
-  const { state, inputAmplitude, start, stop } = useLiveVoice();
-
-  const connecting = state === "connecting";
-  // Anything past connecting (listening/transcribing/thinking/speaking/ending)
-  // means a session is live and the button acts as a stop control.
-  const active =
-    state !== "idle" && state !== "failed" && state !== "connecting";
-
-  const handleClick = useCallback(() => {
-    if (connecting) return;
-    if (active) {
-      // An active session must always be stoppable, even if the parent has
-      // raised `disabled` in the meantime — otherwise the user is stuck with a
-      // live mic/socket until some automatic teardown.
-      void stop();
-    } else {
-      // Only the start path honours the external `disabled` prop.
-      if (disabled) return;
-      void start(assistantId, conversationId);
-    }
-  }, [active, connecting, disabled, start, stop, assistantId, conversationId]);
 
   if (!voiceMode) return null;
-
-  const label = connecting
-    ? "Connecting live voice"
-    : active
-      ? "Stop voice mode"
-      : "Start voice mode";
 
   return (
     <Button
       variant="ghost"
-      iconOnly={
-        connecting ? (
-          <Loader2 className="animate-spin" strokeWidth={2} />
-        ) : active ? (
-          <StopCircle strokeWidth={2} />
-        ) : (
-          <Mic strokeWidth={2} />
-        )
-      }
-      onClick={handleClick}
-      // An active session is always stoppable; the external `disabled` prop
-      // only gates the start path. `connecting` stays disabled/busy.
-      disabled={connecting || (!active && disabled)}
-      aria-label={label}
-      aria-pressed={active}
-      aria-busy={connecting}
-      title={label}
+      iconOnly={<Mic strokeWidth={2} />}
+      onClick={onStart}
+      disabled={disabled}
+      aria-label="Start voice mode"
+      title="Start voice mode"
       className="[--vbtn-fg:var(--content-secondary)]"
-      style={
-        // While listening, scale the icon with live amplitude so the control
-        // visibly reacts to the user's voice (clamped to a gentle 1.0–1.25).
-        active
-          ? { transform: `scale(${1 + Math.min(inputAmplitude, 1) * 0.25})` }
-          : undefined
-      }
     />
   );
 }

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -191,27 +191,31 @@ function pcmChunk(ms: number): ArrayBuffer {
   return new Int16Array(samples).buffer;
 }
 
-function renderController() {
+function renderController(extraOptions: { observeAudioState?: boolean } = {}) {
   const client = new FakeClient();
   const player = new FakePlayer();
   let capture!: FakeCapture;
+  let renderCount = 0;
 
-  const view = renderHook(() =>
-    useLiveVoice({
+  const view = renderHook(() => {
+    renderCount++;
+    return useLiveVoice({
       createClient: () => client as unknown as LiveVoiceChannelClient,
       createPlayer: () => player as unknown as LiveVoiceAudioPlayer,
       createCapture: (options) => {
         capture = new FakeCapture(options);
         return capture as unknown as LiveVoiceAudioCapture;
       },
-    }),
-  );
+      ...extraOptions,
+    });
+  });
 
   return {
     view,
     client,
     player,
     getCapture: () => capture,
+    getRenderCount: () => renderCount,
   };
 }
 
@@ -689,6 +693,75 @@ describe("session context and controls", () => {
     expect(store.controls).toBeNull();
     expect(store.assistantId).toBeNull();
     expect(store.conversationId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// observeAudioState — high-frequency subscription opt-out
+// ---------------------------------------------------------------------------
+
+describe("observeAudioState", () => {
+  test("default: amplitude and transcript updates re-render the consumer and surface values", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    // Amplitude below the speech/barge-in thresholds so no phase transition
+    // can account for the re-render — only the amplitude subscription.
+    act(() => {
+      h.getCapture().pushAmplitude(0.02);
+    });
+    expect(h.view.result.current.inputAmplitude).toBe(0.02);
+
+    act(() => {
+      h.client.emit("sttPartial", { type: "stt_partial", seq: 2, text: "hel" });
+    });
+    expect(h.view.result.current.partialTranscript).toBe("hel");
+  });
+
+  test("false: amplitude ticks do not re-render the consumer; fields pinned at defaults", async () => {
+    const h = renderController({ observeAudioState: false });
+    await startListening(h);
+    expect(h.view.result.current.state).toBe("listening");
+
+    const rendersBefore = h.getRenderCount();
+    act(() => {
+      // A burst of mic-level samples (all below the speech/barge-in
+      // thresholds, so no state transition is involved).
+      h.getCapture().pushAmplitude(0.01);
+      h.getCapture().pushAmplitude(0.02);
+      h.getCapture().pushAmplitude(0.015);
+    });
+
+    // The store received the samples (the voice bar polls them via
+    // getState())...
+    expect(useLiveVoiceStore.getState().inputAmplitude).toBe(0.015);
+    // ...but the opted-out consumer did not re-render and returns the
+    // pinned default.
+    expect(h.getRenderCount()).toBe(rendersBefore);
+    expect(h.view.result.current.inputAmplitude).toBe(0);
+  });
+
+  test("false: transcript deltas do not re-render; state transitions still do", async () => {
+    const h = renderController({ observeAudioState: false });
+    await startListening(h);
+
+    const rendersBefore = h.getRenderCount();
+    act(() => {
+      h.client.emit("sttPartial", { type: "stt_partial", seq: 2, text: "hel" });
+      h.client.emit("sttPartial", { type: "stt_partial", seq: 3, text: "hello" });
+    });
+    // Transcript writes reached the store but not the consumer.
+    expect(useLiveVoiceStore.getState().partialTranscript).toBe("hello");
+    expect(h.getRenderCount()).toBe(rendersBefore);
+    expect(h.view.result.current.partialTranscript).toBe("");
+
+    // Low-frequency session state still flows: releasing push-to-talk moves
+    // the returned state to `transcribing` (a re-render).
+    act(() => {
+      h.view.result.current.release();
+    });
+    expect(h.view.result.current.state).toBe("transcribing");
+    expect(h.getRenderCount()).toBeGreaterThan(rendersBefore);
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -91,13 +91,13 @@ const MINIMUM_SPEECH_DURATION_BEFORE_RELEASE_MS = 120;
 export interface UseLiveVoiceResult {
   /** Current session phase. */
   state: LiveVoiceSessionState;
-  /** In-flight partial user transcript. */
+  /** In-flight partial user transcript. Pinned at `""` when the consumer opted out via {@link UseLiveVoiceOptions.observeAudioState}. */
   partialTranscript: string;
-  /** Last finalized user transcript. */
+  /** Last finalized user transcript. Pinned at `""` when `observeAudioState` is false. */
   finalTranscript: string;
-  /** Accumulated assistant response text for the current turn. */
+  /** Accumulated assistant response text for the current turn. Pinned at `""` when `observeAudioState` is false. */
   assistantTranscript: string;
-  /** Smoothed mic amplitude in [0, 1]. */
+  /** Smoothed mic amplitude in [0, 1]. Pinned at `0` when `observeAudioState` is false. */
   inputAmplitude: number;
   /** Failure message when `state === "failed"`, else `null`. */
   error: string | null;
@@ -120,6 +120,22 @@ export interface UseLiveVoiceOptions {
     options: ConstructorParameters<typeof LiveVoiceAudioCapture>[0],
   ) => LiveVoiceAudioCapture;
   createPlayer?: () => LiveVoiceAudioPlayer;
+  /**
+   * When `false`, this hook instance does not subscribe to the high-frequency
+   * audio/transcript store fields — `inputAmplitude` (updated on every mic
+   * amplitude sample), `partialTranscript`, `finalTranscript`, and
+   * `assistantTranscript` — so those updates never re-render the consumer. The
+   * corresponding returned fields are pinned at their idle defaults (`0` /
+   * `""`); read them via `useLiveVoiceStore` (selectors or `getState()`)
+   * instead. The low-frequency `state`/`error` fields and the actions are
+   * unaffected.
+   *
+   * For consumers that only need the session phase + actions — e.g. the
+   * composer, whose voice bar polls amplitude with `getState()` inside its
+   * canvas draw loop. Must be stable for the lifetime of the hook instance.
+   * Defaults to `true` (subscribe to everything, the original behavior).
+   */
+  observeAudioState?: boolean;
 }
 
 /**
@@ -170,11 +186,24 @@ function chunkDurationMs(buf: ArrayBuffer): number {
 export function useLiveVoice(
   options: UseLiveVoiceOptions = {},
 ): UseLiveVoiceResult {
+  const observeAudioState = options.observeAudioState ?? true;
   const state = useLiveVoiceStore.use.state();
-  const partialTranscript = useLiveVoiceStore.use.partialTranscript();
-  const finalTranscript = useLiveVoiceStore.use.finalTranscript();
-  const assistantTranscript = useLiveVoiceStore.use.assistantTranscript();
-  const inputAmplitude = useLiveVoiceStore.use.inputAmplitude();
+  // High-frequency / transcript fields are read through conditional selectors:
+  // when the consumer opted out, the selector returns the idle default, so the
+  // subscription exists but never produces a changed value — i.e. amplitude
+  // ticks and transcript deltas cannot re-render the consumer.
+  const partialTranscript = useLiveVoiceStore((s) =>
+    observeAudioState ? s.partialTranscript : "",
+  );
+  const finalTranscript = useLiveVoiceStore((s) =>
+    observeAudioState ? s.finalTranscript : "",
+  );
+  const assistantTranscript = useLiveVoiceStore((s) =>
+    observeAudioState ? s.assistantTranscript : "",
+  );
+  const inputAmplitude = useLiveVoiceStore((s) =>
+    observeAudioState ? s.inputAmplitude : 0,
+  );
   const error = useLiveVoiceStore.use.error();
 
   const sessionRef = useRef<SessionContext | null>(null);


### PR DESCRIPTION
## Summary
- Composer action row swaps to VoiceComposerBar while a live-voice session is active (X ends, green ↑ manual release)
- Moves the single `useLiveVoice()` controller from `LiveVoiceButton` into `ChatComposer`: the row swap unmounts the button, and the hook tears the session down when its owner unmounts — a button-owned controller would have killed the session the moment it started. The button is now a purely presentational entry point (flag-gated mic that fires a composer-bound `onStart`), which also removes its amplitude icon-scale pulse.
- Removes the old inline transcript strip (`aria-label="Live voice transcript"`) and its `liveVoicePartial`/`liveVoiceFinal`/`liveVoiceAssistant` plumbing; textarea stays mounted but disabled during a session (a later PR streams the live transcript into it)
- Failure UX: `failed` falls back to the normal composer row and surfaces the hook's `error` as a dismissible design-library `Notice` above the form, mirroring the dictation `voiceError` Notice in `ComposerNotices`; dismissing resets the store to idle
- Dictation/live-voice mutual exclusion preserved: structural in one direction (the row swap removes the dictation mic, with the `isLiveVoiceActive` disable kept as defense-in-depth), `isVoiceActive`-disable in the other
- Tests: swap on active state, revert + dictation re-enable on idle/failed, ✕→stop, ↑→release, inert textarea, error-notice render/dismiss; `LiveVoiceButton` tests rewritten for the presentational contract

Part of plan: voice-mode-ui.md (PR 4 of 7)