### PR TITLE
test(ces): fix flaky onTransportClose tests by polling instead of fixed sleep

### DIFF
--- a/assistant/src/credential-execution/process-manager.test.ts
+++ b/assistant/src/credential-execution/process-manager.test.ts
@@ -14,6 +14,18 @@ import {
 
 import { createCesProcessManager, logCesLine } from "./process-manager.js";
 
+// Poll until `predicate` holds or the deadline passes. Fixed sleeps flake on
+// loaded CI runners where socket-close events take >50ms to propagate.
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 2000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate() && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
 function makeLogger() {
   return {
     debug: mock((_obj: object, _msg: string) => {}),
@@ -156,7 +168,9 @@ describe("CesProcessManager.onTransportClose", () => {
       connections.push(socket);
       socket.on("error", () => {});
     });
-    await new Promise<void>((resolve) => server.listen(mockSocketPath, resolve));
+    await new Promise<void>((resolve) =>
+      server.listen(mockSocketPath, resolve),
+    );
   });
 
   afterEach(async () => {
@@ -188,8 +202,8 @@ describe("CesProcessManager.onTransportClose", () => {
       sock.destroy();
     }
 
-    // Give the close event a tick to propagate.
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    // Wait for the close event to propagate (poll — timing varies on CI).
+    await waitFor(() => closeFired);
 
     expect(closeFired).toBe(true);
     expect(transport.isAlive()).toBe(false);
@@ -221,7 +235,7 @@ describe("CesProcessManager.onTransportClose", () => {
     for (const sock of connections) {
       sock.destroy();
     }
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await waitFor(() => !transport.isAlive());
     expect(transport.isAlive()).toBe(false);
 
     // Register handler AFTER transport is already dead.


### PR DESCRIPTION
## Summary
- The `onTransportClose` tests in `process-manager.test.ts` waited a fixed 50ms for the socket-close event to propagate, then asserted. On loaded Linux CI runners that propagation occasionally exceeds 50ms, so "fires handler when the transport dies" intermittently failed with `closeFired` still `false`.
- Replaced the two condition-waiting sleeps with a small `waitFor(predicate)` poll (5ms interval, 2s cap). The negative-assertion test ("does not fire before the transport dies") keeps its fixed wait — it must give a spurious fire time to happen.

## Original prompt
Fix the flaky test `src/credential-execution/process-manager.test.ts`. It passes locally and in most CI runs but intermittently fails on the Linux runner at `expect(closeFired).toBe(true)` — the socket-close event hadn't propagated within the hardcoded 50ms window. The fix is to poll for the awaited condition rather than sleeping a fixed duration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->