### PR TITLE
refactor(assistant): deny copy reads guardianDisplayName from the verdict

### DIFF
--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -871,8 +871,8 @@ export async function handleChannelInbound({
     // Canned reply mirrors the not_a_member surface. §8.2: no upgrade
     // challenge text for `trusted_contacts` / `guardian_only` denials —
     // sender gets the standard "ask the guardian" copy.
-    const replyText = await composeAccessDenialReply({
-      sourceChannel,
+    const replyText = composeAccessDenialReply({
+      verdict: inboundVerdict,
       guardianNotified,
       handshakeInProgress,
     });

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
@@ -30,14 +30,14 @@ mock.module("../../../contacts/contact-store.js", () => ({
   },
 }));
 
-// resolveGuardianLabel resolves the guardian via the gateway delivery reader.
-let guardianDeliveryList: Array<Record<string, unknown>> = [];
+// Deny copy reads the guardian name from the stamped verdict; this tracker
+// proves no per-deny guardian-delivery IPC fires.
+const guardianDeliveryCalls: unknown[] = [];
 mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
-  getGuardianDelivery: async () => guardianDeliveryList,
-  guardianForChannel: (
-    list: Array<Record<string, unknown>>,
-    channelType: string,
-  ) => list.find((g) => g.channelType === channelType && g.status === "active"),
+  getGuardianDelivery: async () => {
+    guardianDeliveryCalls.push({});
+    return [];
+  },
 }));
 
 mock.module("../../../prompts/user-reference.js", () => ({
@@ -136,7 +136,7 @@ beforeEach(() => {
   accessRequestCalls.length = 0;
   accessRequestDeniedForTest = false;
   approvalHandshakeForTest = false;
-  guardianDeliveryList = [];
+  guardianDeliveryCalls.length = 0;
 });
 
 describe("enforceIngressAcl — verdict-sourced member resolution", () => {
@@ -424,19 +424,32 @@ describe("enforceIngressAcl — fail-closed on resolutionFailed verdict", () => 
   });
 });
 
-describe("enforceIngressAcl — deny copy names the gateway guardian", () => {
-  test("non-member deny reply uses the guardian displayName from the gateway list", async () => {
-    guardianDeliveryList = [
-      {
-        channelType: "vellum",
-        contactId: "c-1",
-        principalId: "p-anchor",
-        displayName: "Alice Guardian",
-        address: "p-anchor",
-        status: "active",
-      },
-    ];
+describe("enforceIngressAcl — deny copy names the guardian from the verdict", () => {
+  test("non-member deny reply uses the verdict's guardianDisplayName with zero guardian-delivery reads", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceMetadata: withVerdict({
+          trustClass: "unknown",
+          canonicalSenderId: "stranger-1",
+          guardianDisplayName: "Alice Guardian",
+        }),
+      }),
+    );
 
+    expect(result.earlyResponse!.reason).toBe("not_a_member");
+    const denyReply = deliverReplyCalls.find((c) =>
+      String((c.payload as { text?: string }).text ?? "").includes(
+        "tried talking to me",
+      ),
+    );
+    expect(denyReply).toBeDefined();
+    expect((denyReply!.payload as { text: string }).text).toContain(
+      "Alice Guardian",
+    );
+    expect(guardianDeliveryCalls.length).toBe(0);
+  });
+
+  test("absent guardianDisplayName degrades to the default reference", async () => {
     const result = await enforceIngressAcl(
       makeParams({
         sourceMetadata: withVerdict({
@@ -453,9 +466,33 @@ describe("enforceIngressAcl — deny copy names the gateway guardian", () => {
       ),
     );
     expect(denyReply).toBeDefined();
-    expect((denyReply!.payload as { text: string }).text).toContain(
-      "Alice Guardian",
+    expect((denyReply!.payload as { text: string }).text).toContain("my human");
+    expect(guardianDeliveryCalls.length).toBe(0);
+  });
+
+  test("Slack verification DM uses the verdict's guardianDisplayName", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceChannel: "slack",
+        canonicalSenderId: "U123STRANGER",
+        rawSenderId: "U123STRANGER",
+        sourceMetadata: withVerdict({
+          trustClass: "unknown",
+          canonicalSenderId: "U123STRANGER",
+          guardianDisplayName: "Alice Guardian",
+        }),
+      }),
     );
+
+    expect(result.earlyResponse!.reason).toBe("verification_challenge_sent");
+    const dm = deliverReplyCalls.find((c) =>
+      String((c.payload as { text?: string }).text ?? "").includes(
+        "don't recognize you yet",
+      ),
+    );
+    expect(dm).toBeDefined();
+    expect((dm!.payload as { text: string }).text).toContain("Alice Guardian");
+    expect(guardianDeliveryCalls.length).toBe(0);
   });
 });
 

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -6,7 +6,11 @@
  * Invite code/token redemption is intercepted at gateway ingress; redeemed
  * messages never reach this stage.
  */
-import type { AdmissionPolicy, SourceMetadata } from "@vellumai/gateway-client";
+import type {
+  AdmissionPolicy,
+  SourceMetadata,
+  TrustVerdict,
+} from "@vellumai/gateway-client";
 import { isTrustClass } from "@vellumai/gateway-client";
 
 import type { VerificationSessionWire } from "../../../channels/gateway-verification-sessions.js";
@@ -17,7 +21,6 @@ import {
   resolveBootstrapToken,
 } from "../../../channels/gateway-verification-sessions.js";
 import type { ChannelId } from "../../../channels/types.js";
-import { getGuardianDelivery } from "../../../contacts/guardian-delivery-reader.js";
 import { channelStatusToMemberStatus } from "../../../contacts/member-status.js";
 import { MESSAGE_PREVIEW_MAX_LENGTH } from "../../../notifications/notification-utils.js";
 import { resolveGuardianName } from "../../../prompts/user-reference.js";
@@ -28,7 +31,6 @@ import {
   isApprovalHandshakeInProgress,
   notifyGuardianOfAccessRequest,
 } from "../../access-request-helper.js";
-import { resolveAnchoredGuardian } from "../../anchored-guardian.js";
 import { deliverChannelReply } from "../../gateway-client.js";
 import type { VerdictMember } from "../../trust-verdict-consumer.js";
 import { verdictMemberFromVerdict } from "../../trust-verdict-consumer.js";
@@ -38,21 +40,13 @@ const log = getLogger("runtime-http");
 /**
  * Resolve the guardian's display name for use in requester-facing messages.
  *
- * Uses the assistant's anchored vellum principal to validate the guardian
- * binding, matching the same strategy used by `notifyGuardianOfAccessRequest`.
- * This prevents stale or cross-assistant bindings from leaking a wrong name.
- * Cosmetic copy, not an admission decision, so a null gateway list degrades
- * gracefully to the default reference.
+ * Cosmetic copy read from the gateway-stamped verdict's `guardianDisplayName`
+ * — the deny decision was already made from the same verdict, so the name
+ * needs no independent validation. An absent field (or absent verdict)
+ * degrades to the default reference.
  */
-async function resolveGuardianLabel(sourceChannel: ChannelId): Promise<string> {
-  // Cosmetic copy, not an admission decision: no local-store fallback, and a
-  // missing anchor principal degrades to the default reference.
-  const anchored = resolveAnchoredGuardian({
-    guardians: await getGuardianDelivery(),
-    sourceChannel,
-    requireAnchorPrincipal: true,
-  });
-  return resolveGuardianName(anchored?.displayName);
+function resolveGuardianLabel(verdict: TrustVerdict | undefined): string {
+  return resolveGuardianName(verdict?.guardianDisplayName);
 }
 
 /**
@@ -67,16 +61,16 @@ async function resolveGuardianLabel(sourceChannel: ChannelId): Promise<string> {
  * - Guardian notified: the standard "I'll let <guardian> know" copy.
  * - Otherwise: the plain not-approved copy.
  */
-export async function composeAccessDenialReply(params: {
-  sourceChannel: ChannelId;
+export function composeAccessDenialReply(params: {
+  verdict: TrustVerdict | undefined;
   guardianNotified: boolean;
   handshakeInProgress: boolean;
-}): Promise<string> {
+}): string {
   if (params.handshakeInProgress) {
-    return `Your access request was approved! Reply here with the 6-digit verification code to finish connecting — if you don't have it, ask ${await resolveGuardianLabel(params.sourceChannel)} for it.`;
+    return `Your access request was approved! Reply here with the 6-digit verification code to finish connecting — if you don't have it, ask ${resolveGuardianLabel(params.verdict)} for it.`;
   }
   if (params.guardianNotified) {
-    return `Hmm looks like you don't have access to talk to me. I'll let ${await resolveGuardianLabel(params.sourceChannel)} know you tried talking to me and get back to you.`;
+    return `Hmm looks like you don't have access to talk to me. I'll let ${resolveGuardianLabel(params.verdict)} know you tried talking to me and get back to you.`;
   }
   return "Sorry, you haven't been approved to message this assistant.";
 }
@@ -472,7 +466,7 @@ export async function enforceIngressAcl(
               try {
                 await deliverChannelReply(dmCallbackUrl, {
                   chatId: senderUserId,
-                  text: `I don't recognize you yet! I've let ${await resolveGuardianLabel(sourceChannel)} know you're trying to reach me. They'll need to share a 6-digit verification code with you — ask them directly if you know them. Once you have the code, reply here with it.`,
+                  text: `I don't recognize you yet! I've let ${resolveGuardianLabel(verdict)} know you're trying to reach me. They'll need to share a 6-digit verification code with you — ask them directly if you know them. Once you have the code, reply here with it.`,
                   assistantId,
                 });
               } catch (err) {
@@ -593,8 +587,8 @@ export async function enforceIngressAcl(
           }
         }
 
-        const replyText = await composeAccessDenialReply({
-          sourceChannel,
+        const replyText = composeAccessDenialReply({
+          verdict,
           guardianNotified,
           handshakeInProgress,
         });
@@ -781,7 +775,7 @@ export async function enforceIngressAcl(
                 try {
                   await deliverChannelReply(dmCallbackUrl, {
                     chatId: senderUserId,
-                    text: `I don't recognize you yet! I've let ${await resolveGuardianLabel(sourceChannel)} know you're trying to reach me. They'll need to share a 6-digit verification code with you — ask them directly if you know them. Once you have the code, reply here with it.`,
+                    text: `I don't recognize you yet! I've let ${resolveGuardianLabel(verdict)} know you're trying to reach me. They'll need to share a 6-digit verification code with you — ask them directly if you know them. Once you have the code, reply here with it.`,
                     assistantId,
                   });
                 } catch (err) {
@@ -852,8 +846,8 @@ export async function enforceIngressAcl(
             }
           }
 
-          const inactiveReplyText = await composeAccessDenialReply({
-            sourceChannel,
+          const inactiveReplyText = composeAccessDenialReply({
+            verdict,
             guardianNotified,
             handshakeInProgress,
           });


### PR DESCRIPTION
## Summary
- resolveGuardianLabel consumes the stamped verdict field; per-deny getGuardianDelivery IPC removed
- Absent field degrades to the default reference exactly as before

Part of plan: acl-hardening-sweep.md (PR 5 of 18)