### PR TITLE
feat(gateway): fail loud when the gateway DB has lost its guardian rows

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -15565,6 +15565,54 @@ paths:
                     required:
                       - skipped
                     additionalProperties: false
+  /v1/internal/telemetry/watchdog:
+    post:
+      operationId: internal_telemetry_watchdog_post
+      summary: Relay a watchdog telemetry event
+      description:
+        Emits a gateway-origin watchdog telemetry event directly to platform ingest, bypassing the SQLite watchdog
+        buffer, so integrity alarms never depend on the state they report on.
+      tags:
+        - internal
+        - telemetry
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                check_name:
+                  type: string
+                  minLength: 1
+                  maxLength: 128
+                detail:
+                  anyOf:
+                    - type: object
+                      propertyNames:
+                        type: string
+                      additionalProperties: {}
+                    - type: "null"
+                value:
+                  anyOf:
+                    - type: number
+                    - type: "null"
+              required:
+                - check_name
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    const: true
+                required:
+                  - ok
+                additionalProperties: false
   /v1/internal/twilio/status:
     post:
       operationId: internal_twilio_status_post

--- a/assistant/src/__tests__/internal-telemetry-routes.test.ts
+++ b/assistant/src/__tests__/internal-telemetry-routes.test.ts
@@ -18,6 +18,23 @@ mock.module("../platform/consent-cache.js", () => ({
   getCachedShareAnalytics: () => shareAnalytics,
 }));
 
+// The watchdog relay must go through the direct (unbuffered) emit; capture the
+// forwarded arguments instead of POSTing to the platform.
+const emitCalls: {
+  checkName: string;
+  detail: Record<string, unknown> | null;
+  value: number | null;
+}[] = [];
+mock.module("../telemetry/watchdog-direct-emit.js", () => ({
+  emitWatchdogEventDirect: async (
+    checkName: string,
+    detail: Record<string, unknown> | null,
+    value: number | null = null,
+  ) => {
+    emitCalls.push({ checkName, detail, value });
+  },
+}));
+
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { authFallbackEvents } from "../persistence/schema/index.js";
@@ -97,5 +114,60 @@ describe("internal-telemetry-routes: auth-fallback", () => {
       }),
     ).toThrow(RouteError);
     expect(queryUnreportedAuthFallbackEvents(0, undefined, 100).length).toBe(0);
+  });
+});
+
+describe("internal-telemetry-routes: watchdog relay", () => {
+  const watchdogRoute = ROUTES.find(
+    (r) => r.operationId === "internal_telemetry_watchdog",
+  );
+
+  function callWatchdog(body: unknown) {
+    if (!watchdogRoute) {
+      throw new Error("route not found");
+    }
+    return watchdogRoute.handler({ body } as RouteHandlerArgs);
+  }
+
+  beforeEach(() => {
+    emitCalls.length = 0;
+  });
+
+  test("route is locked to service-token callers (GATEWAY_PRINCIPALS + internal.write)", () => {
+    expect(watchdogRoute).toBeDefined();
+    expect(watchdogRoute?.endpoint).toBe("internal/telemetry/watchdog");
+    expect(watchdogRoute?.method).toBe("POST");
+    expect(watchdogRoute?.policy?.allowedPrincipalTypes).toEqual(
+      GATEWAY_PRINCIPALS,
+    );
+    expect(watchdogRoute?.policy?.requiredScopes).toEqual(["internal.write"]);
+  });
+
+  test("valid event is forwarded to the direct emit", async () => {
+    const result = await callWatchdog({
+      check_name: "gateway_guardian_missing",
+      detail: { has_contacts: true, has_actor_tokens: false },
+    });
+    expect(result).toEqual({ ok: true });
+    expect(emitCalls).toEqual([
+      {
+        checkName: "gateway_guardian_missing",
+        detail: { has_contacts: true, has_actor_tokens: false },
+        value: null,
+      },
+    ]);
+  });
+
+  test("detail and value are optional", async () => {
+    await callWatchdog({ check_name: "some_check" });
+    expect(emitCalls).toEqual([
+      { checkName: "some_check", detail: null, value: null },
+    ]);
+  });
+
+  test("rejects a malformed body without emitting", async () => {
+    await expect(callWatchdog({})).rejects.toThrow(RouteError);
+    await expect(callWatchdog({ check_name: "" })).rejects.toThrow(RouteError);
+    expect(emitCalls.length).toBe(0);
   });
 });

--- a/assistant/src/runtime/routes/internal-telemetry-routes.ts
+++ b/assistant/src/runtime/routes/internal-telemetry-routes.ts
@@ -6,6 +6,12 @@
  * requests served via the legacy loopback auth fallback. The gateway counts
  * fallbacks in memory and flushes them here per window; the usage telemetry
  * reporter ships the persisted rows to the platform.
+ *
+ * POST /v1/internal/telemetry/watchdog — relay a gateway-origin watchdog
+ * event straight to platform ingest via the direct (unbuffered) emit path,
+ * bypassing the SQLite watchdog buffer. Used for integrity alarms (e.g.
+ * `gateway_guardian_missing`) that must not depend on the state they report
+ * on. Consent/platform gating happens inside the direct emit.
  */
 
 import { z } from "zod";
@@ -14,6 +20,7 @@ import {
   type AuthFallbackCount,
   recordAuthFallbackCounts,
 } from "../../security/auth-fallback-events-store.js";
+import { emitWatchdogEventDirect } from "../../telemetry/watchdog-direct-emit.js";
 import { getLogger } from "../../util/logger.js";
 import { GATEWAY_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError } from "./errors.js";
@@ -60,6 +67,25 @@ function handleRecordAuthFallback({ body }: RouteHandlerArgs) {
   return { recorded };
 }
 
+const watchdogRelayBody = z.object({
+  check_name: z.string().min(1).max(128),
+  detail: z.record(z.string(), z.unknown()).nullable().optional(),
+  value: z.number().nullable().optional(),
+});
+
+async function handleRelayWatchdogEvent({ body }: RouteHandlerArgs) {
+  const parsed = watchdogRelayBody.safeParse(body);
+  if (!parsed.success) {
+    throw new BadRequestError(
+      `Invalid watchdog payload: ${parsed.error.message}`,
+    );
+  }
+  const { check_name, detail, value } = parsed.data;
+  // Never throws; opt-out and platform gates are enforced inside.
+  await emitWatchdogEventDirect(check_name, detail ?? null, value ?? null);
+  return { ok: true as const };
+}
+
 export const ROUTES: RouteDefinition[] = [
   {
     operationId: "internal_telemetry_auth_fallback",
@@ -84,5 +110,23 @@ export const ROUTES: RouteDefinition[] = [
       }),
     ]),
     handler: handleRecordAuthFallback,
+  },
+  {
+    operationId: "internal_telemetry_watchdog",
+    endpoint: "internal/telemetry/watchdog",
+    method: "POST",
+    policy: {
+      requiredScopes: ["internal.write"],
+      allowedPrincipalTypes: GATEWAY_PRINCIPALS,
+    },
+    summary: "Relay a watchdog telemetry event",
+    description:
+      "Emits a gateway-origin watchdog telemetry event directly to platform " +
+      "ingest, bypassing the SQLite watchdog buffer, so integrity alarms " +
+      "never depend on the state they report on.",
+    tags: ["internal", "telemetry"],
+    requestBody: watchdogRelayBody,
+    responseBody: z.object({ ok: z.literal(true) }),
+    handler: handleRelayWatchdogEvent,
   },
 ];

