### PR TITLE
fix(providers): gate adaptive thinking on model support, budget for older Claude

### DIFF
--- a/assistant/src/__tests__/retry-thinking-adaptive-only.test.ts
+++ b/assistant/src/__tests__/retry-thinking-adaptive-only.test.ts
@@ -243,3 +243,149 @@ describe("retry normalization: adaptive-only thinking models", () => {
     expect(lastConfig()?.temperature).toBe(1);
   });
 });
+
+describe("retry normalization: non-adaptive thinking models", () => {
+  test("rewrites enabled thinking to budgeted shape for Sonnet 4.5", async () => {
+    // GIVEN a pass-through caller enabling thinking on Sonnet 4.5, which does
+    // NOT support adaptive thinking (Anthropic 400s the adaptive shape)
+    const { provider, lastConfig } = makePipeline("anthropic");
+
+    // WHEN sending with an explicit max_tokens so the budget is deterministic
+    await provider.sendMessage([userMessage], {
+      config: {
+        model: "claude-sonnet-4-5-20250929",
+        thinking: { enabled: true },
+        max_tokens: 64000,
+      },
+    });
+
+    // THEN the adaptive shape is rewritten to Anthropic's classic budgeted
+    // shape, with a budget strictly below max_tokens
+    expect(lastConfig()?.thinking).toEqual({
+      type: "enabled",
+      budget_tokens: 16000,
+    });
+  });
+
+  test("clamps budget below a small max_tokens", async () => {
+    // GIVEN a caller with a max_tokens below the default thinking budget
+    const { provider, lastConfig } = makePipeline("anthropic");
+
+    // WHEN thinking is enabled on a non-adaptive model
+    await provider.sendMessage([userMessage], {
+      config: {
+        model: "claude-sonnet-4-5-20250929",
+        thinking: { enabled: true },
+        max_tokens: 4000,
+      },
+    });
+
+    // THEN the budget is clamped to stay strictly below max_tokens
+    expect(lastConfig()?.thinking).toEqual({
+      type: "enabled",
+      budget_tokens: 3999,
+    });
+  });
+
+  test("rewrites enabled thinking to budgeted shape for OpenRouter-proxied Sonnet 4.5", async () => {
+    // GIVEN the OpenRouter-proxied Sonnet 4.5 id, which delegates to the
+    // Anthropic Messages API and hits the same adaptive-thinking rejection
+    const { provider, lastConfig } = makePipeline("openrouter");
+
+    // WHEN thinking is enabled
+    await provider.sendMessage([userMessage], {
+      config: {
+        model: "anthropic/claude-sonnet-4.5",
+        thinking: { enabled: true },
+        max_tokens: 64000,
+      },
+    });
+
+    // THEN the adaptive shape is rewritten to the budgeted shape
+    expect(lastConfig()?.thinking).toEqual({
+      type: "enabled",
+      budget_tokens: 16000,
+    });
+  });
+
+  test("preserves adaptive thinking for Opus 4.8", async () => {
+    // GIVEN Opus 4.8, one of the newer families that DOES support adaptive
+    // thinking
+    const { provider, lastConfig } = makePipeline("anthropic");
+
+    // WHEN thinking is enabled
+    await provider.sendMessage([userMessage], {
+      config: {
+        model: "claude-opus-4-8",
+        thinking: { enabled: true },
+        max_tokens: 64000,
+      },
+    });
+
+    // THEN the adaptive shape is preserved (no budgeted downgrade)
+    expect(lastConfig()?.thinking).toEqual({ type: "adaptive" });
+  });
+
+  test("preserves adaptive thinking for an unknown model", async () => {
+    // GIVEN a model not in the catalog: behavior must be conservative and
+    // leave the adaptive shape untouched rather than guessing it needs a budget
+    const { provider, lastConfig } = makePipeline("anthropic");
+
+    // WHEN thinking is enabled
+    await provider.sendMessage([userMessage], {
+      config: {
+        model: "claude-some-future-model",
+        thinking: { enabled: true },
+        max_tokens: 64000,
+      },
+    });
+
+    // THEN the adaptive shape is preserved
+    expect(lastConfig()?.thinking).toEqual({ type: "adaptive" });
+  });
+
+  test("rewrites enabled thinking to budgeted shape via resolved call-site config (Sonnet 4.5)", async () => {
+    // GIVEN a profile mirroring the production incident: a `balanced` profile
+    // pointing Sonnet 4.5 at thinking: enabled, resolved through a call site
+    setLlmConfig({
+      default: {
+        provider: "anthropic",
+        model: "claude-sonnet-4-5-20250929",
+        thinking: { enabled: true },
+      },
+    });
+    const { provider, lastConfig } = makePipeline("anthropic");
+
+    // WHEN a request resolves through the call-site config
+    await provider.sendMessage([userMessage], {
+      config: { callSite: "memoryExtraction" },
+    });
+
+    // THEN thinking resolves to the budgeted shape (not adaptive), with a valid
+    // budget strictly below the resolved max_tokens
+    const thinking = lastConfig()?.thinking as Record<string, unknown>;
+    const maxTokens = lastConfig()?.max_tokens as number;
+    expect(thinking.type).toBe("enabled");
+    expect(typeof thinking.budget_tokens).toBe("number");
+    expect(thinking.budget_tokens as number).toBeGreaterThanOrEqual(1024);
+    expect(thinking.budget_tokens as number).toBeLessThan(maxTokens);
+  });
+
+  test("preserves disabled thinking for a non-adaptive model (no budgeted rewrite)", async () => {
+    // GIVEN a non-adaptive model with thinking explicitly disabled: the mirror
+    // rewrite must only touch the enabled/adaptive shape, never a disabled one
+    const { provider, lastConfig } = makePipeline("anthropic");
+
+    // WHEN thinking is disabled
+    await provider.sendMessage([userMessage], {
+      config: {
+        model: "claude-sonnet-4-5-20250929",
+        thinking: { enabled: false },
+        max_tokens: 64000,
+      },
+    });
+
+    // THEN the disabled shape is preserved unchanged
+    expect(lastConfig()?.thinking).toEqual({ type: "disabled" });
+  });
+});

