### PR TITLE
Voice mode: in-app voice UI surface (JARVIS-1241)

### DIFF
--- a/clients/web/src/components/window-drag-region.test.tsx
+++ b/clients/web/src/components/window-drag-region.test.tsx
@@ -19,6 +19,7 @@ import { WindowDragRegion } from "@/components/window-drag-region";
 beforeEach(() => {
   isElectronMock = false;
   inlineTitleBarActiveMock = false;
+  window.history.replaceState({}, "", "/");
 });
 
 describe("WindowDragRegion", () => {
@@ -39,6 +40,16 @@ describe("WindowDragRegion", () => {
     // out-stack and swallow the header's button clicks.
     isElectronMock = true;
     inlineTitleBarActiveMock = true;
+    expect(renderToStaticMarkup(<WindowDragRegion />)).toBe("");
+  });
+
+  test("yields in pop-out thread windows (?popout=1)", () => {
+    // Pop-outs keep their native title bar (the desktop shell passes no
+    // titleBarStyle) and never mount ChatLayoutHeader, so the strip would
+    // stay up forever — swallowing clicks on the standalone voice-session
+    // pill floated at the window's top-right.
+    isElectronMock = true;
+    window.history.replaceState({}, "", "/?popout=1");
     expect(renderToStaticMarkup(<WindowDragRegion />)).toBe("");
   });
 });

--- a/clients/web/src/components/window-drag-region.tsx
+++ b/clients/web/src/components/window-drag-region.tsx
@@ -1,4 +1,7 @@
+import { useState } from "react";
+
 import { isElectron } from "@/runtime/is-electron";
