### PR TITLE
feat(slack): extract channel enumeration module + enrich normalized channel shape + memberOnly filter

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -27316,7 +27316,9 @@ paths:
             enum:
               - "true"
               - "false"
-          description: When 'true', only return conversations the connected identity is a member of
+          description:
+            "When 'true', only return conversations the connected identity is in: channels/groups with is_member, plus
+            all DMs and group DMs"
       responses:
         "200":
           description: Successful response

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -27307,6 +27307,16 @@ paths:
       description: List Slack channels, groups, and DMs for the channel picker.
       tags:
         - integrations
+      parameters:
+        - name: memberOnly
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - "true"
+              - "false"
+          description: When 'true', only return conversations the connected identity is a member of
       responses:
         "200":
           description: Successful response
@@ -27332,11 +27342,20 @@ paths:
                             - dm
                         isPrivate:
                           type: boolean
+                        isMember:
+                          type: boolean
+                        memberCount:
+                          type: number
+                        topic:
+                          type: string
+                        imageUrl:
+                          type: string
                       required:
                         - id
                         - name
                         - type
                         - isPrivate
+                        - isMember
                       additionalProperties: false
                 required:
                   - channels

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -27345,17 +27345,26 @@ paths:
                         isMember:
                           type: boolean
                         memberCount:
-                          type: number
+                          anyOf:
+                            - type: number
+                            - type: "null"
                         topic:
-                          type: string
+                          anyOf:
+                            - type: string
+                            - type: "null"
                         imageUrl:
-                          type: string
+                          anyOf:
+                            - type: string
+                            - type: "null"
                       required:
                         - id
                         - name
                         - type
                         - isPrivate
                         - isMember
+                        - memberCount
+                        - topic
+                        - imageUrl
                       additionalProperties: false
                 required:
                   - channels

