### PR TITLE
feat(skills): multi-account support & docs for google/outlook calendar skills

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -305,7 +305,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "updatedAt": "2026-07-06T23:31:38.000Z"
     },
     {
       "id": "guardian-verify-setup",
@@ -626,7 +626,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "updatedAt": "2026-07-06T23:31:38.000Z"
     },
     {
       "id": "plugin-builder",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -296,7 +296,12 @@
         "vellum": {
           "category": "calendar",
           "display-name": "Google Calendar",
-          "user-invocable": "true"
+          "user-invocable": "true",
+          "activation-hints": [
+            "check my availability this week",
+            "find open time slots / when am I free",
+            "cross-calendar free/busy across my connected accounts"
+          ]
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
@@ -612,7 +617,12 @@
         "vellum": {
           "category": "calendar",
           "display-name": "Outlook Calendar",
-          "user-invocable": "true"
+          "user-invocable": "true",
+          "activation-hints": [
+            "check my availability this week",
+            "find open time slots / when am I free",
+            "cross-calendar free/busy across my connected accounts"
+          ]
         }
       },
       "compatibility": "Designed for Vellum personal assistants",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -305,7 +305,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-06T23:31:38.000Z"
+      "updatedAt": "2026-07-07T04:37:57.000Z"
     },
     {
       "id": "guardian-verify-setup",
@@ -626,7 +626,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-06T23:31:38.000Z"
+      "updatedAt": "2026-07-07T04:37:57.000Z"
     },
     {
       "id": "plugin-builder",

--- a/skills/google-calendar/SKILL.md
+++ b/skills/google-calendar/SKILL.md
@@ -9,6 +9,10 @@ metadata:
     category: "calendar"
     display-name: "Google Calendar"
     user-invocable: true
+    activation-hints:
+      - "check my availability this week"
+      - "find open time slots / when am I free"
+      - "cross-calendar free/busy across my connected accounts"
 ---
 
 ## Script Reference
@@ -43,11 +47,17 @@ bun scripts/gcal.ts availability --time-min "2024-01-15T00:00:00Z" --time-max "2
 
 # RSVP to an event invitation
 bun scripts/gcal.ts rsvp --event-id "abc123" --response accepted
+
+# Target a specific connected account (see "Multiple Accounts" below)
+bun scripts/gcal.ts list --time-min "2024-01-15T00:00:00Z" --time-max "2024-01-22T00:00:00Z" --account "work@example.com"
 ```
+
+Every subcommand accepts `--account <email>` to select which connected Google account the request runs against. When omitted, the request runs against a single account chosen by the daemon — safe only when exactly one Google account is connected. Each JSON envelope echoes the queried account in an `account` field when the daemon reports one, so an empty result is self-describing (e.g. `No events found in the specified time range for work@example.com.`).
 
 ## Connection Setup
 
 1. **Check connection health first.** Run `assistant oauth status google`. This checks whether the user's Google account is connected and the token is valid. Google Calendar shares the same OAuth connection as Gmail — if the user already connected Gmail, calendar access is included.
+   - **If the status output shows more than one active connection, you MUST pass `--account <email>` on every `scripts/gcal.ts` invocation**, matching the calendar the user is asking about. When the user references a calendar by name or company (e.g. "my Acme calendar"), map it to the connected account email before querying. **Omitting `--account` with multiple connections silently queries one arbitrary account** — an empty or partial result then looks like a genuinely free calendar when it is really the wrong account. Confirm the `account` field in each response matches the account you intended.
 2. **If no connection is found or the status check fails:** Load the `vellum-oauth-integrations` skill. The skill will evaluate whether managed or your-own mode is appropriate and guide the user accordingly.
 
 ## Scheduling Playbook

--- a/skills/google-calendar/SKILL.md
+++ b/skills/google-calendar/SKILL.md
@@ -52,7 +52,7 @@ bun scripts/gcal.ts rsvp --event-id "abc123" --response accepted
 bun scripts/gcal.ts list --time-min "2024-01-15T00:00:00Z" --time-max "2024-01-22T00:00:00Z" --account "work@example.com"
 ```
 
-Every subcommand accepts `--account <email>` to select which connected Google account the request runs against. When omitted, the request runs against a single account chosen by the daemon — safe only when exactly one Google account is connected. Each JSON envelope echoes the queried account in an `account` field when the daemon reports one, so an empty result is self-describing (e.g. `No events found in the specified time range for work@example.com.`).
+Every subcommand accepts `--account <email>` to select which connected Google account the request runs against. When omitted, the request runs against a single account chosen automatically — safe only when exactly one Google account is connected. Each JSON envelope echoes the queried account in an `account` field when it is reported by the OAuth layer, so an empty result is self-describing (e.g. `No events found in the specified time range for work@example.com.`).
 
 ## Connection Setup
 

--- a/skills/google-calendar/scripts/gcal.ts
+++ b/skills/google-calendar/scripts/gcal.ts
@@ -89,18 +89,27 @@ async function list(argv: string[]): Promise<void> {
     account,
   });
 
