### PR TITLE
fix: popout pill surface, failure surfacing, start guard + voice UI cleanup

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -661,6 +661,10 @@ export function ChatLayout() {
       {isMobile ? (
         <main className="relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden">
           <Outlet  />
+          {/* A popout narrowed below the mobile breakpoint lands in this
+              branch — still headerless, so it still needs the floating
+              session surface (see the desktop popout branch below). */}
+          {isPopout ? <VoiceSessionPillHost variant="standalone" /> : null}
           {drawerVisible ? (
             <div
               ref={drawerRef}
@@ -696,8 +700,15 @@ export function ChatLayout() {
           ) : null}
         </main>
       ) : isPopout ? (
-        <main className="flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden p-4">
+        <main className="relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden p-4">
           <Outlet />
+          {/* Pop-outs render no header, but they DO support in-window
+              conversation switching (Cmd+Up/Down) — so a live session started
+              here can lose its owning composer exactly like in the main
+              window. The standalone variant floats the pill (or the failed
+              chip) over the top-right corner; it renders nothing while the
+              on-screen composer owns the session. */}
+          <VoiceSessionPillHost variant="standalone" />
         </main>
       ) : (
         <div className="flex min-w-0 flex-1 gap-4 p-4 min-h-0 overflow-hidden flex-col md:flex-row">

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -56,6 +56,10 @@ mock.module("@/stores/assistant-feature-flag-store", () => ({
 }));
 
 import {
+  makeControlsSpies,
+  seedLiveVoiceSession as seedLiveVoiceStore,
+} from "@/domains/chat/voice/live-voice/live-voice-fakes.test-helper";
+import {
   useLiveVoiceStore,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
@@ -63,26 +67,24 @@ import {
 const liveStarterSpy = mock(
   (_assistantId: string, _conversationId: string | null) => {},
 );
-const liveControls = {
-  stop: mock(() => {}),
-  release: mock(() => {}),
-  interrupt: mock(() => {}),
-};
+const liveControls = makeControlsSpies();
 
 /**
- * Seed the real live-voice store with an active session. `conversationId`
- * defaults to the id `renderVoiceComposer` binds, so the rendered composer
- * owns the session; pass another id to simulate a session owned by a
- * different thread, or `null` for a draft-started session.
+ * Seed the real live-voice store with an active session (shared helper bound
+ * to this file's ids/spies). `conversationId` defaults to the id
+ * `renderVoiceComposer` binds, so the rendered composer owns the session;
+ * pass another id to simulate a session owned by a different thread, or
+ * `null` for a draft-started session.
  */
 function seedLiveVoiceSession(
   state: LiveVoiceSessionState,
   conversationId: string | null = "conv_test",
 ) {
-  const store = useLiveVoiceStore.getState();
-  store.setSessionContext("asst_test", conversationId);
-  store.setControls(liveControls);
-  store.setState(state);
+  seedLiveVoiceStore(state, {
+    assistantId: "asst_test",
+    conversationId,
+    controls: liveControls,
+  });
 }
 
 // The real `VoiceInputButton` self-suppresses (returns null) unless the test

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -34,8 +34,10 @@ import {
 } from "@/domains/chat/components/voice-input-button";
 import { type TurnPhase, useTurnStore } from "@/domains/chat/turn-store";
 import {
+    endLiveVoiceSession,
     getLiveVoiceInputAmplitude,
     isLiveVoiceSessionActive,
+    releaseLiveVoiceTurn,
     useIsLiveVoiceSessionOwnedBy,
     useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
@@ -272,20 +274,16 @@ export function ChatComposer({
   const showLiveVoiceTranscript = isLiveVoiceActive && hasLiveVoiceTranscript;
   // Session verbs go through the store seams registered by the layout-owned
   // controller: `starter` (registered for the controller's whole mount) to
-  // start, per-session `controls` to stop/release. Read via `getState()` in
-  // handlers per STATE_MANAGEMENT.md — no subscription needed.
+  // start, per-session `controls` to stop/release — the latter via the shared
+  // module-level `endLiveVoiceSession`/`releaseLiveVoiceTurn` helpers, which
+  // read the store with `getState()` per STATE_MANAGEMENT.md (no subscription
+  // needed for callback-only reads).
   const handleLiveVoiceStart = useCallback(() => {
     if (!assistantId) {
       return;
     }
     useLiveVoiceStore.getState().starter?.(assistantId, conversationId ?? null);
   }, [assistantId, conversationId]);
-  const handleLiveVoiceEnd = useCallback(() => {
-    useLiveVoiceStore.getState().controls?.stop();
-  }, []);
-  const handleLiveVoiceSend = useCallback(() => {
-    useLiveVoiceStore.getState().controls?.release();
-  }, []);
   // Dismissing the failure notice resets the store back to idle — `failed` is
   // terminal for the session, so this only clears the surfaced error.
   const dismissLiveVoiceError = useCallback(() => {
@@ -667,8 +665,8 @@ export function ChatComposer({
               <VoiceComposerBar
                 state={liveVoiceState}
                 getAmplitude={getLiveVoiceInputAmplitude}
-                onEnd={handleLiveVoiceEnd}
-                onSend={handleLiveVoiceSend}
+                onEnd={endLiveVoiceSession}
+                onSend={releaseLiveVoiceTurn}
               />
             ) : (
               <div className="flex items-center justify-between px-2 pb-2">

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.test.tsx
@@ -26,6 +26,10 @@ import type { Conversation } from "@/types/conversation-types";
 import { routes } from "@/utils/routes";
 
 import {
+  makeControlsSpies,
+  seedLiveVoiceSession,
+} from "@/domains/chat/voice/live-voice/live-voice-fakes.test-helper";
+import {
   useLiveVoiceStore,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
@@ -78,21 +82,18 @@ const { VoiceSessionPillHost } = await import(
   "@/domains/chat/components/voice-session-pill-host"
 );
 
-const controls = {
-  stop: mock(() => {}),
-  release: mock(() => {}),
-  interrupt: mock(() => {}),
-};
+const controls = makeControlsSpies();
 
 /** Put the live-voice store into an active session owned by `conversationId`. */
 function startSession(
   state: LiveVoiceSessionState = "listening",
   conversationId: string | null = OWNING_CONVERSATION_ID,
 ) {
-  const store = useLiveVoiceStore.getState();
-  store.setSessionContext(ASSISTANT_ID, conversationId);
-  store.setControls(controls);
-  store.setState(state);
+  seedLiveVoiceSession(state, {
+    assistantId: ASSISTANT_ID,
+    conversationId,
+    controls,
+  });
 }
 
 beforeEach(() => {
@@ -229,11 +230,95 @@ describe("VoiceSessionPillHost — visibility", () => {
     expect(pill()).not.toBeNull();
   });
 
-  test("renders nothing after the session fails", () => {
+  test("failure on a composer route renders nothing — the composer's Notice owns the error there", () => {
+    // beforeEach: viewing OTHER_CONVERSATION_ID's chat route, where a
+    // voice-enabled composer renders its own failure Notice. The host must
+    // not double-surface the error next to it.
     startSession("listening");
     useLiveVoiceStore.getState().fail("boom");
     const { container } = render(<VoiceSessionPillHost />);
     expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("VoiceSessionPillHost — failure surface", () => {
+  const errorChip = () => screen.queryByRole("alert");
+
+  test("failure while on a composer-less route shows the dismissible error chip", () => {
+    startSession("listening");
+    mockPathname = routes.home;
+    useLiveVoiceStore.getState().fail("Microphone capture could not start.");
+    render(<VoiceSessionPillHost />);
+    expect(errorChip()).not.toBeNull();
+    expect(
+      screen.getByText("Microphone capture could not start."),
+    ).toBeTruthy();
+    // The pill and the chip never both render: the failed session is inactive.
+    expect(pill()).toBeNull();
+  });
+
+  test("failure over the desktop fullscreen app viewer shows the error chip", () => {
+    startSession("listening");
+    useConversationStore
+      .getState()
+      .setActiveConversationId(OWNING_CONVERSATION_ID);
+    mockPathname = routes.conversation(OWNING_CONVERSATION_ID);
+    mockMainView = "app";
+    useLiveVoiceStore.getState().fail("Connection lost.");
+    render(<VoiceSessionPillHost />);
+    expect(errorChip()).not.toBeNull();
+  });
+
+  test("dismissing the chip resets the store to idle, mirroring the composer Notice", () => {
+    startSession("listening");
+    mockPathname = routes.home;
+    useLiveVoiceStore.getState().fail("boom");
+    render(<VoiceSessionPillHost />);
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(useLiveVoiceStore.getState().state).toBe("idle");
+    expect(useLiveVoiceStore.getState().error).toBeNull();
+    expect(errorChip()).toBeNull();
+  });
+
+  test("no chip without an error message", () => {
+    mockPathname = routes.home;
+    useLiveVoiceStore.getState().setState("failed");
+    const { container } = render(<VoiceSessionPillHost />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("VoiceSessionPillHost — standalone variant (headerless pop-outs)", () => {
+  test("renders nothing when no session is active", () => {
+    const { container } = render(<VoiceSessionPillHost variant="standalone" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("floats the pill for a session owned by another conversation", () => {
+    startSession("listening");
+    render(<VoiceSessionPillHost variant="standalone" />);
+    expect(pill()).not.toBeNull();
+    // Wired to the same controls as the header placement.
+    fireEvent.click(screen.getByRole("button", { name: "End voice session" }));
+    expect(controls.stop).toHaveBeenCalledTimes(1);
+  });
+
+  test("stays hidden while the on-screen composer owns the session", () => {
+    startSession("listening");
+    useConversationStore
+      .getState()
+      .setActiveConversationId(OWNING_CONVERSATION_ID);
+    mockPathname = routes.conversation(OWNING_CONVERSATION_ID);
+    const { container } = render(<VoiceSessionPillHost variant="standalone" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("floats the error chip for a failure on a composer-less route", () => {
+    startSession("listening");
+    mockPathname = routes.home;
+    useLiveVoiceStore.getState().fail("boom");
+    render(<VoiceSessionPillHost variant="standalone" />);
+    expect(screen.queryByRole("alert")).not.toBeNull();
   });
 });
 

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
@@ -5,7 +5,11 @@
  * `topBarRightSlot` content rather than registered through
  * `useChatLayoutSlotsStore`, because slot registration is owned by per-route
  * hooks that unmount on navigation, which is exactly when the pill must
- * persist.
+ * persist. Electron pop-out thread windows render no header at all, so
+ * `ChatLayout` mounts a second host there with `variant="standalone"`, which
+ * floats the same surface over the window's top-right corner — a session
+ * carried to another conversation via in-window switching (Cmd+Up/Down) must
+ * still have a visible control.
  *
  * Visibility is the exact complement of the composer's voice bar so that for
  * any active session exactly one of the two surfaces renders: the pill shows
@@ -20,15 +24,27 @@
  *   deliberately persists across route changes (see `chat-layout.tsx`), so
  *   the id comparison alone can't detect this,
  * - the desktop fullscreen app viewer covers the thread (`mainView === "app"`;
- *   on mobile that view keeps the composer mounted under a portal overlay
- *   that covers the header too, so the composer stays the owning surface).
- *   `app-editing` (split view) and the right-drawer detail panels keep the
- *   composer visible, so they don't count.
+ *   on mobile that view keeps the composer — the owning surface — mounted,
+ *   but under the `MobileAppOverlay` portal, which covers the composer AND
+ *   the header, so neither surface is actually visible while the overlay is
+ *   expanded. Accepted limitation: the mic stays hot with no on-screen
+ *   control until the overlay closes or minimizes, at which point the
+ *   composer's voice bar is the control again). `app-editing` (split view)
+ *   and the right-drawer detail panels keep the composer visible, so they
+ *   don't count.
  *
  * A session not yet attached to a conversation (started from a draft, before
  * the server's `ready` frame) still shows the pill when the user is away from
  * the owning composer — a live mic must always have a visible control — just
  * without a thread name or navigation target.
+ *
+ * A `failed` session unmounts the pill (no longer active), but the failure
+ * must not vanish silently: when no composer is on screen to render its
+ * failure `Notice` (see `chat-composer.tsx`), this host renders a dismissible
+ * `VoiceSessionErrorChip` in the same slot instead. On composer routes the
+ * chip stays hidden — the composer's Notice owns the error there — so the
+ * two error surfaces never double-render. Dismissing the chip resets the
+ * store to idle, mirroring the composer Notice's dismiss.
  *
  * The ■ "stop response" control is deliberately not wired: V1's `interrupt()`
  * ends the whole session, contradicting the control's "without ending the
@@ -38,28 +54,47 @@
 
 import { useCallback } from "react";
 import { useLocation, useNavigate } from "react-router";
+import type { ReactNode } from "react";
 
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { navigateToConversation } from "@/utils/conversation-navigation";
 import { isConversationChatPath } from "@/utils/routes";
 
-import { VoiceSessionPill } from "@/domains/chat/components/voice-session-pill";
+import {
+  VoiceSessionErrorChip,
+  VoiceSessionPill,
+} from "@/domains/chat/components/voice-session-pill";
 import { useActiveConversation } from "@/domains/chat/hooks/use-active-conversation";
 import {
   LIVE_VOICE_STATE_LABELS,
+  endLiveVoiceSession,
   getLiveVoiceInputAmplitude,
   isLiveVoiceSessionActive,
+  releaseLiveVoiceTurn,
   useIsLiveVoiceSessionOwnedBy,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore } from "@/stores/viewer-store";
 
-export function VoiceSessionPillHost() {
+export interface VoiceSessionPillHostProps {
+  /**
+   * Placement variant. `"header"` (default) renders the bare surface for
+   * composition into the header's right slot. `"standalone"` floats it over
+   * the window's top-right corner with its own chrome, for windows without a
+   * header (Electron pop-out thread windows). Renders nothing either way when
+   * there is neither an active session to control nor a failure to surface.
+   */
+  variant?: "header" | "standalone";
+}
+
+export function VoiceSessionPillHost({
+  variant = "header",
+}: VoiceSessionPillHostProps) {
   const state = useLiveVoiceStore.use.state();
+  const error = useLiveVoiceStore.use.error();
   const sessionAssistantId = useLiveVoiceStore.use.assistantId();
   const sessionConversationId = useLiveVoiceStore.use.conversationId();
-  const controls = useLiveVoiceStore.use.controls();
 
   const activeConversationId = useConversationStore.use.activeConversationId();
   const mainView = useViewerStore.use.mainView();
@@ -83,6 +118,9 @@ export function VoiceSessionPillHost() {
     useIsLiveVoiceSessionOwnedBy(activeConversationId);
   const visible =
     sessionActive && !(composerOnScreen && activeComposerOwnsSession);
+  // Failure surface: exact complement of the composer's failure Notice, which
+  // any on-screen voice-enabled composer renders regardless of ownership.
+  const showFailure = state === "failed" && error !== null && !composerOnScreen;
 
   // Resolves the owning row from whichever list cache holds it, fetching the
   // single row when absent. Enabled only while the pill is shown so hidden
@@ -99,24 +137,54 @@ export function VoiceSessionPillHost() {
     }
   }, [navigate, sessionConversationId]);
 
-  const handleEnd = useCallback(() => controls?.stop(), [controls]);
-  const handleSend = useCallback(() => controls?.release(), [controls]);
+  // Mirrors the composer Notice's dismiss: `failed` is terminal for the
+  // session, so resetting only clears the surfaced error.
+  const handleDismissError = useCallback(() => {
+    useLiveVoiceStore.getState().reset();
+  }, []);
 
-  if (!visible) {
+  let content: ReactNode = null;
+  if (showFailure) {
+    content = (
+      <VoiceSessionErrorChip message={error} onDismiss={handleDismissError} />
+    );
+  } else if (visible) {
+    content = (
+      <VoiceSessionPill
+        primaryLabel={LIVE_VOICE_STATE_LABELS[state]}
+        secondaryLabel={
+          owningConversation ? (owningConversation.title ?? "Untitled") : undefined
+        }
+        state={state}
+        getAmplitude={getLiveVoiceInputAmplitude}
+        onEnd={endLiveVoiceSession}
+        onSend={releaseLiveVoiceTurn}
+        onNavigate={sessionConversationId ? handleNavigate : undefined}
+      />
+    );
+  }
+
+  if (content === null) {
     return null;
   }
 
-  return (
-    <VoiceSessionPill
-      primaryLabel={LIVE_VOICE_STATE_LABELS[state]}
-      secondaryLabel={
-        owningConversation ? (owningConversation.title ?? "Untitled") : undefined
-      }
-      state={state}
-      getAmplitude={getLiveVoiceInputAmplitude}
-      onEnd={handleEnd}
-      onSend={handleSend}
-      onNavigate={sessionConversationId ? handleNavigate : undefined}
-    />
-  );
+  if (variant === "standalone") {
+    // Floats over the pop-out's content (which owns its own scrolling), so an
+    // absolute corner anchor never disturbs layout. The pill needs chrome of
+    // its own here — in the header the surrounding title bar provides it —
+    // while the error chip already carries a filled background.
+    return (
+      <div className="absolute right-4 top-4 z-30">
+        {showFailure ? (
+          content
+        ) : (
+          <div className="rounded-full border border-[var(--border-base)] bg-[var(--surface-lift)] py-1 pl-4 pr-1.5 shadow-md">
+            {content}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return content;
 }

--- a/clients/web/src/domains/chat/components/voice-session-pill.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.tsx
@@ -18,7 +18,7 @@
  * 44px min-height with 32px controls, so the pill must never stretch it.
  */
 
-import { ArrowUp, Mic, Square, X } from "lucide-react";
+import { ArrowUp, Mic, Square, TriangleAlert, X } from "lucide-react";
 
 import { Button, Typography, cn } from "@vellumai/design-library";
 
@@ -43,6 +43,8 @@ export interface VoiceSessionPillProps {
    * Stop the in-flight assistant response without ending the session. The
    * ■ control is hidden when absent — hosts must only wire this once a
    * turn-scoped interrupt exists; the ✕ (`onEnd`) is the destructive control.
+   * Dormant until the turn-scoped interrupt lands (engine plan, JARVIS-1240):
+   * no host passes it yet, deliberately.
    */
   onStop?: () => void;
   /** End the voice session. */
@@ -146,6 +148,53 @@ export function VoiceSessionPill({
         tooltip="Send now"
         onClick={onSend}
       />
+    </div>
+  );
+}
+
+export interface VoiceSessionErrorChipProps {
+  /** Failure message from the live-voice store (`error` when `failed`). */
+  message: string;
+  /** Dismiss the failure (host resets the store back to idle). */
+  onDismiss: () => void;
+}
+
+/**
+ * Compact failed-session chip rendered in the pill's slot when a session
+ * fails while no composer (and thus no composer failure `Notice`) is on
+ * screen — Home, Library, the inspector, the fullscreen app viewer. Same
+ * height budget as the pill (`h-8`, title-bar safe), error tone tokens per
+ * the design-library `Notice` error treatment.
+ */
+export function VoiceSessionErrorChip({
+  message,
+  onDismiss,
+}: VoiceSessionErrorChipProps) {
+  return (
+    <div
+      role="alert"
+      className="flex h-8 max-w-80 items-center gap-2 rounded-full border border-[color-mix(in_srgb,var(--system-negative-strong)_25%,transparent)] bg-[var(--system-negative-weak)] py-1 pl-3 pr-1.5 [-webkit-app-region:no-drag]"
+    >
+      <TriangleAlert
+        aria-hidden
+        className="size-3.5 shrink-0 text-[color:var(--system-negative-strong)]"
+      />
+      <Typography
+        as="p"
+        variant="label-medium-default"
+        className="truncate text-[var(--content-default)]"
+        title={message}
+      >
+        {message}
+      </Typography>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Dismiss"
+        className="shrink-0 cursor-pointer rounded-full p-0.5 text-[color:var(--content-secondary)] opacity-70 transition-opacity hover:opacity-100"
+      >
+        <X aria-hidden className="size-3.5" strokeWidth={2} />
+      </button>
     </div>
   );
 }

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
@@ -7,11 +7,20 @@
  * assert state-machine transitions, barge-in, automatic ptt_release, and
  * teardown.
  *
+ * Also exports the store-seeding helpers (`makeControlsSpies`,
+ * `seedLiveVoiceSession`) shared by the surface tests that drive the real
+ * `useLiveVoiceStore` directly (`chat-composer.test.tsx`,
+ * `voice-session-pill-host.test.tsx`, `live-voice-store.test.ts`).
+ *
  * Shared by `use-live-voice.test.ts` and
- * `use-live-voice-session-controller.test.tsx`. Type-only imports keep the
- * generated-SDK import graph out of test files (the real client's
- * `connection.ts` is mocked separately by each test).
+ * `use-live-voice-session-controller.test.tsx`. Imports from the primitives
+ * stay type-only to keep the generated-SDK import graph out of test files
+ * (the real client's `connection.ts` is mocked separately by each test); the
+ * store is a value import, but it is self-contained zustand with no heavy
+ * dependencies.
  */
+
+import { mock } from "bun:test";
 
 import type {
   LiveVoiceClientEventMap,
@@ -21,6 +30,11 @@ import type {
   LiveVoiceAudioCaptureOptions,
   LiveVoiceCaptureResult,
 } from "@/domains/chat/voice/live-voice/pcm-capture";
+import {
+  useLiveVoiceStore,
+  type LiveVoiceSessionControls,
+  type LiveVoiceSessionState,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
 
 export class FakeClient {
   connectArgs: { assistantId: string; conversationId?: string } | null = null;
@@ -162,4 +176,35 @@ export class FakePlayer {
 export function pcmChunk(ms: number): ArrayBuffer {
   const samples = Math.round((16000 * ms) / 1000);
   return new Int16Array(samples).buffer;
+}
+
+/** Spy implementations of the store-registered session controls. */
+export function makeControlsSpies() {
+  return {
+    stop: mock(() => {}),
+    release: mock(() => {}),
+    interrupt: mock(() => {}),
+  } satisfies LiveVoiceSessionControls;
+}
+
+/**
+ * Seed the real `useLiveVoiceStore` with a session, mirroring the writes the
+ * controller performs on `start()` (context → controls → state). Pass
+ * `conversationId: null` for a draft-started session; omit `controls` to
+ * leave none registered.
+ */
+export function seedLiveVoiceSession(
+  state: LiveVoiceSessionState,
+  options: {
+    assistantId: string;
+    conversationId: string | null;
+    controls?: LiveVoiceSessionControls;
+  },
+): void {
+  const store = useLiveVoiceStore.getState();
+  store.setSessionContext(options.assistantId, options.conversationId);
+  if (options.controls) {
+    store.setControls(options.controls);
+  }
+  store.setState(state);
 }

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -7,19 +7,17 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { makeControlsSpies } from "@/domains/chat/voice/live-voice/live-voice-fakes.test-helper";
 import {
+  endLiveVoiceSession,
   getLiveVoiceInputAmplitude,
   isLiveVoiceMicLive,
   isLiveVoiceSessionActive,
   isLiveVoiceSessionOwnedBy,
+  releaseLiveVoiceTurn,
   useLiveVoiceStore,
-  type LiveVoiceSessionControls,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
-
-function makeControls(): LiveVoiceSessionControls {
-  return { stop: mock(() => {}), release: mock(() => {}), interrupt: mock(() => {}) };
-}
 
 beforeEach(() => {
   useLiveVoiceStore.getState().reset();
@@ -172,21 +170,45 @@ describe("useLiveVoiceStore — session controls", () => {
   });
 
   test("setControls registers the owning controller's controls", () => {
-    const controls = makeControls();
+    const controls = makeControlsSpies();
     useLiveVoiceStore.getState().setControls(controls);
     expect(useLiveVoiceStore.getState().controls).toBe(controls);
   });
 
   test("setControls(null) deregisters controls", () => {
-    useLiveVoiceStore.getState().setControls(makeControls());
+    useLiveVoiceStore.getState().setControls(makeControlsSpies());
     useLiveVoiceStore.getState().setControls(null);
     expect(useLiveVoiceStore.getState().controls).toBeNull();
   });
 
   test("reset clears registered controls", () => {
-    useLiveVoiceStore.getState().setControls(makeControls());
+    useLiveVoiceStore.getState().setControls(makeControlsSpies());
     useLiveVoiceStore.getState().reset();
     expect(useLiveVoiceStore.getState().controls).toBeNull();
+  });
+});
+
+describe("endLiveVoiceSession / releaseLiveVoiceTurn", () => {
+  test("route to the registered controls (and only the matching verb)", () => {
+    const controls = makeControlsSpies();
+    useLiveVoiceStore.getState().setControls(controls);
+
+    endLiveVoiceSession();
+    expect(controls.stop).toHaveBeenCalledTimes(1);
+    expect(controls.release).not.toHaveBeenCalled();
+
+    releaseLiveVoiceTurn();
+    expect(controls.release).toHaveBeenCalledTimes(1);
+    expect(controls.stop).toHaveBeenCalledTimes(1);
+    expect(controls.interrupt).not.toHaveBeenCalled();
+  });
+
+  test("no-op when no controls are registered", () => {
+    expect(useLiveVoiceStore.getState().controls).toBeNull();
+    expect(() => {
+      endLiveVoiceSession();
+      releaseLiveVoiceTurn();
+    }).not.toThrow();
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -92,7 +92,8 @@ export interface LiveVoiceSessionControls {
    * Stop in-flight assistant playback without the user having to speak. V1
    * behavior: same path as barge-in interrupt, which ends the session (a later
    * engine revision makes it turn-scoped). No-op unless the session is
-   * `speaking`.
+   * `speaking`. Dormant until the turn-scoped interrupt lands (engine plan,
+   * JARVIS-1240) — deliberately kept registered, but no surface wires it yet.
    */
   interrupt: () => void;
 }
@@ -302,6 +303,28 @@ export const useLiveVoiceStore = createSelectors(useLiveVoiceStoreBase);
  */
 export function getLiveVoiceInputAmplitude(): number {
   return useLiveVoiceStore.getState().inputAmplitude;
+}
+
+/**
+ * End the active live-voice session through the store-registered
+ * {@link LiveVoiceSessionControls}. No-op when no session (or no controls)
+ * exists. Module-level so every surface with an "end session" affordance (the
+ * composer's voice bar, the title-bar pill) shares one stable identity and
+ * reads `controls` via `getState()` in the callback — subscribing to
+ * `controls` just to call it would re-render on register/clear (see
+ * STATE_MANAGEMENT.md).
+ */
+export function endLiveVoiceSession(): void {
+  useLiveVoiceStore.getState().controls?.stop();
+}
+
+/**
+ * Manually release the current push-to-talk turn ("send now") through the
+ * store-registered controls. No-op when no session is `listening`. See
+ * {@link endLiveVoiceSession} for why this is module-level.
+ */
+export function releaseLiveVoiceTurn(): void {
+  useLiveVoiceStore.getState().controls?.release();
 }
 
 /**

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -456,33 +456,6 @@ describe("session context and controls", () => {
     expect(store.startedConversationId).toBeNull();
   });
 
-  test("release() while listening sends ptt_release and moves to transcribing", async () => {
-    const h = renderController();
-    await startListening(h);
-
-    act(() => {
-      h.view.result.current.release();
-    });
-
-    expect(h.client.pttReleaseCount).toBe(1);
-    expect(h.view.result.current.state).toBe("transcribing");
-  });
-
-  test("release() outside listening is a no-op", async () => {
-    const h = renderController();
-    await act(async () => {
-      await h.view.result.current.start("assistant-1", "conv-1");
-    });
-    expect(h.view.result.current.state).toBe("connecting");
-
-    act(() => {
-      h.view.result.current.release();
-    });
-
-    expect(h.client.pttReleaseCount).toBe(0);
-    expect(h.view.result.current.state).toBe("connecting");
-  });
-
   test("store controls.release drives the manual ptt release", async () => {
     const h = renderController();
     await startListening(h);
@@ -493,6 +466,21 @@ describe("session context and controls", () => {
 
     expect(h.client.pttReleaseCount).toBe(1);
     expect(h.view.result.current.state).toBe("transcribing");
+  });
+
+  test("store controls.release outside listening is a no-op", async () => {
+    const h = renderController();
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-1");
+    });
+    expect(h.view.result.current.state).toBe("connecting");
+
+    act(() => {
+      useLiveVoiceStore.getState().controls?.release();
+    });
+
+    expect(h.client.pttReleaseCount).toBe(0);
+    expect(h.view.result.current.state).toBe("connecting");
   });
 
   test("store controls.interrupt stops playback while speaking and is a no-op otherwise", async () => {
@@ -620,7 +608,7 @@ describe("observeAudioState", () => {
     // Low-frequency session state still flows: releasing push-to-talk moves
     // the returned state to `transcribing` (a re-render).
     act(() => {
-      h.view.result.current.release();
+      useLiveVoiceStore.getState().controls?.release();
     });
     expect(h.view.result.current.state).toBe("transcribing");
     expect(h.getRenderCount()).toBeGreaterThan(rendersBefore);
@@ -675,5 +663,145 @@ describe("teardown", () => {
       await h.view.result.current.stop();
     });
     expect(h.view.result.current.state).toBe("idle");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stop()/start() races
+// ---------------------------------------------------------------------------
+
+describe("stop/start races", () => {
+  /**
+   * Like `renderController`, but tracks every created primitive so a test can
+   * observe a second session, and lets a test hold the first player's
+   * `dispose()` open to pause `stop()` mid-teardown.
+   */
+  function renderRacingController() {
+    const clients: FakeClient[] = [];
+    const players: FakePlayer[] = [];
+
+    const view = renderHook(() =>
+      useLiveVoice({
+        createClient: () => {
+          const client = new FakeClient();
+          clients.push(client);
+          return client as unknown as LiveVoiceChannelClient;
+        },
+        createPlayer: () => {
+          const player = new FakePlayer();
+          players.push(player);
+          return player as unknown as LiveVoiceAudioPlayer;
+        },
+        createCapture: (options) =>
+          new FakeCapture(options) as unknown as LiveVoiceAudioCapture,
+      }),
+    );
+
+    return { view, clients, players };
+  }
+
+  /** Replace `player.dispose` with one that resolves only on command. */
+  function holdDisposeOpen(player: FakePlayer): () => void {
+    let releaseDispose!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseDispose = resolve;
+    });
+    player.dispose = async () => {
+      player.stop();
+      await gate;
+    };
+    return releaseDispose;
+  }
+
+  test("start() during `ending` is a no-op (no second session behind stop()'s teardown)", async () => {
+    const h = renderRacingController();
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-1");
+      h.clients[0]!.emit("ready", {
+        type: "ready",
+        seq: 1,
+        sessionId: "s1",
+        conversationId: "conv-1",
+      });
+      await Promise.resolve();
+    });
+    expect(h.view.result.current.state).toBe("listening");
+
+    const releaseDispose = holdDisposeOpen(h.players[0]!);
+    let stopPromise!: Promise<void>;
+    act(() => {
+      stopPromise = h.view.result.current.stop();
+    });
+    expect(useLiveVoiceStore.getState().state).toBe("ending");
+
+    // A starter call in the ending window must not open a new session: the
+    // old stop()'s trailing reset would wipe it (hot mic behind idle UI).
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-2");
+    });
+    expect(h.clients).toHaveLength(1);
+    expect(useLiveVoiceStore.getState().state).toBe("ending");
+
+    await act(async () => {
+      releaseDispose();
+      await stopPromise;
+    });
+    expect(useLiveVoiceStore.getState().state).toBe("idle");
+  });
+
+  test("stop()'s late reset does not clobber a session started after a double-stop", async () => {
+    const h = renderRacingController();
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-1");
+      h.clients[0]!.emit("ready", {
+        type: "ready",
+        seq: 1,
+        sessionId: "s1",
+        conversationId: "conv-1",
+      });
+      await Promise.resolve();
+    });
+
+    // First stop is paused mid-await; a second stop (no session ref left)
+    // resets the store to idle immediately — which unblocks start().
+    const releaseDispose = holdDisposeOpen(h.players[0]!);
+    let firstStop!: Promise<void>;
+    act(() => {
+      firstStop = h.view.result.current.stop();
+    });
+    await act(async () => {
+      await h.view.result.current.stop();
+    });
+    expect(useLiveVoiceStore.getState().state).toBe("idle");
+
+    // A new session starts while the first stop() is still awaiting teardown.
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-2");
+    });
+    expect(h.clients).toHaveLength(2);
+    expect(useLiveVoiceStore.getState().state).toBe("connecting");
+
+    // The first stop() finally finishes — its trailing reset must yield to
+    // the newer session instead of wiping its store state.
+    await act(async () => {
+      releaseDispose();
+      await firstStop;
+    });
+    expect(useLiveVoiceStore.getState().state).toBe("connecting");
+    expect(useLiveVoiceStore.getState().conversationId).toBe("conv-2");
+    expect(useLiveVoiceStore.getState().controls).not.toBeNull();
+    expect(h.clients[1]!.closed).toBe(false);
+
+    // The surviving session still works end-to-end: `ready` moves it along.
+    await act(async () => {
+      h.clients[1]!.emit("ready", {
+        type: "ready",
+        seq: 1,
+        sessionId: "s2",
+        conversationId: "conv-2",
+      });
+      await Promise.resolve();
+    });
+    expect(useLiveVoiceStore.getState().state).toBe("listening");
   });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -64,6 +64,7 @@ import {
   type TtsAudioChunk,
 } from "@/domains/chat/voice/live-voice/tts-playback";
 import {
+  isLiveVoiceSessionActive,
   useLiveVoiceStore,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
@@ -105,12 +106,6 @@ export interface UseLiveVoiceResult {
   start: (assistantId: string, conversationId?: string) => Promise<void>;
   /** End the session and release the mic, socket, and audio context. */
   stop: () => Promise<void>;
-  /**
-   * Manually release push-to-talk (the "send now" button) — force-ends the
-   * current user turn exactly like the automatic silence release. No-op unless
-   * the session is `listening`.
-   */
-  release: () => void;
 }
 
 /** Injectable factories so tests can supply mock primitives. */
@@ -208,6 +203,13 @@ export function useLiveVoice(
 
   const sessionRef = useRef<SessionContext | null>(null);
 
+  // Monotonic count of `start()` calls for this hook instance. `stop()`
+  // captures it before its awaits and skips its trailing store reset when a
+  // newer session started in the meantime — the per-session `generation`
+  // can't cover this because `stop()` nulls `sessionRef` synchronously, so
+  // the racing session is a different context object entirely.
+  const startGenerationRef = useRef(0);
+
   // Keep the factories in a ref so start()/stop() stay stable across renders
   // even if callers pass inline option objects. The ref is updated in an effect
   // (not during render) to satisfy the react-compiler "no refs during render"
@@ -249,6 +251,7 @@ export function useLiveVoice(
       useLiveVoiceStore.getState().reset();
       return;
     }
+    const startGeneration = startGenerationRef.current;
     sessionRef.current = null;
     session.generation += 1;
     useLiveVoiceStore.getState().setState("ending");
@@ -258,6 +261,10 @@ export function useLiveVoice(
     // Release the AudioContext, not just the scheduled sources (see teardown).
     await session.player.dispose();
     await session.capture.shutdown();
+    // A start() that raced the awaits owns the store now (e.g. a second ✕
+    // click resets `ending` → idle mid-await, unblocking start()); wiping it
+    // here would leave that session's mic hot behind idle UI.
+    if (startGenerationRef.current !== startGeneration) return;
     useLiveVoiceStore.getState().reset();
   }, []);
 
@@ -285,11 +292,14 @@ export function useLiveVoice(
 
   const start = useCallback(
     async (assistantId: string, conversationId?: string) => {
-      const current = sessionRef.current;
-      // A live session (anything but idle/failed) blocks a new start.
-      const phase = useLiveVoiceStore.getState().state;
-      if (current && phase !== "idle" && phase !== "failed") return;
-      if (current) teardown();
+      // A live session (anything but idle/failed) blocks a new start. Keyed
+      // on the store phase alone — NOT on `sessionRef` — because during
+      // `ending` stop() has already nulled the ref while its async teardown
+      // is still in flight; a start() admitted in that window would be wiped
+      // by stop()'s trailing reset (hot mic behind idle UI).
+      if (isLiveVoiceSessionActive(useLiveVoiceStore.getState().state)) return;
+      if (sessionRef.current) teardown();
+      startGenerationRef.current += 1;
 
       const store = useLiveVoiceStore.getState();
       store.reset();
@@ -433,7 +443,6 @@ export function useLiveVoice(
     error,
     start,
     stop,
-    release,
   };
 }
 
@@ -536,11 +545,6 @@ function releasePushToTalk(session: SessionContext): void {
   s.setInputAmplitude(0);
 }
 
-/**
- * Resume listening for the next utterance: re-open the forwarding gate, clear
- * the per-utterance counters/flags, and move to `listening`. The mic is already
- * running (continuous capture), so there is nothing to restart here.
- */
 /**
  * Barge-in: stop playback and interrupt the server once per response, then end
  * the session (→ idle). The interrupted session is terminal on the runtime — it


### PR DESCRIPTION
## Summary
Round-2 review fixes for voice-mode-ui.md:
- Session pill renders in popout thread windows (no header there) so a live session always has a visible control
- Session failures surface on composer-less routes via a dismissible pill error state; start() guard fixed for the ending window; stop()'s late reset generation-guarded
- Cleanup: shared end/release helpers, deduped test seeding, removed unconsumed hook-result release, doc fixes