### PR TITLE
feat(plugins): add astrology-horoscope to the marketplace

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -160,6 +160,18 @@
       "category": "creative",
       "homepage": "https://github.com/vellum-ai/motion-design",
       "license": "MIT"
+    },
+    {
+      "name": "astrology-horoscope",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/astrology-horoscope",
+        "ref": "2ea2839ccad14ec502f7754331051cace09a5a08"
+      },
+      "description": "Western tropical natal chart and transit computation. Local ephemeris (astronomy-engine, no API keys) for planet positions, ascendant/midheaven, whole-sign houses, and aspects, plus a natal-reading skill that interprets the raw chart into a readable report.",
+      "category": "hobby",
+      "homepage": "https://github.com/vellum-ai/astrology-horoscope",
+      "license": "MIT"
     }
   ]
 }

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -166,7 +166,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/astrology-horoscope",
-        "ref": "2ea2839ccad14ec502f7754331051cace09a5a08"
+        "ref": "d226ce2e0a021e12cbf89ca7313f7c76a0bd8e39"
       },
       "description": "Western tropical natal chart and transit computation. Local ephemeris (astronomy-engine, no API keys) for planet positions, ascendant/midheaven, whole-sign houses, and aspects, plus a natal-reading skill that interprets the raw chart into a readable report.",
       "category": "hobby",


### PR DESCRIPTION
## What

Registers the **astrology-horoscope** plugin in `plugins/marketplace.json`, pinned to [`vellum-ai/astrology-horoscope@2ea2839`](https://github.com/vellum-ai/astrology-horoscope/commit/2ea2839ccad14ec502f7754331051cace09a5a08).

Western tropical natal chart and transit computation for the Vellum assistant. All computation is local via [astronomy-engine](https://github.com/cosinekitty/astronomy) (VSOP87 model, ±1 arcminute) — **no API keys, no network calls**.

- `natal_chart` tool — planet positions, ascendant/midheaven, whole-sign houses, and major aspects from birth date/time/location
- `transits` tool — current transit positions and transit-to-natal aspects
- `natal-reading` skill — interprets the raw chart data into a human-readable reading

## Shape

Follows the standard marketplace pattern (external repo + SHA-pinned entry). Plugin source lives in its own repo `vellum-ai/astrology-horoscope`; this PR only adds the `marketplace.json` entry. Category `hobby`, license MIT.

## Review focus (risk: low)

- Confirm the pinned SHA / repo owner are what the team wants for a first-party plugin.
- The plugin's `tools/natal_chart.ts` has some leftover stream-of-consciousness comments and a duplicated timezone-offset computation — non-blocking for the marketplace entry, but worth a cleanup in the source repo before wide adoption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)