### PR TITLE
fix(tts): close review gaps in the shared synthesis core and its adopters

### DIFF
--- a/assistant/src/__tests__/telephony-tts-guard.test.ts
+++ b/assistant/src/__tests__/telephony-tts-guard.test.ts
@@ -619,4 +619,53 @@ describe("speakSystemPrompt aborted synthesis", () => {
     expect(sentPlayUrls).toEqual([]);
     expect(sentTokens).toEqual([]);
   });
+
+  test("provider AbortError without our signal aborted is a failure — WAV fallback retry still runs", async () => {
+    testConfig.services.tts.provider = "deepgram";
+    storedKeys["deepgram"] = "dg-key";
+    storedKeys["elevenlabs"] = "el-key";
+
+    // Provider-internal network abort: it throws AbortError, but the
+    // caller's signal was never aborted — not a cancellation.
+    const controller = new AbortController();
+    const deepgramSynthesize = jest.fn(async () => {
+      throw new DOMException("socket torn down", "AbortError");
+    });
+    const elevenlabsSynthesize = jest.fn(async () => {
+      return { audio: Buffer.from("pcm-bytes"), contentType: "audio/pcm" };
+    });
+    registerStubProvider("deepgram", deepgramSynthesize);
+    registerStubProvider("elevenlabs", elevenlabsSynthesize);
+
+    const { relay, sentTokens, sentPlayUrls } = createRelay(true);
+    await speakSystemPrompt(
+      relay,
+      "You have a new message.",
+      controller.signal,
+    );
+
+    expect(deepgramSynthesize).toHaveBeenCalledTimes(1);
+    expect(elevenlabsSynthesize).toHaveBeenCalledTimes(1);
+    expect(sentPlayUrls.length).toBe(1);
+    expect(sentTokens).toEqual([{ token: "", last: true }]);
+  });
+
+  test("provider AbortError without any signal is a failure — non-WAV native fallback still runs", async () => {
+    testConfig.services.tts.provider = "fish-audio";
+    testConfig.services.tts.providers["fish-audio"].referenceId = "ref-123";
+
+    const fishSynthesize = jest.fn(async () => {
+      throw new DOMException("socket torn down", "AbortError");
+    });
+    registerStubProvider("fish-audio", fishSynthesize);
+
+    const { relay, sentTokens, sentPlayUrls } = createRelay(false);
+    await speakSystemPrompt(relay, "You have a new message.");
+
+    expect(fishSynthesize).toHaveBeenCalledTimes(1);
+    expect(sentPlayUrls).toEqual([]);
+    expect(sentTokens).toEqual([
+      { token: "You have a new message.", last: true },
+    ]);
+  });
 });

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -836,6 +836,7 @@ export class CallController {
   ): Promise<void> {
     let sink: AudioStoreSink | null = null;
     let playUrlSent = false;
+    const abortController = new AbortController();
     try {
       // When format is WAV (media-stream transport), request raw PCM from
       // the provider so the audio bytes match the store's content-type.
@@ -861,7 +862,6 @@ export class CallController {
         },
       });
 