--- a/gateway/src/__tests__/edge-auth.test.ts
+++ b/gateway/src/__tests__/edge-auth.test.ts
@@ -24,7 +24,11 @@ import "./test-preload.js";
 let mockReadCredential = mock(
   async (_key: string): Promise<string | undefined> => undefined,
 );
+// Spread the actual module so untouched exports (getWorkspaceDir, …) stay
+// importable by transitive dependencies of the modules under test.
+const actualCredentialReader = await import("../credential-reader.js");
 mock.module("../credential-reader.js", () => ({
+  ...actualCredentialReader,
   readCredential: (key: string) => mockReadCredential(key),
 }));
 
@@ -38,7 +42,9 @@ let mockValidateEdgeToken = mock(
     reason: "noop",
   }),
 );
+const actualTokenExchange = await import("../auth/token-exchange.js");
 mock.module("../auth/token-exchange.js", () => ({
+  ...actualTokenExchange,
   validateEdgeToken: (token: string) => mockValidateEdgeToken(token),
 }));
 

--- a/gateway/src/__tests__/guardian-integrity-reporter.test.ts
+++ b/gateway/src/__tests__/guardian-integrity-reporter.test.ts
@@ -5,19 +5,14 @@
  *    `gateway_guardian_missing` check name and the caller's detail.
  *  - Subsequent reports inside the hourly window are dropped (rate limit).
  *  - Relay failures never throw out of the caller.
+ *
+ * Logging is observed through the reporter's test-only `log` override —
+ * bun's mock.module is process-global and would leak into other test files.
  */
-import { beforeEach, afterEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, afterEach, describe, expect, test } from "bun:test";
 
 const errorLogs: unknown[] = [];
 const warnLogs: unknown[] = [];
-mock.module("../logger.js", () => ({
-  getLogger: () => ({
-    error: (...args: unknown[]) => errorLogs.push(args),
-    warn: (...args: unknown[]) => warnLogs.push(args),
-    info: () => {},
-    debug: () => {},
-  }),
-}));
 
 await import("./test-preload.js");
 const {
@@ -45,6 +40,14 @@ beforeEach(() => {
     },
     mintToken: () => "svc-token",
     baseUrl: "http://127.0.0.1:7821",
+    log: {
+      error: (detail, msg) => {
+        errorLogs.push([detail, msg]);
+      },
+      warn: (detail, msg) => {
+        warnLogs.push([detail, msg]);
+      },
+    },
   });
 });
 

--- a/gateway/src/__tests__/guardian-integrity-reporter.test.ts
+++ b/gateway/src/__tests__/guardian-integrity-reporter.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Fail-loud missing-guardian reporter (guardian-integrity-reporter.ts):
+ *
+ *  - First report emits one error log and one telemetry relay POST with the
+ *    `gateway_guardian_missing` check name and the caller's detail.
+ *  - Subsequent reports inside the hourly window are dropped (rate limit).
+ *  - Relay failures never throw out of the caller.
+ */
+import { beforeEach, afterEach, describe, expect, mock, test } from "bun:test";
+
+const errorLogs: unknown[] = [];
+const warnLogs: unknown[] = [];
+mock.module("../logger.js", () => ({
+  getLogger: () => ({
+    error: (...args: unknown[]) => errorLogs.push(args),
+    warn: (...args: unknown[]) => warnLogs.push(args),
+    info: () => {},
+    debug: () => {},
+  }),
+}));
+
+await import("./test-preload.js");
+const {
+  GUARDIAN_MISSING_CHECK_NAME,
+  flushGuardianIntegrityReporterForTesting,
+  reportMissingGuardian,
+  resetGuardianIntegrityReporterForTesting,
+  setGuardianIntegrityReporterOverridesForTesting,
+} = await import("../guardian-integrity-reporter.js");
+
+type FetchCall = { url: string; init: RequestInit };
+let fetchCalls: FetchCall[] = [];
+let fetchResult: () => Promise<Response> = async () => new Response("{}");
+
+beforeEach(() => {
+  fetchCalls = [];
+  fetchResult = async () => new Response("{}");
+  errorLogs.length = 0;
+  warnLogs.length = 0;
+  resetGuardianIntegrityReporterForTesting();
+  setGuardianIntegrityReporterOverridesForTesting({
+    fetchImpl: async (url, init) => {
+      fetchCalls.push({ url: String(url), init: init ?? {} });
+      return fetchResult();
+    },
+    mintToken: () => "svc-token",
+    baseUrl: "http://127.0.0.1:7821",
+  });
+});
+
+afterEach(() => {
+  resetGuardianIntegrityReporterForTesting();
+});
+
+describe("reportMissingGuardian", () => {
+  test("first report logs an error and relays one watchdog event", async () => {
+    reportMissingGuardian({ has_contacts: true, has_actor_tokens: false });
+    await flushGuardianIntegrityReporterForTesting();
+
+    expect(errorLogs.length).toBe(1);
+    expect(fetchCalls.length).toBe(1);
+    expect(fetchCalls[0].url).toBe(
+      "http://127.0.0.1:7821/v1/internal/telemetry/watchdog",
+    );
+    const headers = fetchCalls[0].init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer svc-token");
+    expect(JSON.parse(String(fetchCalls[0].init.body))).toEqual({
+      check_name: GUARDIAN_MISSING_CHECK_NAME,
+      detail: { has_contacts: true, has_actor_tokens: false },
+    });
+  });
+
+  test("repeat reports inside the hourly window are dropped", async () => {
+    reportMissingGuardian({ has_contacts: true, has_actor_tokens: false });
+    reportMissingGuardian({ has_contacts: true, has_actor_tokens: false });
+    reportMissingGuardian({ has_contacts: true, has_actor_tokens: true });
+    await flushGuardianIntegrityReporterForTesting();
+
+    expect(errorLogs.length).toBe(1);
+    expect(fetchCalls.length).toBe(1);
+  });
+
+  test("a rejected relay never throws out of the caller", async () => {
+    fetchResult = async () => {
+      throw new Error("daemon unreachable");
+    };
+
+    expect(() =>
+      reportMissingGuardian({ has_contacts: false, has_actor_tokens: true }),
+    ).not.toThrow();
+    await flushGuardianIntegrityReporterForTesting();
+
+    expect(errorLogs.length).toBe(1);
+    expect(warnLogs.length).toBe(1);
+  });
+
+  test("a non-ok relay response is swallowed with a warning", async () => {
+    fetchResult = async () => new Response("nope", { status: 500 });
+
+    reportMissingGuardian({ has_contacts: true, has_actor_tokens: true });
+    await flushGuardianIntegrityReporterForTesting();
+
+    expect(fetchCalls.length).toBe(1);
+    expect(warnLogs.length).toBe(1);
+  });
+});

--- a/gateway/src/__tests__/guardian-integrity.test.ts
+++ b/gateway/src/__tests__/guardian-integrity.test.ts
@@ -36,6 +36,9 @@ const {
   guardianIntegrityState,
   hasEvidenceOfPriorGuardian,
 } = await import("../auth/guardian-integrity.js");
+const { applyGuardianBindingGatewayWrites } = await import(
+  "../auth/guardian-bootstrap.js"
+);
 
 // The reporter's first-report error log carries the detail payload; capture
 // it as the "reported" signal.
