### PR TITLE
Mobile: notification deep-links, appUrlOpen routing, and haptics

### DIFF
--- a/assistant/src/__tests__/notification-deep-link.test.ts
+++ b/assistant/src/__tests__/notification-deep-link.test.ts
@@ -4,7 +4,9 @@
  * Validates that the VellumAdapter broadcasts notification_intent with
  * deepLinkMetadata, and that the broadcaster correctly passes deepLinkTarget
  * from the decision through to the adapter payload — regardless of whether
- * the conversation was newly created or reused.
+ * the conversation was newly created or reused. Also covers the platform
+ * (APNs) channel, whose deepLinkTarget must be enriched with the
+ * conversationId so remote-push taps can navigate.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -667,6 +669,171 @@ describe("notification deep-link metadata", () => {
       // Decision did not carry a deepLinkTarget either — the resulting
       // deep link should be undefined or have no conversationId.
       expect(deepLink?.conversationId).toBeUndefined();
+    });
+
+    // ── Platform (APNs) channel deep-link enrichment ──────────────────
+    //
+    // The platform adapter forwards deepLinkTarget verbatim as
+    // deep_link_metadata, so the broadcaster must enrich it with the
+    // conversationId the same way it does for vellum — otherwise remote-push
+    // taps have no routing key and cannot navigate.
+
+    test("broadcaster merges pairing conversationId and messageId into deepLinkTarget for platform", async () => {
+      const platformAdapter = new MockAdapter("platform");
+      const broadcaster = new NotificationBroadcaster([platformAdapter]);
+
+      nextPairingResult = {
+        conversationId: "conv-paired-platform",
+        messageId: "msg-paired-platform",
+        strategy: "start_new_conversation" as const,
+        createdNewConversation: true,
+        conversationFallbackUsed: false,
+      };
+
+      const signal = makeSignal();
+      const decision = makeDecision({
+        selectedChannels: ["platform"],
+        renderedCopy: {
+          platform: { title: "Test Alert", body: "Something happened" },
+        },
+      });
+
+      await broadcaster.broadcastDecision(signal, decision);
+
+      expect(platformAdapter.sent).toHaveLength(1);
+      const deepLink = platformAdapter.sent[0].deepLinkTarget;
+      expect(deepLink).toBeDefined();
+      expect(deepLink!.conversationId).toBe("conv-paired-platform");
+      expect(deepLink!.messageId).toBe("msg-paired-platform");
+    });
+
+    test("platform deep link falls back to signal.sourceContextId when pairing returns no conversation", async () => {
+      const platformAdapter = new MockAdapter("platform");
+      const broadcaster = new NotificationBroadcaster([platformAdapter]);
+
+      // Production platform pairing: push_only strategy pairs no conversation.
+      nextPairingResult = {
+        conversationId: null,
+        messageId: null,
+        strategy: "push_only" as const,
+        createdNewConversation: false,
+        conversationFallbackUsed: false,
+      };
+
+      const originConvId = "conv-origin-of-push";
+      mockExistingConversations[originConvId] = { id: originConvId };
+
+      const signal = makeSignal({ sourceContextId: originConvId });
+      const decision = makeDecision({
+        selectedChannels: ["platform"],
+        renderedCopy: {
+          platform: { title: "Turn done", body: "Your task finished" },
+        },
+      });
+
+      await broadcaster.broadcastDecision(signal, decision);
+
+      expect(platformAdapter.sent).toHaveLength(1);
+      const deepLink = platformAdapter.sent[0].deepLinkTarget;
+      expect(deepLink).toBeDefined();
+      expect(deepLink!.conversationId).toBe(originConvId);
+    });
+
+    test("platform deep link omits conversationId when sourceContextId is a sentinel", async () => {
+      const platformAdapter = new MockAdapter("platform");
+      const broadcaster = new NotificationBroadcaster([platformAdapter]);
+
+      nextPairingResult = {
+        conversationId: null,
+        messageId: null,
+        strategy: "push_only" as const,
+        createdNewConversation: false,
+        conversationFallbackUsed: false,
+      };
+
+      const signal = makeSignal({ sourceContextId: "job-sentinel-123" });
+      const decision = makeDecision({
+        selectedChannels: ["platform"],
+        renderedCopy: {
+          platform: { title: "Alert", body: "Body" },
+        },
+      });
+
+      await broadcaster.broadcastDecision(signal, decision);
+
+      expect(platformAdapter.sent).toHaveLength(1);
+      expect(
+        platformAdapter.sent[0].deepLinkTarget?.conversationId,
+      ).toBeUndefined();
+    });
+
+    test("vellum and platform each receive deep-link enrichment in the same broadcast", async () => {
+      const vellumAdapter = new MockAdapter("vellum");
+      const platformAdapter = new MockAdapter("platform");
+      const broadcaster = new NotificationBroadcaster([
+        vellumAdapter,
+        platformAdapter,
+      ]);
+
+      // Vellum is ordered first and consumes the queued pairing result;
+      // the platform pairing call then receives the mock's auto-generated
+      // conversation, so each channel is enriched from its own pairing.
+      nextPairingResult = {
+        conversationId: "conv-vellum-paired",
+        messageId: "msg-vellum-paired",
+        strategy: "start_new_conversation" as const,
+        createdNewConversation: true,
+        conversationFallbackUsed: false,
+      };
+
+      const signal = makeSignal();
+      const decision = makeDecision({
+        selectedChannels: ["platform", "vellum"],
+        renderedCopy: {
+          vellum: { title: "Test Alert", body: "Something happened" },
+          platform: { title: "Test Alert", body: "Something happened" },
+        },
+      });
+
+      await broadcaster.broadcastDecision(signal, decision);
+
+      // Vellum behavior unchanged: paired conversation wins.
+      expect(vellumAdapter.sent).toHaveLength(1);
+      expect(vellumAdapter.sent[0].deepLinkTarget?.conversationId).toBe(
+        "conv-vellum-paired",
+      );
+
+      // Platform enriched independently from its own pairing call.
+      expect(platformAdapter.sent).toHaveLength(1);
+      const platformConvId =
+        platformAdapter.sent[0].deepLinkTarget?.conversationId;
+      expect(String(platformConvId)).toStartWith("mock-conv-");
+    });
+
+    test("channels other than vellum and platform do not receive deterministic enrichment", async () => {
+      const telegramAdapter = new MockAdapter("telegram");
+      const broadcaster = new NotificationBroadcaster([telegramAdapter]);
+
+      nextPairingResult = {
+        conversationId: "conv-telegram-paired",
+        messageId: "msg-telegram-paired",
+        strategy: "continue_existing_conversation" as const,
+        createdNewConversation: true,
+        conversationFallbackUsed: false,
+      };
+
+      const signal = makeSignal();
+      const decision = makeDecision({
+        selectedChannels: ["telegram"],
+        renderedCopy: {
+          telegram: { title: "Alert", body: "Body" },
+        },
+      });
+
+      await broadcaster.broadcastDecision(signal, decision);
+
+      expect(telegramAdapter.sent).toHaveLength(1);
+      expect(telegramAdapter.sent[0].deepLinkTarget).toBeUndefined();
     });
   });
 });

