### PR TITLE
fix(oauth): surface multi-account connection resolution to the model

### DIFF
--- a/assistant/src/__tests__/oauth-commands-routes.test.ts
+++ b/assistant/src/__tests__/oauth-commands-routes.test.ts
@@ -111,14 +111,23 @@ mock.module("../oauth/oauth-store.js", () => ({
   listConnections: (provider: string) => mockAllConnections[provider] ?? [],
 }));
 
-mock.module("../oauth/connection-resolver.js", () => ({
-  resolveOAuthConnection: async (_provider: string) => ({
+mock.module("../oauth/connection-resolver.js", () => {
+  const makeConnection = () => ({
+    accountInfo: "user@example.com",
     request: async (req: unknown) => {
       mockResolveRequests.push(req);
       return mockResolveResponse;
     },
-  }),
-}));
+  });
+  return {
+    resolveOAuthConnection: async (_provider: string) => makeConnection(),
+    resolveOAuthConnectionWithMeta: async (_provider: string) => ({
+      connection: makeConnection(),
+      ambiguous: false,
+      allAccounts: ["user@example.com"],
+    }),
+  };
+});
 
 mock.module("../oauth/manual-token-connection.js", () => ({
   syncManualTokenConnection: async (provider: string) => {

--- a/assistant/src/cli/commands/oauth/request.ts
+++ b/assistant/src/cli/commands/oauth/request.ts
@@ -216,6 +216,8 @@ Examples:
             headers: Record<string, string>;
             body: unknown;
             hint?: string;
+            account?: string | null;
+            accountWarning?: string;
           }>("oauth_request", { body });
 
           if (!r.ok) return exitFromIpcResult(r);
@@ -225,6 +227,14 @@ Examples:
           // Non-2xx exit code
           if (result.status < 200 || result.status >= 300) {
             process.exitCode = 1;
+          }
+
+          // Which account served the request, and any multi-account ambiguity.
+          if (result.account) {
+            writeInfo(`* Account: ${result.account}`);
+          }
+          if (result.accountWarning) {
+            writeInfo(result.accountWarning);
           }
 
           // Auth hint

--- a/assistant/src/oauth/connection-resolver.test.ts
+++ b/assistant/src/oauth/connection-resolver.test.ts
@@ -80,6 +80,7 @@ import { BYOOAuthConnection } from "./byo-connection.js";
 import {
   resolveEffectiveBaseUrl,
   resolveOAuthConnection,
+  resolveOAuthConnectionWithMeta,
 } from "./connection-resolver.js";
 import { PlatformOAuthConnection } from "./platform-connection.js";
 
@@ -459,6 +460,119 @@ describe("resolveOAuthConnection scope-awareness", () => {
     });
     expect(result).toBeInstanceOf(BYOOAuthConnection);
     expect(result.id).toBe("full");
+  });
+});
+
+describe("resolveOAuthConnectionWithMeta multi-account visibility", () => {
+  function clientReturning(results: unknown[]) {
+    return {
+      ...makeMockClient(),
+      fetch: mock(
+        async () => new Response(JSON.stringify({ results }), { status: 200 }),
+      ),
+    };
+  }
+
+  beforeEach(() => {
+    setupDefaults();
+  });
+
+  test("managed: multiple connections + no account surfaces ambiguity and the selected label", async () => {
+    mockProvider!.managedServiceConfigKey = "google-oauth";
+    mockPlatformClient = clientReturning([
+      { id: "conn-personal", account_label: "user@example.com" },
+      { id: "conn-work", account_label: "work@example.com" },
+    ]);
+
+    const { connection, ambiguous, allAccounts } =
+      await resolveOAuthConnectionWithMeta("google");
+
+    expect(ambiguous).toBe(true);
+    expect(allAccounts).toEqual(["user@example.com", "work@example.com"]);
+    // The most-recently-created connection (first) serves the request.
+    expect(connection.accountInfo).toBe("user@example.com");
+  });
+
+  test("managed: account passed disambiguates and clears the warning", async () => {
+    mockProvider!.managedServiceConfigKey = "google-oauth";
+    mockPlatformClient = clientReturning([
+      { id: "conn-work", account_label: "work@example.com" },
+    ]);
+
+    const { ambiguous } = await resolveOAuthConnectionWithMeta("google", {
+      account: "work@example.com",
+    });
+
+    expect(ambiguous).toBe(false);
+  });
+
+  test("managed: single connection is never ambiguous", async () => {
+    mockProvider!.managedServiceConfigKey = "google-oauth";
+    mockPlatformClient = clientReturning([
+      { id: "conn-only", account_label: "user@example.com" },
+    ]);
+
+    const { ambiguous, allAccounts } =
+      await resolveOAuthConnectionWithMeta("google");
+
+    expect(ambiguous).toBe(false);
+    expect(allAccounts).toEqual(["user@example.com"]);
+  });
+
+  test("BYO: multiple connections + no account surfaces ambiguity and the selected label", async () => {
+    mockConnections = [
+      {
+        id: "conn-personal",
+        provider: "google",
+        accountInfo: "user@example.com",
+        grantedScopes: JSON.stringify([]),
+        status: "active",
+      },
+      {
+        id: "conn-work",
+        provider: "google",
+        accountInfo: "work@example.com",
+        grantedScopes: JSON.stringify([]),
+        status: "active",
+      },
+    ];
+
+    const { connection, ambiguous, allAccounts } =
+      await resolveOAuthConnectionWithMeta("google");
+
+    expect(ambiguous).toBe(true);
+    expect(allAccounts).toEqual(["user@example.com", "work@example.com"]);
+    expect(connection).toBeInstanceOf(BYOOAuthConnection);
+    expect(connection.id).toBe("conn-personal");
+    expect(connection.accountInfo).toBe("user@example.com");
+  });
+
+  test("BYO: account passed disambiguates and clears the warning", async () => {
+    mockConnections = [
+      {
+        id: "conn-work",
+        provider: "google",
+        accountInfo: "work@example.com",
+        grantedScopes: JSON.stringify([]),
+        status: "active",
+      },
+    ];
+
+    const { ambiguous, connection } = await resolveOAuthConnectionWithMeta(
+      "google",
+      { account: "work@example.com" },
+    );
+
+    expect(ambiguous).toBe(false);
+    expect(connection.id).toBe("conn-work");
+  });
+
+  test("BYO: single connection is never ambiguous", async () => {
+    const { ambiguous, allAccounts } =
+      await resolveOAuthConnectionWithMeta("google");
+
+    expect(ambiguous).toBe(false);
+    expect(allAccounts).toEqual(["user@example.com"]);
   });
 });
 

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -38,13 +38,32 @@ export interface ResolveOAuthConnectionOptions {
 }
 
 /**
+ * Outcome of resolving a connection, carrying the account that actually served
+ * the request plus the ambiguity signal callers surface to the model.
+ *
+ * When several active connections match a provider and the caller did not pin
+ * an account, resolution silently picks the most-recently-created one. That
+ * choice is invisible unless it is reported: `ambiguous` flags the situation
+ * and `allAccounts` lists every candidate's label so a caller can warn that a
+ * specific account should be selected.
+ */
+export interface OAuthConnectionResolution {
+  connection: OAuthConnection;
+  /** True when more than one active connection matched and no account was pinned. */
+  ambiguous: boolean;
+  /**
+   * Labels of every active connection considered, most-recent first. The first
+   * entry is always the one that served the request. Labels fall back to the
+   * connection ID when no human-readable account label is available.
+   */
+  allAccounts: string[];
+}
+
+/**
  * Resolve an OAuthConnection for a given provider.
  *
- * Managed providers (where the service config `mode` is `"managed"`) are
- * routed through the platform proxy with no local state required.
- *
- * BYO providers resolve from the local SQLite oauth-store and require an
- * active connection row and a stored access token.
+ * Thin wrapper over {@link resolveOAuthConnectionWithMeta} for callers that
+ * only need the connection and not the resolution metadata.
  *
  * @param provider - Provider identifier (e.g. "google").
  *   Maps to the `provider_key` primary key in the `oauth_providers` table.
@@ -58,6 +77,27 @@ export async function resolveOAuthConnection(
   provider: string,
   options?: ResolveOAuthConnectionOptions,
 ): Promise<OAuthConnection> {
+  const { connection } = await resolveOAuthConnectionWithMeta(
+    provider,
+    options,
+  );
+  return connection;
+}
+
+/**
+ * Resolve an OAuthConnection along with the account that served it and whether
+ * the selection was ambiguous.
+ *
+ * Managed providers (where the service config `mode` is `"managed"`) are
+ * routed through the platform proxy with no local state required.
+ *
+ * BYO providers resolve from the local SQLite oauth-store and require an
+ * active connection row and a stored access token.
+ */
+export async function resolveOAuthConnectionWithMeta(
+  provider: string,
+  options?: ResolveOAuthConnectionOptions,
+): Promise<OAuthConnectionResolution> {
   const { clientId, account, requiredScopes } = options ?? {};
   const providerRow = getProvider(provider);
   const managedKey = providerRow?.managedServiceConfigKey;
@@ -76,22 +116,27 @@ export async function resolveOAuthConnection(
         );
       }
 
