### PR TITLE
chore: align dev setup, git hooks, and docs with the workspace

### DIFF
--- a/.githooks/bun-install-if-deps-changed.sh
+++ b/.githooks/bun-install-if-deps-changed.sh
@@ -1,19 +1,17 @@
 #!/usr/bin/env bash
 #
-# Re-run `bun install` in each sub-package whose `package.json` or `bun.lock`
-# changed between two git revisions. Meant to be invoked by `post-merge` and
-# `post-checkout` hooks so a `git pull` / branch switch that adds a new
-# dependency does not leave `node_modules` stale.
+# Re-run `bun install` after a pull or branch switch changes dependency
+# inputs, so node_modules doesn't go stale.
 #
-# This repo has no root manifest — every package lives in its own sub-dir
-# (assistant/, cli/, gateway/, credential-executor/, packages/*, etc.) with
-# its own package.json and bun.lock.
+# One root install covers every workspace member. Directories outside the
+# workspace (clients/chrome-extension, clients/ios, scripts) keep their own
+# lockfiles and get a per-directory install when their manifest changes.
 #
 # Usage: bun-install-if-deps-changed.sh <OLD_SHA> <NEW_SHA>
 #
-# Silent no-op when OLD == NEW or when no dep-tracking file changed.
-# Emits a warning (and exits 0) when `bun` is not executable so `git pull`
-# never fails because of this hook.
+# Silent no-op when OLD == NEW or when no dependency input changed. Emits a
+# warning (and exits 0) when `bun` is not executable so `git pull` never
+# fails because of this hook.
 
 set -u
 
@@ -24,8 +22,6 @@ if [ -z "$OLD" ] || [ -z "$NEW" ] || [ "$OLD" = "$NEW" ]; then
     exit 0
 fi
 
-# Handle the null SHA git passes for post-checkout when a branch is created
-# from an unborn HEAD. Nothing to compare against.
 NULL_SHA="0000000000000000000000000000000000000000"
 if [ "$OLD" = "$NULL_SHA" ] || [ "$NEW" = "$NULL_SHA" ]; then
     exit 0
@@ -36,76 +32,70 @@ if [ -z "$REPO_ROOT" ]; then
     exit 0
 fi
 
-# List changed paths; bail quietly if git can't produce a diff for this range
-# (e.g. one side is unknown to this worktree).
 changed="$(git diff --name-only "$OLD" "$NEW" -- 2>/dev/null || true)"
 if [ -z "$changed" ]; then
     exit 0
 fi
 
-if ! printf '%s\n' "$changed" | grep -Eq '(^|/)(package\.json|bun\.lock)$'; then
+deps_changed="$(printf '%s\n' "$changed" | grep -E '(^|/)(package\.json|bun\.lock)$|^patches/|^clients/web/patches/' || true)"
+if [ -z "$deps_changed" ]; then
     exit 0
 fi
 
-# Git hooks run in non-interactive shells where ~/.zshrc PATH tweaks aren't
-# sourced, so fall back to the default bun install location.
 BUN="${BUN:-$(command -v bun 2>/dev/null || echo "$HOME/.bun/bin/bun")}"
-
 if [ ! -x "$BUN" ]; then
-    echo "[git-hook] package.json/bun.lock changed but 'bun' is not available at $BUN — skipping bun install." >&2
-    echo "[git-hook] Run 'bun install' manually once bun is available." >&2
+    echo "[git-hook] Dependency inputs changed but 'bun' is not available at $BUN — run 'bun install' manually." >&2
     exit 0
 fi
 
-# Derive unique sub-package dirs that had a manifest change. Strip the trailing
-# `package.json` / `bun.lock` segment to get the package dir (empty string means
-# the repo root, which we skip since there is no root manifest).
-pkgs="$(printf '%s\n' "$changed" \
-    | grep -E '(^|/)(package\.json|bun\.lock)$' \
-    | sed -E 's#/?(package\.json|bun\.lock)$##' \
-    | awk 'NF' \
-    | sort -u)"
+# Non-member directories that manage their own lockfiles. meta/ and plugin
+# dirs are skipped: meta ships only bin/+Dockerfile, and plugin manifests
+# declare only peerDependencies.
+NON_MEMBER_DIRS="clients/chrome-extension clients/ios scripts"
 
-if [ -z "$pkgs" ]; then
-    exit 0
-fi
+run_root_install=0
+non_member_installs=""
 