+  const resolvedAccount = account ?? response.account;
+
   if (!response.ok) {
-    printError(`Failed to list events: status ${response.status}`);
+    printError(
+      `Failed to list events: status ${response.status}`,
+      resolvedAccount,
+    );
     return;
   }
 
   const result = response.data;
   if (!result.items?.length) {
-    ok("No events found in the specified time range.");
+    const suffix = resolvedAccount ? ` for ${resolvedAccount}` : "";
+    ok(
+      `No events found in the specified time range${suffix}.`,
+      resolvedAccount,
+    );
     return;
   }
 
-  ok(result);
+  ok(result, resolvedAccount);
 }
 
 // ---------------------------------------------------------------------------
@@ -114,13 +123,17 @@ async function get(argv: string[]): Promise<void> {
   const account = optionalArg(args, "account");
 
   const response = await getEvent(eventId, calendarId, account);
+  const resolvedAccount = account ?? response.account;
 
   if (!response.ok) {
-    printError(`Failed to get event: status ${response.status}`);
+    printError(
+      `Failed to get event: status ${response.status}`,
+      resolvedAccount,
+    );
     return;
   }
 
-  ok(response.data);
+  ok(response.data, resolvedAccount);
 }
 
 // ---------------------------------------------------------------------------
@@ -157,7 +170,7 @@ async function create(argv: string[]): Promise<void> {
     });
 
     if (!confirmed) {
-      ok({ created: false, reason: "User did not confirm" });
+      ok({ created: false, reason: "User did not confirm" }, account);
       return;
     }
   }
@@ -185,15 +198,19 @@ async function create(argv: string[]): Promise<void> {
   }
 
   const response = await createEvent(eventBody, calendarId, "all", account);
+  const resolvedAccount = account ?? response.account;
 
   if (!response.ok) {
-    printError(`Failed to create event: status ${response.status}`);
+    printError(
+      `Failed to create event: status ${response.status}`,
+      resolvedAccount,
+    );
     return;
   }
 
   const event = response.data;
   const link = event.htmlLink ? ` View it here: ${event.htmlLink}` : "";
-  ok(`Event created (ID: ${event.id}).${link}`);
+  ok(`Event created (ID: ${event.id}).${link}`, resolvedAccount);
 }
 
 // ---------------------------------------------------------------------------
@@ -220,12 +237,17 @@ async function availability(argv: string[]): Promise<void> {
     account,
   );
 
+  const resolvedAccount = account ?? response.account;
+
   if (!response.ok) {
-    printError(`Failed to check availability: status ${response.status}`);
+    printError(
+      `Failed to check availability: status ${response.status}`,
+      resolvedAccount,
+    );
     return;
   }
 
-  ok(response.data);
+  ok(response.data, resolvedAccount);
 }
 
 // ---------------------------------------------------------------------------
