### PR TITLE
refactor(web): call trust-rules, thresholds, and admission-policy through the generated gateway SDK

### DIFF
--- a/clients/web/src/domains/chat/api/interactions.ts
+++ b/clients/web/src/domains/chat/api/interactions.ts
@@ -7,7 +7,6 @@
 
 import type { ConfirmationDecision } from "@/types/event-types";
 import type { QuestionSubmission } from "@/domains/chat/api/event-types";
-import { client } from "@/generated/api/client.gen";
 import {
   confirmPost,
   pendinginteractionsGet,
@@ -269,29 +268,3 @@ export async function submitQuestionResponse(
   }
 }
 
-export async function submitTrustRule(
-  assistantId: string,
-  requestId: string,
-  rule: Record<string, unknown>,
-): Promise<SubmitSecretResponseResult> {
-  try {
-    const { error, response } = await client.post<unknown, unknown>({
-      url: "/v1/assistants/{assistant_id}/trust-rules/",
-      path: { assistant_id: assistantId },
-      body: { requestId, ...rule },
-      throwOnError: false,
-    });
-    assertHasResponse(response, error, "Failed to submit trust rule");
-    if (!response.ok) {
-      const msg = extractErrorMessage(error, response);
-      return { ok: false, status: response.status, error: msg };
-    }
-    return { ok: true };
-  } catch (err) {
-    return {
-      ok: false,
-      status: 500,
-      error: err instanceof Error ? err.message : "Something went wrong.",
-    };
-  }
-}

