### PR TITLE
fix: live-voice ingest mode semantics, STT tiering, and preflight hardening

### DIFF
--- a/assistant/src/calls/telephony-tts-capability.ts
+++ b/assistant/src/calls/telephony-tts-capability.ts
@@ -86,41 +86,107 @@ export async function resolveTelephonyTtsCapability(): Promise<TelephonyTtsCapab
 export async function evaluateTelephonyTtsPlayability(
   providerId: string,
 ): Promise<TelephonyTtsCapability> {
+  const result = await findTtsProviderGap(
+    providerId,
+    (entry) => entry.mediaStreamPlayback.outputFormat !== "none",
+  );
+  if (result.gap === null) {
+    return { status: "playable", providerId: result.entry.id };
+  }
+
+  switch (result.gap.kind) {
+    case "unknown-provider":
+      // Unknown providers have no declared playable format.
+      return {
+        status: "not-playable",
+        providerId,
+        reason: "unsupported-format",
+      };
+    case "unsupported-capability":
+      return {
+        status: "not-playable",
+        providerId: result.gap.entry.id,
+        reason: "unsupported-format",
+      };
+    case "missing-credentials":
+      return {
+        status: "not-playable",
+        providerId: result.gap.entry.id,
+        reason: "missing-credentials",
+      };
+    case "missing-fish-audio-reference-id":
+      return {
+        status: "not-playable",
+        providerId: result.gap.entry.id,
+        reason: "missing-fish-audio-reference-id",
+      };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared provider-gap skeleton
+// ---------------------------------------------------------------------------
+
+/** A required secret declared by a TTS catalog entry. */
+export type TtsProviderSecret =
+  TtsProviderCatalogEntry["secretRequirements"][number];
+
+/**
+ * Why a TTS provider fails a capability preflight, before the caller maps it
+ * onto its own transport-specific result/message shape.
+ */
+export type TtsProviderGap =
+  | { kind: "unknown-provider" }
+  | { kind: "unsupported-capability"; entry: TtsProviderCatalogEntry }
+  | {
+      kind: "missing-credentials";
+      entry: TtsProviderCatalogEntry;
+      secret: TtsProviderSecret;
+    }
+  | { kind: "missing-fish-audio-reference-id"; entry: TtsProviderCatalogEntry };
+
+/** Result of {@link findTtsProviderGap}: the first gap found, or none. */
+export type TtsProviderGapResult =
+  | { gap: null; entry: TtsProviderCatalogEntry }
+  | { gap: TtsProviderGap };
+
+/**
+ * Run the shared TTS-provider preflight skeleton: catalog lookup →
+ * transport-specific capability predicate → required-secret resolution →
+ * fish-audio referenceId invariant. Returns the first gap found, in that
+ * order, or the catalog entry when the provider passes every check.
+ *
+ * Shared by {@link evaluateTelephonyTtsPlayability} (predicate:
+ * media-stream-playable output format) and the live-voice credential
+ * preflight (predicate: streaming synthesis support) so the two transports
+ * stay behaviorally aligned everywhere except the capability itself.
+ */
+export async function findTtsProviderGap(
+  providerId: string,
+  supportsCapability: (entry: TtsProviderCatalogEntry) => boolean,
+): Promise<TtsProviderGapResult> {
   let entry: TtsProviderCatalogEntry;
   try {
     entry = getCatalogProvider(providerId);
   } catch {
-    // Unknown providers have no declared playable format.
-    return { status: "not-playable", providerId, reason: "unsupported-format" };
+    return { gap: { kind: "unknown-provider" } };
   }
 
-  if (entry.mediaStreamPlayback.outputFormat === "none") {
-    return {
-      status: "not-playable",
-      providerId: entry.id,
-      reason: "unsupported-format",
-    };
+  if (!supportsCapability(entry)) {
+    return { gap: { kind: "unsupported-capability", entry } };
   }
 
   for (const secret of entry.secretRequirements) {
     if (!(await ttsSecretResolves(secret.credentialStoreKey))) {
-      return {
-        status: "not-playable",
-        providerId: entry.id,
-        reason: "missing-credentials",
-      };
+      return { gap: { kind: "missing-credentials", entry, secret } };
     }
   }
 
   if (entry.id === "fish-audio" && !fishAudioReferenceIdConfigured()) {
-    return {
-      status: "not-playable",
-      providerId: entry.id,
-      reason: "missing-fish-audio-reference-id",
-    };
+    return { gap: { kind: "missing-fish-audio-reference-id", entry } };
   }
 
-  return { status: "playable", providerId: entry.id };
+  return { gap: null, entry };
 }
 
 /**

--- a/assistant/src/config/schemas/__tests__/live-voice.test.ts
+++ b/assistant/src/config/schemas/__tests__/live-voice.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import type { LiveVoiceSessionMode } from "../../../live-voice/protocol.js";
 import {
   LiveVoiceConfigSchema,
   LiveVoiceVadConfigSchema,
@@ -88,5 +89,20 @@ describe("LiveVoiceConfigSchema", () => {
 
   test("VALID_LIVE_VOICE_MODES lists ptt and open-mic", () => {
     expect(VALID_LIVE_VOICE_MODES).toEqual(["ptt", "open-mic"]);
+  });
+
+  test("VALID_LIVE_VOICE_MODES stays in lockstep with the protocol's LiveVoiceSessionMode", () => {
+    // The schema's `satisfies` clause proves every listed mode is a valid
+    // protocol mode; this compile-time assertion proves the reverse — the
+    // list is exhaustive over LiveVoiceSessionMode — so the two disconnected
+    // arrays (protocol.ts's const is module-private) cannot drift.
+    type Assert<T extends true> = T;
+    type _EveryProtocolModeListed = Assert<
+      LiveVoiceSessionMode extends (typeof VALID_LIVE_VOICE_MODES)[number]
+        ? true
+        : false
+    >;
+    const modes: readonly LiveVoiceSessionMode[] = VALID_LIVE_VOICE_MODES;
+    expect(modes.length).toBe(2);
   });
 });

--- a/assistant/src/config/schemas/live-voice.ts
+++ b/assistant/src/config/schemas/live-voice.ts
@@ -1,6 +1,20 @@
 import { z } from "zod";
 
-export const VALID_LIVE_VOICE_MODES = ["ptt", "open-mic"] as const;
+import type { LiveVoiceSessionMode } from "../../live-voice/protocol.js";
+
+/**
+ * Valid live-voice microphone modes. The wire source of truth is the
+ * protocol's `LiveVoiceSessionMode` (`live-voice/protocol.ts`), whose
+ * backing const is module-private — the values are restated here for the
+ * zod enum, with `satisfies` proving every listed mode is a valid protocol
+ * mode (the schema test asserts the reverse direction, so the two lists
+ * cannot drift). The type-only import is erased at runtime, so this adds
+ * no config→live-voice runtime dependency.
+ */
+export const VALID_LIVE_VOICE_MODES = [
+  "ptt",
+  "open-mic",
+] as const satisfies readonly LiveVoiceSessionMode[];
 
 export const LiveVoiceVadConfigSchema = z
   .object({

--- a/assistant/src/live-voice/__tests__/live-voice-credential-preflight.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-credential-preflight.test.ts
@@ -38,23 +38,30 @@ const realConfigLoaderModule = {
 
 // -- Mutable stub state --------------------------------------------------------
 
+import type { ResolveStreamingTranscriberOptions } from "../../providers/speech-to-text/resolve.js";
 import type {
   BatchTranscriber,
   StreamingTranscriber,
 } from "../../stt/types.js";
 
 let streamingTranscriber: StreamingTranscriber | null;
+let resolveStreamingImpl: (
+  options: ResolveStreamingTranscriberOptions,
+) => Promise<StreamingTranscriber | null>;
 let batchTranscriber: BatchTranscriber | null;
 let providerKeys: Record<string, string>;
 let sttProvider: string;
 let ttsProvider: string;
+let ttsProviderConfigs: Record<string, unknown>;
 
 mock.module("../../providers/speech-to-text/resolve.js", () => ({
   ...realSttResolveModule,
-  resolveStreamingTranscriber: async () =>
+  resolveStreamingTranscriber: async (
+    options?: ResolveStreamingTranscriberOptions,
+  ) =>
     preflightMocksActive
-      ? streamingTranscriber
-      : realSttResolveModule.resolveStreamingTranscriber(),
+      ? resolveStreamingImpl(options ?? {})
+      : realSttResolveModule.resolveStreamingTranscriber(options),
   resolveBatchTranscriber: async () =>
     preflightMocksActive
       ? batchTranscriber
@@ -80,7 +87,7 @@ mock.module("../../config/loader.js", () => ({
       ? ({
           services: {
             stt: { provider: sttProvider },
-            tts: { provider: ttsProvider, providers: {} },
+            tts: { provider: ttsProvider, providers: ttsProviderConfigs },
           },
         } as unknown as ReturnType<typeof realConfigLoaderModule.getConfig>)
       : realConfigLoaderModule.getConfig(),
@@ -98,12 +105,15 @@ afterAll(() => {
 
 beforeEach(() => {
   // Baseline: everything ready — a streaming STT transcriber resolves and
-  // the streaming-capable fish-audio TTS provider has credentials.
+  // the streaming-capable fish-audio TTS provider has credentials and a
+  // configured voice reference ID.
   streamingTranscriber = {} as StreamingTranscriber;
+  resolveStreamingImpl = async () => streamingTranscriber;
   batchTranscriber = null;
   providerKeys = { deepgram: "test-key", "fish-audio": "test-key" };
   sttProvider = "deepgram";
   ttsProvider = "fish-audio";
+  ttsProviderConfigs = { "fish-audio": { referenceId: "ref_test" } };
 });
 
 function expectNotReady(
@@ -128,6 +138,24 @@ describe("resolveLiveVoiceCredentialReadiness", () => {
 
     const readiness = await resolveLiveVoiceCredentialReadiness();
     expect(readiness).toEqual({ status: "ready" });
+  });
+
+  test("STT leg attempts the same streaming tiers as the ingest: boundary finals, then plain", async () => {
+    const calls: ResolveStreamingTranscriberOptions[] = [];
+    resolveStreamingImpl = async (options) => {
+      calls.push(options);
+      // Boundary tier unavailable (e.g. openai-whisper); plain tier works.
+      return options.utteranceBoundaryFinals
+        ? null
+        : ({} as StreamingTranscriber);
+    };
+
+    const readiness = await resolveLiveVoiceCredentialReadiness();
+    expect(readiness).toEqual({ status: "ready" });
+    expect(calls.map((o) => Boolean(o.utteranceBoundaryFinals))).toEqual([
+      true,
+      false,
+    ]);
   });
 
   test("STT credentials missing → not-ready with an stt entry naming the credential provider", async () => {
@@ -221,6 +249,26 @@ describe("resolveLiveVoiceCredentialReadiness", () => {
     expect(readiness.userMessage).toContain('"fish-audio"');
     expect(readiness.userMessage).toContain("text-to-speech");
     expect(readiness.userMessage).toContain("Fish Audio API Key");
+  });
+
+  test("fish-audio with credentials but no referenceId → not-ready naming the missing reference ID", async () => {
+    ttsProviderConfigs = {};
+
+    const readiness = expectNotReady(
+      await resolveLiveVoiceCredentialReadiness(),
+    );
+    expect(readiness.missing).toEqual([
+      {
+        kind: "tts",
+        providerId: "fish-audio",
+        reason:
+          'TTS provider "fish-audio" has no Fish Audio reference ID configured (services.tts.providers.fish-audio.referenceId)',
+      },
+    ]);
+    expect(readiness.userMessage).toContain("Fish Audio voice reference ID");
+    expect(readiness.userMessage).toContain(
+      "services.tts.providers.fish-audio.referenceId",
+    );
   });
 
   test("unknown TTS provider → not-ready with a catalog gap naming the configured id", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-ingest.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-ingest.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import type { ResolveStreamingTranscriberOptions } from "../../providers/speech-to-text/resolve.js";
 import type {
   BatchTranscriber,
   StreamingTranscriber,
@@ -41,18 +42,42 @@ class MockStreamingTranscriber implements StreamingTranscriber {
   }
 }
 
+/**
+ * Plain-tier streaming mock: like openai-whisper, it emits its `final` only
+ * at end-of-stream — `stop()` flushes the pending final and then closes.
+ */
+class MockPlainStreamingTranscriber extends MockStreamingTranscriber {
+  constructor(private readonly finalOnStop: string) {
+    super();
+  }
+
+  override stop(): void {
+    super.stop();
+    this.emit({ type: "final", text: this.finalOnStop });
+    this.emit({ type: "closed" });
+  }
+}
+
 class MockBatchTranscriber implements BatchTranscriber {
   readonly providerId = "openai-whisper" as const;
   readonly boundaryId = "daemon-batch" as const;
   readonly requests: SttTranscribeRequest[] = [];
 
-  constructor(private readonly texts: string[] = []) {}
+  constructor(
+    private readonly texts: string[] = [],
+    private readonly delaysMs: number[] = [],
+  ) {}
 
   async transcribe(
     request: SttTranscribeRequest,
   ): Promise<SttTranscribeResult> {
+    const index = this.requests.length;
     this.requests.push(request);
-    return { text: this.texts[this.requests.length - 1] ?? "transcript" };
+    const delay = this.delaysMs[index] ?? 0;
+    if (delay > 0) {
+      await sleep(delay);
+    }
+    return { text: this.texts[index] ?? "transcript" };
   }
 }
 
@@ -253,6 +278,8 @@ describe("LiveVoiceIngest batch fallback", () => {
     const transcriber = new MockStreamingTranscriber();
     const batch = new MockBatchTranscriber(["after the crash"]);
     const { events, ingest } = createIngest({
+      // Open-mic so the post-crash turn auto-ends on silence.
+      config: { mode: "open-mic" },
       deps: {
         resolveStreamingTranscriber: async () => transcriber,
         resolveBatchTranscriber: async () => batch,
@@ -282,6 +309,8 @@ describe("LiveVoiceIngest batch fallback", () => {
     });
     const batch = new MockBatchTranscriber(["queued turn", "live turn"]);
     const { events, ingest } = createIngest({
+      // Open-mic so turns auto-end on silence while streaming is pending.
+      config: { mode: "open-mic" },
       deps: {
         resolveStreamingTranscriber: () => pending,
         resolveBatchTranscriber: async () => batch,
@@ -363,10 +392,243 @@ describe("LiveVoiceIngest batch fallback", () => {
   });
 });
 
+describe("LiveVoiceIngest mode semantics", () => {
+  test("ptt: sustained silence after speech does not end the turn; forceTurnEnd does", async () => {
+    const batch = new MockBatchTranscriber(["held utterance"]);
+    const { events, ingest } = createIngest({
+      config: { mode: "ptt" },
+      deps: {
+        resolveStreamingTranscriber: async () => null,
+        resolveBatchTranscriber: async () => batch,
+      },
+    });
+
+    ingest.start();
+    await sleep(5);
+    ingest.pushAudio(speechChunk());
+
+    // Sustained silence well past the silence threshold while the user
+    // keeps holding push-to-talk: no auto turn end, no final.
+    for (let i = 0; i < 3; i++) {
+      await sleep(SILENCE_THRESHOLD_MS + 20);
+      ingest.pushAudio(quietChunk(1));
+    }
+    expect(events).not.toContain("turn-boundary");
+    expect(events.filter((event) => event.startsWith("final:"))).toEqual([]);
+
+    // Release ends the turn and both halves of the utterance transcribe.
+    ingest.forceTurnEnd();
+    await waitFor(() => events.includes("final:held utterance"));
+    expect(events).toContain("turn-boundary");
+    expect(batch.requests).toHaveLength(1);
+
+    ingest.dispose();
+  });
+
+  test("open-mic: silence after speech ends the turn without forceTurnEnd", async () => {
+    const batch = new MockBatchTranscriber(["hands free"]);
+    const { events, ingest } = createIngest({
+      config: { mode: "open-mic" },
+      deps: {
+        resolveStreamingTranscriber: async () => null,
+        resolveBatchTranscriber: async () => batch,
+      },
+    });
+
+    ingest.start();
+    await sleep(5);
+    ingest.pushAudio(speechChunk());
+
+    await waitFor(() => events.includes("final:hands free"));
+    expect(events).toContain("turn-boundary");
+
+    ingest.dispose();
+  });
+
+  test("max-turn-duration cap ends the turn in both modes", async () => {
+    for (const mode of ["ptt", "open-mic"] as const) {
+      const batch = new MockBatchTranscriber([`${mode} capped`]);
+      const { events, ingest } = createIngest({
+        config: {
+          mode,
+          vad: {
+            speechEnergyThreshold: 800,
+            // High silence threshold proves the boundary comes from the cap.
+            silenceThresholdMs: 10_000,
+            maxTurnDurationMs: 40,
+          },
+        },
+        deps: {
+          resolveStreamingTranscriber: async () => null,
+          resolveBatchTranscriber: async () => batch,
+        },
+      });
+
+      ingest.start();
+      await sleep(5);
+      ingest.pushAudio(speechChunk());
+
+      await waitFor(() => events.includes(`final:${mode} capped`));
+      expect(events).toContain("turn-boundary");
+
+      ingest.dispose();
+    }
+  });
+});
+
+describe("LiveVoiceIngest two-tier streaming resolution", () => {
+  test("uses the boundary tier when it resolves and never cycles the session per turn", async () => {
+    const transcriber = new MockStreamingTranscriber();
+    const calls: ResolveStreamingTranscriberOptions[] = [];
+    const { ingest } = createIngest({
+      deps: {
+        resolveStreamingTranscriber: async (options) => {
+          calls.push(options);
+          return options.utteranceBoundaryFinals ? transcriber : null;
+        },
+      },
+    });
+
+    ingest.start();
+    ingest.pushAudio(speechChunk());
+    await waitFor(() => transcriber.sentChunks.length === 1);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.utteranceBoundaryFinals).toBe(true);
+    expect(calls[0]?.sampleRate).toBe(SAMPLE_RATE);
+
+    // Boundary tier: a turn end relies on provider utterance finals — the
+    // provider session is not stopped/restarted.
+    ingest.forceTurnEnd();
+    await sleep(10);
+    expect(transcriber.stopped).toBe(false);
+    expect(calls).toHaveLength(1);
+
+    ingest.dispose();
+  });
+
+  test("plain tier: partials flow and finals are forced per turn via stop/restart", async () => {
+    const first = new MockPlainStreamingTranscriber("first turn");
+    const second = new MockPlainStreamingTranscriber("second turn");
+    const transcribers = [first, second];
+    const calls: ResolveStreamingTranscriberOptions[] = [];
+    const { events, ingest } = createIngest({
+      deps: {
+        resolveStreamingTranscriber: async (options) => {
+          calls.push(options);
+          if (options.utteranceBoundaryFinals) {
+            return null;
+          }
+          return transcribers.shift() ?? null;
+        },
+        resolveBatchTranscriber: async () => {
+          throw new Error("batch fallback must not be used in plain tier");
+        },
+      },
+    });
+
+    ingest.start();
+    ingest.pushAudio(speechChunk());
+    await waitFor(() => first.sentChunks.length === 1);
+
+    // Live partials flow in the plain tier.
+    first.emit({ type: "partial", text: "liv" });
+    expect(events).toContain("partial:liv");
+
+    // Turn end (PTT release) forces the utterance final by stopping the
+    // provider session (which flushes its end-of-stream final).
+    ingest.forceTurnEnd();
+    expect(first.stopped).toBe(true);
+    expect(events).toContain("final:first turn");
+
+    // The next turn's audio reaches a fresh provider session and its
+    // forced final arrives in order.
+    ingest.pushAudio(speechChunk());
+    await waitFor(() => second.sentChunks.length === 1);
+    ingest.forceTurnEnd();
+    await waitFor(() => events.includes("final:second turn"));
+    expect(events.filter((event) => event.startsWith("final:"))).toEqual([
+      "final:first turn",
+      "final:second turn",
+    ]);
+
+    // Tier order: boundary attempted once up front, then plain; the two
+    // per-turn restarts skip the boundary attempt.
+    expect(calls.map((o) => Boolean(o.utteranceBoundaryFinals))).toEqual([
+      true,
+      false,
+      false,
+      false,
+    ]);
+    expect(events.filter((event) => event.startsWith("error:"))).toEqual([]);
+
+    ingest.dispose();
+  });
+
+  test("falls back to batch only after both streaming tiers resolve null", async () => {
+    const calls: ResolveStreamingTranscriberOptions[] = [];
+    const batch = new MockBatchTranscriber(["batch final"]);
+    const { events, ingest } = createIngest({
+      deps: {
+        resolveStreamingTranscriber: async (options) => {
+          calls.push(options);
+          return null;
+        },
+        resolveBatchTranscriber: async () => batch,
+      },
+    });
+
+    ingest.start();
+    await waitFor(() => calls.length === 2);
+    expect(calls.map((o) => Boolean(o.utteranceBoundaryFinals))).toEqual([
+      true,
+      false,
+    ]);
+
+    ingest.pushAudio(speechChunk());
+    ingest.forceTurnEnd();
+    await waitFor(() => events.includes("final:batch final"));
+
+    ingest.dispose();
+  });
+});
+
+describe("LiveVoiceIngest batch turn ordering", () => {
+  test("finals emit strictly in turn order even when the first transcription is slow", async () => {
+    const batch = new MockBatchTranscriber(["first", "second"], [60, 0]);
+    const { events, ingest } = createIngest({
+      deps: {
+        resolveStreamingTranscriber: async () => null,
+        resolveBatchTranscriber: async () => batch,
+      },
+    });
+
+    ingest.start();
+    await sleep(5);
+
+    ingest.pushAudio(speechChunk());
+    ingest.forceTurnEnd();
+    ingest.pushAudio(speechChunk());
+    ingest.forceTurnEnd();
+
+    await waitFor(
+      () => events.filter((event) => event.startsWith("final:")).length === 2,
+    );
+    expect(events.filter((event) => event.startsWith("final:"))).toEqual([
+      "final:first",
+      "final:second",
+    ]);
+
+    ingest.dispose();
+  });
+});
+
 describe("LiveVoiceIngest VAD and turn detection", () => {
   test("fires onSpeechStart exactly once per speech onset", async () => {
     const batch = new MockBatchTranscriber();
     const { events, ingest } = createIngest({
+      // Open-mic so silence ends the first turn between the two onsets.
+      config: { mode: "open-mic" },
       deps: {
         resolveStreamingTranscriber: async () => null,
         resolveBatchTranscriber: async () => batch,
@@ -389,9 +651,10 @@ describe("LiveVoiceIngest VAD and turn detection", () => {
     ingest.dispose();
   });
 
-  test("fires onTurnBoundary after the silence threshold", async () => {
+  test("open-mic: fires onTurnBoundary after the silence threshold", async () => {
     const batch = new MockBatchTranscriber();
     const { events, ingest } = createIngest({
+      config: { mode: "open-mic" },
       deps: {
         resolveStreamingTranscriber: async () => null,
         resolveBatchTranscriber: async () => batch,

--- a/assistant/src/live-voice/live-voice-credential-preflight.ts
+++ b/assistant/src/live-voice/live-voice-credential-preflight.ts
@@ -9,10 +9,22 @@
  * start instead of mid-conversation. It opens no live connections and
  * performs no session wiring — the session composition root gates startup
  * on the verdict. Mirrors `calls/telephony-credential-preflight.ts` for
- * the phone-call transport.
+ * the phone-call transport, sharing its gap/readiness shapes and the
+ * TTS-provider gap skeleton (`findTtsProviderGap`); only the capability
+ * predicates differ (streaming synthesis here, media-stream playability
+ * there).
+ *
+ * The STT leg attempts the exact tiers the ingest uses at runtime
+ * ({@link resolveTieredStreamingTranscriber}: utterance-boundary finals,
+ * then plain streaming), then the batch fallback, so ready/not-ready
+ * matches what a session would actually resolve.
  */
 
-import { ttsSecretResolves } from "../calls/telephony-tts-capability.js";
+import type {
+  TelephonyCredentialGap,
+  TelephonyCredentialReadiness,
+} from "../calls/telephony-credential-preflight.js";
+import { findTtsProviderGap } from "../calls/telephony-tts-capability.js";
 import { getConfig } from "../config/loader.js";
 import { getProviderEntry } from "../providers/speech-to-text/provider-catalog.js";
 import {
@@ -21,33 +33,27 @@ import {
   sttProviderKeyResolves,
 } from "../providers/speech-to-text/resolve.js";
 import type { SttProviderId } from "../stt/types.js";
-import type { TtsProviderCatalogEntry } from "../tts/provider-catalog.js";
-import { getCatalogProvider, getTtsProvider } from "../tts/provider-catalog.js";
+import { getTtsProvider } from "../tts/provider-catalog.js";
 import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
+import { resolveTieredStreamingTranscriber } from "./live-voice-ingest.js";
 
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
 
-/** A single credential/capability gap blocking live-voice readiness. */
-export interface LiveVoiceCredentialGap {
-  kind: "stt" | "tts";
-  providerId: string;
-  reason: string;
-}
+/**
+ * A single credential/capability gap blocking live-voice readiness.
+ * Structurally shared with the telephony preflight — the two transports
+ * report gaps identically.
+ */
+export type LiveVoiceCredentialGap = TelephonyCredentialGap;
 
-/** Result of resolving whether live-voice STT+TTS credentials are in order. */
-export type LiveVoiceCredentialReadiness =
-  | { status: "ready" }
-  | {
-      status: "not-ready";
-      missing: LiveVoiceCredentialGap[];
-      /**
-       * A single human-readable sentence naming the offending provider(s)
-       * and missing credential(s), suitable for the client `error` frame.
-       */
-      userMessage: string;
-    };
+/**
+ * Result of resolving whether live-voice STT+TTS credentials are in order.
+ * Structurally shared with the telephony preflight; the `userMessage` is a
+ * single human-readable sentence suitable for the client `error` frame.
+ */
+export type LiveVoiceCredentialReadiness = TelephonyCredentialReadiness;
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -59,9 +65,12 @@ export type LiveVoiceCredentialReadiness =
  *
  * Readiness requires:
  * - STT: the configured `services.stt.provider` resolves a streaming
- *   transcriber, or — acceptable fallback mode — a batch transcriber.
+ *   transcriber on either tier the ingest uses (boundary finals, then
+ *   plain streaming), or — acceptable fallback mode — a batch transcriber.
  * - TTS: the configured `services.tts.provider` supports streaming
- *   synthesis (`synthesizeStream`) and all of its required secrets resolve.
+ *   synthesis (`synthesizeStream`), all of its required secrets resolve,
+ *   and provider-specific invariants hold (fish-audio needs a configured
+ *   `referenceId`, or `synthesizeStream` fails on the first response).
  */
 export async function resolveLiveVoiceCredentialReadiness(): Promise<LiveVoiceCredentialReadiness> {
   const gaps = (await Promise.all([resolveSttGap(), resolveTtsGap()])).filter(
@@ -92,12 +101,16 @@ interface GapWithClause {
 }
 
 /**
- * Resolve the STT leg: no gap when the configured provider yields a
- * streaming transcriber or (batch-fallback mode) a batch transcriber.
- * When neither resolves, classify why so the gap names the missing piece.
+ * Resolve the STT leg: no gap when the configured provider resolves a
+ * streaming transcriber on either runtime tier, or (batch-fallback mode) a
+ * batch transcriber. When nothing resolves, classify why so the gap names
+ * the missing piece.
  */
 async function resolveSttGap(): Promise<GapWithClause | null> {
-  if ((await resolveStreamingTranscriber()) !== null) {
+  if (
+    (await resolveTieredStreamingTranscriber(resolveStreamingTranscriber)) !==
+    null
+  ) {
     return null;
   }
   if ((await resolveBatchTranscriber()) !== null) {
@@ -139,54 +152,68 @@ async function resolveSttGap(): Promise<GapWithClause | null> {
 }
 
 /**
- * Resolve the TTS leg: no gap when the configured provider supports
- * streaming synthesis and every secret its catalog entry requires
- * resolves to a value.
+ * Resolve the TTS leg via the shared provider-gap skeleton
+ * ({@link findTtsProviderGap}): no gap when the configured provider
+ * supports streaming synthesis, every required secret resolves, and the
+ * fish-audio `referenceId` invariant holds.
  */
 async function resolveTtsGap(): Promise<GapWithClause | null> {
   const { provider: providerId } = resolveTtsConfig(getConfig());
 
-  let entry: TtsProviderCatalogEntry;
-  try {
-    entry = getCatalogProvider(providerId);
-  } catch {
-    return {
-      gap: {
-        kind: "tts",
-        providerId,
-        reason: `TTS provider "${providerId}" is not in the provider catalog`,
-      },
-      clause: `a recognized text-to-speech provider (the configured "${providerId}" is not in the provider catalog)`,
-    };
+  const result = await findTtsProviderGap(providerId, (entry) => {
+    const adapter = getTtsProvider(entry.id);
+    return (
+      adapter.capabilities.supportsStreaming &&
+      typeof adapter.synthesizeStream === "function"
+    );
+  });
+  if (result.gap === null) {
+    return null;
   }
 
-  const adapter = getTtsProvider(entry.id);
-  if (
-    !adapter.capabilities.supportsStreaming ||
-    typeof adapter.synthesizeStream !== "function"
-  ) {
-    return {
-      gap: {
-        kind: "tts",
-        providerId: entry.id,
-        reason: `TTS provider "${entry.id}" does not support streaming synthesis`,
-      },
-      clause: `a text-to-speech provider that supports streaming synthesis (the configured "${entry.id}" does not)`,
-    };
-  }
-
-  for (const secret of entry.secretRequirements) {
-    if (!(await ttsSecretResolves(secret.credentialStoreKey))) {
+  switch (result.gap.kind) {
+    case "unknown-provider":
       return {
         gap: {
           kind: "tts",
-          providerId: entry.id,
-          reason: `TTS provider "${entry.id}" is missing credentials (${secret.displayName})`,
+          providerId,
+          reason: `TTS provider "${providerId}" is not in the provider catalog`,
         },
-        clause: `an API key for the text-to-speech provider "${entry.id}" (${secret.displayName})`,
+        clause: `a recognized text-to-speech provider (the configured "${providerId}" is not in the provider catalog)`,
+      };
+    case "unsupported-capability": {
+      const { id } = result.gap.entry;
+      return {
+        gap: {
+          kind: "tts",
+          providerId: id,
+          reason: `TTS provider "${id}" does not support streaming synthesis`,
+        },
+        clause: `a text-to-speech provider that supports streaming synthesis (the configured "${id}" does not)`,
+      };
+    }
+    case "missing-credentials": {
+      const { id } = result.gap.entry;
+      const { displayName } = result.gap.secret;
+      return {
+        gap: {
+          kind: "tts",
+          providerId: id,
+          reason: `TTS provider "${id}" is missing credentials (${displayName})`,
+        },
+        clause: `an API key for the text-to-speech provider "${id}" (${displayName})`,
+      };
+    }
+    case "missing-fish-audio-reference-id": {
+      const { id } = result.gap.entry;
+      return {
+        gap: {
+          kind: "tts",
+          providerId: id,
+          reason: `TTS provider "${id}" has no Fish Audio reference ID configured (services.tts.providers.fish-audio.referenceId)`,
+        },
+        clause: `a Fish Audio voice reference ID for the text-to-speech provider "${id}" (set services.tts.providers.fish-audio.referenceId)`,
       };
     }
   }
-
-  return null;
 }

--- a/assistant/src/live-voice/live-voice-ingest.ts
+++ b/assistant/src/live-voice/live-voice-ingest.ts
@@ -8,20 +8,32 @@
  *
  * - **Streaming** (default) — chunks are fed to a
  *   {@link StreamingTranscriber} resolved for the configured `services.stt`
- *   provider with utterance-boundary finals. Partials are forwarded via
- *   `onPartial` (the in-app UI displays live transcripts); non-empty finals
- *   fire `onTranscriptFinal`. Chunks arriving while the provider session is
- *   still starting are held in a bounded buffer and flushed on start
- *   (overflow drops the oldest chunks and is counted + logged at teardown).
+ *   provider in two tiers: utterance-boundary finals when the provider
+ *   supports them (`"boundary"` tier — Deepgram), otherwise plain streaming
+ *   (`"plain"` tier — live partials flow, and the ingest forces the
+ *   utterance final at each local turn boundary by stopping the provider
+ *   session and starting a fresh one for the next turn). Partials are
+ *   forwarded via `onPartial` (the in-app UI displays live transcripts);
+ *   non-empty finals fire `onTranscriptFinal`. Chunks arriving while the
+ *   provider session is starting (or restarting between plain-tier turns)
+ *   are held in a bounded buffer and flushed on start (overflow drops the
+ *   oldest chunks and is counted + logged at teardown).
  * - **Batch** — segmented audio turns are wrapped in a WAV container and
- *   transcribed per turn via the batch transcriber. Used when no streaming
- *   transcriber is available for the configured provider or the provider
- *   closed the streaming session unexpectedly mid-session.
+ *   transcribed per turn via the batch transcriber, strictly in turn order.
+ *   Used when no streaming transcriber is available for the configured
+ *   provider or the provider closed the streaming session unexpectedly
+ *   mid-session.
  *
  * Speech-start (`onSpeechStart`) and turn boundaries (`onTurnBoundary`)
  * always come from the local VAD/turn detector, never from transcriber
  * events — the session layer decides what they mean (barge-in in open-mic,
  * informational in PTT).
+ *
+ * The session `mode` drives turn detection: in `open-mic`, trailing silence
+ * (`vad.silenceThresholdMs`) auto-ends the user's turn; in `ptt`, silence
+ * never ends a turn — turns end only via {@link LiveVoiceIngest.forceTurnEnd}
+ * (the client's `ptt_release`) or the `vad.maxTurnDurationMs` hard cap.
+ * The VAD's `onSpeechStart` fires in both modes (barge-in needs it).
  *
  * This module is **transport-neutral** — it exposes callback hooks rather
  * than driving any session flow itself; the live-voice session instantiates
@@ -56,7 +68,13 @@ export interface LiveVoiceIngestConfig {
   /** Sample rate of the inbound PCM16 audio in Hz. */
   sampleRate: number;
 
-  /** Microphone mode the session negotiated (informational for the ingest). */
+  /**
+   * Microphone mode the session negotiated. Drives turn detection:
+   * `open-mic` auto-ends turns after `vad.silenceThresholdMs` of trailing
+   * silence; `ptt` disables silence-based auto-end — turns end only via
+   * {@link LiveVoiceIngest.forceTurnEnd} (client `ptt_release`) or the
+   * `vad.maxTurnDurationMs` cap. Speech-start detection runs in both modes.
+   */
   mode: LiveVoiceSessionMode;
 
   /** VAD thresholds (from `getConfig().liveVoice.vad` at the call site). */
@@ -76,6 +94,14 @@ const DEFAULT_TRANSCRIPTION_TIMEOUT_MS = 10_000;
 
 /** Default bound for the startup chunk buffer. */
 const DEFAULT_STREAMING_STARTUP_BUFFER_FRAMES = 500;
+
+/**
+ * Silence threshold used in `ptt` mode: the maximum delay `setTimeout`
+ * supports (2^31 - 1 ms, ~24.8 days), so the turn detector's silence timer
+ * effectively never fires and turns end only via `forceTurnEnd` (client
+ * `ptt_release`) or the max-turn-duration cap.
+ */
+const PTT_SILENCE_THRESHOLD_MS = 2 ** 31 - 1;
 
 /**
  * Transcription mode:
@@ -153,6 +179,57 @@ export interface LiveVoiceIngestDeps {
 }
 
 // ---------------------------------------------------------------------------
+// Two-tier streaming resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * How a resolved streaming transcriber delivers utterance finals.
+ *
+ * - `"boundary"` — the provider emits `final` events at utterance
+ *   boundaries itself (Deepgram).
+ * - `"plain"` — the provider streams live partials but only emits its
+ *   `final` at end-of-stream (or per committed segment), so the ingest
+ *   forces the utterance final at each local turn boundary by stopping the
+ *   provider session and starting a fresh one for the next turn.
+ */
+export type LiveVoiceStreamingTier = "boundary" | "plain";
+
+/** A streaming transcriber together with the tier it resolved under. */
+export interface TieredStreamingTranscriber {
+  transcriber: StreamingTranscriber;
+  tier: LiveVoiceStreamingTier;
+}
+
+/**
+ * Resolve a streaming transcriber for live voice in two tiers: first with
+ * utterance-boundary finals (`"boundary"`), then plain streaming
+ * (`"plain"`). Returns `null` only when neither tier resolves — the caller
+ * falls back to per-turn batch transcription.
+ *
+ * Shared by {@link LiveVoiceIngest} (runtime) and the live-voice credential
+ * preflight, so the preflight's ready/not-ready verdict validates exactly
+ * the legs the runtime will use.
+ */
+export async function resolveTieredStreamingTranscriber(
+  resolve: LiveVoiceIngestStreamingResolver,
+  sampleRate?: number,
+): Promise<TieredStreamingTranscriber | null> {
+  const rateOption = sampleRate === undefined ? {} : { sampleRate };
+  const boundary = await resolve({
+    ...rateOption,
+    utteranceBoundaryFinals: true,
+  });
+  if (boundary) {
+    return { transcriber: boundary, tier: "boundary" };
+  }
+  const plain = await resolve(rateOption);
+  if (plain) {
+    return { transcriber: plain, tier: "plain" };
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
 // Ingest
 // ---------------------------------------------------------------------------
 
@@ -179,6 +256,20 @@ export class LiveVoiceIngest {
 
   /** Live streaming transcriber (streaming mode only). */
   private streamingTranscriber: StreamingTranscriber | null = null;
+
+  /**
+   * Tier the streaming transcriber resolved under. Settled by the first
+   * successful resolution; plain-tier restarts skip the boundary attempt
+   * (it would re-log the fallback warning every turn).
+   */
+  private streamingTier: LiveVoiceStreamingTier | null = null;
+
+  /**
+   * Serializes per-turn batch transcriptions (and empty-turn finals) so
+   * `onTranscriptFinal` fires strictly in turn order even when an earlier
+   * turn's transcription request is slower than a later one.
+   */
+  private batchTurnQueue: Promise<void> = Promise.resolve();
 
   /**
    * Whether the ingest deliberately stopped the streaming transcriber
@@ -230,7 +321,13 @@ export class LiveVoiceIngest {
 
     this.turnDetector = new MediaTurnDetector(
       {
-        silenceThresholdMs: config.vad.silenceThresholdMs,
+        // PTT: silence never auto-ends a turn — the turn ends only on
+        // forceTurnEnd (client ptt_release) or the max-duration cap.
+        // Open-mic: trailing silence is the primary turn-end signal.
+        silenceThresholdMs:
+          config.mode === "ptt"
+            ? PTT_SILENCE_THRESHOLD_MS
+            : config.vad.silenceThresholdMs,
         maxTurnDurationMs: config.vad.maxTurnDurationMs,
       },
       {
@@ -242,7 +339,7 @@ export class LiveVoiceIngest {
         },
         onTurnEnd: (_reason, durationMs) => {
           this.callbacks.onTurnBoundary?.();
-          void this.handleTurnEnd(durationMs);
+          this.handleTurnEnd(durationMs);
         },
       },
     );
@@ -306,11 +403,13 @@ export class LiveVoiceIngest {
   }
 
   /**
-   * End the current utterance immediately — the PTT release path.
+   * End the current utterance immediately — the PTT release path (and the
+   * only silence-independent turn-end signal in `ptt` mode).
    *
    * Flushes the turn detector: in batch mode the buffered turn is
-   * transcribed now; in streaming mode the provider's utterance-boundary
-   * finals deliver the transcript.
+   * transcribed now; in boundary-tier streaming the provider's
+   * utterance-boundary finals deliver the transcript; in plain-tier
+   * streaming the ingest forces the final by cycling the provider session.
    */
   forceTurnEnd(): void {
     this.turnDetector.forceEnd();
@@ -327,8 +426,10 @@ export class LiveVoiceIngest {
     if (this.disposed) {
       return;
     }
-    this.turnDetector.forceEnd();
+    // Set before forceEnd so a plain-tier turn end skips its stop/restart
+    // cycle — the direct stop below flushes the trailing final instead.
     this.deliberateStop = true;
+    this.turnDetector.forceEnd();
     stopStreamingBestEffort(this.streamingTranscriber);
     this.logStartupDrops();
     this.callbacks.onStop?.();
@@ -361,19 +462,30 @@ export class LiveVoiceIngest {
   // ── Streaming mode ─────────────────────────────────────────────────
 
   /**
-   * Resolve and start the streaming transcriber, then flush the chunks
-   * buffered during startup. Falls back to the batch path when no
-   * streaming transcriber is available or the provider session cannot be
-   * established — the mode is settled before streaming ever becomes
-   * active, so modes are never mixed mid-session.
+   * Resolve and start the streaming transcriber (two-tier: boundary
+   * finals, then plain streaming), then flush the chunks buffered during
+   * startup. Falls back to the batch path when neither tier resolves or
+   * the provider session cannot be established — the mode is settled
+   * before streaming ever becomes active, so modes are never mixed
+   * mid-session. Also serves plain-tier per-turn restarts, which reuse
+   * the same startup-buffer machinery for the restart gap.
    */
   private async startStreaming(): Promise<void> {
-    let transcriber: StreamingTranscriber | null = null;
+    let resolved: TieredStreamingTranscriber | null = null;
     try {
-      transcriber = await this.resolveStreaming({
-        sampleRate: this.config.sampleRate,
-        utteranceBoundaryFinals: true,
-      });
+      if (this.streamingTier === "plain") {
+        // Per-turn restart: the tier already settled plain — skip the
+        // boundary attempt (it would re-log its fallback warning per turn).
+        const transcriber = await this.resolveStreaming({
+          sampleRate: this.config.sampleRate,
+        });
+        resolved = transcriber ? { transcriber, tier: "plain" } : null;
+      } else {
+        resolved = await resolveTieredStreamingTranscriber(
+          this.resolveStreaming,
+          this.config.sampleRate,
+        );
+      }
     } catch (err) {
       log.warn(
         { error: err },
@@ -381,18 +493,21 @@ export class LiveVoiceIngest {
       );
     }
 
-    if (this.disposed) {
-      stopStreamingBestEffort(transcriber);
+    if (this.disposed || this.deliberateStop) {
+      stopStreamingBestEffort(resolved?.transcriber ?? null);
       return;
     }
 
-    if (!transcriber) {
+    if (!resolved) {
       this.enterBatchMode();
       return;
     }
 
+    const { transcriber, tier } = resolved;
     try {
-      await transcriber.start((event) => this.handleStreamingEvent(event));
+      await transcriber.start((event) =>
+        this.handleStreamingEvent(event, transcriber),
+      );
     } catch (err) {
       log.warn(
         { error: err },
@@ -404,12 +519,13 @@ export class LiveVoiceIngest {
       return;
     }
 
-    if (this.disposed) {
+    if (this.disposed || this.deliberateStop) {
       stopStreamingBestEffort(transcriber);
       return;
     }
 
     this.streamingTranscriber = transcriber;
+    this.streamingTier = tier;
     this.mode = "streaming";
 
     // Flush audio buffered while the provider session was starting.
@@ -446,11 +562,9 @@ export class LiveVoiceIngest {
         { turnCount: pending.length },
         "Transcribing turns completed during streaming startup via batch fallback",
       );
-      void (async () => {
-        for (const { chunks, durationMs } of pending) {
-          await this.transcribeTurn(chunks, durationMs);
-        }
-      })();
+      for (const { chunks, durationMs } of pending) {
+        this.enqueueTurnTranscription(chunks, durationMs);
+      }
     }
   }
 
@@ -459,9 +573,17 @@ export class LiveVoiceIngest {
    *
    * Partials are forwarded (the in-app UI displays live transcripts) but
    * never drive turn-taking: turn boundaries come from the local VAD and
-   * transcripts commit on the provider's utterance-boundary finals.
+   * transcripts commit on the provider's finals (utterance-boundary finals
+   * in the boundary tier; per-turn forced finals in the plain tier).
+   *
+   * @param source - The transcriber that emitted the event, so `closed`
+   *   from a deliberately replaced plain-tier session is not mistaken for
+   *   a provider-initiated close of the live one.
    */
-  private handleStreamingEvent(event: SttStreamServerEvent): void {
+  private handleStreamingEvent(
+    event: SttStreamServerEvent,
+    source: StreamingTranscriber,
+  ): void {
     if (this.disposed) {
       return;
     }
@@ -483,6 +605,11 @@ export class LiveVoiceIngest {
         this.callbacks.onError?.(event.category, event.message);
         return;
       case "closed":
+        if (this.streamingTranscriber !== source) {
+          // Stale close from a stopped/replaced session (e.g. the previous
+          // plain-tier turn's transcriber) — the live session is unaffected.
+          return;
+        }
         this.streamingTranscriber = null;
         // Provider-initiated close mid-session: without a live transcriber
         // the streaming mode would silently drop all subsequent audio.
@@ -496,6 +623,21 @@ export class LiveVoiceIngest {
         }
         return;
     }
+  }
+
+  /**
+   * Force the just-ended turn's utterance final in the plain streaming
+   * tier: stop the provider session (plain-tier providers flush their
+   * final at end-of-stream — V1's ptt_release did exactly this) and start
+   * a fresh session for the next turn, reusing the startup-buffer
+   * machinery so no audio is lost in the restart gap.
+   */
+  private async restartPlainStreamingForNextTurn(): Promise<void> {
+    const transcriber = this.streamingTranscriber;
+    this.streamingTranscriber = null;
+    this.mode = "streaming-pending";
+    stopStreamingBestEffort(transcriber);
+    await this.startStreaming();
   }
 
   /**
@@ -524,11 +666,10 @@ export class LiveVoiceIngest {
 
   // ── Turn completion ────────────────────────────────────────────────
 
-  private async handleTurnEnd(durationMs: number): Promise<void> {
-    // Streaming modes take transcripts from the provider's
-    // utterance-boundary finals, not the local VAD. Turns completed
-    // while streaming is still pending are queued so a later batch
-    // fallback can transcribe their buffered audio.
+  private handleTurnEnd(durationMs: number): void {
+    // Streaming modes take transcripts from the provider's finals, not
+    // the local VAD. Turns completed while streaming is still pending are
+    // queued so a later batch fallback can transcribe their buffered audio.
     if (this.mode !== "batch") {
       if (this.mode === "streaming-pending") {
         const chunks = this.currentTurnChunks;
@@ -536,20 +677,42 @@ export class LiveVoiceIngest {
         if (chunks.length > 0) {
           this.pendingCompletedTurns.push({ chunks, durationMs });
         }
+        return;
+      }
+      // Plain-tier streaming never emits an utterance-boundary final on
+      // its own — force it by cycling the provider session. (During a
+      // deliberate stop the direct transcriber stop flushes it instead.)
+      if (this.streamingTier === "plain" && !this.deliberateStop) {
+        void this.restartPlainStreamingForNextTurn();
       }
       return;
     }
 
+    // Capture the turn's audio synchronously (the next turn's onTurnStart
+    // clears the buffer), then transcribe on the serialized queue so
+    // finals emit strictly in turn order.
     const chunks = this.currentTurnChunks;
     this.currentTurnChunks = [];
+    this.enqueueTurnTranscription(chunks, durationMs);
+  }
 
-    if (chunks.length === 0) {
-      // Silence turn — no audio to transcribe.
-      this.callbacks.onTranscriptFinal?.("", durationMs);
-      return;
-    }
-
-    await this.transcribeTurn(chunks, durationMs);
+  /**
+   * Chain a completed turn onto the serialized transcription queue.
+   * Empty (silence) turns emit an empty final from the same queue so
+   * ordering holds across every turn kind.
+   */
+  private enqueueTurnTranscription(chunks: Buffer[], durationMs: number): void {
+    this.batchTurnQueue = this.batchTurnQueue.then(async () => {
+      if (this.disposed) {
+        return;
+      }
+      if (chunks.length === 0) {
+        // Silence turn — no audio to transcribe.
+        this.callbacks.onTranscriptFinal?.("", durationMs);
+        return;
+      }
+      await this.transcribeTurn(chunks, durationMs);
+    });
   }
 
   /** Batch-transcribe a completed turn's audio chunks. */


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for voice-mode-engine.md: PTT vs open-mic turn-detection semantics (mode now drives behavior), two-tier streaming STT resolution with per-turn forced finals for non-boundary providers (+ preflight parity), serialized batch turn transcription, Fish Audio referenceId preflight, preflight type/TTS-gap dedupe with telephony, mode-enum single-sourcing.