### PR TITLE
fix: live-voice session lifetime and ownership scoping

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -12,7 +12,7 @@ import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { MOBILE_MEDIA_QUERY, useIsMobile } from "@/hooks/use-is-mobile";
 import { getLocalBool, getLocalNumber, setLocalBool, setLocalNumber } from "@/utils/local-settings";
-import { isAboutAssistantPath, routes } from "@/utils/routes";
+import { isAboutAssistantPath, isConversationPath, routes } from "@/utils/routes";
 
 import { useChatLayoutSlotsStore } from "@/components/layout/chat-layout-slots-store";
 import { useElectronDockSync } from "@/domains/chat/hooks/use-electron-dock-sync";
@@ -62,6 +62,7 @@ import { ResearchResultsOverlay } from "@/domains/chat/onboarding-research/resea
 import { OnboardingCheckinOverlay } from "@/components/onboarding-checkin-overlay";
 import { OnboardingAvatarApplier } from "@/components/onboarding-avatar-applier";
 import { VoiceSessionPillHost } from "@/domains/chat/components/voice-session-pill-host";
+import { useLiveVoiceSessionController } from "@/domains/chat/voice/live-voice/use-live-voice-session-controller";
 import { ChatConversationHeader } from "./chat-conversation-header";
 import { ChatLayoutHeader } from "./chat-layout-header";
 import { RenameDialogFromStore } from "./rename-dialog-from-store";
@@ -138,6 +139,13 @@ export function ChatLayout() {
     (s) => s.assistantState.kind,
   );
   const isAssistantActive = assistantStateKind === "active";
+
+  // Live-voice session controller. Owned at layout scope — not by the
+  // composer — so a session survives every chat-side navigation (thread
+  // switch, Home/Library, the fullscreen app viewer) with the title-bar
+  // pill as its control surface. The composer starts/stops sessions
+  // through the seams this registers in `useLiveVoiceStore`.
+  useLiveVoiceSessionController();
 
   // Subscribe to the sidebar conversation list at the layout level so every
   // chat-layout child route (home, library, contacts, identity, chat)
