### PR TITLE
fix(daemon): humanize unclassified provider 4xx rejections

### DIFF
--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -455,6 +455,73 @@ describe("classifyConversationError", () => {
       expect(result.userMessage).not.toContain("{");
     });
 
+    it("unwraps OpenRouter's metadata.raw so the downstream detail surfaces instead of 'Provider returned error'", () => {
+      // OpenRouter envelope: the top-level message is a generic wrapper and
+      // the downstream provider's actual error is a stringified JSON envelope
+      // in `error.metadata.raw`.
+      const rawBody =
+        '{"error":{"message":"Provider returned error","code":400,"metadata":{"raw":"{\\"type\\":\\"error\\",\\"error\\":{\\"type\\":\\"invalid_request_error\\",\\"message\\":\\"adaptive thinking is not supported on this model\\"}}","provider_name":"Anthropic","is_byok":false}}}';
+      const err = new ProviderError(
+        "OpenRouter API error (400): Provider returned error",
+        "openrouter",
+        400,
+        { rawBody },
+      );
+      const result = classifyConversationError(err, baseCtx);
+
+      expect(result.code).toBe("PROVIDER_API");
+      expect(result.errorCategory).toBe("provider_api_error");
+      // The downstream detail surfaces, not the generic wrapper …
+      expect(result.userMessage).toContain(
+        "adaptive thinking is not supported on this model",
+      );
+      expect(result.userMessage).not.toContain("Provider returned error");
+      // … and no JSON leaks.
+      expect(result.userMessage).not.toContain("{");
+      expect(result.userMessage).not.toContain("}");
+      expect(result.userMessage).not.toContain("metadata");
+      expect(result.userMessage).not.toContain("invalid_request_error");
+      // The downstream error class drives the model-config hint.
+      expect(result.userMessage).toMatch(/model configuration/i);
+    });
+
+    it("never persists the bare 'Provider returned error' wrapper when metadata.raw is unusable", () => {
+      const rawBody =
+        '{"error":{"message":"Provider returned error","code":400,"metadata":{"raw":"{truncated-and-not-json","provider_name":"Anthropic"}}}';
+      const err = new ProviderError(
+        "OpenRouter API error (400): Provider returned error",
+        "openrouter",
+        400,
+        { rawBody },
+      );
+      const result = classifyConversationError(err, baseCtx);
+
+      expect(result.code).toBe("PROVIDER_API");
+      // Falls back to the generic assistant-voice sentence rather than
+      // surfacing the non-actionable wrapper or the malformed raw blob.
+      expect(result.userMessage).toContain(
+        "The model provider rejected this request",
+      );
+      expect(result.userMessage).not.toContain("Provider returned error");
+      expect(result.userMessage).not.toContain("{");
+    });
+
+    it("uses a plain-text metadata.raw directly as the detail", () => {
+      const rawBody =
+        '{"error":{"message":"Provider returned error","code":404,"metadata":{"raw":"model not found: some-model-slug","provider_name":"ExampleProvider"}}}';
+      const err = new ProviderError(
+        "OpenRouter API error (404): Provider returned error",
+        "openrouter",
+        404,
+        { rawBody },
+      );
+      const result = classifyConversationError(err, baseCtx);
+
+      expect(result.userMessage).toContain("model not found: some-model-slug");
+      expect(result.userMessage).not.toContain("Provider returned error");
+      expect(result.userMessage).not.toContain("{");
+    });
+
     it("falls back to a generic assistant-voice message when no detail can be extracted", () => {
       const err = new ProviderError("Bad Request", "anthropic", 400);
       const result = classifyConversationError(err, baseCtx);

--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -385,6 +385,90 @@ describe("classifyConversationError", () => {
     });
   });
 
