### PR TITLE
refactor(conversation): make parentConversationId constructor-set, derive isSubagent from it

### DIFF
--- a/assistant/src/__tests__/agent-loop-override-profile.test.ts
+++ b/assistant/src/__tests__/agent-loop-override-profile.test.ts
@@ -203,8 +203,7 @@ const capturedRunAgentLoopOptions: CapturedRunAgentLoopOptions[] = [];
 class FakeConversation {
   constructor() {}
   updateClient() {}
-  setIsSubagent() {}
-  setParentConversationId() {}
+
   setTrustContext() {}
   setAuthContext() {}
   getAuthContext() {

--- a/assistant/src/__tests__/conversation-lifecycle.test.ts
+++ b/assistant/src/__tests__/conversation-lifecycle.test.ts
@@ -128,7 +128,10 @@ mock.module("../plugins/defaults/memory/v3/ever-injected-store.js", () => ({
       : realEverInjectedStore.getPrunedSlugs(conversationId),
 }));
 
-import { Conversation } from "../daemon/conversation.js";
+import {
+  Conversation,
+  type ConversationConstructorOptions,
+} from "../daemon/conversation.js";
 
 beforeEach(() => {
   lifecycleStoreMockActive = true;
@@ -139,7 +142,9 @@ afterAll(() => {
   lifecycleStoreMockActive = false;
 });
 
-function makeConversation(): Conversation {
+function makeConversation(
+  options: ConversationConstructorOptions = { maxTokens: 4096 },
+): Conversation {
   const provider = {
     name: "mock",
     sendMessage: async () => ({
@@ -155,7 +160,7 @@ function makeConversation(): Conversation {
     "system prompt",
     () => {},
     "/tmp",
-    { maxTokens: 4096 },
+    options,
   );
   // Default to guardian trust so tests load all messages.
   conv.setTrustContext({ trustClass: "guardian", sourceChannel: "vellum" });
@@ -172,6 +177,23 @@ function defaultConv() {
     totalEstimatedCost: 0,
   };
 }
+
+describe("Conversation — subagent identity", () => {
+  test("is not a subagent by default", () => {
+    const conv = makeConversation();
+    expect(conv.parentConversationId).toBeUndefined();
+    expect(conv.isSubagent).toBe(false);
+  });
+
+  test("derives isSubagent from the constructor parentConversationId", () => {
+    const conv = makeConversation({
+      maxTokens: 4096,
+      parentConversationId: "parent-1",
+    });
+    expect(conv.parentConversationId).toBe("parent-1");
+    expect(conv.isSubagent).toBe(true);
+  });
+});
 
 describe("loadFromDb metadata injection rehydration", () => {
   beforeEach(() => {

--- a/assistant/src/__tests__/subagent-call-site-routing.test.ts
+++ b/assistant/src/__tests__/subagent-call-site-routing.test.ts
@@ -52,8 +52,7 @@ class FakeConversation {
     capturedConversations.push(this.capturedState);
   }
   updateClient() {}
-  setIsSubagent() {}
-  setParentConversationId() {}
+
   setTrustContext(ctx: unknown) {
     this.capturedState.trustContext = ctx ?? undefined;
   }

--- a/assistant/src/__tests__/subagent-fork-prompt-role.test.ts
+++ b/assistant/src/__tests__/subagent-fork-prompt-role.test.ts
@@ -55,8 +55,7 @@ class FakeConversation {
   }
   conversationType = "background";
   updateClient() {}
-  setIsSubagent() {}
-  setParentConversationId() {}
+
   setTrustContext() {}
   setAuthContext() {}
   getAuthContext() {

--- a/assistant/src/__tests__/subagent-notify-parent.test.ts
+++ b/assistant/src/__tests__/subagent-notify-parent.test.ts
@@ -61,7 +61,7 @@ mock.module("../daemon/conversation-registry.js", () => ({
   findConversationOrSubagent: (id: string) => {
     const live = liveSubagents.get(id);
     return live
-      ? { isSubagent: true, parentConversationId: live.parentConversationId }
+      ? { parentConversationId: live.parentConversationId }
       : undefined;
   },
 }));

--- a/assistant/src/__tests__/subagent-spawn-and-await.test.ts
+++ b/assistant/src/__tests__/subagent-spawn-and-await.test.ts
@@ -82,8 +82,7 @@ class FakeConversation {
     // wrappedSendToClient tap is the one the deltas flow through.
     this.sendToClient = sendToClient;
   }
-  setIsSubagent() {}
-  setParentConversationId() {}
+
   setTrustContext() {}
   setAuthContext() {}
   getAuthContext() {

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -263,6 +263,13 @@ export interface ConversationConstructorOptions {
    * access; non-native providers get nothing. Defaults to false.
    */
   enableNativeWebSearch?: boolean;
+  /**
+   * For subagent conversations, the id of the parent that spawned this one.
+   * Set once here (there is no setter) so it is the authoritative, non-writable
+   * source for {@link Conversation.isSubagent} and for routing child → parent
+   * notifications. Omitted for top-level conversations.
+   */
+  parentConversationId?: string;
 }
 
 export class Conversation {
@@ -356,16 +363,16 @@ export class Conversation {
    */
   currentCallSite?: LLMCallSite;
   /** @internal */ hasNoClient = false;
-  /** @internal */ isSubagent = false;
   /**
-   * For subagent conversations, the id of the parent that spawned this one.
-   * Set once at spawn from the trusted spawn config, so it is the authoritative
-   * (non-writable) source for routing child → parent notifications — as opposed
-   * to the durable subagent record, which lives under the sandbox workspace and
-   * could be tampered with by a subagent running sandbox tools.
+   * For subagent conversations, the id of the parent that spawned this one; set
+   * once at construction and never reassigned. `undefined` for top-level
+   * conversations. It is the single source of truth for {@link isSubagent} and
+   * the authoritative (non-writable) routing target for child → parent
+   * notifications — as opposed to the durable subagent record, which lives under
+   * the sandbox workspace and could be tampered with by a sandbox-tool subagent.
    * @internal
    */
-  parentConversationId?: string;
+  readonly parentConversationId?: string;
   /** @internal */ headlessLock = false;
   /** @internal */ taskRunId?: string;
   /** @internal */ callSessionId?: string;
@@ -654,6 +661,7 @@ export class Conversation {
     const { maxTokens, speedOverride, cacheTtl, modelOverride } = options ?? {};
     const enableNativeWebSearch = options?.enableNativeWebSearch ?? false;
     this.conversationId = conversationId;
+    this.parentConversationId = options?.parentConversationId;
     this.systemPrompt = systemPrompt;
     this.provider = provider;
     this.workingDir = workingDir;
@@ -1409,12 +1417,9 @@ export class Conversation {
     this.enabledPlugins = plugins;
   }
 
-  setIsSubagent(value: boolean): void {
-    this.isSubagent = value;
-  }
-
-  setParentConversationId(parentConversationId: string): void {
-    this.parentConversationId = parentConversationId;
+  /** True when this conversation was spawned as a subagent (has a parent). */
+  get isSubagent(): boolean {
+    return this.parentConversationId !== undefined;
   }
 
   /**

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -489,6 +489,9 @@ export class SubagentManager {
       {
         maxTokens,
         cacheTtl: "5m",
+        // Records the parent at construction; drives isSubagent and notify
+        // routing from non-writable in-process state.
+        parentConversationId: config.parentConversationId,
         // The advisor consult runs tool-less for CLIENT tools but should ground
         // its guidance with provider-native web search when the resolved
         // provider supports it. This is a server tool the provider runs itself,
@@ -501,8 +504,6 @@ export class SubagentManager {
     // Mark conversation as having no direct client — it routes through parent.
     // This ensures interactive prompts (host attachment reads) fail fast.
     conversation.updateClient(wrappedSendToClient, true);
-    conversation.setIsSubagent(true);
-    conversation.setParentConversationId(config.parentConversationId);
     // Subagents are created as background conversations (see the
     // `bootstrapConversation` call above) and never call `loadFromDb`, so cache
     // the type on the live conversation directly for the runtime-assembly path.

--- a/assistant/src/subagent/notify.ts
+++ b/assistant/src/subagent/notify.ts
@@ -81,10 +81,10 @@ export function notifyParentFromChild(
   urgency: string,
 ): boolean {
   const child = findConversationOrSubagent(childConversationId);
-  if (!child?.isSubagent || !child.parentConversationId) {
+  const parentConversationId = child?.parentConversationId;
+  if (parentConversationId === undefined) {
     return false;
   }
-  const parentConversationId = child.parentConversationId;
 
   // Cosmetic metadata only — a tampered record can at most mislabel a
   // notification to the child's own (routing is fixed to the live parent above).


### PR DESCRIPTION
## Prompt / plan

Follow-up to review feedback on #37259 (merged). Two requests on `manager.ts:505`:

> - we should be able to pass in parentConversationId directly into the constructor and remove the setter, to prevent other consumers from reassigning
> - IsSubagent is now redundant with the existence of parent conversation id and can be removed

Both addressed:

- **`parentConversationId` is now a constructor option and `readonly`.** It's set once at spawn from the trusted config (via `ConversationConstructorOptions`), and there is no setter — so no consumer can reassign the notify routing target after construction.
- **`isSubagent` becomes a derived getter** over `parentConversationId` (`get isSubagent() { return this.parentConversationId !== undefined }`). It was a redundant mutable boolean mirroring "has a parent"; collapsing it to a computed accessor means single source of truth, no drift, and no setter to reassign. The three readers (`notify.ts`, `turn-call-site.ts`, `getSubagentChildren`) are unchanged; `notify.ts`'s now-redundant `isSubagent` check is dropped.
- **`SubagentManager`** passes `parentConversationId` when constructing the child and drops the `setIsSubagent` / `setParentConversationId` calls (both setters removed).

I kept `isSubagent` as a derived accessor rather than inlining `parentConversationId !== undefined` at every call site — it removes the redundant *state* the review flagged (nothing to keep in sync, nothing to reassign) while leaving the ~6 readers and their tests untouched. Happy to fully inline it if you'd prefer the property gone entirely.

**Note on the separate "why not drizzle?" comment** (`subagent-store.ts`): there's no `subagents` table in the Drizzle schema layer (`src/persistence/schema/*.ts`) — that table is raw-migration-only, and every function in `subagent-store.ts` (`upsert`/`loadAll`/`delete`) uses the `raw-query` helpers, so `getSubagentRecordByConversationId` followed the file's convention. Converting to Drizzle means adding a `subagents` schema table and migrating the whole file; I left that as a separate modernization rather than mixing raw + Drizzle in one file. Happy to do it as its own PR if you want it.

## Test plan

- `bunx tsc --noEmit` clean.
- Added `Conversation — subagent identity` coverage in `conversation-lifecycle.test.ts`: a real `Conversation` built with `parentConversationId` reports `isSubagent === true`; without it, `false`.
- Re-ran every touched/adjacent suite individually (all green): `conversation-lifecycle`, `conversation-app-control-lifecycle`, `subagent-notify-parent` (incl. the tamper regression), `subagent-manager-notify`, `subagent-fork-notifications`, `subagent-spawn-and-await`, `subagent-fork-spawn`, `subagent-call-site-routing`, `agent-loop-override-profile`, `subagent-fork-prompt-role`, `turn-call-site`, `subagent-tool-filtering`, `subagent-tools`.
- Removed the now-dead `setIsSubagent` / `setParentConversationId` no-ops from four test fakes (the manager no longer calls them; typecheck confirms nothing references the removed setters).

## CLI verb checklist

No new routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMTJwVtEMgnh38Jzwfxspk

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMTJwVtEMgnh38Jzwfxspk)_