### PR TITLE
fix: popout drag-region conflict + error chip composition

### DIFF
--- a/clients/web/src/components/window-drag-region.test.tsx
+++ b/clients/web/src/components/window-drag-region.test.tsx
@@ -19,6 +19,7 @@ import { WindowDragRegion } from "@/components/window-drag-region";
 beforeEach(() => {
   isElectronMock = false;
   inlineTitleBarActiveMock = false;
+  window.history.replaceState({}, "", "/");
 });
 
 describe("WindowDragRegion", () => {
@@ -39,6 +40,16 @@ describe("WindowDragRegion", () => {
     // out-stack and swallow the header's button clicks.
     isElectronMock = true;
     inlineTitleBarActiveMock = true;
+    expect(renderToStaticMarkup(<WindowDragRegion />)).toBe("");
+  });
+
+  test("yields in pop-out thread windows (?popout=1)", () => {
+    // Pop-outs keep their native title bar (the desktop shell passes no
+    // titleBarStyle) and never mount ChatLayoutHeader, so the strip would
+    // stay up forever — swallowing clicks on the standalone voice-session
+    // pill floated at the window's top-right.
+    isElectronMock = true;
+    window.history.replaceState({}, "", "/?popout=1");
     expect(renderToStaticMarkup(<WindowDragRegion />)).toBe("");
   });
 });

--- a/clients/web/src/components/window-drag-region.tsx
+++ b/clients/web/src/components/window-drag-region.tsx
@@ -1,4 +1,7 @@
+import { useState } from "react";
+
 import { isElectron } from "@/runtime/is-electron";
