### PR TITLE
fix(persistence): stop duplicating tool-result lines in transcript disk view

### DIFF
--- a/assistant/src/__tests__/conversation-toolresult-disk-dedup.test.ts
+++ b/assistant/src/__tests__/conversation-toolresult-disk-dedup.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Regression test: a turn with multiple parallel tool calls must project
+ * exactly one grouped tool-result line into the conversation disk view
+ * (`messages.jsonl`), carrying every result once.
+ *
+ * The grouped `user` row is reserved once per batch and rewritten in place in
+ * SQLite as sibling parallel results land. Because `syncMessageToDisk` appends
+ * to the append-only JSONL rather than upserting the row, projecting on every
+ * arrival emitted one duplicate line per result (N results -> N+1 identical
+ * lines). The disk-view projection is deferred to `finalizePendingToolResultRow`
+ * so the batch lands as a single line.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, mock, test } from "bun:test";
+
+// ── Mocks (must precede imports that read them) ──────────────────────────────
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+  LOG_FILE_PATTERN: /assistant-(\d{4}-\d{2}-\d{2})\.log/,
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    llm: { pricingOverrides: {} },
+    rateLimit: { maxRequestsPerMinute: 0 },
+  }),
+  loadConfig: () => ({}),
+}));
+
+// ── Imports (after mocks) ────────────────────────────────────────────────────
+import type { AgentEvent } from "../agent/loop.js";
+import type {
+  EventHandlerDeps,
+  EventHandlerState,
+} from "../daemon/conversation-agent-loop-handlers.js";
+import {
+  createEventHandlerState,
+  finalizePendingToolResultRow,
+  handleToolResult,
+} from "../daemon/conversation-agent-loop-handlers.js";
+import type { ServerMessage } from "../daemon/message-protocol.js";
+import { createConversation } from "../persistence/conversation-crud.js";
+import { getConversationDirPath } from "../persistence/conversation-disk-view.js";
+import { initializeDb } from "../persistence/db-init.js";
+
+await initializeDb();
+
+const noopLog = new Proxy({} as Record<string, unknown>, {
+  get: () => () => {},
+}) as unknown as EventHandlerDeps["rlog"];
+
+function createDeps(conversationId: string): EventHandlerDeps {
+  return {
+    ctx: {
+      conversationId,
+      provider: { name: "anthropic" },
+      traceEmitter: { emit: () => {} },
+      streamThinking: false,
+      emitActivityState: () => {},
+      markWorkspaceTopLevelDirty: () => {},
+      currentTurnSurfaces: [],
+    } as unknown as EventHandlerDeps["ctx"],
+    onEvent: (_msg: ServerMessage) => {},
+    reqId: "req-dedup",
+    isFirstMessage: false,
+    shouldGenerateTitle: false,
+    rlog: noopLog,
+    turnChannelContext: {
+      userMessageChannel: "vellum",
+      assistantMessageChannel: "vellum",
+    } as EventHandlerDeps["turnChannelContext"],
+    turnInterfaceContext: {
+      userMessageInterface: "macos",
+      assistantMessageInterface: "macos",
+    } as EventHandlerDeps["turnInterfaceContext"],
+    applyCompaction: async () => {},
+  } as EventHandlerDeps;
+}
+
+function toolResultEvent(
+  toolUseId: string,
+  content: string,
+): Extract<AgentEvent, { type: "tool_result" }> {
+  return { type: "tool_result", toolUseId, content, isError: false };
+}
+
+describe("parallel tool results → disk view", () => {
+  test("projects one grouped JSONL line holding every result exactly once", async () => {
+    const conv = createConversation("Parallel Tools");
+    const deps = createDeps(conv.id);
+    const state: EventHandlerState = createEventHandlerState();
+
+    // Simulate three parallel tool results arriving for one assistant turn.
+    // Each arrival persists the shared grouped row on arrival (DB-only).
+    await handleToolResult(state, deps, toolResultEvent("toolu_a", "result A"));
+    await handleToolResult(state, deps, toolResultEvent("toolu_b", "result B"));
+    await handleToolResult(state, deps, toolResultEvent("toolu_c", "result C"));
+
+    // Turn boundary: drain the buffer and project the completed row to disk.
+    await finalizePendingToolResultRow(
+      state,
+      conv.id,
+      { provenanceTrustClass: "unknown" },
+      noopLog,
+    );
+
+    const jsonlPath = join(
+      getConversationDirPath(conv.id, conv.createdAt),
+      "messages.jsonl",
+    );
+    const lines = readFileSync(jsonlPath, "utf-8")
+      .trim()
+      .split("\n")
+      .filter((line) => line.length > 0);
+
+    // Exactly one grouped tool-result line — not N+1 duplicates.
+    expect(lines).toHaveLength(1);
+
+    const record = JSON.parse(lines[0]) as {
+      role: string;
+      toolResults?: Array<{ content: unknown }>;
+    };
+    expect(record.role).toBe("user");
+    expect(record.toolResults).toHaveLength(3);
+    expect(record.toolResults?.map((r) => r.content)).toEqual([
+      "result A",
+      "result B",
+      "result C",
+    ]);
+  });
+});