@@ -254,9 +276,13 @@ async function rsvp(argv: string[]): Promise<void> {
 
   // First GET the event to find the user's attendee entry
   const eventResponse = await getEvent(eventId, calendarId, account);
+  const resolvedAccount = account ?? eventResponse.account;
 
   if (!eventResponse.ok) {
-    printError(`Failed to get event: status ${eventResponse.status}`);
+    printError(
+      `Failed to get event: status ${eventResponse.status}`,
+      resolvedAccount,
+    );
     return;
   }
 
@@ -267,11 +293,15 @@ async function rsvp(argv: string[]): Promise<void> {
     // If the user is the organizer and not in the attendees list,
     // they don't need to RSVP
     if (event.organizer?.self) {
-      ok("You are the organizer of this event. No RSVP needed.");
+      ok(
+        "You are the organizer of this event. No RSVP needed.",
+        resolvedAccount,
+      );
       return;
     }
     ok(
       "Could not find your attendee entry for this event. You may not be invited.",
+      resolvedAccount,
     );
     return;
   }
@@ -292,7 +322,7 @@ async function rsvp(argv: string[]): Promise<void> {
     });
 
     if (!confirmed) {
-      ok({ rsvp: false, reason: "User did not confirm" });
+      ok({ rsvp: false, reason: "User did not confirm" }, resolvedAccount);
       return;
     }
   }
@@ -310,8 +340,10 @@ async function rsvp(argv: string[]): Promise<void> {
     account,
   );
 
+  const patchAccount = account ?? patchResponse.account ?? resolvedAccount;
+
   if (!patchResponse.ok) {
-    printError(`Failed to RSVP: status ${patchResponse.status}`);
+    printError(`Failed to RSVP: status ${patchResponse.status}`, patchAccount);
     return;
   }
 
@@ -321,7 +353,7 @@ async function rsvp(argv: string[]): Promise<void> {
       : responseStatus === "declined"
         ? "Declined"
         : "Tentatively accepted";
-  ok(`${responseLabel} the event "${event.summary ?? eventId}".`);
+  ok(`${responseLabel} the event "${event.summary ?? eventId}".`, patchAccount);
 }
 
 // ---------------------------------------------------------------------------

