### PR TITLE
fix: pill visibility on inspector route + voice UI consolidation

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/domains/chat/components/voice-input-button";
 import { type TurnPhase, useTurnStore } from "@/domains/chat/turn-store";
 import {
+    getLiveVoiceInputAmplitude,
     isLiveVoiceSessionActive,
     useIsLiveVoiceSessionOwnedBy,
     useLiveVoiceStore,
@@ -269,12 +270,6 @@ export function ChatComposer({
   // transcript yet, the textarea stays visible so its placeholder shows
   // through (Light 53 baseline).
   const showLiveVoiceTranscript = isLiveVoiceActive && hasLiveVoiceTranscript;
-  // Amplitude is polled by the voice bar's canvas draw loop straight from the
-  // store (~30 Hz), so per-sample updates never flow through props.
-  const getLiveVoiceAmplitude = useCallback(
-    () => useLiveVoiceStore.getState().inputAmplitude,
-    [],
-  );
   // Session verbs go through the store seams registered by the layout-owned
   // controller: `starter` (registered for the controller's whole mount) to
   // start, per-session `controls` to stop/release. Read via `getState()` in
@@ -671,7 +666,7 @@ export function ChatComposer({
               // green ↑ manually releases the current turn while listening.
               <VoiceComposerBar
                 state={liveVoiceState}
-                getAmplitude={getLiveVoiceAmplitude}
+                getAmplitude={getLiveVoiceInputAmplitude}
                 onEnd={handleLiveVoiceEnd}
                 onSend={handleLiveVoiceSend}
               />

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
@@ -19,29 +19,12 @@ import { ArrowUp, Mic, X } from "lucide-react";
 
 import { Button } from "@vellumai/design-library";
 
-import type { LiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live-voice-store";
+import {
+  LIVE_VOICE_STATE_LABELS,
+  isLiveVoiceMicLive,
+  type LiveVoiceSessionState,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
 import { VoiceTimelineWaveform } from "@/domains/chat/voice/voice-timeline-waveform";
-
-/**
- * Deliberately minimal state treatment (decided 2026-07-06): assistant
- * output streams into the thread transcript like text chat, so the bar
- * only carries a small label. `idle`/`failed` map to an empty label —
- * the parent unmounts the bar in those states.
- *
- * Exported for the title-bar session pill (`voice-session-pill-host.tsx`),
- * which shows the same activity label while the user is away from the
- * owning thread.
- */
-export const STATE_LABELS: Record<LiveVoiceSessionState, string> = {
-  idle: "",
-  connecting: "Connecting…",
-  listening: "Listening…",
-  transcribing: "Transcribing…",
-  thinking: "Thinking…",
-  speaking: "Speaking…",
-  ending: "Ending…",
-  failed: "",
-};
 
 export interface VoiceComposerBarProps {
   state: LiveVoiceSessionState;
@@ -76,12 +59,12 @@ export function VoiceComposerBar({
           aria-live="polite"
           className="text-chat text-[var(--content-disabled)]"
         >
-          {STATE_LABELS[state]}
+          {LIVE_VOICE_STATE_LABELS[state]}
         </span>
       </div>
       <VoiceTimelineWaveform
         getAmplitude={getAmplitude}
-        active={state === "listening"}
+        active={isLiveVoiceMicLive(state)}
         className="min-w-0 flex-1"
       />
       <div className="flex shrink-0 items-center gap-1">

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.test.tsx
@@ -147,6 +147,20 @@ describe("VoiceSessionPillHost — visibility", () => {
     expect(container.firstChild).toBeNull();
   });
 
+  test("shows the pill on the owning conversation's inspector route (no composer there)", () => {
+    // `/assistant/conversations/:id/inspect` mounts `InspectPage`, which has
+    // no composer — even though the pathname sits under the owning
+    // conversation, the pill must stay up as the session's only control
+    // surface.
+    startSession("listening");
+    useConversationStore
+      .getState()
+      .setActiveConversationId(OWNING_CONVERSATION_ID);
+    mockPathname = routes.inspect(OWNING_CONVERSATION_ID);
+    render(<VoiceSessionPillHost />);
+    expect(pill()).not.toBeNull();
+  });
+
   test("shows the pill over the desktop fullscreen app viewer even in the owning conversation", () => {
     startSession("listening");
     useConversationStore

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
@@ -14,9 +14,11 @@
  * when:
  *
  * - the user is viewing a different conversation than the session's,
- * - the user is off the conversation routes entirely (Home, Library, …) —
- *   `activeConversationId` deliberately persists across route changes (see
- *   `chat-layout.tsx`), so the id comparison alone can't detect this,
+ * - the user is off the chat routes entirely (Home, Library, …) or on a
+ *   composer-less conversation subroute like the inspector
+ *   (`/assistant/conversations/:id/inspect`) — `activeConversationId`
+ *   deliberately persists across route changes (see `chat-layout.tsx`), so
+ *   the id comparison alone can't detect this,
  * - the desktop fullscreen app viewer covers the thread (`mainView === "app"`;
  *   on mobile that view keeps the composer mounted under a portal overlay
  *   that covers the header too, so the composer stays the owning surface).
@@ -39,12 +41,13 @@ import { useLocation, useNavigate } from "react-router";
 
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { navigateToConversation } from "@/utils/conversation-navigation";
-import { isConversationPath } from "@/utils/routes";
+import { isConversationChatPath } from "@/utils/routes";
 
-import { STATE_LABELS } from "@/domains/chat/components/chat-composer/voice-composer-bar";
 import { VoiceSessionPill } from "@/domains/chat/components/voice-session-pill";
 import { useActiveConversation } from "@/domains/chat/hooks/use-active-conversation";
 import {
+  LIVE_VOICE_STATE_LABELS,
+  getLiveVoiceInputAmplitude,
   isLiveVoiceSessionActive,
   useIsLiveVoiceSessionOwnedBy,
   useLiveVoiceStore,
@@ -67,9 +70,13 @@ export function VoiceSessionPillHost() {
   const sessionActive = isLiveVoiceSessionActive(state);
   // Mirror of `chat-content-layout.tsx`: the desktop `app` view replaces
   // `ChatMainPanel` (composer included); every other view — and mobile's
-  // portal-overlay `app` view — keeps the composer mounted.
+  // portal-overlay `app` view — keeps the composer mounted. The strict chat
+  // predicate matters: conversation subroutes like the inspector
+  // (`/assistant/conversations/:id/inspect`) render no composer, so the pill
+  // must stay up there even for the owning conversation.
   const composerOnScreen =
-    isConversationPath(location.pathname) && !(mainView === "app" && !isMobile);
+    isConversationChatPath(location.pathname) &&
+    !(mainView === "app" && !isMobile);
   // Same ownership predicate the composer's voice bar uses, evaluated for the
   // composer currently on screen — keeps the two surfaces exact complements.
   const activeComposerOwnsSession =
@@ -84,14 +91,6 @@ export function VoiceSessionPillHost() {
     sessionAssistantId,
     sessionConversationId,
     visible && sessionConversationId !== null,
-  );
-
-  // Stable poll function — the waveform samples ~30 Hz via its draw loop, so
-  // amplitude must not flow through props/re-renders (same pattern as the
-  // composer's voice bar wiring).
-  const getAmplitude = useCallback(
-    () => useLiveVoiceStore.getState().inputAmplitude,
-    [],
   );
 
   const handleNavigate = useCallback(() => {
@@ -109,12 +108,12 @@ export function VoiceSessionPillHost() {
 
   return (
     <VoiceSessionPill
-      primaryLabel={STATE_LABELS[state]}
+      primaryLabel={LIVE_VOICE_STATE_LABELS[state]}
       secondaryLabel={
         owningConversation ? (owningConversation.title ?? "Untitled") : undefined
       }
       state={state}
-      getAmplitude={getAmplitude}
+      getAmplitude={getLiveVoiceInputAmplitude}
       onEnd={handleEnd}
       onSend={handleSend}
       onNavigate={sessionConversationId ? handleNavigate : undefined}

--- a/clients/web/src/domains/chat/components/voice-session-pill.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.tsx
@@ -22,23 +22,17 @@ import { ArrowUp, Mic, Square, X } from "lucide-react";
 
 import { Button, Typography, cn } from "@vellumai/design-library";
 
-import type { LiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live-voice-store";
+import {
+  isLiveVoiceMicLive,
+  type LiveVoiceSessionState,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
 import { VoiceTimelineWaveform } from "@/domains/chat/voice/voice-timeline-waveform";
 
-/**
- * States in which the mic is live and the waveform should keep scrolling in
- * new amplitude samples. Outside these (connecting/ending/terminal states) the
- * bars freeze in place.
- */
-const WAVEFORM_ACTIVE_STATES: ReadonlySet<LiveVoiceSessionState> = new Set([
-  "listening",
-  "transcribing",
-  "thinking",
-  "speaking",
-]);
-
 export interface VoiceSessionPillProps {
-  /** Line 1: what the assistant is doing (e.g. "Working on App…"). */
+  /**
+   * Line 1: the session's activity label (e.g. "Listening…" — see
+   * `LIVE_VOICE_STATE_LABELS`).
+   */
   primaryLabel: string;
   /** Line 2: the owning thread's name. */
   secondaryLabel?: string;
@@ -128,7 +122,7 @@ export function VoiceSessionPill({
         <Mic aria-hidden className="size-3.5 shrink-0 text-[var(--content-default)]" />
         <VoiceTimelineWaveform
           compact
-          active={WAVEFORM_ACTIVE_STATES.has(state)}
+          active={isLiveVoiceMicLive(state)}
           getAmplitude={getAmplitude}
           className="w-24"
         />

--- a/clients/web/src/domains/chat/hooks/use-open-app-from-chat.ts
+++ b/clients/web/src/domains/chat/hooks/use-open-app-from-chat.ts
@@ -5,7 +5,7 @@ import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore } from "@/stores/viewer-store";
 import { haptic } from "@/utils/haptics";
-import { routes } from "@/utils/routes";
+import { isConversationChatPath, routes } from "@/utils/routes";
 
 /**
  * Open an app in the viewer panel from inside the chat surface — sidebar
@@ -28,10 +28,10 @@ import { routes } from "@/utils/routes";
  */
 /**
  * Decide the route to navigate to before opening an app from the sidebar.
- * The viewer panel only renders under `ChatPage` (mounted at `/assistant`
- * index + `/assistant/conversations/:id`). From any other route (home,
- * library, identity, inspector, …) the viewer-store mutation would have
- * no surface to display against, so we have to navigate first.
+ * The viewer panel only renders under `ChatPage` (the routes matched by
+ * `isConversationChatPath`). From any other route (home, library, identity,
+ * inspector, …) the viewer-store mutation would have no surface to display
+ * against, so we have to navigate first.
  *
  * Returns `null` when the caller is already on a route that mounts the
  * viewer — no navigation needed.
@@ -43,12 +43,7 @@ export function chooseSidebarOpenAppDestination(
   pathname: string,
   activeConversationId: string | null,
 ): string | null {
-  const onChatRoute =
-    pathname === routes.assistant ||
-    pathname === `${routes.assistant}/` ||
-    (pathname.startsWith("/assistant/conversations/") &&
-      !pathname.endsWith("/inspect"));
-  if (onChatRoute) return null;
+  if (isConversationChatPath(pathname)) return null;
   return activeConversationId
     ? routes.conversation(activeConversationId)
     : routes.assistant;

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -8,6 +8,8 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {
+  getLiveVoiceInputAmplitude,
+  isLiveVoiceMicLive,
   isLiveVoiceSessionActive,
   isLiveVoiceSessionOwnedBy,
   useLiveVoiceStore,
@@ -185,5 +187,34 @@ describe("useLiveVoiceStore — session controls", () => {
     useLiveVoiceStore.getState().setControls(makeControls());
     useLiveVoiceStore.getState().reset();
     expect(useLiveVoiceStore.getState().controls).toBeNull();
+  });
+});
+
+describe("isLiveVoiceMicLive", () => {
+  test("true for the whole listening→speaking span (amplitude keeps flowing for barge-in)", () => {
+    const micLive: LiveVoiceSessionState[] = [
+      "listening",
+      "transcribing",
+      "thinking",
+      "speaking",
+    ];
+    for (const state of micLive) {
+      expect(isLiveVoiceMicLive(state)).toBe(true);
+    }
+  });
+
+  test("false before capture starts and during/after teardown", () => {
+    const micOff: LiveVoiceSessionState[] = ["idle", "connecting", "ending", "failed"];
+    for (const state of micOff) {
+      expect(isLiveVoiceMicLive(state)).toBe(false);
+    }
+  });
+});
+
+describe("getLiveVoiceInputAmplitude", () => {
+  test("reads the store's current amplitude", () => {
+    expect(getLiveVoiceInputAmplitude()).toBe(0);
+    useLiveVoiceStore.getState().setInputAmplitude(0.42);
+    expect(getLiveVoiceInputAmplitude()).toBe(0.42);
   });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -53,6 +53,27 @@ export type LiveVoiceSessionState =
   | "failed";
 
 /**
+ * User-facing activity label per session state, shared by every surface that
+ * shows session activity (the composer's voice bar and the title-bar session
+ * pill), so the two always agree.
+ *
+ * Deliberately minimal treatment (decided 2026-07-06): assistant output
+ * streams into the thread transcript like text chat, so surfaces only carry a
+ * small label. `idle`/`failed` map to an empty label — hosts unmount their
+ * voice UI in those states.
+ */
+export const LIVE_VOICE_STATE_LABELS: Record<LiveVoiceSessionState, string> = {
+  idle: "",
+  connecting: "Connecting…",
+  listening: "Listening…",
+  transcribing: "Transcribing…",
+  thinking: "Thinking…",
+  speaking: "Speaking…",
+  ending: "Ending…",
+  failed: "",
+};
+
+/**
  * Imperative controls for the active session, registered by the
  * {@link useLiveVoice} controller instance that owns it. Lets a globally
  * mounted component (e.g. the title-bar session pill) drive a session owned by
@@ -179,6 +200,27 @@ export function isLiveVoiceSessionActive(state: LiveVoiceSessionState): boolean 
 }
 
 /**
+ * Whether the mic is live in `state` — capturing audio with amplitude flowing
+ * into the store. True for the whole listening→speaking span: the capture
+ * graph runs for the entire session so amplitude keeps flowing for barge-in
+ * even while the assistant is transcribing/thinking/speaking (see
+ * `use-live-voice.ts` "Mic forwarding"). False for `connecting` (capture not
+ * started) and `ending`/terminal states (teardown).
+ *
+ * Drives the `active` flag of every session waveform (composer voice bar and
+ * title-bar pill): the bars scroll in new samples exactly while the mic is
+ * hot, and freeze otherwise.
+ */
+export function isLiveVoiceMicLive(state: LiveVoiceSessionState): boolean {
+  return (
+    state === "listening" ||
+    state === "transcribing" ||
+    state === "thinking" ||
+    state === "speaking"
+  );
+}
+
+/**
  * Whether the composer bound to `composerConversationId` owns the active
  * session — i.e. it is the surface whose action row swaps to the voice bar
  * (and whose title-bar pill therefore hides).
@@ -251,6 +293,16 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
 }));
 
 export const useLiveVoiceStore = createSelectors(useLiveVoiceStoreBase);
+
+/**
+ * Stable amplitude poll function for waveform canvases: sampled ~30 Hz inside
+ * their draw loops, so amplitude must never flow through props/re-renders.
+ * Module-level (not a per-component `useCallback`) so every surface shares the
+ * one identity.
+ */
+export function getLiveVoiceInputAmplitude(): number {
+  return useLiveVoiceStore.getState().inputAmplitude;
+}
 
 /**
  * Reactive form of {@link isLiveVoiceSessionOwnedBy} for components: whether

--- a/clients/web/src/domains/chat/voice/voice-timeline-waveform.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-timeline-waveform.test.tsx
@@ -101,21 +101,27 @@ describe("VoiceTimelineWaveform — rendering", () => {
   });
 
   test("default sizing uses the full-height canvas class", () => {
-    const { container } = render(<VoiceTimelineWaveform active />);
+    const { container } = render(
+      <VoiceTimelineWaveform active getAmplitude={() => 0} />,
+    );
     const canvas = container.querySelector("canvas")!;
     expect(canvas.className).toContain("h-6");
     expect(canvas.className).toContain("w-full");
   });
 
   test("compact sizing uses the shorter canvas class", () => {
-    const { container } = render(<VoiceTimelineWaveform active compact />);
+    const { container } = render(
+      <VoiceTimelineWaveform active compact getAmplitude={() => 0} />,
+    );
     const canvas = container.querySelector("canvas")!;
     expect(canvas.className).toContain("h-4");
     expect(canvas.className).not.toContain("h-6");
   });
 
   test("merges a caller-supplied className", () => {
-    const { container } = render(<VoiceTimelineWaveform active className="flex-1" />);
+    const { container } = render(
+      <VoiceTimelineWaveform active className="flex-1" getAmplitude={() => 0} />,
+    );
     expect(container.querySelector("canvas")!.className).toContain("flex-1");
   });
 });
@@ -162,7 +168,9 @@ describe("VoiceTimelineWaveform — animation loop", () => {
   test("does not start a loop when the 2d context is unavailable", () => {
     HTMLCanvasElement.prototype.getContext = (() =>
       null) as unknown as typeof HTMLCanvasElement.prototype.getContext;
-    const { unmount } = render(<VoiceTimelineWaveform active />);
+    const { unmount } = render(
+      <VoiceTimelineWaveform active getAmplitude={() => 0} />,
+    );
     expect(rafCallCount).toBe(0);
     expect(() => unmount()).not.toThrow();
   });

--- a/clients/web/src/domains/chat/voice/voice-timeline-waveform.tsx
+++ b/clients/web/src/domains/chat/voice/voice-timeline-waveform.tsx
@@ -9,12 +9,11 @@
  * component because the visual — dotted baseline + bounded bar segment — is
  * distinct from that component's full-width bar field.
  *
- * Amplitude is preferably supplied via `getAmplitude` so the parent can poll
- * a store/analyser without re-rendering per sample; a plain `amplitude` prop
- * is the fallback. Colors resolve from CSS var tokens at draw time so all
- * themes (including runtime `data-theme` switches) render correctly. Under
- * reduced motion the component draws a single static, amplitude-independent
- * frame and never starts the animation loop.
+ * Amplitude is supplied via `getAmplitude` so the parent can poll a
+ * store/analyser without re-rendering per sample. Colors resolve from CSS var
+ * tokens at draw time so all themes (including runtime `data-theme` switches)
+ * render correctly. Under reduced motion the component draws a single static,
+ * amplitude-independent frame and never starts the animation loop.
  */
 
 import { useReducedMotion } from "motion/react";
@@ -119,12 +118,10 @@ function drawTimeline(
 
 export interface VoiceTimelineWaveformProps {
   /**
-   * Preferred amplitude source (0–1), polled at ~30 Hz inside the draw loop
-   * so the parent never re-renders per sample.
+   * Amplitude source (0–1), polled at ~30 Hz inside the draw loop so the
+   * parent never re-renders per sample.
    */
-  getAmplitude?: () => number;
-  /** Plain amplitude fallback (0–1) when no poll function is supplied. */
-  amplitude?: number;
+  getAmplitude: () => number;
   /** While true new samples scroll in; when false the bars freeze in place. */
   active: boolean;
   /** Title-bar pill sizing: shorter canvas and a narrower bar segment. */
@@ -134,7 +131,6 @@ export interface VoiceTimelineWaveformProps {
 
 export function VoiceTimelineWaveform({
   getAmplitude,
-  amplitude = 0,
   active,
   compact = false,
   className,
@@ -143,17 +139,12 @@ export function VoiceTimelineWaveform({
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   // Refs let the rAF loop read the latest inputs without re-initializing.
   const getAmplitudeRef = useRef(getAmplitude);
-  const amplitudeRef = useRef(amplitude);
   const activeRef = useRef(active);
   const samplesRef = useRef<number[]>([]);
 
   useLayoutEffect(() => {
     getAmplitudeRef.current = getAmplitude;
   }, [getAmplitude]);
-
-  useLayoutEffect(() => {
-    amplitudeRef.current = amplitude;
-  }, [amplitude]);
 
   useLayoutEffect(() => {
     activeRef.current = active;
@@ -194,10 +185,7 @@ export function VoiceTimelineWaveform({
     const tick = (ts: number) => {
       if (activeRef.current && ts - lastSampleTs >= SAMPLE_MS) {
         lastSampleTs = ts;
-        const raw = getAmplitudeRef.current
-          ? getAmplitudeRef.current()
-          : amplitudeRef.current;
-        samplesRef.current.push(clamp01(raw));
+        samplesRef.current.push(clamp01(getAmplitudeRef.current()));
         const maxBars = Math.floor(segmentWidth / STEP);
         if (samplesRef.current.length > maxBars * 2) {
           samplesRef.current = samplesRef.current.slice(-maxBars);

--- a/clients/web/src/utils/routes.test.ts
+++ b/clients/web/src/utils/routes.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { routes } from "@/utils/routes";
+import {
+  isConversationChatPath,
+  isConversationPath,
+  routes,
+} from "@/utils/routes";
 
 describe("routes", () => {
   test("builds schedule-filtered usage URLs", () => {
@@ -20,5 +24,49 @@ describe("routes", () => {
     expect(routes.schedules.detail("sch_123")).toBe(
       "/assistant/schedules/sch_123",
     );
+  });
+});
+
+describe("isConversationPath (conversation area, subroutes included)", () => {
+  test("matches the chat index and conversation routes", () => {
+    expect(isConversationPath("/assistant")).toBe(true);
+    expect(isConversationPath("/assistant/")).toBe(true);
+    expect(isConversationPath(routes.conversation("conv-1"))).toBe(true);
+  });
+
+  test("matches conversation subroutes like the inspector", () => {
+    expect(isConversationPath(routes.inspect("conv-1"))).toBe(true);
+  });
+
+  test("rejects non-conversation routes", () => {
+    expect(isConversationPath("/assistant/home")).toBe(false);
+    expect(isConversationPath("/assistant/library")).toBe(false);
+  });
+});
+
+describe("isConversationChatPath (composer-mounting routes only)", () => {
+  test("matches the chat index (draft conversation)", () => {
+    expect(isConversationChatPath("/assistant")).toBe(true);
+    expect(isConversationChatPath("/assistant/")).toBe(true);
+  });
+
+  test("matches a bare conversation route, tolerating a trailing slash", () => {
+    expect(isConversationChatPath(routes.conversation("conv-1"))).toBe(true);
+    expect(
+      isConversationChatPath(`${routes.conversation("conv-1")}/`),
+    ).toBe(true);
+  });
+
+  test("rejects the inspector subroute — InspectPage has no composer", () => {
+    expect(isConversationChatPath(routes.inspect("conv-1"))).toBe(false);
+  });
+
+  test("rejects the conversations list prefix without an id", () => {
+    expect(isConversationChatPath(`${routes.conversations}/`)).toBe(false);
+  });
+
+  test("rejects non-conversation routes", () => {
+    expect(isConversationChatPath("/assistant/home")).toBe(false);
+    expect(isConversationChatPath("/assistant/library")).toBe(false);
   });
 });

--- a/clients/web/src/utils/routes.ts
+++ b/clients/web/src/utils/routes.ts
@@ -213,9 +213,13 @@ export function isAboutAssistantPath(pathname: string): boolean {
 }
 
 /**
- * Whether `pathname` is a conversation route — the `/assistant` index (draft
- * conversation) or `/assistant/conversations/:id` — i.e. a route where
- * `ChatPage` mounts the active conversation's composer.
+ * Whether `pathname` falls inside the conversation *area* — the `/assistant`
+ * index (draft conversation) or anything under `/assistant/conversations/`,
+ * including subroutes like the inspector
+ * (`/assistant/conversations/:id/inspect`). Use for "is the user working in
+ * the context of a conversation" semantics (e.g. the sidebar's active-row
+ * highlight). For "is the chat composer on screen" semantics use
+ * {@link isConversationChatPath} — the inspector has no composer.
  */
 export function isConversationPath(pathname: string): boolean {
   return (
@@ -223,6 +227,29 @@ export function isConversationPath(pathname: string): boolean {
     pathname === `${routes.assistant}/` ||
     pathname.startsWith(`${routes.conversations}/`)
   );
+}
+
+/**
+ * Whether `pathname` mounts the conversation chat surface — the `/assistant`
+ * index (draft conversation, via `ConversationRedirect`) or exactly
+ * `/assistant/conversations/:id` — i.e. a route where `ChatPage` renders the
+ * active conversation's composer. Stricter than {@link isConversationPath}:
+ * conversation subroutes such as the inspector
+ * (`/assistant/conversations/:id/inspect`) are excluded because `InspectPage`
+ * replaces `ChatPage` and has no composer.
+ */
+export function isConversationChatPath(pathname: string): boolean {
+  if (pathname === routes.assistant || pathname === `${routes.assistant}/`) {
+    return true;
+  }
+  const prefix = `${routes.conversations}/`;
+  if (!pathname.startsWith(prefix)) {
+    return false;
+  }
+  // Exactly one path segment after the prefix (a bare conversation id,
+  // tolerating a trailing slash) — deeper segments are other pages.
+  const rest = pathname.slice(prefix.length).replace(/\/+$/, "");
+  return rest.length > 0 && !rest.includes("/");
 }
 
 const WWW_DOMAIN = "vellum.ai";


### PR DESCRIPTION
## Summary
Fixes remaining review gaps for voice-mode-ui.md:
- Session pill now shows on the conversation inspector route (no composer there): new strict `isConversationChatPath` predicate (exact composer-mounting routes) used by the pill host and `chooseSidebarOpenAppDestination`; the broad `isConversationPath` keeps its conversation-area semantics for the sidebar highlight in `chat-layout.tsx`
- Shared amplitude getter (`getLiveVoiceInputAmplitude`), relocated STATE_LABELS (`LIVE_VOICE_STATE_LABELS` beside the state type), unified waveform-active predicate, removed unused waveform `amplitude` prop (`getAmplitude` now required)

## Waveform-active decision
Unified both surfaces on the broader predicate (`isLiveVoiceMicLive`: listening/transcribing/thinking/speaking), which the pill already used. Per `use-live-voice.ts` ("Mic forwarding"), the mic capture graph runs for the entire session and amplitude keeps flowing into the store for barge-in even while the assistant is transcribing/thinking/speaking — only *forwarding* is gated to the user's turn. A scrolling waveform in those states honestly signals a hot mic (barge-in is possible); the composer bar's previous `listening`-only freeze understated that. `connecting`/`ending` stay frozen (no capture / teardown, amplitude pinned at 0).