--- a/assistant/src/__tests__/workspace-migration-028-recover-conversations-from-disk-view.test.ts
+++ b/assistant/src/__tests__/workspace-migration-028-recover-conversations-from-disk-view.test.ts
@@ -237,6 +237,54 @@ describe("028-recover-conversations-from-disk-view migration", () => {
     expect(typeof contentBlocks[1].id).toBe("string");
   });
 
+  test("collapses consecutive byte-identical lines from legacy duplicated transcripts", () => {
+    const id = "conv-028-dupes";
+    const createdAt = "2026-03-18T16:00:00.000Z";
+
+    // A grouped tool-result row projected once per parallel result by an older
+    // build: adjacent lines share an identical `ts` and content.
+    const toolResultLine = JSON.stringify({
+      role: "user",
+      ts: "2026-03-18T16:00:20.000Z",
+      toolResults: [{ content: "result A" }, { content: "result B" }],
+    });
+    const assistantLine = JSON.stringify({
+      role: "assistant",
+      ts: "2026-03-18T16:00:30.000Z",
+      content: "done",
+    });
+
+    createDiskViewDir(
+      id,
+      {
+        id,
+        title: "Duplicated Transcript",
+        type: "standard",
+        createdAt,
+        updatedAt: createdAt,
+      },
+      [toolResultLine, toolResultLine, toolResultLine, assistantLine].join(
+        "\n",
+      ) + "\n",
+    );
+
+    recoverConversationsFromDiskViewMigration.run(workspaceDir);
+
+    const db = getDb();
+    const msgRows = db.select().from(messages).all();
+    // The three identical tool-result lines collapse to one row.
+    expect(msgRows).toHaveLength(2);
+
+    const userMsgs = msgRows.filter((m) => m.role === "user");
+    expect(userMsgs).toHaveLength(1);
+    const userContent = JSON.parse(userMsgs[0].content);
+    expect(userContent).toHaveLength(2);
+    expect(userContent.map((b: { content: unknown }) => b.content)).toEqual([
+      "result A",
+      "result B",
+    ]);
+  });
+
   test("skips existing conversations", () => {
     const id = "conv-028-existing";
     const createdAt = "2026-03-18T16:00:00.000Z";

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -1252,7 +1252,15 @@ function ensureToolResultRowReserved(
  * `tool_result` blocks of one turn in a single message. `seq` is the position
  * stamped on the triggering `tool_result` event, captured by the caller before
  * any await so it reflects exactly the content now durable in the row.
- * Indexing and the buffer drain are deferred to `finalizePendingToolResultRow`.
+ *
+ * On-arrival work is DB-only: durability comes from rewriting the reserved
+ * SQLite row in place. The JSONL disk-view projection, memory indexing, and the
+ * buffer drain are all deferred to `finalizePendingToolResultRow`, which runs
+ * once per batch. `syncMessageToDisk` appends a line rather than upserting the
+ * row, so projecting on every parallel arrival would emit one duplicate JSONL
+ * line per result; syncing a single time at finalize keeps the disk view at
+ * exactly one line per batch, mirroring how the assistant row is synced once
+ * after the loop.
  */
 async function persistPendingToolResultRow(
   state: EventHandlerState,
@@ -1277,10 +1285,6 @@ async function persistPendingToolResultRow(
   );
   if (persisted) {
     recordConversationPersistedSeq(deps.ctx.conversationId, seq);
-  }
-  const conv = getConversation(deps.ctx.conversationId);
-  if (conv != null) {
-    syncMessageToDisk(deps.ctx.conversationId, rowId, conv.createdAt);
   }
 }
 

--- a/assistant/src/workspace/migrations/028-recover-conversations-from-disk-view.ts
+++ b/assistant/src/workspace/migrations/028-recover-conversations-from-disk-view.ts
@@ -175,9 +175,22 @@ export const recoverConversationsFromDiskViewMigration: WorkspaceMigration = {
       if (existsSync(messagesPath)) {
         try {
           const raw = readFileSync(messagesPath, "utf-8");
+          // Collapse consecutive byte-identical lines. Transcripts written by
+          // older builds can carry a grouped tool-result row projected once per
+          // parallel result (same `ts` and content on adjacent lines); replaying
+          // those as-is would insert duplicate `messages` rows that then inflate
+          // model context. A run of identical lines always denotes one logical
+          // message, so keeping the first is safe.
+          let previousTrimmed: string | undefined;
           for (const line of raw.split("\n")) {
             const trimmed = line.trim();
-            if (!trimmed) continue;
+            if (!trimmed) {
+              continue;
+            }
+            if (trimmed === previousTrimmed) {
+              continue;
+            }
+            previousTrimmed = trimmed;
             try {
               messageRecords.push(JSON.parse(trimmed) as DiskMessageRecord);
             } catch {


### PR DESCRIPTION
## Summary

Fixes duplicated tool-result messages in persisted conversation transcripts (`$VELLUM_WORKSPACE_DIR/conversations/<ts>_<id>/messages.jsonl`), observed as 3–4 identical consecutive `user` tool-result lines (same `ts` and content) after a turn with parallel tool calls, surfaced via the platform log-export flow.

## Root cause (Hypothesis A confirmed)

The SQLite row is single and correct. A turn with N parallel tool calls reserves **one** grouped `user` tool-result row and rewrites it in place as sibling results land (`persistPendingToolResultRow`). But that on-arrival path *also* called `syncMessageToDisk`, which does a blind `appendFileSync` to the append-only `messages.jsonl`. So it appended one line per parallel arrival, plus one more at `finalizePendingToolResultRow` — **N+1 identical consecutive lines** (3 tools → 4 lines, 2 tools → 3 lines, matching the report exactly). The assistant row never duplicated because it projects to disk exactly once after the loop.

- **Not the export** (Hypothesis B false): the log-export route faithfully copies the workspace file; it does not introduce the duplication.
- **Not merge/consolidation** (Hypothesis C false): consolidation goes through `rebuildConversationDiskViewFromDbState`, which rewrites the whole file from DB.

## Blast radius — does it inflate model context?

**No, not on the live path.** Model context on resume/compaction is built from the DB via `getMessages()`, and the DB row is single and correct — the agent loop was never token-bloated. The duplication was a **write-side disk-artifact defect**: it bloated the browsable disk view and the diagnostic export bundle, and made transcripts confusing to read.

Secondary readers of `messages.jsonl`:
- **Memory graph extraction** (`loadTranscriptFromDisk`) skips lines without a `content` field; grouped tool-result lines have only `toolResults`, so duplicates were already filtered out there.
- **Disaster-recovery migration 028** (`028-recover-conversations-from-disk-view`) is the *one* path where duplicated JSONL could reach the DB — it re-inserts transcripts from disk when a conversation is missing from SQLite. On an already-duplicated transcript this would create duplicate `messages` rows that then *would* reach model context.

## Fix

1. **Write-side root fix** — defer the grouped tool-result row's disk projection to `finalizePendingToolResultRow` (which runs once per batch and already drains the buffer + indexes). On-arrival work stays DB-only, which is what actually backs refresh/replay durability. This mirrors how the assistant row is synced a single time after the loop, so the batch now lands as exactly one JSONL line.
2. **Compat for existing duplicated transcripts** — migration 028 now collapses consecutive byte-identical lines before re-inserting, so users who already have duplicated transcripts on disk don't propagate duplicate rows (and thus model-context bloat) if recovery ever runs.

## Backwards compatibility

- Schema unchanged — no migration needed for the write-side fix.
- Existing already-duplicated `messages.jsonl` files remain on disk and are tolerated by all readers (memory extraction skips them; recovery now dedupes them). They are rewritten cleanly whenever `rebuildConversationDiskViewFromDbState` runs.

## Tests

- `conversation-toolresult-disk-dedup.test.ts` (new) — drives the real handlers + real DB + real disk view: three parallel `handleToolResult` calls + `finalizePendingToolResultRow`, asserts `messages.jsonl` has **exactly one** line holding all three results. Verified it fails on base (`Received length: 4`) and passes with the fix.
- `workspace-migration-028-...test.ts` (new case) — three identical tool-result lines collapse to one recovered row.
- Typecheck: `bun run typecheck:fast` clean. Prettier/lint clean (2 pre-existing `curly` warnings on untouched lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->