--- a/skills/google-calendar/scripts/gcal.ts
+++ b/skills/google-calendar/scripts/gcal.ts
@@ -258,9 +258,7 @@ async function rsvp(argv: string[]): Promise<void> {
   const args = parseArgs(argv);
   const eventId = requireArg(args, "event-id");
   const responseStatus = requireArg(args, "response") as
-    | "accepted"
-    | "declined"
-    | "tentative";
+    "accepted" | "declined" | "tentative";
   const calendarId = optionalArg(args, "calendar-id") ?? "primary";
   const account = optionalArg(args, "account");
   const skipConfirm = args["skip-confirm"] === true;

--- a/skills/google-calendar/scripts/lib/common.test.ts
+++ b/skills/google-calendar/scripts/lib/common.test.ts
@@ -1,0 +1,61 @@
+import { test, expect, spyOn } from "bun:test";
+
+import { ok, printError } from "./common.js";
+
+/** Capture everything written to stdout while running `fn`. */
+function captureStdout(fn: () => void): string {
+  const writes: string[] = [];
+  const spy = spyOn(process.stdout, "write").mockImplementation((chunk) => {
+    writes.push(String(chunk));
+    return true;
+  });
+  try {
+    fn();
+  } finally {
+    spy.mockRestore();
+  }
+  return writes.join("");
+}
+
+test("ok includes the account field when an account is provided", () => {
+  const out = captureStdout(() => {
+    ok(
+      "No events found in the specified time range for user@example.com.",
+      "user@example.com",
+    );
+  });
+  expect(JSON.parse(out)).toEqual({
+    ok: true,
+    data: "No events found in the specified time range for user@example.com.",
+    account: "user@example.com",
+  });
+});
+
+test("ok omits the account field when no account is known", () => {
+  const out = captureStdout(() => {
+    ok({ items: [] });
+  });
+  const parsed = JSON.parse(out);
+  expect(parsed).toEqual({ ok: true, data: { items: [] } });
+  expect(parsed.account).toBeUndefined();
+});
+
+test("printError includes the account field and exits non-zero", () => {
+  const exitSpy = spyOn(process, "exit").mockImplementation(((
+    code?: number,
+  ) => {
+    throw new Error(`exit:${code}`);
+  }) as never);
+  try {
+    const out = captureStdout(() => {
+      expect(() => printError("boom", "work@example.com")).toThrow("exit:1");
+    });
+    expect(JSON.parse(out)).toEqual({
+      ok: false,
+      error: "boom",
+      account: "work@example.com",
+    });
+  } finally {
+    exitSpy.mockRestore();
+  }
+});

--- a/skills/google-calendar/scripts/lib/common.ts
+++ b/skills/google-calendar/scripts/lib/common.ts
@@ -28,15 +28,37 @@ export function printJson(data: unknown): void {
   process.stdout.write(JSON.stringify(data) + "\n");
 }
 
-/** Write `{ ok: false, error: message }` to stdout and exit. */
-export function printError(message: string): void {
-  printJson({ ok: false, error: message });
+/**
+ * Write `{ ok: false, error: message }` to stdout and exit.
+ * When `account` is known, include it so the caller can tell which
+ * connected account produced the failure.
+ */
+export function printError(message: string, account?: string): void {
+  const envelope: { ok: false; error: string; account?: string } = {
+    ok: false,
+    error: message,
+  };
+  if (account) {
+    envelope.account = account;
+  }
+  printJson(envelope);
   process.exit(1);
 }
 
-/** Write `{ ok: true, data }` to stdout. */
-export function ok(data: unknown): void {
-  printJson({ ok: true, data });
+/**
+ * Write `{ ok: true, data }` to stdout.
+ * When `account` is known, include it so an otherwise ambiguous result
+ * (e.g. "no events found") identifies which connected account was queried.
+ */
+export function ok(data: unknown, account?: string): void {
+  const envelope: { ok: true; data: unknown; account?: string } = {
+    ok: true,
+    data,
+  };
+  if (account) {
+    envelope.account = account;
+  }
+  printJson(envelope);
 }
 
 /** Extract a required string argument or call `printError`. */

--- a/skills/google-calendar/scripts/lib/gcal-client.ts
+++ b/skills/google-calendar/scripts/lib/gcal-client.ts
@@ -18,6 +18,11 @@ export interface GcalResponse<T = unknown> {
   ok: boolean;
   status: number;
   data: T;
+  /**
+   * The connected account the daemon used to satisfy the request, when it
+   * reports one. Absent when the daemon does not surface an `account` field.
+   */
+  account?: string;
 }
 
 /** Event time - either a dateTime with timezone or a date for all-day events. */
@@ -192,6 +197,7 @@ export async function gcalRequest<T = unknown>(
       status: number;
       headers: Record<string, string>;
       body: unknown;
+      account?: string;
     };
     try {
       result = JSON.parse(stdout);
@@ -222,6 +228,7 @@ export async function gcalRequest<T = unknown>(
       ok: result.ok,
       status: result.status,
       data: result.body as T,
+      account: result.account,
     };
   }
 

--- a/skills/outlook-calendar/SKILL.md
+++ b/skills/outlook-calendar/SKILL.md
@@ -55,7 +55,7 @@ bun scripts/outlook-cal.ts rsvp --event-id "AAMkAD..." --response accepted
 bun scripts/outlook-cal.ts list --start-date-time "2024-01-15T00:00:00Z" --end-date-time "2024-01-22T00:00:00Z" --account "work@example.com"
 ```
 
-Every subcommand accepts `--account <email>` to select which connected Outlook/Microsoft account the request runs against. When omitted, the request runs against a single account chosen by the daemon — safe only when exactly one Outlook account is connected. Each JSON envelope echoes the queried account in an `account` field when the daemon reports one, so an empty result is self-describing (e.g. `No events found in the specified time range for work@example.com.`).
+Every subcommand accepts `--account <email>` to select which connected Outlook/Microsoft account the request runs against. When omitted, the request runs against a single account chosen automatically — safe only when exactly one Outlook account is connected. Each JSON envelope echoes the queried account in an `account` field when it is reported by the OAuth layer, so an empty result is self-describing (e.g. `No events found in the specified time range for work@example.com.`).
 
 ## Connection Setup
 

--- a/skills/outlook-calendar/SKILL.md
+++ b/skills/outlook-calendar/SKILL.md
@@ -9,6 +9,10 @@ metadata:
     category: "calendar"
     display-name: "Outlook Calendar"
     user-invocable: true
+    activation-hints:
+      - "check my availability this week"
+      - "find open time slots / when am I free"
+      - "cross-calendar free/busy across my connected accounts"
 ---
 
 ## Script Reference
@@ -46,11 +50,17 @@ bun scripts/outlook-cal.ts availability --start "2024-01-15T00:00:00Z" --end "20
 
 # RSVP to an event invitation
 bun scripts/outlook-cal.ts rsvp --event-id "AAMkAD..." --response accepted
+
+# Target a specific connected account (see "Multiple Accounts" below)
+bun scripts/outlook-cal.ts list --start-date-time "2024-01-15T00:00:00Z" --end-date-time "2024-01-22T00:00:00Z" --account "work@example.com"
 ```
+
+Every subcommand accepts `--account <email>` to select which connected Outlook/Microsoft account the request runs against. When omitted, the request runs against a single account chosen by the daemon — safe only when exactly one Outlook account is connected. Each JSON envelope echoes the queried account in an `account` field when the daemon reports one, so an empty result is self-describing (e.g. `No events found in the specified time range for work@example.com.`).
 
 ## Connection Setup
 
 1. **Check connection health first.** Run `assistant oauth status outlook`. This checks whether the user's Outlook/Microsoft account is connected and the token is valid. Outlook Calendar shares the same OAuth connection as Outlook email — if the user already connected Outlook email, calendar access is included.
+   - **If the status output shows more than one active connection, you MUST pass `--account <email>` on every `scripts/outlook-cal.ts` invocation**, matching the calendar the user is asking about. When the user references a calendar by name or company (e.g. "my Acme calendar"), map it to the connected account email before querying. **Omitting `--account` with multiple connections silently queries one arbitrary account** — an empty or partial result then looks like a genuinely free calendar when it is really the wrong account. Confirm the `account` field in each response matches the account you intended.
 2. **If no connection is found or the status check fails:** Load the `vellum-oauth-integrations` skill. The skill will evaluate whether managed or your-own mode is appropriate and guide the user accordingly.
 
 ## Scheduling Playbook

--- a/skills/outlook-calendar/scripts/lib/common.test.ts
+++ b/skills/outlook-calendar/scripts/lib/common.test.ts
@@ -1,0 +1,61 @@
+import { test, expect, spyOn } from "bun:test";
+
+import { ok, printError } from "./common.js";
+
+/** Capture everything written to stdout while running `fn`. */
+function captureStdout(fn: () => void): string {
+  const writes: string[] = [];
+  const spy = spyOn(process.stdout, "write").mockImplementation((chunk) => {
+    writes.push(String(chunk));
+    return true;
+  });
+  try {
+    fn();
+  } finally {
+    spy.mockRestore();
+  }
+  return writes.join("");
+}
+
+test("ok includes the account field when an account is provided", () => {
+  const out = captureStdout(() => {
+    ok(
+      "No events found in the specified time range for user@example.com.",
+      "user@example.com",
+    );
+  });
+  expect(JSON.parse(out)).toEqual({
+    ok: true,
+    data: "No events found in the specified time range for user@example.com.",
+    account: "user@example.com",
+  });
+});
+
+test("ok omits the account field when no account is known", () => {
+  const out = captureStdout(() => {
+    ok({ value: [] });
+  });
+  const parsed = JSON.parse(out);
+  expect(parsed).toEqual({ ok: true, data: { value: [] } });
+  expect(parsed.account).toBeUndefined();
+});
+
+test("printError includes the account field and exits non-zero", () => {
+  const exitSpy = spyOn(process, "exit").mockImplementation(((
+    code?: number,
+  ) => {
+    throw new Error(`exit:${code}`);
+  }) as never);
+  try {
+    const out = captureStdout(() => {
+      expect(() => printError("boom", "work@example.com")).toThrow("exit:1");
+    });
+    expect(JSON.parse(out)).toEqual({
+      ok: false,
+      error: "boom",
+      account: "work@example.com",
+    });
+  } finally {
+    exitSpy.mockRestore();
+  }
+});

--- a/skills/outlook-calendar/scripts/lib/common.ts
+++ b/skills/outlook-calendar/scripts/lib/common.ts
@@ -28,15 +28,37 @@ export function printJson(data: unknown): void {
   process.stdout.write(JSON.stringify(data) + "\n");
 }
 
-/** Write `{ ok: false, error: message }` to stdout and exit. */
-export function printError(message: string): void {
-  printJson({ ok: false, error: message });
+/**
+ * Write `{ ok: false, error: message }` to stdout and exit.
+ * When `account` is known, include it so the caller can tell which
+ * connected account produced the failure.
+ */
+export function printError(message: string, account?: string): void {
+  const envelope: { ok: false; error: string; account?: string } = {
+    ok: false,
+    error: message,
+  };
+  if (account) {
+    envelope.account = account;
+  }
+  printJson(envelope);
   process.exit(1);
 }
 
-/** Write `{ ok: true, data }` to stdout. */
-export function ok(data: unknown): void {
-  printJson({ ok: true, data });
+/**
+ * Write `{ ok: true, data }` to stdout.
+ * When `account` is known, include it so an otherwise ambiguous result
+ * (e.g. "no events found") identifies which connected account was queried.
+ */
+export function ok(data: unknown, account?: string): void {
+  const envelope: { ok: true; data: unknown; account?: string } = {
+    ok: true,
+    data,
+  };
+  if (account) {
+    envelope.account = account;
+  }
+  printJson(envelope);
 }
 
 /** Extract a required string argument or call `printError`. */

--- a/skills/outlook-calendar/scripts/lib/outlook-cal-client.ts
+++ b/skills/outlook-calendar/scripts/lib/outlook-cal-client.ts
@@ -239,12 +239,7 @@ export interface OutlookCalendarEvent {
   isAllDay?: boolean;
   isCancelled?: boolean;
   showAs?:
-    | "free"
-    | "tentative"
-    | "busy"
-    | "oof"
-    | "workingElsewhere"
-    | "unknown";
+    "free" | "tentative" | "busy" | "oof" | "workingElsewhere" | "unknown";
   importance?: "low" | "normal" | "high";
   sensitivity?: "normal" | "personal" | "private" | "confidential";
   webLink?: string;
@@ -268,12 +263,7 @@ export interface OutlookCalendarEventListResponse {
 /** A single schedule item (free/busy block). */
 export interface OutlookScheduleItem {
   status:
-    | "free"
-    | "tentative"
-    | "busy"
-    | "oof"
-    | "workingElsewhere"
-    | "unknown";
+    "free" | "tentative" | "busy" | "oof" | "workingElsewhere" | "unknown";
   start: OutlookDateTimeZone;
   end: OutlookDateTimeZone;
   subject?: string;

--- a/skills/outlook-calendar/scripts/lib/outlook-cal-client.ts
+++ b/skills/outlook-calendar/scripts/lib/outlook-cal-client.ts
@@ -22,6 +22,11 @@ export interface GraphResponse<T = unknown> {
   ok: boolean;
   status: number;
   data: T;
+  /**
+   * The connected account the daemon used to satisfy the request, when it
+   * reports one. Absent when the daemon does not surface an `account` field.
+   */
+  account?: string;
 }
 
 const MAX_RETRIES = 3;
@@ -105,6 +110,7 @@ export async function graphRequest<T = unknown>(
       status: number;
       headers: Record<string, string>;
       body: unknown;
+      account?: string;
     };
     try {
       result = JSON.parse(stdout);
@@ -135,6 +141,7 @@ export async function graphRequest<T = unknown>(
       ok: result.ok,
       status: result.status,
       data: result.body as T,
+      account: result.account,
     };
   }
 

--- a/skills/outlook-calendar/scripts/outlook-cal.ts
+++ b/skills/outlook-calendar/scripts/outlook-cal.ts
@@ -131,17 +131,26 @@ Options:
     account,
   });
 
+  const resolvedAccount = account ?? result.account;
+
   if (!result.ok) {
-    printError(`Failed to list events: status ${result.status}`);
+    printError(
+      `Failed to list events: status ${result.status}`,
+      resolvedAccount,
+    );
     return;
   }
 
   if (!result.data.value?.length) {
-    ok("No events found in the specified time range.");
+    const suffix = resolvedAccount ? ` for ${resolvedAccount}` : "";
+    ok(
+      `No events found in the specified time range${suffix}.`,
+      resolvedAccount,
+    );
     return;
   }
 
-  ok(result.data);
+  ok(result.data, resolvedAccount);
 }
 
 // ---------------------------------------------------------------------------
@@ -164,13 +173,14 @@ Options:
   const account = optionalArg(args, "account");
 
   const result = await getEvent(eventId, undefined, account);
+  const resolvedAccount = account ?? result.account;
 
   if (!result.ok) {
-    printError(`Failed to get event: status ${result.status}`);
+    printError(`Failed to get event: status ${result.status}`, resolvedAccount);
     return;
   }
 
-  ok(result.data);
+  ok(result.data, resolvedAccount);
 }
 
 // ---------------------------------------------------------------------------
@@ -231,7 +241,7 @@ Options:
     });
 
     if (!confirmed) {
-      ok({ created: false, reason: "User did not confirm" });
+      ok({ created: false, reason: "User did not confirm" }, account);
       return;
     }
   }
@@ -284,15 +294,19 @@ Options:
   }
 
   const result = await createEvent(eventBody, calendarId, account);
