### PR TITLE
fix: duplex session lifecycle, archiving, and barge-in hardening

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -3730,9 +3730,150 @@ describe("call-controller", () => {
 
       expect(profile.timers.maxDurationMs()).toBe(1800 * 1000);
       expect(profile.timers.endCallListenWindowMs()).toBe(0);
-      expect(profile.timers.silenceTimeoutMs()).toBe(30_000);
       expect(profile.guardianConsultation.mode).toBe("disabled");
+      expect(profile.unpromptedSpeech).toBe("disabled");
       expect(profile.speechOutput).toBe("token-stream");
+    });
+
+    test("persisted-message-id hooks are forwarded to startVoiceTurn as event callbacks", async () => {
+      const userIds: string[] = [];
+      const assistantIds: string[] = [];
+      let captured:
+        | {
+            callbacks?: {
+              persisted_user_message_id?: (id: string) => void;
+              persisted_assistant_message_id?: (id: string) => void;
+            };
+          }
+        | undefined;
+      mockStartVoiceTurn.mockImplementation(
+        async (opts: {
+          callbacks?: {
+            persisted_user_message_id?: (id: string) => void;
+            persisted_assistant_message_id?: (id: string) => void;
+          };
+          onTextDelta: (t: string) => void;
+          onComplete: () => void;
+        }) => {
+          captured = opts;
+          opts.callbacks?.persisted_user_message_id?.("msg-user-1");
+          opts.onTextDelta("Hi.");
+          opts.callbacks?.persisted_assistant_message_id?.("msg-assistant-1");
+          opts.onComplete();
+          return { turnId: "run-hooks", abort: () => {} };
+        },
+      );
+
+      ensureConversation("conv-inapp-hooks");
+      const sessionSource: VoiceSessionSource = {
+        conversationId: "conv-inapp-hooks",
+        skipDisclosure: true,
+        getSnapshot: () => ({
+          status: "in_progress",
+          conversationId: "conv-inapp-hooks",
+          initiatedFromConversationId: null,
+          startedAt: Date.now(),
+          toNumber: "",
+        }),
+      };
+      const controller = new CallController(
+        "live-voice-session-hooks",
+        createMockTransport(),
+        null,
+        {
+          sessionSource,
+          profile: createInAppVoiceControllerProfile({
+            onPersistedUserMessageId: (id) => userIds.push(id),
+            onPersistedAssistantMessageId: (id) => assistantIds.push(id),
+          }),
+        },
+      );
+
+      await controller.handleCallerUtterance("Hello");
+
+      expect(captured?.callbacks?.persisted_user_message_id).toBeDefined();
+      expect(captured?.callbacks?.persisted_assistant_message_id).toBeDefined();
+      expect(userIds).toEqual(["msg-user-1"]);
+      expect(assistantIds).toEqual(["msg-assistant-1"]);
+
+      controller.destroy();
+    });
+
+    test("without hooks the in-app profile passes no callbacks (phone shape preserved)", () => {
+      expect(createInAppVoiceControllerProfile().voiceTurn.callbacks).toBe(
+        undefined,
+      );
+    });
+
+    test("unprompted speech disabled: no silence nudge fires even with a tiny timeout", async () => {
+      ensureConversation("conv-inapp-silence");
+      const sessionSource: VoiceSessionSource = {
+        conversationId: "conv-inapp-silence",
+        skipDisclosure: true,
+        getSnapshot: () => ({
+          status: "in_progress",
+          conversationId: "conv-inapp-silence",
+          initiatedFromConversationId: null,
+          startedAt: Date.now(),
+          toNumber: "",
+        }),
+      };
+      const profile = createInAppVoiceControllerProfile();
+      profile.timers = { ...profile.timers, silenceTimeoutMs: () => 10 };
+      const transport = createMockTransport();
+      const controller = new CallController(
+        "live-voice-session-silence",
+        transport,
+        null,
+        { sessionSource, profile },
+      );
+
+      await controller.handleCallerUtterance("Hello");
+      // A phone profile would arm the nudge on returning to idle; give it
+      // several timeout windows to (incorrectly) fire.
+      await new Promise((r) => setTimeout(r, 80));
+
+      const allText = transport.sentTokens.map((t) => t.token).join("");
+      expect(allText).not.toContain("Are you still there?");
+
+      controller.destroy();
+    });
+
+    test("unprompted speech disabled: no pre-max-duration warning is spoken", async () => {
+      ensureConversation("conv-inapp-warning");
+      const sessionSource: VoiceSessionSource = {
+        conversationId: "conv-inapp-warning",
+        skipDisclosure: true,
+        getSnapshot: () => ({
+          status: "in_progress",
+          conversationId: "conv-inapp-warning",
+          initiatedFromConversationId: null,
+          startedAt: Date.now(),
+          toNumber: "",
+        }),
+      };
+      const profile = createInAppVoiceControllerProfile();
+      // warningMs = maxDurationMs - 2min → 20ms; the max-duration end
+      // timer itself stays far in the future.
+      profile.timers = {
+        ...profile.timers,
+        maxDurationMs: () => 2 * 60 * 1000 + 20,
+      };
+      const transport = createMockTransport();
+      const controller = new CallController(
+        "live-voice-session-warning",
+        transport,
+        null,
+        { sessionSource, profile },
+      );
+
+      await new Promise((r) => setTimeout(r, 80));
+
+      const allText = transport.sentTokens.map((t) => t.token).join("");
+      expect(allText).not.toContain("running low on time");
+      expect(transport.endCalled).toBe(false);
+
+      controller.destroy();
     });
   });
 });

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -1549,7 +1549,10 @@ export class CallController {
     const maxDurationMs = this.profile.timers.maxDurationMs();
     const warningMs = maxDurationMs - 2 * 60 * 1000; // 2 minutes before max
 
-    if (warningMs > 0) {
+    // The warning is unprompted speech (spoken outside any caller turn);
+    // profiles that disable unprompted speech skip it. The max-duration
+    // goodbye + endSession below still applies.
+    if (warningMs > 0 && this.profile.unpromptedSpeech === "enabled") {
       this.durationWarningTimer = setTimeout(() => {
         log.info(
           { callSessionId: this.callSessionId },
@@ -1602,6 +1605,9 @@ export class CallController {
   private resetSilenceTimer(): void {
     if (this.silenceTimer) clearTimeout(this.silenceTimer);
     if (this.destroyed) return;
+    // The silence nudge is unprompted speech; profiles that disable it
+    // never arm the watchdog (in-app sessions have no idle hangup notion).
+    if (this.profile.unpromptedSpeech === "disabled") return;
     this.silenceTimer = setTimeout(() => {
       // During an in-call guardian consultation, suppress the generic
       // "Are you still there?" — it is confusing when the caller is

--- a/assistant/src/calls/voice-session-source.ts
+++ b/assistant/src/calls/voice-session-source.ts
@@ -35,7 +35,10 @@ import type {
   CallPendingQuestion,
   CallStatus,
 } from "./types.js";
-import { buildLiveVoiceControlPrompt } from "./voice-session-bridge.js";
+import {
+  buildLiveVoiceControlPrompt,
+  type VoiceTurnCallbacks,
+} from "./voice-session-bridge.js";
 
 /** Point-in-time view of the session lifecycle fields CallController reads. */
 export interface VoiceSessionSnapshot {
@@ -96,6 +99,12 @@ export interface VoiceTurnProfileContext {
   assistantMessageInterface: InterfaceId;
   /** Per-turn control prompt. Undefined builds the phone prompt; null disables it. */
   voiceControlPrompt: string | null | undefined;
+  /**
+   * Event-name callbacks forwarded to every startVoiceTurn call. The in-app
+   * profile uses these to learn the persisted user/assistant message ids so
+   * the live-voice session can link per-turn audio archives to them.
+   */
+  callbacks?: VoiceTurnCallbacks;
 }
 
 /**
@@ -154,6 +163,14 @@ export interface VoiceControllerProfile {
   voiceTurn: VoiceTurnProfileContext;
   timers: VoiceControllerTimers;
   /**
+   * Whether the controller may speak outside a user-initiated turn (the
+   * silence nudge and the pre-max-duration warning). Phone calls keep
+   * these; in-app live-voice disables them because out-of-turn speech has
+   * no turn to anchor its `tts_done` and wedges the client state machine.
+   * The max-duration END-of-session (with its goodbye) applies regardless.
+   */
+  unpromptedSpeech: "enabled" | "disabled";
+  /**
    * "auto": resolve the call TTS provider per turn (synthesized-play vs
    * native token streaming). "token-stream": always stream tokens through
    * the transport — the transport owns synthesis and sendPlayUrl is never
@@ -211,8 +228,19 @@ export function createPhoneVoiceControllerProfile(
       endCallListenWindowMs: getEndCallListenWindowMs,
       consultTimeoutMs: getUserConsultationTimeoutMs,
     },
+    unpromptedSpeech: "enabled",
     speechOutput: "auto",
   };
+}
+
+/**
+ * Per-turn persistence hooks the in-app profile forwards to the voice
+ * bridge, letting the live-voice session link archived turn audio to the
+ * conversation messages the pipeline persisted.
+ */
+export interface InAppVoiceProfileHooks {
+  onPersistedUserMessageId?: (messageId: string) => void;
+  onPersistedAssistantMessageId?: (messageId: string) => void;
 }
 
 /**
@@ -222,7 +250,18 @@ export function createPhoneVoiceControllerProfile(
  * approvals surface interactively through the client; and the transport
  * owns TTS synthesis (token-stream).
  */
-export function createInAppVoiceControllerProfile(): VoiceControllerProfile {
+export function createInAppVoiceControllerProfile(
+  hooks: InAppVoiceProfileHooks = {},
+): VoiceControllerProfile {
+  const callbacks: VoiceTurnCallbacks = {
+    ...(hooks.onPersistedUserMessageId
+      ? { persisted_user_message_id: hooks.onPersistedUserMessageId }
+      : {}),
+    ...(hooks.onPersistedAssistantMessageId
+      ? { persisted_assistant_message_id: hooks.onPersistedAssistantMessageId }
+      : {}),
+  };
+
   return {
     recordEvent() {},
     updateStatus() {},
@@ -235,6 +274,7 @@ export function createInAppVoiceControllerProfile(): VoiceControllerProfile {
       userMessageInterface: "macos",
       assistantMessageInterface: "macos",
       voiceControlPrompt: buildLiveVoiceControlPrompt(),
+      ...(Object.keys(callbacks).length > 0 ? { callbacks } : {}),
     },
     timers: {
       maxDurationMs: () =>
@@ -246,6 +286,10 @@ export function createInAppVoiceControllerProfile(): VoiceControllerProfile {
       // Unreachable while guardian consultation is disabled.
       consultTimeoutMs: getUserConsultationTimeoutMs,
     },
+    // Out-of-turn speech (silence nudge, duration warning) has no place in
+    // the in-app protocol: its tts_done has no current turn and the web
+    // client would stick in `speaking`.
+    unpromptedSpeech: "disabled",
     speechOutput: "token-stream",
   };
 }

--- a/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
@@ -175,7 +175,7 @@ describe("LiveVoiceSession duplex orchestration", () => {
     });
   });
 
-  test("empty final transcripts are not dispatched and cancel the listening turn", async () => {
+  test("empty final transcripts cancel the listening turn with a turn_cancelled notice", async () => {
     const harness = createSessionHarness({ emitMetrics: true });
     const { session, frames, ingest, controller } = harness;
 
@@ -190,6 +190,53 @@ describe("LiveVoiceSession duplex orchestration", () => {
 
     expect(controller.utterances).toEqual([]);
     expect(frames.some((frame) => frame.type === "thinking")).toBe(false);
+    // The client is told the turn died so it resumes listening.
+    expect(
+      frames.find((frame) => frame.type === "turn_cancelled"),
+    ).toMatchObject({ type: "turn_cancelled", reason: "empty_transcript" });
+  });
+
+  test("a failed assistant turn emits turn_failed and cancels the turn", async () => {
+    const harness = createSessionHarness({ emitMetrics: true });
+    const { session, frames, ingest, controller } = harness;
+
+    controller.handleCallerUtterance = async () => {
+      throw new Error("pipeline exploded");
+    };
+
+    await session.start();
+    await session.handleClientFrame(audioFrame("user audio"));
+    ingest.callbacks.onTranscriptFinal?.("hello there");
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "turn_cancelled"),
+    );
+
+    expect(frames.find((frame) => frame.type === "error")).toMatchObject({
+      type: "error",
+      code: "turn_failed",
+      message: expect.stringContaining("pipeline exploded"),
+    });
+    expect(
+      frames.find((frame) => frame.type === "turn_cancelled"),
+    ).toMatchObject({ reason: "turn_failed" });
+    await waitFor(() =>
+      frames.some(
+        (frame) => frame.type === "metrics" && frame.event === "turn_cancelled",
+      ),
+    );
+  });
+
+  test("transcription errors carry the stt_failed code", async () => {
+    const { session, frames, ingest } = createSessionHarness();
+
+    await session.start();
+    ingest.callbacks.onError?.("stream", "provider connection dropped");
+    await waitFor(() => frames.some((frame) => frame.type === "error"));
+
+    expect(frames.find((frame) => frame.type === "error")).toMatchObject({
+      code: "stt_failed",
+      message: expect.stringContaining("provider connection dropped"),
+    });
   });
 
   test("forwards partials and turn boundaries", async () => {
@@ -371,7 +418,7 @@ describe("LiveVoiceSession duplex orchestration", () => {
     ).toBe(true);
   });
 
-  test("controller endSession closes the session and stops accepting input", async () => {
+  test("controller endSession emits session_ended, closes the session, and stops accepting input", async () => {
     const harness = createSessionHarness({ emitMetrics: true });
     const { session, frames, ingest, transport, controller } = harness;
 
@@ -387,10 +434,98 @@ describe("LiveVoiceSession duplex orchestration", () => {
     expect(ingest.disposed).toBe(true);
     expect(controller.destroyed).toBe(true);
 
+    // The client is told the session ended (with the controller's reason)
+    // before the final metrics frame.
+    const sessionEndedIndex = frames.findIndex(
+      (frame) => frame.type === "session_ended",
+    );
+    expect(frames[sessionEndedIndex]).toMatchObject({
+      type: "session_ended",
+      reason: "Call completed",
+    });
+    expect(sessionEndedIndex).toBeLessThan(
+      frames.findIndex(
+        (frame) => frame.type === "metrics" && frame.event === "session_ended",
+      ),
+    );
+
     const pushedBefore = ingest.pushed.length;
     await session.handleClientFrame(audioFrame("late audio"));
     expect(ingest.pushed).toHaveLength(pushedBefore);
     expect(frames.filter((frame) => frame.type === "error")).toEqual([]);
+  });
+
+  test("server-initiated end drains the TTS queue (goodbye) before session_ended and close", async () => {
+    const harness = createSessionHarness({ emitMetrics: true });
+    const { session, frames, ingest, transport } = harness;
+
+    await session.start();
+    let releaseDrain!: () => void;
+    transport.ttsDrainGate = new Promise<void>((resolve) => {
+      releaseDrain = resolve;
+    });
+
+    transport.endSession("Call completed");
+    // Give the async end flow time to (incorrectly) race ahead.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // The goodbye is still synthesizing: nothing torn down, nothing sent.
+    expect(transport.ttsDrainWaits).toBe(1);
+    expect(frames.some((frame) => frame.type === "session_ended")).toBe(false);
+    expect(ingest.disposed).toBe(false);
+
+    releaseDrain();
+    await waitFor(() => frames.some((frame) => frame.type === "session_ended"));
+    await waitFor(() =>
+      frames.some(
+        (frame) => frame.type === "metrics" && frame.event === "session_ended",
+      ),
+    );
+    expect(ingest.disposed).toBe(true);
+  });
+
+  test("interrupt during the synthesis tail (controller already idle) cancels the turn at the session layer", async () => {
+    const harness = createSessionHarness({ emitMetrics: true });
+    const { session, frames, transport, controller } = harness;
+
+    await startRespondingTurn(harness);
+    // Generation finished: the controller went idle, but the transport's
+    // synthesis tail is still playing (no tts_done processed yet).
+    controller.state = "idle";
+
+    await session.handleClientFrame({ type: "interrupt" });
+    await waitFor(() => frames.some((frame) => frame.type === "interrupted"));
+
+    // The controller rejected the barge-in (not speaking); the session
+    // flushed the tail itself.
+    expect(controller.bargeInCount).toBe(0);
+    expect(transport.discardCount).toBe(1);
+    expect(frames.find((frame) => frame.type === "interrupted")).toMatchObject({
+      turnId: "live-turn-1",
+    });
+    await waitFor(() =>
+      frames.some(
+        (frame) => frame.type === "metrics" && frame.event === "turn_cancelled",
+      ),
+    );
+
+    // A straggler tts_done from the aborted tail is dropped.
+    await transport.emitTtsDone("live-turn-1");
+    expect(frames.some((frame) => frame.type === "tts_done")).toBe(false);
+  });
+
+  test("speech onset during the synthesis tail triggers the session-level interrupt", async () => {
+    const harness = createSessionHarness();
+    const { frames, ingest, transport, controller } = harness;
+
+    await startRespondingTurn(harness);
+    controller.state = "idle";
+
+    ingest.callbacks.onSpeechStart?.();
+    await waitFor(() => frames.some((frame) => frame.type === "interrupted"));
+
+    expect(controller.bargeInCount).toBe(0);
+    expect(transport.discardCount).toBe(1);
   });
 
   test("close tears down collaborators, cancels the open turn, and emits session_ended", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-archive.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-archive.test.ts
@@ -253,7 +253,7 @@ describe("live voice audio archive", () => {
     expect(getLiveVoiceArtifacts(message.id)).toEqual([result.artifact]);
   });
 
-  test("returns an unlinked result when the assistant message id is unavailable", () => {
+  test("stores an unlinked artifact when the assistant message id is unavailable", async () => {
     const result = linkLiveVoiceAssistantResponseAudioToMessage({
       messageId: undefined,
       sessionId: "session-assistant-unlinked",
@@ -265,18 +265,37 @@ describe("live voice audio archive", () => {
       },
     });
 
-    expect(result).toEqual({
+    // The audio must never be silently dropped: it is stored as an
+    // attachment even though no message exists to link it to.
+    expect(result).toMatchObject({
       type: "unlinked",
-      warning: {
-        code: "message_id_unavailable",
-        message:
-          "Live voice audio archive could not be linked because no message id was available.",
-      },
+      warning: { code: "message_id_unavailable" },
       sessionId: "session-assistant-unlinked",
       turnId: "turn-assistant-unlinked",
       role: "assistant",
+      artifact: {
+        archiveKey:
+          "live-voice:session-assistant-unlinked:turn-assistant-unlinked:assistant",
+        role: "assistant",
+        mimeType: "audio/pcm",
+      },
     });
-    expect(countAllAttachments()).toBe(0);
+    if (result.type !== "unlinked" || !result.artifact) {
+      throw new Error("expected stored unlinked result");
+    }
+    expect(countAllAttachments()).toBe(1);
+    expect(getAttachmentContent(result.artifact.attachmentId)?.toString()).toBe(
+      "unlinked assistant audio",
+    );
+
+    // The stored artifact can be linked once a message id is known.
+    const { message } = await createMessage("assistant");
+    const linked = linkLiveVoiceAudioArtifactToMessage({
+      messageId: message.id,
+      artifact: result.artifact,
+    });
+    expect(linked.type).toBe("archived");
+    expect(getAttachmentsForMessage(message.id)).toHaveLength(1);
   });
 
   test("is idempotent for the session turn role key", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-events.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-events.test.ts
@@ -294,6 +294,107 @@ describe("LiveVoiceSession archive and metrics events", () => {
     expect(frames.filter((frame) => frame.type === "error")).toEqual([]);
   });
 
+  test("persisted message ids reported during the turn are linked into the archives", async () => {
+    const archiveAudio = mock(
+      async (input: LiveVoiceSessionArchiveAudioInput) =>
+        makeArchiveResult(input),
+    );
+    const harness = createArchivingHarness(archiveAudio);
+    const { frames, transport, controller } = harness;
+
+    await startRespondingTurn(harness, "hello");
+    // The voice bridge reports the persisted user message right after
+    // dispatch and the assistant message at generation complete — both
+    // while the turn is still responding.
+    controller.options?.onPersistedUserMessageId("msg-user-1");
+    controller.options?.onPersistedAssistantMessageId("msg-assistant-1");
+    await transport.emitTtsAudio("assistant audio");
+    await transport.emitTtsDone();
+    await waitFor(() =>
+      frames.some(
+        (frame) => frame.type === "metrics" && frame.event === "turn_completed",
+      ),
+    );
+
+    expect(
+      archiveAudio.mock.calls.map((call) => [call[0].role, call[0].messageId]),
+    ).toEqual([
+      ["user", "msg-user-1"],
+      ["assistant", "msg-assistant-1"],
+    ]);
+  });
+
+  test("archives with null message ids when none arrived before finalize (unlinked fallback)", async () => {
+    const archiveAudio = mock(
+      async (input: LiveVoiceSessionArchiveAudioInput) =>
+        makeArchiveResult(input),
+    );
+    const harness = createArchivingHarness(archiveAudio);
+    const { frames, transport } = harness;
+
+    await startRespondingTurn(harness, "hello");
+    await transport.emitTtsAudio("assistant audio");
+    await transport.emitTtsDone();
+    await waitFor(() =>
+      frames.some(
+        (frame) => frame.type === "metrics" && frame.event === "turn_completed",
+      ),
+    );
+
+    expect(
+      archiveAudio.mock.calls.map((call) => call[0].messageId ?? null),
+    ).toEqual([null, null]);
+  });
+
+  test("message ids arriving after the turn finalized are dropped, not misattributed", async () => {
+    const archiveAudio = mock(
+      async (input: LiveVoiceSessionArchiveAudioInput) =>
+        makeArchiveResult(input),
+    );
+    const harness = createArchivingHarness(archiveAudio);
+    const { session, frames, ingest, transport, controller } = harness;
+
+    await startRespondingTurn(harness, "first utterance");
+    controller.options?.onPersistedUserMessageId("msg-user-1");
+    // Barge-in finalizes the turn before the assistant message persists.
+    controller.state = "speaking";
+    ingest.callbacks.onSpeechStart?.();
+    await waitFor(() =>
+      frames.some(
+        (frame) => frame.type === "metrics" && frame.event === "turn_cancelled",
+      ),
+    );
+    // Late id for the aborted generation: no responding turn — dropped.
+    controller.options?.onPersistedAssistantMessageId("msg-assistant-stale");
+
+    await session.handleClientFrame(audioFrame("second user audio"));
+    ingest.callbacks.onTranscriptFinal?.("second utterance");
+    await waitFor(
+      () => frames.filter((frame) => frame.type === "thinking").length === 2,
+    );
+    controller.options?.onPersistedUserMessageId("msg-user-2");
+    controller.options?.onPersistedAssistantMessageId("msg-assistant-2");
+    await transport.emitTtsAudio("second assistant audio");
+    await transport.emitTtsDone();
+    await waitFor(() =>
+      frames.some(
+        (frame) => frame.type === "metrics" && frame.event === "turn_completed",
+      ),
+    );
+
+    expect(
+      archiveAudio.mock.calls.map((call) => [
+        call[0].turnId,
+        call[0].role,
+        call[0].messageId ?? null,
+      ]),
+    ).toEqual([
+      ["live-turn-1", "user", "msg-user-1"],
+      ["live-turn-2", "user", "msg-user-2"],
+      ["live-turn-2", "assistant", "msg-assistant-2"],
+    ]);
+  });
+
   test("session close cancels the open turn and archives its user audio", async () => {
     const archiveAudio = mock(
       async (input: LiveVoiceSessionArchiveAudioInput) =>

--- a/assistant/src/live-voice/__tests__/live-voice-integration.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-integration.test.ts
@@ -94,6 +94,7 @@ import type {
 import { LiveVoiceIngest } from "../live-voice-ingest.js";
 import {
   createLiveVoiceSession,
+  type LiveVoiceControllerFactory,
   type LiveVoiceSession,
   type LiveVoiceSessionArchiveAudioInput,
   type LiveVoiceTtsStreamer,
@@ -197,6 +198,8 @@ function createWiredHarness(
     /** Streaming resolver returns null so the ingest settles on batch. */
     batchTranscript?: string;
     silenceThresholdMs?: number;
+    /** Override the controller factory (default: real CallController). */
+    createController?: LiveVoiceControllerFactory;
   } = {},
 ): WiredHarness {
   const sequencer = createLiveVoiceServerFrameSequencer();
@@ -252,6 +255,9 @@ function createWiredHarness(
           ...deps,
           streamTtsAudio: fakeStreamTtsAudio,
         }),
+      ...(options.createController
+        ? { createController: options.createController }
+        : {}),
       credentialPreflight: async () => ({ status: "ready" }),
       archiveAudio,
       emitMetrics: true,
@@ -489,9 +495,74 @@ describe("LiveVoiceSession wired duplex integration", () => {
     expect(deltas.join("")).not.toContain("[END_CALL]");
     expect(frames.filter((frame) => frame.type === "error")).toEqual([]);
 
+    // The goodbye's synthesized audio was flushed (tts_audio + tts_done)
+    // before the session announced its end and closed.
+    const sessionEndedSeq = typedFrames(frames, "session_ended")[0]?.seq;
+    expect(sessionEndedSeq).toBeDefined();
+    const goodbyeDoneSeq = typedFrames(frames, "tts_done").at(-1)?.seq;
+    expect(goodbyeDoneSeq).toBeDefined();
+    expect(goodbyeDoneSeq!).toBeLessThan(sessionEndedSeq!);
+    expect(typedFrames(frames, "tts_audio").length).toBeGreaterThan(0);
+
     // The session is closed: further audio is ignored.
     const pushedBefore = transcriber.audioChunks.length;
     await session.handleBinaryAudio(loudChunk());
     expect(transcriber.audioChunks).toHaveLength(pushedBefore);
   });
+
+  test(
+    "max session duration ends the session gracefully with session_ended and final metrics",
+    async () => {
+      const { session, frames } = createWiredHarness({
+        createController: async (options) => {
+          const [{ CallController }, { createInAppVoiceControllerProfile }] =
+            await Promise.all([
+              import("../../calls/call-controller.js"),
+              import("../../calls/voice-session-source.js"),
+            ]);
+          const profile = createInAppVoiceControllerProfile({
+            onPersistedUserMessageId: options.onPersistedUserMessageId,
+            onPersistedAssistantMessageId:
+              options.onPersistedAssistantMessageId,
+          });
+          // Shrink the in-app max session duration so the composed timer
+          // path (goodbye → 3s grace → endSession) runs inside the test.
+          profile.timers = { ...profile.timers, maxDurationMs: () => 150 };
+          return new CallController(
+            options.callSessionId,
+            options.transport,
+            null,
+            { sessionSource: options.sessionSource, profile },
+          );
+        },
+      });
+
+      await session.start();
+
+      // Duration elapses → goodbye speech → grace period → session end.
+      const deadline = Date.now() + 8_000;
+      while (
+        !frames.some((frame) => frame.type === "session_ended") &&
+        Date.now() < deadline
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+
+      expect(typedFrames(frames, "session_ended")[0]).toMatchObject({
+        type: "session_ended",
+        reason: "Maximum call duration reached",
+      });
+      // The goodbye was synthesized and flushed before the end.
+      expect(typedFrames(frames, "tts_audio").length).toBeGreaterThan(0);
+
+      await waitFor(() =>
+        frames.some(
+          (frame) =>
+            frame.type === "metrics" && frame.event === "session_ended",
+        ),
+      );
+      expect(frames.filter((frame) => frame.type === "error")).toEqual([]);
+    },
+    { timeout: 15_000 },
+  );
 });

--- a/assistant/src/live-voice/__tests__/live-voice-session-harness.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-session-harness.ts
@@ -98,6 +98,9 @@ export class FakeTransport implements CallTransport {
   deps: LiveVoiceCallTransportDeps | null = null;
   readonly tokens: Array<{ token: string; last: boolean }> = [];
   discardCount = 0;
+  ttsDrainWaits = 0;
+  /** When set, waitForTtsDrain blocks on this until the test resolves it. */
+  ttsDrainGate: Promise<void> | null = null;
   private assistantAudio: Buffer[] = [];
 
   sendTextToken(token: string, last: boolean): void {
@@ -120,6 +123,11 @@ export class FakeTransport implements CallTransport {
     const chunks = this.assistantAudio;
     this.assistantAudio = [];
     return chunks;
+  }
+
+  waitForTtsDrain(): Promise<void> {
+    this.ttsDrainWaits += 1;
+    return this.ttsDrainGate ?? Promise.resolve();
   }
 
   /** Simulate a streaming-TTS audio chunk reaching the socket. */

--- a/assistant/src/live-voice/__tests__/live-voice-session-manager.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-session-manager.test.ts
@@ -193,6 +193,43 @@ describe("LiveVoiceSessionManager", () => {
     expect(sessions).toHaveLength(2);
   });
 
+  test("a session-initiated end releases the lock and notifies the sink", async () => {
+    const sessions: TestSession[] = [];
+    const contexts: LiveVoiceSessionFactoryContext[] = [];
+    const manager = new LiveVoiceSessionManager({
+      createSessionId: mock(() => `session-${sessions.length + 1}`),
+      createSession: (context) => {
+        contexts.push(context);
+        const session = createTestSession();
+        sessions.push(session);
+        return session;
+      },
+    });
+    const first = createSink();
+    const endedNotices: Array<{ sessionId: string; reason: string }> = [];
+
+    await manager.startSession(START_FRAME, {
+      ...first.sink,
+      onSessionEnded: (sessionId, reason) => {
+        endedNotices.push({ sessionId, reason });
+      },
+    });
+    expect(manager.activeSessionId).toBe("session-1");
+
+    // The session closed itself (e.g. [END_CALL] / max duration) — no
+    // socket event or manager release call is coming.
+    contexts[0]?.onSessionEnded?.("client_end");
+
+    expect(manager.activeSessionId).toBeNull();
+    expect(endedNotices).toEqual([
+      { sessionId: "session-1", reason: "client_end" },
+    ]);
+
+    // The slot is genuinely free: a new session is accepted.
+    const next = await manager.startSession(START_FRAME, createSink().sink);
+    expect(next).toEqual({ status: "accepted", sessionId: "session-2" });
+  });
+
   test("releases the lock when session start throws", async () => {
     const sessions: TestSession[] = [];
     const manager = new LiveVoiceSessionManager({

--- a/assistant/src/live-voice/__tests__/live-voice-transport.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-transport.test.ts
@@ -259,9 +259,65 @@ describe("LiveVoiceCallTransport", () => {
 
     expect(frames.find((frame) => frame.type === "error")).toMatchObject({
       type: "error",
+      code: "tts_failed",
       message: expect.stringContaining("provider unavailable"),
     });
     expect(frames.at(-1)).toEqual({ type: "tts_done", turnId: "turn-1" });
+  });
+
+  test("discardPendingText suppresses tts_audio sends that were already chained", async () => {
+    // Block the frame sink so a second chunk gets *chained* behind an
+    // in-flight send before the barge-in lands.
+    let releaseFirstSend!: () => void;
+    const firstSendGate = new Promise<void>((resolve) => {
+      releaseFirstSend = resolve;
+    });
+    const frames: LiveVoiceServerFramePayload[] = [];
+    let sends = 0;
+    const sendFrame = mock(async (payload: LiveVoiceServerFramePayload) => {
+      sends += 1;
+      if (sends === 1) {
+        await firstSendGate;
+      }
+      frames.push(payload);
+    });
+
+    let activeOptions: LiveVoiceTtsOptions | undefined;
+    let resolveActive: ((result: LiveVoiceTtsResult) => void) | undefined;
+    const streamTtsAudio = mock(
+      (options: LiveVoiceTtsOptions) =>
+        new Promise<LiveVoiceTtsResult>((resolve) => {
+          activeOptions = options;
+          resolveActive = resolve;
+        }),
+    );
+    const transport = new LiveVoiceCallTransport({
+      sendFrame,
+      streamTtsAudio,
+      sampleRate: 24_000,
+      turnId: () => "turn-1",
+      onSessionEnd: () => {},
+    });
+
+    transport.sendTextToken("First one.", true);
+    await waitFor(() => activeOptions !== undefined);
+    // Two chunks: the first send blocks; the second is chained behind it.
+    activeOptions?.onAudioChunk(makeTtsChunk("chunk-1"));
+    activeOptions?.onAudioChunk(makeTtsChunk("chunk-2"));
+    await waitFor(() => sends === 1);
+
+    transport.discardPendingText();
+    releaseFirstSend();
+    resolveActive?.(makeTtsResult("First one."));
+    await flushAsyncCallbacks();
+
+    // The in-flight first chunk completes, but the chained second chunk
+    // rechecks the abort and never reaches the sink — and neither does
+    // the aborted turn's tts_done.
+    expect(frames.filter((frame) => frame.type === "tts_audio")).toHaveLength(
+      1,
+    );
+    expect(frames.some((frame) => frame.type === "tts_done")).toBe(false);
   });
 
   test("collectAssistantAudio returns emitted chunks once and resets", async () => {

--- a/assistant/src/live-voice/live-voice-archive.ts
+++ b/assistant/src/live-voice/live-voice-archive.ts
@@ -6,6 +6,8 @@ import {
   attachmentExists,
   getAttachmentById,
   linkAttachmentToMessage,
+  uploadAttachment,
+  uploadFileBackedAttachment,
 } from "../persistence/attachments-store.js";
 import { rawAll, rawGet, rawRun } from "../persistence/raw-query.js";
 import { getLogger } from "../util/logger.js";
@@ -365,7 +367,7 @@ function sanitizeOptionalPositiveNumber(
   return Number.isFinite(value) && value > 0 ? value : undefined;
 }
 
-function validateInput(input: ArchiveLiveVoiceAudioInput):
+function validateInput(input: Omit<ArchiveLiveVoiceAudioInput, "messageId">):
   | {
       archiveKey: string;
       filename: string;
@@ -624,19 +626,97 @@ function linkLiveVoiceAudioToMessage(
   },
 ): LiveVoiceAudioArchiveResult {
   const messageId = normalizeMessageId(input.messageId);
+  const { messageId: _messageId, ...archiveInput } = input;
   if (!messageId) {
-    return resultUnlinked(
-      "message_id_unavailable",
-      "Live voice audio archive could not be linked because no message id was available.",
-      input,
-    );
+    // No message to link against (e.g. the turn was cancelled before the
+    // pipeline persisted a message). Store the audio as an unlinked
+    // attachment instead of dropping it; the returned artifact can be
+    // linked later via linkLiveVoiceAudioArtifactToMessage.
+    return storeLiveVoiceAudioArtifactUnlinked(archiveInput);
   }
 
-  const { messageId: _messageId, ...archiveInput } = input;
   return archiveLiveVoiceAudioArtifact({
     ...archiveInput,
     messageId,
   });
+}
+
+/**
+ * Store live-voice audio as an attachment without a message link. Returns
+ * an `unlinked` result carrying the stored artifact metadata so a caller
+ * that later learns the message id can link it retroactively.
+ */
+function storeLiveVoiceAudioArtifactUnlinked(
+  input: Omit<ArchiveLiveVoiceAudioInput, "messageId">,
+): LiveVoiceAudioArchiveResult {
+  const validated = validateInput(input);
+  if ("type" in validated) return validated;
+
+  try {
+    const stored =
+      input.audio.type === "base64"
+        ? uploadAttachment(
+            validated.filename,
+            validated.mimeType,
+            input.audio.dataBase64,
+          )
+        : (() => {
+            if (!existsSync(input.audio.filePath)) {
+              return null;
+            }
+            const sizeBytes =
+              input.audio.sizeBytes ?? statSync(input.audio.filePath).size;
+            return uploadFileBackedAttachment(
+              validated.filename,
+              validated.mimeType,
+              input.audio.filePath,
+              sizeBytes,
+            );
+          })();
+
+    if (!stored) {
+      return resultWarning(
+        "invalid_audio_source",
+        "Live voice audio file is not readable.",
+      );
+    }
+
+    const artifact = artifactFromAttachment({
+      attachmentId: stored.id,
+      archiveKey: validated.archiveKey,
+      sessionId: input.sessionId,
+      turnId: input.turnId,
+      role: input.role,
+      mimeType: validated.mimeType,
+      sampleRate: validated.sampleRate,
+      durationMs: validated.durationMs,
+      sizeBytes: stored.sizeBytes,
+      filename: stored.originalFilename,
+      archivedAt: stored.createdAt,
+    });
+    return resultUnlinked(
+      "message_id_unavailable",
+      "Live voice audio was stored but could not be linked because no message id was available.",
+      {
+        sessionId: input.sessionId,
+        turnId: input.turnId,
+        role: input.role,
+        artifact,
+      },
+    );
+  } catch (err) {
+    log.warn(
+      {
+        archiveKey: validated.archiveKey,
+        errorName: err instanceof Error ? err.name : typeof err,
+      },
+      "Failed to store unlinked live voice audio artifact",
+    );
+    return resultWarning(
+      "archive_failed",
+      "Live voice audio archive failed without blocking the turn.",
+    );
+  }
 }
 
 export function linkLiveVoiceUserUtteranceAudioToMessage(

--- a/assistant/src/live-voice/live-voice-session-manager.ts
+++ b/assistant/src/live-voice/live-voice-session-manager.ts
@@ -25,12 +25,26 @@ export interface LiveVoiceSession {
 
 export interface LiveVoiceServerFrameSink {
   sendFrame(frame: LiveVoiceServerFrame): MaybePromise<void>;
+  /**
+   * Invoked once a session under this sink has fully closed and its
+   * manager slot is released — including server-initiated ends ([END_CALL],
+   * max session duration) where no client/socket event triggered the close.
+   * The socket owner should detach and close the connection; this must be
+   * idempotent for owner-initiated closes where the socket is already gone.
+   */
+  onSessionEnded?(sessionId: string, reason: string): void;
 }
 
 export interface LiveVoiceSessionFactoryContext {
   sessionId: string;
   startFrame: LiveVoiceClientStartFrame;
   sendFrame(frame: LiveVoiceServerFramePayload): Promise<LiveVoiceServerFrame>;
+  /**
+   * Owner-release hook: the session calls this once when it has finished
+   * closing, so the owner (manager) can drop its active-session slot even
+   * when the close was session-initiated rather than owner-initiated.
+   */
+  onSessionEnded?(reason: string): void;
 }
 
 export type LiveVoiceSessionFactory = (
@@ -130,6 +144,12 @@ export class LiveVoiceSessionManager {
         const frame = sequencer.next(payload);
         await sink.sendFrame(frame);
         return frame;
+      },
+      onSessionEnded: (reason) => {
+        if (this.activeSession?.sessionId === sessionId) {
+          this.activeSession = null;
+        }
+        sink.onSessionEnded?.(sessionId, reason);
       },
     };
     const session = this.createSession(context);

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -34,6 +34,7 @@ import type {
   VoiceSessionSource,
 } from "../calls/voice-session-source.js";
 import { getConfig } from "../config/loader.js";
+import { errorMessage } from "../util/errors.js";
 import type {
   LiveVoiceAudioArchiveResult,
   LiveVoiceAudioArchiveRole,
@@ -96,10 +97,12 @@ export type LiveVoiceIngestFactory = (
 /**
  * Transport surface the session drives. Extends the controller-facing
  * `CallTransport` with the per-turn assistant-audio drain used for
- * archiving (production: {@link LiveVoiceCallTransport}).
+ * archiving and the TTS-queue drain awaited before a server-initiated
+ * close (production: {@link LiveVoiceCallTransport}).
  */
 export interface LiveVoiceSessionTransport extends CallTransport {
   collectAssistantAudio(): Buffer[];
+  waitForTtsDrain(): Promise<void>;
 }
 
 export type LiveVoiceTransportFactory = (
@@ -121,6 +124,13 @@ export interface LiveVoiceSessionControllerOptions {
   transport: CallTransport;
   /** In-app session source (no call_sessions row backs these sessions). */
   sessionSource: VoiceSessionSource;
+  /**
+   * Persisted-message-id hooks the controller profile forwards into each
+   * voice turn; the session uses them to link per-turn audio archives to
+   * the conversation messages.
+   */
+  onPersistedUserMessageId: (messageId: string) => void;
+  onPersistedAssistantMessageId: (messageId: string) => void;
 }
 
 export type LiveVoiceControllerFactory = (
@@ -179,8 +189,19 @@ interface SessionTurn {
   userAudioBytes: number;
   assistantAudioMimeType: string;
   assistantAudioSampleRate?: number;
+  /**
+   * Persisted conversation message ids for this exchange, reported by the
+   * voice bridge (via the in-app profile hooks) once the pipeline persists
+   * each message. Null until reported; archives fall back to unlinked
+   * storage when a turn finalizes before the id arrives.
+   */
+  userMessageId: string | null;
+  assistantMessageId: string | null;
   finalized: boolean;
 }
+
+/** How long a server-initiated end waits for queued TTS (the goodbye). */
+const SERVER_END_TTS_DRAIN_TIMEOUT_MS = 5_000;
 
 export class LiveVoiceSession implements LiveVoiceSessionContract {
   private readonly context: LiveVoiceSessionFactoryContext;
@@ -209,6 +230,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private lastAssistantTurnId: string | null = null;
   private outboundFrames: Promise<void> = Promise.resolve();
   private sessionEndMetricsEmitted = false;
+  /** Guards the async server-initiated end flow against re-entry. */
+  private serverEndStarted = false;
 
   constructor(
     context: LiveVoiceSessionFactoryContext,
@@ -278,7 +301,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           this.currentTurn?.turnId ??
           this.lastAssistantTurnId ??
           this.context.sessionId,
-        onSessionEnd: () => this.handleControllerSessionEnd(),
+        onSessionEnd: (reason) => this.handleControllerSessionEnd(reason),
       });
       this.transport = transport;
 
@@ -286,6 +309,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         callSessionId: this.context.sessionId,
         transport: this.wrapTransportForController(transport),
         sessionSource: this.createSessionSource(),
+        onPersistedUserMessageId: (messageId) =>
+          this.handlePersistedMessageId("user", messageId),
+        onPersistedAssistantMessageId: (messageId) =>
+          this.handlePersistedMessageId("assistant", messageId),
       });
       if (this.state !== "open") {
         this.controller.destroy();
@@ -359,7 +386,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     await this.drainOutboundFrames();
   }
 
-  async close(_reason: LiveVoiceSessionCloseReason): Promise<void> {
+  async close(reason: LiveVoiceSessionCloseReason): Promise<void> {
     if (this.state !== "open") {
       return;
     }
@@ -374,6 +401,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     await this.emitSessionEndMetrics();
     this.state = "closed";
     await this.drainOutboundFrames();
+    // Release the owner last so the manager slot (and the socket) is only
+    // freed once the session has fully unwound.
+    this.context.onSessionEnded?.(reason);
   }
 
   // ── Inbound audio ────────────────────────────────────────────────────
@@ -421,7 +451,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         if (this.state !== "open") {
           return;
         }
-        if (this.controller?.getState() === "speaking") {
+        // Barge-in while the controller speaks, or while a responding
+        // turn's synthesis tail is still playing after the controller
+        // already went idle (tryBargeIn handles both).
+        if (
+          this.controller?.getState() === "speaking" ||
+          this.currentTurn?.phase === "responding"
+        ) {
           this.tryBargeIn();
           return;
         }
@@ -459,7 +495,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         }
         void this.sendFrame({
           type: "error",
-          code: LiveVoiceProtocolErrorCode.InvalidField,
+          code: LiveVoiceProtocolErrorCode.SttFailed,
           message: `Live voice transcription error (${category}): ${message}`,
         });
       },
@@ -477,10 +513,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     let turn = this.currentTurn;
     if (content.length === 0) {
       // Nothing to dispatch. A listening turn that transcribed to nothing
-      // is retired; a responding turn is left alone (the empty final came
-      // from residual noise, not a competing utterance).
+      // is retired — with a turn_cancelled notice so the client resumes
+      // listening instead of waiting for a response that never starts. A
+      // responding turn is left alone (the empty final came from residual
+      // noise, not a competing utterance).
       if (turn?.phase === "listening") {
-        void this.finalizeTurn(turn, "cancelled", "empty_transcript");
+        this.cancelTurnWithNotice(turn, "empty_transcript");
       }
       return;
     }
@@ -501,27 +539,51 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     void this.sendFrame({ type: "thinking", turnId: turn.turnId });
 
     const controller = this.controller;
+    const dispatchedTurn = turn;
     void controller.handleCallerUtterance(content).catch((err) => {
       if (this.state !== "open") {
         return;
       }
       void this.sendFrame({
         type: "error",
-        code: LiveVoiceProtocolErrorCode.InvalidField,
+        code: LiveVoiceProtocolErrorCode.TurnFailed,
         message: `Live voice assistant turn failed: ${errorMessage(err)}`,
       });
+      // The turn will never produce a response; retire it so the client
+      // resumes listening instead of waiting on a dead turn.
+      if (!dispatchedTurn.finalized) {
+        this.cancelTurnWithNotice(dispatchedTurn, "turn_failed");
+      }
     });
+  }
+
+  /**
+   * Retire a turn that will never produce an assistant response and tell
+   * the client so it resumes listening (the `archived`/`metrics` frames
+   * alone do not advance the client's state machine).
+   */
+  private cancelTurnWithNotice(turn: SessionTurn, reason: string): void {
+    void this.sendFrame({ type: "turn_cancelled", reason });
+    void this.finalizeTurn(turn, "cancelled", reason);
   }
 
   // ── Barge-in ─────────────────────────────────────────────────────────
 
   /**
-   * Attempt to interrupt the assistant. Accepted only while the
-   * controller is `speaking`; the controller flushes the transport's
-   * pending text/synthesis itself (via discardPendingText) inside
-   * handleInterrupt. `onAccepted` runs before that flush, so the
-   * `interrupted` frame and the turn's cancellation are ordered ahead
-   * of any frames the flush suppresses.
+   * Attempt to interrupt the assistant.
+   *
+   * Controller path: accepted while the controller is `speaking`; the
+   * controller flushes the transport's pending text/synthesis itself (via
+   * discardPendingText) inside handleInterrupt. `onAccepted` runs before
+   * that flush, so the `interrupted` frame and the turn's cancellation are
+   * ordered ahead of any frames the flush suppresses.
+   *
+   * Session path: the controller flips `idle` when *generation* ends, but
+   * the synthesized tail can still be playing (tts_done not yet emitted).
+   * An interrupt in that window is handled at the session layer — flush
+   * the transport's remaining synthesis, emit `interrupted`, and retire
+   * the turn — without touching the controller's (shared, phone-critical)
+   * turn lifecycle.
    */
   private tryBargeIn(): boolean {
     const controller = this.controller;
@@ -530,7 +592,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
 
     const turn = this.currentTurn;
-    return controller.handleBargeIn(() => {
+    const accepted = controller.handleBargeIn(() => {
       const interruptedTurnId =
         turn?.turnId ?? this.lastAssistantTurnId ?? this.context.sessionId;
       void this.sendFrame({ type: "interrupted", turnId: interruptedTurnId });
@@ -538,6 +600,22 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         void this.finalizeTurn(turn, "cancelled", "barge_in");
       }
     });
+    if (accepted) {
+      return true;
+    }
+
+    if (
+      controller.getState() === "idle" &&
+      turn?.phase === "responding" &&
+      !turn.finalized
+    ) {
+      this.transport?.discardPendingText?.();
+      void this.sendFrame({ type: "interrupted", turnId: turn.turnId });
+      void this.finalizeTurn(turn, "cancelled", "barge_in");
+      return true;
+    }
+
+    return false;
   }
 
   // ── Assistant output ─────────────────────────────────────────────────
@@ -561,6 +639,27 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       setAudioStartCallback: (cb) => transport.setAudioStartCallback?.(cb),
       discardPendingText: () => transport.discardPendingText?.(),
     };
+  }
+
+  /**
+   * The voice bridge persisted a conversation message for the in-flight
+   * exchange. Recorded on the responding turn so its audio archives link
+   * to the message. Ids for a turn that already finalized (barge-in,
+   * supersession) are dropped — that turn's audio was archived unlinked.
+   */
+  private handlePersistedMessageId(
+    role: LiveVoiceAudioArchiveRole,
+    messageId: string,
+  ): void {
+    const turn = this.currentTurn;
+    if (turn?.phase !== "responding") {
+      return;
+    }
+    if (role === "user") {
+      turn.userMessageId = messageId;
+    } else {
+      turn.assistantMessageId = messageId;
+    }
   }
 
   private handleAssistantToken(token: string): void {
@@ -612,9 +711,38 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     return this.sendFrame(payload);
   }
 
-  /** [END_CALL] / max-duration: the controller asked to end the session. */
-  private handleControllerSessionEnd(): void {
-    void this.close("client_end");
+  /**
+   * [END_CALL] / max-duration: the controller asked to end the session.
+   * The goodbye is typically still in the transport's TTS queue at this
+   * point, so drain it (bounded — a hung provider must not block close),
+   * tell the client the session is over, then close. Closing eagerly would
+   * destroy the controller, whose teardown discards the queued goodbye.
+   */
+  private handleControllerSessionEnd(reason?: string): void {
+    if (this.state !== "open" || this.serverEndStarted) {
+      return;
+    }
+    this.serverEndStarted = true;
+
+    void (async () => {
+      const drained = this.transport?.waitForTtsDrain();
+      if (drained) {
+        await Promise.race([
+          drained,
+          new Promise<void>((resolve) =>
+            setTimeout(resolve, SERVER_END_TTS_DRAIN_TIMEOUT_MS),
+          ),
+        ]);
+      }
+      if (this.state !== "open") {
+        return;
+      }
+      await this.sendFrame({
+        type: "session_ended",
+        reason: reason ?? "session_ended",
+      });
+      await this.close("client_end");
+    })();
   }
 
   // ── Turn lifecycle ───────────────────────────────────────────────────
@@ -630,6 +758,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       userAudioChunks: [],
       userAudioBytes: 0,
       assistantAudioMimeType: "audio/pcm",
+      userMessageId: null,
+      assistantMessageId: null,
       finalized: false,
     };
     this.currentTurn = turn;
@@ -674,6 +804,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         userAudioChunks,
         assistantAudioChunks,
         assistantAudioMimeType: turn.assistantAudioMimeType,
+        userMessageId: turn.userMessageId,
+        assistantMessageId: turn.assistantMessageId,
         ...(turn.assistantAudioSampleRate !== undefined
           ? { assistantAudioSampleRate: turn.assistantAudioSampleRate }
           : {}),
@@ -695,6 +827,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     assistantAudioChunks: Buffer[];
     assistantAudioMimeType: string;
     assistantAudioSampleRate?: number;
+    userMessageId: string | null;
+    assistantMessageId: string | null;
   }): Promise<void> {
     const userAudio = takeBufferedAudio(input.userAudioChunks);
     if (userAudio) {
@@ -704,6 +838,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         mimeType: this.context.startFrame.audio.mimeType,
         sampleRate: this.context.startFrame.audio.sampleRate,
         audio: userAudio,
+        messageId: input.userMessageId,
       });
     }
 
@@ -718,6 +853,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         mimeType: input.assistantAudioMimeType,
         sampleRate,
         audio: assistantAudio,
+        messageId: input.assistantMessageId,
       });
     }
   }
@@ -728,6 +864,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     mimeType: string;
     sampleRate: number;
     audio: Buffer;
+    /** Persisted message to link to; null archives unlinked (but stored). */
+    messageId: string | null;
   }): Promise<void> {
     const archiveAudio = this.archiveAudio;
     if (!archiveAudio) {
@@ -742,7 +880,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     let result: LiveVoiceAudioArchiveResult;
     try {
       result = await archiveAudio({
-        messageId: null,
+        messageId: input.messageId,
         sessionId: this.context.sessionId,
         turnId: input.turnId,
         role: input.role,
@@ -936,7 +1074,10 @@ async function defaultCreateController(
   // startInitialGreeting) — in-app users speak first.
   return new CallController(options.callSessionId, options.transport, null, {
     sessionSource: options.sessionSource,
-    profile: createInAppVoiceControllerProfile(),
+    profile: createInAppVoiceControllerProfile({
+      onPersistedUserMessageId: options.onPersistedUserMessageId,
+      onPersistedAssistantMessageId: options.onPersistedAssistantMessageId,
+    }),
   });
 }
 
@@ -996,8 +1137,4 @@ function estimatePcmDurationMs(input: {
   return Math.round(
     (input.byteLength / (input.sampleRate * bytesPerMonoSample)) * 1000,
   );
-}
-
-function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
 }

--- a/assistant/src/live-voice/live-voice-transport.ts
+++ b/assistant/src/live-voice/live-voice-transport.ts
@@ -1,6 +1,7 @@
 import { Buffer } from "node:buffer";
 
 import type { CallTransport } from "../calls/call-transport.js";
+import { errorMessage } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import { extractSpeakableSegments } from "./live-voice-segments.js";
 import type { LiveVoiceTtsStreamer } from "./live-voice-session.js";
@@ -125,6 +126,15 @@ export class LiveVoiceCallTransport implements CallTransport {
     return chunks;
   }
 
+  /**
+   * Resolves when every TTS job enqueued so far has finished (audio and
+   * `tts_done` frames handed to the sink). The session awaits this before
+   * a server-initiated close so a queued goodbye is not cut off.
+   */
+  waitForTtsDrain(): Promise<void> {
+    return this.ttsQueue;
+  }
+
   // ── TTS queue ───────────────────────────────────────────────────────
 
   private enqueueTtsSegment(segment: string): void {
@@ -135,9 +145,12 @@ export class LiveVoiceCallTransport implements CallTransport {
       }
 
       try {
-        // sendFrame calls are chained so the job only completes after
-        // every chunk frame for this segment has been handed to the
-        // socket, keeping tts_done ordered behind the audio.
+        // The job awaits the chain before completing so every chunk frame
+        // has been handed to the sink before the next queued job (and
+        // ultimately tts_done) starts — backpressure, not frame ordering,
+        // which the session's own outbound chain already guarantees. Each
+        // chained send rechecks the abort so a barge-in also suppresses
+        // chunks that were queued before discardPendingText ran.
         let frameChain: Promise<unknown> = Promise.resolve();
         await this.deps.streamTtsAudio({
           text: segment,
@@ -152,14 +165,17 @@ export class LiveVoiceCallTransport implements CallTransport {
               Buffer.from(chunk.dataBase64, "base64"),
             );
             this.fireAudioStartCallback();
-            frameChain = frameChain.then(() =>
-              this.deps.sendFrame({
+            frameChain = frameChain.then(() => {
+              if (abort.signal.aborted) {
+                return;
+              }
+              return this.deps.sendFrame({
                 type: "tts_audio",
                 mimeType: chunk.contentType,
                 sampleRate: chunk.sampleRate,
                 dataBase64: chunk.dataBase64,
-              }),
-            );
+              });
+            });
           },
         });
         await frameChain;
@@ -169,7 +185,7 @@ export class LiveVoiceCallTransport implements CallTransport {
         }
         await this.deps.sendFrame({
           type: "error",
-          code: LiveVoiceProtocolErrorCode.InvalidField,
+          code: LiveVoiceProtocolErrorCode.TtsFailed,
           message: `Live voice TTS failed: ${errorMessage(err)}`,
         });
       } finally {
@@ -213,8 +229,4 @@ export class LiveVoiceCallTransport implements CallTransport {
     this.audioStartCallback = null;
     callback();
   }
-}
-
-function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
 }

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -19,8 +19,10 @@ const _LIVE_VOICE_SERVER_FRAME_TYPES = [
   "assistant_text_delta",
   "tts_audio",
   "tts_done",
+  "turn_cancelled",
   "metrics",
   "archived",
+  "session_ended",
   "error",
 ] as const;
 
@@ -34,6 +36,9 @@ export const LiveVoiceProtocolErrorCode = {
   InvalidField: "invalid_field",
   InvalidAudioPayload: "invalid_audio_payload",
   CredentialsMissing: "credentials_missing",
+  TtsFailed: "tts_failed",
+  SttFailed: "stt_failed",
+  TurnFailed: "turn_failed",
 } as const;
 
 export type LiveVoiceProtocolErrorCode =
@@ -162,6 +167,26 @@ export interface LiveVoiceTtsDoneServerFrame extends LiveVoiceServerFrameBase {
   readonly turnId: string;
 }
 
+/**
+ * The in-flight user turn was retired without an assistant response (e.g.
+ * empty transcript, failed assistant turn). The client should resume
+ * listening rather than keep waiting for `thinking`/`tts_done`.
+ */
+export interface LiveVoiceTurnCancelledServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "turn_cancelled";
+  readonly reason?: string;
+}
+
+/**
+ * The server ended the session ([END_CALL] goodbye, max session duration).
+ * Sent after any pending TTS has been flushed and before the session closes;
+ * the client should tear down cleanly back to idle.
+ */
+export interface LiveVoiceSessionEndedServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "session_ended";
+  readonly reason: string;
+}
+
 export interface LiveVoiceMetricsServerFrame extends LiveVoiceServerFrameBase {
   readonly type: "metrics";
   readonly event?: string;
@@ -206,8 +231,10 @@ export type LiveVoiceServerFrame =
   | LiveVoiceAssistantTextDeltaServerFrame
   | LiveVoiceTtsAudioServerFrame
   | LiveVoiceTtsDoneServerFrame
+  | LiveVoiceTurnCancelledServerFrame
   | LiveVoiceMetricsServerFrame
   | LiveVoiceArchivedServerFrame
+  | LiveVoiceSessionEndedServerFrame
   | LiveVoiceErrorServerFrame;
 
 type WithoutSeq<T extends LiveVoiceServerFrameBase> = Omit<T, "seq">;
@@ -223,8 +250,10 @@ export type LiveVoiceServerFramePayload =
   | WithoutSeq<LiveVoiceAssistantTextDeltaServerFrame>
   | WithoutSeq<LiveVoiceTtsAudioServerFrame>
   | WithoutSeq<LiveVoiceTtsDoneServerFrame>
+  | WithoutSeq<LiveVoiceTurnCancelledServerFrame>
   | WithoutSeq<LiveVoiceMetricsServerFrame>
   | WithoutSeq<LiveVoiceArchivedServerFrame>
+  | WithoutSeq<LiveVoiceSessionEndedServerFrame>
   | WithoutSeq<LiveVoiceErrorServerFrame>;
 
 class LiveVoiceServerFrameSequencer {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -899,6 +899,20 @@ export class RuntimeHttpServer {
         sendFrame: async (serverFrame) => {
           this.sendLiveVoiceFrame(ws, serverFrame);
         },
+        onSessionEnded: (sessionId) => {
+          // Fires for every session close — including server-initiated ends
+          // ([END_CALL], max duration) where no socket event exists to
+          // trigger cleanup. Detach and close; both are no-ops when the
+          // close originated from the socket side.
+          if (ws.data.sessionId === sessionId) {
+            ws.data.sessionId = undefined;
+          }
+          try {
+            ws.close(1000, "live voice session ended");
+          } catch {
+            // The socket may already be closed/closing.
+          }
+        },
       });
       if (result.status === "accepted") {
         ws.data.sessionId = result.sessionId;

--- a/assistant/src/util/errors.ts
+++ b/assistant/src/util/errors.ts
@@ -24,6 +24,13 @@ export enum ErrorCode {
   INTERNAL_ERROR = "INTERNAL_ERROR",
 }
 
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Best-effort human-readable message for an unknown thrown value. */
+export function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 // ── Root ──────────────────────────────────────────────────────────────────────
 
 /** Root base class for all named Vellum errors. */

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
@@ -291,8 +291,10 @@ describe("server frame dispatch", () => {
     client.on("assistantTextDelta", record("assistantTextDelta"));
     client.on("ttsAudio", record("ttsAudio"));
     client.on("ttsDone", record("ttsDone"));
+    client.on("turnCancelled", record("turnCancelled"));
     client.on("metrics", record("metrics"));
     client.on("archived", record("archived"));
+    client.on("sessionEnded", record("sessionEnded"));
 
     ws.receive({ type: "stt_partial", seq: 2, text: "hel" });
     ws.receive({ type: "stt_final", seq: 3, text: "hello" });
@@ -308,6 +310,8 @@ describe("server frame dispatch", () => {
       dataBase64: "AAAA",
     });
     ws.receive({ type: "tts_done", seq: 7, turnId: "t1" });
+    ws.receive({ type: "turn_cancelled", seq: 12, reason: "empty_transcript" });
+    ws.receive({ type: "session_ended", seq: 13, reason: "Call completed" });
     ws.receive({
       type: "metrics",
       seq: 8,
@@ -336,6 +340,12 @@ describe("server frame dispatch", () => {
     ]);
     expect(got.ttsAudio).toHaveLength(1);
     expect(got.ttsDone).toEqual([{ type: "tts_done", seq: 7, turnId: "t1" }]);
+    expect(got.turnCancelled).toEqual([
+      { type: "turn_cancelled", seq: 12, reason: "empty_transcript" },
+    ]);
+    expect(got.sessionEnded).toEqual([
+      { type: "session_ended", seq: 13, reason: "Call completed" },
+    ]);
     expect(got.metrics).toHaveLength(1);
     expect(got.archived).toHaveLength(1);
   });

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
@@ -30,11 +30,13 @@ import {
   type LiveVoiceInterruptedServerFrame,
   type LiveVoiceMetricsServerFrame,
   type LiveVoiceReadyServerFrame,
+  type LiveVoiceSessionEndedServerFrame,
   type LiveVoiceSessionMode,
   type LiveVoiceSttFinalServerFrame,
   type LiveVoiceSttPartialServerFrame,
   type LiveVoiceThinkingServerFrame,
   type LiveVoiceTurnBoundaryServerFrame,
+  type LiveVoiceTurnCancelledServerFrame,
   type LiveVoiceTtsAudioServerFrame,
   type LiveVoiceTtsDoneServerFrame,
   parseServerFrame,
@@ -71,8 +73,10 @@ export interface LiveVoiceClientEventMap {
   assistantTextDelta: LiveVoiceAssistantTextDeltaServerFrame;
   ttsAudio: LiveVoiceTtsAudioServerFrame;
   ttsDone: LiveVoiceTtsDoneServerFrame;
+  turnCancelled: LiveVoiceTurnCancelledServerFrame;
   metrics: LiveVoiceMetricsServerFrame;
   archived: LiveVoiceArchivedServerFrame;
+  sessionEnded: LiveVoiceSessionEndedServerFrame;
   busy: LiveVoiceBusyServerFrame;
   error: LiveVoiceClientError;
   /** Fired exactly once when the transport closes (clean or otherwise). */
@@ -89,10 +93,7 @@ export interface LiveVoiceConnectArgs {
   assistantId: string;
   /** Optional conversation to attach the session to. */
   conversationId?: string;
-  /**
-   * Optional session mode sent in the `start` frame. Omitted for servers that
-   * predate mode negotiation (they default to PTT).
-   */
+  /** Optional session mode sent in the `start` frame; the server defaults to PTT. */
   mode?: LiveVoiceSessionMode;
 }
 
@@ -134,8 +135,10 @@ export class LiveVoiceChannelClient {
     assistantTextDelta: new Set(),
     ttsAudio: new Set(),
     ttsDone: new Set(),
+    turnCancelled: new Set(),
     metrics: new Set(),
     archived: new Set(),
+    sessionEnded: new Set(),
     busy: new Set(),
     error: new Set(),
     closed: new Set(),
@@ -312,11 +315,17 @@ export class LiveVoiceChannelClient {
       case "tts_done":
         this.emit("ttsDone", frame);
         return;
+      case "turn_cancelled":
+        this.emit("turnCancelled", frame);
+        return;
       case "metrics":
         this.emit("metrics", frame);
         return;
       case "archived":
         this.emit("archived", frame);
+        return;
+      case "session_ended":
+        this.emit("sessionEnded", frame);
         return;
       case "error":
         this.fail("protocol-error", frame.message, frame.code);

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.test.ts
@@ -23,6 +23,8 @@ describe("parseServerFrame", () => {
       dataBase64: "AAAA",
     },
     { type: "tts_done", seq: 8, turnId: "t1" },
+    { type: "turn_cancelled", seq: 14, reason: "empty_transcript" },
+    { type: "session_ended", seq: 15, reason: "Call completed" },
     {
       type: "metrics",
       seq: 9,

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.ts
@@ -87,8 +87,10 @@ const LIVE_VOICE_SERVER_FRAME_TYPES = [
   "assistant_text_delta",
   "tts_audio",
   "tts_done",
+  "turn_cancelled",
   "metrics",
   "archived",
+  "session_ended",
   "error",
 ] as const;
 
@@ -161,6 +163,26 @@ export interface LiveVoiceTtsDoneServerFrame extends LiveVoiceServerFrameBase {
   readonly turnId: string;
 }
 
+/**
+ * The in-flight user turn was retired without an assistant response (e.g.
+ * empty transcript, failed assistant turn). Resume listening rather than
+ * waiting for `thinking`/`tts_done` that will never come.
+ */
+export interface LiveVoiceTurnCancelledServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "turn_cancelled";
+  readonly reason?: string;
+}
+
+/**
+ * The server ended the session ([END_CALL] goodbye, max session duration).
+ * Sent after pending TTS has been flushed and before the session closes;
+ * tear down cleanly back to idle.
+ */
+export interface LiveVoiceSessionEndedServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "session_ended";
+  readonly reason: string;
+}
+
 export interface LiveVoiceMetricsServerFrame extends LiveVoiceServerFrameBase {
   readonly type: "metrics";
   readonly turnId: string;
@@ -201,8 +223,10 @@ export type LiveVoiceServerFrame =
   | LiveVoiceAssistantTextDeltaServerFrame
   | LiveVoiceTtsAudioServerFrame
   | LiveVoiceTtsDoneServerFrame
+  | LiveVoiceTurnCancelledServerFrame
   | LiveVoiceMetricsServerFrame
   | LiveVoiceArchivedServerFrame
+  | LiveVoiceSessionEndedServerFrame
   | LiveVoiceErrorServerFrame;
 
 /**

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -50,7 +50,11 @@ const { useLiveVoiceStore } = await import(
 // ---------------------------------------------------------------------------
 
 class FakeClient {
-  connectArgs: { assistantId: string; conversationId?: string } | null = null;
+  connectArgs: {
+    assistantId: string;
+    conversationId?: string;
+    mode?: "ptt" | "open-mic";
+  } | null = null;
   sentAudio: ArrayBuffer[] = [];
   pttReleaseCount = 0;
   interruptCount = 0;
@@ -78,6 +82,7 @@ class FakeClient {
   async connect(args: {
     assistantId: string;
     conversationId?: string;
+    mode?: "ptt" | "open-mic";
   }): Promise<void> {
     this.connectArgs = args;
   }
@@ -191,7 +196,7 @@ function pcmChunk(ms: number): ArrayBuffer {
   return new Int16Array(samples).buffer;
 }
 
-function renderController() {
+function renderController(options: { stuckTurnTimeoutMs?: number } = {}) {
   const client = new FakeClient();
   const player = new FakePlayer();
   let capture!: FakeCapture;
@@ -200,10 +205,11 @@ function renderController() {
     useLiveVoice({
       createClient: () => client as unknown as LiveVoiceChannelClient,
       createPlayer: () => player as unknown as LiveVoiceAudioPlayer,
-      createCapture: (options) => {
-        capture = new FakeCapture(options);
+      createCapture: (opts) => {
+        capture = new FakeCapture(opts);
         return capture as unknown as LiveVoiceAudioCapture;
       },
+      ...options,
     }),
   );
 
@@ -468,6 +474,46 @@ describe("barge-in", () => {
     expect(h.getCapture().shutdownCount).toBe(0);
   });
 
+  test("interrupted (e.g. during the synthesis tail) re-arms barge-in for the next response", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    // First response: local barge-in consumes the one-shot interrupt.
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 3,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+      h.getCapture().pushAmplitude(0.2);
+    });
+    expect(h.client.interruptCount).toBe(1);
+
+    // The server confirms — even when the confirmation came from the
+    // session-level tail interrupt rather than the controller.
+    act(() => {
+      h.client.emit("interrupted", { type: "interrupted", seq: 4, turnId: "t1" });
+    });
+    expect(h.view.result.current.state).toBe("listening");
+
+    // Next response: the one-shot was reset, so barge-in works again.
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 5, turnId: "t2" });
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 6,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+      h.getCapture().pushAmplitude(0.3);
+    });
+    expect(h.client.interruptCount).toBe(2);
+  });
+
   test("interrupt is sent at most once per response", async () => {
     const h = renderController();
     await startListening(h);
@@ -617,6 +663,207 @@ describe("turn_boundary", () => {
     });
 
     expect(h.view.result.current.state).toBe("thinking");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Server-initiated session end
+// ---------------------------------------------------------------------------
+
+describe("session_ended", () => {
+  test("plays out buffered goodbye audio, then tears down to idle — the trailing socket close does not cut it off", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    // The server speaks a goodbye (out-of-turn tts is buffered/played),
+    // announces the end, then closes the socket.
+    await act(async () => {
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 2,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+      h.client.emit("sessionEnded", {
+        type: "session_ended",
+        seq: 3,
+        reason: "Call completed",
+      });
+      h.client.emit("closed", undefined);
+      await Promise.resolve();
+    });
+
+    // Goodbye still playing: the session drains before tearing down.
+    expect(h.player.isPlaying).toBe(true);
+    expect(h.view.result.current.state).toBe("ending");
+    expect(h.getCapture().shutdownCount).toBe(0);
+
+    await act(async () => {
+      h.player.finishPlayback();
+      await Promise.resolve();
+    });
+
+    expect(h.view.result.current.state).toBe("idle");
+    expect(h.player.disposeCount).toBeGreaterThanOrEqual(1);
+    expect(h.getCapture().shutdownCount).toBe(1);
+  });
+
+  test("with no pending audio it tears down to idle immediately", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    await act(async () => {
+      h.client.emit("sessionEnded", {
+        type: "session_ended",
+        seq: 2,
+        reason: "Maximum call duration reached",
+      });
+      await Promise.resolve();
+    });
+
+    expect(h.view.result.current.state).toBe("idle");
+    expect(h.getCapture().shutdownCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Empty-turn recovery
+// ---------------------------------------------------------------------------
+
+describe("turn_cancelled", () => {
+  test("while thinking resumes listening for the next utterance", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    act(() => {
+      h.client.emit("turnBoundary", { type: "turn_boundary", seq: 2 });
+      h.client.emit("thinking", { type: "thinking", seq: 3, turnId: "t1" });
+    });
+    expect(h.view.result.current.state).toBe("thinking");
+
+    act(() => {
+      h.client.emit("turnCancelled", {
+        type: "turn_cancelled",
+        seq: 4,
+        reason: "empty_transcript",
+      });
+    });
+
+    expect(h.view.result.current.state).toBe("listening");
+
+    // Forwarding re-opened: the next utterance streams again.
+    act(() => {
+      h.getCapture().pushAmplitude(0.1);
+      h.getCapture().pushChunk(pcmChunk(20));
+    });
+    expect(h.client.sentAudio).toHaveLength(1);
+  });
+
+  test("an empty stt_final after release does not advance to thinking", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    // Auto-release: speech then silence.
+    act(() => {
+      h.getCapture().pushAmplitude(0.1);
+      h.getCapture().pushChunk(pcmChunk(200));
+      h.getCapture().pushAmplitude(0.0);
+      h.getCapture().pushChunk(pcmChunk(1000));
+    });
+    expect(h.view.result.current.state).toBe("transcribing");
+
+    act(() => {
+      h.client.emit("sttFinal", { type: "stt_final", seq: 2, text: "   " });
+    });
+
+    // No assistant turn is coming for an empty transcript — hold until
+    // turn_cancelled resumes listening.
+    expect(h.view.result.current.state).toBe("transcribing");
+
+    act(() => {
+      h.client.emit("turnCancelled", {
+        type: "turn_cancelled",
+        seq: 3,
+        reason: "empty_transcript",
+      });
+    });
+    expect(h.view.result.current.state).toBe("listening");
+  });
+
+  test("stuck-turn backstop resumes listening when the server goes silent", async () => {
+    const h = renderController({ stuckTurnTimeoutMs: 40 });
+    await startListening(h);
+
+    act(() => {
+      h.client.emit("turnBoundary", { type: "turn_boundary", seq: 2 });
+    });
+    expect(h.view.result.current.state).toBe("transcribing");
+
+    // No server frames arrive; the backstop fires and recovers the session.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 90));
+    });
+
+    expect(h.view.result.current.state).toBe("listening");
+    expect(h.client.closed).toBe(false);
+  });
+
+  test("stuck-turn backstop does not fire once the response is speaking", async () => {
+    const h = renderController({ stuckTurnTimeoutMs: 40 });
+    await startListening(h);
+
+    act(() => {
+      h.client.emit("turnBoundary", { type: "turn_boundary", seq: 2 });
+      h.client.emit("thinking", { type: "thinking", seq: 3, turnId: "t1" });
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 4,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+    });
+    expect(h.view.result.current.state).toBe("speaking");
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 90));
+    });
+
+    expect(h.view.result.current.state).toBe("speaking");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mode threading
+// ---------------------------------------------------------------------------
+
+describe("session mode", () => {
+  test("start() forwards a requested mode to the connect args", async () => {
+    const h = renderController();
+
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-1", "open-mic");
+    });
+
+    expect(h.client.connectArgs).toEqual({
+      assistantId: "assistant-1",
+      conversationId: "conv-1",
+      mode: "open-mic",
+    });
+  });
+
+  test("start() without a mode leaves it out (server default PTT)", async () => {
+    const h = renderController();
+
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-1");
+    });
+
+    expect(h.client.connectArgs).toEqual({
+      assistantId: "assistant-1",
+      conversationId: "conv-1",
+    });
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -16,8 +16,9 @@
  * One session spans many turns over a single socket and a single mic
  * acquisition: after the assistant's response finishes playing (or is
  * interrupted), the controller re-opens audio forwarding and returns to
- * `listening` for the next utterance. The session ends only via `stop()`
- * (user), a server/socket `closed`, `busy`, or an error.
+ * `listening` for the next utterance. The session ends via `stop()` (user), a
+ * server `session_ended` (goodbye plays out, then teardown), a server/socket
+ * `closed`, `busy`, or an error.
  *
  * ## State transitions
  * `idle → connecting` (start) → `listening` (ready + capture started) →
@@ -64,6 +65,7 @@ import {
   useLiveVoiceStore,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
+import type { LiveVoiceSessionMode } from "@/domains/chat/voice/live-voice/protocol";
 
 // ---------------------------------------------------------------------------
 // Client-side amplitude/timing thresholds
@@ -80,6 +82,13 @@ const SILENCE_DURATION_BEFORE_RELEASE_MS = 1000;
 
 /** Minimum speech (ms) required before a silence window can trigger release. */
 const MINIMUM_SPEECH_DURATION_BEFORE_RELEASE_MS = 120;
+
+/**
+ * Backstop for a wedged turn: if the session sits in `transcribing`/`thinking`
+ * this long with no server progress (no partial/final/delta/audio), resume
+ * listening so a turn the server silently dropped can't strand the client.
+ */
+const STUCK_TURN_TIMEOUT_MS = 15_000;
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -98,8 +107,15 @@ export interface UseLiveVoiceResult {
   inputAmplitude: number;
   /** Failure message when `state === "failed"`, else `null`. */
   error: string | null;
-  /** Start a session for `assistantId`, optionally attaching a conversation. */
-  start: (assistantId: string, conversationId?: string) => Promise<void>;
+  /**
+   * Start a session for `assistantId`, optionally attaching a conversation
+   * and requesting a session mode (default: server-side PTT).
+   */
+  start: (
+    assistantId: string,
+    conversationId?: string,
+    mode?: LiveVoiceSessionMode,
+  ) => Promise<void>;
   /** End the session and release the mic, socket, and audio context. */
   stop: () => Promise<void>;
 }
@@ -111,6 +127,8 @@ export interface UseLiveVoiceOptions {
     options: ConstructorParameters<typeof LiveVoiceAudioCapture>[0],
   ) => LiveVoiceAudioCapture;
   createPlayer?: () => LiveVoiceAudioPlayer;
+  /** Override the stuck-turn backstop timeout (tests). */
+  stuckTurnTimeoutMs?: number;
 }
 
 /**
@@ -145,6 +163,16 @@ interface SessionContext {
   speechMs: number;
   /** Accumulated trailing silence (ms) after speech in the current utterance. */
   silenceMs: number;
+  /**
+   * Set when the server announced `session_ended`; the drain-then-teardown
+   * path owns cleanup, so the socket `closed` that follows must not tear
+   * down mid-goodbye.
+   */
+  serverEnded: boolean;
+  /** Stuck-turn backstop timer (armed while transcribing/thinking). */
+  turnBackstopTimer: ReturnType<typeof setTimeout> | null;
+  /** Backstop timeout (injectable for tests). */
+  stuckTurnTimeoutMs: number;
 }
 
 /** Number of bytes per Int16 PCM sample. */
@@ -193,6 +221,7 @@ export function useLiveVoice(
     sessionRef.current = null;
     // Bump the generation so any in-flight async callbacks become stale no-ops.
     session.generation += 1;
+    clearTurnBackstop(session);
     for (const unsubscribe of session.unsubscribes) unsubscribe();
     session.unsubscribes = [];
     session.client.close();
@@ -211,6 +240,7 @@ export function useLiveVoice(
     }
     sessionRef.current = null;
     session.generation += 1;
+    clearTurnBackstop(session);
     useLiveVoiceStore.getState().setState("ending");
     for (const unsubscribe of session.unsubscribes) unsubscribe();
     session.unsubscribes = [];
@@ -222,7 +252,11 @@ export function useLiveVoice(
   }, []);
 
   const start = useCallback(
-    async (assistantId: string, conversationId?: string) => {
+    async (
+      assistantId: string,
+      conversationId?: string,
+      mode?: LiveVoiceSessionMode,
+    ) => {
       const current = sessionRef.current;
       // A live session (anything but idle/failed) blocks a new start.
       const phase = useLiveVoiceStore.getState().state;
@@ -250,6 +284,9 @@ export function useLiveVoice(
         releaseInFlight: false,
         speechMs: 0,
         silenceMs: 0,
+        serverEnded: false,
+        turnBackstopTimer: null,
+        stuckTurnTimeoutMs: opts.stuckTurnTimeoutMs ?? STUCK_TURN_TIMEOUT_MS,
       };
 
       const capture = (opts.createCapture ?? ((o) => new LiveVoiceAudioCapture(o)))({
@@ -275,15 +312,23 @@ export function useLiveVoice(
           // Only while still forwarding (the user's turn) does a partial keep
           // us in `listening`; after ptt-release we're transcribing/thinking.
           if (session.forwardingAudio) s.setState("listening");
+          syncTurnBackstop(session);
         }),
         client.on("sttFinal", (frame) => {
           if (!live()) return;
           const s = useLiveVoiceStore.getState();
           s.setFinalTranscript(frame.text);
           s.setPartialTranscript("");
-          // Forwarding ⇒ the user is still speaking (stay listening); otherwise
-          // ptt was released and the server is about to think.
-          s.setState(session.forwardingAudio ? "listening" : "thinking");
+          // Forwarding ⇒ the user is still speaking (stay listening). After
+          // release, a non-empty final means the server is about to think; an
+          // empty final produces no assistant turn — hold the current state
+          // and wait for `turn_cancelled` (or the stuck-turn backstop).
+          if (session.forwardingAudio) {
+            s.setState("listening");
+          } else if (frame.text.trim().length > 0) {
+            s.setState("thinking");
+          }
+          syncTurnBackstop(session);
         }),
         client.on("thinking", () => {
           if (!live()) return;
@@ -293,6 +338,7 @@ export function useLiveVoice(
           const s = useLiveVoiceStore.getState();
           s.clearAssistantTranscript();
           s.setState("thinking");
+          syncTurnBackstop(session);
         }),
         client.on("assistantTextDelta", (frame) => {
           if (!live() || frame.text.length === 0) return;
@@ -302,6 +348,7 @@ export function useLiveVoice(
           if (phase === "listening" || phase === "transcribing") {
             s.setState("thinking");
           }
+          syncTurnBackstop(session);
         }),
         client.on("ttsAudio", (frame) => {
           if (!live()) return;
@@ -313,10 +360,20 @@ export function useLiveVoice(
           };
           session.player.enqueue(chunk);
           useLiveVoiceStore.getState().setState("speaking");
+          syncTurnBackstop(session);
         }),
         client.on("ttsDone", () => {
           if (!live()) return;
           void finishResponseAfterPlayback(session);
+        }),
+        client.on("turnCancelled", () => {
+          if (!live()) return;
+          // The server retired the turn without a response (empty transcript,
+          // failed turn). Resume listening instead of waiting forever.
+          const phase = useLiveVoiceStore.getState().state;
+          if (phase === "transcribing" || phase === "thinking") {
+            resumeListening(session);
+          }
         }),
         client.on("turnBoundary", () => {
           if (!live()) return;
@@ -325,6 +382,7 @@ export function useLiveVoice(
           // already advanced); in open-mic it is the primary end-of-turn signal.
           const s = useLiveVoiceStore.getState();
           if (s.state === "listening") s.setState("transcribing");
+          syncTurnBackstop(session);
         }),
         client.on("interrupted", () => {
           if (!live()) return;
@@ -340,6 +398,13 @@ export function useLiveVoice(
           if (!live()) return;
           // Persisted; nothing user-visible to do here.
         }),
+        client.on("sessionEnded", () => {
+          if (!live()) return;
+          // Server-initiated end ([END_CALL] goodbye, max duration): let any
+          // buffered goodbye audio finish playing, then tear down to idle.
+          session.serverEnded = true;
+          void finishSessionAfterServerEnd(session, teardown);
+        }),
         client.on("busy", () => {
           if (!live()) return;
           finishWithError(session, teardown, "Another live-voice session is active.");
@@ -351,13 +416,20 @@ export function useLiveVoice(
         client.on("closed", () => {
           // A transport close after a clean end()/teardown is expected; only an
           // unexpected close while still attached needs cleanup. teardown()
-          // resets the store to idle.
+          // resets the store to idle. After a server `session_ended` the
+          // drain path owns teardown — the close that follows must not cut
+          // the goodbye off.
           if (!live()) return;
+          if (session.serverEnded) return;
           teardown();
         }),
       );
 
-      await client.connect({ assistantId, conversationId });
+      await client.connect({
+        assistantId,
+        conversationId,
+        ...(mode ? { mode } : {}),
+      });
     },
     [teardown],
   );
@@ -472,6 +544,35 @@ function releasePushToTalk(session: SessionContext): void {
   const s = useLiveVoiceStore.getState();
   if (s.state === "listening") s.setState("transcribing");
   s.setInputAmplitude(0);
+  syncTurnBackstop(session);
+}
+
+/**
+ * Arm the stuck-turn backstop while awaiting the server (`transcribing` /
+ * `thinking`), clear it otherwise. Every server signal re-syncs, so the
+ * timeout measures *silence from the server*, not total turn duration. On
+ * expiry the session resumes listening (generation-guarded).
+ */
+function syncTurnBackstop(session: SessionContext): void {
+  clearTurnBackstop(session);
+  const phase = useLiveVoiceStore.getState().state;
+  if (phase !== "transcribing" && phase !== "thinking") return;
+
+  const generation = session.generation;
+  session.turnBackstopTimer = setTimeout(() => {
+    session.turnBackstopTimer = null;
+    if (session.generation !== generation) return;
+    const now = useLiveVoiceStore.getState().state;
+    if (now === "transcribing" || now === "thinking") {
+      resumeListening(session);
+    }
+  }, session.stuckTurnTimeoutMs);
+}
+
+function clearTurnBackstop(session: SessionContext): void {
+  if (session.turnBackstopTimer === null) return;
+  clearTimeout(session.turnBackstopTimer);
+  session.turnBackstopTimer = null;
 }
 
 /**
@@ -481,6 +582,7 @@ function releasePushToTalk(session: SessionContext): void {
  * to restart here.
  */
 function resumeListening(session: SessionContext): void {
+  clearTurnBackstop(session);
   session.forwardingAudio = true;
   session.interruptSent = false;
   session.responseAudioStarted = false;
@@ -530,6 +632,26 @@ async function finishResponseAfterPlayback(
   if (session.generation !== generation) return;
   if (useLiveVoiceStore.getState().state === "listening") return;
   resumeListening(session);
+}
+
+/**
+ * Server-initiated session end: suspend forwarding, let buffered goodbye
+ * audio finish playing, then tear down to idle. The `closed` handler defers
+ * to this path (via `session.serverEnded`) so the socket close that follows
+ * `session_ended` cannot cut the goodbye off.
+ */
+async function finishSessionAfterServerEnd(
+  session: SessionContext,
+  teardown: () => void,
+): Promise<void> {
+  const generation = session.generation;
+  session.forwardingAudio = false;
+  clearTurnBackstop(session);
+  useLiveVoiceStore.getState().setState("ending");
+
+  await session.player.waitUntilDrained();
+  if (session.generation !== generation) return;
+  teardown();
 }
 
 /** Fail the session: tear down primitives and surface the message. */


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for voice-mode-engine.md: turn-audio archiving (message-id threading + unlinked fallback), server-initiated session end (manager release, session_ended frame, goodbye drain), in-app unprompted-speech gating, playback-tail barge-in, empty-turn recovery (turn_cancelled + client backstop), runtime error codes, tts_audio abort recheck, max-duration test, error-helper dedupe.