### PR TITLE
fix(skills): don't 500 the skill list on an unknown install-meta origin

### DIFF
--- a/assistant/src/__tests__/slim-skill-category.test.ts
+++ b/assistant/src/__tests__/slim-skill-category.test.ts
@@ -225,9 +225,8 @@ describe("listSkills — origin derivation", () => {
     expect(skill.kind).toBe("installed");
   });
 
-  // Regression: an install-meta.json origin outside the known set used to fall
-  // off the end of toSlimSkillResponse's switch and return undefined, poisoning
-  // listSkills() and 500-ing the whole /v1/skills listing.
+  // An install-meta.json origin outside the known set degrades to "custom", and
+  // every listSkills() entry is a defined response.
   test("managed skill with an unknown origin degrades to custom, never undefined", () => {
     mockSummaries = [makeSummary({ id: "weird-origin", source: "managed" })];
     mockCachedCatalog = [];

--- a/assistant/src/__tests__/slim-skill-category.test.ts
+++ b/assistant/src/__tests__/slim-skill-category.test.ts
@@ -224,4 +224,20 @@ describe("listSkills — origin derivation", () => {
     expect(skill.origin).toBe("custom");
     expect(skill.kind).toBe("installed");
   });
+
+  // Regression: an install-meta.json origin outside the known set used to fall
+  // off the end of toSlimSkillResponse's switch and return undefined, poisoning
+  // listSkills() and 500-ing the whole /v1/skills listing.
+  test("managed skill with an unknown origin degrades to custom, never undefined", () => {
+    mockSummaries = [makeSummary({ id: "weird-origin", source: "managed" })];
+    mockCachedCatalog = [];
+    mockInstallMeta = {
+      origin: "some-unhandled-origin" as never,
+      installedAt: "2026-01-01T00:00:00.000Z",
+    };
+
+    const skills = listSkills();
+    expect(skills.every((s) => s !== undefined)).toBe(true);
+    expect(skills[0].origin).toBe("custom");
+  });
 });

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -404,10 +404,9 @@ function toSlimSkillResponse(
     case "assistant-memory":
       return { ...base, origin };
     default:
-      // An install-meta.json with an origin outside the known set (e.g. a raw
-      // unnormalized "skills.sh", or a hand-synced first-party value) must not
-      // return undefined — one bad skill dir would poison listSkills() and 500
-      // the entire /v1/skills listing. Degrade to "custom".
+      // origin comes from install-meta.json on disk and isn't validated, so it
+      // may hold a value outside the known set. Degrade any such origin to
+      // "custom" — every skill must map to a defined response.
       return { ...base, origin: "custom" };
   }
 }

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -403,6 +403,12 @@ function toSlimSkillResponse(
     case "custom":
     case "assistant-memory":
       return { ...base, origin };
+    default:
+      // An install-meta.json with an origin outside the known set (e.g. a raw
+      // unnormalized "skills.sh", or a hand-synced first-party value) must not
+      // return undefined — one bad skill dir would poison listSkills() and 500
+      // the entire /v1/skills listing. Degrade to "custom".
+      return { ...base, origin: "custom" };
   }
 }
 


### PR DESCRIPTION
## Incident

Reported by Marina Trajkovska — platform-hosted prod, assistant 0.10.5-dev. "Becky doesn't have skills anymore." `GET /v1/skills` → **500 ×16**, UI shows no skills.

```
TypeError: undefined is not an object (evaluating 's.id')
  at assistant/src/daemon/handlers/skills.ts:439 (installed.map((s) => s.id))
```

## Root cause

`toSlimSkillResponse` switches on `origin` with **no `default` branch**. `origin` comes from `deriveOrigin` → `meta?.origin`, which `readInstallMeta` casts straight from `install-meta.json` on disk **without validation**. Becky's `/workspace/skills/app-builder/install-meta.json` carried `"origin": "workspace"` — a `SkillSummary.source` enum value that leaked into the `origin` slot. That value matches no `case`, so the switch fell off the end and returned `undefined`.

The `undefined` entered `listSkills()`'s array, and `listSkillsWithCatalog` crashed at `installed.map((s) => s.id)`, 500-ing the whole listing. `/v1/skills/categories` survived because it never walks per-skill objects.

The `app-builder overriding: bundled` log line is a red herring — that override succeeded; app-builder is just the last skill processed before the poison one.

### On the writer

No code path writes `origin: "workspace"`. All six `writeInstallMeta` call sites and migration-026 emit only `vellum`/`clawhub`/`skillssh`/`custom`; git pickaxe finds nothing historical. The bad file was written outside the typed `writeInstallMeta` helper — most likely the app-builder "materialize a skill into the workspace" flow (untracked `apps/` WIP) or a manual edit. That's a separate follow-up; this PR fixes the read side, which must not trust on-disk `origin` regardless of how garbage gets there.

## Fix

Add a `default` branch that degrades an unknown origin to `custom`. One malformed skill dir now renders as a plain custom skill instead of taking down the entire list.

## Test

`slim-skill-category.test.ts`: a managed skill with an unhandled origin resolves to `custom` and `listSkills()` returns no `undefined` entries.

## Unblock for the reporter (no deploy needed)

Fix the one file on the pod: change `"origin": "workspace"` → `"origin": "custom"` in `/workspace/skills/app-builder/install-meta.json`, or delete the shadow `app-builder` dir so the bundled skill shows through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)