@@ -149,6 +152,25 @@ describe("guardianIntegrityState", () => {
     expect(guardianIntegrityState()).toBe("missing_guardian");
 
     bustGuardianIntegrityCache();
+    expect(guardianIntegrityState()).toBe("ok");
+  });
+
+  test("applyGuardianBindingGatewayWrites busts a cached missing_guardian (phone rebind path)", () => {
+    seedActorToken();
+    expect(guardianIntegrityState()).toBe("missing_guardian");
+
+    // The outbound phone rebind commits guardian rows through this shared
+    // helper without going through createGuardianBinding.
+    getGatewayDb().transaction(() =>
+      applyGuardianBindingGatewayWrites({
+        channel: "phone",
+        externalUserId: "+15551230001",
+        deliveryChatId: "+15551230001",
+        guardianPrincipalId: "principal-123",
+      }),
+    );
+
+    // No manual bust and no TTL wait: the write itself invalidates the cache.
     expect(guardianIntegrityState()).toBe("ok");
   });
 });

--- a/gateway/src/__tests__/guardian-integrity.test.ts
+++ b/gateway/src/__tests__/guardian-integrity.test.ts
@@ -7,17 +7,12 @@
  *  - Guardian row present → "ok" regardless of evidence.
  *  - State is TTL-cached; bustGuardianIntegrityCache() forces a recompute.
  *
- * The reporter module is mocked — its logging/relay behavior has its own
- * tests (guardian-integrity-reporter.test.ts).
+ * The reporter is silenced and observed through its test-only overrides
+ * (bun's mock.module is process-global and would leak into other test
+ * files); its logging/relay behavior has its own tests
+ * (guardian-integrity-reporter.test.ts).
  */