@@ -511,10 +519,7 @@ export function ChatLayout() {
   // is intentionally left intact — many other consumers (SSE streams,
   // attention tracking, message reconciliation) rely on it persisting
   // across route changes.
-  const isOnConversationRoute =
-    location.pathname === routes.assistant ||
-    location.pathname === `${routes.assistant}/` ||
-    location.pathname.startsWith(`${routes.conversations}/`);
+  const isOnConversationRoute = isConversationPath(location.pathname);
   const sidebarActiveConversationId = isOnConversationRoute
     ? (activeConversationId ?? undefined)
     : undefined;

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -38,14 +38,14 @@ mock.module("@/runtime/is-electron", () => ({
   isElectron: () => mockIsElectron,
 }));
 
-// Live-voice integration mocks. The composer owns the single `useLiveVoice()`
-// controller (it must outlive the `LiveVoiceButton`, which is swapped out with
-// the rest of the action row during a session) and polls amplitude through
-// `useLiveVoiceStore.getState()`. Both are mocked so the composer renders in
-// isolation: the flag via a mutable `mockVoiceMode` (consumed by the real
-// `LiveVoiceButton`, which self-gates on it), and the session via a mutable
-// state/error bag exposed through the mocked hook. Defaults (flag off, idle,
-// no error) keep the existing HTML-surface assertions unchanged.
+// Live-voice integration. The session controller (`useLiveVoice`) lives in
+// the layout-mounted `useLiveVoiceSessionController`, NOT in the composer —
+// the composer only reads the real `useLiveVoiceStore` (self-contained
+// zustand, no heavy imports) and drives the session through the
+// `starter`/`controls` seams registered there. Tests therefore seed the real
+// store and register spy seams; only the flag store is mocked (consumed by
+// the real `LiveVoiceButton`, which self-gates on it). Defaults (flag off,
+// idle) keep the existing HTML-surface assertions unchanged.
 let mockVoiceMode = false;
 mock.module("@/stores/assistant-feature-flag-store", () => ({
   useAssistantFeatureFlagStore: {
@@ -55,66 +55,35 @@ mock.module("@/stores/assistant-feature-flag-store", () => ({
   },
 }));
 
-// Local mirror of the live-voice session phases this test exercises. Kept as a
-// narrow union (not an import from the `voice` domain) so the `chat` test stays
-// free of cross-domain coupling — the composer only ever distinguishes idle
-// from non-idle, so the precise phase taxonomy is irrelevant here.
-type MockLiveVoiceState = "idle" | "listening" | "failed";
+import {
+  useLiveVoiceStore,
+  type LiveVoiceSessionState,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
 
-let mockLiveVoiceState: MockLiveVoiceState = "idle";
-let mockLiveVoiceError: string | null = null;
-let mockLiveVoicePartial = "";
-let mockLiveVoiceFinal = "";
-const liveStartSpy = mock(
-  async (_assistantId: string, _conversationId?: string) => {},
+const liveStarterSpy = mock(
+  (_assistantId: string, _conversationId: string | null) => {},
 );
-const liveStopSpy = mock(async () => {});
-const liveReleaseSpy = mock(() => {});
-const liveResetSpy = mock(() => {});
-// The store mock mirrors the three surfaces the composer tree touches:
-// `getState()` (voice bar amplitude poll + failed-session reset), a callable
-// selector subscription (the composer's low-frequency transcript-presence
-// bit), and `.use` per-field hooks (`VoiceLiveTranscript`'s self-sourced
-// transcript). Reactive session state flows through the mocked hook below.
-const liveVoiceStoreState = () => ({
-  inputAmplitude: 0,
-  partialTranscript: mockLiveVoicePartial,
-  finalTranscript: mockLiveVoiceFinal,
-  reset: liveResetSpy,
-});
-type MockLiveVoiceStoreState = ReturnType<typeof liveVoiceStoreState>;
-const useLiveVoiceStoreMock = Object.assign(
-  <T,>(selector: (s: MockLiveVoiceStoreState) => T): T =>
-    selector(liveVoiceStoreState()),
-  {
-    getState: liveVoiceStoreState,
-    use: {
-      partialTranscript: () => mockLiveVoicePartial,
-      finalTranscript: () => mockLiveVoiceFinal,
-    },
-  },
-);
-mock.module("@/domains/chat/voice/live-voice/live-voice-store", () => ({
-  useLiveVoiceStore: useLiveVoiceStoreMock,
-}));
-// Spy wrapper so tests can assert the composer opts out of the hook's
-// high-frequency audio-state subscription (`observeAudioState: false`) —
-// the guard that keeps per-mic-sample amplitude updates from re-rendering
-// the whole composer (the voice bar polls amplitude via `getState()`).
-const useLiveVoiceSpy = mock((_options?: { observeAudioState?: boolean }) => ({
-  state: mockLiveVoiceState,
-  partialTranscript: "",
-  finalTranscript: "",
-  assistantTranscript: "",
-  inputAmplitude: 0,
-  error: mockLiveVoiceError,
-  start: liveStartSpy,
-  stop: liveStopSpy,
-  release: liveReleaseSpy,
-}));
-mock.module("@/domains/chat/voice/live-voice/use-live-voice", () => ({
-  useLiveVoice: useLiveVoiceSpy,
-}));
+const liveControls = {
+  stop: mock(() => {}),
+  release: mock(() => {}),
+  interrupt: mock(() => {}),
+};
+
+/**
+ * Seed the real live-voice store with an active session. `conversationId`
+ * defaults to the id `renderVoiceComposer` binds, so the rendered composer
+ * owns the session; pass another id to simulate a session owned by a
+ * different thread, or `null` for a draft-started session.
+ */
+function seedLiveVoiceSession(
+  state: LiveVoiceSessionState,
+  conversationId: string | null = "conv_test",
+) {
+  const store = useLiveVoiceStore.getState();
+  store.setSessionContext("asst_test", conversationId);
+  store.setControls(liveControls);
+  store.setState(state);
+}
 
 // The real `VoiceInputButton` self-suppresses (returns null) unless the test
 // DOM exposes `MediaRecorder` + `getUserMedia`, which happy-dom does not. Mock
@@ -150,22 +119,19 @@ mock.module("@/domains/chat/voice/voice-recording-store", () => ({
 function resetLiveVoiceMocks() {
   mockIsElectron = false;
   mockVoiceMode = false;
-  mockLiveVoiceState = "idle";
-  mockLiveVoiceError = null;
-  mockLiveVoicePartial = "";
-  mockLiveVoiceFinal = "";
   mockVoicePhase = "idle";
   setAudioLevelSpy.mockClear();
-  liveStartSpy.mockClear();
-  liveStopSpy.mockClear();
-  liveReleaseSpy.mockClear();
-  liveResetSpy.mockClear();
-  useLiveVoiceSpy.mockClear();
+  liveStarterSpy.mockClear();
+  liveControls.stop.mockClear();
+  liveControls.release.mockClear();
+  liveControls.interrupt.mockClear();
+  useLiveVoiceStore.getState().reset();
+  useLiveVoiceStore.getState().setStarter(liveStarterSpy);
 }
 
 // Imported after the mocks so the component (and its transitive flag-store /
-// live-voice / voice-input-button imports) resolve against the mocked modules.
-// The pure helpers (computeGhostSuffix / shouldSubmitOnEnter) come from
+// voice-input-button imports) resolve against the mocked modules. The pure
+// helpers (computeGhostSuffix / shouldSubmitOnEnter) come from
 // `chat-composer-utils`, imported statically above.
 const { ChatComposer } = await import(
   "@/domains/chat/components/chat-composer/chat-composer"
@@ -802,7 +768,6 @@ describe("ChatComposer — live-voice integration", () => {
     // GIVEN the flag is on with no active session
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "idle";
 
     // WHEN the composer renders
     const { getByLabelText, queryByLabelText, queryByRole } =
@@ -819,26 +784,26 @@ describe("ChatComposer — live-voice integration", () => {
     expect(getByLabelText("Send message")).toBeTruthy();
   });
 
-  test("clicking the live-voice button starts a session for the conversation", () => {
+  test("clicking the live-voice button starts a session through the store-registered starter", () => {
     // GIVEN the flag is on with no active session
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "idle";
 
     // WHEN the user clicks the entry-point mic
     const { getByLabelText } = renderVoiceComposer();
     fireEvent.click(getByLabelText("Start voice mode"));
 
-    // THEN the composer-owned controller starts with the bound context
-    expect(liveStartSpy).toHaveBeenCalledTimes(1);
-    expect(liveStartSpy).toHaveBeenCalledWith("asst_test", "conv_test");
+    // THEN the layout-owned controller is asked to start with the bound
+    // context (the composer holds no controller of its own)
+    expect(liveStarterSpy).toHaveBeenCalledTimes(1);
+    expect(liveStarterSpy).toHaveBeenCalledWith("asst_test", "conv_test");
   });
 
-  test("active session swaps the action row for the voice bar (mutual exclusion by absence)", () => {
-    // GIVEN a live-voice session is listening
+  test("owned active session swaps the action row for the voice bar (mutual exclusion by absence)", () => {
+    // GIVEN a live-voice session owned by this composer's conversation
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "listening";
+    seedLiveVoiceSession("listening");
 
     // WHEN the composer renders
     const { getByRole, queryByLabelText } = renderVoiceComposer();
@@ -853,17 +818,58 @@ describe("ChatComposer — live-voice integration", () => {
     expect(queryByLabelText("Live voice transcript")).toBeNull();
   });
 
-  test("active session keeps the textarea mounted but inert", () => {
-    // GIVEN a live-voice session is listening
+  test("session owned by another conversation leaves this composer untouched (pill is the surface)", () => {
+    // GIVEN a session owned by thread A while this composer shows thread B
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "listening";
+    seedLiveVoiceSession("listening", "conv-other-thread");
+
+    // WHEN the composer renders
+    const { container, getByLabelText, queryByRole } = renderVoiceComposer();
+
+    // THEN no voice bar, no transcript region, and the textarea stays
+    // editable — thread B behaves like a normal composer...
+    expect(queryByRole("group", { name: "Voice session" })).toBeNull();
+    expect(getByLabelText("Send message")).toBeTruthy();
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea.disabled).toBe(false);
+    // ...except both mic entry points are disabled: the running session owns
+    // the microphone, so no second capture flow may start from here
+    const liveVoice = getByLabelText("Start voice mode") as HTMLButtonElement;
+    expect(liveVoice.disabled).toBe(true);
+    const dictation = getByLabelText("Start voice input") as HTMLButtonElement;
+    expect(dictation.disabled).toBe(true);
+  });
+
+  test("draft composer keeps owning a draft-started session after the server assigns a conversation", () => {
+    // GIVEN a session started from a draft (no conversation) whose `ready`
+    // frame has since republished a server-assigned conversation id
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    seedLiveVoiceSession("listening", null);
+    useLiveVoiceStore.getState().setConversationId("conv-server-assigned");
+
+    // WHEN the draft composer (bound to no conversation) renders
+    const { getByRole } = renderVoiceComposer({ conversationId: undefined });
+
+    // THEN it still owns the session — the voice bar stays, so the user
+    // sitting at the composer that started the session never sees it
+    // handed off to the title-bar pill
+    expect(getByRole("group", { name: "Voice session" })).toBeTruthy();
+  });
+
+  test("owned session keeps the textarea mounted but inert", () => {
+    // GIVEN a live-voice session owned by this composer's conversation
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    seedLiveVoiceSession("listening");
 
     // WHEN the composer renders
     const { container } = renderVoiceComposer();
 
-    // THEN the textarea stays (a later PR streams the transcript into it)
-    // but is disabled so focus/typing can't fight the session
+    // THEN the textarea stays mounted (VoiceLiveTranscript renders into its
+    // grid cell once speech streams) but is disabled so focus/typing can't
+    // fight the session
     const textarea = container.querySelector("textarea");
     expect(textarea).not.toBeNull();
     expect((textarea as HTMLTextAreaElement).disabled).toBe(true);
@@ -873,31 +879,32 @@ describe("ChatComposer — live-voice integration", () => {
     // GIVEN a live session AND the composer is otherwise disabled
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "listening";
+    seedLiveVoiceSession("listening");
 
     // WHEN the composer renders with typingDisabled raised
     const { getByLabelText } = renderVoiceComposer({ typingDisabled: true });
 
-    // THEN the end control is still actionable and clicking it stops
+    // THEN the end control is still actionable and clicking it stops the
+    // session through the store-registered controls
     const end = getByLabelText("End voice session") as HTMLButtonElement;
     expect(end.disabled).toBe(false);
     fireEvent.click(end);
-    expect(liveStopSpy).toHaveBeenCalledTimes(1);
+    expect(liveControls.stop).toHaveBeenCalledTimes(1);
   });
 
   test("voice bar ↑ manually releases the turn while listening", () => {
-    // GIVEN a listening session
+    // GIVEN a listening session owned by this composer
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "listening";
+    seedLiveVoiceSession("listening");
 
     // WHEN the user clicks send-now
     const { getByLabelText } = renderVoiceComposer();
     fireEvent.click(getByLabelText("Send now"));
 
-    // THEN the composer-owned controller releases the turn
-    expect(liveReleaseSpy).toHaveBeenCalledTimes(1);
-    expect(liveStopSpy).not.toHaveBeenCalled();
+    // THEN the turn is released through the store-registered controls
+    expect(liveControls.release).toHaveBeenCalledTimes(1);
+    expect(liveControls.stop).not.toHaveBeenCalled();
   });
 
   test("dictation active disables the live-voice button (reverse mutual exclusion)", () => {
@@ -909,7 +916,6 @@ describe("ChatComposer — live-voice integration", () => {
     // same either way.
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "idle";
     mockVoicePhase = "processing";
 
     // WHEN the composer renders
@@ -926,7 +932,6 @@ describe("ChatComposer — live-voice integration", () => {
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockIsElectron = true;
     mockVoiceMode = true;
-    mockLiveVoiceState = "idle";
     mockVoicePhase = "processing";
 
     // WHEN the composer renders
@@ -943,7 +948,8 @@ describe("ChatComposer — live-voice integration", () => {
     // GIVEN the flag is on and a live-voice session has failed
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "failed";
+    seedLiveVoiceSession("listening");
+    useLiveVoiceStore.getState().fail("boom");
 
     // WHEN the composer renders (dictation idle)
     const { getByLabelText, queryByRole } = renderVoiceComposer();
@@ -958,32 +964,31 @@ describe("ChatComposer — live-voice integration", () => {
     expect(dictation.disabled).toBe(false);
   });
 
-  test("failed session surfaces the hook error as a dismissible notice", () => {
+  test("failed session surfaces the error as a dismissible notice", () => {
     // GIVEN a failed session carrying an error message
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "failed";
-    mockLiveVoiceError = "Microphone capture could not start.";
+    seedLiveVoiceSession("listening");
+    useLiveVoiceStore.getState().fail("Microphone capture could not start.");
 
     // WHEN the composer renders
     const { getByText, getByLabelText } = renderVoiceComposer();
 
-    // THEN the error notice is visible with the hook's message
+    // THEN the error notice is visible with the session's message
     expect(getByText("Microphone capture could not start.")).toBeTruthy();
 
     // WHEN the user dismisses it
     fireEvent.click(getByLabelText("Dismiss"));
 
     // THEN the store is reset back to idle (which clears the error)
-    expect(liveResetSpy).toHaveBeenCalledTimes(1);
+    expect(useLiveVoiceStore.getState().state).toBe("idle");
+    expect(useLiveVoiceStore.getState().error).toBeNull();
   });
 
   test("no live-voice error notice while idle or without an error", () => {
     // GIVEN the flag is on with an idle session and no error
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "idle";
-    mockLiveVoiceError = null;
 
     // WHEN the composer renders
     const { queryByLabelText } = renderVoiceComposer();
@@ -992,29 +997,12 @@ describe("ChatComposer — live-voice integration", () => {
     expect(queryByLabelText("Dismiss")).toBeNull();
   });
 
-  test("composer opts out of the hook's high-frequency audio state (observeAudioState: false)", () => {
-    // GIVEN a voice-enabled composer
-    useTurnStore.setState(INITIAL_TURN_STATE);
-    mockVoiceMode = true;
-
-    // WHEN it renders
-    renderVoiceComposer();
-
-    // THEN it consumes only the low-frequency session state + actions —
-    // amplitude ticks and transcript deltas must not re-render the whole
-    // composer (the voice bar polls amplitude via getState() instead)
-    expect(useLiveVoiceSpy).toHaveBeenCalled();
-    for (const call of useLiveVoiceSpy.mock.calls) {
-      expect(call[0]).toEqual({ observeAudioState: false });
-    }
-  });
-
   test("voice bar persists when the flag flips off mid-session (no stranded session)", () => {
-    // GIVEN an active session but the voice-mode flag has since flipped off
-    // while the composer (and its session-owning controller) stayed mounted
+    // GIVEN an active owned session but the voice-mode flag has since
+    // flipped off while the layout-owned controller keeps the session live
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = false;
-    mockLiveVoiceState = "listening";
+    seedLiveVoiceSession("listening");
 
     // WHEN the composer renders
     const { getByRole, getByLabelText, queryByLabelText } =
@@ -1030,14 +1018,15 @@ describe("ChatComposer — live-voice integration", () => {
 
     // AND the ✕ still ends the live session
     fireEvent.click(end);
-    expect(liveStopSpy).toHaveBeenCalledTimes(1);
+    expect(liveControls.stop).toHaveBeenCalledTimes(1);
   });
 
   test("voice bar persists when assistantId is transiently cleared mid-session", () => {
-    // GIVEN an active session whose assistantId has been cleared from props
+    // GIVEN an active owned session whose assistantId has been cleared from
+    // props
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "listening";
+    seedLiveVoiceSession("listening");
 
     // WHEN the composer renders without an assistant id
     const { getByRole, getByLabelText } = renderVoiceComposer({
@@ -1047,15 +1036,15 @@ describe("ChatComposer — live-voice integration", () => {
     // THEN the stop control remains available for the live mic/socket
     expect(getByRole("group", { name: "Voice session" })).toBeTruthy();
     fireEvent.click(getByLabelText("End voice session"));
-    expect(liveStopSpy).toHaveBeenCalledTimes(1);
+    expect(liveControls.stop).toHaveBeenCalledTimes(1);
   });
 
   test("failure after an eligibility drop still surfaces the error notice", () => {
     // GIVEN a session that failed right after the flag flipped off
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = false;
-    mockLiveVoiceState = "failed";
-    mockLiveVoiceError = "Connection lost.";
+    seedLiveVoiceSession("listening");
+    useLiveVoiceStore.getState().fail("Connection lost.");
 
     // WHEN the composer renders
     const { getByText } = renderVoiceComposer();
@@ -1065,11 +1054,11 @@ describe("ChatComposer — live-voice integration", () => {
   });
 
   test("no-voice variant (app-editing) never swaps its row for a session it doesn't own", () => {
-    // GIVEN a live session exists in the global store (owned by another
-    // composer instance) and this variant has no voice props
+    // GIVEN a live session exists in the global store (owned elsewhere) and
+    // this variant has no voice props
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "listening";
+    seedLiveVoiceSession("listening", "conv-other-thread");
 
     // WHEN the app-editing variant renders (no voiceInputRef/onVoiceTranscript)
     const html = renderComposer();
@@ -1090,11 +1079,13 @@ describe("ChatComposer — live-voice integration", () => {
 
 describe("ChatComposer — live-voice transcript area", () => {
   test("streaming speech hides the textarea and renders the transcript in its place", () => {
-    // GIVEN a listening session with an in-flight partial transcript
+    // GIVEN a listening owned session with an in-flight partial transcript
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "listening";
-    mockLiveVoicePartial = "this is a text that I am just speaking";
+    seedLiveVoiceSession("listening");
+    useLiveVoiceStore
+      .getState()
+      .setPartialTranscript("this is a text that I am just speaking");
 
     // WHEN the composer renders
     const { container, getByLabelText } = renderVoiceComposer();
@@ -1112,11 +1103,30 @@ describe("ChatComposer — live-voice transcript area", () => {
     expect(textarea.disabled).toBe(true);
   });
 
-  test("empty transcript keeps the textarea (and its placeholder) visible", () => {
-    // GIVEN an active session with no speech yet (Light 53 baseline)
+  test("speech from a session owned by another thread never streams into this composer", () => {
+    // GIVEN a session owned by thread A streaming speech while this composer
+    // shows thread B
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "listening";
+    seedLiveVoiceSession("listening", "conv-other-thread");
+    useLiveVoiceStore.getState().setPartialTranscript("thread A's words");
+
+    // WHEN the composer renders
+    const { container, queryByLabelText } = renderVoiceComposer();
+
+    // THEN no transcript region mounts and the textarea stays editable —
+    // thread A's speech must not leak into thread B's input
+    expect(queryByLabelText("Voice transcript")).toBeNull();
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea.className).not.toContain("hidden");
+    expect(textarea.disabled).toBe(false);
+  });
+
+  test("empty transcript keeps the textarea (and its placeholder) visible", () => {
+    // GIVEN an active owned session with no speech yet (Light 53 baseline)
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    seedLiveVoiceSession("listening");
 
     // WHEN the composer renders
     const { container, queryByLabelText } = renderVoiceComposer();
@@ -1128,11 +1138,10 @@ describe("ChatComposer — live-voice transcript area", () => {
   });
 
   test("textarea is restored after the session ends, even with a leftover final transcript", () => {
-    // GIVEN the session has ended (store not yet reset, final text lingering)
+    // GIVEN the session has ended (store back to idle, final text lingering)
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "idle";
-    mockLiveVoiceFinal = "what I said last";
+    useLiveVoiceStore.getState().setFinalTranscript("what I said last");
 
     // WHEN the composer renders
     const { container, queryByLabelText } = renderVoiceComposer();

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -33,8 +33,11 @@ import {
     type VoiceInputButtonHandle,
 } from "@/domains/chat/components/voice-input-button";
 import { type TurnPhase, useTurnStore } from "@/domains/chat/turn-store";
-import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
-import { useLiveVoice } from "@/domains/chat/voice/live-voice/use-live-voice";
+import {
+    isLiveVoiceSessionActive,
+    useIsLiveVoiceSessionOwnedBy,
+    useLiveVoiceStore,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
 import { useAudioAmplitude } from "@/domains/chat/voice/use-audio-amplitude";
 import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
 import { useIsMobile } from "@/hooks/use-is-mobile";
@@ -113,10 +116,13 @@ export interface ChatComposerProps {
   // assistant id used by AttachFileButton's disabled guard
   assistantId: string | null;
 
-  // Active conversation the live-voice session should attach to. Optional —
-  // when absent (e.g. the empty/new-conversation state) live voice still
-  // starts a fresh session for the assistant. The app-editing variant, which
-  // has no voice, leaves this undefined.
+  // Conversation this composer is bound to — used to attach live-voice
+  // sessions and to decide whether this composer owns the active session
+  // (see `isLiveVoiceSessionOwnedBy`). Pass the routing-truth id
+  // (`activeConversationId`), including client-generated draft ids, so the
+  // session lands in the thread the user is looking at. Optional — when
+  // absent the session starts without a conversation and the server assigns
+  // one. The app-editing variant, which has no voice, leaves this undefined.
   conversationId?: string | null;
 
   // chrome surfacing existing buttons (rendered in the form's bottom-left row)
@@ -217,53 +223,44 @@ export function ChatComposer({
   // dictation button (`showVoiceInput` + a non-null assistant id) — so with
   // the flag off no session can ever start and the session state below stays
   // `idle`, keeping the composer byte-identical for users without the flag.
-  // The composer owns the single `useLiveVoice()` controller instance. It has
-  // to live here (not in `LiveVoiceButton`): while a session is active the
-  // action row that hosts the button is swapped out for `VoiceComposerBar`,
-  // and the hook tears the session down when its owner unmounts — a
-  // button-owned controller would kill the session the moment it started.
-  // The button is purely the presentational entry point (see its docs).
   //
-  // `observeAudioState: false` — the composer only needs the low-frequency
-  // session phase + error + actions. Without it the hook would subscribe this
-  // whole component to `inputAmplitude` (updated per mic sample) and the
-  // transcript fields, re-rendering the entire composer on every mic-level
-  // tick; the voice bar's waveform instead polls amplitude via `getState()`
-  // in its canvas draw loop (see `getLiveVoiceAmplitude` below).
-  const {
-    state: liveVoiceState,
-    error: liveVoiceError,
-    start: liveVoiceStart,
-    stop: liveVoiceStop,
-    release: liveVoiceRelease,
-  } = useLiveVoice({ observeAudioState: false });
-  // Anything but idle/failed counts as an active session; while active the
-  // whole action row (including both mic buttons) is replaced by the voice
-  // bar, so the two capture flows can never run at once. `failed` is a
-  // retryable/inactive state, so it must fall back to the normal row —
-  // otherwise dictation would stay unavailable after a failed start.
+  // The session controller (`useLiveVoice`) is NOT owned here: it lives in
+  // the persistent `useLiveVoiceSessionController` mount in `ChatLayout`, so
+  // a session survives thread switches, Home/Library navigation, and the
+  // fullscreen app viewer — the navigations that unmount this composer. The
+  // composer only observes the session through narrow store selectors and
+  // drives it through the store-registered `starter`/`controls` seams.
+  const liveVoiceState = useLiveVoiceStore.use.state();
+  const liveVoiceError = useLiveVoiceStore.use.error();
+  // Whether any session is live anywhere (this thread or another). `failed`
+  // is a retryable/inactive state, so it must count as inactive — otherwise
+  // dictation would stay unavailable after a failed start.
+  const isLiveVoiceSessionLive = isLiveVoiceSessionActive(liveVoiceState);
+  // Whether THIS composer owns the active session — its conversation matches
+  // the session's, or the session was started from this composer's draft.
+  // Ownership scopes the surface swap: a session started in thread A must
+  // not hijack thread B's composer — B keeps its normal row and the
+  // title-bar pill is the session surface there (exactly one of the two
+  // renders at any time; see `isLiveVoiceSessionOwnedBy`).
   //
-  // Deliberately based on the session state alone — NOT on the entry-point
-  // eligibility (the `voice-mode` flag / a non-null `assistantId`) — so a
-  // mid-session eligibility drop (flag flip, `assistantId` transiently
-  // cleared) can't unmount the voice bar while the still-mounted controller
-  // keeps the mic/socket live: the bar's ✕ stays available until teardown
-  // completes and the state returns to `idle`. `showVoiceInput` (static per
-  // variant) scopes the swap to the voice-enabled composer — the app-editing
-  // variant shares the global live-voice store but must never swap its row
-  // for a session it doesn't own.
-  const isLiveVoiceActive =
-    showVoiceInput &&
-    liveVoiceState !== "idle" &&
-    liveVoiceState !== "failed";
+  // Deliberately based on session state + ownership alone — NOT on the
+  // entry-point eligibility (the `voice-mode` flag / a non-null
+  // `assistantId`) — so a mid-session eligibility drop (flag flip,
+  // `assistantId` transiently cleared) can't unmount the voice bar while the
+  // session keeps the mic/socket live: the bar's ✕ stays available until
+  // teardown completes. `showVoiceInput` (static per variant) scopes the
+  // swap to the voice-enabled composer — the app-editing variant shares the
+  // global live-voice store but must never swap its row.
+  const ownsLiveVoiceSession = useIsLiveVoiceSessionOwnedBy(conversationId);
+  const isLiveVoiceActive = showVoiceInput && ownsLiveVoiceSession;
   // Whether the session has any speech transcript to show. A boolean
   // *presence* subscription, not the text itself: zustand only re-renders
   // when the selected value changes identity, so per-delta transcript
   // updates never reach the composer — the bit flips once when speech
   // starts and once when the store clears. The streaming text is rendered
   // by `VoiceLiveTranscript`, which subscribes to the store on its own,
-  // keeping this component's deliberate opt-out of high-frequency
-  // live-voice updates (see `observeAudioState: false` above) intact.
+  // keeping the composer's deliberate opt-out of high-frequency live-voice
+  // updates (amplitude ticks, transcript deltas) intact.
   const hasLiveVoiceTranscript = useLiveVoiceStore(
     (s) => Boolean(s.partialTranscript || s.finalTranscript),
   );
@@ -278,13 +275,22 @@ export function ChatComposer({
     () => useLiveVoiceStore.getState().inputAmplitude,
     [],
   );
+  // Session verbs go through the store seams registered by the layout-owned
+  // controller: `starter` (registered for the controller's whole mount) to
+  // start, per-session `controls` to stop/release. Read via `getState()` in
+  // handlers per STATE_MANAGEMENT.md — no subscription needed.
   const handleLiveVoiceStart = useCallback(() => {
-    if (!assistantId) return;
-    void liveVoiceStart(assistantId, conversationId ?? undefined);
-  }, [assistantId, conversationId, liveVoiceStart]);
+    if (!assistantId) {
+      return;
+    }
+    useLiveVoiceStore.getState().starter?.(assistantId, conversationId ?? null);
+  }, [assistantId, conversationId]);
   const handleLiveVoiceEnd = useCallback(() => {
-    void liveVoiceStop();
-  }, [liveVoiceStop]);
+    useLiveVoiceStore.getState().controls?.stop();
+  }, []);
+  const handleLiveVoiceSend = useCallback(() => {
+    useLiveVoiceStore.getState().controls?.release();
+  }, []);
   // Dismissing the failure notice resets the store back to idle — `failed` is
   // terminal for the session, so this only clears the surfaced error.
   const dismissLiveVoiceError = useCallback(() => {
@@ -393,12 +399,12 @@ export function ChatComposer({
       {/* Composer-owned draft/attachment notices (self-sourced), above the
           orchestration banner stack. */}
       <ComposerDraftNotices />
-      {/* Live-voice failure notice — composer-owned (the session controller
-          lives here), mirroring the dictation `voiceError` Notice rendered by
-          `ComposerNotices` in the orchestration stack below. Keyed on the
-          session state (not entry eligibility) for the same reason as
-          `isLiveVoiceActive`: a session that fails right after an eligibility
-          drop must still surface its error. */}
+      {/* Live-voice failure notice — surfaced by the voice-enabled composer
+          the user is looking at, mirroring the dictation `voiceError` Notice
+          rendered by `ComposerNotices` in the orchestration stack below.
+          Keyed on the session state (not entry eligibility) for the same
+          reason as `isLiveVoiceActive`: a session that fails right after an
+          eligibility drop must still surface its error. */}
       {showVoiceInput && liveVoiceState === "failed" && liveVoiceError && (
         <div className="mb-2">
           <Notice tone="error" onDismiss={dismissLiveVoiceError}>
@@ -605,9 +611,10 @@ export function ChatComposer({
                   }
                 }}
                 placeholder={ghostSuffix ? "" : placeholder}
-                // Inert during a live-voice session so focus/typing can't
-                // fight the session (a later PR streams the live transcript
-                // into this region). The grid mirror keeps the height stable.
+                // Inert while this composer's live-voice session is active so
+                // focus/typing can't fight the session — `VoiceLiveTranscript`
+                // streams the live speech into this grid cell (see below).
+                // The grid mirror keeps the height stable.
                 disabled={typingDisabled || isLiveVoiceActive}
                 rows={1}
                 className={`col-start-1 row-start-1 w-full resize-none overflow-y-auto border-none bg-transparent px-4 pt-3 pb-2 text-chat text-[var(--content-default)] placeholder:text-[var(--content-disabled)] focus:outline-none disabled:opacity-50 ${
@@ -666,7 +673,7 @@ export function ChatComposer({
                 state={liveVoiceState}
                 getAmplitude={getLiveVoiceAmplitude}
                 onEnd={handleLiveVoiceEnd}
-                onSend={liveVoiceRelease}
+                onSend={handleLiveVoiceSend}
               />
             ) : (
               <div className="flex items-center justify-between px-2 pb-2">
@@ -718,12 +725,12 @@ export function ChatComposer({
                         <VoiceInputButton
                           ref={voiceInputRef}
                           assistantId={assistantId}
-                          // Mutual exclusion: an active live-voice session
-                          // replaces this whole row with the voice bar, so the
-                          // two capture flows never run simultaneously; the
-                          // `isLiveVoiceActive` term is defense-in-depth for
-                          // that structural guarantee.
-                          disabled={typingDisabled || isLiveVoiceActive}
+                          // Mutual exclusion: a live-voice session anywhere —
+                          // owned by this composer (whose row is swapped for
+                          // the voice bar anyway) or by another thread — must
+                          // block dictation, or two mic capture flows could
+                          // run at once.
+                          disabled={typingDisabled || isLiveVoiceSessionLive}
                           onTranscript={onVoiceTranscript}
                           onInterimTranscript={onVoiceInterimTranscript}
                           onError={onVoiceError}
@@ -742,12 +749,17 @@ export function ChatComposer({
                         // owns stopping.
                         //
                         // Mutual exclusion (reverse direction): while dictation
-                        // is active (`isVoiceActive`) live voice is disabled so
-                        // it can't start a second mic/voice session alongside
-                        // the recorder.
+                        // is active (`isVoiceActive`) — or a live-voice session
+                        // already runs in another thread — starting a session
+                        // here is disabled so a second mic/voice session can't
+                        // open alongside the running one.
                         <LiveVoiceButton
                           onStart={handleLiveVoiceStart}
-                          disabled={typingDisabled || isVoiceActive}
+                          disabled={
+                            typingDisabled ||
+                            isVoiceActive ||
+                            isLiveVoiceSessionLive
+                          }
                         />
                       )}
                       {/* macOS parity: the send button is hidden during recording

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
@@ -4,7 +4,7 @@
  * glyph and muted state label on the left, the dotted timeline waveform
  * filling the middle, and end (✕) / send-now (↑) controls on the right.
  *
- * Purely presentational: the parent owns the `useLiveVoice` session and
+ * Purely presentational: the composer observes the live-voice store and
  * wires `state`, an amplitude poll function, and the two callbacks. The
  * green ↑ is a manual "send now" (push-to-talk release) and is only
  * meaningful while the session is listening; the red ✕ ends the session

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -900,7 +900,12 @@ export function ChatMainPanel({
       onStopGenerating={handleStopGenerating}
       canStopGenerating={canStopGenerating}
       assistantId={assistantId}
-      conversationId={activeConversation?.conversationId}
+      // Routing-truth id (NOT `activeConversation?.conversationId`, which is
+      // transiently undefined until the row loads and always undefined for
+      // drafts): live-voice session ownership compares against this, and the
+      // session should attach to the thread the user is looking at — draft
+      // ids included (the runtime accepts client-generated conversation ids).
+      conversationId={activeConversationId}
       onRecallLastMessage={isIdle && isNativeConversation ? handleRecallLastMessage : undefined}
       onCancelEdit={isEditing ? handleCancelEdit : undefined}
       textareaMaxHeightPx={isEmptyConversation ? 320 : undefined}

--- a/clients/web/src/domains/chat/components/live-voice-button.tsx
+++ b/clients/web/src/domains/chat/components/live-voice-button.tsx
@@ -7,11 +7,13 @@
  * playback + barge-in). The button is gated behind the `voice-mode` assistant
  * flag and renders nothing when the flag is off.
  *
- * Purely presentational: the `useLiveVoice` controller lives in the composer
- * (which binds the assistant/conversation into `onStart`). While a session is
- * active the composer swaps its whole action row — this button included — for
- * the `VoiceComposerBar`, whose ✕ owns ending the session; so this control only
- * ever renders while no session is active and never needs a stop affordance.
+ * Purely presentational: the `useLiveVoice` controller lives in the
+ * layout-mounted `useLiveVoiceSessionController`; the composer binds the
+ * assistant/conversation into `onStart`, which drives the store-registered
+ * session starter. While a session is active the owning composer swaps its
+ * whole action row — this button included — for the `VoiceComposerBar`, whose
+ * ✕ owns ending the session; in non-owning composers the button stays visible
+ * but disabled, so this control never needs a stop affordance.
  */
 
 import { Mic } from "lucide-react";

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.test.tsx
@@ -5,8 +5,12 @@
  * presentational `VoiceSessionPill`, so tests drive those stores directly and
  * mock only the modules with heavy dependency graphs: router hooks (mutable
  * pathname + navigate spy), `useActiveConversation` (TanStack Query), the
- * viewer store (generated SDK imports), and the imperative
- * `navigateToConversation` util (haptics/sounds).
+ * viewer store (generated SDK imports), the `useIsMobile` media-query hook,
+ * and the imperative `navigateToConversation` util (haptics/sounds).
+ *
+ * Visibility is asserted as the exact complement of the composer's voice bar
+ * (`isLiveVoiceSessionOwnedBy`): for any active session exactly one of
+ * {composer bar, title-bar pill} renders.
  *
  * The embedded `VoiceTimelineWaveform` renders a real canvas — happy-dom's
  * `getContext("2d")` returns `null`, which that component treats as "don't
@@ -56,6 +60,12 @@ mock.module("@/stores/viewer-store", () => ({
   },
 }));
 
+let mockIsMobile = false;
+mock.module("@/hooks/use-is-mobile", () => ({
+  useIsMobile: () => mockIsMobile,
+  MOBILE_MEDIA_QUERY: "(max-width: 767px)",
+}));
+
 const navigateToConversationSpy = mock(
   (_navigate: unknown, _conversationId: string) => {},
 );
@@ -88,6 +98,7 @@ function startSession(
 beforeEach(() => {
   mockPathname = routes.conversation(OTHER_CONVERSATION_ID);
   mockMainView = "chat";
+  mockIsMobile = false;
   mockOwningConversation = {
     conversationId: OWNING_CONVERSATION_ID,
     title: "Owning thread",
@@ -136,7 +147,7 @@ describe("VoiceSessionPillHost — visibility", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  test("shows the pill over the fullscreen app viewer even in the owning conversation", () => {
+  test("shows the pill over the desktop fullscreen app viewer even in the owning conversation", () => {
     startSession("listening");
     useConversationStore
       .getState()
@@ -145,6 +156,18 @@ describe("VoiceSessionPillHost — visibility", () => {
     mockMainView = "app";
     render(<VoiceSessionPillHost />);
     expect(pill()).not.toBeNull();
+  });
+
+  test("keeps the pill hidden for the mobile app view (composer stays mounted under the overlay)", () => {
+    startSession("listening");
+    useConversationStore
+      .getState()
+      .setActiveConversationId(OWNING_CONVERSATION_ID);
+    mockPathname = routes.conversation(OWNING_CONVERSATION_ID);
+    mockMainView = "app";
+    mockIsMobile = true;
+    const { container } = render(<VoiceSessionPillHost />);
+    expect(container.firstChild).toBeNull();
   });
 
   test("shows the pill on a non-conversation route even when the owning id is still active", () => {
@@ -159,10 +182,37 @@ describe("VoiceSessionPillHost — visibility", () => {
     expect(pill()).not.toBeNull();
   });
 
-  test("hides the pill for a session with no owning conversation", () => {
+  test("shows the pill for a not-yet-attached session when away from the owning composer", () => {
+    // A live mic must always have a visible control: a session still in its
+    // pre-`ready` window (no conversation yet) shows the pill — without a
+    // thread name or navigation target — whenever another composer is the
+    // current surface.
+    startSession("connecting", null);
+    render(<VoiceSessionPillHost />);
+    expect(pill()).not.toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Go to voice session thread" }),
+    ).toBeNull();
+  });
+
+  test("hides the pill while the draft composer that started the session is on screen", () => {
+    // Draft case: started with no conversation; the server assigned one on
+    // `ready`. The draft composer (bound to no conversation) still owns the
+    // session, so the pill must not double-render next to its voice bar.
     startSession("listening", null);
+    useLiveVoiceStore.getState().setConversationId("conv-server-assigned");
+    useConversationStore.getState().setActiveConversationId(null);
+    mockPathname = routes.assistant;
     const { container } = render(<VoiceSessionPillHost />);
     expect(container.firstChild).toBeNull();
+  });
+
+  test("shows the pill for a draft-started session once another thread is viewed", () => {
+    startSession("listening", null);
+    useLiveVoiceStore.getState().setConversationId("conv-server-assigned");
+    // beforeEach: viewing OTHER_CONVERSATION_ID on its conversation route.
+    render(<VoiceSessionPillHost />);
+    expect(pill()).not.toBeNull();
   });
 
   test("renders nothing after the session fails", () => {
@@ -218,14 +268,13 @@ describe("VoiceSessionPillHost — controls", () => {
     expect(controls.stop).not.toHaveBeenCalled();
   });
 
-  test("■ interrupts the assistant via controls.interrupt while speaking", () => {
+  test("■ stop-response control is not offered — V1 interrupt would end the whole session", () => {
     startSession("speaking");
     render(<VoiceSessionPillHost />);
-    fireEvent.click(
-      screen.getByRole("button", { name: "Stop assistant response" }),
-    );
-    expect(controls.interrupt).toHaveBeenCalledTimes(1);
-    expect(controls.stop).not.toHaveBeenCalled();
+    expect(pill()).not.toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Stop assistant response" }),
+    ).toBeNull();
   });
 
   test("controls are no-ops when none are registered", () => {

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
@@ -7,43 +7,50 @@
  * hooks that unmount on navigation, which is exactly when the pill must
  * persist.
  *
- * Renders `VoiceSessionPill` only while a live-voice session is active AND
- * the owning conversation's composer is not the current surface, i.e. when
- * any of these hold:
+ * Visibility is the exact complement of the composer's voice bar so that for
+ * any active session exactly one of the two surfaces renders: the pill shows
+ * whenever a session is active AND the composer currently on screen (if any)
+ * does not own it (`isLiveVoiceSessionOwnedBy`). Concretely, the pill shows
+ * when:
  *
- * - the user is viewing a different conversation,
+ * - the user is viewing a different conversation than the session's,
  * - the user is off the conversation routes entirely (Home, Library, …) —
  *   `activeConversationId` deliberately persists across route changes (see
  *   `chat-layout.tsx`), so the id comparison alone can't detect this,
- * - the fullscreen app viewer covers the thread (`mainView === "app"`).
+ * - the desktop fullscreen app viewer covers the thread (`mainView === "app"`;
+ *   on mobile that view keeps the composer mounted under a portal overlay
+ *   that covers the header too, so the composer stays the owning surface).
  *   `app-editing` (split view) and the right-drawer detail panels keep the
  *   composer visible, so they don't count.
  *
- * A session with no owning conversation (started from an unsent draft) has
- * no thread to return to, so the pill stays hidden for it.
+ * A session not yet attached to a conversation (started from a draft, before
+ * the server's `ready` frame) still shows the pill when the user is away from
+ * the owning composer — a live mic must always have a visible control — just
+ * without a thread name or navigation target.
+ *
+ * The ■ "stop response" control is deliberately not wired: V1's `interrupt()`
+ * ends the whole session, contradicting the control's "without ending the
+ * session" contract, so the pill offers only ✕ (end) until a turn-scoped
+ * interrupt exists (engine plan, JARVIS-1240).
  */
 
 import { useCallback } from "react";
 import { useLocation, useNavigate } from "react-router";
 
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { navigateToConversation } from "@/utils/conversation-navigation";
-import { routes } from "@/utils/routes";
+import { isConversationPath } from "@/utils/routes";
 
 import { STATE_LABELS } from "@/domains/chat/components/chat-composer/voice-composer-bar";
 import { VoiceSessionPill } from "@/domains/chat/components/voice-session-pill";
 import { useActiveConversation } from "@/domains/chat/hooks/use-active-conversation";
-import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+import {
+  isLiveVoiceSessionActive,
+  useIsLiveVoiceSessionOwnedBy,
+  useLiveVoiceStore,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore } from "@/stores/viewer-store";
-
-/** Routes where ChatPage mounts the active conversation's composer. */
-function isConversationRoute(pathname: string): boolean {
-  return (
-    pathname === routes.assistant ||
-    pathname === `${routes.assistant}/` ||
-    pathname.startsWith(`${routes.conversations}/`)
-  );
-}
 
 export function VoiceSessionPillHost() {
   const state = useLiveVoiceStore.use.state();
@@ -53,17 +60,22 @@ export function VoiceSessionPillHost() {
 
   const activeConversationId = useConversationStore.use.activeConversationId();
   const mainView = useViewerStore.use.mainView();
+  const isMobile = useIsMobile();
   const location = useLocation();
   const navigate = useNavigate();
 
-  const sessionActive = state !== "idle" && state !== "failed";
-  const viewingOwningComposer =
-    sessionConversationId !== null &&
-    sessionConversationId === activeConversationId &&
-    isConversationRoute(location.pathname) &&
-    mainView !== "app";
+  const sessionActive = isLiveVoiceSessionActive(state);
+  // Mirror of `chat-content-layout.tsx`: the desktop `app` view replaces
+  // `ChatMainPanel` (composer included); every other view — and mobile's
+  // portal-overlay `app` view — keeps the composer mounted.
+  const composerOnScreen =
+    isConversationPath(location.pathname) && !(mainView === "app" && !isMobile);
+  // Same ownership predicate the composer's voice bar uses, evaluated for the
+  // composer currently on screen — keeps the two surfaces exact complements.
+  const activeComposerOwnsSession =
+    useIsLiveVoiceSessionOwnedBy(activeConversationId);
   const visible =
-    sessionActive && sessionConversationId !== null && !viewingOwningComposer;
+    sessionActive && !(composerOnScreen && activeComposerOwnsSession);
 
   // Resolves the owning row from whichever list cache holds it, fetching the
   // single row when absent. Enabled only while the pill is shown so hidden
@@ -71,7 +83,7 @@ export function VoiceSessionPillHost() {
   const owningConversation = useActiveConversation(
     sessionAssistantId,
     sessionConversationId,
-    visible,
+    visible && sessionConversationId !== null,
   );
 
   // Stable poll function — the waveform samples ~30 Hz via its draw loop, so
@@ -88,7 +100,6 @@ export function VoiceSessionPillHost() {
     }
   }, [navigate, sessionConversationId]);
 
-  const handleStop = useCallback(() => controls?.interrupt(), [controls]);
   const handleEnd = useCallback(() => controls?.stop(), [controls]);
   const handleSend = useCallback(() => controls?.release(), [controls]);
 
@@ -104,10 +115,9 @@ export function VoiceSessionPillHost() {
       }
       state={state}
       getAmplitude={getAmplitude}
-      onStop={handleStop}
       onEnd={handleEnd}
       onSend={handleSend}
-      onNavigate={handleNavigate}
+      onNavigate={sessionConversationId ? handleNavigate : undefined}
     />
   );
 }

--- a/clients/web/src/domains/chat/components/voice-session-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.test.tsx
@@ -99,6 +99,14 @@ describe("VoiceSessionPill — stop control", () => {
     expect(onStop).toHaveBeenCalledTimes(1);
     expect(onNavigate).not.toHaveBeenCalled();
   });
+
+  test("hidden even while speaking when onStop is not provided", () => {
+    // Hosts omit onStop while stopping a response would end the whole
+    // session (V1 interrupt); the ✕ stays the only destructive control.
+    renderPill({ state: "speaking", onStop: undefined });
+    expect(stopButton()).toBeNull();
+    expect(endButton()).toBeTruthy();
+  });
 });
 
 describe("VoiceSessionPill — send control", () => {

--- a/clients/web/src/domains/chat/components/voice-session-pill.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.tsx
@@ -3,9 +3,10 @@
  * Presentational — the mounting host owns store wiring and visibility rules.
  *
  * Layout, left → right: two-line context label (primary action text over the
- * owning thread's name), circular stop control (only while the assistant is
- * `speaking`), mic glyph + compact timeline waveform, red ✕ (end session),
- * green ↑ (manual turn release — enabled only while `listening`).
+ * owning thread's name), optional circular stop control (only when the host
+ * provides `onStop` and the assistant is `speaking`), mic glyph + compact
+ * timeline waveform, red ✕ (end session), green ↑ (manual turn release —
+ * enabled only while `listening`).
  *
  * The pill lives inside `ChatLayoutHeader`, which doubles as the Electron
  * macOS title bar (`-webkit-app-region: drag`). The root opts the whole
@@ -44,8 +45,12 @@ export interface VoiceSessionPillProps {
   state: LiveVoiceSessionState;
   /** Polled by the waveform at ~30 Hz; must not force parent re-renders. */
   getAmplitude: () => number;
-  /** Stop the in-flight assistant response without ending the session. */
-  onStop: () => void;
+  /**
+   * Stop the in-flight assistant response without ending the session. The
+   * ■ control is hidden when absent — hosts must only wire this once a
+   * turn-scoped interrupt exists; the ✕ (`onEnd`) is the destructive control.
+   */
+  onStop?: () => void;
   /** End the voice session. */
   onEnd: () => void;
   /** Manual turn release ("send now") while listening. */
@@ -106,7 +111,7 @@ export function VoiceSessionPill({
       ) : (
         <div className={labelClass}>{labelContent}</div>
       )}
-      {state === "speaking" ? (
+      {onStop && state === "speaking" ? (
         <Button
           variant="primary"
           iconOnly={<Square fill="currentColor" />}

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
@@ -1,0 +1,165 @@
+/**
+ * Hand-rolled fakes for the three live-voice primitives — client (transport),
+ * capture (mic → PCM), player (TTS playback) — injected through
+ * `useLiveVoice`'s factory options so tests touch no WebSocket, microphone,
+ * or AudioContext. The fakes expose drivers (`emit`, `pushChunk`,
+ * `pushAmplitude`, `finishPlayback`) so a test can drive a full turn and
+ * assert state-machine transitions, barge-in, automatic ptt_release, and
+ * teardown.
+ *
+ * Shared by `use-live-voice.test.ts` and
+ * `use-live-voice-session-controller.test.tsx`. Type-only imports keep the
+ * generated-SDK import graph out of test files (the real client's
+ * `connection.ts` is mocked separately by each test).
+ */
+
+import type {
+  LiveVoiceClientEventMap,
+  LiveVoiceClientEventName,
+} from "@/domains/chat/voice/live-voice/live-voice-client";
+import type {
+  LiveVoiceAudioCaptureOptions,
+  LiveVoiceCaptureResult,
+} from "@/domains/chat/voice/live-voice/pcm-capture";
+
+export class FakeClient {
+  connectArgs: { assistantId: string; conversationId?: string } | null = null;
+  sentAudio: ArrayBuffer[] = [];
+  pttReleaseCount = 0;
+  interruptCount = 0;
+  ended = false;
+  closed = false;
+
+  private handlers = new Map<
+    LiveVoiceClientEventName,
+    Set<(payload: never) => void>
+  >();
+
+  on<E extends LiveVoiceClientEventName>(
+    event: E,
+    handler: (payload: LiveVoiceClientEventMap[E]) => void,
+  ): () => void {
+    let set = this.handlers.get(event);
+    if (!set) {
+      set = new Set();
+      this.handlers.set(event, set);
+    }
+    set.add(handler as (payload: never) => void);
+    return () => set?.delete(handler as (payload: never) => void);
+  }
+
+  async connect(args: {
+    assistantId: string;
+    conversationId?: string;
+  }): Promise<void> {
+    this.connectArgs = args;
+  }
+
+  sendAudio(pcm: ArrayBuffer): void {
+    this.sentAudio.push(pcm);
+  }
+  pttRelease(): void {
+    this.pttReleaseCount++;
+  }
+  interrupt(): void {
+    this.interruptCount++;
+  }
+  end(): void {
+    this.ended = true;
+  }
+  close(): void {
+    this.closed = true;
+  }
+
+  /** Drive a server event to the controller's subscribed handlers. */
+  emit<E extends LiveVoiceClientEventName>(
+    event: E,
+    payload: LiveVoiceClientEventMap[E],
+  ): void {
+    for (const handler of this.handlers.get(event) ?? []) {
+      (handler as (payload: LiveVoiceClientEventMap[E]) => void)(payload);
+    }
+  }
+}
+
+export class FakeCapture {
+  readonly onChunk: (buf: ArrayBuffer) => void;
+  readonly onAmplitude?: (amplitude: number) => void;
+
+  startCount = 0;
+  stopCount = 0;
+  shutdownCount = 0;
+  startResult: LiveVoiceCaptureResult = { ok: true };
+
+  constructor(options: LiveVoiceAudioCaptureOptions) {
+    this.onChunk = options.onChunk;
+    this.onAmplitude = options.onAmplitude;
+  }
+
+  async start(): Promise<LiveVoiceCaptureResult> {
+    this.startCount++;
+    return this.startResult;
+  }
+  async stop(): Promise<void> {
+    this.stopCount++;
+  }
+  async shutdown(): Promise<void> {
+    this.shutdownCount++;
+  }
+
+  /** Feed a captured PCM chunk to the controller. */
+  pushChunk(buf: ArrayBuffer): void {
+    this.onChunk(buf);
+  }
+  /** Feed an amplitude reading to the controller. */
+  pushAmplitude(amplitude: number): void {
+    this.onAmplitude?.(amplitude);
+  }
+}
+
+export class FakePlayer {
+  enqueued: unknown[] = [];
+  stopCount = 0;
+  disposeCount = 0;
+  isPlaying = false;
+  private drainResolvers: Array<() => void> = [];
+
+  enqueue(chunk: unknown): void {
+    this.enqueued.push(chunk);
+    this.isPlaying = true;
+  }
+  stop(): void {
+    this.stopCount++;
+    this.isPlaying = false;
+    this.resolveDrain();
+  }
+  async dispose(): Promise<void> {
+    this.disposeCount++;
+    this.stop();
+  }
+  async waitUntilDrained(): Promise<void> {
+    if (!this.isPlaying) {
+      return;
+    }
+    await new Promise<void>((resolve) => this.drainResolvers.push(resolve));
+  }
+
+  /** Simulate playback finishing naturally. */
+  finishPlayback(): void {
+    this.isPlaying = false;
+    this.resolveDrain();
+  }
+  private resolveDrain(): void {
+    const resolvers = this.drainResolvers;
+    this.drainResolvers = [];
+    for (const resolve of resolvers) {
+      resolve();
+    }
+  }
+}
+
+/** A PCM chunk of `ms` milliseconds at 16 kHz mono Int16. */
+export function pcmChunk(ms: number): ArrayBuffer {
+  const samples = Math.round((16000 * ms) / 1000);
+  return new Int16Array(samples).buffer;
+}

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -1,14 +1,18 @@
 /**
- * Tests for the live-voice store's session context and shared controls — the
- * seam that lets globally mounted surfaces (e.g. the title-bar session pill)
- * observe and drive a session owned by the composer's `useLiveVoice` instance.
+ * Tests for the live-voice store's session context, shared controls, and
+ * starter — the seams that let globally mounted surfaces (the title-bar
+ * session pill) and the composer observe and drive a session owned by the
+ * layout-mounted controller — plus the session-ownership predicates.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {
+  isLiveVoiceSessionActive,
+  isLiveVoiceSessionOwnedBy,
   useLiveVoiceStore,
   type LiveVoiceSessionControls,
+  type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 
 function makeControls(): LiveVoiceSessionControls {
@@ -17,24 +21,39 @@ function makeControls(): LiveVoiceSessionControls {
 
 beforeEach(() => {
   useLiveVoiceStore.getState().reset();
+  // reset() deliberately preserves the starter (mount-scoped); clear it
+  // explicitly so tests can't leak a registered starter into each other.
+  useLiveVoiceStore.getState().setStarter(null);
 });
 
 describe("useLiveVoiceStore — session context", () => {
   test("defaults to null assistant/conversation when idle", () => {
     expect(useLiveVoiceStore.getState().assistantId).toBeNull();
     expect(useLiveVoiceStore.getState().conversationId).toBeNull();
+    expect(useLiveVoiceStore.getState().startedConversationId).toBeNull();
   });
 
   test("setSessionContext records the owning assistant and conversation", () => {
     useLiveVoiceStore.getState().setSessionContext("assistant-1", "conv-1");
     expect(useLiveVoiceStore.getState().assistantId).toBe("assistant-1");
     expect(useLiveVoiceStore.getState().conversationId).toBe("conv-1");
+    expect(useLiveVoiceStore.getState().startedConversationId).toBe("conv-1");
   });
 
   test("setSessionContext accepts a null conversation", () => {
     useLiveVoiceStore.getState().setSessionContext("assistant-1", null);
     expect(useLiveVoiceStore.getState().assistantId).toBe("assistant-1");
     expect(useLiveVoiceStore.getState().conversationId).toBeNull();
+    expect(useLiveVoiceStore.getState().startedConversationId).toBeNull();
+  });
+
+  test("setConversationId republishes the authoritative id without touching the started id", () => {
+    useLiveVoiceStore.getState().setSessionContext("assistant-1", null);
+    useLiveVoiceStore.getState().setConversationId("conv-server-assigned");
+    expect(useLiveVoiceStore.getState().conversationId).toBe(
+      "conv-server-assigned",
+    );
+    expect(useLiveVoiceStore.getState().startedConversationId).toBeNull();
   });
 
   test("reset clears the session context", () => {
@@ -42,6 +61,106 @@ describe("useLiveVoiceStore — session context", () => {
     useLiveVoiceStore.getState().reset();
     expect(useLiveVoiceStore.getState().assistantId).toBeNull();
     expect(useLiveVoiceStore.getState().conversationId).toBeNull();
+    expect(useLiveVoiceStore.getState().startedConversationId).toBeNull();
+  });
+});
+
+describe("useLiveVoiceStore — session starter", () => {
+  test("defaults to null when no controller is mounted", () => {
+    expect(useLiveVoiceStore.getState().starter).toBeNull();
+  });
+
+  test("setStarter registers and deregisters the controller's starter", () => {
+    const starter = mock(() => {});
+    useLiveVoiceStore.getState().setStarter(starter);
+    expect(useLiveVoiceStore.getState().starter).toBe(starter);
+    useLiveVoiceStore.getState().setStarter(null);
+    expect(useLiveVoiceStore.getState().starter).toBeNull();
+  });
+
+  test("reset preserves the starter — session teardown must not deregister the mounted controller", () => {
+    const starter = mock(() => {});
+    useLiveVoiceStore.getState().setStarter(starter);
+    // Simulate a full session lifecycle ending in teardown's reset().
+    useLiveVoiceStore.getState().setSessionContext("assistant-1", "conv-1");
+    useLiveVoiceStore.getState().setState("listening");
+    useLiveVoiceStore.getState().reset();
+    expect(useLiveVoiceStore.getState().starter).toBe(starter);
+  });
+});
+
+describe("isLiveVoiceSessionActive", () => {
+  test("false for idle and failed, true for every live phase", () => {
+    expect(isLiveVoiceSessionActive("idle")).toBe(false);
+    expect(isLiveVoiceSessionActive("failed")).toBe(false);
+    const live: LiveVoiceSessionState[] = [
+      "connecting",
+      "listening",
+      "transcribing",
+      "thinking",
+      "speaking",
+      "ending",
+    ];
+    for (const state of live) {
+      expect(isLiveVoiceSessionActive(state)).toBe(true);
+    }
+  });
+});
+
+describe("isLiveVoiceSessionOwnedBy", () => {
+  const session = (
+    state: LiveVoiceSessionState,
+    conversationId: string | null,
+    startedConversationId: string | null,
+  ) => ({ state, conversationId, startedConversationId });
+
+  test("no ownership without an active session, even with matching ids", () => {
+    expect(isLiveVoiceSessionOwnedBy(session("idle", "conv-1", "conv-1"), "conv-1")).toBe(false);
+    expect(isLiveVoiceSessionOwnedBy(session("failed", "conv-1", "conv-1"), "conv-1")).toBe(false);
+  });
+
+  test("composer bound to the session's conversation owns it", () => {
+    expect(
+      isLiveVoiceSessionOwnedBy(session("listening", "conv-1", "conv-1"), "conv-1"),
+    ).toBe(true);
+  });
+
+  test("composer bound to a different conversation does not own it", () => {
+    expect(
+      isLiveVoiceSessionOwnedBy(session("listening", "conv-1", "conv-1"), "conv-other"),
+    ).toBe(false);
+  });
+
+  test("draft composer owns a draft-started session before AND after the server assigns a conversation", () => {
+    // Before `ready`: the session has no conversation yet.
+    expect(
+      isLiveVoiceSessionOwnedBy(session("connecting", null, null), undefined),
+    ).toBe(true);
+    // After `ready`: authoritative id assigned, started id stays null — the
+    // draft composer (still bound to no conversation) keeps owning it.
+    expect(
+      isLiveVoiceSessionOwnedBy(session("listening", "conv-server", null), undefined),
+    ).toBe(true);
+    expect(
+      isLiveVoiceSessionOwnedBy(session("listening", "conv-server", null), null),
+    ).toBe(true);
+    // A composer bound to some other thread never picks it up.
+    expect(
+      isLiveVoiceSessionOwnedBy(session("listening", "conv-server", null), "conv-other"),
+    ).toBe(false);
+    // Navigating to the assigned conversation makes that composer the owner.
+    expect(
+      isLiveVoiceSessionOwnedBy(session("listening", "conv-server", null), "conv-server"),
+    ).toBe(true);
+  });
+
+  test("draft composer does not own a session started with a conversation", () => {
+    expect(
+      isLiveVoiceSessionOwnedBy(session("listening", "conv-1", "conv-1"), null),
+    ).toBe(false);
+    expect(
+      isLiveVoiceSessionOwnedBy(session("listening", "conv-1", "conv-1"), undefined),
+    ).toBe(false);
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -76,15 +76,46 @@ export interface LiveVoiceSessionControls {
   interrupt: () => void;
 }
 
+/**
+ * Starts a live-voice session for `assistantId`, attaching `conversationId`
+ * when non-null. Registered into the store by the persistently mounted
+ * session-controller hook (see `use-live-voice-session-controller.ts`) so any
+ * surface — e.g. the composer's entry-point mic — can start a session without
+ * owning the controller hook instance.
+ */
+export type LiveVoiceSessionStarter = (
+  assistantId: string,
+  conversationId: string | null,
+) => void;
+
 export interface LiveVoiceState {
   /** Current phase of the session lifecycle. */
   state: LiveVoiceSessionState;
   /** Assistant the active session was started for, `null` when idle. */
   assistantId: string | null;
-  /** Conversation the active session is attached to, if any. */
+  /**
+   * Conversation the active session is attached to, if any. Authoritative:
+   * when a session starts without a conversation, the server assigns one and
+   * this field is updated on the `ready` frame.
+   */
   conversationId: string | null;
+  /**
+   * Conversation id the session was *started* with — `null` for a session
+   * started without an attached conversation (a draft composer). Unlike
+   * `conversationId`, this is never overwritten by the server's `ready`
+   * frame, so the composer that started a draft session keeps matching it
+   * (see {@link isLiveVoiceSessionOwnedBy}).
+   */
+  startedConversationId: string | null;
   /** Controls registered by the owning controller, `null` when no session. */
   controls: LiveVoiceSessionControls | null;
+  /**
+   * Session starter registered by the persistently mounted controller hook.
+   * `null` only when no controller is mounted (e.g. outside the chat layout).
+   * Mount-scoped, not session-scoped: {@link LiveVoiceActions.reset} leaves it
+   * registered.
+   */
+  starter: LiveVoiceSessionStarter | null;
   /** In-flight partial transcript of the user's current utterance. */
   partialTranscript: string;
   /** Last finalized user transcript. */
@@ -100,13 +131,24 @@ export interface LiveVoiceState {
 export interface LiveVoiceActions {
   /** Replace the session phase. */
   setState: (state: LiveVoiceSessionState) => void;
-  /** Record which assistant/conversation the active session belongs to. */
+  /**
+   * Record which assistant/conversation the session was started for. Sets
+   * both `conversationId` and `startedConversationId`; called once per
+   * session, at start.
+   */
   setSessionContext: (
     assistantId: string,
     conversationId: string | null,
   ) => void;
+  /**
+   * Republish the authoritative conversation id from the server's `ready`
+   * frame. Leaves `startedConversationId` at its start-time value.
+   */
+  setConversationId: (conversationId: string) => void;
   /** Register (or clear) the owning controller's session controls. */
   setControls: (controls: LiveVoiceSessionControls | null) => void;
+  /** Register (or clear) the mounted controller's session starter. */
+  setStarter: (starter: LiveVoiceSessionStarter | null) => void;
   setPartialTranscript: (text: string) => void;
   setFinalTranscript: (text: string) => void;
   /** Append a delta to the accumulated assistant transcript. */
@@ -116,20 +158,70 @@ export interface LiveVoiceActions {
   setInputAmplitude: (amplitude: number) => void;
   /** Transition to `failed` with a message. */
   fail: (message: string) => void;
-  /** Reset every field back to the idle defaults. */
+  /**
+   * Reset every session field back to the idle defaults. Deliberately leaves
+   * `starter` registered — it belongs to the controller's mount lifecycle,
+   * not the session lifecycle, and must survive session teardown so the next
+   * session can start.
+   */
   reset: () => void;
 }
 
 export type LiveVoiceStore = LiveVoiceState & LiveVoiceActions;
 
 // ---------------------------------------------------------------------------
+// Predicates
+// ---------------------------------------------------------------------------
+
+/** Whether `state` is a live session phase (anything but idle/failed). */
+export function isLiveVoiceSessionActive(state: LiveVoiceSessionState): boolean {
+  return state !== "idle" && state !== "failed";
+}
+
+/**
+ * Whether the composer bound to `composerConversationId` owns the active
+ * session — i.e. it is the surface whose action row swaps to the voice bar
+ * (and whose title-bar pill therefore hides).
+ *
+ * A composer owns the session when its conversation matches either the
+ * session's authoritative `conversationId` or the `startedConversationId` it
+ * was started with. The second arm covers the draft case: a session started
+ * from a composer with no conversation (`null`) gets a server-assigned
+ * `conversationId` on `ready`, but the draft composer — still bound to no
+ * conversation — must keep owning it until the user navigates away.
+ *
+ * Exactly one of {composer voice bar, title-bar pill} renders for an active
+ * session: the composer shows its voice UI iff this returns `true` for it,
+ * and the pill host shows the pill iff the currently visible composer (if
+ * any) does not own the session.
+ */
+export function isLiveVoiceSessionOwnedBy(
+  session: Pick<
+    LiveVoiceState,
+    "state" | "conversationId" | "startedConversationId"
+  >,
+  composerConversationId: string | null | undefined,
+): boolean {
+  if (!isLiveVoiceSessionActive(session.state)) {
+    return false;
+  }
+  const composerId = composerConversationId ?? null;
+  return (
+    composerId === session.conversationId ||
+    composerId === session.startedConversationId
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Store
 // ---------------------------------------------------------------------------
 
-const INITIAL_STATE: LiveVoiceState = {
+/** Session-scoped fields restored by `reset()`. Excludes `starter` (mount-scoped). */
+const INITIAL_SESSION_STATE: Omit<LiveVoiceState, "starter"> = {
   state: "idle",
   assistantId: null,
   conversationId: null,
+  startedConversationId: null,
   controls: null,
   partialTranscript: "",
   finalTranscript: "",
@@ -139,12 +231,15 @@ const INITIAL_STATE: LiveVoiceState = {
 };
 
 const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
-  ...INITIAL_STATE,
+  ...INITIAL_SESSION_STATE,
+  starter: null,
 
   setState: (state) => set({ state }),
   setSessionContext: (assistantId, conversationId) =>
-    set({ assistantId, conversationId }),
+    set({ assistantId, conversationId, startedConversationId: conversationId }),
+  setConversationId: (conversationId) => set({ conversationId }),
   setControls: (controls) => set({ controls }),
+  setStarter: (starter) => set({ starter }),
   setPartialTranscript: (partialTranscript) => set({ partialTranscript }),
   setFinalTranscript: (finalTranscript) => set({ finalTranscript }),
   appendAssistantTranscript: (delta) =>
@@ -152,7 +247,21 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
   clearAssistantTranscript: () => set({ assistantTranscript: "" }),
   setInputAmplitude: (inputAmplitude) => set({ inputAmplitude }),
   fail: (message) => set({ state: "failed", error: message }),
-  reset: () => set({ ...INITIAL_STATE }),
+  reset: () => set({ ...INITIAL_SESSION_STATE }),
 }));
 
 export const useLiveVoiceStore = createSelectors(useLiveVoiceStoreBase);
+
+/**
+ * Reactive form of {@link isLiveVoiceSessionOwnedBy} for components: whether
+ * the active session is owned by the composer bound to
+ * `composerConversationId`. Boolean-valued so per-field session churn never
+ * re-renders the subscriber.
+ */
+export function useIsLiveVoiceSessionOwnedBy(
+  composerConversationId: string | null | undefined,
+): boolean {
+  return useLiveVoiceStore((s) =>
+    isLiveVoiceSessionOwnedBy(s, composerConversationId),
+  );
+}

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
@@ -1,0 +1,225 @@
+/**
+ * Tests for `useLiveVoiceSessionController` — the persistent (layout-mounted)
+ * owner of the live-voice session controller.
+ *
+ * Uses the shared fakes from `live-voice-fakes.test-helper.ts` so no
+ * WebSocket, microphone, or AudioContext is touched. The controller renders
+ * nothing; everything is asserted through the store seams it maintains
+ * (`starter`, per-session `controls`, session state).
+ *
+ * The load-bearing property is lifetime: consumers (composer, pill) come and
+ * go with navigation while the controller stays mounted, so a session driven
+ * entirely through the store must keep running until the controller itself
+ * unmounts (leaving the chat layout) or `controls.stop()` fires.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+// The default client factory in use-live-voice statically imports the real
+// LiveVoiceChannelClient, which pulls in connection.ts -> the generated SDK.
+// Tests inject fake primitives, so we never construct the real client; mock the
+// connection module so importing the controller doesn't drag in the SDK client.
+mock.module("@/domains/chat/voice/live-voice/connection", () => ({
+  resolveLiveVoiceWsUrl: mock(
+    async () => "wss://velay.vellum.ai/a/v1/live-voice",
+  ),
+}));
+
+import type { LiveVoiceChannelClient } from "@/domains/chat/voice/live-voice/live-voice-client";
+import type { LiveVoiceAudioCapture } from "@/domains/chat/voice/live-voice/pcm-capture";
+import type { LiveVoiceAudioPlayer } from "@/domains/chat/voice/live-voice/tts-playback";
+
+import {
+  FakeCapture,
+  FakeClient,
+  FakePlayer,
+} from "@/domains/chat/voice/live-voice/live-voice-fakes.test-helper";
+
+// Imported after the connection mock so the real connection.ts never enters
+// the static import graph.
+const { useLiveVoiceSessionController } = await import(
+  "@/domains/chat/voice/live-voice/use-live-voice-session-controller"
+);
+const { useLiveVoiceStore } = await import(
+  "@/domains/chat/voice/live-voice/live-voice-store"
+);
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function renderPersistentController() {
+  // One client/capture pair per started session, like the real factories.
+  const clients: FakeClient[] = [];
+  const captures: FakeCapture[] = [];
+  const player = new FakePlayer();
+
+  const view = renderHook(() =>
+    useLiveVoiceSessionController({
+      createClient: () => {
+        const client = new FakeClient();
+        clients.push(client);
+        return client as unknown as LiveVoiceChannelClient;
+      },
+      createPlayer: () => player as unknown as LiveVoiceAudioPlayer,
+      createCapture: (options) => {
+        const capture = new FakeCapture(options);
+        captures.push(capture);
+        return capture as unknown as LiveVoiceAudioCapture;
+      },
+    }),
+  );
+
+  return {
+    view,
+    player,
+    clients,
+    captures,
+    lastClient: () => clients[clients.length - 1]!,
+    lastCapture: () => captures[captures.length - 1]!,
+  };
+}
+
+/** Start a session through the store-registered starter and reach `listening`. */
+async function startListeningViaStarter(
+  h: ReturnType<typeof renderPersistentController>,
+  conversationId: string | null = "conv-1",
+) {
+  await act(async () => {
+    useLiveVoiceStore.getState().starter?.("assistant-1", conversationId);
+    await Promise.resolve();
+  });
+  await act(async () => {
+    h.lastClient().emit("ready", {
+      type: "ready",
+      seq: 1,
+      sessionId: "s1",
+      conversationId: conversationId ?? "conv-server-assigned",
+    });
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  useLiveVoiceStore.getState().reset();
+  useLiveVoiceStore.getState().setStarter(null);
+});
+
+afterEach(() => {
+  cleanup();
+  useLiveVoiceStore.getState().reset();
+  useLiveVoiceStore.getState().setStarter(null);
+});
+
+// ---------------------------------------------------------------------------
+// Starter registration
+// ---------------------------------------------------------------------------
+
+describe("starter registration", () => {
+  test("registers a starter on mount and deregisters it on unmount", () => {
+    const h = renderPersistentController();
+    expect(useLiveVoiceStore.getState().starter).not.toBeNull();
+
+    act(() => {
+      h.view.unmount();
+    });
+    expect(useLiveVoiceStore.getState().starter).toBeNull();
+  });
+
+  test("starter starts a session with the given conversation", async () => {
+    const h = renderPersistentController();
+    await startListeningViaStarter(h, "conv-1");
+
+    expect(h.lastClient().connectArgs).toEqual({
+      assistantId: "assistant-1",
+      conversationId: "conv-1",
+    });
+    expect(useLiveVoiceStore.getState().state).toBe("listening");
+    expect(useLiveVoiceStore.getState().conversationId).toBe("conv-1");
+    expect(useLiveVoiceStore.getState().controls).not.toBeNull();
+  });
+
+  test("starter maps a null conversation to a conversation-less start (draft case)", async () => {
+    const h = renderPersistentController();
+    await act(async () => {
+      useLiveVoiceStore.getState().starter?.("assistant-1", null);
+      await Promise.resolve();
+    });
+
+    expect(h.lastClient().connectArgs).toEqual({
+      assistantId: "assistant-1",
+      conversationId: undefined,
+    });
+    expect(useLiveVoiceStore.getState().startedConversationId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session lifetime — the reason the controller lives in the layout
+// ---------------------------------------------------------------------------
+
+describe("session lifetime", () => {
+  test("session keeps running while store consumers (composer, pill) mount and unmount around it", async () => {
+    const h = renderPersistentController();
+    await startListeningViaStarter(h);
+
+    // A store consumer standing in for the composer/pill: subscribes, then
+    // unmounts (navigation to another thread / Home / the app viewer). Only
+    // the controller's unmount may tear the session down.
+    const consumer = renderHook(() => useLiveVoiceStore.use.state());
+    expect(consumer.result.current).toBe("listening");
+    act(() => {
+      consumer.unmount();
+    });
+
+    expect(useLiveVoiceStore.getState().state).toBe("listening");
+    expect(h.lastClient().closed).toBe(false);
+    expect(h.lastCapture().shutdownCount).toBe(0);
+  });
+
+  test("controls registered by the session remain driveable after consumers are gone", async () => {
+    const h = renderPersistentController();
+    await startListeningViaStarter(h);
+
+    await act(async () => {
+      useLiveVoiceStore.getState().controls?.stop();
+      await Promise.resolve();
+    });
+
+    expect(h.lastClient().ended).toBe(true);
+    expect(useLiveVoiceStore.getState().state).toBe("idle");
+    expect(h.lastCapture().shutdownCount).toBe(1);
+  });
+
+  test("starter survives session teardown — a second session can start after the first ends", async () => {
+    const h = renderPersistentController();
+    await startListeningViaStarter(h, "conv-1");
+    await act(async () => {
+      useLiveVoiceStore.getState().controls?.stop();
+      await Promise.resolve();
+    });
+    expect(useLiveVoiceStore.getState().state).toBe("idle");
+    expect(useLiveVoiceStore.getState().starter).not.toBeNull();
+
+    await startListeningViaStarter(h, "conv-2");
+    expect(useLiveVoiceStore.getState().state).toBe("listening");
+    expect(useLiveVoiceStore.getState().conversationId).toBe("conv-2");
+    expect(h.clients).toHaveLength(2);
+  });
+
+  test("unmounting the controller (leaving the chat layout) tears the session down", async () => {
+    const h = renderPersistentController();
+    await startListeningViaStarter(h);
+
+    act(() => {
+      h.view.unmount();
+    });
+
+    // No invisible live microphone: mic + socket released, store idle.
+    expect(h.lastClient().closed).toBe(true);
+    expect(h.lastCapture().shutdownCount).toBe(1);
+    expect(useLiveVoiceStore.getState().state).toBe("idle");
+    expect(useLiveVoiceStore.getState().starter).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
@@ -1,0 +1,59 @@
+/**
+ * `useLiveVoiceSessionController()` — persistent owner of the live-voice
+ * session controller.
+ *
+ * Mounted once by `ChatLayout`, which stays mounted across every chat-side
+ * child route (conversations, home, library, identity, documents, the
+ * fullscreen app viewer, …). Because {@link useLiveVoice} tears the session
+ * down when its owner unmounts, the hook must live at this layout scope — a
+ * composer-owned controller would kill the mic/socket on exactly the
+ * navigations the title-bar session pill exists for.
+ *
+ * Routes outside the chat layout (settings, logs, account) unmount this hook
+ * and therefore end any active session. That is deliberate: no session
+ * control surface (composer bar or title-bar pill) exists there, and a live
+ * microphone must never outlive its last visible control.
+ *
+ * The hook renders nothing and exposes nothing. Surfaces interact with the
+ * session exclusively through `useLiveVoiceStore`:
+ *
+ * - `starter` — registered here for the lifetime of the mount; the composer's
+ *   entry-point mic calls it to start a session.
+ * - `controls` (stop/release/interrupt) — registered per-session by
+ *   {@link useLiveVoice} itself.
+ * - `state`/`error`/transcripts/amplitude — observable session state.
+ */
+
+import { useEffect } from "react";
+
+import {
+  useLiveVoice,
+  type UseLiveVoiceOptions,
+} from "@/domains/chat/voice/live-voice/use-live-voice";
+import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+
+/** Injectable primitive factories, for tests. */
+export type UseLiveVoiceSessionControllerOptions = Pick<
+  UseLiveVoiceOptions,
+  "createClient" | "createCapture" | "createPlayer"
+>;
+
+export function useLiveVoiceSessionController(
+  options: UseLiveVoiceSessionControllerOptions = {},
+): void {
+  // `observeAudioState: false` — the controller consumes nothing reactive
+  // beyond the low-frequency `state`/`error` fields, so high-frequency
+  // amplitude/transcript updates must not re-render the mounting layout.
+  const { start } = useLiveVoice({ ...options, observeAudioState: false });
+
+  useEffect(() => {
+    useLiveVoiceStore
+      .getState()
+      .setStarter((assistantId, conversationId) =>
+        void start(assistantId, conversationId ?? undefined),
+      );
+    return () => {
+      useLiveVoiceStore.getState().setStarter(null);
+    };
+  }, [start]);
+}

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -2,11 +2,9 @@
  * Tests for the `useLiveVoice` session controller.
  *
  * The three merged primitives — client, capture, player — are replaced with
- * hand-rolled fakes injected through `useLiveVoice`'s factory options, so no
- * WebSocket, microphone, or AudioContext is touched. The fakes expose drivers
- * (`emit`, `pushChunk`, `pushAmplitude`) so a test can drive a full turn and
- * assert the state-machine transitions, barge-in, automatic ptt_release, and
- * teardown.
+ * the shared fakes from `live-voice-fakes.test-helper.ts`, injected through
+ * `useLiveVoice`'s factory options, so no WebSocket, microphone, or
+ * AudioContext is touched.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -25,15 +23,16 @@ mock.module("@/domains/chat/voice/live-voice/connection", () => ({
 import type {
   LiveVoiceChannelClient,
   LiveVoiceClientError,
-  LiveVoiceClientEventMap,
-  LiveVoiceClientEventName,
 } from "@/domains/chat/voice/live-voice/live-voice-client";
-import type {
-  LiveVoiceAudioCapture,
-  LiveVoiceAudioCaptureOptions,
-  LiveVoiceCaptureResult,
-} from "@/domains/chat/voice/live-voice/pcm-capture";
+import type { LiveVoiceAudioCapture } from "@/domains/chat/voice/live-voice/pcm-capture";
 import type { LiveVoiceAudioPlayer } from "@/domains/chat/voice/live-voice/tts-playback";
+
+import {
+  FakeCapture,
+  FakeClient,
+  FakePlayer,
+  pcmChunk,
+} from "@/domains/chat/voice/live-voice/live-voice-fakes.test-helper";
 
 // Import the controller + store *after* the connection mock is registered, so
 // the real connection.ts (which imports the generated SDK) never enters the
@@ -46,150 +45,8 @@ const { useLiveVoiceStore } = await import(
 );
 
 // ---------------------------------------------------------------------------
-// Fakes
-// ---------------------------------------------------------------------------
-
-class FakeClient {
-  connectArgs: { assistantId: string; conversationId?: string } | null = null;
-  sentAudio: ArrayBuffer[] = [];
-  pttReleaseCount = 0;
-  interruptCount = 0;
-  ended = false;
-  closed = false;
-
-  private handlers = new Map<
-    LiveVoiceClientEventName,
-    Set<(payload: never) => void>
-  >();
-
-  on<E extends LiveVoiceClientEventName>(
-    event: E,
-    handler: (payload: LiveVoiceClientEventMap[E]) => void,
-  ): () => void {
-    let set = this.handlers.get(event);
-    if (!set) {
-      set = new Set();
-      this.handlers.set(event, set);
-    }
-    set.add(handler as (payload: never) => void);
-    return () => set?.delete(handler as (payload: never) => void);
-  }
-
-  async connect(args: {
-    assistantId: string;
-    conversationId?: string;
-  }): Promise<void> {
-    this.connectArgs = args;
-  }
-
-  sendAudio(pcm: ArrayBuffer): void {
-    this.sentAudio.push(pcm);
-  }
-  pttRelease(): void {
-    this.pttReleaseCount++;
-  }
-  interrupt(): void {
-    this.interruptCount++;
-  }
-  end(): void {
-    this.ended = true;
-  }
-  close(): void {
-    this.closed = true;
-  }
-
-  /** Drive a server event to the controller's subscribed handlers. */
-  emit<E extends LiveVoiceClientEventName>(
-    event: E,
-    payload: LiveVoiceClientEventMap[E],
-  ): void {
-    for (const handler of this.handlers.get(event) ?? []) {
-      (handler as (payload: LiveVoiceClientEventMap[E]) => void)(payload);
-    }
-  }
-}
-
-class FakeCapture {
-  readonly onChunk: (buf: ArrayBuffer) => void;
-  readonly onAmplitude?: (amplitude: number) => void;
-
-  startCount = 0;
-  stopCount = 0;
-  shutdownCount = 0;
-  startResult: LiveVoiceCaptureResult = { ok: true };
-
-  constructor(options: LiveVoiceAudioCaptureOptions) {
-    this.onChunk = options.onChunk;
-    this.onAmplitude = options.onAmplitude;
-  }
-
-  async start(): Promise<LiveVoiceCaptureResult> {
-    this.startCount++;
-    return this.startResult;
-  }
-  async stop(): Promise<void> {
-    this.stopCount++;
-  }
-  async shutdown(): Promise<void> {
-    this.shutdownCount++;
-  }
-
-  /** Feed a captured PCM chunk to the controller. */
-  pushChunk(buf: ArrayBuffer): void {
-    this.onChunk(buf);
-  }
-  /** Feed an amplitude reading to the controller. */
-  pushAmplitude(amplitude: number): void {
-    this.onAmplitude?.(amplitude);
-  }
-}
-
-class FakePlayer {
-  enqueued: unknown[] = [];
-  stopCount = 0;
-  disposeCount = 0;
-  isPlaying = false;
-  private drainResolvers: Array<() => void> = [];
-
-  enqueue(chunk: unknown): void {
-    this.enqueued.push(chunk);
-    this.isPlaying = true;
-  }
-  stop(): void {
-    this.stopCount++;
-    this.isPlaying = false;
-    this.resolveDrain();
-  }
-  async dispose(): Promise<void> {
-    this.disposeCount++;
-    this.stop();
-  }
-  async waitUntilDrained(): Promise<void> {
-    if (!this.isPlaying) return;
-    await new Promise<void>((resolve) => this.drainResolvers.push(resolve));
-  }
-
-  /** Simulate playback finishing naturally. */
-  finishPlayback(): void {
-    this.isPlaying = false;
-    this.resolveDrain();
-  }
-  private resolveDrain(): void {
-    const resolvers = this.drainResolvers;
-    this.drainResolvers = [];
-    for (const resolve of resolvers) resolve();
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Harness
 // ---------------------------------------------------------------------------
-
-/** A PCM chunk of `ms` milliseconds at 16 kHz mono Int16. */
-function pcmChunk(ms: number): ArrayBuffer {
-  const samples = Math.round((16000 * ms) / 1000);
-  return new Int16Array(samples).buffer;
-}
 
 function renderController(extraOptions: { observeAudioState?: boolean } = {}) {
   const client = new FakeClient();
@@ -559,6 +416,7 @@ describe("session context and controls", () => {
     const store = useLiveVoiceStore.getState();
     expect(store.assistantId).toBe("assistant-1");
     expect(store.conversationId).toBe("conv-1");
+    expect(store.startedConversationId).toBe("conv-1");
     expect(store.controls).not.toBeNull();
   });
 
@@ -570,9 +428,10 @@ describe("session context and controls", () => {
 
     expect(useLiveVoiceStore.getState().assistantId).toBe("assistant-1");
     expect(useLiveVoiceStore.getState().conversationId).toBeNull();
+    expect(useLiveVoiceStore.getState().startedConversationId).toBeNull();
   });
 
-  test("ready frame updates a null conversationId with the server-assigned id", async () => {
+  test("ready frame updates a null conversationId with the server-assigned id, keeping the started id", async () => {
     const h = renderController();
     await act(async () => {
       await h.view.result.current.start("assistant-1");
@@ -592,6 +451,9 @@ describe("session context and controls", () => {
     const store = useLiveVoiceStore.getState();
     expect(store.assistantId).toBe("assistant-1");
     expect(store.conversationId).toBe("conv-server-assigned");
+    // The started id must survive the republish: draft-session ownership
+    // (`isLiveVoiceSessionOwnedBy`) matches the draft composer against it.
+    expect(store.startedConversationId).toBeNull();
   });
 
   test("release() while listening sends ptt_release and moves to transcribing", async () => {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -336,10 +336,11 @@ export function useLiveVoice(
           // When started from a new/empty conversation, `conversationId` was
           // undefined at start() and the store published `null`. The server
           // assigns (or confirms) the attached conversation on `ready`, so
-          // republish the context with the authoritative id.
-          useLiveVoiceStore
-            .getState()
-            .setSessionContext(assistantId, frame.conversationId);
+          // republish the authoritative id. `setConversationId` (not
+          // `setSessionContext`) so `startedConversationId` keeps its
+          // start-time value — session ownership for a draft-started session
+          // hinges on it (see `isLiveVoiceSessionOwnedBy`).
+          useLiveVoiceStore.getState().setConversationId(frame.conversationId);
           void startCapture(session, teardown);
         }),
         client.on("sttPartial", (frame) => {

--- a/clients/web/src/utils/routes.ts
+++ b/clients/web/src/utils/routes.ts
@@ -212,6 +212,19 @@ export function isAboutAssistantPath(pathname: string): boolean {
   );
 }
 
+/**
+ * Whether `pathname` is a conversation route — the `/assistant` index (draft
+ * conversation) or `/assistant/conversations/:id` — i.e. a route where
+ * `ChatPage` mounts the active conversation's composer.
+ */
+export function isConversationPath(pathname: string): boolean {
+  return (
+    pathname === routes.assistant ||
+    pathname === `${routes.assistant}/` ||
+    pathname.startsWith(`${routes.conversations}/`)
+  );
+}
+
 const WWW_DOMAIN = "vellum.ai";
 
 /** Full external URL for a legal/docs page hosted on the marketing site. */


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for voice-mode-ui.md:
- Session controller moves to a persistent host so sessions survive app-view/Home/Library navigation (the pill's core use cases)
- Composer voice UI (bar, transcript, textarea lock) now scoped to the owning conversation; exactly one surface (composer bar XOR title-bar pill) renders per session
- Draft-started session ownership reconciled on server-assigned conversation id
- Stale future-tense comment reworded; pill stop control hidden until turn-scoped interrupt lands (engine plan)