-      const abortController = new AbortController();
       this.activeSynthesisAbort = abortController;
 
       await synthesizeAndEmit({
@@ -875,7 +875,10 @@ export class CallController {
         onFirstAudio: sink.onFirstAudio,
       });
     } catch (err) {
-      if (err instanceof DOMException && err.name === "AbortError") {
+      // Cancellation requires our own signal to be aborted — a
+      // provider-internal AbortError without it is a synthesis failure
+      // and must take the fallback path below.
+      if (abortController.signal.aborted) {
         log.debug(
           { provider: provider.id },
           "TTS synthesis aborted (barge-in)",

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -95,9 +95,10 @@ export async function speakSystemPrompt(
  *   still hears the message; providers without one (e.g. Deepgram) log
  *   the error and send only the end-of-turn signal.
  *
- * Aborted synthesis (`AbortError` or an aborted `signal`) short-circuits
- * all of the above: no fallback, no end-of-turn token — the canceller
- * owns turn state.
+ * Cancellation (our own `signal` aborted) short-circuits all of the
+ * above: no fallback, no end-of-turn token — the canceller owns turn
+ * state. A provider-internal `AbortError` without our signal aborted is
+ * a synthesis failure and takes the normal fallback path.
  */
 async function synthesizeAndPlay(
   relay: CallTransport,
@@ -126,7 +127,7 @@ async function synthesizeAndPlay(
       onPlayUrl: (url) => relay.sendPlayUrl(url),
     });
 
-    await synthesizeAndEmit({
+    const result = await synthesizeAndEmit({
       provider,
       text,
       useCase: "phone-call",
@@ -140,7 +141,7 @@ async function synthesizeAndPlay(
     // signal aborts after the provider resolves but before queued emits
     // run. Same contract as the catch-side abort: the canceller owns turn
     // state, so skip the end-of-turn token.
-    if (signal?.aborted) {
+    if (result.stopped) {
       log.debug(
         { provider: provider.id },
         "System prompt TTS synthesis aborted after resolve — skipping end-of-turn",
@@ -156,14 +157,12 @@ async function synthesizeAndPlay(
     // state.
     relay.sendTextToken("", true);
   } catch (err) {
-    // Aborted synthesis (e.g. barge-in cancellation): the canceller owns
-    // turn state, so skip fallback and the end-of-turn signal entirely
-    // (mirrors call-controller's aborted-synthesis handling).
-    const isAbort =
-      signal?.aborted ||
-      ((err instanceof Error || err instanceof DOMException) &&
-        err.name === "AbortError");
-    if (isAbort) {
+    // Cancelled synthesis (e.g. barge-in): the canceller owns turn state,
+    // so skip fallback and the end-of-turn signal entirely (mirrors
+    // call-controller's aborted-synthesis handling). Requires our own
+    // signal to be aborted — a provider-internal AbortError without it is
+    // a synthesis failure and must take the fallback/end-of-turn path.
+    if (signal?.aborted) {
       log.debug(
         { provider: provider.id },
         "System prompt TTS synthesis aborted — skipping fallback",

--- a/assistant/src/calls/media-stream-stt-session.ts
+++ b/assistant/src/calls/media-stream-stt-session.ts
@@ -42,6 +42,7 @@ import {
   type TelephonySttCapability,
 } from "../providers/speech-to-text/resolve.js";
 import { normalizeSttError } from "../stt/daemon-batch-transcriber.js";
+import { DEFAULT_SPEECH_ENERGY_THRESHOLD } from "../stt/speech-energy.js";
 import type {
   StreamingTranscriber,
   SttCallContextHints,
@@ -722,8 +723,6 @@ function stopStreamingBestEffort(
  * @returns `true` if the chunk likely contains speech, `false` otherwise.
  */
 function detectSpeechActivity(raw: Buffer): boolean {
-  const SPEECH_ENERGY_THRESHOLD = 800;
-
   if (raw.length === 0) {
     return false;
   }
@@ -735,7 +734,7 @@ function detectSpeechActivity(raw: Buffer): boolean {
   }
   const avgAmplitude = totalAmplitude / raw.length;
 
-  return avgAmplitude > SPEECH_ENERGY_THRESHOLD;
+  return avgAmplitude > DEFAULT_SPEECH_ENERGY_THRESHOLD;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/live-voice/live-voice-tts.ts
+++ b/assistant/src/live-voice/live-voice-tts.ts
@@ -109,7 +109,6 @@ export async function streamLiveVoiceTtsAudio(
       useCase: options.useCase ?? "phone-call",
       voiceId: options.voiceId,
       outputFormat: options.outputFormat,
-      sampleRate,
       signal: options.signal,
       onChunk: (chunk) => {
         if (canStreamChunks) {
@@ -123,7 +122,7 @@ export async function streamLiveVoiceTtsAudio(
 
     // An abort mid-stream resolves without throwing; skip the buffered emit
     // so a truncated payload is never delivered after cancellation.
-    if (!canStreamChunks && !options.signal?.aborted) {
+    if (!canStreamChunks && !result.stopped) {
       emitAudioFrame(contentType, Buffer.concat(bufferedAudio));
     }
 

--- a/assistant/src/tts/__tests__/synthesis-stream.test.ts
+++ b/assistant/src/tts/__tests__/synthesis-stream.test.ts
@@ -116,7 +116,11 @@ describe("synthesizeAndEmit (streaming)", () => {
     });
 
     expect(sink.events).toEqual(["firstAudio", "chunk:a", "chunk:b"]);
-    expect(result).toEqual({ emittedChunks: 2, contentType: "audio/mpeg" });
+    expect(result).toEqual({
+      emittedChunks: 2,
+      contentType: "audio/mpeg",
+      stopped: false,
+    });
   });
 
   test("skips empty chunks", async () => {
@@ -183,6 +187,7 @@ describe("synthesizeAndEmit (streaming)", () => {
 
     expect(sink.events).toEqual([]);
     expect(result.emittedChunks).toBe(0);
+    expect(result.stopped).toBe(true);
   });
 
   test("isCurrent() returning false mid-stream stops emission silently", async () => {
@@ -210,6 +215,7 @@ describe("synthesizeAndEmit (streaming)", () => {
 
     expect(sink.events).toEqual([]);
     expect(result.emittedChunks).toBe(0);
+    expect(result.stopped).toBe(true);
   });
 
   test("abort while an async sink call is in flight suppresses queued chunks", async () => {
@@ -243,6 +249,7 @@ describe("synthesizeAndEmit (streaming)", () => {
     expect(reached).toEqual(["a"]);
     expect(events).toEqual(["firstAudio", "chunk:a"]);
     expect(result.emittedChunks).toBe(1);
+    expect(result.stopped).toBe(true);
   });
 
   test("isCurrent() flipping false while an async sink call is in flight suppresses queued chunks", async () => {
@@ -270,6 +277,7 @@ describe("synthesizeAndEmit (streaming)", () => {
 
     expect(reached).toEqual(["a"]);
     expect(result.emittedChunks).toBe(1);
+    expect(result.stopped).toBe(true);
   });
 
   test("isCurrent() false before the first chunk emits nothing and does not throw", async () => {
@@ -287,6 +295,7 @@ describe("synthesizeAndEmit (streaming)", () => {
 
     expect(sink.events).toEqual([]);
     expect(result.emittedChunks).toBe(0);
+    expect(result.stopped).toBe(true);
   });
 
   test("async onChunk sinks observe chunks in emission order", async () => {
@@ -477,7 +486,11 @@ describe("synthesizeAndEmit (buffer)", () => {
 
     expect(sink.events).toEqual(["firstAudio", "chunk:abc"]);
     expect(sink.chunks[0]?.contentType).toBe("audio/wav");
-    expect(result).toEqual({ emittedChunks: 1, contentType: "audio/wav" });
+    expect(result).toEqual({
+      emittedChunks: 1,
+      contentType: "audio/wav",
+      stopped: false,
+    });
   });
 
   test("throws on an empty audio payload", async () => {
@@ -511,6 +524,7 @@ describe("synthesizeAndEmit (buffer)", () => {
 
     expect(sink.events).toEqual([]);
     expect(result.emittedChunks).toBe(0);
+    expect(result.stopped).toBe(true);
   });
 
   test("aborted signal skips the emit silently", async () => {
@@ -530,6 +544,7 @@ describe("synthesizeAndEmit (buffer)", () => {
 
     expect(sink.events).toEqual([]);
     expect(result.emittedChunks).toBe(0);
+    expect(result.stopped).toBe(true);
   });
 
   test("passes the request through to synthesize", async () => {

--- a/assistant/src/tts/synthesis-stream.ts
+++ b/assistant/src/tts/synthesis-stream.ts
@@ -50,13 +50,6 @@ export interface SynthesisEmitOptions {
   /** Output-encoding hint forwarded on the provider request (e.g. `"pcm"`). */
   outputFormat?: TtsSynthesisRequest["outputFormat"];
 
-  /**
-   * Advisory playback sample rate for sinks/consumers. Not part of
-   * {@link TtsSynthesisRequest} — providers negotiate sample rate via their
-   * own config.
-   */
-  sampleRate?: number;
-
   /** Abort signal forwarded to the provider and checked before each emit. */
   signal?: AbortSignal;
 
@@ -79,6 +72,13 @@ export interface SynthesisEmitResult {
 
   /** Provider-reported MIME type of the complete synthesized audio. */
   contentType: string;
+
+  /**
+   * `true` when emission was halted by an aborted `signal` or an
+   * `isCurrent()` staleness flip — the silent-resolve path. Callers use
+   * this instead of re-probing the signal after resolve.
+   */
+  stopped: boolean;
 }
 
 /**
@@ -166,7 +166,7 @@ export async function synthesizeAndEmit(
     if (emittedChunks === 0 && !stopped) {
       throw new Error("Streaming TTS returned no audio chunks");
     }
-    return { emittedChunks, contentType: result.contentType };
+    return { emittedChunks, contentType: result.contentType, stopped };
   }
 
   const result = await provider.synthesize(request);
@@ -178,7 +178,7 @@ export async function synthesizeAndEmit(
     emittedChunks = 1;
     await onChunk({ audio: result.audio, contentType: result.contentType });
   }
-  return { emittedChunks, contentType: result.contentType };
+  return { emittedChunks, contentType: result.contentType, stopped };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for live-voice-server-barge-in.md:
- synthesizeAndEmit now returns stopped so adopters no longer re-derive abort state (call-speech-output, live-voice-tts)
- an AbortError without our own aborted signal is a synthesis failure again (fallback + end-of-turn run), not a cancellation — prevents dangling Twilio turn state on provider-internal aborts
- removed the never-read sampleRate option from SynthesisEmitOptions
- media-stream-stt-session now imports DEFAULT_SPEECH_ENERGY_THRESHOLD instead of duplicating the constant