### PR TITLE
feat(web): stream live-voice transcript into the composer text area

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -63,22 +63,39 @@ type MockLiveVoiceState = "idle" | "listening" | "failed";
 
 let mockLiveVoiceState: MockLiveVoiceState = "idle";
 let mockLiveVoiceError: string | null = null;
+let mockLiveVoicePartial = "";
+let mockLiveVoiceFinal = "";
 const liveStartSpy = mock(
   async (_assistantId: string, _conversationId?: string) => {},
 );
 const liveStopSpy = mock(async () => {});
 const liveReleaseSpy = mock(() => {});
 const liveResetSpy = mock(() => {});
-// The composer only touches the store imperatively (`getState()` for the voice
-// bar's amplitude poll and for resetting a failed session from the error
-// notice); reactive session state flows through the mocked hook below.
-mock.module("@/domains/chat/voice/live-voice/live-voice-store", () => ({
-  useLiveVoiceStore: {
-    getState: () => ({
-      inputAmplitude: 0,
-      reset: liveResetSpy,
-    }),
+// The store mock mirrors the three surfaces the composer tree touches:
+// `getState()` (voice bar amplitude poll + failed-session reset), a callable
+// selector subscription (the composer's low-frequency transcript-presence
+// bit), and `.use` per-field hooks (`VoiceLiveTranscript`'s self-sourced
+// transcript). Reactive session state flows through the mocked hook below.
+const liveVoiceStoreState = () => ({
+  inputAmplitude: 0,
+  partialTranscript: mockLiveVoicePartial,
+  finalTranscript: mockLiveVoiceFinal,
+  reset: liveResetSpy,
+});
+type MockLiveVoiceStoreState = ReturnType<typeof liveVoiceStoreState>;
+const useLiveVoiceStoreMock = Object.assign(
+  <T,>(selector: (s: MockLiveVoiceStoreState) => T): T =>
+    selector(liveVoiceStoreState()),
+  {
+    getState: liveVoiceStoreState,
+    use: {
+      partialTranscript: () => mockLiveVoicePartial,
+      finalTranscript: () => mockLiveVoiceFinal,
+    },
   },
+);
+mock.module("@/domains/chat/voice/live-voice/live-voice-store", () => ({
+  useLiveVoiceStore: useLiveVoiceStoreMock,
 }));
 // Spy wrapper so tests can assert the composer opts out of the hook's
 // high-frequency audio-state subscription (`observeAudioState: false`) —
@@ -135,6 +152,8 @@ function resetLiveVoiceMocks() {
   mockVoiceMode = false;
   mockLiveVoiceState = "idle";
   mockLiveVoiceError = null;
+  mockLiveVoicePartial = "";
+  mockLiveVoiceFinal = "";
   mockVoicePhase = "idle";
   setAudioLevelSpy.mockClear();
   liveStartSpy.mockClear();
@@ -1058,5 +1077,70 @@ describe("ChatComposer — live-voice integration", () => {
     // THEN its action row is untouched — no voice bar, normal send button
     expect(html).not.toContain('aria-label="Voice session"');
     expect(html).toContain('aria-label="Send message"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Live-voice transcript in the composer text area (Light 55)
+//
+// While speech streams, the disabled textarea is visually hidden and the
+// display-only `VoiceLiveTranscript` renders in its grid cell; with no
+// transcript yet the textarea (and its placeholder) stays visible.
+// ---------------------------------------------------------------------------
+
+describe("ChatComposer — live-voice transcript area", () => {
+  test("streaming speech hides the textarea and renders the transcript in its place", () => {
+    // GIVEN a listening session with an in-flight partial transcript
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockLiveVoiceState = "listening";
+    mockLiveVoicePartial = "this is a text that I am just speaking";
+
+    // WHEN the composer renders
+    const { container, getByLabelText } = renderVoiceComposer();
+
+    // THEN the transcript region shows the speech as composer text...
+    const region = getByLabelText("Voice transcript");
+    expect(region.textContent).toContain(
+      "this is a text that I am just speaking",
+    );
+    // ...with a caret, in place of the visually hidden (still-mounted,
+    // still-uneditable) textarea
+    expect(region.querySelector('[data-testid="voice-transcript-caret"]')).toBeTruthy();
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea.className).toContain("hidden");
+    expect(textarea.disabled).toBe(true);
+  });
+
+  test("empty transcript keeps the textarea (and its placeholder) visible", () => {
+    // GIVEN an active session with no speech yet (Light 53 baseline)
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockLiveVoiceState = "listening";
+
+    // WHEN the composer renders
+    const { container, queryByLabelText } = renderVoiceComposer();
+
+    // THEN nothing replaces the textarea — its placeholder shows through
+    expect(queryByLabelText("Voice transcript")).toBeNull();
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea.className).not.toContain("hidden");
+  });
+
+  test("textarea is restored after the session ends, even with a leftover final transcript", () => {
+    // GIVEN the session has ended (store not yet reset, final text lingering)
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockLiveVoiceState = "idle";
+    mockLiveVoiceFinal = "what I said last";
+
+    // WHEN the composer renders
+    const { container, queryByLabelText } = renderVoiceComposer();
+
+    // THEN the composer behaves normally: no transcript region, editable textarea
+    expect(queryByLabelText("Voice transcript")).toBeNull();
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea.className).not.toContain("hidden");
+    expect(textarea.disabled).toBe(false);
   });
 });

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -26,6 +26,7 @@ import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 import { ComposerDraftNotices } from "@/domains/chat/components/composer-draft-notices";
 import { StreamingWaveform } from "@/domains/chat/components/chat-composer/streaming-waveform";
 import { VoiceComposerBar } from "@/domains/chat/components/chat-composer/voice-composer-bar";
+import { VoiceLiveTranscript } from "@/domains/chat/components/chat-composer/voice-live-transcript";
 import { LiveVoiceButton } from "@/domains/chat/components/live-voice-button";
 import {
     VoiceInputButton,
@@ -255,6 +256,22 @@ export function ChatComposer({
     showVoiceInput &&
     liveVoiceState !== "idle" &&
     liveVoiceState !== "failed";
+  // Whether the session has any speech transcript to show. A boolean
+  // *presence* subscription, not the text itself: zustand only re-renders
+  // when the selected value changes identity, so per-delta transcript
+  // updates never reach the composer — the bit flips once when speech
+  // starts and once when the store clears. The streaming text is rendered
+  // by `VoiceLiveTranscript`, which subscribes to the store on its own,
+  // keeping this component's deliberate opt-out of high-frequency
+  // live-voice updates (see `observeAudioState: false` above) intact.
+  const hasLiveVoiceTranscript = useLiveVoiceStore(
+    (s) => Boolean(s.partialTranscript || s.finalTranscript),
+  );
+  // While speech is streaming, the disabled textarea is visually hidden and
+  // the display-only transcript renders in its grid cell (Light 55). With no
+  // transcript yet, the textarea stays visible so its placeholder shows
+  // through (Light 53 baseline).
+  const showLiveVoiceTranscript = isLiveVoiceActive && hasLiveVoiceTranscript;
   // Amplitude is polled by the voice bar's canvas draw loop straight from the
   // store (~30 Hz), so per-sample updates never flow through props.
   const getLiveVoiceAmplitude = useCallback(
@@ -593,9 +610,22 @@ export function ChatComposer({
                 // into this region). The grid mirror keeps the height stable.
                 disabled={typingDisabled || isLiveVoiceActive}
                 rows={1}
-                className="col-start-1 row-start-1 w-full resize-none overflow-y-auto border-none bg-transparent px-4 pt-3 pb-2 text-chat text-[var(--content-default)] placeholder:text-[var(--content-disabled)] focus:outline-none disabled:opacity-50"
+                className={`col-start-1 row-start-1 w-full resize-none overflow-y-auto border-none bg-transparent px-4 pt-3 pb-2 text-chat text-[var(--content-default)] placeholder:text-[var(--content-disabled)] focus:outline-none disabled:opacity-50 ${
+                  showLiveVoiceTranscript ? "hidden" : ""
+                }`}
                 style={{ maxHeight: `${textareaMaxHeightPx}px` }}
               />
+              {isLiveVoiceActive && (
+                // Live speech streams display-only into the textarea's grid
+                // cell (Light 55); renders nothing until there is text, so
+                // the placeholder above stays visible. The shared cell keeps
+                // the grid's auto-grow/max-height behavior identical to the
+                // textarea it visually replaces.
+                <VoiceLiveTranscript
+                  className="col-start-1 row-start-1"
+                  maxHeightPx={textareaMaxHeightPx}
+                />
+              )}
             </div>
             {showInlineVoicePreview && (
               // Non-Electron fallback: Electron uses the shared top-center

--- a/clients/web/src/domains/chat/components/chat-composer/voice-live-transcript.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-live-transcript.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * Tests for `VoiceLiveTranscript`.
+ *
+ * The component subscribes to the real live-voice store (that self-sourcing
+ * is its whole point — the composer deliberately does not re-render on
+ * transcript deltas), so tests drive it by writing transcript fields through
+ * the store and asserting the rendered surface: partial/final precedence,
+ * store-driven clearing, the empty-renders-nothing contract, and the caret's
+ * reduced-motion behavior (verified by stubbing `motion/react`, mirroring
+ * `voice-timeline-waveform.test.tsx`).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { act, cleanup, render, screen } from "@testing-library/react";
+
+import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+
+import { VoiceLiveTranscript } from "@/domains/chat/components/chat-composer/voice-live-transcript";
+
+beforeEach(() => {
+  useLiveVoiceStore.getState().reset();
+});
+
+afterEach(() => {
+  cleanup();
+  useLiveVoiceStore.getState().reset();
+});
+
+function seedTranscripts(partial: string, final = "") {
+  act(() => {
+    useLiveVoiceStore.getState().setPartialTranscript(partial);
+    useLiveVoiceStore.getState().setFinalTranscript(final);
+  });
+}
+
+describe("VoiceLiveTranscript — transcript text", () => {
+  test("renders the partial transcript as display-only text", () => {
+    seedTranscripts("hello wor");
+    render(<VoiceLiveTranscript />);
+    const region = screen.getByLabelText("Voice transcript");
+    expect(region.textContent).toContain("hello wor");
+  });
+
+  test("prefers the partial over the final while both are present", () => {
+    // Same precedence as the old inline strip's `liveVoicePartial ||
+    // liveVoiceFinal`: the in-flight partial is the fresher signal.
+    seedTranscripts("still speaking", "previous final");
+    render(<VoiceLiveTranscript />);
+    const region = screen.getByLabelText("Voice transcript");
+    expect(region.textContent).toContain("still speaking");
+    expect(region.textContent).not.toContain("previous final");
+  });
+
+  test("falls back to the final transcript when no partial is in flight", () => {
+    seedTranscripts("", "what I said");
+    render(<VoiceLiveTranscript />);
+    expect(
+      screen.getByLabelText("Voice transcript").textContent,
+    ).toContain("what I said");
+  });
+
+  test("streams partial updates without remounting", () => {
+    seedTranscripts("hel");
+    render(<VoiceLiveTranscript />);
+    act(() => {
+      useLiveVoiceStore.getState().setPartialTranscript("hello world");
+    });
+    expect(
+      screen.getByLabelText("Voice transcript").textContent,
+    ).toContain("hello world");
+  });
+});
+
+describe("VoiceLiveTranscript — empty and clearing", () => {
+  test("renders nothing while both transcripts are empty", () => {
+    const { container } = render(<VoiceLiveTranscript />);
+    // Nothing in the composer's text area — the disabled textarea's
+    // placeholder shows through (Light 53 baseline).
+    expect(container.innerHTML).toBe("");
+    expect(screen.queryByLabelText("Voice transcript")).toBeNull();
+  });
+
+  test("clears when the store resets", () => {
+    seedTranscripts("about to be sent", "about to be sent");
+    const { container } = render(<VoiceLiveTranscript />);
+    expect(screen.getByLabelText("Voice transcript")).toBeTruthy();
+
+    act(() => {
+      useLiveVoiceStore.getState().reset();
+    });
+
+    expect(screen.queryByLabelText("Voice transcript")).toBeNull();
+    expect(container.innerHTML).toBe("");
+  });
+});
+
+describe("VoiceLiveTranscript — accessibility and styling", () => {
+  test("announces updates via a polite live region", () => {
+    seedTranscripts("hello");
+    render(<VoiceLiveTranscript />);
+    const region = screen.getByLabelText("Voice transcript");
+    expect(region.getAttribute("aria-live")).toBe("polite");
+  });
+
+  test("styles the text like the composer textarea and caps growth at maxHeightPx", () => {
+    seedTranscripts("hello");
+    render(<VoiceLiveTranscript className="col-start-1" maxHeightPx={240} />);
+    const region = screen.getByLabelText("Voice transcript");
+    // Same font class + text inset as the textarea, so speech reads as
+    // typed composer text; caller placement classes are merged in.
+    expect(region.className).toContain("text-chat");
+    expect(region.className).toContain("px-4");
+    expect(region.className).toContain("col-start-1");
+    expect(region.style.maxHeight).toBe("240px");
+  });
+
+  test("renders a blinking caret after the text by default", () => {
+    seedTranscripts("hello");
+    render(<VoiceLiveTranscript />);
+    const caret = screen.getByTestId("voice-transcript-caret");
+    expect(caret.getAttribute("aria-hidden")).toBe("true");
+    expect(caret.className).toContain("voice-caret-blink");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reduced-motion path — verified by stubbing `motion/react`.
+// ---------------------------------------------------------------------------
+
+describe("VoiceLiveTranscript — reduced motion", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("caret is static (no blink animation class) under reduced motion", async () => {
+    mock.module("motion/react", () => ({
+      useReducedMotion: () => true,
+    }));
+
+    const { VoiceLiveTranscript: ReducedTranscript } = await import(
+      "./voice-live-transcript"
+    );
+    seedTranscripts("hello");
+    render(<ReducedTranscript />);
+
+    const caret = screen.getByTestId("voice-transcript-caret");
+    // The caret stays visible as a static bar — only the blink is dropped.
+    expect(caret.className).not.toContain("voice-caret-blink");
+    expect(caret.className).toContain("bg-[var(--content-default)]");
+  });
+});

--- a/clients/web/src/domains/chat/components/chat-composer/voice-live-transcript.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-live-transcript.tsx
@@ -1,0 +1,93 @@
+/**
+ * Display-only live transcript rendered in the composer's text area during a
+ * live-voice session (Light 55): the user's speech streams in as normal
+ * composer-styled text followed by a blinking caret. Not editable — the turn
+ * auto-sends on silence/turn end (or via the voice bar's green ↑).
+ *
+ * Subscribes to the live-voice store itself via per-field selectors. This is
+ * deliberate: the composer opts out of high-frequency live-voice updates
+ * (`observeAudioState: false`), so per-delta transcript re-renders must stay
+ * contained to this leaf component.
+ *
+ * Shows `partialTranscript || finalTranscript` — the in-flight partial wins
+ * while both are present (same precedence as the old inline transcript
+ * strip). When both are empty it renders nothing, letting the disabled
+ * textarea's placeholder show through (Light 53 baseline).
+ *
+ * Clearing is store-driven: V1 resets transcripts per session; when the
+ * engine lands multi-turn sessions the store clears per turn and this
+ * component follows automatically — no turn logic lives here.
+ */
+
+import { useReducedMotion } from "motion/react";
+import { useEffect, useRef } from "react";
+
+import { cn } from "@vellumai/design-library";
+
+import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+
+export interface VoiceLiveTranscriptProps {
+  /** Placement classes from the composer (e.g. the textarea's grid cell). */
+  className?: string;
+  /**
+   * Cap for the transcript's auto-grow height — mirrors the textarea's
+   * `textareaMaxHeightPx` so the swap preserves the composer's height
+   * behavior; content beyond the cap scrolls.
+   */
+  maxHeightPx?: number;
+}
+
+export function VoiceLiveTranscript({
+  className,
+  maxHeightPx,
+}: VoiceLiveTranscriptProps) {
+  const partialTranscript = useLiveVoiceStore.use.partialTranscript();
+  const finalTranscript = useLiveVoiceStore.use.finalTranscript();
+  const reducedMotion = useReducedMotion();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const text = partialTranscript || finalTranscript;
+
+  // Keep the newest words (and the caret) in view once the transcript
+  // overflows the max height — mirrors how a textarea tracks its caret.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [text]);
+
+  if (!text) {
+    return null;
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      aria-live="polite"
+      aria-label="Voice transcript"
+      // Text styling matches the composer textarea exactly (same padding,
+      // font class, and color) so speech reads as typed composer text.
+      className={cn(
+        "overflow-y-auto whitespace-pre-wrap break-words px-4 pt-3 pb-2 text-chat text-[var(--content-default)]",
+        className,
+      )}
+      style={
+        maxHeightPx !== undefined ? { maxHeight: `${maxHeightPx}px` } : undefined
+      }
+    >
+      {text}
+      <span
+        aria-hidden
+        data-testid="voice-transcript-caret"
+        // Thin caret bar sized to the text's cap height; blinks via the
+        // `voice-caret-blink` keyframes in index.css, held static under
+        // reduced motion.
+        className={cn(
+          "ml-px inline-block h-[1.1em] w-[1.5px] translate-y-[0.2em] bg-[var(--content-default)]",
+          !reducedMotion && "voice-caret-blink",
+        )}
+      />
+    </div>
+  );
+}

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -105,6 +105,25 @@ body {
   animation: busy-pulse 1s ease-in-out infinite;
 }
 
+/* Live-voice transcript caret — a thin bar blinking like a text caret at the
+ * end of the streaming speech transcript in the composer (Light 55). The
+ * component also holds it static via useReducedMotion; the media query is
+ * defense-in-depth matching .avatar-streaming-ring below. */
+@keyframes voice-caret-blink {
+  0%, 50% { opacity: 1; }
+  50.01%, 100% { opacity: 0; }
+}
+
+.voice-caret-blink {
+  animation: voice-caret-blink 1.1s step-end infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .voice-caret-blink {
+    animation: none;
+  }
+}
+
 /* Deep-link message highlight — a one-shot background flash applied when the
  * transcript scrolls to a message (e.g. opening a saved bookmark). Fades from
  * the active-surface tint back to transparent over 2s. */


### PR DESCRIPTION
## Summary
- New VoiceLiveTranscript renders partial/final speech display-only in the composer text area with a blinking caret (Light 55)
- Self-subscribing to the live-voice store so the composer keeps its low-frequency render profile; textarea hidden during sessions and restored after
- Tests for precedence, clearing, reduced motion, and composer integration

Part of plan: voice-mode-ui.md (PR 5 of 7)