### PR TITLE
refactor(gateway): contact-helpers identity reads use the typed lookup; newest-row ordering fixed

### DIFF
--- a/assistant/src/ipc/__tests__/contacts-info-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/contacts-info-ipc.test.ts
@@ -60,6 +60,7 @@ function insertChannel(params: {
   type?: string;
   address: string;
   externalChatId?: string | null;
+  updatedAt?: number | null;
 }): void {
   const now = Date.now();
   getSqlite().run(
@@ -71,7 +72,7 @@ function insertChannel(params: {
       params.address,
       params.externalChatId ?? null,
       now,
-      now,
+      params.updatedAt !== undefined ? params.updatedAt : now,
     ],
   );
 }
@@ -203,6 +204,58 @@ describe("handleContactChannelIdentityLookup", () => {
       body: { channelId: "nope" },
     });
     expect(result).toEqual({ channel: null });
+  });
+
+  test("duplicate (type,address) rows resolve to the most-recently-updated", () => {
+    // The unique (type,address) index is case-SENSITIVE while this lookup is
+    // COLLATE NOCASE, so case-variant duplicates can match; the newest row must
+    // win deterministically (matches the raw SQL it replaced).
+    insertContact({ id: "c-old" });
+    insertContact({ id: "c-new" });
+    insertChannel({
+      id: "ch-old",
+      contactId: "c-old",
+      type: "email",
+      address: "Dup@Example.com",
+      updatedAt: 1_000,
+    });
+    insertChannel({
+      id: "ch-new",
+      contactId: "c-new",
+      type: "email",
+      address: "dup@example.com",
+      updatedAt: 2_000,
+    });
+
+    const result = handleContactChannelIdentityLookup({
+      body: { type: "email", address: "DUP@example.com" },
+    }) as { channel: { id: string; contactId: string } | null };
+    expect(result.channel?.id).toBe("ch-new");
+    expect(result.channel?.contactId).toBe("c-new");
+  });
+
+  test("a duplicate with NULL updated_at loses to a stamped row", () => {
+    insertContact({ id: "c-null" });
+    insertContact({ id: "c-stamped" });
+    insertChannel({
+      id: "ch-null",
+      contactId: "c-null",
+      type: "email",
+      address: "Nulldup@Example.com",
+      updatedAt: null,
+    });
+    insertChannel({
+      id: "ch-stamped",
+      contactId: "c-stamped",
+      type: "email",
+      address: "nulldup@example.com",
+      updatedAt: 1_000,
+    });
+
+    const result = handleContactChannelIdentityLookup({
+      body: { type: "email", address: "nulldup@example.com" },
+    }) as { channel: { id: string } | null };
+    expect(result.channel?.id).toBe("ch-stamped");
   });
 
   test("rejects a selector with neither channelId nor (type,address)", () => {

--- a/assistant/src/ipc/routes/contacts-info-ipc-routes.ts
+++ b/assistant/src/ipc/routes/contacts-info-ipc-routes.ts
@@ -14,7 +14,7 @@
  * route schema.
  */
 
-import { and, eq, inArray, like, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, like, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb } from "../../persistence/db-connection.js";
@@ -125,7 +125,9 @@ const CHANNEL_IDENTITY_PROJECTION = {
  * Resolve a contact-channel identity by `channelId` OR by logical
  * `(type, address)` (COLLATE NOCASE). Replaces the raw identity SELECTs in the
  * verification helpers and the gateway channel resolver. Returns the channel's
- * identity fields (no ACL/status).
+ * identity fields (no ACL/status). The unique `(type, address)` index is
+ * case-sensitive while this lookup is NOCASE, so case-variant duplicates can
+ * match; they resolve to the most-recently-updated row.
  */
 export function handleContactChannelIdentityLookup({
   body = {},
@@ -146,6 +148,7 @@ export function handleContactChannelIdentityLookup({
     .from(contactChannels)
     .innerJoin(contacts, eq(contacts.id, contactChannels.contactId))
     .where(where)
+    .orderBy(desc(contactChannels.updatedAt))
     .get();
 
   return { channel: row ?? null };

--- a/gateway/src/__tests__/db-proxy-allowlist.test.ts
+++ b/gateway/src/__tests__/db-proxy-allowlist.test.ts
@@ -10,13 +10,11 @@ import { join, sep } from "node:path";
  * either raw-SQL bridge method (`db_proxy` / `db_proxy_transaction`), so the
  * surface can only shrink, never grow.
  *
- * The proxy currently serves three groups (the allowlist below):
+ * The proxy currently serves two groups (the allowlist below):
  *   1. The contact-merge identity-mirror cluster (`contact-store.ts`) — a
  *      notes-only survivor UPDATE and a resolved-slug dual-write INSERT that no
  *      existing typed mirror op expresses; pending a merge-shaped op.
- *   2. Residual raw-SQL contact reads in `verification/contact-helpers.ts` —
- *      deferred cleanup.
- *   3. Data migrations — one-time backfills that legitimately touch the
+ *   2. Data migrations — one-time backfills that legitimately touch the
  *      assistant DB broadly.
  */
 
@@ -25,10 +23,6 @@ import { join, sep } from "node:path";
 const ALLOWLIST = new Set<string>([
   // The proxy definition itself (calls ipcCallAssistant("db_proxy")).
   "db/assistant-db-proxy.ts",
-
-  // Residual raw-SQL (type,address) lookup in the verification intercept flow;
-  // identity/info reads and mirror writes are already typed IPC.
-  "verification/contact-helpers.ts",
 
   // Contact-merge identity-mirror cluster. Pending a merge-shaped op: a
   // notes-only survivor UPDATE (must not overwrite the survivor's display

--- a/gateway/src/__tests__/handle-inbound-invite-intercept.test.ts
+++ b/gateway/src/__tests__/handle-inbound-invite-intercept.test.ts
@@ -53,9 +53,19 @@ let interceptResult: { intercepted: boolean; [k: string]: unknown } = {
 const tryTextVerificationInterceptMock = mock(async () => interceptResult);
 
 let ipcCalls: { method: string; params?: Record<string, unknown> }[] = [];
+// Simulates a down assistant daemon for the identity mirror only: the typed
+// identity lookup + contacts_mirror_* writes throw; unrelated IPC still acks.
+let assistantMirrorDown = false;
 const ipcCallAssistantMock = mock(
   async (method: string, params?: Record<string, unknown>) => {
     ipcCalls.push({ method, params });
+    if (
+      assistantMirrorDown &&
+      (method === "contact_channel_identity_lookup" ||
+        method.startsWith("contacts_mirror_"))
+    ) {
+      throw new Error("assistant IPC unavailable");
+    }
     return { ok: true };
   },
 );
@@ -219,6 +229,7 @@ beforeEach(async () => {
   ipcCalls = [];
   forwardToRuntimeMock.mockClear();
   interceptResult = { intercepted: false };
+  assistantMirrorDown = false;
   assistantDbQueryImpl = async () => [];
   assistantDbRunImpl = async () => {};
 });
@@ -402,15 +413,10 @@ describe("handle-inbound invite redemption intercept", () => {
     expect(ipcCalls.find((c) => c.method === "invite_redeemed")).toBeUndefined();
   });
 
-  test("assistant DB proxy down: valid code still redeems with the success reply, never forwards", async () => {
+  test("assistant mirror IPC down: valid code still redeems with the success reply, never forwards", async () => {
     seedContact("c1");
     const inviteId = seedInvite();
-    assistantDbQueryImpl = async () => {
-      throw new Error("assistant IPC unavailable");
-    };
-    assistantDbRunImpl = async () => {
-      throw new Error("assistant IPC unavailable");
-    };
+    assistantMirrorDown = true;
 
     const result = await handleInbound(makeConfig(), makeEvent(), {
       ...ROUTING,

--- a/gateway/src/__tests__/invite-redemption-engine.test.ts
+++ b/gateway/src/__tests__/invite-redemption-engine.test.ts
@@ -41,6 +41,24 @@ mock.module("../ipc/assistant-client.js", () => ({
   },
 }));
 
+// The ACL helper resolves the existing mirror channel via the typed identity
+// lookup; mutable so tests can serve a mirror row or simulate a down daemon.
+type IdentityChannel = {
+  id: string;
+  contactId: string;
+  type: string;
+  address: string;
+  externalChatId: string | null;
+  displayName: string | null;
+};
+let identityLookupImpl: () => Promise<IdentityChannel | null> = async () =>
+  null;
+const actualContactsInfoClient = await import("../ipc/contacts-info-client.js");
+mock.module("../ipc/contacts-info-client.js", () => ({
+  ...actualContactsInfoClient,
+  lookupContactChannelIdentity: () => identityLookupImpl(),
+}));
+
 
 await import("./test-preload.js");
 
@@ -73,6 +91,7 @@ beforeEach(() => {
   db.delete(contacts).run();
   assistantDbQueryImpl = async () => [];
   assistantDbRunImpl = async () => {};
+  identityLookupImpl = async () => null;
   ipcCallAssistantCalls = [];
 });
 
@@ -451,7 +470,7 @@ describe("post-claim failure isolation", () => {
   test("assistant mirror IPC down (lookup + writes throw): still redeemed, gateway ACL active", async () => {
     seedContact("c1");
     const inviteId = seedInvite();
-    assistantDbQueryImpl = async () => {
+    identityLookupImpl = async () => {
       throw new Error("assistant IPC unavailable");
     };
     assistantDbRunImpl = async () => {
@@ -473,9 +492,14 @@ describe("post-claim failure isolation", () => {
   test("assistant mirror write fails on an existing mirror row: still redeemed, gateway ACL active", async () => {
     seedContact("c1");
     const inviteId = seedInvite();
-    assistantDbQueryImpl = async () => [
-      { channelId: "mirror-ch-1", contactId: "c1" },
-    ];
+    identityLookupImpl = async () => ({
+      id: "mirror-ch-1",
+      contactId: "c1",
+      type: CHANNEL,
+      address: "U_SENDER",
+      externalChatId: null,
+      displayName: null,
+    });
     assistantDbRunImpl = async () => {
       throw new Error("mirror UPDATE failed");
     };

--- a/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
+++ b/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
@@ -20,8 +20,14 @@ type ExistingRow = {
   channelStatus: string;
 };
 
+// Assistant-mirror rows served by the typed identity lookup; the daemon
+// handler returns the most-recently-updated match, modeled here as rows[0].
 let queryRows: ExistingRow[] = [];
-const queryCalls: { sql: string; params: unknown[] }[] = [];
+// Typed identity-lookup selectors, recorded per test.
+const lookupCalls: { type?: string; address?: string; channelId?: string }[] =
+  [];
+// When true, lookupContactChannelIdentity throws (unreachable daemon).
+let lookupThrow = false;
 // Typed identity-mirror IPC calls (contacts_mirror_*), recorded per test.
 const mirrorCalls: { method: string; body: Record<string, unknown> }[] = [];
 // When true, ipcCallAssistant throws for any mirror method (models an
@@ -122,10 +128,28 @@ const TEST_SOCKET_PATH = join(
   `vellum-upsert-contact-channel-test-${process.pid}.sock`,
 );
 
-mock.module("../db/assistant-db-proxy.js", () => ({
-  assistantDbQuery: async (sql: string, params: unknown[]) => {
-    queryCalls.push({ sql, params });
-    return queryRows;
+mock.module("../ipc/contacts-info-client.js", () => ({
+  lookupContactChannelIdentity: async (selector: {
+    type?: string;
+    address?: string;
+    channelId?: string;
+  }) => {
+    lookupCalls.push(selector);
+    if (lookupThrow) throw new Error("identity lookup IPC failed");
+    const row = queryRows[0];
+    if (!row) return null;
+    return {
+      id: row.channelId,
+      contactId: row.contactId,
+      type: selector.type ?? "phone",
+      address: selector.address ?? "",
+      externalChatId: null,
+      displayName: null,
+    };
+  },
+  // Not exercised here (deleteContactIfOrphaned only).
+  probeContactMirror: async () => {
+    throw new Error("probeContactMirror not stubbed for this suite");
   },
 }));
 
@@ -178,7 +202,8 @@ const { upsertContactChannel, upsertVerifiedContactChannel } =
 
 beforeEach(() => {
   queryRows = [];
-  queryCalls.length = 0;
+  lookupCalls.length = 0;
+  lookupThrow = false;
   mirrorCalls.length = 0;
   mirrorThrow = false;
   gwUpdates.length = 0;
@@ -1039,6 +1064,59 @@ describe("upsertVerifiedContactChannel — mirror reparent tracks gateway repare
   });
 });
 
+describe("identity lookup failure posture", () => {
+  test("soft mode: a thrown identity lookup proceeds gateway-only via the create path", async () => {
+    queryRows = [
+      { channelId: "ch-hidden", contactId: "co-hidden", channelStatus: "active" },
+    ];
+    lookupThrow = true;
+    gwSelectStatus = null;
+
+    const result = await upsertVerifiedContactChannel({
+      sourceChannel: "phone",
+      externalUserId: "+15550002323",
+      externalChatId: "+15550002323",
+      softMirrorFailures: true,
+    });
+
+    // The failed lookup is swallowed; the create path runs gateway-first (a
+    // fresh parent contact is inserted) and the result reflects the gateway.
+    expect(result).toEqual({ verified: true });
+    expect(gwInserts.some((i) => i.values.role === "contact")).toBe(true);
+    expect(mirrorUpserts()).toHaveLength(1);
+  });
+
+  test("hard mode (default): a thrown identity lookup propagates", async () => {
+    lookupThrow = true;
+
+    await expect(
+      upsertVerifiedContactChannel({
+        sourceChannel: "phone",
+        externalUserId: "+15550002424",
+        externalChatId: "+15550002424",
+      }),
+    ).rejects.toThrow("identity lookup IPC failed");
+    // Nothing was written on either store.
+    expect(mirrorUpserts()).toHaveLength(0);
+    expect(gwUpdates).toHaveLength(0);
+    expect(gwInserts).toHaveLength(0);
+  });
+
+  test("upsertContactChannel: a thrown identity lookup propagates (no soft mode)", async () => {
+    lookupThrow = true;
+
+    await expect(
+      upsertContactChannel({
+        sourceChannel: "slack",
+        externalUserId: "ULOOKUPFAIL",
+        externalChatId: "DLOOKUPFAIL",
+      }),
+    ).rejects.toThrow("identity lookup IPC failed");
+    expect(mirrorUpserts()).toHaveLength(0);
+    expect(gwInserts).toHaveLength(0);
+  });
+});
+
 describe("upsertContactChannel — channel address casing", () => {
   test("preserves original Slack address casing", async () => {
     queryRows = [];
@@ -1054,8 +1132,9 @@ describe("upsertContactChannel — channel address casing", () => {
     // address preserves original casing
     expect(upsert!.body.address).toBe("U123EXAMPLE");
 
-    expect(queryCalls[0]!.sql).toContain("cc.address = ? COLLATE NOCASE");
-    expect(queryCalls[0]!.params).toEqual(["slack", "U123EXAMPLE"]);
+    // The typed identity lookup receives the original casing; the daemon
+    // handler owns the NOCASE match.
+    expect(lookupCalls[0]).toEqual({ type: "slack", address: "U123EXAMPLE" });
   });
 });
 

--- a/gateway/src/__tests__/verification-session-consume.test.ts
+++ b/gateway/src/__tests__/verification-session-consume.test.ts
@@ -76,9 +76,11 @@ mock.module("../ipc/assistant-client.js", () => ({
   IpcHandlerError: class IpcHandlerError extends Error {},
 }));
 
-// Contact-info reads (daemon-backed) — no known contacts by default.
+// Contact-info reads (daemon-backed) — no known contacts by default; the
+// lookup impl is mutable so a test can induce an assistant-IPC failure.
+let lookupContactChannelIdentityImpl: () => Promise<null> = async () => null;
 mock.module("../ipc/contacts-info-client.js", () => ({
-  lookupContactChannelIdentity: async () => null,
+  lookupContactChannelIdentity: () => lookupContactChannelIdentityImpl(),
   probeContactMirror: async () => ({ exists: false, hasChannels: false }),
 }));
 
@@ -236,6 +238,7 @@ beforeEach(async () => {
   testAssistantDb = new Database(":memory:");
   seedAssistantMirrorTables(testAssistantDb);
   mirrorCalls.length = 0;
+  lookupContactChannelIdentityImpl = async () => null;
 
   resetGatewayDb();
   await initGatewayDb();
@@ -716,12 +719,13 @@ describe("trusted-contact consume — verified channel upsert", () => {
     // Induce an assistant-IPC failure in the upsert's decision path (the
     // trusted-contact side effect spans real IO, so it compensates by
     // restoring the session instead of sharing the consume's transaction).
-    const saved = testAssistantDb;
-    testAssistantDb = null;
+    lookupContactChannelIdentityImpl = async () => {
+      throw new Error("assistant IPC unavailable");
+    };
     await expect(
       validateAndConsumeSession("phone", secret, PHONE, PHONE),
-    ).rejects.toThrow("test assistant DB not initialized");
-    testAssistantDb = saved;
+    ).rejects.toThrow("assistant IPC unavailable");
+    lookupContactChannelIdentityImpl = async () => null;
 
     expect(sessionRow(sessionId)?.status).toBe("awaiting_response");
 

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -1,9 +1,8 @@
 /**
  * Contact upsert/lookup helpers for gateway-owned verification.
  *
- * Identity/info READS go through typed daemon IPC (contacts-info-client), with
- * a residual raw-SQL `assistantDbQuery` lookup for the (type,address) existing
- * row; identity-mirror WRITES go through the typed `contacts_mirror_*` IPC
+ * Identity/info READS go through typed daemon IPC (contacts-info-client);
+ * identity-mirror WRITES go through the typed `contacts_mirror_*` IPC
  * methods. The gateway DB stays the ACL source of truth.
  *
  * These helpers cover the subset of contact operations needed by the
@@ -16,7 +15,6 @@ import { existsSync } from "node:fs";
 
 import { and, eq, sql } from "drizzle-orm";
 
-import { assistantDbQuery } from "../db/assistant-db-proxy.js";
 import { getGatewayDb } from "../db/connection.js";
 import {
   contactChannels as gwContactChannels,
@@ -524,29 +522,26 @@ export async function upsertVerifiedContactChannel(params: {
 
   // Resolve the existing channel's identity (id, parent contact) only. The
   // ACL/status decision is owned by the gateway pre-check below; the most
-  // recently updated mirror row is preferred. In soft mode a failed lookup
-  // falls through to the create path: the gateway write resolves by logical
-  // key either way, and the mirror writes below are soft too.
-  let existing: { channelId: string; contactId: string }[];
+  // recently updated mirror row is preferred (the typed lookup orders by
+  // updated_at DESC). In soft mode a failed lookup falls through to the create
+  // path: the gateway write resolves by logical key either way, and the mirror
+  // writes below are soft too.
+  let existing: { channelId: string; contactId: string } | null;
   try {
-    existing = await assistantDbQuery<{
-      channelId: string;
-      contactId: string;
-    }>(
-      `SELECT cc.id AS channelId, cc.contact_id AS contactId
-       FROM contact_channels cc
-       WHERE cc.type = ? AND cc.address = ? COLLATE NOCASE
-       ORDER BY cc.updated_at DESC
-       LIMIT 1`,
-      [sourceChannel, address],
-    );
+    const channel = await lookupContactChannelIdentity({
+      type: sourceChannel,
+      address,
+    });
+    existing = channel
+      ? { channelId: channel.id, contactId: channel.contactId }
+      : null;
   } catch (mirrorErr) {
     if (!mirrorSoft) throw mirrorErr;
     log.warn(
       { err: mirrorErr, sourceChannel },
       "Assistant mirror lookup failed (soft); proceeding gateway-only",
     );
-    existing = [];
+    existing = null;
   }
 
   // The gateway is the source of truth: a blocked/revoked gateway row rejects
@@ -565,8 +560,8 @@ export async function upsertVerifiedContactChannel(params: {
     return { verified: false };
   }
 
-  if (existing.length > 0) {
-    const row = existing[0];
+  if (existing) {
+    const row = existing;
 
     // The block/revoke decision is owned by the authoritative gateway row,
     // already gated above. The assistant mirror's status is not consulted: it
@@ -811,20 +806,15 @@ export async function upsertContactChannel(params: {
     params.externalUserId;
   const contactDisplayName = displayName ?? username ?? address;
 
-  const existing = await assistantDbQuery<{
-    channelId: string;
-    contactId: string;
-  }>(
-    `SELECT cc.id AS channelId, cc.contact_id AS contactId
-     FROM contact_channels cc
-     WHERE cc.type = ? AND cc.address = ? COLLATE NOCASE
-     ORDER BY cc.updated_at DESC
-     LIMIT 1`,
-    [sourceChannel, address],
-  );
+  // Most-recently-updated mirror row wins. Socket presence was guarded above;
+  // an IPC failure propagates.
+  const existing = await lookupContactChannelIdentity({
+    type: sourceChannel,
+    address,
+  });
 
-  if (existing.length > 0) {
-    const row = existing[0];
+  if (existing) {
+    const row = { channelId: existing.id, contactId: existing.contactId };
     // Gateway DB is the source of truth for ACL: a blocked channel stays blocked.
     if (gatewayChannelStatus(sourceChannel, address) === "blocked") return;
 


### PR DESCRIPTION
## Summary
- contact_channel_identity_lookup now orders by updated_at DESC (fixes latent arbitrary-row-on-duplicate bug)
- Both raw identity SELECTs in verification/contact-helpers flipped to the typed IPC; allowlist entry removed

Part of plan: acl-hardening-sweep.md (PR 11 of 18)