### PR TITLE
docs: fix migration-number and stale-architecture comment residue; note the platform replyText contract

### DIFF
--- a/gateway/src/db/data-migrations/assistant-invite-id-column.ts
+++ b/gateway/src/db/data-migrations/assistant-invite-id-column.ts
@@ -1,6 +1,6 @@
 /**
  * `contact_channels.invite_id` exists only on assistant DBs that predate its
- * drop (assistant persistence migration 314). Migrations that read the column
+ * drop (assistant persistence migration 316). Migrations that read the column
  * over the db proxy build their SELECT with this fragment so the row shape is
  * preserved — `NULL AS invite_id` — when the column is absent.
  */

--- a/gateway/src/db/data-migrations/m0013-verification-sessions-backfill.ts
+++ b/gateway/src/db/data-migrations/m0013-verification-sessions-backfill.ts
@@ -18,7 +18,7 @@
  * `INSERT OR IGNORE` lets the gateway win conflicts on both the id PK and
  * the unique (channel, actor_external_user_id, actor_chat_id) index.
  *
- * Copy, not move: never writes to the assistant DB (m0013 does the drop,
+ * Copy, not move: never writes to the assistant DB (m0014 does the drop,
  * gated on this migration's checkpoint). Returns "done" when the assistant
  * source table is already gone; any failure returns "skip" to retry on the
  * next startup.

--- a/gateway/src/db/data-migrations/m0014-drop-assistant-verification-tables.ts
+++ b/gateway/src/db/data-migrations/m0014-drop-assistant-verification-tables.ts
@@ -50,13 +50,13 @@ export async function up(): Promise<MigrationResult> {
   } catch (err) {
     log.error(
       { err },
-      "m0013: assistant verification table drop failed — will retry on next startup",
+      "m0014: assistant verification table drop failed — will retry on next startup",
     );
     return "skip";
   }
 
   log.info(
-    "m0013: dropped assistant channel_verification_sessions and channel_guardian_rate_limits",
+    "m0014: dropped assistant channel_verification_sessions and channel_guardian_rate_limits",
   );
   return "done";
 }

--- a/gateway/src/db/schema.ts
+++ b/gateway/src/db/schema.ts
@@ -110,8 +110,8 @@ export const oneTimeMigrations = sqliteTable("one_time_migrations", {
 //
 // The gateway DB owns ONLY the data the ACL needs to answer "can this contact
 // do X?". Informational / UX / product data that does NOT affect access
-// decisions lives in the assistant DB and is joined at read time via
-// `assistantDbQuery` (see contacts-info-joiner.ts).
+// decisions lives in the assistant DB and is joined at read time via the
+// typed `contacts_info_batch` IPC (see contacts-info-joiner.ts).
 //
 // Gateway-owned (this table + contact_channels): id, role, principalId,
 // displayName (cache only — NOT used for ACL, kept for log readability),

--- a/gateway/src/http/routes/email-webhook.ts
+++ b/gateway/src/http/routes/email-webhook.ts
@@ -180,6 +180,9 @@ export function createEmailWebhookHandler(
           { from: event.actor.actorExternalId, to: recipientAddress },
           "Gateway intercept — returning reply text to platform",
         );
+        // replyText contract: the gateway cannot send email on this path — the
+        // reply rides the HTTP response for the platform (vembda) to deliver,
+        // and delivery is tracked platform-side.
         return Response.json({
           ok: true,
           [intercept.flag]: true,
@@ -226,7 +229,8 @@ export function createEmailWebhookHandler(
 
       // Propagate the runtime's full response (including denied/reason/replyText)
       // so the platform can decide whether to persist the email and how to respond
-      // to the sender.
+      // to the sender. Same replyText contract as above: the gateway cannot send
+      // email here — the platform (vembda) delivers any reply and tracks delivery.
       const runtimeBody = result.runtimeResponse ?? {};
       return Response.json({ ok: true, ...runtimeBody });
     } catch (err) {

--- a/gateway/src/verification/session-service.ts
+++ b/gateway/src/verification/session-service.ts
@@ -1,8 +1,7 @@
 /**
  * Gateway-native verification session service (Combo 13).
  *
- * Ports secret minting from the daemon's channel-verification-service:
- * sessions are created here, secrets are minted here, and only SHA-256
+ * Sessions are created here, secrets are minted here, and only SHA-256
  * hashes are persisted (via the gateway session store). The raw secret
  * transits back to the daemon in the create-IPC response because message
  * composition and channel delivery stay daemon-owned — mirror of how
@@ -11,11 +10,10 @@
  * Validate-and-consume lives here too (the
  * `verification_sessions_validate_consume` route): rate limiting, identity
  * binding, the status-guarded atomic consume, and the in-engine role side
- * effects (guardian phone binding / trusted-contact channel upsert) that
- * replaced the old gateway polling loop for outbound voice sessions. The
+ * effects (guardian phone binding / trusted-contact channel upsert). The
  * voice guardian binding commits in the same gateway transaction as the
- * consume, so the poller's replay job is structurally unnecessary: a binding
- * failure rolls the consume back and the code stays redeemable.
+ * consume, so a binding failure rolls the consume back and the code stays
+ * redeemable.
  */
 
 import { randomBytes, randomUUID } from "node:crypto";


### PR DESCRIPTION
## Summary
- m0013/m0014 renumber residue, wrong migration-316 reference, stale assistantDbQuery-join headers, poller narration — all fixed to present tense
- email-webhook platform-relay replyText contract documented inline

Part of plan: acl-hardening-sweep.md (PR 16 of 18)