### PR TITLE
fix(daemon): tell the model when a conversation has no tools

### DIFF
--- a/assistant/src/__tests__/conversation-toolless-notice-sync.test.ts
+++ b/assistant/src/__tests__/conversation-toolless-notice-sync.test.ts
@@ -1,0 +1,406 @@
+/**
+ * Regression tests for tool-less-notice composition across turns.
+ *
+ * `syncLoopSystemPrompt` runs before every agent turn. The notice must be
+ * applied fresh over the notice-free base each time — never persisted into
+ * `Conversation.systemPrompt` — or an override-prompt tool-less conversation
+ * (a subagent fork with `allowedTools: []`) re-appends it every turn:
+ * `buildCurrentSystemPrompt` reads `this.systemPrompt` as the base when
+ * `hasSystemPromptOverride` is true, so a notice written back there compounds
+ * unboundedly (~300 tokens/turn) and leaks into child forks via
+ * `getCurrentSystemPrompt`.
+ *
+ * Covers:
+ * - Override-prompt tool-less conversation: multiple syncs → notice exactly
+ *   once, and only one loop push (later syncs are byte-identical no-ops).
+ * - Non-override tool-less conversation: same invariant.
+ * - `getCurrentSystemPrompt()` (fork base) never contains the notice.
+ * - Advisor-style conversation (empty allowlist + provider-native web search):
+ *   no notice — the loop appends a server-side web_search tool, so the model
+ *   has a real search capability the notice would falsely deny.
+ * - Normal tool-bearing conversation: no notice.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+import { CompactionCircuit } from "../agent/compaction-circuit.js";
+import type { AgentEvent, AgentLoopConfig } from "../agent/loop.js";
+import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { Message, ProviderResponse } from "../providers/types.js";
+
+// ---------------------------------------------------------------------------
+// Mocks — must precede Conversation import
+// ---------------------------------------------------------------------------
+
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of [
+    "info",
+    "warn",
+    "error",
+    "debug",
+    "trace",
+    "fatal",
+    "silent",
+    "child",
+  ]) {
+    stub[m] = m === "child" ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeLoggerStub(),
+}));
+
+mock.module("../providers/registry.js", () => ({
+  getProvider: () => ({ name: "mock-provider" }),
+  initializeProviders: async () => {},
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    llm: {
+      default: {
+        provider: "mock-provider",
+        model: "mock-model",
+        maxTokens: 4096,
+        effort: "high" as const,
+        speed: "standard" as const,
+        temperature: null,
+        thinking: { enabled: false, streamThinking: true },
+        contextWindow: {
+          enabled: true,
+          maxInputTokens: 100000,
+          targetBudgetRatio: 0.3,
+          compactThreshold: 0.8,
+          summaryBudgetRatio: 0.05,
+          overflowRecovery: {
+            enabled: true,
+            safetyMarginRatio: 0.05,
+            maxAttempts: 3,
+            interactiveLatestTurnCompression: "summarize",
+            nonInteractiveLatestTurnCompression: "truncate",
+          },
+        },
+      },
+      profiles: {},
+      callSites: {},
+      pricingOverrides: [],
+    },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    timeouts: { permissionTimeoutSec: 1 },
+    skills: { entries: {}, allowBundled: true },
+    permissions: { mode: "workspace" },
+    tools: { exclude: [] },
+  }),
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: () => false,
+}));
+
+// The mocked persona-free prompt build: any constructor arg differing from
+// this string marks the conversation as having a system-prompt override.
+const BUILT_PROMPT = "built system prompt";
+
+mock.module("../prompts/system-prompt.js", () => ({
+  buildSystemPrompt: () => BUILT_PROMPT,
+}));
+
+mock.module("../config/skills.js", () => ({
+  loadSkillCatalog: () => [],
+  loadSkillBySelector: () => ({ skill: null }),
+  ensureSkillIcon: async () => null,
+}));
+
+mock.module("../config/skill-state.js", () => ({
+  resolveSkillStates: () => [],
+}));
+
+mock.module("../permissions/trust-store.js", () => ({
+  addRule: () => {},
+  findHighestPriorityRule: () => null,
+  clearCache: () => {},
+}));
+
+mock.module("../security/secret-allowlist.js", () => ({
+  resetAllowlist: () => {},
+}));
+
+mock.module("../persistence/conversation-crud.js", () => ({
+  setConversationProcessingStartedAt: () => {},
+  isConversationProcessing: () => false,
+  setConversationOriginChannelIfUnset: () => {},
+  updateConversationContextWindow: () => {},
+  deleteMessageById: () => {},
+  provenanceFromTrustContext: () => ({
+    source: "user",
+    trustContext: undefined,
+  }),
+  getConversationOriginInterface: () => null,
+  getConversationOriginChannel: () => null,
+  getMessages: () => [],
+  getConversation: () => ({
+    id: "conv-1",
+    contextSummary: null,
+    contextCompactedMessageCount: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalEstimatedCost: 0,
+  }),
+  createConversation: () => ({ id: "conv-1" }),
+  addMessage: () => ({ id: `msg-${Date.now()}` }),
+  updateConversationUsage: () => {},
+  updateConversationTitle: () => {},
+  reserveMessage: mock(async () => ({ id: "msg-reserve" })),
+}));
+
+mock.module("../persistence/conversation-queries.js", () => ({
+  listConversations: () => [],
+}));
+
+mock.module("../persistence/attachments-store.js", () => ({
+  uploadAttachment: () => ({ id: `att-${Date.now()}` }),
+  linkAttachmentToMessage: () => {},
+}));
+
+mock.module("../memory/retriever.js", () => ({
+  buildMemoryRecall: async () => ({
+    enabled: false,
+    degraded: false,
+    injectedText: "",
+    semanticHits: 0,
+    injectedTokens: 0,
+    latencyMs: 0,
+  }),
+  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
+}));
+
+mock.module("../plugins/defaults/compaction/window-manager.js", () => ({
+  ContextWindowManager: class {
+    estimateInputTokens() {
+      return 0;
+    }
+    get tokenCountInputs() {
+      return { systemPrompt: "", tools: undefined };
+    }
+    constructor() {}
+    updateConfig() {}
+    shouldCompact() {
+      return { needed: false, estimatedTokens: 0 };
+    }
+    async maybeCompact() {
+      return { compacted: false };
+    }
+    resetOverflowRecovery() {}
+  },
+  createContextSummaryMessage: () => ({
+    role: "user",
+    content: [{ type: "text", text: "summary" }],
+  }),
+  getSummaryFromContextMessage: () => null,
+}));
+
+mock.module("../persistence/llm-usage-store.js", () => ({
+  recordUsageEvent: () => ({ id: "mock-id", createdAt: Date.now() }),
+  listUsageEvents: () => [],
+}));
+
+// Capture the system prompts pushed to the agent loop.
+let pushedLoopPrompts: string[] = [];
+
+mock.module("../agent/loop.js", () => ({
+  AgentLoop: class {
+    compactionCircuit = new CompactionCircuit("test-conv");
+    constructor(_options?: {
+      provider?: unknown;
+      systemPrompt?: string;
+      config?: Partial<AgentLoopConfig>;
+    }) {}
+    setSystemPrompt(systemPrompt: string) {
+      pushedLoopPrompts.push(systemPrompt);
+    }
+    getToolTokenBudget() {
+      return 0;
+    }
+    getResolvedTools() {
+      return [];
+    }
+    getActiveModel() {
+      return undefined;
+    }
+    async run(_options: {
+      messages: Message[];
+      onEvent: (event: AgentEvent) => void;
+    }): Promise<Message[]> {
+      return [];
+    }
+  },
+}));
+
+mock.module("../contacts/canonical-guardian-store.js", () => ({
+  listPendingCanonicalGuardianRequestsByDestinationConversation: () => [],
+  listCanonicalGuardianRequests: () => [],
+  listPendingRequestsByConversationScope: () => [],
+  createCanonicalGuardianRequest: () => ({
+    id: "mock-cg-id",
+    code: "MOCK",
+    status: "pending",
+  }),
+  getCanonicalGuardianRequest: () => null,
+  getCanonicalGuardianRequestByCode: () => null,
+  updateCanonicalGuardianRequest: () => {},
+  resolveCanonicalGuardianRequest: () => {},
+  createCanonicalGuardianDelivery: () => ({ id: "mock-cgd-id" }),
+  listCanonicalGuardianDeliveries: () => [],
+  listPendingCanonicalGuardianRequestsByDestinationChat: () => [],
+  updateCanonicalGuardianDelivery: () => {},
+  generateCanonicalRequestCode: () => "MOCK-CODE",
+}));
+
+// ---------------------------------------------------------------------------
+// Import Conversation AFTER mocks
+// ---------------------------------------------------------------------------
+
+import { Conversation } from "../daemon/conversation.js";
+import { TOOLLESS_CONVERSATION_NOTICE } from "../daemon/conversation-tool-setup.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProvider() {
+  return {
+    name: "mock",
+    async sendMessage(): Promise<ProviderResponse> {
+      return {
+        content: [],
+        model: "mock",
+        usage: { inputTokens: 0, outputTokens: 0 },
+        stopReason: "end_turn",
+      };
+    },
+  };
+}
+
+function makeSendToClient(): (msg: ServerMessage) => void {
+  return () => {};
+}
+
+function makeConversation(
+  id: string,
+  systemPrompt: string,
+  options?: { enableNativeWebSearch?: boolean },
+): Conversation {
+  return new Conversation(
+    id,
+    makeProvider(),
+    systemPrompt,
+    makeSendToClient(),
+    "/tmp",
+    { maxTokens: 4096, ...options },
+  );
+}
+
+function countNoticeOccurrences(prompt: string): number {
+  return prompt.split(TOOLLESS_CONVERSATION_NOTICE).length - 1;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("syncLoopSystemPrompt — tool-less notice stability across turns", () => {
+  test("override-prompt tool-less conversation gets the notice exactly once over multiple turns", () => {
+    pushedLoopPrompts = [];
+    const OVERRIDE = "FORK OVERRIDE PROMPT";
+    const conversation = makeConversation("conv-override-toolless", OVERRIDE);
+    expect(conversation.hasSystemPromptOverride).toBe(true);
+
+    // Subagent fork with an empty role allowlist (e.g. `allowedTools: []`).
+    conversation.setSubagentAllowedTools(new Set<string>());
+
+    // Three turns' worth of pre-run prompt syncs.
+    conversation.syncLoopSystemPrompt();
+    conversation.syncLoopSystemPrompt();
+    conversation.syncLoopSystemPrompt();
+
+    // The loop received the notice exactly once, on the first sync; later
+    // syncs rebuilt byte-identical prompts and pushed nothing.
+    expect(pushedLoopPrompts.length).toBe(1);
+    expect(pushedLoopPrompts[0]!.startsWith(OVERRIDE)).toBe(true);
+    expect(countNoticeOccurrences(pushedLoopPrompts[0]!)).toBe(1);
+
+    // The current build also carries it exactly once — no compounding.
+    expect(
+      countNoticeOccurrences(conversation.buildCurrentSystemPrompt()),
+    ).toBe(1);
+  });
+
+  test("non-override tool-less conversation gets the notice exactly once over multiple turns", () => {
+    pushedLoopPrompts = [];
+    const conversation = makeConversation(
+      "conv-rebuilt-toolless",
+      BUILT_PROMPT,
+    );
+    expect(conversation.hasSystemPromptOverride).toBe(false);
+
+    conversation.setSubagentAllowedTools(new Set<string>());
+
+    conversation.syncLoopSystemPrompt();
+    conversation.syncLoopSystemPrompt();
+
+    expect(pushedLoopPrompts.length).toBe(1);
+    expect(countNoticeOccurrences(pushedLoopPrompts[0]!)).toBe(1);
+    expect(
+      countNoticeOccurrences(conversation.buildCurrentSystemPrompt()),
+    ).toBe(1);
+  });
+
+  test("getCurrentSystemPrompt (fork base) never contains the notice", () => {
+    pushedLoopPrompts = [];
+    const OVERRIDE = "FORK OVERRIDE PROMPT";
+    const conversation = makeConversation("conv-fork-base", OVERRIDE);
+    conversation.setSubagentAllowedTools(new Set<string>());
+
+    conversation.syncLoopSystemPrompt();
+    conversation.syncLoopSystemPrompt();
+
+    expect(conversation.getCurrentSystemPrompt()).toBe(OVERRIDE);
+  });
+
+  test("advisor-style conversation (empty allowlist + native web search) gets no notice", () => {
+    pushedLoopPrompts = [];
+    const conversation = makeConversation(
+      "conv-advisor",
+      "ADVISOR OVERRIDE PROMPT",
+      { enableNativeWebSearch: true },
+    );
+    conversation.setSubagentAllowedTools(new Set<string>());
+
+    conversation.syncLoopSystemPrompt();
+
+    // The rebuilt prompt is byte-identical to the construction prompt, so no
+    // push happens and no notice is ever composed.
+    expect(pushedLoopPrompts.length).toBe(0);
+    expect(
+      countNoticeOccurrences(conversation.buildCurrentSystemPrompt()),
+    ).toBe(0);
+  });
+
+  test("normal tool-bearing conversation gets no notice", () => {
+    pushedLoopPrompts = [];
+    const conversation = makeConversation("conv-normal", BUILT_PROMPT);
+
+    conversation.syncLoopSystemPrompt();
+
+    expect(pushedLoopPrompts.length).toBe(0);
+    expect(
+      countNoticeOccurrences(conversation.buildCurrentSystemPrompt()),
+    ).toBe(0);
+  });
+});

--- a/assistant/src/__tests__/conversation-toolless-notice.test.ts
+++ b/assistant/src/__tests__/conversation-toolless-notice.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for the tool-less-conversation system-prompt notice.
+ *
+ * A manual "analyze conversation" run strips every tool from the conversation
+ * (`setSubagentAllowedTools(new Set())`) as a prompt-injection defense over
+ * attacker-influenced transcript content. If the user keeps chatting in that
+ * conversation, every later turn also runs with zero tools while the default
+ * system prompt still describes a tool-using assistant — so the model emits
+ * raw tool-call JSON as plain text. The notice tells the model there are no
+ * tools and to answer from context instead.
+ *
+ * Covers:
+ * - `isToollessConversationSurface` truth table (the durable per-conversation
+ *   signal, excluding the transient `toolsDisabledDepth` disable).
+ * - Parity: the predicate reports empty exactly when `createResolveToolsCallback`
+ *   actually resolves zero tools for the empty-wire-allowlist case.
+ * - `withToollessConversationNotice` appends the notice for tool-less
+ *   conversations and leaves normal conversations untouched.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import type { SkillProjectionCache } from "../daemon/conversation-skill-tools.js";
+import type { Message, ToolDefinition } from "../providers/types.js";
+
+// Keep the skill projection empty so resolved tools come only from base defs.
+mock.module("../daemon/conversation-skill-tools.js", () => ({
+  projectSkillTools: mock((_history: Message[], _opts: unknown) => ({
+    allowedToolNames: new Set<string>(),
+    toolDefinitions: [],
+  })),
+}));
+
+import {
+  createResolveToolsCallback,
+  isToollessConversationSurface,
+  type SkillProjectionContext,
+  TOOLLESS_CONVERSATION_NOTICE,
+  withToollessConversationNotice,
+} from "../daemon/conversation-tool-setup.js";
+
+function makeToolDef(name: string): ToolDefinition {
+  return { name, description: `${name} tool`, input_schema: {} };
+}
+
+function makeCtx(
+  overrides: Partial<SkillProjectionContext> = {},
+): SkillProjectionContext {
+  return {
+    skillProjectionState: new Map(),
+    skillProjectionCache: {} as SkillProjectionCache,
+    coreToolNames: new Set(["tool_a", "tool_b"]),
+    toolsDisabledDepth: 0,
+    ...overrides,
+  };
+}
+
+const EMPTY_HISTORY: Message[] = [];
+
+describe("isToollessConversationSurface", () => {
+  test("false when no subagent allowlist is set (normal conversation)", () => {
+    expect(isToollessConversationSurface(makeCtx())).toBe(false);
+  });
+
+  test("true when a wire-gated subagent allowlist is empty (analyze surface)", () => {
+    const ctx = makeCtx({ subagentAllowedTools: new Set<string>() });
+    expect(isToollessConversationSurface(ctx)).toBe(true);
+  });
+
+  test("false when the empty allowlist is enforced at execution time", () => {
+    const ctx = makeCtx({
+      subagentAllowedTools: new Set<string>(),
+      subagentToolGateMode: "execution",
+    });
+    expect(isToollessConversationSurface(ctx)).toBe(false);
+  });
+
+  test("false when the allowlist has entries", () => {
+    const ctx = makeCtx({ subagentAllowedTools: new Set(["tool_a"]) });
+    expect(isToollessConversationSurface(ctx)).toBe(false);
+  });
+
+  test("false for the transient toolsDisabledDepth disable (kept cache-stable)", () => {
+    // Pointer-generation turns bump `toolsDisabledDepth`, which toggles within a
+    // conversation's lifetime. The durable predicate deliberately ignores it so
+    // the notice stays stable per conversation.
+    expect(
+      isToollessConversationSurface(makeCtx({ toolsDisabledDepth: 1 })),
+    ).toBe(false);
+  });
+});
+
+describe("isToollessConversationSurface — parity with resolveTools", () => {
+  test("reports empty exactly when the resolver yields zero tools", () => {
+    const toolDefs = [makeToolDef("tool_a"), makeToolDef("tool_b")];
+
+    const toollessCtx = makeCtx({ subagentAllowedTools: new Set<string>() });
+    const resolveToolless = createResolveToolsCallback(toolDefs, toollessCtx)!;
+    expect(resolveToolless(EMPTY_HISTORY)).toEqual([]);
+    expect(isToollessConversationSurface(toollessCtx)).toBe(true);
+
+    const normalCtx = makeCtx();
+    const resolveNormal = createResolveToolsCallback(toolDefs, normalCtx)!;
+    expect(resolveNormal(EMPTY_HISTORY).length).toBeGreaterThan(0);
+    expect(isToollessConversationSurface(normalCtx)).toBe(false);
+  });
+});
+
+describe("withToollessConversationNotice", () => {
+  const BASE = "SOUL and identity prompt";
+
+  test("appends the notice for a tool-less conversation", () => {
+    const ctx = makeCtx({ subagentAllowedTools: new Set<string>() });
+    const result = withToollessConversationNotice(BASE, ctx);
+    expect(result.startsWith(BASE)).toBe(true);
+    expect(result).toContain(TOOLLESS_CONVERSATION_NOTICE);
+  });
+
+  test("leaves a normal conversation's prompt untouched", () => {
+    const result = withToollessConversationNotice(BASE, makeCtx());
+    expect(result).toBe(BASE);
+    expect(result).not.toContain(TOOLLESS_CONVERSATION_NOTICE);
+  });
+
+  test("does not append when the empty allowlist is execution-gated", () => {
+    const ctx = makeCtx({
+      subagentAllowedTools: new Set<string>(),
+      subagentToolGateMode: "execution",
+    });
+    expect(withToollessConversationNotice(BASE, ctx)).toBe(BASE);
+  });
+
+  test("notice instructs the model not to emit tool-call syntax", () => {
+    // The production incident: the model emitted raw tool-call JSON as text.
+    expect(TOOLLESS_CONVERSATION_NOTICE.toLowerCase()).toContain(
+      "tool-call syntax",
+    );
+    expect(TOOLLESS_CONVERSATION_NOTICE.toLowerCase()).toContain("no tools");
+  });
+});

--- a/assistant/src/__tests__/conversation-toolless-notice.test.ts
+++ b/assistant/src/__tests__/conversation-toolless-notice.test.ts
@@ -88,6 +88,18 @@ describe("isToollessConversationSurface", () => {
       isToollessConversationSurface(makeCtx({ toolsDisabledDepth: 1 })),
     ).toBe(false);
   });
+
+  test("false when provider-native web search is enabled (advisor consult)", () => {
+    // The advisor consult runs with an empty client-tool allowlist but the
+    // agent loop appends a server-side web_search tool the provider executes
+    // itself — the model has a real search capability, so the notice must not
+    // deny it.
+    const ctx = {
+      ...makeCtx({ subagentAllowedTools: new Set<string>() }),
+      enableNativeWebSearch: true,
+    };
+    expect(isToollessConversationSurface(ctx)).toBe(false);
+  });
 });
 
 describe("isToollessConversationSurface — parity with resolveTools", () => {
@@ -127,6 +139,14 @@ describe("withToollessConversationNotice", () => {
       subagentAllowedTools: new Set<string>(),
       subagentToolGateMode: "execution",
     });
+    expect(withToollessConversationNotice(BASE, ctx)).toBe(BASE);
+  });
+
+  test("does not append when provider-native web search is enabled", () => {
+    const ctx = {
+      ...makeCtx({ subagentAllowedTools: new Set<string>() }),
+      enableNativeWebSearch: true,
+    };
     expect(withToollessConversationNotice(BASE, ctx)).toBe(BASE);
   });
 

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -787,6 +787,12 @@ This conversation exposes no tools. You cannot run commands, edit or read files,
  * surface on the wire and rejects at execution time, so it is not tool-less
  * from the model's perspective and is excluded.
  *
+ * A conversation with provider-native web search enabled (the advisor consult
+ * subagent) is also excluded even when its client-tool allowlist is empty:
+ * the agent loop appends a server-side `web_search` tool the provider runs
+ * itself, so the model DOES have a tool and telling it otherwise would deny
+ * its real search capability.
+ *
  * The transient per-turn `toolsDisabledDepth` disable (pointer-generation
  * turns) is deliberately NOT covered here: it toggles within a conversation's
  * lifetime, so folding it in would make the notice appear and disappear
@@ -797,8 +803,11 @@ export function isToollessConversationSurface(
   ctx: Pick<
     SkillProjectionContext,
     "subagentAllowedTools" | "subagentToolGateMode"
-  >,
+  > & { enableNativeWebSearch?: boolean },
 ): boolean {
+  if (ctx.enableNativeWebSearch === true) {
+    return false;
+  }
   return (
     ctx.subagentAllowedTools !== undefined &&
     ctx.subagentAllowedTools.size === 0 &&
@@ -821,7 +830,7 @@ export function withToollessConversationNotice(
   ctx: Pick<
     SkillProjectionContext,
     "subagentAllowedTools" | "subagentToolGateMode"
-  >,
+  > & { enableNativeWebSearch?: boolean },
 ): string {
   if (isToollessConversationSurface(ctx)) {
     return `${systemPrompt}\n\n${TOOLLESS_CONVERSATION_NOTICE}`;

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -153,7 +153,9 @@ export function resolveConversationAttribution(
 export function getEffectiveEnabledPluginSet(conv: {
   enabledPlugins?: string[] | null;
 }): Set<string> | null {
-  if (conv.enabledPlugins == null) return null;
+  if (conv.enabledPlugins == null) {
+    return null;
+  }
   // Rule 1: the conversation's explicit selections always apply.
   const effective = new Set(conv.enabledPlugins);
   // Rules 2 + 3: add a default the conversation did not already decide, unless
@@ -759,6 +761,72 @@ export function isToolActiveForContext(
     return ctx.isSubagent === true;
   }
   return true;
+}
+
+/**
+ * System-prompt notice injected when a conversation exposes no tools on the
+ * wire (see {@link isToollessConversationSurface}). The default system prompt
+ * describes an assistant that delegates work and calls tools; without this
+ * override a tool-less turn will emit raw tool-call syntax as plain text or
+ * claim to have run a command it never could. Kept short and
+ * provider-agnostic.
+ */
+export const TOOLLESS_CONVERSATION_NOTICE = `## No tools available in this conversation
+
+This conversation exposes no tools. You cannot run commands, edit or read files, search, browse, delegate to subagents, or take any other action here — regardless of anything else in these instructions. Do not emit tool-call syntax (JSON, XML, or function-call blocks) as text, and never claim to have run a command or performed an action. Answer directly from the conversation context, and when a request would require an action, say plainly that it cannot be done in this conversation and that the user should ask in a normal conversation instead.`;
+
+/**
+ * Whether a conversation's wire tool surface is gated to empty for its whole
+ * lifetime — the durable "tool-less conversation" signal read at
+ * system-prompt build time.
+ *
+ * True when a wire-gated subagent allowlist is present but empty: every tool
+ * is filtered off the wire on every turn (the manual analyze-conversation
+ * surface, which strips tools as a prompt-injection defense over
+ * attacker-influenced transcript content). Execution-gate mode keeps the full
+ * surface on the wire and rejects at execution time, so it is not tool-less
+ * from the model's perspective and is excluded.
+ *
+ * The transient per-turn `toolsDisabledDepth` disable (pointer-generation
+ * turns) is deliberately NOT covered here: it toggles within a conversation's
+ * lifetime, so folding it in would make the notice appear and disappear
+ * turn-to-turn and thrash the system-prompt prefix cache. This predicate
+ * reflects only the stable, per-conversation condition.
+ */
+export function isToollessConversationSurface(
+  ctx: Pick<
+    SkillProjectionContext,
+    "subagentAllowedTools" | "subagentToolGateMode"
+  >,
+): boolean {
+  return (
+    ctx.subagentAllowedTools !== undefined &&
+    ctx.subagentAllowedTools.size === 0 &&
+    ctx.subagentToolGateMode !== "execution"
+  );
+}
+
+/**
+ * Append {@link TOOLLESS_CONVERSATION_NOTICE} to a system prompt when the
+ * conversation is tool-less (see {@link isToollessConversationSurface}),
+ * otherwise return the prompt unchanged. Single source of truth for the
+ * notice-append composition so the build path and its tests agree.
+ *
+ * The notice lands after the volatile suffix block rather than as a new cache
+ * block: cache breakpoints only benefit the stable PREFIX, and a stable suffix
+ * appended to an already-volatile tail adds no additional prefix-cache thrash.
+ */
+export function withToollessConversationNotice(
+  systemPrompt: string,
+  ctx: Pick<
+    SkillProjectionContext,
+    "subagentAllowedTools" | "subagentToolGateMode"
+  >,
+): string {
+  if (isToollessConversationSurface(ctx)) {
+    return `${systemPrompt}\n\n${TOOLLESS_CONVERSATION_NOTICE}`;
+  }
+  return systemPrompt;
 }
 
 /**

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -590,6 +590,24 @@ export class Conversation {
   };
   public readonly traceEmitter: TraceEmitter;
   /** @internal */ hasSystemPromptOverride: boolean;
