### PR TITLE
fix(usage): attribute usage to the profile a PRE_MODEL_CALL hook actually routed to

### DIFF
--- a/assistant/src/__tests__/agent-loop-output-hooks.test.ts
+++ b/assistant/src/__tests__/agent-loop-output-hooks.test.ts
@@ -34,6 +34,18 @@ function collect(events: AgentEvent[]): (event: AgentEvent) => void {
   return (event) => events.push(event);
 }
 
+function usageEvent(
+  events: AgentEvent[],
+): Extract<AgentEvent, { type: "usage" }> {
+  const usage = events.find(
+    (e): e is Extract<AgentEvent, { type: "usage" }> => e.type === "usage",
+  );
+  if (!usage) {
+    throw new Error("no usage event emitted");
+  }
+  return usage;
+}
+
 function streamedText(events: AgentEvent[]): string {
   return events
     .filter(
@@ -423,6 +435,92 @@ describe("agent loop output hooks", () => {
     expect(seeded).toBe("seed-profile");
     // AND clearing it sends no override on the provider call
     expect(calls[0].options?.config?.overrideProfile).toBeUndefined();
+  });
+
+  test("usage event reports the hook's routed profile as the applied override", async () => {
+    // GIVEN a hook that routes the user-facing call to a different profile
+    registerOutputHookPlugin({
+      preModelCall: (ctx) => {
+        if (ctx.callSite !== "mainAgent") return;
+        ctx.modelProfile = "quality-profile";
+      },
+    });
+    const { provider } = createMockProvider([textResponse("hi")]);
+    const loop = new AgentLoop({
+      provider: provider,
+      systemPrompt: "system",
+      conversationId: "test-conversation",
+    });
+
+    // WHEN the loop runs (no turn-level override — the hook is the only source)
+    const events: AgentEvent[] = [];
+    await loop.run({
+      requestId: "test-request",
+      messages: [userMessage],
+      onEvent: collect(events),
+      callSite: "mainAgent",
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+    });
+
+    // THEN the usage event credits the hook's profile so downstream
+    // attribution records what actually ran, not the pre-hook (default) profile
+    const usage = usageEvent(events);
+    expect(usage.appliedOverrideProfile).toBe("quality-profile");
+    expect(usage.appliedForceOverrideProfile).toBe(false);
+  });
+
+  test("usage event reports the turn override when no hook re-routes the call", async () => {
+    // GIVEN a turn-level override and no hook mutation
+    registerOutputHookPlugin({ preModelCall: () => {} });
+    const { provider } = createMockProvider([textResponse("hi")]);
+    const loop = new AgentLoop({
+      provider: provider,
+      systemPrompt: "system",
+      conversationId: "test-conversation",
+    });
+
+    // WHEN the loop runs with an ad-hoc override profile
+    const events: AgentEvent[] = [];
+    await loop.run({
+      requestId: "test-request",
+      messages: [userMessage],
+      onEvent: collect(events),
+      callSite: "mainAgent",
+      overrideProfile: "pinned-profile",
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+    });
+
+    // THEN the usage event carries the turn override
+    expect(usageEvent(events).appliedOverrideProfile).toBe("pinned-profile");
+  });
+
+  test("usage event reports no applied override when the hook clears the seeded one", async () => {
+    // GIVEN a hook that clears the loop's seeded override
+    registerOutputHookPlugin({
+      preModelCall: (ctx) => {
+        ctx.modelProfile = null;
+      },
+    });
+    const { provider } = createMockProvider([textResponse("hi")]);
+    const loop = new AgentLoop({
+      provider: provider,
+      systemPrompt: "system",
+      conversationId: "test-conversation",
+    });
+
+    // WHEN the loop runs with an ad-hoc override the hook then clears
+    const events: AgentEvent[] = [];
+    await loop.run({
+      requestId: "test-request",
+      messages: [userMessage],
+      onEvent: collect(events),
+      callSite: "mainAgent",
+      overrideProfile: "seed-profile",
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+    });
+
+    // THEN the usage event records no override, matching the cleared request
+    expect(usageEvent(events).appliedOverrideProfile).toBeNull();
   });
 
   // Context-window sizing and overflow recovery read the profile resolved

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -363,6 +363,19 @@ export type AgentEvent =
        * for this call (e.g. legacy/stubbed code paths).
        */
       estimatedInputTokens?: number;
+      /**
+       * The inference-profile override actually applied to this call — the
+       * turn-level override, or the `PRE_MODEL_CALL` hook's per-message
+       * `modelProfile` when a model router seeded one. Null when no override
+       * was in effect. Usage attribution credits this so `llm_usage` rows
+       * report the profile that determined the request, not the pre-hook one.
+       */
+      appliedOverrideProfile?: string | null;
+      /**
+       * Whether `appliedOverrideProfile` was floated above the call-site
+       * profile for this call (mirrors the resolver's `forceOverrideProfile`).
+       */
+      appliedForceOverrideProfile?: boolean;
     }
   | {
       /**
@@ -1490,10 +1503,18 @@ export class AgentLoop {
         // share an `AgentLoop` instance but ought to inherit a different
         // profile correct — and matches how `callSite` is plumbed.
         const effectiveOverrideProfile = resolveEffectiveOverrideProfile();
+        // Tracks the override that actually determines this request so usage
+        // attribution can credit it. Seeded from the turn-level override and
+        // updated below if the `PRE_MODEL_CALL` hook routes to a different
+        // profile.
+        let appliedOverrideProfile: string | null =
+          effectiveOverrideProfile ?? null;
+        let appliedForceOverrideProfile = false;
         if (effectiveOverrideProfile) {
           providerConfig.overrideProfile = effectiveOverrideProfile;
           if (forceOverrideProfile) {
             providerConfig.forceOverrideProfile = true;
+            appliedForceOverrideProfile = true;
           }
         }
 
@@ -1683,12 +1704,16 @@ export class AgentLoop {
           const hookModelProfile = finalPreModelCtx.modelProfile?.trim();
           if (hookModelProfile) {
             providerConfig.overrideProfile = hookModelProfile;
+            appliedOverrideProfile = hookModelProfile;
             if (forceOverrideProfile) {
               providerConfig.forceOverrideProfile = true;
+              appliedForceOverrideProfile = true;
             }
           } else {
             delete providerConfig.overrideProfile;
             delete providerConfig.forceOverrideProfile;
+            appliedOverrideProfile = null;
+            appliedForceOverrideProfile = false;
           }
           // The hook owns the policy (it sees `callSite`/conversation and
           // self-gates); the loop honors whatever it decides.
@@ -1782,6 +1807,8 @@ export class AgentLoop {
           rawRequest: response.rawRequest,
           rawResponse: response.rawResponse,
           estimatedInputTokens: preSendEstimatedTokens,
+          appliedOverrideProfile,
+          appliedForceOverrideProfile,
         });
 
         // Flush any buffered streaming text from the substitution pipeline

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -168,6 +168,15 @@ export interface EventHandlerState {
   exchangeLlmCallCount: number;
   readonly exchangeRawResponses: unknown[];
   model: string;
+  /**
+   * Inference-profile override actually applied to the most recent LLM API
+   * call (overwritten, not accumulated — mirrors `model`), including any
+   * `PRE_MODEL_CALL` hook selection. Null when no override was in effect.
+   * Feeds usage attribution so the persisted profile matches what ran.
+   */
+  appliedOverrideProfile: string | null;
+  /** Whether `appliedOverrideProfile` was force-floated for the most recent call. */
+  appliedForceOverrideProfile: boolean;
   providerErrorUserMessage: string | null;
   persistProviderErrorAsAssistantMessage: boolean;
   lastAssistantMessageId: string | undefined;
@@ -383,6 +392,8 @@ export function createEventHandlerState(): EventHandlerState {
     exchangeLlmCallCount: 0,
     exchangeRawResponses: [],
     model: "",
+    appliedOverrideProfile: null,
+    appliedForceOverrideProfile: false,
     providerErrorUserMessage: null,
     persistProviderErrorAsAssistantMessage: false,
     lastAssistantMessageId: undefined,
@@ -2214,6 +2225,9 @@ function handleUsage(
   state.exchangeCacheReadInputTokens += event.cacheReadInputTokens ?? 0;
   state.exchangeOutputTokens += event.outputTokens;
   state.model = event.model;
+  state.appliedOverrideProfile = event.appliedOverrideProfile ?? null;
+  state.appliedForceOverrideProfile =
+    event.appliedForceOverrideProfile ?? false;
 
   // Feed the self-calibration loop: compare the pre-send estimate to the
   // provider's ground-truth inputTokens. `recordEstimate` silently ignores

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1363,7 +1363,14 @@ export async function runAgentLoopImpl(
       },
       {
         callSite: turnCallSite,
-        overrideProfile: resolveCurrentOverrideProfile() ?? null,
+        // Attribute to the override actually applied to the turn's calls
+        // (including a `PRE_MODEL_CALL` hook's per-message routing), not the
+        // turn-level override — otherwise `llm_usage` reports the pre-hook
+        // profile while the request ran on the hook's. Mirrors `state.model`:
+        // last-call wins for the aggregated exchange row.
+        overrideProfile: state.appliedOverrideProfile,
+        forceOverrideProfile: state.appliedForceOverrideProfile,
+        selectionSeed: ctx.conversationId,
       },
       turnCronRunId,
     );
@@ -1653,6 +1660,8 @@ function emitUsage(
   attribution?: {
     callSite: LLMCallSite | null;
     overrideProfile?: string | null;
+    forceOverrideProfile?: boolean;
+    selectionSeed?: string;
   },
   cronRunId: string | null = null,
 ): void {

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -2520,6 +2520,92 @@ describe("wakeAgentForOpportunity", () => {
     });
   });
 
+  test("wake records the hook-applied profile from the usage event, not the pre-run override", async () => {
+    // The loop stamps the override applied at send time onto the usage event
+    // (a PRE_MODEL_CALL hook can route the call to a different profile after
+    // the wake resolves its pre-run override). Attribution must credit the
+    // event's applied profile so the usage row matches what actually ran.
+    const usageEvent: AgentEvent = {
+      type: "usage",
+      inputTokens: 100,
+      outputTokens: 5,
+      model: "test-model",
+      actualProvider: "test-provider",
+      providerDurationMs: 10,
+      rawRequest: { request: "hook-routed wake" },
+      rawResponse: { response: "real reply" },
+      appliedOverrideProfile: "hook-routed-profile",
+      appliedForceOverrideProfile: false,
+    };
+    const conversation = makeWakeConversation({
+      baseline: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      scriptedEvents: [usageEvent],
+      scriptedAssistant: {
+        role: "assistant",
+        content: [{ type: "text", text: "real reply" }],
+      },
+    });
+
+    await wakeAgentForOpportunity(
+      {
+        conversationId: conversation.conversationId,
+        hint: "do reply",
+        source: "unit-test",
+        callSite: "memoryRetrospective",
+        // The wake's pre-run override — superseded by the hook's routing.
+        forceOverrideProfile: "source-profile",
+      },
+      { resolveTarget: async () => conversation },
+    );
+
+    expect(recordUsageCalls).toHaveLength(1);
+    expect(recordUsageCalls[0]).toMatchObject({
+      overrideProfile: "hook-routed-profile",
+      forceOverrideProfile: false,
+      selectionSeed: conversation.conversationId,
+    });
+  });
+
+  test("wake records a null applied override when the hook cleared the pre-run one", async () => {
+    const usageEvent: AgentEvent = {
+      type: "usage",
+      inputTokens: 100,
+      outputTokens: 5,
+      model: "test-model",
+      actualProvider: "test-provider",
+      providerDurationMs: 10,
+      rawRequest: { request: "hook-cleared wake" },
+      rawResponse: { response: "real reply" },
+      appliedOverrideProfile: null,
+      appliedForceOverrideProfile: false,
+    };
+    const conversation = makeWakeConversation({
+      baseline: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      scriptedEvents: [usageEvent],
+      scriptedAssistant: {
+        role: "assistant",
+        content: [{ type: "text", text: "real reply" }],
+      },
+    });
+
+    await wakeAgentForOpportunity(
+      {
+        conversationId: conversation.conversationId,
+        hint: "do reply",
+        source: "unit-test",
+        callSite: "memoryRetrospective",
+        forceOverrideProfile: "source-profile",
+      },
+      { resolveTarget: async () => conversation },
+    );
+
+    expect(recordUsageCalls).toHaveLength(1);
+    expect(recordUsageCalls[0]).toMatchObject({
+      overrideProfile: null,
+      forceOverrideProfile: false,
+    });
+  });
+
   test("silent no-op wake still records usage even though its request log is dropped", async () => {
     const usageEvent: AgentEvent = {
       type: "usage",

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -987,16 +987,22 @@ export async function wakeAgentForOpportunity(
             event.rawResponse,
             1,
             undefined,
-            // Mirror the profile state the request actually ran under:
-            // `forceOverrideProfile` floats the override above the call-site
-            // profile (fork retrospectives with matchConversationProfile), and
-            // the conversation-id seed resolves the same mix arm the dispatch
-            // path chose. Without these, attribution credits the call-site
-            // profile/arm instead of the one that ran.
+            // Mirror the profile state the request actually ran under. The
+            // loop stamps the override applied at send time onto the usage
+            // event — the wake's pinned override (fork retrospectives with
+            // matchConversationProfile keep their forced float) or a
+            // `PRE_MODEL_CALL` hook's per-message routing, null when the hook
+            // cleared it. The conversation-id seed resolves the same mix arm
+            // the dispatch path chose. Falling back to the wake's pre-run
+            // values covers usage events that don't carry the applied fields.
             {
               callSite,
-              overrideProfile: overrideProfile ?? null,
-              forceOverrideProfile,
+              overrideProfile:
+                event.appliedOverrideProfile !== undefined
+                  ? event.appliedOverrideProfile
+                  : (overrideProfile ?? null),
+              forceOverrideProfile:
+                event.appliedForceOverrideProfile ?? forceOverrideProfile,
               selectionSeed: conversationId,
             },
             opts.cronRunId ?? null,

--- a/assistant/src/usage/attribution.ts
+++ b/assistant/src/usage/attribution.ts
@@ -173,6 +173,10 @@ function resolveAppliedProfile(input: {
       input.overrideProfile != null &&
       input.profiles[input.overrideProfile] != null
     ) {
+      // "conversation" covers any per-request override floated above the
+      // active profile — a conversation-scoped selection or a `PRE_MODEL_CALL`
+      // hook's per-message routing. Both reach here through `overrideProfile`,
+      // so the source is the same.
       return {
         appliedProfile: input.overrideProfile,
         profileSource: "conversation",


### PR DESCRIPTION
## The bug

The `PRE_MODEL_CALL` plugin hook can set `modelProfile`, which the agent loop writes to `providerConfig.overrideProfile` so a model router can pick the inference profile per message. The provider request correctly honored the hook's profile — but the per-turn `llm_usage` row attributed usage to the **turn-level override the orchestrator resolved before the hook ran**.

Result: a cost-sensitive setup whose router routed some messages to a quality profile (and others to a cheap one) was billed for what actually ran, while its `llm_usage` rows — and therefore its cost dashboard — reported the pre-hook profile (`inference_profile: "balanced"` / source `"active"`). The dashboard contradicted the bill.

## Where the override was being lost

- The agent loop applies the hook's profile to `providerConfig.overrideProfile` right before the provider call, and emits a per-call `usage` event carrying the **actual** model/provider. That event never surfaced the override that determined the request.
- The daemon orchestrator's `emitUsage` built its attribution input from `resolveCurrentOverrideProfile()` — the turn-level (pre-hook) override — so `resolveUsageAttribution` recomputed `inferenceProfile` / `inferenceProfileSource` (and would recompute provider/model) from the wrong profile.

## The fix

Thread the effective per-call override from the point it is applied through to attribution:

1. Add `appliedOverrideProfile` / `appliedForceOverrideProfile` to the loop's `usage` event, sourced from the override in effect at send time (turn-level or the hook's selection, or `null` when the hook clears it).
2. Capture them into the event-handler state in `handleUsage` (last-call-wins, mirroring how `state.model` already tracks the actual model for the aggregated exchange row).
3. `emitUsage` passes the captured override (plus `selectionSeed` for mix-arm resolution) into `recordUsage`'s attribution input, so `resolveUsageAttribution` resolves `inferenceProfile`, `inferenceProfileSource`, `provider`, and `model` from the profile that actually ran.

Runtime model selection is unchanged — this is an attribution/reporting-only fix.

### On `profileSource`

A hook-driven override reuses the existing `"conversation"` source value. A hook override and a conversation-scoped override both reach attribution through the same `overrideProfile` field, so they share a source. The `inference_profile_source` column is unconstrained `TEXT` with no validating enum (confirmed across the repo), so a new value would be safe to add — but reusing the existing one keeps the change additive for any platform-side consumer and avoids a speculative enum value. Documented inline in `attribution.ts`.

## Testing

- New regression tests in `agent-loop-output-hooks.test.ts` assert the loop's `usage` event reports the hook's routed profile as the applied override, carries the turn override when no hook re-routes, and reports `null` when the hook clears the seeded override.
- `bun test` passes per-file for the touched/adjacent suites: `agent-loop-output-hooks` (22 pass), `usage-attribution` (8), `conversation-usage` (6), `conversation-agent-loop-inference-profile` (8), `conversation-agent-loop-handlers-max-tokens` (1), `retry-callsite` + `conversation-agent-loop` (98).
- `typecheck:fast`: 0 errors. Lint: 0 errors on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->