-      const connectionId = await resolvePlatformConnectionId({
+      const resolution = await resolvePlatformConnectionId({
         client,
         provider,
         account,
         requiredScopes,
       });
 
-      return new PlatformOAuthConnection({
+      const connection = new PlatformOAuthConnection({
         id: provider,
         provider,
         externalId: provider,
-        accountInfo: account ?? null,
+        accountInfo: resolution.accountLabel ?? account ?? null,
         client,
-        connectionId,
+        connectionId: resolution.id,
         baseUrl: providerRow?.baseUrl ?? undefined,
       });
+      return {
+        connection,
+        ambiguous: resolution.ambiguous,
+        allAccounts: resolution.allAccountLabels,
+      };
     }
   }
 
@@ -120,7 +165,7 @@ export async function resolveOAuthConnection(
   // Only fail when EVERY active connection positively lacks a required scope;
   // unknown scope data never blocks. Without requiredScopes, behavior is
   // unchanged: take the most-recently-created connection.
-  let conn = candidates[0];
+  let selectionPool = candidates;
   if (requiredScopes?.length) {
     const { eligible, missingScopes } = partitionByScopes(
       candidates,
@@ -130,7 +175,25 @@ export async function resolveOAuthConnection(
     if (eligible.length === 0) {
       throw new Error(missingScopesMessage(provider, missingScopes));
     }
-    conn = eligible[0];
+    selectionPool = eligible;
+  }
+  const conn = selectionPool[0];
+
+  const allAccounts = selectionPool.map(
+    (row) => (row.accountInfo as string | null) ?? (row.id as string),
+  );
+  const ambiguous = selectionPool.length > 1 && !account;
+  if (ambiguous) {
+    log.warn(
+      {
+        provider,
+        count: selectionPool.length,
+        selectedId: conn.id,
+        allAccounts: allAccounts.join(", "),
+      },
+      "Multiple active OAuth connections found; using the most recently created. " +
+        "Pass an account option to select a specific connection.",
+    );
   }
 
   const tokenResult = await getConnectionAccessTokenResult({
@@ -150,12 +213,13 @@ export async function resolveOAuthConnection(
     );
   }
 
-  return new BYOOAuthConnection({
+  const connection = new BYOOAuthConnection({
     id: conn.id,
     provider: conn.provider,
     baseUrl: resolveEffectiveBaseUrl(conn.provider, baseUrl, conn.metadata),
     accountInfo: conn.accountInfo,
   });
+  return { connection, ambiguous, allAccounts };
 }
 
 /**
@@ -231,6 +295,22 @@ interface PlatformConnectionEntry {
   scopes_granted?: string[] | null;
 }
 
+interface PlatformConnectionResolution {
+  /** Platform-side connection ID used in the proxy URL path. */
+  id: string;
+  /** Human-readable account label of the connection that served the request. */
+  accountLabel: string | null;
+  /** Labels (falling back to IDs) of every connection considered, most-recent first. */
+  allAccountLabels: string[];
+  /** True when more than one active connection matched and no account was pinned. */
+  ambiguous: boolean;
+}
+
+/** Human-readable label for a platform connection, falling back to its ID. */
+function platformConnectionLabel(entry: PlatformConnectionEntry): string {
+  return entry.account_label ?? entry.id;
+}
+
 /**
  * Fetch active platform connections for a managed provider by calling the
  * List Connections endpoint.
@@ -276,7 +356,7 @@ async function fetchPlatformConnections(options: {
  */
 async function resolvePlatformConnectionId(
   options: ResolvePlatformConnectionIdOptions,
-): Promise<string> {
+): Promise<PlatformConnectionResolution> {
   const { client, provider, account, requiredScopes } = options;
 
   let connections = await fetchPlatformConnections({
@@ -324,23 +404,28 @@ async function resolvePlatformConnectionId(
     connections = eligible;
   }
 
-  if (connections.length > 1 && !account) {
-    const allAccounts = connections
-      .map((c) => c.account_label ?? c.id)
-      .join(", ");
+  const allAccountLabels = connections.map(platformConnectionLabel);
+  const ambiguous = connections.length > 1 && !account;
+  if (ambiguous) {
     log.warn(
       {
         provider,
         count: connections.length,
         selectedId: connections[0].id,
-        allAccounts,
+        allAccounts: allAccountLabels.join(", "),
       },
       "Multiple active platform connections found; using the most recently created. " +
         "Pass an account option to select a specific connection.",
     );
   }
 
-  return connections[0].id;
+  const selected = connections[0];
+  return {
+    id: selected.id,
+    accountLabel: selected.account_label ?? null,
+    allAccountLabels,
+    ambiguous,
+  };
 }
 
 /**

--- a/assistant/src/runtime/routes/oauth-commands-routes.ts
+++ b/assistant/src/runtime/routes/oauth-commands-routes.ts
@@ -22,6 +22,7 @@ import type { OAuthConnectionRequest } from "../../oauth/connection.js";
 import {
   resolveOAuthConnection,
   type ResolveOAuthConnectionOptions,
+  resolveOAuthConnectionWithMeta,
 } from "../../oauth/connection-resolver.js";
 import { syncManualTokenConnection } from "../../oauth/manual-token-connection.js";
 import {
@@ -863,7 +864,8 @@ async function handleRequest({ body = {} }: RouteHandlerArgs) {
     resolveOptions.account = b.account;
   }
 
-  const connection = await resolveOAuthConnection(b.provider, resolveOptions);
+  const { connection, ambiguous, allAccounts } =
+    await resolveOAuthConnectionWithMeta(b.provider, resolveOptions);
 
   const headers = b.headers ?? {};
 
@@ -883,7 +885,20 @@ async function handleRequest({ body = {} }: RouteHandlerArgs) {
     status: response.status,
     headers: response.headers,
     body: response.body,
+    // Which connected account actually served the request, so the caller can
+    // tell whether the intended account was used.
+    account: connection.accountInfo,
   };
+
+  // Surface a caller-visible warning when the provider had several active
+  // connections and no account was pinned — the model must see that a
+  // silent pick happened, not just the daemon log.
+  if (ambiguous && allAccounts.length > 1) {
+    const selected = allAccounts[0];
+    result.accountWarning =
+      `Multiple ${b.provider} accounts are connected (${allAccounts.join(", ")}); ` +
+      `used "${selected}". Pass --account to select a specific one.`;
+  }
 
   if (response.status === 401 || response.status === 403) {
     result.hint = managed


### PR DESCRIPTION
## Problem

Found in a real user feedback session. A user had two active platform-managed connections for one provider (a personal and a work account) and two for another. Calendar skill scripts call `assistant oauth request --provider <p> ...` without an `--account` flag. `resolvePlatformConnectionId()` silently picked the most-recently-created connection and only emitted a daemon-side `log.warn` — invisible to the LLM. The wrong (empty) account returned "no events", and the assistant confidently told the user their week was wide open. The same silent pick existed on the BYO path (`candidates[0]`).

The ambiguity never reached the model, so it had no way to notice it had queried the wrong account.

## Fix

- **New `resolveOAuthConnectionWithMeta()`** returns `{ connection, ambiguous, allAccounts }` alongside the connection. `resolveOAuthConnection()` stays a thin wrapper over it, so its many other callers are untouched.
- **Managed path**: `resolvePlatformConnectionId()` now returns the resolved connection's `account_label`, the labels of all candidates, and an `ambiguous` flag. `PlatformOAuthConnection.accountInfo` carries the *resolved* label instead of the *requested* account.
- **`oauth_request` route result** gains two additive fields:
  - `account` — which connected account actually served the request.
  - `accountWarning` — set only when multiple connections matched and no account was pinned: `Multiple <provider> accounts are connected (<label1>, <label2>); used "<selected>". Pass --account to select a specific one.` This is the critical part: the ambiguity now reaches the LLM in the tool result.
- **BYO path** gains the same ambiguity signal and a `log.warn` matching the one the managed path already had.
- **CLI** (`oauth request`): JSON mode passes the new fields through automatically; non-JSON mode prints the account line and any warning to stderr via the existing `writeInfo` helper (respects `-s`).
- Existing daemon-side `log.warn` observability is preserved on both paths.

## Test coverage

Extended `assistant/src/oauth/connection-resolver.test.ts` with a `resolveOAuthConnectionWithMeta` suite covering, for both the managed and BYO paths:
- multiple connections + no account → `ambiguous: true`, `allAccounts` populated, selected label surfaced via `connection.accountInfo`;
- account passed → `ambiguous: false`;
- single connection → `ambiguous: false`.

All 34 tests in the file pass. Typecheck of the touched files is clean (the local repo has 23 pre-existing, unrelated `service-contracts` type errors, identical on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->