--- a/assistant/src/__tests__/notification-deep-link.test.ts
+++ b/assistant/src/__tests__/notification-deep-link.test.ts
@@ -57,15 +57,26 @@ mock.module("../persistence/conversation-crud.js", () => ({
 let nextPairingResult:
   | import("../notifications/conversation-pairing.js").PairingResult
   | null = null;
+// Per-channel results take precedence over nextPairingResult, so mixed
+// broadcasts can drive prod-realistic pairings (e.g. platform is push_only
+// and pairs null while vellum creates a conversation).
+let pairingResultsByChannel: Record<
+  string,
+  import("../notifications/conversation-pairing.js").PairingResult
+> = {};
 let pairingCallCount = 0;
 
 mock.module("../notifications/conversation-pairing.js", () => ({
   pairDeliveryWithConversation: async (
     _signal: unknown,
-    _channel: string,
+    channel: string,
     _copy: unknown,
     _options?: PairingOptions,
   ) => {
+    const byChannel = pairingResultsByChannel[channel];
+    if (byChannel) {
+      return byChannel;
+    }
     if (nextPairingResult) {
       const result = nextPairingResult;
       nextPairingResult = null;
@@ -156,6 +167,7 @@ class MockAdapter implements ChannelAdapter {
 describe("notification deep-link metadata", () => {
   beforeEach(() => {
     nextPairingResult = null;
+    pairingResultsByChannel = {};
     mockExistingConversations = {};
   });
 
@@ -808,6 +820,166 @@ describe("notification deep-link metadata", () => {
       const platformConvId =
         platformAdapter.sent[0].deepLinkTarget?.conversationId;
       expect(String(platformConvId)).toStartWith("mock-conv-");
+    });
+
+    // ── Vellum pairing carried into the platform deep link ─────────────
+    //
+    // In production the platform channel is push_only: its own pairing
+    // returns null. When the vellum channel creates (or reuses) a
+    // conversation in the same broadcast, the platform deep link must
+    // carry that conversation so remote-push taps land in the thread the
+    // notification is about (approval requests, guardian questions).
+
+    test("platform deep link carries the vellum-created conversation in a mixed broadcast", async () => {
+      const vellumAdapter = new MockAdapter("vellum");
+      const platformAdapter = new MockAdapter("platform");
+      const broadcaster = new NotificationBroadcaster([
+        vellumAdapter,
+        platformAdapter,
+      ]);
+
+      pairingResultsByChannel = {
+        vellum: {
+          conversationId: "conv-vellum-created",
+          messageId: "msg-vellum-seed",
+          strategy: "start_new_conversation",
+          createdNewConversation: true,
+          conversationFallbackUsed: false,
+        },
+        platform: {
+          conversationId: null,
+          messageId: null,
+          strategy: "push_only",
+          createdNewConversation: false,
+          conversationFallbackUsed: false,
+        },
+      };
+
+      // Sentinel source context (access-req-*) that resolves to no
+      // conversation, so the vellum carry is the only viable deep-link source.
+      const signal = makeSignal({ sourceContextId: "access-req-123" });
+      // Platform listed first to prove the vellum-first ordering makes the
+      // carry available regardless of selectedChannels order.
+      const decision = makeDecision({
+        selectedChannels: ["platform", "vellum"],
+        renderedCopy: {
+          vellum: { title: "Approval needed", body: "Allow file access?" },
+          platform: { title: "Approval needed", body: "Allow file access?" },
+        },
+      });
+
+      await broadcaster.broadcastDecision(signal, decision);
+
+      // Vellum unchanged: enriched from its own pairing.
+      expect(vellumAdapter.sent).toHaveLength(1);
+      expect(vellumAdapter.sent[0].deepLinkTarget?.conversationId).toBe(
+        "conv-vellum-created",
+      );
+      expect(vellumAdapter.sent[0].deepLinkTarget?.messageId).toBe(
+        "msg-vellum-seed",
+      );
+
+      // Platform carries the vellum-created conversation and seed message.
+      expect(platformAdapter.sent).toHaveLength(1);
+      expect(platformAdapter.sent[0].deepLinkTarget?.conversationId).toBe(
+        "conv-vellum-created",
+      );
+      expect(platformAdapter.sent[0].deepLinkTarget?.messageId).toBe(
+        "msg-vellum-seed",
+      );
+    });
+
+    test("platform prefers the vellum pairing over the source-context fallback in a mixed broadcast", async () => {
+      const vellumAdapter = new MockAdapter("vellum");
+      const platformAdapter = new MockAdapter("platform");
+      const broadcaster = new NotificationBroadcaster([
+        vellumAdapter,
+        platformAdapter,
+      ]);
+
+      pairingResultsByChannel = {
+        vellum: {
+          conversationId: "conv-approval-thread",
+          messageId: "msg-approval-card",
+          strategy: "start_new_conversation",
+          createdNewConversation: true,
+          conversationFallbackUsed: false,
+        },
+        platform: {
+          conversationId: null,
+          messageId: null,
+          strategy: "push_only",
+          createdNewConversation: false,
+          conversationFallbackUsed: false,
+        },
+      };
+
+      // The source context resolves to a real conversation, but the tap
+      // should land in the created approval thread, not the source.
+      const originConvId = "conv-source-of-signal";
+      mockExistingConversations[originConvId] = { id: originConvId };
+
+      const signal = makeSignal({ sourceContextId: originConvId });
+      const decision = makeDecision({
+        selectedChannels: ["vellum", "platform"],
+        renderedCopy: {
+          vellum: { title: "Question", body: "Approve?" },
+          platform: { title: "Question", body: "Approve?" },
+        },
+      });
+
+      await broadcaster.broadcastDecision(signal, decision);
+
+      expect(platformAdapter.sent).toHaveLength(1);
+      expect(platformAdapter.sent[0].deepLinkTarget?.conversationId).toBe(
+        "conv-approval-thread",
+      );
+    });
+
+    test("platform falls back to sourceContextId in a mixed broadcast when vellum pairs no conversation", async () => {
+      const vellumAdapter = new MockAdapter("vellum");
+      const platformAdapter = new MockAdapter("platform");
+      const broadcaster = new NotificationBroadcaster([
+        vellumAdapter,
+        platformAdapter,
+      ]);
+
+      // Passive vellum signal: pairing skips conversation creation.
+      pairingResultsByChannel = {
+        vellum: {
+          conversationId: null,
+          messageId: null,
+          strategy: "start_new_conversation",
+          createdNewConversation: false,
+          conversationFallbackUsed: false,
+        },
+        platform: {
+          conversationId: null,
+          messageId: null,
+          strategy: "push_only",
+          createdNewConversation: false,
+          conversationFallbackUsed: false,
+        },
+      };
+
+      const originConvId = "conv-passive-origin";
+      mockExistingConversations[originConvId] = { id: originConvId };
+
+      const signal = makeSignal({ sourceContextId: originConvId });
+      const decision = makeDecision({
+        selectedChannels: ["vellum", "platform"],
+        renderedCopy: {
+          vellum: { title: "Turn done", body: "Task finished" },
+          platform: { title: "Turn done", body: "Task finished" },
+        },
+      });
+
+      await broadcaster.broadcastDecision(signal, decision);
+
+      expect(platformAdapter.sent).toHaveLength(1);
+      expect(platformAdapter.sent[0].deepLinkTarget?.conversationId).toBe(
+        originConvId,
+      );
     });
 
     test("channels other than vellum and platform do not receive deterministic enrichment", async () => {

--- a/assistant/src/__tests__/notification-deep-link.test.ts
+++ b/assistant/src/__tests__/notification-deep-link.test.ts
@@ -37,11 +37,23 @@ mock.module("../notifications/destination-resolver.js", () => ({
   },
 }));
 
-// Mock deliveries-store to avoid DB access
+// Mock deliveries-store to avoid DB access. Existing deliveries are
+// configurable per channel so duplicate-delivery retry paths can be driven;
+// the default (no rows) leaves every channel on the fresh-delivery path.
+let existingDeliveriesByChannel: Record<
+  string,
+  {
+    id: string;
+    conversationId: string | null;
+    messageId: string | null;
+    conversationStrategy: string | null;
+  }
+> = {};
 mock.module("../notifications/deliveries-store.js", () => ({
   createDelivery: () => {},
   updateDeliveryStatus: () => {},
-  findDeliveryByDecisionAndChannel: () => undefined,
+  findDeliveryByDecisionAndChannel: (_decisionId: string, channel: string) =>
+    existingDeliveriesByChannel[channel],
 }));
 
 // Mock conversation-crud so the broadcaster's source-context fallback lookup
@@ -169,6 +181,7 @@ describe("notification deep-link metadata", () => {
     nextPairingResult = null;
     pairingResultsByChannel = {};
     mockExistingConversations = {};
+    existingDeliveriesByChannel = {};
   });
 
   describe("VellumAdapter", () => {
@@ -933,6 +946,65 @@ describe("notification deep-link metadata", () => {
       expect(platformAdapter.sent).toHaveLength(1);
       expect(platformAdapter.sent[0].deepLinkTarget?.conversationId).toBe(
         "conv-approval-thread",
+      );
+    });
+
+    test("platform deep link carries the conversation from a duplicate vellum delivery on retry", async () => {
+      const vellumAdapter = new MockAdapter("vellum");
+      const platformAdapter = new MockAdapter("platform");
+      const broadcaster = new NotificationBroadcaster([
+        vellumAdapter,
+        platformAdapter,
+      ]);
+
+      // Persisted-decision retry: the vellum delivery row already exists
+      // (with the paired conversation), so the vellum channel skips as a
+      // duplicate before any fresh pairing runs.
+      existingDeliveriesByChannel = {
+        vellum: {
+          id: "delivery-vellum-existing",
+          conversationId: "conv-from-existing-row",
+          messageId: "msg-from-existing-row",
+          conversationStrategy: "start_new_conversation",
+        },
+      };
+      pairingResultsByChannel = {
+        platform: {
+          conversationId: null,
+          messageId: null,
+          strategy: "push_only",
+          createdNewConversation: false,
+          conversationFallbackUsed: false,
+        },
+      };
+
+      // Sentinel source context (access-req-*) that resolves to no
+      // conversation, so the duplicate-row carry is the only viable source.
+      const signal = makeSignal({ sourceContextId: "access-req-retry-456" });
+      const decision = makeDecision({
+        persistedDecisionId: "decision-retry-001",
+        selectedChannels: ["platform", "vellum"],
+        renderedCopy: {
+          vellum: { title: "Approval needed", body: "Allow file access?" },
+          platform: { title: "Approval needed", body: "Allow file access?" },
+        },
+      });
+
+      const results = await broadcaster.broadcastDecision(signal, decision);
+
+      // Vellum duplicate is skipped without re-sending.
+      expect(vellumAdapter.sent).toHaveLength(0);
+      const vellumResult = results.find((r) => r.channel === "vellum");
+      expect(vellumResult?.status).toBe("skipped");
+      expect(vellumResult?.conversationId).toBe("conv-from-existing-row");
+
+      // Platform still delivers, carrying the existing row's conversation.
+      expect(platformAdapter.sent).toHaveLength(1);
+      expect(platformAdapter.sent[0].deepLinkTarget?.conversationId).toBe(
+        "conv-from-existing-row",
+      );
+      expect(platformAdapter.sent[0].deepLinkTarget?.messageId).toBe(
+        "msg-from-existing-row",
       );
     });
 

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -359,16 +359,13 @@ export class NotificationBroadcaster {
       }
 
       // For the vellum and platform channels, merge the conversationId into
-      // deep-link metadata so clients can navigate directly to the conversation
-      // (macOS reads it from notification_intent; the platform relays it to
-      // iOS inside the APNs payload as deep_link). Prefer the channel's own
-      // paired conversation (interactive opt-in flows); the platform channel
-      // is a push_only relay that pairs no conversation of its own, so it
-      // prefers the vellum pairing from this broadcast. Otherwise fall back
-      // to the originating conversation referenced by `sourceContextId` when it
-      // resolves to a real row. Sentinel context ids (job IDs, call session IDs,
-      // access-req-* strings) leave the deep link without a conversation, and
-      // the client opens the app to its default landing.
+      // deep-link metadata so notification taps can navigate to the
+      // conversation. Prefer the channel's own pairing; platform (push_only,
+      // pairs nothing) takes this broadcast's vellum pairing; otherwise fall
+      // back to sourceContextId when it resolves to a real row. Sentinel
+      // context ids (job IDs, call session IDs, access-req-* strings) leave
+      // the deep link without a conversation, and the client opens the app to
+      // its default landing.
       let deepLinkTarget = decision.deepLinkTarget;
       if (channel === "vellum" || channel === "platform") {
         const deepLinkPairing =

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -335,15 +335,17 @@ export class NotificationBroadcaster {
         { conversationAction, bindingContext: destination.bindingContext },
       );
 
-      // For the vellum channel, merge the conversationId into deep-link metadata
-      // so the macOS client can navigate directly to the conversation. Prefer
-      // the paired conversation (interactive opt-in flows); otherwise fall back
+      // For the vellum and platform channels, merge the conversationId into
+      // deep-link metadata so clients can navigate directly to the conversation
+      // (macOS reads it from notification_intent; the platform relays it to
+      // iOS inside the APNs payload as deep_link). Prefer the
+      // paired conversation (interactive opt-in flows); otherwise fall back
       // to the originating conversation referenced by `sourceContextId` when it
       // resolves to a real row. Sentinel context ids (job IDs, call session IDs,
       // access-req-* strings) leave the deep link without a conversation, and
-      // the macOS handler opens the app to its default landing.
+      // the client opens the app to its default landing.
       let deepLinkTarget = decision.deepLinkTarget;
-      if (channel === "vellum") {
+      if (channel === "vellum" || channel === "platform") {
         const deepLinkConversationId =
           pairing.conversationId ??
           resolveSourceConversationId(signal.sourceContextId);
@@ -359,68 +361,68 @@ export class NotificationBroadcaster {
             };
           }
         }
+      }
 
-        if (pairing.conversationId) {
-          // Resolve guardian scoping for conversation-created events so clients
-          // can filter guardian-sensitive conversations the same way they filter
-          // guardian-sensitive notification intents.
-          const guardianPrincipalId =
-            typeof destination.metadata?.guardianPrincipalId === "string"
-              ? destination.metadata.guardianPrincipalId
-              : undefined;
-          const targetGuardianPrincipalId =
-            guardianPrincipalId &&
-            isGuardianSensitiveEvent(signal.sourceEventName)
-              ? guardianPrincipalId
-              : undefined;
+      if (channel === "vellum" && pairing.conversationId) {
+        // Resolve guardian scoping for conversation-created events so clients
+        // can filter guardian-sensitive conversations the same way they filter
+        // guardian-sensitive notification intents.
+        const guardianPrincipalId =
+          typeof destination.metadata?.guardianPrincipalId === "string"
+            ? destination.metadata.guardianPrincipalId
+            : undefined;
+        const targetGuardianPrincipalId =
+          guardianPrincipalId &&
+          isGuardianSensitiveEvent(signal.sourceEventName)
+            ? guardianPrincipalId
+            : undefined;
 
-          const conversationTitle =
-            copy.conversationTitle ?? copy.title ?? signal.sourceEventName;
-          const conversationSilent =
-            signal.attentionHints.urgency !== "high" &&
-            signal.attentionHints.urgency !== "critical";
-          const info: ConversationCreatedInfo = {
-            conversationId: pairing.conversationId,
-            title: conversationTitle,
-            sourceEventName: signal.sourceEventName,
-            targetGuardianPrincipalId,
-            groupId: signal.conversationMetadata?.groupId,
-            source: signal.conversationMetadata?.source,
-            silent: conversationSilent,
-          };
+        const conversationTitle =
+          copy.conversationTitle ?? copy.title ?? signal.sourceEventName;
+        const conversationSilent =
+          signal.attentionHints.urgency !== "high" &&
+          signal.attentionHints.urgency !== "critical";
+        const info: ConversationCreatedInfo = {
+          conversationId: pairing.conversationId,
+          title: conversationTitle,
+          sourceEventName: signal.sourceEventName,
+          targetGuardianPrincipalId,
+          groupId: signal.conversationMetadata?.groupId,
+          source: signal.conversationMetadata?.source,
+          silent: conversationSilent,
+        };
 
-          // The per-dispatch onConversationCreated callback fires whenever a vellum
-          // conversation is paired (new or reused) because callers like
-          // dispatchGuardianQuestion rely on it to create delivery bookkeeping
-          // rows before emitNotificationSignal() returns.
-          if (options?.onConversationCreated) {
+        // The per-dispatch onConversationCreated callback fires whenever a vellum
+        // conversation is paired (new or reused) because callers like
+        // dispatchGuardianQuestion rely on it to create delivery bookkeeping
+        // rows before emitNotificationSignal() returns.
+        if (options?.onConversationCreated) {
+          try {
+            options.onConversationCreated(info);
+          } catch (err) {
+            log.error(
+              { err, signalId: signal.signalId },
+              "per-dispatch onConversationCreated callback failed — continuing broadcast",
+            );
+          }
+        }
+
+        // Emit notification_conversation_created event only when a NEW
+        // conversation was actually created. Reusing an existing conversation
+        // should not fire the event — the client already knows about the
+        // conversation.
+        if (
+          pairing.createdNewConversation &&
+          pairing.strategy === "start_new_conversation"
+        ) {
+          if (this.onConversationCreated) {
             try {
-              options.onConversationCreated(info);
+              this.onConversationCreated(info);
             } catch (err) {
               log.error(
                 { err, signalId: signal.signalId },
-                "per-dispatch onConversationCreated callback failed — continuing broadcast",
+                "onConversationCreated callback failed — continuing broadcast",
               );
-            }
-          }
-
-          // Emit notification_conversation_created event only when a NEW
-          // conversation was actually created. Reusing an existing conversation
-          // should not fire the event — the client already knows about the
-          // conversation.
-          if (
-            pairing.createdNewConversation &&
-            pairing.strategy === "start_new_conversation"
-          ) {
-            if (this.onConversationCreated) {
-              try {
-                this.onConversationCreated(info);
-              } catch (err) {
-                log.error(
-                  { err, signalId: signal.signalId },
-                  "onConversationCreated callback failed — continuing broadcast",
-                );
-              }
             }
           }
         }

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -209,6 +209,13 @@ export class NotificationBroadcaster {
         : undefined;
     const results: NotificationDeliveryResult[] = [];
 
+    // Vellum pairing carried forward for the platform channel's deep link.
+    // A single-pass carry is safe because orderedChannels sorts vellum first.
+    let vellumPairing: {
+      conversationId: string;
+      messageId: string | null;
+    } | null = null;
+
     for (const channel of orderedChannels) {
       const adapter = this.adapters.get(channel);
       if (!adapter) {
@@ -335,29 +342,42 @@ export class NotificationBroadcaster {
         { conversationAction, bindingContext: destination.bindingContext },
       );
 
+      if (channel === "vellum" && pairing.conversationId) {
+        vellumPairing = {
+          conversationId: pairing.conversationId,
+          messageId: pairing.messageId,
+        };
+      }
+
       // For the vellum and platform channels, merge the conversationId into
       // deep-link metadata so clients can navigate directly to the conversation
       // (macOS reads it from notification_intent; the platform relays it to
-      // iOS inside the APNs payload as deep_link). Prefer the
-      // paired conversation (interactive opt-in flows); otherwise fall back
+      // iOS inside the APNs payload as deep_link). Prefer the channel's own
+      // paired conversation (interactive opt-in flows); the platform channel
+      // is a push_only relay that pairs no conversation of its own, so it
+      // prefers the vellum pairing from this broadcast. Otherwise fall back
       // to the originating conversation referenced by `sourceContextId` when it
       // resolves to a real row. Sentinel context ids (job IDs, call session IDs,
       // access-req-* strings) leave the deep link without a conversation, and
       // the client opens the app to its default landing.
       let deepLinkTarget = decision.deepLinkTarget;
       if (channel === "vellum" || channel === "platform") {
+        const deepLinkPairing =
+          channel === "platform" && !pairing.conversationId
+            ? (vellumPairing ?? pairing)
+            : pairing;
         const deepLinkConversationId =
-          pairing.conversationId ??
+          deepLinkPairing.conversationId ??
           resolveSourceConversationId(signal.sourceContextId);
         if (deepLinkConversationId) {
           deepLinkTarget = {
             ...deepLinkTarget,
             conversationId: deepLinkConversationId,
           };
-          if (pairing.messageId) {
+          if (deepLinkPairing.messageId) {
             deepLinkTarget = {
               ...deepLinkTarget,
-              messageId: pairing.messageId,
+              messageId: deepLinkPairing.messageId,
             };
           }
         }

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -311,6 +311,15 @@ export class NotificationBroadcaster {
           channel,
         );
         if (existingDelivery) {
+          // On retry paths the vellum row already exists, so the fresh-pairing
+          // carry below never runs — seed the platform deep-link carry from
+          // the duplicate row's conversation instead.
+          if (channel === "vellum" && existingDelivery.conversationId) {
+            vellumPairing = {
+              conversationId: existingDelivery.conversationId,
+              messageId: existingDelivery.messageId,
+            };
+          }
           log.info(
             {
               channel,

--- a/clients/web/docs/EVENT_BUS.md
+++ b/clients/web/docs/EVENT_BUS.md
@@ -57,6 +57,7 @@ Every event name in `BusEventMap` has a typed payload. Producers:
 - `runtime/event-sources/*` for host-environment signals (`app.*`, `power.*`, `deeplink.*`).
 - `assistant/sse-service.ts` for SSE-derived signals (`sse.*`).
 - `use-event-stream.ts`'s burst-limited reachability retry for `reachability.retry-requested`.
+- `hooks/use-notification-tap-navigation.ts` and `runtime/push-registration.ts` for notification-tap `deeplink.openThread`.
 
 | Event | Payload | Produced when |
 |---|---|---|
@@ -73,9 +74,9 @@ Every event name in `BusEventMap` has a typed payload. Producers:
 | `power.lock` | `{}` | Electron host: screen locked. No bus-owned action today. Off Electron never fires. |
 | `power.unlock` | `{}` | Electron host: screen unlocked. Bus bounces its SSE (same shape as `power.resume`). Off Electron never fires. |
 | `power.active` | `{}` | Electron host: `user-did-become-active` after idle. No bus-owned action today; future ticket may nudge stale state. Off Electron never fires. |
-| `deeplink.send` | `{ message }` | Electron host: inbound `vellum://send?message=…` URL routed by Launch Services. Chat domain consumes to pre-fill the composer. |
-| `deeplink.openThread` | `{ threadId }` | Electron host: inbound `vellum://thread/<id>` URL. Chat domain consumes to navigate. |
-| `deeplink.unknown` | `{ url }` | Parser fallback for foreign schemes / malformed URLs. Consumers typically log + drop; exists so the bridge surface is exhaustive. |
+| `deeplink.send` | `{ message }` | Electron host only: inbound `vellum://send?message=…` URL routed by Launch Services. Chat domain consumes to pre-fill the composer. |
+| `deeplink.openThread` | `{ threadId }` | Electron host: inbound `vellum://thread/<id>` URL. Also published by the notification-tap handler (`hooks/use-notification-tap-navigation.ts`) on every platform — Capacitor local notifications, Electron notification actions, browser `Notification.onclick` — and by APNs remote-push taps on Capacitor iOS (`runtime/push-registration.ts`). Chat domain consumes to navigate. |
+| `deeplink.unknown` | `{ url }` | Parser fallback for foreign schemes / malformed URLs — from the Electron deep-link path and from Capacitor iOS `App.appUrlOpen` URLs no handler claims (`runtime/event-sources/capacitor-deep-links.ts`). Consumers typically log + drop; exists so the bridge surface is exhaustive. |
 
 ## Subscribing
 
@@ -110,8 +111,11 @@ const unsubscribeResume = subscribe("app.resume", () => {
 
 Publishing is reserved for the bus's owner files (`sseService`,
 `runtime/event-sources/*`) and the narrow surfaces that need to ask
-the bus to do something — today only `reachability.retry-requested`.
-Don't add new producers without a documented reason.
+the bus to do something — today `reachability.retry-requested` and
+the notification-tap `deeplink.openThread` publishers
+(`hooks/use-notification-tap-navigation.ts`,
+`runtime/push-registration.ts`). Don't add new producers without a
+documented reason.
 
 ```ts
 import { publish } from "@/lib/event-bus";

--- a/clients/web/src/hooks/use-event-bus-init.ts
+++ b/clients/web/src/hooks/use-event-bus-init.ts
@@ -5,8 +5,9 @@
  *
  * 1. **Signal sources.** Wires each `runtime/event-sources/*` helper
  *    once at mount so DOM visibility, network online/offline,
- *    Capacitor app state, Electron `powerMonitor`, and Electron
- *    deep-link events flow into the bus. The lifecycle diagnostics
+ *    Capacitor app state, Capacitor deep links, Electron
+ *    `powerMonitor`, and Electron deep-link events flow into the bus.
+ *    The lifecycle diagnostics
  *    recorder is attached in the same effect so those signals are
  *    captured for support bundles.
  *
@@ -27,6 +28,7 @@ import { sseService } from "@/assistant/sse-service";
 import { subscribeLifecycleDiagnostics } from "@/lib/lifecycle-diagnostics";
 import { setupQueryFocusManager } from "@/lib/query-focus-manager";
 import { publishCapacitorAppStateSource } from "@/runtime/event-sources/capacitor-app-state";
+import { publishCapacitorDeepLinksSource } from "@/runtime/event-sources/capacitor-deep-links";
 import { publishVisibilitySource } from "@/runtime/event-sources/dom-visibility";
 import { publishElectronConnectivitySource } from "@/runtime/event-sources/electron-connectivity";
 import { publishElectronDeepLinksSource } from "@/runtime/event-sources/electron-deep-links";
@@ -57,6 +59,7 @@ export function useEventBusInit({
       publishVisibilitySource(),
       publishWindowOnlineSource(),
       publishCapacitorAppStateSource(),
+      publishCapacitorDeepLinksSource(),
       publishElectronPowerSource(),
       publishElectronDeepLinksSource(),
       publishElectronConnectivitySource(),

--- a/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, renderHook, act } from "@testing-library/react";
 
+import { useSubagentStore } from "@/domains/chat/subagent-store";
+import { useWorkflowStore } from "@/domains/chat/workflow-store";
 import { __resetForTesting, publish } from "@/lib/event-bus";
+import { useConversationStore } from "@/stores/conversation-store";
 import {
   __resetPendingDeepLinkForTesting,
   usePendingDeepLinkStore,
@@ -30,20 +33,27 @@ mock.module("@sentry/react", () => ({
 const { useGlobalDeepLinkConsumer } =
   await import("./use-global-deep-link-consumer");
 
+const resetStores = () => {
+  useViewerStore.setState({ mainView: "chat" });
+  useSubagentStore.getState().reset();
+  useWorkflowStore.getState().reset();
+  useConversationStore.getState().reset();
+};
+
 beforeEach(() => {
   __resetForTesting();
   __resetPendingDeepLinkForTesting();
   navigateMock.mockClear();
   ensureMainWindowVisibleMock.mockClear();
   sentryBreadcrumbMock.mockClear();
-  useViewerStore.setState({ mainView: "chat" });
+  resetStores();
 });
 
 afterEach(() => {
   cleanup();
   __resetForTesting();
   __resetPendingDeepLinkForTesting();
-  useViewerStore.setState({ mainView: "chat" });
+  resetStores();
 });
 
 describe("deeplink.send", () => {
@@ -87,6 +97,23 @@ describe("deeplink.openThread", () => {
     expect(useViewerStore.getState().mainView).toBe("chat");
     expect(navigateMock).toHaveBeenCalledWith(
       "/assistant/conversations/abc-123",
+    );
+  });
+
+  test("runs the full conversation-switch path — subagent/workflow resets + active id sync", () => {
+    useSubagentStore.setState({ orderedIds: ["sub-1"] });
+    useWorkflowStore.setState({ orderedIds: ["wf-1"] });
+    useConversationStore.setState({ activeConversationId: "old-conversation" });
+    renderHook(() => useGlobalDeepLinkConsumer());
+
+    act(() => {
+      publish("deeplink.openThread", { threadId: "abc-123" });
+    });
+
+    expect(useSubagentStore.getState().orderedIds).toEqual([]);
+    expect(useWorkflowStore.getState().orderedIds).toEqual([]);
+    expect(useConversationStore.getState().activeConversationId).toBe(
+      "abc-123",
     );
   });
 });

--- a/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
@@ -116,6 +116,27 @@ describe("deeplink.openThread", () => {
       "abc-123",
     );
   });
+
+  test("same-thread tap keeps live subagent/workflow state — the id doesn't change, so re-seed effects wouldn't re-run", () => {
+    useSubagentStore.setState({ orderedIds: ["sub-1"] });
+    useWorkflowStore.setState({ orderedIds: ["wf-1"] });
+    useConversationStore.setState({ activeConversationId: "abc-123" });
+    useViewerStore.setState({ mainView: "app" });
+    renderHook(() => useGlobalDeepLinkConsumer());
+
+    act(() => {
+      publish("deeplink.openThread", { threadId: "abc-123" });
+    });
+
+    expect(useSubagentStore.getState().orderedIds).toEqual(["sub-1"]);
+    expect(useWorkflowStore.getState().orderedIds).toEqual(["wf-1"]);
+    // Viewer reset + URL sync + window activation still apply.
+    expect(useViewerStore.getState().mainView).toBe("chat");
+    expect(navigateMock).toHaveBeenCalledWith(
+      "/assistant/conversations/abc-123",
+    );
+    expect(ensureMainWindowVisibleMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("deeplink.unknown", () => {

--- a/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
@@ -1,14 +1,12 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, renderHook, act } from "@testing-library/react";
 
-import {
-  __resetForTesting,
-  publish,
-} from "@/lib/event-bus";
+import { __resetForTesting, publish } from "@/lib/event-bus";
 import {
   __resetPendingDeepLinkForTesting,
   usePendingDeepLinkStore,
 } from "@/stores/pending-deep-link-store";
+import { useViewerStore } from "@/stores/viewer-store";
 
 const navigateMock = mock((_to: string) => undefined);
 mock.module("react-router", () => ({
@@ -29,9 +27,8 @@ mock.module("@sentry/react", () => ({
   captureException: () => {},
 }));
 
-const { useGlobalDeepLinkConsumer } = await import(
-  "./use-global-deep-link-consumer"
-);
+const { useGlobalDeepLinkConsumer } =
+  await import("./use-global-deep-link-consumer");
 
 beforeEach(() => {
   __resetForTesting();
@@ -39,12 +36,14 @@ beforeEach(() => {
   navigateMock.mockClear();
   ensureMainWindowVisibleMock.mockClear();
   sentryBreadcrumbMock.mockClear();
+  useViewerStore.setState({ mainView: "chat" });
 });
 
 afterEach(() => {
   cleanup();
   __resetForTesting();
   __resetPendingDeepLinkForTesting();
+  useViewerStore.setState({ mainView: "chat" });
 });
 
 describe("deeplink.send", () => {
@@ -75,6 +74,20 @@ describe("deeplink.openThread", () => {
       "/assistant/conversations/abc-123",
     );
     expect(ensureMainWindowVisibleMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("resets the main view to chat so the thread isn't hidden behind the app viewer", () => {
+    useViewerStore.setState({ mainView: "app" });
+    renderHook(() => useGlobalDeepLinkConsumer());
+
+    act(() => {
+      publish("deeplink.openThread", { threadId: "abc-123" });
+    });
+
+    expect(useViewerStore.getState().mainView).toBe("chat");
+    expect(navigateMock).toHaveBeenCalledWith(
+      "/assistant/conversations/abc-123",
+    );
   });
 });
 

--- a/clients/web/src/hooks/use-global-deep-link-consumer.ts
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.ts
@@ -19,12 +19,7 @@ import { routes } from "@/utils/routes";
  * Responsibilities:
  *
  * - `deeplink.openThread` → `ensureMainWindowVisible()` +
- *   `navigateToConversation()` — the same shared path as an in-app
- *   conversation switch (viewer reset, subagent/workflow store resets,
- *   active-conversation sync, navigation). If the thread is already the
- *   active conversation, the subagent/workflow resets are skipped — the
- *   id doesn't change, so the re-seed effects wouldn't re-run and live
- *   cards would vanish — but the viewer reset and URL sync still apply.
+ *   `navigateToConversation()`
  * - `deeplink.send` → `ensureMainWindowVisible()` + navigate to
  *   `/assistant` + park the message in `usePendingDeepLinkStore`
  *   for `ChatPage`'s composer-domain hook to consume on mount.
@@ -51,6 +46,7 @@ export function useGlobalDeepLinkConsumer(): void {
 
   useBusSubscription("deeplink.openThread", ({ threadId }) => {
     void ensureMainWindowVisible();
+    // Same thread: skip store resets — the id doesn't change, so re-seed effects wouldn't re-run and live cards would vanish.
     if (threadId === useConversationStore.getState().activeConversationId) {
       useViewerStore.getState().setMainView("chat");
       navigateRef.current(routes.conversation(threadId));

--- a/clients/web/src/hooks/use-global-deep-link-consumer.ts
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.ts
@@ -5,7 +5,7 @@ import { useNavigate } from "react-router";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { ensureMainWindowVisible } from "@/runtime/main-window";
 import { usePendingDeepLinkStore } from "@/stores/pending-deep-link-store";
-import { useViewerStore } from "@/stores/viewer-store";
+import { navigateToConversation } from "@/utils/conversation-navigation";
 import { routes } from "@/utils/routes";
 
 /**
@@ -16,17 +16,19 @@ import { routes } from "@/utils/routes";
  *
  * Responsibilities:
  *
- * - `deeplink.openThread` → `ensureMainWindowVisible()` + reset the
- *   viewer to chat (dismisses a full-width app viewer) +
- *   `navigate(routes.conversation(threadId))`.
+ * - `deeplink.openThread` → `ensureMainWindowVisible()` +
+ *   `navigateToConversation()` — the same shared path as an in-app
+ *   conversation switch (viewer reset, subagent/workflow store resets,
+ *   active-conversation sync, navigation).
  * - `deeplink.send` → `ensureMainWindowVisible()` + navigate to
  *   `/assistant` + park the message in `usePendingDeepLinkStore`
  *   for `ChatPage`'s composer-domain hook to consume on mount.
  * - `deeplink.unknown` → Sentry breadcrumb.
  *
  * The composer pre-fill itself stays in the chat domain
- * (`useDeepLinkConsumer`) because it owns `setInput`. This hook is
- * intentionally generic — it doesn't import chat-specific state.
+ * (`useDeepLinkConsumer`) because it owns `setInput`. This hook stays
+ * generic — chat-specific store handling lives in the shared
+ * `navigateToConversation` util.
  */
 
 export function useGlobalDeepLinkConsumer(): void {
@@ -44,10 +46,7 @@ export function useGlobalDeepLinkConsumer(): void {
 
   useBusSubscription("deeplink.openThread", ({ threadId }) => {
     void ensureMainWindowVisible();
-    // Mirror the normal conversation-switch path: dismiss the full-width
-    // app viewer so the navigated-to thread is actually visible.
-    useViewerStore.getState().setMainView("chat");
-    navigateRef.current(routes.conversation(threadId));
+    navigateToConversation(navigateRef.current, threadId);
   });
 
   useBusSubscription("deeplink.unknown", ({ url }) => {

--- a/clients/web/src/hooks/use-global-deep-link-consumer.ts
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.ts
@@ -4,7 +4,9 @@ import { useNavigate } from "react-router";
 
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { ensureMainWindowVisible } from "@/runtime/main-window";
+import { useConversationStore } from "@/stores/conversation-store";
 import { usePendingDeepLinkStore } from "@/stores/pending-deep-link-store";
+import { useViewerStore } from "@/stores/viewer-store";
 import { navigateToConversation } from "@/utils/conversation-navigation";
 import { routes } from "@/utils/routes";
 
@@ -19,7 +21,10 @@ import { routes } from "@/utils/routes";
  * - `deeplink.openThread` → `ensureMainWindowVisible()` +
  *   `navigateToConversation()` — the same shared path as an in-app
  *   conversation switch (viewer reset, subagent/workflow store resets,
- *   active-conversation sync, navigation).
+ *   active-conversation sync, navigation). If the thread is already the
+ *   active conversation, the subagent/workflow resets are skipped — the
+ *   id doesn't change, so the re-seed effects wouldn't re-run and live
+ *   cards would vanish — but the viewer reset and URL sync still apply.
  * - `deeplink.send` → `ensureMainWindowVisible()` + navigate to
  *   `/assistant` + park the message in `usePendingDeepLinkStore`
  *   for `ChatPage`'s composer-domain hook to consume on mount.
@@ -46,6 +51,11 @@ export function useGlobalDeepLinkConsumer(): void {
 
   useBusSubscription("deeplink.openThread", ({ threadId }) => {
     void ensureMainWindowVisible();
+    if (threadId === useConversationStore.getState().activeConversationId) {
+      useViewerStore.getState().setMainView("chat");
+      navigateRef.current(routes.conversation(threadId));
+      return;
+    }
     navigateToConversation(navigateRef.current, threadId);
   });
 

--- a/clients/web/src/hooks/use-global-deep-link-consumer.ts
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.ts
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { ensureMainWindowVisible } from "@/runtime/main-window";
 import { usePendingDeepLinkStore } from "@/stores/pending-deep-link-store";
+import { useViewerStore } from "@/stores/viewer-store";
 import { routes } from "@/utils/routes";
 
 /**
@@ -15,7 +16,8 @@ import { routes } from "@/utils/routes";
  *
  * Responsibilities:
  *
- * - `deeplink.openThread` → `ensureMainWindowVisible()` +
+ * - `deeplink.openThread` → `ensureMainWindowVisible()` + reset the
+ *   viewer to chat (dismisses a full-width app viewer) +
  *   `navigate(routes.conversation(threadId))`.
  * - `deeplink.send` → `ensureMainWindowVisible()` + navigate to
  *   `/assistant` + park the message in `usePendingDeepLinkStore`
@@ -42,6 +44,9 @@ export function useGlobalDeepLinkConsumer(): void {
 
   useBusSubscription("deeplink.openThread", ({ threadId }) => {
     void ensureMainWindowVisible();
+    // Mirror the normal conversation-switch path: dismiss the full-width
+    // app viewer so the navigated-to thread is actually visible.
+    useViewerStore.getState().setMainView("chat");
     navigateRef.current(routes.conversation(threadId));
   });
 

--- a/clients/web/src/hooks/use-notification-tap-navigation.test.tsx
+++ b/clients/web/src/hooks/use-notification-tap-navigation.test.tsx
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook, act } from "@testing-library/react";
+
+import { __resetForTesting, subscribe } from "@/lib/event-bus";
+import type { NotificationTapPayload } from "@/runtime/notifications";
+
+let capturedHandler: ((payload: NotificationTapPayload) => void) | null = null;
+const setNotificationTapHandlerMock = mock(
+  (handler: (payload: NotificationTapPayload) => void) => {
+    capturedHandler = handler;
+  },
+);
+mock.module("@/runtime/notifications", () => ({
+  setNotificationTapHandler: setNotificationTapHandlerMock,
+}));
+
+const sentryBreadcrumbMock = mock((_args: unknown) => undefined);
+// Full Sentry surface — `mock.module` is process-global in bun, so a
+// partial mock would shadow `captureException` (used by `runtime/event-sources/*`
+// and `sse-service`) for every later test file in the run.
+mock.module("@sentry/react", () => ({
+  addBreadcrumb: sentryBreadcrumbMock,
+  captureException: () => {},
+}));
+
+const { useNotificationTapNavigation } =
+  await import("./use-notification-tap-navigation");
+
+beforeEach(() => {
+  __resetForTesting();
+  capturedHandler = null;
+  setNotificationTapHandlerMock.mockClear();
+  sentryBreadcrumbMock.mockClear();
+  window.history.pushState(null, "", "/");
+});
+
+afterEach(() => {
+  cleanup();
+  __resetForTesting();
+  window.history.pushState(null, "", "/");
+});
+
+describe("useNotificationTapNavigation", () => {
+  test("mounting registers a tap handler", () => {
+    renderHook(() => useNotificationTapNavigation());
+
+    expect(setNotificationTapHandlerMock).toHaveBeenCalledTimes(1);
+    expect(capturedHandler).not.toBeNull();
+  });
+
+  test("a pop-out window registers no tap handler", () => {
+    window.history.pushState(null, "", "/?popout=1");
+
+    renderHook(() => useNotificationTapNavigation());
+
+    expect(setNotificationTapHandlerMock).not.toHaveBeenCalled();
+    expect(capturedHandler).toBeNull();
+  });
+
+  test("a tap with a conversationId publishes deeplink.openThread", () => {
+    renderHook(() => useNotificationTapNavigation());
+
+    const received: Array<{ threadId: string }> = [];
+    subscribe("deeplink.openThread", (payload) => {
+      received.push(payload);
+    });
+
+    act(() => {
+      capturedHandler?.({ conversationId: "abc", sourceEventName: "x" });
+    });
+
+    expect(received).toEqual([{ threadId: "abc" }]);
+    expect(sentryBreadcrumbMock).not.toHaveBeenCalled();
+  });
+
+  test("a tap without a conversationId publishes nothing", () => {
+    renderHook(() => useNotificationTapNavigation());
+
+    const received: Array<{ threadId: string }> = [];
+    subscribe("deeplink.openThread", (payload) => {
+      received.push(payload);
+    });
+
+    act(() => {
+      capturedHandler?.({ sourceEventName: "x" });
+    });
+
+    expect(received).toEqual([]);
+    expect(sentryBreadcrumbMock).toHaveBeenCalledTimes(1);
+    const args = sentryBreadcrumbMock.mock.calls[0]?.[0] as {
+      category?: string;
+      message?: string;
+      data?: { sourceEventName?: string };
+    };
+    expect(args.category).toBe("notification");
+    expect(args.message).toBe("tap_without_conversation");
+    expect(args.data?.sourceEventName).toBe("x");
+  });
+});

--- a/clients/web/src/hooks/use-notification-tap-navigation.ts
+++ b/clients/web/src/hooks/use-notification-tap-navigation.ts
@@ -1,0 +1,46 @@
+import { useEffect } from "react";
+import * as Sentry from "@sentry/react";
+
+import { publish } from "@/lib/event-bus";
+import { setNotificationTapHandler } from "@/runtime/notifications";
+
+/**
+ * Routes notification taps to the originating conversation. Mounted at
+ * `RootLayout` so a tap arriving on any authenticated route navigates.
+ *
+ * The handler publishes `deeplink.openThread` on the event bus rather
+ * than navigating directly — `useGlobalDeepLinkConsumer` (also mounted
+ * at `RootLayout`) turns that into `ensureMainWindowVisible()` +
+ * `navigate(routes.conversation(threadId))`, so notification taps get
+ * identical behavior to `vellum://thread/...` deep links. One wiring
+ * covers all three tap paths in `runtime/notifications.ts`: Capacitor
+ * `localNotificationActionPerformed`, Electron notification actions,
+ * and browser `Notification.onclick`.
+ *
+ * No effect cleanup: `setNotificationTapHandler` swaps the handler
+ * reference in place and registers the platform listeners only once
+ * for the app's lifetime, so there is nothing to tear down.
+ */
+export function useNotificationTapNavigation(): void {
+  useEffect(() => {
+    // Electron pop-out windows (`?popout=1`) mount `RootLayout` too, and
+    // the macOS notification bridge broadcasts each action to every
+    // BrowserWindow. Only the main window may handle taps — a pop-out
+    // navigating would replace the conversation it exists to keep open.
+    if (window.location.search.includes("popout=1")) {
+      return;
+    }
+    setNotificationTapHandler((payload) => {
+      if (payload.conversationId) {
+        publish("deeplink.openThread", { threadId: payload.conversationId });
+        return;
+      }
+      Sentry.addBreadcrumb({
+        category: "notification",
+        level: "info",
+        message: "tap_without_conversation",
+        data: { sourceEventName: payload.sourceEventName },
+      });
+    });
+  }, []);
+}

--- a/clients/web/src/hooks/use-notification-tap-navigation.ts
+++ b/clients/web/src/hooks/use-notification-tap-navigation.ts
@@ -8,14 +8,9 @@ import { setNotificationTapHandler } from "@/runtime/notifications";
  * Routes notification taps to the originating conversation. Mounted at
  * `RootLayout` so a tap arriving on any authenticated route navigates.
  *
- * The handler publishes `deeplink.openThread` on the event bus rather
- * than navigating directly — `useGlobalDeepLinkConsumer` (also mounted
- * at `RootLayout`) turns that into `ensureMainWindowVisible()` +
- * `navigate(routes.conversation(threadId))`, so notification taps get
- * identical behavior to `vellum://thread/...` deep links. One wiring
- * covers all three tap paths in `runtime/notifications.ts`: Capacitor
- * `localNotificationActionPerformed`, Electron notification actions,
- * and browser `Notification.onclick`.
+ * Publishes `deeplink.openThread` rather than navigating directly so
+ * taps share the `vellum://thread/...` deep-link path; one wiring
+ * covers all three tap paths in `runtime/notifications.ts`.
  *
  * No effect cleanup: `setNotificationTapHandler` swaps the handler
  * reference in place and registers the platform listeners only once

--- a/clients/web/src/lib/event-bus.ts
+++ b/clients/web/src/lib/event-bus.ts
@@ -133,25 +133,11 @@ export interface BusEventMap {
    * conversation. Domain consumers (chat composer, conversation
    * router) subscribe here to take action.
    *
-   * Publishers per event:
-   *   - `deeplink.send`: Electron host only —
-   *     `vellum://send?message=…` URLs parsed into discriminated
-   *     payloads in `clients/macos/src/main/deep-links.ts` and
-   *     re-published by
-   *     `runtime/event-sources/electron-deep-links.ts`.
-   *   - `deeplink.openThread`: Electron `vellum://thread/<id>` URLs
-   *     (same path as above); notification taps carrying a
-   *     conversation id on every platform via
-   *     `hooks/use-notification-tap-navigation.ts` (Capacitor local
-   *     notifications, Electron notification actions, browser
-   *     `Notification.onclick`); and APNs remote-push taps on
-   *     Capacitor iOS via `runtime/push-registration.ts`.
-   *   - `deeplink.unknown`: parser fallbacks — foreign schemes,
-   *     malformed URLs, unrecognized hosts — from the Electron path
-   *     and from Capacitor iOS `App.appUrlOpen` URLs no handler
-   *     claims (`runtime/event-sources/capacitor-deep-links.ts`).
-   *     Consumers typically log and drop these; useful as a
-   *     no-action signal so the bridge surface is exhaustive.
+   * Publishers: Electron deep links, the notification tap handler,
+   * push-registration, and Capacitor `appUrlOpen` — see
+   * docs/EVENT_BUS.md for the per-event table. `deeplink.unknown` is a
+   * no-action signal (consumers log and drop it) so the bridge surface
+   * stays exhaustive.
    */
   "deeplink.send": { message: string };
   "deeplink.openThread": { threadId: string };

--- a/clients/web/src/lib/event-bus.ts
+++ b/clients/web/src/lib/event-bus.ts
@@ -16,6 +16,9 @@
  *   - `assistant/sse-service.ts` for SSE-derived signals
  *   - `domains/chat/hooks/use-event-stream.ts` for
  *     `reachability.retry-requested`
+ *   - `hooks/use-notification-tap-navigation.ts` and
+ *     `runtime/push-registration.ts` for notification-tap
+ *     `deeplink.openThread`
  *
  * Consumers: `useBusSubscription` (React) or `subscribe` directly
  * (non-React).
@@ -125,18 +128,30 @@ export interface BusEventMap {
   "power.unlock": Record<string, never>;
   "power.active": Record<string, never>;
   /**
-   * Inbound deep links from the Electron host — `vellum://` and
-   * `vellum-assistant://` URL schemes the OS routed to us. Parsed
-   * into discriminated payloads in `clients/macos/src/main/deep-links.ts`.
-   * Domain consumers (chat composer, conversation router) subscribe
-   * here to take action.
+   * Inbound deep links — `vellum://` / `vellum-assistant://` URLs
+   * the OS routed to us, plus notification taps that resolve to a
+   * conversation. Domain consumers (chat composer, conversation
+   * router) subscribe here to take action.
    *
-   * `deeplink.unknown` covers parser fallbacks — foreign schemes,
-   * malformed URLs, unrecognized hosts. Consumers typically log
-   * and drop these; useful as a no-action signal so the bridge
-   * surface is exhaustive.
-   *
-   * Off Electron these never fire.
+   * Publishers per event:
+   *   - `deeplink.send`: Electron host only —
+   *     `vellum://send?message=…` URLs parsed into discriminated
+   *     payloads in `clients/macos/src/main/deep-links.ts` and
+   *     re-published by
+   *     `runtime/event-sources/electron-deep-links.ts`.
+   *   - `deeplink.openThread`: Electron `vellum://thread/<id>` URLs
+   *     (same path as above); notification taps carrying a
+   *     conversation id on every platform via
+   *     `hooks/use-notification-tap-navigation.ts` (Capacitor local
+   *     notifications, Electron notification actions, browser
+   *     `Notification.onclick`); and APNs remote-push taps on
+   *     Capacitor iOS via `runtime/push-registration.ts`.
+   *   - `deeplink.unknown`: parser fallbacks — foreign schemes,
+   *     malformed URLs, unrecognized hosts — from the Electron path
+   *     and from Capacitor iOS `App.appUrlOpen` URLs no handler
+   *     claims (`runtime/event-sources/capacitor-deep-links.ts`).
+   *     Consumers typically log and drop these; useful as a
+   *     no-action signal so the bridge surface is exhaustive.
    */
   "deeplink.send": { message: string };
   "deeplink.openThread": { threadId: string };

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -28,6 +28,7 @@ import { useAssistantResourceSync } from "@/hooks/use-assistant-resource-sync";
 import { useDocumentEditorSync } from "@/hooks/use-document-editor-sync";
 import { useBookmarksSync } from "@/hooks/use-bookmarks-sync";
 import { useNotificationIntentSync } from "@/hooks/use-notification-intent-sync";
+import { useNotificationTapNavigation } from "@/hooks/use-notification-tap-navigation";
 import { usePushRegistration } from "@/hooks/use-push-registration";
 import { useSoundEffects } from "@/hooks/use-sound-effects";
 import { useOnboardingWindowSize } from "@/hooks/use-onboarding-window-size";
@@ -138,6 +139,7 @@ export function RootLayout() {
   useFeatureFlagBusSync(assistantId, isAssistantActive);
   useNotificationIntentSync(assistantId);
   usePushRegistration(assistantId);
+  useNotificationTapNavigation();
   useSoundEffects(assistantId, isAssistantActive);
   useDocumentEditorSync();
   useBookmarksSync();
@@ -304,7 +306,8 @@ export function RootLayout() {
           keyboardOpen && visibleViewport
             ? `${visibleViewport.height + keyboardOffsetTop}px`
             : "100dvh",
-        paddingTop: keyboardOffsetTop > 0 ? `${keyboardOffsetTop}px` : undefined,
+        paddingTop:
+          keyboardOffsetTop > 0 ? `${keyboardOffsetTop}px` : undefined,
         paddingBottom: keyboardOpen
           ? "0px"
           : "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))",
@@ -321,7 +324,10 @@ export function RootLayout() {
       {!electron && !isPopout && !suppressStatusBanner ? (
         <StatusBanner placement="web" reserveTopSafeArea />
       ) : null}
-      <div className="flex min-w-0 flex-col overflow-hidden w-full" style={{ flex: "1 1 0%", minHeight: 0 }}>
+      <div
+        className="flex min-w-0 flex-col overflow-hidden w-full"
+        style={{ flex: "1 1 0%", minHeight: 0 }}
+      >
         <Outlet />
       </div>
 

--- a/clients/web/src/runtime/browser.ts
+++ b/clients/web/src/runtime/browser.ts
@@ -1,5 +1,6 @@
 import { Capacitor } from "@capacitor/core";
 
+import { subscribeCapacitorListener } from "@/runtime/capacitor-listener";
 import { isElectron } from "@/runtime/is-electron";
 
 /**
@@ -42,20 +43,8 @@ export const openUrl = async (url: string): Promise<void> => {
  * Usage:
  *   useEffect(() => openUrlFinishedListener(() => { refetch(); onClose(); }), []);
  */
-export const openUrlFinishedListener = (
-  callback: () => void,
-): (() => void) => {
-  if (!Capacitor.isNativePlatform()) return () => {};
-
-  let handle: { remove: () => void } | null = null;
-
-  void import("@capacitor/browser").then(({ Browser }) => {
-    void Browser.addListener("browserFinished", callback).then((h) => {
-      handle = h;
-    });
+export const openUrlFinishedListener = (callback: () => void): (() => void) =>
+  subscribeCapacitorListener("capacitor_browser_finished", async () => {
+    const { Browser } = await import("@capacitor/browser");
+    return Browser.addListener("browserFinished", callback);
   });
-
-  return () => {
-    handle?.remove();
-  };
-};

--- a/clients/web/src/runtime/capacitor-listener.test.ts
+++ b/clients/web/src/runtime/capacitor-listener.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { PluginListenerHandle } from "@capacitor/core";
+
+let isNative = true;
+const isNativePlatformMock = mock(() => isNative);
+mock.module("@/runtime/native-auth", () => ({
+  isNativePlatform: isNativePlatformMock,
+}));
+
+const captureErrorMock = mock(() => {});
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: captureErrorMock,
+}));
+
+const { subscribeCapacitorListener } =
+  await import("@/runtime/capacitor-listener");
+
+const handleRemoveMock = mock(async () => {});
+let subscribeResolver: ((handle: PluginListenerHandle) => void) | null = null;
+let subscribeRejecter: ((err: Error) => void) | null = null;
+
+const subscribeMock = mock(
+  () =>
+    new Promise<PluginListenerHandle>((resolve, reject) => {
+      subscribeResolver = resolve;
+      subscribeRejecter = reject;
+    }),
+);
+
+const flushMicrotasks = async (rounds = 4) => {
+  for (let i = 0; i < rounds; i++) {
+    await Promise.resolve();
+  }
+};
+
+beforeEach(() => {
+  isNative = true;
+  subscribeResolver = null;
+  subscribeRejecter = null;
+  isNativePlatformMock.mockClear();
+  subscribeMock.mockClear();
+  handleRemoveMock.mockClear();
+  captureErrorMock.mockClear();
+});
+
+describe("subscribeCapacitorListener", () => {
+  test("is a no-op off Capacitor iOS (returns a no-op unsubscribe, never calls subscribe)", () => {
+    isNative = false;
+
+    const unsubscribe = subscribeCapacitorListener("ctx", subscribeMock);
+    unsubscribe();
+
+    expect(subscribeMock).not.toHaveBeenCalled();
+  });
+
+  test("returned unsubscribe removes the listener once subscribe resolves", async () => {
+    const unsubscribe = subscribeCapacitorListener("ctx", subscribeMock);
+
+    subscribeResolver?.({ remove: handleRemoveMock });
+    await flushMicrotasks();
+    expect(handleRemoveMock).not.toHaveBeenCalled();
+
+    unsubscribe();
+    expect(handleRemoveMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("unsubscribe BEFORE subscribe resolves still removes the just-registered listener", async () => {
+    const unsubscribe = subscribeCapacitorListener("ctx", subscribeMock);
+
+    // Unsubscribe first — the internal `cancelled` flag must catch the
+    // late resolution and remove the listener.
+    unsubscribe();
+    subscribeResolver?.({ remove: handleRemoveMock });
+    await flushMicrotasks();
+
+    expect(handleRemoveMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("reports a subscribe failure under the given context instead of throwing", async () => {
+    subscribeCapacitorListener("my_context", subscribeMock);
+
+    const err = new Error("plugin missing");
+    subscribeRejecter?.(err);
+    await flushMicrotasks();
+
+    expect(captureErrorMock).toHaveBeenCalledWith(err, {
+      context: "my_context",
+      level: "warning",
+    });
+  });
+});

--- a/clients/web/src/runtime/capacitor-listener.ts
+++ b/clients/web/src/runtime/capacitor-listener.ts
@@ -1,0 +1,60 @@
+import { captureError } from "@/lib/sentry/capture-error";
+import type { PluginListenerHandle } from "@capacitor/core";
+
+import { isNativePlatform } from "@/runtime/native-auth";
+
+/**
+ * Shared subscription scaffold for Capacitor plugin event listeners.
+ * Owns the pieces every native listener source needs:
+ *
+ * - The `isNativePlatform()` guard — off Capacitor iOS this returns a
+ *   no-op unsubscribe without ever invoking `subscribe` (so the plugin
+ *   is never loaded).
+ * - The unsubscribe-before-registration race: `subscribe()` resolves
+ *   asynchronously (lazy plugin import), so an unsubscribe that runs
+ *   first sets the internal `cancelled` flag and the resolution path
+ *   removes the just-registered listener instead of leaking it.
+ * - Failure reporting: a rejected `subscribe()` is captured under
+ *   `errorContext` at warning level instead of surfacing as an
+ *   unhandled rejection.
+ *
+ * `subscribe` must lazy-import the plugin and call `addListener`
+ * inline, per CAPACITOR.md's "lazy-import rule" — the plugin Proxy
+ * must never cross a Promise-resolution context, so it stays inside
+ * the caller's closure and only the listener handle escapes:
+ *
+ * ```ts
+ * subscribeCapacitorListener("my_context", async () => {
+ *   const { App } = await import("@capacitor/app");
+ *   return App.addListener("appStateChange", handler);
+ * });
+ * ```
+ */
+export function subscribeCapacitorListener(
+  errorContext: string,
+  subscribe: () => Promise<PluginListenerHandle>,
+): () => void {
+  if (!isNativePlatform()) {
+    return () => undefined;
+  }
+
+  let handle: PluginListenerHandle | null = null;
+  let cancelled = false;
+
+  subscribe()
+    .then((registered) => {
+      if (cancelled) {
+        void registered.remove();
+        return;
+      }
+      handle = registered;
+    })
+    .catch((err) => {
+      captureError(err, { context: errorContext, level: "warning" });
+    });
+
+  return () => {
+    cancelled = true;
+    void handle?.remove();
+  };
+}

--- a/clients/web/src/runtime/capacitor-listener.ts
+++ b/clients/web/src/runtime/capacitor-listener.ts
@@ -5,18 +5,11 @@ import { isNativePlatform } from "@/runtime/native-auth";
 
 /**
  * Shared subscription scaffold for Capacitor plugin event listeners.
- * Owns the pieces every native listener source needs:
  *
- * - The `isNativePlatform()` guard — off Capacitor iOS this returns a
- *   no-op unsubscribe without ever invoking `subscribe` (so the plugin
- *   is never loaded).
- * - The unsubscribe-before-registration race: `subscribe()` resolves
- *   asynchronously (lazy plugin import), so an unsubscribe that runs
- *   first sets the internal `cancelled` flag and the resolution path
- *   removes the just-registered listener instead of leaking it.
- * - Failure reporting: a rejected `subscribe()` is captured under
- *   `errorContext` at warning level instead of surfacing as an
- *   unhandled rejection.
+ * Handles the unsubscribe-before-registration race: `subscribe()`
+ * resolves asynchronously (lazy plugin import), so an unsubscribe that
+ * runs first sets the internal `cancelled` flag and the resolution path
+ * removes the just-registered listener instead of leaking it.
  *
  * `subscribe` must lazy-import the plugin and call `addListener`
  * inline, per CAPACITOR.md's "lazy-import rule" — the plugin Proxy

--- a/clients/web/src/runtime/event-sources/capacitor-app-state.test.ts
+++ b/clients/web/src/runtime/event-sources/capacitor-app-state.test.ts
@@ -3,29 +3,15 @@ import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 type AppStatePayload = { isActive: boolean };
 type AppStateHandler = (payload: AppStatePayload) => void;
 
-let isNative = true;
-const isNativePlatformMock = mock(() => isNative);
 mock.module("@/runtime/native-auth", () => ({
-  isNativePlatform: isNativePlatformMock,
+  isNativePlatform: () => true,
 }));
 
 let activeHandler: AppStateHandler | null = null;
-const handleRemoveMock = mock(async () => {});
-let addListenerResolver: ((value: { remove: typeof handleRemoveMock }) => void) | null = null;
-let addListenerRejecter: ((err: Error) => void) | null = null;
-let pendingAddListenerPromise: Promise<{ remove: typeof handleRemoveMock }> | null =
-  null;
-
 const addListenerMock = mock(
   (_event: "appStateChange", handler: AppStateHandler) => {
     activeHandler = handler;
-    pendingAddListenerPromise = new Promise<{ remove: typeof handleRemoveMock }>(
-      (resolve, reject) => {
-        addListenerResolver = resolve;
-        addListenerRejecter = reject;
-      },
-    );
-    return pendingAddListenerPromise;
+    return Promise.resolve({ remove: async () => {} });
   },
 );
 
@@ -35,72 +21,47 @@ mock.module("@capacitor/app", () => ({
   },
 }));
 
-const captureExceptionMock = mock(() => {});
-// Full Sentry surface — `mock.module` is process-global in bun, so a
-// partial shape would shadow `addBreadcrumb` (used by other modules
-// transitively loaded in this run) for every later test file. Both
-// methods are kept here so the mock can satisfy any consumer that
-// happens to load Sentry through our module under test.
-mock.module("@sentry/browser", () => ({
-  captureException: captureExceptionMock,
-  addBreadcrumb: () => {},
-  setContext: () => {},
-}));
-mock.module("@sentry/react", () => ({
-  captureException: captureExceptionMock,
-  addBreadcrumb: () => {},
-  setContext: () => {},
+// Warm the module cache so the source's lazy `import("@capacitor/app")`
+// resolves within microtasks instead of a full loader turn.
+await import("@capacitor/app");
+
+const captureErrorMock = mock(() => {});
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: captureErrorMock,
 }));
 
 import * as eventBus from "@/lib/event-bus";
 
 const publishSpy = spyOn(eventBus, "publish");
 
-const { publishCapacitorAppStateSource } = await import(
-  "@/runtime/event-sources/capacitor-app-state"
-);
+const { publishCapacitorAppStateSource } =
+  await import("@/runtime/event-sources/capacitor-app-state");
 
+// The dynamic `import("@capacitor/app")` and its `.then` chain each
+// queue a microtask, so listener registration lags synchronous test
+// code — flush before driving the captured handler.
 const flushMicrotasks = async (rounds = 4) => {
-  for (let i = 0; i < rounds; i++) await Promise.resolve();
-};
-const resolveAddListener = async () => {
-  // The dynamic `import("@capacitor/app")` and its `.then` chain each
-  // queue a microtask, so the source's `addListenerMock` call lags
-  // synchronous test code. Flush before resolving the pending promise,
-  // then flush again so the `.then` that stores the `handle` runs.
-  await flushMicrotasks();
-  addListenerResolver?.({ remove: handleRemoveMock });
-  await flushMicrotasks();
+  for (let i = 0; i < rounds; i++) {
+    await Promise.resolve();
+  }
 };
 
 beforeEach(() => {
-  isNative = true;
   activeHandler = null;
-  addListenerResolver = null;
-  addListenerRejecter = null;
-  pendingAddListenerPromise = null;
-  isNativePlatformMock.mockClear();
   addListenerMock.mockClear();
-  handleRemoveMock.mockClear();
-  captureExceptionMock.mockClear();
+  captureErrorMock.mockClear();
   publishSpy.mockClear();
 });
 
+// The platform guard, unsubscribe races, and failure reporting are the
+// `subscribeCapacitorListener` contract, covered by
+// `runtime/capacitor-listener.test.ts`. This suite covers only this
+// source's wiring: what it publishes and its error context.
 describe("publishCapacitorAppStateSource", () => {
-  test("is a no-op off Capacitor iOS (returns a no-op unsubscribe, never imports the plugin)", () => {
-    isNative = false;
-
-    const unsubscribe = publishCapacitorAppStateSource();
-    unsubscribe();
-
-    expect(addListenerMock).not.toHaveBeenCalled();
-    expect(publishSpy).not.toHaveBeenCalled();
-  });
-
   test("publishes app.resume(signal:'app_state') when isActive flips true", async () => {
     publishCapacitorAppStateSource();
+    await flushMicrotasks();
 
-    await resolveAddListener();
     activeHandler!({ isActive: true });
 
     expect(publishSpy).toHaveBeenCalledWith("app.resume", {
@@ -110,8 +71,8 @@ describe("publishCapacitorAppStateSource", () => {
 
   test("publishes app.hidden(signal:'app_state') when isActive flips false", async () => {
     publishCapacitorAppStateSource();
+    await flushMicrotasks();
 
-    await resolveAddListener();
     activeHandler!({ isActive: false });
 
     expect(publishSpy).toHaveBeenCalledWith("app.hidden", {
@@ -119,38 +80,16 @@ describe("publishCapacitorAppStateSource", () => {
     });
   });
 
-  test("returned unsubscribe removes the listener once it resolves", async () => {
-    const unsubscribe = publishCapacitorAppStateSource();
-
-    await resolveAddListener();
-    expect(handleRemoveMock).not.toHaveBeenCalled();
-
-    unsubscribe();
-    expect(handleRemoveMock).toHaveBeenCalledTimes(1);
-  });
-
-  test("unsubscribe BEFORE the lazy import resolves still removes the just-registered listener", async () => {
-    const unsubscribe = publishCapacitorAppStateSource();
-
-    // Unsubscribe is called first — internal `cancelled` flag must
-    // catch the late `.then` and remove the listener.
-    unsubscribe();
-    await resolveAddListener();
-
-    expect(handleRemoveMock).toHaveBeenCalledTimes(1);
-  });
-
-  test("reports a lazy-import failure to Sentry instead of throwing", async () => {
-    publishCapacitorAppStateSource();
-
-    await flushMicrotasks();
+  test("reports listener-registration failures under the 'event_bus_capacitor_init' context", async () => {
     const err = new Error("plugin missing");
-    addListenerRejecter?.(err);
+    addListenerMock.mockImplementationOnce(() => Promise.reject(err));
+
+    publishCapacitorAppStateSource();
     await flushMicrotasks();
 
-    expect(captureExceptionMock).toHaveBeenCalledWith(err, {
+    expect(captureErrorMock).toHaveBeenCalledWith(err, {
+      context: "event_bus_capacitor_init",
       level: "warning",
-      tags: { context: "event_bus_capacitor_init" },
     });
   });
 });

--- a/clients/web/src/runtime/event-sources/capacitor-app-state.ts
+++ b/clients/web/src/runtime/event-sources/capacitor-app-state.ts
@@ -9,10 +9,7 @@ import { subscribeCapacitorListener } from "@/runtime/capacitor-listener";
  * `publishVisibilitySource` / `publishWindowOnlineSource`
  * / `publishElectronPowerSource` instead.
  *
- * `subscribeCapacitorListener` owns the platform guard, the
- * unsubscribe-before-import-resolves race, and failure reporting; the
- * `@capacitor/app` import stays lazy and inline here per CAPACITOR.md's
- * "lazy-import rule".
+ * Lazy inline `@capacitor/app` import per CAPACITOR.md's "lazy-import rule".
  */
 export function publishCapacitorAppStateSource(): () => void {
   return subscribeCapacitorListener("event_bus_capacitor_init", async () => {

--- a/clients/web/src/runtime/event-sources/capacitor-app-state.ts
+++ b/clients/web/src/runtime/event-sources/capacitor-app-state.ts
@@ -1,57 +1,28 @@
-import { captureError } from "@/lib/sentry/capture-error";
-import type { PluginListenerHandle } from "@capacitor/core";
-
 import { publish } from "@/lib/event-bus";
-import { isNativePlatform } from "@/runtime/native-auth";
+import { subscribeCapacitorListener } from "@/runtime/capacitor-listener";
 
 /**
  * Capacitor iOS shell's `App.appStateChange` →
  * `app.resume(signal: "app_state")` on active, `app.hidden(signal:
  * "app_state")` on inactive. Off Capacitor iOS the function is a no-op
- * (`isNativePlatform()` returns false) — web and Electron get their
- * lifecycle signals from `publishVisibilitySource` / `publishWindowOnlineSource`
+ * — web and Electron get their lifecycle signals from
+ * `publishVisibilitySource` / `publishWindowOnlineSource`
  * / `publishElectronPowerSource` instead.
  *
- * The `@capacitor/app` plugin import is lazy (per CAPACITOR.md's
- * "lazy-import rule"): Capacitor plugins are Proxy objects whose
- * `.then` trap hangs an outer `await` indefinitely if the Proxy
- * crosses a Promise-resolution context. The dynamic import inside
- * the helper keeps the Proxy out of any async return.
- *
- * The sync return + internal `cancelled` flag covers the case where
- * the caller unsubscribes before the import resolves: we mark
- * cancelled, the import-resolution path checks it and removes the
- * just-registered listener.
+ * `subscribeCapacitorListener` owns the platform guard, the
+ * unsubscribe-before-import-resolves race, and failure reporting; the
+ * `@capacitor/app` import stays lazy and inline here per CAPACITOR.md's
+ * "lazy-import rule".
  */
 export function publishCapacitorAppStateSource(): () => void {
-  if (!isNativePlatform()) return () => undefined;
-
-  let handle: PluginListenerHandle | null = null;
-  let cancelled = false;
-
-  import("@capacitor/app")
-    .then(({ App }) =>
-      App.addListener("appStateChange", ({ isActive }) => {
-        if (isActive) {
-          publish("app.resume", { signal: "app_state" });
-        } else {
-          publish("app.hidden", { signal: "app_state" });
-        }
-      }),
-    )
-    .then((registered) => {
-      if (cancelled) {
-        void registered.remove();
-        return;
+  return subscribeCapacitorListener("event_bus_capacitor_init", async () => {
+    const { App } = await import("@capacitor/app");
+    return App.addListener("appStateChange", ({ isActive }) => {
+      if (isActive) {
+        publish("app.resume", { signal: "app_state" });
+      } else {
+        publish("app.hidden", { signal: "app_state" });
       }
-      handle = registered;
-    })
-    .catch((err) => {
-      captureError(err, { context: "event_bus_capacitor_init", level: "warning" });
     });
-
-  return () => {
-    cancelled = true;
-    void handle?.remove();
-  };
+  });
 }

--- a/clients/web/src/runtime/event-sources/capacitor-deep-links.test.ts
+++ b/clients/web/src/runtime/event-sources/capacitor-deep-links.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+type AppUrlOpenHandler = (payload: { url: string }) => void;
+
+let isNative = true;
+const isNativePlatformMock = mock(() => isNative);
+mock.module("@/runtime/native-auth", () => ({
+  isNativePlatform: isNativePlatformMock,
+}));
+
+let urlOpenHandler: AppUrlOpenHandler | null = null;
+const handleRemoveMock = mock(async () => {});
+let addListenerResolver:
+  ((value: { remove: typeof handleRemoveMock }) => void) | null = null;
+let addListenerRejecter: ((err: Error) => void) | null = null;
+
+const addListenerMock = mock(
+  (_event: "appUrlOpen", handler: AppUrlOpenHandler) => {
+    urlOpenHandler = handler;
+    return new Promise<{ remove: typeof handleRemoveMock }>(
+      (resolve, reject) => {
+        addListenerResolver = resolve;
+        addListenerRejecter = reject;
+      },
+    );
+  },
+);
+
+mock.module("@capacitor/app", () => ({
+  App: {
+    addListener: addListenerMock,
+  },
+}));
+
+const captureErrorMock = mock(() => {});
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: captureErrorMock,
+}));
+
+import { subscribe } from "@/lib/event-bus";
+import {
+  buildOAuthCompleteDeepLink,
+  OAUTH_COMPLETE_DEEP_LINK_EVENT,
+  type OAuthCompleteDeepLinkPayload,
+} from "@/runtime/native-deep-link";
+
+const { publishCapacitorDeepLinksSource } =
+  await import("@/runtime/event-sources/capacitor-deep-links");
+
+const flushMicrotasks = async (rounds = 4) => {
+  for (let i = 0; i < rounds; i++) await Promise.resolve();
+};
+const resolveAddListener = async () => {
+  // The dynamic `import("@capacitor/app")` and its `.then` chain each
+  // queue a microtask, so the source's `addListenerMock` call lags
+  // synchronous test code. Flush before resolving the pending promise,
+  // then flush again so the `.then` that stores the `handle` runs.
+  await flushMicrotasks();
+  addListenerResolver?.({ remove: handleRemoveMock });
+  await flushMicrotasks();
+};
+
+beforeEach(() => {
+  isNative = true;
+  urlOpenHandler = null;
+  addListenerResolver = null;
+  addListenerRejecter = null;
+  isNativePlatformMock.mockClear();
+  addListenerMock.mockClear();
+  handleRemoveMock.mockClear();
+  captureErrorMock.mockClear();
+});
+
+describe("publishCapacitorDeepLinksSource", () => {
+  test("is a no-op off Capacitor iOS (returns a no-op unsubscribe, never imports the plugin)", () => {
+    isNative = false;
+
+    const unsubscribe = publishCapacitorDeepLinksSource();
+    unsubscribe();
+
+    expect(addListenerMock).not.toHaveBeenCalled();
+  });
+
+  test("dispatches the OAuth-complete window CustomEvent for an oauth-complete deep link", async () => {
+    const received: OAuthCompleteDeepLinkPayload[] = [];
+    const windowListener = (
+      event: CustomEvent<OAuthCompleteDeepLinkPayload>,
+    ) => {
+      received.push(event.detail);
+    };
+    window.addEventListener(OAUTH_COMPLETE_DEEP_LINK_EVENT, windowListener);
+
+    try {
+      const unsubscribe = publishCapacitorDeepLinksSource();
+      await resolveAddListener();
+
+      const payload: OAuthCompleteDeepLinkPayload = {
+        requestId: "req-123",
+        oauthStatus: "success",
+        oauthProvider: "google",
+        oauthCode: "code-abc",
+      };
+      urlOpenHandler!({
+        url: buildOAuthCompleteDeepLink("vellum-assistant", payload),
+      });
+
+      expect(received).toEqual([payload]);
+      unsubscribe();
+    } finally {
+      window.removeEventListener(
+        OAUTH_COMPLETE_DEEP_LINK_EVENT,
+        windowListener,
+      );
+    }
+  });
+
+  test("publishes deeplink.unknown on the bus for a non-OAuth URL", async () => {
+    const received: { url: string }[] = [];
+    const unsubscribeBus = subscribe("deeplink.unknown", (payload) => {
+      received.push(payload);
+    });
+
+    try {
+      const unsubscribe = publishCapacitorDeepLinksSource();
+      await resolveAddListener();
+
+      urlOpenHandler!({ url: "vellum-assistant://some-future-link?x=1" });
+
+      expect(received).toEqual([
+        { url: "vellum-assistant://some-future-link?x=1" },
+      ]);
+      unsubscribe();
+    } finally {
+      unsubscribeBus();
+    }
+  });
+
+  test("returned unsubscribe removes the listener once it resolves", async () => {
+    const unsubscribe = publishCapacitorDeepLinksSource();
+
+    await resolveAddListener();
+    expect(handleRemoveMock).not.toHaveBeenCalled();
+
+    unsubscribe();
+    expect(handleRemoveMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("unsubscribe BEFORE the lazy import resolves still removes the just-registered listener", async () => {
+    const unsubscribe = publishCapacitorDeepLinksSource();
+
+    unsubscribe();
+    await resolveAddListener();
+
+    expect(handleRemoveMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("reports a lazy-import failure instead of throwing", async () => {
+    publishCapacitorDeepLinksSource();
+
+    await flushMicrotasks();
+    const err = new Error("plugin missing");
+    addListenerRejecter?.(err);
+    await flushMicrotasks();
+
+    expect(captureErrorMock).toHaveBeenCalledWith(err, {
+      context: "capacitor_deep_links",
+      level: "warning",
+    });
+  });
+});

--- a/clients/web/src/runtime/event-sources/capacitor-deep-links.test.ts
+++ b/clients/web/src/runtime/event-sources/capacitor-deep-links.test.ts
@@ -2,27 +2,15 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 type AppUrlOpenHandler = (payload: { url: string }) => void;
 
-let isNative = true;
-const isNativePlatformMock = mock(() => isNative);
 mock.module("@/runtime/native-auth", () => ({
-  isNativePlatform: isNativePlatformMock,
+  isNativePlatform: () => true,
 }));
 
 let urlOpenHandler: AppUrlOpenHandler | null = null;
-const handleRemoveMock = mock(async () => {});
-let addListenerResolver:
-  ((value: { remove: typeof handleRemoveMock }) => void) | null = null;
-let addListenerRejecter: ((err: Error) => void) | null = null;
-
 const addListenerMock = mock(
   (_event: "appUrlOpen", handler: AppUrlOpenHandler) => {
     urlOpenHandler = handler;
-    return new Promise<{ remove: typeof handleRemoveMock }>(
-      (resolve, reject) => {
-        addListenerResolver = resolve;
-        addListenerRejecter = reject;
-      },
-    );
+    return Promise.resolve({ remove: async () => {} });
   },
 );
 
@@ -31,6 +19,10 @@ mock.module("@capacitor/app", () => ({
     addListener: addListenerMock,
   },
 }));
+
+// Warm the module cache so the source's lazy `import("@capacitor/app")`
+// resolves within microtasks instead of a full loader turn.
+await import("@capacitor/app");
 
 const captureErrorMock = mock(() => {});
 mock.module("@/lib/sentry/capture-error", () => ({
@@ -47,40 +39,26 @@ import {
 const { publishCapacitorDeepLinksSource } =
   await import("@/runtime/event-sources/capacitor-deep-links");
 
+// The dynamic `import("@capacitor/app")` and its `.then` chain each
+// queue a microtask, so listener registration lags synchronous test
+// code — flush before driving the captured handler.
 const flushMicrotasks = async (rounds = 4) => {
-  for (let i = 0; i < rounds; i++) await Promise.resolve();
-};
-const resolveAddListener = async () => {
-  // The dynamic `import("@capacitor/app")` and its `.then` chain each
-  // queue a microtask, so the source's `addListenerMock` call lags
-  // synchronous test code. Flush before resolving the pending promise,
-  // then flush again so the `.then` that stores the `handle` runs.
-  await flushMicrotasks();
-  addListenerResolver?.({ remove: handleRemoveMock });
-  await flushMicrotasks();
+  for (let i = 0; i < rounds; i++) {
+    await Promise.resolve();
+  }
 };
 
 beforeEach(() => {
-  isNative = true;
   urlOpenHandler = null;
-  addListenerResolver = null;
-  addListenerRejecter = null;
-  isNativePlatformMock.mockClear();
   addListenerMock.mockClear();
-  handleRemoveMock.mockClear();
   captureErrorMock.mockClear();
 });
 
+// The platform guard, unsubscribe races, and failure reporting are the
+// `subscribeCapacitorListener` contract, covered by
+// `runtime/capacitor-listener.test.ts`. This suite covers only this
+// source's wiring: URL routing and its error context.
 describe("publishCapacitorDeepLinksSource", () => {
-  test("is a no-op off Capacitor iOS (returns a no-op unsubscribe, never imports the plugin)", () => {
-    isNative = false;
-
-    const unsubscribe = publishCapacitorDeepLinksSource();
-    unsubscribe();
-
-    expect(addListenerMock).not.toHaveBeenCalled();
-  });
-
   test("dispatches the OAuth-complete window CustomEvent for an oauth-complete deep link", async () => {
     const received: OAuthCompleteDeepLinkPayload[] = [];
     const windowListener = (
@@ -91,8 +69,8 @@ describe("publishCapacitorDeepLinksSource", () => {
     window.addEventListener(OAUTH_COMPLETE_DEEP_LINK_EVENT, windowListener);
 
     try {
-      const unsubscribe = publishCapacitorDeepLinksSource();
-      await resolveAddListener();
+      publishCapacitorDeepLinksSource();
+      await flushMicrotasks();
 
       const payload: OAuthCompleteDeepLinkPayload = {
         requestId: "req-123",
@@ -105,7 +83,6 @@ describe("publishCapacitorDeepLinksSource", () => {
       });
 
       expect(received).toEqual([payload]);
-      unsubscribe();
     } finally {
       window.removeEventListener(
         OAUTH_COMPLETE_DEEP_LINK_EVENT,
@@ -121,45 +98,24 @@ describe("publishCapacitorDeepLinksSource", () => {
     });
 
     try {
-      const unsubscribe = publishCapacitorDeepLinksSource();
-      await resolveAddListener();
+      publishCapacitorDeepLinksSource();
+      await flushMicrotasks();
 
       urlOpenHandler!({ url: "vellum-assistant://some-future-link?x=1" });
 
       expect(received).toEqual([
         { url: "vellum-assistant://some-future-link?x=1" },
       ]);
-      unsubscribe();
     } finally {
       unsubscribeBus();
     }
   });
 
-  test("returned unsubscribe removes the listener once it resolves", async () => {
-    const unsubscribe = publishCapacitorDeepLinksSource();
-
-    await resolveAddListener();
-    expect(handleRemoveMock).not.toHaveBeenCalled();
-
-    unsubscribe();
-    expect(handleRemoveMock).toHaveBeenCalledTimes(1);
-  });
-
-  test("unsubscribe BEFORE the lazy import resolves still removes the just-registered listener", async () => {
-    const unsubscribe = publishCapacitorDeepLinksSource();
-
-    unsubscribe();
-    await resolveAddListener();
-
-    expect(handleRemoveMock).toHaveBeenCalledTimes(1);
-  });
-
-  test("reports a lazy-import failure instead of throwing", async () => {
-    publishCapacitorDeepLinksSource();
-
-    await flushMicrotasks();
+  test("reports listener-registration failures under the 'capacitor_deep_links' context", async () => {
     const err = new Error("plugin missing");
-    addListenerRejecter?.(err);
+    addListenerMock.mockImplementationOnce(() => Promise.reject(err));
+
+    publishCapacitorDeepLinksSource();
     await flushMicrotasks();
 
     expect(captureErrorMock).toHaveBeenCalledWith(err, {

--- a/clients/web/src/runtime/event-sources/capacitor-deep-links.test.ts
+++ b/clients/web/src/runtime/event-sources/capacitor-deep-links.test.ts
@@ -101,11 +101,49 @@ describe("publishCapacitorDeepLinksSource", () => {
       publishCapacitorDeepLinksSource();
       await flushMicrotasks();
 
-      urlOpenHandler!({ url: "vellum-assistant://some-future-link?x=1" });
+      urlOpenHandler!({ url: "vellum-assistant://some-future-link" });
 
       expect(received).toEqual([
-        { url: "vellum-assistant://some-future-link?x=1" },
+        { url: "vellum-assistant://some-future-link" },
       ]);
+    } finally {
+      unsubscribeBus();
+    }
+  });
+
+  test("strips the query and fragment from unknown URLs before publishing (auth codes must not reach telemetry)", async () => {
+    const received: { url: string }[] = [];
+    const unsubscribeBus = subscribe("deeplink.unknown", (payload) => {
+      received.push(payload);
+    });
+
+    try {
+      publishCapacitorDeepLinksSource();
+      await flushMicrotasks();
+
+      urlOpenHandler!({
+        url: "vellum-assistant://oauth-done/path?oauth_code=secret-code&x=1#frag-token",
+      });
+
+      expect(received).toEqual([{ url: "vellum-assistant://oauth-done/path" }]);
+    } finally {
+      unsubscribeBus();
+    }
+  });
+
+  test("truncates unparseable unknown URLs at the first ? or #", async () => {
+    const received: { url: string }[] = [];
+    const unsubscribeBus = subscribe("deeplink.unknown", (payload) => {
+      received.push(payload);
+    });
+
+    try {
+      publishCapacitorDeepLinksSource();
+      await flushMicrotasks();
+
+      urlOpenHandler!({ url: "::not-a-parseable-url?oauth_code=secret" });
+
+      expect(received).toEqual([{ url: "::not-a-parseable-url" }]);
     } finally {
       unsubscribeBus();
     }

--- a/clients/web/src/runtime/event-sources/capacitor-deep-links.ts
+++ b/clients/web/src/runtime/event-sources/capacitor-deep-links.ts
@@ -1,8 +1,5 @@
-import { captureError } from "@/lib/sentry/capture-error";
-import type { PluginListenerHandle } from "@capacitor/core";
-
 import { publish } from "@/lib/event-bus";
-import { isNativePlatform } from "@/runtime/native-auth";
+import { subscribeCapacitorListener } from "@/runtime/capacitor-listener";
 import {
   OAUTH_COMPLETE_DEEP_LINK_EVENT,
   parseOAuthCompleteDeepLink,
@@ -20,40 +17,19 @@ import {
  * `deeplink.unknown { url }` on the bus — future URL kinds
  * (conversation universal links, quick actions) branch here.
  *
- * Off Capacitor iOS the function is a no-op (`isNativePlatform()`
- * returns false) — Electron deep links flow through
- * `publishElectronDeepLinksSource` instead.
+ * Off Capacitor iOS the function is a no-op — Electron deep links flow
+ * through `publishElectronDeepLinksSource` instead.
  *
- * The `@capacitor/app` plugin import is lazy (per CAPACITOR.md's
- * "lazy-import rule"), and the sync return + internal `cancelled` flag
- * covers unsubscribing before the import resolves — both mirror
- * `publishCapacitorAppStateSource`.
+ * `subscribeCapacitorListener` owns the platform guard, the
+ * unsubscribe-before-import-resolves race, and failure reporting; the
+ * `@capacitor/app` import stays lazy and inline here per CAPACITOR.md's
+ * "lazy-import rule".
  */
 export function publishCapacitorDeepLinksSource(): () => void {
-  if (!isNativePlatform()) return () => undefined;
-
-  let handle: PluginListenerHandle | null = null;
-  let cancelled = false;
-
-  import("@capacitor/app")
-    .then(({ App }) =>
-      App.addListener("appUrlOpen", ({ url }) => handleUrl(url)),
-    )
-    .then((registered) => {
-      if (cancelled) {
-        void registered.remove();
-        return;
-      }
-      handle = registered;
-    })
-    .catch((err) => {
-      captureError(err, { context: "capacitor_deep_links", level: "warning" });
-    });
-
-  return () => {
-    cancelled = true;
-    void handle?.remove();
-  };
+  return subscribeCapacitorListener("capacitor_deep_links", async () => {
+    const { App } = await import("@capacitor/app");
+    return App.addListener("appUrlOpen", ({ url }) => handleUrl(url));
+  });
 }
 
 function handleUrl(url: string): void {

--- a/clients/web/src/runtime/event-sources/capacitor-deep-links.ts
+++ b/clients/web/src/runtime/event-sources/capacitor-deep-links.ts
@@ -1,0 +1,68 @@
+import { captureError } from "@/lib/sentry/capture-error";
+import type { PluginListenerHandle } from "@capacitor/core";
+
+import { publish } from "@/lib/event-bus";
+import { isNativePlatform } from "@/runtime/native-auth";
+import {
+  OAUTH_COMPLETE_DEEP_LINK_EVENT,
+  parseOAuthCompleteDeepLink,
+} from "@/runtime/native-deep-link";
+
+/**
+ * Capacitor iOS shell's `App.appUrlOpen` → deep-link routing.
+ *
+ * OAuth-complete URLs (`vellum-assistant://oauth-complete?…`) dispatch
+ * the `OAUTH_COMPLETE_DEEP_LINK_EVENT` window CustomEvent that
+ * `useOAuthCompleteDeepLinkListener` already consumes, making OAuth
+ * completion event-driven instead of relying only on the
+ * `browserFinished` poll fallback in `runtime/browser.ts` (which stays
+ * in place as a safety net). Any other URL publishes
+ * `deeplink.unknown { url }` on the bus — future URL kinds
+ * (conversation universal links, quick actions) branch here.
+ *
+ * Off Capacitor iOS the function is a no-op (`isNativePlatform()`
+ * returns false) — Electron deep links flow through
+ * `publishElectronDeepLinksSource` instead.
+ *
+ * The `@capacitor/app` plugin import is lazy (per CAPACITOR.md's
+ * "lazy-import rule"), and the sync return + internal `cancelled` flag
+ * covers unsubscribing before the import resolves — both mirror
+ * `publishCapacitorAppStateSource`.
+ */
+export function publishCapacitorDeepLinksSource(): () => void {
+  if (!isNativePlatform()) return () => undefined;
+
+  let handle: PluginListenerHandle | null = null;
+  let cancelled = false;
+
+  import("@capacitor/app")
+    .then(({ App }) =>
+      App.addListener("appUrlOpen", ({ url }) => handleUrl(url)),
+    )
+    .then((registered) => {
+      if (cancelled) {
+        void registered.remove();
+        return;
+      }
+      handle = registered;
+    })
+    .catch((err) => {
+      captureError(err, { context: "capacitor_deep_links", level: "warning" });
+    });
+
+  return () => {
+    cancelled = true;
+    void handle?.remove();
+  };
+}
+
+function handleUrl(url: string): void {
+  const payload = parseOAuthCompleteDeepLink(url);
+  if (payload !== null) {
+    window.dispatchEvent(
+      new CustomEvent(OAUTH_COMPLETE_DEEP_LINK_EVENT, { detail: payload }),
+    );
+    return;
+  }
+  publish("deeplink.unknown", { url });
+}

--- a/clients/web/src/runtime/event-sources/capacitor-deep-links.ts
+++ b/clients/web/src/runtime/event-sources/capacitor-deep-links.ts
@@ -20,10 +20,7 @@ import {
  * Off Capacitor iOS the function is a no-op — Electron deep links flow
  * through `publishElectronDeepLinksSource` instead.
  *
- * `subscribeCapacitorListener` owns the platform guard, the
- * unsubscribe-before-import-resolves race, and failure reporting; the
- * `@capacitor/app` import stays lazy and inline here per CAPACITOR.md's
- * "lazy-import rule".
+ * Lazy inline `@capacitor/app` import per CAPACITOR.md's "lazy-import rule".
  */
 export function publishCapacitorDeepLinksSource(): () => void {
   return subscribeCapacitorListener("capacitor_deep_links", async () => {

--- a/clients/web/src/runtime/event-sources/capacitor-deep-links.ts
+++ b/clients/web/src/runtime/event-sources/capacitor-deep-links.ts
@@ -10,13 +10,9 @@ import {
  *
  * OAuth-complete URLs (`vellum-assistant://oauth-complete?…`) dispatch
  * the `OAUTH_COMPLETE_DEEP_LINK_EVENT` window CustomEvent that
- * `useOAuthCompleteDeepLinkListener` already consumes, making OAuth
- * completion event-driven instead of relying only on the
- * `browserFinished` poll fallback in `runtime/browser.ts` (which stays
- * in place as a safety net). Any other URL publishes
- * `deeplink.unknown { url }` on the bus (query/fragment stripped) —
- * future URL kinds (conversation universal links, quick actions)
- * branch here.
+ * `useOAuthCompleteDeepLinkListener` already consumes; any other URL
+ * publishes `deeplink.unknown { url }` on the bus (query/fragment
+ * stripped).
  *
  * Off Capacitor iOS the function is a no-op — Electron deep links flow
  * through `publishElectronDeepLinksSource` instead.

--- a/clients/web/src/runtime/event-sources/capacitor-deep-links.ts
+++ b/clients/web/src/runtime/event-sources/capacitor-deep-links.ts
@@ -14,8 +14,9 @@ import {
  * completion event-driven instead of relying only on the
  * `browserFinished` poll fallback in `runtime/browser.ts` (which stays
  * in place as a safety net). Any other URL publishes
- * `deeplink.unknown { url }` on the bus — future URL kinds
- * (conversation universal links, quick actions) branch here.
+ * `deeplink.unknown { url }` on the bus (query/fragment stripped) —
+ * future URL kinds (conversation universal links, quick actions)
+ * branch here.
  *
  * Off Capacitor iOS the function is a no-op — Electron deep links flow
  * through `publishElectronDeepLinksSource` instead.
@@ -37,5 +38,18 @@ function handleUrl(url: string): void {
     );
     return;
   }
-  publish("deeplink.unknown", { url });
+  // A malformed OAuth-complete URL can carry one-time auth codes in its
+  // query/fragment — strip both so they never reach telemetry breadcrumbs.
+  publish("deeplink.unknown", { url: sanitizeUnknownUrl(url) });
+}
+
+function sanitizeUnknownUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    parsed.search = "";
+    parsed.hash = "";
+    return parsed.toString();
+  } catch {
+    return url.split(/[?#]/, 1)[0];
+  }
 }

--- a/clients/web/src/runtime/push-registration.test.ts
+++ b/clients/web/src/runtime/push-registration.test.ts
@@ -1,4 +1,6 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { subscribe } from "@/lib/event-bus";
 
 // ── platform guards ──────────────────────────────────────────────────────────
 //
@@ -22,17 +24,27 @@ mock.module("@capacitor/core", () => ({
 
 type RegistrationHandler = (token: { value: string }) => void;
 type ErrorHandler = (error: { error: string }) => void;
+type ActionPerformedHandler = (action: {
+  actionId: string;
+  notification: { data?: unknown };
+}) => void;
 
 let registrationHandler: RegistrationHandler | null = null;
 let registrationErrorHandler: ErrorHandler | null = null;
+let actionPerformedHandler: ActionPerformedHandler | null = null;
 let permissionState: "granted" | "denied" | "prompt" = "granted";
 
 const addListenerMock = mock(
-  async (event: string, handler: RegistrationHandler | ErrorHandler) => {
+  async (
+    event: string,
+    handler: RegistrationHandler | ErrorHandler | ActionPerformedHandler,
+  ) => {
     if (event === "registration") {
       registrationHandler = handler as RegistrationHandler;
     } else if (event === "registrationError") {
       registrationErrorHandler = handler as ErrorHandler;
+    } else if (event === "pushNotificationActionPerformed") {
+      actionPerformedHandler = handler as ActionPerformedHandler;
     }
     return { remove: async () => {} };
   },
@@ -113,6 +125,7 @@ mock.module("@/lib/sentry/capture-error", () => ({
 }));
 
 const {
+  extractPushConversationId,
   isRemotePushSupported,
   registerForRemotePush,
   unregisterFromRemotePush,
@@ -128,6 +141,22 @@ const flushMicrotasks = async (rounds = 10) => {
   }
 };
 
+// Bus subscriptions made by a test; unsubscribed in afterEach so cases
+// stay isolated.
+const busUnsubscribes: Array<() => void> = [];
+const subscribeForTest: typeof subscribe = (event, handler) => {
+  const unsubscribe = subscribe(event, handler);
+  busUnsubscribes.push(unsubscribe);
+  return unsubscribe;
+};
+
+afterEach(() => {
+  for (const unsubscribe of busUnsubscribes) {
+    unsubscribe();
+  }
+  busUnsubscribes.length = 0;
+});
+
 beforeEach(() => {
   isNative = true;
   platform = "ios";
@@ -135,6 +164,7 @@ beforeEach(() => {
   bundleId = "ai.vocify-inc.vellum-assistant-ios";
   registrationHandler = null;
   registrationErrorHandler = null;
+  actionPerformedHandler = null;
   lastUpsertArg = null;
   lastDeleteArg = null;
   upsertError = undefined;
@@ -234,6 +264,92 @@ describe("registerForRemotePush", () => {
 
     expect(captureErrorMock).toHaveBeenCalledTimes(1);
     expect(upsertMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("pushNotificationActionPerformed tap routing", () => {
+  const tap = (data?: unknown) => {
+    actionPerformedHandler?.({ actionId: "tap", notification: { data } });
+  };
+
+  let published: Array<{ threadId: string }> = [];
+  beforeEach(() => {
+    published = [];
+    subscribeForTest("deeplink.openThread", (payload) => {
+      published.push(payload);
+    });
+  });
+
+  test("publishes deeplink.openThread from data.deep_link.conversationId", async () => {
+    await registerForRemotePush("assistant-1");
+    tap({ deep_link: { conversationId: "conv-123" } });
+
+    expect(published).toEqual([{ threadId: "conv-123" }]);
+  });
+
+  test("falls back to a top-level data.conversationId", async () => {
+    await registerForRemotePush("assistant-1");
+    tap({ conversationId: "conv-456" });
+
+    expect(published).toEqual([{ threadId: "conv-456" }]);
+  });
+
+  test("publishes nothing for absent or malformed data", async () => {
+    await registerForRemotePush("assistant-1");
+    tap(undefined);
+    tap(null);
+    tap("not-an-object");
+    tap({});
+    tap({ deep_link: "not-an-object" });
+    tap({ deep_link: { conversationId: 42 } });
+    tap({ conversationId: { nested: true } });
+
+    expect(published).toEqual([]);
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("extractPushConversationId", () => {
+  test("reads data.deep_link.conversationId", () => {
+    expect(
+      extractPushConversationId({ deep_link: { conversationId: "conv-1" } }),
+    ).toBe("conv-1");
+  });
+
+  test("falls back to a top-level conversationId", () => {
+    expect(extractPushConversationId({ conversationId: "conv-2" })).toBe(
+      "conv-2",
+    );
+  });
+
+  test("prefers deep_link over a top-level conversationId", () => {
+    expect(
+      extractPushConversationId({
+        deep_link: { conversationId: "conv-deep" },
+        conversationId: "conv-top",
+      }),
+    ).toBe("conv-deep");
+  });
+
+  test("falls back to top-level when deep_link.conversationId is malformed", () => {
+    expect(
+      extractPushConversationId({
+        deep_link: { conversationId: 42 },
+        conversationId: "conv-top",
+      }),
+    ).toBe("conv-top");
+  });
+
+  test("returns undefined for non-object, absent, and malformed shapes", () => {
+    expect(extractPushConversationId(undefined)).toBeUndefined();
+    expect(extractPushConversationId(null)).toBeUndefined();
+    expect(extractPushConversationId("conv-1")).toBeUndefined();
+    expect(extractPushConversationId(42)).toBeUndefined();
+    expect(extractPushConversationId([])).toBeUndefined();
+    expect(extractPushConversationId({})).toBeUndefined();
+    expect(extractPushConversationId({ deep_link: null })).toBeUndefined();
+    expect(extractPushConversationId({ deep_link: {} })).toBeUndefined();
+    expect(extractPushConversationId({ conversationId: 42 })).toBeUndefined();
   });
 });
 

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -192,12 +192,16 @@ async function upsertToken(token: string, assistantId: string): Promise<void> {
 /**
  * Extract the conversation id a tapped push notification routes to.
  *
- * APNs custom keys arrive as `notification.data`. The daemon's
- * `deep_link_metadata` reaches us as `data.deep_link.conversationId` (the
- * platform forwards it into the APNs payload); producers that embed routing
- * directly in `context_payload` put `conversationId` at the top level, so
- * that is the fallback. Returns `undefined` for absent or malformed shapes —
- * never throws.
+ * APNs custom keys arrive as `notification.data`. The intended contract is
+ * daemon → platform → client: the daemon's `platform` channel sends
+ * `deep_link_metadata` with the dispatch, the platform forwards it into the
+ * APNs payload as `deep_link`, and this reads `data.deep_link.conversationId`.
+ * Producers that embed routing directly in `context_payload` put
+ * `conversationId` at the top level, so that is the fallback. Pushes whose
+ * payload carries no routing keys (a hop of the contract not yet deployed)
+ * gracefully yield `undefined` — the tap foregrounds the app without
+ * navigating. Returns `undefined` for absent or malformed shapes; never
+ * throws.
  */
 export function extractPushConversationId(data: unknown): string | undefined {
   if (typeof data !== "object" || data === null) {
@@ -242,9 +246,9 @@ async function ensureListeners(): Promise<void> {
     await PushNotifications.addListener(
       "pushNotificationActionPerformed",
       (action) => {
-        // Pushes dispatched by a platform that does not yet forward the
-        // daemon's `deep_link_metadata` carry no routing keys — the tap
-        // foregrounds the app without navigating.
+        // A payload without routing keys is a graceful no-op: the tap
+        // foregrounds the app without navigating (see
+        // extractPushConversationId for the deep-link contract).
         const conversationId = extractPushConversationId(
           action.notification.data,
         );

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -1,5 +1,6 @@
 /**
- * APNs remote-push device-token registration for the Capacitor iOS app.
+ * APNs remote-push device-token registration and tap routing for the
+ * Capacitor iOS app.
  *
  * The daemon's `platform` notification channel POSTs background notifications
  * (reminders, activity completions, etc.) to the Vellum platform's
@@ -22,6 +23,11 @@
  *   - {@link unregisterFromRemotePush} — call from the logout path BEFORE the
  *     session cookie is cleared (see `stores/auth-store.ts`) so the platform
  *     delete is authenticated. Removes the token for the bound assistant.
+ *   - Tap routing — alongside the token listeners, a
+ *     `pushNotificationActionPerformed` listener publishes
+ *     `deeplink.openThread` on the event bus when a tapped notification
+ *     carries a conversation id, so `useGlobalDeepLinkConsumer` (mounted in
+ *     `RootLayout`) navigates to the conversation.
  *
  * iOS-only and best-effort: no-ops on Electron, desktop browsers, and Android
  * (no native Capacitor Android shell ships today); registration/delete failures
@@ -39,6 +45,7 @@ import {
   assistantsPushTokensUpsert,
 } from "@/generated/api/sdk.gen";
 import type { ApnsEnvironmentEnum } from "@/generated/api/types.gen";
+import { publish } from "@/lib/event-bus";
 import { captureError } from "@/lib/sentry/capture-error";
 import { isNativePlatform } from "@/runtime/native-auth";
 import { createStorageAccessor } from "@/utils/typed-storage";
@@ -68,7 +75,11 @@ function parseRegisteredToken(raw: string): RegisteredToken | null {
     typeof value.bundleId === "string" &&
     typeof value.assistantId === "string"
   ) {
-    return { token: value.token, bundleId: value.bundleId, assistantId: value.assistantId };
+    return {
+      token: value.token,
+      bundleId: value.bundleId,
+      assistantId: value.assistantId,
+    };
   }
   return null;
 }
@@ -179,10 +190,38 @@ async function upsertToken(token: string, assistantId: string): Promise<void> {
 }
 
 /**
- * Register the APNs `registration` / `registrationError` listeners exactly
- * once. The `registration` handler upserts the token under whichever assistant
- * is current when iOS delivers it (iOS may emit the token asynchronously, and
- * re-emits the cached token on subsequent `register()` calls).
+ * Extract the conversation id a tapped push notification routes to.
+ *
+ * APNs custom keys arrive as `notification.data`. The daemon's
+ * `deep_link_metadata` reaches us as `data.deep_link.conversationId` (the
+ * platform forwards it into the APNs payload); producers that embed routing
+ * directly in `context_payload` put `conversationId` at the top level, so
+ * that is the fallback. Returns `undefined` for absent or malformed shapes —
+ * never throws.
+ */
+export function extractPushConversationId(data: unknown): string | undefined {
+  if (typeof data !== "object" || data === null) {
+    return undefined;
+  }
+  const record = data as Record<string, unknown>;
+  const deepLink = record.deep_link;
+  if (typeof deepLink === "object" && deepLink !== null) {
+    const conversationId = (deepLink as Record<string, unknown>).conversationId;
+    if (typeof conversationId === "string") {
+      return conversationId;
+    }
+  }
+  return typeof record.conversationId === "string"
+    ? record.conversationId
+    : undefined;
+}
+
+/**
+ * Register the APNs `registration` / `registrationError` / tap listeners
+ * exactly once. The `registration` handler upserts the token under whichever
+ * assistant is current when iOS delivers it (iOS may emit the token
+ * asynchronously, and re-emits the cached token on subsequent `register()`
+ * calls).
  */
 async function ensureListeners(): Promise<void> {
   if (listenersRegistered) return;
@@ -200,6 +239,20 @@ async function ensureListeners(): Promise<void> {
         level: "warning",
       });
     });
+    await PushNotifications.addListener(
+      "pushNotificationActionPerformed",
+      (action) => {
+        // Pushes dispatched by a platform that does not yet forward the
+        // daemon's `deep_link_metadata` carry no routing keys — the tap
+        // foregrounds the app without navigating.
+        const conversationId = extractPushConversationId(
+          action.notification.data,
+        );
+        if (conversationId) {
+          publish("deeplink.openThread", { threadId: conversationId });
+        }
+      },
+    );
   } catch (err) {
     // Allow a later call to retry listener registration.
     listenersRegistered = false;
@@ -220,7 +273,9 @@ async function ensureListeners(): Promise<void> {
  * authorization backs the local-notification path, so this does not introduce a
  * second OS prompt.
  */
-export async function registerForRemotePush(assistantId: string): Promise<void> {
+export async function registerForRemotePush(
+  assistantId: string,
+): Promise<void> {
   if (!isRemotePushSupported()) return;
   currentAssistantId = assistantId;
 

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -23,11 +23,9 @@
  *   - {@link unregisterFromRemotePush} — call from the logout path BEFORE the
  *     session cookie is cleared (see `stores/auth-store.ts`) so the platform
  *     delete is authenticated. Removes the token for the bound assistant.
- *   - Tap routing — alongside the token listeners, a
- *     `pushNotificationActionPerformed` listener publishes
- *     `deeplink.openThread` on the event bus when a tapped notification
- *     carries a conversation id, so `useGlobalDeepLinkConsumer` (mounted in
- *     `RootLayout`) navigates to the conversation.
+ *   - Tap routing — a `pushNotificationActionPerformed` listener publishes
+ *     `deeplink.openThread` when the tapped notification carries a
+ *     conversation id.
  *
  * iOS-only and best-effort: no-ops on Electron, desktop browsers, and Android
  * (no native Capacitor Android shell ships today); registration/delete failures
@@ -190,18 +188,10 @@ async function upsertToken(token: string, assistantId: string): Promise<void> {
 }
 
 /**
- * Extract the conversation id a tapped push notification routes to.
- *
- * APNs custom keys arrive as `notification.data`. The intended contract is
- * daemon → platform → client: the daemon's `platform` channel sends
- * `deep_link_metadata` with the dispatch, the platform forwards it into the
- * APNs payload as `deep_link`, and this reads `data.deep_link.conversationId`.
- * Producers that embed routing directly in `context_payload` put
- * `conversationId` at the top level, so that is the fallback. Pushes whose
- * payload carries no routing keys (a hop of the contract not yet deployed)
- * gracefully yield `undefined` — the tap foregrounds the app without
- * navigating. Returns `undefined` for absent or malformed shapes; never
- * throws.
+ * Conversation id a tapped push routes to: `data.deep_link.conversationId`
+ * (daemon `deep_link_metadata`, relayed by the platform into the APNs
+ * payload), falling back to a top-level `conversationId`. Undefined for
+ * absent/malformed shapes — the tap then just foregrounds the app.
  */
 export function extractPushConversationId(data: unknown): string | undefined {
   if (typeof data !== "object" || data === null) {
@@ -246,9 +236,6 @@ async function ensureListeners(): Promise<void> {
     await PushNotifications.addListener(
       "pushNotificationActionPerformed",
       (action) => {
-        // A payload without routing keys is a graceful no-op: the tap
-        // foregrounds the app without navigating (see
-        // extractPushConversationId for the deep-link contract).
         const conversationId = extractPushConversationId(
           action.notification.data,
         );

--- a/clients/web/src/utils/haptics.test.ts
+++ b/clients/web/src/utils/haptics.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── platform guard ───────────────────────────────────────────────────────────
+//
+// `native-auth` is mocked rather than loaded because its module-load
+// `registerPlugin("NativeAuth")` would fail outside a Capacitor runtime
+// (mirrors push-registration.test.ts).
+
+let isNative = true;
+mock.module("@/runtime/native-auth", () => ({
+  isNativePlatform: () => isNative,
+}));
+
+// ── @capacitor/haptics (lazy-imported plugin Proxy) ──────────────────────────
+
+let pluginError: Error | null = null;
+
+const impactMock = mock(async (_options: { style: string }) => {
+  if (pluginError) {
+    throw pluginError;
+  }
+});
+const notificationMock = mock(async (_options: { type: string }) => {
+  if (pluginError) {
+    throw pluginError;
+  }
+});
+
+mock.module("@capacitor/haptics", () => ({
+  Haptics: {
+    impact: impactMock,
+    notification: notificationMock,
+  },
+  ImpactStyle: {
+    Light: "LIGHT",
+    Medium: "MEDIUM",
+    Heavy: "HEAVY",
+  },
+  NotificationType: {
+    Success: "SUCCESS",
+    Warning: "WARNING",
+    Error: "ERROR",
+  },
+}));
+
+const { haptic } = await import("@/utils/haptics");
+
+beforeEach(() => {
+  isNative = true;
+  pluginError = null;
+  impactMock.mockClear();
+  notificationMock.mockClear();
+});
+
+describe("haptic on native", () => {
+  test("light() fires a Light impact", async () => {
+    await haptic.light();
+
+    expect(impactMock).toHaveBeenCalledTimes(1);
+    expect(impactMock).toHaveBeenCalledWith({ style: "LIGHT" });
+  });
+
+  test("medium() fires a Medium impact", async () => {
+    await haptic.medium();
+
+    expect(impactMock).toHaveBeenCalledTimes(1);
+    expect(impactMock).toHaveBeenCalledWith({ style: "MEDIUM" });
+  });
+
+  test("success() fires a Success notification", async () => {
+    await haptic.success();
+
+    expect(notificationMock).toHaveBeenCalledTimes(1);
+    expect(notificationMock).toHaveBeenCalledWith({ type: "SUCCESS" });
+  });
+
+  test("error() fires an Error notification", async () => {
+    await haptic.error();
+
+    expect(notificationMock).toHaveBeenCalledTimes(1);
+    expect(notificationMock).toHaveBeenCalledWith({ type: "ERROR" });
+  });
+});
+
+describe("haptic on web", () => {
+  test("never touches the plugin", async () => {
+    isNative = false;
+
+    await haptic.light();
+    await haptic.medium();
+    await haptic.success();
+    await haptic.error();
+
+    expect(impactMock).not.toHaveBeenCalled();
+    expect(notificationMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("haptic error handling", () => {
+  test("resolves even when the plugin throws (best-effort)", async () => {
+    pluginError = new Error("haptics unavailable");
+
+    await expect(haptic.light()).resolves.toBeUndefined();
+    await expect(haptic.medium()).resolves.toBeUndefined();
+    await expect(haptic.success()).resolves.toBeUndefined();
+    await expect(haptic.error()).resolves.toBeUndefined();
+
+    expect(impactMock).toHaveBeenCalledTimes(2);
+    expect(notificationMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/clients/web/src/utils/haptics.ts
+++ b/clients/web/src/utils/haptics.ts
@@ -1,3 +1,16 @@
+import { isNativePlatform } from "@/runtime/native-auth";
+
+const runNative = async (fire: () => Promise<void>): Promise<void> => {
+  if (!isNativePlatform()) {
+    return;
+  }
+  try {
+    await fire();
+  } catch {
+    // Best-effort: call sites fire-and-forget and must never see a rejection.
+  }
+};
+
 /**
  * Thin haptic-feedback wrapper. On native Capacitor platforms this delegates
  * to `@capacitor/haptics`; on web it's a no-op. The lazy import ensures the
@@ -5,16 +18,24 @@
  * runtime) never runs in a plain browser context.
  */
 export const haptic = {
-  light: async () => {
-    /* no-op until Capacitor is integrated */
-  },
-  medium: async () => {
-    /* no-op until Capacitor is integrated */
-  },
-  success: async () => {
-    /* no-op until Capacitor is integrated */
-  },
-  error: async () => {
-    /* no-op until Capacitor is integrated */
-  },
+  light: () =>
+    runNative(async () => {
+      const { Haptics, ImpactStyle } = await import("@capacitor/haptics");
+      await Haptics.impact({ style: ImpactStyle.Light });
+    }),
+  medium: () =>
+    runNative(async () => {
+      const { Haptics, ImpactStyle } = await import("@capacitor/haptics");
+      await Haptics.impact({ style: ImpactStyle.Medium });
+    }),
+  success: () =>
+    runNative(async () => {
+      const { Haptics, NotificationType } = await import("@capacitor/haptics");
+      await Haptics.notification({ type: NotificationType.Success });
+    }),
+  error: () =>
+    runNative(async () => {
+      const { Haptics, NotificationType } = await import("@capacitor/haptics");
+      await Haptics.notification({ type: NotificationType.Error });
+    }),
 };


### PR DESCRIPTION
## Summary
Completes mobile improvements #3–#5 (web half of #4): every notification tap (Capacitor local, APNs remote push, Electron, desktop browser) now navigates to the originating conversation; the previously-unregistered Capacitor `appUrlOpen` listener gives OAuth completion and future deep links an event-driven routing spine; and the no-op haptics stub now drives real `@capacitor/haptics` feedback at 25+ prewired call sites. A daemon fix extends deep-link `conversationId` enrichment to the platform (APNs) channel — without it the push payload would never carry a routing key.

Companion (separate repo, not yet executed): `vellum-assistant-platform` plan forwards `deep_link_metadata` into the APNs payload and rolls out the `ios-remote-push-enabled` badge flag. Both deploy orders degrade gracefully.

## Self-review result
3 rounds, 7 gaps found and fixed across 7 fix PRs; final round PASS. One codex P2 deferred with a tracked follow-up (Electron closed-main-window tap buffering — pre-existing-adjacent desktop edge, documented in the repo TODO).

## PRs merged into feature branch
- #37200: feat(web): implement the haptic bridge over @capacitor/haptics
- #37203: feat(web): register the Capacitor appUrlOpen deep-link event source
- #37201: feat(web): navigate to the conversation when a notification is tapped
- #37204: feat(web): deep-link into the conversation from APNs remote-push taps

### Fix PRs (self-review rounds 1–2)
- #37225: fix(notifications): enrich platform-channel deep links with the conversation id
- #37220: fix(web): route deeplink.openThread through navigateToConversation
- #37223: refactor(web): extract shared Capacitor listener subscription helper
- #37221: docs(web): correct deeplink.* event publisher docs
- #37226: fix(web): keep live panels when a deep link targets the active conversation
- #37227: fix(notifications): prefer the vellum pairing for platform-channel deep links
- #37228: test(web): consolidate Capacitor listener contract tests in the helper suite

## Manual QA checklist (before merge)
- [ ] Dev iOS build: background the app, trigger a notification for another conversation, tap the banner → lands on that conversation
- [ ] Dev iOS build: send a message → soft haptic on send; archive a conversation → firmer haptic; pull-to-refresh → tick at threshold
- [ ] Electron: click a notification → main window focuses on the right conversation
- [ ] Desktop browser: click a web Notification → tab focuses on the right conversation
- [ ] (After platform PR deploys + flag on) suspend iOS app, tap an APNs push → lands on the conversation

Part of plan: mobile-push-deeplink-haptics.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)