+  describe("unclassified provider 4xx rejections (friendly messaging)", () => {
+    it("surfaces the provider detail without dumping the raw JSON envelope, and hints at model config for invalid_request_error", () => {
+      // The production incident: a config-induced Anthropic 400 whose raw wire
+      // body was persisted verbatim as the assistant message.
+      const err = new ProviderError(
+        'Anthropic API error (400): 400 {"type":"error","error":{"type":"invalid_request_error","message":"adaptive thinking is not supported on this model"},"request_id":"req_011CabcdEFGH"}',
+        "anthropic",
+        400,
+      );
+      const result = classifyConversationError(err, baseCtx);
+
+      expect(result.code).toBe("PROVIDER_API");
+      expect(result.errorCategory).toBe("provider_api_error");
+      expect(result.retryable).toBe(true);
+
+      // The human-relevant provider detail is surfaced …
+      expect(result.userMessage).toContain(
+        "adaptive thinking is not supported on this model",
+      );
+      // … but no raw JSON envelope, request id, or HTTP-status jargon leaks.
+      expect(result.userMessage).not.toContain("{");
+      expect(result.userMessage).not.toContain("}");
+      expect(result.userMessage).not.toContain("invalid_request_error");
+      expect(result.userMessage).not.toContain("request_id");
+      expect(result.userMessage).not.toContain("req_011CabcdEFGH");
+      expect(result.userMessage).not.toMatch(/HTTP\s*400/i);
+      expect(result.userMessage).not.toMatch(/\bHTTP\b/);
+
+      // invalid_request_error → point the user at model configuration.
+      expect(result.userMessage).toMatch(/model configuration/i);
+      expect(result.userMessage).toContain("Settings → Models & Services");
+    });
+
+    it("reads the detail and error class from structured ProviderError fields when present", () => {
+      const err = new ProviderError(
+        "Provider rejected the request",
+        "openai",
+        400,
+        {
+          apiErrorType: "invalid_request_error",
+          requestId: "req_openai_123",
+          rawBody:
+            '{"error":{"message":"temperature is not supported with this model","type":"invalid_request_error","code":"unsupported_parameter"}}',
+        },
+      );
+      const result = classifyConversationError(err, baseCtx);
+
+      expect(result.code).toBe("PROVIDER_API");
+      expect(result.userMessage).toContain(
+        "temperature is not supported with this model",
+      );
+      expect(result.userMessage).not.toContain("{");
+      expect(result.userMessage).toMatch(/model configuration/i);
+    });
+
+    it("omits the model-config hint for non-invalid_request 4xx classes", () => {
+      const err = new ProviderError(
+        'Anthropic API error (400): 400 {"type":"error","error":{"type":"not_found_error","message":"model: unknown-model-xyz"}}',
+        "anthropic",
+        400,
+      );
+      const result = classifyConversationError(err, baseCtx);
+
+      expect(result.code).toBe("PROVIDER_API");
+      expect(result.userMessage).toContain("model: unknown-model-xyz");
+      expect(result.userMessage).not.toMatch(/model configuration/i);
+      expect(result.userMessage).toMatch(/try again/i);
+      expect(result.userMessage).not.toContain("{");
+    });
+
+    it("falls back to a generic assistant-voice message when no detail can be extracted", () => {
+      const err = new ProviderError("Bad Request", "anthropic", 400);
+      const result = classifyConversationError(err, baseCtx);
+
+      expect(result.code).toBe("PROVIDER_API");
+      expect(result.errorCategory).toBe("provider_api_error");
+      expect(result.userMessage).toContain(
+        "The model provider rejected this request",
+      );
+      expect(result.userMessage).not.toContain("{");
+      expect(result.userMessage).not.toMatch(/\bHTTP\b/);
+    });
+  });
+
   describe("ordering errors (tool_use/tool_result mismatches)", () => {
     const cases = [
       "tool_result block not immediately after tool_use block",

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -437,23 +437,156 @@ function classifyCore(
           errorCategory: "vision_not_supported",
         };
       }
-      // Extract the provider detail after "API error (NNN): " prefix
-      const detailMatch = message.match(/API error \(\d+\):\s*(.+)/i);
-      const detail = detailMatch?.[1];
-      const suffix = detail
-        ? `: ${detail.length > 200 ? detail.slice(0, 200) + "…" : detail}`
-        : "";
-      return {
-        code: "PROVIDER_API",
-        userMessage: `The AI provider rejected the request (HTTP ${error.statusCode})${suffix}`,
-        retryable: true,
-        errorCategory: "provider_api_error",
-      };
+      return unclassifiedProviderRejectionClassification(error, message);
     }
   }
 
   // Regex fallback for non-ProviderError or ProviderError without statusCode
   return classifyByMessage(error, message);
