### PR TITLE
fix(live-voice): close review gaps in the server-VAD session machinery

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-integration.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-integration.test.ts
@@ -37,6 +37,21 @@ const START_FRAME = {
   },
 } as const satisfies LiveVoiceClientStartFrame;
 
+// Multi-turn sessions are a server_vad capability; the multi-cycle tests
+// drive utterance boundaries via the ptt_release manual override.
+const VAD_START_FRAME = {
+  ...START_FRAME,
+  turnDetection: "server_vad",
+} as const satisfies LiveVoiceClientStartFrame;
+
+function loudPcmChunk(amplitude: number, sampleCount = 240): Uint8Array {
+  const buffer = Buffer.alloc(sampleCount * 2);
+  for (let index = 0; index < sampleCount; index += 1) {
+    buffer.writeInt16LE(amplitude, index * 2);
+  }
+  return new Uint8Array(buffer);
+}
+
 class FakeStreamingTranscriber implements StreamingTranscriber {
   readonly providerId = "deepgram" as const;
   readonly boundaryId = "daemon-streaming" as const;
@@ -66,7 +81,7 @@ class FakeStreamingTranscriber implements StreamingTranscriber {
   }
 }
 
-function createContext(): {
+function createContext(startFrame: LiveVoiceClientStartFrame = START_FRAME): {
   context: LiveVoiceSessionFactoryContext;
   frames: LiveVoiceServerFrame[];
 } {
@@ -77,7 +92,7 @@ function createContext(): {
     frames,
     context: {
       sessionId: "session-123",
-      startFrame: START_FRAME,
+      startFrame,
       sendFrame: mock(async (payload) => {
         const frame = sequencer.next(payload);
         frames.push(frame);
@@ -188,15 +203,14 @@ function createMultiCycleHarness(startVoiceTurn: LiveVoiceTurnStarter) {
     transcribers.push(transcriber);
     return transcriber;
   });
-  const archiveAudio = mock(
-    async (input: LiveVoiceSessionArchiveAudioInput) =>
-      makeArchiveResult(input),
+  const archiveAudio = mock(async (input: LiveVoiceSessionArchiveAudioInput) =>
+    makeArchiveResult(input),
   );
   const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
     options.onAudioChunk(makeTtsChunk(`audio:${options.text}`));
     return makeTtsResult(options.text);
   });
-  const { context, frames } = createContext();
+  const { context, frames } = createContext(VAD_START_FRAME);
   let turnCount = 0;
   const session = createLiveVoiceSession(context, {
     resolveTranscriber,
@@ -395,7 +409,7 @@ describe("LiveVoiceSession integration smoke harness", () => {
     });
   });
 
-  test("runs two full push-to-talk cycles on one session with isolated per-turn archives", async () => {
+  test("runs two full utterance cycles on one server_vad session with isolated per-turn archives", async () => {
     const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
       options.callbacks?.persisted_user_message_id?.("user-message-123");
       options.callbacks?.assistant_text_delta?.(
@@ -406,15 +420,17 @@ describe("LiveVoiceSession integration smoke harness", () => {
     });
     const { archiveAudio, frames, session, transcribers } =
       createMultiCycleHarness(startVoiceTurn);
+    const firstUtteranceAudio = loudPcmChunk(8_000);
+    const secondUtteranceAudio = loudPcmChunk(9_000);
 
     await session.start();
-    await session.handleBinaryAudio(new Uint8Array([1, 1, 1]));
+    await session.handleBinaryAudio(firstUtteranceAudio);
     await session.handleClientFrame({ type: "ptt_release" });
     await waitFor(
       () => frames.filter((frame) => frame.type === "tts_done").length === 1,
     );
 
-    await session.handleBinaryAudio(new Uint8Array([2, 2, 2, 2]));
+    await session.handleBinaryAudio(secondUtteranceAudio);
     await session.handleClientFrame({ type: "ptt_release" });
     await waitFor(
       () => frames.filter((frame) => frame.type === "tts_done").length === 2,
@@ -444,10 +460,10 @@ describe("LiveVoiceSession integration smoke harness", () => {
     ]);
     const archivedUserAudio = archiveAudio.mock.calls
       .filter((call) => call[0].role === "user")
-      .map((call) => [...Buffer.from(call[0].audio.dataBase64, "base64")]);
+      .map((call) => Buffer.from(call[0].audio.dataBase64, "base64"));
     expect(archivedUserAudio).toEqual([
-      [1, 1, 1],
-      [2, 2, 2, 2],
+      Buffer.from(firstUtteranceAudio),
+      Buffer.from(secondUtteranceAudio),
     ]);
     const archivedAssistantAudio = archiveAudio.mock.calls
       .filter((call) => call[0].role === "assistant")
@@ -479,9 +495,11 @@ describe("LiveVoiceSession integration smoke harness", () => {
     });
     const { archiveAudio, frames, session } =
       createMultiCycleHarness(startVoiceTurn);
+    const firstUtteranceAudio = loudPcmChunk(8_000);
+    const secondUtteranceAudio = loudPcmChunk(9_000);
 
     await session.start();
-    await session.handleBinaryAudio(new Uint8Array([1, 2]));
+    await session.handleBinaryAudio(firstUtteranceAudio);
     await session.handleClientFrame({ type: "ptt_release" });
     await waitFor(() => frames.some((frame) => frame.type === "thinking"));
 
@@ -493,7 +511,7 @@ describe("LiveVoiceSession integration smoke harness", () => {
     );
     expect(abort).toHaveBeenCalledTimes(1);
 
-    await session.handleBinaryAudio(new Uint8Array([3, 4, 5]));
+    await session.handleBinaryAudio(secondUtteranceAudio);
     await session.handleClientFrame({ type: "ptt_release" });
     await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
 
@@ -523,10 +541,10 @@ describe("LiveVoiceSession integration smoke harness", () => {
     ]);
     const archivedUserAudio = archiveAudio.mock.calls
       .filter((call) => call[0].role === "user")
-      .map((call) => [...Buffer.from(call[0].audio.dataBase64, "base64")]);
+      .map((call) => Buffer.from(call[0].audio.dataBase64, "base64"));
     expect(archivedUserAudio).toEqual([
-      [1, 2],
-      [3, 4, 5],
+      Buffer.from(firstUtteranceAudio),
+      Buffer.from(secondUtteranceAudio),
     ]);
   });
 });

--- a/assistant/src/live-voice/__tests__/live-voice-metrics.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-metrics.test.ts
@@ -204,6 +204,31 @@ describe("LiveVoiceMetricsCollector", () => {
     expect(turn.timestamps.utteranceEndAtMs).toBe(2_000);
   });
 
+  test("markBargeIn records a first-wins timestamp on the active turn", () => {
+    const clock = makeClock(3_000);
+    const collector = new LiveVoiceMetricsCollector({
+      sessionId: "session-7",
+      clock: clock.now,
+    });
+
+    collector.startTurn("turn-barge");
+    clock.advance(40);
+    const frame = collector.markBargeIn("turn-barge");
+
+    expect(frame.event).toBe("barge_in");
+    expect(frame.turnId).toBe("turn-barge");
+    expect(frame.metrics.activeTurn?.timestamps.bargeInAtMs).toBe(3_040);
+
+    clock.advance(25);
+    collector.markBargeIn("turn-barge");
+    expect(collector.getSnapshot().activeTurn?.timestamps.bargeInAtMs).toBe(
+      3_040,
+    );
+
+    const cancelled = collector.cancelTurn("barge_in", "turn-barge");
+    expect(cancelled.timestamps.bargeInAtMs).toBe(3_040);
+  });
+
   test("records only the first timestamp for first-phase metrics", () => {
     const clock = makeClock(10_000);
     const collector = new LiveVoiceMetricsCollector({

--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -89,6 +89,14 @@ function createContext(overrides: Partial<LiveVoiceClientStartFrame> = {}): {
   };
 }
 
+function loudPcmChunk(amplitude = 8_000, sampleCount = 240): Uint8Array {
+  const buffer = Buffer.alloc(sampleCount * 2);
+  for (let index = 0; index < sampleCount; index += 1) {
+    buffer.writeInt16LE(amplitude, index * 2);
+  }
+  return new Uint8Array(buffer);
+}
+
 function createSessionWithTranscriber(
   transcriber = new MockStreamingTranscriber(),
 ) {
@@ -191,7 +199,7 @@ describe("LiveVoiceSession STT", () => {
     ]);
   });
 
-  test("arms a fresh streaming transcriber for the next utterance after a completed turn", async () => {
+  test("manual mode does not re-arm after a completed turn and rejects later audio", async () => {
     const transcribers: MockStreamingTranscriber[] = [];
     const resolver = mock(async () => {
       const transcriber = new MockStreamingTranscriber();
@@ -216,23 +224,27 @@ describe("LiveVoiceSession STT", () => {
     await session.handleBinaryAudio(new Uint8Array([1]));
     await session.handleClientFrame({ type: "ptt_release" });
     await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    // Give any stray speculative re-arm a chance to run.
+    await new Promise((resolve) => setTimeout(resolve, 20));
 
     expect(startVoiceTurn).toHaveBeenCalledTimes(1);
-    expect(transcribers).toHaveLength(2);
-    expect(transcribers[1]?.started).toBe(true);
-    expect(transcribers[1]?.stopped).toBe(false);
+    expect(resolver).toHaveBeenCalledTimes(1);
+    expect(transcribers).toHaveLength(1);
 
     await session.handleBinaryAudio(new Uint8Array([2]));
 
     expect(transcribers[0]?.audioChunks.map((chunk) => [...chunk])).toEqual([
       [1],
     ]);
-    expect(transcribers[1]?.audioChunks.map((chunk) => [...chunk])).toEqual([
-      [2],
-    ]);
+    const errors = frames.filter((frame) => frame.type === "error");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      code: "invalid_audio_payload",
+      message: "Live voice audio received after push-to-talk release.",
+    });
   });
 
-  test("sends tts_done even when the next transcriber's startup never resolves", async () => {
+  test("sends tts_done even when the next transcriber's startup never resolves (server_vad)", async () => {
     const firstTranscriber = new MockStreamingTranscriber();
     let resolverCalls = 0;
     const resolver: LiveVoiceStreamingTranscriberResolver = mock(async () => {
@@ -248,30 +260,29 @@ describe("LiveVoiceSession STT", () => {
       });
       return { turnId: "bridge-turn-1", abort: mock() };
     });
-    const { context, frames } = createContext();
+    const { context, frames } = createContext({ turnDetection: "server_vad" });
     const session = new LiveVoiceSession(context, {
       resolveTranscriber: resolver,
       startVoiceTurn,
     });
 
     await session.start();
-    await session.handleBinaryAudio(new Uint8Array([1]));
+    // No detector turn is open, so ptt_release releases the utterance
+    // directly; the mock transcriber's stop() supplies the transcript.
     await session.handleClientFrame({ type: "ptt_release" });
     await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
     await waitFor(() => resolverCalls === 2);
 
     expect(frames.filter((frame) => frame.type === "error")).toEqual([]);
 
-    // Audio ahead of the still-starting transcriber buffers instead of erroring.
-    await session.handleBinaryAudio(new Uint8Array([2]));
+    // Speech ahead of the still-starting transcriber buffers instead of erroring.
+    await session.handleBinaryAudio(loudPcmChunk());
 
     expect(frames.filter((frame) => frame.type === "error")).toEqual([]);
-    expect(firstTranscriber.audioChunks.map((chunk) => [...chunk])).toEqual([
-      [1],
-    ]);
+    expect(firstTranscriber.audioChunks).toEqual([]);
   });
 
-  test("surfaces a re-arm startup failure after tts_done without failing the completed turn", async () => {
+  test("surfaces a re-arm startup failure after tts_done without failing the completed turn (server_vad)", async () => {
     let resolverCalls = 0;
     const resolver: LiveVoiceStreamingTranscriberResolver = mock(async () => {
       resolverCalls += 1;
@@ -286,7 +297,7 @@ describe("LiveVoiceSession STT", () => {
       });
       return { turnId: "bridge-turn-1", abort: mock() };
     });
-    const { context, frames } = createContext();
+    const { context, frames } = createContext({ turnDetection: "server_vad" });
     const session = new LiveVoiceSession(context, {
       resolveTranscriber: resolver,
       startVoiceTurn,
@@ -294,7 +305,6 @@ describe("LiveVoiceSession STT", () => {
     });
 
     await session.start();
-    await session.handleBinaryAudio(new Uint8Array([1]));
     await session.handleClientFrame({ type: "ptt_release" });
     await waitFor(() => frames.some((frame) => frame.type === "error"));
 
@@ -320,7 +330,7 @@ describe("LiveVoiceSession STT", () => {
     ).toBe(false);
   });
 
-  test("stops the late transcriber when the session closes during re-arm", async () => {
+  test("stops the late transcriber when the session closes during re-arm (server_vad)", async () => {
     const secondTranscriber = new MockStreamingTranscriber();
     let resolveSecond:
       | ((transcriber: StreamingTranscriber | null) => void)
@@ -343,14 +353,13 @@ describe("LiveVoiceSession STT", () => {
       });
       return { turnId: "bridge-turn-1", abort: mock() };
     });
-    const { context, frames } = createContext();
+    const { context, frames } = createContext({ turnDetection: "server_vad" });
     const session = new LiveVoiceSession(context, {
       resolveTranscriber: resolver,
       startVoiceTurn,
     });
 
     await session.start();
-    await session.handleBinaryAudio(new Uint8Array([1]));
     await session.handleClientFrame({ type: "ptt_release" });
     await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
     await waitFor(() => resolveSecond !== undefined);

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -65,7 +65,10 @@ class MockStreamingTranscriber implements StreamingTranscriber {
   stopped = false;
   private onEvent: ((event: SttStreamServerEvent) => void) | null = null;
 
-  constructor(private readonly stopEvents: SttStreamServerEvent[]) {}
+  constructor(
+    private readonly stopEvents: SttStreamServerEvent[],
+    private readonly holdStopEvents = false,
+  ) {}
 
   async start(onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
     this.onEvent = onEvent;
@@ -78,6 +81,12 @@ class MockStreamingTranscriber implements StreamingTranscriber {
   stop(): void {
     if (this.stopped) return;
     this.stopped = true;
+    if (!this.holdStopEvents) {
+      this.flushStopEvents();
+    }
+  }
+
+  flushStopEvents(): void {
     for (const event of this.stopEvents) {
       this.onEvent?.(event);
     }
@@ -98,6 +107,8 @@ function createHarness(options: {
   holdSendFrame?: (
     payload: Parameters<LiveVoiceSessionFactoryContext["sendFrame"]>[0],
   ) => Promise<void> | null;
+  // Transcriber indices whose stop events wait for flushStopEvents().
+  holdStopEventsFor?: number[];
 }) {
   const sequencer = createLiveVoiceServerFrameSequencer();
   const frames: LiveVoiceServerFrame[] = [];
@@ -117,10 +128,10 @@ function createHarness(options: {
   const resolveTranscriber = mock(async () => {
     const text =
       finals[transcribers.length] ?? `utterance ${transcribers.length + 1}`;
-    const transcriber = new MockStreamingTranscriber([
-      { type: "final", text },
-      { type: "closed" },
-    ]);
+    const transcriber = new MockStreamingTranscriber(
+      [{ type: "final", text }, { type: "closed" }],
+      options.holdStopEventsFor?.includes(transcribers.length) ?? false,
+    );
     transcribers.push(transcriber);
     return transcriber;
   });
@@ -561,9 +572,7 @@ describe("LiveVoiceSession server VAD", () => {
     await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
     await waitFor(() => archivedUserAudio.length === 1);
     // Archived user audio covers pre-roll + speech, not the idle stretch.
-    expect(archivedUserAudio[0]?.byteLength).toBe(
-      26 * SILENT_CHUNK.byteLength,
-    );
+    expect(archivedUserAudio[0]?.byteLength).toBe(26 * SILENT_CHUNK.byteLength);
   });
 
   test("an utterance captured during an open turn seeds its metrics marks", async () => {
@@ -636,6 +645,157 @@ describe("LiveVoiceSession server VAD", () => {
     );
     expect(turn?.timestamps.speechStartAtMs).not.toBeNull();
     expect(turn?.timestamps.utteranceEndAtMs).not.toBeNull();
+  });
+
+  test("barge-in racing message_complete cancels the turn and keeps the interrupting utterance", async () => {
+    let firstTurnCallbacks: VoiceTurnCallbacks | undefined;
+    const abort = mock();
+    let turnCalls = 0;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      turnCalls += 1;
+      if (turnCalls === 1) {
+        firstTurnCallbacks = options.callbacks;
+        return { turnId: "bridge-turn-1", abort };
+      }
+      options.callbacks?.assistant_text_delta?.(makeTextDelta("Sure."));
+      options.callbacks?.message_complete?.(makeMessageComplete());
+      return { turnId: "bridge-turn-2", abort: mock() };
+    });
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk(`audio:${options.text}`));
+      return makeTtsResult(options.text);
+    });
+    const { frames, session } = createHarness({
+      finals: ["what's the weather", "actually never mind"],
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+    firstTurnCallbacks?.assistant_text_delta?.(
+      makeTextDelta("It is sunny today."),
+    );
+    await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
+
+    // The LLM finishes just as the user barges in: message_complete queues
+    // the completion continuation and the abort fires before it runs.
+    firstTurnCallbacks?.message_complete?.(makeMessageComplete());
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "turn_cancelled"),
+    );
+
+    // The cancelled turn never completes: no tts_done for it.
+    expect(
+      frames.some(
+        (frame) => frame.type === "tts_done" && frame.turnId === "live-turn-1",
+      ),
+    ).toBe(false);
+    expect(
+      frames.find((frame) => frame.type === "turn_cancelled"),
+    ).toMatchObject({ turnId: "live-turn-1" });
+
+    // The interrupting utterance survives and drives the next turn.
+    await waitFor(() => turnCalls === 2);
+    expect(startVoiceTurn.mock.calls[1]?.[0]).toMatchObject({
+      content: "actually never mind",
+    });
+    await waitFor(() =>
+      frames.some(
+        (frame) => frame.type === "tts_done" && frame.turnId === "live-turn-2",
+      ),
+    );
+    expect(abort).toHaveBeenCalledTimes(1);
+  });
+
+  test("speech in the release→turn-start window is pre-rolled into the next utterance", async () => {
+    const { startVoiceTurn, calls } = makeAutoCompletingTurnStarter([
+      "First reply.",
+      "Second reply.",
+    ]);
+    const { frames, session, transcribers } = createHarness({
+      finals: ["hello world", "resumed speech"],
+      startVoiceTurn,
+      // A long silence threshold keeps utterance boundaries under the
+      // test's control via ptt_release.
+      turnDetectorConfig: { silenceThresholdMs: 5_000 },
+      holdStopEventsFor: [0],
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => transcribers[0]?.stopped === true);
+
+    // Speech resumes while the released utterance still waits for its
+    // transcriber to close — the turn cannot start yet.
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    expect(transcribers[0]?.received).toHaveLength(1);
+
+    // The transcriber closes; turn 1 runs and the next utterance arms.
+    transcribers[0]?.flushStopEvents();
+    await waitFor(() => countType(frames, "tts_done") === 1);
+    await waitFor(() => transcribers.length === 2);
+
+    // The next chunk flushes the window speech ahead of itself.
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => (transcribers[1]?.received.length ?? 0) === 3);
+    const loud = Buffer.from(LOUD_CHUNK);
+    expect(transcribers[1]?.received.every((chunk) => chunk.equals(loud))).toBe(
+      true,
+    );
+
+    // The resumed speech still becomes a turn.
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => calls.length === 2);
+    expect(calls[1]?.content).toBe("resumed speech");
+  });
+
+  test("an empty VAD utterance emits utterance_discarded", async () => {
+    const startVoiceTurn = mock(async () => ({
+      turnId: "bridge-turn",
+      abort: mock(),
+    }));
+    const { frames, session } = createHarness({
+      finals: ["   "],
+      startVoiceTurn,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "utterance_discarded"),
+    );
+
+    expect(startVoiceTurn).not.toHaveBeenCalled();
+    const types = frameTypes(frames);
+    expect(types.indexOf("utterance_end")).toBeLessThan(
+      types.indexOf("utterance_discarded"),
+    );
+  });
+
+  test("manual mode does not emit utterance_discarded for an empty transcript", async () => {
+    const startVoiceTurn = mock(async () => ({
+      turnId: "bridge-turn",
+      abort: mock(),
+    }));
+    const { frames, session } = createHarness({
+      startFrame: MANUAL_START_FRAME,
+      finals: ["   "],
+      startVoiceTurn,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await session.handleClientFrame({ type: "ptt_release" });
+    await flushAsyncCallbacks();
+
+    expect(startVoiceTurn).not.toHaveBeenCalled();
+    expect(countType(frames, "utterance_discarded")).toBe(0);
   });
 
   test("manual mode emits none of the VAD frames", async () => {

--- a/assistant/src/live-voice/__tests__/protocol.test.ts
+++ b/assistant/src/live-voice/__tests__/protocol.test.ts
@@ -401,6 +401,17 @@ describe("LiveVoiceServerFrameSequencer", () => {
     expect(sequencer.lastSeq).toBe(3);
   });
 
+  test("sequences utterance_discarded frames", () => {
+    const sequencer = createLiveVoiceServerFrameSequencer();
+
+    const discarded: LiveVoiceServerFrame = sequencer.next({
+      type: "utterance_discarded",
+    });
+
+    expect(discarded).toEqual({ type: "utterance_discarded", seq: 1 });
+    expect(sequencer.lastSeq).toBe(1);
+  });
+
   test("sequences both utterance_end reasons", () => {
     const sequencer = createLiveVoiceServerFrameSequencer();
 

--- a/assistant/src/live-voice/live-voice-metrics.ts
+++ b/assistant/src/live-voice/live-voice-metrics.ts
@@ -60,6 +60,7 @@ interface LiveVoiceTurnTimestamps {
   speechStartAtMs: number | null;
   pttReleaseAtMs: number | null;
   utteranceEndAtMs: number | null;
+  bargeInAtMs: number | null;
   finalTranscriptAtMs: number | null;
   firstAssistantDeltaAtMs: number | null;
   firstTtsAudioAtMs: number | null;
@@ -186,6 +187,7 @@ export class LiveVoiceMetricsCollector {
         speechStartAtMs: null,
         pttReleaseAtMs: null,
         utteranceEndAtMs: null,
+        bargeInAtMs: null,
         finalTranscriptAtMs: null,
         firstAssistantDeltaAtMs: null,
         firstTtsAudioAtMs: null,
@@ -260,7 +262,11 @@ export class LiveVoiceMetricsCollector {
   }
 
   markBargeIn(turnId?: string): LiveVoiceMetricsFrame {
-    return this.emit("barge_in", turnId ?? this.activeTurn?.turnId);
+    const turn = this.ensureActiveTurn(turnId);
+    if (turn.timestamps.bargeInAtMs === null) {
+      turn.timestamps.bargeInAtMs = this.timestamp();
+    }
+    return this.emit("barge_in", turn.turnId);
   }
 
   markFinalTranscript(turnId?: string): LiveVoiceMetricsFrame {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -50,8 +50,6 @@ import {
 type LiveVoiceSessionState =
   | "initializing"
   | "active"
-  | "utterance_released"
-  | "transcriber_closed"
   | "interrupted"
   | "failed"
   | "closed";
@@ -300,9 +298,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   // Creates the next utterance record and arms a fresh streaming transcriber
-  // for it. Called once from start() and again after every finalized turn so
-  // the session cycles: active → utterance_released → transcriber_closed →
-  // (turn) → active.
+  // for it. Called once from start() and, in server_vad mode, again after
+  // every finalized turn (per-utterance phase tracks the cycle).
   private async beginUtterance(): Promise<UtteranceStartResult> {
     const utterance: UtteranceCycle = {
       phase: "pending",
@@ -388,8 +385,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
   // Fire-and-forget re-arm: end-of-turn work (terminal frames, archival,
   // metrics) must never block on the next transcriber's startup. Failures
-  // surface through rearmAfterTurn's error frame.
+  // surface through rearmAfterTurn's error frame. Multi-turn cycling is a
+  // server_vad capability; manual sessions keep single-utterance semantics
+  // (no speculative post-turn transcriber).
   private scheduleRearmAfterTurn(): void {
+    if (!this.turnDetector) return;
     void this.rearmAfterTurn().catch(() => {});
   }
 
@@ -465,17 +465,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // collecting or streaming them; flushed on speech onset so the
     // transcriber still gets leading context ahead of the first syllable.
     if (!hasSpeech && !detector.isActive) {
-      this.vadPreRollChunks.push(Buffer.from(chunk));
-      while (this.vadPreRollChunks.length > SERVER_VAD_PRE_ROLL_MAX_CHUNKS) {
-        this.vadPreRollChunks.shift();
-      }
+      this.pushVadPreRoll(chunk);
       return;
     }
 
     let utterance = this.currentUtterance;
     if (!utterance) return;
     if (utterance.released || utterance.completed) {
-      if (!hasSpeech || !this.canArmNextUtterance(utterance)) return;
+      if (!hasSpeech) return;
+      if (!this.canArmNextUtterance(utterance)) {
+        // Speech in the release→turn-start window: hold it in the pre-roll
+        // ring so it flushes into the next utterance once it arms.
+        this.pushVadPreRoll(chunk);
+        return;
+      }
       // Sets currentUtterance synchronously; the transcriber resolves async
       // while this chunk lands in the new utterance's pending buffer.
       void this.armUtterance();
@@ -508,9 +511,16 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // A released utterance's transcription pipeline still reads
   // currentUtterance; replacing it is only safe once its assistant turn has
   // started (or the cycle fully finalized). Speech in the short
-  // release→turn-start window is not captured.
+  // release→turn-start window waits in the pre-roll ring.
   private canArmNextUtterance(utterance: UtteranceCycle): boolean {
     return utterance.completed || utterance.assistantTurnStarted;
+  }
+
+  private pushVadPreRoll(chunk: Buffer): void {
+    this.vadPreRollChunks.push(Buffer.from(chunk));
+    while (this.vadPreRollChunks.length > SERVER_VAD_PRE_ROLL_MAX_CHUNKS) {
+      this.vadPreRollChunks.shift();
+    }
   }
 
   private bufferPendingUtteranceAudio(
@@ -649,7 +659,6 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     utterance: UtteranceCycle,
   ): Promise<void> {
     utterance.phase = "released";
-    this.state = "utterance_released";
     try {
       utterance.transcriber?.stop();
     } catch (err) {
@@ -661,7 +670,6 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         )}`,
       });
       utterance.phase = "transcriber_closed";
-      this.state = "transcriber_closed";
     }
     await this.startAssistantTurnIfReady();
     await this.drainOutboundFrames();
@@ -709,7 +717,6 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       case "closed":
         utterance.phase = "transcriber_closed";
         utterance.transcriber = null;
-        this.state = "transcriber_closed";
         await this.startAssistantTurnIfReady();
         return;
     }
@@ -758,6 +765,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (content.length === 0) {
       utterance.assistantTurnStarted = true;
       await this.finalizePendingUtterance(utterance, "empty_transcript");
+      if (this.turnDetector) {
+        // Hands-free clients moved to "transcribing" on utterance_end; tell
+        // them the utterance was dropped so they return to listening.
+        await this.sendFrame({ type: "utterance_discarded" });
+      }
       this.scheduleRearmAfterTurn();
       return;
     }
@@ -816,6 +828,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             if (
               activeTurn?.token !== token ||
               activeTurn.assistantCompleted ||
+              // A barged-in turn finalizes through cancelAssistantTurn.
+              activeTurn.abortController.signal.aborted ||
               this.isClosed
             ) {
               return;
@@ -903,8 +917,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       }
     }
 
+    // In server_vad mode currentUtterance may already be the next cycle
+    // (e.g. barge-in speech); only finalize it when it belongs to the
+    // cancelled turn or no turn was active (close/interrupt paths).
     const utterance = this.currentUtterance;
-    if (utterance) {
+    if (utterance && (!turn || turn.utterance === utterance)) {
       await this.finalizePendingUtterance(utterance, reason);
     }
     this.scheduleRearmAfterTurn();
@@ -958,6 +975,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       .then(async () => {
         const currentTurn = this.activeAssistantTurn;
         if (currentTurn?.token !== token || currentTurn.ttsDone) return;
+        // Barge-in can abort while this continuation is queued; the turn
+        // then finalizes as cancelled through cancelAssistantTurn.
+        if (currentTurn.abortController.signal.aborted) return;
 
         currentTurn.ttsDone = true;
         await this.finalizeAssistantTurn(

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -13,6 +13,7 @@ const _LIVE_VOICE_SERVER_FRAME_TYPES = [
   "busy",
   "speech_started",
   "utterance_end",
+  "utterance_discarded",
   "stt_partial",
   "stt_final",
   "thinking",
@@ -136,6 +137,15 @@ export interface LiveVoiceUtteranceEndServerFrame extends LiveVoiceServerFrameBa
   readonly reason: "silence" | "max-duration";
 }
 
+/**
+ * Emitted only in server_vad mode when the closed utterance produced no
+ * usable speech: it is dropped without an assistant turn and the client
+ * should return to listening.
+ */
+export interface LiveVoiceUtteranceDiscardedServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "utterance_discarded";
+}
+
 export interface LiveVoiceSttPartialServerFrame extends LiveVoiceServerFrameBase {
   readonly type: "stt_partial";
   readonly text: string;
@@ -215,6 +225,7 @@ export type LiveVoiceServerFrame =
   | LiveVoiceBusyServerFrame
   | LiveVoiceSpeechStartedServerFrame
   | LiveVoiceUtteranceEndServerFrame
+  | LiveVoiceUtteranceDiscardedServerFrame
   | LiveVoiceSttPartialServerFrame
   | LiveVoiceSttFinalServerFrame
   | LiveVoiceThinkingServerFrame
@@ -233,6 +244,7 @@ export type LiveVoiceServerFramePayload =
   | WithoutSeq<LiveVoiceBusyServerFrame>
   | WithoutSeq<LiveVoiceSpeechStartedServerFrame>
   | WithoutSeq<LiveVoiceUtteranceEndServerFrame>
+  | WithoutSeq<LiveVoiceUtteranceDiscardedServerFrame>
   | WithoutSeq<LiveVoiceSttPartialServerFrame>
   | WithoutSeq<LiveVoiceSttFinalServerFrame>
   | WithoutSeq<LiveVoiceThinkingServerFrame>


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for live-voice-server-barge-in.md:
- barge-in racing turn completion could emit tts_done for a cancelled turn and swallow the user's interrupting utterance — completion paths now respect the abort signal and cancelAssistantTurn only finalizes the utterance that belongs to the cancelled turn
- post-turn transcriber re-arm is now server_vad-only (manual/PTT sessions keep legacy single-utterance semantics — no speculative STT streams, no fatal error frames on re-arm failure)
- speech in the release→turn-start window now flows through the pre-roll ring into the next utterance instead of being dropped
- new utterance_discarded frame tells hands-free clients an empty VAD utterance was dropped (returns UI to listening)
- markBargeIn records a real timestamp; removed two write-only session states