### PR TITLE
feat(web): presence-only Slack channel list in the Slack sub-tab

### DIFF
--- a/clients/web/docs/BACKWARDS_COMPAT.md
+++ b/clients/web/docs/BACKWARDS_COMPAT.md
@@ -124,6 +124,7 @@ Each module owns one feature's old/new split. Current registry:
 | `conversation-processing-state.ts` | `0.8.8` | Client-side optimistic mirror (`processingConversationIds`), cleared manually on terminal events | Trust the server `isProcessing` flag on the conversation row |
 | `llm-context-summary-view.ts` | `0.8.12` | Inline context sections from the list response | `view=summary` light list + lazy per-log detail via `GET /v1/llm-request-logs/:id/context` |
 | `vision-attachment-gate.ts` | `0.10.0-dev.202606211252.5cf8576` | Client filters images out for non-vision models | Allow any file type; the image-fallback plugin filters/captions server-side |
+| `slack-channel-list.ts` | `0.10.7` | Slack sub-tab shows only connection state + thread controls; no channels query | Presence channel list below the thread controls, fed by `GET /v1/slack/channels?memberOnly=true` |
 
 When you delete a row here, also delete its module, its test, and the now-dead
 legacy branch at the call site.

--- a/clients/web/src/domains/contacts/components/assistant-channels-list.stories.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-list.stories.tsx
@@ -78,6 +78,38 @@ export const ChannelsTabSlackConnected: Story = {
     onSlackThreadModeChange: () => {},
     channelPolicies: { slack: "trusted_contacts" },
     onChannelPolicyChange: () => {},
+    slackChannels: [
+      {
+        id: "C001",
+        name: "general",
+        type: "channel",
+        isPrivate: false,
+        isMember: true,
+        memberCount: 42,
+        topic: null,
+        imageUrl: null,
+      },
+      {
+        id: "C002",
+        name: "leadership",
+        type: "channel",
+        isPrivate: true,
+        isMember: true,
+        memberCount: 4,
+        topic: null,
+        imageUrl: null,
+      },
+      {
+        id: "D001",
+        name: "Alice",
+        type: "dm",
+        isPrivate: true,
+        isMember: true,
+        memberCount: null,
+        topic: null,
+        imageUrl: null,
+      },
+    ],
   },
 };
 

--- a/clients/web/src/domains/contacts/components/assistant-channels-list.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-list.tsx
@@ -13,8 +13,9 @@ import { Typography } from "@vellumai/design-library/components/typography";
 import { EmptyState } from "@/components/empty-state";
 import { assistantDisplayName as toAssistantDisplayName } from "@/domains/contacts/assistant-display-name";
 import { SlackChannelCard } from "@/domains/contacts/components/slack-channel-card";
+import { SlackChannelList } from "@/domains/contacts/components/slack-channel-list";
 import { SlackSetupWizard, type SlackThreadMode, type MutationStatus } from "@/components/slack-setup-wizard";
