### PR TITLE
refactor(invites): INVITES_IPC_METHODS map + schema-validated daemon invite client

### DIFF
--- a/assistant/src/__tests__/invite-routes-http.test.ts
+++ b/assistant/src/__tests__/invite-routes-http.test.ts
@@ -146,7 +146,12 @@ describe("invite redeem relay routes", () => {
   test("POST /v1/contacts/invites/redeem — token body relays to the gateway and returns its payload", async () => {
     redeemRelay.result = {
       ok: true,
-      invite: { id: "inv-gw-1", status: "redeemed", useCount: 1 },
+      invite: {
+        id: "inv-gw-1",
+        sourceChannel: "telegram",
+        status: "redeemed",
+        useCount: 1,
+      },
       type: "redeemed",
     };
 

--- a/assistant/src/calls/gateway-invite-reader.ts
+++ b/assistant/src/calls/gateway-invite-reader.ts
@@ -11,14 +11,21 @@
  * - Redemption fails CLOSED — any IPC failure is the generic
  *   `invalid_or_expired` outcome. There is no local fallback: the gateway
  *   row is the single lifecycle authority for voice invites.
+ *
+ * Deliberately NOT built on `channels/gateway-invites.ts` /
+ * `ipcCallPersistentValidated`: this is the hot call-setup path, so it uses
+ * one-shot `ipcCall` with explicit per-operation timeouts and the fail
+ * postures above instead of the persistent throw-fail-closed client the
+ * control-plane relays share.
  */
 
 import {
   type ActiveVoiceInvite,
-  ActiveVoiceInviteSchema,
-  InviteRedemptionOutcomeSchema,
+  GetActiveVoiceInviteIpcResponseSchema,
+  INVITES_IPC_METHODS,
+  type RedeemVoiceInviteIpcResponse,
+  RedeemVoiceInviteIpcResponseSchema,
 } from "@vellumai/gateway-client";
-import { z } from "zod";
 
 import { ipcCall } from "../ipc/gateway-client.js";
 
@@ -29,18 +36,7 @@ const DETECTION_IPC_TIMEOUT_MS = 2_000;
 // headroom — a timeout still fails closed.
 const REDEMPTION_IPC_TIMEOUT_MS = 10_000;
 
-const GetActiveVoiceInviteResponseSchema = z.object({
-  invite: ActiveVoiceInviteSchema.nullable(),
-});
-
-const RedeemVoiceInviteResponseSchema = z.discriminatedUnion("ok", [
-  z.object({ ok: z.literal(true), outcome: InviteRedemptionOutcomeSchema }),
-  z.object({ ok: z.literal(false), reason: z.literal("invalid_or_expired") }),
-]);
-
-export type GatewayVoiceRedemptionResult = z.infer<
-  typeof RedeemVoiceInviteResponseSchema
->;
+export type GatewayVoiceRedemptionResult = RedeemVoiceInviteIpcResponse;
 
 const REDEMPTION_FAILURE: GatewayVoiceRedemptionResult = {
   ok: false,
@@ -59,11 +55,11 @@ export async function getActiveVoiceInvite(
   }
   try {
     const result = await ipcCall(
-      "get_active_voice_invite",
+      INVITES_IPC_METHODS.getActiveVoiceInvite,
       { callerExternalUserId: fromNumber },
       DETECTION_IPC_TIMEOUT_MS,
     );
-    const parsed = GetActiveVoiceInviteResponseSchema.safeParse(result);
+    const parsed = GetActiveVoiceInviteIpcResponseSchema.safeParse(result);
     if (!parsed.success) {
       return null;
     }
@@ -83,11 +79,11 @@ export async function redeemVoiceInviteViaGateway(
 ): Promise<GatewayVoiceRedemptionResult> {
   try {
     const result = await ipcCall(
-      "redeem_voice_invite",
+      INVITES_IPC_METHODS.redeemVoiceInvite,
       { callerExternalUserId: fromNumber, code },
       REDEMPTION_IPC_TIMEOUT_MS,
     );
-    const parsed = RedeemVoiceInviteResponseSchema.safeParse(result);
+    const parsed = RedeemVoiceInviteIpcResponseSchema.safeParse(result);
     if (!parsed.success) {
       return REDEMPTION_FAILURE;
     }

--- a/assistant/src/channels/__tests__/gateway-invites.test.ts
+++ b/assistant/src/channels/__tests__/gateway-invites.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Tests for the gateway-backed invite client.
+ *
+ * The IPC transport is stubbed; each wrapper is exercised for wire-method +
+ * param mapping, contract-schema validation of responses, malformed-response
+ * rejection, and unchanged propagation of transport errors (fail-closed —
+ * an `IpcCallError` keeps its gateway statusCode for the relay routes).
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { INVITES_IPC_METHODS } from "@vellumai/gateway-client";
+import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
+
+type IpcCall = { method: string; params?: Record<string, unknown> };
+
+let ipcCalls: IpcCall[] = [];
+let ipcResponse: unknown;
+let ipcError: Error | null = null;
+
+const ipcCallPersistentMock = mock(
+  async (method: string, params?: Record<string, unknown>) => {
+    ipcCalls.push({ method, params });
+    if (ipcError) {
+      throw ipcError;
+    }
+    return ipcResponse;
+  },
+);
+const actualGatewayClient = await import("../../ipc/gateway-client.js");
+mock.module("../../ipc/gateway-client.js", () => ({
+  ...actualGatewayClient,
+  ipcCallPersistent: ipcCallPersistentMock,
+}));
+
+const client = await import("../gateway-invites.js");
+
+const inviteRow = {
+  id: "inv-1",
+  sourceChannel: "telegram",
+  status: "active",
+  maxUses: 1,
+  useCount: 0,
+};
+
+beforeEach(() => {
+  ipcCalls = [];
+  ipcResponse = undefined;
+  ipcError = null;
+});
+
+describe("listInvites", () => {
+  test("relays invites_list with only the provided filters", async () => {
+    ipcResponse = { invites: [inviteRow] };
+
+    const invites = await client.listInvites({
+      sourceChannel: "telegram",
+      status: "active",
+    });
+
+    expect(ipcCalls).toEqual([
+      {
+        method: INVITES_IPC_METHODS.list,
+        params: { sourceChannel: "telegram", status: "active" },
+      },
+    ]);
+    expect(invites).toEqual([inviteRow]);
+  });
+
+  test("sends empty params when no filters are given", async () => {
+    ipcResponse = { invites: [] };
+
+    await client.listInvites();
+
+    expect(ipcCalls).toEqual([
+      { method: INVITES_IPC_METHODS.list, params: {} },
+    ]);
+  });
+
+  test("rejects a malformed response", async () => {
+    ipcResponse = { invites: [{ sourceChannel: "telegram" }] };
+
+    await expect(client.listInvites()).rejects.toThrow(
+      "malformed invites_list response",
+    );
+  });
+});
+
+describe("createInvite", () => {
+  test("relays invites_create and returns the one-time payload", async () => {
+    ipcResponse = {
+      invite: { ...inviteRow, token: "raw-tok" },
+      rawToken: "raw-tok",
+    };
+
+    const result = await client.createInvite({
+      contactId: "c1",
+      sourceChannel: "telegram",
+      note: "hi",
+      maxUses: 2,
+    });
+
+    expect(ipcCalls).toEqual([
+      {
+        method: INVITES_IPC_METHODS.create,
+        params: {
+          contactId: "c1",
+          sourceChannel: "telegram",
+          note: "hi",
+          maxUses: 2,
+        },
+      },
+    ]);
+    expect(result).toEqual({
+      invite: { ...inviteRow, token: "raw-tok" },
+      rawToken: "raw-tok",
+    });
+  });
+
+  test("tolerates an absent rawToken (voice invites)", async () => {
+    ipcResponse = { invite: { ...inviteRow, sourceChannel: "phone" } };
+
+    const result = await client.createInvite({
+      contactId: "c1",
+      sourceChannel: "phone",
+    });
+
+    expect(result.rawToken).toBeUndefined();
+  });
+
+  test("rejects a malformed response", async () => {
+    ipcResponse = { invite: { id: "inv-1" } };
+
+    await expect(
+      client.createInvite({ contactId: "c1", sourceChannel: "telegram" }),
+    ).rejects.toThrow("malformed invites_create response");
+  });
+});
+
+describe("revokeInvite", () => {
+  test("relays invites_revoke and returns the sanitized row", async () => {
+    ipcResponse = { invite: { ...inviteRow, status: "revoked" } };
+
+    const invite = await client.revokeInvite("inv-1");
+
+    expect(ipcCalls).toEqual([
+      { method: INVITES_IPC_METHODS.revoke, params: { id: "inv-1" } },
+    ]);
+    expect(invite).toEqual({ ...inviteRow, status: "revoked" });
+  });
+
+  test("rejects a malformed response", async () => {
+    ipcResponse = { ok: true };
+
+    await expect(client.revokeInvite("inv-1")).rejects.toThrow(
+      "malformed invites_revoke response",
+    );
+  });
+});
+
+describe("redeemInviteByToken", () => {
+  test("relays the token branch and returns the parsed payload", async () => {
+    ipcResponse = {
+      ok: true,
+      invite: { ...inviteRow, status: "redeemed" },
+      type: "redeemed",
+    };
+
+    const result = await client.redeemInviteByToken({
+      token: "raw-tok",
+      sourceChannel: "telegram",
+      externalUserId: "u1",
+      displayName: "Alice",
+    });
+
+    expect(ipcCalls).toEqual([
+      {
+        method: INVITES_IPC_METHODS.redeem,
+        params: {
+          token: "raw-tok",
+          sourceChannel: "telegram",
+          externalUserId: "u1",
+          displayName: "Alice",
+        },
+      },
+    ]);
+    expect(result.type).toBe("redeemed");
+  });
+
+  test("rejects a response with an off-contract type", async () => {
+    ipcResponse = { ok: true, invite: inviteRow, type: "maybe" };
+
+    await expect(
+      client.redeemInviteByToken({ token: "t", sourceChannel: "telegram" }),
+    ).rejects.toThrow("malformed invites_redeem response");
+  });
+});
+
+describe("redeemInviteByVoiceCode", () => {
+  test("relays the voice branch with the assistantId passthrough", async () => {
+    ipcResponse = {
+      ok: true,
+      type: "already_member",
+      memberId: "ct-1",
+    };
+
+    const result = await client.redeemInviteByVoiceCode({
+      callerExternalUserId: "+15555550100",
+      code: "123456",
+      assistantId: "asst-1",
+    });
+
+    expect(ipcCalls).toEqual([
+      {
+        method: INVITES_IPC_METHODS.redeem,
+        params: {
+          callerExternalUserId: "+15555550100",
+          code: "123456",
+          assistantId: "asst-1",
+        },
+      },
+    ]);
+    expect(result).toEqual({
+      ok: true,
+      type: "already_member",
+      memberId: "ct-1",
+    });
+  });
+
+  test("rejects a malformed response", async () => {
+    ipcResponse = { ok: true };
+
+    await expect(
+      client.redeemInviteByVoiceCode({
+        callerExternalUserId: "+15555550100",
+        code: "123456",
+      }),
+    ).rejects.toThrow("malformed invites_redeem response");
+  });
+});
+
+describe("transport failures", () => {
+  test("an IpcCallError propagates unchanged (statusCode preserved)", async () => {
+    ipcError = new IpcCallError("Invite not found", {
+      statusCode: 404,
+      errorCode: "NOT_FOUND",
+    });
+
+    try {
+      await client.revokeInvite("missing");
+      throw new Error("expected revokeInvite to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(IpcCallError);
+      expect((err as IpcCallError).statusCode).toBe(404);
+    }
+  });
+});

--- a/assistant/src/channels/gateway-invites.ts
+++ b/assistant/src/channels/gateway-invites.ts
@@ -1,0 +1,128 @@
+/**
+ * Gateway-backed invite client.
+ *
+ * Typed async wrappers over the gateway's invite IPC routes
+ * (`gateway/src/ipc/invite-handlers.ts`). The gateway owns the canonical
+ * invite lifecycle — mint, list, revoke, redemption — against
+ * `ingress_invites`; the daemon relays its CLI/HTTP invite surfaces here and
+ * layers presentation fields on afterwards. Responses are validated against
+ * the shared contract schemas in `@vellumai/gateway-client` — the same
+ * schemas the gateway routes are pinned to.
+ *
+ * Error posture (fail-closed — there is no local fallback): every wrapper
+ * THROWS on transport failure or a malformed response. An `IpcCallError`
+ * keeps the gateway's statusCode/errorCode so relay routes surface 4xx
+ * engine reasons as 4xx. Voice-call invite detection/redemption does NOT
+ * live here: the hot call-setup path uses `calls/gateway-invite-reader.ts`
+ * (one-shot `ipcCall`, explicit short timeouts, fail-soft detection) instead
+ * of the persistent client these control-plane relays share.
+ */
+
+import {
+  CreateInviteIpcResponseSchema,
+  INVITES_IPC_METHODS,
+  type InviteWire,
+  ListInvitesIpcResponseSchema,
+  type RedeemInviteByTokenRequest,
+  type RedeemInviteTokenIpcResponse,
+  RedeemInviteTokenIpcResponseSchema,
+  type RedeemInviteVoiceIpcResponse,
+  RedeemInviteVoiceIpcResponseSchema,
+  type RedeemVoiceInviteRequest,
+  RevokeInviteIpcResponseSchema,
+} from "@vellumai/gateway-client";
+
+import { ipcCallPersistentValidated } from "../ipc/gateway-validated-call.js";
+
+export type { InviteWire } from "@vellumai/gateway-client";
+
+export interface ListInvitesFilters {
+  sourceChannel?: string;
+  status?: string;
+}
+
+/** List sanitized gateway invite rows, optionally filtered. */
+export async function listInvites(
+  filters: ListInvitesFilters = {},
+): Promise<InviteWire[]> {
+  const response = await ipcCallPersistentValidated(
+    INVITES_IPC_METHODS.list,
+    {
+      ...(filters.sourceChannel
+        ? { sourceChannel: filters.sourceChannel }
+        : {}),
+      ...(filters.status ? { status: filters.status } : {}),
+    },
+    ListInvitesIpcResponseSchema,
+  );
+  return response.invites;
+}
+
+/**
+ * Create-invite params. Field validation is gateway-owned
+ * (`gateway/src/http/routes/invite-validation.ts`) — invalid input surfaces
+ * as a relayed 400.
+ */
+export interface CreateInviteParams {
+  contactId: string;
+  sourceChannel?: string;
+  note?: string;
+  maxUses?: number;
+  expiresInMs?: number;
+  expectedExternalUserId?: string;
+  guardianName?: string;
+  sourceConversationId?: string;
+}
+
+/**
+ * Mint an invite. Returns the gateway's one-time payload — row fields plus
+ * the plaintext secrets (`rawToken` for link invites), never fetchable later.
+ */
+export async function createInvite(
+  params: CreateInviteParams,
+): Promise<{ invite: InviteWire; rawToken?: string }> {
+  return ipcCallPersistentValidated(
+    INVITES_IPC_METHODS.create,
+    { ...params },
+    CreateInviteIpcResponseSchema,
+  );
+}
+
+/** Revoke an invite (idempotent for already-terminal invites). */
+export async function revokeInvite(id: string): Promise<InviteWire> {
+  const response = await ipcCallPersistentValidated(
+    INVITES_IPC_METHODS.revoke,
+    { id },
+    RevokeInviteIpcResponseSchema,
+  );
+  return response.invite;
+}
+
+/**
+ * Redeem a link-token invite (`invites_redeem`, token branch — selected by
+ * the absence of `code`). Engine failures throw a relayed 400 with the
+ * engine reason.
+ */
+export async function redeemInviteByToken(
+  params: RedeemInviteByTokenRequest,
+): Promise<RedeemInviteTokenIpcResponse> {
+  return ipcCallPersistentValidated(
+    INVITES_IPC_METHODS.redeem,
+    params as unknown as Record<string, unknown>,
+    RedeemInviteTokenIpcResponseSchema,
+  );
+}
+
+/**
+ * Redeem a spoken voice code (`invites_redeem`, voice branch — selected by
+ * the presence of `code`). `assistantId` is a daemon passthrough.
+ */
+export async function redeemInviteByVoiceCode(
+  params: RedeemVoiceInviteRequest & { assistantId?: string },
+): Promise<RedeemInviteVoiceIpcResponse> {
+  return ipcCallPersistentValidated(
+    INVITES_IPC_METHODS.redeem,
+    params as unknown as Record<string, unknown>,
+    RedeemInviteVoiceIpcResponseSchema,
+  );
+}

--- a/assistant/src/channels/gateway-verification-sessions.ts
+++ b/assistant/src/channels/gateway-verification-sessions.ts
@@ -36,7 +36,7 @@ import {
 } from "@vellumai/gateway-client";
 import type { ZodType } from "zod";
 
-import { ipcCallPersistent } from "../ipc/gateway-client.js";
+import { ipcCallPersistentValidated } from "../ipc/gateway-validated-call.js";
 import { composeApprovalMessage } from "../runtime/approval-message-composer.js";
 
 export type { VerificationSessionWire } from "@vellumai/gateway-client";
@@ -57,19 +57,15 @@ export type ValidateVerificationResult = ValidateConsumeSessionIpcResponse;
 
 /**
  * Call a gateway session route and validate the response against its
- * contract schema. Throws on transport failure or a malformed response.
+ * contract schema. Throws on transport failure or a malformed response
+ * (shared helper; typed to the session method union).
  */
 async function callGateway<T>(
   method: VerificationSessionsIpcMethod,
   params: Record<string, unknown>,
   responseSchema: ZodType<T>,
 ): Promise<T> {
-  const result = await ipcCallPersistent(method, params);
-  const parsed = responseSchema.safeParse(result);
-  if (!parsed.success) {
-    throw new Error(`Gateway returned a malformed ${method} response`);
-  }
-  return parsed.data;
+  return ipcCallPersistentValidated(method, params, responseSchema);
 }
 
 /** Call a mutation route; throws unless the gateway acks `{ ok: true }`. */

--- a/assistant/src/cli/commands/contacts.ts
+++ b/assistant/src/cli/commands/contacts.ts
@@ -522,6 +522,10 @@ Examples:
       // invites
       // -----------------------------------------------------------------------
 
+      // Invite subcommands dispatch daemon route operationIds that mirror the
+      // gateway wire names in INVITES_IPC_METHODS (@vellumai/gateway-client) —
+      // kept as literals because `ipc`-tagged CLI commands may not import
+      // contract modules (cli/no-daemon-internals).
       const invites = contacts
         .command("invites")
         .description("Manage contact invites");

--- a/assistant/src/ipc/gateway-validated-call.ts
+++ b/assistant/src/ipc/gateway-validated-call.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared "IPC call → schema-validate → throw" helper for the daemon's typed
+ * gateway clients (`channels/gateway-verification-sessions.ts`,
+ * `channels/gateway-invites.ts`).
+ *
+ * Uses the persistent IPC client: these are fail-closed control-plane relays
+ * and the persistent socket avoids per-call connect overhead. Transport
+ * failures (`IpcCallError`, carrying the gateway's statusCode/errorCode)
+ * propagate unchanged so relay routes surface 4xx engine reasons as 4xx; a
+ * schema-invalid response throws a generic malformed-response error.
+ *
+ * The hot voice call-setup path (`calls/gateway-invite-reader.ts`)
+ * deliberately does NOT use this — it needs one-shot `ipcCall` with explicit
+ * short timeouts and fail-soft handling.
+ */
+
+import type { ZodType } from "zod";
+
+import { ipcCallPersistent } from "./gateway-client.js";
+
+export async function ipcCallPersistentValidated<T>(
+  method: string,
+  params: Record<string, unknown> | undefined,
+  responseSchema: ZodType<T>,
+): Promise<T> {
+  const result = await ipcCallPersistent(method, params);
+  const parsed = responseSchema.safeParse(result);
+  if (!parsed.success) {
+    throw new Error(`Gateway returned a malformed ${method} response`);
+  }
+  return parsed.data;
+}

--- a/assistant/src/runtime/routes/__tests__/invite-relay-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/invite-relay-routes.test.ts
@@ -2,9 +2,11 @@
  * Unit tests for the CLI invite relay routes.
  *
  * Three CLI invite handlers (list/create/revoke) are thin relays to the gateway
- * IPC methods via `ipcCallPersistent`. These tests assert each relays with the
- * correct method + params, returns the parsed gateway response, and surfaces a
- * relayed IpcCallError with its statusCode. `invites_redeem` and `invites_trigger_call` stay daemon-local: the
+ * IPC methods via the typed `channels/gateway-invites` client (transport:
+ * `ipcCallPersistent`, responses contract-schema-validated). These tests
+ * assert each relays with the correct wire method + params, returns the
+ * parsed gateway response, and surfaces a relayed IpcCallError with its
+ * statusCode. `invites_redeem` and `invites_trigger_call` stay daemon-local: the
  * gateway delegates the actual provider call to the daemon-local handler, so
  * relaying it back would loop gateway→assistant→gateway.
  */
@@ -99,7 +101,9 @@ describe("invite relay routes", () => {
 
   describe("handleListInvites", () => {
     test("relays invites_list with filters from queryParams", async () => {
-      ipcResult = { invites: [{ id: "i1" }] };
+      ipcResult = {
+        invites: [{ id: "i1", sourceChannel: "telegram", status: "active" }],
+      };
       const result = await handleListInvites({
         queryParams: { sourceChannel: "telegram", status: "active" },
       });
@@ -112,7 +116,10 @@ describe("invite relay routes", () => {
           timeoutMs: undefined,
         },
       ]);
-      expect(result).toEqual({ ok: true, invites: [{ id: "i1" }] });
+      expect(result).toEqual({
+        ok: true,
+        invites: [{ id: "i1", sourceChannel: "telegram", status: "active" }],
+      });
     });
 
     test("omits absent filters", async () => {
@@ -127,7 +134,15 @@ describe("invite relay routes", () => {
 
   describe("handleCreateInvite", () => {
     test("relays invites_create with mapped body and returns invite + rawToken", async () => {
-      ipcResult = { invite: { id: "i9", token: "tok-9" }, rawToken: "tok-9" };
+      ipcResult = {
+        invite: {
+          id: "i9",
+          sourceChannel: "telegram",
+          status: "active",
+          token: "tok-9",
+        },
+        rawToken: "tok-9",
+      };
       const result = await handleCreateInvite({
         body: {
           contactId: "c1",
@@ -155,13 +170,26 @@ describe("invite relay routes", () => {
       ]);
       expect(result).toEqual({
         ok: true,
-        invite: { id: "i9", token: "tok-9" },
+        invite: {
+          id: "i9",
+          sourceChannel: "telegram",
+          status: "active",
+          token: "tok-9",
+        },
         rawToken: "tok-9",
       });
     });
 
     test("composes presentation daemon-side exactly once on the relayed mint payload", async () => {
-      ipcResult = { invite: { id: "i9", token: "tok-9" }, rawToken: "tok-9" };
+      ipcResult = {
+        invite: {
+          id: "i9",
+          sourceChannel: "telegram",
+          status: "active",
+          token: "tok-9",
+        },
+        rawToken: "tok-9",
+      };
       composeInvitePresentationResult = (params) => ({
         ...params.invite,
         share: { url: "https://t.me/example_bot?start=tok-9" },
@@ -175,13 +203,20 @@ describe("invite relay routes", () => {
       expect(composeInvitePresentationMock).toHaveBeenCalledTimes(1);
       expect(composeInvitePresentationMock.mock.calls[0][0]).toEqual({
         contactId: "c1",
-        invite: { id: "i9", token: "tok-9" },
+        invite: {
+          id: "i9",
+          sourceChannel: "telegram",
+          status: "active",
+          token: "tok-9",
+        },
         rawToken: "tok-9",
       });
       expect(result).toEqual({
         ok: true,
         invite: {
           id: "i9",
+          sourceChannel: "telegram",
+          status: "active",
           token: "tok-9",
           share: { url: "https://t.me/example_bot?start=tok-9" },
           guardianInstruction: "Send the link to your friend.",
@@ -191,16 +226,23 @@ describe("invite relay routes", () => {
     });
 
     test("omits rawToken when the gateway returns none", async () => {
-      ipcResult = { invite: { id: "i9" } };
+      ipcResult = {
+        invite: { id: "i9", sourceChannel: "phone", status: "active" },
+      };
       const result = await handleCreateInvite({
         body: { contactId: "c1", sourceChannel: "phone" },
       });
 
-      expect(result).toEqual({ ok: true, invite: { id: "i9" } });
+      expect(result).toEqual({
+        ok: true,
+        invite: { id: "i9", sourceChannel: "phone", status: "active" },
+      });
     });
 
     test("supplies guardianName (voice) and sourceConversationId passthrough", async () => {
-      ipcResult = { invite: { id: "iv" } };
+      ipcResult = {
+        invite: { id: "iv", sourceChannel: "phone", status: "active" },
+      };
       await handleCreateInvite({
         body: {
           contactId: "c1",
@@ -220,7 +262,9 @@ describe("invite relay routes", () => {
     });
 
     test("omits guardianName for non-voice creates", async () => {
-      ipcResult = { invite: { id: "i9" } };
+      ipcResult = {
+        invite: { id: "i9", sourceChannel: "telegram", status: "active" },
+      };
       await handleCreateInvite({
         body: { contactId: "c1", sourceChannel: "telegram" },
       });
@@ -231,7 +275,9 @@ describe("invite relay routes", () => {
 
   describe("handleRevokeInvite", () => {
     test("relays invites_revoke with id from pathParams", async () => {
-      ipcResult = { invite: { id: "i3", status: "revoked" } };
+      ipcResult = {
+        invite: { id: "i3", sourceChannel: "telegram", status: "revoked" },
+      };
       const result = await handleRevokeInvite({ pathParams: { id: "i3" } });
 
       expect(ipcCalls).toEqual([
@@ -243,7 +289,7 @@ describe("invite relay routes", () => {
       ]);
       expect(result).toEqual({
         ok: true,
-        invite: { id: "i3", status: "revoked" },
+        invite: { id: "i3", sourceChannel: "telegram", status: "revoked" },
       });
     });
   });
@@ -307,6 +353,15 @@ describe("invite relay routes", () => {
   });
 
   describe("error propagation", () => {
+    test("a schema-invalid gateway response fails closed (throws, no partial result)", async () => {
+      // Missing the pinned id/status fields.
+      ipcResult = { invites: [{ sourceChannel: "telegram" }] };
+
+      await expect(handleListInvites({ queryParams: {} })).rejects.toThrow(
+        "malformed invites_list response",
+      );
+    });
+
     test("relayed IpcCallError surfaces with its statusCode/errorCode", async () => {
       ipcError = new IpcCallError("Invite not found", {
         statusCode: 404,

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -9,6 +9,7 @@
  */
 
 import {
+  INVITES_IPC_METHODS,
   RedeemInviteByTokenRequestSchema,
   RedeemVoiceInviteRequestSchema,
 } from "@vellumai/gateway-client";
@@ -21,6 +22,14 @@ import {
 import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
 import { z } from "zod";
 
+import {
+  createInvite,
+  type InviteWire,
+  listInvites,
+  redeemInviteByToken,
+  redeemInviteByVoiceCode,
+  revokeInvite,
+} from "../../channels/gateway-invites.js";
 import {
   listContacts,
   mergeContacts,
@@ -411,21 +420,20 @@ export async function handleGetContact(contactId: string) {
 // ---------------------------------------------------------------------------
 
 // The gateway owns the canonical invite lifecycle: mint, list, revoke, and
-// redemption. These CLI handlers relay via `ipcCallPersistent`; the daemon
-// then layers the presentation fields (share link, LLM guardian instruction,
-// channel handle) onto the gateway's one-time create payload.
+// redemption. These handlers relay via the typed `channels/gateway-invites`
+// client (schema-validated responses); the daemon then layers the
+// presentation fields (share link, LLM guardian instruction, channel handle)
+// onto the gateway's one-time create payload.
 
 export async function handleListInvites({
   queryParams = {},
 }: RouteHandlerArgs) {
   try {
-    const result = (await ipcCallPersistent("invites_list", {
-      ...(queryParams.sourceChannel
-        ? { sourceChannel: queryParams.sourceChannel }
-        : {}),
-      ...(queryParams.status ? { status: queryParams.status } : {}),
-    })) as { invites: Array<Record<string, unknown>> };
-    return { ok: true, invites: result.invites };
+    const invites = await listInvites({
+      sourceChannel: queryParams.sourceChannel,
+      status: queryParams.status,
+    });
+    return { ok: true, invites };
   } catch (err) {
     rethrowGatewayError(err);
   }
@@ -438,9 +446,9 @@ export async function handleCreateInvite({ body = {} }: RouteHandlerArgs) {
   // through to the gateway, which stores it and never interprets it.
   const guardianName =
     sourceChannel === "phone" ? resolveInviteGuardianName() : undefined;
-  let result: { invite: Record<string, unknown>; rawToken?: string };
+  let result: { invite: InviteWire; rawToken?: string };
   try {
-    result = (await ipcCallPersistent("invites_create", {
+    result = await createInvite({
       contactId,
       sourceChannel,
       note: body.note as string | undefined,
@@ -453,7 +461,7 @@ export async function handleCreateInvite({ body = {} }: RouteHandlerArgs) {
       ...(typeof body.sourceConversationId === "string"
         ? { sourceConversationId: body.sourceConversationId }
         : {}),
-    })) as { invite: Record<string, unknown>; rawToken?: string };
+    });
   } catch (err) {
     rethrowGatewayError(err);
   }
@@ -473,10 +481,8 @@ export async function handleRevokeInvite({
   pathParams = {},
 }: RouteHandlerArgs) {
   try {
-    const result = (await ipcCallPersistent("invites_revoke", {
-      id: pathParams.id,
-    })) as { invite: Record<string, unknown> };
-    return { ok: true, invite: result.invite };
+    const invite = await revokeInvite(pathParams.id);
+    return { ok: true, invite };
   } catch (err) {
     rethrowGatewayError(err);
   }
@@ -499,12 +505,12 @@ async function handleRedeemVoiceInvite({ body = {} }: RouteHandlerArgs) {
   }
 
   try {
-    return (await ipcCallPersistent("invites_redeem", {
+    return await redeemInviteByVoiceCode({
       ...parsed.data,
       ...(typeof body.assistantId === "string"
         ? { assistantId: body.assistantId }
         : {}),
-    })) as { ok: true; type: string; memberId: string; inviteId?: string };
+    });
   } catch (err) {
     rethrowGatewayError(err);
   }
@@ -540,11 +546,7 @@ async function handleRedeemTokenInvite({ body = {} }: RouteHandlerArgs) {
   try {
     // The `type` is surfaced so callers can tell a real redeem apart from an
     // `already_member` no-op (which consumes no invite use).
-    return (await ipcCallPersistent("invites_redeem", parsed.data)) as {
-      ok: true;
-      invite: Record<string, unknown>;
-      type: string;
-    };
+    return await redeemInviteByToken(parsed.data);
   } catch (err) {
     rethrowGatewayError(err);
   }
@@ -639,8 +641,10 @@ export const ROUTES: RouteDefinition[] = [
   },
 
   // ── contacts/invites (must precede contacts/:id) ────────────────────
+  // The relayed invite routes' operationIds deliberately reuse the gateway
+  // wire method names (single shared map; CLI dispatch uses the same names).
   {
-    operationId: "invites_list",
+    operationId: INVITES_IPC_METHODS.list,
     endpoint: "contacts/invites",
     method: "GET",
     policy: {
@@ -668,7 +672,7 @@ export const ROUTES: RouteDefinition[] = [
     }),
   },
   {
-    operationId: "invites_create",
+    operationId: INVITES_IPC_METHODS.create,
     endpoint: "contacts/invites",
     method: "POST",
     policy: {
@@ -717,7 +721,7 @@ export const ROUTES: RouteDefinition[] = [
     // Relays to the gateway `invites_redeem` IPC: the gateway redemption
     // engine is the single lifecycle authority (validation, atomic claim,
     // ACL upsert). Fail-closed when the gateway is unreachable.
-    operationId: "invites_redeem",
+    operationId: INVITES_IPC_METHODS.redeem,
     endpoint: "contacts/invites/redeem",
     method: "POST",
     policy: {
@@ -773,7 +777,7 @@ export const ROUTES: RouteDefinition[] = [
     },
   },
   {
-    operationId: "invites_revoke",
+    operationId: INVITES_IPC_METHODS.revoke,
     endpoint: "contacts/invites/:id",
     method: "DELETE",
     policy: {

--- a/gateway/src/ipc/invite-handlers.ts
+++ b/gateway/src/ipc/invite-handlers.ts
@@ -69,6 +69,7 @@
 
 import {
   GetActiveVoiceInviteRequestSchema,
+  INVITES_IPC_METHODS,
   RedeemVoiceInviteRequestSchema,
 } from "@vellumai/gateway-client";
 import { z } from "zod";
@@ -133,7 +134,7 @@ export const inviteRoutes: IpcRoute[] = [
     // Explicit redemption relay for the daemon's CLI/HTTP redeem routes:
     // voice-code and token requests dispatch into the same gateway-native
     // engine the HTTP redeem handler uses (redeemInviteNative).
-    method: "invites_redeem",
+    method: INVITES_IPC_METHODS.redeem,
     schema: RedeemInviteParamsSchema,
     handler: async (params?: Record<string, unknown>) => {
       const parsed = parseRedeemInviteBody(params ?? {});
@@ -146,7 +147,7 @@ export const inviteRoutes: IpcRoute[] = [
   {
     // Single gateway-DB read, sanitized (no code/token hashes). Shares the
     // HTTP list native implementation.
-    method: "invites_list",
+    method: INVITES_IPC_METHODS.list,
     schema: ListInvitesParamsSchema,
     handler: async (params?: Record<string, unknown>) => {
       const query = ListInvitesParamsSchema.parse(params ?? {});
@@ -156,7 +157,7 @@ export const inviteRoutes: IpcRoute[] = [
   {
     // Verify contact → mint secrets natively → write the canonical gateway
     // row. Returns the gateway's one-time minted payload + rawToken.
-    method: "invites_create",
+    method: INVITES_IPC_METHODS.create,
     schema: CreateInviteParamsSchema,
     handler: async (params?: Record<string, unknown>) => {
       const input = CreateInviteParamsSchema.parse(params);
@@ -166,7 +167,7 @@ export const inviteRoutes: IpcRoute[] = [
   {
     // Single gateway-DB UPDATE, idempotent for already-terminal invites.
     // Returns the sanitized invite.
-    method: "invites_revoke",
+    method: INVITES_IPC_METHODS.revoke,
     schema: InviteIdParamsSchema,
     handler: async (params?: Record<string, unknown>) => {
       const { id } = InviteIdParamsSchema.parse(params);
@@ -176,7 +177,7 @@ export const inviteRoutes: IpcRoute[] = [
   {
     // Voice-invite detection for an inbound caller: the active phone invite
     // bound to the caller's number, projected to display metadata only.
-    method: "get_active_voice_invite",
+    method: INVITES_IPC_METHODS.getActiveVoiceInvite,
     schema: GetActiveVoiceInviteRequestSchema,
     handler: (params?: Record<string, unknown>) => {
       const { callerExternalUserId } =
@@ -190,7 +191,7 @@ export const inviteRoutes: IpcRoute[] = [
     // Voice-code redemption through the gateway engine. The engine fires the
     // best-effort `invite_redeemed` daemon info-mirror event on a real redeem
     // (already_member consumed nothing, so there is nothing to mirror).
-    method: "redeem_voice_invite",
+    method: INVITES_IPC_METHODS.redeemVoiceInvite,
     schema: RedeemVoiceInviteRequestSchema,
     handler: async (params?: Record<string, unknown>) => {
       const parsed = RedeemVoiceInviteRequestSchema.parse(params);

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -93,30 +93,49 @@ export type {
 } from "./trust-verdict-contract.js";
 
 // Invite contract (shared gateway ↔ daemon) — hash/generate helpers,
-// channel gating, redemption outcome + invite IPC schemas
+// channel gating, redemption outcome, method map + invite IPC schemas
 export {
   ActiveVoiceInviteSchema,
+  CreateInviteIpcResponseSchema,
   generateInviteCode,
   generateInviteToken,
+  GetActiveVoiceInviteIpcResponseSchema,
   GetActiveVoiceInviteRequestSchema,
   hashInviteCode,
   hashInviteToken,
+  INVITES_IPC_METHODS,
   InviteRedemptionOutcomeSchema,
+  InviteRedemptionResultSchema,
+  InviteWireSchema,
   isInviteCodeRedemptionEnabled,
   isValidE164,
+  ListInvitesIpcResponseSchema,
   RedeemInviteByCodeRequestSchema,
   RedeemInviteByTokenRequestSchema,
+  RedeemInviteTokenIpcResponseSchema,
+  RedeemInviteVoiceIpcResponseSchema,
+  RedeemVoiceInviteIpcResponseSchema,
   RedeemVoiceInviteRequestSchema,
+  RevokeInviteIpcResponseSchema,
 } from "./invite-contract.js";
 
 export type {
   ActiveVoiceInvite,
+  CreateInviteIpcResponse,
+  GetActiveVoiceInviteIpcResponse,
   GetActiveVoiceInviteRequest,
   InviteRedemptionOutcome,
   InviteRedemptionResult,
+  InvitesIpcMethod,
+  InviteWire,
+  ListInvitesIpcResponse,
   RedeemInviteByCodeRequest,
   RedeemInviteByTokenRequest,
+  RedeemInviteTokenIpcResponse,
+  RedeemInviteVoiceIpcResponse,
+  RedeemVoiceInviteIpcResponse,
   RedeemVoiceInviteRequest,
+  RevokeInviteIpcResponse,
 } from "./invite-contract.js";
 
 // Verification-session contract (shared gateway ↔ daemon) — hash helper,

--- a/packages/gateway-client/src/invite-contract.ts
+++ b/packages/gateway-client/src/invite-contract.ts
@@ -92,10 +92,41 @@ export function isInviteCodeRedemptionEnabled(channelType: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// IPC methods
+// ---------------------------------------------------------------------------
+
+/**
+ * Gateway IPC method names for the invite lifecycle. Keys match the daemon
+ * client's wrapper names; values are the wire method strings. The daemon's
+ * relay routes deliberately reuse the same strings as their HTTP/CLI
+ * operationIds (unlike sessions, where the daemon surface owns distinct
+ * `channel_verification_sessions_*` names).
+ *
+ * Deliberately NOT here: `invites_compose_presentation` and
+ * `invites_trigger_call` are daemon-SERVED invite routes the gateway calls
+ * (reverse direction), not gateway invite methods.
+ */
+export const INVITES_IPC_METHODS = {
+  list: "invites_list",
+  create: "invites_create",
+  revoke: "invites_revoke",
+  redeem: "invites_redeem",
+  getActiveVoiceInvite: "get_active_voice_invite",
+  redeemVoiceInvite: "redeem_voice_invite",
+} as const;
+
+export type InvitesIpcMethod =
+  (typeof INVITES_IPC_METHODS)[keyof typeof INVITES_IPC_METHODS];
+
+// ---------------------------------------------------------------------------
 // Redemption outcome
 // ---------------------------------------------------------------------------
 
 const INVITE_REDEMPTION_RESULT_VALUES = ["redeemed", "already_member"] as const;
+
+export const InviteRedemptionResultSchema = z.enum(
+  INVITE_REDEMPTION_RESULT_VALUES,
+);
 
 export type InviteRedemptionResult =
   (typeof INVITE_REDEMPTION_RESULT_VALUES)[number];
@@ -214,3 +245,105 @@ export const ActiveVoiceInviteSchema = z.object({
 });
 
 export type ActiveVoiceInvite = z.infer<typeof ActiveVoiceInviteSchema>;
+
+// ---------------------------------------------------------------------------
+// IPC response schemas
+// ---------------------------------------------------------------------------
+
+/**
+ * Sanitized gateway invite payload as carried on the daemon ↔ gateway wire
+ * (list/revoke rows, the one-time create payload, and the token-redeem row).
+ * Only the stable identity/lifecycle fields are pinned; everything else
+ * passes through — the create payload carries conditional one-time plaintext
+ * secrets and the daemon layers presentation fields on afterwards, so the
+ * wire shape is deliberately open. Never carries `inviteCodeHash` /
+ * `tokenHash` / `voiceCodeHash` (see the gateway's sanitizeInviteRow).
+ */
+export const InviteWireSchema = z
+  .object({
+    id: z.string(),
+    sourceChannel: z.string(),
+    status: z.string(),
+  })
+  .passthrough();
+
+export type InviteWire = z.infer<typeof InviteWireSchema>;
+
+/** Response for gateway IPC `invites_list`. */
+export const ListInvitesIpcResponseSchema = z.object({
+  invites: z.array(InviteWireSchema),
+});
+
+export type ListInvitesIpcResponse = z.infer<
+  typeof ListInvitesIpcResponseSchema
+>;
+
+/**
+ * Response for gateway IPC `invites_create` — the one-time minted payload.
+ * `rawToken` (link invites only) is never fetchable again.
+ */
+export const CreateInviteIpcResponseSchema = z.object({
+  invite: InviteWireSchema,
+  rawToken: z.string().optional(),
+});
+
+export type CreateInviteIpcResponse = z.infer<
+  typeof CreateInviteIpcResponseSchema
+>;
+
+/** Response for gateway IPC `invites_revoke` (idempotent; sanitized row). */
+export const RevokeInviteIpcResponseSchema = z.object({
+  invite: InviteWireSchema,
+});
+
+export type RevokeInviteIpcResponse = z.infer<
+  typeof RevokeInviteIpcResponseSchema
+>;
+
+/**
+ * Success response for the `invites_redeem` voice branch. Failures throw a
+ * 400 typed error with the engine reason, so only success travels here.
+ */
+export const RedeemInviteVoiceIpcResponseSchema = z.object({
+  ok: z.literal(true),
+  type: InviteRedemptionResultSchema,
+  memberId: z.string(),
+  inviteId: z.string().optional(),
+});
+
+export type RedeemInviteVoiceIpcResponse = z.infer<
+  typeof RedeemInviteVoiceIpcResponseSchema
+>;
+
+/** Success response for the `invites_redeem` token branch. */
+export const RedeemInviteTokenIpcResponseSchema = z.object({
+  ok: z.literal(true),
+  invite: InviteWireSchema,
+  type: InviteRedemptionResultSchema,
+});
+
+export type RedeemInviteTokenIpcResponse = z.infer<
+  typeof RedeemInviteTokenIpcResponseSchema
+>;
+
+/** Response for gateway IPC `get_active_voice_invite`. */
+export const GetActiveVoiceInviteIpcResponseSchema = z.object({
+  invite: ActiveVoiceInviteSchema.nullable(),
+});
+
+export type GetActiveVoiceInviteIpcResponse = z.infer<
+  typeof GetActiveVoiceInviteIpcResponseSchema
+>;
+
+/**
+ * Response for gateway IPC `redeem_voice_invite`. The single generic failure
+ * reason never leaks which check refused.
+ */
+export const RedeemVoiceInviteIpcResponseSchema = z.discriminatedUnion("ok", [
+  z.object({ ok: z.literal(true), outcome: InviteRedemptionOutcomeSchema }),
+  z.object({ ok: z.literal(false), reason: z.literal("invalid_or_expired") }),
+]);
+
+export type RedeemVoiceInviteIpcResponse = z.infer<
+  typeof RedeemVoiceInviteIpcResponseSchema
+>;


### PR DESCRIPTION
## Summary
- Invite IPC method names centralized in `INVITES_IPC_METHODS` (`packages/gateway-client/src/invite-contract.ts`), mirroring `VERIFICATION_SESSIONS_IPC_METHODS`; wire DTO response schemas added (`InviteWireSchema` + list/create/revoke/redeem/voice response schemas). Gateway route registrations (`gateway/src/ipc/invite-handlers.ts`) now use the map, like the sessions handlers.
- New typed daemon client `assistant/src/channels/gateway-invites.ts` (mirrors the sessions client): every response schema-validated, fail-closed throws, `IpcCallError` statusCodes preserved for the relay routes. The shared "IPC call → safeParse → posture" helper fell out cleanly into `assistant/src/ipc/gateway-validated-call.ts`, now used by both credential clients.
- `contact-routes.ts` invite relays flipped off bare method strings + `as` casts onto the typed client; relayed route operationIds reference the map. `gateway-invite-reader.ts` imports method names + response schemas from the contract (keeps its one-shot `ipcCall` + explicit timeouts — hot call-setup path, fail-soft detection — with a deciding comment).

## Deliberate exceptions (documented in code)
- `cli/commands/contacts.ts` keeps literal method strings: `ipc`-tagged CLI commands are forbidden from importing contract modules by the `cli/no-daemon-internals` ESLint rule (they dispatch daemon route operationIds, which deliberately mirror the gateway wire names). Comment added at the invites command group.
- `invites_trigger_call` / `invites_compose_presentation` stay out of the map: they are daemon-SERVED routes the gateway calls (reverse direction), noted in the map's doc comment.

## Tests
- New `gateway-invites.test.ts`: method/param mapping, schema round-trips, malformed-response rejection, transport-error passthrough.
- `invite-relay-routes.test.ts` / `invite-routes-http.test.ts` repointed with schema-valid fixtures + a new fail-closed malformed-response relay test; sessions client test green on the shared helper.
- Note: `gateway/src/__tests__/ipc-invite-routes.test.ts` + `ipc-voice-invite-routes.test.ts` fail locally with AF_UNIX socket-listen errors on the clean base branch too (pre-existing/environmental) — CI is the arbiter. `gateway/src/ipc/__tests__/invite-ipc-routes.test.ts` (30 tests) passes.

Part of plan: acl-hardening-sweep.md (PR 18 of 18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
