### PR TITLE
feat(web): Channels page — drop redundant heading, replace accordion with adapter sub-tabs

### DIFF
--- a/clients/web/src/components/empty-state.stories.tsx
+++ b/clients/web/src/components/empty-state.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Button } from "@vellumai/design-library";
+import { Inbox, Send } from "lucide-react";
+
+import { EmptyState } from "@/components/empty-state";
+
+const meta: Meta<typeof EmptyState> = {
+  title: "Components/EmptyState",
+  component: EmptyState,
+  args: {
+    icon: <Inbox className="h-6 w-6" />,
+    title: "Nothing here yet",
+    description: "Items you add will show up in this list.",
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 640, margin: "2rem auto" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof EmptyState>;
+
+export const Default: Story = {};
+
+/** With a call-to-action, as used by the disconnected channel tabs. */
+export const WithAction: Story = {
+  args: {
+    icon: <Send className="h-6 w-6" />,
+    title: "Telegram isn't connected",
+    description:
+      "Connect a Telegram bot so your assistant can send and receive messages on Telegram.",
+    action: <Button variant="outlined">Set up</Button>,
+  },
+};
+
+/** Text-only, no icon well or action. */
+export const TextOnly: Story = {
+  args: {
+    icon: undefined,
+    title: "No results",
+    description: "Try a different search term.",
+    action: undefined,
+  },
+};

--- a/clients/web/src/components/empty-state.tsx
+++ b/clients/web/src/components/empty-state.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@vellumai/design-library";
+
+export interface EmptyStateProps {
+  /** Glyph or brand mark rendered inside the icon well. */
+  icon?: ReactNode;
+  title: string;
+  description?: ReactNode;
+  /** Call-to-action slot, typically a design-library `Button`. */
+  action?: ReactNode;
+  className?: string;
+}
+
+/**
+ * Centered placeholder for a surface with nothing to show yet: an optional
+ * icon well, a short title, a one-line description, and an action slot.
+ * Domain-agnostic — callers supply all content via props.
+ */
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center gap-3 px-4 py-12 text-center",
+        className,
+      )}
+    >
+      {icon ? (
+        <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-[var(--surface-sunken)] text-[var(--content-tertiary)]">
+          {icon}
+        </div>
+      ) : null}
+      <h3 className="text-title-small text-[var(--content-default)]">{title}</h3>
+      {description ? (
+        <p className="max-w-md text-body-medium-lighter text-[color:var(--content-tertiary)]">
+          {description}
+        </p>
+      ) : null}
+      {action ? <div className="mt-1">{action}</div> : null}
+    </div>
+  );
+}