+  const resolvedAccount = account ?? result.account;
 
   if (!result.ok) {
-    printError(`Failed to create event: status ${result.status}`);
+    printError(
+      `Failed to create event: status ${result.status}`,
+      resolvedAccount,
+    );
     return;
   }
 
   const event = result.data;
   const webLink = event.webLink ? ` View it here: ${event.webLink}` : "";
-  ok(`Event created (ID: ${event.id}).${webLink}`);
+  ok(`Event created (ID: ${event.id}).${webLink}`, resolvedAccount);
 }
 
 // ---------------------------------------------------------------------------
@@ -336,6 +350,7 @@ Options:
     printError(
       "No schedules provided and could not determine your email address from your Microsoft profile. " +
         "Please provide at least one email address via --schedules.",
+      account,
     );
     return;
   }
@@ -349,12 +364,17 @@ Options:
     account,
   );
 
+  const resolvedAccount = account ?? result.account;
+
   if (!result.ok) {
-    printError(`Failed to check availability: status ${result.status}`);
+    printError(
+      `Failed to check availability: status ${result.status}`,
+      resolvedAccount,
+    );
     return;
   }
 
-  ok(result.data);
+  ok(result.data, resolvedAccount);
 }
 
 // ---------------------------------------------------------------------------
@@ -391,9 +411,13 @@ Options:
 
   // First GET the event to check if user is organizer
   const eventResult = await getEvent(eventId, undefined, account);