+import { isPopoutWindow } from "@/runtime/popout-window";
 import { useTitleBarStore } from "@/stores/title-bar-store";
 
 /**
@@ -23,10 +26,22 @@ import { useTitleBarStore } from "@/stores/title-bar-store";
  *   `.app-shell` (an `isolation: isolate` stacking context), so leaving it up
  *   would out-stack the header's buttons and swallow their clicks. See
  *   {@link useTitleBarStore}.
+ * - Yields entirely in Electron pop-out thread windows (`?popout=1`): those
+ *   windows keep their NATIVE title bar (the desktop shell's
+ *   `popout-window.ts` passes no `titleBarStyle`), so the OS already provides
+ *   dragging — and since pop-outs never mount `ChatLayoutHeader` (the only
+ *   `inlineTitleBarActive` setter), leaving the strip up would permanently
+ *   swallow clicks on the standalone voice-session pill floated at the
+ *   window's top-right (see `VoiceSessionPillHost`).
  */
 export function WindowDragRegion() {
   const inlineTitleBarActive = useTitleBarStore.use.inlineTitleBarActive();
+  // Captured once at mount, mirroring `ChatLayout`: pop-out URLs carry the
+  // flag only on initial load. This component mounts outside the router, so
+  // it reads `window.location` directly rather than `useLocation`.
+  const [isPopout] = useState(() => isPopoutWindow(window.location.search));
   if (!isElectron()) return null;
+  if (isPopout) return null;
   if (inlineTitleBarActive) return null;
 
   return (

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -43,7 +43,7 @@ import {
 import { openCommandPaletteWindow } from "@/runtime/command-palette-window";
 import { isElectron } from "@/runtime/is-electron";
 import { useIsNativePlatform } from "@/runtime/native-auth";
-import { openPopoutWindow } from "@/runtime/popout-window";
+import { isPopoutWindow, openPopoutWindow } from "@/runtime/popout-window";
 import { useVellumCommands } from "@/runtime/vellum-commands";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useOnboardingFocusStore } from "@/stores/onboarding-focus-store";
@@ -120,7 +120,7 @@ export function ChatLayout() {
   // navigations (e.g. conversation switching via Cmd+Up/Down). ChatLayout is a
   // persistent layout route — it stays mounted when child routes change, so
   // this initial value remains stable for the window's lifetime.
-  const [isPopout] = useState(() => location.search.includes("popout=1"));
+  const [isPopout] = useState(() => isPopoutWindow(location.search));
 
   // SPIKE — research-onboarding focused presentation. When set, a full-viewport
   // overlay (rendered below, on top of this layout) covers the chrome so the

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/domains/chat/components/voice-input-button";
 import { type TurnPhase, useTurnStore } from "@/domains/chat/turn-store";
 import {
+    dismissLiveVoiceFailure,
     endLiveVoiceSession,
     getLiveVoiceInputAmplitude,
     isLiveVoiceSessionActive,
@@ -284,11 +285,6 @@ export function ChatComposer({
     }
     useLiveVoiceStore.getState().starter?.(assistantId, conversationId ?? null);
   }, [assistantId, conversationId]);
-  // Dismissing the failure notice resets the store back to idle — `failed` is
-  // terminal for the session, so this only clears the surfaced error.
-  const dismissLiveVoiceError = useCallback(() => {
-    useLiveVoiceStore.getState().reset();
-  }, []);
 
   const pointerCoarse = useMemo(() => isPointerCoarse(), []);
   const isMobile = useIsMobile();
@@ -400,7 +396,7 @@ export function ChatComposer({
           eligibility drop must still surface its error. */}
       {showVoiceInput && liveVoiceState === "failed" && liveVoiceError && (
         <div className="mb-2">
-          <Notice tone="error" onDismiss={dismissLiveVoiceError}>
+          <Notice tone="error" onDismiss={dismissLiveVoiceFailure}>
             {liveVoiceError}
           </Notice>
         </div>

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -33,6 +33,7 @@ import { QuoteReplyBubble } from "@/domains/chat/components/quote-reply-bubble";
 import { TextSelectionPopover } from "@/domains/chat/components/text-selection-popover";
 import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 import { isChannelConversation } from "@/domains/chat/utils/conversation-channel";
+import { isPopoutWindow } from "@/runtime/popout-window";
 
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { useChatAttachmentDropZone } from "@/domains/chat/components/chat-attachments/use-chat-attachment-drop-zone";
@@ -224,7 +225,7 @@ export function ChatMainPanel({
 }: ChatMainPanelProps) {
   const location = useLocation();
   const navigate = useNavigate();
-  const statusBannerVisible = !location.search.includes("popout=1");
+  const statusBannerVisible = !isPopoutWindow(location.search);
 
   // -------------------------------------------------------------------------
   // Derived UI state (provides assistantId, activeConversationId,

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
@@ -67,6 +67,7 @@ import {
 import { useActiveConversation } from "@/domains/chat/hooks/use-active-conversation";
 import {
   LIVE_VOICE_STATE_LABELS,
+  dismissLiveVoiceFailure,
   endLiveVoiceSession,
   getLiveVoiceInputAmplitude,
   isLiveVoiceSessionActive,
@@ -137,16 +138,10 @@ export function VoiceSessionPillHost({
     }
   }, [navigate, sessionConversationId]);
 
-  // Mirrors the composer Notice's dismiss: `failed` is terminal for the
-  // session, so resetting only clears the surfaced error.
-  const handleDismissError = useCallback(() => {
-    useLiveVoiceStore.getState().reset();
-  }, []);
-
   let content: ReactNode = null;
   if (showFailure) {
     content = (
-      <VoiceSessionErrorChip message={error} onDismiss={handleDismissError} />
+      <VoiceSessionErrorChip message={error} onDismiss={dismissLiveVoiceFailure} />
     );
   } else if (visible) {
     content = (

--- a/clients/web/src/domains/chat/components/voice-session-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.test.tsx
@@ -14,6 +14,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 import type { LiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live-voice-store";
 import {
+  VoiceSessionErrorChip,
   VoiceSessionPill,
   type VoiceSessionPillProps,
 } from "@/domains/chat/components/voice-session-pill";
@@ -156,5 +157,42 @@ describe("VoiceSessionPill — navigation", () => {
     expect(onStop).not.toHaveBeenCalled();
     expect(onEnd).not.toHaveBeenCalled();
     expect(onSend).not.toHaveBeenCalled();
+  });
+});
+
+describe("VoiceSessionErrorChip", () => {
+  function renderChip() {
+    const onDismiss = mock(() => {});
+    render(
+      <VoiceSessionErrorChip
+        message="Microphone capture could not start."
+        onDismiss={onDismiss}
+      />,
+    );
+    return onDismiss;
+  }
+
+  test("announces the failure as an alert carrying the message", () => {
+    renderChip();
+    const alert = screen.getByRole("alert");
+    expect(alert.textContent).toContain("Microphone capture could not start.");
+    expect(alert.className).toContain("[-webkit-app-region:no-drag]");
+    expect(alert.className).toContain("h-8");
+  });
+
+  test("dismiss button fires onDismiss", () => {
+    const onDismiss = renderChip();
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  test("dismiss button carries the Tag primitive's keyboard focus ring", () => {
+    // The chip composes the design-library Tag; its remove button must keep a
+    // keyboard focus affordance (matching Notice's dismiss button), not a
+    // bare outline-none.
+    renderChip();
+    const dismiss = screen.getByRole("button", { name: "Dismiss" });
+    expect(dismiss.className).toContain("keyboard-focus:ring-2");
+    expect(dismiss.className).toContain("keyboard-focus:ring-[var(--ring)]");
   });
 });

--- a/clients/web/src/domains/chat/components/voice-session-pill.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.tsx
@@ -20,7 +20,7 @@
 
 import { ArrowUp, Mic, Square, TriangleAlert, X } from "lucide-react";
 
-import { Button, Typography, cn } from "@vellumai/design-library";
+import { Button, Tag, Typography, cn } from "@vellumai/design-library";
 
 import {
   isLiveVoiceMicLive,
@@ -162,39 +162,28 @@ export interface VoiceSessionErrorChipProps {
 /**
  * Compact failed-session chip rendered in the pill's slot when a session
  * fails while no composer (and thus no composer failure `Notice`) is on
- * screen — Home, Library, the inspector, the fullscreen app viewer. Same
- * height budget as the pill (`h-8`, title-bar safe), error tone tokens per
- * the design-library `Notice` error treatment.
+ * screen — Home, Library, the inspector, the fullscreen app viewer. Composes
+ * the design-library `Tag` in its dismissible-chip form (negative tone,
+ * `onRemove`), overriding only what the title-bar slot demands: the pill's
+ * `h-8` height budget, pill radius, a subtle negative border, and the
+ * Electron `no-drag` opt-out.
  */
 export function VoiceSessionErrorChip({
   message,
   onDismiss,
 }: VoiceSessionErrorChipProps) {
   return (
-    <div
+    <Tag
       role="alert"
-      className="flex h-8 max-w-80 items-center gap-2 rounded-full border border-[color-mix(in_srgb,var(--system-negative-strong)_25%,transparent)] bg-[var(--system-negative-weak)] py-1 pl-3 pr-1.5 [-webkit-app-region:no-drag]"
+      tone="negative"
+      leftIcon={<TriangleAlert />}
+      onRemove={onDismiss}
+      removeLabel="Dismiss"
+      className="h-8 max-w-80 gap-2 rounded-full border border-[color-mix(in_srgb,var(--system-negative-strong)_25%,transparent)] py-1 pl-3 pr-1.5 [-webkit-app-region:no-drag]"
     >
-      <TriangleAlert
-        aria-hidden
-        className="size-3.5 shrink-0 text-[color:var(--system-negative-strong)]"
-      />
-      <Typography
-        as="p"
-        variant="label-medium-default"
-        className="truncate text-[var(--content-default)]"
-        title={message}
-      >
+      <span className="min-w-0 truncate" title={message}>
         {message}
-      </Typography>
-      <button
-        type="button"
-        onClick={onDismiss}
-        aria-label="Dismiss"
-        className="shrink-0 cursor-pointer rounded-full p-0.5 text-[color:var(--content-secondary)] opacity-70 transition-opacity hover:opacity-100"
-      >
-        <X aria-hidden className="size-3.5" strokeWidth={2} />
-      </button>
-    </div>
+      </span>
+    </Tag>
   );
 }

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -9,6 +9,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { makeControlsSpies } from "@/domains/chat/voice/live-voice/live-voice-fakes.test-helper";
 import {
+  dismissLiveVoiceFailure,
   endLiveVoiceSession,
   getLiveVoiceInputAmplitude,
   isLiveVoiceMicLive,
@@ -209,6 +210,30 @@ describe("endLiveVoiceSession / releaseLiveVoiceTurn", () => {
       endLiveVoiceSession();
       releaseLiveVoiceTurn();
     }).not.toThrow();
+  });
+});
+
+describe("dismissLiveVoiceFailure", () => {
+  test("resets a failed session back to idle and clears the error", () => {
+    useLiveVoiceStore.getState().setSessionContext("assistant-1", "conv-1");
+    useLiveVoiceStore.getState().fail("boom");
+
+    dismissLiveVoiceFailure();
+
+    expect(useLiveVoiceStore.getState().state).toBe("idle");
+    expect(useLiveVoiceStore.getState().error).toBeNull();
+    expect(useLiveVoiceStore.getState().assistantId).toBeNull();
+    expect(useLiveVoiceStore.getState().conversationId).toBeNull();
+  });
+
+  test("preserves the mount-scoped starter, like any reset", () => {
+    const starter = mock(() => {});
+    useLiveVoiceStore.getState().setStarter(starter);
+    useLiveVoiceStore.getState().fail("boom");
+
+    dismissLiveVoiceFailure();
+
+    expect(useLiveVoiceStore.getState().starter).toBe(starter);
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -328,6 +328,19 @@ export function releaseLiveVoiceTurn(): void {
 }
 
 /**
+ * Dismiss a surfaced live-voice failure by resetting the store back to idle.
+ * `failed` is terminal for the session, so this only clears the surfaced
+ * error (the mount-scoped `starter` survives, as with any reset). Module-level
+ * for the same stable-identity reasons as {@link endLiveVoiceSession}: both
+ * failure surfaces — the composer's error `Notice` and the title-bar
+ * `VoiceSessionErrorChip` — share this one reference, keeping their dismiss
+ * behavior identical by construction.
+ */
+export function dismissLiveVoiceFailure(): void {
+  useLiveVoiceStore.getState().reset();
+}
+
+/**
  * Reactive form of {@link isLiveVoiceSessionOwnedBy} for components: whether
  * the active session is owned by the composer bound to
  * `composerConversationId`. Boolean-valued so per-field session churn never

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -208,6 +208,15 @@ export function useLiveVoice(
   // newer session started in the meantime — the per-session `generation`
   // can't cover this because `stop()` nulls `sessionRef` synchronously, so
   // the racing session is a different context object entirely.
+  //
+  // Considered and rejected: guarding the trailing reset with
+  // `if (sessionRef.current !== null)` instead. That is behaviorally
+  // equivalent *today* only because `start()` assigns `sessionRef`
+  // synchronously; a refactor that introduces an await before that
+  // assignment would silently reopen the race — the null-check would see no
+  // session yet and wrongly reset the newer session's store state. The
+  // counter increments synchronously at `start()`'s entry, so it stays
+  // correct regardless of where awaits land later.
   const startGenerationRef = useRef(0);
 
   // Keep the factories in a ref so start()/stop() stay stable across renders

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -47,6 +47,7 @@ import { useElectronIdentitySync } from "@/hooks/use-electron-identity-sync";
 import { useElectronStatusSync } from "@/hooks/use-electron-status-sync";
 import { useElectronFeatureFlagBridge } from "@/runtime/electron-feature-flags";
 import { isElectron } from "@/runtime/is-electron";
+import { isPopoutWindow } from "@/runtime/popout-window";
 import { GlobalPushToTalkBridge } from "@/domains/chat/voice/global-push-to-talk-bridge";
 import { TimezoneSync } from "@/components/timezone-sync";
 import { StatusBanner } from "@/components/status-banner";
@@ -288,7 +289,7 @@ export function RootLayout() {
   const keyboardOffsetTop =
     keyboardOpen && visibleViewport ? visibleViewport.offsetTop : 0;
   const electron = isElectron();
-  const isPopout = location.search.includes("popout=1");
+  const isPopout = isPopoutWindow(location.search);
   const suppressStatusBanner = shouldSuppressRootStatusBanner(
     location.pathname,
     location.search,

--- a/clients/web/src/runtime/popout-window.ts
+++ b/clients/web/src/runtime/popout-window.ts
@@ -1,6 +1,18 @@
 import { isElectron } from "@/runtime/is-electron";
 
 /**
+ * Whether a location search string marks the window as an Electron pop-out
+ * thread window (`?popout=1`, appended by the desktop shell's popout-window
+ * loader). Pop-out URLs carry the flag only on the window's initial load —
+ * in-window navigations (e.g. conversation switching via Cmd+Up/Down) drop
+ * the query — so callers that need the answer for the window's lifetime must
+ * capture it once at mount (see `ChatLayout` / `WindowDragRegion`).
+ */
+export function isPopoutWindow(search: string): boolean {
+  return search.includes("popout=1");
+}
+
+/**
  * Request the Electron host to open (or focus) a pop-out window for the given
  * conversation. No-ops on web and Capacitor iOS where pop-out windows don't
  * exist. Also no-ops gracefully on older Electron shells that predate the

--- a/packages/design-library/src/components/tag.tsx
+++ b/packages/design-library/src/components/tag.tsx
@@ -127,7 +127,11 @@ export function Tag({
             "text-[color:var(--content-secondary)]",
             "transition-colors duration-150",
             "hover:bg-[color-mix(in_srgb,currentColor_15%,transparent)]",
-            "focus-visible:outline-none",
+            // Same keyboard focus affordance as Notice's dismiss button:
+            // suppress the default outline but replace it with the ring, so
+            // keyboard users never lose the focus indicator.
+            "keyboard-focus:outline-none keyboard-focus:ring-2",
+            "keyboard-focus:ring-[var(--ring)]",
           )}
         >
           <X style={iconStyle} aria-hidden="true" />


### PR DESCRIPTION
## Summary
Round-3 review fixes for voice-mode-ui.md:
- WindowDragRegion yields in popout windows (native title bar there), unblocking the standalone voice pill's controls
- VoiceSessionErrorChip composes the design-library Tag primitive, restoring the keyboard focus affordance on Dismiss
- Shared dismissLiveVoiceFailure() helper; startGenerationRef rationale documented