--- a/assistant/src/__tests__/retry-thinking-adaptive-only.test.ts
+++ b/assistant/src/__tests__/retry-thinking-adaptive-only.test.ts
@@ -267,8 +267,31 @@ describe("retry normalization: non-adaptive thinking models", () => {
     });
   });
 
+  test("caps the budget at half of max_tokens to preserve response headroom", async () => {
+    // GIVEN a max_tokens equal to the standard 16000 budget: Anthropic counts
+    // the thinking budget against max_tokens, so taking (nearly) all of it
+    // would leave no room for the visible response
+    const { provider, lastConfig } = makePipeline("anthropic");
+
+    // WHEN thinking is enabled on a non-adaptive model
+    await provider.sendMessage([userMessage], {
+      config: {
+        model: "claude-sonnet-4-5-20250929",
+        thinking: { enabled: true },
+        max_tokens: 16000,
+      },
+    });
+
+    // THEN the budget is capped at half of max_tokens, reserving the other
+    // half for the response
+    expect(lastConfig()?.thinking).toEqual({
+      type: "enabled",
+      budget_tokens: 8000,
+    });
+  });
+
   test("clamps budget below a small max_tokens", async () => {
-    // GIVEN a caller with a max_tokens below the default thinking budget
+    // GIVEN a caller with a max_tokens below twice the default thinking budget
     const { provider, lastConfig } = makePipeline("anthropic");
 
     // WHEN thinking is enabled on a non-adaptive model
@@ -280,11 +303,69 @@ describe("retry normalization: non-adaptive thinking models", () => {
       },
     });
 
-    // THEN the budget is clamped to stay strictly below max_tokens
+    // THEN the budget is half of max_tokens — valid (>= 1024, < max_tokens)
+    // and with headroom for the response
     expect(lastConfig()?.thinking).toEqual({
       type: "enabled",
-      budget_tokens: 3999,
+      budget_tokens: 2000,
     });
+  });
+
+  test("emits the minimum budget at the exact-fit boundary (max_tokens 2048)", async () => {
+    // GIVEN the smallest max_tokens whose half still meets Anthropic's 1024
+    // minimum budget
+    const { provider, lastConfig } = makePipeline("anthropic");
+
+    // WHEN thinking is enabled on a non-adaptive model
+    await provider.sendMessage([userMessage], {
+      config: {
+        model: "claude-sonnet-4-5-20250929",
+        thinking: { enabled: true },
+        max_tokens: 2048,
+      },
+    });
+
+    // THEN the budget is exactly the 1024 minimum, strictly below max_tokens
+    expect(lastConfig()?.thinking).toEqual({
+      type: "enabled",
+      budget_tokens: 1024,
+    });
+  });
+
+  test("drops thinking when max_tokens cannot fit the minimum budget (1024)", async () => {
+    // GIVEN max_tokens: 1024 — the old clamp produced budget_tokens: 1024 ==
+    // max_tokens, which Anthropic 400s (budget must be strictly < max_tokens)
+    const { provider, lastConfig } = makePipeline("anthropic");
+
+    // WHEN thinking is enabled on a non-adaptive model
+    await provider.sendMessage([userMessage], {
+      config: {
+        model: "claude-sonnet-4-5-20250929",
+        thinking: { enabled: true },
+        max_tokens: 1024,
+      },
+    });
+
+    // THEN thinking is dropped: a working non-thinking response beats a
+    // guaranteed 400 from an invalid budget
+    expect(lastConfig()?.thinking).toBeUndefined();
+  });
+
+  test("drops thinking when max_tokens is below the minimum budget", async () => {
+    // GIVEN max_tokens: 500 — no valid budget exists at all (min is 1024)
+    const { provider, lastConfig } = makePipeline("anthropic");
+
+    // WHEN thinking is enabled on a non-adaptive model
+    await provider.sendMessage([userMessage], {
+      config: {
+        model: "claude-sonnet-4-5-20250929",
+        thinking: { enabled: true },
+        max_tokens: 500,
+      },
+    });
+
+    // THEN thinking is dropped instead of sending an invalid shape
+    expect(lastConfig()?.thinking).toBeUndefined();
   });
 
   test("rewrites enabled thinking to budgeted shape for OpenRouter-proxied Sonnet 4.5", async () => {

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1473,3 +1473,55 @@ export function isAdaptiveThinkingOnlyModel(modelId: string): boolean {
     p.models.some((m) => m.id === modelId && m.adaptiveThinkingOnly === true),
   );
 }
+
+/**
+ * Model-id patterns for the Claude families that accept Anthropic's adaptive
+ * thinking mode (`thinking: { type: "adaptive" }`) beyond the always-on
+ * adaptive-only models. Only the newest families support it; older Claude
+ * models (Sonnet 4.5, Opus 4.5/4.6, Sonnet 4.6, Haiku 4.5) reject it with a 400
+ * "adaptive thinking is not supported on this model" and must instead receive
+ * the classic budgeted shape (`{ type: "enabled", budget_tokens }`).
+ *
+ * Patterns match both the bare Anthropic ids (`claude-opus-4-8`) and the
+ * OpenRouter mirror ids (`anthropic/claude-opus-4.8`), which differ only in the
+ * version separator. This is the adaptive-thinking counterpart to the
+ * `deprecatesSamplingParams` families in `anthropic/client.ts`: the two share a
+ * model set today but track distinct capabilities, so they are kept separate.
+ */
+const ADAPTIVE_THINKING_MODEL_PATTERNS: readonly RegExp[] = [
+  /claude-opus-4[.-][78]\b/,
+  /claude-sonnet-5\b/,
+];
+
+/**
+ * Whether the model supports Anthropic's adaptive thinking mode. True for the
+ * always-on adaptive-only models (Fable) and for the newer Claude families that
+ * accept the adaptive shape. Unknown models return false (conservative — an
+ * unrecognized model is treated as not supporting adaptive thinking).
+ */
+export function supportsAdaptiveThinking(modelId: string): boolean {
+  if (isAdaptiveThinkingOnlyModel(modelId)) {
+    return true;
+  }
+  return ADAPTIVE_THINKING_MODEL_PATTERNS.some((p) => p.test(modelId));
+}
+
+/** Whether the model ID exists under any provider in the catalog. */
+function isKnownCatalogModel(modelId: string): boolean {
+  return PROVIDER_CATALOG.some((p) => p.models.some((m) => m.id === modelId));
+}
+
+/**
+ * Whether the model is a known catalog model that does NOT support adaptive
+ * thinking — i.e. sending it `thinking: { type: "adaptive" }` would 400. The
+ * daemon rewrites an enabled/adaptive thinking config into the classic budgeted
+ * shape for these models. Unknown models return false so their existing wire
+ * behavior is preserved: the daemon leaves the adaptive shape untouched rather
+ * than guessing that an unrecognized model needs the budgeted form.
+ */
+export function requiresBudgetedThinking(modelId: string): boolean {
+  if (!isKnownCatalogModel(modelId)) {
+    return false;
+  }
+  return !supportsAdaptiveThinking(modelId);
+}

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -84,9 +84,9 @@ const VERBOSITY_SUPPORTED_PROVIDERS = new Set(["openai"]);
 /**
  * Default `budget_tokens` used when an enabled/adaptive thinking config is
  * rewritten to Anthropic's classic budgeted shape for a model that doesn't
- * support adaptive thinking. Clamped below `max_tokens` per call so the request
- * satisfies Anthropic's `1024 <= budget_tokens < max_tokens` constraint while
- * leaving room for the visible response.
+ * support adaptive thinking. Clamped per call so the request satisfies
+ * Anthropic's `1024 <= budget_tokens < max_tokens` constraint while leaving
+ * room for the visible response (see {@link budgetedThinkingConfig}).
  */
 const NON_ADAPTIVE_THINKING_BUDGET_TOKENS = 16000;
 
@@ -126,20 +126,31 @@ function isAdaptiveWireThinking(thinking: unknown): boolean {
 
 /**
  * Build the classic budgeted Anthropic thinking shape (`{ type: "enabled",
- * budget_tokens }`) for a model that rejects the adaptive shape. The budget is
- * clamped to stay strictly below `max_tokens` (Anthropic requires
- * `budget_tokens < max_tokens`); when `max_tokens` is unset the Anthropic
- * client's own default is large enough for the standard budget.
+ * budget_tokens }`) for a model that rejects the adaptive shape.
+ *
+ * Anthropic counts the thinking budget against `max_tokens` and requires
+ * `1024 <= budget_tokens < max_tokens`, so the budget is capped at half of
+ * `max_tokens` — reserving at least half of the output cap for the visible
+ * response — and at the standard {@link NON_ADAPTIVE_THINKING_BUDGET_TOKENS}.
+ * When `max_tokens` is unset, the Anthropic client's own default (8192–64000)
+ * comfortably fits the standard budget.
+ *
+ * Returns `undefined` when the halved cap falls below Anthropic's 1024
+ * minimum (`max_tokens < 2048`): there is no budget that is both valid and
+ * leaves room for a response, so the caller drops thinking for the request —
+ * a working non-thinking response beats a guaranteed 400.
  */
 function budgetedThinkingConfig(
   maxTokens: number | undefined,
-): Record<string, unknown> {
+): Record<string, unknown> | undefined {
   const ceiling =
-    typeof maxTokens === "number" ? maxTokens - 1 : Number.POSITIVE_INFINITY;
-  const budget = Math.max(
-    MIN_THINKING_BUDGET_TOKENS,
-    Math.min(NON_ADAPTIVE_THINKING_BUDGET_TOKENS, ceiling),
-  );
+    typeof maxTokens === "number"
+      ? Math.floor(maxTokens / 2)
+      : Number.POSITIVE_INFINITY;
+  const budget = Math.min(NON_ADAPTIVE_THINKING_BUDGET_TOKENS, ceiling);
+  if (budget < MIN_THINKING_BUDGET_TOKENS) {
+    return undefined;
+  }
   return { type: "enabled", budget_tokens: budget };
 }
 
@@ -450,18 +461,38 @@ function normalizeSendMessageOptions(
   // for known non-adaptive models so their turns don't hard-fail. Runs before
   // the temperature/top_p guards below because budgeted thinking is still
   // "enabled" on the wire and carries the same temperature/top_p constraints.
-  // Unknown models keep the adaptive shape (existing behavior).
+  // Unknown models keep the adaptive shape (existing behavior). When
+  // `max_tokens` is too small to fit a valid budget plus response headroom
+  // (`budgetedThinkingConfig` returns undefined), thinking is dropped for the
+  // request instead — for these models an absent config means thinking off.
   if (
     typeof nextConfig.model === "string" &&
     isAnthropicWireRequest(providerName, nextConfig.model) &&
     requiresBudgetedThinking(nextConfig.model) &&
     isAdaptiveWireThinking(nextConfig.thinking)
   ) {
-    nextConfig.thinking = budgetedThinkingConfig(
+    const budgeted = budgetedThinkingConfig(
       typeof nextConfig.max_tokens === "number"
         ? nextConfig.max_tokens
         : undefined,
     );
+    if (budgeted === undefined) {
+      log.warn(
+        {
+          providerName,
+          callSite: config.callSite,
+          model: nextConfig.model,
+          maxTokens: nextConfig.max_tokens,
+        },
+        "Dropping enabled thinking — max_tokens is too small to fit the " +
+          "minimum thinking budget (1024) plus response headroom on a model " +
+          "without adaptive thinking. Raise max_tokens to at least 2048 to " +
+          "keep thinking enabled.",
+      );
+      delete nextConfig.thinking;
+    } else {
+      nextConfig.thinking = budgeted;
+    }
   }
 
   // thinking is Anthropic-specific on the wire; OpenRouter reads it as a

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -14,7 +14,10 @@ import {
   sleep,
 } from "../util/retry.js";
 import { resolveLogitBiasPreset } from "./inference/logit-bias.js";
-import { isAdaptiveThinkingOnlyModel } from "./model-catalog.js";
+import {
+  isAdaptiveThinkingOnlyModel,
+  requiresBudgetedThinking,
+} from "./model-catalog.js";
 import {
   isThinkingConfigDisabled,
   normalizeThinkingConfigForWire,
@@ -77,6 +80,68 @@ const THINKING_EXTRA_FIELDS_AWARE_PROVIDERS = new Set(["gemini"]);
  * `text.verbosity` on the Responses API — a GPT-5-series parameter).
  */
 const VERBOSITY_SUPPORTED_PROVIDERS = new Set(["openai"]);
+
+/**
+ * Default `budget_tokens` used when an enabled/adaptive thinking config is
+ * rewritten to Anthropic's classic budgeted shape for a model that doesn't
+ * support adaptive thinking. Clamped below `max_tokens` per call so the request
+ * satisfies Anthropic's `1024 <= budget_tokens < max_tokens` constraint while
+ * leaving room for the visible response.
+ */
+const NON_ADAPTIVE_THINKING_BUDGET_TOKENS = 16000;
+
+/** Anthropic's minimum accepted `budget_tokens` for extended thinking. */
+const MIN_THINKING_BUDGET_TOKENS = 1024;
+
+/**
+ * Whether a request sent to the given provider/model reaches Anthropic's
+ * Messages API — either the native Anthropic provider or OpenRouter fronting an
+ * `anthropic/*` model (which delegates to `AnthropicProvider`). Anthropic-wire
+ * thinking constraints (adaptive support, budgeted shape, temperature/top_p)
+ * only apply to these requests.
+ */
+function isAnthropicWireRequest(providerName: string, model: string): boolean {
+  if (providerName === "anthropic") {
+    return true;
+  }
+  if (providerName === "openrouter") {
+    return model.startsWith("anthropic/");
+  }
+  return false;
+}
+
+/**
+ * Whether the normalized wire `thinking` config is Anthropic's adaptive shape
+ * (`{ type: "adaptive" }`). `normalizeThinkingConfigForWire` produces this for
+ * every enabled config.
+ */
+function isAdaptiveWireThinking(thinking: unknown): boolean {
+  return (
+    typeof thinking === "object" &&
+    thinking !== null &&
+    !Array.isArray(thinking) &&
+    (thinking as Record<string, unknown>).type === "adaptive"
+  );
+}
+
+/**
+ * Build the classic budgeted Anthropic thinking shape (`{ type: "enabled",
+ * budget_tokens }`) for a model that rejects the adaptive shape. The budget is
+ * clamped to stay strictly below `max_tokens` (Anthropic requires
+ * `budget_tokens < max_tokens`); when `max_tokens` is unset the Anthropic
+ * client's own default is large enough for the standard budget.
+ */
+function budgetedThinkingConfig(
+  maxTokens: number | undefined,
+): Record<string, unknown> {
+  const ceiling =
+    typeof maxTokens === "number" ? maxTokens - 1 : Number.POSITIVE_INFINITY;
+  const budget = Math.max(
+    MIN_THINKING_BUDGET_TOKENS,
+    Math.min(NON_ADAPTIVE_THINKING_BUDGET_TOKENS, ceiling),
+  );
+  return { type: "enabled", budget_tokens: budget };
+}
 
 /** Patterns that indicate a transient streaming corruption from the SDK. */
 const RETRYABLE_STREAM_PATTERNS = [
@@ -375,6 +440,30 @@ function normalizeSendMessageOptions(
     delete nextConfig.thinking;
   }
 
+  // Mirror direction: older Anthropic models (Sonnet 4.5, Opus 4.5/4.6, Sonnet
+  // 4.6, Haiku 4.5) reject `thinking: { type: "adaptive" }` with a 400
+  // "adaptive thinking is not supported on this model" — only the newest
+  // families (Opus 4.7/4.8, Sonnet 5, Fable) accept it. `normalizeThinking-
+  // ConfigForWire` maps every enabled config to the adaptive shape regardless
+  // of model, so rewrite it here — where the resolved model is known — to
+  // Anthropic's classic budgeted shape (`{ type: "enabled", budget_tokens }`)
+  // for known non-adaptive models so their turns don't hard-fail. Runs before
+  // the temperature/top_p guards below because budgeted thinking is still
+  // "enabled" on the wire and carries the same temperature/top_p constraints.
+  // Unknown models keep the adaptive shape (existing behavior).
+  if (
+    typeof nextConfig.model === "string" &&
+    isAnthropicWireRequest(providerName, nextConfig.model) &&
+    requiresBudgetedThinking(nextConfig.model) &&
+    isAdaptiveWireThinking(nextConfig.thinking)
+  ) {
+    nextConfig.thinking = budgetedThinkingConfig(
+      typeof nextConfig.max_tokens === "number"
+        ? nextConfig.max_tokens
+        : undefined,
+    );
+  }
+
   // thinking is Anthropic-specific on the wire; OpenRouter reads it as a
   // signal for its unified reasoning parameter; Gemini reads `level` from it.
   // Strip it for other providers.
@@ -418,17 +507,18 @@ function normalizeSendMessageOptions(
   // into OpenRouter's `reasoning` parameter via `buildExtraCreateParams`
   // and may support reasoning with forced tool_choice.
   const isThinkingForcedToolConflict = (() => {
-    if (nextConfig.thinking == null) return false;
-    if (isThinkingConfigDisabled(nextConfig.thinking)) return false;
-    const tc = nextConfig.tool_choice as Record<string, unknown> | undefined;
-    if (tc == null || (tc.type !== "tool" && tc.type !== "any")) return false;
-    if (providerName === "anthropic") return true;
-    if (providerName === "openrouter") {
-      const model =
-        typeof nextConfig.model === "string" ? nextConfig.model : "";
-      return model.startsWith("anthropic/");
+    if (nextConfig.thinking == null) {
+      return false;
     }
-    return false;
+    if (isThinkingConfigDisabled(nextConfig.thinking)) {
+      return false;
+    }
+    const tc = nextConfig.tool_choice as Record<string, unknown> | undefined;
+    if (tc == null || (tc.type !== "tool" && tc.type !== "any")) {
+      return false;
+    }
+    const model = typeof nextConfig.model === "string" ? nextConfig.model : "";
+    return isAnthropicWireRequest(providerName, model);
   })();
   if (isThinkingForcedToolConflict) {
     delete nextConfig.thinking;
@@ -473,13 +563,7 @@ function normalizeSendMessageOptions(
         return false;
       }
     }
-    if (providerName === "anthropic") {
-      return true;
-    }
-    if (providerName === "openrouter") {
-      return model.startsWith("anthropic/");
-    }
-    return false;
+    return isAnthropicWireRequest(providerName, model);
   })();
   const isThinkingTemperatureConflict = (() => {
     if (!isThinkingEnabledOnAnthropicWire) {


### PR DESCRIPTION
## The bug

`normalizeThinkingConfigForWire()` in `assistant/src/providers/thinking-config.ts` maps every `thinking.enabled === true` config to `{ type: "adaptive" }` **unconditionally**, with no knowledge of the target model.

Adaptive thinking is only supported by the newest Anthropic models (Opus 4.7/4.8, Sonnet 5, the Fable family). Older models like Sonnet 4.5 reject it: Anthropic returns HTTP 400 `"adaptive thinking is not supported on this model"`, and the **entire agent turn hard-fails**.

In a production incident, a user profile configured Sonnet 4.5 with `thinking: { enabled: true }`, and every single call on that profile 400'd — the assistant was completely broken for that user.

`retry.ts` already handled the mirror case (dropping a `disabled` thinking config for adaptive-only models). The missing direction was: an enabled/adaptive config sent to a model that does **not** support adaptive thinking.

## The fix

1. **Model-catalog capability** (`model-catalog.ts`): add `supportsAdaptiveThinking()` and `requiresBudgetedThinking()`. The adaptive-capable set is the always-on adaptive-only models (Fable, via the existing `adaptiveThinkingOnly` catalog flag) plus the newer families matched by pattern (Opus 4.7/4.8, Sonnet 5) — the counterpart to the `deprecatesSamplingParams` families in `anthropic/client.ts`, kept as a separate helper since the two track distinct capabilities. Patterns match both the bare Anthropic ids (`claude-opus-4-8`) and the OpenRouter mirror ids (`anthropic/claude-opus-4.8`).
2. **Gate at the layer where the model is known** (`retry.ts`, next to the existing adaptive-only handling): rewrite an enabled/adaptive thinking config to Anthropic's classic budgeted shape (`{ type: "enabled", budget_tokens }`) for **known non-adaptive** Anthropic (and OpenRouter-fronted `anthropic/*`) models. The budget is clamped to stay strictly below `max_tokens` (Anthropic requires `1024 <= budget_tokens < max_tokens`). The Anthropic client consumes the `thinking` object verbatim via `...restConfig`, so the budgeted shape is what the SDK expects.
3. **Conservative on unknown models**: models not in the catalog keep the adaptive shape (no behavior change) rather than guessing they need a budget. Even a stale catalog only degrades a newer adaptive model to budgeted thinking (still accepted) — it never introduces a hard failure.
4. `normalizeThinkingConfigForWire()` stays model-agnostic/pure. The rewrite runs **before** the temperature/top_p guards, which still apply to budgeted thinking (also "enabled" on the wire). Extracted the repeated Anthropic-wire predicate into `isAnthropicWireRequest()`.

## Testing

Added tests to `retry-thinking-adaptive-only.test.ts` (the mirror-direction companion suite):
- enabled thinking + Sonnet 4.5 → budgeted shape (pass-through and resolved-call-site paths, incl. the production-incident profile shape)
- budget clamped strictly below a small `max_tokens`
- enabled thinking + OpenRouter-proxied `anthropic/claude-sonnet-4.5` → budgeted shape
- enabled thinking + Opus 4.8 → adaptive preserved
- unknown model → adaptive preserved (conservative)
- disabled thinking on a non-adaptive model → left unchanged (no spurious rewrite)

Results:
- `bun test src/__tests__/retry-thinking-adaptive-only.test.ts` → 16 pass
- `bun test src/providers/__tests__/retry-callsite.test.ts src/__tests__/thinking-block-replay.test.ts` → 31 pass, no regressions
- `bun test src/__tests__/llm-catalog-parity.test.ts` → 17 pass (no catalog fields added, generated JSON unchanged; `sync:llm-catalog --check` clean)
- Typecheck clean for changed files; prettier clean; lint clean for touched blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->