+  const resolvedAccount = account ?? eventResult.account;
 
   if (!eventResult.ok) {
-    printError(`Failed to get event: status ${eventResult.status}`);
+    printError(
+      `Failed to get event: status ${eventResult.status}`,
+      resolvedAccount,
+    );
     return;
   }
 
@@ -401,7 +425,7 @@ Options:
 
   // If the user is the organizer, no RSVP is needed
   if (event.responseStatus?.response === "organizer") {
-    ok("You are the organizer of this event. No RSVP needed.");
+    ok("You are the organizer of this event. No RSVP needed.", resolvedAccount);
     return;
   }
 
@@ -428,7 +452,7 @@ Options:
     });
 
     if (!confirmed) {
-      ok({ rsvped: false, reason: "User did not confirm" });
+      ok({ rsvped: false, reason: "User did not confirm" }, resolvedAccount);
       return;
     }
   }
@@ -442,8 +466,10 @@ Options:
     account,
   );
 
+  const rsvpAccount = account ?? rsvpResult.account ?? resolvedAccount;
+
   if (!rsvpResult.ok) {
-    printError(`Failed to RSVP: status ${rsvpResult.status}`);
+    printError(`Failed to RSVP: status ${rsvpResult.status}`, rsvpAccount);
     return;
   }
 
