### PR TITLE
feat(calls): channel admission reader fails closed on gateway outage

### DIFF
--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -168,17 +168,22 @@ mock.module("../calls/call-setup-router.js", () => ({
 }));
 
 // Mock the channel admission reader. handleStart awaits this before routing;
-// tests override mockAdmissionPolicy to exercise floor enforcement. Returning
-// a resolved promise introduces a microtask hop, so tests await
+// tests override mockAdmissionPolicy to exercise floor enforcement, or set
+// mockAdmissionUnavailable to exercise the fail-closed deny (the reader
+// resolves { ok: false } when the gateway is unreachable). Returning a
+// resolved promise introduces a microtask hop, so tests await
 // session.whenSetupSettled() after sending the start frame.
 let mockAdmissionPolicy: unknown = null;
+let mockAdmissionUnavailable = false;
 // Optional gate: when set, getChannelAdmissionPolicy awaits this promise before
 // resolving, letting a test dispose the session mid-read (simulating a WS close
 // while the admission IPC read is pending).
 let mockAdmissionGate: Promise<void> | null = null;
 const mockGetChannelAdmissionPolicy = jest.fn(async () => {
   if (mockAdmissionGate) {await mockAdmissionGate;}
-  return mockAdmissionPolicy;
+  return mockAdmissionUnavailable
+    ? { ok: false as const }
+    : { ok: true as const, policy: mockAdmissionPolicy };
 });
 mock.module("../calls/channel-admission-reader.js", () => ({
   getChannelAdmissionPolicy: mockGetChannelAdmissionPolicy,
@@ -534,6 +539,7 @@ beforeEach(() => {
   (routeSetup as jest.Mock).mockClear();
   mockGetChannelAdmissionPolicy.mockClear();
   mockAdmissionPolicy = null;
+  mockAdmissionUnavailable = false;
   mockAdmissionGate = null;
   mockGetInboundTrustVerdict.mockClear();
   mockInboundVerdict = null;
@@ -1491,6 +1497,95 @@ describe("media-stream setup outcome scenarios", () => {
       // Normal call proceeds: controller registered + greeting fired.
       expect(registerCallController).toHaveBeenCalledWith(
         "call-floor-null-1",
+        expect.anything(),
+      );
+      expect(mockStartInitialGreeting).toHaveBeenCalled();
+    });
+
+    test("unreachable gateway fails closed — inbound setup denied without routing", async () => {
+      mockAdmissionUnavailable = true;
+
+      const mockWs = createMockWs();
+      mockSessions.set("call-floor-unavail-1", {
+        id: "call-floor-unavail-1",
+        conversationId: "conv-floor-unavail-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+15555550142",
+        toNumber: "+15555550143",
+      });
+
+      const session = new MediaStreamCallSession(
+        mockWs.ws,
+        "call-floor-unavail-1",
+      );
+      session.handleMessage(makeStartMessage());
+      await session.whenSetupSettled();
+
+      // Fail closed promptly: no routing, no verdict read.
+      expect(routeSetup).not.toHaveBeenCalled();
+      expect(mockGetInboundTrustVerdict).not.toHaveBeenCalled();
+
+      // Standard deny teardown: unavailable copy spoken, session failed,
+      // no controller, finalization ran.
+      expect(speakSystemPrompt).toHaveBeenCalledWith(
+        expect.anything(),
+        "The assistant can't take calls right now. Please try again later.",
+      );
+      expect(updateCallSession).toHaveBeenCalledWith(
+        "call-floor-unavail-1",
+        expect.objectContaining({
+          status: "failed",
+          lastError: "Inbound voice admission floor: gateway unreachable",
+        }),
+      );
+      expect(registerCallController).not.toHaveBeenCalled();
+      expect(mockStartInitialGreeting).not.toHaveBeenCalled();
+      expect(finalizeCall).toHaveBeenCalledWith(
+        "call-floor-unavail-1",
+        "conv-floor-unavail-1",
+      );
+    });
+
+    test("unreachable gateway does not affect an outbound call (admission not consulted)", async () => {
+      mockAdmissionUnavailable = true;
+      mockRouteSetupResult = {
+        outcome: { action: "normal_call", isInbound: false },
+        resolved: {
+          assistantId: "self",
+          isInbound: false,
+          otherPartyNumber: "+15555550144",
+          actorTrust: { trustClass: "guardian", memberRecord: null },
+        },
+      };
+
+      const mockWs = createMockWs();
+      mockSessions.set("call-outbound-unavail-1", {
+        id: "call-outbound-unavail-1",
+        conversationId: "conv-outbound-unavail-1",
+        initiatedFromConversationId: "conv-outbound-unavail-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+15555550143",
+        toNumber: "+15555550144",
+      });
+
+      const session = new MediaStreamCallSession(
+        mockWs.ws,
+        "call-outbound-unavail-1",
+      );
+      session.handleMessage(makeStartMessage());
+      await session.whenSetupSettled();
+
+      // Outbound routes normally; the failed read degrades to a null policy
+      // (the router ignores admission on outbound).
+      expect(routeSetup).toHaveBeenCalledWith(
+        expect.objectContaining({ admissionPolicy: null }),
+      );
+      expect(registerCallController).toHaveBeenCalledWith(
+        "call-outbound-unavail-1",
         expect.anything(),
       );
       expect(mockStartInitialGreeting).toHaveBeenCalled();

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -112,7 +112,7 @@ let admissionPolicyReads = 0;
 mock.module("../calls/channel-admission-reader.js", () => ({
   getChannelAdmissionPolicy: async () => {
     admissionPolicyReads++;
-    return mockAdmissionPolicy;
+    return { ok: true as const, policy: mockAdmissionPolicy };
   },
 }));
 

--- a/assistant/src/calls/__tests__/channel-admission-reader.test.ts
+++ b/assistant/src/calls/__tests__/channel-admission-reader.test.ts
@@ -1,8 +1,10 @@
 /**
  * Tests for the gateway-backed channel admission policy reader.
  *
- * The reader fails open (returns null = admit) so a gateway IPC failure can
- * never block a live call. These tests pin that contract plus the TTL cache.
+ * The reader fails closed: a gateway IPC failure resolves to `{ ok: false }`
+ * so the caller denies, while an explicit `{ policy: null }` gateway answer
+ * stays a successful "no enforcement" admit. These tests pin that contract,
+ * the TTL cache, and that failures are never cached.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -53,13 +55,19 @@ describe("getChannelAdmissionPolicy", () => {
   test("returns the gateway-resolved policy and caches it within the TTL", async () => {
     ipcHandlers.set(METHOD, () => ({ policy: "guardian_only" }));
 
-    expect(await getChannelAdmissionPolicy("telegram")).toBe("guardian_only");
+    expect(await getChannelAdmissionPolicy("telegram")).toEqual({
+      ok: true,
+      policy: "guardian_only",
+    });
     // Second call within TTL is served from cache — no extra IPC round-trip.
-    expect(await getChannelAdmissionPolicy("telegram")).toBe("guardian_only");
+    expect(await getChannelAdmissionPolicy("telegram")).toEqual({
+      ok: true,
+      policy: "guardian_only",
+    });
     expect(countCalls(METHOD)).toBe(1);
   });
 
-  test("bounds the IPC read with a short timeout so it fails open promptly", async () => {
+  test("bounds the IPC read with a short timeout so it fails closed promptly", async () => {
     ipcHandlers.set(METHOD, () => ({ policy: "guardian_only" }));
 
     await getChannelAdmissionPolicy("telegram");
@@ -68,45 +76,57 @@ describe("getChannelAdmissionPolicy", () => {
     expect(call?.timeoutMs).toBe(1_000);
   });
 
-  test("returns null when IPC transport fails (undefined)", async () => {
+  test("fails closed when IPC transport fails (undefined)", async () => {
     ipcHandlers.set(METHOD, () => undefined);
-    expect(await getChannelAdmissionPolicy("telegram")).toBeNull();
+    expect(await getChannelAdmissionPolicy("telegram")).toEqual({ ok: false });
   });
 
-  test("returns null when the gateway explicitly resolves no policy", async () => {
+  test("an explicit no-enforcement (null) answer is a successful admit", async () => {
     ipcHandlers.set(METHOD, () => ({ policy: null }));
-    expect(await getChannelAdmissionPolicy("telegram")).toBeNull();
+    expect(await getChannelAdmissionPolicy("telegram")).toEqual({
+      ok: true,
+      policy: null,
+    });
   });
 
-  test("returns null when the IPC call throws", async () => {
+  test("fails closed when the IPC call throws", async () => {
     ipcHandlers.set(METHOD, () => {
       throw new Error("socket exploded");
     });
-    expect(await getChannelAdmissionPolicy("telegram")).toBeNull();
+    expect(await getChannelAdmissionPolicy("telegram")).toEqual({ ok: false });
   });
 
-  test("returns null for an invalid policy string", async () => {
+  test("fails closed for an invalid policy string", async () => {
     ipcHandlers.set(METHOD, () => ({ policy: "definitely-not-a-policy" }));
-    expect(await getChannelAdmissionPolicy("telegram")).toBeNull();
+    expect(await getChannelAdmissionPolicy("telegram")).toEqual({ ok: false });
   });
 
   test("caches the explicit no-enforcement (null) answer within the TTL", async () => {
     // The gateway successfully said "no enforcement" — a real, cacheable answer.
     ipcHandlers.set(METHOD, () => ({ policy: null }));
-    expect(await getChannelAdmissionPolicy("telegram")).toBeNull();
-    expect(await getChannelAdmissionPolicy("telegram")).toBeNull();
+    expect(await getChannelAdmissionPolicy("telegram")).toEqual({
+      ok: true,
+      policy: null,
+    });
+    expect(await getChannelAdmissionPolicy("telegram")).toEqual({
+      ok: true,
+      policy: null,
+    });
     expect(countCalls(METHOD)).toBe(1);
   });
 
   test("does NOT cache a transport failure (undefined) — re-consults the gateway", async () => {
-    // First setup: gateway hiccup → fail open to null, NOT cached.
+    // First setup: gateway hiccup → fail closed, NOT cached.
     ipcHandlers.set(METHOD, () => undefined);
-    expect(await getChannelAdmissionPolicy("telegram")).toBeNull();
+    expect(await getChannelAdmissionPolicy("telegram")).toEqual({ ok: false });
 
-    // Gateway recovers with a restrictive policy: the next setup must re-attempt
-    // the IPC (not serve a stale fail-open null) and honor the now-recovered floor.
+    // Gateway recovers: the next setup must re-attempt the IPC (not serve a
+    // stale failure) and admit per the recovered answer.
     ipcHandlers.set(METHOD, () => ({ policy: "guardian_only" }));
-    expect(await getChannelAdmissionPolicy("telegram")).toBe("guardian_only");
+    expect(await getChannelAdmissionPolicy("telegram")).toEqual({
+      ok: true,
+      policy: "guardian_only",
+    });
     expect(countCalls(METHOD)).toBe(2);
   });
 
@@ -114,19 +134,25 @@ describe("getChannelAdmissionPolicy", () => {
     ipcHandlers.set(METHOD, () => {
       throw new Error("socket exploded");
     });
-    expect(await getChannelAdmissionPolicy("telegram")).toBeNull();
+    expect(await getChannelAdmissionPolicy("telegram")).toEqual({ ok: false });
 
     ipcHandlers.set(METHOD, () => ({ policy: "no_one" }));
-    expect(await getChannelAdmissionPolicy("telegram")).toBe("no_one");
+    expect(await getChannelAdmissionPolicy("telegram")).toEqual({
+      ok: true,
+      policy: "no_one",
+    });
     expect(countCalls(METHOD)).toBe(2);
   });
 
   test("does NOT cache a malformed shape — re-consults the gateway", async () => {
     ipcHandlers.set(METHOD, () => ({ policy: "definitely-not-a-policy" }));
-    expect(await getChannelAdmissionPolicy("telegram")).toBeNull();
+    expect(await getChannelAdmissionPolicy("telegram")).toEqual({ ok: false });
 
     ipcHandlers.set(METHOD, () => ({ policy: "guardian_only" }));
-    expect(await getChannelAdmissionPolicy("telegram")).toBe("guardian_only");
+    expect(await getChannelAdmissionPolicy("telegram")).toEqual({
+      ok: true,
+      policy: "guardian_only",
+    });
     expect(countCalls(METHOD)).toBe(2);
   });
 });

--- a/assistant/src/calls/channel-admission-reader.ts
+++ b/assistant/src/calls/channel-admission-reader.ts
@@ -2,18 +2,20 @@
  * Gateway-backed channel admission policy reader.
  *
  * Reads a channel's resolved admission floor from the gateway via the
- * `get_channel_admission_policy` IPC route. Admission must never break call
- * setup, so this reader FAILS OPEN: any transport failure, malformed shape,
- * or thrown error resolves to `null` (= admit, no enforcement). A policy is
- * only returned when the gateway responds with `{ policy: <valid policy> }`.
+ * `get_channel_admission_policy` IPC route. The reader FAILS CLOSED,
+ * consistent with the text path: a gateway outage must not admit unvetted
+ * callers past the floor. Any transport failure, thrown error, or malformed
+ * shape resolves to `{ ok: false }` — the caller must DENY, not admit. A
+ * successful round-trip resolves to `{ ok: true, policy }`, where `policy:
+ * null` is the gateway's explicit "no enforcement configured" answer (still
+ * an admit) — distinct from an unreachable gateway.
  *
  * Caches per channelType with a short TTL, mirroring the conversation
  * threshold cache in `../permissions/gateway-threshold-reader.ts`. Only the
  * result of a SUCCESSFUL gateway round-trip is cached (a valid policy, or an
- * explicit `{ policy: null }` "no enforcement" answer); a transport failure /
- * throw / malformed shape fails open to `null` WITHOUT caching, so a recovered
- * gateway is re-consulted on the next call setup rather than skipping the
- * admission floor for the rest of the TTL.
+ * explicit `{ policy: null }` "no enforcement" answer); a failure is NOT
+ * cached, so a recovered gateway is re-consulted on the next call setup
+ * rather than denying calls for the rest of the TTL.
  */
 
 import {
@@ -26,7 +28,7 @@ import { ipcCall } from "../ipc/gateway-client.js";
 
 const CACHE_TTL_MS = 5_000;
 
-// Short IPC timeout so admission fails open PROMPTLY: a gateway that accepts
+// Short IPC timeout so admission fails closed PROMPTLY: a gateway that accepts
 // the socket but stalls must never delay a live call handshake. 1s is generous
 // under normal conditions yet far below ipcCall's 5s default.
 const ADMISSION_IPC_TIMEOUT_MS = 1_000;
@@ -42,34 +44,38 @@ export function _clearCacheForTesting(): void {
 }
 
 /**
- * Outcome of a single gateway fetch. Only a SUCCESSFUL round-trip (a valid
- * policy, or an explicit `{ policy: null }` "no enforcement" answer) is
- * cacheable. A transport failure, thrown error, or malformed shape is NOT
- * cached so a recovered gateway is re-consulted on the next call setup.
+ * Result of an admission-policy read. `{ ok: false }` means the gateway was
+ * unreachable or answered with a malformed shape — the caller must deny.
+ * `{ ok: true, policy: null }` is the gateway's explicit "no enforcement
+ * configured" answer, which admits.
  */
-type FetchResult =
+export type AdmissionPolicyReadResult =
   | { ok: true; policy: AdmissionPolicy | null }
   | { ok: false };
 
 async function fetchAdmissionPolicy(
   channelType: ChannelId,
-): Promise<FetchResult> {
+): Promise<AdmissionPolicyReadResult> {
   try {
     // ipcCall() returns undefined on transport failure (socket not found,
     // timeout, parse error). That, a throw, or a malformed shape is a FAILURE:
-    // fail open without caching so the next setup re-attempts the IPC.
+    // fail closed without caching so the next setup re-attempts the IPC.
     const result = (await ipcCall(
       "get_channel_admission_policy",
       { channelType },
       ADMISSION_IPC_TIMEOUT_MS,
     )) as { policy?: unknown } | null | undefined;
 
-    if (result === undefined) return { ok: false };
+    if (result === undefined) {
+      return { ok: false };
+    }
     if (result && isAdmissionPolicy(result.policy)) {
       return { ok: true, policy: result.policy };
     }
     // Explicit "no enforcement" — the gateway successfully answered. Cacheable.
-    if (result && result.policy === null) return { ok: true, policy: null };
+    if (result && result.policy === null) {
+      return { ok: true, policy: null };
+    }
     // Anything else (missing/invalid policy field) is a malformed shape.
     return { ok: false };
   } catch {
@@ -78,27 +84,27 @@ async function fetchAdmissionPolicy(
 }
 
 /**
- * Resolve a channel's admission policy from the gateway, or `null` on any
- * failure / absence. `null` means admit with no enforcement.
+ * Resolve a channel's admission policy from the gateway.
  *
- * Always fails open to `null` on failure, but only caches the result of a
- * SUCCESSFUL gateway round-trip — a transient hiccup must not skip the
- * admission floor for the rest of the TTL.
+ * Fails closed: `{ ok: false }` on any transport failure / malformed shape,
+ * and the caller must deny. Only the result of a SUCCESSFUL gateway
+ * round-trip is cached — a transient hiccup must not deny (or admit) for the
+ * rest of the TTL.
  */
 export async function getChannelAdmissionPolicy(
   channelType: ChannelId,
-): Promise<AdmissionPolicy | null> {
+): Promise<AdmissionPolicyReadResult> {
   const cached = cache.get(channelType);
   if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
-    return cached.policy;
+    return { ok: true, policy: cached.policy };
   }
 
   const result = await fetchAdmissionPolicy(channelType);
   if (!result.ok) {
-    // Fail open WITHOUT caching so a recovered gateway is re-consulted next time.
-    return null;
+    // Never cached: a recovered gateway is re-consulted on the next setup.
+    return result;
   }
 
   cache.set(channelType, { policy: result.policy, timestamp: Date.now() });
-  return result.policy;
+  return result;
 }

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -49,6 +49,8 @@ import {
 import { getAssistantName } from "../daemon/identity-helpers.js";
 import { addMessage } from "../persistence/conversation-crud.js";
 import { resolveGuardianName } from "../prompts/user-reference.js";
+import type { ActorTrustContext } from "../runtime/actor-trust-resolver.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getLogger } from "../util/logger.js";
 import { CallController } from "./call-controller.js";
 import {
@@ -57,7 +59,11 @@ import {
 } from "./call-pointer-messages.js";
 import { CallSetupFlow, type CallSetupFlowDeps } from "./call-setup-flow.js";
 import type { SetupFlowResult } from "./call-setup-flow-types.js";
-import { routeSetup } from "./call-setup-router.js";
+import {
+  routeSetup,
+  type SetupOutcome,
+  type SetupResolved,
+} from "./call-setup-router.js";
 import { speakSystemPrompt } from "./call-speech-output.js";
 import {
   fireCallTranscriptNotifier,
@@ -100,6 +106,49 @@ function resolveAssistantLabel(): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Deny routing for an inbound call whose admission floor could not be read
+ * (gateway unreachable / malformed answer). Mirrors the router's floor-deny
+ * outcome shape so the setup flow runs the standard deny teardown (denial
+ * copy + hangup). Trust is stamped `unknown`: with no gateway answer the
+ * caller cannot be vetted.
+ */
+function admissionUnavailableDeny(otherPartyNumber: string): {
+  outcome: SetupOutcome;
+  resolved: SetupResolved;
+} {
+  const actorTrust: ActorTrustContext = {
+    canonicalSenderId: null,
+    guardianBindingMatch: null,
+    guardianPrincipalId: undefined,
+    memberRecord: null,
+    trustClass: "unknown",
+    actorMetadata: {
+      identifier: otherPartyNumber || undefined,
+      displayName: undefined,
+      senderDisplayName: undefined,
+      memberDisplayName: undefined,
+      username: undefined,
+      channel: "phone",
+      trustStatus: "unknown",
+    },
+  };
+  return {
+    outcome: {
+      action: "deny",
+      message:
+        "The assistant can't take calls right now. Please try again later.",
+      logReason: "Inbound voice admission floor: gateway unreachable",
+    },
+    resolved: {
+      assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+      isInbound: true,
+      otherPartyNumber,
+      actorTrust,
+    },
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -421,18 +470,21 @@ export class MediaStreamCallSession {
     // transport.
     const from = session?.fromNumber ?? "";
     const to = session?.toNumber ?? "";
+    const isInbound = session?.initiatedFromConversationId == null;
+    const otherPartyNumber = isInbound ? from : to;
 
     // Resolve the phone channel's inbound admission floor so the trust floor
     // (e.g. guardian_only) is enforced on this transport too — not just the
-    // gateway webhook's no_one kill switch. The reader fails open to `null`
-    // by contract, so a transport hiccup admits the caller.
+    // gateway webhook's no_one kill switch. The reader fails closed by
+    // contract: an unreachable gateway denies inbound setup below rather
+    // than admitting unvetted callers past the floor.
     //
     // Concurrently, prime the guardian displayName used by setup-flow copy
     // and warm the phone-channel guardian-delivery cache for routeSetup's
     // SYNC resolveActorTrust fallback (gateway-side binding writes don't
     // invalidate the daemon cache, so read fresh). All three are independent
     // IPC reads on different cache keys.
-    const [admissionPolicy] = await Promise.all([
+    const [admissionRead] = await Promise.all([
       getChannelAdmissionPolicy("phone"),
       this.primeGuardianDisplayName(),
       getGuardianDeliveryFresh({ channelTypes: ["phone"] }),
@@ -446,35 +498,46 @@ export class MediaStreamCallSession {
       return;
     }
 
-    // Verdict-first caller trust so this transport enforces the gateway
-    // ACL. routeSetup uses it when present and not resolutionFailed, else
-    // falls back to local resolution. The reader returns null on failure,
-    // keeping the local path on a gateway blip.
-    const isInbound = session?.initiatedFromConversationId == null;
-    const otherPartyNumber = isInbound ? from : to;
-    const verdict = await getPhoneCallerVerdict(otherPartyNumber);
+    let routed: { outcome: SetupOutcome; resolved: SetupResolved };
+    if (isInbound && !admissionRead.ok) {
+      // Fail closed: with no gateway answer the floor cannot be enforced, so
+      // the caller cannot be vetted. Outbound calls never consult admission
+      // and route normally below.
+      log.warn(
+        { callSessionId: this.callSessionId, from },
+        "Inbound voice admission floor unavailable — denying call setup",
+      );
+      routed = admissionUnavailableDeny(otherPartyNumber);
+    } else {
+      // Verdict-first caller trust so this transport enforces the gateway
+      // ACL. routeSetup uses it when present and not resolutionFailed, else
+      // falls back to local resolution. The reader returns null on failure,
+      // keeping the local path on a gateway blip.
+      const verdict = await getPhoneCallerVerdict(otherPartyNumber);
 
-    // The verdict read above yields the event loop; abort if the session was
-    // disposed meanwhile, matching the admission-read guard above.
-    if (this.abortIfDisposed("verdict read")) {
-      return;
+      // The verdict read above yields the event loop; abort if the session was
+      // disposed meanwhile, matching the admission-read guard above.
+      if (this.abortIfDisposed("verdict read")) {
+        return;
+      }
+
+      routed = await routeSetup({
+        callSessionId: this.callSessionId,
+        session: session ?? null,
+        from,
+        to,
+        customParameters: event.start.customParameters,
+        admissionPolicy: admissionRead.ok ? admissionRead.policy : null,
+        verdict,
+      });
+
+      // routeSetup can yield the event loop (gateway voice-invite read); abort
+      // if the session was disposed meanwhile, matching the guards above.
+      if (this.abortIfDisposed("setup routing")) {
+        return;
+      }
     }
-
-    const { outcome, resolved } = await routeSetup({
-      callSessionId: this.callSessionId,
-      session: session ?? null,
-      from,
-      to,
-      customParameters: event.start.customParameters,
-      admissionPolicy,
-      verdict,
-    });
-
-    // routeSetup can yield the event loop (gateway voice-invite read); abort
-    // if the session was disposed meanwhile, matching the guards above.
-    if (this.abortIfDisposed("setup routing")) {
-      return;
-    }
+    const { outcome, resolved } = routed;
 
     log.info(
       {


### PR DESCRIPTION
## Summary
- Admission reader failure contract flips from fail-open to fail-closed (unavailable => deny inbound setup)
- Explicit { policy: null } gateway answer still admits with no enforcement; failures never cached
- Deny pinned by tests

Part of plan: acl-hardening-sweep.md (PR 1 of 18)