+import { isPopoutWindow } from "@/runtime/popout-window";
 import { useTitleBarStore } from "@/stores/title-bar-store";
 
 /**
@@ -23,10 +26,22 @@ import { useTitleBarStore } from "@/stores/title-bar-store";
  *   `.app-shell` (an `isolation: isolate` stacking context), so leaving it up
  *   would out-stack the header's buttons and swallow their clicks. See
  *   {@link useTitleBarStore}.
+ * - Yields entirely in Electron pop-out thread windows (`?popout=1`): those
+ *   windows keep their NATIVE title bar (the desktop shell's
+ *   `popout-window.ts` passes no `titleBarStyle`), so the OS already provides
+ *   dragging — and since pop-outs never mount `ChatLayoutHeader` (the only
+ *   `inlineTitleBarActive` setter), leaving the strip up would permanently
+ *   swallow clicks on the standalone voice-session pill floated at the
+ *   window's top-right (see `VoiceSessionPillHost`).
  */
 export function WindowDragRegion() {
   const inlineTitleBarActive = useTitleBarStore.use.inlineTitleBarActive();
+  // Captured once at mount, mirroring `ChatLayout`: pop-out URLs carry the
+  // flag only on initial load. This component mounts outside the router, so
+  // it reads `window.location` directly rather than `useLocation`.
+  const [isPopout] = useState(() => isPopoutWindow(window.location.search));
   if (!isElectron()) return null;
+  if (isPopout) return null;
   if (inlineTitleBarActive) return null;
 
   return (

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -12,7 +12,7 @@ import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { MOBILE_MEDIA_QUERY, useIsMobile } from "@/hooks/use-is-mobile";
 import { getLocalBool, getLocalNumber, setLocalBool, setLocalNumber } from "@/utils/local-settings";
-import { isAboutAssistantPath, routes } from "@/utils/routes";
+import { isAboutAssistantPath, isConversationPath, routes } from "@/utils/routes";
 
 import { useChatLayoutSlotsStore } from "@/components/layout/chat-layout-slots-store";
 import { useElectronDockSync } from "@/domains/chat/hooks/use-electron-dock-sync";
@@ -67,6 +67,7 @@ import { ResearchResultsOverlay } from "@/domains/chat/onboarding-research/resea
 import { OnboardingCheckinOverlay } from "@/components/onboarding-checkin-overlay";
 import { OnboardingAvatarApplier } from "@/components/onboarding-avatar-applier";
 import { VoiceSessionPillHost } from "@/domains/chat/components/voice-session-pill-host";
+import { useLiveVoiceSessionController } from "@/domains/chat/voice/live-voice/use-live-voice-session-controller";
 import { ChatConversationHeader } from "./chat-conversation-header";
 import { ChatLayoutHeader } from "./chat-layout-header";
 import { RenameDialogFromStore } from "./rename-dialog-from-store";
@@ -143,6 +144,13 @@ export function ChatLayout() {
     (s) => s.assistantState.kind,
   );
   const isAssistantActive = assistantStateKind === "active";
+
+  // Live-voice session controller. Owned at layout scope — not by the
+  // composer — so a session survives every chat-side navigation (thread
+  // switch, Home/Library, the fullscreen app viewer) with the title-bar
+  // pill as its control surface. The composer starts/stops sessions
+  // through the seams this registers in `useLiveVoiceStore`.
+  useLiveVoiceSessionController();
 
   // Subscribe to the sidebar conversation list at the layout level so every
   // chat-layout child route (home, library, contacts, identity, chat)
@@ -539,10 +547,7 @@ export function ChatLayout() {
   // is intentionally left intact — many other consumers (SSE streams,
   // attention tracking, message reconciliation) rely on it persisting
   // across route changes.
-  const isOnConversationRoute =
-    location.pathname === routes.assistant ||
-    location.pathname === `${routes.assistant}/` ||
-    location.pathname.startsWith(`${routes.conversations}/`);
+  const isOnConversationRoute = isConversationPath(location.pathname);
   const sidebarActiveConversationId = isOnConversationRoute
     ? (activeConversationId ?? undefined)
     : undefined;

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -66,6 +66,7 @@ import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { ResearchResultsOverlay } from "@/domains/chat/onboarding-research/research-results-overlay";
 import { OnboardingCheckinOverlay } from "@/components/onboarding-checkin-overlay";
 import { OnboardingAvatarApplier } from "@/components/onboarding-avatar-applier";
+import { VoiceSessionPillHost } from "@/domains/chat/components/voice-session-pill-host";
 import { ChatConversationHeader } from "./chat-conversation-header";
 import { ChatLayoutHeader } from "./chat-layout-header";
 import { RenameDialogFromStore } from "./rename-dialog-from-store";
@@ -650,7 +651,18 @@ export function ChatLayout() {
           sidebarWidth={sidebarWidth}
           toggleSidebar={toggleSidebar}
           topBarCenter={topBarCenter}
-          topBarRightSlot={topBarRightSlot}
+          // The voice-session pill is composed here — NOT registered through
+          // useChatLayoutSlotsStore — because slot registration is owned by
+          // per-route hooks that unmount on navigation, exactly when the pill
+          // must persist. The host renders null when no session is active (or
+          // while viewing the owning thread's composer), so the header is
+          // unaffected otherwise.
+          topBarRightSlot={
+            <>
+              {topBarRightSlot}
+              <VoiceSessionPillHost />
+            </>
+          }
           canGoBack={canGoBack}
           canGoForward={canGoForward}
           onGoBack={handleGoBack}

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -689,6 +689,10 @@ export function ChatLayout() {
       {isMobile ? (
         <main className="relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden">
           <Outlet  />
+          {/* A popout narrowed below the mobile breakpoint lands in this
+              branch — still headerless, so it still needs the floating
+              session surface (see the desktop popout branch below). */}
+          {isPopout ? <VoiceSessionPillHost variant="standalone" /> : null}
           {drawerVisible || drawerDragging ? (
             <div
               ref={drawerRef}
@@ -728,8 +732,15 @@ export function ChatLayout() {
           ) : null}
         </main>
       ) : isPopout ? (
-        <main className="flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden p-4">
+        <main className="relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden p-4">
           <Outlet />
+          {/* Pop-outs render no header, but they DO support in-window
+              conversation switching (Cmd+Up/Down) — so a live session started
+              here can lose its owning composer exactly like in the main
+              window. The standalone variant floats the pill (or the failed
+              chip) over the top-right corner; it renders nothing while the
+              on-screen composer owns the session. */}
+          <VoiceSessionPillHost variant="standalone" />
         </main>
       ) : (
         <div className="flex min-w-0 flex-1 gap-4 p-4 min-h-0 overflow-hidden flex-col md:flex-row">

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -48,7 +48,7 @@ import {
 import { openCommandPaletteWindow } from "@/runtime/command-palette-window";
 import { isElectron } from "@/runtime/is-electron";
 import { useIsNativePlatform } from "@/runtime/native-auth";
-import { openPopoutWindow } from "@/runtime/popout-window";
+import { isPopoutWindow, openPopoutWindow } from "@/runtime/popout-window";
 import { useVellumCommands } from "@/runtime/vellum-commands";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useOnboardingFocusStore } from "@/stores/onboarding-focus-store";
@@ -125,7 +125,7 @@ export function ChatLayout() {
   // navigations (e.g. conversation switching via Cmd+Up/Down). ChatLayout is a
   // persistent layout route — it stays mounted when child routes change, so
   // this initial value remains stable for the window's lifetime.
-  const [isPopout] = useState(() => location.search.includes("popout=1"));
+  const [isPopout] = useState(() => isPopoutWindow(location.search));
 
   // SPIKE — research-onboarding focused presentation. When set, a full-viewport
   // overlay (rendered below, on top of this layout) covers the chrome so the

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -56,6 +56,10 @@ mock.module("@/stores/assistant-feature-flag-store", () => ({
 }));
 
 import {
+  makeControlsSpies,
+  seedLiveVoiceSession as seedLiveVoiceStore,
+} from "@/domains/chat/voice/live-voice/live-voice-fakes.test-helper";
+import {
   useLiveVoiceStore,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
@@ -63,26 +67,24 @@ import {
 const liveStarterSpy = mock(
   (_assistantId: string, _conversationId: string | null) => {},
 );
-const liveControls = {
-  stop: mock(() => {}),
-  release: mock(() => {}),
-  interrupt: mock(() => {}),
-};
+const liveControls = makeControlsSpies();
 
 /**
- * Seed the real live-voice store with an active session. `conversationId`
- * defaults to the id `renderVoiceComposer` binds, so the rendered composer
- * owns the session; pass another id to simulate a session owned by a
- * different thread, or `null` for a draft-started session.
+ * Seed the real live-voice store with an active session (shared helper bound
+ * to this file's ids/spies). `conversationId` defaults to the id
+ * `renderVoiceComposer` binds, so the rendered composer owns the session;
+ * pass another id to simulate a session owned by a different thread, or
+ * `null` for a draft-started session.
  */
 function seedLiveVoiceSession(
   state: LiveVoiceSessionState,
   conversationId: string | null = "conv_test",
 ) {
-  const store = useLiveVoiceStore.getState();
-  store.setSessionContext("asst_test", conversationId);
-  store.setControls(liveControls);
-  store.setState(state);
+  seedLiveVoiceStore(state, {
+    assistantId: "asst_test",
+    conversationId,
+    controls: liveControls,
+  });
 }
 
 // The real `VoiceInputButton` self-suppresses (returns null) unless the test

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -38,14 +38,14 @@ mock.module("@/runtime/is-electron", () => ({
   isElectron: () => mockIsElectron,
 }));
 
-// Live-voice integration mocks. The composer owns the single `useLiveVoice()`
-// controller (it must outlive the `LiveVoiceButton`, which is swapped out with
-// the rest of the action row during a session) and polls amplitude through
-// `useLiveVoiceStore.getState()`. Both are mocked so the composer renders in
-// isolation: the flag via a mutable `mockVoiceMode` (consumed by the real
-// `LiveVoiceButton`, which self-gates on it), and the session via a mutable
-// state/error bag exposed through the mocked hook. Defaults (flag off, idle,
-// no error) keep the existing HTML-surface assertions unchanged.
+// Live-voice integration. The session controller (`useLiveVoice`) lives in
+// the layout-mounted `useLiveVoiceSessionController`, NOT in the composer —
+// the composer only reads the real `useLiveVoiceStore` (self-contained
+// zustand, no heavy imports) and drives the session through the
+// `starter`/`controls` seams registered there. Tests therefore seed the real
+// store and register spy seams; only the flag store is mocked (consumed by
+// the real `LiveVoiceButton`, which self-gates on it). Defaults (flag off,
+// idle) keep the existing HTML-surface assertions unchanged.
 let mockVoiceMode = false;
 mock.module("@/stores/assistant-feature-flag-store", () => ({
   useAssistantFeatureFlagStore: {
@@ -55,66 +55,35 @@ mock.module("@/stores/assistant-feature-flag-store", () => ({
   },
 }));
 
-// Local mirror of the live-voice session phases this test exercises. Kept as a
-// narrow union (not an import from the `voice` domain) so the `chat` test stays
-// free of cross-domain coupling — the composer only ever distinguishes idle
-// from non-idle, so the precise phase taxonomy is irrelevant here.
-type MockLiveVoiceState = "idle" | "listening" | "failed";
+import {
+  useLiveVoiceStore,
+  type LiveVoiceSessionState,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
 
-let mockLiveVoiceState: MockLiveVoiceState = "idle";
-let mockLiveVoiceError: string | null = null;
-let mockLiveVoicePartial = "";
-let mockLiveVoiceFinal = "";
-const liveStartSpy = mock(
-  async (_assistantId: string, _conversationId?: string) => {},
+const liveStarterSpy = mock(
+  (_assistantId: string, _conversationId: string | null) => {},
 );
-const liveStopSpy = mock(async () => {});
-const liveReleaseSpy = mock(() => {});
-const liveResetSpy = mock(() => {});
-// The store mock mirrors the three surfaces the composer tree touches:
-// `getState()` (voice bar amplitude poll + failed-session reset), a callable
-// selector subscription (the composer's low-frequency transcript-presence
-// bit), and `.use` per-field hooks (`VoiceLiveTranscript`'s self-sourced
-// transcript). Reactive session state flows through the mocked hook below.
-const liveVoiceStoreState = () => ({
-  inputAmplitude: 0,
-  partialTranscript: mockLiveVoicePartial,
-  finalTranscript: mockLiveVoiceFinal,
-  reset: liveResetSpy,
-});
-type MockLiveVoiceStoreState = ReturnType<typeof liveVoiceStoreState>;
-const useLiveVoiceStoreMock = Object.assign(
-  <T,>(selector: (s: MockLiveVoiceStoreState) => T): T =>
-    selector(liveVoiceStoreState()),
-  {
-    getState: liveVoiceStoreState,
-    use: {
-      partialTranscript: () => mockLiveVoicePartial,
-      finalTranscript: () => mockLiveVoiceFinal,
-    },
-  },
-);
-mock.module("@/domains/chat/voice/live-voice/live-voice-store", () => ({
-  useLiveVoiceStore: useLiveVoiceStoreMock,
-}));
-// Spy wrapper so tests can assert the composer opts out of the hook's
-// high-frequency audio-state subscription (`observeAudioState: false`) —
-// the guard that keeps per-mic-sample amplitude updates from re-rendering
-// the whole composer (the voice bar polls amplitude via `getState()`).
-const useLiveVoiceSpy = mock((_options?: { observeAudioState?: boolean }) => ({
-  state: mockLiveVoiceState,
-  partialTranscript: "",
-  finalTranscript: "",
-  assistantTranscript: "",
-  inputAmplitude: 0,
-  error: mockLiveVoiceError,
-  start: liveStartSpy,
-  stop: liveStopSpy,
-  release: liveReleaseSpy,
-}));
-mock.module("@/domains/chat/voice/live-voice/use-live-voice", () => ({
-  useLiveVoice: useLiveVoiceSpy,
-}));
+const liveControls = {
+  stop: mock(() => {}),
+  release: mock(() => {}),
+  interrupt: mock(() => {}),
+};
+
+/**
+ * Seed the real live-voice store with an active session. `conversationId`
+ * defaults to the id `renderVoiceComposer` binds, so the rendered composer
+ * owns the session; pass another id to simulate a session owned by a
+ * different thread, or `null` for a draft-started session.
+ */
+function seedLiveVoiceSession(
+  state: LiveVoiceSessionState,
+  conversationId: string | null = "conv_test",
+) {
+  const store = useLiveVoiceStore.getState();
+  store.setSessionContext("asst_test", conversationId);
+  store.setControls(liveControls);
+  store.setState(state);
+}
 
 // The real `VoiceInputButton` self-suppresses (returns null) unless the test
 // DOM exposes `MediaRecorder` + `getUserMedia`, which happy-dom does not. Mock
@@ -150,22 +119,19 @@ mock.module("@/domains/chat/voice/voice-recording-store", () => ({
 function resetLiveVoiceMocks() {
   mockIsElectron = false;
   mockVoiceMode = false;
-  mockLiveVoiceState = "idle";
-  mockLiveVoiceError = null;
-  mockLiveVoicePartial = "";
-  mockLiveVoiceFinal = "";
   mockVoicePhase = "idle";
   setAudioLevelSpy.mockClear();
-  liveStartSpy.mockClear();
-  liveStopSpy.mockClear();
-  liveReleaseSpy.mockClear();
-  liveResetSpy.mockClear();
-  useLiveVoiceSpy.mockClear();
+  liveStarterSpy.mockClear();
+  liveControls.stop.mockClear();
+  liveControls.release.mockClear();
+  liveControls.interrupt.mockClear();
+  useLiveVoiceStore.getState().reset();
+  useLiveVoiceStore.getState().setStarter(liveStarterSpy);
 }
 
 // Imported after the mocks so the component (and its transitive flag-store /
-// live-voice / voice-input-button imports) resolve against the mocked modules.
-// The pure helpers (computeGhostSuffix / shouldSubmitOnEnter) come from
+// voice-input-button imports) resolve against the mocked modules. The pure
+// helpers (computeGhostSuffix / shouldSubmitOnEnter) come from
 // `chat-composer-utils`, imported statically above.
 const { ChatComposer } = await import(
   "@/domains/chat/components/chat-composer/chat-composer"
@@ -802,7 +768,6 @@ describe("ChatComposer — live-voice integration", () => {
     // GIVEN the flag is on with no active session
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "idle";
 
     // WHEN the composer renders
     const { getByLabelText, queryByLabelText, queryByRole } =
@@ -819,26 +784,26 @@ describe("ChatComposer — live-voice integration", () => {
     expect(getByLabelText("Send message")).toBeTruthy();
   });
 
-  test("clicking the live-voice button starts a session for the conversation", () => {
+  test("clicking the live-voice button starts a session through the store-registered starter", () => {
     // GIVEN the flag is on with no active session
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "idle";
 
     // WHEN the user clicks the entry-point mic
     const { getByLabelText } = renderVoiceComposer();
     fireEvent.click(getByLabelText("Start voice mode"));
 
-    // THEN the composer-owned controller starts with the bound context
-    expect(liveStartSpy).toHaveBeenCalledTimes(1);
-    expect(liveStartSpy).toHaveBeenCalledWith("asst_test", "conv_test");
+    // THEN the layout-owned controller is asked to start with the bound
+    // context (the composer holds no controller of its own)
+    expect(liveStarterSpy).toHaveBeenCalledTimes(1);
+    expect(liveStarterSpy).toHaveBeenCalledWith("asst_test", "conv_test");
   });
 
-  test("active session swaps the action row for the voice bar (mutual exclusion by absence)", () => {
-    // GIVEN a live-voice session is listening
+  test("owned active session swaps the action row for the voice bar (mutual exclusion by absence)", () => {
+    // GIVEN a live-voice session owned by this composer's conversation
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "listening";
+    seedLiveVoiceSession("listening");
 
     // WHEN the composer renders
     const { getByRole, queryByLabelText } = renderVoiceComposer();
@@ -853,17 +818,58 @@ describe("ChatComposer — live-voice integration", () => {
     expect(queryByLabelText("Live voice transcript")).toBeNull();
   });
 
-  test("active session keeps the textarea mounted but inert", () => {
-    // GIVEN a live-voice session is listening
+  test("session owned by another conversation leaves this composer untouched (pill is the surface)", () => {
+    // GIVEN a session owned by thread A while this composer shows thread B
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "listening";
+    seedLiveVoiceSession("listening", "conv-other-thread");
+
+    // WHEN the composer renders
+    const { container, getByLabelText, queryByRole } = renderVoiceComposer();
+
+    // THEN no voice bar, no transcript region, and the textarea stays
+    // editable — thread B behaves like a normal composer...
+    expect(queryByRole("group", { name: "Voice session" })).toBeNull();
+    expect(getByLabelText("Send message")).toBeTruthy();
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea.disabled).toBe(false);
+    // ...except both mic entry points are disabled: the running session owns
+    // the microphone, so no second capture flow may start from here
+    const liveVoice = getByLabelText("Start voice mode") as HTMLButtonElement;
+    expect(liveVoice.disabled).toBe(true);
+    const dictation = getByLabelText("Start voice input") as HTMLButtonElement;
+    expect(dictation.disabled).toBe(true);
+  });
+
+  test("draft composer keeps owning a draft-started session after the server assigns a conversation", () => {
+    // GIVEN a session started from a draft (no conversation) whose `ready`
+    // frame has since republished a server-assigned conversation id
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    seedLiveVoiceSession("listening", null);
+    useLiveVoiceStore.getState().setConversationId("conv-server-assigned");
+
+    // WHEN the draft composer (bound to no conversation) renders
+    const { getByRole } = renderVoiceComposer({ conversationId: undefined });
+
+    // THEN it still owns the session — the voice bar stays, so the user
+    // sitting at the composer that started the session never sees it
+    // handed off to the title-bar pill
+    expect(getByRole("group", { name: "Voice session" })).toBeTruthy();
+  });
+
+  test("owned session keeps the textarea mounted but inert", () => {
+    // GIVEN a live-voice session owned by this composer's conversation
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    seedLiveVoiceSession("listening");
 
     // WHEN the composer renders
     const { container } = renderVoiceComposer();
 
-    // THEN the textarea stays (a later PR streams the transcript into it)
-    // but is disabled so focus/typing can't fight the session
+    // THEN the textarea stays mounted (VoiceLiveTranscript renders into its
+    // grid cell once speech streams) but is disabled so focus/typing can't
+    // fight the session
     const textarea = container.querySelector("textarea");
     expect(textarea).not.toBeNull();
     expect((textarea as HTMLTextAreaElement).disabled).toBe(true);
@@ -873,31 +879,32 @@ describe("ChatComposer — live-voice integration", () => {
     // GIVEN a live session AND the composer is otherwise disabled
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "listening";
+    seedLiveVoiceSession("listening");
 
     // WHEN the composer renders with typingDisabled raised
     const { getByLabelText } = renderVoiceComposer({ typingDisabled: true });
 
-    // THEN the end control is still actionable and clicking it stops
+    // THEN the end control is still actionable and clicking it stops the
+    // session through the store-registered controls
     const end = getByLabelText("End voice session") as HTMLButtonElement;
     expect(end.disabled).toBe(false);
     fireEvent.click(end);
-    expect(liveStopSpy).toHaveBeenCalledTimes(1);
+    expect(liveControls.stop).toHaveBeenCalledTimes(1);
   });
 
   test("voice bar ↑ manually releases the turn while listening", () => {
-    // GIVEN a listening session
+    // GIVEN a listening session owned by this composer
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "listening";
+    seedLiveVoiceSession("listening");
 
     // WHEN the user clicks send-now
     const { getByLabelText } = renderVoiceComposer();
     fireEvent.click(getByLabelText("Send now"));
 
-    // THEN the composer-owned controller releases the turn
-    expect(liveReleaseSpy).toHaveBeenCalledTimes(1);
-    expect(liveStopSpy).not.toHaveBeenCalled();
+    // THEN the turn is released through the store-registered controls
+    expect(liveControls.release).toHaveBeenCalledTimes(1);
+    expect(liveControls.stop).not.toHaveBeenCalled();
   });
 
   test("dictation active disables the live-voice button (reverse mutual exclusion)", () => {
@@ -909,7 +916,6 @@ describe("ChatComposer — live-voice integration", () => {
     // same either way.
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "idle";
     mockVoicePhase = "processing";
 
     // WHEN the composer renders
@@ -926,7 +932,6 @@ describe("ChatComposer — live-voice integration", () => {
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockIsElectron = true;
     mockVoiceMode = true;
-    mockLiveVoiceState = "idle";
     mockVoicePhase = "processing";
 
     // WHEN the composer renders
@@ -943,7 +948,8 @@ describe("ChatComposer — live-voice integration", () => {
     // GIVEN the flag is on and a live-voice session has failed
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "failed";
+    seedLiveVoiceSession("listening");
+    useLiveVoiceStore.getState().fail("boom");
 
     // WHEN the composer renders (dictation idle)
     const { getByLabelText, queryByRole } = renderVoiceComposer();
@@ -958,32 +964,31 @@ describe("ChatComposer — live-voice integration", () => {
     expect(dictation.disabled).toBe(false);
   });
 
-  test("failed session surfaces the hook error as a dismissible notice", () => {
+  test("failed session surfaces the error as a dismissible notice", () => {
     // GIVEN a failed session carrying an error message
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "failed";
-    mockLiveVoiceError = "Microphone capture could not start.";
+    seedLiveVoiceSession("listening");
+    useLiveVoiceStore.getState().fail("Microphone capture could not start.");
 
     // WHEN the composer renders
     const { getByText, getByLabelText } = renderVoiceComposer();
 
-    // THEN the error notice is visible with the hook's message
+    // THEN the error notice is visible with the session's message
     expect(getByText("Microphone capture could not start.")).toBeTruthy();
 
     // WHEN the user dismisses it
     fireEvent.click(getByLabelText("Dismiss"));
 
     // THEN the store is reset back to idle (which clears the error)
-    expect(liveResetSpy).toHaveBeenCalledTimes(1);
+    expect(useLiveVoiceStore.getState().state).toBe("idle");
+    expect(useLiveVoiceStore.getState().error).toBeNull();
   });
 
   test("no live-voice error notice while idle or without an error", () => {
     // GIVEN the flag is on with an idle session and no error
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "idle";
-    mockLiveVoiceError = null;
 
     // WHEN the composer renders
     const { queryByLabelText } = renderVoiceComposer();
@@ -992,29 +997,12 @@ describe("ChatComposer — live-voice integration", () => {
     expect(queryByLabelText("Dismiss")).toBeNull();
   });
 
-  test("composer opts out of the hook's high-frequency audio state (observeAudioState: false)", () => {
-    // GIVEN a voice-enabled composer
-    useTurnStore.setState(INITIAL_TURN_STATE);
-    mockVoiceMode = true;
-
-    // WHEN it renders
-    renderVoiceComposer();
-
-    // THEN it consumes only the low-frequency session state + actions —
-    // amplitude ticks and transcript deltas must not re-render the whole
-    // composer (the voice bar polls amplitude via getState() instead)
-    expect(useLiveVoiceSpy).toHaveBeenCalled();
-    for (const call of useLiveVoiceSpy.mock.calls) {
-      expect(call[0]).toEqual({ observeAudioState: false });
-    }
-  });
-
   test("voice bar persists when the flag flips off mid-session (no stranded session)", () => {
-    // GIVEN an active session but the voice-mode flag has since flipped off
-    // while the composer (and its session-owning controller) stayed mounted
+    // GIVEN an active owned session but the voice-mode flag has since
+    // flipped off while the layout-owned controller keeps the session live
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = false;
-    mockLiveVoiceState = "listening";
+    seedLiveVoiceSession("listening");
 
     // WHEN the composer renders
     const { getByRole, getByLabelText, queryByLabelText } =
@@ -1030,14 +1018,15 @@ describe("ChatComposer — live-voice integration", () => {
 
     // AND the ✕ still ends the live session
     fireEvent.click(end);
-    expect(liveStopSpy).toHaveBeenCalledTimes(1);
+    expect(liveControls.stop).toHaveBeenCalledTimes(1);
   });
 
   test("voice bar persists when assistantId is transiently cleared mid-session", () => {
-    // GIVEN an active session whose assistantId has been cleared from props
+    // GIVEN an active owned session whose assistantId has been cleared from
+    // props
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "listening";
+    seedLiveVoiceSession("listening");
 
     // WHEN the composer renders without an assistant id
     const { getByRole, getByLabelText } = renderVoiceComposer({
@@ -1047,15 +1036,15 @@ describe("ChatComposer — live-voice integration", () => {
     // THEN the stop control remains available for the live mic/socket
     expect(getByRole("group", { name: "Voice session" })).toBeTruthy();
     fireEvent.click(getByLabelText("End voice session"));
-    expect(liveStopSpy).toHaveBeenCalledTimes(1);
+    expect(liveControls.stop).toHaveBeenCalledTimes(1);
   });
 
   test("failure after an eligibility drop still surfaces the error notice", () => {
     // GIVEN a session that failed right after the flag flipped off
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = false;
-    mockLiveVoiceState = "failed";
-    mockLiveVoiceError = "Connection lost.";
+    seedLiveVoiceSession("listening");
+    useLiveVoiceStore.getState().fail("Connection lost.");
 
     // WHEN the composer renders
     const { getByText } = renderVoiceComposer();
@@ -1065,11 +1054,11 @@ describe("ChatComposer — live-voice integration", () => {
   });
 
   test("no-voice variant (app-editing) never swaps its row for a session it doesn't own", () => {
-    // GIVEN a live session exists in the global store (owned by another
-    // composer instance) and this variant has no voice props
+    // GIVEN a live session exists in the global store (owned elsewhere) and
+    // this variant has no voice props
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "listening";
+    seedLiveVoiceSession("listening", "conv-other-thread");
 
     // WHEN the app-editing variant renders (no voiceInputRef/onVoiceTranscript)
     const html = renderComposer();
@@ -1090,11 +1079,13 @@ describe("ChatComposer — live-voice integration", () => {
 
 describe("ChatComposer — live-voice transcript area", () => {
   test("streaming speech hides the textarea and renders the transcript in its place", () => {
-    // GIVEN a listening session with an in-flight partial transcript
+    // GIVEN a listening owned session with an in-flight partial transcript
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "listening";
-    mockLiveVoicePartial = "this is a text that I am just speaking";
+    seedLiveVoiceSession("listening");
+    useLiveVoiceStore
+      .getState()
+      .setPartialTranscript("this is a text that I am just speaking");
 
     // WHEN the composer renders
     const { container, getByLabelText } = renderVoiceComposer();
@@ -1112,11 +1103,30 @@ describe("ChatComposer — live-voice transcript area", () => {
     expect(textarea.disabled).toBe(true);
   });
 
-  test("empty transcript keeps the textarea (and its placeholder) visible", () => {
-    // GIVEN an active session with no speech yet (Light 53 baseline)
+  test("speech from a session owned by another thread never streams into this composer", () => {
+    // GIVEN a session owned by thread A streaming speech while this composer
+    // shows thread B
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "listening";
+    seedLiveVoiceSession("listening", "conv-other-thread");
+    useLiveVoiceStore.getState().setPartialTranscript("thread A's words");
+
+    // WHEN the composer renders
+    const { container, queryByLabelText } = renderVoiceComposer();
+
+    // THEN no transcript region mounts and the textarea stays editable —
+    // thread A's speech must not leak into thread B's input
+    expect(queryByLabelText("Voice transcript")).toBeNull();
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea.className).not.toContain("hidden");
+    expect(textarea.disabled).toBe(false);
+  });
+
+  test("empty transcript keeps the textarea (and its placeholder) visible", () => {
+    // GIVEN an active owned session with no speech yet (Light 53 baseline)
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    seedLiveVoiceSession("listening");
 
     // WHEN the composer renders
     const { container, queryByLabelText } = renderVoiceComposer();
@@ -1128,11 +1138,10 @@ describe("ChatComposer — live-voice transcript area", () => {
   });
 
   test("textarea is restored after the session ends, even with a leftover final transcript", () => {
-    // GIVEN the session has ended (store not yet reset, final text lingering)
+    // GIVEN the session has ended (store back to idle, final text lingering)
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "idle";
-    mockLiveVoiceFinal = "what I said last";
+    useLiveVoiceStore.getState().setFinalTranscript("what I said last");
 
     // WHEN the composer renders
     const { container, queryByLabelText } = renderVoiceComposer();

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -63,22 +63,39 @@ type MockLiveVoiceState = "idle" | "listening" | "failed";
 
 let mockLiveVoiceState: MockLiveVoiceState = "idle";
 let mockLiveVoiceError: string | null = null;
+let mockLiveVoicePartial = "";
+let mockLiveVoiceFinal = "";
 const liveStartSpy = mock(
   async (_assistantId: string, _conversationId?: string) => {},
 );
 const liveStopSpy = mock(async () => {});
 const liveReleaseSpy = mock(() => {});
 const liveResetSpy = mock(() => {});
-// The composer only touches the store imperatively (`getState()` for the voice
-// bar's amplitude poll and for resetting a failed session from the error
-// notice); reactive session state flows through the mocked hook below.
-mock.module("@/domains/chat/voice/live-voice/live-voice-store", () => ({
-  useLiveVoiceStore: {
-    getState: () => ({
-      inputAmplitude: 0,
-      reset: liveResetSpy,
-    }),
+// The store mock mirrors the three surfaces the composer tree touches:
+// `getState()` (voice bar amplitude poll + failed-session reset), a callable
+// selector subscription (the composer's low-frequency transcript-presence
+// bit), and `.use` per-field hooks (`VoiceLiveTranscript`'s self-sourced
+// transcript). Reactive session state flows through the mocked hook below.
+const liveVoiceStoreState = () => ({
+  inputAmplitude: 0,
+  partialTranscript: mockLiveVoicePartial,
+  finalTranscript: mockLiveVoiceFinal,
+  reset: liveResetSpy,
+});
+type MockLiveVoiceStoreState = ReturnType<typeof liveVoiceStoreState>;
+const useLiveVoiceStoreMock = Object.assign(
+  <T,>(selector: (s: MockLiveVoiceStoreState) => T): T =>
+    selector(liveVoiceStoreState()),
+  {
+    getState: liveVoiceStoreState,
+    use: {
+      partialTranscript: () => mockLiveVoicePartial,
+      finalTranscript: () => mockLiveVoiceFinal,
+    },
   },
+);
+mock.module("@/domains/chat/voice/live-voice/live-voice-store", () => ({
+  useLiveVoiceStore: useLiveVoiceStoreMock,
 }));
 // Spy wrapper so tests can assert the composer opts out of the hook's
 // high-frequency audio-state subscription (`observeAudioState: false`) —
@@ -135,6 +152,8 @@ function resetLiveVoiceMocks() {
   mockVoiceMode = false;
   mockLiveVoiceState = "idle";
   mockLiveVoiceError = null;
+  mockLiveVoicePartial = "";
+  mockLiveVoiceFinal = "";
   mockVoicePhase = "idle";
   setAudioLevelSpy.mockClear();
   liveStartSpy.mockClear();
@@ -1058,5 +1077,70 @@ describe("ChatComposer — live-voice integration", () => {
     // THEN its action row is untouched — no voice bar, normal send button
     expect(html).not.toContain('aria-label="Voice session"');
     expect(html).toContain('aria-label="Send message"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Live-voice transcript in the composer text area (Light 55)
+//
+// While speech streams, the disabled textarea is visually hidden and the
+// display-only `VoiceLiveTranscript` renders in its grid cell; with no
+// transcript yet the textarea (and its placeholder) stays visible.
+// ---------------------------------------------------------------------------
+
+describe("ChatComposer — live-voice transcript area", () => {
+  test("streaming speech hides the textarea and renders the transcript in its place", () => {
+    // GIVEN a listening session with an in-flight partial transcript
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockLiveVoiceState = "listening";
+    mockLiveVoicePartial = "this is a text that I am just speaking";
+
+    // WHEN the composer renders
+    const { container, getByLabelText } = renderVoiceComposer();
+
+    // THEN the transcript region shows the speech as composer text...
+    const region = getByLabelText("Voice transcript");
+    expect(region.textContent).toContain(
+      "this is a text that I am just speaking",
+    );
+    // ...with a caret, in place of the visually hidden (still-mounted,
+    // still-uneditable) textarea
+    expect(region.querySelector('[data-testid="voice-transcript-caret"]')).toBeTruthy();
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea.className).toContain("hidden");
+    expect(textarea.disabled).toBe(true);
+  });
+
+  test("empty transcript keeps the textarea (and its placeholder) visible", () => {
+    // GIVEN an active session with no speech yet (Light 53 baseline)
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockLiveVoiceState = "listening";
+
+    // WHEN the composer renders
+    const { container, queryByLabelText } = renderVoiceComposer();
+
+    // THEN nothing replaces the textarea — its placeholder shows through
+    expect(queryByLabelText("Voice transcript")).toBeNull();
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea.className).not.toContain("hidden");
+  });
+
+  test("textarea is restored after the session ends, even with a leftover final transcript", () => {
+    // GIVEN the session has ended (store not yet reset, final text lingering)
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockLiveVoiceState = "idle";
+    mockLiveVoiceFinal = "what I said last";
+
+    // WHEN the composer renders
+    const { container, queryByLabelText } = renderVoiceComposer();
+
+    // THEN the composer behaves normally: no transcript region, editable textarea
+    expect(queryByLabelText("Voice transcript")).toBeNull();
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea.className).not.toContain("hidden");
+    expect(textarea.disabled).toBe(false);
   });
 });

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -38,14 +38,14 @@ mock.module("@/runtime/is-electron", () => ({
   isElectron: () => mockIsElectron,
 }));
 
-// Live-voice integration mocks. The composer mounts `LiveVoiceButton` (which
-// self-gates on `voice-mode`) and reads live-voice session state via the
-// `useLiveVoiceStore` per-field selectors for the transcript surface +
-// dictation mutual-exclusion. Both are mocked so the composer renders in
-// isolation: the flag via a mutable `mockVoiceMode`, and the session via a
-// mutable state + transcript bag exposed through the store's `.use.*`
-// selectors. Defaults (flag off, idle, empty) keep the existing HTML-surface
-// assertions unchanged.
+// Live-voice integration mocks. The composer owns the single `useLiveVoice()`
+// controller (it must outlive the `LiveVoiceButton`, which is swapped out with
+// the rest of the action row during a session) and polls amplitude through
+// `useLiveVoiceStore.getState()`. Both are mocked so the composer renders in
+// isolation: the flag via a mutable `mockVoiceMode` (consumed by the real
+// `LiveVoiceButton`, which self-gates on it), and the session via a mutable
+// state/error bag exposed through the mocked hook. Defaults (flag off, idle,
+// no error) keep the existing HTML-surface assertions unchanged.
 let mockVoiceMode = false;
 mock.module("@/stores/assistant-feature-flag-store", () => ({
   useAssistantFeatureFlagStore: {
@@ -59,41 +59,44 @@ mock.module("@/stores/assistant-feature-flag-store", () => ({
 // narrow union (not an import from the `voice` domain) so the `chat` test stays
 // free of cross-domain coupling — the composer only ever distinguishes idle
 // from non-idle, so the precise phase taxonomy is irrelevant here.
-type MockLiveVoiceState = "idle" | "connecting" | "listening" | "failed";
+type MockLiveVoiceState = "idle" | "listening" | "failed";
 
 let mockLiveVoiceState: MockLiveVoiceState = "idle";
-let mockLivePartial = "";
-let mockLiveFinal = "";
-let mockLiveAssistant = "";
+let mockLiveVoiceError: string | null = null;
 const liveStartSpy = mock(
   async (_assistantId: string, _conversationId?: string) => {},
 );
 const liveStopSpy = mock(async () => {});
-// The composer reads session state through the store's per-field selectors
-// (`useLiveVoiceStore.use.state()` etc.), so mock the store rather than the
-// `useLiveVoice` controller. `LiveVoiceButton` is the only `useLiveVoice`
-// consumer, and it is mocked separately below.
+const liveReleaseSpy = mock(() => {});
+const liveResetSpy = mock(() => {});
+// The composer only touches the store imperatively (`getState()` for the voice
+// bar's amplitude poll and for resetting a failed session from the error
+// notice); reactive session state flows through the mocked hook below.
 mock.module("@/domains/chat/voice/live-voice/live-voice-store", () => ({
   useLiveVoiceStore: {
-    use: {
-      state: () => mockLiveVoiceState,
-      partialTranscript: () => mockLivePartial,
-      finalTranscript: () => mockLiveFinal,
-      assistantTranscript: () => mockLiveAssistant,
-    },
+    getState: () => ({
+      inputAmplitude: 0,
+      reset: liveResetSpy,
+    }),
   },
 }));
+// Spy wrapper so tests can assert the composer opts out of the hook's
+// high-frequency audio-state subscription (`observeAudioState: false`) —
+// the guard that keeps per-mic-sample amplitude updates from re-rendering
+// the whole composer (the voice bar polls amplitude via `getState()`).
+const useLiveVoiceSpy = mock((_options?: { observeAudioState?: boolean }) => ({
+  state: mockLiveVoiceState,
+  partialTranscript: "",
+  finalTranscript: "",
+  assistantTranscript: "",
+  inputAmplitude: 0,
+  error: mockLiveVoiceError,
+  start: liveStartSpy,
+  stop: liveStopSpy,
+  release: liveReleaseSpy,
+}));
 mock.module("@/domains/chat/voice/live-voice/use-live-voice", () => ({
-  useLiveVoice: () => ({
-    state: mockLiveVoiceState,
-    partialTranscript: mockLivePartial,
-    finalTranscript: mockLiveFinal,
-    assistantTranscript: mockLiveAssistant,
-    inputAmplitude: 0,
-    error: null,
-    start: liveStartSpy,
-    stop: liveStopSpy,
-  }),
+  useLiveVoice: useLiveVoiceSpy,
 }));
 
 // The real `VoiceInputButton` self-suppresses (returns null) unless the test
@@ -131,13 +134,14 @@ function resetLiveVoiceMocks() {
   mockIsElectron = false;
   mockVoiceMode = false;
   mockLiveVoiceState = "idle";
-  mockLivePartial = "";
-  mockLiveFinal = "";
-  mockLiveAssistant = "";
+  mockLiveVoiceError = null;
   mockVoicePhase = "idle";
   setAudioLevelSpy.mockClear();
   liveStartSpy.mockClear();
   liveStopSpy.mockClear();
+  liveReleaseSpy.mockClear();
+  liveResetSpy.mockClear();
+  useLiveVoiceSpy.mockClear();
 }
 
 // Imported after the mocks so the component (and its transitive flag-store /
@@ -768,7 +772,6 @@ describe("ChatComposer — live-voice integration", () => {
 
     // THEN the live-voice control is absent and dictation is unaffected
     expect(queryByLabelText("Start voice mode")).toBeNull();
-    expect(queryByLabelText("Stop voice mode")).toBeNull();
     const dictation = queryByLabelText(
       "Start voice input",
     ) as HTMLButtonElement | null;
@@ -776,59 +779,78 @@ describe("ChatComposer — live-voice integration", () => {
     expect(dictation?.disabled).toBe(false);
   });
 
-  test("flag ON, idle: live-voice button present, dictation still enabled", () => {
+  test("flag ON, idle: live-voice button present, normal row, no voice bar", () => {
     // GIVEN the flag is on with no active session
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
     mockLiveVoiceState = "idle";
 
     // WHEN the composer renders
-    const { getByLabelText, queryByLabelText } = renderVoiceComposer();
+    const { getByLabelText, queryByLabelText, queryByRole } =
+      renderVoiceComposer();
 
-    // THEN both mics are available and neither is forced disabled
+    // THEN both mics are available, neither is forced disabled, and the
+    // action row is the normal composer row (no voice bar)
     expect(getByLabelText("Start voice mode")).toBeTruthy();
     const dictation = queryByLabelText(
       "Start voice input",
     ) as HTMLButtonElement | null;
     expect(dictation?.disabled).toBe(false);
+    expect(queryByRole("group", { name: "Voice session" })).toBeNull();
+    expect(getByLabelText("Send message")).toBeTruthy();
   });
 
-  test("active session disables dictation (mutual exclusion)", () => {
+  test("clicking the live-voice button starts a session for the conversation", () => {
+    // GIVEN the flag is on with no active session
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockLiveVoiceState = "idle";
+
+    // WHEN the user clicks the entry-point mic
+    const { getByLabelText } = renderVoiceComposer();
+    fireEvent.click(getByLabelText("Start voice mode"));
+
+    // THEN the composer-owned controller starts with the bound context
+    expect(liveStartSpy).toHaveBeenCalledTimes(1);
+    expect(liveStartSpy).toHaveBeenCalledWith("asst_test", "conv_test");
+  });
+
+  test("active session swaps the action row for the voice bar (mutual exclusion by absence)", () => {
     // GIVEN a live-voice session is listening
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
     mockLiveVoiceState = "listening";
 
     // WHEN the composer renders
-    const { getByLabelText } = renderVoiceComposer();
+    const { getByRole, queryByLabelText } = renderVoiceComposer();
 
-    // THEN the live-voice control is a stop affordance and the dictation
-    // mic is disabled so the two capture flows can't run together
-    expect(getByLabelText("Stop voice mode")).toBeTruthy();
-    const dictation = getByLabelText(
-      "Start voice input",
-    ) as HTMLButtonElement;
-    expect(dictation.disabled).toBe(true);
+    // THEN the voice bar replaces the whole action row — attach, both mic
+    // buttons, and send are gone, so the two capture flows can't coexist
+    expect(getByRole("group", { name: "Voice session" })).toBeTruthy();
+    expect(queryByLabelText("Start voice mode")).toBeNull();
+    expect(queryByLabelText("Start voice input")).toBeNull();
+    expect(queryByLabelText("Send message")).toBeNull();
+    // ...and the old inline transcript strip is gone for good
+    expect(queryByLabelText("Live voice transcript")).toBeNull();
   });
 
-  test("active session surfaces user + assistant transcripts", () => {
-    // GIVEN a listening session with partial speech and a streaming reply
+  test("active session keeps the textarea mounted but inert", () => {
+    // GIVEN a live-voice session is listening
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
     mockLiveVoiceState = "listening";
-    mockLivePartial = "what is the";
-    mockLiveAssistant = "Let me check";
 
     // WHEN the composer renders
-    const { getByLabelText } = renderVoiceComposer();
+    const { container } = renderVoiceComposer();
 
-    // THEN the transcript surface shows both sides of the turn
-    const surface = getByLabelText("Live voice transcript");
-    expect(surface.textContent).toContain("what is the");
-    expect(surface.textContent).toContain("Let me check");
+    // THEN the textarea stays (a later PR streams the transcript into it)
+    // but is disabled so focus/typing can't fight the session
+    const textarea = container.querySelector("textarea");
+    expect(textarea).not.toBeNull();
+    expect((textarea as HTMLTextAreaElement).disabled).toBe(true);
   });
 
-  test("active session stays stoppable even when the composer is busy", () => {
+  test("voice bar ✕ ends the session even when the composer is busy", () => {
     // GIVEN a live session AND the composer is otherwise disabled
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
@@ -837,24 +859,26 @@ describe("ChatComposer — live-voice integration", () => {
     // WHEN the composer renders with typingDisabled raised
     const { getByLabelText } = renderVoiceComposer({ typingDisabled: true });
 
-    // THEN the stop control is still actionable and clicking it stops
-    const stop = getByLabelText("Stop voice mode") as HTMLButtonElement;
-    expect(stop.disabled).toBe(false);
-    fireEvent.click(stop);
+    // THEN the end control is still actionable and clicking it stops
+    const end = getByLabelText("End voice session") as HTMLButtonElement;
+    expect(end.disabled).toBe(false);
+    fireEvent.click(end);
     expect(liveStopSpy).toHaveBeenCalledTimes(1);
   });
 
-  test("flag ON but no transcript content: surface stays empty when idle", () => {
-    // GIVEN the flag is on but the session is idle
+  test("voice bar ↑ manually releases the turn while listening", () => {
+    // GIVEN a listening session
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
-    mockLiveVoiceState = "idle";
+    mockLiveVoiceState = "listening";
 
-    // WHEN the composer renders
-    const { queryByLabelText } = renderVoiceComposer();
+    // WHEN the user clicks send-now
+    const { getByLabelText } = renderVoiceComposer();
+    fireEvent.click(getByLabelText("Send now"));
 
-    // THEN no transcript surface is rendered (idle = nothing to show)
-    expect(queryByLabelText("Live voice transcript")).toBeNull();
+    // THEN the composer-owned controller releases the turn
+    expect(liveReleaseSpy).toHaveBeenCalledTimes(1);
+    expect(liveStopSpy).not.toHaveBeenCalled();
   });
 
   test("dictation active disables the live-voice button (reverse mutual exclusion)", () => {
@@ -896,21 +920,143 @@ describe("ChatComposer — live-voice integration", () => {
     expect(liveVoice.disabled).toBe(true);
   });
 
-  test("failed live-voice state is inactive: dictation re-enabled, no transcript surface", () => {
-    // GIVEN the flag is on and a live-voice start attempt has failed
+  test("failed live-voice state is inactive: normal row restored, dictation re-enabled", () => {
+    // GIVEN the flag is on and a live-voice session has failed
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
     mockLiveVoiceState = "failed";
 
     // WHEN the composer renders (dictation idle)
-    const { getByLabelText, queryByLabelText } = renderVoiceComposer();
+    const { getByLabelText, queryByRole } = renderVoiceComposer();
 
-    // THEN dictation is treated as available again (failed = inactive)...
+    // THEN the voice bar is unmounted and the normal row is back...
+    expect(queryByRole("group", { name: "Voice session" })).toBeNull();
+    expect(getByLabelText("Send message")).toBeTruthy();
+    // ...with dictation treated as available again (failed = inactive)
     const dictation = getByLabelText(
       "Start voice input",
     ) as HTMLButtonElement;
     expect(dictation.disabled).toBe(false);
-    // ...and the transcript surface is unmounted rather than left hanging
-    expect(queryByLabelText("Live voice transcript")).toBeNull();
+  });
+
+  test("failed session surfaces the hook error as a dismissible notice", () => {
+    // GIVEN a failed session carrying an error message
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockLiveVoiceState = "failed";
+    mockLiveVoiceError = "Microphone capture could not start.";
+
+    // WHEN the composer renders
+    const { getByText, getByLabelText } = renderVoiceComposer();
+
+    // THEN the error notice is visible with the hook's message
+    expect(getByText("Microphone capture could not start.")).toBeTruthy();
+
+    // WHEN the user dismisses it
+    fireEvent.click(getByLabelText("Dismiss"));
+
+    // THEN the store is reset back to idle (which clears the error)
+    expect(liveResetSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("no live-voice error notice while idle or without an error", () => {
+    // GIVEN the flag is on with an idle session and no error
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockLiveVoiceState = "idle";
+    mockLiveVoiceError = null;
+
+    // WHEN the composer renders
+    const { queryByLabelText } = renderVoiceComposer();
+
+    // THEN no dismissible notice is mounted
+    expect(queryByLabelText("Dismiss")).toBeNull();
+  });
+
+  test("composer opts out of the hook's high-frequency audio state (observeAudioState: false)", () => {
+    // GIVEN a voice-enabled composer
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+
+    // WHEN it renders
+    renderVoiceComposer();
+
+    // THEN it consumes only the low-frequency session state + actions —
+    // amplitude ticks and transcript deltas must not re-render the whole
+    // composer (the voice bar polls amplitude via getState() instead)
+    expect(useLiveVoiceSpy).toHaveBeenCalled();
+    for (const call of useLiveVoiceSpy.mock.calls) {
+      expect(call[0]).toEqual({ observeAudioState: false });
+    }
+  });
+
+  test("voice bar persists when the flag flips off mid-session (no stranded session)", () => {
+    // GIVEN an active session but the voice-mode flag has since flipped off
+    // while the composer (and its session-owning controller) stayed mounted
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = false;
+    mockLiveVoiceState = "listening";
+
+    // WHEN the composer renders
+    const { getByRole, getByLabelText, queryByLabelText } =
+      renderVoiceComposer();
+
+    // THEN the active-UI swap follows the session state, not eligibility:
+    // the bar (and its ✕ stop control) stays until teardown completes...
+    expect(getByRole("group", { name: "Voice session" })).toBeTruthy();
+    const end = getByLabelText("End voice session") as HTMLButtonElement;
+    expect(end.disabled).toBe(false);
+    // ...while the entry-point button stays flag-gated off
+    expect(queryByLabelText("Start voice mode")).toBeNull();
+
+    // AND the ✕ still ends the live session
+    fireEvent.click(end);
+    expect(liveStopSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("voice bar persists when assistantId is transiently cleared mid-session", () => {
+    // GIVEN an active session whose assistantId has been cleared from props
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockLiveVoiceState = "listening";
+
+    // WHEN the composer renders without an assistant id
+    const { getByRole, getByLabelText } = renderVoiceComposer({
+      assistantId: null,
+    });
+
+    // THEN the stop control remains available for the live mic/socket
+    expect(getByRole("group", { name: "Voice session" })).toBeTruthy();
+    fireEvent.click(getByLabelText("End voice session"));
+    expect(liveStopSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("failure after an eligibility drop still surfaces the error notice", () => {
+    // GIVEN a session that failed right after the flag flipped off
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = false;
+    mockLiveVoiceState = "failed";
+    mockLiveVoiceError = "Connection lost.";
+
+    // WHEN the composer renders
+    const { getByText } = renderVoiceComposer();
+
+    // THEN the user still learns why voice stopped
+    expect(getByText("Connection lost.")).toBeTruthy();
+  });
+
+  test("no-voice variant (app-editing) never swaps its row for a session it doesn't own", () => {
+    // GIVEN a live session exists in the global store (owned by another
+    // composer instance) and this variant has no voice props
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockLiveVoiceState = "listening";
+
+    // WHEN the app-editing variant renders (no voiceInputRef/onVoiceTranscript)
+    const html = renderComposer();
+
+    // THEN its action row is untouched — no voice bar, normal send button
+    expect(html).not.toContain('aria-label="Voice session"');
+    expect(html).toContain('aria-label="Send message"');
   });
 });

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -26,6 +26,7 @@ import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 import { ComposerDraftNotices } from "@/domains/chat/components/composer-draft-notices";
 import { StreamingWaveform } from "@/domains/chat/components/chat-composer/streaming-waveform";
 import { VoiceComposerBar } from "@/domains/chat/components/chat-composer/voice-composer-bar";
+import { VoiceLiveTranscript } from "@/domains/chat/components/chat-composer/voice-live-transcript";
 import { LiveVoiceButton } from "@/domains/chat/components/live-voice-button";
 import {
     VoiceInputButton,
@@ -255,6 +256,22 @@ export function ChatComposer({
     showVoiceInput &&
     liveVoiceState !== "idle" &&
     liveVoiceState !== "failed";
+  // Whether the session has any speech transcript to show. A boolean
+  // *presence* subscription, not the text itself: zustand only re-renders
+  // when the selected value changes identity, so per-delta transcript
+  // updates never reach the composer — the bit flips once when speech
+  // starts and once when the store clears. The streaming text is rendered
+  // by `VoiceLiveTranscript`, which subscribes to the store on its own,
+  // keeping this component's deliberate opt-out of high-frequency
+  // live-voice updates (see `observeAudioState: false` above) intact.
+  const hasLiveVoiceTranscript = useLiveVoiceStore(
+    (s) => Boolean(s.partialTranscript || s.finalTranscript),
+  );
+  // While speech is streaming, the disabled textarea is visually hidden and
+  // the display-only transcript renders in its grid cell (Light 55). With no
+  // transcript yet, the textarea stays visible so its placeholder shows
+  // through (Light 53 baseline).
+  const showLiveVoiceTranscript = isLiveVoiceActive && hasLiveVoiceTranscript;
   // Amplitude is polled by the voice bar's canvas draw loop straight from the
   // store (~30 Hz), so per-sample updates never flow through props.
   const getLiveVoiceAmplitude = useCallback(
@@ -593,9 +610,22 @@ export function ChatComposer({
                 // into this region). The grid mirror keeps the height stable.
                 disabled={typingDisabled || isLiveVoiceActive}
                 rows={1}
-                className="col-start-1 row-start-1 w-full resize-none overflow-y-auto border-none bg-transparent px-4 pt-3 pb-2 text-chat text-[var(--content-default)] placeholder:text-[var(--content-disabled)] focus:outline-none disabled:opacity-50"
+                className={`col-start-1 row-start-1 w-full resize-none overflow-y-auto border-none bg-transparent px-4 pt-3 pb-2 text-chat text-[var(--content-default)] placeholder:text-[var(--content-disabled)] focus:outline-none disabled:opacity-50 ${
+                  showLiveVoiceTranscript ? "hidden" : ""
+                }`}
                 style={{ maxHeight: `${textareaMaxHeightPx}px` }}
               />
+              {isLiveVoiceActive && (
+                // Live speech streams display-only into the textarea's grid
+                // cell (Light 55); renders nothing until there is text, so
+                // the placeholder above stays visible. The shared cell keeps
+                // the grid's auto-grow/max-height behavior identical to the
+                // textarea it visually replaces.
+                <VoiceLiveTranscript
+                  className="col-start-1 row-start-1"
+                  maxHeightPx={textareaMaxHeightPx}
+                />
+              )}
             </div>
             {showInlineVoicePreview && (
               // Non-Electron fallback: Electron uses the shared top-center

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/domains/chat/components/voice-input-button";
 import { type TurnPhase, useTurnStore } from "@/domains/chat/turn-store";
 import {
+    getLiveVoiceInputAmplitude,
     isLiveVoiceSessionActive,
     useIsLiveVoiceSessionOwnedBy,
     useLiveVoiceStore,
@@ -269,12 +270,6 @@ export function ChatComposer({
   // transcript yet, the textarea stays visible so its placeholder shows
   // through (Light 53 baseline).
   const showLiveVoiceTranscript = isLiveVoiceActive && hasLiveVoiceTranscript;
-  // Amplitude is polled by the voice bar's canvas draw loop straight from the
-  // store (~30 Hz), so per-sample updates never flow through props.
-  const getLiveVoiceAmplitude = useCallback(
-    () => useLiveVoiceStore.getState().inputAmplitude,
-    [],
-  );
   // Session verbs go through the store seams registered by the layout-owned
   // controller: `starter` (registered for the controller's whole mount) to
   // start, per-session `controls` to stop/release. Read via `getState()` in
@@ -671,7 +666,7 @@ export function ChatComposer({
               // green ↑ manually releases the current turn while listening.
               <VoiceComposerBar
                 state={liveVoiceState}
-                getAmplitude={getLiveVoiceAmplitude}
+                getAmplitude={getLiveVoiceInputAmplitude}
                 onEnd={handleLiveVoiceEnd}
                 onSend={handleLiveVoiceSend}
               />

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/domains/chat/components/voice-input-button";
 import { type TurnPhase, useTurnStore } from "@/domains/chat/turn-store";
 import {
+    dismissLiveVoiceFailure,
     endLiveVoiceSession,
     getLiveVoiceInputAmplitude,
     isLiveVoiceSessionActive,
@@ -284,11 +285,6 @@ export function ChatComposer({
     }
     useLiveVoiceStore.getState().starter?.(assistantId, conversationId ?? null);
   }, [assistantId, conversationId]);
-  // Dismissing the failure notice resets the store back to idle — `failed` is
-  // terminal for the session, so this only clears the surfaced error.
-  const dismissLiveVoiceError = useCallback(() => {
-    useLiveVoiceStore.getState().reset();
-  }, []);
 
   const pointerCoarse = useMemo(() => isPointerCoarse(), []);
   const isMobile = useIsMobile();
@@ -400,7 +396,7 @@ export function ChatComposer({
           eligibility drop must still surface its error. */}
       {showVoiceInput && liveVoiceState === "failed" && liveVoiceError && (
         <div className="mb-2">
-          <Notice tone="error" onDismiss={dismissLiveVoiceError}>
+          <Notice tone="error" onDismiss={dismissLiveVoiceFailure}>
             {liveVoiceError}
           </Notice>
         </div>

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -34,8 +34,10 @@ import {
 } from "@/domains/chat/components/voice-input-button";
 import { type TurnPhase, useTurnStore } from "@/domains/chat/turn-store";
 import {
+    endLiveVoiceSession,
     getLiveVoiceInputAmplitude,
     isLiveVoiceSessionActive,
+    releaseLiveVoiceTurn,
     useIsLiveVoiceSessionOwnedBy,
     useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
@@ -272,20 +274,16 @@ export function ChatComposer({
   const showLiveVoiceTranscript = isLiveVoiceActive && hasLiveVoiceTranscript;
   // Session verbs go through the store seams registered by the layout-owned
   // controller: `starter` (registered for the controller's whole mount) to
-  // start, per-session `controls` to stop/release. Read via `getState()` in
-  // handlers per STATE_MANAGEMENT.md — no subscription needed.
+  // start, per-session `controls` to stop/release — the latter via the shared
+  // module-level `endLiveVoiceSession`/`releaseLiveVoiceTurn` helpers, which
+  // read the store with `getState()` per STATE_MANAGEMENT.md (no subscription
+  // needed for callback-only reads).
   const handleLiveVoiceStart = useCallback(() => {
     if (!assistantId) {
       return;
     }
     useLiveVoiceStore.getState().starter?.(assistantId, conversationId ?? null);
   }, [assistantId, conversationId]);
-  const handleLiveVoiceEnd = useCallback(() => {
-    useLiveVoiceStore.getState().controls?.stop();
-  }, []);
-  const handleLiveVoiceSend = useCallback(() => {
-    useLiveVoiceStore.getState().controls?.release();
-  }, []);
   // Dismissing the failure notice resets the store back to idle — `failed` is
   // terminal for the session, so this only clears the surfaced error.
   const dismissLiveVoiceError = useCallback(() => {
@@ -667,8 +665,8 @@ export function ChatComposer({
               <VoiceComposerBar
                 state={liveVoiceState}
                 getAmplitude={getLiveVoiceInputAmplitude}
-                onEnd={handleLiveVoiceEnd}
-                onSend={handleLiveVoiceSend}
+                onEnd={endLiveVoiceSession}
+                onSend={releaseLiveVoiceTurn}
               />
             ) : (
               <div className="flex items-center justify-between px-2 pb-2">

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -25,6 +25,7 @@ import {
 import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 import { ComposerDraftNotices } from "@/domains/chat/components/composer-draft-notices";
 import { StreamingWaveform } from "@/domains/chat/components/chat-composer/streaming-waveform";
+import { VoiceComposerBar } from "@/domains/chat/components/chat-composer/voice-composer-bar";
 import { LiveVoiceButton } from "@/domains/chat/components/live-voice-button";
 import {
     VoiceInputButton,
@@ -32,14 +33,14 @@ import {
 } from "@/domains/chat/components/voice-input-button";
 import { type TurnPhase, useTurnStore } from "@/domains/chat/turn-store";
 import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { useLiveVoice } from "@/domains/chat/voice/live-voice/use-live-voice";
 import { useAudioAmplitude } from "@/domains/chat/voice/use-audio-amplitude";
 import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { isElectron } from "@/runtime/is-electron";
 import { useIsNativePlatform } from "@/runtime/native-auth";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { isPointerCoarse } from "@/utils/pointer";
-import { Button, Popover } from "@vellumai/design-library";
+import { Button, Notice, Popover } from "@vellumai/design-library";
 
 import {
     computeGhostSuffix,
@@ -210,32 +211,68 @@ export function ChatComposer({
     voiceInputRef !== undefined && onVoiceTranscript !== undefined;
 
   // ---- Live voice (full-duplex conversation) ----------------------------
-  // Coexists with dictation: `LiveVoiceButton` self-gates on the `voice-mode`
-  // flag, but the transcript surface and the mutual-exclusion wiring below
-  // must also no-op when the flag is off so the composer is byte-identical for
-  // users without the flag. The live-voice button only appears alongside the
-  // dictation button (same `showVoiceInput` precondition + a non-null id).
-  const voiceMode = useAssistantFeatureFlagStore.use.voiceMode();
-  const liveVoiceEligible = voiceMode && showVoiceInput && !!assistantId;
-  // Read session state via the store's per-field selectors rather than mounting
-  // a second `useLiveVoice()` controller. The single controller instance lives
-  // in `LiveVoiceButton` (which drives start/stop + owns the unmount-teardown
-  // effect); the composer only ever *reads* the projected state, so two
-  // controllers with competing teardown effects on the same store would be a
-  // footgun. These atomic selectors re-render only on the fields they read.
-  const liveVoiceState = useLiveVoiceStore.use.state();
-  const liveVoicePartial = useLiveVoiceStore.use.partialTranscript();
-  const liveVoiceFinal = useLiveVoiceStore.use.finalTranscript();
-  const liveVoiceAssistant = useLiveVoiceStore.use.assistantTranscript();
+  // Coexists with dictation: entry is gated on eligibility — `LiveVoiceButton`
+  // self-gates on the `voice-mode` flag and only renders alongside the
+  // dictation button (`showVoiceInput` + a non-null assistant id) — so with
+  // the flag off no session can ever start and the session state below stays
+  // `idle`, keeping the composer byte-identical for users without the flag.
+  // The composer owns the single `useLiveVoice()` controller instance. It has
+  // to live here (not in `LiveVoiceButton`): while a session is active the
+  // action row that hosts the button is swapped out for `VoiceComposerBar`,
+  // and the hook tears the session down when its owner unmounts — a
+  // button-owned controller would kill the session the moment it started.
+  // The button is purely the presentational entry point (see its docs).
+  //
+  // `observeAudioState: false` — the composer only needs the low-frequency
+  // session phase + error + actions. Without it the hook would subscribe this
+  // whole component to `inputAmplitude` (updated per mic sample) and the
+  // transcript fields, re-rendering the entire composer on every mic-level
+  // tick; the voice bar's waveform instead polls amplitude via `getState()`
+  // in its canvas draw loop (see `getLiveVoiceAmplitude` below).
+  const {
+    state: liveVoiceState,
+    error: liveVoiceError,
+    start: liveVoiceStart,
+    stop: liveVoiceStop,
+    release: liveVoiceRelease,
+  } = useLiveVoice({ observeAudioState: false });
   // Anything but idle/failed counts as an active session; while active the
-  // dictation mic is disabled so the two capture flows never run at once.
-  // `failed` is a retryable/inactive state in `useLiveVoice`/`LiveVoiceButton`,
-  // so we must treat it as inactive — otherwise dictation stays disabled and
-  // the (empty) transcript surface stays mounted after a failed start.
+  // whole action row (including both mic buttons) is replaced by the voice
+  // bar, so the two capture flows can never run at once. `failed` is a
+  // retryable/inactive state, so it must fall back to the normal row —
+  // otherwise dictation would stay unavailable after a failed start.
+  //
+  // Deliberately based on the session state alone — NOT on the entry-point
+  // eligibility (the `voice-mode` flag / a non-null `assistantId`) — so a
+  // mid-session eligibility drop (flag flip, `assistantId` transiently
+  // cleared) can't unmount the voice bar while the still-mounted controller
+  // keeps the mic/socket live: the bar's ✕ stays available until teardown
+  // completes and the state returns to `idle`. `showVoiceInput` (static per
+  // variant) scopes the swap to the voice-enabled composer — the app-editing
+  // variant shares the global live-voice store but must never swap its row
+  // for a session it doesn't own.
   const isLiveVoiceActive =
-    liveVoiceEligible &&
+    showVoiceInput &&
     liveVoiceState !== "idle" &&
     liveVoiceState !== "failed";
+  // Amplitude is polled by the voice bar's canvas draw loop straight from the
+  // store (~30 Hz), so per-sample updates never flow through props.
+  const getLiveVoiceAmplitude = useCallback(
+    () => useLiveVoiceStore.getState().inputAmplitude,
+    [],
+  );
+  const handleLiveVoiceStart = useCallback(() => {
+    if (!assistantId) return;
+    void liveVoiceStart(assistantId, conversationId ?? undefined);
+  }, [assistantId, conversationId, liveVoiceStart]);
+  const handleLiveVoiceEnd = useCallback(() => {
+    void liveVoiceStop();
+  }, [liveVoiceStop]);
+  // Dismissing the failure notice resets the store back to idle — `failed` is
+  // terminal for the session, so this only clears the surfaced error.
+  const dismissLiveVoiceError = useCallback(() => {
+    useLiveVoiceStore.getState().reset();
+  }, []);
 
   const pointerCoarse = useMemo(() => isPointerCoarse(), []);
   const isMobile = useIsMobile();
@@ -339,6 +376,19 @@ export function ChatComposer({
       {/* Composer-owned draft/attachment notices (self-sourced), above the
           orchestration banner stack. */}
       <ComposerDraftNotices />
+      {/* Live-voice failure notice — composer-owned (the session controller
+          lives here), mirroring the dictation `voiceError` Notice rendered by
+          `ComposerNotices` in the orchestration stack below. Keyed on the
+          session state (not entry eligibility) for the same reason as
+          `isLiveVoiceActive`: a session that fails right after an eligibility
+          drop must still surface its error. */}
+      {showVoiceInput && liveVoiceState === "failed" && liveVoiceError && (
+        <div className="mb-2">
+          <Notice tone="error" onDismiss={dismissLiveVoiceError}>
+            {liveVoiceError}
+          </Notice>
+        </div>
+      )}
       {noticesAboveFormSlot}
       <Popover.Root open={emoji.show || slash.show}>
         <Popover.Anchor asChild>
@@ -538,7 +588,10 @@ export function ChatComposer({
                   }
                 }}
                 placeholder={ghostSuffix ? "" : placeholder}
-                disabled={typingDisabled}
+                // Inert during a live-voice session so focus/typing can't
+                // fight the session (a later PR streams the live transcript
+                // into this region). The grid mirror keeps the height stable.
+                disabled={typingDisabled || isLiveVoiceActive}
                 rows={1}
                 className="col-start-1 row-start-1 w-full resize-none overflow-y-auto border-none bg-transparent px-4 pt-3 pb-2 text-chat text-[var(--content-default)] placeholder:text-[var(--content-disabled)] focus:outline-none disabled:opacity-50"
                 style={{ maxHeight: `${textareaMaxHeightPx}px` }}
@@ -573,139 +626,130 @@ export function ChatComposer({
                 )}
               </div>
             )}
-            {isLiveVoiceActive && (
-              // Live-voice transcript surface — distinct from the dictation
-              // interim preview above, which only exists while the dictation
-              // recorder is running. Shows the user's partial/final speech and
-              // the streaming assistant reply for the in-flight turn.
-              <div
-                className="px-4 pb-1 space-y-0.5"
-                aria-label="Live voice transcript"
-                aria-live="polite"
-              >
-                {(liveVoicePartial || liveVoiceFinal) && (
-                  <p className="truncate text-[11px] text-[var(--content-secondary)]">
-                    {liveVoicePartial || liveVoiceFinal}
-                  </p>
-                )}
-                {liveVoiceAssistant && (
-                  <p className="truncate text-[11px] italic text-[var(--content-tertiary)]">
-                    {liveVoiceAssistant}
-                  </p>
-                )}
+            {isLiveVoiceActive ? (
+              // Voice session bar (Light 53): the whole action row — slots,
+              // attach, both mic buttons, and send — is replaced by the bar
+              // for the duration of the session. ✕ ends the session (the
+              // normal row returns via `isLiveVoiceActive` flipping false);
+              // green ↑ manually releases the current turn while listening.
+              <VoiceComposerBar
+                state={liveVoiceState}
+                getAmplitude={getLiveVoiceAmplitude}
+                onEnd={handleLiveVoiceEnd}
+                onSend={liveVoiceRelease}
+              />
+            ) : (
+              <div className="flex items-center justify-between px-2 pb-2">
+                <div className="flex items-center gap-1">
+                  {thresholdPickerSlot}
+                  {contextWindowIndicatorSlot}
+                </div>
+                <div className="flex items-center gap-1">
+                  {canStopGenerating ? (
+                    <>
+                      {/* Desktop: always show stop. Mobile: show stop only when there is no sendable content. */}
+                      {(!isMobile || !canSendMessageContent) && (
+                        <Button
+                          variant="primary"
+                          iconOnly={
+                            <Square className="h-3 w-3" fill="currentColor" />
+                          }
+                          onClick={onStopGenerating}
+                          aria-label="Stop generating"
+                        />
+                      )}
+                      {/* Mobile: show send instead of stop when content can be queued. */}
+                      {isMobile && canSendMessageContent && (
+                        <Button
+                          variant="primary"
+                          iconOnly={
+                            <ArrowUp className="h-4 w-4" strokeWidth={2.5} />
+                          }
+                          type="submit"
+                          disabled={sendDisabled || attachmentsUploadingCount > 0}
+                          title={
+                            sendDisabled
+                              ? "Type a message to send"
+                              : attachmentsUploadingCount > 0
+                                ? "Uploading attachments…"
+                                : "Send message"
+                          }
+                          aria-label="Send message"
+                        />
+                      )}
+                    </>
+                  ) : (
+                    <>
+                      <AttachFileButton
+                        disabled={typingDisabled || !assistantId}
+                        onFilesSelected={onAddAttachmentFiles}
+                      />
+                      {showVoiceInput && (
+                        <VoiceInputButton
+                          ref={voiceInputRef}
+                          assistantId={assistantId}
+                          // Mutual exclusion: an active live-voice session
+                          // replaces this whole row with the voice bar, so the
+                          // two capture flows never run simultaneously; the
+                          // `isLiveVoiceActive` term is defense-in-depth for
+                          // that structural guarantee.
+                          disabled={typingDisabled || isLiveVoiceActive}
+                          onTranscript={onVoiceTranscript}
+                          onInterimTranscript={onVoiceInterimTranscript}
+                          onError={onVoiceError}
+                          onBeforeStart={onVoiceBeforeStart}
+                          onStreamReady={(stream: MediaStream | null) => {
+                            voiceStreamRef.current = stream;
+                            setVoiceStream(stream);
+                          }}
+                        />
+                      )}
+                      {showVoiceInput && assistantId && (
+                        // Self-gates on the `voice-mode` flag (renders null when
+                        // off — no layout shift). Purely the session entry
+                        // point: once a session starts, this row (button
+                        // included) is swapped for `VoiceComposerBar`, whose ✕
+                        // owns stopping.
+                        //
+                        // Mutual exclusion (reverse direction): while dictation
+                        // is active (`isVoiceActive`) live voice is disabled so
+                        // it can't start a second mic/voice session alongside
+                        // the recorder.
+                        <LiveVoiceButton
+                          onStart={handleLiveVoiceStart}
+                          disabled={typingDisabled || isVoiceActive}
+                        />
+                      )}
+                      {/* macOS parity: the send button is hidden during recording
+                      and while transcription is being processed. Only the voice
+                      button (mic / stop / spinner) is shown. */}
+                      {!isVoiceActive && (
+                        <Button
+                          variant="primary"
+                          iconOnly={
+                            <ArrowUp className="h-4 w-4" strokeWidth={2.5} />
+                          }
+                          type="submit"
+                          disabled={
+                            sendDisabled ||
+                            attachmentsUploadingCount > 0 ||
+                            !canSendMessageContent
+                          }
+                          title={
+                            sendDisabled || !canSendMessageContent
+                              ? "Type a message to send"
+                              : attachmentsUploadingCount > 0
+                                ? "Uploading attachments…"
+                                : "Send message"
+                          }
+                          aria-label="Send message"
+                        />
+                      )}
+                    </>
+                  )}
+                </div>
               </div>
             )}
-            <div className="flex items-center justify-between px-2 pb-2">
-              <div className="flex items-center gap-1">
-                {thresholdPickerSlot}
-                {contextWindowIndicatorSlot}
-              </div>
-              <div className="flex items-center gap-1">
-                {canStopGenerating ? (
-                  <>
-                    {/* Desktop: always show stop. Mobile: show stop only when there is no sendable content. */}
-                    {(!isMobile || !canSendMessageContent) && (
-                      <Button
-                        variant="primary"
-                        iconOnly={
-                          <Square className="h-3 w-3" fill="currentColor" />
-                        }
-                        onClick={onStopGenerating}
-                        aria-label="Stop generating"
-                      />
-                    )}
-                    {/* Mobile: show send instead of stop when content can be queued. */}
-                    {isMobile && canSendMessageContent && (
-                      <Button
-                        variant="primary"
-                        iconOnly={
-                          <ArrowUp className="h-4 w-4" strokeWidth={2.5} />
-                        }
-                        type="submit"
-                        disabled={sendDisabled || attachmentsUploadingCount > 0}
-                        title={
-                          sendDisabled
-                            ? "Type a message to send"
-                            : attachmentsUploadingCount > 0
-                              ? "Uploading attachments…"
-                              : "Send message"
-                        }
-                        aria-label="Send message"
-                      />
-                    )}
-                  </>
-                ) : (
-                  <>
-                    <AttachFileButton
-                      disabled={typingDisabled || !assistantId}
-                      onFilesSelected={onAddAttachmentFiles}
-                    />
-                    {showVoiceInput && (
-                      <VoiceInputButton
-                        ref={voiceInputRef}
-                        assistantId={assistantId}
-                        // Mutual exclusion: an active live-voice session
-                        // disables the dictation mic so the two capture flows
-                        // never run simultaneously.
-                        disabled={typingDisabled || isLiveVoiceActive}
-                        onTranscript={onVoiceTranscript}
-                        onInterimTranscript={onVoiceInterimTranscript}
-                        onError={onVoiceError}
-                        onBeforeStart={onVoiceBeforeStart}
-                        onStreamReady={(stream: MediaStream | null) => {
-                          voiceStreamRef.current = stream;
-                          setVoiceStream(stream);
-                        }}
-                      />
-                    )}
-                    {showVoiceInput && assistantId && (
-                      // Self-gates on the `voice-mode` flag (renders null when
-                      // off — no layout shift). The composer's busy/disabled
-                      // signal only gates the START path; an active session
-                      // stays stoppable even while the composer is otherwise
-                      // busy (see LiveVoiceButton).
-                      //
-                      // Mutual exclusion (reverse direction): while dictation is
-                      // active (`isVoiceActive`) we disable live voice so it
-                      // can't START a second mic/voice session alongside the
-                      // recorder. `LiveVoiceButton` only applies external
-                      // `disabled` to its START path, so an in-flight live-voice
-                      // session is never trapped by this.
-                      <LiveVoiceButton
-                        assistantId={assistantId}
-                        conversationId={conversationId ?? undefined}
-                        disabled={typingDisabled || isVoiceActive}
-                      />
-                    )}
-                    {/* macOS parity: the send button is hidden during recording
-                    and while transcription is being processed. Only the voice
-                    button (mic / stop / spinner) is shown. */}
-                    {!isVoiceActive && (
-                      <Button
-                        variant="primary"
-                        iconOnly={
-                          <ArrowUp className="h-4 w-4" strokeWidth={2.5} />
-                        }
-                        type="submit"
-                        disabled={
-                          sendDisabled ||
-                          attachmentsUploadingCount > 0 ||
-                          !canSendMessageContent
-                        }
-                        title={
-                          sendDisabled || !canSendMessageContent
-                            ? "Type a message to send"
-                            : attachmentsUploadingCount > 0
-                              ? "Uploading attachments…"
-                              : "Send message"
-                        }
-                        aria-label="Send message"
-                      />
-                    )}
-                  </>
-                )}
-              </div>
-            </div>
           </form>
         </Popover.Anchor>
         <Popover.Content

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -33,8 +33,11 @@ import {
     type VoiceInputButtonHandle,
 } from "@/domains/chat/components/voice-input-button";
 import { type TurnPhase, useTurnStore } from "@/domains/chat/turn-store";
-import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
-import { useLiveVoice } from "@/domains/chat/voice/live-voice/use-live-voice";
+import {
+    isLiveVoiceSessionActive,
+    useIsLiveVoiceSessionOwnedBy,
+    useLiveVoiceStore,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
 import { useAudioAmplitude } from "@/domains/chat/voice/use-audio-amplitude";
 import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
 import { useIsMobile } from "@/hooks/use-is-mobile";
@@ -113,10 +116,13 @@ export interface ChatComposerProps {
   // assistant id used by AttachFileButton's disabled guard
   assistantId: string | null;
 
-  // Active conversation the live-voice session should attach to. Optional —
-  // when absent (e.g. the empty/new-conversation state) live voice still
-  // starts a fresh session for the assistant. The app-editing variant, which
-  // has no voice, leaves this undefined.
+  // Conversation this composer is bound to — used to attach live-voice
+  // sessions and to decide whether this composer owns the active session
+  // (see `isLiveVoiceSessionOwnedBy`). Pass the routing-truth id
+  // (`activeConversationId`), including client-generated draft ids, so the
+  // session lands in the thread the user is looking at. Optional — when
+  // absent the session starts without a conversation and the server assigns
+  // one. The app-editing variant, which has no voice, leaves this undefined.
   conversationId?: string | null;
 
   // chrome surfacing existing buttons (rendered in the form's bottom-left row)
@@ -217,53 +223,44 @@ export function ChatComposer({
   // dictation button (`showVoiceInput` + a non-null assistant id) — so with
   // the flag off no session can ever start and the session state below stays
   // `idle`, keeping the composer byte-identical for users without the flag.
-  // The composer owns the single `useLiveVoice()` controller instance. It has
-  // to live here (not in `LiveVoiceButton`): while a session is active the
-  // action row that hosts the button is swapped out for `VoiceComposerBar`,
-  // and the hook tears the session down when its owner unmounts — a
-  // button-owned controller would kill the session the moment it started.
-  // The button is purely the presentational entry point (see its docs).
   //
-  // `observeAudioState: false` — the composer only needs the low-frequency
-  // session phase + error + actions. Without it the hook would subscribe this
-  // whole component to `inputAmplitude` (updated per mic sample) and the
-  // transcript fields, re-rendering the entire composer on every mic-level
-  // tick; the voice bar's waveform instead polls amplitude via `getState()`
-  // in its canvas draw loop (see `getLiveVoiceAmplitude` below).
-  const {
-    state: liveVoiceState,
-    error: liveVoiceError,
-    start: liveVoiceStart,
-    stop: liveVoiceStop,
-    release: liveVoiceRelease,
-  } = useLiveVoice({ observeAudioState: false });
-  // Anything but idle/failed counts as an active session; while active the
-  // whole action row (including both mic buttons) is replaced by the voice
-  // bar, so the two capture flows can never run at once. `failed` is a
-  // retryable/inactive state, so it must fall back to the normal row —
-  // otherwise dictation would stay unavailable after a failed start.
+  // The session controller (`useLiveVoice`) is NOT owned here: it lives in
+  // the persistent `useLiveVoiceSessionController` mount in `ChatLayout`, so
+  // a session survives thread switches, Home/Library navigation, and the
+  // fullscreen app viewer — the navigations that unmount this composer. The
+  // composer only observes the session through narrow store selectors and
+  // drives it through the store-registered `starter`/`controls` seams.
+  const liveVoiceState = useLiveVoiceStore.use.state();
+  const liveVoiceError = useLiveVoiceStore.use.error();
+  // Whether any session is live anywhere (this thread or another). `failed`
+  // is a retryable/inactive state, so it must count as inactive — otherwise
+  // dictation would stay unavailable after a failed start.
+  const isLiveVoiceSessionLive = isLiveVoiceSessionActive(liveVoiceState);
+  // Whether THIS composer owns the active session — its conversation matches
+  // the session's, or the session was started from this composer's draft.
+  // Ownership scopes the surface swap: a session started in thread A must
+  // not hijack thread B's composer — B keeps its normal row and the
+  // title-bar pill is the session surface there (exactly one of the two
+  // renders at any time; see `isLiveVoiceSessionOwnedBy`).
   //
-  // Deliberately based on the session state alone — NOT on the entry-point
-  // eligibility (the `voice-mode` flag / a non-null `assistantId`) — so a
-  // mid-session eligibility drop (flag flip, `assistantId` transiently
-  // cleared) can't unmount the voice bar while the still-mounted controller
-  // keeps the mic/socket live: the bar's ✕ stays available until teardown
-  // completes and the state returns to `idle`. `showVoiceInput` (static per
-  // variant) scopes the swap to the voice-enabled composer — the app-editing
-  // variant shares the global live-voice store but must never swap its row
-  // for a session it doesn't own.
-  const isLiveVoiceActive =
-    showVoiceInput &&
-    liveVoiceState !== "idle" &&
-    liveVoiceState !== "failed";
+  // Deliberately based on session state + ownership alone — NOT on the
+  // entry-point eligibility (the `voice-mode` flag / a non-null
+  // `assistantId`) — so a mid-session eligibility drop (flag flip,
+  // `assistantId` transiently cleared) can't unmount the voice bar while the
+  // session keeps the mic/socket live: the bar's ✕ stays available until
+  // teardown completes. `showVoiceInput` (static per variant) scopes the
+  // swap to the voice-enabled composer — the app-editing variant shares the
+  // global live-voice store but must never swap its row.
+  const ownsLiveVoiceSession = useIsLiveVoiceSessionOwnedBy(conversationId);
+  const isLiveVoiceActive = showVoiceInput && ownsLiveVoiceSession;
   // Whether the session has any speech transcript to show. A boolean
   // *presence* subscription, not the text itself: zustand only re-renders
   // when the selected value changes identity, so per-delta transcript
   // updates never reach the composer — the bit flips once when speech
   // starts and once when the store clears. The streaming text is rendered
   // by `VoiceLiveTranscript`, which subscribes to the store on its own,
-  // keeping this component's deliberate opt-out of high-frequency
-  // live-voice updates (see `observeAudioState: false` above) intact.
+  // keeping the composer's deliberate opt-out of high-frequency live-voice
+  // updates (amplitude ticks, transcript deltas) intact.
   const hasLiveVoiceTranscript = useLiveVoiceStore(
     (s) => Boolean(s.partialTranscript || s.finalTranscript),
   );
@@ -278,13 +275,22 @@ export function ChatComposer({
     () => useLiveVoiceStore.getState().inputAmplitude,
     [],
   );
+  // Session verbs go through the store seams registered by the layout-owned
+  // controller: `starter` (registered for the controller's whole mount) to
+  // start, per-session `controls` to stop/release. Read via `getState()` in
+  // handlers per STATE_MANAGEMENT.md — no subscription needed.
   const handleLiveVoiceStart = useCallback(() => {
-    if (!assistantId) return;
-    void liveVoiceStart(assistantId, conversationId ?? undefined);
-  }, [assistantId, conversationId, liveVoiceStart]);
+    if (!assistantId) {
+      return;
+    }
+    useLiveVoiceStore.getState().starter?.(assistantId, conversationId ?? null);
+  }, [assistantId, conversationId]);
   const handleLiveVoiceEnd = useCallback(() => {
-    void liveVoiceStop();
-  }, [liveVoiceStop]);
+    useLiveVoiceStore.getState().controls?.stop();
+  }, []);
+  const handleLiveVoiceSend = useCallback(() => {
+    useLiveVoiceStore.getState().controls?.release();
+  }, []);
   // Dismissing the failure notice resets the store back to idle — `failed` is
   // terminal for the session, so this only clears the surfaced error.
   const dismissLiveVoiceError = useCallback(() => {
@@ -393,12 +399,12 @@ export function ChatComposer({
       {/* Composer-owned draft/attachment notices (self-sourced), above the
           orchestration banner stack. */}
       <ComposerDraftNotices />
-      {/* Live-voice failure notice — composer-owned (the session controller
-          lives here), mirroring the dictation `voiceError` Notice rendered by
-          `ComposerNotices` in the orchestration stack below. Keyed on the
-          session state (not entry eligibility) for the same reason as
-          `isLiveVoiceActive`: a session that fails right after an eligibility
-          drop must still surface its error. */}
+      {/* Live-voice failure notice — surfaced by the voice-enabled composer
+          the user is looking at, mirroring the dictation `voiceError` Notice
+          rendered by `ComposerNotices` in the orchestration stack below.
+          Keyed on the session state (not entry eligibility) for the same
+          reason as `isLiveVoiceActive`: a session that fails right after an
+          eligibility drop must still surface its error. */}
       {showVoiceInput && liveVoiceState === "failed" && liveVoiceError && (
         <div className="mb-2">
           <Notice tone="error" onDismiss={dismissLiveVoiceError}>
@@ -605,9 +611,10 @@ export function ChatComposer({
                   }
                 }}
                 placeholder={ghostSuffix ? "" : placeholder}
-                // Inert during a live-voice session so focus/typing can't
-                // fight the session (a later PR streams the live transcript
-                // into this region). The grid mirror keeps the height stable.
+                // Inert while this composer's live-voice session is active so
+                // focus/typing can't fight the session — `VoiceLiveTranscript`
+                // streams the live speech into this grid cell (see below).
+                // The grid mirror keeps the height stable.
                 disabled={typingDisabled || isLiveVoiceActive}
                 rows={1}
                 className={`col-start-1 row-start-1 w-full resize-none overflow-y-auto border-none bg-transparent px-4 pt-3 pb-2 text-chat text-[var(--content-default)] placeholder:text-[var(--content-disabled)] focus:outline-none disabled:opacity-50 ${
@@ -666,7 +673,7 @@ export function ChatComposer({
                 state={liveVoiceState}
                 getAmplitude={getLiveVoiceAmplitude}
                 onEnd={handleLiveVoiceEnd}
-                onSend={liveVoiceRelease}
+                onSend={handleLiveVoiceSend}
               />
             ) : (
               <div className="flex items-center justify-between px-2 pb-2">
@@ -718,12 +725,12 @@ export function ChatComposer({
                         <VoiceInputButton
                           ref={voiceInputRef}
                           assistantId={assistantId}
-                          // Mutual exclusion: an active live-voice session
-                          // replaces this whole row with the voice bar, so the
-                          // two capture flows never run simultaneously; the
-                          // `isLiveVoiceActive` term is defense-in-depth for
-                          // that structural guarantee.
-                          disabled={typingDisabled || isLiveVoiceActive}
+                          // Mutual exclusion: a live-voice session anywhere —
+                          // owned by this composer (whose row is swapped for
+                          // the voice bar anyway) or by another thread — must
+                          // block dictation, or two mic capture flows could
+                          // run at once.
+                          disabled={typingDisabled || isLiveVoiceSessionLive}
                           onTranscript={onVoiceTranscript}
                           onInterimTranscript={onVoiceInterimTranscript}
                           onError={onVoiceError}
@@ -742,12 +749,17 @@ export function ChatComposer({
                         // owns stopping.
                         //
                         // Mutual exclusion (reverse direction): while dictation
-                        // is active (`isVoiceActive`) live voice is disabled so
-                        // it can't start a second mic/voice session alongside
-                        // the recorder.
+                        // is active (`isVoiceActive`) — or a live-voice session
+                        // already runs in another thread — starting a session
+                        // here is disabled so a second mic/voice session can't
+                        // open alongside the running one.
                         <LiveVoiceButton
                           onStart={handleLiveVoiceStart}
-                          disabled={typingDisabled || isVoiceActive}
+                          disabled={
+                            typingDisabled ||
+                            isVoiceActive ||
+                            isLiveVoiceSessionLive
+                          }
                         />
                       )}
                       {/* macOS parity: the send button is hidden during recording

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * Tests for `VoiceComposerBar`.
+ *
+ * The bar is purely presentational, so tests drive it prop-by-prop: state
+ * label mapping, send-button enablement, callback wiring, and accessibility
+ * attributes. The embedded `VoiceTimelineWaveform` renders a real canvas —
+ * happy-dom's `getContext("2d")` returns `null`, which that component
+ * handles by skipping its draw loop, so no canvas/rAF harness is needed
+ * here (its rendering behavior is covered by its own test file).
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { VoiceComposerBar } from "@/domains/chat/components/chat-composer/voice-composer-bar";
+import type { LiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live-voice-store";
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderBar(state: LiveVoiceSessionState, overrides?: {
+  onEnd?: () => void;
+  onSend?: () => void;
+}) {
+  return render(
+    <VoiceComposerBar
+      state={state}
+      getAmplitude={() => 0.5}
+      onEnd={overrides?.onEnd ?? (() => {})}
+      onSend={overrides?.onSend ?? (() => {})}
+    />,
+  );
+}
+
+describe("VoiceComposerBar — state label", () => {
+  const labels: Array<[LiveVoiceSessionState, string]> = [
+    ["connecting", "Connecting…"],
+    ["listening", "Listening…"],
+    ["transcribing", "Transcribing…"],
+    ["thinking", "Thinking…"],
+    ["speaking", "Speaking…"],
+    ["ending", "Ending…"],
+  ];
+
+  for (const [state, label] of labels) {
+    test(`renders "${label}" for the ${state} state`, () => {
+      renderBar(state);
+      expect(screen.getByText(label)).toBeTruthy();
+    });
+  }
+
+  test("announces state changes via an aria-live region", () => {
+    renderBar("listening");
+    const label = screen.getByText("Listening…");
+    expect(label.getAttribute("aria-live")).toBe("polite");
+  });
+});
+
+describe("VoiceComposerBar — send enablement", () => {
+  test("send is enabled while listening", () => {
+    renderBar("listening");
+    const send = screen.getByRole("button", { name: "Send now" });
+    expect((send as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  const nonListening: LiveVoiceSessionState[] = [
+    "connecting",
+    "transcribing",
+    "thinking",
+    "speaking",
+    "ending",
+  ];
+
+  for (const state of nonListening) {
+    test(`send is disabled while ${state}`, () => {
+      renderBar(state);
+      const send = screen.getByRole("button", { name: "Send now" });
+      expect((send as HTMLButtonElement).disabled).toBe(true);
+    });
+  }
+
+  test("end stays enabled in every session state", () => {
+    for (const state of ["connecting", "listening", "speaking", "ending"] as const) {
+      const { unmount } = renderBar(state);
+      const end = screen.getByRole("button", { name: "End voice session" });
+      expect((end as HTMLButtonElement).disabled).toBe(false);
+      unmount();
+    }
+  });
+});
+
+describe("VoiceComposerBar — callbacks", () => {
+  test("clicking end fires onEnd", () => {
+    const onEnd = mock(() => {});
+    renderBar("speaking", { onEnd });
+    fireEvent.click(screen.getByRole("button", { name: "End voice session" }));
+    expect(onEnd).toHaveBeenCalledTimes(1);
+  });
+
+  test("clicking send while listening fires onSend", () => {
+    const onSend = mock(() => {});
+    renderBar("listening", { onSend });
+    fireEvent.click(screen.getByRole("button", { name: "Send now" }));
+    expect(onSend).toHaveBeenCalledTimes(1);
+  });
+
+  test("clicking send while disabled does not fire onSend", () => {
+    const onSend = mock(() => {});
+    renderBar("thinking", { onSend });
+    fireEvent.click(screen.getByRole("button", { name: "Send now" }));
+    expect(onSend).not.toHaveBeenCalled();
+  });
+});
+
+describe("VoiceComposerBar — structure and accessibility", () => {
+  test("bar container is a labelled group", () => {
+    renderBar("listening");
+    const group = screen.getByRole("group", { name: "Voice session" });
+    expect(group).toBeTruthy();
+  });
+
+  test("renders the timeline waveform canvas", () => {
+    const { container } = renderBar("listening");
+    expect(container.querySelector("canvas")).toBeTruthy();
+  });
+
+  test("both control buttons carry aria labels", () => {
+    renderBar("listening");
+    expect(
+      screen.getByRole("button", { name: "End voice session" }),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Send now" })).toBeTruthy();
+  });
+});

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
@@ -1,0 +1,100 @@
+/**
+ * Voice-session composer bar (Light 53): while a live-voice session is
+ * active the composer's action row is replaced by this bar — a small mic
+ * glyph and muted state label on the left, the dotted timeline waveform
+ * filling the middle, and end (✕) / send-now (↑) controls on the right.
+ *
+ * Purely presentational: the parent owns the `useLiveVoice` session and
+ * wires `state`, an amplitude poll function, and the two callbacks. The
+ * green ↑ is a manual "send now" (push-to-talk release) and is only
+ * meaningful while the session is listening; the red ✕ ends the session
+ * and is always available.
+ *
+ * Layout mirrors the composer's bottom action row (`px-2 pb-2`, regular
+ * `h-8` icon buttons) so swapping the rows in during a session causes no
+ * layout shift.
+ */
+
+import { ArrowUp, Mic, X } from "lucide-react";
+
+import { Button } from "@vellumai/design-library";
+
+import type { LiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { VoiceTimelineWaveform } from "@/domains/chat/voice/voice-timeline-waveform";
+
+/**
+ * Deliberately minimal state treatment (decided 2026-07-06): assistant
+ * output streams into the thread transcript like text chat, so the bar
+ * only carries a small label. `idle`/`failed` map to an empty label —
+ * the parent unmounts the bar in those states.
+ */
+const STATE_LABELS: Record<LiveVoiceSessionState, string> = {
+  idle: "",
+  connecting: "Connecting…",
+  listening: "Listening…",
+  transcribing: "Transcribing…",
+  thinking: "Thinking…",
+  speaking: "Speaking…",
+  ending: "Ending…",
+  failed: "",
+};
+
+export interface VoiceComposerBarProps {
+  state: LiveVoiceSessionState;
+  /** Polled ~30 Hz by the waveform's draw loop — no re-render per sample. */
+  getAmplitude: () => number;
+  /** Red ✕ — end the voice session. */
+  onEnd: () => void;
+  /** Green ↑ — manually release the current turn (send now). */
+  onSend: () => void;
+}
+
+export function VoiceComposerBar({
+  state,
+  getAmplitude,
+  onEnd,
+  onSend,
+}: VoiceComposerBarProps) {
+  return (
+    <div
+      role="group"
+      aria-label="Voice session"
+      className="flex items-center gap-3 px-2 pb-2"
+    >
+      {/* pl-2 lines the mic up with the textarea's px-4 text inset. */}
+      <div className="flex shrink-0 items-center gap-2 pl-2">
+        <Mic
+          aria-hidden
+          className="h-4 w-4 text-[var(--content-secondary)]"
+        />
+        {/* Muted placeholder styling — matches the textarea's placeholder. */}
+        <span
+          aria-live="polite"
+          className="text-chat text-[var(--content-disabled)]"
+        >
+          {STATE_LABELS[state]}
+        </span>
+      </div>
+      <VoiceTimelineWaveform
+        getAmplitude={getAmplitude}
+        active={state === "listening"}
+        className="min-w-0 flex-1"
+      />
+      <div className="flex shrink-0 items-center gap-1">
+        <Button
+          variant="danger"
+          iconOnly={<X className="h-4 w-4" strokeWidth={2.5} />}
+          onClick={onEnd}
+          aria-label="End voice session"
+        />
+        <Button
+          variant="primary"
+          iconOnly={<ArrowUp className="h-4 w-4" strokeWidth={2.5} />}
+          onClick={onSend}
+          disabled={state !== "listening"}
+          aria-label="Send now"
+        />
+      </div>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
@@ -4,7 +4,7 @@
  * glyph and muted state label on the left, the dotted timeline waveform
  * filling the middle, and end (✕) / send-now (↑) controls on the right.
  *
- * Purely presentational: the parent owns the `useLiveVoice` session and
+ * Purely presentational: the composer observes the live-voice store and
  * wires `state`, an amplitude poll function, and the two callbacks. The
  * green ↑ is a manual "send now" (push-to-talk release) and is only
  * meaningful while the session is listening; the red ✕ ends the session

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
@@ -27,8 +27,12 @@ import { VoiceTimelineWaveform } from "@/domains/chat/voice/voice-timeline-wavef
  * output streams into the thread transcript like text chat, so the bar
  * only carries a small label. `idle`/`failed` map to an empty label —
  * the parent unmounts the bar in those states.
+ *
+ * Exported for the title-bar session pill (`voice-session-pill-host.tsx`),
+ * which shows the same activity label while the user is away from the
+ * owning thread.
  */
-const STATE_LABELS: Record<LiveVoiceSessionState, string> = {
+export const STATE_LABELS: Record<LiveVoiceSessionState, string> = {
   idle: "",
   connecting: "Connecting…",
   listening: "Listening…",

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
@@ -19,29 +19,12 @@ import { ArrowUp, Mic, X } from "lucide-react";
 
 import { Button } from "@vellumai/design-library";
 
-import type { LiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live-voice-store";
+import {
+  LIVE_VOICE_STATE_LABELS,
+  isLiveVoiceMicLive,
+  type LiveVoiceSessionState,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
 import { VoiceTimelineWaveform } from "@/domains/chat/voice/voice-timeline-waveform";
-
-/**
- * Deliberately minimal state treatment (decided 2026-07-06): assistant
- * output streams into the thread transcript like text chat, so the bar
- * only carries a small label. `idle`/`failed` map to an empty label —
- * the parent unmounts the bar in those states.
- *
- * Exported for the title-bar session pill (`voice-session-pill-host.tsx`),
- * which shows the same activity label while the user is away from the
- * owning thread.
- */
-export const STATE_LABELS: Record<LiveVoiceSessionState, string> = {
-  idle: "",
-  connecting: "Connecting…",
-  listening: "Listening…",
-  transcribing: "Transcribing…",
-  thinking: "Thinking…",
-  speaking: "Speaking…",
-  ending: "Ending…",
-  failed: "",
-};
 
 export interface VoiceComposerBarProps {
   state: LiveVoiceSessionState;
@@ -76,12 +59,12 @@ export function VoiceComposerBar({
           aria-live="polite"
           className="text-chat text-[var(--content-disabled)]"
         >
-          {STATE_LABELS[state]}
+          {LIVE_VOICE_STATE_LABELS[state]}
         </span>
       </div>
       <VoiceTimelineWaveform
         getAmplitude={getAmplitude}
-        active={state === "listening"}
+        active={isLiveVoiceMicLive(state)}
         className="min-w-0 flex-1"
       />
       <div className="flex shrink-0 items-center gap-1">

--- a/clients/web/src/domains/chat/components/chat-composer/voice-live-transcript.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-live-transcript.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * Tests for `VoiceLiveTranscript`.
+ *
+ * The component subscribes to the real live-voice store (that self-sourcing
+ * is its whole point — the composer deliberately does not re-render on
+ * transcript deltas), so tests drive it by writing transcript fields through
+ * the store and asserting the rendered surface: partial/final precedence,
+ * store-driven clearing, the empty-renders-nothing contract, and the caret's
+ * reduced-motion behavior (verified by stubbing `motion/react`, mirroring
+ * `voice-timeline-waveform.test.tsx`).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { act, cleanup, render, screen } from "@testing-library/react";
+
+import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+
+import { VoiceLiveTranscript } from "@/domains/chat/components/chat-composer/voice-live-transcript";
+
+beforeEach(() => {
+  useLiveVoiceStore.getState().reset();
+});
+
+afterEach(() => {
+  cleanup();
+  useLiveVoiceStore.getState().reset();
+});
+
+function seedTranscripts(partial: string, final = "") {
+  act(() => {
+    useLiveVoiceStore.getState().setPartialTranscript(partial);
+    useLiveVoiceStore.getState().setFinalTranscript(final);
+  });
+}
+
+describe("VoiceLiveTranscript — transcript text", () => {
+  test("renders the partial transcript as display-only text", () => {
+    seedTranscripts("hello wor");
+    render(<VoiceLiveTranscript />);
+    const region = screen.getByLabelText("Voice transcript");
+    expect(region.textContent).toContain("hello wor");
+  });
+
+  test("prefers the partial over the final while both are present", () => {
+    // Same precedence as the old inline strip's `liveVoicePartial ||
+    // liveVoiceFinal`: the in-flight partial is the fresher signal.
+    seedTranscripts("still speaking", "previous final");
+    render(<VoiceLiveTranscript />);
+    const region = screen.getByLabelText("Voice transcript");
+    expect(region.textContent).toContain("still speaking");
+    expect(region.textContent).not.toContain("previous final");
+  });
+
+  test("falls back to the final transcript when no partial is in flight", () => {
+    seedTranscripts("", "what I said");
+    render(<VoiceLiveTranscript />);
+    expect(
+      screen.getByLabelText("Voice transcript").textContent,
+    ).toContain("what I said");
+  });
+
+  test("streams partial updates without remounting", () => {
+    seedTranscripts("hel");
+    render(<VoiceLiveTranscript />);
+    act(() => {
+      useLiveVoiceStore.getState().setPartialTranscript("hello world");
+    });
+    expect(
+      screen.getByLabelText("Voice transcript").textContent,
+    ).toContain("hello world");
+  });
+});
+
+describe("VoiceLiveTranscript — empty and clearing", () => {
+  test("renders nothing while both transcripts are empty", () => {
+    const { container } = render(<VoiceLiveTranscript />);
+    // Nothing in the composer's text area — the disabled textarea's
+    // placeholder shows through (Light 53 baseline).
+    expect(container.innerHTML).toBe("");
+    expect(screen.queryByLabelText("Voice transcript")).toBeNull();
+  });
+
+  test("clears when the store resets", () => {
+    seedTranscripts("about to be sent", "about to be sent");
+    const { container } = render(<VoiceLiveTranscript />);
+    expect(screen.getByLabelText("Voice transcript")).toBeTruthy();
+
+    act(() => {
+      useLiveVoiceStore.getState().reset();
+    });
+
+    expect(screen.queryByLabelText("Voice transcript")).toBeNull();
+    expect(container.innerHTML).toBe("");
+  });
+});
+
+describe("VoiceLiveTranscript — accessibility and styling", () => {
+  test("announces updates via a polite live region", () => {
+    seedTranscripts("hello");
+    render(<VoiceLiveTranscript />);
+    const region = screen.getByLabelText("Voice transcript");
+    expect(region.getAttribute("aria-live")).toBe("polite");
+  });
+
+  test("styles the text like the composer textarea and caps growth at maxHeightPx", () => {
+    seedTranscripts("hello");
+    render(<VoiceLiveTranscript className="col-start-1" maxHeightPx={240} />);
+    const region = screen.getByLabelText("Voice transcript");
+    // Same font class + text inset as the textarea, so speech reads as
+    // typed composer text; caller placement classes are merged in.
+    expect(region.className).toContain("text-chat");
+    expect(region.className).toContain("px-4");
+    expect(region.className).toContain("col-start-1");
+    expect(region.style.maxHeight).toBe("240px");
+  });
+
+  test("renders a blinking caret after the text by default", () => {
+    seedTranscripts("hello");
+    render(<VoiceLiveTranscript />);
+    const caret = screen.getByTestId("voice-transcript-caret");
+    expect(caret.getAttribute("aria-hidden")).toBe("true");
+    expect(caret.className).toContain("voice-caret-blink");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reduced-motion path — verified by stubbing `motion/react`.
+// ---------------------------------------------------------------------------
+
+describe("VoiceLiveTranscript — reduced motion", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("caret is static (no blink animation class) under reduced motion", async () => {
+    mock.module("motion/react", () => ({
+      useReducedMotion: () => true,
+    }));
+
+    const { VoiceLiveTranscript: ReducedTranscript } = await import(
+      "./voice-live-transcript"
+    );
+    seedTranscripts("hello");
+    render(<ReducedTranscript />);
+
+    const caret = screen.getByTestId("voice-transcript-caret");
+    // The caret stays visible as a static bar — only the blink is dropped.
+    expect(caret.className).not.toContain("voice-caret-blink");
+    expect(caret.className).toContain("bg-[var(--content-default)]");
+  });
+});

--- a/clients/web/src/domains/chat/components/chat-composer/voice-live-transcript.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-live-transcript.tsx
@@ -1,0 +1,93 @@
+/**
+ * Display-only live transcript rendered in the composer's text area during a
+ * live-voice session (Light 55): the user's speech streams in as normal
+ * composer-styled text followed by a blinking caret. Not editable — the turn
+ * auto-sends on silence/turn end (or via the voice bar's green ↑).
+ *
+ * Subscribes to the live-voice store itself via per-field selectors. This is
+ * deliberate: the composer opts out of high-frequency live-voice updates
+ * (`observeAudioState: false`), so per-delta transcript re-renders must stay
+ * contained to this leaf component.
+ *
+ * Shows `partialTranscript || finalTranscript` — the in-flight partial wins
+ * while both are present (same precedence as the old inline transcript
+ * strip). When both are empty it renders nothing, letting the disabled
+ * textarea's placeholder show through (Light 53 baseline).
+ *
+ * Clearing is store-driven: V1 resets transcripts per session; when the
+ * engine lands multi-turn sessions the store clears per turn and this
+ * component follows automatically — no turn logic lives here.
+ */
+
+import { useReducedMotion } from "motion/react";
+import { useEffect, useRef } from "react";
+
+import { cn } from "@vellumai/design-library";
+
+import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+
+export interface VoiceLiveTranscriptProps {
+  /** Placement classes from the composer (e.g. the textarea's grid cell). */
+  className?: string;
+  /**
+   * Cap for the transcript's auto-grow height — mirrors the textarea's
+   * `textareaMaxHeightPx` so the swap preserves the composer's height
+   * behavior; content beyond the cap scrolls.
+   */
+  maxHeightPx?: number;
+}
+
+export function VoiceLiveTranscript({
+  className,
+  maxHeightPx,
+}: VoiceLiveTranscriptProps) {
+  const partialTranscript = useLiveVoiceStore.use.partialTranscript();
+  const finalTranscript = useLiveVoiceStore.use.finalTranscript();
+  const reducedMotion = useReducedMotion();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const text = partialTranscript || finalTranscript;
+
+  // Keep the newest words (and the caret) in view once the transcript
+  // overflows the max height — mirrors how a textarea tracks its caret.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [text]);
+
+  if (!text) {
+    return null;
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      aria-live="polite"
+      aria-label="Voice transcript"
+      // Text styling matches the composer textarea exactly (same padding,
+      // font class, and color) so speech reads as typed composer text.
+      className={cn(
+        "overflow-y-auto whitespace-pre-wrap break-words px-4 pt-3 pb-2 text-chat text-[var(--content-default)]",
+        className,
+      )}
+      style={
+        maxHeightPx !== undefined ? { maxHeight: `${maxHeightPx}px` } : undefined
+      }
+    >
+      {text}
+      <span
+        aria-hidden
+        data-testid="voice-transcript-caret"
+        // Thin caret bar sized to the text's cap height; blinks via the
+        // `voice-caret-blink` keyframes in index.css, held static under
+        // reduced motion.
+        className={cn(
+          "ml-px inline-block h-[1.1em] w-[1.5px] translate-y-[0.2em] bg-[var(--content-default)]",
+          !reducedMotion && "voice-caret-blink",
+        )}
+      />
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -927,7 +927,12 @@ export function ChatMainPanel({
       onStopGenerating={handleStopGenerating}
       canStopGenerating={canStopGenerating}
       assistantId={assistantId}
-      conversationId={activeConversation?.conversationId}
+      // Routing-truth id (NOT `activeConversation?.conversationId`, which is
+      // transiently undefined until the row loads and always undefined for
+      // drafts): live-voice session ownership compares against this, and the
+      // session should attach to the thread the user is looking at — draft
+      // ids included (the runtime accepts client-generated conversation ids).
+      conversationId={activeConversationId}
       onRecallLastMessage={isIdle && isNativeConversation ? handleRecallLastMessage : undefined}
       onCancelEdit={isEditing ? handleCancelEdit : undefined}
       textareaMaxHeightPx={isEmptyConversation ? 320 : undefined}

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -33,6 +33,7 @@ import { QuoteReplyBubble } from "@/domains/chat/components/quote-reply-bubble";
 import { TextSelectionPopover } from "@/domains/chat/components/text-selection-popover";
 import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 import { isChannelConversation } from "@/domains/chat/utils/conversation-channel";
+import { isPopoutWindow } from "@/runtime/popout-window";
 
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { useChatAttachmentDropZone } from "@/domains/chat/components/chat-attachments/use-chat-attachment-drop-zone";
@@ -225,7 +226,7 @@ export function ChatMainPanel({
 }: ChatMainPanelProps) {
   const location = useLocation();
   const navigate = useNavigate();
-  const statusBannerVisible = !location.search.includes("popout=1");
+  const statusBannerVisible = !isPopoutWindow(location.search);
 
   // -------------------------------------------------------------------------
   // Derived UI state (provides assistantId, activeConversationId,

--- a/clients/web/src/domains/chat/components/live-voice-button.test.tsx
+++ b/clients/web/src/domains/chat/components/live-voice-button.test.tsx
@@ -1,10 +1,10 @@
 /**
  * Tests for `LiveVoiceButton`.
  *
- * The button is gated behind the `voice-mode` assistant flag and toggles a
- * {@link useLiveVoice} session. We mock both so the component renders in
- * isolation: the flag store via a mutable `mockVoiceMode`, and `useLiveVoice`
- * via spies for `start`/`stop` plus a mutable `mockState`/`mockInputAmplitude`.
+ * The button is a purely presentational entry point: it self-gates on the
+ * `voice-mode` assistant flag (mocked via a mutable `mockVoiceMode`) and
+ * forwards clicks to the composer-bound `onStart`. Session lifecycle lives in
+ * the composer's `useLiveVoice` controller, so there is nothing else to mock.
  *
  * Uses happy-dom via the bun:test preload configured in `web/bunfig.toml`.
  */
@@ -19,8 +19,6 @@ import {
 } from "bun:test";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
-import type { LiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live-voice-store";
-
 let mockVoiceMode = false;
 mock.module("@/stores/assistant-feature-flag-store", () => ({
   useAssistantFeatureFlagStore: {
@@ -30,40 +28,16 @@ mock.module("@/stores/assistant-feature-flag-store", () => ({
   },
 }));
 
-const startSpy = mock(
-  async (
-    _assistantId: string,
-    _conversationId?: string,
-    _options?: { handsFree?: boolean },
-  ) => {},
-);
-const stopSpy = mock(async () => {});
-let mockState: LiveVoiceSessionState = "idle";
-let mockInputAmplitude = 0;
-mock.module("@/domains/chat/voice/live-voice/use-live-voice", () => ({
-  useLiveVoice: () => ({
-    state: mockState,
-    partialTranscript: "",
-    finalTranscript: "",
-    assistantTranscript: "",
-    inputAmplitude: mockInputAmplitude,
-    error: null,
-    start: startSpy,
-    stop: stopSpy,
-  }),
-}));
-
 // Imported after the mocks so the component picks up the mocked modules.
 const { LiveVoiceButton } = await import(
   "@/domains/chat/components/live-voice-button"
 );
 
+const onStartSpy = mock(() => {});
+
 beforeEach(() => {
   mockVoiceMode = false;
-  mockState = "idle";
-  mockInputAmplitude = 0;
-  startSpy.mockClear();
-  stopSpy.mockClear();
+  onStartSpy.mockClear();
 });
 
 afterEach(() => {
@@ -76,103 +50,40 @@ describe("LiveVoiceButton", () => {
     mockVoiceMode = false;
 
     // WHEN the button renders
-    const { container } = render(<LiveVoiceButton assistantId="a1" />);
+    const { container } = render(<LiveVoiceButton onStart={onStartSpy} />);
 
     // THEN nothing is painted
     expect(container.firstChild).toBeNull();
   });
 
-  test("renders a start control when the flag is on and idle", () => {
-    // GIVEN the flag is enabled and no session is active
+  test("renders a start control when the flag is on", () => {
+    // GIVEN the flag is enabled
     mockVoiceMode = true;
-    mockState = "idle";
 
     // WHEN the button renders
-    const { getByLabelText } = render(<LiveVoiceButton assistantId="a1" />);
+    const { getByLabelText } = render(<LiveVoiceButton onStart={onStartSpy} />);
 
-    // THEN it offers to start voice mode and is not pressed
-    const button = getByLabelText("Start voice mode");
-    expect(button).toBeTruthy();
-    expect(button.getAttribute("aria-pressed")).toBe("false");
+    // THEN it offers to start voice mode
+    expect(getByLabelText("Start voice mode")).toBeTruthy();
   });
 
-  test("starts a hands-free session on click when idle", () => {
-    // GIVEN an idle, flag-enabled button with a conversation
+  test("fires onStart on click", () => {
+    // GIVEN a flag-enabled button
     mockVoiceMode = true;
-    mockState = "idle";
-    const { getByLabelText } = render(
-      <LiveVoiceButton assistantId="a1" conversationId="c1" />,
-    );
+    const { getByLabelText } = render(<LiveVoiceButton onStart={onStartSpy} />);
 
     // WHEN the user clicks it
     fireEvent.click(getByLabelText("Start voice mode"));
 
-    // THEN it starts a hands-free live-voice session for the assistant +
-    // conversation (manual mode survives only as the version-skew fallback)
-    expect(startSpy).toHaveBeenCalledTimes(1);
-    expect(startSpy).toHaveBeenCalledWith("a1", "c1", { handsFree: true });
-    expect(stopSpy).not.toHaveBeenCalled();
+    // THEN the composer-bound start callback fires once
+    expect(onStartSpy).toHaveBeenCalledTimes(1);
   });
 
-  test("stops the session on click when active", () => {
-    // GIVEN an active session (listening)
+  test("prevents starting a session when disabled", () => {
+    // GIVEN a flag-enabled button that the parent has disabled
     mockVoiceMode = true;
-    mockState = "listening";
-    const { getByLabelText } = render(<LiveVoiceButton assistantId="a1" />);
-
-    // THEN the control reflects the live session
-    const button = getByLabelText("Stop voice mode");
-    expect(button.getAttribute("aria-pressed")).toBe("true");
-
-    // WHEN the user clicks it
-    fireEvent.click(button);
-
-    // THEN it stops the session
-    expect(stopSpy).toHaveBeenCalledTimes(1);
-    expect(startSpy).not.toHaveBeenCalled();
-  });
-
-  test("reflects connecting as a busy, non-toggling state", () => {
-    // GIVEN a session that is still connecting
-    mockVoiceMode = true;
-    mockState = "connecting";
-    const { getByLabelText } = render(<LiveVoiceButton assistantId="a1" />);
-
-    // THEN the control is busy and disabled
-    const button = getByLabelText("Connecting live voice") as HTMLButtonElement;
-    expect(button.getAttribute("aria-busy")).toBe("true");
-    expect(button.disabled).toBe(true);
-
-    // WHEN the user clicks it, neither start nor stop fire
-    fireEvent.click(button);
-    expect(startSpy).not.toHaveBeenCalled();
-    expect(stopSpy).not.toHaveBeenCalled();
-  });
-
-  test("stays stoppable when disabled while a session is active", () => {
-    // GIVEN an active session and a parent that has raised `disabled`
-    mockVoiceMode = true;
-    mockState = "listening";
     const { getByLabelText } = render(
-      <LiveVoiceButton assistantId="a1" disabled />,
-    );
-
-    // THEN the stop control remains enabled despite the external disabled prop
-    const button = getByLabelText("Stop voice mode") as HTMLButtonElement;
-    expect(button.disabled).toBe(false);
-
-    // WHEN the user clicks it, the session is stopped
-    fireEvent.click(button);
-    expect(stopSpy).toHaveBeenCalledTimes(1);
-    expect(startSpy).not.toHaveBeenCalled();
-  });
-
-  test("prevents starting a session when disabled while idle", () => {
-    // GIVEN an idle, flag-enabled button that the parent has disabled
-    mockVoiceMode = true;
-    mockState = "idle";
-    const { getByLabelText } = render(
-      <LiveVoiceButton assistantId="a1" disabled />,
+      <LiveVoiceButton onStart={onStartSpy} disabled />,
     );
 
     // THEN the start control is disabled
@@ -181,19 +92,6 @@ describe("LiveVoiceButton", () => {
 
     // WHEN the user clicks it, no session is started
     fireEvent.click(button);
-    expect(startSpy).not.toHaveBeenCalled();
-    expect(stopSpy).not.toHaveBeenCalled();
-  });
-
-  test("scales the icon with live amplitude while active", () => {
-    // GIVEN an active session with non-zero mic amplitude
-    mockVoiceMode = true;
-    mockState = "listening";
-    mockInputAmplitude = 1;
-    const { getByLabelText } = render(<LiveVoiceButton assistantId="a1" />);
-
-    // THEN the control carries an amplitude-driven transform
-    const button = getByLabelText("Stop voice mode");
-    expect(button.style.transform).toContain("scale(");
+    expect(onStartSpy).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/chat/components/live-voice-button.tsx
+++ b/clients/web/src/domains/chat/components/live-voice-button.tsx
@@ -1,107 +1,49 @@
 /**
- * `LiveVoiceButton` — composer control that toggles a live-voice conversation.
+ * `LiveVoiceButton` — composer entry point for a live-voice conversation.
  *
  * Distinct from the dictation {@link import("./voice-input-button").VoiceInputButton}:
  * that one records a single utterance and drops a transcript into the composer,
- * while this one opens a full-duplex live-voice session via {@link useLiveVoice}
- * (mic streaming + TTS playback + barge-in). The button is gated behind the
- * `voice-mode` assistant flag and renders nothing when the flag is off.
- * Sessions run hands-free (server-side turn detection, multi-turn); per-turn
- * push-to-talk survives only as the version-skew fallback against daemons
- * that don't acknowledge server_vad.
+ * while this one starts a full-duplex live-voice session (mic streaming + TTS
+ * playback + barge-in). The button is gated behind the `voice-mode` assistant
+ * flag and renders nothing when the flag is off.
  *
- * Appearance reflects the {@link useLiveVoice} session phase:
- *   - `idle`/`failed`     → mic icon, click to start
- *   - `connecting`        → spinning loader, disabled (token mint / socket open)
- *   - any other (active)  → stop-circle icon, click to stop; the live
- *                           `inputAmplitude` drives a subtle pulse so the user
- *                           sees the mic is hearing them.
+ * Purely presentational: the `useLiveVoice` controller lives in the composer
+ * (which binds the assistant/conversation into `onStart`). While a session is
+ * active the composer swaps its whole action row — this button included — for
+ * the `VoiceComposerBar`, whose ✕ owns ending the session; so this control only
+ * ever renders while no session is active and never needs a stop affordance.
  */
 
-import { Loader2, Mic, StopCircle } from "lucide-react";
-import { useCallback } from "react";
+import { Mic } from "lucide-react";
 
 import { Button } from "@vellumai/design-library";
 
-import { useLiveVoice } from "@/domains/chat/voice/live-voice/use-live-voice";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 interface LiveVoiceButtonProps {
-  /** Assistant whose live-voice channel the session attaches to. */
-  assistantId: string;
-  /** Optional conversation to continue inside the session. */
-  conversationId?: string;
-  /** Disable the control (e.g. while the composer is otherwise busy). */
+  /** Start a live-voice session (the composer binds assistant + conversation). */
+  onStart: () => void;
+  /** Disable the control (e.g. while dictation is recording). */
   disabled?: boolean;
 }
 
 export function LiveVoiceButton({
-  assistantId,
-  conversationId,
+  onStart,
   disabled = false,
 }: LiveVoiceButtonProps) {
   const voiceMode = useAssistantFeatureFlagStore.use.voiceMode();
-  const { state, inputAmplitude, start, stop } = useLiveVoice();
-
-  const connecting = state === "connecting";
-  // Anything past connecting (listening/transcribing/thinking/speaking/ending)
-  // means a session is live and the button acts as a stop control.
-  const active =
-    state !== "idle" && state !== "failed" && state !== "connecting";
-
-  const handleClick = useCallback(() => {
-    if (connecting) return;
-    if (active) {
-      // An active session must always be stoppable, even if the parent has
-      // raised `disabled` in the meantime — otherwise the user is stuck with a
-      // live mic/socket until some automatic teardown.
-      void stop();
-    } else {
-      // Only the start path honours the external `disabled` prop.
-      if (disabled) return;
-      // Hands-free (server turn detection) is the only session mode; the
-      // manual path survives solely as the version-skew fallback when the
-      // daemon doesn't acknowledge server_vad on the ready frame.
-      void start(assistantId, conversationId, { handsFree: true });
-    }
-  }, [active, connecting, disabled, start, stop, assistantId, conversationId]);
 
   if (!voiceMode) return null;
-
-  const label = connecting
-    ? "Connecting live voice"
-    : active
-      ? "Stop voice mode"
-      : "Start voice mode";
 
   return (
     <Button
       variant="ghost"
-      iconOnly={
-        connecting ? (
-          <Loader2 className="animate-spin" strokeWidth={2} />
-        ) : active ? (
-          <StopCircle strokeWidth={2} />
-        ) : (
-          <Mic strokeWidth={2} />
-        )
-      }
-      onClick={handleClick}
-      // An active session is always stoppable; the external `disabled` prop
-      // only gates the start path. `connecting` stays disabled/busy.
-      disabled={connecting || (!active && disabled)}
-      aria-label={label}
-      aria-pressed={active}
-      aria-busy={connecting}
-      title={label}
+      iconOnly={<Mic strokeWidth={2} />}
+      onClick={onStart}
+      disabled={disabled}
+      aria-label="Start voice mode"
+      title="Start voice mode"
       className="[--vbtn-fg:var(--content-secondary)]"
-      style={
-        // While listening, scale the icon with live amplitude so the control
-        // visibly reacts to the user's voice (clamped to a gentle 1.0–1.25).
-        active
-          ? { transform: `scale(${1 + Math.min(inputAmplitude, 1) * 0.25})` }
-          : undefined
-      }
     />
   );
 }

--- a/clients/web/src/domains/chat/components/live-voice-button.tsx
+++ b/clients/web/src/domains/chat/components/live-voice-button.tsx
@@ -7,11 +7,13 @@
  * playback + barge-in). The button is gated behind the `voice-mode` assistant
  * flag and renders nothing when the flag is off.
  *
- * Purely presentational: the `useLiveVoice` controller lives in the composer
- * (which binds the assistant/conversation into `onStart`). While a session is
- * active the composer swaps its whole action row — this button included — for
- * the `VoiceComposerBar`, whose ✕ owns ending the session; so this control only
- * ever renders while no session is active and never needs a stop affordance.
+ * Purely presentational: the `useLiveVoice` controller lives in the
+ * layout-mounted `useLiveVoiceSessionController`; the composer binds the
+ * assistant/conversation into `onStart`, which drives the store-registered
+ * session starter. While a session is active the owning composer swaps its
+ * whole action row — this button included — for the `VoiceComposerBar`, whose
+ * ✕ owns ending the session; in non-owning composers the button stays visible
+ * but disabled, so this control never needs a stop affordance.
  */
 
 import { Mic } from "lucide-react";

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.test.tsx
@@ -26,6 +26,10 @@ import type { Conversation } from "@/types/conversation-types";
 import { routes } from "@/utils/routes";
 
 import {
+  makeControlsSpies,
+  seedLiveVoiceSession,
+} from "@/domains/chat/voice/live-voice/live-voice-fakes.test-helper";
+import {
   useLiveVoiceStore,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
@@ -78,21 +82,18 @@ const { VoiceSessionPillHost } = await import(
   "@/domains/chat/components/voice-session-pill-host"
 );
 
-const controls = {
-  stop: mock(() => {}),
-  release: mock(() => {}),
-  interrupt: mock(() => {}),
-};
+const controls = makeControlsSpies();
 
 /** Put the live-voice store into an active session owned by `conversationId`. */
 function startSession(
   state: LiveVoiceSessionState = "listening",
   conversationId: string | null = OWNING_CONVERSATION_ID,
 ) {
-  const store = useLiveVoiceStore.getState();
-  store.setSessionContext(ASSISTANT_ID, conversationId);
-  store.setControls(controls);
-  store.setState(state);
+  seedLiveVoiceSession(state, {
+    assistantId: ASSISTANT_ID,
+    conversationId,
+    controls,
+  });
 }
 
 beforeEach(() => {
@@ -229,11 +230,95 @@ describe("VoiceSessionPillHost — visibility", () => {
     expect(pill()).not.toBeNull();
   });
 
-  test("renders nothing after the session fails", () => {
+  test("failure on a composer route renders nothing — the composer's Notice owns the error there", () => {
+    // beforeEach: viewing OTHER_CONVERSATION_ID's chat route, where a
+    // voice-enabled composer renders its own failure Notice. The host must
+    // not double-surface the error next to it.
     startSession("listening");
     useLiveVoiceStore.getState().fail("boom");
     const { container } = render(<VoiceSessionPillHost />);
     expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("VoiceSessionPillHost — failure surface", () => {
+  const errorChip = () => screen.queryByRole("alert");
+
+  test("failure while on a composer-less route shows the dismissible error chip", () => {
+    startSession("listening");
+    mockPathname = routes.home;
+    useLiveVoiceStore.getState().fail("Microphone capture could not start.");
+    render(<VoiceSessionPillHost />);
+    expect(errorChip()).not.toBeNull();
+    expect(
+      screen.getByText("Microphone capture could not start."),
+    ).toBeTruthy();
+    // The pill and the chip never both render: the failed session is inactive.
+    expect(pill()).toBeNull();
+  });
+
+  test("failure over the desktop fullscreen app viewer shows the error chip", () => {
+    startSession("listening");
+    useConversationStore
+      .getState()
+      .setActiveConversationId(OWNING_CONVERSATION_ID);
+    mockPathname = routes.conversation(OWNING_CONVERSATION_ID);
+    mockMainView = "app";
+    useLiveVoiceStore.getState().fail("Connection lost.");
+    render(<VoiceSessionPillHost />);
+    expect(errorChip()).not.toBeNull();
+  });
+
+  test("dismissing the chip resets the store to idle, mirroring the composer Notice", () => {
+    startSession("listening");
+    mockPathname = routes.home;
+    useLiveVoiceStore.getState().fail("boom");
+    render(<VoiceSessionPillHost />);
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(useLiveVoiceStore.getState().state).toBe("idle");
+    expect(useLiveVoiceStore.getState().error).toBeNull();
+    expect(errorChip()).toBeNull();
+  });
+
+  test("no chip without an error message", () => {
+    mockPathname = routes.home;
+    useLiveVoiceStore.getState().setState("failed");
+    const { container } = render(<VoiceSessionPillHost />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("VoiceSessionPillHost — standalone variant (headerless pop-outs)", () => {
+  test("renders nothing when no session is active", () => {
+    const { container } = render(<VoiceSessionPillHost variant="standalone" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("floats the pill for a session owned by another conversation", () => {
+    startSession("listening");
+    render(<VoiceSessionPillHost variant="standalone" />);
+    expect(pill()).not.toBeNull();
+    // Wired to the same controls as the header placement.
+    fireEvent.click(screen.getByRole("button", { name: "End voice session" }));
+    expect(controls.stop).toHaveBeenCalledTimes(1);
+  });
+
+  test("stays hidden while the on-screen composer owns the session", () => {
+    startSession("listening");
+    useConversationStore
+      .getState()
+      .setActiveConversationId(OWNING_CONVERSATION_ID);
+    mockPathname = routes.conversation(OWNING_CONVERSATION_ID);
+    const { container } = render(<VoiceSessionPillHost variant="standalone" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("floats the error chip for a failure on a composer-less route", () => {
+    startSession("listening");
+    mockPathname = routes.home;
+    useLiveVoiceStore.getState().fail("boom");
+    render(<VoiceSessionPillHost variant="standalone" />);
+    expect(screen.queryByRole("alert")).not.toBeNull();
   });
 });
 

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.test.tsx
@@ -5,8 +5,12 @@
  * presentational `VoiceSessionPill`, so tests drive those stores directly and
  * mock only the modules with heavy dependency graphs: router hooks (mutable
  * pathname + navigate spy), `useActiveConversation` (TanStack Query), the
- * viewer store (generated SDK imports), and the imperative
- * `navigateToConversation` util (haptics/sounds).
+ * viewer store (generated SDK imports), the `useIsMobile` media-query hook,
+ * and the imperative `navigateToConversation` util (haptics/sounds).
+ *
+ * Visibility is asserted as the exact complement of the composer's voice bar
+ * (`isLiveVoiceSessionOwnedBy`): for any active session exactly one of
+ * {composer bar, title-bar pill} renders.
  *
  * The embedded `VoiceTimelineWaveform` renders a real canvas — happy-dom's
  * `getContext("2d")` returns `null`, which that component treats as "don't
@@ -56,6 +60,12 @@ mock.module("@/stores/viewer-store", () => ({
   },
 }));
 
+let mockIsMobile = false;
+mock.module("@/hooks/use-is-mobile", () => ({
+  useIsMobile: () => mockIsMobile,
+  MOBILE_MEDIA_QUERY: "(max-width: 767px)",
+}));
+
 const navigateToConversationSpy = mock(
   (_navigate: unknown, _conversationId: string) => {},
 );
@@ -88,6 +98,7 @@ function startSession(
 beforeEach(() => {
   mockPathname = routes.conversation(OTHER_CONVERSATION_ID);
   mockMainView = "chat";
+  mockIsMobile = false;
   mockOwningConversation = {
     conversationId: OWNING_CONVERSATION_ID,
     title: "Owning thread",
@@ -136,7 +147,7 @@ describe("VoiceSessionPillHost — visibility", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  test("shows the pill over the fullscreen app viewer even in the owning conversation", () => {
+  test("shows the pill over the desktop fullscreen app viewer even in the owning conversation", () => {
     startSession("listening");
     useConversationStore
       .getState()
@@ -145,6 +156,18 @@ describe("VoiceSessionPillHost — visibility", () => {
     mockMainView = "app";
     render(<VoiceSessionPillHost />);
     expect(pill()).not.toBeNull();
+  });
+
+  test("keeps the pill hidden for the mobile app view (composer stays mounted under the overlay)", () => {
+    startSession("listening");
+    useConversationStore
+      .getState()
+      .setActiveConversationId(OWNING_CONVERSATION_ID);
+    mockPathname = routes.conversation(OWNING_CONVERSATION_ID);
+    mockMainView = "app";
+    mockIsMobile = true;
+    const { container } = render(<VoiceSessionPillHost />);
+    expect(container.firstChild).toBeNull();
   });
 
   test("shows the pill on a non-conversation route even when the owning id is still active", () => {
@@ -159,10 +182,37 @@ describe("VoiceSessionPillHost — visibility", () => {
     expect(pill()).not.toBeNull();
   });
 
-  test("hides the pill for a session with no owning conversation", () => {
+  test("shows the pill for a not-yet-attached session when away from the owning composer", () => {
+    // A live mic must always have a visible control: a session still in its
+    // pre-`ready` window (no conversation yet) shows the pill — without a
+    // thread name or navigation target — whenever another composer is the
+    // current surface.
+    startSession("connecting", null);
+    render(<VoiceSessionPillHost />);
+    expect(pill()).not.toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Go to voice session thread" }),
+    ).toBeNull();
+  });
+
+  test("hides the pill while the draft composer that started the session is on screen", () => {
+    // Draft case: started with no conversation; the server assigned one on
+    // `ready`. The draft composer (bound to no conversation) still owns the
+    // session, so the pill must not double-render next to its voice bar.
     startSession("listening", null);
+    useLiveVoiceStore.getState().setConversationId("conv-server-assigned");
+    useConversationStore.getState().setActiveConversationId(null);
+    mockPathname = routes.assistant;
     const { container } = render(<VoiceSessionPillHost />);
     expect(container.firstChild).toBeNull();
+  });
+
+  test("shows the pill for a draft-started session once another thread is viewed", () => {
+    startSession("listening", null);
+    useLiveVoiceStore.getState().setConversationId("conv-server-assigned");
+    // beforeEach: viewing OTHER_CONVERSATION_ID on its conversation route.
+    render(<VoiceSessionPillHost />);
+    expect(pill()).not.toBeNull();
   });
 
   test("renders nothing after the session fails", () => {
@@ -218,14 +268,13 @@ describe("VoiceSessionPillHost — controls", () => {
     expect(controls.stop).not.toHaveBeenCalled();
   });
 
-  test("■ interrupts the assistant via controls.interrupt while speaking", () => {
+  test("■ stop-response control is not offered — V1 interrupt would end the whole session", () => {
     startSession("speaking");
     render(<VoiceSessionPillHost />);
-    fireEvent.click(
-      screen.getByRole("button", { name: "Stop assistant response" }),
-    );
-    expect(controls.interrupt).toHaveBeenCalledTimes(1);
-    expect(controls.stop).not.toHaveBeenCalled();
+    expect(pill()).not.toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Stop assistant response" }),
+    ).toBeNull();
   });
 
   test("controls are no-ops when none are registered", () => {

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.test.tsx
@@ -1,0 +1,256 @@
+/**
+ * Tests for `VoiceSessionPillHost`.
+ *
+ * The host wires real Zustand stores (live-voice, conversation) to the
+ * presentational `VoiceSessionPill`, so tests drive those stores directly and
+ * mock only the modules with heavy dependency graphs: router hooks (mutable
+ * pathname + navigate spy), `useActiveConversation` (TanStack Query), the
+ * viewer store (generated SDK imports), and the imperative
+ * `navigateToConversation` util (haptics/sounds).
+ *
+ * The embedded `VoiceTimelineWaveform` renders a real canvas — happy-dom's
+ * `getContext("2d")` returns `null`, which that component treats as "don't
+ * start the draw loop", so no canvas harness is needed.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import type { MainView } from "@/stores/viewer-store";
+import type { Conversation } from "@/types/conversation-types";
+import { routes } from "@/utils/routes";
+
+import {
+  useLiveVoiceStore,
+  type LiveVoiceSessionState,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
+import { useConversationStore } from "@/stores/conversation-store";
+
+const OWNING_CONVERSATION_ID = "conv-owning";
+const OTHER_CONVERSATION_ID = "conv-other";
+const ASSISTANT_ID = "assistant-1";
+
+let mockPathname = routes.conversation(OTHER_CONVERSATION_ID);
+const navigateFn = mock(() => {});
+mock.module("react-router", () => ({
+  useLocation: () => ({ pathname: mockPathname }),
+  useNavigate: () => navigateFn,
+}));
+
+let mockOwningConversation: Conversation | undefined;
+const useActiveConversationSpy = mock(
+  (_assistantId: string | null, _conversationId: string | null | undefined, _enabled: boolean) =>
+    mockOwningConversation,
+);
+mock.module("@/domains/chat/hooks/use-active-conversation", () => ({
+  useActiveConversation: useActiveConversationSpy,
+}));
+
+let mockMainView: MainView = "chat";
+mock.module("@/stores/viewer-store", () => ({
+  useViewerStore: {
+    use: {
+      mainView: () => mockMainView,
+    },
+  },
+}));
+
+const navigateToConversationSpy = mock(
+  (_navigate: unknown, _conversationId: string) => {},
+);
+mock.module("@/utils/conversation-navigation", () => ({
+  navigateToConversation: navigateToConversationSpy,
+}));
+
+// Imported after the mocks so the host picks up the mocked modules.
+const { VoiceSessionPillHost } = await import(
+  "@/domains/chat/components/voice-session-pill-host"
+);
+
+const controls = {
+  stop: mock(() => {}),
+  release: mock(() => {}),
+  interrupt: mock(() => {}),
+};
+
+/** Put the live-voice store into an active session owned by `conversationId`. */
+function startSession(
+  state: LiveVoiceSessionState = "listening",
+  conversationId: string | null = OWNING_CONVERSATION_ID,
+) {
+  const store = useLiveVoiceStore.getState();
+  store.setSessionContext(ASSISTANT_ID, conversationId);
+  store.setControls(controls);
+  store.setState(state);
+}
+
+beforeEach(() => {
+  mockPathname = routes.conversation(OTHER_CONVERSATION_ID);
+  mockMainView = "chat";
+  mockOwningConversation = {
+    conversationId: OWNING_CONVERSATION_ID,
+    title: "Owning thread",
+  };
+  navigateFn.mockClear();
+  navigateToConversationSpy.mockClear();
+  useActiveConversationSpy.mockClear();
+  controls.stop.mockClear();
+  controls.release.mockClear();
+  controls.interrupt.mockClear();
+  useLiveVoiceStore.getState().reset();
+  useConversationStore
+    .getState()
+    .setActiveConversationId(OTHER_CONVERSATION_ID);
+});
+
+afterEach(() => {
+  cleanup();
+  useLiveVoiceStore.getState().reset();
+  useConversationStore.getState().reset();
+});
+
+const pill = () => screen.queryByRole("group", { name: "Voice session" });
+
+describe("VoiceSessionPillHost — visibility", () => {
+  test("renders nothing when no session is active", () => {
+    const { container } = render(<VoiceSessionPillHost />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders the pill while viewing a different conversation", () => {
+    startSession("listening");
+    render(<VoiceSessionPillHost />);
+    expect(pill()).not.toBeNull();
+    expect(screen.getByText("Listening…")).toBeTruthy();
+    expect(screen.getByText("Owning thread")).toBeTruthy();
+  });
+
+  test("hides the pill while viewing the owning conversation's composer", () => {
+    startSession("listening");
+    useConversationStore
+      .getState()
+      .setActiveConversationId(OWNING_CONVERSATION_ID);
+    mockPathname = routes.conversation(OWNING_CONVERSATION_ID);
+    const { container } = render(<VoiceSessionPillHost />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("shows the pill over the fullscreen app viewer even in the owning conversation", () => {
+    startSession("listening");
+    useConversationStore
+      .getState()
+      .setActiveConversationId(OWNING_CONVERSATION_ID);
+    mockPathname = routes.conversation(OWNING_CONVERSATION_ID);
+    mockMainView = "app";
+    render(<VoiceSessionPillHost />);
+    expect(pill()).not.toBeNull();
+  });
+
+  test("shows the pill on a non-conversation route even when the owning id is still active", () => {
+    // `activeConversationId` deliberately persists across route changes, so
+    // the id comparison alone can't detect that the composer left the screen.
+    startSession("listening");
+    useConversationStore
+      .getState()
+      .setActiveConversationId(OWNING_CONVERSATION_ID);
+    mockPathname = routes.home;
+    render(<VoiceSessionPillHost />);
+    expect(pill()).not.toBeNull();
+  });
+
+  test("hides the pill for a session with no owning conversation", () => {
+    startSession("listening", null);
+    const { container } = render(<VoiceSessionPillHost />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders nothing after the session fails", () => {
+    startSession("listening");
+    useLiveVoiceStore.getState().fail("boom");
+    const { container } = render(<VoiceSessionPillHost />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("VoiceSessionPillHost — labels", () => {
+  test("omits the thread name while the owning row is still loading", () => {
+    mockOwningConversation = undefined;
+    startSession("thinking");
+    render(<VoiceSessionPillHost />);
+    expect(screen.getByText("Thinking…")).toBeTruthy();
+    expect(screen.queryByText("Owning thread")).toBeNull();
+  });
+
+  test("falls back to Untitled for an owning row without a title", () => {
+    mockOwningConversation = { conversationId: OWNING_CONVERSATION_ID };
+    startSession("listening");
+    render(<VoiceSessionPillHost />);
+    expect(screen.getByText("Untitled")).toBeTruthy();
+  });
+
+  test("resolves the owning row only while visible", () => {
+    startSession("listening");
+    render(<VoiceSessionPillHost />);
+    expect(useActiveConversationSpy).toHaveBeenCalledWith(
+      ASSISTANT_ID,
+      OWNING_CONVERSATION_ID,
+      true,
+    );
+  });
+});
+
+describe("VoiceSessionPillHost — controls", () => {
+  test("✕ ends the session via controls.stop", () => {
+    startSession("listening");
+    render(<VoiceSessionPillHost />);
+    fireEvent.click(screen.getByRole("button", { name: "End voice session" }));
+    expect(controls.stop).toHaveBeenCalledTimes(1);
+    expect(controls.release).not.toHaveBeenCalled();
+    expect(controls.interrupt).not.toHaveBeenCalled();
+  });
+
+  test("↑ releases the current turn via controls.release", () => {
+    startSession("listening");
+    render(<VoiceSessionPillHost />);
+    fireEvent.click(screen.getByRole("button", { name: "Send now" }));
+    expect(controls.release).toHaveBeenCalledTimes(1);
+    expect(controls.stop).not.toHaveBeenCalled();
+  });
+
+  test("■ interrupts the assistant via controls.interrupt while speaking", () => {
+    startSession("speaking");
+    render(<VoiceSessionPillHost />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Stop assistant response" }),
+    );
+    expect(controls.interrupt).toHaveBeenCalledTimes(1);
+    expect(controls.stop).not.toHaveBeenCalled();
+  });
+
+  test("controls are no-ops when none are registered", () => {
+    startSession("listening");
+    useLiveVoiceStore.getState().setControls(null);
+    render(<VoiceSessionPillHost />);
+    expect(() => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "End voice session" }),
+      );
+    }).not.toThrow();
+  });
+});
+
+describe("VoiceSessionPillHost — navigation", () => {
+  test("clicking the label navigates to the owning conversation", () => {
+    startSession("listening");
+    render(<VoiceSessionPillHost />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Go to voice session thread" }),
+    );
+    expect(navigateToConversationSpy).toHaveBeenCalledTimes(1);
+    expect(navigateToConversationSpy).toHaveBeenCalledWith(
+      navigateFn,
+      OWNING_CONVERSATION_ID,
+    );
+  });
+});

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.test.tsx
@@ -147,6 +147,20 @@ describe("VoiceSessionPillHost — visibility", () => {
     expect(container.firstChild).toBeNull();
   });
 
+  test("shows the pill on the owning conversation's inspector route (no composer there)", () => {
+    // `/assistant/conversations/:id/inspect` mounts `InspectPage`, which has
+    // no composer — even though the pathname sits under the owning
+    // conversation, the pill must stay up as the session's only control
+    // surface.
+    startSession("listening");
+    useConversationStore
+      .getState()
+      .setActiveConversationId(OWNING_CONVERSATION_ID);
+    mockPathname = routes.inspect(OWNING_CONVERSATION_ID);
+    render(<VoiceSessionPillHost />);
+    expect(pill()).not.toBeNull();
+  });
+
   test("shows the pill over the desktop fullscreen app viewer even in the owning conversation", () => {
     startSession("listening");
     useConversationStore

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
@@ -7,43 +7,50 @@
  * hooks that unmount on navigation, which is exactly when the pill must
  * persist.
  *
- * Renders `VoiceSessionPill` only while a live-voice session is active AND
- * the owning conversation's composer is not the current surface, i.e. when
- * any of these hold:
+ * Visibility is the exact complement of the composer's voice bar so that for
+ * any active session exactly one of the two surfaces renders: the pill shows
+ * whenever a session is active AND the composer currently on screen (if any)
+ * does not own it (`isLiveVoiceSessionOwnedBy`). Concretely, the pill shows
+ * when:
  *
- * - the user is viewing a different conversation,
+ * - the user is viewing a different conversation than the session's,
  * - the user is off the conversation routes entirely (Home, Library, …) —
  *   `activeConversationId` deliberately persists across route changes (see
  *   `chat-layout.tsx`), so the id comparison alone can't detect this,
- * - the fullscreen app viewer covers the thread (`mainView === "app"`).
+ * - the desktop fullscreen app viewer covers the thread (`mainView === "app"`;
+ *   on mobile that view keeps the composer mounted under a portal overlay
+ *   that covers the header too, so the composer stays the owning surface).
  *   `app-editing` (split view) and the right-drawer detail panels keep the
  *   composer visible, so they don't count.
  *
- * A session with no owning conversation (started from an unsent draft) has
- * no thread to return to, so the pill stays hidden for it.
+ * A session not yet attached to a conversation (started from a draft, before
+ * the server's `ready` frame) still shows the pill when the user is away from
+ * the owning composer — a live mic must always have a visible control — just
+ * without a thread name or navigation target.
+ *
+ * The ■ "stop response" control is deliberately not wired: V1's `interrupt()`
+ * ends the whole session, contradicting the control's "without ending the
+ * session" contract, so the pill offers only ✕ (end) until a turn-scoped
+ * interrupt exists (engine plan, JARVIS-1240).
  */
 
 import { useCallback } from "react";
 import { useLocation, useNavigate } from "react-router";
 
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { navigateToConversation } from "@/utils/conversation-navigation";
-import { routes } from "@/utils/routes";
+import { isConversationPath } from "@/utils/routes";
 
 import { STATE_LABELS } from "@/domains/chat/components/chat-composer/voice-composer-bar";
 import { VoiceSessionPill } from "@/domains/chat/components/voice-session-pill";
 import { useActiveConversation } from "@/domains/chat/hooks/use-active-conversation";
-import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+import {
+  isLiveVoiceSessionActive,
+  useIsLiveVoiceSessionOwnedBy,
+  useLiveVoiceStore,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore } from "@/stores/viewer-store";
-
-/** Routes where ChatPage mounts the active conversation's composer. */
-function isConversationRoute(pathname: string): boolean {
-  return (
-    pathname === routes.assistant ||
-    pathname === `${routes.assistant}/` ||
-    pathname.startsWith(`${routes.conversations}/`)
-  );
-}
 
 export function VoiceSessionPillHost() {
   const state = useLiveVoiceStore.use.state();
@@ -53,17 +60,22 @@ export function VoiceSessionPillHost() {
 
   const activeConversationId = useConversationStore.use.activeConversationId();
   const mainView = useViewerStore.use.mainView();
+  const isMobile = useIsMobile();
   const location = useLocation();
   const navigate = useNavigate();
 
-  const sessionActive = state !== "idle" && state !== "failed";
-  const viewingOwningComposer =
-    sessionConversationId !== null &&
-    sessionConversationId === activeConversationId &&
-    isConversationRoute(location.pathname) &&
-    mainView !== "app";
+  const sessionActive = isLiveVoiceSessionActive(state);
+  // Mirror of `chat-content-layout.tsx`: the desktop `app` view replaces
+  // `ChatMainPanel` (composer included); every other view — and mobile's
+  // portal-overlay `app` view — keeps the composer mounted.
+  const composerOnScreen =
+    isConversationPath(location.pathname) && !(mainView === "app" && !isMobile);
+  // Same ownership predicate the composer's voice bar uses, evaluated for the
+  // composer currently on screen — keeps the two surfaces exact complements.
+  const activeComposerOwnsSession =
+    useIsLiveVoiceSessionOwnedBy(activeConversationId);
   const visible =
-    sessionActive && sessionConversationId !== null && !viewingOwningComposer;
+    sessionActive && !(composerOnScreen && activeComposerOwnsSession);
 
   // Resolves the owning row from whichever list cache holds it, fetching the
   // single row when absent. Enabled only while the pill is shown so hidden
@@ -71,7 +83,7 @@ export function VoiceSessionPillHost() {
   const owningConversation = useActiveConversation(
     sessionAssistantId,
     sessionConversationId,
-    visible,
+    visible && sessionConversationId !== null,
   );
 
   // Stable poll function — the waveform samples ~30 Hz via its draw loop, so
@@ -88,7 +100,6 @@ export function VoiceSessionPillHost() {
     }
   }, [navigate, sessionConversationId]);
 
-  const handleStop = useCallback(() => controls?.interrupt(), [controls]);
   const handleEnd = useCallback(() => controls?.stop(), [controls]);
   const handleSend = useCallback(() => controls?.release(), [controls]);
 
@@ -104,10 +115,9 @@ export function VoiceSessionPillHost() {
       }
       state={state}
       getAmplitude={getAmplitude}
-      onStop={handleStop}
       onEnd={handleEnd}
       onSend={handleSend}
-      onNavigate={handleNavigate}
+      onNavigate={sessionConversationId ? handleNavigate : undefined}
     />
   );
 }

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
@@ -1,0 +1,113 @@
+/**
+ * Store-wiring host for the title-bar voice-session pill (Light 54).
+ *
+ * Mounted once by `ChatLayout` — composed directly with the header's
+ * `topBarRightSlot` content rather than registered through
+ * `useChatLayoutSlotsStore`, because slot registration is owned by per-route
+ * hooks that unmount on navigation, which is exactly when the pill must
+ * persist.
+ *
+ * Renders `VoiceSessionPill` only while a live-voice session is active AND
+ * the owning conversation's composer is not the current surface, i.e. when
+ * any of these hold:
+ *
+ * - the user is viewing a different conversation,
+ * - the user is off the conversation routes entirely (Home, Library, …) —
+ *   `activeConversationId` deliberately persists across route changes (see
+ *   `chat-layout.tsx`), so the id comparison alone can't detect this,
+ * - the fullscreen app viewer covers the thread (`mainView === "app"`).
+ *   `app-editing` (split view) and the right-drawer detail panels keep the
+ *   composer visible, so they don't count.
+ *
+ * A session with no owning conversation (started from an unsent draft) has
+ * no thread to return to, so the pill stays hidden for it.
+ */
+
+import { useCallback } from "react";
+import { useLocation, useNavigate } from "react-router";
+
+import { navigateToConversation } from "@/utils/conversation-navigation";
+import { routes } from "@/utils/routes";
+
+import { STATE_LABELS } from "@/domains/chat/components/chat-composer/voice-composer-bar";
+import { VoiceSessionPill } from "@/domains/chat/components/voice-session-pill";
+import { useActiveConversation } from "@/domains/chat/hooks/use-active-conversation";
+import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { useConversationStore } from "@/stores/conversation-store";
+import { useViewerStore } from "@/stores/viewer-store";
+
+/** Routes where ChatPage mounts the active conversation's composer. */
+function isConversationRoute(pathname: string): boolean {
+  return (
+    pathname === routes.assistant ||
+    pathname === `${routes.assistant}/` ||
+    pathname.startsWith(`${routes.conversations}/`)
+  );
+}
+
+export function VoiceSessionPillHost() {
+  const state = useLiveVoiceStore.use.state();
+  const sessionAssistantId = useLiveVoiceStore.use.assistantId();
+  const sessionConversationId = useLiveVoiceStore.use.conversationId();
+  const controls = useLiveVoiceStore.use.controls();
+
+  const activeConversationId = useConversationStore.use.activeConversationId();
+  const mainView = useViewerStore.use.mainView();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const sessionActive = state !== "idle" && state !== "failed";
+  const viewingOwningComposer =
+    sessionConversationId !== null &&
+    sessionConversationId === activeConversationId &&
+    isConversationRoute(location.pathname) &&
+    mainView !== "app";
+  const visible =
+    sessionActive && sessionConversationId !== null && !viewingOwningComposer;
+
+  // Resolves the owning row from whichever list cache holds it, fetching the
+  // single row when absent. Enabled only while the pill is shown so hidden
+  // states cost nothing.
+  const owningConversation = useActiveConversation(
+    sessionAssistantId,
+    sessionConversationId,
+    visible,
+  );
+
+  // Stable poll function — the waveform samples ~30 Hz via its draw loop, so
+  // amplitude must not flow through props/re-renders (same pattern as the
+  // composer's voice bar wiring).
+  const getAmplitude = useCallback(
+    () => useLiveVoiceStore.getState().inputAmplitude,
+    [],
+  );
+
+  const handleNavigate = useCallback(() => {
+    if (sessionConversationId) {
+      navigateToConversation(navigate, sessionConversationId);
+    }
+  }, [navigate, sessionConversationId]);
+
+  const handleStop = useCallback(() => controls?.interrupt(), [controls]);
+  const handleEnd = useCallback(() => controls?.stop(), [controls]);
+  const handleSend = useCallback(() => controls?.release(), [controls]);
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <VoiceSessionPill
+      primaryLabel={STATE_LABELS[state]}
+      secondaryLabel={
+        owningConversation ? (owningConversation.title ?? "Untitled") : undefined
+      }
+      state={state}
+      getAmplitude={getAmplitude}
+      onStop={handleStop}
+      onEnd={handleEnd}
+      onSend={handleSend}
+      onNavigate={handleNavigate}
+    />
+  );
+}

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
@@ -67,6 +67,7 @@ import {
 import { useActiveConversation } from "@/domains/chat/hooks/use-active-conversation";
 import {
   LIVE_VOICE_STATE_LABELS,
+  dismissLiveVoiceFailure,
   endLiveVoiceSession,
   getLiveVoiceInputAmplitude,
   isLiveVoiceSessionActive,
@@ -137,16 +138,10 @@ export function VoiceSessionPillHost({
     }
   }, [navigate, sessionConversationId]);
 
-  // Mirrors the composer Notice's dismiss: `failed` is terminal for the
-  // session, so resetting only clears the surfaced error.
-  const handleDismissError = useCallback(() => {
-    useLiveVoiceStore.getState().reset();
-  }, []);
-
   let content: ReactNode = null;
   if (showFailure) {
     content = (
-      <VoiceSessionErrorChip message={error} onDismiss={handleDismissError} />
+      <VoiceSessionErrorChip message={error} onDismiss={dismissLiveVoiceFailure} />
     );
   } else if (visible) {
     content = (

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
@@ -5,7 +5,11 @@
  * `topBarRightSlot` content rather than registered through
  * `useChatLayoutSlotsStore`, because slot registration is owned by per-route
  * hooks that unmount on navigation, which is exactly when the pill must
- * persist.
+ * persist. Electron pop-out thread windows render no header at all, so
+ * `ChatLayout` mounts a second host there with `variant="standalone"`, which
+ * floats the same surface over the window's top-right corner — a session
+ * carried to another conversation via in-window switching (Cmd+Up/Down) must
+ * still have a visible control.
  *
  * Visibility is the exact complement of the composer's voice bar so that for
  * any active session exactly one of the two surfaces renders: the pill shows
@@ -20,15 +24,27 @@
  *   deliberately persists across route changes (see `chat-layout.tsx`), so
  *   the id comparison alone can't detect this,
  * - the desktop fullscreen app viewer covers the thread (`mainView === "app"`;
- *   on mobile that view keeps the composer mounted under a portal overlay
- *   that covers the header too, so the composer stays the owning surface).
- *   `app-editing` (split view) and the right-drawer detail panels keep the
- *   composer visible, so they don't count.
+ *   on mobile that view keeps the composer — the owning surface — mounted,
+ *   but under the `MobileAppOverlay` portal, which covers the composer AND
+ *   the header, so neither surface is actually visible while the overlay is
+ *   expanded. Accepted limitation: the mic stays hot with no on-screen
+ *   control until the overlay closes or minimizes, at which point the
+ *   composer's voice bar is the control again). `app-editing` (split view)
+ *   and the right-drawer detail panels keep the composer visible, so they
+ *   don't count.
  *
  * A session not yet attached to a conversation (started from a draft, before
  * the server's `ready` frame) still shows the pill when the user is away from
  * the owning composer — a live mic must always have a visible control — just
  * without a thread name or navigation target.
+ *
+ * A `failed` session unmounts the pill (no longer active), but the failure
+ * must not vanish silently: when no composer is on screen to render its
+ * failure `Notice` (see `chat-composer.tsx`), this host renders a dismissible
+ * `VoiceSessionErrorChip` in the same slot instead. On composer routes the
+ * chip stays hidden — the composer's Notice owns the error there — so the
+ * two error surfaces never double-render. Dismissing the chip resets the
+ * store to idle, mirroring the composer Notice's dismiss.
  *
  * The ■ "stop response" control is deliberately not wired: V1's `interrupt()`
  * ends the whole session, contradicting the control's "without ending the
@@ -38,28 +54,47 @@
 
 import { useCallback } from "react";
 import { useLocation, useNavigate } from "react-router";
+import type { ReactNode } from "react";
 
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { navigateToConversation } from "@/utils/conversation-navigation";
 import { isConversationChatPath } from "@/utils/routes";
 
-import { VoiceSessionPill } from "@/domains/chat/components/voice-session-pill";
+import {
+  VoiceSessionErrorChip,
+  VoiceSessionPill,
+} from "@/domains/chat/components/voice-session-pill";
 import { useActiveConversation } from "@/domains/chat/hooks/use-active-conversation";
 import {
   LIVE_VOICE_STATE_LABELS,
+  endLiveVoiceSession,
   getLiveVoiceInputAmplitude,
   isLiveVoiceSessionActive,
+  releaseLiveVoiceTurn,
   useIsLiveVoiceSessionOwnedBy,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore } from "@/stores/viewer-store";
 
-export function VoiceSessionPillHost() {
+export interface VoiceSessionPillHostProps {
+  /**
+   * Placement variant. `"header"` (default) renders the bare surface for
+   * composition into the header's right slot. `"standalone"` floats it over
+   * the window's top-right corner with its own chrome, for windows without a
+   * header (Electron pop-out thread windows). Renders nothing either way when
+   * there is neither an active session to control nor a failure to surface.
+   */
+  variant?: "header" | "standalone";
+}
+
+export function VoiceSessionPillHost({
+  variant = "header",
+}: VoiceSessionPillHostProps) {
   const state = useLiveVoiceStore.use.state();
+  const error = useLiveVoiceStore.use.error();
   const sessionAssistantId = useLiveVoiceStore.use.assistantId();
   const sessionConversationId = useLiveVoiceStore.use.conversationId();
-  const controls = useLiveVoiceStore.use.controls();
 
   const activeConversationId = useConversationStore.use.activeConversationId();
   const mainView = useViewerStore.use.mainView();
@@ -83,6 +118,9 @@ export function VoiceSessionPillHost() {
     useIsLiveVoiceSessionOwnedBy(activeConversationId);
   const visible =
     sessionActive && !(composerOnScreen && activeComposerOwnsSession);
+  // Failure surface: exact complement of the composer's failure Notice, which
+  // any on-screen voice-enabled composer renders regardless of ownership.
+  const showFailure = state === "failed" && error !== null && !composerOnScreen;
 
   // Resolves the owning row from whichever list cache holds it, fetching the
   // single row when absent. Enabled only while the pill is shown so hidden
@@ -99,24 +137,54 @@ export function VoiceSessionPillHost() {
     }
   }, [navigate, sessionConversationId]);
 
-  const handleEnd = useCallback(() => controls?.stop(), [controls]);
-  const handleSend = useCallback(() => controls?.release(), [controls]);
+  // Mirrors the composer Notice's dismiss: `failed` is terminal for the
+  // session, so resetting only clears the surfaced error.
+  const handleDismissError = useCallback(() => {
+    useLiveVoiceStore.getState().reset();
+  }, []);
 
-  if (!visible) {
+  let content: ReactNode = null;
+  if (showFailure) {
+    content = (
+      <VoiceSessionErrorChip message={error} onDismiss={handleDismissError} />
+    );
+  } else if (visible) {
+    content = (
+      <VoiceSessionPill
+        primaryLabel={LIVE_VOICE_STATE_LABELS[state]}
+        secondaryLabel={
+          owningConversation ? (owningConversation.title ?? "Untitled") : undefined
+        }
+        state={state}
+        getAmplitude={getLiveVoiceInputAmplitude}
+        onEnd={endLiveVoiceSession}
+        onSend={releaseLiveVoiceTurn}
+        onNavigate={sessionConversationId ? handleNavigate : undefined}
+      />
+    );
+  }
+
+  if (content === null) {
     return null;
   }
 
-  return (
-    <VoiceSessionPill
-      primaryLabel={LIVE_VOICE_STATE_LABELS[state]}
-      secondaryLabel={
-        owningConversation ? (owningConversation.title ?? "Untitled") : undefined
-      }
-      state={state}
-      getAmplitude={getLiveVoiceInputAmplitude}
-      onEnd={handleEnd}
-      onSend={handleSend}
-      onNavigate={sessionConversationId ? handleNavigate : undefined}
-    />
-  );
+  if (variant === "standalone") {
+    // Floats over the pop-out's content (which owns its own scrolling), so an
+    // absolute corner anchor never disturbs layout. The pill needs chrome of
+    // its own here — in the header the surrounding title bar provides it —
+    // while the error chip already carries a filled background.
+    return (
+      <div className="absolute right-4 top-4 z-30">
+        {showFailure ? (
+          content
+        ) : (
+          <div className="rounded-full border border-[var(--border-base)] bg-[var(--surface-lift)] py-1 pl-4 pr-1.5 shadow-md">
+            {content}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return content;
 }

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
@@ -14,9 +14,11 @@
  * when:
  *
  * - the user is viewing a different conversation than the session's,
- * - the user is off the conversation routes entirely (Home, Library, …) —
- *   `activeConversationId` deliberately persists across route changes (see
- *   `chat-layout.tsx`), so the id comparison alone can't detect this,
+ * - the user is off the chat routes entirely (Home, Library, …) or on a
+ *   composer-less conversation subroute like the inspector
+ *   (`/assistant/conversations/:id/inspect`) — `activeConversationId`
+ *   deliberately persists across route changes (see `chat-layout.tsx`), so
+ *   the id comparison alone can't detect this,
  * - the desktop fullscreen app viewer covers the thread (`mainView === "app"`;
  *   on mobile that view keeps the composer mounted under a portal overlay
  *   that covers the header too, so the composer stays the owning surface).
@@ -39,12 +41,13 @@ import { useLocation, useNavigate } from "react-router";
 
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { navigateToConversation } from "@/utils/conversation-navigation";
-import { isConversationPath } from "@/utils/routes";
+import { isConversationChatPath } from "@/utils/routes";
 
-import { STATE_LABELS } from "@/domains/chat/components/chat-composer/voice-composer-bar";
 import { VoiceSessionPill } from "@/domains/chat/components/voice-session-pill";
 import { useActiveConversation } from "@/domains/chat/hooks/use-active-conversation";
 import {
+  LIVE_VOICE_STATE_LABELS,
+  getLiveVoiceInputAmplitude,
   isLiveVoiceSessionActive,
   useIsLiveVoiceSessionOwnedBy,
   useLiveVoiceStore,
@@ -67,9 +70,13 @@ export function VoiceSessionPillHost() {
   const sessionActive = isLiveVoiceSessionActive(state);
   // Mirror of `chat-content-layout.tsx`: the desktop `app` view replaces
   // `ChatMainPanel` (composer included); every other view — and mobile's
-  // portal-overlay `app` view — keeps the composer mounted.
+  // portal-overlay `app` view — keeps the composer mounted. The strict chat
+  // predicate matters: conversation subroutes like the inspector
+  // (`/assistant/conversations/:id/inspect`) render no composer, so the pill
+  // must stay up there even for the owning conversation.
   const composerOnScreen =
-    isConversationPath(location.pathname) && !(mainView === "app" && !isMobile);
+    isConversationChatPath(location.pathname) &&
+    !(mainView === "app" && !isMobile);
   // Same ownership predicate the composer's voice bar uses, evaluated for the
   // composer currently on screen — keeps the two surfaces exact complements.
   const activeComposerOwnsSession =
@@ -84,14 +91,6 @@ export function VoiceSessionPillHost() {
     sessionAssistantId,
     sessionConversationId,
     visible && sessionConversationId !== null,
-  );
-
-  // Stable poll function — the waveform samples ~30 Hz via its draw loop, so
-  // amplitude must not flow through props/re-renders (same pattern as the
-  // composer's voice bar wiring).
-  const getAmplitude = useCallback(
-    () => useLiveVoiceStore.getState().inputAmplitude,
-    [],
   );
 
   const handleNavigate = useCallback(() => {
@@ -109,12 +108,12 @@ export function VoiceSessionPillHost() {
 
   return (
     <VoiceSessionPill
-      primaryLabel={STATE_LABELS[state]}
+      primaryLabel={LIVE_VOICE_STATE_LABELS[state]}
       secondaryLabel={
         owningConversation ? (owningConversation.title ?? "Untitled") : undefined
       }
       state={state}
-      getAmplitude={getAmplitude}
+      getAmplitude={getLiveVoiceInputAmplitude}
       onEnd={handleEnd}
       onSend={handleSend}
       onNavigate={sessionConversationId ? handleNavigate : undefined}

--- a/clients/web/src/domains/chat/components/voice-session-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.test.tsx
@@ -99,6 +99,14 @@ describe("VoiceSessionPill — stop control", () => {
     expect(onStop).toHaveBeenCalledTimes(1);
     expect(onNavigate).not.toHaveBeenCalled();
   });
+
+  test("hidden even while speaking when onStop is not provided", () => {
+    // Hosts omit onStop while stopping a response would end the whole
+    // session (V1 interrupt); the ✕ stays the only destructive control.
+    renderPill({ state: "speaking", onStop: undefined });
+    expect(stopButton()).toBeNull();
+    expect(endButton()).toBeTruthy();
+  });
 });
 
 describe("VoiceSessionPill — send control", () => {

--- a/clients/web/src/domains/chat/components/voice-session-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * Tests for `VoiceSessionPill`.
+ *
+ * The pill is purely presentational, so tests drive it directly through
+ * props. The embedded `VoiceTimelineWaveform` renders a real canvas —
+ * happy-dom's `getContext("2d")` returns `null`, which that component treats
+ * as "don't start the draw loop", so no canvas harness is needed here (its
+ * own test file covers the drawing behavior).
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import type { LiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live-voice-store";
+import {
+  VoiceSessionPill,
+  type VoiceSessionPillProps,
+} from "@/domains/chat/components/voice-session-pill";
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderPill(overrides: Partial<VoiceSessionPillProps> = {}) {
+  const handlers = {
+    onStop: mock(() => {}),
+    onEnd: mock(() => {}),
+    onSend: mock(() => {}),
+    onNavigate: mock(() => {}),
+  };
+  render(
+    <VoiceSessionPill
+      primaryLabel="Working on App…"
+      secondaryLabel="Thread name here"
+      state="listening"
+      getAmplitude={() => 0.5}
+      {...handlers}
+      {...overrides}
+    />,
+  );
+  return handlers;
+}
+
+const stopButton = () => screen.queryByRole("button", { name: "Stop assistant response" });
+const endButton = () => screen.getByRole("button", { name: "End voice session" });
+const sendButton = () => screen.getByRole("button", { name: "Send now" });
+const labelButton = () => screen.queryByRole("button", { name: "Go to voice session thread" });
+
+describe("VoiceSessionPill — labels", () => {
+  test("renders both label lines with truncation", () => {
+    renderPill();
+    const primary = screen.getByText("Working on App…");
+    const secondary = screen.getByText("Thread name here");
+    expect(primary.className).toContain("truncate");
+    expect(secondary.className).toContain("truncate");
+  });
+
+  test("omits the secondary line when not provided", () => {
+    renderPill({ secondaryLabel: undefined });
+    expect(screen.getByText("Working on App…")).toBeTruthy();
+    expect(screen.queryByText("Thread name here")).toBeNull();
+  });
+
+  test("label area is a plain (non-interactive) element without onNavigate", () => {
+    renderPill({ onNavigate: undefined });
+    expect(labelButton()).toBeNull();
+    expect(screen.getByText("Working on App…")).toBeTruthy();
+  });
+});
+
+describe("VoiceSessionPill — title-bar constraints", () => {
+  test("root is a no-drag group capped to the header control height", () => {
+    renderPill();
+    const root = screen.getByRole("group", { name: "Voice session" });
+    expect(root.className).toContain("[-webkit-app-region:no-drag]");
+    expect(root.className).toContain("h-8");
+  });
+});
+
+describe("VoiceSessionPill — stop control", () => {
+  test("hidden outside the speaking state", () => {
+    for (const state of [
+      "connecting",
+      "listening",
+      "transcribing",
+      "thinking",
+      "ending",
+    ] as LiveVoiceSessionState[]) {
+      renderPill({ state });
+      expect(stopButton()).toBeNull();
+      cleanup();
+    }
+  });
+
+  test("shown while speaking and fires onStop", () => {
+    const { onStop, onNavigate } = renderPill({ state: "speaking" });
+    fireEvent.click(stopButton()!);
+    expect(onStop).toHaveBeenCalledTimes(1);
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+});
+
+describe("VoiceSessionPill — send control", () => {
+  test("enabled while listening and fires onSend", () => {
+    const { onSend, onNavigate } = renderPill({ state: "listening" });
+    const send = sendButton();
+    expect(send.hasAttribute("disabled")).toBe(false);
+    fireEvent.click(send);
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  test("disabled in every non-listening state", () => {
+    for (const state of [
+      "connecting",
+      "transcribing",
+      "thinking",
+      "speaking",
+      "ending",
+    ] as LiveVoiceSessionState[]) {
+      const { onSend } = renderPill({ state });
+      const send = sendButton();
+      expect(send.hasAttribute("disabled")).toBe(true);
+      fireEvent.click(send);
+      expect(onSend).not.toHaveBeenCalled();
+      cleanup();
+    }
+  });
+});
+
+describe("VoiceSessionPill — end control", () => {
+  test("always enabled and fires onEnd", () => {
+    const { onEnd, onNavigate } = renderPill({ state: "thinking" });
+    const end = endButton();
+    expect(end.hasAttribute("disabled")).toBe(false);
+    fireEvent.click(end);
+    expect(onEnd).toHaveBeenCalledTimes(1);
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+});
+
+describe("VoiceSessionPill — navigation", () => {
+  test("clicking the label area fires onNavigate only", () => {
+    const { onNavigate, onStop, onEnd, onSend } = renderPill();
+    fireEvent.click(labelButton()!);
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+    expect(onStop).not.toHaveBeenCalled();
+    expect(onEnd).not.toHaveBeenCalled();
+    expect(onSend).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/domains/chat/components/voice-session-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.test.tsx
@@ -14,6 +14,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 import type { LiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live-voice-store";
 import {
+  VoiceSessionErrorChip,
   VoiceSessionPill,
   type VoiceSessionPillProps,
 } from "@/domains/chat/components/voice-session-pill";
@@ -156,5 +157,42 @@ describe("VoiceSessionPill — navigation", () => {
     expect(onStop).not.toHaveBeenCalled();
     expect(onEnd).not.toHaveBeenCalled();
     expect(onSend).not.toHaveBeenCalled();
+  });
+});
+
+describe("VoiceSessionErrorChip", () => {
+  function renderChip() {
+    const onDismiss = mock(() => {});
+    render(
+      <VoiceSessionErrorChip
+        message="Microphone capture could not start."
+        onDismiss={onDismiss}
+      />,
+    );
+    return onDismiss;
+  }
+
+  test("announces the failure as an alert carrying the message", () => {
+    renderChip();
+    const alert = screen.getByRole("alert");
+    expect(alert.textContent).toContain("Microphone capture could not start.");
+    expect(alert.className).toContain("[-webkit-app-region:no-drag]");
+    expect(alert.className).toContain("h-8");
+  });
+
+  test("dismiss button fires onDismiss", () => {
+    const onDismiss = renderChip();
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  test("dismiss button carries the Tag primitive's keyboard focus ring", () => {
+    // The chip composes the design-library Tag; its remove button must keep a
+    // keyboard focus affordance (matching Notice's dismiss button), not a
+    // bare outline-none.
+    renderChip();
+    const dismiss = screen.getByRole("button", { name: "Dismiss" });
+    expect(dismiss.className).toContain("keyboard-focus:ring-2");
+    expect(dismiss.className).toContain("keyboard-focus:ring-[var(--ring)]");
   });
 });

--- a/clients/web/src/domains/chat/components/voice-session-pill.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.tsx
@@ -3,9 +3,10 @@
  * Presentational — the mounting host owns store wiring and visibility rules.
  *
  * Layout, left → right: two-line context label (primary action text over the
- * owning thread's name), circular stop control (only while the assistant is
- * `speaking`), mic glyph + compact timeline waveform, red ✕ (end session),
- * green ↑ (manual turn release — enabled only while `listening`).
+ * owning thread's name), optional circular stop control (only when the host
+ * provides `onStop` and the assistant is `speaking`), mic glyph + compact
+ * timeline waveform, red ✕ (end session), green ↑ (manual turn release —
+ * enabled only while `listening`).
  *
  * The pill lives inside `ChatLayoutHeader`, which doubles as the Electron
  * macOS title bar (`-webkit-app-region: drag`). The root opts the whole
@@ -44,8 +45,12 @@ export interface VoiceSessionPillProps {
   state: LiveVoiceSessionState;
   /** Polled by the waveform at ~30 Hz; must not force parent re-renders. */
   getAmplitude: () => number;
-  /** Stop the in-flight assistant response without ending the session. */
-  onStop: () => void;
+  /**
+   * Stop the in-flight assistant response without ending the session. The
+   * ■ control is hidden when absent — hosts must only wire this once a
+   * turn-scoped interrupt exists; the ✕ (`onEnd`) is the destructive control.
+   */
+  onStop?: () => void;
   /** End the voice session. */
   onEnd: () => void;
   /** Manual turn release ("send now") while listening. */
@@ -106,7 +111,7 @@ export function VoiceSessionPill({
       ) : (
         <div className={labelClass}>{labelContent}</div>
       )}
-      {state === "speaking" ? (
+      {onStop && state === "speaking" ? (
         <Button
           variant="primary"
           iconOnly={<Square fill="currentColor" />}

--- a/clients/web/src/domains/chat/components/voice-session-pill.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.tsx
@@ -20,7 +20,7 @@
 
 import { ArrowUp, Mic, Square, TriangleAlert, X } from "lucide-react";
 
-import { Button, Typography, cn } from "@vellumai/design-library";
+import { Button, Tag, Typography, cn } from "@vellumai/design-library";
 
 import {
   isLiveVoiceMicLive,
@@ -162,39 +162,28 @@ export interface VoiceSessionErrorChipProps {
 /**
  * Compact failed-session chip rendered in the pill's slot when a session
  * fails while no composer (and thus no composer failure `Notice`) is on
- * screen — Home, Library, the inspector, the fullscreen app viewer. Same
- * height budget as the pill (`h-8`, title-bar safe), error tone tokens per
- * the design-library `Notice` error treatment.
+ * screen — Home, Library, the inspector, the fullscreen app viewer. Composes
+ * the design-library `Tag` in its dismissible-chip form (negative tone,
+ * `onRemove`), overriding only what the title-bar slot demands: the pill's
+ * `h-8` height budget, pill radius, a subtle negative border, and the
+ * Electron `no-drag` opt-out.
  */
 export function VoiceSessionErrorChip({
   message,
   onDismiss,
 }: VoiceSessionErrorChipProps) {
   return (
-    <div
+    <Tag
       role="alert"
-      className="flex h-8 max-w-80 items-center gap-2 rounded-full border border-[color-mix(in_srgb,var(--system-negative-strong)_25%,transparent)] bg-[var(--system-negative-weak)] py-1 pl-3 pr-1.5 [-webkit-app-region:no-drag]"
+      tone="negative"
+      leftIcon={<TriangleAlert />}
+      onRemove={onDismiss}
+      removeLabel="Dismiss"
+      className="h-8 max-w-80 gap-2 rounded-full border border-[color-mix(in_srgb,var(--system-negative-strong)_25%,transparent)] py-1 pl-3 pr-1.5 [-webkit-app-region:no-drag]"
     >
-      <TriangleAlert
-        aria-hidden
-        className="size-3.5 shrink-0 text-[color:var(--system-negative-strong)]"
-      />
-      <Typography
-        as="p"
-        variant="label-medium-default"
-        className="truncate text-[var(--content-default)]"
-        title={message}
-      >
+      <span className="min-w-0 truncate" title={message}>
         {message}
-      </Typography>
-      <button
-        type="button"
-        onClick={onDismiss}
-        aria-label="Dismiss"
-        className="shrink-0 cursor-pointer rounded-full p-0.5 text-[color:var(--content-secondary)] opacity-70 transition-opacity hover:opacity-100"
-      >
-        <X aria-hidden className="size-3.5" strokeWidth={2} />
-      </button>
-    </div>
+      </span>
+    </Tag>
   );
 }

--- a/clients/web/src/domains/chat/components/voice-session-pill.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.tsx
@@ -22,23 +22,17 @@ import { ArrowUp, Mic, Square, X } from "lucide-react";
 
 import { Button, Typography, cn } from "@vellumai/design-library";
 
-import type { LiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live-voice-store";
+import {
+  isLiveVoiceMicLive,
+  type LiveVoiceSessionState,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
 import { VoiceTimelineWaveform } from "@/domains/chat/voice/voice-timeline-waveform";
 
-/**
- * States in which the mic is live and the waveform should keep scrolling in
- * new amplitude samples. Outside these (connecting/ending/terminal states) the
- * bars freeze in place.
- */
-const WAVEFORM_ACTIVE_STATES: ReadonlySet<LiveVoiceSessionState> = new Set([
-  "listening",
-  "transcribing",
-  "thinking",
-  "speaking",
-]);
-
 export interface VoiceSessionPillProps {
-  /** Line 1: what the assistant is doing (e.g. "Working on App…"). */
+  /**
+   * Line 1: the session's activity label (e.g. "Listening…" — see
+   * `LIVE_VOICE_STATE_LABELS`).
+   */
   primaryLabel: string;
   /** Line 2: the owning thread's name. */
   secondaryLabel?: string;
@@ -128,7 +122,7 @@ export function VoiceSessionPill({
         <Mic aria-hidden className="size-3.5 shrink-0 text-[var(--content-default)]" />
         <VoiceTimelineWaveform
           compact
-          active={WAVEFORM_ACTIVE_STATES.has(state)}
+          active={isLiveVoiceMicLive(state)}
           getAmplitude={getAmplitude}
           className="w-24"
         />

--- a/clients/web/src/domains/chat/components/voice-session-pill.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.tsx
@@ -18,7 +18,7 @@
  * 44px min-height with 32px controls, so the pill must never stretch it.
  */
 
-import { ArrowUp, Mic, Square, X } from "lucide-react";
+import { ArrowUp, Mic, Square, TriangleAlert, X } from "lucide-react";
 
 import { Button, Typography, cn } from "@vellumai/design-library";
 
@@ -43,6 +43,8 @@ export interface VoiceSessionPillProps {
    * Stop the in-flight assistant response without ending the session. The
    * ■ control is hidden when absent — hosts must only wire this once a
    * turn-scoped interrupt exists; the ✕ (`onEnd`) is the destructive control.
+   * Dormant until the turn-scoped interrupt lands (engine plan, JARVIS-1240):
+   * no host passes it yet, deliberately.
    */
   onStop?: () => void;
   /** End the voice session. */
@@ -146,6 +148,53 @@ export function VoiceSessionPill({
         tooltip="Send now"
         onClick={onSend}
       />
+    </div>
+  );
+}
+
+export interface VoiceSessionErrorChipProps {
+  /** Failure message from the live-voice store (`error` when `failed`). */
+  message: string;
+  /** Dismiss the failure (host resets the store back to idle). */
+  onDismiss: () => void;
+}
+
+/**
+ * Compact failed-session chip rendered in the pill's slot when a session
+ * fails while no composer (and thus no composer failure `Notice`) is on
+ * screen — Home, Library, the inspector, the fullscreen app viewer. Same
+ * height budget as the pill (`h-8`, title-bar safe), error tone tokens per
+ * the design-library `Notice` error treatment.
+ */
+export function VoiceSessionErrorChip({
+  message,
+  onDismiss,
+}: VoiceSessionErrorChipProps) {
+  return (
+    <div
+      role="alert"
+      className="flex h-8 max-w-80 items-center gap-2 rounded-full border border-[color-mix(in_srgb,var(--system-negative-strong)_25%,transparent)] bg-[var(--system-negative-weak)] py-1 pl-3 pr-1.5 [-webkit-app-region:no-drag]"
+    >
+      <TriangleAlert
+        aria-hidden
+        className="size-3.5 shrink-0 text-[color:var(--system-negative-strong)]"
+      />
+      <Typography
+        as="p"
+        variant="label-medium-default"
+        className="truncate text-[var(--content-default)]"
+        title={message}
+      >
+        {message}
+      </Typography>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Dismiss"
+        className="shrink-0 cursor-pointer rounded-full p-0.5 text-[color:var(--content-secondary)] opacity-70 transition-opacity hover:opacity-100"
+      >
+        <X aria-hidden className="size-3.5" strokeWidth={2} />
+      </button>
     </div>
   );
 }

--- a/clients/web/src/domains/chat/components/voice-session-pill.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.tsx
@@ -1,0 +1,152 @@
+/**
+ * Title-bar pill for an active live-voice session (Light 54's right cluster).
+ * Presentational — the mounting host owns store wiring and visibility rules.
+ *
+ * Layout, left → right: two-line context label (primary action text over the
+ * owning thread's name), circular stop control (only while the assistant is
+ * `speaking`), mic glyph + compact timeline waveform, red ✕ (end session),
+ * green ↑ (manual turn release — enabled only while `listening`).
+ *
+ * The pill lives inside `ChatLayoutHeader`, which doubles as the Electron
+ * macOS title bar (`-webkit-app-region: drag`). The root opts the whole
+ * cluster out via `no-drag` so every child — including the non-`button`
+ * canvas/label area — stays clickable, matching the header's own treatment of
+ * its interactive children.
+ *
+ * Height is capped at `h-8` (32px): the header's Electron title-bar row is
+ * 44px min-height with 32px controls, so the pill must never stretch it.
+ */
+
+import { ArrowUp, Mic, Square, X } from "lucide-react";
+
+import { Button, Typography, cn } from "@vellumai/design-library";
+
+import type { LiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { VoiceTimelineWaveform } from "@/domains/chat/voice/voice-timeline-waveform";
+
+/**
+ * States in which the mic is live and the waveform should keep scrolling in
+ * new amplitude samples. Outside these (connecting/ending/terminal states) the
+ * bars freeze in place.
+ */
+const WAVEFORM_ACTIVE_STATES: ReadonlySet<LiveVoiceSessionState> = new Set([
+  "listening",
+  "transcribing",
+  "thinking",
+  "speaking",
+]);
+
+export interface VoiceSessionPillProps {
+  /** Line 1: what the assistant is doing (e.g. "Working on App…"). */
+  primaryLabel: string;
+  /** Line 2: the owning thread's name. */
+  secondaryLabel?: string;
+  state: LiveVoiceSessionState;
+  /** Polled by the waveform at ~30 Hz; must not force parent re-renders. */
+  getAmplitude: () => number;
+  /** Stop the in-flight assistant response without ending the session. */
+  onStop: () => void;
+  /** End the voice session. */
+  onEnd: () => void;
+  /** Manual turn release ("send now") while listening. */
+  onSend: () => void;
+  /** Invoked when the label area is clicked (navigate to the owning thread). */
+  onNavigate?: () => void;
+}
+
+export function VoiceSessionPill({
+  primaryLabel,
+  secondaryLabel,
+  state,
+  getAmplitude,
+  onStop,
+  onEnd,
+  onSend,
+  onNavigate,
+}: VoiceSessionPillProps) {
+  const labelContent = (
+    <>
+      <Typography
+        as="p"
+        variant="body-medium-default"
+        className="truncate text-[var(--content-default)]"
+      >
+        {primaryLabel}
+      </Typography>
+      {secondaryLabel ? (
+        <Typography
+          as="p"
+          variant="label-medium-default"
+          className="truncate text-[var(--content-tertiary)]"
+        >
+          {secondaryLabel}
+        </Typography>
+      ) : null}
+    </>
+  );
+
+  // Right-aligned per Light 54: both lines rag toward the stop control.
+  const labelClass = "flex h-8 min-w-0 max-w-40 flex-col justify-center gap-0.5 text-right";
+
+  return (
+    <div
+      role="group"
+      aria-label="Voice session"
+      className="flex h-8 items-center gap-2 [-webkit-app-region:no-drag]"
+    >
+      {onNavigate ? (
+        <button
+          type="button"
+          onClick={onNavigate}
+          aria-label="Go to voice session thread"
+          className={cn(labelClass, "cursor-pointer")}
+        >
+          {labelContent}
+        </button>
+      ) : (
+        <div className={labelClass}>{labelContent}</div>
+      )}
+      {state === "speaking" ? (
+        <Button
+          variant="primary"
+          iconOnly={<Square fill="currentColor" />}
+          className="rounded-full"
+          // Compact title-bar affordance: keep desktop sizing so the pill
+          // never exceeds the header row height on touch-mobile web.
+          expandOnMobile={false}
+          aria-label="Stop assistant response"
+          tooltip="Stop assistant response"
+          onClick={onStop}
+        />
+      ) : null}
+      <div className="flex items-center gap-1">
+        <Mic aria-hidden className="size-3.5 shrink-0 text-[var(--content-default)]" />
+        <VoiceTimelineWaveform
+          compact
+          active={WAVEFORM_ACTIVE_STATES.has(state)}
+          getAmplitude={getAmplitude}
+          className="w-24"
+        />
+      </div>
+      <Button
+        variant="danger"
+        iconOnly={<X strokeWidth={2.5} />}
+        className="rounded-full"
+        expandOnMobile={false}
+        aria-label="End voice session"
+        tooltip="End voice session"
+        onClick={onEnd}
+      />
+      <Button
+        variant="primary"
+        iconOnly={<ArrowUp strokeWidth={2.5} />}
+        className="rounded-full"
+        expandOnMobile={false}
+        disabled={state !== "listening"}
+        aria-label="Send now"
+        tooltip="Send now"
+        onClick={onSend}
+      />
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/hooks/use-open-app-from-chat.ts
+++ b/clients/web/src/domains/chat/hooks/use-open-app-from-chat.ts
@@ -5,7 +5,7 @@ import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore } from "@/stores/viewer-store";
 import { haptic } from "@/utils/haptics";
-import { routes } from "@/utils/routes";
+import { isConversationChatPath, routes } from "@/utils/routes";
 
 /**
  * Open an app in the viewer panel from inside the chat surface — sidebar
@@ -28,10 +28,10 @@ import { routes } from "@/utils/routes";
  */
 /**
  * Decide the route to navigate to before opening an app from the sidebar.
- * The viewer panel only renders under `ChatPage` (mounted at `/assistant`
- * index + `/assistant/conversations/:id`). From any other route (home,
- * library, identity, inspector, …) the viewer-store mutation would have
- * no surface to display against, so we have to navigate first.
+ * The viewer panel only renders under `ChatPage` (the routes matched by
+ * `isConversationChatPath`). From any other route (home, library, identity,
+ * inspector, …) the viewer-store mutation would have no surface to display
+ * against, so we have to navigate first.
  *
  * Returns `null` when the caller is already on a route that mounts the
  * viewer — no navigation needed.
@@ -43,12 +43,7 @@ export function chooseSidebarOpenAppDestination(
   pathname: string,
   activeConversationId: string | null,
 ): string | null {
-  const onChatRoute =
-    pathname === routes.assistant ||
-    pathname === `${routes.assistant}/` ||
-    (pathname.startsWith("/assistant/conversations/") &&
-      !pathname.endsWith("/inspect"));
-  if (onChatRoute) return null;
+  if (isConversationChatPath(pathname)) return null;
   return activeConversationId
     ? routes.conversation(activeConversationId)
     : routes.assistant;

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
@@ -1,0 +1,170 @@
+/**
+ * Hand-rolled fakes for the three live-voice primitives — client (transport),
+ * capture (mic → PCM), player (TTS playback) — injected through
+ * `useLiveVoice`'s factory options so tests touch no WebSocket, microphone,
+ * or AudioContext. The fakes expose drivers (`emit`, `pushChunk`,
+ * `pushAmplitude`, `finishPlayback`) so a test can drive a full turn and
+ * assert state-machine transitions, barge-in, automatic ptt_release, and
+ * teardown.
+ *
+ * Shared by `use-live-voice.test.ts` and
+ * `use-live-voice-session-controller.test.tsx`. Type-only imports keep the
+ * generated-SDK import graph out of test files (the real client's
+ * `connection.ts` is mocked separately by each test).
+ */
+
+import type {
+  LiveVoiceClientEventMap,
+  LiveVoiceClientEventName,
+} from "@/domains/chat/voice/live-voice/live-voice-client";
+import type {
+  LiveVoiceAudioCaptureOptions,
+  LiveVoiceCaptureResult,
+} from "@/domains/chat/voice/live-voice/pcm-capture";
+
+export class FakeClient {
+  connectArgs: {
+    assistantId: string;
+    conversationId?: string;
+    turnDetection?: "manual" | "server_vad";
+  } | null = null;
+  sentAudio: ArrayBuffer[] = [];
+  pttReleaseCount = 0;
+  interruptCount = 0;
+  ended = false;
+  closed = false;
+
+  private handlers = new Map<
+    LiveVoiceClientEventName,
+    Set<(payload: never) => void>
+  >();
+
+  on<E extends LiveVoiceClientEventName>(
+    event: E,
+    handler: (payload: LiveVoiceClientEventMap[E]) => void,
+  ): () => void {
+    let set = this.handlers.get(event);
+    if (!set) {
+      set = new Set();
+      this.handlers.set(event, set);
+    }
+    set.add(handler as (payload: never) => void);
+    return () => set?.delete(handler as (payload: never) => void);
+  }
+
+  async connect(args: {
+    assistantId: string;
+    conversationId?: string;
+    turnDetection?: "manual" | "server_vad";
+  }): Promise<void> {
+    this.connectArgs = args;
+  }
+
+  sendAudio(pcm: ArrayBuffer): void {
+    this.sentAudio.push(pcm);
+  }
+  pttRelease(): void {
+    this.pttReleaseCount++;
+  }
+  interrupt(): void {
+    this.interruptCount++;
+  }
+  end(): void {
+    this.ended = true;
+  }
+  close(): void {
+    this.closed = true;
+  }
+
+  /** Drive a server event to the controller's subscribed handlers. */
+  emit<E extends LiveVoiceClientEventName>(
+    event: E,
+    payload: LiveVoiceClientEventMap[E],
+  ): void {
+    for (const handler of this.handlers.get(event) ?? []) {
+      (handler as (payload: LiveVoiceClientEventMap[E]) => void)(payload);
+    }
+  }
+}
+
+export class FakeCapture {
+  readonly onChunk: (buf: ArrayBuffer) => void;
+  readonly onAmplitude?: (amplitude: number) => void;
+
+  startCount = 0;
+  stopCount = 0;
+  shutdownCount = 0;
+  startResult: LiveVoiceCaptureResult = { ok: true };
+
+  constructor(options: LiveVoiceAudioCaptureOptions) {
+    this.onChunk = options.onChunk;
+    this.onAmplitude = options.onAmplitude;
+  }
+
+  async start(): Promise<LiveVoiceCaptureResult> {
+    this.startCount++;
+    return this.startResult;
+  }
+  async stop(): Promise<void> {
+    this.stopCount++;
+  }
+  async shutdown(): Promise<void> {
+    this.shutdownCount++;
+  }
+
+  /** Feed a captured PCM chunk to the controller. */
+  pushChunk(buf: ArrayBuffer): void {
+    this.onChunk(buf);
+  }
+  /** Feed an amplitude reading to the controller. */
+  pushAmplitude(amplitude: number): void {
+    this.onAmplitude?.(amplitude);
+  }
+}
+
+export class FakePlayer {
+  enqueued: unknown[] = [];
+  stopCount = 0;
+  disposeCount = 0;
+  isPlaying = false;
+  private drainResolvers: Array<() => void> = [];
+
+  enqueue(chunk: unknown): void {
+    this.enqueued.push(chunk);
+    this.isPlaying = true;
+  }
+  stop(): void {
+    this.stopCount++;
+    this.isPlaying = false;
+    this.resolveDrain();
+  }
+  async dispose(): Promise<void> {
+    this.disposeCount++;
+    this.stop();
+  }
+  async waitUntilDrained(): Promise<void> {
+    if (!this.isPlaying) {
+      return;
+    }
+    await new Promise<void>((resolve) => this.drainResolvers.push(resolve));
+  }
+
+  /** Simulate playback finishing naturally. */
+  finishPlayback(): void {
+    this.isPlaying = false;
+    this.resolveDrain();
+  }
+  private resolveDrain(): void {
+    const resolvers = this.drainResolvers;
+    this.drainResolvers = [];
+    for (const resolve of resolvers) {
+      resolve();
+    }
+  }
+}
+
+/** A PCM chunk of `ms` milliseconds at 16 kHz mono Int16. */
+export function pcmChunk(ms: number): ArrayBuffer {
+  const samples = Math.round((16000 * ms) / 1000);
+  return new Int16Array(samples).buffer;
+}

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
@@ -7,11 +7,20 @@
  * assert state-machine transitions, barge-in, automatic ptt_release, and
  * teardown.
  *
+ * Also exports the store-seeding helpers (`makeControlsSpies`,
+ * `seedLiveVoiceSession`) shared by the surface tests that drive the real
+ * `useLiveVoiceStore` directly (`chat-composer.test.tsx`,
+ * `voice-session-pill-host.test.tsx`, `live-voice-store.test.ts`).
+ *
  * Shared by `use-live-voice.test.ts` and
- * `use-live-voice-session-controller.test.tsx`. Type-only imports keep the
- * generated-SDK import graph out of test files (the real client's
- * `connection.ts` is mocked separately by each test).
+ * `use-live-voice-session-controller.test.tsx`. Imports from the primitives
+ * stay type-only to keep the generated-SDK import graph out of test files
+ * (the real client's `connection.ts` is mocked separately by each test); the
+ * store is a value import, but it is self-contained zustand with no heavy
+ * dependencies.
  */
+
+import { mock } from "bun:test";
 
 import type {
   LiveVoiceClientEventMap,
@@ -21,6 +30,11 @@ import type {
   LiveVoiceAudioCaptureOptions,
   LiveVoiceCaptureResult,
 } from "@/domains/chat/voice/live-voice/pcm-capture";
+import {
+  useLiveVoiceStore,
+  type LiveVoiceSessionControls,
+  type LiveVoiceSessionState,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
 
 export class FakeClient {
   connectArgs: {
@@ -167,4 +181,35 @@ export class FakePlayer {
 export function pcmChunk(ms: number): ArrayBuffer {
   const samples = Math.round((16000 * ms) / 1000);
   return new Int16Array(samples).buffer;
+}
+
+/** Spy implementations of the store-registered session controls. */
+export function makeControlsSpies() {
+  return {
+    stop: mock(() => {}),
+    release: mock(() => {}),
+    interrupt: mock(() => {}),
+  } satisfies LiveVoiceSessionControls;
+}
+
+/**
+ * Seed the real `useLiveVoiceStore` with a session, mirroring the writes the
+ * controller performs on `start()` (context → controls → state). Pass
+ * `conversationId: null` for a draft-started session; omit `controls` to
+ * leave none registered.
+ */
+export function seedLiveVoiceSession(
+  state: LiveVoiceSessionState,
+  options: {
+    assistantId: string;
+    conversationId: string | null;
+    controls?: LiveVoiceSessionControls;
+  },
+): void {
+  const store = useLiveVoiceStore.getState();
+  store.setSessionContext(options.assistantId, options.conversationId);
+  if (options.controls) {
+    store.setControls(options.controls);
+  }
+  store.setState(state);
 }

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for the live-voice store's session context and shared controls — the
+ * seam that lets globally mounted surfaces (e.g. the title-bar session pill)
+ * observe and drive a session owned by the composer's `useLiveVoice` instance.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  useLiveVoiceStore,
+  type LiveVoiceSessionControls,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
+
+function makeControls(): LiveVoiceSessionControls {
+  return { stop: mock(() => {}), release: mock(() => {}), interrupt: mock(() => {}) };
+}
+
+beforeEach(() => {
+  useLiveVoiceStore.getState().reset();
+});
+
+describe("useLiveVoiceStore — session context", () => {
+  test("defaults to null assistant/conversation when idle", () => {
+    expect(useLiveVoiceStore.getState().assistantId).toBeNull();
+    expect(useLiveVoiceStore.getState().conversationId).toBeNull();
+  });
+
+  test("setSessionContext records the owning assistant and conversation", () => {
+    useLiveVoiceStore.getState().setSessionContext("assistant-1", "conv-1");
+    expect(useLiveVoiceStore.getState().assistantId).toBe("assistant-1");
+    expect(useLiveVoiceStore.getState().conversationId).toBe("conv-1");
+  });
+
+  test("setSessionContext accepts a null conversation", () => {
+    useLiveVoiceStore.getState().setSessionContext("assistant-1", null);
+    expect(useLiveVoiceStore.getState().assistantId).toBe("assistant-1");
+    expect(useLiveVoiceStore.getState().conversationId).toBeNull();
+  });
+
+  test("reset clears the session context", () => {
+    useLiveVoiceStore.getState().setSessionContext("assistant-1", "conv-1");
+    useLiveVoiceStore.getState().reset();
+    expect(useLiveVoiceStore.getState().assistantId).toBeNull();
+    expect(useLiveVoiceStore.getState().conversationId).toBeNull();
+  });
+});
+
+describe("useLiveVoiceStore — session controls", () => {
+  test("defaults to null controls when idle", () => {
+    expect(useLiveVoiceStore.getState().controls).toBeNull();
+  });
+
+  test("setControls registers the owning controller's controls", () => {
+    const controls = makeControls();
+    useLiveVoiceStore.getState().setControls(controls);
+    expect(useLiveVoiceStore.getState().controls).toBe(controls);
+  });
+
+  test("setControls(null) deregisters controls", () => {
+    useLiveVoiceStore.getState().setControls(makeControls());
+    useLiveVoiceStore.getState().setControls(null);
+    expect(useLiveVoiceStore.getState().controls).toBeNull();
+  });
+
+  test("reset clears registered controls", () => {
+    useLiveVoiceStore.getState().setControls(makeControls());
+    useLiveVoiceStore.getState().reset();
+    expect(useLiveVoiceStore.getState().controls).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -1,14 +1,18 @@
 /**
- * Tests for the live-voice store's session context and shared controls — the
- * seam that lets globally mounted surfaces (e.g. the title-bar session pill)
- * observe and drive a session owned by the composer's `useLiveVoice` instance.
+ * Tests for the live-voice store's session context, shared controls, and
+ * starter — the seams that let globally mounted surfaces (the title-bar
+ * session pill) and the composer observe and drive a session owned by the
+ * layout-mounted controller — plus the session-ownership predicates.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {
+  isLiveVoiceSessionActive,
+  isLiveVoiceSessionOwnedBy,
   useLiveVoiceStore,
   type LiveVoiceSessionControls,
+  type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 
 function makeControls(): LiveVoiceSessionControls {
@@ -17,24 +21,39 @@ function makeControls(): LiveVoiceSessionControls {
 
 beforeEach(() => {
   useLiveVoiceStore.getState().reset();
+  // reset() deliberately preserves the starter (mount-scoped); clear it
+  // explicitly so tests can't leak a registered starter into each other.
+  useLiveVoiceStore.getState().setStarter(null);
 });
 
 describe("useLiveVoiceStore — session context", () => {
   test("defaults to null assistant/conversation when idle", () => {
     expect(useLiveVoiceStore.getState().assistantId).toBeNull();
     expect(useLiveVoiceStore.getState().conversationId).toBeNull();
+    expect(useLiveVoiceStore.getState().startedConversationId).toBeNull();
   });
 
   test("setSessionContext records the owning assistant and conversation", () => {
     useLiveVoiceStore.getState().setSessionContext("assistant-1", "conv-1");
     expect(useLiveVoiceStore.getState().assistantId).toBe("assistant-1");
     expect(useLiveVoiceStore.getState().conversationId).toBe("conv-1");
+    expect(useLiveVoiceStore.getState().startedConversationId).toBe("conv-1");
   });
 
   test("setSessionContext accepts a null conversation", () => {
     useLiveVoiceStore.getState().setSessionContext("assistant-1", null);
     expect(useLiveVoiceStore.getState().assistantId).toBe("assistant-1");
     expect(useLiveVoiceStore.getState().conversationId).toBeNull();
+    expect(useLiveVoiceStore.getState().startedConversationId).toBeNull();
+  });
+
+  test("setConversationId republishes the authoritative id without touching the started id", () => {
+    useLiveVoiceStore.getState().setSessionContext("assistant-1", null);
+    useLiveVoiceStore.getState().setConversationId("conv-server-assigned");
+    expect(useLiveVoiceStore.getState().conversationId).toBe(
+      "conv-server-assigned",
+    );
+    expect(useLiveVoiceStore.getState().startedConversationId).toBeNull();
   });
 
   test("reset clears the session context", () => {
@@ -42,6 +61,106 @@ describe("useLiveVoiceStore — session context", () => {
     useLiveVoiceStore.getState().reset();
     expect(useLiveVoiceStore.getState().assistantId).toBeNull();
     expect(useLiveVoiceStore.getState().conversationId).toBeNull();
+    expect(useLiveVoiceStore.getState().startedConversationId).toBeNull();
+  });
+});
+
+describe("useLiveVoiceStore — session starter", () => {
+  test("defaults to null when no controller is mounted", () => {
+    expect(useLiveVoiceStore.getState().starter).toBeNull();
+  });
+
+  test("setStarter registers and deregisters the controller's starter", () => {
+    const starter = mock(() => {});
+    useLiveVoiceStore.getState().setStarter(starter);
+    expect(useLiveVoiceStore.getState().starter).toBe(starter);
+    useLiveVoiceStore.getState().setStarter(null);
+    expect(useLiveVoiceStore.getState().starter).toBeNull();
+  });
+
+  test("reset preserves the starter — session teardown must not deregister the mounted controller", () => {
+    const starter = mock(() => {});
+    useLiveVoiceStore.getState().setStarter(starter);
+    // Simulate a full session lifecycle ending in teardown's reset().
+    useLiveVoiceStore.getState().setSessionContext("assistant-1", "conv-1");
+    useLiveVoiceStore.getState().setState("listening");
+    useLiveVoiceStore.getState().reset();
+    expect(useLiveVoiceStore.getState().starter).toBe(starter);
+  });
+});
+
+describe("isLiveVoiceSessionActive", () => {
+  test("false for idle and failed, true for every live phase", () => {
+    expect(isLiveVoiceSessionActive("idle")).toBe(false);
+    expect(isLiveVoiceSessionActive("failed")).toBe(false);
+    const live: LiveVoiceSessionState[] = [
+      "connecting",
+      "listening",
+      "transcribing",
+      "thinking",
+      "speaking",
+      "ending",
+    ];
+    for (const state of live) {
+      expect(isLiveVoiceSessionActive(state)).toBe(true);
+    }
+  });
+});
+
+describe("isLiveVoiceSessionOwnedBy", () => {
+  const session = (
+    state: LiveVoiceSessionState,
+    conversationId: string | null,
+    startedConversationId: string | null,
+  ) => ({ state, conversationId, startedConversationId });
+
+  test("no ownership without an active session, even with matching ids", () => {
+    expect(isLiveVoiceSessionOwnedBy(session("idle", "conv-1", "conv-1"), "conv-1")).toBe(false);
+    expect(isLiveVoiceSessionOwnedBy(session("failed", "conv-1", "conv-1"), "conv-1")).toBe(false);
+  });
+
+  test("composer bound to the session's conversation owns it", () => {
+    expect(
+      isLiveVoiceSessionOwnedBy(session("listening", "conv-1", "conv-1"), "conv-1"),
+    ).toBe(true);
+  });
+
+  test("composer bound to a different conversation does not own it", () => {
+    expect(
+      isLiveVoiceSessionOwnedBy(session("listening", "conv-1", "conv-1"), "conv-other"),
+    ).toBe(false);
+  });
+
+  test("draft composer owns a draft-started session before AND after the server assigns a conversation", () => {
+    // Before `ready`: the session has no conversation yet.
+    expect(
+      isLiveVoiceSessionOwnedBy(session("connecting", null, null), undefined),
+    ).toBe(true);
+    // After `ready`: authoritative id assigned, started id stays null — the
+    // draft composer (still bound to no conversation) keeps owning it.
+    expect(
+      isLiveVoiceSessionOwnedBy(session("listening", "conv-server", null), undefined),
+    ).toBe(true);
+    expect(
+      isLiveVoiceSessionOwnedBy(session("listening", "conv-server", null), null),
+    ).toBe(true);
+    // A composer bound to some other thread never picks it up.
+    expect(
+      isLiveVoiceSessionOwnedBy(session("listening", "conv-server", null), "conv-other"),
+    ).toBe(false);
+    // Navigating to the assigned conversation makes that composer the owner.
+    expect(
+      isLiveVoiceSessionOwnedBy(session("listening", "conv-server", null), "conv-server"),
+    ).toBe(true);
+  });
+
+  test("draft composer does not own a session started with a conversation", () => {
+    expect(
+      isLiveVoiceSessionOwnedBy(session("listening", "conv-1", "conv-1"), null),
+    ).toBe(false);
+    expect(
+      isLiveVoiceSessionOwnedBy(session("listening", "conv-1", "conv-1"), undefined),
+    ).toBe(false);
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -9,6 +9,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { makeControlsSpies } from "@/domains/chat/voice/live-voice/live-voice-fakes.test-helper";
 import {
+  dismissLiveVoiceFailure,
   endLiveVoiceSession,
   getLiveVoiceInputAmplitude,
   isLiveVoiceMicLive,
@@ -209,6 +210,30 @@ describe("endLiveVoiceSession / releaseLiveVoiceTurn", () => {
       endLiveVoiceSession();
       releaseLiveVoiceTurn();
     }).not.toThrow();
+  });
+});
+
+describe("dismissLiveVoiceFailure", () => {
+  test("resets a failed session back to idle and clears the error", () => {
+    useLiveVoiceStore.getState().setSessionContext("assistant-1", "conv-1");
+    useLiveVoiceStore.getState().fail("boom");
+
+    dismissLiveVoiceFailure();
+
+    expect(useLiveVoiceStore.getState().state).toBe("idle");
+    expect(useLiveVoiceStore.getState().error).toBeNull();
+    expect(useLiveVoiceStore.getState().assistantId).toBeNull();
+    expect(useLiveVoiceStore.getState().conversationId).toBeNull();
+  });
+
+  test("preserves the mount-scoped starter, like any reset", () => {
+    const starter = mock(() => {});
+    useLiveVoiceStore.getState().setStarter(starter);
+    useLiveVoiceStore.getState().fail("boom");
+
+    dismissLiveVoiceFailure();
+
+    expect(useLiveVoiceStore.getState().starter).toBe(starter);
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -8,6 +8,8 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {
+  getLiveVoiceInputAmplitude,
+  isLiveVoiceMicLive,
   isLiveVoiceSessionActive,
   isLiveVoiceSessionOwnedBy,
   useLiveVoiceStore,
@@ -185,5 +187,34 @@ describe("useLiveVoiceStore — session controls", () => {
     useLiveVoiceStore.getState().setControls(makeControls());
     useLiveVoiceStore.getState().reset();
     expect(useLiveVoiceStore.getState().controls).toBeNull();
+  });
+});
+
+describe("isLiveVoiceMicLive", () => {
+  test("true for the whole listening→speaking span (amplitude keeps flowing for barge-in)", () => {
+    const micLive: LiveVoiceSessionState[] = [
+      "listening",
+      "transcribing",
+      "thinking",
+      "speaking",
+    ];
+    for (const state of micLive) {
+      expect(isLiveVoiceMicLive(state)).toBe(true);
+    }
+  });
+
+  test("false before capture starts and during/after teardown", () => {
+    const micOff: LiveVoiceSessionState[] = ["idle", "connecting", "ending", "failed"];
+    for (const state of micOff) {
+      expect(isLiveVoiceMicLive(state)).toBe(false);
+    }
+  });
+});
+
+describe("getLiveVoiceInputAmplitude", () => {
+  test("reads the store's current amplitude", () => {
+    expect(getLiveVoiceInputAmplitude()).toBe(0);
+    useLiveVoiceStore.getState().setInputAmplitude(0.42);
+    expect(getLiveVoiceInputAmplitude()).toBe(0.42);
   });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -7,19 +7,17 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { makeControlsSpies } from "@/domains/chat/voice/live-voice/live-voice-fakes.test-helper";
 import {
+  endLiveVoiceSession,
   getLiveVoiceInputAmplitude,
   isLiveVoiceMicLive,
   isLiveVoiceSessionActive,
   isLiveVoiceSessionOwnedBy,
+  releaseLiveVoiceTurn,
   useLiveVoiceStore,
-  type LiveVoiceSessionControls,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
-
-function makeControls(): LiveVoiceSessionControls {
-  return { stop: mock(() => {}), release: mock(() => {}), interrupt: mock(() => {}) };
-}
 
 beforeEach(() => {
   useLiveVoiceStore.getState().reset();
@@ -172,21 +170,45 @@ describe("useLiveVoiceStore — session controls", () => {
   });
 
   test("setControls registers the owning controller's controls", () => {
-    const controls = makeControls();
+    const controls = makeControlsSpies();
     useLiveVoiceStore.getState().setControls(controls);
     expect(useLiveVoiceStore.getState().controls).toBe(controls);
   });
 
   test("setControls(null) deregisters controls", () => {
-    useLiveVoiceStore.getState().setControls(makeControls());
+    useLiveVoiceStore.getState().setControls(makeControlsSpies());
     useLiveVoiceStore.getState().setControls(null);
     expect(useLiveVoiceStore.getState().controls).toBeNull();
   });
 
   test("reset clears registered controls", () => {
-    useLiveVoiceStore.getState().setControls(makeControls());
+    useLiveVoiceStore.getState().setControls(makeControlsSpies());
     useLiveVoiceStore.getState().reset();
     expect(useLiveVoiceStore.getState().controls).toBeNull();
+  });
+});
+
+describe("endLiveVoiceSession / releaseLiveVoiceTurn", () => {
+  test("route to the registered controls (and only the matching verb)", () => {
+    const controls = makeControlsSpies();
+    useLiveVoiceStore.getState().setControls(controls);
+
+    endLiveVoiceSession();
+    expect(controls.stop).toHaveBeenCalledTimes(1);
+    expect(controls.release).not.toHaveBeenCalled();
+
+    releaseLiveVoiceTurn();
+    expect(controls.release).toHaveBeenCalledTimes(1);
+    expect(controls.stop).toHaveBeenCalledTimes(1);
+    expect(controls.interrupt).not.toHaveBeenCalled();
+  });
+
+  test("no-op when no controls are registered", () => {
+    expect(useLiveVoiceStore.getState().controls).toBeNull();
+    expect(() => {
+      endLiveVoiceSession();
+      releaseLiveVoiceTurn();
+    }).not.toThrow();
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -76,15 +76,46 @@ export interface LiveVoiceSessionControls {
   interrupt: () => void;
 }
 
+/**
+ * Starts a live-voice session for `assistantId`, attaching `conversationId`
+ * when non-null. Registered into the store by the persistently mounted
+ * session-controller hook (see `use-live-voice-session-controller.ts`) so any
+ * surface — e.g. the composer's entry-point mic — can start a session without
+ * owning the controller hook instance.
+ */
+export type LiveVoiceSessionStarter = (
+  assistantId: string,
+  conversationId: string | null,
+) => void;
+
 export interface LiveVoiceState {
   /** Current phase of the session lifecycle. */
   state: LiveVoiceSessionState;
   /** Assistant the active session was started for, `null` when idle. */
   assistantId: string | null;
-  /** Conversation the active session is attached to, if any. */
+  /**
+   * Conversation the active session is attached to, if any. Authoritative:
+   * when a session starts without a conversation, the server assigns one and
+   * this field is updated on the `ready` frame.
+   */
   conversationId: string | null;
+  /**
+   * Conversation id the session was *started* with — `null` for a session
+   * started without an attached conversation (a draft composer). Unlike
+   * `conversationId`, this is never overwritten by the server's `ready`
+   * frame, so the composer that started a draft session keeps matching it
+   * (see {@link isLiveVoiceSessionOwnedBy}).
+   */
+  startedConversationId: string | null;
   /** Controls registered by the owning controller, `null` when no session. */
   controls: LiveVoiceSessionControls | null;
+  /**
+   * Session starter registered by the persistently mounted controller hook.
+   * `null` only when no controller is mounted (e.g. outside the chat layout).
+   * Mount-scoped, not session-scoped: {@link LiveVoiceActions.reset} leaves it
+   * registered.
+   */
+  starter: LiveVoiceSessionStarter | null;
   /** In-flight partial transcript of the user's current utterance. */
   partialTranscript: string;
   /** Last finalized user transcript. */
@@ -100,13 +131,24 @@ export interface LiveVoiceState {
 export interface LiveVoiceActions {
   /** Replace the session phase. */
   setState: (state: LiveVoiceSessionState) => void;
-  /** Record which assistant/conversation the active session belongs to. */
+  /**
+   * Record which assistant/conversation the session was started for. Sets
+   * both `conversationId` and `startedConversationId`; called once per
+   * session, at start.
+   */
   setSessionContext: (
     assistantId: string,
     conversationId: string | null,
   ) => void;
+  /**
+   * Republish the authoritative conversation id from the server's `ready`
+   * frame. Leaves `startedConversationId` at its start-time value.
+   */
+  setConversationId: (conversationId: string) => void;
   /** Register (or clear) the owning controller's session controls. */
   setControls: (controls: LiveVoiceSessionControls | null) => void;
+  /** Register (or clear) the mounted controller's session starter. */
+  setStarter: (starter: LiveVoiceSessionStarter | null) => void;
   setPartialTranscript: (text: string) => void;
   setFinalTranscript: (text: string) => void;
   /** Append a delta to the accumulated assistant transcript. */
@@ -121,20 +163,70 @@ export interface LiveVoiceActions {
   setInputAmplitude: (amplitude: number) => void;
   /** Transition to `failed` with a message. */
   fail: (message: string) => void;
-  /** Reset every field back to the idle defaults. */
+  /**
+   * Reset every session field back to the idle defaults. Deliberately leaves
+   * `starter` registered — it belongs to the controller's mount lifecycle,
+   * not the session lifecycle, and must survive session teardown so the next
+   * session can start.
+   */
   reset: () => void;
 }
 
 export type LiveVoiceStore = LiveVoiceState & LiveVoiceActions;
 
 // ---------------------------------------------------------------------------
+// Predicates
+// ---------------------------------------------------------------------------
+
+/** Whether `state` is a live session phase (anything but idle/failed). */
+export function isLiveVoiceSessionActive(state: LiveVoiceSessionState): boolean {
+  return state !== "idle" && state !== "failed";
+}
+
+/**
+ * Whether the composer bound to `composerConversationId` owns the active
+ * session — i.e. it is the surface whose action row swaps to the voice bar
+ * (and whose title-bar pill therefore hides).
+ *
+ * A composer owns the session when its conversation matches either the
+ * session's authoritative `conversationId` or the `startedConversationId` it
+ * was started with. The second arm covers the draft case: a session started
+ * from a composer with no conversation (`null`) gets a server-assigned
+ * `conversationId` on `ready`, but the draft composer — still bound to no
+ * conversation — must keep owning it until the user navigates away.
+ *
+ * Exactly one of {composer voice bar, title-bar pill} renders for an active
+ * session: the composer shows its voice UI iff this returns `true` for it,
+ * and the pill host shows the pill iff the currently visible composer (if
+ * any) does not own the session.
+ */
+export function isLiveVoiceSessionOwnedBy(
+  session: Pick<
+    LiveVoiceState,
+    "state" | "conversationId" | "startedConversationId"
+  >,
+  composerConversationId: string | null | undefined,
+): boolean {
+  if (!isLiveVoiceSessionActive(session.state)) {
+    return false;
+  }
+  const composerId = composerConversationId ?? null;
+  return (
+    composerId === session.conversationId ||
+    composerId === session.startedConversationId
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Store
 // ---------------------------------------------------------------------------
 
-const INITIAL_STATE: LiveVoiceState = {
+/** Session-scoped fields restored by `reset()`. Excludes `starter` (mount-scoped). */
+const INITIAL_SESSION_STATE: Omit<LiveVoiceState, "starter"> = {
   state: "idle",
   assistantId: null,
   conversationId: null,
+  startedConversationId: null,
   controls: null,
   partialTranscript: "",
   finalTranscript: "",
@@ -144,12 +236,15 @@ const INITIAL_STATE: LiveVoiceState = {
 };
 
 const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
-  ...INITIAL_STATE,
+  ...INITIAL_SESSION_STATE,
+  starter: null,
 
   setState: (state) => set({ state }),
   setSessionContext: (assistantId, conversationId) =>
-    set({ assistantId, conversationId }),
+    set({ assistantId, conversationId, startedConversationId: conversationId }),
+  setConversationId: (conversationId) => set({ conversationId }),
   setControls: (controls) => set({ controls }),
+  setStarter: (starter) => set({ starter }),
   setPartialTranscript: (partialTranscript) => set({ partialTranscript }),
   setFinalTranscript: (finalTranscript) => set({ finalTranscript }),
   appendAssistantTranscript: (delta) =>
@@ -158,7 +253,21 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
   clearUserTranscripts: () => set({ partialTranscript: "", finalTranscript: "" }),
   setInputAmplitude: (inputAmplitude) => set({ inputAmplitude }),
   fail: (message) => set({ state: "failed", error: message }),
-  reset: () => set({ ...INITIAL_STATE }),
+  reset: () => set({ ...INITIAL_SESSION_STATE }),
 }));
 
 export const useLiveVoiceStore = createSelectors(useLiveVoiceStoreBase);
+
+/**
+ * Reactive form of {@link isLiveVoiceSessionOwnedBy} for components: whether
+ * the active session is owned by the composer bound to
+ * `composerConversationId`. Boolean-valued so per-field session churn never
+ * re-renders the subscriber.
+ */
+export function useIsLiveVoiceSessionOwnedBy(
+  composerConversationId: string | null | undefined,
+): boolean {
+  return useLiveVoiceStore((s) =>
+    isLiveVoiceSessionOwnedBy(s, composerConversationId),
+  );
+}

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -92,7 +92,8 @@ export interface LiveVoiceSessionControls {
    * Stop in-flight assistant playback without the user having to speak. V1
    * behavior: same path as barge-in interrupt, which ends the session (a later
    * engine revision makes it turn-scoped). No-op unless the session is
-   * `speaking`.
+   * `speaking`. Dormant until the turn-scoped interrupt lands (engine plan,
+   * JARVIS-1240) — deliberately kept registered, but no surface wires it yet.
    */
   interrupt: () => void;
 }
@@ -308,6 +309,28 @@ export const useLiveVoiceStore = createSelectors(useLiveVoiceStoreBase);
  */
 export function getLiveVoiceInputAmplitude(): number {
   return useLiveVoiceStore.getState().inputAmplitude;
+}
+
+/**
+ * End the active live-voice session through the store-registered
+ * {@link LiveVoiceSessionControls}. No-op when no session (or no controls)
+ * exists. Module-level so every surface with an "end session" affordance (the
+ * composer's voice bar, the title-bar pill) shares one stable identity and
+ * reads `controls` via `getState()` in the callback — subscribing to
+ * `controls` just to call it would re-render on register/clear (see
+ * STATE_MANAGEMENT.md).
+ */
+export function endLiveVoiceSession(): void {
+  useLiveVoiceStore.getState().controls?.stop();
+}
+
+/**
+ * Manually release the current push-to-talk turn ("send now") through the
+ * store-registered controls. No-op when no session is `listening`. See
+ * {@link endLiveVoiceSession} for why this is module-level.
+ */
+export function releaseLiveVoiceTurn(): void {
+  useLiveVoiceStore.getState().controls?.release();
 }
 
 /**

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -52,9 +52,39 @@ export type LiveVoiceSessionState =
   | "ending"
   | "failed";
 
+/**
+ * Imperative controls for the active session, registered by the
+ * {@link useLiveVoice} controller instance that owns it. Lets a globally
+ * mounted component (e.g. the title-bar session pill) drive a session owned by
+ * the composer's hook instance.
+ */
+export interface LiveVoiceSessionControls {
+  /** End the voice session (release mic, socket, and audio). */
+  stop: () => void;
+  /**
+   * Force-end the current user turn — a manual push-to-talk release, identical
+   * to the automatic silence release (the green ↑ "send now" button). No-op
+   * unless the session is `listening`.
+   */
+  release: () => void;
+  /**
+   * Stop in-flight assistant playback without the user having to speak. V1
+   * behavior: same path as barge-in interrupt, which ends the session (a later
+   * engine revision makes it turn-scoped). No-op unless the session is
+   * `speaking`.
+   */
+  interrupt: () => void;
+}
+
 export interface LiveVoiceState {
   /** Current phase of the session lifecycle. */
   state: LiveVoiceSessionState;
+  /** Assistant the active session was started for, `null` when idle. */
+  assistantId: string | null;
+  /** Conversation the active session is attached to, if any. */
+  conversationId: string | null;
+  /** Controls registered by the owning controller, `null` when no session. */
+  controls: LiveVoiceSessionControls | null;
   /** In-flight partial transcript of the user's current utterance. */
   partialTranscript: string;
   /** Last finalized user transcript. */
@@ -70,6 +100,13 @@ export interface LiveVoiceState {
 export interface LiveVoiceActions {
   /** Replace the session phase. */
   setState: (state: LiveVoiceSessionState) => void;
+  /** Record which assistant/conversation the active session belongs to. */
+  setSessionContext: (
+    assistantId: string,
+    conversationId: string | null,
+  ) => void;
+  /** Register (or clear) the owning controller's session controls. */
+  setControls: (controls: LiveVoiceSessionControls | null) => void;
   setPartialTranscript: (text: string) => void;
   setFinalTranscript: (text: string) => void;
   /** Append a delta to the accumulated assistant transcript. */
@@ -96,6 +133,9 @@ export type LiveVoiceStore = LiveVoiceState & LiveVoiceActions;
 
 const INITIAL_STATE: LiveVoiceState = {
   state: "idle",
+  assistantId: null,
+  conversationId: null,
+  controls: null,
   partialTranscript: "",
   finalTranscript: "",
   assistantTranscript: "",
@@ -107,6 +147,9 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
   ...INITIAL_STATE,
 
   setState: (state) => set({ state }),
+  setSessionContext: (assistantId, conversationId) =>
+    set({ assistantId, conversationId }),
+  setControls: (controls) => set({ controls }),
   setPartialTranscript: (partialTranscript) => set({ partialTranscript }),
   setFinalTranscript: (finalTranscript) => set({ finalTranscript }),
   appendAssistantTranscript: (delta) =>

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -53,6 +53,27 @@ export type LiveVoiceSessionState =
   | "failed";
 
 /**
+ * User-facing activity label per session state, shared by every surface that
+ * shows session activity (the composer's voice bar and the title-bar session
+ * pill), so the two always agree.
+ *
+ * Deliberately minimal treatment (decided 2026-07-06): assistant output
+ * streams into the thread transcript like text chat, so surfaces only carry a
+ * small label. `idle`/`failed` map to an empty label — hosts unmount their
+ * voice UI in those states.
+ */
+export const LIVE_VOICE_STATE_LABELS: Record<LiveVoiceSessionState, string> = {
+  idle: "",
+  connecting: "Connecting…",
+  listening: "Listening…",
+  transcribing: "Transcribing…",
+  thinking: "Thinking…",
+  speaking: "Speaking…",
+  ending: "Ending…",
+  failed: "",
+};
+
+/**
  * Imperative controls for the active session, registered by the
  * {@link useLiveVoice} controller instance that owns it. Lets a globally
  * mounted component (e.g. the title-bar session pill) drive a session owned by
@@ -184,6 +205,27 @@ export function isLiveVoiceSessionActive(state: LiveVoiceSessionState): boolean 
 }
 
 /**
+ * Whether the mic is live in `state` — capturing audio with amplitude flowing
+ * into the store. True for the whole listening→speaking span: the capture
+ * graph runs for the entire session so amplitude keeps flowing for barge-in
+ * even while the assistant is transcribing/thinking/speaking (see
+ * `use-live-voice.ts` "Mic forwarding"). False for `connecting` (capture not
+ * started) and `ending`/terminal states (teardown).
+ *
+ * Drives the `active` flag of every session waveform (composer voice bar and
+ * title-bar pill): the bars scroll in new samples exactly while the mic is
+ * hot, and freeze otherwise.
+ */
+export function isLiveVoiceMicLive(state: LiveVoiceSessionState): boolean {
+  return (
+    state === "listening" ||
+    state === "transcribing" ||
+    state === "thinking" ||
+    state === "speaking"
+  );
+}
+
+/**
  * Whether the composer bound to `composerConversationId` owns the active
  * session — i.e. it is the surface whose action row swaps to the voice bar
  * (and whose title-bar pill therefore hides).
@@ -257,6 +299,16 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
 }));
 
 export const useLiveVoiceStore = createSelectors(useLiveVoiceStoreBase);
+
+/**
+ * Stable amplitude poll function for waveform canvases: sampled ~30 Hz inside
+ * their draw loops, so amplitude must never flow through props/re-renders.
+ * Module-level (not a per-component `useCallback`) so every surface shares the
+ * one identity.
+ */
+export function getLiveVoiceInputAmplitude(): number {
+  return useLiveVoiceStore.getState().inputAmplitude;
+}
 
 /**
  * Reactive form of {@link isLiveVoiceSessionOwnedBy} for components: whether

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -334,6 +334,19 @@ export function releaseLiveVoiceTurn(): void {
 }
 
 /**
+ * Dismiss a surfaced live-voice failure by resetting the store back to idle.
+ * `failed` is terminal for the session, so this only clears the surfaced
+ * error (the mount-scoped `starter` survives, as with any reset). Module-level
+ * for the same stable-identity reasons as {@link endLiveVoiceSession}: both
+ * failure surfaces — the composer's error `Notice` and the title-bar
+ * `VoiceSessionErrorChip` — share this one reference, keeping their dismiss
+ * behavior identical by construction.
+ */
+export function dismissLiveVoiceFailure(): void {
+  useLiveVoiceStore.getState().reset();
+}
+
+/**
  * Reactive form of {@link isLiveVoiceSessionOwnedBy} for components: whether
  * the active session is owned by the composer bound to
  * `composerConversationId`. Boolean-valued so per-field session churn never

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
@@ -1,0 +1,225 @@
+/**
+ * Tests for `useLiveVoiceSessionController` — the persistent (layout-mounted)
+ * owner of the live-voice session controller.
+ *
+ * Uses the shared fakes from `live-voice-fakes.test-helper.ts` so no
+ * WebSocket, microphone, or AudioContext is touched. The controller renders
+ * nothing; everything is asserted through the store seams it maintains
+ * (`starter`, per-session `controls`, session state).
+ *
+ * The load-bearing property is lifetime: consumers (composer, pill) come and
+ * go with navigation while the controller stays mounted, so a session driven
+ * entirely through the store must keep running until the controller itself
+ * unmounts (leaving the chat layout) or `controls.stop()` fires.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+// The default client factory in use-live-voice statically imports the real
+// LiveVoiceChannelClient, which pulls in connection.ts -> the generated SDK.
+// Tests inject fake primitives, so we never construct the real client; mock the
+// connection module so importing the controller doesn't drag in the SDK client.
+mock.module("@/domains/chat/voice/live-voice/connection", () => ({
+  resolveLiveVoiceWsUrl: mock(
+    async () => "wss://velay.vellum.ai/a/v1/live-voice",
+  ),
+}));
+
+import type { LiveVoiceChannelClient } from "@/domains/chat/voice/live-voice/live-voice-client";
+import type { LiveVoiceAudioCapture } from "@/domains/chat/voice/live-voice/pcm-capture";
+import type { LiveVoiceAudioPlayer } from "@/domains/chat/voice/live-voice/tts-playback";
+
+import {
+  FakeCapture,
+  FakeClient,
+  FakePlayer,
+} from "@/domains/chat/voice/live-voice/live-voice-fakes.test-helper";
+
+// Imported after the connection mock so the real connection.ts never enters
+// the static import graph.
+const { useLiveVoiceSessionController } = await import(
+  "@/domains/chat/voice/live-voice/use-live-voice-session-controller"
+);
+const { useLiveVoiceStore } = await import(
+  "@/domains/chat/voice/live-voice/live-voice-store"
+);
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function renderPersistentController() {
+  // One client/capture pair per started session, like the real factories.
+  const clients: FakeClient[] = [];
+  const captures: FakeCapture[] = [];
+  const player = new FakePlayer();
+
+  const view = renderHook(() =>
+    useLiveVoiceSessionController({
+      createClient: () => {
+        const client = new FakeClient();
+        clients.push(client);
+        return client as unknown as LiveVoiceChannelClient;
+      },
+      createPlayer: () => player as unknown as LiveVoiceAudioPlayer,
+      createCapture: (options) => {
+        const capture = new FakeCapture(options);
+        captures.push(capture);
+        return capture as unknown as LiveVoiceAudioCapture;
+      },
+    }),
+  );
+
+  return {
+    view,
+    player,
+    clients,
+    captures,
+    lastClient: () => clients[clients.length - 1]!,
+    lastCapture: () => captures[captures.length - 1]!,
+  };
+}
+
+/** Start a session through the store-registered starter and reach `listening`. */
+async function startListeningViaStarter(
+  h: ReturnType<typeof renderPersistentController>,
+  conversationId: string | null = "conv-1",
+) {
+  await act(async () => {
+    useLiveVoiceStore.getState().starter?.("assistant-1", conversationId);
+    await Promise.resolve();
+  });
+  await act(async () => {
+    h.lastClient().emit("ready", {
+      type: "ready",
+      seq: 1,
+      sessionId: "s1",
+      conversationId: conversationId ?? "conv-server-assigned",
+    });
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  useLiveVoiceStore.getState().reset();
+  useLiveVoiceStore.getState().setStarter(null);
+});
+
+afterEach(() => {
+  cleanup();
+  useLiveVoiceStore.getState().reset();
+  useLiveVoiceStore.getState().setStarter(null);
+});
+
+// ---------------------------------------------------------------------------
+// Starter registration
+// ---------------------------------------------------------------------------
+
+describe("starter registration", () => {
+  test("registers a starter on mount and deregisters it on unmount", () => {
+    const h = renderPersistentController();
+    expect(useLiveVoiceStore.getState().starter).not.toBeNull();
+
+    act(() => {
+      h.view.unmount();
+    });
+    expect(useLiveVoiceStore.getState().starter).toBeNull();
+  });
+
+  test("starter starts a session with the given conversation", async () => {
+    const h = renderPersistentController();
+    await startListeningViaStarter(h, "conv-1");
+
+    expect(h.lastClient().connectArgs).toEqual({
+      assistantId: "assistant-1",
+      conversationId: "conv-1",
+    });
+    expect(useLiveVoiceStore.getState().state).toBe("listening");
+    expect(useLiveVoiceStore.getState().conversationId).toBe("conv-1");
+    expect(useLiveVoiceStore.getState().controls).not.toBeNull();
+  });
+
+  test("starter maps a null conversation to a conversation-less start (draft case)", async () => {
+    const h = renderPersistentController();
+    await act(async () => {
+      useLiveVoiceStore.getState().starter?.("assistant-1", null);
+      await Promise.resolve();
+    });
+
+    expect(h.lastClient().connectArgs).toEqual({
+      assistantId: "assistant-1",
+      conversationId: undefined,
+    });
+    expect(useLiveVoiceStore.getState().startedConversationId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session lifetime — the reason the controller lives in the layout
+// ---------------------------------------------------------------------------
+
+describe("session lifetime", () => {
+  test("session keeps running while store consumers (composer, pill) mount and unmount around it", async () => {
+    const h = renderPersistentController();
+    await startListeningViaStarter(h);
+
+    // A store consumer standing in for the composer/pill: subscribes, then
+    // unmounts (navigation to another thread / Home / the app viewer). Only
+    // the controller's unmount may tear the session down.
+    const consumer = renderHook(() => useLiveVoiceStore.use.state());
+    expect(consumer.result.current).toBe("listening");
+    act(() => {
+      consumer.unmount();
+    });
+
+    expect(useLiveVoiceStore.getState().state).toBe("listening");
+    expect(h.lastClient().closed).toBe(false);
+    expect(h.lastCapture().shutdownCount).toBe(0);
+  });
+
+  test("controls registered by the session remain driveable after consumers are gone", async () => {
+    const h = renderPersistentController();
+    await startListeningViaStarter(h);
+
+    await act(async () => {
+      useLiveVoiceStore.getState().controls?.stop();
+      await Promise.resolve();
+    });
+
+    expect(h.lastClient().ended).toBe(true);
+    expect(useLiveVoiceStore.getState().state).toBe("idle");
+    expect(h.lastCapture().shutdownCount).toBe(1);
+  });
+
+  test("starter survives session teardown — a second session can start after the first ends", async () => {
+    const h = renderPersistentController();
+    await startListeningViaStarter(h, "conv-1");
+    await act(async () => {
+      useLiveVoiceStore.getState().controls?.stop();
+      await Promise.resolve();
+    });
+    expect(useLiveVoiceStore.getState().state).toBe("idle");
+    expect(useLiveVoiceStore.getState().starter).not.toBeNull();
+
+    await startListeningViaStarter(h, "conv-2");
+    expect(useLiveVoiceStore.getState().state).toBe("listening");
+    expect(useLiveVoiceStore.getState().conversationId).toBe("conv-2");
+    expect(h.clients).toHaveLength(2);
+  });
+
+  test("unmounting the controller (leaving the chat layout) tears the session down", async () => {
+    const h = renderPersistentController();
+    await startListeningViaStarter(h);
+
+    act(() => {
+      h.view.unmount();
+    });
+
+    // No invisible live microphone: mic + socket released, store idle.
+    expect(h.lastClient().closed).toBe(true);
+    expect(h.lastCapture().shutdownCount).toBe(1);
+    expect(useLiveVoiceStore.getState().state).toBe("idle");
+    expect(useLiveVoiceStore.getState().starter).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
@@ -1,0 +1,59 @@
+/**
+ * `useLiveVoiceSessionController()` — persistent owner of the live-voice
+ * session controller.
+ *
+ * Mounted once by `ChatLayout`, which stays mounted across every chat-side
+ * child route (conversations, home, library, identity, documents, the
+ * fullscreen app viewer, …). Because {@link useLiveVoice} tears the session
+ * down when its owner unmounts, the hook must live at this layout scope — a
+ * composer-owned controller would kill the mic/socket on exactly the
+ * navigations the title-bar session pill exists for.
+ *
+ * Routes outside the chat layout (settings, logs, account) unmount this hook
+ * and therefore end any active session. That is deliberate: no session
+ * control surface (composer bar or title-bar pill) exists there, and a live
+ * microphone must never outlive its last visible control.
+ *
+ * The hook renders nothing and exposes nothing. Surfaces interact with the
+ * session exclusively through `useLiveVoiceStore`:
+ *
+ * - `starter` — registered here for the lifetime of the mount; the composer's
+ *   entry-point mic calls it to start a session.
+ * - `controls` (stop/release/interrupt) — registered per-session by
+ *   {@link useLiveVoice} itself.
+ * - `state`/`error`/transcripts/amplitude — observable session state.
+ */
+
+import { useEffect } from "react";
+
+import {
+  useLiveVoice,
+  type UseLiveVoiceOptions,
+} from "@/domains/chat/voice/live-voice/use-live-voice";
+import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+
+/** Injectable primitive factories, for tests. */
+export type UseLiveVoiceSessionControllerOptions = Pick<
+  UseLiveVoiceOptions,
+  "createClient" | "createCapture" | "createPlayer"
+>;
+
+export function useLiveVoiceSessionController(
+  options: UseLiveVoiceSessionControllerOptions = {},
+): void {
+  // `observeAudioState: false` — the controller consumes nothing reactive
+  // beyond the low-frequency `state`/`error` fields, so high-frequency
+  // amplitude/transcript updates must not re-render the mounting layout.
+  const { start } = useLiveVoice({ ...options, observeAudioState: false });
+
+  useEffect(() => {
+    useLiveVoiceStore
+      .getState()
+      .setStarter((assistantId, conversationId) =>
+        void start(assistantId, conversationId ?? undefined),
+      );
+    return () => {
+      useLiveVoiceStore.getState().setStarter(null);
+    };
+  }, [start]);
+}

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -1089,6 +1089,157 @@ describe("failure", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Session context + shared controls
+// ---------------------------------------------------------------------------
+
+describe("session context and controls", () => {
+  test("start() publishes the session context and controls to the store", async () => {
+    const h = renderController();
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-1");
+    });
+
+    const store = useLiveVoiceStore.getState();
+    expect(store.assistantId).toBe("assistant-1");
+    expect(store.conversationId).toBe("conv-1");
+    expect(store.controls).not.toBeNull();
+  });
+
+  test("start() without a conversation publishes a null conversationId", async () => {
+    const h = renderController();
+    await act(async () => {
+      await h.view.result.current.start("assistant-1");
+    });
+
+    expect(useLiveVoiceStore.getState().assistantId).toBe("assistant-1");
+    expect(useLiveVoiceStore.getState().conversationId).toBeNull();
+  });
+
+  test("ready frame updates a null conversationId with the server-assigned id", async () => {
+    const h = renderController();
+    await act(async () => {
+      await h.view.result.current.start("assistant-1");
+    });
+    expect(useLiveVoiceStore.getState().conversationId).toBeNull();
+
+    await act(async () => {
+      h.client.emit("ready", {
+        type: "ready",
+        seq: 1,
+        sessionId: "s1",
+        conversationId: "conv-server-assigned",
+      });
+      await Promise.resolve();
+    });
+
+    const store = useLiveVoiceStore.getState();
+    expect(store.assistantId).toBe("assistant-1");
+    expect(store.conversationId).toBe("conv-server-assigned");
+  });
+
+  test("release() while listening sends ptt_release and moves to transcribing", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    act(() => {
+      h.view.result.current.release();
+    });
+
+    expect(h.client.pttReleaseCount).toBe(1);
+    expect(h.view.result.current.state).toBe("transcribing");
+  });
+
+  test("release() outside listening is a no-op", async () => {
+    const h = renderController();
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-1");
+    });
+    expect(h.view.result.current.state).toBe("connecting");
+
+    act(() => {
+      h.view.result.current.release();
+    });
+
+    expect(h.client.pttReleaseCount).toBe(0);
+    expect(h.view.result.current.state).toBe("connecting");
+  });
+
+  test("store controls.release drives the manual ptt release", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    act(() => {
+      useLiveVoiceStore.getState().controls?.release();
+    });
+
+    expect(h.client.pttReleaseCount).toBe(1);
+    expect(h.view.result.current.state).toBe("transcribing");
+  });
+
+  test("store controls.interrupt stops playback while speaking and is a no-op otherwise", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    // Not speaking yet: interrupt is a guarded no-op.
+    act(() => {
+      useLiveVoiceStore.getState().controls?.interrupt();
+    });
+    expect(h.client.interruptCount).toBe(0);
+    expect(h.view.result.current.state).toBe("listening");
+
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 3,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+    });
+    expect(h.view.result.current.state).toBe("speaking");
+
+    act(() => {
+      useLiveVoiceStore.getState().controls?.interrupt();
+    });
+
+    // Same path as barge-in: playback stopped, one interrupt, session ends.
+    expect(h.player.isPlaying).toBe(false);
+    expect(h.client.interruptCount).toBe(1);
+    expect(h.view.result.current.state).toBe("idle");
+  });
+
+  test("teardown clears the session context and controls", async () => {
+    const h = renderController();
+    await startListening(h);
+    expect(useLiveVoiceStore.getState().controls).not.toBeNull();
+
+    act(() => {
+      h.view.unmount();
+    });
+
+    const store = useLiveVoiceStore.getState();
+    expect(store.controls).toBeNull();
+    expect(store.assistantId).toBeNull();
+    expect(store.conversationId).toBeNull();
+  });
+
+  test("stop() clears the session context and controls", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    await act(async () => {
+      await h.view.result.current.stop();
+    });
+
+    const store = useLiveVoiceStore.getState();
+    expect(store.controls).toBeNull();
+    expect(store.assistantId).toBeNull();
+    expect(store.conversationId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Teardown
 // ---------------------------------------------------------------------------
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -196,27 +196,31 @@ function pcmChunk(ms: number): ArrayBuffer {
   return new Int16Array(samples).buffer;
 }
 
-function renderController() {
+function renderController(extraOptions: { observeAudioState?: boolean } = {}) {
   const client = new FakeClient();
   const player = new FakePlayer();
   let capture!: FakeCapture;
+  let renderCount = 0;
 
-  const view = renderHook(() =>
-    useLiveVoice({
+  const view = renderHook(() => {
+    renderCount++;
+    return useLiveVoice({
       createClient: () => client as unknown as LiveVoiceChannelClient,
       createPlayer: () => player as unknown as LiveVoiceAudioPlayer,
       createCapture: (options) => {
         capture = new FakeCapture(options);
         return capture as unknown as LiveVoiceAudioCapture;
       },
-    }),
-  );
+      ...extraOptions,
+    });
+  });
 
   return {
     view,
     client,
     player,
     getCapture: () => capture,
+    getRenderCount: () => renderCount,
   };
 }
 
@@ -1236,6 +1240,75 @@ describe("session context and controls", () => {
     expect(store.controls).toBeNull();
     expect(store.assistantId).toBeNull();
     expect(store.conversationId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// observeAudioState — high-frequency subscription opt-out
+// ---------------------------------------------------------------------------
+
+describe("observeAudioState", () => {
+  test("default: amplitude and transcript updates re-render the consumer and surface values", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    // Amplitude below the speech/barge-in thresholds so no phase transition
+    // can account for the re-render — only the amplitude subscription.
+    act(() => {
+      h.getCapture().pushAmplitude(0.02);
+    });
+    expect(h.view.result.current.inputAmplitude).toBe(0.02);
+
+    act(() => {
+      h.client.emit("sttPartial", { type: "stt_partial", seq: 2, text: "hel" });
+    });
+    expect(h.view.result.current.partialTranscript).toBe("hel");
+  });
+
+  test("false: amplitude ticks do not re-render the consumer; fields pinned at defaults", async () => {
+    const h = renderController({ observeAudioState: false });
+    await startListening(h);
+    expect(h.view.result.current.state).toBe("listening");
+
+    const rendersBefore = h.getRenderCount();
+    act(() => {
+      // A burst of mic-level samples (all below the speech/barge-in
+      // thresholds, so no state transition is involved).
+      h.getCapture().pushAmplitude(0.01);
+      h.getCapture().pushAmplitude(0.02);
+      h.getCapture().pushAmplitude(0.015);
+    });
+
+    // The store received the samples (the voice bar polls them via
+    // getState())...
+    expect(useLiveVoiceStore.getState().inputAmplitude).toBe(0.015);
+    // ...but the opted-out consumer did not re-render and returns the
+    // pinned default.
+    expect(h.getRenderCount()).toBe(rendersBefore);
+    expect(h.view.result.current.inputAmplitude).toBe(0);
+  });
+
+  test("false: transcript deltas do not re-render; state transitions still do", async () => {
+    const h = renderController({ observeAudioState: false });
+    await startListening(h);
+
+    const rendersBefore = h.getRenderCount();
+    act(() => {
+      h.client.emit("sttPartial", { type: "stt_partial", seq: 2, text: "hel" });
+      h.client.emit("sttPartial", { type: "stt_partial", seq: 3, text: "hello" });
+    });
+    // Transcript writes reached the store but not the consumer.
+    expect(useLiveVoiceStore.getState().partialTranscript).toBe("hello");
+    expect(h.getRenderCount()).toBe(rendersBefore);
+    expect(h.view.result.current.partialTranscript).toBe("");
+
+    // Low-frequency session state still flows: releasing push-to-talk moves
+    // the returned state to `transcribing` (a re-render).
+    act(() => {
+      h.view.result.current.release();
+    });
+    expect(h.view.result.current.state).toBe("transcribing");
+    expect(h.getRenderCount()).toBeGreaterThan(rendersBefore);
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -998,33 +998,6 @@ describe("session context and controls", () => {
     expect(store.startedConversationId).toBeNull();
   });
 
-  test("release() while listening sends ptt_release and moves to transcribing", async () => {
-    const h = renderController();
-    await startListening(h);
-
-    act(() => {
-      h.view.result.current.release();
-    });
-
-    expect(h.client.pttReleaseCount).toBe(1);
-    expect(h.view.result.current.state).toBe("transcribing");
-  });
-
-  test("release() outside listening is a no-op", async () => {
-    const h = renderController();
-    await act(async () => {
-      await h.view.result.current.start("assistant-1", "conv-1");
-    });
-    expect(h.view.result.current.state).toBe("connecting");
-
-    act(() => {
-      h.view.result.current.release();
-    });
-
-    expect(h.client.pttReleaseCount).toBe(0);
-    expect(h.view.result.current.state).toBe("connecting");
-  });
-
   test("store controls.release drives the manual ptt release", async () => {
     const h = renderController();
     await startListening(h);
@@ -1035,6 +1008,21 @@ describe("session context and controls", () => {
 
     expect(h.client.pttReleaseCount).toBe(1);
     expect(h.view.result.current.state).toBe("transcribing");
+  });
+
+  test("store controls.release outside listening is a no-op", async () => {
+    const h = renderController();
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-1");
+    });
+    expect(h.view.result.current.state).toBe("connecting");
+
+    act(() => {
+      useLiveVoiceStore.getState().controls?.release();
+    });
+
+    expect(h.client.pttReleaseCount).toBe(0);
+    expect(h.view.result.current.state).toBe("connecting");
   });
 
   test("store controls.interrupt stops playback while speaking and is a no-op otherwise", async () => {
@@ -1162,7 +1150,7 @@ describe("observeAudioState", () => {
     // Low-frequency session state still flows: releasing push-to-talk moves
     // the returned state to `transcribing` (a re-render).
     act(() => {
-      h.view.result.current.release();
+      useLiveVoiceStore.getState().controls?.release();
     });
     expect(h.view.result.current.state).toBe("transcribing");
     expect(h.getRenderCount()).toBeGreaterThan(rendersBefore);
@@ -1217,5 +1205,145 @@ describe("teardown", () => {
       await h.view.result.current.stop();
     });
     expect(h.view.result.current.state).toBe("idle");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stop()/start() races
+// ---------------------------------------------------------------------------
+
+describe("stop/start races", () => {
+  /**
+   * Like `renderController`, but tracks every created primitive so a test can
+   * observe a second session, and lets a test hold the first player's
+   * `dispose()` open to pause `stop()` mid-teardown.
+   */
+  function renderRacingController() {
+    const clients: FakeClient[] = [];
+    const players: FakePlayer[] = [];
+
+    const view = renderHook(() =>
+      useLiveVoice({
+        createClient: () => {
+          const client = new FakeClient();
+          clients.push(client);
+          return client as unknown as LiveVoiceChannelClient;
+        },
+        createPlayer: () => {
+          const player = new FakePlayer();
+          players.push(player);
+          return player as unknown as LiveVoiceAudioPlayer;
+        },
+        createCapture: (options) =>
+          new FakeCapture(options) as unknown as LiveVoiceAudioCapture,
+      }),
+    );
+
+    return { view, clients, players };
+  }
+
+  /** Replace `player.dispose` with one that resolves only on command. */
+  function holdDisposeOpen(player: FakePlayer): () => void {
+    let releaseDispose!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseDispose = resolve;
+    });
+    player.dispose = async () => {
+      player.stop();
+      await gate;
+    };
+    return releaseDispose;
+  }
+
+  test("start() during `ending` is a no-op (no second session behind stop()'s teardown)", async () => {
+    const h = renderRacingController();
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-1");
+      h.clients[0]!.emit("ready", {
+        type: "ready",
+        seq: 1,
+        sessionId: "s1",
+        conversationId: "conv-1",
+      });
+      await Promise.resolve();
+    });
+    expect(h.view.result.current.state).toBe("listening");
+
+    const releaseDispose = holdDisposeOpen(h.players[0]!);
+    let stopPromise!: Promise<void>;
+    act(() => {
+      stopPromise = h.view.result.current.stop();
+    });
+    expect(useLiveVoiceStore.getState().state).toBe("ending");
+
+    // A starter call in the ending window must not open a new session: the
+    // old stop()'s trailing reset would wipe it (hot mic behind idle UI).
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-2");
+    });
+    expect(h.clients).toHaveLength(1);
+    expect(useLiveVoiceStore.getState().state).toBe("ending");
+
+    await act(async () => {
+      releaseDispose();
+      await stopPromise;
+    });
+    expect(useLiveVoiceStore.getState().state).toBe("idle");
+  });
+
+  test("stop()'s late reset does not clobber a session started after a double-stop", async () => {
+    const h = renderRacingController();
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-1");
+      h.clients[0]!.emit("ready", {
+        type: "ready",
+        seq: 1,
+        sessionId: "s1",
+        conversationId: "conv-1",
+      });
+      await Promise.resolve();
+    });
+
+    // First stop is paused mid-await; a second stop (no session ref left)
+    // resets the store to idle immediately — which unblocks start().
+    const releaseDispose = holdDisposeOpen(h.players[0]!);
+    let firstStop!: Promise<void>;
+    act(() => {
+      firstStop = h.view.result.current.stop();
+    });
+    await act(async () => {
+      await h.view.result.current.stop();
+    });
+    expect(useLiveVoiceStore.getState().state).toBe("idle");
+
+    // A new session starts while the first stop() is still awaiting teardown.
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-2");
+    });
+    expect(h.clients).toHaveLength(2);
+    expect(useLiveVoiceStore.getState().state).toBe("connecting");
+
+    // The first stop() finally finishes — its trailing reset must yield to
+    // the newer session instead of wiping its store state.
+    await act(async () => {
+      releaseDispose();
+      await firstStop;
+    });
+    expect(useLiveVoiceStore.getState().state).toBe("connecting");
+    expect(useLiveVoiceStore.getState().conversationId).toBe("conv-2");
+    expect(useLiveVoiceStore.getState().controls).not.toBeNull();
+    expect(h.clients[1]!.closed).toBe(false);
+
+    // The surviving session still works end-to-end: `ready` moves it along.
+    await act(async () => {
+      h.clients[1]!.emit("ready", {
+        type: "ready",
+        seq: 1,
+        sessionId: "s2",
+        conversationId: "conv-2",
+      });
+      await Promise.resolve();
+    });
+    expect(useLiveVoiceStore.getState().state).toBe("listening");
   });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -2,11 +2,9 @@
  * Tests for the `useLiveVoice` session controller.
  *
  * The three merged primitives — client, capture, player — are replaced with
- * hand-rolled fakes injected through `useLiveVoice`'s factory options, so no
- * WebSocket, microphone, or AudioContext is touched. The fakes expose drivers
- * (`emit`, `pushChunk`, `pushAmplitude`) so a test can drive a full turn and
- * assert the state-machine transitions, barge-in, automatic ptt_release, and
- * teardown.
+ * the shared fakes from `live-voice-fakes.test-helper.ts`, injected through
+ * `useLiveVoice`'s factory options, so no WebSocket, microphone, or
+ * AudioContext is touched.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -25,15 +23,16 @@ mock.module("@/domains/chat/voice/live-voice/connection", () => ({
 import type {
   LiveVoiceChannelClient,
   LiveVoiceClientError,
-  LiveVoiceClientEventMap,
-  LiveVoiceClientEventName,
 } from "@/domains/chat/voice/live-voice/live-voice-client";
-import type {
-  LiveVoiceAudioCapture,
-  LiveVoiceAudioCaptureOptions,
-  LiveVoiceCaptureResult,
-} from "@/domains/chat/voice/live-voice/pcm-capture";
+import type { LiveVoiceAudioCapture } from "@/domains/chat/voice/live-voice/pcm-capture";
 import type { LiveVoiceAudioPlayer } from "@/domains/chat/voice/live-voice/tts-playback";
+
+import {
+  FakeCapture,
+  FakeClient,
+  FakePlayer,
+  pcmChunk,
+} from "@/domains/chat/voice/live-voice/live-voice-fakes.test-helper";
 
 // Import the controller + store *after* the connection mock is registered, so
 // the real connection.ts (which imports the generated SDK) never enters the
@@ -46,155 +45,8 @@ const { useLiveVoiceStore } = await import(
 );
 
 // ---------------------------------------------------------------------------
-// Fakes
-// ---------------------------------------------------------------------------
-
-class FakeClient {
-  connectArgs: {
-    assistantId: string;
-    conversationId?: string;
-    turnDetection?: "manual" | "server_vad";
-  } | null = null;
-  sentAudio: ArrayBuffer[] = [];
-  pttReleaseCount = 0;
-  interruptCount = 0;
-  ended = false;
-  closed = false;
-
-  private handlers = new Map<
-    LiveVoiceClientEventName,
-    Set<(payload: never) => void>
-  >();
-
-  on<E extends LiveVoiceClientEventName>(
-    event: E,
-    handler: (payload: LiveVoiceClientEventMap[E]) => void,
-  ): () => void {
-    let set = this.handlers.get(event);
-    if (!set) {
-      set = new Set();
-      this.handlers.set(event, set);
-    }
-    set.add(handler as (payload: never) => void);
-    return () => set?.delete(handler as (payload: never) => void);
-  }
-
-  async connect(args: {
-    assistantId: string;
-    conversationId?: string;
-    turnDetection?: "manual" | "server_vad";
-  }): Promise<void> {
-    this.connectArgs = args;
-  }
-
-  sendAudio(pcm: ArrayBuffer): void {
-    this.sentAudio.push(pcm);
-  }
-  pttRelease(): void {
-    this.pttReleaseCount++;
-  }
-  interrupt(): void {
-    this.interruptCount++;
-  }
-  end(): void {
-    this.ended = true;
-  }
-  close(): void {
-    this.closed = true;
-  }
-
-  /** Drive a server event to the controller's subscribed handlers. */
-  emit<E extends LiveVoiceClientEventName>(
-    event: E,
-    payload: LiveVoiceClientEventMap[E],
-  ): void {
-    for (const handler of this.handlers.get(event) ?? []) {
-      (handler as (payload: LiveVoiceClientEventMap[E]) => void)(payload);
-    }
-  }
-}
-
-class FakeCapture {
-  readonly onChunk: (buf: ArrayBuffer) => void;
-  readonly onAmplitude?: (amplitude: number) => void;
-
-  startCount = 0;
-  stopCount = 0;
-  shutdownCount = 0;
-  startResult: LiveVoiceCaptureResult = { ok: true };
-
-  constructor(options: LiveVoiceAudioCaptureOptions) {
-    this.onChunk = options.onChunk;
-    this.onAmplitude = options.onAmplitude;
-  }
-
-  async start(): Promise<LiveVoiceCaptureResult> {
-    this.startCount++;
-    return this.startResult;
-  }
-  async stop(): Promise<void> {
-    this.stopCount++;
-  }
-  async shutdown(): Promise<void> {
-    this.shutdownCount++;
-  }
-
-  /** Feed a captured PCM chunk to the controller. */
-  pushChunk(buf: ArrayBuffer): void {
-    this.onChunk(buf);
-  }
-  /** Feed an amplitude reading to the controller. */
-  pushAmplitude(amplitude: number): void {
-    this.onAmplitude?.(amplitude);
-  }
-}
-
-class FakePlayer {
-  enqueued: unknown[] = [];
-  stopCount = 0;
-  disposeCount = 0;
-  isPlaying = false;
-  private drainResolvers: Array<() => void> = [];
-
-  enqueue(chunk: unknown): void {
-    this.enqueued.push(chunk);
-    this.isPlaying = true;
-  }
-  stop(): void {
-    this.stopCount++;
-    this.isPlaying = false;
-    this.resolveDrain();
-  }
-  async dispose(): Promise<void> {
-    this.disposeCount++;
-    this.stop();
-  }
-  async waitUntilDrained(): Promise<void> {
-    if (!this.isPlaying) return;
-    await new Promise<void>((resolve) => this.drainResolvers.push(resolve));
-  }
-
-  /** Simulate playback finishing naturally. */
-  finishPlayback(): void {
-    this.isPlaying = false;
-    this.resolveDrain();
-  }
-  private resolveDrain(): void {
-    const resolvers = this.drainResolvers;
-    this.drainResolvers = [];
-    for (const resolve of resolvers) resolve();
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Harness
 // ---------------------------------------------------------------------------
-
-/** A PCM chunk of `ms` milliseconds at 16 kHz mono Int16. */
-function pcmChunk(ms: number): ArrayBuffer {
-  const samples = Math.round((16000 * ms) / 1000);
-  return new Int16Array(samples).buffer;
-}
 
 function renderController(extraOptions: { observeAudioState?: boolean } = {}) {
   const client = new FakeClient();
@@ -1106,6 +958,7 @@ describe("session context and controls", () => {
     const store = useLiveVoiceStore.getState();
     expect(store.assistantId).toBe("assistant-1");
     expect(store.conversationId).toBe("conv-1");
+    expect(store.startedConversationId).toBe("conv-1");
     expect(store.controls).not.toBeNull();
   });
 
@@ -1117,9 +970,10 @@ describe("session context and controls", () => {
 
     expect(useLiveVoiceStore.getState().assistantId).toBe("assistant-1");
     expect(useLiveVoiceStore.getState().conversationId).toBeNull();
+    expect(useLiveVoiceStore.getState().startedConversationId).toBeNull();
   });
 
-  test("ready frame updates a null conversationId with the server-assigned id", async () => {
+  test("ready frame updates a null conversationId with the server-assigned id, keeping the started id", async () => {
     const h = renderController();
     await act(async () => {
       await h.view.result.current.start("assistant-1");
@@ -1139,6 +993,9 @@ describe("session context and controls", () => {
     const store = useLiveVoiceStore.getState();
     expect(store.assistantId).toBe("assistant-1");
     expect(store.conversationId).toBe("conv-server-assigned");
+    // The started id must survive the republish: draft-session ownership
+    // (`isLiveVoiceSessionOwnedBy`) matches the draft composer against it.
+    expect(store.startedConversationId).toBeNull();
   });
 
   test("release() while listening sends ptt_release and moves to transcribing", async () => {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -86,6 +86,7 @@ import {
   type TtsAudioChunk,
 } from "@/domains/chat/voice/live-voice/tts-playback";
 import {
+  isLiveVoiceSessionActive,
   useLiveVoiceStore,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
@@ -131,12 +132,6 @@ export interface UseLiveVoiceResult {
   ) => Promise<void>;
   /** End the session and release the mic, socket, and audio context. */
   stop: () => Promise<void>;
-  /**
-   * Manually release push-to-talk (the "send now" button) — force-ends the
-   * current user turn exactly like the automatic silence release. No-op unless
-   * the session is `listening`.
-   */
-  release: () => void;
 }
 
 /** Per-session options for {@link UseLiveVoiceResult.start}. */
@@ -256,6 +251,13 @@ export function useLiveVoice(
 
   const sessionRef = useRef<SessionContext | null>(null);
 
+  // Monotonic count of `start()` calls for this hook instance. `stop()`
+  // captures it before its awaits and skips its trailing store reset when a
+  // newer session started in the meantime — the per-session `generation`
+  // can't cover this because `stop()` nulls `sessionRef` synchronously, so
+  // the racing session is a different context object entirely.
+  const startGenerationRef = useRef(0);
+
   // Keep the factories in a ref so start()/stop() stay stable across renders
   // even if callers pass inline option objects. The ref is updated in an effect
   // (not during render) to satisfy the react-compiler "no refs during render"
@@ -297,6 +299,7 @@ export function useLiveVoice(
       useLiveVoiceStore.getState().reset();
       return;
     }
+    const startGeneration = startGenerationRef.current;
     sessionRef.current = null;
     session.generation += 1;
     useLiveVoiceStore.getState().setState("ending");
@@ -306,6 +309,10 @@ export function useLiveVoice(
     // Release the AudioContext, not just the scheduled sources (see teardown).
     await session.player.dispose();
     await session.capture.shutdown();
+    // A start() that raced the awaits owns the store now (e.g. a second ✕
+    // click resets `ending` → idle mid-await, unblocking start()); wiping it
+    // here would leave that session's mic hot behind idle UI.
+    if (startGenerationRef.current !== startGeneration) return;
     useLiveVoiceStore.getState().reset();
   }, []);
 
@@ -337,11 +344,14 @@ export function useLiveVoice(
       conversationId?: string,
       startOptions?: LiveVoiceStartOptions,
     ) => {
-      const current = sessionRef.current;
-      // A live session (anything but idle/failed) blocks a new start.
-      const phase = useLiveVoiceStore.getState().state;
-      if (current && phase !== "idle" && phase !== "failed") return;
-      if (current) teardown();
+      // A live session (anything but idle/failed) blocks a new start. Keyed
+      // on the store phase alone — NOT on `sessionRef` — because during
+      // `ending` stop() has already nulled the ref while its async teardown
+      // is still in flight; a start() admitted in that window would be wiped
+      // by stop()'s trailing reset (hot mic behind idle UI).
+      if (isLiveVoiceSessionActive(useLiveVoiceStore.getState().state)) return;
+      if (sessionRef.current) teardown();
+      startGenerationRef.current += 1;
 
       const store = useLiveVoiceStore.getState();
       store.reset();
@@ -556,7 +566,6 @@ export function useLiveVoice(
     error,
     start,
     stop,
-    release,
   };
 }
 
@@ -665,11 +674,6 @@ function releasePushToTalk(session: SessionContext): void {
   s.setInputAmplitude(0);
 }
 
-/**
- * Resume listening for the next utterance: re-open the forwarding gate, clear
- * the per-utterance counters/flags, and move to `listening`. The mic is already
- * running (continuous capture), so there is nothing to restart here.
- */
 /**
  * Barge-in: stop playback and interrupt the server once per response, then end
  * the session (→ idle). The interrupted session is terminal on the runtime — it

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -131,6 +131,12 @@ export interface UseLiveVoiceResult {
   ) => Promise<void>;
   /** End the session and release the mic, socket, and audio context. */
   stop: () => Promise<void>;
+  /**
+   * Manually release push-to-talk (the "send now" button) — force-ends the
+   * current user turn exactly like the automatic silence release. No-op unless
+   * the session is `listening`.
+   */
+  release: () => void;
 }
 
 /** Per-session options for {@link UseLiveVoiceResult.start}. */
@@ -274,6 +280,28 @@ export function useLiveVoice(
     useLiveVoiceStore.getState().reset();
   }, []);
 
+  /**
+   * Manual push-to-talk release — same internal path as the automatic silence
+   * release. Guarded to `listening` so a stray click (or the store-registered
+   * control firing late) can't disturb another phase.
+   */
+  const release = useCallback(() => {
+    const session = sessionRef.current;
+    if (!session) return;
+    if (useLiveVoiceStore.getState().state !== "listening") return;
+    releasePushToTalk(session);
+  }, []);
+
+  /**
+   * Stop in-flight assistant playback — the barge-in interrupt path without
+   * the amplitude gate. `interruptIfSpeaking` itself guards to `speaking`.
+   */
+  const interrupt = useCallback(() => {
+    const session = sessionRef.current;
+    if (!session) return;
+    interruptIfSpeaking(session, teardown);
+  }, [teardown]);
+
   const start = useCallback(
     async (
       assistantId: string,
@@ -289,6 +317,11 @@ export function useLiveVoice(
       const store = useLiveVoiceStore.getState();
       store.reset();
       store.setState("connecting");
+      store.setSessionContext(assistantId, conversationId ?? null);
+      // Registered here (not on `ready`) so a globally mounted surface can
+      // drive the session from the moment it exists; cleared by the store
+      // reset in teardown()/stop().
+      store.setControls({ stop: () => void stop(), release, interrupt });
 
       const opts = optionsRef.current;
       const client = (opts.createClient ?? (() => new LiveVoiceChannelClient()))();
@@ -332,6 +365,13 @@ export function useLiveVoice(
           if (session.handsFree && frame.turnDetection !== "server_vad") {
             session.handsFree = false;
           }
+          // When started from a new/empty conversation, `conversationId` was
+          // undefined at start() and the store published `null`. The server
+          // assigns (or confirms) the attached conversation on `ready`, so
+          // republish the context with the authoritative id.
+          useLiveVoiceStore
+            .getState()
+            .setSessionContext(assistantId, frame.conversationId);
           void startCapture(session, teardown);
         }),
         client.on("speechStarted", () => {
@@ -469,7 +509,7 @@ export function useLiveVoice(
         ...(session.handsFree ? { turnDetection: "server_vad" as const } : {}),
       });
     },
-    [teardown],
+    [teardown, stop, release, interrupt],
   );
 
   // Release everything if the consumer unmounts mid-session. teardown() also
@@ -486,6 +526,7 @@ export function useLiveVoice(
     error,
     start,
     stop,
+    release,
   };
 }
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -397,10 +397,11 @@ export function useLiveVoice(
           // When started from a new/empty conversation, `conversationId` was
           // undefined at start() and the store published `null`. The server
           // assigns (or confirms) the attached conversation on `ready`, so
-          // republish the context with the authoritative id.
-          useLiveVoiceStore
-            .getState()
-            .setSessionContext(assistantId, frame.conversationId);
+          // republish the authoritative id. `setConversationId` (not
+          // `setSessionContext`) so `startedConversationId` keeps its
+          // start-time value — session ownership for a draft-started session
+          // hinges on it (see `isLiveVoiceSessionOwnedBy`).
+          useLiveVoiceStore.getState().setConversationId(frame.conversationId);
           void startCapture(session, teardown);
         }),
         client.on("speechStarted", () => {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -256,6 +256,15 @@ export function useLiveVoice(
   // newer session started in the meantime — the per-session `generation`
   // can't cover this because `stop()` nulls `sessionRef` synchronously, so
   // the racing session is a different context object entirely.
+  //
+  // Considered and rejected: guarding the trailing reset with
+  // `if (sessionRef.current !== null)` instead. That is behaviorally
+  // equivalent *today* only because `start()` assigns `sessionRef`
+  // synchronously; a refactor that introduces an await before that
+  // assignment would silently reopen the race — the null-check would see no
+  // session yet and wrongly reset the newer session's store state. The
+  // counter increments synchronously at `start()`'s entry, so it stays
+  // correct regardless of where awaits land later.
   const startGenerationRef = useRef(0);
 
   // Keep the factories in a ref so start()/stop() stay stable across renders

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -113,13 +113,13 @@ const MINIMUM_SPEECH_DURATION_BEFORE_RELEASE_MS = 120;
 export interface UseLiveVoiceResult {
   /** Current session phase. */
   state: LiveVoiceSessionState;
-  /** In-flight partial user transcript. */
+  /** In-flight partial user transcript. Pinned at `""` when the consumer opted out via {@link UseLiveVoiceOptions.observeAudioState}. */
   partialTranscript: string;
-  /** Last finalized user transcript. */
+  /** Last finalized user transcript. Pinned at `""` when `observeAudioState` is false. */
   finalTranscript: string;
-  /** Accumulated assistant response text for the current turn. */
+  /** Accumulated assistant response text for the current turn. Pinned at `""` when `observeAudioState` is false. */
   assistantTranscript: string;
-  /** Smoothed mic amplitude in [0, 1]. */
+  /** Smoothed mic amplitude in [0, 1]. Pinned at `0` when `observeAudioState` is false. */
   inputAmplitude: number;
   /** Failure message when `state === "failed"`, else `null`. */
   error: string | null;
@@ -156,6 +156,22 @@ export interface UseLiveVoiceOptions {
     options: ConstructorParameters<typeof LiveVoiceAudioCapture>[0],
   ) => LiveVoiceAudioCapture;
   createPlayer?: () => LiveVoiceAudioPlayer;
+  /**
+   * When `false`, this hook instance does not subscribe to the high-frequency
+   * audio/transcript store fields — `inputAmplitude` (updated on every mic
+   * amplitude sample), `partialTranscript`, `finalTranscript`, and
+   * `assistantTranscript` — so those updates never re-render the consumer. The
+   * corresponding returned fields are pinned at their idle defaults (`0` /
+   * `""`); read them via `useLiveVoiceStore` (selectors or `getState()`)
+   * instead. The low-frequency `state`/`error` fields and the actions are
+   * unaffected.
+   *
+   * For consumers that only need the session phase + actions — e.g. the
+   * composer, whose voice bar polls amplitude with `getState()` inside its
+   * canvas draw loop. Must be stable for the lifetime of the hook instance.
+   * Defaults to `true` (subscribe to everything, the original behavior).
+   */
+  observeAudioState?: boolean;
 }
 
 /**
@@ -218,11 +234,24 @@ function chunkDurationMs(buf: ArrayBuffer): number {
 export function useLiveVoice(
   options: UseLiveVoiceOptions = {},
 ): UseLiveVoiceResult {
+  const observeAudioState = options.observeAudioState ?? true;
   const state = useLiveVoiceStore.use.state();
-  const partialTranscript = useLiveVoiceStore.use.partialTranscript();
-  const finalTranscript = useLiveVoiceStore.use.finalTranscript();
-  const assistantTranscript = useLiveVoiceStore.use.assistantTranscript();
-  const inputAmplitude = useLiveVoiceStore.use.inputAmplitude();
+  // High-frequency / transcript fields are read through conditional selectors:
+  // when the consumer opted out, the selector returns the idle default, so the
+  // subscription exists but never produces a changed value — i.e. amplitude
+  // ticks and transcript deltas cannot re-render the consumer.
+  const partialTranscript = useLiveVoiceStore((s) =>
+    observeAudioState ? s.partialTranscript : "",
+  );
+  const finalTranscript = useLiveVoiceStore((s) =>
+    observeAudioState ? s.finalTranscript : "",
+  );
+  const assistantTranscript = useLiveVoiceStore((s) =>
+    observeAudioState ? s.assistantTranscript : "",
+  );
+  const inputAmplitude = useLiveVoiceStore((s) =>
+    observeAudioState ? s.inputAmplitude : 0,
+  );
   const error = useLiveVoiceStore.use.error();
 
   const sessionRef = useRef<SessionContext | null>(null);

--- a/clients/web/src/domains/chat/voice/voice-timeline-waveform.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-timeline-waveform.test.tsx
@@ -101,21 +101,27 @@ describe("VoiceTimelineWaveform — rendering", () => {
   });
 
   test("default sizing uses the full-height canvas class", () => {
-    const { container } = render(<VoiceTimelineWaveform active />);
+    const { container } = render(
+      <VoiceTimelineWaveform active getAmplitude={() => 0} />,
+    );
     const canvas = container.querySelector("canvas")!;
     expect(canvas.className).toContain("h-6");
     expect(canvas.className).toContain("w-full");
   });
 
   test("compact sizing uses the shorter canvas class", () => {
-    const { container } = render(<VoiceTimelineWaveform active compact />);
+    const { container } = render(
+      <VoiceTimelineWaveform active compact getAmplitude={() => 0} />,
+    );
     const canvas = container.querySelector("canvas")!;
     expect(canvas.className).toContain("h-4");
     expect(canvas.className).not.toContain("h-6");
   });
 
   test("merges a caller-supplied className", () => {
-    const { container } = render(<VoiceTimelineWaveform active className="flex-1" />);
+    const { container } = render(
+      <VoiceTimelineWaveform active className="flex-1" getAmplitude={() => 0} />,
+    );
     expect(container.querySelector("canvas")!.className).toContain("flex-1");
   });
 });
@@ -162,7 +168,9 @@ describe("VoiceTimelineWaveform — animation loop", () => {
   test("does not start a loop when the 2d context is unavailable", () => {
     HTMLCanvasElement.prototype.getContext = (() =>
       null) as unknown as typeof HTMLCanvasElement.prototype.getContext;
-    const { unmount } = render(<VoiceTimelineWaveform active />);
+    const { unmount } = render(
+      <VoiceTimelineWaveform active getAmplitude={() => 0} />,
+    );
     expect(rafCallCount).toBe(0);
     expect(() => unmount()).not.toThrow();
   });

--- a/clients/web/src/domains/chat/voice/voice-timeline-waveform.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-timeline-waveform.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * Tests for `VoiceTimelineWaveform`.
+ *
+ * happy-dom's `canvas.getContext("2d")` returns `null`, so a minimal fake 2D
+ * context is installed on `HTMLCanvasElement.prototype` to let the draw loop
+ * run. `requestAnimationFrame` is monkey-patched to capture callbacks so
+ * frames are driven manually with controlled timestamps (same approach as the
+ * `setTimeout` harness in `website-carousel.test.tsx`).
+ *
+ * The reduced-motion branch is verified by stubbing `motion/react` so
+ * `useReducedMotion()` returns `true` and asserting the animation loop never
+ * starts — mirroring the reduced-motion pattern in
+ * `website-carousel.test.tsx`.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, render } from "@testing-library/react";
+
+import { VoiceTimelineWaveform } from "@/domains/chat/voice/voice-timeline-waveform";
+
+// ---------------------------------------------------------------------------
+// requestAnimationFrame harness
+// ---------------------------------------------------------------------------
+
+let rafCallbacks: Map<number, FrameRequestCallback>;
+let nextRafId = 1;
+let rafCallCount = 0;
+let canceledRafIds: number[];
+let originalRaf: typeof globalThis.requestAnimationFrame;
+let originalCancelRaf: typeof globalThis.cancelAnimationFrame;
+
+/** Fire every pending rAF callback once with the given timestamp. */
+function fireFrame(ts: number) {
+  const callbacks = [...rafCallbacks.values()];
+  rafCallbacks.clear();
+  for (const cb of callbacks) {
+    cb(ts);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fake 2D context — happy-dom has no canvas implementation.
+// ---------------------------------------------------------------------------
+
+function makeFakeContext() {
+  return {
+    fillStyle: "",
+    setTransform: mock(() => {}),
+    clearRect: mock(() => {}),
+    beginPath: mock(() => {}),
+    roundRect: mock(() => {}),
+    fill: mock(() => {}),
+  };
+}
+
+let fakeCtx: ReturnType<typeof makeFakeContext>;
+let originalGetContext: typeof HTMLCanvasElement.prototype.getContext;
+
+beforeEach(() => {
+  rafCallbacks = new Map();
+  nextRafId = 1;
+  rafCallCount = 0;
+  canceledRafIds = [];
+  originalRaf = globalThis.requestAnimationFrame;
+  originalCancelRaf = globalThis.cancelAnimationFrame;
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+    rafCallCount += 1;
+    const id = nextRafId++;
+    rafCallbacks.set(id, cb);
+    return id;
+  }) as typeof globalThis.requestAnimationFrame;
+  globalThis.cancelAnimationFrame = ((id: number) => {
+    canceledRafIds.push(id);
+    rafCallbacks.delete(id);
+  }) as typeof globalThis.cancelAnimationFrame;
+
+  fakeCtx = makeFakeContext();
+  originalGetContext = HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = ((type: string) =>
+    type === "2d" ? fakeCtx : null) as typeof HTMLCanvasElement.prototype.getContext;
+});
+
+afterEach(() => {
+  globalThis.requestAnimationFrame = originalRaf;
+  globalThis.cancelAnimationFrame = originalCancelRaf;
+  HTMLCanvasElement.prototype.getContext = originalGetContext;
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("VoiceTimelineWaveform — rendering", () => {
+  test("renders an aria-hidden canvas", () => {
+    const { container } = render(<VoiceTimelineWaveform active getAmplitude={() => 0.5} />);
+    const canvas = container.querySelector("canvas");
+    expect(canvas).toBeTruthy();
+    expect(canvas!.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  test("default sizing uses the full-height canvas class", () => {
+    const { container } = render(<VoiceTimelineWaveform active />);
+    const canvas = container.querySelector("canvas")!;
+    expect(canvas.className).toContain("h-6");
+    expect(canvas.className).toContain("w-full");
+  });
+
+  test("compact sizing uses the shorter canvas class", () => {
+    const { container } = render(<VoiceTimelineWaveform active compact />);
+    const canvas = container.querySelector("canvas")!;
+    expect(canvas.className).toContain("h-4");
+    expect(canvas.className).not.toContain("h-6");
+  });
+
+  test("merges a caller-supplied className", () => {
+    const { container } = render(<VoiceTimelineWaveform active className="flex-1" />);
+    expect(container.querySelector("canvas")!.className).toContain("flex-1");
+  });
+});
+
+describe("VoiceTimelineWaveform — animation loop", () => {
+  test("starts the rAF loop and reschedules each frame", () => {
+    render(<VoiceTimelineWaveform active getAmplitude={() => 0.5} />);
+    expect(rafCallCount).toBe(1);
+    fireFrame(100);
+    expect(rafCallCount).toBe(2);
+    fireFrame(200);
+    expect(rafCallCount).toBe(3);
+  });
+
+  test("polls getAmplitude while active", () => {
+    const getAmplitude = mock(() => 0.5);
+    render(<VoiceTimelineWaveform active getAmplitude={getAmplitude} />);
+    fireFrame(100);
+    fireFrame(200);
+    expect(getAmplitude.mock.calls.length).toBe(2);
+  });
+
+  test("stops sampling (but keeps drawing) when not active", () => {
+    const getAmplitude = mock(() => 0.5);
+    render(<VoiceTimelineWaveform active={false} getAmplitude={getAmplitude} />);
+    fireFrame(100);
+    fireFrame(200);
+    expect(getAmplitude.mock.calls.length).toBe(0);
+    expect(fakeCtx.clearRect.mock.calls.length).toBe(2);
+  });
+
+  test("cancels the pending frame on unmount and a late frame does not throw", () => {
+    const { unmount } = render(<VoiceTimelineWaveform active getAmplitude={() => 0.5} />);
+    // Capture the pending callback before unmount cancels it, simulating a
+    // frame already dispatched when cleanup runs.
+    const pending = [...rafCallbacks.values()];
+    expect(pending).toHaveLength(1);
+    unmount();
+    expect(canceledRafIds).toHaveLength(1);
+    expect(rafCallbacks.size).toBe(0);
+    expect(() => pending[0]!(300)).not.toThrow();
+  });
+
+  test("does not start a loop when the 2d context is unavailable", () => {
+    HTMLCanvasElement.prototype.getContext = (() =>
+      null) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+    const { unmount } = render(<VoiceTimelineWaveform active />);
+    expect(rafCallCount).toBe(0);
+    expect(() => unmount()).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reduced-motion path — verified by stubbing `motion/react`.
+// ---------------------------------------------------------------------------
+
+describe("VoiceTimelineWaveform — reduced motion", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("renders a static frame without starting the animation loop", async () => {
+    mock.module("motion/react", () => ({
+      useReducedMotion: () => true,
+    }));
+
+    const { VoiceTimelineWaveform: ReducedWaveform } = await import(
+      "./voice-timeline-waveform"
+    );
+    const { container, unmount } = render(
+      <ReducedWaveform active getAmplitude={() => 0.5} />,
+    );
+
+    expect(container.querySelector("canvas")).toBeTruthy();
+    // No animation loop — the static branch draws once, synchronously.
+    expect(rafCallCount).toBe(0);
+    expect(fakeCtx.clearRect.mock.calls.length).toBe(1);
+    expect(() => unmount()).not.toThrow();
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-timeline-waveform.tsx
+++ b/clients/web/src/domains/chat/voice/voice-timeline-waveform.tsx
@@ -9,12 +9,11 @@
  * component because the visual — dotted baseline + bounded bar segment — is
  * distinct from that component's full-width bar field.
  *
- * Amplitude is preferably supplied via `getAmplitude` so the parent can poll
- * a store/analyser without re-rendering per sample; a plain `amplitude` prop
- * is the fallback. Colors resolve from CSS var tokens at draw time so all
- * themes (including runtime `data-theme` switches) render correctly. Under
- * reduced motion the component draws a single static, amplitude-independent
- * frame and never starts the animation loop.
+ * Amplitude is supplied via `getAmplitude` so the parent can poll a
+ * store/analyser without re-rendering per sample. Colors resolve from CSS var
+ * tokens at draw time so all themes (including runtime `data-theme` switches)
+ * render correctly. Under reduced motion the component draws a single static,
+ * amplitude-independent frame and never starts the animation loop.
  */
 
 import { useReducedMotion } from "motion/react";
@@ -119,12 +118,10 @@ function drawTimeline(
 
 export interface VoiceTimelineWaveformProps {
   /**
-   * Preferred amplitude source (0–1), polled at ~30 Hz inside the draw loop
-   * so the parent never re-renders per sample.
+   * Amplitude source (0–1), polled at ~30 Hz inside the draw loop so the
+   * parent never re-renders per sample.
    */
-  getAmplitude?: () => number;
-  /** Plain amplitude fallback (0–1) when no poll function is supplied. */
-  amplitude?: number;
+  getAmplitude: () => number;
   /** While true new samples scroll in; when false the bars freeze in place. */
   active: boolean;
   /** Title-bar pill sizing: shorter canvas and a narrower bar segment. */
@@ -134,7 +131,6 @@ export interface VoiceTimelineWaveformProps {
 
 export function VoiceTimelineWaveform({
   getAmplitude,
-  amplitude = 0,
   active,
   compact = false,
   className,
@@ -143,17 +139,12 @@ export function VoiceTimelineWaveform({
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   // Refs let the rAF loop read the latest inputs without re-initializing.
   const getAmplitudeRef = useRef(getAmplitude);
-  const amplitudeRef = useRef(amplitude);
   const activeRef = useRef(active);
   const samplesRef = useRef<number[]>([]);
 
   useLayoutEffect(() => {
     getAmplitudeRef.current = getAmplitude;
   }, [getAmplitude]);
-
-  useLayoutEffect(() => {
-    amplitudeRef.current = amplitude;
-  }, [amplitude]);
 
   useLayoutEffect(() => {
     activeRef.current = active;
@@ -194,10 +185,7 @@ export function VoiceTimelineWaveform({
     const tick = (ts: number) => {
       if (activeRef.current && ts - lastSampleTs >= SAMPLE_MS) {
         lastSampleTs = ts;
-        const raw = getAmplitudeRef.current
-          ? getAmplitudeRef.current()
-          : amplitudeRef.current;
-        samplesRef.current.push(clamp01(raw));
+        samplesRef.current.push(clamp01(getAmplitudeRef.current()));
         const maxBars = Math.floor(segmentWidth / STEP);
         if (samplesRef.current.length > maxBars * 2) {
           samplesRef.current = samplesRef.current.slice(-maxBars);

--- a/clients/web/src/domains/chat/voice/voice-timeline-waveform.tsx
+++ b/clients/web/src/domains/chat/voice/voice-timeline-waveform.tsx
@@ -1,0 +1,231 @@
+/**
+ * Voice-session timeline waveform: a dotted hairline baseline spanning the
+ * full width, with a live amplitude-bar cluster drawn over a bounded segment
+ * of the line (right of center). Presentational — the parent owns the voice
+ * session and supplies an amplitude source.
+ *
+ * Rendering mirrors the composer's `StreamingWaveform` (dense 2×2px bars,
+ * ~30 Hz sampling, right→left history, DPR-scaled canvas) but is a separate
+ * component because the visual — dotted baseline + bounded bar segment — is
+ * distinct from that component's full-width bar field.
+ *
+ * Amplitude is preferably supplied via `getAmplitude` so the parent can poll
+ * a store/analyser without re-rendering per sample; a plain `amplitude` prop
+ * is the fallback. Colors resolve from CSS var tokens at draw time so all
+ * themes (including runtime `data-theme` switches) render correctly. Under
+ * reduced motion the component draws a single static, amplitude-independent
+ * frame and never starts the animation loop.
+ */
+
+import { useReducedMotion } from "motion/react";
+import { useEffect, useLayoutEffect, useRef } from "react";
+
+import { cn } from "@vellumai/design-library";
+
+// ---------------------------------------------------------------------------
+// Visual constants — bar metrics match StreamingWaveform.
+// ---------------------------------------------------------------------------
+const BAR_W = 2; // px width of each amplitude bar
+const BAR_GAP = 2; // px gap between bars
+const STEP = BAR_W + BAR_GAP;
+const MIN_BAR_H_PX = 2; // silent bars render as baseline dots
+const MAX_H_RATIO = 0.85; // max bar is 85% of canvas height
+const SAMPLE_MS = 33; // ~30 Hz sampling cadence
+
+const DOT_SIZE = 1.5; // px square of each baseline dot
+const DOT_STEP = 5; // px between dot starts
+const SEGMENT_CENTER_RATIO = 0.7; // bar segment centers right of the midline
+const SEGMENT_W = 120; // px width of the bar segment
+const SEGMENT_W_COMPACT = 72; // narrower segment for the title-bar pill
+
+// Fallbacks mirror the light-theme values in design-library tokens.css; they
+// only apply when the CSS vars fail to resolve (e.g. headless tests).
+const FALLBACK_LINE_COLOR = "#71808E";
+const FALLBACK_BAR_COLOR = "#24292E";
+
+function clamp01(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+/** Deterministic, amplitude-independent bar heights for the static render. */
+function staticBarLevel(index: number): number {
+  return 0.2 + 0.6 * Math.abs(Math.sin((index + 1) * 2.4));
+}
+
+function resolveColors(): { line: string; bar: string } {
+  const style = getComputedStyle(document.documentElement);
+  return {
+    line: style.getPropertyValue("--content-tertiary").trim() || FALLBACK_LINE_COLOR,
+    bar: style.getPropertyValue("--content-default").trim() || FALLBACK_BAR_COLOR,
+  };
+}
+
+/** Resize the backing store to CSS size × DPR and return the CSS-px size. */
+function syncCanvasSize(
+  canvas: HTMLCanvasElement,
+  ctx: CanvasRenderingContext2D,
+): { w: number; h: number } {
+  const dpr = window.devicePixelRatio ?? 1;
+  const w = canvas.offsetWidth;
+  const h = canvas.offsetHeight;
+  if (canvas.width !== Math.round(w * dpr) || canvas.height !== Math.round(h * dpr)) {
+    canvas.width = Math.round(w * dpr);
+    canvas.height = Math.round(h * dpr);
+  }
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  return { w, h };
+}
+
+/** Draw the dotted baseline plus the bar segment. */
+function drawTimeline(
+  ctx: CanvasRenderingContext2D,
+  w: number,
+  h: number,
+  segmentWidth: number,
+  barLevelAt: (barIndex: number, numBars: number) => number,
+): void {
+  ctx.clearRect(0, 0, w, h);
+  if (w <= 0 || h <= 0) {
+    return;
+  }
+
+  const { line, bar } = resolveColors();
+  const midY = h / 2;
+  const segW = Math.min(segmentWidth, w);
+  const segLeft = Math.min(Math.max(w * SEGMENT_CENTER_RATIO - segW / 2, 0), w - segW);
+
+  // Dotted hairline across the full width, skipping the bar segment.
+  ctx.fillStyle = line;
+  for (let x = 0; x + DOT_SIZE <= w; x += DOT_STEP) {
+    if (x >= segLeft - DOT_SIZE && x < segLeft + segW) {
+      continue;
+    }
+    ctx.beginPath();
+    ctx.roundRect(x, midY - DOT_SIZE / 2, DOT_SIZE, DOT_SIZE, DOT_SIZE / 2);
+    ctx.fill();
+  }
+
+  // Amplitude bars over the segment; newest sample → rightmost bar.
+  ctx.fillStyle = bar;
+  const numBars = Math.floor(segW / STEP);
+  const maxBarH = h * MAX_H_RATIO;
+  for (let i = 0; i < numBars; i++) {
+    const bh = Math.max(MIN_BAR_H_PX, barLevelAt(i, numBars) * maxBarH);
+    ctx.beginPath();
+    ctx.roundRect(segLeft + i * STEP, midY - bh / 2, BAR_W, bh, BAR_W / 2);
+    ctx.fill();
+  }
+}
+
+export interface VoiceTimelineWaveformProps {
+  /**
+   * Preferred amplitude source (0–1), polled at ~30 Hz inside the draw loop
+   * so the parent never re-renders per sample.
+   */
+  getAmplitude?: () => number;
+  /** Plain amplitude fallback (0–1) when no poll function is supplied. */
+  amplitude?: number;
+  /** While true new samples scroll in; when false the bars freeze in place. */
+  active: boolean;
+  /** Title-bar pill sizing: shorter canvas and a narrower bar segment. */
+  compact?: boolean;
+  className?: string;
+}
+
+export function VoiceTimelineWaveform({
+  getAmplitude,
+  amplitude = 0,
+  active,
+  compact = false,
+  className,
+}: VoiceTimelineWaveformProps) {
+  const reducedMotion = useReducedMotion();
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  // Refs let the rAF loop read the latest inputs without re-initializing.
+  const getAmplitudeRef = useRef(getAmplitude);
+  const amplitudeRef = useRef(amplitude);
+  const activeRef = useRef(active);
+  const samplesRef = useRef<number[]>([]);
+
+  useLayoutEffect(() => {
+    getAmplitudeRef.current = getAmplitude;
+  }, [getAmplitude]);
+
+  useLayoutEffect(() => {
+    amplitudeRef.current = amplitude;
+  }, [amplitude]);
+
+  useLayoutEffect(() => {
+    activeRef.current = active;
+  }, [active]);
+
+  const segmentWidth = compact ? SEGMENT_W_COMPACT : SEGMENT_W;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      return;
+    }
+
+    if (reducedMotion) {
+      // Static frame: dotted line + fixed bar cluster, no animation loop.
+      const drawStatic = () => {
+        const { w, h } = syncCanvasSize(canvas, ctx);
+        drawTimeline(ctx, w, h, segmentWidth, staticBarLevel);
+      };
+      drawStatic();
+      if (typeof ResizeObserver === "undefined") {
+        return;
+      }
+      const observer = new ResizeObserver(drawStatic);
+      observer.observe(canvas);
+      return () => {
+        observer.disconnect();
+      };
+    }
+
+    let rafId: ReturnType<typeof requestAnimationFrame>;
+    let lastSampleTs = 0;
+
+    const tick = (ts: number) => {
+      if (activeRef.current && ts - lastSampleTs >= SAMPLE_MS) {
+        lastSampleTs = ts;
+        const raw = getAmplitudeRef.current
+          ? getAmplitudeRef.current()
+          : amplitudeRef.current;
+        samplesRef.current.push(clamp01(raw));
+        const maxBars = Math.floor(segmentWidth / STEP);
+        if (samplesRef.current.length > maxBars * 2) {
+          samplesRef.current = samplesRef.current.slice(-maxBars);
+        }
+      }
+
+      const { w, h } = syncCanvasSize(canvas, ctx);
+      const samples = samplesRef.current;
+      drawTimeline(ctx, w, h, segmentWidth, (i, numBars) => {
+        const si = samples.length - numBars + i;
+        return si >= 0 ? (samples[si] ?? 0) : 0;
+      });
+
+      rafId = requestAnimationFrame(tick);
+    };
+
+    rafId = requestAnimationFrame(tick);
+    return () => {
+      cancelAnimationFrame(rafId);
+    };
+  }, [reducedMotion, segmentWidth]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden
+      // width/height backing store is set by the draw code; CSS drives layout.
+      className={cn("block w-full", compact ? "h-4" : "h-6", className)}
+    />
+  );
+}

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -105,6 +105,25 @@ body {
   animation: busy-pulse 1s ease-in-out infinite;
 }
 
+/* Live-voice transcript caret — a thin bar blinking like a text caret at the
+ * end of the streaming speech transcript in the composer (Light 55). The
+ * component also holds it static via useReducedMotion; the media query is
+ * defense-in-depth matching .avatar-streaming-ring below. */
+@keyframes voice-caret-blink {
+  0%, 50% { opacity: 1; }
+  50.01%, 100% { opacity: 0; }
+}
+
+.voice-caret-blink {
+  animation: voice-caret-blink 1.1s step-end infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .voice-caret-blink {
+    animation: none;
+  }
+}
+
 /* Deep-link message highlight — a one-shot background flash applied when the
  * transcript scrolls to a message (e.g. opening a saved bookmark). Fades from
  * the active-surface tint back to transparent over 2s. */

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -52,6 +52,7 @@ import { useElectronIdentitySync } from "@/hooks/use-electron-identity-sync";
 import { useElectronStatusSync } from "@/hooks/use-electron-status-sync";
 import { useElectronFeatureFlagBridge } from "@/runtime/electron-feature-flags";
 import { isElectron } from "@/runtime/is-electron";
+import { isPopoutWindow } from "@/runtime/popout-window";
 import { GlobalPushToTalkBridge } from "@/domains/chat/voice/global-push-to-talk-bridge";
 import { TimezoneSync } from "@/components/timezone-sync";
 import { StatusBanner } from "@/components/status-banner";
@@ -291,7 +292,7 @@ export function RootLayout() {
   const keyboardOffsetTop =
     keyboardOpen && visibleViewport ? visibleViewport.offsetTop : 0;
   const electron = isElectron();
-  const isPopout = location.search.includes("popout=1");
+  const isPopout = isPopoutWindow(location.search);
   const suppressStatusBanner = shouldSuppressRootStatusBanner(
     location.pathname,
     location.search,

--- a/clients/web/src/runtime/popout-window.ts
+++ b/clients/web/src/runtime/popout-window.ts
@@ -1,6 +1,18 @@
 import { isElectron } from "@/runtime/is-electron";
 
 /**
+ * Whether a location search string marks the window as an Electron pop-out
+ * thread window (`?popout=1`, appended by the desktop shell's popout-window
+ * loader). Pop-out URLs carry the flag only on the window's initial load —
+ * in-window navigations (e.g. conversation switching via Cmd+Up/Down) drop
+ * the query — so callers that need the answer for the window's lifetime must
+ * capture it once at mount (see `ChatLayout` / `WindowDragRegion`).
+ */
+export function isPopoutWindow(search: string): boolean {
+  return search.includes("popout=1");
+}
+
+/**
  * Request the Electron host to open (or focus) a pop-out window for the given
  * conversation. No-ops on web and Capacitor iOS where pop-out windows don't
  * exist. Also no-ops gracefully on older Electron shells that predate the

--- a/clients/web/src/utils/routes.test.ts
+++ b/clients/web/src/utils/routes.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { routes } from "@/utils/routes";
+import {
+  isConversationChatPath,
+  isConversationPath,
+  routes,
+} from "@/utils/routes";
 
 describe("routes", () => {
   test("builds schedule-filtered usage URLs", () => {
@@ -20,5 +24,49 @@ describe("routes", () => {
     expect(routes.schedules.detail("sch_123")).toBe(
       "/assistant/schedules/sch_123",
     );
+  });
+});
+
+describe("isConversationPath (conversation area, subroutes included)", () => {
+  test("matches the chat index and conversation routes", () => {
+    expect(isConversationPath("/assistant")).toBe(true);
+    expect(isConversationPath("/assistant/")).toBe(true);
+    expect(isConversationPath(routes.conversation("conv-1"))).toBe(true);
+  });
+
+  test("matches conversation subroutes like the inspector", () => {
+    expect(isConversationPath(routes.inspect("conv-1"))).toBe(true);
+  });
+
+  test("rejects non-conversation routes", () => {
+    expect(isConversationPath("/assistant/home")).toBe(false);
+    expect(isConversationPath("/assistant/library")).toBe(false);
+  });
+});
+
+describe("isConversationChatPath (composer-mounting routes only)", () => {
+  test("matches the chat index (draft conversation)", () => {
+    expect(isConversationChatPath("/assistant")).toBe(true);
+    expect(isConversationChatPath("/assistant/")).toBe(true);
+  });
+
+  test("matches a bare conversation route, tolerating a trailing slash", () => {
+    expect(isConversationChatPath(routes.conversation("conv-1"))).toBe(true);
+    expect(
+      isConversationChatPath(`${routes.conversation("conv-1")}/`),
+    ).toBe(true);
+  });
+
+  test("rejects the inspector subroute — InspectPage has no composer", () => {
+    expect(isConversationChatPath(routes.inspect("conv-1"))).toBe(false);
+  });
+
+  test("rejects the conversations list prefix without an id", () => {
+    expect(isConversationChatPath(`${routes.conversations}/`)).toBe(false);
+  });
+
+  test("rejects non-conversation routes", () => {
+    expect(isConversationChatPath("/assistant/home")).toBe(false);
+    expect(isConversationChatPath("/assistant/library")).toBe(false);
   });
 });

--- a/clients/web/src/utils/routes.ts
+++ b/clients/web/src/utils/routes.ts
@@ -212,6 +212,19 @@ export function isAboutAssistantPath(pathname: string): boolean {
   );
 }
 
+/**
+ * Whether `pathname` is a conversation route — the `/assistant` index (draft
+ * conversation) or `/assistant/conversations/:id` — i.e. a route where
+ * `ChatPage` mounts the active conversation's composer.
+ */
+export function isConversationPath(pathname: string): boolean {
+  return (
+    pathname === routes.assistant ||
+    pathname === `${routes.assistant}/` ||
+    pathname.startsWith(`${routes.conversations}/`)
+  );
+}
+
 const WWW_DOMAIN = "vellum.ai";
 
 /** Full external URL for a legal/docs page hosted on the marketing site. */

--- a/clients/web/src/utils/routes.ts
+++ b/clients/web/src/utils/routes.ts
@@ -213,9 +213,13 @@ export function isAboutAssistantPath(pathname: string): boolean {
 }
 
 /**
- * Whether `pathname` is a conversation route — the `/assistant` index (draft
- * conversation) or `/assistant/conversations/:id` — i.e. a route where
- * `ChatPage` mounts the active conversation's composer.
+ * Whether `pathname` falls inside the conversation *area* — the `/assistant`
+ * index (draft conversation) or anything under `/assistant/conversations/`,
+ * including subroutes like the inspector
+ * (`/assistant/conversations/:id/inspect`). Use for "is the user working in
+ * the context of a conversation" semantics (e.g. the sidebar's active-row
+ * highlight). For "is the chat composer on screen" semantics use
+ * {@link isConversationChatPath} — the inspector has no composer.
  */
 export function isConversationPath(pathname: string): boolean {
   return (
@@ -223,6 +227,29 @@ export function isConversationPath(pathname: string): boolean {
     pathname === `${routes.assistant}/` ||
     pathname.startsWith(`${routes.conversations}/`)
   );
+}
+
+/**
+ * Whether `pathname` mounts the conversation chat surface — the `/assistant`
+ * index (draft conversation, via `ConversationRedirect`) or exactly
+ * `/assistant/conversations/:id` — i.e. a route where `ChatPage` renders the
+ * active conversation's composer. Stricter than {@link isConversationPath}:
+ * conversation subroutes such as the inspector
+ * (`/assistant/conversations/:id/inspect`) are excluded because `InspectPage`
+ * replaces `ChatPage` and has no composer.
+ */
+export function isConversationChatPath(pathname: string): boolean {
+  if (pathname === routes.assistant || pathname === `${routes.assistant}/`) {
+    return true;
+  }
+  const prefix = `${routes.conversations}/`;
+  if (!pathname.startsWith(prefix)) {
+    return false;
+  }
+  // Exactly one path segment after the prefix (a bare conversation id,
+  // tolerating a trailing slash) — deeper segments are other pages.
+  const rest = pathname.slice(prefix.length).replace(/\/+$/, "");
+  return rest.length > 0 && !rest.includes("/");
 }
 
 const WWW_DOMAIN = "vellum.ai";

--- a/packages/design-library/src/components/tag.tsx
+++ b/packages/design-library/src/components/tag.tsx
@@ -127,7 +127,11 @@ export function Tag({
             "text-[color:var(--content-secondary)]",
             "transition-colors duration-150",
             "hover:bg-[color-mix(in_srgb,currentColor_15%,transparent)]",
-            "focus-visible:outline-none",
+            // Same keyboard focus affordance as Notice's dismiss button:
+            // suppress the default outline but replace it with the ring, so
+            // keyboard users never lose the focus indicator.
+            "keyboard-focus:outline-none keyboard-focus:ring-2",
+            "keyboard-focus:ring-[var(--ring)]",
           )}
         >
           <X style={iconStyle} aria-hidden="true" />


### PR DESCRIPTION
## Summary

Product UX surface for full-duplex in-app live voice (design source: Alex's Figma frames). The composer transforms into a voice bar (mic + state label + dotted-timeline waveform + end/send controls), speech streams display-only into the composer text area with a caret and auto-sends on turn end, and a persistent session pill lives in the window top bar (and standalone in Electron popouts) whenever the user is away from the owning thread. Assistant replies stream into the thread as normal messages while TTS plays.

Built engine-independent: everything renders V1 `useLiveVoice`/store semantics, so this ships before the engine work and picks up multi-turn behavior from JARVIS-1240 (feature PR #37287) with no UI changes. The session controller lives in a persistent `ChatLayout`-mounted host with an ownership invariant guaranteeing exactly one control surface (composer bar XOR title-bar pill) per active session — a live mic never outlives its last visible control.

## Self-review result

4 rounds (external-feedback / plan-faithfulness / repo-integration / slop passes each round): 15 gaps found and fixed across 4 fix PRs; final round PASS on all four passes.

## PRs merged into feature branch

- #37238: voice timeline waveform component
- #37236: live-voice session context + controls via store
- #37239: voice composer bar component
- #37240: voice session title-bar pill component
- #37243: swap composer to voice bar during live-voice sessions
- #37242: session pill mount in chat layout header
- #37255: live transcript in composer text area

### Fix PRs (self-review remediation)

- #37270: session lifetime (persistent controller host) + ownership scoping
- #37284: pill visibility on inspector route + UI consolidation
- #37286: popout pill surface, failure surfacing, start-guard race fixes
- #37290: popout drag-region conflict, error chip composes Tag (+ library-wide focus-ring fix)

## Known limitations / follow-ups

- The pill's ■ stop-response control is deliberately dormant until JARVIS-1240's turn-scoped interrupt lands (V1 interrupt ends the whole session); ✕/↑ are live.
- Mobile fullscreen app overlay covers all voice controls while expanded (documented accepted limitation; PTT default makes it low-risk).
- Buttons use design-library `primary`/`danger` token variants rather than the mocks' literal green/orange — needs design confirmation.
- Screenshots pending manual verification in the running app (components verified against mocks numerically + by test).

Part of plan: voice-mode-ui.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)