@@ -453,7 +479,7 @@ Options:
       : response === "declined"
         ? "Declined"
         : "Tentatively accepted";
-  ok(`${responseLabel} the event "${event.subject ?? eventId}".`);
+  ok(`${responseLabel} the event "${event.subject ?? eventId}".`, rsvpAccount);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## The failure (from a real feedback session)

A user with **two Google accounts and two Outlook accounts** connected asked for their availability across specific calendars. The assistant ran `skills/google-calendar/scripts/gcal.ts list` and `skills/outlook-calendar/scripts/outlook-cal.ts list` **without `--account`**. The underlying `assistant oauth request` silently fell back to one arbitrary connection (the wrong, empty account) and the scripts returned:

```json
{"ok":true,"data":"No events found in the specified time range."}
```

Nothing in that envelope said *which* account was queried, so the assistant told the user their week was wide open. It wasn't — it had queried the wrong account. Both scripts already accepted `--account`, but neither SKILL.md mentioned it and an empty result was indistinguishable from a genuinely free calendar.

## What changed

### Docs (`SKILL.md` x2)
- Document `--account <email>` in the usage/script-reference sections with generic example emails (`user@example.com` / `work@example.com`).
- Extend Connection Setup step 1: when `assistant oauth status <provider>` shows **more than one active connection**, `--account` becomes mandatory on every invocation; when the user names a calendar by company, map it to the connected account email first; and an explicit warning that omitting `--account` with multiple connections silently queries one arbitrary account. The assistant is told to confirm the response's `account` field matches its intent.

