### PR TITLE
refactor(persistence): call indexMessageNow directly from addMessage; drop the onMessagePersisted seam member

### DIFF
--- a/assistant/src/__tests__/edit-propagation.test.ts
+++ b/assistant/src/__tests__/edit-propagation.test.ts
@@ -303,9 +303,9 @@ describe("Slack edit propagation", () => {
 
   test("a content-changing edit enqueues a lexical reindex for the message", async () => {
     // Regression: channel edits update the row in-place via
-    // updateMessageContentAndMetadata / updateMessageContent, bypassing
-    // onMessagePersisted. The lexical index must be refreshed so the old Qdrant
-    // point does not go stale against the edited (FTS-updated) content.
+    // updateMessageContentAndMetadata / updateMessageContent, bypassing the
+    // addMessage persist path. The lexical index must be refreshed so the old
+    // Qdrant point does not go stale against the edited (FTS-updated) content.
     const seeded = await seedSlackMessage({
       conversationExternalId: "C0123CHANNEL",
       channelTs: "1234.5678",

--- a/assistant/src/__tests__/lexical-index-dual-write.test.ts
+++ b/assistant/src/__tests__/lexical-index-dual-write.test.ts
@@ -31,11 +31,11 @@ mock.module("../util/logger.js", () => ({
   getLogger: () => makeMockLogger(),
 }));
 
-// Stub the segment indexer so `onMessagePersisted` runs cheaply. The lexical
-// enqueue in the hook is a separate call and still fires. Other exports are
-// provided so any transitive importer of this module resolves. `throwFromIndex`
-// lets a test simulate a transient segment-indexing failure to prove the
-// lexical enqueue survives it.
+// Stub the segment indexer so the persist path's memory indexing runs cheaply.
+// The lexical enqueue is a separate call on the persist path and still fires.
+// Other exports are provided so any transitive importer of this module
+// resolves. `throwFromIndex` lets a test simulate a transient segment-indexing
+// failure to prove the lexical enqueue survives it.
 let throwFromIndex = false;
 mock.module("../plugins/defaults/memory/indexer.js", () => ({
   MIN_SEGMENT_CHARS: 50,
@@ -176,7 +176,8 @@ describe("messages lexical-index dual-write", () => {
   test("lexical job is still enqueued when segment indexing (indexMessageNow) throws", async () => {
     // The sparse lexical job is independent of the dense embedding path, so a
     // transient segment-indexing failure must not leave the message missing
-    // from the lexical index. `addMessage` catches the hook throw as non-fatal.
+    // from the lexical index. `addMessage` catches the indexing throw as
+    // non-fatal.
     throwFromIndex = true;
     const conv = createConversation("Segment failure thread");
     const message = await addMessage(
@@ -216,7 +217,8 @@ describe("messages lexical-index dual-write", () => {
     const beforeFork = countJobs("index_message_lexical");
     expect(beforeFork).toBe(3);
 
-    // The fork copies every source row directly, bypassing onMessagePersisted.
+    // The fork copies every source row directly, bypassing the addMessage
+    // persist path (and its lexical enqueue).
     const fork = forkConversation({ conversationId: source.id });
     expect(fork.id).not.toBe(source.id);
 

--- a/assistant/src/__tests__/persistence-layering-guard.test.ts
+++ b/assistant/src/__tests__/persistence-layering-guard.test.ts
@@ -41,11 +41,14 @@ const MEMORY_DIR = join(ASSISTANT_SRC, "plugins", "defaults", "memory");
  * a NEW back-import is introduced. Do not add an entry without a decoupling
  * plan.
  *
- * Current entry: the conversation write paths invoke the memory plugin's
- * persistence-lifecycle handlers (`memory/persistence-hooks.ts`) at each
- * lifecycle point — every event on that surface is memory-domain.
- * Decoupling plan: the per-event lifecycle notifications migrate to the
- * first-class `hooks` system, retiring the entry.
+ * Current entries, both on the conversation write paths:
+ * - `persistence-hooks` — the memory plugin's fork-time state carry, invoked
+ *   synchronously inside the fork transaction (see the module docstring for
+ *   why it resists the `hooks`-system migration the other lifecycle events
+ *   took).
+ * - `indexer` — the plain `addMessage` path invokes `indexMessageNow` to feed
+ *   the persisted message into memory segment indexing, matching the other
+ *   (non-persistence) write seams that already call it directly.
  *
  * Keyed by the importing persistence file (relative to repo root); the value
  * is the set of allowed `memory/<specifier>` module paths it may import.
@@ -53,6 +56,7 @@ const MEMORY_DIR = join(ASSISTANT_SRC, "plugins", "defaults", "memory");
 const PERSISTENCE_TO_MEMORY_ALLOWLIST: Record<string, ReadonlySet<string>> = {
   "assistant/src/persistence/conversation-crud.ts": new Set([
     "persistence-hooks",
+    "indexer",
   ]),
 };
 

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -1370,8 +1370,8 @@ export async function finalizePendingToolResultRow(
       );
     }
     // Dual-write the finalized tool-result content into the lexical index. The
-    // reserve+finalize path bypasses `onMessagePersisted`, so enqueue here to
-    // keep the lexical index in lockstep with the segment index.
+    // reserve+finalize path bypasses the `addMessage` persist path, so enqueue
+    // here to keep the lexical index in lockstep with the segment index.
     enqueueLexicalIndexForMessage(rowId);
   }
   for (const id of state.pendingToolResults.keys()) {

--- a/assistant/src/daemon/conversation-turn-finalize.ts
+++ b/assistant/src/daemon/conversation-turn-finalize.ts
@@ -98,8 +98,8 @@ export function buildDeferredFinalizeEffect(params: {
       );
     }
     // Dual-write the finalized assistant content into the lexical index. The
-    // reserve+finalize path bypasses `onMessagePersisted`, so enqueue here to
-    // keep the lexical index in lockstep with the segment index.
+    // reserve+finalize path bypasses the `addMessage` persist path, so enqueue
+    // here to keep the lexical index in lockstep with the segment index.
     enqueueLexicalIndexForMessage(assistantMessageId);
     try {
       const attentionStateChanged = projectAssistantMessage({

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -31,6 +31,7 @@ import type { TrustContext } from "../daemon/trust-context.js";
 import { clearAllConversationIds } from "../home/feed-writer.js";
 import type { ConversationDeletedInputContext } from "../hooks/types.js";
 import { HOOKS } from "../plugin-api/constants.js";
+import { indexMessageNow } from "../plugins/defaults/memory/indexer.js";
 import { memoryPersistenceHooks } from "../plugins/defaults/memory/persistence-hooks.js";
 import { runHook } from "../plugins/pipeline.js";
 import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
@@ -1726,11 +1727,13 @@ export async function addMessage(
   // Hidden rows are machine signals suppressed from the transcript — they
   // must not surface as search excerpts or be embedded into memory either.
   if (!skipIndexing && !isHiddenMessageMetadata(metadata)) {
-    // Message-content lexical indexing is host infrastructure, invoked
-    // directly (not through the memory hook seam, whose active side effects go
-    // inert while the memory plugin is disabled — search indexing must not).
-    // The direct write seams (streaming finalize, import, edit) enqueue for
-    // themselves; this covers the plain addMessage path.
+    // Message-content lexical indexing is host infrastructure and must run
+    // even while the memory plugin is disabled (search indexing is not a
+    // memory-feature side effect), so it is enqueued unconditionally. The
+    // memory segment indexing below is the memory feature's own write path and
+    // self-gates on the memory config. The direct write seams (streaming
+    // finalize, import, edit) run both for themselves; this covers the plain
+    // addMessage path.
     enqueueLexicalIndexForMessage(message.id);
     try {
       const parsed = metadata
@@ -1740,15 +1743,19 @@ export async function addMessage(
         ? parsed.data.provenanceTrustClass
         : undefined;
       const automated = parsed?.success ? parsed.data.automated : undefined;
-      await memoryPersistenceHooks.onMessagePersisted({
-        messageId: message.id,
-        conversationId: message.conversationId,
-        role: message.role,
-        content: message.content,
-        createdAt: message.createdAt,
-        provenanceTrustClass,
-        automated,
-      });
+      await indexMessageNow(
+        {
+          messageId: message.id,
+          conversationId: message.conversationId,
+          role: message.role,
+          content: message.content,
+          createdAt: message.createdAt,
+          scopeId: "default",
+          provenanceTrustClass,
+          automated,
+        },
+        getConfig().memory,
+      );
     } catch (err) {
       log.warn(
         { err, conversationId, messageId: message.id },

--- a/assistant/src/plugins/defaults/memory/persistence-hooks.ts
+++ b/assistant/src/plugins/defaults/memory/persistence-hooks.ts
@@ -1,8 +1,5 @@
 import type { DrizzleDb } from "../../../persistence/db-connection.js";
-import type { TrustClass } from "../../../runtime/actor-trust-resolver.js";
-import { getMemoryConfig } from "./config.js";
 import { forkGraphMemoryState } from "./graph/graph-memory-state-store.js";
-import { indexMessageNow } from "./indexer.js";
 import { forkRetrospectiveState } from "./memory-retrospective-state.js";
 import {
   forkActivationState,
@@ -17,20 +14,6 @@ import {
   MEMORY_V3_INJECTED_BLOCK_METADATA_KEY,
   seedEverInjectedFromSlugs,
 } from "./v3/ever-injected-store.js";
-
-/** A message that was just persisted to a conversation. */
-export interface MessagePersistedEvent {
-  messageId: string;
-  conversationId: string;
-  role: string;
-  /** Stored message content (JSON content-block array, serialized). */
-  content: string;
-  createdAt: number;
-  /** Trust class of the actor who produced the message, captured at persist time. */
-  provenanceTrustClass?: TrustClass;
-  /** True when the message was auto-sent by the client (e.g. a wake-up greeting). */
-  automated?: boolean;
-}
 
 /** A conversation was forked; the memory feature carries per-conversation state into the child. */
 export interface ConversationForkedEvent {
@@ -52,25 +35,21 @@ export interface ConversationForkedEvent {
 }
 
 /**
- * The memory plugin's persistence-lifecycle handlers. The persistence layer's
- * conversation write paths (`conversation-crud.ts`) import this object
- * directly and invoke the relevant handler at each lifecycle point — the one
- * documented persistence → memory back-import in the persistence-layering
- * guard, to be unwound by exposing these events through the first-class
- * `hooks` system.
+ * The memory plugin's fork-time state carry. The persistence layer's fork path
+ * (`conversation-crud.ts`) imports this object directly and invokes it inside
+ * the fork transaction — a persistence → memory back-import documented in the
+ * persistence-layering guard. It resists the `hooks`-system migration the other
+ * lifecycle events took: it runs synchronously inside the fork's DB
+ * transaction, threading the live transaction handle so the child's memory
+ * state commits atomically with the fork.
  *
  * The direct import puts this module on an import cycle (persistence imports
- * it; it transitively imports persistence). The cycle is benign: every
- * binding on it is read at call time — the persistence call sites invoke the
- * handlers inside functions, and this object references its imports only
- * inside method bodies — so no module body ever observes a half-initialized
- * module.
+ * it; it transitively imports persistence). The cycle is benign: the binding
+ * is read at call time — the persistence call site invokes the handler inside
+ * a function, and this object references its imports only inside the method
+ * body — so no module body ever observes a half-initialized module.
  */
 export const memoryPersistenceHooks = {
-  async onMessagePersisted(event: MessagePersistedEvent): Promise<void> {
-    await indexMessageNow({ ...event, scopeId: "default" }, getMemoryConfig());
-  },
-
   onConversationForked(event: ConversationForkedEvent): void {
     const {
       db,

--- a/assistant/src/runtime/routes/conversations-import-routes.ts
+++ b/assistant/src/runtime/routes/conversations-import-routes.ts
@@ -194,8 +194,8 @@ async function handleConversationsImport({ body }: RouteHandlerArgs) {
           );
         }
         // Dual-write the imported message into the lexical index. Import inserts
-        // rows directly, bypassing `onMessagePersisted`, so enqueue here to keep
-        // the lexical index in lockstep with the segment index.
+        // rows directly, bypassing the `addMessage` persist path, so enqueue
+        // here to keep the lexical index in lockstep with the segment index.
         enqueueLexicalIndexForMessage(dbMessages[i].id);
       }
 

--- a/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
@@ -160,9 +160,9 @@ export async function handleEditIntercept(
       updateMessageContent(original.messageId, newContent);
     }
     // The edit changed searchable text (the no-op guard above already returned
-    // for identical content) and this path bypasses `onMessagePersisted`, so
-    // reindex the message into the lexical index — the idempotent upsert
-    // replaces the stale Qdrant point with the edited content.
+    // for identical content) and this path bypasses the `addMessage` persist
+    // path, so reindex the message into the lexical index — the idempotent
+    // upsert replaces the stale Qdrant point with the edited content.
     enqueueLexicalIndexForMessage(original.messageId);
     log.info(
       { assistantId, sourceMessageId, messageId: original.messageId },


### PR DESCRIPTION
## Why

The plain `addMessage` persist path routed its memory segment indexing through `memoryPersistenceHooks.onMessagePersisted`, whose entire body was a one-line `indexMessageNow(...)` call. The **three other write seams already call `indexMessageNow` directly** — streaming reserve+finalize (`conversation-turn-finalize.ts`), agent-loop finalize (`conversation-agent-loop-handlers.ts`), and conversation import (`conversations-import-routes.ts`). So this seam member was indirection that didn't carry its weight: `addMessage` was the odd one out routing through the seam for the same call the others make inline.

This inlines it to match, and deletes `onMessagePersisted`. (Not a hooks-framework migration — that was explored in #37168 and closed; here we just collapse the one-liner into the same direct call its siblings already use, while the message-persist indexing design is still being figured out.)

## What

- `addMessage` calls `indexMessageNow(..., getConfig().memory)` directly, with the same `{ scopeId: "default", provenanceTrustClass, automated }` shape the other seams pass.
- `onMessagePersisted` + the `MessagePersistedEvent` type are removed from `persistence-hooks.ts`, along with its now-unused imports (`indexMessageNow`, `getMemoryConfig`, `TrustClass`).
- The seam is now a **single member, `onConversationForked`** — kept because it runs synchronously inside the fork DB transaction threading the live transaction handle, which doesn't fit the async hooks pipeline. Its module docstring is rewritten to describe just that.
- Comments across the four write seams that referenced `onMessagePersisted` now describe the `addMessage` persist path instead (per the repo's no-removed-code comment rule).

## Layering

`conversation-crud.ts` already imported the memory plugin (the seam object); it now also imports `memory/indexer` directly. The persistence-layering guard's allowlist gains an `indexer` entry for `conversation-crud.ts` alongside the existing `persistence-hooks`, both documented in the guard. The config argument reuses the already-imported `getConfig().memory` (from `config/loader`, not a memory module), so this adds exactly one new memory import, not two.

## Tests

`lexical-index-dual-write.test.ts` already stubbed `indexMessageNow` (which `addMessage` now calls directly), so its coverage transfers unchanged — including the "lexical enqueue survives a segment-indexing throw" case, which now exercises the direct call's try/catch instead of the seam's. Green in isolation: lexical-index-dual-write (15), persistence-layering-guard (3), plugin-import-boundary-guard (5), edit-propagation (6), memory-upsert-concurrency (6), auto-analysis-end-to-end (10), task-compiler (12), conversations-import-system-filter (1). `bunx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJrJxRhsHjdpApeuL3dqfG

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJrJxRhsHjdpApeuL3dqfG)_