### PR TITLE
refactor(gateway-client): drop unused trust-verdict fields verifiedVia and lastInteraction

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4037,18 +4037,10 @@ paths:
                           anyOf:
                             - type: number
                             - type: "null"
-                        verifiedVia:
-                          anyOf:
-                            - type: string
-                            - type: "null"
                         memberDisplayName:
                           type: string
                         interactionCount:
                           type: number
-                        lastInteraction:
-                          anyOf:
-                            - type: number
-                            - type: "null"
                         hasInterceptableVerificationSession:
                           type: boolean
                       required:

--- a/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
+++ b/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
@@ -342,7 +342,6 @@ describe("actorTrustContextFromVerdict", () => {
       policy: "allow",
       externalChatId: "chat-1",
       verifiedAt: 1700000000,
-      verifiedVia: "code",
       memberDisplayName: "Dora",
     } satisfies TrustVerdict;
 

--- a/gateway/src/risk/__tests__/trust-verdict-resolver.test.ts
+++ b/gateway/src/risk/__tests__/trust-verdict-resolver.test.ts
@@ -49,9 +49,7 @@ function insertChannel(args: {
   status?: string;
   policy?: string;
   verifiedAt?: number | null;
-  verifiedVia?: string | null;
   interactionCount?: number;
-  lastInteraction?: number | null;
 }): void {
   const now = Date.now();
   getGatewayDb()
@@ -65,9 +63,7 @@ function insertChannel(args: {
       status: args.status ?? "active",
       policy: args.policy ?? "allow",
       verifiedAt: args.verifiedAt ?? now,
-      verifiedVia: args.verifiedVia ?? "challenge",
       interactionCount: args.interactionCount ?? 0,
-      lastInteraction: args.lastInteraction ?? null,
       createdAt: now,
     })
     .run();
@@ -158,9 +154,7 @@ describe("resolveTrustVerdict", () => {
       address: "U_MEMBER",
       externalChatId: "chat-member",
       status: "active",
-      verifiedVia: "manual",
       interactionCount: 7,
-      lastInteraction: 1699990000,
     });
 
     const verdict = await resolveTrustVerdict({
@@ -176,10 +170,8 @@ describe("resolveTrustVerdict", () => {
     expect(verdict.address).toBe("U_MEMBER");
     expect(verdict.externalChatId).toBe("chat-member");
     expect(verdict.memberDisplayName).toBe("Trusted Member");
-    expect(verdict.verifiedVia).toBe("manual");
     // Interaction telemetry carried straight off the member channel row.
     expect(verdict.interactionCount).toBe(7);
-    expect(verdict.lastInteraction).toBe(1699990000);
     // Guardian fields still populated from the channel binding.
     expect(verdict.guardianExternalUserId).toBe("U_GUARDIAN");
   });
@@ -192,7 +184,6 @@ describe("resolveTrustVerdict", () => {
       address: "U_PENDING",
       status: "unverified",
       verifiedAt: null,
-      verifiedVia: null,
     });
 
     const verdict = await resolveTrustVerdict({
@@ -219,7 +210,6 @@ describe("resolveTrustVerdict", () => {
     expect(verdict.guardianExternalUserId).toBeUndefined();
     // No member channel → no interaction telemetry.
     expect(verdict.interactionCount).toBeUndefined();
-    expect(verdict.lastInteraction).toBeUndefined();
   });
 
   test("no actorExternalId → unknown, canonicalSenderId null", async () => {
@@ -386,7 +376,6 @@ describe("resolveTrustVerdict", () => {
       address: "U_GUARDIAN_TG",
       status: "pending",
       verifiedAt: null,
-      verifiedVia: null,
     });
 
     const verdict = await resolveTrustVerdict({
@@ -458,7 +447,6 @@ describe("resolveTrustVerdict", () => {
       address: "U_GUARDIAN_TG",
       status: "pending",
       verifiedAt: null,
-      verifiedVia: null,
     });
 
     const verdict = await resolveTrustVerdict({

--- a/gateway/src/risk/trust-verdict-resolver.ts
+++ b/gateway/src/risk/trust-verdict-resolver.ts
@@ -96,9 +96,7 @@ export async function resolveTrustVerdict(
           status: gwContactChannels.status,
           policy: gwContactChannels.policy,
           verifiedAt: gwContactChannels.verifiedAt,
-          verifiedVia: gwContactChannels.verifiedVia,
           interactionCount: gwContactChannels.interactionCount,
-          lastInteraction: gwContactChannels.lastInteraction,
           memberDisplayName: gwContacts.displayName,
           memberRole: gwContacts.role,
           memberPrincipalId: gwContacts.principalId,
@@ -244,9 +242,7 @@ export async function resolveTrustVerdict(
     verdict.status = memberRow.status;
     verdict.policy = memberRow.policy;
     verdict.verifiedAt = memberRow.verifiedAt;
-    verdict.verifiedVia = memberRow.verifiedVia;
     verdict.interactionCount = memberRow.interactionCount;
-    verdict.lastInteraction = memberRow.lastInteraction;
     verdict.memberDisplayName = memberRow.memberDisplayName;
   }
 

--- a/packages/gateway-client/src/__tests__/trust-verdict-contract.test.ts
+++ b/packages/gateway-client/src/__tests__/trust-verdict-contract.test.ts
@@ -28,9 +28,7 @@ const fullVerdict: TrustVerdict = {
   status: "active",
   policy: "allow",
   verifiedAt: 1699999999,
-  verifiedVia: "voice",
   interactionCount: 12,
-  lastInteraction: 1699999998,
   memberDisplayName: "Member Name",
 };
 
@@ -94,15 +92,13 @@ describe("TrustVerdictSchema", () => {
     });
   });
 
-  test("carries interaction telemetry and tolerates a null lastInteraction", () => {
+  test("carries interaction telemetry", () => {
     const parsed = TrustVerdictSchema.parse({
       trustClass: "trusted_contact",
       canonicalSenderId: "+15555550100",
       interactionCount: 0,
-      lastInteraction: null,
     });
     expect(parsed.interactionCount).toBe(0);
-    expect(parsed.lastInteraction).toBeNull();
   });
 
   test("leaves interaction telemetry undefined when absent", () => {
@@ -111,7 +107,6 @@ describe("TrustVerdictSchema", () => {
       canonicalSenderId: null,
     });
     expect(parsed.interactionCount).toBeUndefined();
-    expect(parsed.lastInteraction).toBeUndefined();
   });
 
   test("rejects an invalid trustClass", () => {

--- a/packages/gateway-client/src/trust-verdict-contract.ts
+++ b/packages/gateway-client/src/trust-verdict-contract.ts
@@ -75,14 +75,12 @@ export const TrustVerdictSchema = z.object({
   status: z.string().optional(),
   policy: z.string().optional(),
   verifiedAt: z.number().nullable().optional(),
-  verifiedVia: z.string().nullable().optional(),
   memberDisplayName: z.string().optional(),
 
   // Gateway-owned interaction telemetry (a trust signal, not an info field per
   // the 2×2) — carried straight off the member `contact_channels` row.
   // Present only when a member channel resolves; absent for unknown senders.
   interactionCount: z.number().optional(),
-  lastInteraction: z.number().nullable().optional(),
 
   // CHANNEL-scoped session-presence stamp: true ⇒ an interceptable
   // (pending | pending_bootstrap | awaiting_response), non-expired


### PR DESCRIPTION
## Summary
- Removes the two never-consumed verdict fields from the contract and resolver (verifiedAt stays — it has a consumer)
- openapi.yaml regenerated

Part of plan: acl-hardening-sweep.md (PR 6 of 18)