-# Sub-package dirs we never want to auto-install in:
-#   meta/                — thin installer wrapper, only workspace dep links,
-#                          ships only bin/+Dockerfile per package.json `files`.
-#   plugins/* , */plugins/*
-#                        — plugin packages declare only peerDependencies. The
-#                          resulting bun.lock is empty noise and regenerates
-#                          non-deterministically. Plugins live at the repo-root
-#                          `plugins/` dir as well as nested example dirs.
-# A manual `bun install` in these dirs still works — this just keeps the
-# auto-install hook from making `git status` dirty after every pull/switch.
-should_skip_pkg() {
-    case "$1" in
-        meta) return 0 ;;
-        plugins/*) return 0 ;;
-        */plugins/*) return 0 ;;
+while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    dir="${path%/*}"
+    case "$path" in
+        package.json|bun.lock|patches/*|clients/web/patches/*) run_root_install=1; continue ;;
     esac
-    return 1
-}
-
-# Serialize installs — parallel bun runs can contend on the shared ~/.bun cache.
-while IFS= read -r pkg; do
-    [ -n "$pkg" ] || continue
-    if should_skip_pkg "$pkg"; then
-        echo "[git-hook] Skipping 'bun install' in $pkg (excluded — see hook source)." >&2
-        continue
-    fi
-    target="$REPO_ROOT/$pkg"
-    [ -d "$target" ] || continue
-    [ -f "$target/package.json" ] || continue
-    echo "[git-hook] Dependency manifest changed — running 'bun install' in $pkg..." >&2
-    ( cd "$target" && "$BUN" install ) || {
-        status=$?
-        echo "[git-hook] 'bun install' in $pkg exited with status $status. Run it manually to investigate." >&2
-    }
+    case "$dir" in
+        meta|meta/*|plugins/*|*/plugins/*) continue ;;
+    esac
+    matched=0
+    for nm in $NON_MEMBER_DIRS; do
+        case "$dir" in
+            "$nm"|"$nm"/*)
+                case " $non_member_installs " in
+                    *" $nm "*) ;;
+                    *) non_member_installs="$non_member_installs $nm" ;;
+                esac
+                matched=1
+                break
+                ;;
+        esac
+    done
+    [ "$matched" = "1" ] || run_root_install=1
 done <<EOF
-$pkgs
+$deps_changed
 EOF
+
+if [ "$run_root_install" = "1" ]; then
+    echo "[git-hook] Dependency inputs changed — running 'bun install' at the workspace root..." >&2
+    (cd "$REPO_ROOT" && "$BUN" install) || {
+        echo "[git-hook] 'bun install' exited with status $?. Run it manually to investigate." >&2
+    }
+fi
+
+for nm in $non_member_installs; do
+    [ -f "$REPO_ROOT/$nm/package.json" ] || continue
+    echo "[git-hook] Manifest changed in $nm — running 'bun install' there..." >&2
+    (cd "$REPO_ROOT/$nm" && "$BUN" install) || {
+        echo "[git-hook] 'bun install' in $nm exited with status $?. Run it manually to investigate." >&2
+    }
+done
 
 exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Defend technical positions with evidence. Don't flip-flop to placate the user â€
 - **Package manager**: This is a bun workspace. One root `bun.lock` covers every member (services, `packages/*`, `clients/web`, `clients/macos`, `clients/windows`). Run `bun install` anywhere in the tree (it resolves to the workspace root), or scope it with name filters like `--filter=@vellumai/assistant` (path filters resolve against the cwd, so avoid them). Cross-package deps use `workspace:*`; `overrides`, `patchedDependencies`, and `trustedDependencies` are honored only in the root manifest. Non-members (`clients/chrome-extension`, skills) keep their own lockfiles.
 
 ```bash
-cd assistant && bun install          # Install dependencies
+bun install                          # Install workspace dependencies (any directory works)
 cd assistant && bunx tsc --noEmit    # Type-check
 cd assistant && bun run typecheck:fast  # Fast type-check using tsgo
 cd assistant && bun test src/path/to/changed.test.ts  # Run tests

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -28,7 +28,7 @@ For assistant architecture deep dives, see [`ARCHITECTURE.md`](ARCHITECTURE.md) 
 
 ```bash
 cd assistant
-bun install
+bun install   # installs the whole workspace
 cp .env.example .env
 # Edit .env with your API keys
 ```

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -189,7 +189,7 @@ whichever Swift channel you have around.
 bun run dev                # probe vel-up at :3000, dispatch to dev:electron-only or dev:standalone
 bun run dev:standalone     # explicit: spawn our Vite (:5173) + electron-vite dev (no backends)
 bun run dev:electron-only  # explicit: electron-vite dev only, honors $VELLUM_DEV_URL (default :5173)
-bun run install:all        # bun install in clients/macos and clients/web (called automatically by dev)
+bun run install:all        # workspace bun install + Electron setup (called automatically by dev)
 bun run dev:web            # clients/web Vite (port 5173, strict) — invoked by dev:standalone
 bun run dev:electron       # wait for :5173 (hang capture on timeout) then electron-vite dev — invoked by dev:standalone
 bun run build              # electron-vite build — bundles main + preload to out/

--- a/clients/web/AGENTS.md
+++ b/clients/web/AGENTS.md
@@ -64,7 +64,7 @@ pattern (`assistant/docs/`, `docs/` at the repo root).
 ## Commands
 
 ```bash
-cd clients/web && bun install            # Install dependencies
+bun install                              # Install workspace dependencies (any directory works)
 cd clients/web && bun run dev            # Vite dev server (port 3000)
 cd clients/web && bun run openapi-ts     # Generate API client from OpenAPI specs
 cd clients/web && bunx tsc --noEmit      # Type-check

--- a/clients/web/README.md
+++ b/clients/web/README.md
@@ -26,7 +26,7 @@ Vellum assistant web app (chat, settings, library, docs).
 
 ```bash
 cd clients/web
-bun install
+bun install   # installs the whole workspace
 bun run openapi-ts  # generate API client (required before typecheck/dev)
 bun run dev         # Vite dev server on localhost:3000
 ```

--- a/setup.sh
+++ b/setup.sh
@@ -2,9 +2,9 @@
 #
 # setup.sh — One-time local development setup for vellum-assistant.
 #
-# Installs dependencies for each package, registers local packages as
-# linkable, links them into the meta package, and then links the global
-# `vellum` command to the local meta entry point.
+# Installs workspace dependencies, registers local packages as linkable,
+# links them into the meta package, and then links the global `vellum`
+# command to the local meta entry point.
 #
 # Usage:
 #   ./setup.sh
@@ -45,11 +45,15 @@ info "Configuring git hooks"
 git config core.hooksPath .githooks
 
 # ---------------------------------------------------------------------------
-# Install dependencies and register local packages as linkable
+# Install workspace dependencies (one install covers every member)
+# ---------------------------------------------------------------------------
+info "Installing workspace dependencies"
+(cd "${REPO_ROOT}" && bun install)
+
+# ---------------------------------------------------------------------------
+# Register local packages as linkable
 # ---------------------------------------------------------------------------
 for dir in cli gateway assistant credential-executor; do
-  info "Installing dependencies in ${dir}/"
-  (cd "${REPO_ROOT}/${dir}" && bun install)
   info "Registering ${dir}/ as a linkable package"
   (cd "${REPO_ROOT}/${dir}" && bun link)
 done
@@ -59,32 +63,6 @@ done
 # ---------------------------------------------------------------------------
 info "Installing dependencies in scripts/"
 (cd "${REPO_ROOT}/scripts" && bun install)
-
-# ---------------------------------------------------------------------------
-# Install dependencies for packages in packages/
-# ---------------------------------------------------------------------------
-for dir in "${REPO_ROOT}"/packages/*/; do
-  [ -f "${dir}/package.json" ] || continue
-  pkg="$(basename "${dir}")"
-  info "Installing dependencies in packages/${pkg}/"
-  (cd "${dir}" && bun install)
-done
-
-# ---------------------------------------------------------------------------
-# Install dependencies for skills that have their own package.json
-#
-# assistant/src/daemon/external-skills-bootstrap.ts statically imports
-# skills/meet-join/register.ts, so `tsc --noEmit` in assistant/ follows the
-# import into the skill and needs the skill's own node_modules to resolve
-# transitive imports. Missing deps surface as false-positive "Cannot find
-# module" errors.
-# ---------------------------------------------------------------------------
-for dir in "${REPO_ROOT}"/skills/*/; do
-  [ -f "${dir}/package.json" ] || continue
-  pkg="$(basename "${dir}")"
-  info "Installing dependencies in skills/${pkg}/"
-  (cd "${dir}" && bun install)
-done
 
 # ---------------------------------------------------------------------------
 # Link local packages into meta so it resolves to local source


### PR DESCRIPTION
Dev-experience cleanup after the workspace migration:

- `setup.sh`: one root `bun install` replaces the per-package and `packages/*` loops (~18 redundant workspace installs) and the skills loop, which iterates over nothing — no skill has its own package.json anymore. The `bun link` flow is unchanged and verified.
- `.githooks/bun-install-if-deps-changed.sh`: rewritten workspace-aware — one root install on any dependency-input change (including root lockfile/patches/overrides, previously skipped), per-directory installs only for non-members (chrome-extension, ios, scripts). Behavior tested against real history ranges: member changes → root install, docs-only → no-op, release bumps → root + affected non-members.
- Docs: five spots that still described per-package installs now say workspace-wide.

setup.sh was run end-to-end after the rewrite: install, link registration, meta linking, completions all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)