--- a/assistant/src/__tests__/slack-channels-routes.test.ts
+++ b/assistant/src/__tests__/slack-channels-routes.test.ts
@@ -121,7 +121,7 @@ describe("handleListSlackChannels", () => {
       name: "group-chat",
       type: "group",
       isPrivate: true,
-      isMember: false,
+      isMember: true,
       memberCount: null,
       topic: null,
       imageUrl: null,
@@ -131,7 +131,7 @@ describe("handleListSlackChannels", () => {
       name: "Alice Smith",
       type: "dm",
       isPrivate: true,
-      isMember: false,
+      isMember: true,
       memberCount: null,
       topic: null,
       imageUrl: null,
@@ -245,7 +245,7 @@ describe("handleListSlackChannels", () => {
       name: "Alice Smith",
       type: "dm",
       isPrivate: true,
-      isMember: false,
+      isMember: true,
       memberCount: null,
       topic: null,
       imageUrl: "https://avatars.example.com/u1_48.png",
@@ -255,7 +255,7 @@ describe("handleListSlackChannels", () => {
       name: "Bob Jones",
       type: "dm",
       isPrivate: true,
-      isMember: false,
+      isMember: true,
       memberCount: null,
       topic: null,
       imageUrl: null,
@@ -317,12 +317,13 @@ describe("handleListSlackChannels", () => {
     })) as { channels: Array<Record<string, unknown>> };
 
     expect(result.channels.map((c) => c.id)).toEqual(["G1", "D1"]);
+    expect(result.channels.every((c) => c.isMember === true)).toBe(true);
     expect(result.channels[1]).toEqual({
       id: "D1",
       name: "Alice Smith",
       type: "dm",
       isPrivate: true,
-      isMember: false,
+      isMember: true,
       memberCount: null,
       topic: null,
       imageUrl: null,

--- a/assistant/src/__tests__/slack-channels-routes.test.ts
+++ b/assistant/src/__tests__/slack-channels-routes.test.ts
@@ -1,0 +1,311 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { ServiceUnavailableError } from "../runtime/routes/errors.js";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before any imports that pull in mocked modules
+// ---------------------------------------------------------------------------
+
+const secureKeyValues = new Map<string, string>();
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async (key: string) => secureKeyValues.get(key),
+  setSecureKeyAsync: async () => {},
+}));
+
+let connectionByProvider: Record<string, unknown> = {};
+mock.module("../oauth/oauth-store.js", () => ({
+  getConnectionByProvider: (key: string) =>
+    connectionByProvider[key] ?? undefined,
+}));
+
+let listConversationsResult: unknown = { ok: true, channels: [] };
+let userInfoResults: Map<string, unknown> = new Map();
+
+mock.module("../messaging/providers/slack/client.js", () => ({
+  listConversations: async () => listConversationsResult,
+  userInfo: async (_token: string, userId: string) => {
+    const result = userInfoResults.get(userId);
+    if (result) {
+      return result;
+    }
+    throw new Error(`User not found: ${userId}`);
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const { handleListSlackChannels } =
+  await import("../runtime/routes/integrations/slack/channels.js");
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+function configureToken() {
+  connectionByProvider["slack"] = { id: "conn-slack-1" };
+  secureKeyValues.set(
+    "oauth_connection/conn-slack-1/access_token",
+    "xoxb-test",
+  );
+}
+
+beforeEach(() => {
+  secureKeyValues.clear();
+  connectionByProvider = {};
+  listConversationsResult = { ok: true, channels: [] };
+  userInfoResults = new Map();
+});
+
+describe("handleListSlackChannels", () => {
+  test("throws ServiceUnavailableError when no token is configured", async () => {
+    expect(handleListSlackChannels()).rejects.toThrow(ServiceUnavailableError);
+  });
+
+  test("returns channels sorted by type then name", async () => {
+    configureToken();
+
+    listConversationsResult = {
+      ok: true,
+      channels: [
+        {
+          id: "D1",
+          name: undefined,
+          is_im: true,
+          user: "U1",
+          is_private: true,
+        },
+        { id: "C2", name: "beta-channel", is_channel: true },
+        { id: "C1", name: "alpha-channel", is_channel: true },
+        { id: "G1", name: "group-chat", is_mpim: true, is_private: true },
+      ],
+    };
+
+    userInfoResults.set("U1", {
+      ok: true,
+      user: {
+        id: "U1",
+        name: "alice",
+        profile: { display_name: "Alice Smith" },
+      },
+    });
+
+    const result = (await handleListSlackChannels()) as {
+      channels: Array<Record<string, unknown>>;
+    };
+
+    expect(result.channels).toHaveLength(4);
+    expect(result.channels[0]).toEqual({
+      id: "C1",
+      name: "alpha-channel",
+      type: "channel",
+      isPrivate: false,
+      isMember: false,
+      memberCount: null,
+      topic: null,
+      imageUrl: null,
+    });
+    expect(result.channels[1]).toEqual({
+      id: "C2",
+      name: "beta-channel",
+      type: "channel",
+      isPrivate: false,
+      isMember: false,
+      memberCount: null,
+      topic: null,
+      imageUrl: null,
+    });
+    expect(result.channels[2]).toEqual({
+      id: "G1",
+      name: "group-chat",
+      type: "group",
+      isPrivate: true,
+      isMember: false,
+      memberCount: null,
+      topic: null,
+      imageUrl: null,
+    });
+    expect(result.channels[3]).toEqual({
+      id: "D1",
+      name: "Alice Smith",
+      type: "dm",
+      isPrivate: true,
+      isMember: false,
+      memberCount: null,
+      topic: null,
+      imageUrl: null,
+    });
+  });
+
+  test("maps isMember, memberCount, topic, and purpose fallback from the raw payload", async () => {
+    configureToken();
+
+    listConversationsResult = {
+      ok: true,
+      channels: [
+        {
+          id: "C1",
+          name: "with-topic",
+          is_channel: true,
+          is_member: true,
+          num_members: 42,
+          topic: { value: "P2 incident triage" },
+          purpose: { value: "unused purpose" },
+        },
+        {
+          id: "C2",
+          name: "purpose-fallback",
+          is_channel: true,
+          num_members: 7,
+          topic: { value: "" },
+          purpose: { value: "Escalation hand-offs" },
+        },
+        {
+          id: "C3",
+          name: "bare-channel",
+          is_channel: true,
+        },
+      ],
+    };
+
+    const result = (await handleListSlackChannels()) as {
+      channels: Array<Record<string, unknown>>;
+    };
+
+    expect(result.channels[0]).toEqual({
+      id: "C3",
+      name: "bare-channel",
+      type: "channel",
+      isPrivate: false,
+      isMember: false,
+      memberCount: null,
+      topic: null,
+      imageUrl: null,
+    });
+    expect(result.channels[1]).toEqual({
+      id: "C2",
+      name: "purpose-fallback",
+      type: "channel",
+      isPrivate: false,
+      isMember: false,
+      memberCount: 7,
+      topic: "Escalation hand-offs",
+      imageUrl: null,
+    });
+    expect(result.channels[2]).toEqual({
+      id: "C1",
+      name: "with-topic",
+      type: "channel",
+      isPrivate: false,
+      isMember: true,
+      memberCount: 42,
+      topic: "P2 incident triage",
+      imageUrl: null,
+    });
+  });
+
+  test("populates imageUrl on DM rows from the userInfo profile", async () => {
+    configureToken();
+
+    listConversationsResult = {
+      ok: true,
+      channels: [
+        { id: "D1", is_im: true, user: "U1", is_private: true },
+        { id: "D2", is_im: true, user: "U2", is_private: true },
+      ],
+    };
+
+    userInfoResults.set("U1", {
+      ok: true,
+      user: {
+        id: "U1",
+        name: "alice",
+        profile: {
+          display_name: "Alice Smith",
+          image_48: "https://avatars.example.com/u1_48.png",
+        },
+      },
+    });
+    userInfoResults.set("U2", {
+      ok: true,
+      user: {
+        id: "U2",
+        name: "bob",
+        profile: { display_name: "Bob Jones" },
+      },
+    });
+
+    const result = (await handleListSlackChannels()) as {
+      channels: Array<Record<string, unknown>>;
+    };
+
+    expect(result.channels[0]).toEqual({
+      id: "D1",
+      name: "Alice Smith",
+      type: "dm",
+      isPrivate: true,
+      isMember: false,
+      memberCount: null,
+      topic: null,
+      imageUrl: "https://avatars.example.com/u1_48.png",
+    });
+    expect(result.channels[1]).toEqual({
+      id: "D2",
+      name: "Bob Jones",
+      type: "dm",
+      isPrivate: true,
+      isMember: false,
+      memberCount: null,
+      topic: null,
+      imageUrl: null,
+    });
+  });
+
+  test("memberOnly=true filters to is_member conversations before normalizing", async () => {
+    configureToken();
+
+    listConversationsResult = {
+      ok: true,
+      channels: [
+        { id: "C1", name: "member-channel", is_channel: true, is_member: true },
+        { id: "C2", name: "other-channel", is_channel: true, is_member: false },
+        { id: "D1", is_im: true, user: "U-unresolved", is_private: true },
+      ],
+    };
+
+    const result = (await handleListSlackChannels({
+      queryParams: { memberOnly: "true" },
+    })) as { channels: Array<Record<string, unknown>> };
+
+    expect(result.channels).toHaveLength(1);
+    expect(result.channels[0]).toEqual({
+      id: "C1",
+      name: "member-channel",
+      type: "channel",
+      isPrivate: false,
+      isMember: true,
+      memberCount: null,
+      topic: null,
+      imageUrl: null,
+    });
+  });
+
+  test("omitting memberOnly returns all conversations", async () => {
+    configureToken();
+
+    listConversationsResult = {
+      ok: true,
+      channels: [
+        { id: "C1", name: "member-channel", is_channel: true, is_member: true },
+        { id: "C2", name: "other-channel", is_channel: true, is_member: false },
+      ],
+    };
+
+    const result = (await handleListSlackChannels({})) as {
+      channels: Array<Record<string, unknown>>;
+    };
+
+    expect(result.channels).toHaveLength(2);
+  });
+});

--- a/assistant/src/__tests__/slack-channels-routes.test.ts
+++ b/assistant/src/__tests__/slack-channels-routes.test.ts
@@ -262,7 +262,7 @@ describe("handleListSlackChannels", () => {
     });
   });
 
-  test("memberOnly=true filters to is_member conversations before normalizing", async () => {
+  test("memberOnly=true filters out non-member channels before normalizing", async () => {
     configureToken();
 
     listConversationsResult = {
@@ -270,7 +270,7 @@ describe("handleListSlackChannels", () => {
       channels: [
         { id: "C1", name: "member-channel", is_channel: true, is_member: true },
         { id: "C2", name: "other-channel", is_channel: true, is_member: false },
-        { id: "D1", is_im: true, user: "U-unresolved", is_private: true },
+        { id: "C3", name: "bare-channel", is_channel: true },
       ],
     };
 
@@ -285,6 +285,44 @@ describe("handleListSlackChannels", () => {
       type: "channel",
       isPrivate: false,
       isMember: true,
+      memberCount: null,
+      topic: null,
+      imageUrl: null,
+    });
+  });
+
+  test("memberOnly=true keeps DMs and group DMs despite missing is_member", async () => {
+    configureToken();
+
+    listConversationsResult = {
+      ok: true,
+      channels: [
+        { id: "C2", name: "other-channel", is_channel: true, is_member: false },
+        { id: "D1", is_im: true, user: "U1", is_private: true },
+        { id: "G1", name: "group-chat", is_mpim: true, is_private: true },
+      ],
+    };
+
+    userInfoResults.set("U1", {
+      ok: true,
+      user: {
+        id: "U1",
+        name: "alice",
+        profile: { display_name: "Alice Smith" },
+      },
+    });
+
+    const result = (await handleListSlackChannels({
+      queryParams: { memberOnly: "true" },
+    })) as { channels: Array<Record<string, unknown>> };
+
+    expect(result.channels.map((c) => c.id)).toEqual(["G1", "D1"]);
+    expect(result.channels[1]).toEqual({
+      id: "D1",
+      name: "Alice Smith",
+      type: "dm",
+      isPrivate: true,
+      isMember: false,
       memberCount: null,
       topic: null,
       imageUrl: null,

--- a/assistant/src/__tests__/slack-share-routes.test.ts
+++ b/assistant/src/__tests__/slack-share-routes.test.ts
@@ -41,7 +41,9 @@ mock.module("../messaging/providers/slack/client.js", () => ({
   ) => postMessageResult,
   userInfo: async (_token: string, userId: string) => {
     const result = userInfoResults.get(userId);
-    if (result) return result;
+    if (result) {
+      return result;
+    }
     throw new Error(`User not found: ${userId}`);
   },
 }));
@@ -139,6 +141,7 @@ describe("handleListSlackChannels", () => {
         name: string;
         type: string;
         isPrivate: boolean;
+        isMember: boolean;
       }>;
     };
 
@@ -148,25 +151,203 @@ describe("handleListSlackChannels", () => {
       name: "alpha-channel",
       type: "channel",
       isPrivate: false,
+      isMember: false,
     });
     expect(result.channels[1]).toEqual({
       id: "C2",
       name: "beta-channel",
       type: "channel",
       isPrivate: false,
+      isMember: false,
     });
     expect(result.channels[2]).toEqual({
       id: "G1",
       name: "group-chat",
       type: "group",
       isPrivate: true,
+      isMember: false,
     });
     expect(result.channels[3]).toEqual({
       id: "D1",
       name: "Alice Smith",
       type: "dm",
       isPrivate: true,
+      isMember: false,
     });
+  });
+
+  test("maps isMember, memberCount, topic, and purpose fallback from the raw payload", async () => {
+    connectionByProvider["slack"] = { id: "conn-slack-1" };
+    secureKeyValues.set(
+      "oauth_connection/conn-slack-1/access_token",
+      "xoxb-test",
+    );
+
+    listConversationsResult = {
+      ok: true,
+      channels: [
+        {
+          id: "C1",
+          name: "with-topic",
+          is_channel: true,
+          is_member: true,
+          num_members: 42,
+          topic: { value: "P2 incident triage" },
+          purpose: { value: "unused purpose" },
+        },
+        {
+          id: "C2",
+          name: "purpose-fallback",
+          is_channel: true,
+          num_members: 7,
+          topic: { value: "" },
+          purpose: { value: "Escalation hand-offs" },
+        },
+        {
+          id: "C3",
+          name: "bare-channel",
+          is_channel: true,
+        },
+      ],
+    };
+
+    const result = (await handleListSlackChannels()) as {
+      channels: Array<Record<string, unknown>>;
+    };
+
+    expect(result.channels[0]).toEqual({
+      id: "C3",
+      name: "bare-channel",
+      type: "channel",
+      isPrivate: false,
+      isMember: false,
+    });
+    expect(result.channels[1]).toEqual({
+      id: "C2",
+      name: "purpose-fallback",
+      type: "channel",
+      isPrivate: false,
+      isMember: false,
+      memberCount: 7,
+      topic: "Escalation hand-offs",
+    });
+    expect(result.channels[2]).toEqual({
+      id: "C1",
+      name: "with-topic",
+      type: "channel",
+      isPrivate: false,
+      isMember: true,
+      memberCount: 42,
+      topic: "P2 incident triage",
+    });
+  });
+
+  test("populates imageUrl on DM rows from the userInfo profile", async () => {
+    connectionByProvider["slack"] = { id: "conn-slack-1" };
+    secureKeyValues.set(
+      "oauth_connection/conn-slack-1/access_token",
+      "xoxb-test",
+    );
+
+    listConversationsResult = {
+      ok: true,
+      channels: [
+        { id: "D1", is_im: true, user: "U1", is_private: true },
+        { id: "D2", is_im: true, user: "U2", is_private: true },
+      ],
+    };
+
+    userInfoResults.set("U1", {
+      ok: true,
+      user: {
+        id: "U1",
+        name: "alice",
+        profile: {
+          display_name: "Alice Smith",
+          image_48: "https://avatars.example.com/u1_48.png",
+        },
+      },
+    });
+    userInfoResults.set("U2", {
+      ok: true,
+      user: {
+        id: "U2",
+        name: "bob",
+        profile: { display_name: "Bob Jones" },
+      },
+    });
+
+    const result = (await handleListSlackChannels()) as {
+      channels: Array<Record<string, unknown>>;
+    };
+
+    expect(result.channels[0]).toEqual({
+      id: "D1",
+      name: "Alice Smith",
+      type: "dm",
+      isPrivate: true,
+      isMember: false,
+      imageUrl: "https://avatars.example.com/u1_48.png",
+    });
+    expect(result.channels[1]).toEqual({
+      id: "D2",
+      name: "Bob Jones",
+      type: "dm",
+      isPrivate: true,
+      isMember: false,
+    });
+  });
+
+  test("memberOnly=true filters to is_member conversations before normalizing", async () => {
+    connectionByProvider["slack"] = { id: "conn-slack-1" };
+    secureKeyValues.set(
+      "oauth_connection/conn-slack-1/access_token",
+      "xoxb-test",
+    );
+
+    listConversationsResult = {
+      ok: true,
+      channels: [
+        { id: "C1", name: "member-channel", is_channel: true, is_member: true },
+        { id: "C2", name: "other-channel", is_channel: true, is_member: false },
+        { id: "D1", is_im: true, user: "U-unresolved", is_private: true },
+      ],
+    };
+
+    const result = (await handleListSlackChannels({
+      queryParams: { memberOnly: "true" },
+    })) as { channels: Array<Record<string, unknown>> };
+
+    expect(result.channels).toHaveLength(1);
+    expect(result.channels[0]).toEqual({
+      id: "C1",
+      name: "member-channel",
+      type: "channel",
+      isPrivate: false,
+      isMember: true,
+    });
+  });
+
+  test("omitting memberOnly returns all conversations", async () => {
+    connectionByProvider["slack"] = { id: "conn-slack-1" };
+    secureKeyValues.set(
+      "oauth_connection/conn-slack-1/access_token",
+      "xoxb-test",
+    );
+
+    listConversationsResult = {
+      ok: true,
+      channels: [
+        { id: "C1", name: "member-channel", is_channel: true, is_member: true },
+        { id: "C2", name: "other-channel", is_channel: true, is_member: false },
+      ],
+    };
+
+    const result = (await handleListSlackChannels({})) as {
+      channels: Array<Record<string, unknown>>;
+    };
+
+    expect(result.channels).toHaveLength(2);
   });
 });
 

--- a/assistant/src/__tests__/slack-share-routes.test.ts
+++ b/assistant/src/__tests__/slack-share-routes.test.ts
@@ -22,30 +22,20 @@ mock.module("../oauth/oauth-store.js", () => ({
     connectionByProvider[key] ?? undefined,
 }));
 
-let listConversationsResult: unknown = { ok: true, channels: [] };
 let postMessageResult: unknown = {
   ok: true,
   ts: "1234567890.123456",
   channel: "C123",
   message: { ts: "1234567890.123456", text: "", type: "message" },
 };
-let userInfoResults: Map<string, unknown> = new Map();
 
 mock.module("../messaging/providers/slack/client.js", () => ({
-  listConversations: async () => listConversationsResult,
   postMessage: async (
     _token: string,
     _channel: string,
     _text: string,
     _opts?: unknown,
   ) => postMessageResult,
-  userInfo: async (_token: string, userId: string) => {
-    const result = userInfoResults.get(userId);
-    if (result) {
-      return result;
-    }
-    throw new Error(`User not found: ${userId}`);
-  },
 }));
 
 let appStoreResult: unknown = null;
@@ -77,7 +67,7 @@ mock.module("../util/logger.js", () => ({
 // Import under test (after mocks)
 // ---------------------------------------------------------------------------
 
-const { handleListSlackChannels, handleShareToSlackChannel } =
+const { handleShareToSlackChannel } =
   await import("../runtime/routes/integrations/slack/share.js");
 
 // ---------------------------------------------------------------------------
@@ -87,8 +77,6 @@ const { handleListSlackChannels, handleShareToSlackChannel } =
 beforeEach(() => {
   secureKeyValues.clear();
   connectionByProvider = {};
-  listConversationsResult = { ok: true, channels: [] };
-  userInfoResults = new Map();
   appStoreResult = null;
   postMessageResult = {
     ok: true,
@@ -96,259 +84,6 @@ beforeEach(() => {
     channel: "C123",
     message: { ts: "1234567890.123456", text: "", type: "message" },
   };
-});
-
-describe("handleListSlackChannels", () => {
-  test("throws ServiceUnavailableError when no token is configured", async () => {
-    expect(handleListSlackChannels()).rejects.toThrow(ServiceUnavailableError);
-  });
-
-  test("returns channels sorted by type then name", async () => {
-    connectionByProvider["slack"] = { id: "conn-slack-1" };
-    secureKeyValues.set(
-      "oauth_connection/conn-slack-1/access_token",
-      "xoxb-test",
-    );
-
-    listConversationsResult = {
-      ok: true,
-      channels: [
-        {
-          id: "D1",
-          name: undefined,
-          is_im: true,
-          user: "U1",
-          is_private: true,
-        },
-        { id: "C2", name: "beta-channel", is_channel: true },
-        { id: "C1", name: "alpha-channel", is_channel: true },
-        { id: "G1", name: "group-chat", is_mpim: true, is_private: true },
-      ],
-    };
-
-    userInfoResults.set("U1", {
-      ok: true,
-      user: {
-        id: "U1",
-        name: "alice",
-        profile: { display_name: "Alice Smith" },
-      },
-    });
-
-    const result = (await handleListSlackChannels()) as {
-      channels: Array<{
-        id: string;
-        name: string;
-        type: string;
-        isPrivate: boolean;
-        isMember: boolean;
-      }>;
-    };
-
-    expect(result.channels).toHaveLength(4);
-    expect(result.channels[0]).toEqual({
-      id: "C1",
-      name: "alpha-channel",
-      type: "channel",
-      isPrivate: false,
-      isMember: false,
-    });
-    expect(result.channels[1]).toEqual({
-      id: "C2",
-      name: "beta-channel",
-      type: "channel",
-      isPrivate: false,
-      isMember: false,
-    });
-    expect(result.channels[2]).toEqual({
-      id: "G1",
-      name: "group-chat",
-      type: "group",
-      isPrivate: true,
-      isMember: false,
-    });
-    expect(result.channels[3]).toEqual({
-      id: "D1",
-      name: "Alice Smith",
-      type: "dm",
-      isPrivate: true,
-      isMember: false,
-    });
-  });
-
-  test("maps isMember, memberCount, topic, and purpose fallback from the raw payload", async () => {
-    connectionByProvider["slack"] = { id: "conn-slack-1" };
-    secureKeyValues.set(
-      "oauth_connection/conn-slack-1/access_token",
-      "xoxb-test",
-    );
-
-    listConversationsResult = {
-      ok: true,
-      channels: [
-        {
-          id: "C1",
-          name: "with-topic",
-          is_channel: true,
-          is_member: true,
-          num_members: 42,
-          topic: { value: "P2 incident triage" },
-          purpose: { value: "unused purpose" },
-        },
-        {
-          id: "C2",
-          name: "purpose-fallback",
-          is_channel: true,
-          num_members: 7,
-          topic: { value: "" },
-          purpose: { value: "Escalation hand-offs" },
-        },
-        {
-          id: "C3",
-          name: "bare-channel",
-          is_channel: true,
-        },
-      ],
-    };
-
-    const result = (await handleListSlackChannels()) as {
-      channels: Array<Record<string, unknown>>;
-    };
-
-    expect(result.channels[0]).toEqual({
-      id: "C3",
-      name: "bare-channel",
-      type: "channel",
-      isPrivate: false,
-      isMember: false,
-    });
-    expect(result.channels[1]).toEqual({
-      id: "C2",
-      name: "purpose-fallback",
-      type: "channel",
-      isPrivate: false,
-      isMember: false,
-      memberCount: 7,
-      topic: "Escalation hand-offs",
-    });
-    expect(result.channels[2]).toEqual({
-      id: "C1",
-      name: "with-topic",
-      type: "channel",
-      isPrivate: false,
-      isMember: true,
-      memberCount: 42,
-      topic: "P2 incident triage",
-    });
-  });
-
-  test("populates imageUrl on DM rows from the userInfo profile", async () => {
-    connectionByProvider["slack"] = { id: "conn-slack-1" };
-    secureKeyValues.set(
-      "oauth_connection/conn-slack-1/access_token",
-      "xoxb-test",
-    );
-
-    listConversationsResult = {
-      ok: true,
-      channels: [
-        { id: "D1", is_im: true, user: "U1", is_private: true },
-        { id: "D2", is_im: true, user: "U2", is_private: true },
-      ],
-    };
-
-    userInfoResults.set("U1", {
-      ok: true,
-      user: {
-        id: "U1",
-        name: "alice",
-        profile: {
-          display_name: "Alice Smith",
-          image_48: "https://avatars.example.com/u1_48.png",
-        },
-      },
-    });
-    userInfoResults.set("U2", {
-      ok: true,
-      user: {
-        id: "U2",
-        name: "bob",
-        profile: { display_name: "Bob Jones" },
-      },
-    });
-
-    const result = (await handleListSlackChannels()) as {
-      channels: Array<Record<string, unknown>>;
-    };
-
-    expect(result.channels[0]).toEqual({
-      id: "D1",
-      name: "Alice Smith",
-      type: "dm",
-      isPrivate: true,
-      isMember: false,
-      imageUrl: "https://avatars.example.com/u1_48.png",
-    });
-    expect(result.channels[1]).toEqual({
-      id: "D2",
-      name: "Bob Jones",
-      type: "dm",
-      isPrivate: true,
-      isMember: false,
-    });
-  });
-
-  test("memberOnly=true filters to is_member conversations before normalizing", async () => {
-    connectionByProvider["slack"] = { id: "conn-slack-1" };
-    secureKeyValues.set(
-      "oauth_connection/conn-slack-1/access_token",
-      "xoxb-test",
-    );
-
-    listConversationsResult = {
-      ok: true,
-      channels: [
-        { id: "C1", name: "member-channel", is_channel: true, is_member: true },
-        { id: "C2", name: "other-channel", is_channel: true, is_member: false },
-        { id: "D1", is_im: true, user: "U-unresolved", is_private: true },
-      ],
-    };
-
-    const result = (await handleListSlackChannels({
-      queryParams: { memberOnly: "true" },
-    })) as { channels: Array<Record<string, unknown>> };
-
-    expect(result.channels).toHaveLength(1);
-    expect(result.channels[0]).toEqual({
-      id: "C1",
-      name: "member-channel",
-      type: "channel",
-      isPrivate: false,
-      isMember: true,
-    });
-  });
-
-  test("omitting memberOnly returns all conversations", async () => {
-    connectionByProvider["slack"] = { id: "conn-slack-1" };
-    secureKeyValues.set(
-      "oauth_connection/conn-slack-1/access_token",
-      "xoxb-test",
-    );
-
-    listConversationsResult = {
-      ok: true,
-      channels: [
-        { id: "C1", name: "member-channel", is_channel: true, is_member: true },
-        { id: "C2", name: "other-channel", is_channel: true, is_member: false },
-      ],
-    };
-
-    const result = (await handleListSlackChannels({})) as {
-      channels: Array<Record<string, unknown>>;
-    };
-
-    expect(result.channels).toHaveLength(2);
-  });
 });
 
 describe("handleShareToSlackChannel", () => {

--- a/assistant/src/__tests__/slack-skill.test.ts
+++ b/assistant/src/__tests__/slack-skill.test.ts
@@ -2,44 +2,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
-import type { SlackConversation } from "../messaging/providers/slack/types.js";
-
 const REPO_SKILLS_DIR = join(import.meta.dir, "..", "..", "..", "skills");
-
-describe("slack adapter isPrivate mapping", () => {
-  // Inline the mapping logic to test it independently of the adapter module
-  function mapIsPrivate(conv: Partial<SlackConversation>): boolean {
-    return conv.is_private ?? conv.is_group ?? false;
-  }
-
-  test("public channel is not private", () => {
-    expect(mapIsPrivate({ is_channel: true, is_private: false })).toBe(false);
-  });
-
-  test("private channel with is_private flag", () => {
-    expect(mapIsPrivate({ is_channel: true, is_private: true })).toBe(true);
-  });
-
-  test("private channel via is_group (legacy)", () => {
-    expect(mapIsPrivate({ is_group: true })).toBe(true);
-  });
-
-  test("is_private takes precedence over is_group", () => {
-    expect(mapIsPrivate({ is_private: false, is_group: true })).toBe(false);
-  });
-
-  test("DM defaults to not private when flags absent", () => {
-    expect(mapIsPrivate({ is_im: true })).toBe(false);
-  });
-
-  test("mpim (group DM) defaults to not private when is_private absent", () => {
-    expect(mapIsPrivate({ is_mpim: true })).toBe(false);
-  });
-
-  test("undefined flags default to false", () => {
-    expect(mapIsPrivate({})).toBe(false);
-  });
-});
 
 describe("slack skill has no TOOLS.json (uses Web API via CLI)", () => {
   const toolsPath = join(REPO_SKILLS_DIR, "slack", "TOOLS.json");

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -33,6 +33,11 @@ import type {
 } from "../../provider-types.js";
 import * as slack from "./client.js";
 import { SlackApiError } from "./client.js";
+import {
+  classifyConversationType,
+  isPrivateConversation,
+  slackUserDisplayName,
+} from "./conversation-utils.js";
 import type {
   SlackConversation,
   SlackMessage,
@@ -292,12 +297,7 @@ function normalizeSlackUserInfo(
   contactDisplayName: string | undefined,
 ): NormalizedSlackUserInfo {
   const displayName =
-    contactDisplayName ||
-    user.profile?.display_name ||
-    user.profile?.real_name ||
-    user.real_name ||
-    user.name ||
-    user.id;
+    contactDisplayName || slackUserDisplayName(user) || user.id;
   const timezone = trimNonEmpty(user.tz);
   const timezoneLabel = trimNonEmpty(user.tz_label);
   const timezoneOffsetSeconds =
@@ -337,26 +337,19 @@ function slackUserInfoMetadata(
   };
 }
 
-function mapConversationType(conv: SlackConversation): Conversation["type"] {
-  if (conv.is_im) return "dm";
-  if (conv.is_mpim) return "group";
-  if (conv.is_group) return "group";
-  return "channel";
-}
-
 function mapConversation(conv: SlackConversation): Conversation {
   const latestTs = conv.latest?.ts ? parseFloat(conv.latest.ts) * 1000 : 0;
   return {
     id: conv.id,
     name: conv.name ?? conv.id,
-    type: mapConversationType(conv),
+    type: classifyConversationType(conv),
     platform: "slack",
     unreadCount: conv.unread_count_display ?? conv.unread_count ?? 0,
     lastActivityAt: latestTs,
     memberCount: conv.num_members,
     topic: conv.topic?.value || undefined,
     isArchived: conv.is_archived,
-    isPrivate: conv.is_private ?? conv.is_group ?? false,
+    isPrivate: isPrivateConversation(conv),
     metadata: conv.is_im ? { dmUserId: conv.user } : undefined,
   };
 }

--- a/assistant/src/messaging/providers/slack/conversation-utils.test.ts
+++ b/assistant/src/messaging/providers/slack/conversation-utils.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  classifyConversationType,
+  isMemberConversation,
+  isPrivateConversation,
+  slackUserDisplayName,
+} from "./conversation-utils.js";
+import type { SlackConversation, SlackUser } from "./types.js";
+
+function conv(partial: Partial<SlackConversation>): SlackConversation {
+  return { id: "C1", ...partial };
+}
+
+describe("classifyConversationType", () => {
+  test("IM is a dm", () => {
+    expect(classifyConversationType(conv({ is_im: true }))).toBe("dm");
+  });
+
+  test("MPIM is a group", () => {
+    expect(classifyConversationType(conv({ is_mpim: true }))).toBe("group");
+  });
+
+  test("legacy private group is a group", () => {
+    expect(classifyConversationType(conv({ is_group: true }))).toBe("group");
+  });
+
+  test("everything else is a channel", () => {
+    expect(classifyConversationType(conv({ is_channel: true }))).toBe(
+      "channel",
+    );
+    expect(classifyConversationType(conv({}))).toBe("channel");
+  });
+});
+
+describe("isPrivateConversation", () => {
+  test("public channel is not private", () => {
+    expect(isPrivateConversation({ is_channel: true, is_private: false })).toBe(
+      false,
+    );
+  });
+
+  test("private channel with is_private flag", () => {
+    expect(isPrivateConversation({ is_channel: true, is_private: true })).toBe(
+      true,
+    );
+  });
+
+  test("private channel via is_group (legacy)", () => {
+    expect(isPrivateConversation({ is_group: true })).toBe(true);
+  });
+
+  test("is_private takes precedence over is_group", () => {
+    expect(isPrivateConversation({ is_private: false, is_group: true })).toBe(
+      false,
+    );
+  });
+
+  test("DM defaults to not private when flags absent", () => {
+    expect(isPrivateConversation({ is_im: true })).toBe(false);
+  });
+
+  test("mpim (group DM) defaults to not private when is_private absent", () => {
+    expect(isPrivateConversation({ is_mpim: true })).toBe(false);
+  });
+
+  test("undefined flags default to false", () => {
+    expect(isPrivateConversation({})).toBe(false);
+  });
+});
+
+describe("isMemberConversation", () => {
+  test("channel with is_member true", () => {
+    expect(
+      isMemberConversation(conv({ is_channel: true, is_member: true })),
+    ).toBe(true);
+  });
+
+  test("channel with is_member false or absent", () => {
+    expect(
+      isMemberConversation(conv({ is_channel: true, is_member: false })),
+    ).toBe(false);
+    expect(isMemberConversation(conv({ is_channel: true }))).toBe(false);
+  });
+
+  test("IMs and MPIMs are member conversations despite missing is_member", () => {
+    expect(isMemberConversation(conv({ is_im: true }))).toBe(true);
+    expect(isMemberConversation(conv({ is_mpim: true }))).toBe(true);
+  });
+});
+
+describe("slackUserDisplayName", () => {
+  function user(partial: Partial<SlackUser>): SlackUser {
+    return { id: "U1", name: "handle", ...partial };
+  }
+
+  test("prefers profile display_name", () => {
+    expect(
+      slackUserDisplayName(
+        user({
+          profile: { display_name: "Alice Smith", real_name: "Alice S." },
+          real_name: "Alice",
+        }),
+      ),
+    ).toBe("Alice Smith");
+  });
+
+  test("falls back through profile real_name, real_name, then name", () => {
+    expect(
+      slackUserDisplayName(
+        user({ profile: { real_name: "Alice S." }, real_name: "Alice" }),
+      ),
+    ).toBe("Alice S.");
+    expect(slackUserDisplayName(user({ real_name: "Alice" }))).toBe("Alice");
+    expect(slackUserDisplayName(user({}))).toBe("handle");
+  });
+
+  test("skips empty-string fields", () => {
+    expect(
+      slackUserDisplayName(
+        user({ profile: { display_name: "" }, real_name: "Alice" }),
+      ),
+    ).toBe("Alice");
+  });
+});

--- a/assistant/src/messaging/providers/slack/conversation-utils.ts
+++ b/assistant/src/messaging/providers/slack/conversation-utils.ts
@@ -1,0 +1,55 @@
+/**
+ * Pure helpers for interpreting raw `SlackConversation` / `SlackUser`
+ * payloads. Shared by the messaging adapter and the runtime Slack routes so
+ * the flag semantics (`is_im`/`is_mpim`/`is_group`, `is_member`,
+ * `is_private`) are derived in exactly one place.
+ */
+
+import type { SlackConversation, SlackUser } from "./types.js";
+
+export type SlackConversationType = "channel" | "group" | "dm";
+
+export function classifyConversationType(
+  conv: SlackConversation,
+): SlackConversationType {
+  if (conv.is_im) {
+    return "dm";
+  }
+  if (conv.is_mpim) {
+    return "group";
+  }
+  if (conv.is_group) {
+    return "group";
+  }
+  return "channel";
+}
+
+export function isPrivateConversation(
+  conv: Partial<SlackConversation>,
+): boolean {
+  return conv.is_private ?? conv.is_group ?? false;
+}
+
+/**
+ * Whether the connected identity is in this conversation. Slack omits
+ * `is_member` on IM/MPIM rows, but `conversations.list` only returns
+ * IMs/MPIMs the authenticated identity participates in, so those count
+ * as member conversations.
+ */
+export function isMemberConversation(conv: SlackConversation): boolean {
+  return conv.is_member === true || !!conv.is_im || !!conv.is_mpim;
+}
+
+/**
+ * Best human-readable name for a Slack user, preferring the profile
+ * display name. May return an empty string when every field is blank —
+ * callers append their own last-resort fallback (e.g. the user ID).
+ */
+export function slackUserDisplayName(user: SlackUser): string {
+  return (
+    user.profile?.display_name ||
+    user.profile?.real_name ||
+    user.real_name ||
+    user.name
+  );
+}

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -84,6 +84,7 @@ import { ROUTES as INFERENCE_PROVIDER_CONNECTION_ROUTES } from "./inference-prov
 import { ROUTES as INFERENCE_SEND_ROUTES } from "./inference-send-routes.js";
 import { ROUTES as A2A_ROUTES } from "./integrations/a2a.js";
 import { ROUTES as SLACK_CHANNEL_CONFIG_ROUTES } from "./integrations/slack/channel.js";
+import { ROUTES as SLACK_CHANNELS_ROUTES } from "./integrations/slack/channels.js";
 import { ROUTES as SLACK_SHARE_ROUTES } from "./integrations/slack/share.js";
 import { ROUTES as TELEGRAM_ROUTES } from "./integrations/telegram.js";
 import { ROUTES as TWILIO_ROUTES } from "./integrations/twilio.js";
@@ -262,6 +263,7 @@ export const ROUTES: RouteDefinition[] = [
   ...A2A_ROUTES,
   ...SLACK_CHANNEL_CONFIG_ROUTES,
   ...SLACK_CHANNEL_RESOLVE_ROUTES,
+  ...SLACK_CHANNELS_ROUTES,
   ...SLACK_SHARE_ROUTES,
   ...STT_ROUTES,
   ...SUGGEST_TRUST_RULE_ROUTES,

--- a/assistant/src/runtime/routes/integrations/slack/__tests__/share.test.ts
+++ b/assistant/src/runtime/routes/integrations/slack/__tests__/share.test.ts
@@ -1,12 +1,12 @@
 /**
- * Unit tests for the Share UI Slack route handlers.
+ * Unit tests for Slack route handler token routing.
  *
  * Verifies the read/write auth split mirrors `messaging/providers/slack/adapter.ts`:
- * - Channel enumeration (GET /v1/slack/channels) is a read path and must
- *   prefer the user_token when present so the picker surfaces channels the
- *   user is in but the bot isn't.
- * - Channel sharing (POST /v1/slack/share) is a write path and must always
- *   use the bot_token so posts come from the bot identity.
+ * - Channel enumeration (`channels.ts`, GET /v1/slack/channels) is a read
+ *   path and must prefer the user_token when present so the picker surfaces
+ *   channels the user is in but the bot isn't.
+ * - Channel sharing (`share.ts`, POST /v1/slack/share) is a write path and
+ *   must always use the bot_token so posts come from the bot identity.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -32,8 +32,8 @@ mock.module("../../../../../apps/app-store.js", () => ({
   getApp: (id: string) => (id === FAKE_APP.id ? FAKE_APP : undefined),
 }));
 
-const { handleListSlackChannels, handleShareToSlackChannel } =
-  await import("../share.js");
+const { handleListSlackChannels } = await import("../channels.js");
+const { handleShareToSlackChannel } = await import("../share.js");
 
 // ── fetch capture ───────────────────────────────────────────────────────────
 
@@ -101,7 +101,9 @@ describe("Slack share route token routing", () => {
 
   test("GET /v1/slack/channels: bot-only install reads with bot token", async () => {
     getSecureKeyAsyncMock.mockImplementation(async (key: string) => {
-      if (key === credentialKey("slack_channel", "bot_token")) return BOT_TOKEN;
+      if (key === credentialKey("slack_channel", "bot_token")) {
+        return BOT_TOKEN;
+      }
       return null;
     });
 
@@ -119,9 +121,12 @@ describe("Slack share route token routing", () => {
 
   test("GET /v1/slack/channels: bot + user tokens prefer user_token for reads", async () => {
     getSecureKeyAsyncMock.mockImplementation(async (key: string) => {
-      if (key === credentialKey("slack_channel", "bot_token")) return BOT_TOKEN;
-      if (key === credentialKey("slack_channel", "user_token"))
+      if (key === credentialKey("slack_channel", "bot_token")) {
+        return BOT_TOKEN;
+      }
+      if (key === credentialKey("slack_channel", "user_token")) {
         return USER_TOKEN;
+      }
       return null;
     });
 
@@ -139,9 +144,12 @@ describe("Slack share route token routing", () => {
 
   test("POST /v1/slack/share: bot + user tokens still write with bot token", async () => {
     getSecureKeyAsyncMock.mockImplementation(async (key: string) => {
-      if (key === credentialKey("slack_channel", "bot_token")) return BOT_TOKEN;
-      if (key === credentialKey("slack_channel", "user_token"))
+      if (key === credentialKey("slack_channel", "bot_token")) {
+        return BOT_TOKEN;
+      }
+      if (key === credentialKey("slack_channel", "user_token")) {
         return USER_TOKEN;
+      }
       return null;
     });
 

--- a/assistant/src/runtime/routes/integrations/slack/channels.ts
+++ b/assistant/src/runtime/routes/integrations/slack/channels.ts
@@ -114,7 +114,7 @@ export async function handleListSlackChannels({
       name,
       type,
       isPrivate: isPrivateConversation(c),
-      isMember: c.is_member ?? false,
+      isMember: isMemberConversation(c),
       memberCount: c.num_members ?? null,
       topic: c.topic?.value || c.purpose?.value || null,
       imageUrl,

--- a/assistant/src/runtime/routes/integrations/slack/channels.ts
+++ b/assistant/src/runtime/routes/integrations/slack/channels.ts
@@ -1,0 +1,172 @@
+/**
+ * Route handler for Slack channel enumeration.
+ *
+ * GET /v1/slack/channels — normalized list of channels, groups, and DMs
+ * used by the share picker and the Channels-tab room list.
+ */
+
+import { z } from "zod";
+
+import {
+  listConversations,
+  userInfo,
+} from "../../../../messaging/providers/slack/client.js";
+import type { SlackConversation } from "../../../../messaging/providers/slack/types.js";
+import { ACTOR_PRINCIPALS } from "../../../auth/route-policy.js";
+import { ServiceUnavailableError } from "../../errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "../../types.js";
+import { resolveSlackToken } from "./token.js";
+
+const NormalizedChannelSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: z.enum(["channel", "group", "dm"]),
+  isPrivate: z.boolean(),
+  isMember: z.boolean(),
+  memberCount: z.number().nullable(),
+  topic: z.string().nullable(),
+  imageUrl: z.string().nullable(),
+});
+
+type NormalizedChannel = z.infer<typeof NormalizedChannelSchema>;
+
+const SlackChannelsListResultSchema = z.object({
+  channels: z.array(NormalizedChannelSchema),
+});
+
+function classifyConversation(
+  conv: SlackConversation,
+): "channel" | "group" | "dm" {
+  if (conv.is_im) {
+    return "dm";
+  }
+  if (conv.is_mpim) {
+    return "group";
+  }
+  if (conv.is_group) {
+    return "group";
+  }
+  return "channel";
+}
+
+const TYPE_SORT_ORDER: Record<string, number> = {
+  channel: 0,
+  group: 1,
+  dm: 2,
+};
+
+export async function handleListSlackChannels({
+  queryParams,
+}: RouteHandlerArgs = {}) {
+  const token = await resolveSlackToken("read");
+  if (!token) {
+    throw new ServiceUnavailableError("No Slack token configured");
+  }
+
+  const memberOnly = queryParams?.memberOnly === "true";
+
+  const allChannels: SlackConversation[] = [];
+  let cursor: string | undefined;
+  do {
+    const resp = await listConversations(
+      token,
+      "public_channel,private_channel,mpim,im",
+      true,
+      200,
+      cursor,
+    );
+    allChannels.push(...resp.channels);
+    cursor = resp.response_metadata?.next_cursor || undefined;
+  } while (cursor);
+
+  const conversations = memberOnly
+    ? allChannels.filter((c) => c.is_member === true)
+    : allChannels;
+
+  const dmUserIds = conversations
+    .filter((c) => c.is_im && c.user)
+    .map((c) => c.user!);
+  const uniqueUserIds = [...new Set(dmUserIds)];
+  const userResults = await Promise.allSettled(
+    uniqueUserIds.map((uid) =>
+      userInfo(token, uid).then((r) => ({
+        uid,
+        name:
+          r.user.profile?.display_name ||
+          r.user.profile?.real_name ||
+          r.user.real_name ||
+          r.user.name,
+        imageUrl: r.user.profile?.image_48 ?? null,
+      })),
+    ),
+  );
+  const dmUserMap = new Map<
+    string,
+    { name: string; imageUrl: string | null }
+  >();
+  for (const r of userResults) {
+    if (r.status === "fulfilled") {
+      dmUserMap.set(r.value.uid, {
+        name: r.value.name,
+        imageUrl: r.value.imageUrl,
+      });
+    }
+  }
+
+  const channels: NormalizedChannel[] = conversations.map((c) => {
+    const type = classifyConversation(c);
+    let name = c.name ?? c.id;
+    let imageUrl: string | null = null;
+    if (type === "dm" && c.user) {
+      const dmUser = dmUserMap.get(c.user);
+      name = dmUser?.name ?? c.user;
+      imageUrl = dmUser?.imageUrl ?? null;
+    }
+    return {
+      id: c.id,
+      name,
+      type,
+      isPrivate: c.is_private ?? c.is_group ?? false,
+      isMember: c.is_member ?? false,
+      memberCount: c.num_members ?? null,
+      topic: c.topic?.value || c.purpose?.value || null,
+      imageUrl,
+    };
+  });
+
+  channels.sort((a, b) => {
+    const typeOrder =
+      (TYPE_SORT_ORDER[a.type] ?? 9) - (TYPE_SORT_ORDER[b.type] ?? 9);
+    if (typeOrder !== 0) {
+      return typeOrder;
+    }
+    return a.name.localeCompare(b.name);
+  });
+
+  return { channels };
+}
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "slack_channels_get",
+    endpoint: "slack/channels",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "List Slack channels",
+    description: "List Slack channels, groups, and DMs for the channel picker.",
+    tags: ["integrations"],
+    queryParams: [
+      {
+        name: "memberOnly",
+        schema: { type: "string", enum: ["true", "false"] },
+        description:
+          "When 'true', only return conversations the connected identity is a member of",
+      },
+    ],
+    responseBody: SlackChannelsListResultSchema,
+    handler: handleListSlackChannels,
+  },
+];

--- a/assistant/src/runtime/routes/integrations/slack/channels.ts
+++ b/assistant/src/runtime/routes/integrations/slack/channels.ts
@@ -79,8 +79,10 @@ export async function handleListSlackChannels({
     cursor = resp.response_metadata?.next_cursor || undefined;
   } while (cursor);
 
+  // Slack omits `is_member` on IMs/MPIMs, but any DM or group DM returned by
+  // `conversations.list` is inherently one the connected identity is in.
   const conversations = memberOnly
-    ? allChannels.filter((c) => c.is_member === true)
+    ? allChannels.filter((c) => c.is_member === true || c.is_im || c.is_mpim)
     : allChannels;
 
   const dmUserIds = conversations
@@ -163,7 +165,7 @@ export const ROUTES: RouteDefinition[] = [
         name: "memberOnly",
         schema: { type: "string", enum: ["true", "false"] },
         description:
-          "When 'true', only return conversations the connected identity is a member of",
+          "When 'true', only return conversations the connected identity is in: channels/groups with is_member, plus all DMs and group DMs",
       },
     ],
     responseBody: SlackChannelsListResultSchema,

--- a/assistant/src/runtime/routes/integrations/slack/channels.ts
+++ b/assistant/src/runtime/routes/integrations/slack/channels.ts
@@ -11,6 +11,12 @@ import {
   listConversations,
   userInfo,
 } from "../../../../messaging/providers/slack/client.js";
+import {
+  classifyConversationType,
+  isMemberConversation,
+  isPrivateConversation,
+  slackUserDisplayName,
+} from "../../../../messaging/providers/slack/conversation-utils.js";
 import type { SlackConversation } from "../../../../messaging/providers/slack/types.js";
 import { ACTOR_PRINCIPALS } from "../../../auth/route-policy.js";
 import { ServiceUnavailableError } from "../../errors.js";
@@ -33,21 +39,6 @@ type NormalizedChannel = z.infer<typeof NormalizedChannelSchema>;
 const SlackChannelsListResultSchema = z.object({
   channels: z.array(NormalizedChannelSchema),
 });
-
-function classifyConversation(
-  conv: SlackConversation,
-): "channel" | "group" | "dm" {
-  if (conv.is_im) {
-    return "dm";
-  }
-  if (conv.is_mpim) {
-    return "group";
-  }
-  if (conv.is_group) {
-    return "group";
-  }
-  return "channel";
-}
 
 const TYPE_SORT_ORDER: Record<string, number> = {
   channel: 0,
@@ -79,10 +70,8 @@ export async function handleListSlackChannels({
     cursor = resp.response_metadata?.next_cursor || undefined;
   } while (cursor);
 
-  // Slack omits `is_member` on IMs/MPIMs, but any DM or group DM returned by
-  // `conversations.list` is inherently one the connected identity is in.
   const conversations = memberOnly
-    ? allChannels.filter((c) => c.is_member === true || c.is_im || c.is_mpim)
+    ? allChannels.filter(isMemberConversation)
     : allChannels;
 
   const dmUserIds = conversations
@@ -93,11 +82,7 @@ export async function handleListSlackChannels({
     uniqueUserIds.map((uid) =>
       userInfo(token, uid).then((r) => ({
         uid,
-        name:
-          r.user.profile?.display_name ||
-          r.user.profile?.real_name ||
-          r.user.real_name ||
-          r.user.name,
+        name: slackUserDisplayName(r.user),
         imageUrl: r.user.profile?.image_48 ?? null,
       })),
     ),
@@ -116,7 +101,7 @@ export async function handleListSlackChannels({
   }
 
   const channels: NormalizedChannel[] = conversations.map((c) => {
-    const type = classifyConversation(c);
+    const type = classifyConversationType(c);
     let name = c.name ?? c.id;
     let imageUrl: string | null = null;
     if (type === "dm" && c.user) {
@@ -128,7 +113,7 @@ export async function handleListSlackChannels({
       id: c.id,
       name,
       type,
-      isPrivate: c.is_private ?? c.is_group ?? false,
+      isPrivate: isPrivateConversation(c),
       isMember: c.is_member ?? false,
       memberCount: c.num_members ?? null,
       topic: c.topic?.value || c.purpose?.value || null,

--- a/assistant/src/runtime/routes/integrations/slack/share.ts
+++ b/assistant/src/runtime/routes/integrations/slack/share.ts
@@ -1,19 +1,14 @@
 /**
- * Route handlers for Slack channel listing and direct sharing.
+ * Route handler for direct sharing to Slack channels.
  *
- * These endpoints let the UI post app links directly to Slack channels
- * without going through the legacy Slack share flow.
+ * POST /v1/slack/share — lets the UI post app links directly to Slack
+ * channels without going through the legacy Slack share flow.
  */
 
 import { z } from "zod";
 
 import { getApp } from "../../../../apps/app-store.js";
-import {
-  listConversations,
-  postMessage,
-  userInfo,
-} from "../../../../messaging/providers/slack/client.js";
-import type { SlackConversation } from "../../../../messaging/providers/slack/types.js";
+import { postMessage } from "../../../../messaging/providers/slack/client.js";
 import { getLogger } from "../../../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../../../auth/route-policy.js";
 import {
@@ -27,153 +22,11 @@ import { resolveSlackToken } from "./token.js";
 
 const log = getLogger("slack-share");
 
-// ---------------------------------------------------------------------------
-// GET /v1/slack/channels
-// ---------------------------------------------------------------------------
-
-const NormalizedChannelSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  type: z.enum(["channel", "group", "dm"]),
-  isPrivate: z.boolean(),
-  isMember: z.boolean(),
-  memberCount: z.number().optional(),
-  topic: z.string().optional(),
-  imageUrl: z.string().optional(),
-});
-
-type NormalizedChannel = z.infer<typeof NormalizedChannelSchema>;
-
-const SlackChannelsListResultSchema = z.object({
-  channels: z.array(NormalizedChannelSchema),
-});
-
 const SlackShareResultSchema = z.object({
   ok: z.boolean(),
   ts: z.string(),
   channel: z.string(),
 });
-
-function classifyConversation(
-  conv: SlackConversation,
-): "channel" | "group" | "dm" {
-  if (conv.is_im) {
-    return "dm";
-  }
-  if (conv.is_mpim) {
-    return "group";
-  }
-  if (conv.is_group) {
-    return "group";
-  }
-  return "channel";
-}
-
-const TYPE_SORT_ORDER: Record<string, number> = {
-  channel: 0,
-  group: 1,
-  dm: 2,
-};
-
-export async function handleListSlackChannels({
-  queryParams,
-}: RouteHandlerArgs = {}) {
-  const token = await resolveSlackToken("read");
-  if (!token) {
-    throw new ServiceUnavailableError("No Slack token configured");
-  }
-
-  const memberOnly = queryParams?.memberOnly === "true";
-
-  const allChannels: SlackConversation[] = [];
-  let cursor: string | undefined;
-  do {
-    const resp = await listConversations(
-      token,
-      "public_channel,private_channel,mpim,im",
-      true,
-      200,
-      cursor,
-    );
-    allChannels.push(...resp.channels);
-    cursor = resp.response_metadata?.next_cursor || undefined;
-  } while (cursor);
-
-  const conversations = memberOnly
-    ? allChannels.filter((c) => c.is_member === true)
-    : allChannels;
-
-  const dmUserIds = conversations
-    .filter((c) => c.is_im && c.user)
-    .map((c) => c.user!);
-  const uniqueUserIds = [...new Set(dmUserIds)];
-  const userResults = await Promise.allSettled(
-    uniqueUserIds.map((uid) =>
-      userInfo(token, uid).then((r) => ({
-        uid,
-        name:
-          r.user.profile?.display_name ||
-          r.user.profile?.real_name ||
-          r.user.real_name ||
-          r.user.name,
-        imageUrl: r.user.profile?.image_48,
-      })),
-    ),
-  );
-  const dmUserMap = new Map<string, { name: string; imageUrl?: string }>();
-  for (const r of userResults) {
-    if (r.status === "fulfilled") {
-      dmUserMap.set(r.value.uid, {
-        name: r.value.name,
-        imageUrl: r.value.imageUrl,
-      });
-    }
-  }
-
-  const channels: NormalizedChannel[] = conversations.map((c) => {
-    const type = classifyConversation(c);
-    let name = c.name ?? c.id;
-    let imageUrl: string | undefined;
-    if (type === "dm" && c.user) {
-      const dmUser = dmUserMap.get(c.user);
-      name = dmUser?.name ?? c.user;
-      imageUrl = dmUser?.imageUrl;
-    }
-    const topic = c.topic?.value || c.purpose?.value || undefined;
-    const channel: NormalizedChannel = {
-      id: c.id,
-      name,
-      type,
-      isPrivate: c.is_private ?? c.is_group ?? false,
-      isMember: c.is_member ?? false,
-    };
-    if (c.num_members !== undefined) {
-      channel.memberCount = c.num_members;
-    }
-    if (topic) {
-      channel.topic = topic;
-    }
-    if (imageUrl) {
-      channel.imageUrl = imageUrl;
-    }
-    return channel;
-  });
-
-  channels.sort((a, b) => {
-    const typeOrder =
-      (TYPE_SORT_ORDER[a.type] ?? 9) - (TYPE_SORT_ORDER[b.type] ?? 9);
-    if (typeOrder !== 0) {
-      return typeOrder;
-    }
-    return a.name.localeCompare(b.name);
-  });
-
-  return { channels };
-}
-
-// ---------------------------------------------------------------------------
-// POST /v1/slack/share
-// ---------------------------------------------------------------------------
 
 export async function handleShareToSlackChannel({
   body = {},
@@ -242,33 +95,7 @@ export async function handleShareToSlackChannel({
   }
 }
 
-// ---------------------------------------------------------------------------
-// Route definitions
-// ---------------------------------------------------------------------------
-
 export const ROUTES: RouteDefinition[] = [
-  {
-    operationId: "slack_channels_get",
-    endpoint: "slack/channels",
-    method: "GET",
-    policy: {
-      requiredScopes: ["settings.read"],
-      allowedPrincipalTypes: ACTOR_PRINCIPALS,
-    },
-    summary: "List Slack channels",
-    description: "List Slack channels, groups, and DMs for the channel picker.",
-    tags: ["integrations"],
-    queryParams: [
-      {
-        name: "memberOnly",
-        schema: { type: "string", enum: ["true", "false"] },
-        description:
-          "When 'true', only return conversations the connected identity is a member of",
-      },
-    ],
-    responseBody: SlackChannelsListResultSchema,
-    handler: handleListSlackChannels,
-  },
   {
     operationId: "slack_share_post",
     endpoint: "slack/share",

--- a/assistant/src/runtime/routes/integrations/slack/share.ts
+++ b/assistant/src/runtime/routes/integrations/slack/share.ts
@@ -36,6 +36,10 @@ const NormalizedChannelSchema = z.object({
   name: z.string(),
   type: z.enum(["channel", "group", "dm"]),
   isPrivate: z.boolean(),
+  isMember: z.boolean(),
+  memberCount: z.number().optional(),
+  topic: z.string().optional(),
+  imageUrl: z.string().optional(),
 });
 
 type NormalizedChannel = z.infer<typeof NormalizedChannelSchema>;
@@ -53,9 +57,15 @@ const SlackShareResultSchema = z.object({
 function classifyConversation(
   conv: SlackConversation,
 ): "channel" | "group" | "dm" {
-  if (conv.is_im) return "dm";
-  if (conv.is_mpim) return "group";
-  if (conv.is_group) return "group";
+  if (conv.is_im) {
+    return "dm";
+  }
+  if (conv.is_mpim) {
+    return "group";
+  }
+  if (conv.is_group) {
+    return "group";
+  }
   return "channel";
 }
 
@@ -65,11 +75,15 @@ const TYPE_SORT_ORDER: Record<string, number> = {
   dm: 2,
 };
 
-export async function handleListSlackChannels() {
+export async function handleListSlackChannels({
+  queryParams,
+}: RouteHandlerArgs = {}) {
   const token = await resolveSlackToken("read");
   if (!token) {
     throw new ServiceUnavailableError("No Slack token configured");
   }
+
+  const memberOnly = queryParams?.memberOnly === "true";
 
   const allChannels: SlackConversation[] = [];
   let cursor: string | undefined;
@@ -85,11 +99,15 @@ export async function handleListSlackChannels() {
     cursor = resp.response_metadata?.next_cursor || undefined;
   } while (cursor);
 
-  const dmUserIds = allChannels
+  const conversations = memberOnly
+    ? allChannels.filter((c) => c.is_member === true)
+    : allChannels;
+
+  const dmUserIds = conversations
     .filter((c) => c.is_im && c.user)
     .map((c) => c.user!);
   const uniqueUserIds = [...new Set(dmUserIds)];
-  const nameResults = await Promise.allSettled(
+  const userResults = await Promise.allSettled(
     uniqueUserIds.map((uid) =>
       userInfo(token, uid).then((r) => ({
         uid,
@@ -98,34 +116,55 @@ export async function handleListSlackChannels() {
           r.user.profile?.real_name ||
           r.user.real_name ||
           r.user.name,
+        imageUrl: r.user.profile?.image_48,
       })),
     ),
   );
-  const nameMap = new Map<string, string>();
-  for (const r of nameResults) {
+  const dmUserMap = new Map<string, { name: string; imageUrl?: string }>();
+  for (const r of userResults) {
     if (r.status === "fulfilled") {
-      nameMap.set(r.value.uid, r.value.name);
+      dmUserMap.set(r.value.uid, {
+        name: r.value.name,
+        imageUrl: r.value.imageUrl,
+      });
     }
   }
 
-  const channels: NormalizedChannel[] = allChannels.map((c) => {
+  const channels: NormalizedChannel[] = conversations.map((c) => {
     const type = classifyConversation(c);
     let name = c.name ?? c.id;
+    let imageUrl: string | undefined;
     if (type === "dm" && c.user) {
-      name = nameMap.get(c.user) ?? c.user;
+      const dmUser = dmUserMap.get(c.user);
+      name = dmUser?.name ?? c.user;
+      imageUrl = dmUser?.imageUrl;
     }
-    return {
+    const topic = c.topic?.value || c.purpose?.value || undefined;
+    const channel: NormalizedChannel = {
       id: c.id,
       name,
       type,
       isPrivate: c.is_private ?? c.is_group ?? false,
+      isMember: c.is_member ?? false,
     };
+    if (c.num_members !== undefined) {
+      channel.memberCount = c.num_members;
+    }
+    if (topic) {
+      channel.topic = topic;
+    }
+    if (imageUrl) {
+      channel.imageUrl = imageUrl;
+    }
+    return channel;
   });
 
   channels.sort((a, b) => {
     const typeOrder =
       (TYPE_SORT_ORDER[a.type] ?? 9) - (TYPE_SORT_ORDER[b.type] ?? 9);
-    if (typeOrder !== 0) return typeOrder;
+    if (typeOrder !== 0) {
+      return typeOrder;
+    }
     return a.name.localeCompare(b.name);
   });
 
@@ -219,8 +258,16 @@ export const ROUTES: RouteDefinition[] = [
     summary: "List Slack channels",
     description: "List Slack channels, groups, and DMs for the channel picker.",
     tags: ["integrations"],
+    queryParams: [
+      {
+        name: "memberOnly",
+        schema: { type: "string", enum: ["true", "false"] },
+        description:
+          "When 'true', only return conversations the connected identity is a member of",
+      },
+    ],
     responseBody: SlackChannelsListResultSchema,
-    handler: () => handleListSlackChannels(),
+    handler: handleListSlackChannels,
   },
   {
     operationId: "slack_share_post",


### PR DESCRIPTION
## Prompt / plan

Implements [LUM-2711](https://linear.app/vellum/issue/LUM-2711/featslack-slack-channels-get-enrich-normalized-channel-shape) (extract-plus-enrich scope): before enriching, channel enumeration moves out of the share module so non-share behavior stops accumulating there; then the normalized shape gains the fields the Channels-tab room list (LUM-2713) needs.

**1 — Extract (no behavior or URL changes):** `GET /v1/slack/channels` now lives in `assistant/src/runtime/routes/integrations/slack/channels.ts` (handler, `NormalizedChannelSchema`, `TYPE_SORT_ORDER`, its own `ROUTES` entry); `share.ts` keeps only `POST /v1/slack/share`. Both register through the shared `ROUTES` aggregator in `routes/index.ts`, so the transport-agnostic adapter pattern (dual HTTP/IPC exposure, plain-data handlers, `RouteError` throws) is preserved — and the raw-payload→normalized-shape mapping is isolated per provider, so future channel providers (Telegram, WhatsApp) can add sibling enumeration modules against the same provider-agnostic normalized shape. Note: the module lands in the existing `routes/integrations/slack/` directory (next to `token.ts`, which both files import) rather than a new `routes/slack/` — that's where the Slack route modules already live; named `channels.ts` following sibling naming (`share.ts`, `channel.ts`, `token.ts`).

**1b — Shared conversation helpers:** the conversation-type classification, `isPrivate` derivation, and user display-name fallback chain each existed in two or three copies (route module, messaging adapter, and an inlined copy in `slack-skill.test.ts`). They now live in one pure module, `messaging/providers/slack/conversation-utils.ts` (`classifyConversationType`, `isPrivateConversation`, `isMemberConversation`, `slackUserDisplayName`), imported by both the adapter and the route — behavior unchanged at every call site, with a co-located unit suite.

**2 — Enrich `NormalizedChannelSchema`:** `isMember: boolean` — true when the connected identity is in the conversation (`is_member === true`, or any DM/group DM; same `isMemberConversation` predicate as the `memberOnly` filter, so the field and the filter can't diverge). Plus required-but-nullable `memberCount: number | null` (from `num_members`; null for DMs), `topic: string | null` (from `topic.value`, `purpose.value` fallback when topic is empty; null for DMs), and `imageUrl: string | null` (DM rows only, piggybacking on the existing per-user `userInfo` fetch; null for channels/groups). No new Slack API call sites.

**3 — `?memberOnly=true` query param:** same route, opt-in filter applied before normalization (and before the DM `userInfo` loop, so filtered-out rows cost no lookups). The filter keeps channels/groups with `is_member === true` plus all DMs and group DMs — Slack omits `is_member` on IM/MPIM rows, but `conversations.list` only returns IMs/MPIMs the authenticated identity is in, so they're implicitly member conversations (flagged by Devin/Codex/Vex review; confirmed with Ashlee). Every row in a `memberOnly=true` response carries `isMember: true` by construction. Absent → current behavior, so the existing share picker is unchanged. The gateway control-plane proxy forwards the query string verbatim (`slack-control-plane-proxy.ts` passes `url.search` through), so no gateway change is needed.

**4 — Client regen:** `assistant/openapi.yaml` regenerated via `bun run generate:openapi`; ran the web `openapi-ts` pipeline and verified `src/generated/daemon/types.gen.ts` picks up `memberOnly?: 'true' | 'false'` and the nullable field types (generated output is gitignored and rebuilt from the committed spec at build time, so the spec is the committed artifact).

**Explicit non-additions:** no `unread_count`, `latest`, `is_archived`, or freshness metadata; no programmatic channel join/leave affordance. Auth unchanged — both modules use `resolveSlackToken()` from `./token.js`; no new Slack scopes (`conversations.list`, `users.info` already in use).

Part of LUM-2711

## Test plan

- `bun test src/__tests__/slack-channels-routes.test.ts` — new suite for the extracted module: normalized sort order, `isMember`/`memberCount`/`topic` mapping with purpose fallback and explicit nulls, DM `imageUrl` (present and absent avatar), `memberOnly=true` excluding non-member channels while keeping DMs/group DMs, an invariant check that every `memberOnly=true` row has `isMember: true`, and backward compatibility with the param omitted (7 pass).
- `bun test src/messaging/providers/slack/conversation-utils.test.ts` — unit coverage for the shared helpers, including the isPrivate cases previously inlined in `slack-skill.test.ts` (17 pass).
- `bun test src/__tests__/slack-share-routes.test.ts` — trimmed to the share handler, all passing against the extracted `share.ts` (4 pass).
- `bun test src/runtime/routes/integrations/slack/__tests__/share.test.ts` — read/write token-routing invariant spanning both modules, unchanged behavior (4 pass).
- `bun test src/messaging/providers/slack/__tests__/` — existing adapter suites unchanged (23 pass).
- `bun run typecheck:fast`, `eslint`, and `prettier --check` clean; pre-commit hook runs all three.
- Regenerated `openapi.yaml` diff is scoped to the `slack_channels_get` operation; web `openapi-ts` codegen runs clean against it.

## CLI verb checklist

No new routes — the extraction re-homes the existing `slack_channels_get` route; URLs, operationIds, and policies are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kinn4PapMWqLZzF9qVVKHn