+  /**
+   * Whether this conversation's LLM calls get provider-native (server-side)
+   * web search (see {@link ConversationConstructorOptions.enableNativeWebSearch}).
+   * Read by the tool-less-conversation predicate: a conversation with native
+   * search enabled is not tool-less even when its client-tool allowlist is
+   * empty.
+   * @internal
+   */
+  readonly enableNativeWebSearch: boolean;
+  /**
+   * The prompt most recently pushed to the agent loop: the base
+   * {@link systemPrompt} plus the conditional tool-less-conversation notice.
+   * Tracked separately from {@link systemPrompt} — which stays notice-free —
+   * so {@link syncLoopSystemPrompt} can dedupe pushes without ever feeding a
+   * notice-bearing prompt back through the build as the next turn's base
+   * (which would append the notice again each turn).
+   */
+  private loopSystemPrompt: string;
   /** @internal */ modelOverride: string | undefined;
   /** @internal */ readonly graphMemory: ConversationGraphMemory;
   /** @internal */ activeContextNodeIds?: string[];
@@ -645,8 +663,10 @@ export class Conversation {
   ) {
     const { maxTokens, speedOverride, cacheTtl, modelOverride } = options ?? {};
     const enableNativeWebSearch = options?.enableNativeWebSearch ?? false;
+    this.enableNativeWebSearch = enableNativeWebSearch;
     this.conversationId = conversationId;
     this.systemPrompt = systemPrompt;
+    this.loopSystemPrompt = systemPrompt;
     this.provider = provider;
     this.workingDir = workingDir;
     this.sendToClient = sendToClient;
@@ -844,7 +864,28 @@ export class Conversation {
    * the provider's prefix cache).
    */
   buildCurrentSystemPrompt(): string {
-    const base = this.hasSystemPromptOverride
+    // A conversation whose wire tool surface is gated to empty (the manual
+    // analyze-conversation surface) keeps the default identity prompt, which
+    // describes an assistant that delegates work and calls tools. Append a
+    // notice so the model does not emit tool-call syntax as text or claim to
+    // run commands it cannot. The condition is stable per conversation, so the
+    // appended text is stable too and does not thrash the prefix cache. The
+    // notice is applied fresh over the notice-free base each build — never
+    // persisted into {@link systemPrompt} — so repeated builds cannot stack it.
+    return withToollessConversationNotice(
+      this.buildCurrentBaseSystemPrompt(),
+      this,
+    );
+  }
+
+  /**
+   * The notice-free base of the current system prompt: the construction-time
+   * override verbatim, or a fresh full rebuild (picks up workspace file
+   * changes, live trust/channel context, persona overrides, onboarding
+   * context).
+   */
+  private buildCurrentBaseSystemPrompt(): string {
+    return this.hasSystemPromptOverride
       ? this.systemPrompt
       : buildSystemPrompt({
           hasNoClient: this.hasNoClient,
@@ -854,13 +895,6 @@ export class Conversation {
           onboardingContext: this.getOnboardingContext(),
           conversationId: this.conversationId,
         });
-    // A conversation whose wire tool surface is gated to empty (the manual
-    // analyze-conversation surface) keeps the default identity prompt, which
-    // describes an assistant that delegates work and calls tools. Append a
-    // notice so the model does not emit tool-call syntax as text or claim to
-    // run commands it cannot. The condition is stable per conversation, so the
-    // appended text is stable too and does not thrash the prefix cache.
-    return withToollessConversationNotice(base, this);
   }
 
   /**
@@ -872,22 +906,32 @@ export class Conversation {
    * construction-time persona (the guardian, or `users/default.md`) for the
    * whole conversation.
    *
-   * Pushing only when the rebuilt prompt actually differs keeps the provider's
-   * prefix cache intact for the common case (a stable-identity conversation
-   * rebuilds to the same bytes, so no update is sent). A system-prompt override
-   * resolves verbatim via {@link buildCurrentSystemPrompt}, so override
-   * conversations (subagent forks, stored overrides) are inherently a no-op.
+   * Pushing only when the rebuilt prompt actually differs (tracked via
+   * {@link loopSystemPrompt}) keeps the provider's prefix cache intact for the
+   * common case (a stable-identity conversation rebuilds to the same bytes, so
+   * no update is sent). A system-prompt override resolves verbatim via
+   * {@link buildCurrentBaseSystemPrompt}, so override conversations (subagent
+   * forks, stored overrides) push at most once — when the tool-less notice
+   * first applies — and are a no-op every turn after.
+   *
+   * {@link systemPrompt} is updated with the notice-FREE base: it is the input
+   * to the next rebuild in the override path and the value fork consumers read
+   * via {@link getCurrentSystemPrompt}, so storing the notice-bearing prompt
+   * there would stack the notice turn over turn and leak it into child forks
+   * that resolve their own tool surface.
    *
    * Called by the turn runner before `agentLoop.run()`, once the turn's
    * persona snapshots ({@link currentTurnTrustContext},
    * {@link currentTurnChannelCapabilities}) are set.
    */
   syncLoopSystemPrompt(): void {
-    const next = this.buildCurrentSystemPrompt();
-    if (next === this.systemPrompt) {
+    const base = this.buildCurrentBaseSystemPrompt();
+    const next = withToollessConversationNotice(base, this);
+    if (next === this.loopSystemPrompt) {
       return;
     }
-    this.systemPrompt = next;
+    this.systemPrompt = base;
+    this.loopSystemPrompt = next;
     this.agentLoop.setSystemPrompt(next);
   }
 
@@ -1449,8 +1493,11 @@ export class Conversation {
   }
 
   /**
-   * Return the system prompt string set at construction time (or its override).
-   * Fork consumers use this to pass the parent's system prompt to the fork.
+   * Return the conversation's notice-free base system prompt (the
+   * construction-time override, or the most recent per-turn rebuild). Fork
+   * consumers use this to pass the parent's system prompt to the fork; the
+   * tool-less-conversation notice is excluded because a fork resolves its own
+   * tool surface and applies the notice itself when it qualifies.
    */
   getCurrentSystemPrompt(): string {
     return this.systemPrompt;

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -164,6 +164,7 @@ import type {
 import {
   createResolveToolsCallback,
   createToolExecutor,
+  withToollessConversationNotice,
 } from "./conversation-tool-setup.js";
 import { canonicalizeTimeZone } from "./date-context.js";
 import { HostAppControlProxy } from "./host-app-control-proxy.js";
@@ -843,7 +844,7 @@ export class Conversation {
    * the provider's prefix cache).
    */
   buildCurrentSystemPrompt(): string {
-    return this.hasSystemPromptOverride
+    const base = this.hasSystemPromptOverride
       ? this.systemPrompt
       : buildSystemPrompt({
           hasNoClient: this.hasNoClient,
@@ -853,6 +854,13 @@ export class Conversation {
           onboardingContext: this.getOnboardingContext(),
           conversationId: this.conversationId,
         });
+    // A conversation whose wire tool surface is gated to empty (the manual
+    // analyze-conversation surface) keeps the default identity prompt, which
+    // describes an assistant that delegates work and calls tools. Append a
+    // notice so the model does not emit tool-call syntax as text or claim to
+    // run commands it cannot. The condition is stable per conversation, so the
+    // appended text is stable too and does not thrash the prefix cache.
+    return withToollessConversationNotice(base, this);
   }
 
   /**
@@ -1413,7 +1421,9 @@ export class Conversation {
    * edge would put runtime-assembly's importers on that cycle).
    */
   getSubagentChildren(): SubagentState[] | null {
-    if (this.isSubagent) return null;
+    if (this.isSubagent) {
+      return null;
+    }
     return getSubagentManager().getChildrenOf(this.conversationId);
   }
 


### PR DESCRIPTION
## Bug

A manual "analyze conversation" run creates a fresh conversation and strips **all** tools via `setSubagentAllowedTools(new Set())` — a deliberate prompt-injection defense, since analysis runs over attacker-influenced transcript content. That conversation then appears in the client as a normal chat. When the user keeps chatting in it, every subsequent main-agent turn also resolves to **zero tools**, but the system prompt still describes a tool-using assistant that delegates work.

In a real incident, the model — asked to run a shell command — emitted raw tool-call JSON (e.g. `{"name":"bash","input":{...}}`) as plain **text** for three turns in a row (it had no tools to call), and the web client rendered the raw JSON to the user. The analysis prompt's own "do not use tools" line only covers the first injected turn, not the user's follow-ups.

## Fix

Append a short, stable system-prompt notice whenever a conversation's wire tool surface is gated to empty. It states that no tools are available, that the model must not emit tool-call syntax or claim to have run a command, and that it should answer from context and tell the user plainly when an action requires a normal conversation.

- **Detection** — `isToollessConversationSurface(ctx)` keys on the durable signal: a wire-gated subagent allowlist that is present but empty (the analyze surface). Execution-gate mode (full surface on the wire, rejected at execution) is excluded. The transient per-turn `toolsDisabledDepth` disable (pointer turns) is deliberately excluded so the notice stays stable per conversation and does not thrash the prefix cache.
- **Composition** — `withToollessConversationNotice(prompt, ctx)` is the single append point, called by `Conversation.buildCurrentSystemPrompt()`. `syncLoopSystemPrompt()` re-applies it every turn, so the notice covers all turns of the stripped conversation.
- **Placement** — appended after the volatile suffix block (no new cache breakpoint): cache breakpoints only benefit the stable prefix, and a stable string appended to an already-volatile tail adds no prefix-cache thrash. Normal (tool-bearing) conversations are untouched.
- The tool-stripping security behavior itself is unchanged.

## Testing

- New unit tests in `assistant/src/__tests__/conversation-toolless-notice.test.ts` (10 cases): the `isToollessConversationSurface` truth table; **parity** proving the predicate reports empty exactly when `createResolveToolsCallback` resolves zero tools; and that `withToollessConversationNotice` appends the notice for tool-less conversations and leaves normal ones untouched.
- `bun test` on the new file plus existing `conversation-tool-setup*` and `analyze-conversation` suites: all green (79 + 10 pass).
- `bun run typecheck:fast` clean; ESLint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->