### PR TITLE
fix(live-voice): abort leaked runs, order plain-tier finals, fatal unconfigured STT

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -1387,34 +1387,19 @@ export class CallController {
     callbacks: VoiceTurnCallbacks,
     runVersion: number,
   ): VoiceTurnCallbacks {
+    const guard =
+      <A extends unknown[]>(fn: (...args: A) => void) =>
+      (...args: A): void => {
+        if (this.isCurrentRun(runVersion)) fn(...args);
+      };
     const guarded: VoiceTurnCallbacks = {};
-    const {
-      assistant_text_delta: assistantTextDelta,
-      message_complete: messageComplete,
-      persisted_user_message_id: persistedUserMessageId,
-      persisted_assistant_message_id: persistedAssistantMessageId,
-    } = callbacks;
-    if (assistantTextDelta) {
-      guarded.assistant_text_delta = (msg) => {
-        if (this.isCurrentRun(runVersion)) assistantTextDelta(msg);
-      };
-    }
-    if (messageComplete) {
-      guarded.message_complete = (msg) => {
-        if (this.isCurrentRun(runVersion)) messageComplete(msg);
-      };
-    }
-    if (persistedUserMessageId) {
-      guarded.persisted_user_message_id = (messageId) => {
-        if (this.isCurrentRun(runVersion)) persistedUserMessageId(messageId);
-      };
-    }
-    if (persistedAssistantMessageId) {
-      guarded.persisted_assistant_message_id = (messageId) => {
-        if (this.isCurrentRun(runVersion)) {
-          persistedAssistantMessageId(messageId);
-        }
-      };
+    for (const key of Object.keys(callbacks) as (keyof VoiceTurnCallbacks)[]) {
+      const fn = callbacks[key];
+      if (fn) {
+        // Iterating the present keys (rather than naming them) means a
+        // callback added to VoiceTurnCallbacks can never skip the guard.
+        guarded[key] = guard(fn as (...args: unknown[]) => void);
+      }
     }
     return guarded;
   }

--- a/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
@@ -287,6 +287,30 @@ describe("LiveVoiceSession duplex orchestration", () => {
     });
   });
 