-import { beforeEach, afterEach, describe, expect, mock, test } from "bun:test";
-
-const reportCalls: Record<string, unknown>[] = [];
-mock.module("../guardian-integrity-reporter.js", () => ({
-  reportMissingGuardian: (detail: Record<string, unknown>) => {
-    reportCalls.push(detail);
-  },
-}));
+import { beforeEach, afterEach, describe, expect, test } from "bun:test";
 
 await import("./test-preload.js");
 const { initGatewayDb, resetGatewayDb, getGatewayDb } = await import(
@@ -33,10 +28,18 @@ const { seedActorToken, seedContact } = await import(
   "./helpers/contact-fixtures.js"
 );
 const {
+  resetGuardianIntegrityReporterForTesting,
+  setGuardianIntegrityReporterOverridesForTesting,
+} = await import("../guardian-integrity-reporter.js");
+const {
   bustGuardianIntegrityCache,
   guardianIntegrityState,
   hasEvidenceOfPriorGuardian,
 } = await import("../auth/guardian-integrity.js");
+
+// The reporter's first-report error log carries the detail payload; capture
+// it as the "reported" signal.
+const reportCalls: Record<string, unknown>[] = [];
 
 function insertRefreshToken(): void {
   const now = Date.now();
@@ -68,10 +71,23 @@ beforeEach(async () => {
   getGatewayDb().delete(actorRefreshTokenRecords).run();
   bustGuardianIntegrityCache();
   reportCalls.length = 0;
+  resetGuardianIntegrityReporterForTesting();
+  setGuardianIntegrityReporterOverridesForTesting({
+    fetchImpl: async () => new Response("{}"),
+    mintToken: () => "svc-token",
+    baseUrl: "http://127.0.0.1:7821",
+    log: {
+      error: (detail) => {
+        reportCalls.push(detail);
+      },
+      warn: () => {},
+    },
+  });
 });
 
 afterEach(() => {
   resetGatewayDb();
+  resetGuardianIntegrityReporterForTesting();
 });
 
 describe("hasEvidenceOfPriorGuardian", () => {

--- a/gateway/src/__tests__/guardian-integrity.test.ts
+++ b/gateway/src/__tests__/guardian-integrity.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Guardian-row integrity detection (auth/guardian-integrity.ts):
+ *
+ *  - Fresh empty DB → no evidence, state "ok", no report.
+ *  - Zero guardian rows + evidence (contacts rows, or actor/refresh token
+ *    rows) → "missing_guardian" and the reporter fires with the signals.
+ *  - Guardian row present → "ok" regardless of evidence.
+ *  - State is TTL-cached; bustGuardianIntegrityCache() forces a recompute.
+ *
+ * The reporter module is mocked — its logging/relay behavior has its own
+ * tests (guardian-integrity-reporter.test.ts).
+ */
+import { beforeEach, afterEach, describe, expect, mock, test } from "bun:test";
+
+const reportCalls: Record<string, unknown>[] = [];
+mock.module("../guardian-integrity-reporter.js", () => ({
+  reportMissingGuardian: (detail: Record<string, unknown>) => {
+    reportCalls.push(detail);
+  },
+}));
+
+await import("./test-preload.js");
+const { initGatewayDb, resetGatewayDb, getGatewayDb } = await import(
+  "../db/connection.js"
+);
+const {
+  contacts,
+  contactChannels,
+  actorTokenRecords,
+  actorRefreshTokenRecords,
+} = await import("../db/schema.js");
+const { seedActorToken, seedContact } = await import(
+  "./helpers/contact-fixtures.js"
+);
+const {
+  bustGuardianIntegrityCache,
+  guardianIntegrityState,
+  hasEvidenceOfPriorGuardian,
+} = await import("../auth/guardian-integrity.js");
+
+function insertRefreshToken(): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(actorRefreshTokenRecords)
+    .values({
+      id: `refresh-${now}`,
+      tokenHash: "hash-2",
+      familyId: "family-1",
+      guardianPrincipalId: "principal-123",
+      hashedDeviceId: "device-abc",
+      platform: "macos",
+      status: "active",
+      issuedAt: now,
+      absoluteExpiresAt: now + 1000,
+      inactivityExpiresAt: now + 1000,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+beforeEach(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+  getGatewayDb().delete(contactChannels).run();
+  getGatewayDb().delete(contacts).run();
+  getGatewayDb().delete(actorTokenRecords).run();
+  getGatewayDb().delete(actorRefreshTokenRecords).run();
+  bustGuardianIntegrityCache();
+  reportCalls.length = 0;
+});
+
+afterEach(() => {
+  resetGatewayDb();
+});
+
+describe("hasEvidenceOfPriorGuardian", () => {
+  test("fresh empty DB has no evidence", () => {
+    expect(hasEvidenceOfPriorGuardian()).toBe(false);
+  });
+
+  test("any contacts row is evidence", () => {
+    seedContact({ id: "c1" });
+    expect(hasEvidenceOfPriorGuardian()).toBe(true);
+  });
+
+  test("any actor token row is evidence", () => {
+    seedActorToken();
+    expect(hasEvidenceOfPriorGuardian()).toBe(true);
+  });
+
+  test("any refresh token row is evidence", () => {
+    insertRefreshToken();
+    expect(hasEvidenceOfPriorGuardian()).toBe(true);
+  });
+});
+
+describe("guardianIntegrityState", () => {
+  test("fresh empty DB is ok and does not report", () => {
+    expect(guardianIntegrityState()).toBe("ok");
+    expect(reportCalls.length).toBe(0);
+  });
+
+  test("guardian row present is ok even with token evidence", () => {
+    seedContact({ id: "g1", role: "guardian" });
+    seedActorToken();
+    expect(guardianIntegrityState()).toBe("ok");
+    expect(reportCalls.length).toBe(0);
+  });
+
+  test("zero guardian rows + non-guardian contact is missing_guardian and reports", () => {
+    seedContact({ id: "c1" });
+    expect(guardianIntegrityState()).toBe("missing_guardian");
+    expect(reportCalls).toEqual([
+      { has_contacts: true, has_actor_tokens: false },
+    ]);
+  });
+
+  test("zero guardian rows + actor token evidence is missing_guardian", () => {
+    seedActorToken();
+    expect(guardianIntegrityState()).toBe("missing_guardian");
+    expect(reportCalls).toEqual([
+      { has_contacts: false, has_actor_tokens: true },
+    ]);
+  });
+
+  test("state is cached until bustGuardianIntegrityCache()", () => {
+    seedActorToken();
+    expect(guardianIntegrityState()).toBe("missing_guardian");
+
+    // Re-seed the guardian; the cached state still answers within the TTL.
+    seedContact({ id: "g1", role: "guardian" });
+    expect(guardianIntegrityState()).toBe("missing_guardian");
+
+    bustGuardianIntegrityCache();
+    expect(guardianIntegrityState()).toBe("ok");
+  });
+});

--- a/gateway/src/__tests__/handle-inbound-invite-intercept.test.ts
+++ b/gateway/src/__tests__/handle-inbound-invite-intercept.test.ts
@@ -119,20 +119,23 @@ const { handleInbound } = await import("../handlers/handle-inbound.js");
 const { inviteRow, seedInvite } = await import(
   "./helpers/contact-fixtures.js"
 );
+const { bustGuardianIntegrityCache } = await import(
+  "../auth/guardian-integrity.js"
+);
 
 const CHANNEL = "telegram";
 const CODE = "123456";
 const TOKEN = "tok_raw_abc123";
 const REPLY_URL = "http://127.0.0.1:7830/deliver/telegram";
 
-function seedContact(id: string): void {
+function seedContact(id: string, role = "contact"): void {
   const now = Date.now();
   getGatewayDb()
     .insert(contacts)
     .values({
       id,
       displayName: `name-${id}`,
-      role: "contact",
+      role,
       createdAt: now,
       updatedAt: now,
     })
@@ -213,6 +216,11 @@ beforeEach(async () => {
   getGatewayDb().delete(ingressInvites).run();
   getGatewayDb().delete(contactChannels).run();
   getGatewayDb().delete(contacts).run();
+  // Invites are guardian-issued: a healthy install always has a guardian row.
+  // Without it the resolver stamps resolutionFailed and the intercept fails
+  // closed. Bust the TTL cache in case another suite computed state first.
+  seedContact("guardian-owner", "guardian");
+  bustGuardianIntegrityCache();
   initAdmissionPolicyCache();
   runtimePayloads = [];
   fetchCalls = [];

--- a/gateway/src/__tests__/handle-inbound-trust-verdict.test.ts
+++ b/gateway/src/__tests__/handle-inbound-trust-verdict.test.ts
@@ -77,8 +77,19 @@ const { AdmissionPolicyStore } =
   await import("../db/admission-policy-store.js");
 const { initAdmissionPolicyCache, resetAdmissionPolicyCache } =
   await import("../risk/admission-policy-cache.js");
-const { contacts: gwContacts, contactChannels: gwContactChannels } =
-  await import("../db/schema.js");
+const {
+  contacts: gwContacts,
+  contactChannels: gwContactChannels,
+  actorTokenRecords,
+  actorRefreshTokenRecords,
+} = await import("../db/schema.js");
+const { bustGuardianIntegrityCache } = await import(
+  "../auth/guardian-integrity.js"
+);
+const {
+  resetGuardianIntegrityReporterForTesting,
+  setGuardianIntegrityReporterOverridesForTesting,
+} = await import("../guardian-integrity-reporter.js");
 const { handleInbound } = await import("../handlers/handle-inbound.js");
 
 const CHANNEL = "telegram";
@@ -184,17 +195,32 @@ beforeEach(async () => {
   // (channels first — FK cascade from contacts).
   getGatewayDb().delete(gwContactChannels).run();
   getGatewayDb().delete(gwContacts).run();
+  // Guardian-evidence tables too: leftover token rows from sibling suites
+  // would flip the recomputed integrity state to missing_guardian.
+  getGatewayDb().delete(actorTokenRecords).run();
+  getGatewayDb().delete(actorRefreshTokenRecords).run();
   const store = new AdmissionPolicyStore();
   for (const row of store.list()) store.remove(row.channelType);
   initAdmissionPolicyCache();
   runtimePayloads = [];
   forwardToRuntimeMock.mockClear();
   interceptResult = { intercepted: false };
+  // The integrity state is TTL-cached process-wide; recompute per test and
+  // silence the fail-loud reporter (its behavior has its own suites).
+  bustGuardianIntegrityCache();
+  resetGuardianIntegrityReporterForTesting();
+  setGuardianIntegrityReporterOverridesForTesting({
+    fetchImpl: async () => new Response("{}"),
+    mintToken: () => "svc-token",
+    baseUrl: "http://127.0.0.1:7821",
+    log: { error: () => {}, warn: () => {} },
+  });
 });
 
 afterEach(() => {
   resetAdmissionPolicyCache();
   resetGatewayDb();
+  resetGuardianIntegrityReporterForTesting();
 });
 
 describe("handle-inbound trust verdict stamping", () => {
@@ -402,6 +428,27 @@ describe("handle-inbound sender-authentication downgrade", () => {
 
     const verdict = runtimePayloads[0]!.sourceMetadata!.trustVerdict!;
     expect(verdict.trustClass).toBe("guardian");
+  });
+
+  test("missing-guardian DB + senderAuthenticated=false → downgrade preserves resolutionFailed", async () => {
+    // Evidence of prior onboarding with zero guardian rows: the resolver
+    // stamps resolutionFailed on the unknown verdict. The auth downgrade must
+    // not erase it — a failed-auth sender in a broken-trust DB fails closed
+    // instead of getting stranger-lane treatment.
+    insertContact({ id: "c-residual", displayName: "Residual Member" });
+
+    await handleInbound(makeConfig(), makeEmailEvent(), {
+      ...ROUTING,
+      senderAuthenticated: false,
+    });
+
+    const verdict = runtimePayloads[0]!.sourceMetadata!.trustVerdict!;
+    expect(verdict.trustClass).toBe("unknown");
+    expect(verdict.resolutionFailed).toBe(true);
+    expect(verdict.canonicalSenderId).toBe(GUARDIAN_EMAIL);
+    // The downgrade's stripping semantics are unchanged.
+    expect(verdict.contactId).toBeUndefined();
+    expect(verdict.guardianExternalUserId).toBeUndefined();
   });
 
   test("forged trusted_contact From: with senderAuthenticated=false → downgraded to stranger", async () => {

--- a/gateway/src/__tests__/helpers/contact-fixtures.ts
+++ b/gateway/src/__tests__/helpers/contact-fixtures.ts
@@ -10,7 +10,7 @@ import { hashInviteCode, hashInviteToken } from "@vellumai/gateway-client";
 
 import { getGatewayDb } from "../../db/connection.js";
 import { ContactStore } from "../../db/contact-store.js";
-import { contacts } from "../../db/schema.js";
+import { actorTokenRecords, contacts } from "../../db/schema.js";
 
 const INVITE_CODE = "123456";
 const INVITE_TOKEN = "tok_raw_abc123";
@@ -40,6 +40,25 @@ export function seedContact(opts: {
       principalId: opts.principalId ?? null,
       createdAt: now,
       updatedAt: opts.updatedAt ?? now,
+    })
+    .run();
+}
+
+/** Insert an active actor-token row bound to a guardian principal. */
+export function seedActorToken(opts: { id?: string } = {}): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(actorTokenRecords)
+    .values({
+      id: opts.id ?? crypto.randomUUID(),
+      tokenHash: "hash-1",
+      guardianPrincipalId: "principal-123",
+      hashedDeviceId: "device-abc",
+      platform: "macos",
+      status: "active",
+      issuedAt: now,
+      createdAt: now,
+      updatedAt: now,
     })
     .run();
 }

--- a/gateway/src/__tests__/invite-route-auth.test.ts
+++ b/gateway/src/__tests__/invite-route-auth.test.ts
@@ -27,7 +27,11 @@ let mockValidateEdgeToken = mock(
     | { ok: true; claims: { sub: string; scope_profile: string } }
     | { ok: false; reason: string } => ({ ok: false, reason: "noop" }),
 );
+// Spread the actual module so untouched exports (mintServiceToken, …) stay
+// importable by transitive dependencies of the modules under test.
+const actualTokenExchange = await import("../auth/token-exchange.js");
 mock.module("../auth/token-exchange.js", () => ({
+  ...actualTokenExchange,
   validateEdgeToken: (token: string) => mockValidateEdgeToken(token),
 }));
 

--- a/gateway/src/__tests__/trust-verdict-resolver-guardian-integrity.test.ts
+++ b/gateway/src/__tests__/trust-verdict-resolver-guardian-integrity.test.ts
@@ -10,14 +10,12 @@
  *  - A thrown integrity check degrades to the plain unknown verdict — no
  *    crash, no stamp.
  *
- * The fail-loud reporter is mocked so no relay leaves the test process.
+ * The fail-loud reporter is silenced through its test-only overrides so no
+ * relay or log leaves the test process (bun's mock.module is process-global
+ * and would leak into other test files).
  */
-import { beforeEach, afterEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, afterEach, describe, expect, test } from "bun:test";
 import { sql } from "drizzle-orm";
-
-mock.module("../guardian-integrity-reporter.js", () => ({
-  reportMissingGuardian: () => {},
-}));
 
 await import("./test-preload.js");
 const { initGatewayDb, resetGatewayDb, getGatewayDb } = await import(
@@ -32,6 +30,10 @@ const {
 const { seedActorToken, seedContact } = await import(
   "./helpers/contact-fixtures.js"
 );
+const {
+  resetGuardianIntegrityReporterForTesting,
+  setGuardianIntegrityReporterOverridesForTesting,
+} = await import("../guardian-integrity-reporter.js");
 const { bustGuardianIntegrityCache } = await import(
   "../auth/guardian-integrity.js"
 );
@@ -77,10 +79,18 @@ beforeEach(async () => {
   getGatewayDb().delete(actorTokenRecords).run();
   getGatewayDb().delete(actorRefreshTokenRecords).run();
   bustGuardianIntegrityCache();
+  resetGuardianIntegrityReporterForTesting();
+  setGuardianIntegrityReporterOverridesForTesting({
+    fetchImpl: async () => new Response("{}"),
+    mintToken: () => "svc-token",
+    baseUrl: "http://127.0.0.1:7821",
+    log: { error: () => {}, warn: () => {} },
+  });
 });
 
 afterEach(() => {
   resetGatewayDb();
+  resetGuardianIntegrityReporterForTesting();
 });
 
 describe("missing-guardian state (evidence, zero guardian rows)", () => {

--- a/gateway/src/__tests__/trust-verdict-resolver-guardian-integrity.test.ts
+++ b/gateway/src/__tests__/trust-verdict-resolver-guardian-integrity.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Guardian-integrity stamping in the trust-verdict resolver:
+ *
+ *  - Onboarded-evidence DB with zero guardian rows → every `unknown`
+ *    classification carries `resolutionFailed: true` (consumers fail closed).
+ *  - Non-unknown classifications (e.g. an intact trusted contact) are never
+ *    stamped by the integrity check.
+ *  - Fresh install and healthy (guardian present) install → verdicts
+ *    unchanged, no `resolutionFailed`.
+ *  - A thrown integrity check degrades to the plain unknown verdict — no
+ *    crash, no stamp.
+ *
+ * The fail-loud reporter is mocked so no relay leaves the test process.
+ */
+import { beforeEach, afterEach, describe, expect, mock, test } from "bun:test";
+import { sql } from "drizzle-orm";
+
+mock.module("../guardian-integrity-reporter.js", () => ({
+  reportMissingGuardian: () => {},
+}));
+
+await import("./test-preload.js");
+const { initGatewayDb, resetGatewayDb, getGatewayDb } = await import(
+  "../db/connection.js"
+);
+const {
+  contacts,
+  contactChannels,
+  actorTokenRecords,
+  actorRefreshTokenRecords,
+} = await import("../db/schema.js");
+const { seedActorToken, seedContact } = await import(
+  "./helpers/contact-fixtures.js"
+);
+const { bustGuardianIntegrityCache } = await import(
+  "../auth/guardian-integrity.js"
+);
+const { resolveTrustVerdict } = await import(
+  "../risk/trust-verdict-resolver.js"
+);
+
+const CHANNEL = "telegram";
+
+function insertGuardianContact(id: string): void {
+  seedContact({ id, role: "guardian", principalId: "principal-123" });
+}
+
+function insertChannel(args: {
+  id: string;
+  contactId: string;
+  address: string;
+  status?: string;
+}): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(contactChannels)
+    .values({
+      id: args.id,
+      contactId: args.contactId,
+      type: CHANNEL,
+      address: args.address,
+      status: args.status ?? "active",
+      policy: "allow",
+      verifiedAt: now,
+      verifiedVia: "challenge",
+      interactionCount: 0,
+      createdAt: now,
+    })
+    .run();
+}
+
+beforeEach(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+  getGatewayDb().delete(contactChannels).run();
+  getGatewayDb().delete(contacts).run();
+  getGatewayDb().delete(actorTokenRecords).run();
+  getGatewayDb().delete(actorRefreshTokenRecords).run();
+  bustGuardianIntegrityCache();
+});
+
+afterEach(() => {
+  resetGatewayDb();
+});
+
+describe("missing-guardian state (evidence, zero guardian rows)", () => {
+  test("stranger verdict carries resolutionFailed", async () => {
+    seedActorToken();
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_STRANGER",
+    });
+
+    expect(verdict.trustClass).toBe("unknown");
+    expect(verdict.resolutionFailed).toBe(true);
+  });
+
+  test("blocked-member unknown verdict carries resolutionFailed", async () => {
+    seedContact({ id: "c1" });
+    insertChannel({
+      id: "ch1",
+      contactId: "c1",
+      address: "U_BLOCKED",
+      status: "blocked",
+    });
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_BLOCKED",
+    });
+
+    expect(verdict.trustClass).toBe("unknown");
+    expect(verdict.status).toBe("blocked");
+    expect(verdict.resolutionFailed).toBe(true);
+  });
+
+  test("intact trusted contact still classifies without a stamp", async () => {
+    seedContact({ id: "c1" });
+    insertChannel({ id: "ch1", contactId: "c1", address: "U_MEMBER" });
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_MEMBER",
+    });
+
+    expect(verdict.trustClass).toBe("trusted_contact");
+    expect(verdict.resolutionFailed).toBeUndefined();
+  });
+});
+
+describe("healthy and fresh installs are unaffected", () => {
+  test("guardian row present: stranger stays plain unknown", async () => {
+    insertGuardianContact("g1");
+    insertChannel({ id: "gch1", contactId: "g1", address: "U_GUARDIAN" });
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_STRANGER",
+    });
+
+    expect(verdict.trustClass).toBe("unknown");
+    expect(verdict.resolutionFailed).toBeUndefined();
+  });
+
+  test("guardian row present: guardian classifies guardian", async () => {
+    insertGuardianContact("g1");
+    insertChannel({ id: "gch1", contactId: "g1", address: "U_GUARDIAN" });
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_GUARDIAN",
+    });
+
+    expect(verdict.trustClass).toBe("guardian");
+    expect(verdict.resolutionFailed).toBeUndefined();
+  });
+
+  test("fresh empty DB: stranger stays plain unknown", async () => {
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_STRANGER",
+    });
+
+    expect(verdict.trustClass).toBe("unknown");
+    expect(verdict.resolutionFailed).toBeUndefined();
+  });
+});
+
+describe("integrity-check failure degrades to a plain verdict", () => {
+  test("a thrown evidence read yields plain unknown, no crash", async () => {
+    // Force the integrity evidence read to throw mid-check: zero contacts
+    // rows sends it to the actor-token tables, which no longer exist.
+    getGatewayDb().run(sql`DROP TABLE actor_token_records`);
+    getGatewayDb().run(sql`DROP TABLE actor_refresh_token_records`);
+
+    const verdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_STRANGER",
+    });
+
+    expect(verdict.trustClass).toBe("unknown");
+    expect(verdict.resolutionFailed).toBeUndefined();
+  });
+});

