### PR TITLE
fix(live-voice): version-skew fallback and non-fatal error handling for hands-free

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -134,7 +134,33 @@ describe("LiveVoiceSession STT", () => {
         seq: 1,
         sessionId: "session-123",
         conversationId: "conversation-123",
+        turnDetection: "manual",
       },
+    ]);
+  });
+
+  test("marks transient transcriber errors recoverable while the session continues", async () => {
+    const { frames, session, transcriber } = createSessionWithTranscriber();
+
+    await session.start();
+    transcriber.emit({
+      type: "error",
+      category: "provider-error",
+      message: "whisper poll failed",
+    });
+    await waitFor(() => frames.some((frame) => frame.type === "error"));
+
+    expect(frames.find((frame) => frame.type === "error")).toMatchObject({
+      type: "error",
+      code: "invalid_field",
+      message: "whisper poll failed",
+      recoverable: true,
+    });
+
+    // The session is still live: audio keeps streaming to the transcriber.
+    await session.handleBinaryAudio(new Uint8Array([1, 2, 3]));
+    expect(transcriber.audioChunks.map((chunk) => [...chunk])).toEqual([
+      [1, 2, 3],
     ]);
   });
 

--- a/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
@@ -290,6 +290,7 @@ describe("LiveVoiceSession TTS", () => {
     expect(frames.find((frame) => frame.type === "error")).toMatchObject({
       type: "error",
       message: expect.stringContaining("provider unavailable"),
+      recoverable: true,
     });
     expect(frames.at(-1)).toMatchObject({
       type: "tts_done",

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -237,6 +237,17 @@ async function flushAsyncCallbacks(): Promise<void> {
 }
 
 describe("LiveVoiceSession server VAD", () => {
+  test("ready echoes turnDetection server_vad", async () => {
+    const { frames, session } = createHarness({});
+
+    await session.start();
+
+    expect(frames[0]).toMatchObject({
+      type: "ready",
+      turnDetection: "server_vad",
+    });
+  });
+
   test("silence then speech then silence emits speech_started, utterance_end, and runs a turn", async () => {
     const { frames, session } = createHarness({
       finals: ["hello world"],

--- a/assistant/src/live-voice/__tests__/protocol.test.ts
+++ b/assistant/src/live-voice/__tests__/protocol.test.ts
@@ -401,6 +401,68 @@ describe("LiveVoiceServerFrameSequencer", () => {
     expect(sequencer.lastSeq).toBe(3);
   });
 
+  test("preserves the ready frame's turnDetection echo", () => {
+    const sequencer = createLiveVoiceServerFrameSequencer();
+
+    const manualReady: LiveVoiceServerFrame = sequencer.next({
+      type: "ready",
+      sessionId: "session-123",
+      conversationId: "conversation-123",
+      turnDetection: "manual",
+    });
+    const vadReady: LiveVoiceServerFrame = sequencer.next({
+      type: "ready",
+      sessionId: "session-123",
+      conversationId: "conversation-123",
+      turnDetection: "server_vad",
+    });
+
+    expect(manualReady).toEqual({
+      type: "ready",
+      seq: 1,
+      sessionId: "session-123",
+      conversationId: "conversation-123",
+      turnDetection: "manual",
+    });
+    expect(vadReady).toEqual({
+      type: "ready",
+      seq: 2,
+      sessionId: "session-123",
+      conversationId: "conversation-123",
+      turnDetection: "server_vad",
+    });
+  });
+
+  test("preserves the error frame's recoverable flag", () => {
+    const sequencer = createLiveVoiceServerFrameSequencer();
+
+    const recoverable: LiveVoiceServerFrame = sequencer.next({
+      type: "error",
+      code: "invalid_field",
+      message: "transient transcriber error",
+      recoverable: true,
+    });
+    const terminal: LiveVoiceServerFrame = sequencer.next({
+      type: "error",
+      code: "invalid_field",
+      message: "startup failed",
+    });
+
+    expect(recoverable).toEqual({
+      type: "error",
+      seq: 1,
+      code: "invalid_field",
+      message: "transient transcriber error",
+      recoverable: true,
+    });
+    expect(terminal).toEqual({
+      type: "error",
+      seq: 2,
+      code: "invalid_field",
+      message: "startup failed",
+    });
+  });
+
   test("sequences utterance_discarded frames", () => {
     const sequencer = createLiveVoiceServerFrameSequencer();
 

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -251,6 +251,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           type: "ready",
           sessionId: this.context.sessionId,
           conversationId: this.conversationId,
+          turnDetection: this.turnDetector ? "server_vad" : "manual",
         });
     }
   }
@@ -707,11 +708,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         // Non-terminal: providers like OpenAI Whisper emit `error` for
         // transient poll failures and continue streaming. Let `closed` /
         // `final` drive turn lifecycle so we don't drain audio buffers or
-        // mark the turn cancelled prematurely.
+        // mark the turn cancelled prematurely. The entry guard above ensures
+        // the session is still live, so the frame is recoverable.
         await this.sendFrame({
           type: "error",
           code: LiveVoiceProtocolErrorCode.InvalidField,
           message: event.message,
+          recoverable: true,
         });
         return;
       case "closed":
@@ -1100,11 +1103,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           await ttsAudioFrames;
         } catch (err) {
           if (!this.isForwardingTts(token)) return;
+          // Per-segment failure: the turn (and session) continue, so the
+          // error is recoverable for the client.
           await this.sendFrame(
             {
               type: "error",
               code: LiveVoiceProtocolErrorCode.InvalidField,
               message: `Live voice TTS failed: ${errorMessage(err)}`,
+              recoverable: true,
             },
             () => this.isForwardingTts(token),
           );

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -112,6 +112,12 @@ export interface LiveVoiceReadyServerFrame extends LiveVoiceServerFrameBase {
   readonly type: "ready";
   readonly sessionId: string;
   readonly conversationId: string;
+  /**
+   * Echoes the turn-detection mode the session is actually running, so
+   * clients can detect a daemon that ignored a requested mode. Absent
+   * (older daemons) means "manual".
+   */
+  readonly turnDetection?: LiveVoiceTurnDetectionMode;
 }
 
 export interface LiveVoiceBusyServerFrame extends LiveVoiceServerFrameBase {
@@ -218,6 +224,12 @@ export interface LiveVoiceErrorServerFrame extends LiveVoiceServerFrameBase {
   readonly type: "error";
   readonly code: LiveVoiceProtocolErrorCode;
   readonly message: string;
+  /**
+   * True when the session continues past the error (e.g. a transient
+   * transcriber blip or one failed TTS segment). Absent (including on frames
+   * from older daemons) means the error is terminal for the session.
+   */
+  readonly recoverable?: boolean;
 }
 
 export type LiveVoiceServerFrame =

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
@@ -280,6 +280,32 @@ describe("server frame dispatch", () => {
     ]);
   });
 
+  test("ready preserves the server's turnDetection echo", async () => {
+    const client = makeClient();
+    const ws = await connectAndGetSocket(client);
+    ws.open();
+
+    const seen: unknown[] = [];
+    client.on("ready", (f) => seen.push(f));
+    ws.receive({
+      type: "ready",
+      seq: 1,
+      sessionId: "sess-1",
+      conversationId: "conv-1",
+      turnDetection: "server_vad",
+    });
+
+    expect(seen).toEqual([
+      {
+        type: "ready",
+        seq: 1,
+        sessionId: "sess-1",
+        conversationId: "conv-1",
+        turnDetection: "server_vad",
+      },
+    ]);
+  });
+
   /** Per-test event recorder: `record(name)` handlers append into `got[name]`. */
   function makeRecorder() {
     const got: Record<string, unknown[]> = {};
@@ -342,26 +368,31 @@ describe("server frame dispatch", () => {
     expect(got.archived).toHaveLength(1);
   });
 
-  test("dispatches speech_started / utterance_end / turn_cancelled to their events", async () => {
+  test("dispatches speech_started / utterance_end / utterance_discarded / turn_cancelled to their events", async () => {
     const { client, ws } = await ready();
 
     const { got, record } = makeRecorder();
     client.on("speechStarted", record("speechStarted"));
     client.on("utteranceEnd", record("utteranceEnd"));
+    client.on("utteranceDiscarded", record("utteranceDiscarded"));
     client.on("turnCancelled", record("turnCancelled"));
 
     ws.receive({ type: "speech_started", seq: 2 });
     ws.receive({ type: "utterance_end", seq: 3, reason: "silence" });
     ws.receive({ type: "utterance_end", seq: 4, reason: "max-duration" });
-    ws.receive({ type: "turn_cancelled", seq: 5, turnId: "t1" });
+    ws.receive({ type: "utterance_discarded", seq: 5 });
+    ws.receive({ type: "turn_cancelled", seq: 6, turnId: "t1" });
 
     expect(got.speechStarted).toEqual([{ type: "speech_started", seq: 2 }]);
     expect(got.utteranceEnd).toEqual([
       { type: "utterance_end", seq: 3, reason: "silence" },
       { type: "utterance_end", seq: 4, reason: "max-duration" },
     ]);
+    expect(got.utteranceDiscarded).toEqual([
+      { type: "utterance_discarded", seq: 5 },
+    ]);
     expect(got.turnCancelled).toEqual([
-      { type: "turn_cancelled", seq: 5, turnId: "t1" },
+      { type: "turn_cancelled", seq: 6, turnId: "t1" },
     ]);
   });
 
@@ -397,6 +428,68 @@ describe("server frame dispatch", () => {
     expect(errors).toEqual([
       { reason: "protocol-error", code: "boom", message: "kaboom" },
     ]);
+    expect(closedCount).toBe(1);
+    expect(ws.closed).toBe(true);
+  });
+
+  test("recoverable error frame emits the error but keeps the session alive", async () => {
+    const { client, ws } = await ready();
+    const errors: {
+      reason: string;
+      code?: string;
+      message: string;
+      recoverable?: boolean;
+    }[] = [];
+    let closedCount = 0;
+    client.on("error", (e) => errors.push(e));
+    client.on("closed", () => closedCount++);
+
+    ws.receive({
+      type: "error",
+      seq: 10,
+      code: "invalid_field",
+      message: "transient blip",
+      recoverable: true,
+    });
+
+    expect(errors).toEqual([
+      {
+        reason: "protocol-error",
+        code: "invalid_field",
+        message: "transient blip",
+        recoverable: true,
+      },
+    ]);
+    expect(closedCount).toBe(0);
+    expect(ws.closed).toBe(false);
+
+    // The session stays live: later frames still dispatch.
+    const seen: unknown[] = [];
+    client.on("sttPartial", (f) => seen.push(f));
+    ws.receive({ type: "stt_partial", seq: 11, text: "still here" });
+    expect(seen).toEqual([{ type: "stt_partial", seq: 11, text: "still here" }]);
+  });
+
+  test("recoverable error before ready is still fatal", async () => {
+    const client = makeClient();
+    const ws = await connectAndGetSocket(client);
+    ws.open();
+
+    const errors: { recoverable?: boolean }[] = [];
+    let closedCount = 0;
+    client.on("error", (e) => errors.push(e));
+    client.on("closed", () => closedCount++);
+
+    ws.receive({
+      type: "error",
+      seq: 1,
+      code: "invalid_field",
+      message: "startup failed",
+      recoverable: true,
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.recoverable).toBeUndefined();
     expect(closedCount).toBe(1);
     expect(ws.closed).toBe(true);
   });

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
@@ -37,6 +37,7 @@ import {
   type LiveVoiceTtsDoneServerFrame,
   type LiveVoiceTurnCancelledServerFrame,
   type LiveVoiceTurnDetectionMode,
+  type LiveVoiceUtteranceDiscardedServerFrame,
   type LiveVoiceUtteranceEndServerFrame,
   parseServerFrame,
 } from "@/domains/chat/voice/live-voice/protocol";
@@ -55,6 +56,11 @@ export interface LiveVoiceClientError {
   /** Protocol error code from the server `error` frame, when applicable. */
   readonly code?: string;
   readonly message: string;
+  /**
+   * True when the server marked the error recoverable and the transport was
+   * kept open — the session is still live. Absent means the client tore down.
+   */
+  readonly recoverable?: boolean;
 }
 
 /**
@@ -68,6 +74,8 @@ export interface LiveVoiceClientEventMap {
   speechStarted: LiveVoiceSpeechStartedServerFrame;
   /** Server VAD closed the utterance; transcription begins. */
   utteranceEnd: LiveVoiceUtteranceEndServerFrame;
+  /** The closed utterance had no usable speech — return to listening. */
+  utteranceDiscarded: LiveVoiceUtteranceDiscardedServerFrame;
   sttPartial: LiveVoiceSttPartialServerFrame;
   sttFinal: LiveVoiceSttFinalServerFrame;
   thinking: LiveVoiceThinkingServerFrame;
@@ -133,6 +141,7 @@ export class LiveVoiceChannelClient {
     ready: new Set(),
     speechStarted: new Set(),
     utteranceEnd: new Set(),
+    utteranceDiscarded: new Set(),
     sttPartial: new Set(),
     sttFinal: new Set(),
     thinking: new Set(),
@@ -300,6 +309,9 @@ export class LiveVoiceChannelClient {
       case "utterance_end":
         this.emit("utteranceEnd", frame);
         return;
+      case "utterance_discarded":
+        this.emit("utteranceDiscarded", frame);
+        return;
       case "stt_partial":
         this.emit("sttPartial", frame);
         return;
@@ -328,6 +340,22 @@ export class LiveVoiceChannelClient {
         this.emit("archived", frame);
         return;
       case "error":
+        // A recoverable mid-session error leaves the transport open; the
+        // session controller decides whether the session survives. (`in`
+        // narrows past LiveVoiceInvalidJsonFrame, which is never recoverable.)
+        if (
+          "recoverable" in frame &&
+          frame.recoverable === true &&
+          this.state === "active"
+        ) {
+          this.emit("error", {
+            reason: "protocol-error",
+            code: frame.code,
+            message: frame.message,
+            recoverable: true,
+          });
+          return;
+        }
         this.fail("protocol-error", frame.message, frame.code);
         return;
       case "unknown_frame":

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.test.ts
@@ -8,9 +8,24 @@ import {
 describe("parseServerFrame", () => {
   const frames: LiveVoiceServerFrame[] = [
     { type: "ready", seq: 1, sessionId: "s1", conversationId: "c1" },
+    {
+      type: "ready",
+      seq: 16,
+      sessionId: "s1",
+      conversationId: "c1",
+      turnDetection: "server_vad",
+    },
+    {
+      type: "ready",
+      seq: 17,
+      sessionId: "s1",
+      conversationId: "c1",
+      turnDetection: "manual",
+    },
     { type: "busy", seq: 2, activeSessionId: "s9" },
     { type: "speech_started", seq: 12 },
     { type: "utterance_end", seq: 13, reason: "silence" },
+    { type: "utterance_discarded", seq: 18 },
     { type: "turn_cancelled", seq: 14, turnId: "t2" },
     { type: "stt_partial", seq: 3, text: "hel" },
     { type: "stt_final", seq: 4, text: "hello" },
@@ -45,6 +60,13 @@ describe("parseServerFrame", () => {
       warning: { code: "w", message: "warn" },
     },
     { type: "error", seq: 11, code: "boom", message: "bad" },
+    {
+      type: "error",
+      seq: 19,
+      code: "invalid_field",
+      message: "transient",
+      recoverable: true,
+    },
   ];
 
   for (const frame of frames) {

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.ts
@@ -84,6 +84,7 @@ const LIVE_VOICE_SERVER_FRAME_TYPES = [
   "busy",
   "speech_started",
   "utterance_end",
+  "utterance_discarded",
   "stt_partial",
   "stt_final",
   "thinking",
@@ -107,6 +108,12 @@ export interface LiveVoiceReadyServerFrame extends LiveVoiceServerFrameBase {
   readonly type: "ready";
   readonly sessionId: string;
   readonly conversationId: string;
+  /**
+   * Echoes the turn-detection mode the session is actually running. Absent
+   * (older daemons that ignore the start frame's `turnDetection`) means
+   * "manual" — hands-free callers must fall back accordingly.
+   */
+  readonly turnDetection?: LiveVoiceTurnDetectionMode;
 }
 
 export interface LiveVoiceBusyServerFrame extends LiveVoiceServerFrameBase {
@@ -130,6 +137,16 @@ export interface LiveVoiceSpeechStartedServerFrame extends LiveVoiceServerFrameB
 export interface LiveVoiceUtteranceEndServerFrame extends LiveVoiceServerFrameBase {
   readonly type: "utterance_end";
   readonly reason: "silence" | "max-duration";
+}
+
+/**
+ * Emitted only in server_vad mode when the closed utterance produced no
+ * usable speech (noise/cough): it is dropped without an assistant turn and
+ * the client should return to listening.
+ */
+export interface LiveVoiceUtteranceDiscardedServerFrame
+  extends LiveVoiceServerFrameBase {
+  readonly type: "utterance_discarded";
 }
 
 export interface LiveVoiceSttPartialServerFrame extends LiveVoiceServerFrameBase {
@@ -201,6 +218,12 @@ export interface LiveVoiceErrorServerFrame extends LiveVoiceServerFrameBase {
   readonly type: "error";
   readonly code: string;
   readonly message: string;
+  /**
+   * True when the session continues past the error (e.g. a transient
+   * transcriber blip or one failed TTS segment). Absent (including on frames
+   * from older daemons) means the error is terminal for the session.
+   */
+  readonly recoverable?: boolean;
 }
 
 export type LiveVoiceServerFrame =
@@ -208,6 +231,7 @@ export type LiveVoiceServerFrame =
   | LiveVoiceBusyServerFrame
   | LiveVoiceSpeechStartedServerFrame
   | LiveVoiceUtteranceEndServerFrame
+  | LiveVoiceUtteranceDiscardedServerFrame
   | LiveVoiceSttPartialServerFrame
   | LiveVoiceSttFinalServerFrame
   | LiveVoiceThinkingServerFrame

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -229,12 +229,14 @@ async function startListening(
     await h.view.result.current.start("assistant-1", "conv-1", options);
   });
   // `ready` kicks off capture; await the microtask that resolves capture.start.
+  // A current daemon echoes the session's turn-detection mode.
   await act(async () => {
     h.client.emit("ready", {
       type: "ready",
       seq: 1,
       sessionId: "s1",
       conversationId: "conv-1",
+      turnDetection: options?.handsFree ? "server_vad" : "manual",
     });
     await Promise.resolve();
   });
@@ -806,6 +808,217 @@ describe("hands-free mode", () => {
     expect(h.client.interruptCount).toBe(0);
     expect(h.player.isPlaying).toBe(true);
     expect(h.view.result.current.state).toBe("speaking");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Version skew: hands-free against an older daemon
+// ---------------------------------------------------------------------------
+
+describe("hands-free fallback to manual (older daemon)", () => {
+  test("ready without turnDetection re-enables auto-release, amplitude barge-in, and single-turn teardown", async () => {
+    const h = renderController();
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-1", {
+        handsFree: true,
+      });
+    });
+    // An older daemon ignores the requested server_vad and never echoes it.
+    await act(async () => {
+      h.client.emit("ready", {
+        type: "ready",
+        seq: 1,
+        sessionId: "s1",
+        conversationId: "conv-1",
+      });
+      await Promise.resolve();
+    });
+    expect(h.client.connectArgs).toMatchObject({ turnDetection: "server_vad" });
+    expect(h.view.result.current.state).toBe("listening");
+
+    // Client-local silence auto-release fires again (manual behavior).
+    act(() => {
+      h.getCapture().pushAmplitude(0.1);
+      h.getCapture().pushChunk(pcmChunk(200));
+      h.getCapture().pushAmplitude(0.0);
+      h.getCapture().pushChunk(pcmChunk(1000));
+    });
+    expect(h.client.pttReleaseCount).toBe(1);
+    expect(h.view.result.current.state).toBe("transcribing");
+
+    // Client-local amplitude barge-in fires again and ends the (manual,
+    // single-turn) session — no silent hang against the older daemon.
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 3,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+    });
+    expect(h.view.result.current.state).toBe("speaking");
+    act(() => {
+      h.getCapture().pushAmplitude(0.3);
+    });
+    expect(h.client.interruptCount).toBe(1);
+    expect(h.view.result.current.state).toBe("idle");
+    expect(h.client.closed).toBe(true);
+  });
+
+  test("ready echoing server_vad keeps hands-free behaviors disabled", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    act(() => {
+      h.getCapture().pushAmplitude(0.1);
+      h.getCapture().pushChunk(pcmChunk(200));
+      h.getCapture().pushAmplitude(0.0);
+      h.getCapture().pushChunk(pcmChunk(2000));
+    });
+
+    expect(h.client.pttReleaseCount).toBe(0);
+    expect(h.view.result.current.state).toBe("listening");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Recoverable errors (hands-free survives; manual stays fatal)
+// ---------------------------------------------------------------------------
+
+describe("recoverable errors", () => {
+  test("hands-free: a recoverable error returns to listening and the session continues", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    act(() => {
+      h.client.emit("utteranceEnd", {
+        type: "utterance_end",
+        seq: 2,
+        reason: "silence",
+      });
+    });
+    expect(h.view.result.current.state).toBe("transcribing");
+
+    act(() => {
+      h.client.emit("error", {
+        reason: "protocol-error",
+        message: "whisper poll failed",
+        recoverable: true,
+      });
+    });
+
+    expect(h.view.result.current.state).toBe("listening");
+    expect(h.view.result.current.error).toBe(null);
+    expect(h.client.closed).toBe(false);
+    expect(h.getCapture().shutdownCount).toBe(0);
+
+    // The conversation keeps going on the same socket.
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 3, turnId: "t1" });
+    });
+    expect(h.view.result.current.state).toBe("thinking");
+  });
+
+  test("hands-free: a recoverable error mid-turn leaves the current status alone", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+    });
+    act(() => {
+      h.client.emit("error", {
+        reason: "protocol-error",
+        message: "one TTS segment failed",
+        recoverable: true,
+      });
+    });
+
+    expect(h.view.result.current.state).toBe("thinking");
+    expect(h.client.closed).toBe(false);
+  });
+
+  test("manual mode: a recoverable error is still fatal", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    act(() => {
+      h.client.emit("error", {
+        reason: "protocol-error",
+        message: "transient blip",
+        recoverable: true,
+      });
+    });
+
+    expect(h.view.result.current.state).toBe("failed");
+    expect(h.view.result.current.error).toBe("transient blip");
+    expect(h.client.closed).toBe(true);
+    expect(h.getCapture().shutdownCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// utterance_discarded (hands-free)
+// ---------------------------------------------------------------------------
+
+describe("utterance_discarded", () => {
+  test("a noise-only utterance returns to listening instead of sticking in transcribing", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    act(() => {
+      h.client.emit("speechStarted", { type: "speech_started", seq: 2 });
+      h.client.emit("utteranceEnd", {
+        type: "utterance_end",
+        seq: 3,
+        reason: "silence",
+      });
+    });
+    expect(h.view.result.current.state).toBe("transcribing");
+
+    // A whitespace-only final never starts a server turn; stay transcribing
+    // so the discard can safely resolve the utterance.
+    act(() => {
+      h.client.emit("sttFinal", { type: "stt_final", seq: 4, text: " " });
+    });
+    expect(h.view.result.current.state).toBe("transcribing");
+
+    act(() => {
+      h.client.emit("utteranceDiscarded", {
+        type: "utterance_discarded",
+        seq: 5,
+      });
+    });
+    expect(h.view.result.current.state).toBe("listening");
+    expect(h.client.closed).toBe(false);
+  });
+
+  test("does not clobber a newer turn's thinking", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    act(() => {
+      h.client.emit("utteranceEnd", {
+        type: "utterance_end",
+        seq: 2,
+        reason: "silence",
+      });
+    });
+    // A newer utterance's turn starts before the stale discard arrives.
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 3, turnId: "t2" });
+    });
+    expect(h.view.result.current.state).toBe("thinking");
+
+    act(() => {
+      h.client.emit("utteranceDiscarded", {
+        type: "utterance_discarded",
+        seq: 4,
+      });
+    });
+    expect(h.view.result.current.state).toBe("thinking");
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -31,7 +31,12 @@
  * playback and opens the next utterance, `utterance_end` marks transcription,
  * and `turn_cancelled` drops a barged-in turn's playback. The client-local
  * silence auto-release and amplitude barge-in below are disabled in this mode.
- * The session ends only on user toggle-off, `busy`, `error`, or socket close.
+ * The session ends only on user toggle-off, `busy`, a terminal `error`, or
+ * socket close — errors the daemon marks `recoverable` (transient transcriber
+ * or per-segment TTS failures) keep the conversation alive. If the daemon's
+ * `ready` does not echo `turnDetection: "server_vad"` (older daemon that
+ * ignored the request), the session falls back to full manual behavior so it
+ * still works instead of hanging.
  *
  * ## State transitions
  * Manual (one session = one turn): `idle → connecting` (start) → `listening`
@@ -318,8 +323,15 @@ export function useLiveVoice(
         sessionRef.current === session && session.generation === generation;
 
       session.unsubscribes.push(
-        client.on("ready", () => {
+        client.on("ready", (frame) => {
           if (!live()) return;
+          // Version skew: an older daemon ignores the start frame's
+          // turnDetection and runs a manual session without echoing the mode.
+          // Fall back to manual behavior (auto-release, amplitude barge-in,
+          // single-turn teardown) so the session works instead of hanging.
+          if (session.handsFree && frame.turnDetection !== "server_vad") {
+            session.handsFree = false;
+          }
           void startCapture(session, teardown);
         }),
         client.on("speechStarted", () => {
@@ -334,6 +346,15 @@ export function useLiveVoice(
           if (!live() || !session.handsFree) return;
           // Server VAD closed the utterance; its transcription is finishing.
           useLiveVoiceStore.getState().setState("transcribing");
+        }),
+        client.on("utteranceDiscarded", () => {
+          if (!live() || !session.handsFree) return;
+          // The closed utterance had no usable speech (noise/cough); return
+          // to listening. A discarded utterance never reaches `thinking`
+          // (empty finals stay in `transcribing`), so any other state belongs
+          // to a newer turn and is left alone.
+          const s = useLiveVoiceStore.getState();
+          if (s.state === "transcribing") s.setState("listening");
         }),
         client.on("sttPartial", (frame) => {
           if (!live()) return;
@@ -361,6 +382,10 @@ export function useLiveVoice(
             return;
           }
           if (session.handsFree) {
+            // An empty final never starts a server turn (the utterance will
+            // be discarded); stay in `transcribing` so `utterance_discarded`
+            // can safely return to `listening` without racing a real turn.
+            if (frame.text.trim().length === 0) return;
             // The next turn now owns the state: a prior turn's drain waiter
             // must not reset it to `listening` if it resolves before the
             // server's `thinking` frame (which re-bumps; the guard only
@@ -418,6 +443,15 @@ export function useLiveVoice(
         }),
         client.on("error", (err: LiveVoiceClientError) => {
           if (!live()) return;
+          // Hands-free: a recoverable error (transient transcriber blip,
+          // one failed TTS segment) must not kill the conversation. Resume
+          // listening unless a turn is mid-flight; the transport stayed open.
+          if (session.handsFree && err.recoverable === true) {
+            console.warn(`live-voice: recoverable error: ${err.message}`);
+            const s = useLiveVoiceStore.getState();
+            if (s.state === "transcribing") s.setState("listening");
+            return;
+          }
           finishWithError(session, teardown, err.message);
         }),
         client.on("closed", () => {


### PR DESCRIPTION
## Summary
Fixes the remaining round-1 review gaps for live-voice-server-barge-in.md:
- ready now echoes the session's turnDetection; a hands-free client that doesn't get server_vad back falls back to full manual behavior (older daemons no longer cause a silent hang)
- transcriber-transient and per-segment TTS error frames are marked recoverable; hands-free clients keep the conversation alive instead of tearing down (manual mode unchanged; old daemons unaffected)
- utterance_discarded is handled by the web client: a noise-triggered empty utterance returns the UI to listening without clobbering a newer turn