+  test("an unconfigured transcriber during a user turn cancels it and is still session-fatal", async () => {
+    const { session, frames, ingest } = createSessionHarness();
+
+    await session.start();
+    await session.handleClientFrame(audioFrame("user audio"));
+    ingest.callbacks.onError?.(
+      "unconfigured",
+      "No batch transcriber available for the configured STT provider",
+    );
+    await waitFor(() => frames.some((frame) => frame.type === "error"));
+
+    // The in-flight turn is retired so the client's turn state settles...
+    expect(
+      frames.find((frame) => frame.type === "turn_cancelled"),
+    ).toMatchObject({ reason: "stt_failed" });
+    // ...but the error is session-fatal — every future turn would fail
+    // the same way, so it must not collapse into a per-utterance
+    // cancellation loop.
+    expect(frames.find((frame) => frame.type === "error")).toMatchObject({
+      code: "stt_failed",
+      message: expect.stringContaining("No batch transcriber available"),
+    });
+  });
+
   test("a TTS failure while speaking cancels the turn with tts_failed via barge-in", async () => {
     const harness = createSessionHarness({ emitMetrics: true });
     const { session, frames, ingest, transport, controller } = harness;
@@ -314,6 +338,30 @@ describe("LiveVoiceSession duplex orchestration", () => {
     await waitFor(
       () => frames.filter((frame) => frame.type === "thinking").length === 2,
     );
+  });
+
+  test("a pre-audio TTS failure (controller still processing) hard-aborts the run", async () => {
+    const harness = createSessionHarness();
+    const { frames, transport, controller } = harness;
+
+    await startRespondingTurn(harness);
+    // The generation is running but no audio has been emitted yet, so the
+    // controller never flipped to `speaking`.
+    expect(controller.getState()).toBe("processing");
+
+    transport.deps?.onTtsFailure();
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "turn_cancelled"),
+    );
+
+    expect(
+      frames.find((frame) => frame.type === "turn_cancelled"),
+    ).toMatchObject({ reason: "tts_failed" });
+    // The speaking-gated barge-in was rejected; the hard interrupt must
+    // abort the still-running generation instead (otherwise it keeps
+    // streaming deltas/audio after the client got turn_cancelled).
+    expect(controller.bargeInCount).toBe(0);
+    expect(controller.interruptCount).toBe(1);
   });
 
   test("a TTS failure during the synthesis tail (controller idle) flushes at the session layer", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-ingest.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-ingest.test.ts
@@ -45,6 +45,8 @@ class MockStreamingTranscriber implements StreamingTranscriber {
 /**
  * Plain-tier streaming mock: like openai-whisper, it emits its `final` only
  * at end-of-stream — `stop()` flushes the pending final and then closes.
+ * The flush is asynchronous, as with real providers: the final arrives on
+ * a later network event, never inside the `stop()` call itself.
  */
 class MockPlainStreamingTranscriber extends MockStreamingTranscriber {
   constructor(private readonly finalOnStop: string) {
@@ -53,7 +55,21 @@ class MockPlainStreamingTranscriber extends MockStreamingTranscriber {
 
   override stop(): void {
     super.stop();
-    this.emit({ type: "final", text: this.finalOnStop });
+    setTimeout(() => {
+      this.emit({ type: "final", text: this.finalOnStop });
+      this.emit({ type: "closed" });
+    }, 0);
+  }
+}
+
+/**
+ * Plain-tier mock whose stop-flush is released manually, so a test can
+ * land a stopped session's forced final arbitrarily late — e.g. after a
+ * restart gap already settled with pending completed turns.
+ */
+class ManualFlushPlainStreamingTranscriber extends MockStreamingTranscriber {
+  flushStopFinal(text: string): void {
+    this.emit({ type: "final", text });
     this.emit({ type: "closed" });
   }
 }
@@ -544,10 +560,10 @@ describe("LiveVoiceIngest two-tier streaming resolution", () => {
     expect(events).toContain("partial:liv");
 
     // Turn end (PTT release) forces the utterance final by stopping the
-    // provider session (which flushes its end-of-stream final).
+    // provider session (which flushes its end-of-stream final async).
     ingest.forceTurnEnd();
     expect(first.stopped).toBe(true);
-    expect(events).toContain("final:first turn");
+    await waitFor(() => events.includes("final:first turn"));
 
     // The next turn's audio reaches a fresh provider session and its
     // forced final arrives in order.
@@ -804,6 +820,7 @@ describe("LiveVoiceIngest empty-turn signaling", () => {
     // The forced end-of-stream final is empty: the turn transcribed to
     // nothing and resolves with exactly one empty final.
     ingest.forceTurnEnd();
+    await waitFor(() => finalsOf(events).length === 1);
     expect(finalsOf(events)).toEqual(["final:"]);
 
     // The next turn's real final still flows, with no extra empty final.
@@ -919,10 +936,10 @@ describe("LiveVoiceIngest plain-tier pending turns", () => {
     ingest.pushAudio(speechChunk(320, 8_000));
     await waitFor(() => first.sentChunks.length === 1);
 
-    // Turn 1 ends: the per-turn cycle forces its final and starts the
-    // (deferred) next session.
+    // Turn 1 ends: the per-turn cycle forces its final (flushed async by
+    // the stopped session) and starts the (deferred) next session.
     ingest.forceTurnEnd();
-    expect(events).toContain("final:turn one");
+    await waitFor(() => events.includes("final:turn one"));
 
     // A fast follow-up utterance starts AND completes inside the restart
     // gap — it must not merge into the next streaming turn's final.
@@ -947,6 +964,69 @@ describe("LiveVoiceIngest plain-tier pending turns", () => {
       "final:turn two",
       "final:turn three",
     ]);
+    expect(batch.requests).toHaveLength(1);
+    expect(batch.requests[0]?.audio.readInt16LE(44)).toBe(9_000);
+
+    ingest.dispose();
+  });
+
+  test("a forced final arriving after the restart-gap settle still precedes the pending turn's batch final", async () => {
+    const first = new ManualFlushPlainStreamingTranscriber();
+    let releaseAfterGap!: (t: StreamingTranscriber | null) => void;
+    const gapResolution = new Promise<StreamingTranscriber | null>(
+      (resolve) => {
+        releaseAfterGap = resolve;
+      },
+    );
+    let plainResolutions = 0;
+    const batch = new MockBatchTranscriber(["turn two"]);
+    const { events, ingest } = createIngest({
+      deps: {
+        resolveStreamingTranscriber: (options) => {
+          if (options.utteranceBoundaryFinals) {
+            return Promise.resolve(null);
+          }
+          plainResolutions += 1;
+          if (plainResolutions === 1) {
+            return Promise.resolve<StreamingTranscriber | null>(first);
+          }
+          if (plainResolutions === 2) {
+            return gapResolution;
+          }
+          return Promise.resolve<StreamingTranscriber | null>(
+            new MockPlainStreamingTranscriber(""),
+          );
+        },
+        resolveBatchTranscriber: async () => batch,
+      },
+    });
+
+    ingest.start();
+    ingest.pushAudio(speechChunk(320, 8_000));
+    await waitFor(() => first.sentChunks.length === 1);
+
+    // Turn 1 ends: its forced final is now outstanding on the stopped
+    // session, which has not flushed it yet.
+    ingest.forceTurnEnd();
+    expect(first.stopped).toBe(true);
+
+    // Turn 2 starts AND completes inside the restart gap...
+    ingest.pushAudio(speechChunk(320, 9_000));
+    ingest.forceTurnEnd();
+
+    // ...and the gap settles (routing turn 2 to batch transcription)
+    // while turn 1's final is still outstanding. Turn 2's batch final
+    // must hold until turn 1's final resolves — an inversion here would
+    // make the session treat turn 1's transcript as the newer utterance,
+    // superseding turn 2's response.
+    releaseAfterGap(new MockPlainStreamingTranscriber(""));
+    await sleep(25);
+    expect(finalsOf(events)).toEqual([]);
+
+    // Turn 1's final flushes late. Order must still be turn 1, turn 2.
+    first.flushStopFinal("turn one");
+    await waitFor(() => finalsOf(events).length === 2);
+    expect(finalsOf(events)).toEqual(["final:turn one", "final:turn two"]);
     expect(batch.requests).toHaveLength(1);
     expect(batch.requests[0]?.audio.readInt16LE(44)).toBe(9_000);
 

--- a/assistant/src/live-voice/__tests__/live-voice-integration.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-integration.test.ts
@@ -47,6 +47,14 @@ interface FakeTurnScript {
   deltas: string[];
   /** When false, the turn stays in flight until aborted (barge-in). */
   autoComplete?: boolean;
+  /**
+   * Deltas emitted only after {@link lateGate} resolves, deliberately
+   * WITHOUT re-checking the abort signal: they simulate a bridge that
+   * keeps streaming briefly after an abort, which the controller's
+   * run-version guard must drop.
+   */
+  lateDeltas?: string[];
+  lateGate?: Promise<void>;
 }
 
 let turnScripts: FakeTurnScript[] = [];
@@ -70,6 +78,12 @@ async function fakeStartVoiceTurn(
       break;
     }
     opts.onTextDelta?.(delta);
+  }
+  if (script.lateGate) {
+    await script.lateGate;
+    for (const delta of script.lateDeltas ?? []) {
+      opts.onTextDelta?.(delta);
+    }
   }
   if (script.autoComplete !== false && !opts.signal?.aborted) {
     opts.onComplete?.();
@@ -143,9 +157,15 @@ class MockStreamingTranscriber implements StreamingTranscriber {
 /** Whether the fake TTS holds each synthesis job open until aborted. */
 let ttsHoldUntilAbort = false;
 
+/** Whether the fake TTS fails every job before emitting any audio. */
+let ttsFailSynthesis = false;
+
 const fakeStreamTtsAudio: LiveVoiceTtsStreamer = async (
   options: LiveVoiceTtsOptions,
 ) => {
+  if (ttsFailSynthesis) {
+    throw new Error("synthetic TTS provider failure");
+  }
   options.onAudioChunk({
     type: "tts_audio",
     contentType: "audio/pcm",
@@ -296,6 +316,7 @@ beforeEach(() => {
   turnScripts = [];
   voiceTurnCalls = [];
   ttsHoldUntilAbort = false;
+  ttsFailSynthesis = false;
 });
 
 afterEach(async () => {
@@ -442,6 +463,51 @@ describe("LiveVoiceSession wired duplex integration", () => {
     );
     expect(metricsEvents).toContain("turn_cancelled:live-turn-1");
     expect(metricsEvents).toContain("turn_completed:live-turn-2");
+    expect(frames.filter((frame) => frame.type === "error")).toEqual([]);
+  });
+
+  test("a pre-audio TTS failure aborts the run — no deltas or audio leak after turn_cancelled", async () => {
+    let releaseLateDeltas!: () => void;
+    const lateGate = new Promise<void>((resolve) => {
+      releaseLateDeltas = resolve;
+    });
+    turnScripts = [
+      {
+        deltas: ["First sentence. "],
+        lateDeltas: ["Late sentence after the failure."],
+        lateGate,
+        autoComplete: false,
+      },
+    ];
+    // Every synthesis job fails before emitting audio, so the controller
+    // never leaves `processing` (the audio-start callback never fires).
+    ttsFailSynthesis = true;
+    const { session, frames, transcriber } = createWiredHarness();
+
+    await session.start();
+    await session.handleBinaryAudio(loudChunk());
+    await waitFor(() => transcriber.audioChunks.length >= 1);
+    await session.handleClientFrame({ type: "ptt_release" });
+    transcriber.emit({ type: "final", text: "question one" });
+
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "turn_cancelled"),
+    );
+    expect(
+      frames.find((frame) => frame.type === "turn_cancelled"),
+    ).toMatchObject({ reason: "tts_failed" });
+
+    // The generation streams on after the cancellation: the aborted run's
+    // late tokens must not surface as frames or synthesis to the client.
+    const deltasBeforeLate = typedFrames(frames, "assistant_text_delta");
+    releaseLateDeltas();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    expect(typedFrames(frames, "assistant_text_delta")).toEqual(
+      deltasBeforeLate,
+    );
+    expect(typedFrames(frames, "tts_audio")).toEqual([]);
+    expect(frames.some((frame) => frame.type === "tts_done")).toBe(false);
     expect(frames.filter((frame) => frame.type === "error")).toEqual([]);
   });
 

--- a/assistant/src/live-voice/__tests__/live-voice-session-harness.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-session-harness.ts
@@ -152,6 +152,7 @@ export class FakeController {
   state: "idle" | "processing" | "speaking" = "idle";
   readonly utterances: string[] = [];
   bargeInCount = 0;
+  interruptCount = 0;
   destroyed = false;
 
   async handleCallerUtterance(transcript: string): Promise<void> {
@@ -167,6 +168,11 @@ export class FakeController {
     this.bargeInCount += 1;
     this.state = "idle";
     return true;
+  }
+
+  handleInterrupt(): void {
+    this.interruptCount += 1;
+    this.state = "idle";
   }
 
   getState(): "idle" | "processing" | "speaking" {

--- a/assistant/src/live-voice/live-voice-ingest.ts
+++ b/assistant/src/live-voice/live-voice-ingest.ts
@@ -396,6 +396,15 @@ export class LiveVoiceIngest {
     settled: boolean;
     /** The empty fallback was emitted — drop the source's late finals. */
     emittedEmpty: boolean;
+    /**
+     * Set when a later turn settled onto the batch queue while this final
+     * was still outstanding
+     * ({@link chainBatchQueueBehindOutstandingForcedFinal}): resolution
+     * delivers the text (real final, or `""` for the empty fallback) here
+     * instead of emitting directly, so the queued placeholder emits it in
+     * turn order ahead of the younger turns.
+     */
+    deliver?: (text: string) => void;
   } | null = null;
 
   /**
@@ -560,6 +569,9 @@ export class LiveVoiceIngest {
     this.activeTranscriptionAbort = null;
     this.turnDetector.dispose();
     this.clearBoundaryFinalFallback();
+    // Release a queue placeholder waiting on the forced final (the
+    // placeholder's own disposed check suppresses the emission).
+    this.plainForcedFinal?.deliver?.("");
     this.plainForcedFinal = null;
     this.currentTurnChunks = [];
     this.pendingCompletedTurns = [];
@@ -669,6 +681,10 @@ export class LiveVoiceIngest {
           { turnCount: pending.length },
           "Batch-transcribing turns completed during plain-tier streaming startup",
         );
+        // The previous turn's forced final may still be outstanding (its
+        // stopped session flushes asynchronously): its final must enter
+        // the queue before these younger turns' batch finals.
+        this.chainBatchQueueBehindOutstandingForcedFinal();
         for (const { chunks, durationMs } of pending) {
           this.enqueueTurnTranscription(chunks, durationMs);
         }
@@ -708,6 +724,12 @@ export class LiveVoiceIngest {
     this.startupFrames = [];
     this.startupFramesPushedTotal = 0;
     this.startupFramesCompletedTurnsMark = 0;
+
+    // A plain-tier turn's forced final may still be outstanding (e.g. the
+    // restart's resolution failed into this recovery). Every batch-mode
+    // final flows through the serialized queue, so chaining once here
+    // keeps the outstanding older final ahead of all of them.
+    this.chainBatchQueueBehindOutstandingForcedFinal();
 
     const pending = this.pendingCompletedTurns;
     this.pendingCompletedTurns = [];
@@ -808,7 +830,11 @@ export class LiveVoiceIngest {
         return; // the closed handler emits the empty fallback
       }
       forced.settled = true;
-      this.emitStreamingFinal(text, forced.durationMs);
+      if (forced.deliver) {
+        forced.deliver(text);
+      } else {
+        this.emitStreamingFinal(text, forced.durationMs);
+      }
       return;
     }
 
@@ -916,7 +942,38 @@ export class LiveVoiceIngest {
     }
     forced.settled = true;
     forced.emittedEmpty = true;
-    this.emitStreamingFinal("", forced.durationMs);
+    if (forced.deliver) {
+      forced.deliver("");
+    } else {
+      this.emitStreamingFinal("", forced.durationMs);
+    }
+  }
+
+  /**
+   * If the previous plain-tier stop-cycle's forced final is still
+   * outstanding (the stopped session flushes its end-of-stream final
+   * asynchronously), claim it onto the batch queue ahead of whatever is
+   * enqueued next: the final — real, or the empty fallback when the
+   * stopped session closes without one — is delivered from the queue, so
+   * a younger turn routed through the queue can never overtake it. The
+   * placeholder is bounded by the same signals that settle every forced
+   * final: the stopped session's `final`/`closed` events, the next
+   * restart's settle, or {@link dispose}.
+   */
+  private chainBatchQueueBehindOutstandingForcedFinal(): void {
+    const forced = this.plainForcedFinal;
+    if (forced === null || forced.settled || forced.deliver) {
+      return;
+    }
+    const delivered = new Promise<string>((resolve) => {
+      forced.deliver = resolve;
+    });
+    this.batchTurnQueue = this.batchTurnQueue.then(async () => {
+      const text = await delivered;
+      if (!this.disposed) {
+        this.callbacks.onTranscriptFinal?.(text, forced.durationMs);
+      }
+    });
   }
 
   // ── Boundary-tier empty-final fallback ─────────────────────────────

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -116,6 +116,11 @@ export type LiveVoiceTransportFactory = (
 export interface LiveVoiceSessionController {
   handleCallerUtterance(transcript: string): Promise<void>;
   handleBargeIn(onAccepted?: () => void): boolean;
+  /**
+   * Hard interrupt: aborts the in-flight run in any controller state
+   * (unlike {@link handleBargeIn}, which gates on `speaking`).
+   */
+  handleInterrupt(): void;
   getState(): "idle" | "processing" | "speaking";
   destroy(): void;
 }
@@ -506,24 +511,37 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           return;
         }
         log.warn({ category }, `Live voice transcription error: ${message}`);
-        // A transcription error is turn-scoped whenever a user turn is in
-        // flight: retire that turn with a machine reason so the client
-        // resumes listening instead of treating the session as dead.
         const turn = this.currentTurn;
-        if (turn?.phase === "listening") {
-          this.cancelTurnWithNotice(turn, LiveVoiceProtocolErrorCode.SttFailed);
-          return;
-        }
-        // No user turn to retire. "unconfigured" means no transcriber can
-        // be resolved at all — every future turn would fail the same way,
-        // so that one is session-fatal; other categories are transient
-        // (the ingest keeps running or falls back to batch STT).
+        // "unconfigured" means no transcriber can be resolved at all —
+        // every future turn would fail the same way — so it is
+        // session-fatal regardless of turn state. It fires from a turn's
+        // transcription attempt, i.e. normally WITH a listening turn in
+        // flight; checking the turn-scoped branch first would swallow the
+        // fatality into an endless per-utterance cancellation loop.
+        // Retire the in-flight turn (so the client's turn state machine
+        // settles), then send the fatal error frame.
         if (category === "unconfigured") {
+          if (turn?.phase === "listening") {
+            this.cancelTurnWithNotice(
+              turn,
+              LiveVoiceProtocolErrorCode.SttFailed,
+            );
+          }
           void this.sendFrame({
             type: "error",
             code: LiveVoiceProtocolErrorCode.SttFailed,
             message: `Live voice transcription error (${category}): ${message}`,
           });
+          return;
+        }
+        // Other categories are transient (the ingest keeps running or
+        // falls back to batch STT) and turn-scoped whenever a user turn
+        // is in flight: retire that turn with a machine reason so the
+        // client resumes listening instead of treating the session as
+        // dead. With no turn in flight there is nothing client-visible
+        // to do.
+        if (turn?.phase === "listening") {
+          this.cancelTurnWithNotice(turn, LiveVoiceProtocolErrorCode.SttFailed);
         }
       },
     };
@@ -671,8 +689,18 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (this.controller?.handleBargeIn(cancelTurn)) {
       return;
     }
-    this.transport?.discardPendingText?.();
+    // The speaking-gated barge-in was rejected: the controller is either
+    // still `processing` (the failed job was the turn's first synthesis —
+    // the generation is still running with no audio out) or already
+    // `idle` (only the synthesis tail was live). Order the cancellation
+    // notice first, as the accepted path does, then hard-abort the run:
+    // handleInterrupt works in any state and bumps the run version so no
+    // assistant_text_delta/tts_audio from this run can follow the
+    // turn_cancelled notice (with no audio started it emits no
+    // end-of-turn marker either).
     cancelTurn();
+    this.controller?.handleInterrupt();
+    this.transport?.discardPendingText?.();
   }
 
   // ── Assistant output ─────────────────────────────────────────────────

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -751,10 +751,9 @@ describe("turn_cancelled", () => {
     });
 
     expect(h.view.result.current.state).toBe("listening");
-    // The machine reason is surfaced non-fatally.
-    expect(useLiveVoiceStore.getState().turnCancelledReason).toBe(
-      "empty_transcript",
-    );
+    // The machine reason is surfaced non-fatally through the hook's
+    // public result.
+    expect(h.view.result.current.turnCancelledReason).toBe("empty_transcript");
 
     // Forwarding re-opened: the next utterance streams again.
     act(() => {
@@ -767,7 +766,7 @@ describe("turn_cancelled", () => {
     act(() => {
       h.client.emit("thinking", { type: "thinking", seq: 5, turnId: "t2" });
     });
-    expect(useLiveVoiceStore.getState().turnCancelledReason).toBeNull();
+    expect(h.view.result.current.turnCancelledReason).toBeNull();
   });
 
   test("while speaking flushes playback and resumes listening", async () => {
@@ -798,9 +797,7 @@ describe("turn_cancelled", () => {
 
     expect(h.player.stopCount).toBeGreaterThanOrEqual(1);
     expect(h.view.result.current.state).toBe("listening");
-    expect(useLiveVoiceStore.getState().turnCancelledReason).toBe(
-      "tts_failed",
-    );
+    expect(h.view.result.current.turnCancelledReason).toBe("tts_failed");
     expect(h.client.closed).toBe(false);
   });
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -110,6 +110,12 @@ export interface UseLiveVoiceResult {
   assistantTranscript: string;
   /** Smoothed mic amplitude in [0, 1]. */
   inputAmplitude: number;
+  /**
+   * Machine reason from the last server `turn_cancelled` frame (e.g.
+   * `empty_transcript`, `stt_failed`, `tts_failed`). Non-fatal — the
+   * session resumed listening. Cleared when the next turn is accepted.
+   */
+  turnCancelledReason: string | null;
   /** Failure message when `state === "failed"`, else `null`. */
   error: string | null;
   /**
@@ -203,6 +209,7 @@ export function useLiveVoice(
   const finalTranscript = useLiveVoiceStore.use.finalTranscript();
   const assistantTranscript = useLiveVoiceStore.use.assistantTranscript();
   const inputAmplitude = useLiveVoiceStore.use.inputAmplitude();
+  const turnCancelledReason = useLiveVoiceStore.use.turnCancelledReason();
   const error = useLiveVoiceStore.use.error();
 
   const sessionRef = useRef<SessionContext | null>(null);
@@ -474,6 +481,7 @@ export function useLiveVoice(
     finalTranscript,
     assistantTranscript,
     inputAmplitude,
+    turnCancelledReason,
     error,
     start,
     stop,


### PR DESCRIPTION
## Summary
Final review-round fixes: pre-audio TTS failures now abort the controller run so no frames leak after turn_cancelled; plain-tier restart gaps preserve final ordering by chaining pending-turn batch transcription behind the outstanding forced final (test mock now flushes asynchronously like real providers); unconfigured STT is session-fatal even mid-turn; generic run-guard wrapper; turnCancelledReason exposed from the hook.