### Scripts (`gcal.ts` / `outlook-cal.ts` + their `lib/*`)
- Every JSON envelope now carries an optional `account` field. `ok()` / `printError()` in each skill's `common.ts` take an optional `account` argument and include it only when known.
- **Graceful-degradation contract with the daemon:** the resolved account is `--account arg ?? response.account`, where `response.account` comes from a future daemon-side `account` field on the `assistant oauth request --json` response. The client response types (`GcalResponse` / `GraphResponse`) thread this through. When neither source is present, the field is **omitted rather than guessed** — so this ships safely ahead of the daemon change and starts self-describing results the moment the daemon adds the field.
- "No events found in the specified time range." now appends `for <account>.` when the account is known.

### Catalog (`catalog.json`)
- Added availability-flavored `activation-hints` to both `google-calendar` and `outlook-calendar` entries (via SKILL.md frontmatter; catalog regenerated with `scripts/skills/generate-catalog.mjs`). The `activation-hints` schema is already in active use by ~23 other skills, so this follows an established convention.

### Tests
- New `scripts/lib/common.test.ts` in each skill covering the envelope `account` contract (present when provided, omitted when absent, on both success and error paths).

## Follow-up (out of scope for one logical change)
The `gmail` and `outlook` (email) skills share the same multi-account blind spot in their SKILL.md workflow instructions — their scripts already accept `--account` but the docs don't mandate it for multi-connection setups, and their JSON envelopes span several scripts with differing shapes. Folding those in would meaningfully grow this diff, so they're flagged here as a follow-up rather than bundled.

## Validation
- `scripts/skills/lint-skill-spec.mjs google-calendar outlook-calendar` — pass
- `scripts/skills/lint-skill-imports.mjs` — pass (no cross-skill imports)
- `scripts/skills/check-catalog.mjs` — catalog up to date
- `bun test` in both skill dirs — 3 pass / 0 fail each
- `prettier@3 --check` (CI-equivalent) on both skill trees — clean
- Both scripts load and transpile cleanly (`--help`, `bun build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->