--- a/gateway/src/auth-fallback-reporter.ts
+++ b/gateway/src/auth-fallback-reporter.ts
@@ -5,21 +5,18 @@
 // window. Deliberately does NOT touch the runtime circuit breaker — this is
 // non-critical traffic and must never affect chat routing.
 
-import { buildUpstreamUrl } from "@vellumai/assistant-client";
-
-import { mintServiceToken } from "./auth/token-exchange.js";
 import type {
   AuthFallbackCount,
   AuthFallbackCountTracker,
 } from "./auth-fallback-count-tracker.js";
-import { fetchImpl } from "./fetch.js";
+import type { fetchImpl } from "./fetch.js";
+import { postInternalTelemetry } from "./internal-telemetry-client.js";
 import { getLogger } from "./logger.js";
 
 const log = getLogger("auth-fallback-reporter");
 
 const ROUTE_PATH = "/v1/internal/telemetry/auth-fallback";
 const DEFAULT_FLUSH_INTERVAL_MS = 60_000;
-const POST_TIMEOUT_MS = 10_000;
 
 function getFlushIntervalMs(): number {
   const raw = process.env.AUTH_FALLBACK_FLUSH_INTERVAL_MS;
@@ -54,16 +51,16 @@ export class AuthFallbackReporter {
   private readonly tracker: AuthFallbackCountTracker;
   private readonly baseUrl: string;
   private readonly intervalMs: number;
-  private readonly doFetch: typeof fetchImpl;
-  private readonly mintToken: () => string;
+  private readonly doFetch: typeof fetchImpl | undefined;
+  private readonly mintToken: (() => string) | undefined;
   private timer: ReturnType<typeof setInterval> | null = null;
 
   constructor(config: AuthFallbackReporterConfig) {
     this.tracker = config.tracker;
     this.baseUrl = config.baseUrl;
     this.intervalMs = config.intervalMs ?? getFlushIntervalMs();
-    this.doFetch = config.fetchImpl ?? fetchImpl;
-    this.mintToken = config.mintToken ?? mintServiceToken;
+    this.doFetch = config.fetchImpl;
+    this.mintToken = config.mintToken;
   }
 
   start(): void {
@@ -105,15 +102,12 @@ export class AuthFallbackReporter {
     };
 
     try {
-      const url = buildUpstreamUrl(this.baseUrl, ROUTE_PATH);
-      const resp = await this.doFetch(url, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${this.mintToken()}`,
-        },
-        body: JSON.stringify(body),
-        signal: AbortSignal.timeout(POST_TIMEOUT_MS),
+      const resp = await postInternalTelemetry({
+        baseUrl: this.baseUrl,
+        path: ROUTE_PATH,
+        body,
+        fetchImpl: this.doFetch,
+        mintToken: this.mintToken,
       });
       if (!resp.ok) {
         log.warn(
@@ -121,9 +115,7 @@ export class AuthFallbackReporter {
           "Auth-fallback flush rejected — re-queueing counts for next flush",
         );
         this.tracker.merge(batch.counts);
-        return;
       }
-      await resp.text(); // release the connection
     } catch (err) {
       log.warn(
         { err, keys: batch.counts.length },

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -344,6 +344,11 @@ export function applyGuardianBindingGatewayWrites(
       .run();
   }
 
+  // The guardian row just written supersedes any cached missing-guardian
+  // state. Busting here covers every binding-commit path (createGuardianBinding
+  // and the outbound phone rebind in verification/session-service.ts).
+  bustGuardianIntegrityCache();
+
   return {
     contactId,
     channelId,
@@ -450,9 +455,6 @@ export async function createGuardianBinding(
   const writes = getGatewayDb().transaction(() =>
     applyGuardianBindingGatewayWrites(params),
   );
-
-  // The committed guardian row supersedes any cached missing-guardian state.
-  bustGuardianIntegrityCache();
 
   await mirrorGuardianBinding(writes);
 

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -24,6 +24,7 @@ import { ipcCallAssistant } from "../ipc/assistant-client.js";
 import { getLogger } from "../logger.js";
 import { deleteContactIfOrphaned } from "../verification/contact-helpers.js";
 
+import { bustGuardianIntegrityCache } from "./guardian-integrity.js";
 import { CURRENT_POLICY_EPOCH } from "./policy.js";
 import { mintToken } from "./token-service.js";
 
@@ -449,6 +450,9 @@ export async function createGuardianBinding(
   const writes = getGatewayDb().transaction(() =>
     applyGuardianBindingGatewayWrites(params),
   );
+
+  // The committed guardian row supersedes any cached missing-guardian state.
+  bustGuardianIntegrityCache();
 
   await mirrorGuardianBinding(writes);
 

--- a/gateway/src/auth/guardian-integrity.ts
+++ b/gateway/src/auth/guardian-integrity.ts
@@ -37,7 +37,8 @@ export type GuardianIntegrityState = "ok" | "missing_guardian";
 
 /**
  * TTL on the computed state so the per-verdict overhead is one cached check.
- * Guardian-binding writes bust the cache eagerly (createGuardianBinding);
+ * Guardian-binding writes bust the cache eagerly
+ * (applyGuardianBindingGatewayWrites, shared by every binding-commit path);
  * the TTL bounds staleness for every other write path.
  */
 const STATE_TTL_MS = 30_000;

--- a/gateway/src/auth/guardian-integrity.ts
+++ b/gateway/src/auth/guardian-integrity.ts
@@ -1,0 +1,116 @@
+/**
+ * Guardian-row integrity detection for the gateway ACL DB.
+ *
+ * Every onboarded install has a `role='guardian'` contact row; when that row
+ * is lost (partial restore, manual deletion) the trust-verdict resolver would
+ * silently classify every sender — including the guardian — as a plain
+ * stranger. This module distinguishes that broken state from a genuinely
+ * fresh install so the resolver can stamp `resolutionFailed` (consumers fail
+ * closed) and reporting can fire loudly (guardian-integrity-reporter.ts).
+ *
+ * Evidence signals — ANY one proves a guardian existed at some point:
+ *  - `contacts` has any row: contacts are only ever created by guardian
+ *    onboarding or guardian-issued invites.
+ *  - `actor_token_records` / `actor_refresh_token_records` has any row:
+ *    tokens are minted exclusively for a guardian principal at pairing, and
+ *    survive even when the guardian contact row is deleted.
+ * Both are single-row LIMIT 1 reads. The `one_time_migrations` m0008 key is
+ * deliberately NOT consulted: the migration runner records it on installs
+ * that had nothing to backfill, so it cannot discriminate a fresh install
+ * from a prior-guardian install.
+ *
+ * Detection never blocks or crashes the gateway: callers treat a thrown
+ * check as "no stamp" and serve the plain verdict (degraded, loud).
+ */
+
+import { eq } from "drizzle-orm";
+
+import { getGatewayDb } from "../db/connection.js";
+import {
+  actorRefreshTokenRecords,
+  actorTokenRecords,
+  contacts,
+} from "../db/schema.js";
+import { reportMissingGuardian } from "../guardian-integrity-reporter.js";
+
+export type GuardianIntegrityState = "ok" | "missing_guardian";
+
+/**
+ * TTL on the computed state so the per-verdict overhead is one cached check.
+ * Guardian-binding writes bust the cache eagerly (createGuardianBinding);
+ * the TTL bounds staleness for every other write path.
+ */
+const STATE_TTL_MS = 30_000;
+
+let cached: { state: GuardianIntegrityState; at: number } | null = null;
+
+function evidenceSignals(): { hasContacts: boolean; hasActorTokens: boolean } {
+  const db = getGatewayDb();
+  const hasContacts =
+    db.select({ id: contacts.id }).from(contacts).limit(1).get() !== undefined;
+  const hasActorTokens =
+    db
+      .select({ id: actorTokenRecords.id })
+      .from(actorTokenRecords)
+      .limit(1)
+      .get() !== undefined ||
+    db
+      .select({ id: actorRefreshTokenRecords.id })
+      .from(actorRefreshTokenRecords)
+      .limit(1)
+      .get() !== undefined;
+  return { hasContacts, hasActorTokens };
+}
+
+/** Whether the gateway DB shows any trace of a guardian having existed. */
+export function hasEvidenceOfPriorGuardian(): boolean {
+  const { hasContacts, hasActorTokens } = evidenceSignals();
+  return hasContacts || hasActorTokens;
+}
+
+/**
+ * `missing_guardian` when zero `role='guardian'` contact rows exist AND the
+ * DB carries evidence of prior onboarding; `ok` otherwise (healthy install or
+ * genuinely fresh install). Cached with a short TTL; a `missing_guardian`
+ * computation fires the fail-loud reporter (rate-limited there).
+ */
+export function guardianIntegrityState(): GuardianIntegrityState {
+  const now = Date.now();
+  if (cached && now - cached.at < STATE_TTL_MS) {
+    return cached.state;
+  }
+  const state = computeState();
+  cached = { state, at: now };
+  return state;
+}
+
+function computeState(): GuardianIntegrityState {
+  const guardianRow = getGatewayDb()
+    .select({ id: contacts.id })
+    .from(contacts)
+    .where(eq(contacts.role, "guardian"))
+    .limit(1)
+    .get();
+  if (guardianRow) {
+    return "ok";
+  }
+
+  const { hasContacts, hasActorTokens } = evidenceSignals();
+  if (!hasContacts && !hasActorTokens) {
+    return "ok";
+  }
+
+  reportMissingGuardian({
+    has_contacts: hasContacts,
+    has_actor_tokens: hasActorTokens,
+  });
+  return "missing_guardian";
+}
+
+/**
+ * Drop the cached state so the next read recomputes — called after
+ * guardian-binding writes so a re-seeded guardian is observed immediately.
+ */
+export function bustGuardianIntegrityCache(): void {
+  cached = null;
+}

--- a/gateway/src/guardian-integrity-reporter.ts
+++ b/gateway/src/guardian-integrity-reporter.ts
@@ -1,0 +1,92 @@
+// Fail-loud reporting for a gateway DB that has lost its guardian rows while
+// carrying evidence of prior onboarding (see auth/guardian-integrity.ts).
+// Emits an error-level log and relays a `gateway_guardian_missing` watchdog
+// telemetry event to the daemon's internal telemetry route, which POSTs it
+// directly to platform ingest — bypassing any state owned by the broken trust
+// path so the alarm cannot suppress itself. Rate-limited per process; a lost
+// event is acceptable for a rare, high-signal check (no retry).
+
+import { loadConfig } from "./config.js";
+import type { fetchImpl } from "./fetch.js";
+import { postInternalTelemetry } from "./internal-telemetry-client.js";
+import { getLogger } from "./logger.js";
+
+const log = getLogger("guardian-integrity-reporter");
+
+/**
+ * Watchdog `check_name` for the missing-guardian integrity failure. Platform
+ * dashboards filter on this exact string — it is the cross-repo contract.
+ */
+export const GUARDIAN_MISSING_CHECK_NAME = "gateway_guardian_missing";
+
+const ROUTE_PATH = "/v1/internal/telemetry/watchdog";
+const REPORT_INTERVAL_MS = 60 * 60 * 1000;
+
+type ReporterOverrides = {
+  fetchImpl?: typeof fetchImpl;
+  mintToken?: () => string;
+  baseUrl?: string;
+};
+
+let overrides: ReporterOverrides = {};
+let lastReportAt = Number.NEGATIVE_INFINITY;
+let pendingRelay: Promise<unknown> = Promise.resolve();
+
+/**
+ * Report the missing-guardian state: error log + telemetry relay. Fires on
+ * the first detection per process and at most hourly thereafter (the state is
+ * sticky until the guardian is re-seeded, so every verdict would otherwise
+ * re-fire it). Fire-and-forget — never throws, never blocks the caller.
+ */
+export function reportMissingGuardian(detail: Record<string, unknown>): void {
+  const now = Date.now();
+  if (now - lastReportAt < REPORT_INTERVAL_MS) {
+    return;
+  }
+  lastReportAt = now;
+
+  log.error(
+    detail,
+    "gateway DB has no guardian rows but evidence of prior onboarding — " +
+      "trust verdicts will fail closed until the guardian is re-seeded",
+  );
+
+  pendingRelay = relayToDaemon(detail).catch((err) => {
+    log.warn({ err }, "guardian-missing telemetry relay failed (non-fatal)");
+  });
+}
+
+async function relayToDaemon(detail: Record<string, unknown>): Promise<void> {
+  const resp = await postInternalTelemetry({
+    baseUrl: overrides.baseUrl ?? loadConfig().assistantRuntimeBaseUrl,
+    path: ROUTE_PATH,
+    body: { check_name: GUARDIAN_MISSING_CHECK_NAME, detail },
+    fetchImpl: overrides.fetchImpl,
+    mintToken: overrides.mintToken,
+  });
+  if (!resp.ok) {
+    log.warn(
+      { status: resp.status },
+      "guardian-missing telemetry relay rejected (non-fatal)",
+    );
+  }
+}
+
+/** Test-only: inject fetch/token/baseUrl so tests never touch the network. */
+export function setGuardianIntegrityReporterOverridesForTesting(
+  next: ReporterOverrides,
+): void {
+  overrides = next;
+}
+
+/** Test-only: clear overrides and the rate-limit window. */
+export function resetGuardianIntegrityReporterForTesting(): void {
+  overrides = {};
+  lastReportAt = Number.NEGATIVE_INFINITY;
+  pendingRelay = Promise.resolve();
+}
+
+/** Test-only: await the most recent fire-and-forget relay. */
+export function flushGuardianIntegrityReporterForTesting(): Promise<unknown> {
+  return pendingRelay;
+}

--- a/gateway/src/guardian-integrity-reporter.ts
+++ b/gateway/src/guardian-integrity-reporter.ts
@@ -22,10 +22,16 @@ export const GUARDIAN_MISSING_CHECK_NAME = "gateway_guardian_missing";
 const ROUTE_PATH = "/v1/internal/telemetry/watchdog";
 const REPORT_INTERVAL_MS = 60 * 60 * 1000;
 
+type ReporterLog = {
+  error: (detail: Record<string, unknown>, msg: string) => void;
+  warn: (detail: Record<string, unknown>, msg: string) => void;
+};
+
 type ReporterOverrides = {
   fetchImpl?: typeof fetchImpl;
   mintToken?: () => string;
   baseUrl?: string;
+  log?: ReporterLog;
 };
 
 let overrides: ReporterOverrides = {};
@@ -45,14 +51,17 @@ export function reportMissingGuardian(detail: Record<string, unknown>): void {
   }
   lastReportAt = now;
 
-  log.error(
+  reporterLog().error(
     detail,
     "gateway DB has no guardian rows but evidence of prior onboarding — " +
       "trust verdicts will fail closed until the guardian is re-seeded",
   );
 
   pendingRelay = relayToDaemon(detail).catch((err) => {
-    log.warn({ err }, "guardian-missing telemetry relay failed (non-fatal)");
+    reporterLog().warn(
+      { err },
+      "guardian-missing telemetry relay failed (non-fatal)",
+    );
   });
 }
 
@@ -65,14 +74,21 @@ async function relayToDaemon(detail: Record<string, unknown>): Promise<void> {
     mintToken: overrides.mintToken,
   });
   if (!resp.ok) {
-    log.warn(
+    reporterLog().warn(
       { status: resp.status },
       "guardian-missing telemetry relay rejected (non-fatal)",
     );
   }
 }
 
-/** Test-only: inject fetch/token/baseUrl so tests never touch the network. */
+function reporterLog(): ReporterLog {
+  return overrides.log ?? log;
+}
+
+/**
+ * Test-only: inject fetch/token/baseUrl/log so tests never touch the network
+ * or the process logger.
+ */
 export function setGuardianIntegrityReporterOverridesForTesting(
   next: ReporterOverrides,
 ): void {

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -199,9 +199,14 @@ export async function handleInbound(
   // (non-authenticating channel, or a payload with no result) and is a no-op.
   if (options?.senderAuthenticated === false && trustVerdict) {
     const priorClass = trustVerdict.trustClass;
+    const priorResolutionFailed = trustVerdict.resolutionFailed === true;
     trustVerdict = makeUnauthenticatedSenderVerdict(
       trustVerdict.canonicalSenderId,
     );
+    // A resolver/integrity failure survives the downgrade: could-not-vouch
+    // outranks stranger, so consumers keep failing closed with no
+    // stranger-lane side effects.
+    if (priorResolutionFailed) trustVerdict.resolutionFailed = true;
     if (priorClass !== "unknown") {
       log.warn(
         {

--- a/gateway/src/internal-telemetry-client.ts
+++ b/gateway/src/internal-telemetry-client.ts
@@ -1,0 +1,39 @@
+// Authenticated POST to a daemon internal-telemetry route: service-token
+// auth, JSON body, bounded timeout, response body consumed so the connection
+// is released. Callers own the failure posture (re-queue vs drop) — this
+// helper only performs the transport.
+
+import { buildUpstreamUrl } from "@vellumai/assistant-client";
+
+import { mintServiceToken } from "./auth/token-exchange.js";
+import { fetchImpl as defaultFetchImpl } from "./fetch.js";
+
+const POST_TIMEOUT_MS = 10_000;
+
+export async function postInternalTelemetry(args: {
+  /** Daemon runtime base URL (`config.assistantRuntimeBaseUrl`). */
+  baseUrl: string;
+  /** Route path, e.g. `/v1/internal/telemetry/watchdog`. */
+  path: string;
+  body: unknown;
+  /** Injectable for tests. Defaults to the shared fetch wrapper. */
+  fetchImpl?: typeof defaultFetchImpl;
+  /** Injectable for tests. Defaults to minting a real service token. */
+  mintToken?: () => string;
+}): Promise<Response> {
+  const url = buildUpstreamUrl(args.baseUrl, args.path);
+  const doFetch = args.fetchImpl ?? defaultFetchImpl;
+  const mintToken = args.mintToken ?? mintServiceToken;
+
+  const resp = await doFetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${mintToken()}`,
+    },
+    body: JSON.stringify(args.body),
+    signal: AbortSignal.timeout(POST_TIMEOUT_MS),
+  });
+  await resp.text(); // release the connection
+  return resp;
+}

--- a/gateway/src/risk/trust-verdict-resolver.ts
+++ b/gateway/src/risk/trust-verdict-resolver.ts
@@ -15,6 +15,7 @@
 import type { TrustClass, TrustVerdict } from "@vellumai/gateway-client";
 import { and, desc, eq, sql } from "drizzle-orm";
 
+import { guardianIntegrityState } from "../auth/guardian-integrity.js";
 import { getGatewayDb } from "../db/connection.js";
 import {
   contacts as gwContacts,
@@ -204,6 +205,21 @@ export async function resolveTrustVerdict(
   }
 
   const verdict: TrustVerdict = { trustClass, canonicalSenderId };
+
+  // A gateway DB that has lost its guardian rows (but shows evidence of prior
+  // onboarding) misclassifies every sender as a plain stranger. Stamp
+  // `resolutionFailed` so consumers fail closed with no stranger-lane side
+  // effects. Best-effort: a thrown integrity check degrades to the plain
+  // unknown verdict rather than breaking resolution.
+  if (trustClass === "unknown") {
+    try {
+      if (guardianIntegrityState() === "missing_guardian") {
+        verdict.resolutionFailed = true;
+      }
+    } catch {
+      // Plain unknown verdict; integrity detection must never break resolution.
+    }
+  }
 
   // Session-presence stamp (channel-scoped): lets the daemon's deny branches
   // skip their verification-read IPC pair when no session exists. Best-effort


### PR DESCRIPTION
## Summary
- guardian-integrity module detects onboarded-but-zero-guardian-rows as a distinct integrity failure
- Verdicts stamp resolutionFailed in that state (daemon denies fail-closed); error log + telemetry, rate-limited
- Fresh installs and healthy installs unaffected; gateway never crashes on this state

Part of plan: acl-hardening-sweep.md (PR 3 of 18)