### PR TITLE
fix(oauth): make google relative-path requests resolve per Google product

### DIFF
--- a/assistant/src/__tests__/oauth-commands-routes.test.ts
+++ b/assistant/src/__tests__/oauth-commands-routes.test.ts
@@ -777,6 +777,73 @@ describe("POST oauth/request", () => {
     expect(result.hint).toContain("oauth status");
   });
 
+  test("attaches wrong-host/path hint on HTML 404 for a relative path", async () => {
+    mockResolveResponse = {
+      status: 404,
+      headers: { "content-type": "text/html; charset=UTF-8" },
+      body: "<html><title>Error 404 (Not Found)</title></html>",
+    };
+    const result = (await getRoute("POST", "oauth/request").handler(
+      makeArgs({
+        body: {
+          provider: "google",
+          url: "/calendar/v3/calendars/primary/events",
+        },
+      }),
+    )) as { ok: boolean; status: number; hint?: string };
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(404);
+    expect(result.hint).toContain("HTML");
+    // Reports the resolved base URL the relative path was joined onto.
+    expect(result.hint).toContain("https://api.google.com");
+    // Steers the caller toward an absolute URL.
+    expect(result.hint).toContain("absolute URL");
+  });
+
+  test("does not attach HTML-404 hint when a 404 body is JSON", async () => {
+    mockResolveResponse = {
+      status: 404,
+      headers: { "content-type": "application/json" },
+      body: { error: "not found" },
+    };
+    const result = (await getRoute("POST", "oauth/request").handler(
+      makeArgs({
+        body: { provider: "google", url: "/v1/missing" },
+      }),
+    )) as { ok: boolean; status: number; hint?: string };
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(404);
+    expect(result.hint).toBeUndefined();
+  });
+
+  test("HTML-404 hint reports an absolute URL's own host as the resolved base", async () => {
+    mockProviders.google = {
+      ...baseProvider,
+      injectionTemplates: JSON.stringify([
+        {
+          hostPattern: "www.googleapis.com",
+          injectionType: "header",
+          headerName: "Authorization",
+          valuePrefix: "Bearer ",
+        },
+      ]),
+    };
+    mockResolveResponse = {
+      status: 404,
+      headers: { "content-type": "text/html" },
+      body: "<html>nope</html>",
+    };
+    const result = (await getRoute("POST", "oauth/request").handler(
+      makeArgs({
+        body: {
+          provider: "google",
+          url: "https://www.googleapis.com/calendar/v3/nope",
+        },
+      }),
+    )) as { hint?: string };
+    expect(result.hint).toContain("https://www.googleapis.com");
+  });
+
   test("rejects unregistered client_id in BYO mode", async () => {
     // No entry in mockApps for google:client-x
     await expect(

--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -56,6 +56,7 @@ import {
   isProviderConnected,
   listActiveConnectionsByProvider,
   listConnections,
+  migrateProviderBaseUrl,
   registerProvider,
   seedProviders,
   updateConnection,
@@ -581,6 +582,84 @@ describe("provider operations", () => {
       const outlook = getProvider("outlook");
       expect(outlook).toBeDefined();
       expect(outlook!.revokeUrl).toBeNull();
+    });
+
+    test("seedOAuthProviders seeds google with a host-only base URL", () => {
+      seedOAuthProviders();
+      const google = getProvider("google");
+      expect(google!.baseUrl).toBe("https://www.googleapis.com");
+    });
+
+    test("seedOAuthProviders advances a stale gmail-scoped google base URL to the host-only default", () => {
+      // Simulate a pre-existing install seeded with the old mailbox-scoped base
+      // URL, then preserved by seedProviders' COALESCE on subsequent startups.
+      seedProviders([
+        {
+          provider: "google",
+          authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+          tokenExchangeUrl: "https://oauth2.googleapis.com/token",
+          baseUrl: "https://gmail.googleapis.com/gmail/v1/users/me",
+          defaultScopes: [],
+        },
+      ]);
+      expect(getProvider("google")!.baseUrl).toBe(
+        "https://gmail.googleapis.com/gmail/v1/users/me",
+      );
+
+      seedOAuthProviders();
+
+      expect(getProvider("google")!.baseUrl).toBe("https://www.googleapis.com");
+    });
+
+    test("seedOAuthProviders leaves a user-customized google base URL untouched", () => {
+      seedProviders([
+        {
+          provider: "google",
+          authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+          tokenExchangeUrl: "https://oauth2.googleapis.com/token",
+          baseUrl: "https://proxy.internal.example/google",
+          defaultScopes: [],
+        },
+      ]);
+
+      seedOAuthProviders();
+
+      expect(getProvider("google")!.baseUrl).toBe(
+        "https://proxy.internal.example/google",
+      );
+    });
+
+    test("migrateProviderBaseUrl only rewrites rows holding the stale value", () => {
+      seedProviders([
+        {
+          provider: "test-provider",
+          authorizeUrl: "https://example.com/authorize",
+          tokenExchangeUrl: "https://example.com/token",
+          baseUrl: "https://old.example.com",
+          defaultScopes: [],
+        },
+      ]);
+
+      const changed = migrateProviderBaseUrl({
+        provider: "test-provider",
+        staleBaseUrl: "https://old.example.com",
+        nextBaseUrl: "https://new.example.com",
+      });
+      expect(changed).toBe(1);
+      expect(getProvider("test-provider")!.baseUrl).toBe(
+        "https://new.example.com",
+      );
+
+      // Idempotent: a second run matches nothing.
+      const changedAgain = migrateProviderBaseUrl({
+        provider: "test-provider",
+        staleBaseUrl: "https://old.example.com",
+        nextBaseUrl: "https://new.example.com",
+      });
+      expect(changedAgain).toBe(0);
+      expect(getProvider("test-provider")!.baseUrl).toBe(
+        "https://new.example.com",
+      );
     });
 
     test("applies client_secret_post default when tokenEndpointAuthMethod is omitted from seed", () => {

--- a/assistant/src/cli/commands/oauth/request.ts
+++ b/assistant/src/cli/commands/oauth/request.ts
@@ -109,9 +109,14 @@ the token (using \`assistant oauth token\`) and making the request directly.
 This command resolves the OAuth connection automatically (regardless of whether
 the provider's mode is set to "managed" or "your-own") and injects tokens transparently.
 
-URL can be absolute (https://api.twitter.com/2/tweets) or relative (/2/tweets).
-Absolute URLs have their host extracted as a baseUrl override; relative paths
-use the provider's configured default.
+URL can be absolute (https://api.x.com/2/tweets) or relative (/2/tweets).
+An absolute URL sets the host and full path explicitly. A relative path is
+joined onto the provider's configured default base URL — the base URL shown by
+'assistant oauth providers get <provider>'. For providers whose default base
+URL points at one specific service, a relative path for a different service on
+the same provider will resolve against the wrong host or path and fail (often
+with an opaque HTML 404). When in doubt, pass an absolute URL: it is the safe
+form for any service other than the provider's default.
 
 Note: The Authorization header is set automatically. User-supplied
 -H "Authorization: ..." will be overridden by the OAuth bearer token.
@@ -120,7 +125,7 @@ Examples:
   $ assistant oauth request --provider twitter https://api.x.com/2/tweets
   $ assistant oauth request --provider google /gmail/v1/users/me/messages -G
   $ assistant oauth request --provider twitter -X POST -d '{"text":"Hello"}' https://api.x.com/2/tweets
-  $ assistant oauth request --provider google -d @body.json https://www.googleapis.com/calendar/v3/calendars
+  $ assistant oauth request --provider google https://www.googleapis.com/calendar/v3/calendars/primary/events
   $ assistant oauth request --provider slack -H "Content-Type: application/json" -d '{"channel":"C123"}' /api/chat.postMessage --json`,
     )
     .action(

--- a/assistant/src/messaging/providers/gmail/client.ts
+++ b/assistant/src/messaging/providers/gmail/client.ts
@@ -17,6 +17,15 @@ import type {
 const GMAIL_BATCH_URL = "https://www.googleapis.com/batch/gmail/v1";
 
 /**
+ * Mailbox-scoped Gmail API base URL. Gmail request paths in this module are
+ * relative to the authenticated user's mailbox (e.g. `/messages`, `/profile`),
+ * so they are joined onto this base rather than the google provider's generic
+ * host-only default (`https://www.googleapis.com`).
+ */
+export const GMAIL_API_BASE_URL =
+  "https://gmail.googleapis.com/gmail/v1/users/me";
+
+/**
  * Minimum Google OAuth scope a connection must carry for Gmail read access.
  *
  * The managed `google` OAuth app bundles Gmail + Calendar + Drive, but a
@@ -161,6 +170,7 @@ async function request<T>(
       resp = await connection.request({
         method,
         path,
+        baseUrl: GMAIL_API_BASE_URL,
         query,
         headers: {
           "Content-Type": "application/json",

--- a/assistant/src/oauth/__tests__/seed-providers-managed.test.ts
+++ b/assistant/src/oauth/__tests__/seed-providers-managed.test.ts
@@ -11,6 +11,16 @@ describe("PROVIDER_SEED_DATA managed mode wiring", () => {
     expect("github-oauth" in ServicesSchema.shape).toBe(true);
   });
 
+  test("google base URL is host-only so relative paths select the product", () => {
+    // A host-only base URL (no product path) lets a relative request path pick
+    // the Google product — Gmail (/gmail/v1/...), Calendar (/calendar/v3/...),
+    // Drive (/drive/v3/...) — instead of pinning every relative request to one
+    // product's path prefix.
+    expect(PROVIDER_SEED_DATA.google.baseUrl).toBe(
+      "https://www.googleapis.com",
+    );
+  });
+
   test("every managedServiceConfigKey resolves to a ServicesSchema key", () => {
     // Cross-repo invariant: a provider with managedServiceConfigKey but no
     // matching ServicesSchema entry silently falls back to BYO mode in

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -266,6 +266,35 @@ export function seedProviders(
   }
 }
 
+/**
+ * Rewrite a provider's stored base URL, but only when it still holds a known
+ * stale default value. Existing installs are seeded with `COALESCE(baseUrl,
+ * seedValue)`, so a corrected seed base URL never propagates on its own — a row
+ * created with the old default keeps it forever. This targeted update advances
+ * that specific stale value to the current default while leaving user-customized
+ * base URLs (anything other than `staleBaseUrl`) untouched.
+ *
+ * Idempotent: once the row holds `nextBaseUrl` the WHERE clause matches nothing.
+ * Returns the number of rows updated.
+ */
+export function migrateProviderBaseUrl(params: {
+  provider: string;
+  staleBaseUrl: string;
+  nextBaseUrl: string;
+}): number {
+  const db = getDb();
+  db.update(oauthProviders)
+    .set({ baseUrl: params.nextBaseUrl, updatedAt: Date.now() })
+    .where(
+      and(
+        eq(oauthProviders.provider, params.provider),
+        eq(oauthProviders.baseUrl, params.staleBaseUrl),
+      ),
+    )
+    .run();
+  return rawChanges();
+}
+
 /** Look up a provider by its primary key. */
 export function getProvider(provider: string): OAuthProviderRow | undefined {
   const db = getDb();

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -1,5 +1,13 @@
 import type { AvailableScopes } from "./connect-types.js";
-import { seedProviders } from "./oauth-store.js";
+import { migrateProviderBaseUrl, seedProviders } from "./oauth-store.js";
+
+/**
+ * Base URL the google provider was seeded with before it multiplexed products
+ * behind the host-only `https://www.googleapis.com` base. Rows carrying exactly
+ * this value are advanced to the current default on startup; user-customized
+ * base URLs are left alone.
+ */
+const STALE_GOOGLE_BASE_URL = "https://gmail.googleapis.com/gmail/v1/users/me";
 
 /**
  * Protocol-level seed data for each well-known OAuth provider.
@@ -75,7 +83,14 @@ export const PROVIDER_SEED_DATA: Record<
     tokenExchangeUrl: "https://oauth2.googleapis.com/token",
     userinfoUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
     pingUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
-    baseUrl: "https://gmail.googleapis.com/gmail/v1/users/me",
+    // Google multiplexes many products behind one OAuth token, each on its own
+    // path under the generic API host: Gmail (/gmail/v1/...), Calendar
+    // (/calendar/v3/...), Drive (/drive/v3/...), userinfo (/oauth2/v2/...).
+    // A host-only base URL lets a relative request path select the product,
+    // so `oauth request --provider google /calendar/v3/...` resolves the
+    // same way as `/gmail/v1/...`. Internal Gmail callers pass a mailbox-scoped
+    // base URL override (see GMAIL_API_BASE_URL) for their short paths.
+    baseUrl: "https://www.googleapis.com",
     displayLabel: "Google",
     description: "Gmail, Calendar, Drive, and Contacts",
     dashboardUrl: "https://console.cloud.google.com/apis/credentials",
@@ -782,4 +797,17 @@ export const SEEDED_PROVIDER_KEYS = new Set(Object.keys(PROVIDER_SEED_DATA));
  */
 export function seedOAuthProviders(): void {
   seedProviders(Object.values(PROVIDER_SEED_DATA));
+
+  // seedProviders preserves an existing baseUrl via COALESCE, so a corrected
+  // seed default never reaches rows created with the old value. Advance the
+  // google row off its stale mailbox-scoped default without clobbering a
+  // user-customized base URL.
+  const nextGoogleBaseUrl = PROVIDER_SEED_DATA.google.baseUrl;
+  if (nextGoogleBaseUrl) {
+    migrateProviderBaseUrl({
+      provider: "google",
+      staleBaseUrl: STALE_GOOGLE_BASE_URL,
+      nextBaseUrl: nextGoogleBaseUrl,
+    });
+  }
 }

--- a/assistant/src/runtime/routes/oauth-commands-routes.ts
+++ b/assistant/src/runtime/routes/oauth-commands-routes.ts
@@ -893,9 +893,33 @@ async function handleRequest({ body = {} }: RouteHandlerArgs) {
       : `Request returned HTTP ${response.status}. The OAuth token may be expired or revoked.\n\n` +
         `Run 'assistant oauth status ${b.provider}' to check connection status.\n` +
         `To reconnect, run 'assistant oauth connect --help'.`;
+  } else if (response.status === 404 && isHtmlResponse(response.headers)) {
+    // An HTML 404 (rather than a JSON API error) is the signature of a request
+    // reaching a valid host but a path that host does not serve — e.g. a
+    // relative path resolved against a base URL that points at the wrong
+    // product. Surface the resolved base so the caller can tell where the path
+    // landed, and steer them to an absolute URL for non-default services.
+    const resolvedBaseUrl =
+      baseUrl ?? providerRow.baseUrl ?? "(none configured)";
+    result.hint =
+      `Request returned HTTP ${response.status} with an HTML body, which usually means ` +
+      `the path does not exist on the base URL it resolved against.\n\n` +
+      `This request used base URL "${resolvedBaseUrl}" (relative paths are joined onto it). ` +
+      `If you meant a different service on this provider, pass an absolute URL ` +
+      `(e.g. https://host/full/path) so the host and full path are set explicitly.`;
   }
 
   return result;
+}
+
+/** True when the response's Content-Type header indicates an HTML body. */
+function isHtmlResponse(headers: Record<string, string>): boolean {
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === "content-type") {
+      return value.toLowerCase().includes("text/html");
+    }
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/watcher/providers/gmail.ts
+++ b/assistant/src/watcher/providers/gmail.ts
@@ -9,6 +9,7 @@
 import {
   batchGetMessages,
   getProfile,
+  GMAIL_API_BASE_URL,
   GMAIL_REQUIRED_SCOPES,
   listMessages,
 } from "../../messaging/providers/gmail/client.js";
@@ -84,6 +85,7 @@ async function fetchHistory(
   const resp = await connection.request({
     method: "GET",
     path: "/history",
+    baseUrl: GMAIL_API_BASE_URL,
     query,
   });
 

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -284,7 +284,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-23T21:50:11.000Z"
+      "updatedAt": "2026-07-06T23:36:17.000Z"
     },
     {
       "id": "google-calendar",

--- a/skills/gmail/scripts/gmail-prefs.ts
+++ b/skills/gmail/scripts/gmail-prefs.ts
@@ -255,9 +255,7 @@ function main(): void {
           );
         }
         updates["interrupt-threshold"] = threshold as
-          | "default"
-          | "high"
-          | "low";
+          "default" | "high" | "low";
       }
       if (args["last-run"] != null) {
         updates["last-run"] = args["last-run"] as string;

--- a/skills/gmail/scripts/lib/gmail-client.ts
+++ b/skills/gmail/scripts/lib/gmail-client.ts
@@ -42,6 +42,13 @@ export interface GmailMessagePart {
   parts?: GmailMessagePart[];
 }
 
+/**
+ * Gmail API mailbox base. Request paths in this client are mailbox-relative
+ * (e.g. `/messages`), so the full URL pins the Gmail host and mailbox prefix
+ * explicitly rather than relying on the google provider's default base URL.
+ */
+const GMAIL_API_BASE_URL = "https://gmail.googleapis.com/gmail/v1/users/me";
+
 const MAX_RETRIES = 3;
 /** Higher retry count for batch modify — each retry is cheap relative to restarting the whole run. */
 const MAX_RETRIES_BATCH_MODIFY = 5;
@@ -109,7 +116,7 @@ export async function gmailRequest<T = unknown>(
       args.push("--account", opts.account);
     }
 
-    let path = opts.path;
+    let path = `${GMAIL_API_BASE_URL}${opts.path}`;
     if (opts.query && Object.keys(opts.query).length > 0) {
       const qs = new URLSearchParams(opts.query).toString();
       path += "?" + qs;

--- a/skills/gmail/scripts/lib/op-log.ts
+++ b/skills/gmail/scripts/lib/op-log.ts
@@ -31,18 +31,10 @@ const RETENTION_DAYS = 30;
 // ---------------------------------------------------------------------------
 
 export type OpStatus =
-  | "staged"
-  | "committed"
-  | "failed"
-  | "interrupted"
-  | "completed";
+  "staged" | "committed" | "failed" | "interrupted" | "completed";
 
 export type OpType =
-  | "archive"
-  | "label_add"
-  | "label_remove"
-  | "filter_create"
-  | "trash";
+  "archive" | "label_add" | "label_remove" | "filter_create" | "trash";
 
 export interface OpEntry {
   ts: string;


### PR DESCRIPTION
## Problem

`assistant oauth request --provider google <relative-path>` silently routed every relative path onto the Gmail mailbox path.

The google provider was seeded with `baseUrl: https://gmail.googleapis.com/gmail/v1/users/me`. Both request paths — local BYO and the platform proxy — **join** base + path rather than replacing:

- **BYO** (`byo-connection.ts`): `` `${effectiveBaseUrl}${requestPath}` `` — string concatenation.
- **Platform proxy** (`vellum-assistant-platform` `oauth/views.py`): ensures the base ends in `/`, strips the leading `/` from the path, then `urljoin(base, path)` — i.e. the path is appended relative to the base directory, not substituted.

Both semantics append. So with the Gmail-scoped base, a Calendar request like `/calendar/v3/calendars/primary/events` resolved under the Gmail mailbox path on the Gmail host and Google returned its generic HTML `Error 404 (Not Found)!!1` page — zero diagnostic value. In a real feedback session the assistant supplied the correct account via `--account` on exactly this path, got the opaque 404, wrongly concluded "the proxy path is being rewritten," and burned ~4 turns. (The CLI's own help even used an absolute URL for Calendar — a tell that relative was known-broken.)

## Fix

**Host-only base URL.** Change the google seed base URL to `https://www.googleapis.com`. With no path segment in the base, both join strategies become equivalent and a relative path selects the Google product:
- Gmail → `/gmail/v1/users/me/...`
- Calendar → `/calendar/v3/...`
- userinfo → `/oauth2/v2/...`

`www.googleapis.com` is already a declared `injectionTemplates` host (Bearer injection fires) and is the historical unified Google API host serving all three products, so the allowlist stays coherent.

**Internal Gmail callers get an explicit override.** The Gmail watcher (`history.list`) and the Gmail messaging client pass *short* mailbox-relative paths (`/history`, `/messages`, `/profile`), which only make sense against the mailbox base. They now pass an explicit `baseUrl: GMAIL_API_BASE_URL` (`https://gmail.googleapis.com/gmail/v1/users/me`) so they are independent of the seed default.

## Join semantics verified (platform repo)

`vellum-assistant-platform/django/app/assistant/oauth/views.py`:
```python
if not path.startswith("/"): path = f"/{path}"
if not base_url.endswith("/"): base_url = f"{base_url}/"
upstream_url = urljoin(base_url, path.lstrip("/"))
```
The proxy reads `base_url` per request from the daemon's payload and validates it against `oauth_app.allowed_base_urls` (falling back to `[base_url]`). **No platform change is required** — the base URL is passed per request, and `www.googleapis.com` is a valid host for the granted scopes.

## Seeding / upgrade behavior for existing installs

`seedProviders` upserts with `baseUrl: COALESCE(oauth_providers.baseUrl, <seed>)` — it only backfills a NULL base URL and **preserves any existing value**. A corrected seed default therefore never reaches rows created with the old value. To advance existing installs I added `migrateProviderBaseUrl({ provider, staleBaseUrl, nextBaseUrl })`, called from `seedOAuthProviders()`:

- Idempotent (a WHERE-guarded UPDATE that matches only the exact stale value).
- Advances **only** rows still holding `https://gmail.googleapis.com/gmail/v1/users/me`.
- **Never clobbers a user-customized base URL** (any other value is left untouched).

## Diagnostic hint for the residual failure class

`handleRequest` now appends a `hint` when the upstream response is **404 with an HTML content-type** (the signature of hitting a valid host but a path it does not serve). The hint is generic (no body string-matching): it states the resolved base URL the relative path was joined onto and suggests passing an absolute URL. JSON 404s are unaffected.

The CLI `oauth request` help text now explains that a relative path is joined onto the provider's configured default base URL (as shown by `oauth providers get <provider>`) and that absolute URLs are the safe form for any non-default service.

## Risk assessment — existing relative-path callers audited

| Caller | Uses seed base? | After change |
|---|---|---|
| `watcher/providers/gmail.ts` (`/history`) | **was** relying on seed base | now passes explicit `GMAIL_API_BASE_URL` ✅ |
| `messaging/providers/gmail/client.ts` (`/messages`, `/profile`, `/threads`, `/labels`, `/drafts`, ...) | **was** relying on seed base | central `request()` helper now passes `GMAIL_API_BASE_URL` ✅ |
| `messaging/providers/gmail/people-client.ts` (contacts) | no — passes `GOOGLE_PEOPLE_BASE_URL` | unchanged ✅ |
| `watcher/providers/google-calendar.ts` | no — passes `GOOGLE_CALENDAR_BASE_URL` | unchanged ✅ |
| `onboarding/schedule-checkin.ts` | no — passes `GOOGLE_CALENDAR_BASE_URL` | unchanged ✅ |
| Gmail batch (`GMAIL_BATCH_URL`, absolute via `withToken`) | no | unchanged ✅ |

Risk: **medium** — behavior-affecting for all `--provider google` relative-path callers, but every internal caller that relied on the old base now has an explicit override, and the migration only touches the exact stale default.

## Tests

- `oauth-store.test.ts`: google seeds host-only; `seedOAuthProviders` advances a stale gmail-scoped base and leaves a user-customized base untouched; `migrateProviderBaseUrl` is idempotent and value-scoped.
- `oauth-commands-routes.test.ts`: HTML-404 hint attaches for a relative path (reports resolved base + "absolute URL"); JSON-404 does not; absolute-URL requests report their own host as the resolved base.
- `seed-providers-managed.test.ts`: locks `google.baseUrl === https://www.googleapis.com`.

`bunx tsc --noEmit` clean on all touched files; each touched test file green when run individually (three files run together share a pre-existing cross-file mock pollution that predates this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->