+}
+
+/**
+ * Human-relevant fields pulled from an unclassified provider 4xx rejection.
+ * `detail` is the provider's own error-message string (e.g. "adaptive
+ * thinking is not supported on this model"); `errorType` is the provider's
+ * error class (e.g. "invalid_request_error"); `requestId` is diagnostic-only
+ * and never surfaced in user-facing copy.
+ */
+interface ProviderRejectionDetail {
+  detail?: string;
+  errorType?: string;
+  requestId?: string;
+}
+
+/**
+ * Parse the first JSON object embedded in `text`. Provider SDKs prefix the
+ * raw non-2xx body with the status number (e.g. `400 {"type":"error",…}`),
+ * so `JSON.parse` on the whole string fails; scanning from the first `{`
+ * recovers the envelope.
+ */
+function parseEmbeddedJsonObject(
+  text: string,
+): Record<string, unknown> | undefined {
+  const start = text.indexOf("{");
+  if (start === -1) {
+    return undefined;
+  }
+  try {
+    const parsed: unknown = JSON.parse(text.slice(start));
+    if (typeof parsed === "object" && parsed !== null) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Extract the provider's human-relevant detail, error class, and request id
+ * from an unclassified 4xx rejection. Prefers the structured `ProviderError`
+ * fields when the provider populated them, then falls back to the JSON
+ * envelope embedded in the error message (Anthropic: `{ error: { type,
+ * message } }`; OpenAI/OpenRouter: `{ error: { message, type, code } }`).
+ */
+function extractProviderRejectionDetail(
+  error: unknown,
+  message: string,
+): ProviderRejectionDetail {
+  const out: ProviderRejectionDetail = {};
+  if (error instanceof ProviderError) {
+    if (error.apiErrorType) {
+      out.errorType = error.apiErrorType;
+    }
+    if (error.requestId) {
+      out.requestId = error.requestId;
+    }
+  }
+
+  const rawBody =
+    error instanceof ProviderError && error.rawBody ? error.rawBody : message;
+  const parsed = parseEmbeddedJsonObject(rawBody);
+  if (parsed) {
+    const inner =
+      typeof parsed.error === "object" && parsed.error !== null
+        ? (parsed.error as Record<string, unknown>)
+        : undefined;
+    const detail = inner?.message ?? parsed.message;
+    if (typeof detail === "string" && detail.trim().length > 0) {
+      out.detail = detail.trim();
+    }
+    const type = inner?.type ?? parsed.type;
+    if (!out.errorType && typeof type === "string" && type.length > 0) {
+      out.errorType = type;
+    }
+    const requestId = parsed.request_id ?? parsed.requestId;
+    if (
+      !out.requestId &&
+      typeof requestId === "string" &&
+      requestId.length > 0
+    ) {
+      out.requestId = requestId;
+    }
+  }
+
+  // No JSON envelope — recover the plain-text detail after the
+  // "API error (NNN): " prefix, but only when it isn't itself a JSON blob
+  // (guard against leaking a malformed envelope verbatim).
+  if (!out.detail) {
+    const detailMatch = message.match(/API error \(\d+\):\s*(.+)/is);
+    const raw = detailMatch?.[1]?.trim();
+    if (raw && !raw.includes("{")) {
+      out.detail = raw;
+    }
+  }
+
+  return out;
+}
+
+/** Collapse whitespace and clamp a provider detail string for display. */
+function clampProviderDetail(detail: string): string {
+  const oneLine = detail.replace(/\s+/g, " ").trim();
+  const clamped = oneLine.length > 200 ? `${oneLine.slice(0, 200)}…` : oneLine;
+  return /[.!?…]$/.test(clamped) ? clamped : `${clamped}.`;
+}
+
+/**
+ * Classify a provider 4xx that matched none of the specific classifiers into
+ * an assistant-voice, plain-language message. The raw wire body (JSON
+ * envelope, HTTP status, request id) is deliberately kept out of the
+ * user-facing copy — it lives in the logs for diagnostics. When the provider
+ * flags the rejection as an `invalid_request_error`, the copy points the user
+ * at their model configuration, since that class most often means the request
+ * shape the assistant built is incompatible with the selected model.
+ */
+function unclassifiedProviderRejectionClassification(
+  error: unknown,
+  message: string,
+): Omit<ClassifiedConversationError, "debugDetails"> {
+  const { detail, errorType } = extractProviderRejectionDetail(error, message);
+
+  const configRelated =
+    typeof errorType === "string" && /invalid_request/i.test(errorType);
+
+  const parts: string[] = [
+    detail
+      ? `The model provider rejected this request: ${clampProviderDetail(detail)}`
+      : "The model provider rejected this request.",
+  ];
+  if (configRelated) {
+    parts.push(
+      "This usually means the assistant's model configuration isn't compatible with the selected model. Switching model profiles or reverting a recent change in Settings → Models & Services may fix it.",
+    );
+  } else {
+    parts.push("Please try again in a moment.");
+  }
+
+  return {
+    code: "PROVIDER_API",
+    userMessage: parts.join(" "),
+    retryable: true,
+    errorCategory: "provider_api_error",
+  };
 }
 
 /** Check whether an error message indicates a context-too-large failure. */

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -482,12 +482,89 @@ function parseEmbeddedJsonObject(
   return undefined;
 }
 
+// Aggregator wrapper message (OpenRouter) whose actionable downstream detail
+// lives in `error.metadata.raw` rather than `error.message`.
+const AGGREGATOR_GENERIC_WRAPPER = /^provider returned error\.?$/i;
+
+/**
+ * Bound on `metadata.raw` unwrapping — one aggregator hop (OpenRouter →
+ * downstream provider) is the real-world shape; the limit only guards
+ * against a pathological self-referencing envelope.
+ */
+const MAX_ENVELOPE_UNWRAP_DEPTH = 2;
+
+/**
+ * Pull the human-relevant fields out of one parsed provider error envelope.
+ * Handles Anthropic (`{ error: { type, message } }`), OpenAI/OpenRouter
+ * (`{ error: { message, type, code } }`), and flat (`{ message, type }`)
+ * shapes. For OpenRouter, the downstream provider's actionable error is a
+ * stringified envelope buried in `error.metadata.raw` while `error.message`
+ * is the generic "Provider returned error" wrapper — unwrap it (bounded
+ * depth) and let the downstream fields win over the generic wrapper.
+ */
+function extractEnvelopeFields(
+  parsed: Record<string, unknown>,
+  depth = 0,
+): ProviderRejectionDetail {
+  const out: ProviderRejectionDetail = {};
+  const inner =
+    typeof parsed.error === "object" && parsed.error !== null
+      ? (parsed.error as Record<string, unknown>)
+      : parsed;
+
+  const detail = inner.message ?? parsed.message;
+  if (typeof detail === "string" && detail.trim().length > 0) {
+    out.detail = detail.trim();
+  }
+  const type = inner.type ?? parsed.type;
+  if (typeof type === "string" && type.length > 0) {
+    out.errorType = type;
+  }
+  const requestId = parsed.request_id ?? parsed.requestId;
+  if (typeof requestId === "string" && requestId.length > 0) {
+    out.requestId = requestId;
+  }
+
+  const meta =
+    typeof inner.metadata === "object" && inner.metadata !== null
+      ? (inner.metadata as Record<string, unknown>)
+      : undefined;
+  const raw = meta?.raw;
+  if (depth < MAX_ENVELOPE_UNWRAP_DEPTH && typeof raw === "string") {
+    const nestedParsed = parseEmbeddedJsonObject(raw);
+    // A non-JSON `raw` is used directly as the detail; anything containing a
+    // brace that failed to parse is discarded rather than leaked verbatim.
+    const nested = nestedParsed
+      ? extractEnvelopeFields(nestedParsed, depth + 1)
+      : raw.includes("{") || raw.trim().length === 0
+        ? undefined
+        : { detail: raw.trim() };
+    if (nested?.detail) {
+      const outerIsGenericWrapper =
+        out.detail === undefined || AGGREGATOR_GENERIC_WRAPPER.test(out.detail);
+      if (outerIsGenericWrapper) {
+        out.detail = nested.detail;
+        if (nested.errorType) {
+          out.errorType = nested.errorType;
+        }
+      } else if (nested.errorType && !out.errorType) {
+        out.errorType = nested.errorType;
+      }
+      if (nested.requestId && !out.requestId) {
+        out.requestId = nested.requestId;
+      }
+    }
+  }
+
+  return out;
+}
+
 /**
  * Extract the provider's human-relevant detail, error class, and request id
  * from an unclassified 4xx rejection. Prefers the structured `ProviderError`
  * fields when the provider populated them, then falls back to the JSON
- * envelope embedded in the error message (Anthropic: `{ error: { type,
- * message } }`; OpenAI/OpenRouter: `{ error: { message, type, code } }`).
+ * envelope embedded in the raw body / error message (see
+ * `extractEnvelopeFields` for the supported shapes).
  */
 function extractProviderRejectionDetail(
   error: unknown,
@@ -507,26 +584,23 @@ function extractProviderRejectionDetail(
     error instanceof ProviderError && error.rawBody ? error.rawBody : message;
   const parsed = parseEmbeddedJsonObject(rawBody);
   if (parsed) {
-    const inner =
-      typeof parsed.error === "object" && parsed.error !== null
-        ? (parsed.error as Record<string, unknown>)
-        : undefined;
-    const detail = inner?.message ?? parsed.message;
-    if (typeof detail === "string" && detail.trim().length > 0) {
-      out.detail = detail.trim();
+    const envelope = extractEnvelopeFields(parsed);
+    if (envelope.detail) {
+      out.detail = envelope.detail;
     }
-    const type = inner?.type ?? parsed.type;
-    if (!out.errorType && typeof type === "string" && type.length > 0) {
-      out.errorType = type;
+    if (!out.errorType && envelope.errorType) {
+      out.errorType = envelope.errorType;
     }
-    const requestId = parsed.request_id ?? parsed.requestId;
-    if (
-      !out.requestId &&
-      typeof requestId === "string" &&
-      requestId.length > 0
-    ) {
-      out.requestId = requestId;
+    if (!out.requestId && envelope.requestId) {
+      out.requestId = envelope.requestId;
     }
+  }
+
+  // A detail that is itself the aggregator's generic wrapper carries no
+  // signal — drop it so the copy falls back to the generic assistant-voice
+  // sentence instead of persisting "Provider returned error".
+  if (out.detail && AGGREGATOR_GENERIC_WRAPPER.test(out.detail)) {
+    out.detail = undefined;
   }
 
   // No JSON envelope — recover the plain-text detail after the
@@ -535,7 +609,7 @@ function extractProviderRejectionDetail(
   if (!out.detail) {
     const detailMatch = message.match(/API error \(\d+\):\s*(.+)/is);
     const raw = detailMatch?.[1]?.trim();
-    if (raw && !raw.includes("{")) {
+    if (raw && !raw.includes("{") && !AGGREGATOR_GENERIC_WRAPPER.test(raw)) {
       out.detail = raw;
     }
   }


### PR DESCRIPTION
## Bug

When a model provider rejects a request with an **unclassified 4xx** (e.g. a config-induced Anthropic `400`), the user saw the raw wire error verbatim, styled as a red error:

> The AI provider rejected the request (HTTP 400): 400 {"type":"error","error":{"type":"invalid_request_error","message":"adaptive thinking is not supported on this model"},"request_id":"…"}

Two problems:
1. A raw JSON blob (HTTP status, provider envelope, request id) is the first thing a non-technical user sees, repeatedly.
2. That same text is **persisted as the assistant message**, so it also pollutes the model's context on later turns.

The leak came from the generic 4xx fallback in `classifyConversationError` (`assistant/src/daemon/conversation-error.ts`), which appended the whole post-prefix wire body as the user message. Because the persisted assistant message reuses `classified.userMessage`, fixing the classifier fixes both the chat banner and the persisted history in one place.

## Fix (messaging only)

For unclassified provider 4xx errors, compose an assistant-voice, plain-language message:

- Extract the provider's human-relevant detail (its own `error.message` string) — from the structured `ProviderError` fields when the provider populated them, otherwise from the JSON envelope embedded in the error message (handles both the Anthropic `{ error: { type, message } }` and OpenAI/OpenRouter `{ error: { message, type, code } }` shapes).
- Surface only that detail — no JSON envelope, HTTP-status jargon, or request id leaks into the chat.
- When the provider flags the rejection as `invalid_request_error`, point the user at their model configuration, since that class most often means the request shape the assistant built is incompatible with the selected model.
- The raw detail and request id remain in the logs for diagnostics (already captured via the error message).

No retry or profile-fallback behavior is added — that's a separate design decision. Control flow does not string-match on specific provider messages; it keys off the provider's structured error class. Extracting `error.message` for *display* is the only text parsing.

### Before → After (persisted assistant message)

**Before:**
> The AI provider rejected the request (HTTP 400): 400 {"type":"error","error":{"type":"invalid_request_error","message":"adaptive thinking is not supported on this model"},"request_id":"…"}

**After:**
> The model provider rejected this request: adaptive thinking is not supported on this model. This usually means the assistant's model configuration isn't compatible with the selected model. Switching model profiles or reverting a recent change in Settings → Models & Services may fix it.

## Testing

- Added a `unclassified provider 4xx rejections (friendly messaging)` describe block in `conversation-error.test.ts` asserting: the provider detail is surfaced; no `{`/`}`, error-class token, request id, or `HTTP` string leaks; the config hint appears for `invalid_request_error` and is omitted for other classes; and a generic fallback when no detail can be extracted.
- `bun test src/__tests__/conversation-error.test.ts` — 132 pass.
- `bun test src/__tests__/agent-loop-provider-error-recording.test.ts` — 4 pass.
- Type-check and lint clean for the changed files (a pre-existing, unrelated `@vellumai/service-contracts/credential-rpc` subpath resolution error surfaces in the fresh worktree; verified it also fails on the untouched tree and CI resolves the workspace properly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->