-import type { AssistantChannelState, SetupChannelId } from "@/domains/contacts/types";
+import type { AssistantChannelState, SetupChannelId, SlackChannel } from "@/domains/contacts/types";
 import {
   ADMISSION_POLICY_DEFAULT,
   ADMISSION_POLICY_VALUES,
@@ -67,6 +68,10 @@ export interface AssistantChannelsListProps {
   pendingChannelKey?: ChannelKey | null;
   slackThreadMode?: SlackThreadMode;
   slackThreadModePending?: boolean;
+  /** Member-only Slack channel list for the Slack sub-tab's presence list. */
+  slackChannels?: SlackChannel[];
+  slackChannelsLoading?: boolean;
+  slackChannelsError?: boolean;
   /**
    * Per-channel admission floor, keyed by channel. Omit (or pass no
    * `onChannelPolicyChange`) to hide the trust-floor control entirely — used
@@ -140,6 +145,9 @@ export function AssistantChannelsList({
   pendingChannelKey = null,
   slackThreadMode,
   slackThreadModePending = false,
+  slackChannels,
+  slackChannelsLoading = false,
+  slackChannelsError = false,
   channelPolicies,
   policySavingKey = null,
   policiesLoading = false,
@@ -249,6 +257,9 @@ export function AssistantChannelsList({
                 slackThreadMode={slackThreadMode}
                 slackThreadModePending={slackThreadModePending}
                 onSlackThreadModeChange={onSlackThreadModeChange}
+                slackChannels={slackChannels}
+                slackChannelsLoading={slackChannelsLoading}
+                slackChannelsError={slackChannelsError}
                 onSaveTwilioCredentials={onSaveTwilioCredentials}
                 policy={channelPolicies?.[channel.key]}
                 policySaving={policySavingKey === channel.key}
@@ -376,6 +387,9 @@ interface ChannelPanelProps {
   slackThreadMode?: SlackThreadMode;
   slackThreadModePending?: boolean;
   onSlackThreadModeChange?: (mode: SlackThreadMode) => void;
+  slackChannels?: SlackChannel[];
+  slackChannelsLoading?: boolean;
+  slackChannelsError?: boolean;
   onSaveTwilioCredentials?: (accountSid: string, authToken: string) => Promise<void>;
   policy?: AdmissionPolicy;
   policySaving?: boolean;
@@ -399,6 +413,9 @@ function ChannelPanel({
   slackThreadMode,
   slackThreadModePending = false,
   onSlackThreadModeChange,
+  slackChannels,
+  slackChannelsLoading = false,
+  slackChannelsError = false,
   onSaveTwilioCredentials,
   policy,
   policySaving = false,
@@ -498,6 +515,16 @@ function ChannelPanel({
             onThreadModeChange={onSlackThreadModeChange}
           />
         </SlackChannelCard>
+      ) : null}
+
+      {channel.key === "slack" && connected ? (
+        <SlackChannelList
+          assistantDisplayName={assistantDisplayName}
+          slackHandle={channel.address}
+          channels={slackChannels}
+          loading={slackChannelsLoading}
+          error={slackChannelsError}
+        />
       ) : null}
 
       {channel.key === "phone" && showCredentialForm ? (

--- a/clients/web/src/domains/contacts/components/assistant-channels-list.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-list.tsx
@@ -73,6 +73,12 @@ export interface AssistantChannelsListProps {
   slackChannelsLoading?: boolean;
   slackChannelsError?: boolean;
   /**
+   * Whether the connected assistant serves the channel-list endpoint
+   * (backwards-compat gate). `false` hides the list entirely — the
+   * pre-feature Slack sub-tab layout.
+   */
+  slackChannelsSupported?: boolean;
+  /**
    * Per-channel admission floor, keyed by channel. Omit (or pass no
    * `onChannelPolicyChange`) to hide the trust-floor control entirely — used
    * when the `channelTrustFloors` flag is off.
@@ -148,6 +154,7 @@ export function AssistantChannelsList({
   slackChannels,
   slackChannelsLoading = false,
   slackChannelsError = false,
+  slackChannelsSupported = true,
   channelPolicies,
   policySavingKey = null,
   policiesLoading = false,
@@ -260,6 +267,7 @@ export function AssistantChannelsList({
                 slackChannels={slackChannels}
                 slackChannelsLoading={slackChannelsLoading}
                 slackChannelsError={slackChannelsError}
+                slackChannelsSupported={slackChannelsSupported}
                 onSaveTwilioCredentials={onSaveTwilioCredentials}
                 policy={channelPolicies?.[channel.key]}
                 policySaving={policySavingKey === channel.key}
@@ -390,6 +398,7 @@ interface ChannelPanelProps {
   slackChannels?: SlackChannel[];
   slackChannelsLoading?: boolean;
   slackChannelsError?: boolean;
+  slackChannelsSupported?: boolean;
   onSaveTwilioCredentials?: (accountSid: string, authToken: string) => Promise<void>;
   policy?: AdmissionPolicy;
   policySaving?: boolean;
@@ -416,6 +425,7 @@ function ChannelPanel({
   slackChannels,
   slackChannelsLoading = false,
   slackChannelsError = false,
+  slackChannelsSupported = true,
   onSaveTwilioCredentials,
   policy,
   policySaving = false,
@@ -517,7 +527,7 @@ function ChannelPanel({
         </SlackChannelCard>
       ) : null}
 
-      {channel.key === "slack" && connected ? (
+      {channel.key === "slack" && connected && slackChannelsSupported ? (
         <SlackChannelList
           assistantDisplayName={assistantDisplayName}
           slackHandle={channel.address}

--- a/clients/web/src/domains/contacts/components/slack-channel-list.stories.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-list.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { userEvent, within } from "storybook/test";
+
+import type { SlackChannel } from "@/domains/contacts/types";
+
+import { SlackChannelList } from "./slack-channel-list";
+
+function makeChannel(overrides: Partial<SlackChannel> & Pick<SlackChannel, "id" | "name">): SlackChannel {
+  return {
+    type: "channel",
+    isPrivate: false,
+    isMember: true,
+    memberCount: null,
+    topic: null,
+    imageUrl: null,
+    ...overrides,
+  };
+}
+
+/** A mix of public channels, private channels, and DMs, all member-only. */
+const MIXED_CHANNELS: SlackChannel[] = [
+  makeChannel({ id: "C001", name: "general", memberCount: 42 }),
+  makeChannel({ id: "C002", name: "engineering", memberCount: 18 }),
+  makeChannel({ id: "C003", name: "eng-releases", memberCount: 9 }),
+  makeChannel({ id: "C004", name: "design", memberCount: 7 }),
+  makeChannel({ id: "C005", name: "leadership", isPrivate: true, memberCount: 4 }),
+  makeChannel({ id: "C006", name: "incident-response", isPrivate: true, memberCount: 6 }),
+  makeChannel({ id: "D001", name: "Alice", type: "dm" }),
+  makeChannel({ id: "D002", name: "Bob", type: "dm" }),
+  makeChannel({ id: "G001", name: "Alice, Bob", type: "group", isPrivate: true }),
+];
+
+const meta: Meta<typeof SlackChannelList> = {
+  title: "Contacts/SlackChannelList",
+  component: SlackChannelList,
+  args: {
+    assistantDisplayName: "Example Assistant",
+    slackHandle: "@example-assistant",
+    channels: MIXED_CHANNELS,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 720, margin: "2rem auto" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SlackChannelList>;
+
+/** Loaded list with a mix of public / private channels and DMs. */
+export const Loaded: Story = {};
+
+/** No member channels: the empty state carries the `/invite` copy hint. */
+export const Empty: Story = {
+  args: {
+    channels: [],
+  },
+};
+
+/** Search-as-you-type narrows rows by channel name. */
+export const SearchFiltering: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(canvas.getByLabelText("Search channels"), "eng");
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    channels: undefined,
+    loading: true,
+  },
+};
+
+export const LoadError: Story = {
+  args: {
+    channels: undefined,
+    error: true,
+  },
+};
+
+/** Past ~100 rows the list virtualizes into a fixed-height scroller. */
+export const ManyChannels: Story = {
+  args: {
+    channels: Array.from({ length: 250 }, (_, i) =>
+      makeChannel({
+        id: `C${String(i).padStart(4, "0")}`,
+        name: `team-${String(i).padStart(3, "0")}`,
+        isPrivate: i % 5 === 0,
+        memberCount: (i % 30) + 2,
+      }),
+    ),
+  },
+};

--- a/clients/web/src/domains/contacts/components/slack-channel-list.test.ts
+++ b/clients/web/src/domains/contacts/components/slack-channel-list.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+
+import type { SlackChannel } from "@/domains/contacts/types";
+
+import {
+  classifySlackChannelKind,
+  filterSlackChannels,
+} from "./slack-channel-list";
+
+function makeChannel(
+  overrides: Partial<SlackChannel> & Pick<SlackChannel, "id" | "name">,
+): SlackChannel {
+  return {
+    type: "channel",
+    isPrivate: false,
+    isMember: true,
+    memberCount: null,
+    topic: null,
+    imageUrl: null,
+    ...overrides,
+  };
+}
+
+const general = makeChannel({ id: "C1", name: "general" });
+const leadership = makeChannel({ id: "C2", name: "leadership", isPrivate: true });
+const dmAlice = makeChannel({ id: "D1", name: "Alice", type: "dm" });
+const groupDm = makeChannel({
+  id: "G1",
+  name: "Alice, Bob",
+  type: "group",
+  isPrivate: true,
+});
+const CHANNELS = [leadership, dmAlice, general, groupDm];
+
+describe("classifySlackChannelKind", () => {
+  test("public channels", () => {
+    expect(classifySlackChannelKind(general)).toBe("public");
+  });
+
+  test("private channels", () => {
+    expect(classifySlackChannelKind(leadership)).toBe("private");
+  });
+
+  test("DMs are dm regardless of privacy flags", () => {
+    expect(classifySlackChannelKind(dmAlice)).toBe("dm");
+  });
+
+  test("group DMs count as private", () => {
+    expect(classifySlackChannelKind(groupDm)).toBe("private");
+  });
+});
+
+describe("filterSlackChannels", () => {
+  test("no filters returns everything sorted by name", () => {
+    expect(filterSlackChannels(CHANNELS, "", null).map((c) => c.id)).toEqual([
+      "D1",
+      "G1",
+      "C1",
+      "C2",
+    ]);
+  });
+
+  test("kind filter narrows to one category", () => {
+    expect(
+      filterSlackChannels(CHANNELS, "", "private").map((c) => c.id),
+    ).toEqual(["G1", "C2"]);
+    expect(filterSlackChannels(CHANNELS, "", "dm").map((c) => c.id)).toEqual([
+      "D1",
+    ]);
+  });
+
+  test("search is case-insensitive and trims whitespace", () => {
+    expect(
+      filterSlackChannels(CHANNELS, "  LEAD ", null).map((c) => c.id),
+    ).toEqual(["C2"]);
+  });
+
+  test("search and kind filter compose", () => {
+    expect(
+      filterSlackChannels(CHANNELS, "alice", "private").map((c) => c.id),
+    ).toEqual(["G1"]);
+  });
+});

--- a/clients/web/src/domains/contacts/components/slack-channel-list.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-list.tsx
@@ -1,0 +1,234 @@
+import { CheckCircle, Hash, Lock, MessageCircle, Search } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { cn } from "@vellumai/design-library";
+import { Card } from "@vellumai/design-library/components/card";
+import { Input } from "@vellumai/design-library/components/input";
+import { ListRow } from "@vellumai/design-library/components/list-row";
+import { Tag } from "@vellumai/design-library/components/tag";
+import { Typography } from "@vellumai/design-library/components/typography";
+import { VirtualList } from "@vellumai/design-library/components/virtual-list";
+
+import { EmptyState } from "@/components/empty-state";
+import type { SlackChannel } from "@/domains/contacts/types";
+
+/**
+ * How a channel presents in the filter chips. Mutually exclusive: DMs are
+ * 1:1 conversations, everything else splits on `isPrivate` (group DMs and
+ * legacy private groups count as private).
+ */
+export type SlackChannelKind = "public" | "private" | "dm";
+
+export function classifySlackChannelKind(channel: SlackChannel): SlackChannelKind {
+  if (channel.type === "dm") {
+    return "dm";
+  }
+  return channel.isPrivate ? "private" : "public";
+}
+
+/**
+ * Applies the chip filter (`null` = all kinds) and name search, then sorts
+ * alphabetically by name.
+ */
+export function filterSlackChannels(
+  channels: SlackChannel[],
+  search: string,
+  kind: SlackChannelKind | null,
+): SlackChannel[] {
+  const query = search.trim().toLowerCase();
+  return channels
+    .filter(
+      (channel) =>
+        (kind === null || classifySlackChannelKind(channel) === kind) &&
+        (query === "" || channel.name.toLowerCase().includes(query)),
+    )
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+const CHANNEL_KIND_FILTERS: { value: SlackChannelKind; label: string }[] = [
+  { value: "public", label: "Public" },
+  { value: "private", label: "Private" },
+  { value: "dm", label: "DMs" },
+];
+
+const CHANNEL_KIND_ICONS: Record<SlackChannelKind, typeof Hash> = {
+  public: Hash,
+  private: Lock,
+  dm: MessageCircle,
+};
+
+/**
+ * A workspace can have hundreds of channels; past this row count the list
+ * switches to the virtualized scroller instead of rendering every row.
+ */
+const VIRTUALIZE_THRESHOLD = 100;
+
+export interface SlackChannelListProps {
+  /** Trimmed assistant name with a "your assistant" fallback, for copy. */
+  assistantDisplayName: string;
+  /**
+   * The assistant's Slack handle (e.g. "@example-assistant") for the
+   * `/invite` hint. Falls back to the display name when unknown.
+   */
+  slackHandle?: string;
+  channels?: SlackChannel[];
+  loading?: boolean;
+  error?: boolean;
+}
+
+/**
+ * Presence-only channel list for the Slack sub-tab: every Slack channel the
+ * assistant is a member of, with a per-row presence badge. Search and the
+ * kind chips narrow the list client-side; the membership filter itself is
+ * server-side (`?memberOnly=true`) with no toggle.
+ */
+export function SlackChannelList({
+  assistantDisplayName,
+  slackHandle,
+  channels,
+  loading = false,
+  error = false,
+}: SlackChannelListProps) {
+  const [search, setSearch] = useState("");
+  const [kindFilter, setKindFilter] = useState<SlackChannelKind | null>(null);
+
+  const visibleChannels = useMemo(
+    () => filterSlackChannels(channels ?? [], search, kindFilter),
+    [channels, search, kindFilter],
+  );
+
+  const inviteHint = (
+    <Typography
+      as="p"
+      variant="body-small-default"
+      className="text-[color:var(--content-tertiary)]"
+    >
+      Only showing channels {assistantDisplayName} is in. To add{" "}
+      {assistantDisplayName} to a channel, type{" "}
+      <code className="text-[color:var(--content-secondary)]">
+        /invite {slackHandle ?? `@${assistantDisplayName}`}
+      </code>{" "}
+      inside that Slack channel.
+    </Typography>
+  );
+
+  return (
+    <Card.Root>
+      <Card.Header>
+        <Typography as="span" variant="body-medium-default">
+          Channels
+        </Typography>
+      </Card.Header>
+      <Card.Body>
+        {loading ? (
+          <Typography
+            as="span"
+            variant="body-small-default"
+            className="text-[color:var(--content-tertiary)]"
+          >
+            Loading…
+          </Typography>
+        ) : error ? (
+          <Typography
+            as="span"
+            variant="body-small-default"
+            className="text-[color:var(--content-negative)]"
+          >
+            Couldn’t load channels. Try reopening this page.
+          </Typography>
+        ) : (channels ?? []).length === 0 ? (
+          <EmptyState
+            icon={<Hash className="h-6 w-6" />}
+            title="No channels yet"
+            description={inviteHint}
+          />
+        ) : (
+          <div className="flex flex-col gap-3">
+            <Input
+              type="search"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search channels"
+              aria-label="Search channels"
+              leftIcon={<Search className="h-4 w-4" />}
+              fullWidth
+            />
+            <div
+              className="flex items-center gap-2"
+              role="group"
+              aria-label="Filter channels by type"
+            >
+              {CHANNEL_KIND_FILTERS.map(({ value, label }) => {
+                const active = kindFilter === value;
+                return (
+                  <button
+                    key={value}
+                    type="button"
+                    aria-pressed={active}
+                    onClick={() => setKindFilter(active ? null : value)}
+                    className={cn(
+                      "inline-flex h-6 items-center rounded-full px-2.5 text-body-small-emphasised leading-none transition-colors",
+                      active
+                        ? "bg-[var(--content-default)] text-[var(--surface-base)]"
+                        : "bg-[var(--tag-bg-neutral)] text-[color:var(--content-secondary)] hover:text-[color:var(--content-default)]",
+                    )}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
+            {visibleChannels.length === 0 ? (
+              <Typography
+                as="span"
+                variant="body-small-default"
+                className="py-4 text-center text-[color:var(--content-tertiary)]"
+              >
+                No channels match.
+              </Typography>
+            ) : visibleChannels.length > VIRTUALIZE_THRESHOLD ? (
+              // Virtuoso sizes its scroller to 100% of the wrapper, so the
+              // fixed height lives on the wrapper, not the list itself.
+              <div className="h-96">
+                <VirtualList
+                  items={visibleChannels}
+                  computeItemKey={(_, channel) => channel.id}
+                  itemContent={(_, channel) => (
+                    <SlackChannelRow channel={channel} />
+                  )}
+                />
+              </div>
+            ) : (
+              <div className="flex flex-col">
+                {visibleChannels.map((channel) => (
+                  <SlackChannelRow key={channel.id} channel={channel} />
+                ))}
+              </div>
+            )}
+            {inviteHint}
+          </div>
+        )}
+      </Card.Body>
+    </Card.Root>
+  );
+}
+
+function SlackChannelRow({ channel }: { channel: SlackChannel }) {
+  const kind = classifySlackChannelKind(channel);
+  const Icon = CHANNEL_KIND_ICONS[kind];
+  return (
+    <ListRow
+      leading={<Icon className="h-4 w-4 text-[var(--content-tertiary)]" />}
+      title={channel.name}
+      trailing={
+        channel.isMember ? (
+          <Tag tone="positive" leftIcon={<CheckCircle />}>
+            In channel
+          </Tag>
+        ) : (
+          <Tag tone="neutral">Not in channel</Tag>
+        )
+      }
+    />
+  );
+}

--- a/clients/web/src/domains/contacts/components/slack-channel-list.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-list.tsx
@@ -97,19 +97,17 @@ export function SlackChannelList({
     [channels, search, kindFilter],
   );
 
+  // Inline (no block wrapper): the empty state's own description <p> wraps
+  // it, and the below-list placement adds its own paragraph wrapper.
   const inviteHint = (
-    <Typography
-      as="p"
-      variant="body-small-default"
-      className="text-[color:var(--content-tertiary)]"
-    >
+    <>
       Only showing channels {assistantDisplayName} is in. To add{" "}
       {assistantDisplayName} to a channel, type{" "}
       <code className="text-[color:var(--content-secondary)]">
         /invite {slackHandle ?? `@${assistantDisplayName}`}
       </code>{" "}
       inside that Slack channel.
-    </Typography>
+    </>
   );
 
   return (
@@ -206,7 +204,13 @@ export function SlackChannelList({
                 ))}
               </div>
             )}
-            {inviteHint}
+            <Typography
+              as="p"
+              variant="body-small-default"
+              className="text-[color:var(--content-tertiary)]"
+            >
+              {inviteHint}
+            </Typography>
           </div>
         )}
       </Card.Body>

--- a/clients/web/src/domains/contacts/components/slack-channel-list.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-list.tsx
@@ -196,6 +196,7 @@ export function SlackChannelList({
                   itemContent={(_, channel) => (
                     <SlackChannelRow channel={channel} />
                   )}
+                  className="h-full"
                 />
               </div>
             ) : (

--- a/clients/web/src/domains/contacts/hooks/use-assistant-channels.ts
+++ b/clients/web/src/domains/contacts/hooks/use-assistant-channels.ts
@@ -16,6 +16,7 @@ import {
   integrationsSlackChannelConfigGetOptions,
   integrationsSlackChannelConfigGetQueryKey,
   integrationsSlackChannelConfigPatchMutation,
+  slackChannelsGetOptions,
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import {
   integrationsSlackChannelConfigDelete,
@@ -91,6 +92,17 @@ export function useAssistantChannels({
     ...integrationsSlackChannelConfigGetOptions(pathOpts),
     enabled: slackConnected,
     select: (data: IntegrationsSlackChannelConfigGetResponse) => data.threadMode,
+  });
+
+  // Presence-only channel list for the Slack sub-tab. Member-only is the
+  // product contract (no toggle), so the filter is baked into the query.
+  const slackChannelsQuery = useQuery({
+    ...slackChannelsGetOptions({
+      path: { assistant_id: assistantId },
+      query: { memberOnly: "true" },
+    }),
+    enabled: slackConnected,
+    select: (data) => data.channels,
   });
 
   // Per-channel trust floors (admission policy), shown inline on each connected
@@ -191,6 +203,9 @@ export function useAssistantChannels({
       : null,
     slackThreadMode: slackConfigQuery.data,
     slackThreadModePending: slackThreadModeMutation.isPending,
+    slackChannels: slackChannelsQuery.data,
+    slackChannelsLoading: slackChannelsQuery.isPending,
+    slackChannelsError: slackChannelsQuery.isError,
     channelPolicies: channelTrustFloors.policies,
     policySavingKey: channelTrustFloors.savingKey,
     policiesLoading: channelTrustFloors.isLoading,

--- a/clients/web/src/domains/contacts/hooks/use-assistant-channels.ts
+++ b/clients/web/src/domains/contacts/hooks/use-assistant-channels.ts
@@ -25,6 +25,7 @@ import {
 } from "@/generated/daemon/sdk.gen";
 import type { IntegrationsSlackChannelConfigGetResponse } from "@/generated/daemon/types.gen";
 import { useSaveSlackConfig } from "@/hooks/use-save-slack-config";
+import { useSupportsSlackChannelList } from "@/lib/backwards-compat/slack-channel-list";
 import { useSaveTelegramConfig } from "@/hooks/use-save-telegram-config";
 import { useSaveTwilioCredentials } from "@/hooks/use-save-twilio-credentials";
 
@@ -96,12 +97,15 @@ export function useAssistantChannels({
 
   // Presence-only channel list for the Slack sub-tab. Member-only is the
   // product contract (no toggle), so the filter is baked into the query.
+  // Version-gated: older assistants don't serve GET /v1/slack/channels,
+  // so the query stays off and the list stays hidden against them.
+  const supportsSlackChannelList = useSupportsSlackChannelList();
   const slackChannelsQuery = useQuery({
     ...slackChannelsGetOptions({
       path: { assistant_id: assistantId },
       query: { memberOnly: "true" },
     }),
-    enabled: slackConnected,
+    enabled: slackConnected && supportsSlackChannelList,
     select: (data) => data.channels,
   });
 
@@ -206,6 +210,7 @@ export function useAssistantChannels({
     slackChannels: slackChannelsQuery.data,
     slackChannelsLoading: slackChannelsQuery.isPending,
     slackChannelsError: slackChannelsQuery.isError,
+    slackChannelsSupported: supportsSlackChannelList,
     channelPolicies: channelTrustFloors.policies,
     policySavingKey: channelTrustFloors.savingKey,
     policiesLoading: channelTrustFloors.isLoading,

--- a/clients/web/src/domains/contacts/hooks/use-assistant-channels.ts
+++ b/clients/web/src/domains/contacts/hooks/use-assistant-channels.ts
@@ -10,13 +10,13 @@ import {
   type ChannelReadinessSnapshot,
   type SetupChannelId,
 } from "@/domains/contacts/types";
+import { memberSlackChannelsOptions, memberSlackChannelsQueryKey } from "@/domains/contacts/slack-channels-query";
 import {
   channelsReadinessGetOptions,
   channelsReadinessGetQueryKey,
   integrationsSlackChannelConfigGetOptions,
   integrationsSlackChannelConfigGetQueryKey,
   integrationsSlackChannelConfigPatchMutation,
-  slackChannelsGetOptions,
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import {
   integrationsSlackChannelConfigDelete,
@@ -95,16 +95,12 @@ export function useAssistantChannels({
     select: (data: IntegrationsSlackChannelConfigGetResponse) => data.threadMode,
   });
 
-  // Presence-only channel list for the Slack sub-tab. Member-only is the
-  // product contract (no toggle), so the filter is baked into the query.
+  // Presence-only channel list for the Slack sub-tab.
   // Version-gated: older assistants don't serve GET /v1/slack/channels,
   // so the query stays off and the list stays hidden against them.
   const supportsSlackChannelList = useSupportsSlackChannelList();
   const slackChannelsQuery = useQuery({
-    ...slackChannelsGetOptions({
-      path: { assistant_id: assistantId },
-      query: { memberOnly: "true" },
-    }),
+    ...memberSlackChannelsOptions(assistantId),
     enabled: slackConnected && supportsSlackChannelList,
     select: (data) => data.channels,
   });
@@ -129,7 +125,17 @@ export function useAssistantChannels({
         await integrationsTwilioCredentialsDelete(opts);
       }
     },
-    onSettled: () => invalidateReadiness(),
+    onSettled: (_data, _error, channelKey) => {
+      invalidateReadiness();
+      if (channelKey === "slack") {
+        // Drop the channel-list cache with the credentials: a later
+        // reconnect may target a different workspace, and serving the old
+        // workspace's channels from cache would misreport presence.
+        queryClient.removeQueries({
+          queryKey: memberSlackChannelsQueryKey(assistantId),
+        });
+      }
+    },
   });
 
   // Credential saves reuse the app-wide hooks (also used by the chat-side

--- a/clients/web/src/domains/contacts/slack-channels-query.ts
+++ b/clients/web/src/domains/contacts/slack-channels-query.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared query options/key for the member-only Slack channel list
+ * (`GET /v1/slack/channels?memberOnly=true`) shown in the Slack sub-tab.
+ *
+ * The cached list is scoped to whichever Slack workspace the stored
+ * credentials point at, but the key only carries the assistant id — so
+ * every path that changes those credentials (save, disconnect) must drop
+ * the cache via {@link memberSlackChannelsQueryKey} to avoid showing the
+ * previous workspace's channels while a refetch runs.
+ */
+import {
+  slackChannelsGetOptions,
+  slackChannelsGetQueryKey,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+
+function memberChannelsRequestOptions(assistantId: string) {
+  return {
+    path: { assistant_id: assistantId },
+    // Member-only is the product contract for the presence list (no toggle).
+    query: { memberOnly: "true" } as const,
+  };
+}
+
+export function memberSlackChannelsOptions(assistantId: string) {
+  return slackChannelsGetOptions(memberChannelsRequestOptions(assistantId));
+}
+
+export function memberSlackChannelsQueryKey(assistantId: string) {
+  return slackChannelsGetQueryKey(memberChannelsRequestOptions(assistantId));
+}

--- a/clients/web/src/domains/contacts/types.ts
+++ b/clients/web/src/domains/contacts/types.ts
@@ -2,6 +2,7 @@ import type {
   ChannelsAvailableGetResponse,
   ChannelsReadinessGetResponse,
   ContactsGetResponse,
+  SlackChannelsGetResponse,
 } from "@/generated/daemon/types.gen";
 import type { SetupChannelId } from "@/types/channel-types";
 
@@ -16,6 +17,8 @@ export type ContactPayload = ContactsGetResponse["contacts"][number];
 export type ContactChannelPayload = ContactPayload["channels"][number];
 
 export type ChannelInfo = ChannelsAvailableGetResponse["channels"][number];
+
+export type SlackChannel = SlackChannelsGetResponse["channels"][number];
 
 type ReadinessSnapshot = ChannelsReadinessGetResponse["snapshots"][number];
 export type ChannelReadinessSnapshot = ReadinessSnapshot;

--- a/clients/web/src/hooks/use-save-slack-config.ts
+++ b/clients/web/src/hooks/use-save-slack-config.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
 
+import { memberSlackChannelsQueryKey } from "@/domains/contacts/slack-channels-query";
 import { channelsReadinessGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import { integrationsSlackChannelConfigPost } from "@/generated/daemon/sdk.gen";
 
@@ -11,7 +12,9 @@ interface UseSaveSlackConfigOptions {
 
 /**
  * Shared mutation for saving Slack channel credentials (bot token + app token).
- * Invalidates channel readiness on settle so all consumers see fresh state.
+ * Invalidates channel readiness on settle so all consumers see fresh state,
+ * and drops the cached Slack channel list — new credentials may point at a
+ * different workspace, whose channels the old cache would misreport.
  */
 export function useSaveSlackConfig({
   assistantId,
@@ -46,6 +49,9 @@ export function useSaveSlackConfig({
     onSuccess,
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: readinessQueryKey });
+      queryClient.removeQueries({
+        queryKey: memberSlackChannelsQueryKey(assistantId),
+      });
     },
   });
 }

--- a/clients/web/src/lib/backwards-compat/slack-channel-list.test.ts
+++ b/clients/web/src/lib/backwards-compat/slack-channel-list.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+
+import { useSupportsSlackChannelList } from "@/lib/backwards-compat/slack-channel-list";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+
+/** Read the gate synchronously through the exported hook variant. */
+function readGateViaHook(version: string | null): boolean {
+  useAssistantIdentityStore.getState().setIdentity("test-asst", version);
+  return renderHook(() => useSupportsSlackChannelList()).result.current;
+}
+
+beforeEach(() => {
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+afterEach(() => {
+  cleanup();
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+// Exhaustive truth-table for the underlying semver gate lives in
+// `utils.test.ts`; here we verify the 0.10.7 boundary plus the
+// conservative-on-unknown policy through the public hook.
+describe("useSupportsSlackChannelList", () => {
+  test("reads false when the version is unknown", () => {
+    expect(readGateViaHook(null)).toBe(false);
+  });
+
+  test("reads false for assistants below 0.10.7", () => {
+    expect(readGateViaHook("0.10.6")).toBe(false);
+    expect(readGateViaHook("0.9.0")).toBe(false);
+  });
+
+  test("reads true for assistants on 0.10.7+", () => {
+    expect(readGateViaHook("0.10.7")).toBe(true);
+    expect(readGateViaHook("0.11.0")).toBe(true);
+    expect(readGateViaHook("1.0.0")).toBe(true);
+  });
+
+  test("reads false for unparseable versions", () => {
+    expect(readGateViaHook("garbage")).toBe(false);
+  });
+});

--- a/clients/web/src/lib/backwards-compat/slack-channel-list.ts
+++ b/clients/web/src/lib/backwards-compat/slack-channel-list.ts
@@ -1,0 +1,37 @@
+/**
+ * Backwards-compat gate: the Slack sub-tab's presence channel list.
+ *
+ * The list is fed by `GET /v1/slack/channels?memberOnly=true`, which
+ * first ships in the assistant version below. The web app always serves
+ * the latest bundle, but the assistant can be any locally-installed
+ * version — on an older assistant the route is missing, the query 404s,
+ * and the Slack sub-tab would show an error card on an otherwise
+ * healthy connection.
+ *
+ * Old behavior (< MIN_VERSION): the Slack sub-tab shows only the
+ * connection state and thread-behavior controls — exactly the
+ * pre-feature layout — and the channels query never fires.
+ * New behavior (≥ MIN_VERSION): the presence channel list renders below
+ * the thread controls.
+ *
+ * This is a pure read path with a hide-the-surface fallback, so the
+ * conservative `false`-on-unknown default is safe: the list simply
+ * appears once the version hydrates. Only the hook variant exists.
+ *
+ * TODO(version): MIN_VERSION is a near-future placeholder. The current
+ * assistant release is 0.10.6 and the route is on `main` unreleased;
+ * confirm 0.10.7 is the release that ships it once cut.
+ */
+import { useAssistantSupports } from "./utils";
+
+export const MIN_VERSION = "0.10.7";
+
+/**
+ * Hook gate: `true` when the active assistant serves
+ * `GET /v1/slack/channels`. Subscribes to the identity store so the
+ * Slack sub-tab re-renders (and the query enables) when the version
+ * hydrates or crosses `MIN_VERSION`.
+ */
+export function useSupportsSlackChannelList(): boolean {
+  return useAssistantSupports(MIN_VERSION);
+}


### PR DESCRIPTION
## Prompt / plan

Implements [LUM-2713](https://linear.app/vellum/issue/LUM-2713) — the presence-only v1 channel list for the Slack sub-tab that landed with the LUM-2712 tabs restructure (#37263), backed by the `GET /v1/slack/channels?memberOnly=true` endpoint from LUM-2711 (#37245).

Approach:

- **`SlackChannelList`** (new, `domains/contacts/components/slack-channel-list.tsx`): presentational card with search-as-you-type, Public / Private / DMs filter chips, alphabetically sorted rows (`ListRow` + `Tag` presence badge), the always-visible `/invite` copy hint, and an empty state that carries the same hint. Named "channel" (not "room") to match Slack's own terminology. Row data type derives from the generated client (`SlackChannelsGetResponse["channels"][number]`, exported as `SlackChannel` from `domains/contacts/types.ts`) — no hand-rolled wire shapes.
- **Data**: `useAssistantChannels` gains a `slackChannelsGetOptions` query with `memberOnly: "true"` baked in (member-only is the product contract, no toggle), enabled only once Slack readiness reports connected. Both mount points (Channels tab, Contacts detail) pick it up through the existing controller spread.
- **Rendering**: `ChannelPanel` renders the list below the Slack settings card (thread-behavior controls) when Slack is connected — tabbed layout only; the legacy accordion and the Telegram/Phone panels are untouched.
- **Virtualization**: past 100 rows the list switches to the design-library `VirtualList` (react-virtuoso) inside a fixed-height wrapper. Verification caught that virtuoso inline-styles its scroller to `height: 100%`, so the height must live on a wrapper, not the list's own `className`.
- **Chips semantics**: the spec's "mutually exclusive, all selected by default" is implemented as single-select chips with deselect — everything is shown by default, one chip narrows to that kind, clicking it again returns to all. Group DMs / legacy private groups classify as Private; only 1:1 IMs classify as DMs. The `isMember` derivation (including `is_im` rows) stays server-side in `isMemberConversation` — DM rows keep their badge.
- **Custom UI note**: the filter chips are small styled `<button aria-pressed>` elements — the design library has no toggle-chip primitive (`Tag` is non-interactive, `SegmentControl` can't express "no selection = all").

## Test plan

- Drove Storybook with Playwright and screenshotted every state: loaded mix of public/private/DM rows, search narrowing (`eng` → 2 rows), Private/DMs chip filtering, no-match state, empty state with the `/invite` hint, 250-row virtualized list (8 DOM rows rendered, scrolls correctly), the composed Slack sub-tab (connection state → trust floor → thread behavior → channel list), and the Telegram tab (unchanged).
- New stories: `Loaded`, `Empty`, `SearchFiltering` (play function), `Loading`, `LoadError`, `ManyChannels` (virtualized); plus member-channel data threaded into the existing `ChannelsTabSlackConnected` story.
- Unit tests for `classifySlackChannelKind` and `filterSlackChannels` (kind narrowing, case-insensitive trimmed search, compose, sort) — 8 pass; existing `contacts-page.test.tsx` still green.
- `bunx tsc --noEmit` clean; ESLint clean on all touched files.

Part of LUM-2713

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKCgjYzAHTjXtwD26BFgvj

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKCgjYzAHTjXtwD26BFgvj)_