### PR TITLE
fix(config): validate merged config at write time in `config set`

### DIFF
--- a/assistant/src/__tests__/config-set-route.test.ts
+++ b/assistant/src/__tests__/config-set-route.test.ts
@@ -102,17 +102,130 @@ describe("config_set route - request validation", () => {
     ).rejects.toThrow("`value` is required");
   });
 
-  test("accepts body with explicit null value", async () => {
-    rawConfig = { heartbeat: { activeHoursStart: "09:00" } };
+  test("accepts explicit null on a nullable scalar field (persists null)", async () => {
+    // `llmRequestLogRetentionMs` is schema-nullable (null = "no limit"), so an
+    // explicit-null set is a valid whole-config write and must persist as null.
+    rawConfig = { memory: { cleanup: { llmRequestLogRetentionMs: 86400000 } } };
     savedRaw = null;
     const result = await configSetRoute.handler({
-      body: { path: "heartbeat.activeHoursStart", value: null },
+      body: { path: "memory.cleanup.llmRequestLogRetentionMs", value: null },
     });
     expect(result).toEqual({ ok: true });
     expect(savedRaw).not.toBeNull();
-    const heartbeat = (savedRaw as unknown as Record<string, unknown>)
-      .heartbeat as Record<string, unknown>;
-    expect(heartbeat.activeHoursStart).toBeNull();
+    const cleanup = (
+      (savedRaw as unknown as Record<string, unknown>).memory as Record<
+        string,
+        unknown
+      >
+    ).cleanup as Record<string, unknown>;
+    expect(cleanup.llmRequestLogRetentionMs).toBeNull();
+  });
+
+  test("rejects a write whose merged config fails the schema (invalid enum)", async () => {
+    // `source` accepts only "managed" | "user"; "custom" is rejected. Using a
+    // non-managed profile so the generic schema gate fires (managed profiles
+    // hit the read-only guard first). The error must name the offending path
+    // and state nothing was written.
+    rawConfig = {
+      llm: {
+        profiles: {
+          "my-custom": {
+            source: "user",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+          },
+        },
+      },
+    };
+    savedRaw = null;
+    await expect(
+      configSetRoute.handler({
+        body: { path: "llm.profiles.my-custom.source", value: "custom" },
+      }),
+    ).rejects.toThrow(BadRequestError);
+    await expect(
+      configSetRoute.handler({
+        body: { path: "llm.profiles.my-custom.source", value: "custom" },
+      }),
+    ).rejects.toThrow(/llm\.profiles\.my-custom\.source: .*managed.*user/);
+    await expect(
+      configSetRoute.handler({
+        body: { path: "llm.profiles.my-custom.source", value: "custom" },
+      }),
+    ).rejects.toThrow(/nothing was written/);
+    // No write reached disk.
+    expect(savedRaw).toBeNull();
+  });
+
+  test("rejects a write introducing an unknown llm.callSites key", async () => {
+    rawConfig = {};
+    savedRaw = null;
+    await expect(
+      configSetRoute.handler({
+        body: {
+          path: "llm.callSites.doesNotExist.profile",
+          value: "balanced",
+        },
+      }),
+    ).rejects.toThrow(/llm\.callSites\.doesNotExist/);
+    expect(savedRaw).toBeNull();
+  });
+
+  test("clearing an object profile entry with null deletes it and validates as absent", async () => {
+    // `set llm.profiles.gemini-probe null` removes the entry. The merged config
+    // validates with the key absent (an explicit null would fail ProfileEntry).
+    rawConfig = {
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+          },
+          "gemini-probe": {
+            source: "user",
+            provider: "google",
+            model: "gemini-2.0-flash",
+          },
+        },
+      },
+    };
+    savedRaw = null;
+    const result = await configSetRoute.handler({
+      body: { path: "llm.profiles.gemini-probe", value: null },
+    });
+    expect(result).toEqual({ ok: true });
+    const profiles = (
+      (savedRaw as unknown as Record<string, unknown>).llm as Record<
+        string,
+        unknown
+      >
+    ).profiles as Record<string, unknown>;
+    expect("gemini-probe" in profiles).toBe(false);
+    expect(profiles.balanced).toBeDefined();
+  });
+
+  test("partial-path write validates the merged whole config, not just the fragment", async () => {
+    // `activeProfile` alone parses fine, but the merged config still carries an
+    // invalid on-disk profile-source, so the write is rejected on the merge.
+    rawConfig = {
+      llm: {
+        profiles: {
+          balanced: {
+            source: "bogus",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+          },
+        },
+      },
+    };
+    savedRaw = null;
+    await expect(
+      configSetRoute.handler({
+        body: { path: "llm.activeProfile", value: "balanced" },
+      }),
+    ).rejects.toThrow(/llm\.profiles\.balanced\.source/);
+    expect(savedRaw).toBeNull();
   });
 
   test("rejects body missing path field", async () => {
@@ -211,7 +324,7 @@ describe("config_set route - request validation", () => {
     rawConfig = {
       llm: { default: { provider: "anthropic" } },
       calls: { enabled: true },
-      heartbeat: { activeHoursStart: "09:00", activeHoursEnd: "22:00" },
+      heartbeat: { activeHoursStart: 9, activeHoursEnd: 22 },
     };
     savedRaw = null;
     await configSetRoute.handler({
@@ -222,8 +335,8 @@ describe("config_set route - request validation", () => {
     expect(saved.llm).toEqual({ default: { provider: "anthropic" } });
     expect(saved.calls).toEqual({ enabled: true });
     expect(saved.heartbeat).toEqual({
-      activeHoursStart: "09:00",
-      activeHoursEnd: "22:00",
+      activeHoursStart: 9,
+      activeHoursEnd: 22,
     });
   });
 });

--- a/assistant/src/__tests__/config-set-route.test.ts
+++ b/assistant/src/__tests__/config-set-route.test.ts
@@ -171,6 +171,63 @@ describe("config_set route - request validation", () => {
     expect(savedRaw).toBeNull();
   });
 
+  test("null on an absent nullable scalar creates the path and persists explicit null", async () => {
+    // Sparse config: the path was never written. The explicit-null override
+    // (null = "no retention limit") must be persisted, not silently dropped —
+    // otherwise the effective value stays the schema default.
+    rawConfig = {};
+    savedRaw = null;
+    const result = await configSetRoute.handler({
+      body: { path: "memory.cleanup.llmRequestLogRetentionMs", value: null },
+    });
+    expect(result).toEqual({ ok: true });
+    expect(savedRaw).not.toBeNull();
+    const cleanup = (
+      (savedRaw as unknown as Record<string, unknown>).memory as Record<
+        string,
+        unknown
+      >
+    ).cleanup as Record<string, unknown>;
+    expect("llmRequestLogRetentionMs" in cleanup).toBe(true);
+    expect(cleanup.llmRequestLogRetentionMs).toBeNull();
+    // The effective (schema-parsed) config reflects the override: explicit
+    // null survives parsing instead of being replaced by the default.
+    const { AssistantConfigSchema } = await import("../config/schema.js");
+    const effective = AssistantConfigSchema.parse(savedRaw);
+    expect(effective.memory.cleanup.llmRequestLogRetentionMs).toBeNull();
+  });
+
+  test("null on an absent object entry stays a no-op (no spurious null leaf)", async () => {
+    // Deleting a record entry that does not exist writes nothing at the path.
+    // Persisting explicit null there would fail the schema (ProfileEntry
+    // expects an object).
+    rawConfig = {
+      llm: {
+        profiles: {
+          "my-custom": {
+            source: "user",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+          },
+        },
+      },
+    };
+    savedRaw = null;
+    const result = await configSetRoute.handler({
+      body: { path: "llm.profiles.gemini-probe", value: null },
+    });
+    expect(result).toEqual({ ok: true });
+    expect(savedRaw).not.toBeNull();
+    const profiles = (
+      (savedRaw as unknown as Record<string, unknown>).llm as Record<
+        string,
+        unknown
+      >
+    ).profiles as Record<string, unknown>;
+    expect("gemini-probe" in profiles).toBe(false);
+    expect(profiles["my-custom"]).toBeDefined();
+  });
+
   test("clearing an object profile entry with null deletes it and validates as absent", async () => {
     // `set llm.profiles.gemini-probe null` removes the entry. The merged config
     // validates with the key absent (an explicit null would fail ProfileEntry).

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1022,12 +1022,22 @@ function assertInvariantProfilesPreserved(
 async function commitConfigWrite(
   raw: Record<string, unknown>,
   opLabel: string,
+  options: { validateMergedSchema?: boolean } = {},
 ): Promise<void> {
   // `loadRawConfig()` reads fresh from disk and the save hasn't happened yet,
   // so it is the pre-write state; raw-to-raw comparison avoids parsed-vs-raw
   // false diffs. Runs before the watcher-suppress/save sequence so a
   // rejection needs no suppress-flag or cache cleanup.
   assertInvariantProfilesPreserved(loadRawConfig(), raw);
+
+  // Schema validation runs after the managed-profile guard so its specific,
+  // actionable message wins for a managed-profile write that also happens to
+  // be schema-invalid, and before the file write so a rejection leaves disk
+  // untouched. Opt-in per caller — the `config set` path validates the merged
+  // whole config; other write paths keep their existing narrower validation.
+  if (options.validateMergedSchema) {
+    assertMergedConfigValidForSet(raw);
+  }
 
   // Suppress the file-watcher callback for the duration of the debounce
   // window. Without this, the ConfigWatcher detects the config.json write
@@ -1096,6 +1106,72 @@ async function handlePatchConfig({ body }: RouteHandlerArgs) {
 }
 
 /**
+ * Clear the leaf at `path`, mirroring `deepMergeOverwrite`'s null semantics so
+ * a cleared key validates as the schema intends rather than as an explicit
+ * `null` the schema may reject:
+ *
+ * - **Existing value is a plain object**: delete the key (clear entry). E.g.
+ *   `set llm.profiles.gemini-probe null` removes the profile so it validates
+ *   as absent, not as `null` (which `ProfileEntry` rejects).
+ * - **Existing value is a scalar / null / array**: assign `null`, preserving
+ *   nullable fields (e.g. `memory.cleanup.llmRequestLogRetentionMs`).
+ * - **Key absent**: no-op — assigning `null` to a missing key would persist a
+ *   spurious leaf.
+ */
+function clearLeafForNullSet(raw: Record<string, unknown>, path: string): void {
+  const keys = path.split(".");
+  let parent = raw;
+  for (let i = 0; i < keys.length - 1; i++) {
+    const next = parent[keys[i]!];
+    if (next == null || typeof next !== "object" || Array.isArray(next)) {
+      return;
+    }
+    parent = next as Record<string, unknown>;
+  }
+  const leaf = keys[keys.length - 1]!;
+  if (!(leaf in parent)) {
+    return;
+  }
+  const existing = parent[leaf];
+  if (
+    existing != null &&
+    typeof existing === "object" &&
+    !Array.isArray(existing)
+  ) {
+    delete parent[leaf];
+  } else {
+    parent[leaf] = null;
+  }
+}
+
+/**
+ * Validate the whole post-write raw config against `AssistantConfigSchema`
+ * before it is persisted. A single-key `set` is validated against the merged
+ * config (not the fragment) so cross-field and record-key constraints are
+ * enforced. On failure, throws a `BadRequestError` listing every invalid path
+ * and its issue and stating that nothing was written — the divergence would
+ * otherwise surface only at load time, where invalid leaves are silently
+ * stripped and the effective runtime config diverges from what was written.
+ */
+function assertMergedConfigValidForSet(raw: Record<string, unknown>): void {
+  const result = AssistantConfigSchema.safeParse(raw);
+  if (result.success) {
+    return;
+  }
+  const details = Array.from(
+    new Set(
+      result.error.issues.map((issue) => {
+        const path = issue.path.join(".");
+        return `${path.length > 0 ? path : "(root)"}: ${issue.message}`;
+      }),
+    ),
+  ).join("; ");
+  throw new BadRequestError(
+    `Rejected config write: the resulting configuration is invalid, so nothing was written. ${details}`,
+  );
+}
+
+/**
  * Direct path assignment - replaces `config_patch` for the `assistant
  * config set <key> <value>` CLI path.
  *
@@ -1104,11 +1180,15 @@ async function handlePatchConfig({ body }: RouteHandlerArgs) {
  * replaces) object subtrees. That's correct for partial updates (embedding
  * config, profile patches) but breaks single-key `set` semantics, where the
  * user expects:
- *   - `set heartbeat.activeHoursStart null` to persist explicit `null`
+ *   - `set memory.cleanup.llmRequestLogRetentionMs null` to persist explicit
+ *     `null` (a schema-nullable field)
  *   - `set llm {}` to replace `llm`, not merge into it
  *
- * `config_set` performs `setNestedValue` directly on the loaded raw config
- * (no merge), then runs the same post-write side effects as patch.
+ * `config_set` assigns `value` directly at `path` on the loaded raw config (no
+ * merge), validates the merged config against `AssistantConfigSchema`, and —
+ * only if valid — runs the same post-write side effects as patch. An invalid
+ * result is rejected before any file write. Clearing a key (`value` is `null`)
+ * follows `clearLeafForNullSet` so a cleared object entry validates as absent.
  */
 async function handleSetConfig({ body }: RouteHandlerArgs) {
   if (!body || typeof body !== "object" || Array.isArray(body)) {
@@ -1153,9 +1233,18 @@ async function handleSetConfig({ body }: RouteHandlerArgs) {
   rejectMcpTransportHeaderWrite(patchShape);
 
   const raw = loadRawConfig();
-  setNestedValue(raw, path, value);
+  if (value === null) {
+    clearLeafForNullSet(raw, path);
+  } else {
+    setNestedValue(raw, path, value);
+  }
 
-  await commitConfigWrite(raw, "set");
+  // `validateMergedSchema` rejects a write whose merged config fails the
+  // schema before anything is persisted. Invalid writes used to "succeed"
+  // here and only fail at load time, where the loader strips the bad leaves —
+  // leaving the effective runtime config diverging from what the caller (and
+  // the assistant that wrote it) believed was set.
+  await commitConfigWrite(raw, "set", { validateMergedSchema: true });
   return { ok: true };
 }
 

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1115,32 +1115,48 @@ async function handlePatchConfig({ body }: RouteHandlerArgs) {
  *   as absent, not as `null` (which `ProfileEntry` rejects).
  * - **Existing value is a scalar / null / array**: assign `null`, preserving
  *   nullable fields (e.g. `memory.cleanup.llmRequestLogRetentionMs`).
- * - **Key absent**: no-op — assigning `null` to a missing key would persist a
- *   spurious leaf.
+ * - **Key absent**: schema-directed. A sparse config file usually omits the
+ *   key even when the field is meaningful, so "absent" cannot uniformly mean
+ *   no-op: `set memory.cleanup.llmRequestLogRetentionMs null` against a
+ *   config that never wrote that path must still persist the explicit-null
+ *   override (null = "no limit"), or the effective value silently stays the
+ *   schema default. `getSchemaAtPath` decides: when the leaf schema accepts
+ *   `null` (a nullable field where null is a meaningful value), the path is
+ *   created and explicit `null` persisted — the merged-config validation then
+ *   has the final say, surfacing cross-field constraints as a rejection
+ *   instead of a silent no-op. When it rejects `null` or the path has no
+ *   object-shape schema (record entries like `llm.profiles.*` /
+ *   `llm.callSites.*`, where null means "delete"), clearing a nonexistent
+ *   entry stays a no-op.
  */
 function clearLeafForNullSet(raw: Record<string, unknown>, path: string): void {
   const keys = path.split(".");
-  let parent = raw;
+  let parent: Record<string, unknown> | null = raw;
   for (let i = 0; i < keys.length - 1; i++) {
-    const next = parent[keys[i]!];
+    const next: unknown = parent[keys[i]!];
     if (next == null || typeof next !== "object" || Array.isArray(next)) {
-      return;
+      parent = null;
+      break;
     }
     parent = next as Record<string, unknown>;
   }
   const leaf = keys[keys.length - 1]!;
-  if (!(leaf in parent)) {
+  if (parent != null && leaf in parent) {
+    const existing = parent[leaf];
+    if (
+      existing != null &&
+      typeof existing === "object" &&
+      !Array.isArray(existing)
+    ) {
+      delete parent[leaf];
+    } else {
+      parent[leaf] = null;
+    }
     return;
   }
-  const existing = parent[leaf];
-  if (
-    existing != null &&
-    typeof existing === "object" &&
-    !Array.isArray(existing)
-  ) {
-    delete parent[leaf];
-  } else {
-    parent[leaf] = null;
+  const leafSchema = getSchemaAtPath(AssistantConfigSchema, path);
+  if (leafSchema != null && leafSchema.safeParse(null).success) {
+    setNestedValue(raw, path, null);
   }
 }
 


### PR DESCRIPTION
## Bug

`assistant config set <path> <value>` (the `config_set` route) accepted values that fail `AssistantConfigSchema` and persisted them. In a real incident, writes such as a profile `source` set to a value outside the `managed | user` enum, a profile entry written as `null` (where the schema expects an object), and `llm.callSites` keys absent from the deployed `LLMCallSite` enum all "succeeded" at write time.

The divergence only surfaced at config **load** time, where the loader logs WARN lines nobody sees and silently strips the invalid leaves. The effective runtime config then differed from what the user — and the assistant that wrote it — believed was set, which hard-broke the assistant.

## Fix

Validate the whole merged post-write config against `AssistantConfigSchema` **before** persisting, in the set path:

- A partial-path write (e.g. `set llm.activeProfile balanced`) is validated against the **merged whole config**, not just the fragment, so cross-field and record-key constraints are enforced.
- On failure the write is **rejected**: no file change, an error response (400), and a message listing each invalid path and its issue (mirroring the loader's formatting, e.g. `llm.profiles.balanced.source: Invalid option: expected one of "managed"|"user"`) plus a note that nothing was written.
- Validation runs inside `commitConfigWrite` **after** the managed-profile invariant guard (so that guard's specific, actionable message still wins for a managed-profile write that is also schema-invalid) and **before** the file write. It is **opt-in per caller**; only the set path enables it, leaving other write paths' existing narrower validation unchanged.
- The load-time leaf-stripping fallback in `loader.ts` is left **unchanged** — it still protects against legacy / hand-edited / corrupt files.

### Null-deletion semantics

Clearing a key with `null` now mirrors `deepMergeOverwrite`'s null rules so deletions validate as absence:

- Existing value is an object → the key is **deleted** (e.g. `set llm.profiles.gemini-probe null` removes the entry, validating as absent rather than as an explicit `null` that `ProfileEntry` rejects).
- Existing value is a scalar / null / array → `null` is **assigned** (nullable fields like `memory.cleanup.llmRequestLogRetentionMs` keep working).
- Key absent → no-op (avoids persisting a spurious invalid `null` leaf).

## Behavioral-compatibility note

This is a **behavioral change**: `config set` writes that previously "succeeded" (and were silently stripped at load) now **fail with a 400** at write time. This is the intended fix — the old success was illusory — but it does change the contract for callers that relied on the silent-strip behavior. Existing on-disk invalid configs are unaffected until the next `config set`; the load-time repair path still cleans them.

## Testing

`assistant/src/__tests__/config-set-route.test.ts`:
- invalid enum value rejected, with the offending path and "nothing was written" in the message, and no disk write;
- unknown `llm.callSites` key rejected;
- valid scalar/nested writes still persist (existing coverage retained);
- partial-path write validates the merged whole config (rejects when an unrelated on-disk leaf is invalid);
- `null` on a nullable scalar persists `null`; `null` on an object profile entry deletes it and validates as absent.

Two pre-existing fixtures in that file carried schema-invalid data (heartbeat active-hours as strings; the schema expects numbers) and were corrected to valid values so the new whole-config validation passes.

Commands run (worktree):
- `bun test src/__tests__/config-set-route.test.ts src/__tests__/managed-profile-guard.test.ts src/__tests__/config-set-platform-guard.test.ts` → 76 pass
- `bun test src/__tests__/config-loader-corrupt.test.ts src/__tests__/config-loader-backfill.test.ts src/__tests__/config-get-vision-flag.test.ts src/__tests__/mcp-config-secret-boundary.test.ts` → all pass
- `bun run typecheck:fast` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->