--- a/clients/web/src/domains/contacts/channels-page.tsx
+++ b/clients/web/src/domains/contacts/channels-page.tsx
@@ -15,12 +15,13 @@ export interface ChannelsPageProps {
 }
 
 /**
- * Channels settings — the Slack/Telegram/Phone accordion where the guardian
+ * Channels settings — the Slack/Telegram/Phone sub-tabs where the guardian
  * manages how and where the assistant can be reached. Rendered as its own tab
- * in the About Assistant nav (`/assistant/channels`): a page-level heading
- * above the channel list, like the sibling tabs. The Contacts page's
- * assistant detail renders the same list boxed as a card
- * (`AssistantChannelsDetail`); both compose `useAssistantChannels`.
+ * in the About Assistant nav (`/assistant/channels`): a page-level subtitle
+ * above the tabbed content (the nav's tab already reads "Channels", so the
+ * page repeats no heading). The Contacts page's assistant detail renders the
+ * same tabs boxed as a card (`AssistantChannelsDetail`); both compose
+ * `useAssistantChannels`.
  */
 export function ChannelsPage({
   assistantId,
@@ -42,14 +43,13 @@ export function ChannelsPage({
     <div className="flex flex-col gap-6">
       <DetailCard
         showBorder={false}
-        title="Channels"
         subtitle={`Manage where ${displayName} can be reached.`}
       />
 
       <DetailCard>
         <AssistantChannelsList
           assistantName={displayName}
-          initialExpandedChannel={setupChannel}
+          initialChannel={setupChannel}
           {...channelsController}
         />
       </DetailCard>

--- a/clients/web/src/domains/contacts/channels-page.tsx
+++ b/clients/web/src/domains/contacts/channels-page.tsx
@@ -28,6 +28,9 @@ export function ChannelsPage({
   onStartSetupConversation,
 }: ChannelsPageProps) {
   const a2aChannel = useAssistantFeatureFlagStore.use.a2aChannel();
+  // The Channels-tab restructure (sub-tabs + promoted subtitle) ships with
+  // the channel-trust-floors arc; off keeps the titled card + accordion.
+  const tabbedLayout = useAssistantFeatureFlagStore.use.channelTrustFloors();
   const identityName = useAssistantIdentityStore.use.name();
   const setupChannel = useSetupChannelParam();
   const inviteDialog = useInviteLinkDialog(assistantId);
@@ -43,6 +46,7 @@ export function ChannelsPage({
     <div className="flex flex-col gap-6">
       <DetailCard
         showBorder={false}
+        title={tabbedLayout ? undefined : "Channels"}
         subtitle={`Manage where ${displayName} can be reached.`}
       />
 

--- a/clients/web/src/domains/contacts/components/assistant-channels-detail.stories.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-detail.stories.tsx
@@ -29,7 +29,10 @@ const meta: Meta<typeof AssistantChannelsDetail> = {
   },
   decorators: [
     (Story) => {
-      useAssistantFeatureFlagStore.setState({ channelTrustFloors: true });
+      useAssistantFeatureFlagStore.setState({
+        channelTrustFloors: true,
+        hasHydrated: true,
+      });
       return (
         <div style={{ maxWidth: 800, margin: "2rem auto" }}>
           <Story />
@@ -49,7 +52,10 @@ export const ContactsDetailView: Story = {};
 export const ContactsDetailViewLegacy: Story = {
   decorators: [
     (Story) => {
-      useAssistantFeatureFlagStore.setState({ channelTrustFloors: false });
+      useAssistantFeatureFlagStore.setState({
+        channelTrustFloors: false,
+        hasHydrated: true,
+      });
       return <Story />;
     },
   ],

--- a/clients/web/src/domains/contacts/components/assistant-channels-detail.stories.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-detail.stories.tsx
@@ -1,11 +1,15 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
+
 import { AssistantChannelsDetail } from "./assistant-channels-detail";
 
 /**
  * The assistant's entry in the Contacts detail pane: identity header card +
  * boxed "Channels" card. The standalone Channels tab composition lives in
- * `assistant-channels-list.stories.tsx`.
+ * `assistant-channels-list.stories.tsx`. The card renders the shared
+ * `AssistantChannelsList`, whose layout is gated on `channel-trust-floors`
+ * (sub-tabs on, accordion off).
  */
 const meta: Meta<typeof AssistantChannelsDetail> = {
   title: "Contacts/AssistantChannelsDetail",
@@ -24,11 +28,14 @@ const meta: Meta<typeof AssistantChannelsDetail> = {
     onSaveTwilioCredentials: async () => {},
   },
   decorators: [
-    (Story) => (
-      <div style={{ maxWidth: 800, margin: "2rem auto" }}>
-        <Story />
-      </div>
-    ),
+    (Story) => {
+      useAssistantFeatureFlagStore.setState({ channelTrustFloors: true });
+      return (
+        <div style={{ maxWidth: 800, margin: "2rem auto" }}>
+          <Story />
+        </div>
+      );
+    },
   ],
 };
 
@@ -37,3 +44,13 @@ export default meta;
 type Story = StoryObj<typeof AssistantChannelsDetail>;
 
 export const ContactsDetailView: Story = {};
+
+/** The accordion layout rendered while `channel-trust-floors` is off. */
+export const ContactsDetailViewLegacy: Story = {
+  decorators: [
+    (Story) => {
+      useAssistantFeatureFlagStore.setState({ channelTrustFloors: false });
+      return <Story />;
+    },
+  ],
+};

--- a/clients/web/src/domains/contacts/components/assistant-channels-detail.test.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-detail.test.tsx
@@ -1,10 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 
 import { AssistantChannelsDetail } from "@/domains/contacts/components/assistant-channels-detail";
 import { AssistantChannelsList } from "@/domains/contacts/components/assistant-channels-list";
 import type { AssistantChannelState } from "@/domains/contacts/types";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 const CHANNELS: AssistantChannelState[] = [
   { key: "slack", status: "ready", address: "@vex" },
@@ -12,8 +13,13 @@ const CHANNELS: AssistantChannelState[] = [
   { key: "phone", status: "not_configured" },
 ];
 
+function setTabbedLayout(enabled: boolean) {
+  useAssistantFeatureFlagStore.setState({ channelTrustFloors: enabled });
+}
+
 afterEach(() => {
   cleanup();
+  setTabbedLayout(false);
 });
 
 describe("assistant channels surfaces", () => {
@@ -26,11 +32,52 @@ describe("assistant channels surfaces", () => {
     expect(document.body.textContent).toContain("Slack");
   });
 
-  test("the bare channel tabs (standalone Channels tab) have no identity card", () => {
+  test("the bare channel list (standalone Channels tab) has no identity card", () => {
     render(<AssistantChannelsList assistantName="Vex" channels={CHANNELS} />);
     expect(document.body.textContent).not.toContain("Vex (Your Assistant)");
     expect(document.body.textContent).toContain("Slack");
     expect(document.body.textContent).toContain("Telegram");
+  });
+
+  test("channel-trust-floors off renders the accordion rows", () => {
+    setTabbedLayout(false);
+    render(<AssistantChannelsList assistantName="Vex" channels={CHANNELS} />);
+    expect(document.body.textContent).toContain("Phone Calling");
+    // Accordion rows surface per-channel Set up buttons inline.
+    expect(document.body.textContent).toContain("Set up");
+    expect(document.querySelector('[data-slot="tabs"]')).toBeNull();
+  });
+
+  test("channel-trust-floors on renders the adapter sub-tabs", () => {
+    setTabbedLayout(true);
+    render(<AssistantChannelsList assistantName="Vex" channels={CHANNELS} />);
+    expect(document.querySelector('[data-slot="tabs"]')).not.toBeNull();
     expect(document.body.textContent).toContain("Phone");
+    expect(document.body.textContent).not.toContain("Phone Calling");
+    // Slack (connected) is the default tab: Tag chip + disconnect affordance.
+    expect(document.body.textContent).toContain("Connected");
+    expect(document.body.textContent).toContain("Disconnect");
+  });
+
+  test("disconnected tab swaps the empty state for the manual form on request", () => {
+    setTabbedLayout(true);
+    render(
+      <AssistantChannelsList
+        assistantName="Vex"
+        channels={CHANNELS}
+        initialChannel="telegram"
+      />,
+    );
+    expect(document.body.textContent).toContain("Telegram isn't connected");
+    expect(document.body.textContent).not.toContain("Bot Token");
+
+    const manualButton = Array.from(document.querySelectorAll("button")).find(
+      (b) => b.textContent?.includes("or connect manually"),
+    );
+    expect(manualButton).toBeDefined();
+    fireEvent.click(manualButton!);
+
+    expect(document.body.textContent).toContain("Bot Token");
+    expect(document.body.textContent).not.toContain("Telegram isn't connected");
   });
 });

--- a/clients/web/src/domains/contacts/components/assistant-channels-detail.test.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-detail.test.tsx
@@ -93,13 +93,15 @@ describe("assistant channels surfaces", () => {
 
   test("disconnected tab swaps the empty state for the manual form on request", () => {
     setTabbedLayout(true);
-    render(
-      <AssistantChannelsList
-        assistantName="Vex"
-        channels={CHANNELS}
-        initialChannel="telegram"
-      />,
-    );
+    render(<AssistantChannelsList assistantName="Vex" channels={CHANNELS} />);
+
+    const telegramTab = Array.from(
+      document.querySelectorAll('[data-slot="tabs-trigger"]'),
+    ).find((t) => t.textContent === "Telegram");
+    expect(telegramTab).toBeDefined();
+    // Radix tab triggers select on mousedown (automatic activation), not click.
+    fireEvent.mouseDown(telegramTab!, { button: 0 });
+
     expect(document.body.textContent).toContain("Telegram isn't connected");
     expect(document.body.textContent).not.toContain("Bot Token");
 
@@ -109,6 +111,22 @@ describe("assistant channels surfaces", () => {
     expect(manualButton).toBeDefined();
     fireEvent.click(manualButton!);
 
+    expect(document.body.textContent).toContain("Bot Token");
+    expect(document.body.textContent).not.toContain("Telegram isn't connected");
+  });
+
+  test("a setup deep link opens the manual form directly", () => {
+    // The mobile chat-drawer handoff navigates to `?setup=<channel>` to
+    // continue credential entry here — it must land on the form, not the
+    // empty state whose Set up button would start another conversation.
+    setTabbedLayout(true);
+    render(
+      <AssistantChannelsList
+        assistantName="Vex"
+        channels={CHANNELS}
+        initialChannel="telegram"
+      />,
+    );
     expect(document.body.textContent).toContain("Bot Token");
     expect(document.body.textContent).not.toContain("Telegram isn't connected");
   });

--- a/clients/web/src/domains/contacts/components/assistant-channels-detail.test.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-detail.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
@@ -13,13 +13,26 @@ const CHANNELS: AssistantChannelState[] = [
   { key: "phone", status: "not_configured" },
 ];
 
+// Flag values are only authoritative once /feature-flags has hydrated;
+// pre-hydration the list renders a loading placeholder instead of
+// committing to a layout (see the hydration gate in AssistantChannelsList).
 function setTabbedLayout(enabled: boolean) {
-  useAssistantFeatureFlagStore.setState({ channelTrustFloors: enabled });
+  useAssistantFeatureFlagStore.setState({
+    channelTrustFloors: enabled,
+    hasHydrated: true,
+  });
 }
+
+beforeEach(() => {
+  setTabbedLayout(false);
+});
 
 afterEach(() => {
   cleanup();
-  setTabbedLayout(false);
+  useAssistantFeatureFlagStore.setState({
+    channelTrustFloors: false,
+    hasHydrated: false,
+  });
 });
 
 describe("assistant channels surfaces", () => {
@@ -57,6 +70,25 @@ describe("assistant channels surfaces", () => {
     // Slack (connected) is the default tab: Tag chip + disconnect affordance.
     expect(document.body.textContent).toContain("Connected");
     expect(document.body.textContent).toContain("Disconnect");
+  });
+
+  test("renders a loading placeholder while a false flag is unhydrated", () => {
+    useAssistantFeatureFlagStore.setState({
+      channelTrustFloors: false,
+      hasHydrated: false,
+    });
+    render(<AssistantChannelsList assistantName="Vex" channels={CHANNELS} />);
+    expect(document.body.textContent).toContain("Loading…");
+    expect(document.body.textContent).not.toContain("Slack");
+  });
+
+  test("an unhydrated true flag (env override) renders the tabs immediately", () => {
+    useAssistantFeatureFlagStore.setState({
+      channelTrustFloors: true,
+      hasHydrated: false,
+    });
+    render(<AssistantChannelsList assistantName="Vex" channels={CHANNELS} />);
+    expect(document.querySelector('[data-slot="tabs"]')).not.toBeNull();
   });
 
   test("disconnected tab swaps the empty state for the manual form on request", () => {

--- a/clients/web/src/domains/contacts/components/assistant-channels-detail.test.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-detail.test.tsx
@@ -26,11 +26,11 @@ describe("assistant channels surfaces", () => {
     expect(document.body.textContent).toContain("Slack");
   });
 
-  test("the bare channel list (standalone Channels tab) has no identity card", () => {
+  test("the bare channel tabs (standalone Channels tab) have no identity card", () => {
     render(<AssistantChannelsList assistantName="Vex" channels={CHANNELS} />);
     expect(document.body.textContent).not.toContain("Vex (Your Assistant)");
     expect(document.body.textContent).toContain("Slack");
     expect(document.body.textContent).toContain("Telegram");
-    expect(document.body.textContent).toContain("Phone Calling");
+    expect(document.body.textContent).toContain("Phone");
   });
 });

--- a/clients/web/src/domains/contacts/components/assistant-channels-detail.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-detail.tsx
@@ -10,9 +10,9 @@ interface AssistantChannelsDetailProps extends AssistantChannelsListProps {
 
 /**
  * The assistant's entry in the Contacts detail pane: the contact-style
- * identity header card followed by the channel list in a "Channels" card.
+ * identity header card followed by the channel sub-tabs in a "Channels" card.
  * The standalone Channels tab renders the same `AssistantChannelsList`
- * under its own page heading instead.
+ * under its own page subtitle instead.
  */
 export function AssistantChannelsDetail({
   onGenerateInviteLink,

--- a/clients/web/src/domains/contacts/components/assistant-channels-list.stories.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-list.stories.tsx
@@ -1,6 +1,7 @@
-import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
 
 import { DetailCard } from "@/components/detail-card";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 import { AssistantChannelsList } from "./assistant-channels-list";
 
@@ -9,7 +10,17 @@ import { AssistantChannelsList } from "./assistant-channels-list";
  * wiring): a borderless page subtitle, then the channel sub-tabs in a card —
  * matching the sibling About Assistant tabs rather than the boxed
  * "Channels" card used inside the Contacts detail view.
+ *
+ * The layout is gated on the `channel-trust-floors` flag: sub-tabs when on,
+ * the accordion rows when off (see the Legacy story).
  */
+const withLayoutFlag = (tabbed: boolean): Decorator => {
+  return (Story) => {
+    useAssistantFeatureFlagStore.setState({ channelTrustFloors: tabbed });
+    return <Story />;
+  };
+};
+
 const meta: Meta<typeof AssistantChannelsList> = {
   title: "Contacts/AssistantChannelsList",
   component: AssistantChannelsList,
@@ -27,6 +38,7 @@ const meta: Meta<typeof AssistantChannelsList> = {
     onSaveTwilioCredentials: async () => {},
   },
   decorators: [
+    withLayoutFlag(true),
     (Story) => (
       <div
         style={{
@@ -66,16 +78,21 @@ export const ChannelsTabSlackConnected: Story = {
   },
 };
 
-/** Disconnected Telegram tab: the empty state above the manual token form. */
+/** Disconnected Telegram tab: empty state with guided setup + manual escape hatch. */
 export const ChannelsTabTelegramDisconnected: Story = {
   args: {
     initialChannel: "telegram",
   },
 };
 
-/** Disconnected Phone tab: the empty state above the Twilio credential form. */
+/** Disconnected Phone tab: empty state with guided setup + manual escape hatch. */
 export const ChannelsTabPhoneDisconnected: Story = {
   args: {
     initialChannel: "phone",
   },
+};
+
+/** The accordion layout rendered while `channel-trust-floors` is off. */
+export const LegacyAccordion: Story = {
+  decorators: [withLayoutFlag(false)],
 };

--- a/clients/web/src/domains/contacts/components/assistant-channels-list.stories.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-list.stories.tsx
@@ -81,17 +81,36 @@ export const ChannelsTabSlackConnected: Story = {
   },
 };
 
-/** Disconnected Telegram tab: empty state with guided setup + manual escape hatch. */
+/**
+ * Disconnected Telegram tab: empty state with guided setup + manual escape
+ * hatch. Telegram is listed first so it's the default tab — `initialChannel`
+ * is reserved for setup deep links, which skip straight to the manual form.
+ */
 export const ChannelsTabTelegramDisconnected: Story = {
   args: {
-    initialChannel: "telegram",
+    channels: [
+      { key: "telegram", status: "not_configured" },
+      { key: "slack", status: "ready", address: "@example-assistant" },
+      { key: "phone", status: "not_configured" },
+    ],
   },
 };
 
 /** Disconnected Phone tab: empty state with guided setup + manual escape hatch. */
 export const ChannelsTabPhoneDisconnected: Story = {
   args: {
-    initialChannel: "phone",
+    channels: [
+      { key: "phone", status: "not_configured" },
+      { key: "slack", status: "ready", address: "@example-assistant" },
+      { key: "telegram", status: "not_configured" },
+    ],
+  },
+};
+
+/** A `?setup=telegram` deep link (mobile chat handoff) lands on the manual form. */
+export const ChannelsTabTelegramSetupHandoff: Story = {
+  args: {
+    initialChannel: "telegram",
   },
 };
 

--- a/clients/web/src/domains/contacts/components/assistant-channels-list.stories.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-list.stories.tsx
@@ -16,7 +16,10 @@ import { AssistantChannelsList } from "./assistant-channels-list";
  */
 const withLayoutFlag = (tabbed: boolean): Decorator => {
   return (Story) => {
-    useAssistantFeatureFlagStore.setState({ channelTrustFloors: tabbed });
+    useAssistantFeatureFlagStore.setState({
+      channelTrustFloors: tabbed,
+      hasHydrated: true,
+    });
     return <Story />;
   };
 };

--- a/clients/web/src/domains/contacts/components/assistant-channels-list.stories.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-list.stories.tsx
@@ -6,7 +6,7 @@ import { AssistantChannelsList } from "./assistant-channels-list";
 
 /**
  * The standalone Channels tab composition (`ChannelsPage` minus its data
- * wiring): a borderless page heading, then the channel accordion in a card —
+ * wiring): a borderless page subtitle, then the channel sub-tabs in a card —
  * matching the sibling About Assistant tabs rather than the boxed
  * "Channels" card used inside the Contacts detail view.
  */
@@ -39,7 +39,6 @@ const meta: Meta<typeof AssistantChannelsList> = {
       >
         <DetailCard
           showBorder={false}
-          title="Channels"
           subtitle="Manage where Example Assistant can be reached."
         />
         <DetailCard>
@@ -56,13 +55,27 @@ type Story = StoryObj<typeof AssistantChannelsList>;
 
 export const ChannelsTab: Story = {};
 
-/** Slack expanded with the trust-floor control, as after a `?setup=slack` deep link. */
-export const ChannelsTabSlackExpanded: Story = {
+/** Connected Slack tab with the trust-floor control, as after a `?setup=slack` deep link. */
+export const ChannelsTabSlackConnected: Story = {
   args: {
-    initialExpandedChannel: "slack",
+    initialChannel: "slack",
     slackThreadMode: "mention_then_thread",
     onSlackThreadModeChange: () => {},
     channelPolicies: { slack: "trusted_contacts" },
     onChannelPolicyChange: () => {},
+  },
+};
+
+/** Disconnected Telegram tab: the empty state above the manual token form. */
+export const ChannelsTabTelegramDisconnected: Story = {
+  args: {
+    initialChannel: "telegram",
+  },
+};
+
+/** Disconnected Phone tab: the empty state above the Twilio credential form. */
+export const ChannelsTabPhoneDisconnected: Story = {
+  args: {
+    initialChannel: "phone",
   },
 };

--- a/clients/web/src/domains/contacts/components/assistant-channels-list.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-list.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle, ChevronDown, ChevronRight } from "lucide-react";
+import { CheckCircle } from "lucide-react";
 import { useState } from "react";
 
 import { Button } from "@vellumai/design-library/components/button";
@@ -6,8 +6,11 @@ import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialo
 import { Dropdown } from "@vellumai/design-library/components/dropdown";
 import { Input } from "@vellumai/design-library/components/input";
 import { Notice } from "@vellumai/design-library/components/notice";
+import { Tabs } from "@vellumai/design-library/components/tabs";
+import { Tag } from "@vellumai/design-library/components/tag";
 import { Typography } from "@vellumai/design-library/components/typography";
 
+import { EmptyState } from "@/components/empty-state";
 import { assistantDisplayName as toAssistantDisplayName } from "@/domains/contacts/assistant-display-name";
 import { SlackChannelCard } from "@/domains/contacts/components/slack-channel-card";
 import { SlackSetupWizard, type SlackThreadMode, type MutationStatus } from "@/components/slack-setup-wizard";
@@ -19,6 +22,7 @@ import {
   POLICY_LABELS,
   type AdmissionPolicy,
 } from "@/lib/channel-admission-policy/types";
+import { ChannelIcon, getChannelLabel } from "@/utils/channel-presentation";
 
 type ChannelKey = SetupChannelId;
 
@@ -80,37 +84,46 @@ export interface AssistantChannelsListProps {
   slackSaveError?: string | null;
   onSlackThreadModeChange?: (mode: SlackThreadMode) => void;
   onSaveTwilioCredentials?: (accountSid: string, authToken: string) => Promise<void>;
-  /** Pre-expand a channel on mount (e.g. from a `?setup=slack` deep-link). */
-  initialExpandedChannel?: ChannelKey | null;
+  /** Pre-select a channel tab on mount (e.g. from a `?setup=slack` deep-link). */
+  initialChannel?: ChannelKey | null;
 }
 
 const CHANNEL_META: Record<
   ChannelKey,
-  { label: string; disconnectMessage: string }
+  {
+    disconnectLabel: string;
+    disconnectMessage: string;
+    /** One-line pitch for the disconnected empty state. Slack has none — its disconnected state is the setup wizard. */
+    disconnectedPitch?: (displayName: string) => string;
+  }
 > = {
   slack: {
-    label: "Slack",
+    disconnectLabel: "Slack",
     disconnectMessage:
       "This clears the stored Slack bot and app tokens for this assistant. You can reconnect later.",
   },
   telegram: {
-    label: "Telegram",
+    disconnectLabel: "Telegram",
     disconnectMessage:
       "This clears the stored Telegram bot token for this assistant. You can reconnect later.",
+    disconnectedPitch: (displayName) =>
+      `Connect a Telegram bot so ${displayName} can send and receive messages on Telegram.`,
   },
   phone: {
-    label: "Phone Calling",
+    disconnectLabel: "Phone Calling",
     disconnectMessage:
       "This clears the stored Twilio credentials for this assistant. You can reconnect later.",
+    disconnectedPitch: (displayName) =>
+      `Connect your Twilio account so ${displayName} can make and answer phone calls.`,
   },
 };
 
 /**
- * The Slack/Telegram/Phone accordion rows plus their disconnect and
- * trust-floor confirmation dialogs. Owns which rows are expanded and which
+ * The Slack/Telegram/Phone channel sub-tabs plus their disconnect and
+ * trust-floor confirmation dialogs. Owns which tab is selected and which
  * confirmations are pending; the queries and mutations behind the props live
- * in `useAssistantChannels`. Rendered inside a card by both mount points —
- * the Channels tab and the Contacts assistant detail.
+ * in `useAssistantChannels`. Rendered by both mount points — the Channels
+ * tab (in a card) and the Contacts assistant detail.
  */
 export function AssistantChannelsList({
   assistantName,
@@ -131,11 +144,11 @@ export function AssistantChannelsList({
   slackSaveError,
   onSlackThreadModeChange,
   onSaveTwilioCredentials,
-  initialExpandedChannel = null,
+  initialChannel = null,
 }: AssistantChannelsListProps) {
   const [pendingDisconnect, setPendingDisconnect] = useState<ChannelKey | null>(null);
-  const [expandedChannels, setExpandedChannels] = useState<Set<ChannelKey>>(
-    () => initialExpandedChannel ? new Set([initialExpandedChannel]) : new Set(),
+  const [activeChannel, setActiveChannel] = useState<ChannelKey>(
+    () => initialChannel ?? channels[0]?.key ?? "slack",
   );
   // Floor confirmation: non-null while a floor in POLICY_CONFIRMATIONS awaits
   // the user's go-ahead before persisting.
@@ -160,75 +173,55 @@ export function AssistantChannelsList({
     onChannelPolicyChange?.(channelKey, next);
   };
 
-  const toggleExpanded = (key: ChannelKey) => {
-    setExpandedChannels((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) {
-        next.delete(key);
-      } else {
-        next.add(key);
-      }
-      return next;
-    });
-  };
-
   return (
     <div className="flex flex-col">
-      {channels.map((channel, index) => (
-        <div key={channel.key}>
-          {index > 0 ? (
-            <div
-              className="border-t"
-              style={{ borderColor: "var(--border-base)" }}
-            />
-          ) : null}
-          <ChannelRow
-            channel={channel}
-            assistantName={assistantName}
-            assistantDisplayName={displayName}
-            pending={pendingChannelKey === channel.key}
-            expanded={expandedChannels.has(channel.key)}
-            onToggleExpand={() => toggleExpanded(channel.key)}
-            onSetup={
-              channel.key === "slack"
-                ? () => {
-                    setExpandedChannels((prev) => {
-                      const next = new Set(prev);
-                      next.add(channel.key);
-                      return next;
-                    });
-                  }
-                : onSetup
-                  ? () => onSetup(channel.key)
+      <Tabs.Root
+        value={activeChannel}
+        onValueChange={(value) => setActiveChannel(value as ChannelKey)}
+      >
+        <Tabs.List>
+          {channels.map((channel) => (
+            <Tabs.Trigger key={channel.key} value={channel.key}>
+              {getChannelLabel(channel.key)}
+            </Tabs.Trigger>
+          ))}
+        </Tabs.List>
+        {channels.map((channel) => (
+          <Tabs.Panel key={channel.key} value={channel.key} className="pt-4">
+            <ChannelPanel
+              channel={channel}
+              assistantName={assistantName}
+              assistantDisplayName={displayName}
+              pending={pendingChannelKey === channel.key}
+              onSetup={onSetup ? () => onSetup(channel.key) : undefined}
+              onDisconnect={
+                onDisconnect ? () => setPendingDisconnect(channel.key) : undefined
+              }
+              onSaveTelegramToken={onSaveTelegramToken}
+              onSaveSlackConfig={onSaveSlackConfig}
+              slackSaveStatus={slackSaveStatus}
+              slackSaveError={slackSaveError}
+              slackThreadMode={slackThreadMode}
+              slackThreadModePending={slackThreadModePending}
+              onSlackThreadModeChange={onSlackThreadModeChange}
+              onSaveTwilioCredentials={onSaveTwilioCredentials}
+              policy={channelPolicies?.[channel.key]}
+              policySaving={policySavingKey === channel.key}
+              policyLoading={policiesLoading}
+              policyError={policiesError}
+              onPolicyChange={
+                onChannelPolicyChange
+                  ? (next) => handlePolicyChange(channel.key, next)
                   : undefined
-            }
-            onDisconnect={
-              onDisconnect ? () => setPendingDisconnect(channel.key) : undefined
-            }
-            onSaveTelegramToken={onSaveTelegramToken}
-            onSaveSlackConfig={onSaveSlackConfig}
-            slackSaveStatus={slackSaveStatus}
-            slackSaveError={slackSaveError}
-            slackThreadMode={slackThreadMode}
-            slackThreadModePending={slackThreadModePending}
-            onSlackThreadModeChange={onSlackThreadModeChange}
-            onSaveTwilioCredentials={onSaveTwilioCredentials}
-            policy={channelPolicies?.[channel.key]}
-            policySaving={policySavingKey === channel.key}
-            policyLoading={policiesLoading}
-            policyError={policiesError}
-            onPolicyChange={
-              onChannelPolicyChange
-                ? (next) => handlePolicyChange(channel.key, next)
-                : undefined
-            }
-          />
-        </div>
-      ))}
+              }
+            />
+          </Tabs.Panel>
+        ))}
+      </Tabs.Root>
 
       <ConfirmDialog
         open={pendingDisconnect !== null}
-        title={`Disconnect ${disconnectMeta?.label ?? ""}?`}
+        title={`Disconnect ${disconnectMeta?.disconnectLabel ?? ""}?`}
         message={disconnectMeta?.disconnectMessage ?? ""}
         confirmLabel="Disconnect"
         destructive
@@ -261,17 +254,15 @@ export function AssistantChannelsList({
 }
 
 // ---------------------------------------------------------------------------
-// Channel Row
+// Channel Panel
 // ---------------------------------------------------------------------------
 
-interface ChannelRowProps {
+interface ChannelPanelProps {
   channel: AssistantChannelState;
   assistantName: string;
   /** Trimmed assistant name with a "your assistant" fallback, for copy. */
   assistantDisplayName: string;
   pending: boolean;
-  expanded: boolean;
-  onToggleExpand: () => void;
   onSetup?: () => void;
   onDisconnect?: () => void;
   onSaveTelegramToken?: (botToken: string) => Promise<void>;
@@ -289,13 +280,11 @@ interface ChannelRowProps {
   onPolicyChange?: (policy: AdmissionPolicy) => void;
 }
 
-function ChannelRow({
+function ChannelPanel({
   channel,
   assistantName,
   assistantDisplayName,
   pending,
-  expanded,
-  onToggleExpand,
   onSetup,
   onDisconnect,
   onSaveTelegramToken,
@@ -311,53 +300,44 @@ function ChannelRow({
   policyLoading = false,
   policyError = false,
   onPolicyChange,
-}: ChannelRowProps) {
+}: ChannelPanelProps) {
   const meta = CHANNEL_META[channel.key];
   const connected = channel.status === "ready";
 
   return (
-    <div className="flex flex-col gap-2 py-4">
-      <div className="flex items-center gap-3">
-        <button
-          type="button"
-          className="flex shrink-0 items-center justify-center"
-          onClick={onToggleExpand}
-          style={{ color: "var(--content-secondary)" }}
-        >
-          {expanded ? (
-            <ChevronDown className="h-4 w-4" />
-          ) : (
-            <ChevronRight className="h-4 w-4" />
-          )}
-        </button>
-        <span
-          className="text-body-medium-default"
-          style={{ color: "var(--content-default)" }}
-        >
-          {meta.label}
-        </span>
-        {channel.address ? (
-          <span className="text-body-medium-lighter" style={{ color: "var(--content-tertiary)" }}>
-            {channel.address}
-          </span>
-        ) : null}
-        <div className="ml-auto flex items-center gap-2">
-          {connected ? (
-            <>
-              <span className="inline-flex items-center gap-1 h-8 px-2.5 rounded-md whitespace-nowrap select-none text-body-small-emphasised leading-none bg-[var(--content-default)] text-[var(--surface-base)]">
-                <CheckCircle className="h-3 w-3" />
-                Connected
-              </span>
-              <Button
-                type="button"
-                variant="danger"
-                onClick={onDisconnect}
-                disabled={!onDisconnect || pending}
-              >
-                {pending ? "Disconnecting…" : "Disconnect"}
-              </Button>
-            </>
-          ) : (
+    <div className="flex flex-col gap-4">
+      {connected ? (
+        <div className="flex items-center gap-3">
+          <Tag tone="positive" leftIcon={<CheckCircle />}>
+            Connected
+          </Tag>
+          {channel.address ? (
+            <span
+              className="text-body-medium-lighter"
+              style={{ color: "var(--content-tertiary)" }}
+            >
+              {channel.address}
+            </span>
+          ) : null}
+          <div className="ml-auto">
+            <Button
+              type="button"
+              variant="danger"
+              onClick={onDisconnect}
+              disabled={!onDisconnect || pending}
+            >
+              {pending ? "Disconnecting…" : "Disconnect"}
+            </Button>
+          </div>
+        </div>
+      ) : channel.key !== "slack" ? (
+        // Slack's disconnected state is the setup wizard below; Telegram and
+        // Phone pitch the channel and point at the guided setup.
+        <EmptyState
+          icon={<ChannelIcon channelId={channel.key} className="h-6 w-6" />}
+          title={`${getChannelLabel(channel.key)} isn't connected`}
+          description={meta.disconnectedPitch?.(assistantDisplayName)}
+          action={
             <Button
               type="button"
               variant="outlined"
@@ -366,46 +346,42 @@ function ChannelRow({
             >
               {pending ? "Opening…" : "Set up"}
             </Button>
-          )}
-        </div>
-      </div>
+          }
+        />
+      ) : null}
 
-      {expanded ? (
-        <div className={connected ? "flex flex-col gap-4" : undefined}>
-          {connected && onPolicyChange ? (
-            <ChannelTrustFloorSection
-              assistantDisplayName={assistantDisplayName}
-              policy={policy}
-              saving={policySaving}
-              loading={policyLoading}
-              error={policyError}
-              onChange={onPolicyChange}
-            />
-          ) : null}
+      {connected && onPolicyChange ? (
+        <ChannelTrustFloorSection
+          assistantDisplayName={assistantDisplayName}
+          policy={policy}
+          saving={policySaving}
+          loading={policyLoading}
+          error={policyError}
+          onChange={onPolicyChange}
+        />
+      ) : null}
 
-          {channel.key === "telegram" ? (
-            <TelegramCredentialEntry onSave={onSaveTelegramToken} />
-          ) : null}
+      {channel.key === "telegram" ? (
+        <TelegramCredentialEntry onSave={onSaveTelegramToken} />
+      ) : null}
 
-          {channel.key === "slack" ? (
-            <SlackChannelCard assistantName={assistantName} connected={connected}>
-              <SlackSetupWizard
-                assistantName={assistantName}
-                connected={connected}
-                onSave={onSaveSlackConfig}
-                saveStatus={slackSaveStatus}
-                saveError={slackSaveError}
-                threadMode={slackThreadMode}
-                threadModePending={slackThreadModePending}
-                onThreadModeChange={onSlackThreadModeChange}
-              />
-            </SlackChannelCard>
-          ) : null}
+      {channel.key === "slack" ? (
+        <SlackChannelCard assistantName={assistantName} connected={connected}>
+          <SlackSetupWizard
+            assistantName={assistantName}
+            connected={connected}
+            onSave={onSaveSlackConfig}
+            saveStatus={slackSaveStatus}
+            saveError={slackSaveError}
+            threadMode={slackThreadMode}
+            threadModePending={slackThreadModePending}
+            onThreadModeChange={onSlackThreadModeChange}
+          />
+        </SlackChannelCard>
+      ) : null}
 
-          {channel.key === "phone" ? (
-            <TwilioCredentialEntry onSave={onSaveTwilioCredentials} />
-          ) : null}
-        </div>
+      {channel.key === "phone" ? (
+        <TwilioCredentialEntry onSave={onSaveTwilioCredentials} />
       ) : null}
     </div>
   );
@@ -441,7 +417,7 @@ function ChannelTrustFloorSection({
   }));
 
   return (
-    <div className="flex flex-col gap-2 pl-7">
+    <div className="flex flex-col gap-2">
       <Typography
         as="span"
         variant="body-small-emphasised"
@@ -532,7 +508,7 @@ function TelegramCredentialEntry({ onSave }: TelegramCredentialEntryProps) {
   };
 
   return (
-    <div className="flex flex-col gap-3 pl-7">
+    <div className="flex flex-col gap-3">
       <Input
         label="Bot Token"
         type="password"
@@ -590,7 +566,7 @@ function TwilioCredentialEntry({ onSave }: TwilioCredentialEntryProps) {
   };
 
   return (
-    <div className="flex flex-col gap-3 pl-7">
+    <div className="flex flex-col gap-3">
       <Input
         label="Account SID"
         type="text"

--- a/clients/web/src/domains/contacts/components/assistant-channels-list.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-list.tsx
@@ -156,6 +156,7 @@ export function AssistantChannelsList({
   initialChannel = null,
 }: AssistantChannelsListProps) {
   const tabbedLayout = useAssistantFeatureFlagStore.use.channelTrustFloors();
+  const flagsHydrated = useAssistantFeatureFlagStore.use.hasHydrated();
   const [pendingDisconnect, setPendingDisconnect] = useState<ChannelKey | null>(null);
   const [activeChannel, setActiveChannel] = useState<ChannelKey>(
     () => initialChannel ?? channels[0]?.key ?? "slack",
@@ -197,6 +198,23 @@ export function AssistantChannelsList({
       return next;
     });
   };
+
+  // A `false` flag before /feature-flags hydrates is the registry default,
+  // not the real value — committing to the accordion and swapping to the
+  // tabs after hydration would unmount the credential forms and discard
+  // anything mid-entry. Treat the window as loading instead; a `true`
+  // (env override) is already definitive. Same pattern as `InspectPage`.
+  if (!tabbedLayout && !flagsHydrated) {
+    return (
+      <Typography
+        as="span"
+        variant="body-small-default"
+        className="text-[color:var(--content-tertiary)]"
+      >
+        Loading…
+      </Typography>
+    );
+  }
 
   return (
     <div className="flex flex-col">

--- a/clients/web/src/domains/contacts/components/assistant-channels-list.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-list.tsx
@@ -237,6 +237,7 @@ export function AssistantChannelsList({
                 assistantName={assistantName}
                 assistantDisplayName={displayName}
                 pending={pendingChannelKey === channel.key}
+                initialManualEntry={initialChannel === channel.key}
                 onSetup={onSetup ? () => onSetup(channel.key) : undefined}
                 onDisconnect={
                   onDisconnect ? () => setPendingDisconnect(channel.key) : undefined
@@ -360,6 +361,12 @@ interface ChannelPanelProps {
   /** Trimmed assistant name with a "your assistant" fallback, for copy. */
   assistantDisplayName: string;
   pending: boolean;
+  /**
+   * Open the manual credential form immediately instead of the empty state —
+   * set for `?setup=<channel>` deep links (e.g. the mobile chat-drawer
+   * handoff continues credential entry here).
+   */
+  initialManualEntry?: boolean;
   onSetup?: () => void;
   onDisconnect?: () => void;
   onSaveTelegramToken?: (botToken: string) => Promise<void>;
@@ -382,6 +389,7 @@ function ChannelPanel({
   assistantName,
   assistantDisplayName,
   pending,
+  initialManualEntry = false,
   onSetup,
   onDisconnect,
   onSaveTelegramToken,
@@ -401,8 +409,9 @@ function ChannelPanel({
   const meta = CHANNEL_META[channel.key];
   const connected = channel.status === "ready";
   // Disconnected Telegram/Phone default to the pitch + guided setup; the
-  // manual credential form swaps in when the user opts into it.
-  const [manualEntry, setManualEntry] = useState(false);
+  // manual credential form swaps in when the user opts into it (or arrived
+  // via a setup deep link).
+  const [manualEntry, setManualEntry] = useState(initialManualEntry);
   const showCredentialForm = connected || manualEntry;
 
   return (

--- a/clients/web/src/domains/contacts/components/assistant-channels-list.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-list.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle } from "lucide-react";
+import { CheckCircle, ChevronDown, ChevronRight } from "lucide-react";
 import { useState } from "react";
 
 import { Button } from "@vellumai/design-library/components/button";
@@ -22,6 +22,7 @@ import {
   POLICY_LABELS,
   type AdmissionPolicy,
 } from "@/lib/channel-admission-policy/types";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { ChannelIcon, getChannelLabel } from "@/utils/channel-presentation";
 
 type ChannelKey = SetupChannelId;
@@ -84,33 +85,37 @@ export interface AssistantChannelsListProps {
   slackSaveError?: string | null;
   onSlackThreadModeChange?: (mode: SlackThreadMode) => void;
   onSaveTwilioCredentials?: (accountSid: string, authToken: string) => Promise<void>;
-  /** Pre-select a channel tab on mount (e.g. from a `?setup=slack` deep-link). */
+  /**
+   * Pre-open a channel on mount (e.g. from a `?setup=slack` deep-link):
+   * selects its tab in the tabbed layout, expands its row in the accordion.
+   */
   initialChannel?: ChannelKey | null;
 }
 
 const CHANNEL_META: Record<
   ChannelKey,
   {
-    disconnectLabel: string;
+    /** Row label in the accordion layout; also the disconnect-dialog subject. */
+    label: string;
     disconnectMessage: string;
     /** One-line pitch for the disconnected empty state. Slack has none — its disconnected state is the setup wizard. */
     disconnectedPitch?: (displayName: string) => string;
   }
 > = {
   slack: {
-    disconnectLabel: "Slack",
+    label: "Slack",
     disconnectMessage:
       "This clears the stored Slack bot and app tokens for this assistant. You can reconnect later.",
   },
   telegram: {
-    disconnectLabel: "Telegram",
+    label: "Telegram",
     disconnectMessage:
       "This clears the stored Telegram bot token for this assistant. You can reconnect later.",
     disconnectedPitch: (displayName) =>
       `Connect a Telegram bot so ${displayName} can send and receive messages on Telegram.`,
   },
   phone: {
-    disconnectLabel: "Phone Calling",
+    label: "Phone Calling",
     disconnectMessage:
       "This clears the stored Twilio credentials for this assistant. You can reconnect later.",
     disconnectedPitch: (displayName) =>
@@ -119,11 +124,15 @@ const CHANNEL_META: Record<
 };
 
 /**
- * The Slack/Telegram/Phone channel sub-tabs plus their disconnect and
- * trust-floor confirmation dialogs. Owns which tab is selected and which
+ * The Slack/Telegram/Phone channel sections plus their disconnect and
+ * trust-floor confirmation dialogs. Owns which section is open and which
  * confirmations are pending; the queries and mutations behind the props live
  * in `useAssistantChannels`. Rendered by both mount points — the Channels
  * tab (in a card) and the Contacts assistant detail.
+ *
+ * Layout is gated on the `channel-trust-floors` flag (the Channels-tab
+ * restructure ships with that arc): on → adapter sub-tabs with empty states
+ * for disconnected channels, off → the accordion rows.
  */
 export function AssistantChannelsList({
   assistantName,
@@ -146,9 +155,13 @@ export function AssistantChannelsList({
   onSaveTwilioCredentials,
   initialChannel = null,
 }: AssistantChannelsListProps) {
+  const tabbedLayout = useAssistantFeatureFlagStore.use.channelTrustFloors();
   const [pendingDisconnect, setPendingDisconnect] = useState<ChannelKey | null>(null);
   const [activeChannel, setActiveChannel] = useState<ChannelKey>(
     () => initialChannel ?? channels[0]?.key ?? "slack",
+  );
+  const [expandedChannels, setExpandedChannels] = useState<Set<ChannelKey>>(
+    () => initialChannel ? new Set([initialChannel]) : new Set(),
   );
   // Floor confirmation: non-null while a floor in POLICY_CONFIRMATIONS awaits
   // the user's go-ahead before persisting.
@@ -173,27 +186,93 @@ export function AssistantChannelsList({
     onChannelPolicyChange?.(channelKey, next);
   };
 
+  const toggleExpanded = (key: ChannelKey) => {
+    setExpandedChannels((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
+
   return (
     <div className="flex flex-col">
-      <Tabs.Root
-        value={activeChannel}
-        onValueChange={(value) => setActiveChannel(value as ChannelKey)}
-      >
-        <Tabs.List>
+      {tabbedLayout ? (
+        <Tabs.Root
+          value={activeChannel}
+          onValueChange={(value) => setActiveChannel(value as ChannelKey)}
+        >
+          <Tabs.List>
+            {channels.map((channel) => (
+              <Tabs.Trigger key={channel.key} value={channel.key}>
+                {getChannelLabel(channel.key)}
+              </Tabs.Trigger>
+            ))}
+          </Tabs.List>
           {channels.map((channel) => (
-            <Tabs.Trigger key={channel.key} value={channel.key}>
-              {getChannelLabel(channel.key)}
-            </Tabs.Trigger>
+            <Tabs.Panel key={channel.key} value={channel.key} className="pt-4">
+              <ChannelPanel
+                channel={channel}
+                assistantName={assistantName}
+                assistantDisplayName={displayName}
+                pending={pendingChannelKey === channel.key}
+                onSetup={onSetup ? () => onSetup(channel.key) : undefined}
+                onDisconnect={
+                  onDisconnect ? () => setPendingDisconnect(channel.key) : undefined
+                }
+                onSaveTelegramToken={onSaveTelegramToken}
+                onSaveSlackConfig={onSaveSlackConfig}
+                slackSaveStatus={slackSaveStatus}
+                slackSaveError={slackSaveError}
+                slackThreadMode={slackThreadMode}
+                slackThreadModePending={slackThreadModePending}
+                onSlackThreadModeChange={onSlackThreadModeChange}
+                onSaveTwilioCredentials={onSaveTwilioCredentials}
+                policy={channelPolicies?.[channel.key]}
+                policySaving={policySavingKey === channel.key}
+                policyLoading={policiesLoading}
+                policyError={policiesError}
+                onPolicyChange={
+                  onChannelPolicyChange
+                    ? (next) => handlePolicyChange(channel.key, next)
+                    : undefined
+                }
+              />
+            </Tabs.Panel>
           ))}
-        </Tabs.List>
-        {channels.map((channel) => (
-          <Tabs.Panel key={channel.key} value={channel.key} className="pt-4">
-            <ChannelPanel
+        </Tabs.Root>
+      ) : (
+        channels.map((channel, index) => (
+          <div key={channel.key}>
+            {index > 0 ? (
+              <div
+                className="border-t"
+                style={{ borderColor: "var(--border-base)" }}
+              />
+            ) : null}
+            <ChannelRow
               channel={channel}
               assistantName={assistantName}
               assistantDisplayName={displayName}
               pending={pendingChannelKey === channel.key}
-              onSetup={onSetup ? () => onSetup(channel.key) : undefined}
+              expanded={expandedChannels.has(channel.key)}
+              onToggleExpand={() => toggleExpanded(channel.key)}
+              onSetup={
+                channel.key === "slack"
+                  ? () => {
+                      setExpandedChannels((prev) => {
+                        const next = new Set(prev);
+                        next.add(channel.key);
+                        return next;
+                      });
+                    }
+                  : onSetup
+                    ? () => onSetup(channel.key)
+                    : undefined
+              }
               onDisconnect={
                 onDisconnect ? () => setPendingDisconnect(channel.key) : undefined
               }
@@ -215,13 +294,13 @@ export function AssistantChannelsList({
                   : undefined
               }
             />
-          </Tabs.Panel>
-        ))}
-      </Tabs.Root>
+          </div>
+        ))
+      )}
 
       <ConfirmDialog
         open={pendingDisconnect !== null}
-        title={`Disconnect ${disconnectMeta?.disconnectLabel ?? ""}?`}
+        title={`Disconnect ${disconnectMeta?.label ?? ""}?`}
         message={disconnectMeta?.disconnectMessage ?? ""}
         confirmLabel="Disconnect"
         destructive
@@ -254,7 +333,7 @@ export function AssistantChannelsList({
 }
 
 // ---------------------------------------------------------------------------
-// Channel Panel
+// Channel Panel (tabbed layout)
 // ---------------------------------------------------------------------------
 
 interface ChannelPanelProps {
@@ -303,6 +382,10 @@ function ChannelPanel({
 }: ChannelPanelProps) {
   const meta = CHANNEL_META[channel.key];
   const connected = channel.status === "ready";
+  // Disconnected Telegram/Phone default to the pitch + guided setup; the
+  // manual credential form swaps in when the user opts into it.
+  const [manualEntry, setManualEntry] = useState(false);
+  const showCredentialForm = connected || manualEntry;
 
   return (
     <div className="flex flex-col gap-4">
@@ -330,22 +413,32 @@ function ChannelPanel({
             </Button>
           </div>
         </div>
-      ) : channel.key !== "slack" ? (
+      ) : channel.key !== "slack" && !manualEntry ? (
         // Slack's disconnected state is the setup wizard below; Telegram and
-        // Phone pitch the channel and point at the guided setup.
+        // Phone pitch the channel and point at the guided setup, with a
+        // manual-credentials escape hatch.
         <EmptyState
           icon={<ChannelIcon channelId={channel.key} className="h-6 w-6" />}
           title={`${getChannelLabel(channel.key)} isn't connected`}
           description={meta.disconnectedPitch?.(assistantDisplayName)}
           action={
-            <Button
-              type="button"
-              variant="outlined"
-              onClick={onSetup}
-              disabled={!onSetup || pending}
-            >
-              {pending ? "Opening…" : "Set up"}
-            </Button>
+            <div className="flex flex-col items-center gap-1">
+              <Button
+                type="button"
+                variant="outlined"
+                onClick={onSetup}
+                disabled={!onSetup || pending}
+              >
+                {pending ? "Opening…" : "Set up"}
+              </Button>
+              <Button
+                type="button"
+                variant="link"
+                onClick={() => setManualEntry(true)}
+              >
+                or connect manually
+              </Button>
+            </div>
           }
         />
       ) : null}
@@ -361,7 +454,7 @@ function ChannelPanel({
         />
       ) : null}
 
-      {channel.key === "telegram" ? (
+      {channel.key === "telegram" && showCredentialForm ? (
         <TelegramCredentialEntry onSave={onSaveTelegramToken} />
       ) : null}
 
@@ -380,8 +473,167 @@ function ChannelPanel({
         </SlackChannelCard>
       ) : null}
 
-      {channel.key === "phone" ? (
+      {channel.key === "phone" && showCredentialForm ? (
         <TwilioCredentialEntry onSave={onSaveTwilioCredentials} />
+      ) : null}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Channel Row (accordion layout, `channel-trust-floors` off)
+// ---------------------------------------------------------------------------
+
+interface ChannelRowProps {
+  channel: AssistantChannelState;
+  assistantName: string;
+  /** Trimmed assistant name with a "your assistant" fallback, for copy. */
+  assistantDisplayName: string;
+  pending: boolean;
+  expanded: boolean;
+  onToggleExpand: () => void;
+  onSetup?: () => void;
+  onDisconnect?: () => void;
+  onSaveTelegramToken?: (botToken: string) => Promise<void>;
+  onSaveSlackConfig?: (botToken: string, appToken: string) => void;
+  slackSaveStatus?: MutationStatus;
+  slackSaveError?: string | null;
+  slackThreadMode?: SlackThreadMode;
+  slackThreadModePending?: boolean;
+  onSlackThreadModeChange?: (mode: SlackThreadMode) => void;
+  onSaveTwilioCredentials?: (accountSid: string, authToken: string) => Promise<void>;
+  policy?: AdmissionPolicy;
+  policySaving?: boolean;
+  policyLoading?: boolean;
+  policyError?: boolean;
+  onPolicyChange?: (policy: AdmissionPolicy) => void;
+}
+
+function ChannelRow({
+  channel,
+  assistantName,
+  assistantDisplayName,
+  pending,
+  expanded,
+  onToggleExpand,
+  onSetup,
+  onDisconnect,
+  onSaveTelegramToken,
+  onSaveSlackConfig,
+  slackSaveStatus,
+  slackSaveError,
+  slackThreadMode,
+  slackThreadModePending = false,
+  onSlackThreadModeChange,
+  onSaveTwilioCredentials,
+  policy,
+  policySaving = false,
+  policyLoading = false,
+  policyError = false,
+  onPolicyChange,
+}: ChannelRowProps) {
+  const meta = CHANNEL_META[channel.key];
+  const connected = channel.status === "ready";
+
+  return (
+    <div className="flex flex-col gap-2 py-4">
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          className="flex shrink-0 items-center justify-center"
+          onClick={onToggleExpand}
+          style={{ color: "var(--content-secondary)" }}
+        >
+          {expanded ? (
+            <ChevronDown className="h-4 w-4" />
+          ) : (
+            <ChevronRight className="h-4 w-4" />
+          )}
+        </button>
+        <span
+          className="text-body-medium-default"
+          style={{ color: "var(--content-default)" }}
+        >
+          {meta.label}
+        </span>
+        {channel.address ? (
+          <span className="text-body-medium-lighter" style={{ color: "var(--content-tertiary)" }}>
+            {channel.address}
+          </span>
+        ) : null}
+        <div className="ml-auto flex items-center gap-2">
+          {connected ? (
+            <>
+              <span className="inline-flex items-center gap-1 h-8 px-2.5 rounded-md whitespace-nowrap select-none text-body-small-emphasised leading-none bg-[var(--content-default)] text-[var(--surface-base)]">
+                <CheckCircle className="h-3 w-3" />
+                Connected
+              </span>
+              <Button
+                type="button"
+                variant="danger"
+                onClick={onDisconnect}
+                disabled={!onDisconnect || pending}
+              >
+                {pending ? "Disconnecting…" : "Disconnect"}
+              </Button>
+            </>
+          ) : (
+            <Button
+              type="button"
+              variant="outlined"
+              onClick={onSetup}
+              disabled={!onSetup || pending}
+            >
+              {pending ? "Opening…" : "Set up"}
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {expanded ? (
+        <div className={connected ? "flex flex-col gap-4" : undefined}>
+          {connected && onPolicyChange ? (
+            <div className="pl-7">
+              <ChannelTrustFloorSection
+                assistantDisplayName={assistantDisplayName}
+                policy={policy}
+                saving={policySaving}
+                loading={policyLoading}
+                error={policyError}
+                onChange={onPolicyChange}
+              />
+            </div>
+          ) : null}
+
+          {channel.key === "telegram" ? (
+            <div className="pl-7">
+              <TelegramCredentialEntry onSave={onSaveTelegramToken} />
+            </div>
+          ) : null}
+
+          {channel.key === "slack" ? (
+            <div className="pl-7">
+              <SlackChannelCard assistantName={assistantName} connected={connected}>
+                <SlackSetupWizard
+                  assistantName={assistantName}
+                  connected={connected}
+                  onSave={onSaveSlackConfig}
+                  saveStatus={slackSaveStatus}
+                  saveError={slackSaveError}
+                  threadMode={slackThreadMode}
+                  threadModePending={slackThreadModePending}
+                  onThreadModeChange={onSlackThreadModeChange}
+                />
+              </SlackChannelCard>
+            </div>
+          ) : null}
+
+          {channel.key === "phone" ? (
+            <div className="pl-7">
+              <TwilioCredentialEntry onSave={onSaveTwilioCredentials} />
+            </div>
+          ) : null}
+        </div>
       ) : null}
     </div>
   );

--- a/clients/web/src/domains/contacts/components/slack-channel-card.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-card.tsx
@@ -13,30 +13,28 @@ interface SlackChannelCardProps {
 
 export function SlackChannelCard({ assistantName, connected = false, children }: SlackChannelCardProps) {
   return (
-    <div className="pl-7">
-      <Card.Root>
-        <Card.Header>
-          <div className="flex items-center gap-3">
-            <img
-              src={publicAsset("/images/integrations/slack.svg")}
-              alt=""
-              className="size-8 rounded-lg bg-[var(--surface-sunken)] p-1"
-            />
-            <div className="flex flex-col">
-              <Typography as="span" variant="body-medium-default">
-                {connected ? "Slack settings" : "Slack setup"}
-              </Typography>
-              {connected ? (
-                <span className="flex items-center gap-1.5 text-body-small-default text-[var(--content-secondary)]">
-                  <span className="size-2 rounded-full bg-[var(--system-positive-strong)]" />
-                  Connected as {assistantName}
-                </span>
-              ) : null}
-            </div>
+    <Card.Root>
+      <Card.Header>
+        <div className="flex items-center gap-3">
+          <img
+            src={publicAsset("/images/integrations/slack.svg")}
+            alt=""
+            className="size-8 rounded-lg bg-[var(--surface-sunken)] p-1"
+          />
+          <div className="flex flex-col">
+            <Typography as="span" variant="body-medium-default">
+              {connected ? "Slack settings" : "Slack setup"}
+            </Typography>
+            {connected ? (
+              <span className="flex items-center gap-1.5 text-body-small-default text-[var(--content-secondary)]">
+                <span className="size-2 rounded-full bg-[var(--system-positive-strong)]" />
+                Connected as {assistantName}
+              </span>
+            ) : null}
           </div>
-        </Card.Header>
-        <Card.Body>{children}</Card.Body>
-      </Card.Root>
-    </div>
+        </div>
+      </Card.Header>
+      <Card.Body>{children}</Card.Body>
+    </Card.Root>
   );
 }

--- a/clients/web/src/domains/contacts/contacts-page.tsx
+++ b/clients/web/src/domains/contacts/contacts-page.tsx
@@ -460,7 +460,7 @@ export function ContactsPage({
           <AssistantChannelsDetail
             assistantName={assistantName}
             onGenerateInviteLink={a2aChannel ? inviteDialog.open : undefined}
-            initialExpandedChannel={setupChannel}
+            initialChannel={setupChannel}
             {...channelsController}
           />
         ) : optimisticContact ? (

--- a/clients/web/src/domains/contacts/hooks/use-assistant-channels.ts
+++ b/clients/web/src/domains/contacts/hooks/use-assistant-channels.ts
@@ -48,7 +48,7 @@ export interface UseAssistantChannelsOptions {
  */
 export type AssistantChannelsController = Omit<
   AssistantChannelsListProps,
-  "assistantName" | "initialExpandedChannel"
+  "assistantName" | "initialChannel"
 >;
 
 /**

--- a/clients/web/src/domains/contacts/hooks/use-setup-channel-param.ts
+++ b/clients/web/src/domains/contacts/hooks/use-setup-channel-param.ts
@@ -4,8 +4,8 @@ import { useSearchParams } from "react-router";
 import { isSetupChannelId, type SetupChannelId } from "@/domains/contacts/types";
 
 /**
- * Reads the `?setup=<channel>` deep-link param (used to pre-expand a channel
- * accordion on arrival) and consumes it once on mount so it doesn't persist
+ * Reads the `?setup=<channel>` deep-link param (used to pre-select a channel
+ * tab on arrival) and consumes it once on mount so it doesn't persist
  * across navigations. Returns the channel on the first render and `null`
  * after the param is cleared or when it names no known channel.
  */

--- a/clients/web/src/domains/intelligence/intelligence-layout.test.tsx
+++ b/clients/web/src/domains/intelligence/intelligence-layout.test.tsx
@@ -21,6 +21,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router";
 
 import { MIN_VERSION } from "@/lib/backwards-compat/plugins-surface";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 
 const isMobileRef = { value: false };
@@ -59,6 +60,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   useAssistantIdentityStore.getState().clearIdentity();
+  useAssistantFeatureFlagStore.setState({ channelTrustFloors: false });
 });
 
 describe("IntelligenceLayout", () => {
@@ -97,6 +99,7 @@ describe("IntelligenceLayout — Plugins tab version gate", () => {
 
   test("shows the Plugins tab (between Identity and Skills) on a plugin-capable assistant", () => {
     useAssistantIdentityStore.getState().setIdentity("Ada", MIN_VERSION);
+    useAssistantFeatureFlagStore.setState({ channelTrustFloors: true });
     const { container } = renderLayout();
     expect(tabLabels(container)).toEqual([
       "Identity",
@@ -106,6 +109,12 @@ describe("IntelligenceLayout — Plugins tab version gate", () => {
       "Contacts",
       "Channels",
     ]);
+  });
+
+  test("hides the Channels tab while channel-trust-floors is off", () => {
+    useAssistantIdentityStore.getState().setIdentity("Ada", MIN_VERSION);
+    const { container } = renderLayout();
+    expect(tabLabels(container)).not.toContain("Channels");
   });
 
   test("hides the Plugins tab on an assistant too old for the plugin routes", () => {

--- a/clients/web/src/domains/intelligence/intelligence-layout.tsx
+++ b/clients/web/src/domains/intelligence/intelligence-layout.tsx
@@ -7,6 +7,7 @@ import { useChatLayoutSlotsStore } from "@/components/layout/chat-layout-slots-s
 import { PageShell } from "@/components/page-shell";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useSupportsPluginsSurface } from "@/lib/backwards-compat/plugins-surface";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { routes } from "@/utils/routes";
 
@@ -20,7 +21,6 @@ const BASE_INTELLIGENCE_TABS: readonly IntelligenceTab[] = [
   { label: "Skills", to: routes.skills },
   { label: "Workspace", to: routes.workspace },
   { label: "Contacts", to: routes.contacts.root },
-  { label: "Channels", to: routes.channels },
 ];
 
 const PLUGINS_TAB: IntelligenceTab = {
@@ -28,11 +28,16 @@ const PLUGINS_TAB: IntelligenceTab = {
   to: routes.plugins,
 };
 
+const CHANNELS_TAB: IntelligenceTab = {
+  label: "Channels",
+  to: routes.channels,
+};
+
 /**
  * Shared layout for the "About Assistant" pages (Identity, Skills,
- * Workspace, Contacts, Channels, plus Plugins on plugin-capable
- * assistants). Renders a heading + tab bar above an `<Outlet />` for
- * the active tab's content.
+ * Workspace, Contacts, plus Plugins on plugin-capable assistants and
+ * Channels behind the `channel-trust-floors` flag). Renders a heading +
+ * tab bar above an `<Outlet />` for the active tab's content.
  *
  * Mounted as a pathless layout route in `routes.tsx` so the child
  * routes keep their existing URL paths (`/assistant/identity`, etc.)
@@ -43,6 +48,7 @@ const PLUGINS_TAB: IntelligenceTab = {
 export function IntelligenceLayout() {
   const assistantName = useAssistantIdentityStore.use.name();
   const supportsPlugins = useSupportsPluginsSurface();
+  const showChannelsTab = useAssistantFeatureFlagStore.use.channelTrustFloors();
   const { pathname } = useLocation();
   const isMobile = useIsMobile();
   const setTopBarCenter = useChatLayoutSlotsStore.use.setTopBarCenter();
@@ -53,9 +59,16 @@ export function IntelligenceLayout() {
   // routes 404, so the tab stays hidden rather than linking to a broken
   // catalog. `useSupportsPluginsSurface` returns false until the version
   // hydrates, so the tab appears once identity resolves.
-  const tabs: readonly IntelligenceTab[] = supportsPlugins
+  //
+  // The Channels tab is an unreleased surface gated on the
+  // `channel-trust-floors` flag (it ships with that arc); while the flag is
+  // off, channels are managed from the Contacts assistant detail instead.
+  const withPlugins: readonly IntelligenceTab[] = supportsPlugins
     ? [BASE_INTELLIGENCE_TABS[0], PLUGINS_TAB, ...BASE_INTELLIGENCE_TABS.slice(1)]
     : BASE_INTELLIGENCE_TABS;
+  const tabs: readonly IntelligenceTab[] = showChannelsTab
+    ? [...withPlugins, CHANNELS_TAB]
+    : withPlugins;
 
   // On mobile the title moves out of the page body and into the shared top
   // bar — centered between the hamburger menu and the search icon — so the


### PR DESCRIPTION
## Prompt / plan

Implements [LUM-2712](https://linear.app/vellum/issue/LUM-2712/featweb-channels-page-drop-redundant-heading-replace-accordion-with) against the Primitives Plan approved on the ticket. Closes LUM-2712.

Structural restructure of the Channels surface, **fully gated behind the existing `channel-trust-floors` flag** (no new registry entries — the Channels-tab arc ships with that flag):

**Flag on:**
1. The Channels tab appears in the About Assistant nav, with no duplicated "Channels" heading — the page renders only the promoted subtitle ("Manage where {assistant} can be reached.") via the existing borderless `DetailCard` header form.
2. The Slack / Telegram / Phone accordion is replaced with adapter sub-tabs using the design-library `Tabs` primitive (the state-based equivalent of the About nav's tab styling, already used by the Integrations page's OAuth/MCP sub-tabs).
3. Disconnected Telegram/Phone tabs show an empty state (platform glyph + one-line pitch + "Set up"), with an "or connect manually" link that swaps the empty state for the credential form.

**Flag off:** the Channels nav tab is hidden entirely (it's an unreleased surface from #37179); channels are managed from the Contacts assistant detail, which renders exactly today's accordion — bespoke Connected chip, chevrons, and indents preserved verbatim. Direct navigation to `/assistant/channels` also falls back to the titled card + accordion.

### Primitives touched / added

- **Reused:** `Tabs` (`@vellumai/design-library/components/tabs`) for the sub-tabs; `DetailCard` (borderless, subtitle-only) for the page subtitle; `Tag` (`tone="positive"`) replaces the bespoke inline "Connected" chip span in the tabbed layout; `Button` (`variant="link"` for the manual-entry affordance) / `ConfirmDialog` / `Dropdown` / `Notice` / `Input` / `Typography` unchanged.
- **Added:** `EmptyState` — new design-library primitive at `clients/web/src/components/empty-state.tsx` (props-first: `icon` / `title` / `description` / `action`; existing tokens only, no new tokens) with a Storybook story. Used for the disconnected Telegram/Phone tabs.

### Preserved as-is (moved into tab bodies, no rewrites)

`SlackSetupWizard`, `SlackChannelCard`, `TelegramCredentialEntry`, `TwilioCredentialEntry`, the disconnect + trust-floor confirmation dialogs, and all handler wiring. The `?setup=<channel>` deep link pre-selects a tab (or pre-expands the accordion row when the flag is off); prop renamed `initialExpandedChannel` → `initialChannel` (the type-level reference in `use-assistant-channels.ts` was renamed mechanically — no hook behavior change).

### Scope notes

- **Structural only** — the Slack channel list (LUM-2713) and the Who Can Reach dropdown deprecation are separate tickets; `use-assistant-channels.ts` fetching and cascade/floor logic untouched.
- `AssistantChannelsList` is shared with the Contacts assistant-detail card, so both mount points get the sub-tabs when the flag is on (confirmed on the ticket).
- Vocabulary gate: diff grepped for `\brooms?\b` — no matches; all user-visible copy says "channel".

### Screenshots

Both mount points (Channels page: Slack connected / Telegram + Phone disconnected empty states / manual-entry swap / legacy accordion parity, plus the Contacts detail card) are attached to [LUM-2712](https://linear.app/vellum/issue/LUM-2712/featweb-channels-page-drop-redundant-heading-replace-accordion-with) — this session can't upload images to GitHub, and committing PNGs to the branch would pollute the diff. Captured from the Storybook stories (`Contacts/AssistantChannelsList`, `Contacts/AssistantChannelsDetail`), which cover both flag states.

## Test plan

- `cd clients/web && bunx tsc --noEmit` — clean
- `bun test src/domains/intelligence/intelligence-layout.test.tsx src/domains/contacts/components/assistant-channels-detail.test.tsx src/domains/contacts/contacts-page.test.tsx` — 13 pass (covers: tabs vs accordion per flag state, nav tab hidden when flag off, empty-state → manual-form swap)
- `bunx eslint` on all changed files — no errors (9 pre-existing `curly` warnings in `contacts-page.tsx` on untouched lines)
- Storybook stories for both flag states rendered via Playwright for the screenshots above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148qQJv4PwkBTRxkBFEtkRv