### PR TITLE
feat(web): cascade provenance pill on contact detail channel rows (LUM-2714)

### DIFF
--- a/clients/web/src/domains/contacts/components/contact-channels-section.tsx
+++ b/clients/web/src/domains/contacts/components/contact-channels-section.tsx
@@ -14,9 +14,15 @@ import { useState } from "react";
 import { Button } from "@vellumai/design-library/components/button";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 
-import type {
-    ChannelInfo,
-    ContactChannelPayload,
+import {
+    ProvenancePill,
+    type CascadeProvenance,
+} from "@/domains/contacts/components/provenance-pill";
+import type { ChannelProvenanceMap } from "@/domains/contacts/hooks/use-channel-provenance";
+import {
+    isSetupChannelId,
+    type ChannelInfo,
+    type ContactChannelPayload,
 } from "@/domains/contacts/types";
 
 const KNOWN_CHANNEL_IDS: ReadonlySet<string> = new Set<ChannelInfo["id"]>([
@@ -115,6 +121,12 @@ interface ContactChannelsSectionProps {
   contactChannels: ContactChannelPayload[];
   availableChannels?: ChannelInfo[];
   a2aEnabled?: boolean;
+  /**
+   * Cascade provenance per setup channel. When provided, channel rows the
+   * contact is present on show a pill naming the layer their effective
+   * access comes from. Absent when the `channelTrustFloors` flag is off.
+   */
+  channelProvenance?: ChannelProvenanceMap;
   setupLabel?: string;
   verifyLoading?: boolean;
   verifySubject?: "self" | "contact";
@@ -154,6 +166,7 @@ export function ContactChannelsSection({
   contactChannels,
   availableChannels,
   a2aEnabled,
+  channelProvenance,
   setupLabel = "Invite",
   verifyLoading,
   verifySubject = "self",
@@ -207,6 +220,11 @@ export function ContactChannelsSection({
               <ChannelRow
                 info={info}
                 existing={existing}
+                provenance={
+                  existing && isSetupChannelId(info.id)
+                    ? channelProvenance?.[info.id]
+                    : undefined
+                }
                 setupLabel={setupLabel}
                 verifyLoading={verifyLoading}
                 onSetup={
@@ -271,6 +289,7 @@ export function ContactChannelsSection({
 interface ChannelRowProps {
   info: ChannelInfo;
   existing: ContactChannelPayload | undefined;
+  provenance?: CascadeProvenance;
   setupLabel: string;
   verifyLoading?: boolean;
   onSetup?: () => void;
@@ -281,6 +300,7 @@ interface ChannelRowProps {
 function ChannelRow({
   info,
   existing,
+  provenance,
   setupLabel,
   verifyLoading,
   onSetup,
@@ -311,6 +331,7 @@ function ChannelRow({
         </span>
       ) : null}
       <div className="ml-auto flex shrink-0 items-center gap-2">
+        {provenance ? <ProvenancePill provenance={provenance} /> : null}
         {actionState.kind === "connected" ? (
           <>
             <span className="inline-flex items-center gap-1 h-8 px-2.5 rounded-md whitespace-nowrap select-none text-body-small-emphasised leading-none bg-[var(--content-default)] text-[var(--surface-base)]">

--- a/clients/web/src/domains/contacts/components/contact-detail-view.tsx
+++ b/clients/web/src/domains/contacts/components/contact-detail-view.tsx
@@ -7,6 +7,7 @@ import { Input } from "@vellumai/design-library/components/input";
 import { DetailCard } from "@/components/detail-card";
 import { ContactChannelsSection } from "@/domains/contacts/components/contact-channels-section";
 import { ContactTypeBadge } from "@/domains/contacts/components/contact-type-badge";
+import type { ChannelProvenanceMap } from "@/domains/contacts/hooks/use-channel-provenance";
 import type { ChannelInfo, ContactPayload } from "@/domains/contacts/types";
 
 interface ContactDetailViewProps {
@@ -18,6 +19,7 @@ interface ContactDetailViewProps {
   canMerge?: boolean;
   availableChannels?: ChannelInfo[];
   a2aEnabled?: boolean;
+  channelProvenance?: ChannelProvenanceMap;
   onSave: (patch: { displayName: string; notes: string }) => void;
   onDelete: () => void;
   onMerge?: () => void;
@@ -39,6 +41,7 @@ function ContactDetailViewInner({
   canMerge = false,
   availableChannels,
   a2aEnabled,
+  channelProvenance,
   onSave,
   onDelete,
   onMerge,
@@ -162,6 +165,7 @@ function ContactDetailViewInner({
           contactChannels={contact.channels}
           availableChannels={availableChannels}
           a2aEnabled={a2aEnabled}
+          channelProvenance={channelProvenance}
           verifyLoading={verifyPending}
           verifySubject="contact"
           onSetupChannel={onSetupChannel}

--- a/clients/web/src/domains/contacts/components/provenance-pill.stories.tsx
+++ b/clients/web/src/domains/contacts/components/provenance-pill.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MemoryRouter } from "react-router";
+
+import { ProvenancePill } from "./provenance-pill";
+
+/**
+ * Cascade provenance pill for a contact channel's effective access — names
+ * the layer the admission floor comes from. The channel-default state links
+ * "Channels → Slack" to that channel's sub-tab on the Channels page, so the
+ * stories mount inside a router.
+ */
+const meta: Meta<typeof ProvenancePill> = {
+  title: "Contacts/ProvenancePill",
+  component: ProvenancePill,
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ProvenancePill>;
+
+export const GlobalDefault: Story = {
+  args: {
+    provenance: { source: "global-default" },
+  },
+};
+
+export const ChannelDefaultSlack: Story = {
+  args: {
+    provenance: { source: "channel-default", channel: "slack" },
+  },
+};
+
+export const ChannelDefaultTelegram: Story = {
+  args: {
+    provenance: { source: "channel-default", channel: "telegram" },
+  },
+};

--- a/clients/web/src/domains/contacts/components/provenance-pill.test.tsx
+++ b/clients/web/src/domains/contacts/components/provenance-pill.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+
+import type { ReactElement } from "react";
+
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+import { ProvenancePill } from "./provenance-pill";
+
+function renderPill(ui: ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe("ProvenancePill", () => {
+  it("renders the global-default state", () => {
+    renderPill(<ProvenancePill provenance={{ source: "global-default" }} />);
+    expect(screen.getByText("Global default")).toBeTruthy();
+  });
+
+  it("renders the channel-default state with a link to the channel sub-tab", () => {
+    renderPill(
+      <ProvenancePill
+        provenance={{ source: "channel-default", channel: "slack" }}
+      />,
+    );
+    expect(screen.getByText(/Default from/)).toBeTruthy();
+    const link = screen.getByRole("link", { name: "Channels → Slack" });
+    expect(link.getAttribute("href")).toBe("/assistant/channels?setup=slack");
+  });
+
+  it("labels the linked channel per the channel presentation registry", () => {
+    renderPill(
+      <ProvenancePill
+        provenance={{ source: "channel-default", channel: "telegram" }}
+      />,
+    );
+    const link = screen.getByRole("link", { name: "Channels → Telegram" });
+    expect(link.getAttribute("href")).toBe(
+      "/assistant/channels?setup=telegram",
+    );
+  });
+});

--- a/clients/web/src/domains/contacts/components/provenance-pill.tsx
+++ b/clients/web/src/domains/contacts/components/provenance-pill.tsx
@@ -1,0 +1,43 @@
+import { Link } from "react-router";
+
+import { Button } from "@vellumai/design-library/components/button";
+import { Tag } from "@vellumai/design-library/components/tag";
+
+import type { SetupChannelId } from "@/domains/contacts/types";
+import { getChannelLabel } from "@/utils/channel-presentation";
+import { routes } from "@/utils/routes";
+
+/**
+ * Which layer of the permission cascade sets a channel's effective admission
+ * floor. `global-default` means no channel-level floor is stored; the
+ * built-in default applies. `channel-default` means the floor was explicitly
+ * set for that channel on the Channels tab.
+ */
+export type CascadeProvenance =
+  | { source: "global-default" }
+  | { source: "channel-default"; channel: SetupChannelId };
+
+export interface ProvenancePillProps {
+  provenance: CascadeProvenance;
+}
+
+/**
+ * Neutral pill naming the cascade layer a contact channel's effective access
+ * comes from — "Global default", or "Default from Channels → Slack" with the
+ * channel part linking to that channel's sub-tab on the Channels page.
+ */
+export function ProvenancePill({ provenance }: ProvenancePillProps) {
+  if (provenance.source === "global-default") {
+    return <Tag>Global default</Tag>;
+  }
+  return (
+    <Tag>
+      Default from
+      <Button asChild variant="link" size="compact" className="h-auto px-0">
+        <Link to={`${routes.channels}?setup=${provenance.channel}`}>
+          Channels → {getChannelLabel(provenance.channel)}
+        </Link>
+      </Button>
+    </Tag>
+  );
+}

--- a/clients/web/src/domains/contacts/contacts-page.tsx
+++ b/clients/web/src/domains/contacts/contacts-page.tsx
@@ -36,6 +36,7 @@ import { channelsAvailableGet } from "@/generated/daemon/sdk.gen";
 import type { ChannelsAvailableGetResponse } from "@/generated/daemon/types.gen";
 import { assistantDisplayName } from "@/domains/contacts/assistant-display-name";
 import { useAssistantChannels } from "@/domains/contacts/hooks/use-assistant-channels";
+import { useChannelProvenance } from "@/domains/contacts/hooks/use-channel-provenance";
 import { useInviteLinkDialog } from "@/domains/contacts/hooks/use-invite-link-dialog";
 import { useSetupChannelParam } from "@/domains/contacts/hooks/use-setup-channel-param";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
@@ -135,6 +136,8 @@ export function ContactsPage({
     assistantId,
     onStartSetupConversation,
   });
+
+  const channelProvenance = useChannelProvenance(assistantId);
 
   const availabilityQuery = useQuery({
     ...channelsAvailableGetOptions({
@@ -497,6 +500,7 @@ export function ContactsPage({
               canMerge={canMerge}
               availableChannels={availableChannels}
               a2aEnabled={a2aChannel}
+              channelProvenance={channelProvenance}
               onSave={(patch) => {
                 updateMutation.mutate({
                   contactId: optimisticContact.id,

--- a/clients/web/src/domains/contacts/hooks/use-channel-provenance.test.ts
+++ b/clients/web/src/domains/contacts/hooks/use-channel-provenance.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+
+import type { ChannelPolicyView } from "@/lib/channel-admission-policy/types";
+
+import { deriveChannelProvenance } from "./use-channel-provenance";
+
+function policy(
+  channelType: string,
+  policyValue: ChannelPolicyView["policy"],
+  updatedAt: number | null,
+): ChannelPolicyView {
+  return { channelType, policy: policyValue, note: null, updatedAt };
+}
+
+describe("deriveChannelProvenance", () => {
+  it("treats a gateway-seeded default row (non-null updatedAt) as the global default", () => {
+    const map = deriveChannelProvenance([
+      policy("slack", "trusted_contacts", 1_776_000_000_000),
+    ]);
+    expect(map.slack).toEqual({ source: "global-default" });
+  });
+
+  it("treats a floor differing from the global default as channel-set", () => {
+    const map = deriveChannelProvenance([
+      policy("slack", "guardian_only", 1_776_000_000_000),
+      policy("telegram", "strangers", null),
+    ]);
+    expect(map.slack).toEqual({ source: "channel-default", channel: "slack" });
+    expect(map.telegram).toEqual({
+      source: "channel-default",
+      channel: "telegram",
+    });
+  });
+
+  it("treats a merged-in default view (null updatedAt) as the global default", () => {
+    const map = deriveChannelProvenance([
+      policy("phone", "trusted_contacts", null),
+    ]);
+    expect(map.phone).toEqual({ source: "global-default" });
+  });
+
+  it("skips channels without a setup flow", () => {
+    const map = deriveChannelProvenance([
+      policy("email", "guardian_only", null),
+    ]);
+    expect(Object.keys(map)).toEqual([]);
+  });
+});

--- a/clients/web/src/domains/contacts/hooks/use-channel-provenance.ts
+++ b/clients/web/src/domains/contacts/hooks/use-channel-provenance.ts
@@ -4,7 +4,14 @@ import { useQuery } from "@tanstack/react-query";
 
 import type { CascadeProvenance } from "@/domains/contacts/components/provenance-pill";
 import { isSetupChannelId, type SetupChannelId } from "@/domains/contacts/types";
-import { fetchChannelPolicies } from "@/lib/channel-admission-policy/api";
+import {
+  channelAdmissionPolicyQueryKey,
+  fetchChannelPolicies,
+} from "@/lib/channel-admission-policy/api";
+import {
+  ADMISSION_POLICY_DEFAULT,
+  type ChannelPolicyView,
+} from "@/lib/channel-admission-policy/types";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 export type ChannelProvenanceMap = Partial<
@@ -12,14 +19,41 @@ export type ChannelProvenanceMap = Partial<
 >;
 
 /**
+ * Derive per-channel cascade provenance from the admission-floor list.
+ *
+ * Provenance is decided by value, not by row metadata: the gateway seeds a
+ * row for every enforced channel at startup with a real `updatedAt`
+ * timestamp (`seedAdmissionPolicyDefaults`), so a stored row — even a
+ * recently-stamped one — does not imply the user set a channel-level floor.
+ * A floor that differs from the global default is definitionally
+ * channel-set; a floor equal to it renders as the global default.
+ */
+export function deriveChannelProvenance(
+  policies: ChannelPolicyView[],
+): ChannelProvenanceMap {
+  const map: ChannelProvenanceMap = {};
+  for (const policy of policies) {
+    if (!isSetupChannelId(policy.channelType)) {
+      continue;
+    }
+    map[policy.channelType] =
+      policy.policy !== ADMISSION_POLICY_DEFAULT
+        ? { source: "channel-default", channel: policy.channelType }
+        : { source: "global-default" };
+  }
+  return map;
+}
+
+/**
  * Per-channel cascade provenance for the contact detail's channel rows —
  * whether each setup channel's admission floor comes from the global default
- * (no stored row, `updatedAt` null) or a channel-level default set on the
- * Channels tab. Reads the `channelTrustFloors` flag itself; when off it
- * returns `undefined`, which hides the provenance pill entirely.
+ * or a channel-level default set on the Channels tab (see
+ * {@link deriveChannelProvenance} for the decision rule). Reads the
+ * `channelTrustFloors` flag itself; when off it returns `undefined`, which
+ * hides the provenance pill entirely.
  *
- * Shares its query key with `useChannelTrustFloors` so both surfaces read
- * one cache entry.
+ * Builds its query key via {@link channelAdmissionPolicyQueryKey} so it
+ * shares one cache entry with `useChannelTrustFloors`.
  */
 export function useChannelProvenance(
   assistantId: string,
@@ -27,7 +61,7 @@ export function useChannelProvenance(
   const enabled = useAssistantFeatureFlagStore.use.channelTrustFloors();
 
   const query = useQuery({
-    queryKey: ["channel-admission-policy", assistantId] as const,
+    queryKey: channelAdmissionPolicyQueryKey(assistantId),
     queryFn: () => fetchChannelPolicies(assistantId),
     enabled,
   });
@@ -36,16 +70,6 @@ export function useChannelProvenance(
     if (!enabled || !query.data) {
       return undefined;
     }
-    const map: ChannelProvenanceMap = {};
-    for (const policy of query.data) {
-      if (!isSetupChannelId(policy.channelType)) {
-        continue;
-      }
-      map[policy.channelType] =
-        policy.updatedAt != null
-          ? { source: "channel-default", channel: policy.channelType }
-          : { source: "global-default" };
-    }
-    return map;
+    return deriveChannelProvenance(query.data);
   }, [enabled, query.data]);
 }

--- a/clients/web/src/domains/contacts/hooks/use-channel-provenance.ts
+++ b/clients/web/src/domains/contacts/hooks/use-channel-provenance.ts
@@ -1,17 +1,14 @@
-import { useMemo } from "react";
-
 import { useQuery } from "@tanstack/react-query";
 
 import type { CascadeProvenance } from "@/domains/contacts/components/provenance-pill";
 import { isSetupChannelId, type SetupChannelId } from "@/domains/contacts/types";
-import {
-  channelAdmissionPolicyQueryKey,
-  fetchChannelPolicies,
-} from "@/lib/channel-admission-policy/api";
+import { assistantChannelAdmissionPolicyListOptions } from "@/generated/gateway/@tanstack/react-query.gen";
+import type { AssistantChannelAdmissionPolicyListResponse } from "@/generated/gateway/types.gen";
 import {
   ADMISSION_POLICY_DEFAULT,
   type ChannelPolicyView,
 } from "@/lib/channel-admission-policy/types";
+import { toChannelPolicyViews } from "@/lib/channel-admission-policy/api";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 export type ChannelProvenanceMap = Partial<
@@ -44,6 +41,12 @@ export function deriveChannelProvenance(
   return map;
 }
 
+function selectChannelProvenance(
+  data: AssistantChannelAdmissionPolicyListResponse,
+): ChannelProvenanceMap {
+  return deriveChannelProvenance(toChannelPolicyViews(data));
+}
+
 /**
  * Per-channel cascade provenance for the contact detail's channel rows —
  * whether each setup channel's admission floor comes from the global default
@@ -52,8 +55,9 @@ export function deriveChannelProvenance(
  * `channelTrustFloors` flag itself; when off it returns `undefined`, which
  * hides the provenance pill entirely.
  *
- * Builds its query key via {@link channelAdmissionPolicyQueryKey} so it
- * shares one cache entry with `useChannelTrustFloors`.
+ * Spreads the generated `assistantChannelAdmissionPolicyListOptions` so it
+ * shares the generated query key — and one raw cache entry — with
+ * `useChannelTrustFloors`.
  */
 export function useChannelProvenance(
   assistantId: string,
@@ -61,15 +65,12 @@ export function useChannelProvenance(
   const enabled = useAssistantFeatureFlagStore.use.channelTrustFloors();
 
   const query = useQuery({
-    queryKey: channelAdmissionPolicyQueryKey(assistantId),
-    queryFn: () => fetchChannelPolicies(assistantId),
+    ...assistantChannelAdmissionPolicyListOptions({
+      path: { assistant_id: assistantId },
+    }),
     enabled,
+    select: selectChannelProvenance,
   });
 
-  return useMemo(() => {
-    if (!enabled || !query.data) {
-      return undefined;
-    }
-    return deriveChannelProvenance(query.data);
-  }, [enabled, query.data]);
+  return enabled ? query.data : undefined;
 }

--- a/clients/web/src/domains/contacts/hooks/use-channel-provenance.ts
+++ b/clients/web/src/domains/contacts/hooks/use-channel-provenance.ts
@@ -1,0 +1,51 @@
+import { useMemo } from "react";
+
+import { useQuery } from "@tanstack/react-query";
+
+import type { CascadeProvenance } from "@/domains/contacts/components/provenance-pill";
+import { isSetupChannelId, type SetupChannelId } from "@/domains/contacts/types";
+import { fetchChannelPolicies } from "@/lib/channel-admission-policy/api";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
+
+export type ChannelProvenanceMap = Partial<
+  Record<SetupChannelId, CascadeProvenance>
+>;
+
+/**
+ * Per-channel cascade provenance for the contact detail's channel rows —
+ * whether each setup channel's admission floor comes from the global default
+ * (no stored row, `updatedAt` null) or a channel-level default set on the
+ * Channels tab. Reads the `channelTrustFloors` flag itself; when off it
+ * returns `undefined`, which hides the provenance pill entirely.
+ *
+ * Shares its query key with `useChannelTrustFloors` so both surfaces read
+ * one cache entry.
+ */
+export function useChannelProvenance(
+  assistantId: string,
+): ChannelProvenanceMap | undefined {
+  const enabled = useAssistantFeatureFlagStore.use.channelTrustFloors();
+
+  const query = useQuery({
+    queryKey: ["channel-admission-policy", assistantId] as const,
+    queryFn: () => fetchChannelPolicies(assistantId),
+    enabled,
+  });
+
+  return useMemo(() => {
+    if (!enabled || !query.data) {
+      return undefined;
+    }
+    const map: ChannelProvenanceMap = {};
+    for (const policy of query.data) {
+      if (!isSetupChannelId(policy.channelType)) {
+        continue;
+      }
+      map[policy.channelType] =
+        policy.updatedAt != null
+          ? { source: "channel-default", channel: policy.channelType }
+          : { source: "global-default" };
+    }
+    return map;
+  }, [enabled, query.data]);
+}

--- a/clients/web/src/domains/contacts/hooks/use-channel-trust-floors.ts
+++ b/clients/web/src/domains/contacts/hooks/use-channel-trust-floors.ts
@@ -5,6 +5,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { AssistantChannelState } from "@/domains/contacts/types";
 import { isSetupChannelId } from "@/domains/contacts/types";
 import {
+  channelAdmissionPolicyQueryKey,
   fetchChannelPolicies,
   setChannelPolicy,
 } from "@/lib/channel-admission-policy/api";
@@ -38,7 +39,7 @@ export function useChannelTrustFloors(assistantId: string): ChannelTrustFloors {
   const enabled = useAssistantFeatureFlagStore.use.channelTrustFloors();
 
   const queryKey = useMemo(
-    () => ["channel-admission-policy", assistantId] as const,
+    () => channelAdmissionPolicyQueryKey(assistantId),
     [assistantId],
   );
 

--- a/clients/web/src/domains/contacts/hooks/use-channel-trust-floors.ts
+++ b/clients/web/src/domains/contacts/hooks/use-channel-trust-floors.ts
@@ -5,9 +5,12 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { AssistantChannelState } from "@/domains/contacts/types";
 import { isSetupChannelId } from "@/domains/contacts/types";
 import {
-  channelAdmissionPolicyQueryKey,
-  fetchChannelPolicies,
+  assistantChannelAdmissionPolicyListOptions,
+  assistantChannelAdmissionPolicyListQueryKey,
+} from "@/generated/gateway/@tanstack/react-query.gen";
+import {
   setChannelPolicy,
+  toChannelPolicyViews,
 } from "@/lib/channel-admission-policy/api";
 import type { AdmissionPolicy } from "@/lib/channel-admission-policy/types";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
@@ -38,15 +41,19 @@ export function useChannelTrustFloors(assistantId: string): ChannelTrustFloors {
   const queryClient = useQueryClient();
   const enabled = useAssistantFeatureFlagStore.use.channelTrustFloors();
 
-  const queryKey = useMemo(
-    () => channelAdmissionPolicyQueryKey(assistantId),
+  const pathOptions = useMemo(
+    () => ({ path: { assistant_id: assistantId } }),
     [assistantId],
+  );
+  const queryKey = useMemo(
+    () => assistantChannelAdmissionPolicyListQueryKey(pathOptions),
+    [pathOptions],
   );
 
   const query = useQuery({
-    queryKey,
-    queryFn: () => fetchChannelPolicies(assistantId),
+    ...assistantChannelAdmissionPolicyListOptions(pathOptions),
     enabled,
+    select: toChannelPolicyViews,
   });
 
   const policies = useMemo(() => {

--- a/clients/web/src/lib/channel-admission-policy/api.ts
+++ b/clients/web/src/lib/channel-admission-policy/api.ts
@@ -14,6 +14,7 @@ import {
   assistantChannelAdmissionPolicyList,
   assistantChannelAdmissionPolicySet,
 } from "@/generated/gateway/sdk.gen";
+import type { AssistantChannelAdmissionPolicyListResponse } from "@/generated/gateway/types.gen";
 import {
   ApiError,
   assertHasResponse,
@@ -30,16 +31,6 @@ import {
 
 export { ApiError };
 
-/**
- * TanStack Query key for the channel admission-floor list. Every hook that
- * reads the floors (`useChannelTrustFloors`, `useChannelProvenance`) must
- * build its key here so they all share one cache entry and invalidations
- * reach every reader.
- */
-export function channelAdmissionPolicyQueryKey(assistantId: string) {
-  return ["channel-admission-policy", assistantId] as const;
-}
-
 function isAdmissionPolicy(value: unknown): value is AdmissionPolicy {
   return (
     typeof value === "string" &&
@@ -52,11 +43,34 @@ export function isInternalChannel(channelType: string): boolean {
 }
 
 /**
- * List every client-controllable channel's admission floor.
- *
- * Channels in {@link INTERNAL_CHANNELS} and {@link isHiddenChannel} are
- * filtered out before returning, so callers can render the result directly
- * without re-filtering.
+ * Shape the raw admission-floor list response into client policy views:
+ * channels in {@link INTERNAL_CHANNELS} and {@link isHiddenChannel} are
+ * dropped, and unknown policy strings coerce to the default. Shared by
+ * {@link fetchChannelPolicies} and by the TanStack `select` in the hooks
+ * that spread the generated `assistantChannelAdmissionPolicyListOptions`
+ * (`useChannelTrustFloors`, `useChannelProvenance`), so every reader keys
+ * off the generated query key and one raw cache entry.
+ */
+export function toChannelPolicyViews(
+  data: AssistantChannelAdmissionPolicyListResponse | undefined,
+): ChannelPolicyView[] {
+  const policies = data?.policies ?? [];
+  return policies
+    .filter(
+      (p) =>
+        !isInternalChannel(p.channelType) && !isHiddenChannel(p.channelType),
+    )
+    .map((p) => ({
+      ...p,
+      policy: isAdmissionPolicy(p.policy) ? p.policy : "trusted_contacts",
+    }));
+}
+
+/**
+ * List every client-controllable channel's admission floor. Imperative
+ * accessor for non-query call sites; React hooks should spread the generated
+ * `assistantChannelAdmissionPolicyListOptions` with
+ * `select: toChannelPolicyViews` instead.
  */
 export async function fetchChannelPolicies(
   assistantId: string,
@@ -72,16 +86,7 @@ export async function fetchChannelPolicies(
       extractErrorMessage(error, response, "Failed to load channel policies."),
     );
   }
-  const policies = data?.policies ?? [];
-  return policies
-    .filter(
-      (p) =>
-        !isInternalChannel(p.channelType) && !isHiddenChannel(p.channelType),
-    )
-    .map((p) => ({
-      ...p,
-      policy: isAdmissionPolicy(p.policy) ? p.policy : "trusted_contacts",
-    }));
+  return toChannelPolicyViews(data);
 }
 
 export async function setChannelPolicy(

--- a/clients/web/src/lib/channel-admission-policy/api.ts
+++ b/clients/web/src/lib/channel-admission-policy/api.ts
@@ -30,6 +30,16 @@ import {
 
 export { ApiError };
 
+/**
+ * TanStack Query key for the channel admission-floor list. Every hook that
+ * reads the floors (`useChannelTrustFloors`, `useChannelProvenance`) must
+ * build its key here so they all share one cache entry and invalidations
+ * reach every reader.
+ */
+export function channelAdmissionPolicyQueryKey(assistantId: string) {
+  return ["channel-admission-policy", assistantId] as const;
+}
+
 function isAdmissionPolicy(value: unknown): value is AdmissionPolicy {
   return (
     typeof value === "string" &&


### PR DESCRIPTION
## Prompt / plan

Implements [LUM-2714](https://linear.app/vellum/issue/LUM-2714) per the Primitives Plan approved on the ticket, with the reduced scope agreed there: **states 1–2 only, read-only** — the "Overriding channel default" state and "Reset to default" action ship later with the per-contact override surface, and no Assistant Access dropdown is added.

- `<ProvenancePill>` (`domains/contacts/components/provenance-pill.tsx`) wraps the design-library `Tag` primitive (neutral tone), mirroring the sibling `ContactTypeBadge` pattern. State 2's "Channels → Slack" segment is the design-library `Button` link variant (`asChild` + router `Link`) deep-linking to `/assistant/channels?setup=<channel>`, which `useSetupChannelParam` already consumes to pre-select the sub-tab. Copy is exactly the ticket vocabulary: "Global default" / "Default from Channels → Slack".
- `useChannelProvenance` decides provenance **by value**: a floor differing from `ADMISSION_POLICY_DEFAULT` is channel-set; a floor equal to it renders as the global default. Row metadata can't discriminate — the gateway seeds a timestamped row for every enforced channel at startup (`seedAdmissionPolicyDefaults`), so `updatedAt` is non-null even for untouched defaults (caught by Codex review, fixed in 0938c62). The pure `deriveChannelProvenance` is unit-tested, including the seeded-row case.
- Both `useChannelProvenance` and `useChannelTrustFloors` spread the generated `assistantChannelAdmissionPolicyListOptions` and shape data via `select` (`toChannelPolicyViews`), so all readers share the canonical generated HeyAPI query key and one raw cache entry — no hand-rolled keys (fdac91d).
- The hook reads the `channelTrustFloors` flag itself — flag off returns `undefined` and no pill renders anywhere.
- The pill renders on contact detail channel rows the contact is actually present on (`ContactChannelsSection` → `ChannelRow`), next to the Verified/Connected badge. The guardian detail view doesn't pass the map and is unchanged, since admission floors don't gate the guardian.
- Storybook story with all shipped states.

## Test plan

- Unit tests: `provenance-pill.test.tsx` (3 — both states' copy, link targets, channel labelling) and `use-channel-provenance.test.ts` (4 — seeded-row default, channel-set floors, merged-in defaults, non-setup channels skipped).
- Adjacent suites pass individually (CI-isolated runner): `contacts-page.test.tsx` (2), `assistant-channels-detail.test.tsx` (8), `channel-admission-policy/api.test.ts` (7).
- `bun run openapi-ts && bunx tsc --noEmit` clean; `eslint` clean on all touched files (0 errors; the repo-wide `curly` warnings in `contacts-page.tsx` are pre-existing on untouched lines).
- PR Web Checks green (lint, type check, build, test).

## CLI verb checklist

No new IPC routes — web-only change, reads an existing gateway endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ar9B91QFYMBjye7hjjvpP2