--- a/clients/web/src/domains/chat/api/threshold-api.test.ts
+++ b/clients/web/src/domains/chat/api/threshold-api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
-import { client } from "@/generated/api/client.gen";
+import { client } from "@/generated/gateway/client.gen";
 import { getConversationOverride } from "@/lib/threshold-api";
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/domains/chat/hooks/use-attention-tracking-reconnect-sweep.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-attention-tracking-reconnect-sweep.test.tsx
@@ -81,7 +81,6 @@ mock.module("@/domains/chat/api/interactions", () => ({
   submitConfirmation: stubFromOtherTest("submitConfirmation"),
   submitContactPrompt: stubFromOtherTest("submitContactPrompt"),
   submitQuestionResponse: stubFromOtherTest("submitQuestionResponse"),
-  submitTrustRule: stubFromOtherTest("submitTrustRule"),
 }));
 
 const { useAttentionTracking } = await import(

--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -293,16 +293,15 @@ describe("api-interceptors / self-hosted rewriting", () => {
   });
 
   test("rewrites daemon/gateway-owned segments reached via the platform client", async () => {
-    // config / permissions / trust-rules are daemon- or gateway-owned and
-    // are called through the platform client via raw `client.*` requests
-    // (e.g. the background `TimezoneSync` PATCH to `config`). In local /
-    // self-hosted mode they must route to the gateway like conversations
-    // rather than fall through to the dead platform proxy and flood the
-    // console with 502s. (contacts / contact-channels / artifacts are NOT
-    // listed — their assistant-scoped routes aren't served by the gateway
-    // or daemon, so forwarding them would only 404.)
+    // config is daemon-owned and still called through the platform client
+    // via raw `client.*` requests (the background `TimezoneSync` PATCH).
+    // In local / self-hosted mode it must route to the gateway like
+    // conversations rather than fall through to the dead platform proxy
+    // and flood the console with 502s. (artifacts is NOT listed — its
+    // assistant-scoped routes aren't served by the gateway or daemon, so
+    // forwarding it would only 404.)
     setSelfHostedConnection({ url: INGRESS, token: ACTOR_TOKEN });
-    for (const segment of ["config", "permissions", "trust-rules"]) {
+    for (const segment of ["config"]) {
       const path = `/v1/assistants/${SELF_HOSTED_ID}/${segment}/`;
       const input = new Request(`https://platform.test${path}`, {
         method: "POST",

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -76,7 +76,6 @@ function getRendererTupleOrigin(): string {
  */
 const RUNTIME_PROXIED_FIRST_SEGMENTS = new Set<string>([
   "conversations",
-  "channel-admission-policy",
   // Live SSE event stream — `subscribeEvents` opens it through the
   // platform client, so it must be forwarded to the gateway in local /
   // self-hosted mode like any other runtime route.
@@ -87,29 +86,22 @@ const RUNTIME_PROXIED_FIRST_SEGMENTS = new Set<string>([
   // must be forwarded to the gateway in local / self-hosted mode rather
   // than falling through to the platform proxy.
   "x",
-  // Daemon- and gateway-owned per-assistant resources that are reached
-  // through the platform client via raw `client.*` calls (their gateway
-  // SDK functions aren't generated yet) instead of the daemon client.
-  // Like `events`/`x` above they must be forwarded to the gateway in
-  // local / self-hosted mode rather than falling through to the dead
-  // platform proxy — otherwise e.g. the background `TimezoneSync` PATCH to
-  // `config` retries against a nonexistent platform and floods the console
-  // with 502s. Each is listed only because the gateway (or the daemon it
-  // proxies to) actually serves the assistant-scoped routes the call sites
-  // hit: `config` (daemon GET/PATCH), and `permissions/thresholds` +
-  // `trust-rules` (gateway, all methods).
+  // Daemon-owned config reached through the platform client via raw
+  // `client.*` calls (the background `TimezoneSync` PATCH and the general
+  // settings page). Must be forwarded to the gateway in local /
+  // self-hosted mode rather than falling through to the dead platform
+  // proxy — otherwise the PATCH retries against a nonexistent platform
+  // and floods the console with 502s. Removable once those call sites
+  // move to the generated daemon SDK (LUM-2716).
   //
-  // Deliberately NOT listed: `contacts`, `contact-channels`, `artifacts`,
-  // and `a2a`. Their assistant-scoped routes aren't served by the gateway
-  // or daemon — the contacts control plane is registered at flat
-  // `/v1/contacts...` paths (only an assistant-scoped contacts DELETE
-  // exists), there is no `artifacts` route, and `/a2a/invites/redeem` is a
-  // platform broker route. Forwarding them would only turn the existing
-  // failure into a 404, so they stay on the platform until the
-  // assistant-scoped routes are mirrored.
+  // Every removed entry (contacts, trust-rules, permissions,
+  // channel-admission-policy, …) was retired by migrating its call sites
+  // to the generated gateway SDK, whose client forwards all
+  // assistant-scoped requests without this list — that is the paved road
+  // for new endpoints. Deliberately NOT listed: `artifacts` (no
+  // gateway/daemon route exists) and `a2a` (platform broker route); those
+  // stay on the platform.
   "config",
-  "permissions",
-  "trust-rules",
 ]);
 
 const ASSISTANT_PATH_RE =

--- a/clients/web/src/lib/channel-admission-policy/api.test.ts
+++ b/clients/web/src/lib/channel-admission-policy/api.test.ts
@@ -9,11 +9,9 @@ interface MockResponse {
 let mockGet: ReturnType<typeof mock<(...args: unknown[]) => Promise<MockResponse>>>;
 let mockPut: ReturnType<typeof mock<(...args: unknown[]) => Promise<MockResponse>>>;
 
-mock.module("@/generated/api/client.gen", () => ({
-  client: {
-    get: (...args: unknown[]) => mockGet(...args),
-    put: (...args: unknown[]) => mockPut(...args),
-  },
+mock.module("@/generated/gateway/sdk.gen", () => ({
+  assistantChannelAdmissionPolicyList: (...args: unknown[]) => mockGet(...args),
+  assistantChannelAdmissionPolicySet: (...args: unknown[]) => mockPut(...args),
 }));
 
 const { fetchChannelPolicies, setChannelPolicy, isInternalChannel, ApiError } =
@@ -151,7 +149,7 @@ describe("setChannelPolicy", () => {
     expect(mockPut).not.toHaveBeenCalled();
   });
 
-  test("sends the policy payload to the assistant-scoped PUT route", async () => {
+  test("sends the policy payload through the generated SDK setter", async () => {
     mockPut = mock(async () =>
       ok({
         policy: {
@@ -168,14 +166,10 @@ describe("setChannelPolicy", () => {
     expect(mockPut).toHaveBeenCalledTimes(1);
     const call = mockPut.mock.calls[0] as unknown as [
       {
-        url: string;
         path: { assistant_id: string; channel_type: string };
         body: { policy: string; note: string | null };
       },
     ];
-    expect(call[0].url).toContain(
-      "/v1/assistants/{assistant_id}/channel-admission-policy/{channel_type}",
-    );
     expect(call[0].path).toEqual({
       assistant_id: "asst-1",
       channel_type: "slack",

--- a/clients/web/src/lib/channel-admission-policy/api.ts
+++ b/clients/web/src/lib/channel-admission-policy/api.ts
@@ -10,7 +10,10 @@
  * so a future gateway regression can't leak them into the UI.
  */
 
-import { client } from "@/generated/api/client.gen";
+import {
+  assistantChannelAdmissionPolicyList,
+  assistantChannelAdmissionPolicySet,
+} from "@/generated/gateway/sdk.gen";
 import {
   ApiError,
   assertHasResponse,
@@ -26,14 +29,6 @@ import {
 } from "./types";
 
 export { ApiError };
-
-interface ListResponse {
-  policies: ChannelPolicyView[];
-}
-
-interface SingleResponse {
-  policy: ChannelPolicyView;
-}
 
 function isAdmissionPolicy(value: unknown): value is AdmissionPolicy {
   return (
@@ -56,8 +51,7 @@ export function isInternalChannel(channelType: string): boolean {
 export async function fetchChannelPolicies(
   assistantId: string,
 ): Promise<ChannelPolicyView[]> {
-  const { data, error, response } = await client.get<ListResponse, unknown>({
-    url: "/v1/assistants/{assistant_id}/channel-admission-policy/",
+  const { data, error, response } = await assistantChannelAdmissionPolicyList({
     path: { assistant_id: assistantId },
     throwOnError: false,
   });
@@ -95,11 +89,9 @@ export async function setChannelPolicy(
       `Channel "${channelType}" is internal and is not user-configurable.`,
     );
   }
-  const { data, error, response } = await client.put<SingleResponse, unknown>({
-    url: "/v1/assistants/{assistant_id}/channel-admission-policy/{channel_type}",
+  const { data, error, response } = await assistantChannelAdmissionPolicySet({
     path: { assistant_id: assistantId, channel_type: channelType },
     body: { policy, note: note ?? null },
-    headers: { "Content-Type": "application/json" },
     throwOnError: false,
   });
   assertHasResponse(response, error, "Failed to save channel policy.");

--- a/clients/web/src/lib/threshold-api.ts
+++ b/clients/web/src/lib/threshold-api.ts
@@ -1,36 +1,43 @@
 /**
  * Permission threshold CRUD for global and per-conversation overrides.
  *
- * These endpoints live on the gateway (`/v1/assistants/{id}/permissions/…`),
- * not the daemon, and are not yet part of any generated OpenAPI spec. The
- * functions here use the raw HeyAPI client until gateway codegen is wired up.
+ * These endpoints are gateway-native (`/v1/assistants/{id}/permissions/…`)
+ * and are called through the generated gateway SDK: the schemas live on the
+ * gateway's route metadata (`gateway/src/http/routes/
+ * auto-approve-thresholds-routes.ts`), so the request/response types here
+ * are codegen-derived rather than hand-written. The gateway client's
+ * interceptor routes to the self-hosted gateway in local mode and through
+ * the platform proxy for platform-hosted assistants.
  */
 
-import { client } from "@/generated/api/client.gen";
+import {
+  assistantConversationThresholdDelete,
+  assistantConversationThresholdGet,
+  assistantConversationThresholdPut,
+  assistantPermissionsThresholdsGet,
+  assistantPermissionsThresholdsPut,
+} from "@/generated/gateway/sdk.gen";
+import type {
+  AssistantPermissionsThresholdsGetResponse,
+  AssistantPermissionsThresholdsPutData,
+} from "@/generated/gateway/types.gen";
 import {
   ApiError,
   assertHasResponse,
   extractErrorMessage,
 } from "@/utils/api-errors";
 
-export interface GlobalThresholds {
-  interactive: string;
-  autonomous: string;
-  headless: string;
-}
+export type GlobalThresholds = AssistantPermissionsThresholdsGetResponse;
 
 export async function getGlobalThresholds(
   assistantId: string,
 ): Promise<GlobalThresholds> {
-  const { data, error, response } = await client.get<GlobalThresholds, unknown>(
-    {
-      url: "/v1/assistants/{assistant_id}/permissions/thresholds",
-      path: { assistant_id: assistantId },
-      throwOnError: false,
-    },
-  );
+  const { data, error, response } = await assistantPermissionsThresholdsGet({
+    path: { assistant_id: assistantId },
+    throwOnError: false,
+  });
   assertHasResponse(response, error, "Failed to fetch global thresholds.");
-  if (!response.ok) {
+  if (!response.ok || !data) {
     const msg = extractErrorMessage(
       error,
       response,
@@ -38,29 +45,20 @@ export async function getGlobalThresholds(
     );
     throw new ApiError(response.status, msg);
   }
-  const result = data as GlobalThresholds;
-  return {
-    interactive: result.interactive ?? "medium",
-    autonomous: result.autonomous ?? "low",
-    headless: result.headless ?? "none",
-  };
+  return data;
 }
 
 export async function setGlobalThresholds(
   assistantId: string,
-  thresholds: { interactive?: string; autonomous?: string; headless?: string },
+  thresholds: AssistantPermissionsThresholdsPutData["body"],
 ): Promise<GlobalThresholds> {
-  const { data, error, response } = await client.put<GlobalThresholds, unknown>(
-    {
-      url: "/v1/assistants/{assistant_id}/permissions/thresholds",
-      path: { assistant_id: assistantId },
-      body: thresholds,
-      headers: { "Content-Type": "application/json" },
-      throwOnError: false,
-    },
-  );
+  const { data, error, response } = await assistantPermissionsThresholdsPut({
+    path: { assistant_id: assistantId },
+    body: thresholds,
+    throwOnError: false,
+  });
   assertHasResponse(response, error, "Failed to update global thresholds.");
-  if (!response.ok) {
+  if (!response.ok || !data) {
     const msg = extractErrorMessage(
       error,
       response,
@@ -68,23 +66,14 @@ export async function setGlobalThresholds(
     );
     throw new ApiError(response.status, msg);
   }
-  const result = data as GlobalThresholds;
-  return {
-    interactive: result.interactive ?? "medium",
-    autonomous: result.autonomous ?? "low",
-    headless: result.headless ?? "none",
-  };
+  return data;
 }
 
 export async function getConversationOverride(
   assistantId: string,
   conversationId: string,
 ): Promise<string | null> {
-  const { data, error, response } = await client.get<
-    { threshold: string | null },
-    unknown
-  >({
-    url: "/v1/assistants/{assistant_id}/permissions/thresholds/conversations/{conversation_id}",
+  const { data, error, response } = await assistantConversationThresholdGet({
     path: { assistant_id: assistantId, conversation_id: conversationId },
     throwOnError: false,
   });
@@ -109,20 +98,17 @@ export async function getConversationOverride(
     );
     throw new ApiError(response.status, msg);
   }
-  const result = data as unknown as { threshold: string | null };
-  return result.threshold ?? null;
+  return data?.threshold ?? null;
 }
 
 export async function setConversationOverride(
   assistantId: string,
   conversationId: string,
-  threshold: string,
+  threshold: GlobalThresholds["interactive"],
 ): Promise<void> {
-  const { error, response } = await client.put<unknown, unknown>({
-    url: "/v1/assistants/{assistant_id}/permissions/thresholds/conversations/{conversation_id}",
+  const { error, response } = await assistantConversationThresholdPut({
     path: { assistant_id: assistantId, conversation_id: conversationId },
     body: { threshold },
-    headers: { "Content-Type": "application/json" },
     throwOnError: false,
   });
   assertHasResponse(
@@ -144,8 +130,7 @@ export async function deleteConversationOverride(
   assistantId: string,
   conversationId: string,
 ): Promise<void> {
-  const { error, response } = await client.delete<unknown, unknown>({
-    url: "/v1/assistants/{assistant_id}/permissions/thresholds/conversations/{conversation_id}",
+  const { error, response } = await assistantConversationThresholdDelete({
     path: { assistant_id: assistantId, conversation_id: conversationId },
     throwOnError: false,
   });

--- a/clients/web/src/lib/trust-rules-api.ts
+++ b/clients/web/src/lib/trust-rules-api.ts
@@ -1,10 +1,20 @@
 /**
- * Hand-written fetch wrappers for the assistant daemon's trust-rules endpoints.
- * These endpoints are served via the gateway sidecar under
- * /v1/assistants/{id}/trust-rules/* and are not part of the Django OpenAPI
- * schema.
+ * Trust-rules API wrappers over the generated gateway SDK.
+ *
+ * The endpoints are gateway-native (`/v1/assistants/{id}/trust-rules/*`);
+ * their schemas live on the gateway's route metadata
+ * (`gateway/src/http/routes/trust-rules-routes.ts`), so the types here are
+ * codegen-derived. The gateway client's interceptor routes to the
+ * self-hosted gateway in local mode and through the platform proxy for
+ * platform-hosted assistants.
  */
-import { client } from "@/generated/api/client.gen";
+import {
+  assistantTrustRuleCreate,
+  assistantTrustRuleDelete,
+  assistantTrustRuleSuggest,
+  assistantTrustRulesList,
+  assistantTrustRuleUpdate,
+} from "@/generated/gateway/sdk.gen";
 import {
   ApiError,
   assertHasResponse,
@@ -16,7 +26,6 @@ import type {
   SuggestTrustRuleBody,
   TrustRuleItem,
   TrustRuleOrigin,
-  TrustRulesListResponse,
   TrustRuleSuggestion,
   UpdateTrustRuleBody,
 } from "@/types/trust-rules";
@@ -30,28 +39,18 @@ export interface FetchTrustRulesParams {
   includeAll?: boolean;
 }
 
-function buildFetchQuery(
-  params: FetchTrustRulesParams,
-): Record<string, string> {
-  const query: Record<string, string> = {};
-  if (params.origin) query.origin = params.origin;
-  if (params.tool) query.tool = params.tool;
-  if (params.includeDeleted) query.include_deleted = "true";
-  if (params.includeAll) query.include_all = "true";
-  return query;
-}
-
 export async function fetchTrustRules(
   assistantId: string,
   params: FetchTrustRulesParams = {},
 ): Promise<TrustRuleItem[]> {
-  const { data, error, response } = await client.get<
-    TrustRulesListResponse,
-    unknown
-  >({
-    url: "/v1/assistants/{assistant_id}/trust-rules/",
+  const { data, error, response } = await assistantTrustRulesList({
     path: { assistant_id: assistantId },
-    query: buildFetchQuery(params),
+    query: {
+      origin: params.origin,
+      tool: params.tool,
+      include_deleted: params.includeDeleted ? "true" : undefined,
+      include_all: params.includeAll ? "true" : undefined,
+    },
     throwOnError: false,
   });
   assertHasResponse(response, error, "Failed to load trust rules.");
@@ -68,11 +67,9 @@ export async function addTrustRule(
   assistantId: string,
   body: AddTrustRuleBody,
 ): Promise<void> {
-  const { error, response } = await client.post<unknown, unknown>({
-    url: "/v1/assistants/{assistant_id}/trust-rules/",
+  const { error, response } = await assistantTrustRuleCreate({
     path: { assistant_id: assistantId },
     body,
-    headers: { "Content-Type": "application/json" },
     throwOnError: false,
   });
   assertHasResponse(response, error, "Failed to add trust rule.");
@@ -89,11 +86,9 @@ export async function updateTrustRule(
   ruleId: string,
   body: UpdateTrustRuleBody,
 ): Promise<void> {
-  const { error, response } = await client.patch<unknown, unknown>({
-    url: "/v1/assistants/{assistant_id}/trust-rules/{rule_id}/",
+  const { error, response } = await assistantTrustRuleUpdate({
     path: { assistant_id: assistantId, rule_id: ruleId },
     body,
-    headers: { "Content-Type": "application/json" },
     throwOnError: false,
   });
   assertHasResponse(response, error, "Failed to update trust rule.");
@@ -105,22 +100,13 @@ export async function updateTrustRule(
   }
 }
 
-interface SuggestTrustRuleResponse {
-  suggestion: TrustRuleSuggestion;
-}
-
 export async function suggestTrustRule(
   assistantId: string,
   body: SuggestTrustRuleBody,
 ): Promise<TrustRuleSuggestion> {
-  const { data, error, response } = await client.post<
-    SuggestTrustRuleResponse,
-    unknown
-  >({
-    url: "/v1/assistants/{assistant_id}/trust-rules/suggest/",
+  const { data, error, response } = await assistantTrustRuleSuggest({
     path: { assistant_id: assistantId },
     body,
-    headers: { "Content-Type": "application/json" },
     throwOnError: false,
   });
   assertHasResponse(response, error, "Failed to get trust rule suggestion.");
@@ -140,8 +126,7 @@ export async function deleteTrustRule(
   assistantId: string,
   ruleId: string,
 ): Promise<void> {
-  const { error, response } = await client.delete<unknown, unknown>({
-    url: "/v1/assistants/{assistant_id}/trust-rules/{rule_id}/",
+  const { error, response } = await assistantTrustRuleDelete({
     path: { assistant_id: assistantId, rule_id: ruleId },
     throwOnError: false,
   });

--- a/clients/web/src/types/trust-rules.ts
+++ b/clients/web/src/types/trust-rules.ts
@@ -1,60 +1,25 @@
-export type TrustRuleRisk = "low" | "medium" | "high";
-export type TrustRuleOrigin = "default" | "user_defined";
+/**
+ * Trust-rules view-model types, derived from the generated gateway SDK
+ * types so they cannot drift from the wire (see docs/CONVENTIONS.md
+ * "Generated types are the source of truth"). The schemas originate in
+ * `gateway/src/http/routes/trust-rules-routes.ts`.
+ */
 
-export interface TrustRuleItem {
-  id: string;
-  tool: string;
-  pattern: string;
-  risk: TrustRuleRisk;
-  description: string;
-  origin: TrustRuleOrigin;
-  userModified: boolean;
-  deleted: boolean;
-  createdAt: string;
-  updatedAt: string;
-}
+import type {
+  AssistantTrustRuleCreateData,
+  AssistantTrustRuleSuggestData,
+  AssistantTrustRuleSuggestResponses,
+  AssistantTrustRuleUpdateData,
+  AssistantTrustRulesListResponses,
+} from "@/generated/gateway/types.gen";
 
-export interface TrustRulesListResponse {
-  rules: TrustRuleItem[];
-}
+export type TrustRulesListResponse = AssistantTrustRulesListResponses[200];
+export type TrustRuleItem = TrustRulesListResponse["rules"][number];
+export type TrustRuleRisk = TrustRuleItem["risk"];
+export type TrustRuleOrigin = TrustRuleItem["origin"];
 
-export interface AddTrustRuleBody {
-  tool: string;
-  pattern: string;
-  risk: TrustRuleRisk;
-  description: string;
-  /** Directory scope for this rule (e.g. a specific path, or "everywhere"). */
-  scope?: string;
-}
-
-export interface UpdateTrustRuleBody {
-  risk?: TrustRuleRisk;
-  description?: string;
-}
-
-export interface SuggestTrustRuleBody {
-  tool: string;
-  command: string;
-  riskAssessment: {
-    risk: string;
-    reasoning: string;
-    reasonDescription: string;
-  };
-  scopeOptions: { pattern: string; label: string }[];
-  directoryScopeOptions?: { scope: string; label: string }[];
-  intent: "auto_approve" | "escalate";
-  existingRule?: {
-    id: string;
-    pattern: string;
-    risk: string;
-  };
-}
-
-export interface TrustRuleSuggestion {
-  pattern: string;
-  risk: string;
-  scope: string | null;
-  description: string;
-  scopeOptions: { pattern: string; label: string }[];
-  directoryScopeOptions?: { scope: string; label: string }[] | null;
-}
+export type AddTrustRuleBody = AssistantTrustRuleCreateData["body"];
+export type UpdateTrustRuleBody = AssistantTrustRuleUpdateData["body"];
+export type SuggestTrustRuleBody = AssistantTrustRuleSuggestData["body"];
+export type TrustRuleSuggestion =
+  AssistantTrustRuleSuggestResponses[200]["suggestion"];

--- a/clients/web/src/utils/threshold-presets.ts
+++ b/clients/web/src/utils/threshold-presets.ts
@@ -61,7 +61,7 @@ export function presetFromThreshold(threshold: string): ThresholdPreset {
 export function overrideAction(
   preset: ThresholdPreset,
   globalInteractive: string,
-): { action: "set"; threshold: string } | { action: "clear" } {
+): { action: "set"; threshold: RiskThreshold } | { action: "clear" } {
   if (preset.riskThreshold === globalInteractive) {
     return { action: "clear" };
   }

--- a/gateway/openapi.json
+++ b/gateway/openapi.json
@@ -2,11 +2,352 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Vellum Gateway API",
-    "version": "0.10.5",
+    "version": "0.10.6",
     "description": "Auto-generated OpenAPI specification for the Vellum Gateway HTTP endpoints."
   },
   "servers": [{ "url": "", "description": "Same-origin (gateway)" }],
   "paths": {
+    "/v1/permissions/thresholds": {
+      "get": {
+        "operationId": "permissionsThresholdsGet",
+        "summary": "Get global auto-approve thresholds",
+        "tags": ["permissions"],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "interactive": {
+                      "type": "string",
+                      "enum": ["none", "low", "medium", "high"]
+                    },
+                    "autonomous": {
+                      "type": "string",
+                      "enum": ["none", "low", "medium", "high"]
+                    },
+                    "headless": {
+                      "type": "string",
+                      "enum": ["none", "low", "medium", "high"]
+                    }
+                  },
+                  "required": ["interactive", "autonomous", "headless"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "permissionsThresholdsPut",
+        "summary": "Update global auto-approve thresholds",
+        "tags": ["permissions"],
+        "description": "Partial update — omitted modes keep their current value. Returns the full post-update set.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "interactive": {
+                    "type": "string",
+                    "enum": ["none", "low", "medium", "high"]
+                  },
+                  "autonomous": {
+                    "type": "string",
+                    "enum": ["none", "low", "medium", "high"]
+                  },
+                  "headless": {
+                    "type": "string",
+                    "enum": ["none", "low", "medium", "high"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "interactive": {
+                      "type": "string",
+                      "enum": ["none", "low", "medium", "high"]
+                    },
+                    "autonomous": {
+                      "type": "string",
+                      "enum": ["none", "low", "medium", "high"]
+                    },
+                    "headless": {
+                      "type": "string",
+                      "enum": ["none", "low", "medium", "high"]
+                    }
+                  },
+                  "required": ["interactive", "autonomous", "headless"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/permissions/thresholds/conversations/{conversation_id}": {
+      "get": {
+        "operationId": "conversationThresholdGet",
+        "summary": "Get a conversation's threshold override",
+        "tags": ["permissions"],
+        "description": "Returns { threshold: null } when no override exists. (Gateways predating that behavior returned 404 for the same condition; clients tolerate both during rollout.)",
+        "parameters": [
+          {
+            "name": "conversation_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "The conversation id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "threshold": {
+                      "anyOf": [{ "type": "string" }, { "type": "null" }]
+                    }
+                  },
+                  "required": ["threshold"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "conversationThresholdPut",
+        "summary": "Set a conversation's threshold override",
+        "tags": ["permissions"],
+        "parameters": [
+          {
+            "name": "conversation_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "The conversation id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "threshold": {
+                    "type": "string",
+                    "enum": ["none", "low", "medium", "high"]
+                  }
+                },
+                "required": ["threshold"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "conversationId": { "type": "string" },
+                    "threshold": {
+                      "type": "string",
+                      "enum": ["none", "low", "medium", "high"]
+                    }
+                  },
+                  "required": ["conversationId", "threshold"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "conversationThresholdDelete",
+        "summary": "Clear a conversation's threshold override",
+        "tags": ["permissions"],
+        "description": "Idempotent — succeeds even when no override exists.",
+        "parameters": [
+          {
+            "name": "conversation_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "The conversation id"
+          }
+        ],
+        "responses": { "204": { "description": "Successful response" } }
+      }
+    },
+    "/v1/channel-admission-policy": {
+      "get": {
+        "operationId": "channelAdmissionPolicyList",
+        "summary": "List per-channel admission floors",
+        "tags": ["channel-admission-policy"],
+        "description": "Returns one entry per enforced channel (exempt and hidden channels are omitted), seeded with defaults for channels without a stored row.",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "policies": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "channelType": { "type": "string" },
+                          "policy": {
+                            "type": "string",
+                            "enum": [
+                              "no_one",
+                              "guardian_only",
+                              "trusted_contacts",
+                              "any_contact",
+                              "strangers"
+                            ]
+                          },
+                          "note": {
+                            "anyOf": [{ "type": "string" }, { "type": "null" }]
+                          },
+                          "updatedAt": {
+                            "anyOf": [{ "type": "number" }, { "type": "null" }]
+                          }
+                        },
+                        "required": [
+                          "channelType",
+                          "policy",
+                          "note",
+                          "updatedAt"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": ["policies"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/channel-admission-policy/{channel_type}": {
+      "put": {
+        "operationId": "channelAdmissionPolicySet",
+        "summary": "Set a channel's admission floor",
+        "tags": ["channel-admission-policy"],
+        "description": "Upserts the channel's admission policy. Exempt and hidden channels return 403.",
+        "parameters": [
+          {
+            "name": "channel_type",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "The channel type (e.g. slack)"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "policy": {
+                    "type": "string",
+                    "enum": [
+                      "no_one",
+                      "guardian_only",
+                      "trusted_contacts",
+                      "any_contact",
+                      "strangers"
+                    ]
+                  },
+                  "note": {
+                    "anyOf": [{ "type": "string" }, { "type": "null" }]
+                  }
+                },
+                "required": ["policy"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "policy": {
+                      "type": "object",
+                      "properties": {
+                        "channelType": { "type": "string" },
+                        "policy": {
+                          "type": "string",
+                          "enum": [
+                            "no_one",
+                            "guardian_only",
+                            "trusted_contacts",
+                            "any_contact",
+                            "strangers"
+                          ]
+                        },
+                        "note": {
+                          "anyOf": [{ "type": "string" }, { "type": "null" }]
+                        },
+                        "updatedAt": {
+                          "anyOf": [{ "type": "number" }, { "type": "null" }]
+                        }
+                      },
+                      "required": [
+                        "channelType",
+                        "policy",
+                        "note",
+                        "updatedAt"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["policy"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/contacts": {
       "post": {
         "operationId": "contactsUpsert",
@@ -537,6 +878,494 @@
                     }
                   },
                   "required": ["key", "enabled"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/trust-rules": {
+      "get": {
+        "operationId": "trustRulesList",
+        "summary": "List trust rules",
+        "tags": ["trust-rules"],
+        "description": "Returns trust rules, filtered to user-relevant rules by default. Pass include_all=true for the full set or origin/tool to filter.",
+        "parameters": [
+          {
+            "name": "origin",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string" },
+            "description": "Filter by origin (default | user_defined)"
+          },
+          {
+            "name": "tool",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string" },
+            "description": "Filter by tool name"
+          },
+          {
+            "name": "include_deleted",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string" },
+            "description": "\"true\" to include soft-deleted rules"
+          },
+          {
+            "name": "include_all",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string" },
+            "description": "\"true\" to disable the user-relevant filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "rules": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "string" },
+                          "tool": { "type": "string" },
+                          "pattern": { "type": "string" },
+                          "risk": {
+                            "type": "string",
+                            "enum": ["low", "medium", "high"]
+                          },
+                          "description": { "type": "string" },
+                          "origin": {
+                            "type": "string",
+                            "enum": ["default", "user_defined"]
+                          },
+                          "userModified": { "type": "boolean" },
+                          "deleted": { "type": "boolean" },
+                          "createdAt": { "type": "string" },
+                          "updatedAt": { "type": "string" }
+                        },
+                        "required": [
+                          "id",
+                          "tool",
+                          "pattern",
+                          "risk",
+                          "description",
+                          "origin",
+                          "userModified",
+                          "deleted",
+                          "createdAt",
+                          "updatedAt"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": ["rules"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "trustRuleCreate",
+        "summary": "Create a trust rule",
+        "tags": ["trust-rules"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "tool": { "type": "string", "minLength": 1 },
+                  "pattern": { "type": "string", "minLength": 1 },
+                  "risk": {
+                    "type": "string",
+                    "enum": ["low", "medium", "high"]
+                  },
+                  "description": { "type": "string", "minLength": 1 },
+                  "scope": {
+                    "description": "Directory scope selected in the rule editor. Accepted on the wire but not yet persisted by the gateway.",
+                    "type": "string"
+                  }
+                },
+                "required": ["tool", "pattern", "risk", "description"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "rule": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "string" },
+                        "tool": { "type": "string" },
+                        "pattern": { "type": "string" },
+                        "risk": {
+                          "type": "string",
+                          "enum": ["low", "medium", "high"]
+                        },
+                        "description": { "type": "string" },
+                        "origin": {
+                          "type": "string",
+                          "enum": ["default", "user_defined"]
+                        },
+                        "userModified": { "type": "boolean" },
+                        "deleted": { "type": "boolean" },
+                        "createdAt": { "type": "string" },
+                        "updatedAt": { "type": "string" }
+                      },
+                      "required": [
+                        "id",
+                        "tool",
+                        "pattern",
+                        "risk",
+                        "description",
+                        "origin",
+                        "userModified",
+                        "deleted",
+                        "createdAt",
+                        "updatedAt"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["rule"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/trust-rules/suggest": {
+      "post": {
+        "operationId": "trustRuleSuggest",
+        "summary": "Generate a trust-rule suggestion",
+        "tags": ["trust-rules"],
+        "description": "LLM-backed suggestion for a rule matching the given tool invocation. Returns 503 when the daemon suggestion relay is unavailable.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "tool": { "type": "string", "minLength": 1 },
+                  "command": { "type": "string", "minLength": 1 },
+                  "riskAssessment": {
+                    "type": "object",
+                    "properties": {
+                      "risk": { "type": "string" },
+                      "reasoning": { "type": "string" },
+                      "reasonDescription": { "type": "string" }
+                    },
+                    "required": ["risk", "reasoning", "reasonDescription"]
+                  },
+                  "scopeOptions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "pattern": { "type": "string" },
+                        "label": { "type": "string" }
+                      },
+                      "required": ["pattern", "label"]
+                    }
+                  },
+                  "directoryScopeOptions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "scope": { "type": "string" },
+                        "label": { "type": "string" }
+                      },
+                      "required": ["scope", "label"]
+                    }
+                  },
+                  "intent": {
+                    "type": "string",
+                    "enum": ["auto_approve", "escalate"]
+                  },
+                  "existingRule": {
+                    "type": "object",
+                    "properties": {
+                      "id": { "type": "string" },
+                      "pattern": { "type": "string" },
+                      "risk": { "type": "string" }
+                    },
+                    "required": ["id", "pattern", "risk"]
+                  }
+                },
+                "required": [
+                  "tool",
+                  "command",
+                  "riskAssessment",
+                  "scopeOptions",
+                  "intent"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "suggestion": {
+                      "type": "object",
+                      "properties": {
+                        "pattern": { "type": "string" },
+                        "risk": { "type": "string" },
+                        "scope": {
+                          "anyOf": [{ "type": "string" }, { "type": "null" }]
+                        },
+                        "description": { "type": "string" },
+                        "scopeOptions": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "pattern": { "type": "string" },
+                              "label": { "type": "string" }
+                            },
+                            "required": ["pattern", "label"],
+                            "additionalProperties": false
+                          }
+                        },
+                        "directoryScopeOptions": {
+                          "anyOf": [
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "scope": { "type": "string" },
+                                  "label": { "type": "string" }
+                                },
+                                "required": ["scope", "label"],
+                                "additionalProperties": false
+                              }
+                            },
+                            { "type": "null" }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "pattern",
+                        "risk",
+                        "scope",
+                        "description",
+                        "scopeOptions"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["suggestion"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/trust-rules/{rule_id}": {
+      "patch": {
+        "operationId": "trustRuleUpdate",
+        "summary": "Update a trust rule",
+        "tags": ["trust-rules"],
+        "description": "Updates risk and/or description. Updating a default-origin rule marks it userModified.",
+        "parameters": [
+          {
+            "name": "rule_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "The trust rule id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "risk": {
+                    "type": "string",
+                    "enum": ["low", "medium", "high"]
+                  },
+                  "description": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "rule": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "string" },
+                        "tool": { "type": "string" },
+                        "pattern": { "type": "string" },
+                        "risk": {
+                          "type": "string",
+                          "enum": ["low", "medium", "high"]
+                        },
+                        "description": { "type": "string" },
+                        "origin": {
+                          "type": "string",
+                          "enum": ["default", "user_defined"]
+                        },
+                        "userModified": { "type": "boolean" },
+                        "deleted": { "type": "boolean" },
+                        "createdAt": { "type": "string" },
+                        "updatedAt": { "type": "string" }
+                      },
+                      "required": [
+                        "id",
+                        "tool",
+                        "pattern",
+                        "risk",
+                        "description",
+                        "origin",
+                        "userModified",
+                        "deleted",
+                        "createdAt",
+                        "updatedAt"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["rule"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "trustRuleDelete",
+        "summary": "Delete a trust rule",
+        "tags": ["trust-rules"],
+        "description": "Soft-deletes the rule. Default-origin rules can be reset later.",
+        "parameters": [
+          {
+            "name": "rule_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "The trust rule id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "success": { "type": "boolean" } },
+                  "required": ["success"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/trust-rules/{rule_id}/reset": {
+      "post": {
+        "operationId": "trustRuleReset",
+        "summary": "Reset a default trust rule",
+        "tags": ["trust-rules"],
+        "description": "Restores a default-origin rule to its registry risk and description, clearing userModified and deleted.",
+        "parameters": [
+          {
+            "name": "rule_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "The trust rule id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "rule": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "string" },
+                        "tool": { "type": "string" },
+                        "pattern": { "type": "string" },
+                        "risk": {
+                          "type": "string",
+                          "enum": ["low", "medium", "high"]
+                        },
+                        "description": { "type": "string" },
+                        "origin": {
+                          "type": "string",
+                          "enum": ["default", "user_defined"]
+                        },
+                        "userModified": { "type": "boolean" },
+                        "deleted": { "type": "boolean" },
+                        "createdAt": { "type": "string" },
+                        "updatedAt": { "type": "string" }
+                      },
+                      "required": [
+                        "id",
+                        "tool",
+                        "pattern",
+                        "risk",
+                        "description",
+                        "origin",
+                        "userModified",
+                        "deleted",
+                        "createdAt",
+                        "updatedAt"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["rule"],
                   "additionalProperties": false
                 }
               }

--- a/gateway/scripts/generate-openapi.ts
+++ b/gateway/scripts/generate-openapi.ts
@@ -22,8 +22,11 @@ import type { GatewayRouteDefinition } from "../src/http/routes/types.js";
 
 // Import ROUTES from each route module that declares schemas.
 // Add new route modules here as they adopt zod-openapi schemas.
+import { ROUTES as autoApproveThresholdRoutes } from "../src/http/routes/auto-approve-thresholds-routes.js";
+import { ROUTES as channelAdmissionPolicyRoutes } from "../src/http/routes/channel-admission-policy-routes.js";
 import { ROUTES as contactsControlPlaneRoutes } from "../src/http/routes/contacts-control-plane-routes.js";
 import { ROUTES as featureFlagRoutes } from "../src/http/routes/feature-flags.js";
+import { ROUTES as trustRuleRoutes } from "../src/http/routes/trust-rules-routes.js";
 
 const ROOT = resolve(import.meta.dir, "..");
 const OUTPUT_PATH = resolve(ROOT, "openapi.json");
@@ -31,8 +34,11 @@ const PKG_PATH = resolve(ROOT, "package.json");
 
 // Collect all route definitions
 const ALL_ROUTES: GatewayRouteDefinition[] = [
+  ...autoApproveThresholdRoutes,
+  ...channelAdmissionPolicyRoutes,
   ...contactsControlPlaneRoutes,
   ...featureFlagRoutes,
+  ...trustRuleRoutes,
 ];
 
 // ---------------------------------------------------------------------------
@@ -52,6 +58,17 @@ function buildSpec(version: string) {
           name: param.name,
           in: "path",
           required: true,
+          schema: { type: "string" },
+          ...(param.description ? { description: param.description } : {}),
+        });
+      }
+    }
+    if (route.queryParameters) {
+      for (const param of route.queryParameters) {
+        parameters.push({
+          name: param.name,
+          in: "query",
+          required: false,
           schema: { type: "string" },
           ...(param.description ? { description: param.description } : {}),
         });

--- a/gateway/src/http/routes/auto-approve-thresholds-routes.ts
+++ b/gateway/src/http/routes/auto-approve-thresholds-routes.ts
@@ -1,0 +1,92 @@
+import { z } from "zod";
+
+import type { GatewayRouteDefinition } from "./types.js";
+
+/**
+ * OpenAPI route metadata for the auto-approve threshold API — the global
+ * per-execution-mode risk thresholds and per-conversation overrides.
+ *
+ * These schemas are the codegen source of truth for the generated gateway
+ * SDK (see scripts/generate-openapi.ts). Clients consume the operations
+ * through the SDK, which targets the assistant-scoped
+ * `/v1/assistants/{assistant_id}/permissions/thresholds...` route variants
+ * registered in `index.ts` alongside the flat paths documented here.
+ *
+ * The handlers live in `auto-approve-thresholds.ts`. This module is
+ * intentionally schema-only so the codegen script can import it without
+ * pulling in DB dependencies.
+ */
+
+const ThresholdSchema = z.enum(["none", "low", "medium", "high"]);
+
+const GlobalThresholdsSchema = z.object({
+  interactive: ThresholdSchema,
+  autonomous: ThresholdSchema,
+  headless: ThresholdSchema,
+});
+
+export const ROUTES: GatewayRouteDefinition[] = [
+  {
+    path: "/v1/permissions/thresholds",
+    method: "get",
+    operationId: "permissionsThresholdsGet",
+    summary: "Get global auto-approve thresholds",
+    tags: ["permissions"],
+    responseBody: GlobalThresholdsSchema,
+  },
+  {
+    path: "/v1/permissions/thresholds",
+    method: "put",
+    operationId: "permissionsThresholdsPut",
+    summary: "Update global auto-approve thresholds",
+    description:
+      "Partial update — omitted modes keep their current value. Returns the full post-update set.",
+    tags: ["permissions"],
+    requestBody: z.object({
+      interactive: ThresholdSchema.optional(),
+      autonomous: ThresholdSchema.optional(),
+      headless: ThresholdSchema.optional(),
+    }),
+    responseBody: GlobalThresholdsSchema,
+  },
+  {
+    path: "/v1/permissions/thresholds/conversations/{conversation_id}",
+    method: "get",
+    operationId: "conversationThresholdGet",
+    summary: "Get a conversation's threshold override",
+    description:
+      "Returns { threshold: null } when no override exists. (Gateways predating that behavior returned 404 for the same condition; clients tolerate both during rollout.)",
+    tags: ["permissions"],
+    pathParameters: [
+      { name: "conversation_id", description: "The conversation id" },
+    ],
+    responseBody: z.object({ threshold: z.string().nullable() }),
+  },
+  {
+    path: "/v1/permissions/thresholds/conversations/{conversation_id}",
+    method: "put",
+    operationId: "conversationThresholdPut",
+    summary: "Set a conversation's threshold override",
+    tags: ["permissions"],
+    pathParameters: [
+      { name: "conversation_id", description: "The conversation id" },
+    ],
+    requestBody: z.object({ threshold: ThresholdSchema }),
+    responseBody: z.object({
+      conversationId: z.string(),
+      threshold: ThresholdSchema,
+    }),
+  },
+  {
+    path: "/v1/permissions/thresholds/conversations/{conversation_id}",
+    method: "delete",
+    operationId: "conversationThresholdDelete",
+    summary: "Clear a conversation's threshold override",
+    description: "Idempotent — succeeds even when no override exists.",
+    tags: ["permissions"],
+    pathParameters: [
+      { name: "conversation_id", description: "The conversation id" },
+    ],
+    responseStatus: "204",
+  },
+];

--- a/gateway/src/http/routes/channel-admission-policy-routes.ts
+++ b/gateway/src/http/routes/channel-admission-policy-routes.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+import { AdmissionPolicySchema } from "@vellumai/gateway-client";
+
+import type { GatewayRouteDefinition } from "./types.js";
+
+/**
+ * OpenAPI route metadata for the per-channel admission-floor API.
+ *
+ * These schemas are the codegen source of truth for the generated gateway
+ * SDK (see scripts/generate-openapi.ts). Clients consume the operations
+ * through the SDK, which targets the assistant-scoped
+ * `/v1/assistants/{assistant_id}/channel-admission-policy/...` routes
+ * registered in `index.ts` alongside the flat paths documented here.
+ * The policy enum comes from the shared contract in
+ * `@vellumai/gateway-client` so gateway, clients, and spec share one source.
+ *
+ * The handlers live in `channel-admission-policy.ts`; that module imports
+ * `SetChannelPolicyRequestSchema` so wire validation and the published spec
+ * cannot drift. The gateway additionally accepts POST (PUT alias) and
+ * DELETE (reset to seed default) on the per-channel path for legacy native
+ * clients; only the canonical GET/PUT surface is published here.
+ */
+
+const ChannelPolicyViewSchema = z.object({
+  channelType: z.string(),
+  policy: AdmissionPolicySchema,
+  note: z.string().nullable(),
+  updatedAt: z.number().nullable(),
+});
+
+/**
+ * Request body for PUT /v1/channel-admission-policy/{channel_type}.
+ * `channel-admission-policy.ts` validates inbound bodies with this schema.
+ */
+export const SetChannelPolicyRequestSchema = z.object({
+  policy: AdmissionPolicySchema,
+  note: z.string().nullable().optional(),
+});
+
+export const ROUTES: GatewayRouteDefinition[] = [
+  {
+    path: "/v1/channel-admission-policy",
+    method: "get",
+    operationId: "channelAdmissionPolicyList",
+    summary: "List per-channel admission floors",
+    description:
+      "Returns one entry per enforced channel (exempt and hidden channels are omitted), seeded with defaults for channels without a stored row.",
+    tags: ["channel-admission-policy"],
+    responseBody: z.object({
+      policies: z.array(ChannelPolicyViewSchema),
+    }),
+  },
+  {
+    path: "/v1/channel-admission-policy/{channel_type}",
+    method: "put",
+    operationId: "channelAdmissionPolicySet",
+    summary: "Set a channel's admission floor",
+    description:
+      "Upserts the channel's admission policy. Exempt and hidden channels return 403.",
+    tags: ["channel-admission-policy"],
+    pathParameters: [
+      { name: "channel_type", description: "The channel type (e.g. slack)" },
+    ],
+    requestBody: SetChannelPolicyRequestSchema,
+    responseBody: z.object({ policy: ChannelPolicyViewSchema }),
+  },
+];

--- a/gateway/src/http/routes/channel-admission-policy.ts
+++ b/gateway/src/http/routes/channel-admission-policy.ts
@@ -10,7 +10,6 @@
  * conventions.
  */
 
-import { z } from "zod";
 import {
   isAdmissionPolicyExemptChannel,
   isAdmissionPolicyHiddenChannel,
@@ -24,8 +23,13 @@ import {
   type AdmissionPolicyRow,
 } from "../../db/admission-policy-store.js";
 import { invalidateAdmissionPolicyCache } from "../../risk/admission-policy-cache.js";
-import { CHANNEL_IDS, isChannelId, type ChannelId } from "../../channels/types.js";
+import {
+  CHANNEL_IDS,
+  isChannelId,
+  type ChannelId,
+} from "../../channels/types.js";
 import { getLogger } from "../../logger.js";
+import { SetChannelPolicyRequestSchema } from "./channel-admission-policy-routes.js";
 
 const log = getLogger("channel-admission-policy");
 
@@ -33,10 +37,8 @@ const log = getLogger("channel-admission-policy");
 // Validation
 // ---------------------------------------------------------------------------
 
-const SetPolicyBodySchema = z.object({
-  policy: z.enum(ADMISSION_POLICY_VALUES as readonly [string, ...string[]]),
-  note: z.string().nullable().optional(),
-});
+// Wire schema shared with the published OpenAPI spec (single source).
+const SetPolicyBodySchema = SetChannelPolicyRequestSchema;
 
 // ---------------------------------------------------------------------------
 // Response shape
@@ -117,8 +119,7 @@ export function createChannelAdmissionPolicySetHandler() {
     if (isAdmissionPolicyExemptChannel(channelType)) {
       return Response.json(
         {
-          error:
-            "internal channels are exempt from admission policy",
+          error: "internal channels are exempt from admission policy",
           channelType,
         },
         { status: 403 },

--- a/gateway/src/http/routes/trust-rules-routes.ts
+++ b/gateway/src/http/routes/trust-rules-routes.ts
@@ -1,0 +1,182 @@
+import { z } from "zod";
+
+import type { GatewayRouteDefinition } from "./types.js";
+
+/**
+ * OpenAPI route metadata for the trust-rules v3 API.
+ *
+ * These schemas are the codegen source of truth for the generated gateway
+ * SDK (see scripts/generate-openapi.ts). Clients consume the operations
+ * through the SDK, which targets the assistant-scoped
+ * `/v1/assistants/{assistant_id}/trust-rules/...` route variants registered
+ * in `index.ts` alongside the flat paths documented here.
+ *
+ * The handlers live in `trust-rules.ts`; that module imports the request
+ * schemas defined here so wire validation and the published spec cannot
+ * drift. This module is intentionally schema-only so the codegen script
+ * can import it without pulling in DB or IPC dependencies.
+ */
+
+export const TrustRuleRiskSchema = z.enum(["low", "medium", "high"]);
+
+const TrustRuleSchema = z.object({
+  id: z.string(),
+  tool: z.string(),
+  pattern: z.string(),
+  risk: TrustRuleRiskSchema,
+  description: z.string(),
+  origin: z.enum(["default", "user_defined"]),
+  userModified: z.boolean(),
+  deleted: z.boolean(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+const CreateTrustRuleRequestSchema = z.object({
+  tool: z.string().min(1),
+  pattern: z.string().min(1),
+  risk: TrustRuleRiskSchema,
+  description: z.string().min(1),
+  scope: z
+    .string()
+    .optional()
+    .describe(
+      "Directory scope selected in the rule editor. Accepted on the wire but not yet persisted by the gateway.",
+    ),
+});
+
+const UpdateTrustRuleRequestSchema = z.object({
+  risk: TrustRuleRiskSchema.optional(),
+  description: z.string().optional(),
+});
+
+/**
+ * Request body for POST /v1/trust-rules/suggest. `trust-rules.ts` validates
+ * inbound bodies with this exact schema.
+ */
+export const TrustRuleSuggestRequestSchema = z.object({
+  tool: z.string().min(1),
+  command: z.string().min(1),
+  riskAssessment: z.object({
+    risk: z.string(),
+    reasoning: z.string(),
+    reasonDescription: z.string(),
+  }),
+  scopeOptions: z.array(
+    z.object({
+      pattern: z.string(),
+      label: z.string(),
+    }),
+  ),
+  directoryScopeOptions: z
+    .array(
+      z.object({
+        scope: z.string(),
+        label: z.string(),
+      }),
+    )
+    .optional(),
+  intent: z.enum(["auto_approve", "escalate"]),
+  existingRule: z
+    .object({
+      id: z.string(),
+      pattern: z.string(),
+      risk: z.string(),
+    })
+    .optional(),
+});
+
+const TrustRuleSuggestionSchema = z.object({
+  pattern: z.string(),
+  risk: z.string(),
+  scope: z.string().nullable(),
+  description: z.string(),
+  scopeOptions: z.array(z.object({ pattern: z.string(), label: z.string() })),
+  directoryScopeOptions: z
+    .array(z.object({ scope: z.string(), label: z.string() }))
+    .nullable()
+    .optional(),
+});
+
+export const ROUTES: GatewayRouteDefinition[] = [
+  {
+    path: "/v1/trust-rules",
+    method: "get",
+    operationId: "trustRulesList",
+    summary: "List trust rules",
+    description:
+      "Returns trust rules, filtered to user-relevant rules by default. Pass include_all=true for the full set or origin/tool to filter.",
+    tags: ["trust-rules"],
+    queryParameters: [
+      {
+        name: "origin",
+        description: "Filter by origin (default | user_defined)",
+      },
+      { name: "tool", description: "Filter by tool name" },
+      {
+        name: "include_deleted",
+        description: '"true" to include soft-deleted rules',
+      },
+      {
+        name: "include_all",
+        description: '"true" to disable the user-relevant filter',
+      },
+    ],
+    responseBody: z.object({ rules: z.array(TrustRuleSchema) }),
+  },
+  {
+    path: "/v1/trust-rules",
+    method: "post",
+    operationId: "trustRuleCreate",
+    summary: "Create a trust rule",
+    tags: ["trust-rules"],
+    requestBody: CreateTrustRuleRequestSchema,
+    responseStatus: "201",
+    responseBody: z.object({ rule: TrustRuleSchema }),
+  },
+  {
+    path: "/v1/trust-rules/suggest",
+    method: "post",
+    operationId: "trustRuleSuggest",
+    summary: "Generate a trust-rule suggestion",
+    description:
+      "LLM-backed suggestion for a rule matching the given tool invocation. Returns 503 when the daemon suggestion relay is unavailable.",
+    tags: ["trust-rules"],
+    requestBody: TrustRuleSuggestRequestSchema,
+    responseBody: z.object({ suggestion: TrustRuleSuggestionSchema }),
+  },
+  {
+    path: "/v1/trust-rules/{rule_id}",
+    method: "patch",
+    operationId: "trustRuleUpdate",
+    summary: "Update a trust rule",
+    description:
+      "Updates risk and/or description. Updating a default-origin rule marks it userModified.",
+    tags: ["trust-rules"],
+    pathParameters: [{ name: "rule_id", description: "The trust rule id" }],
+    requestBody: UpdateTrustRuleRequestSchema,
+    responseBody: z.object({ rule: TrustRuleSchema }),
+  },
+  {
+    path: "/v1/trust-rules/{rule_id}",
+    method: "delete",
+    operationId: "trustRuleDelete",
+    summary: "Delete a trust rule",
+    description:
+      "Soft-deletes the rule. Default-origin rules can be reset later.",
+    tags: ["trust-rules"],
+    pathParameters: [{ name: "rule_id", description: "The trust rule id" }],
+    responseBody: z.object({ success: z.boolean() }),
+  },
+  {
+    path: "/v1/trust-rules/{rule_id}/reset",
+    method: "post",
+    operationId: "trustRuleReset",
+    summary: "Reset a default trust rule",
+    description:
+      "Restores a default-origin rule to its registry risk and description, clearing userModified and deleted.",
+    tags: ["trust-rules"],
+    pathParameters: [{ name: "rule_id", description: "The trust rule id" }],
+    responseBody: z.object({ rule: TrustRuleSchema }),
+  },
+];

--- a/gateway/src/http/routes/trust-rules.ts
+++ b/gateway/src/http/routes/trust-rules.ts
@@ -5,7 +5,6 @@
  * classifications reflect the change immediately.
  */
 
-import { z } from "zod";
 import {
   TrustRuleStore,
   VALID_RISK_VALUES,
@@ -18,43 +17,16 @@ import { getGatewayDb } from "../../db/connection.js";
 import { autoApproveThresholds } from "../../db/schema.js";
 import { eq } from "drizzle-orm";
 
+import { TrustRuleSuggestRequestSchema } from "./trust-rules-routes.js";
+
 const log = getLogger("trust-rules");
 
 // ---------------------------------------------------------------------------
 // Zod schema for POST /v1/trust-rules/suggest request body
 // ---------------------------------------------------------------------------
 
-const SuggestRequestSchema = z.object({
-  tool: z.string().min(1),
-  command: z.string().min(1),
-  riskAssessment: z.object({
-    risk: z.string(),
-    reasoning: z.string(),
-    reasonDescription: z.string(),
-  }),
-  scopeOptions: z.array(
-    z.object({
-      pattern: z.string(),
-      label: z.string(),
-    }),
-  ),
-  directoryScopeOptions: z
-    .array(
-      z.object({
-        scope: z.string(),
-        label: z.string(),
-      }),
-    )
-    .optional(),
-  intent: z.enum(["auto_approve", "escalate"]),
-  existingRule: z
-    .object({
-      id: z.string(),
-      pattern: z.string(),
-      risk: z.string(),
-    })
-    .optional(),
-});
+// Wire schema shared with the published OpenAPI spec (single source).
+const SuggestRequestSchema = TrustRuleSuggestRequestSchema;
 
 export interface TrustRulesListParams {
   origin?: string;

--- a/gateway/src/http/routes/types.ts
+++ b/gateway/src/http/routes/types.ts
@@ -17,6 +17,8 @@ export interface GatewayRouteDefinition {
   responseBody?: z.ZodTypeAny;
   requestBody?: z.ZodTypeAny;
   pathParameters?: Array<{ name: string; description?: string }>;
+  /** Optional string query parameters (all documented as non-required). */
+  queryParameters?: Array<{ name: string; description?: string }>;
   /**
    * Success status code documented in the spec. Defaults to "200".
    * Use "204" for empty-body responses (responseBody must be omitted).


### PR DESCRIPTION
## Prompt / plan

Cluster 1 of [LUM-2716](https://linear.app/vellum/issue/LUM-2716/refactorweb-migrate-remaining-hand-written-api-call-sites-to-generated) — migrating the remaining hand-written API call sites onto generated SDKs so the platform client's routing allowlist can shrink toward deletion. Follows the pattern proven by feature flags (#34936) and contacts (#37212/#37218), and is intended as the reference example for the remaining clusters.

**Gateway** (spec coverage only — zero route/handler behavior changes; all three families already have flat + assistant-scoped routes):
- Three schema-only route-metadata modules publish the trust-rules v3 API (list/create/suggest/update/delete/reset), auto-approve thresholds (global get/put, conversation override get/put/delete), and channel admission-policy (list/set). `gateway/openapi.json`: 6 → 19 documented routes.
- **Single-source wiring**: the handlers now import their request schemas from the new modules (`SuggestRequestSchema`, `SetPolicyBodySchema`), so wire validation and the published spec cannot drift; the admission-policy enum comes from the shared `@vellumai/gateway-client` contract.
- `GatewayRouteDefinition` gains `queryParameters` so the trust-rules list filters generate typed SDK query options.

**Web**:
- `threshold-api.ts`, `trust-rules-api.ts`, `channel-admission-policy/api.ts` → generated gateway SDK functions; exported function signatures unchanged (no consumer churn). Request/response types are codegen-derived; `types/trust-rules.ts` now re-derives its view-model types from generated types per CONVENTIONS.md ("Generated types are the source of truth").
- **Allowlist shrinks by three**: `trust-rules`, `permissions`, `channel-admission-policy` removed from `RUNTIME_PROXIED_FIRST_SEGMENTS` (no platform-client call sites remain). Remaining: `conversations`, `events`, `x`, `config`.
- Dead code removed: `submitTrustRule` (zero callers; it posted a confirmation-flow payload to the gateway create route, which never consumed those fields).
- `overrideAction` return type tightened from `string` to the `RiskThreshold` union its value provably is.

**Known gap surfaced (not fixed here)**: the rule editor sends `scope` on trust-rule create and the gateway create handler silently drops it — the schema documents this ("accepted on the wire but not yet persisted"). Worth a follow-up decision alongside LUM-2710.

## Test plan

- Gateway: `generate:openapi --check` byte-exact; `tsc` clean; trust-rules suggest (10), trust-rules routes (15), route auth (1), thresholds (16), conversation thresholds (9), admission-policy routes (14), route-schema-guard (5) all pass.
- Web: `tsc` clean (incl. regenerated SDK); interceptor tests (62), admission-policy api tests (7, rewired to mock the gateway SDK), threshold-api tests (4, pointed at the gateway client), composer-settings-menu (10), attention-tracking sweep (5) all pass; eslint clean on all changed files.

## CLI verb checklist

No new routes — OpenAPI metadata for existing gateway handlers plus web call-site migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQukmCcA8NK2y9wqFVCdjc

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQukmCcA8NK2y9wqFVCdjc)_