### PR TITLE
feat(tts): add sampleRateHz hint to TtsSynthesisRequest and forward it through synthesizeAndEmit

### DIFF
--- a/assistant/src/tts/__tests__/synthesis-stream.test.ts
+++ b/assistant/src/tts/__tests__/synthesis-stream.test.ts
@@ -503,7 +503,7 @@ describe("synthesizeAndEmit (streaming)", () => {
     ]);
   });
 
-  test("passes text/useCase/voiceId/outputFormat/signal through on the request", async () => {
+  test("passes text/useCase/voiceId/outputFormat/sampleRateHz/signal through on the request", async () => {
     const provider = makeStreamingProvider([bytes("a")]);
     const abortController = new AbortController();
 
@@ -513,6 +513,7 @@ describe("synthesizeAndEmit (streaming)", () => {
       useCase: "message-playback",
       voiceId: "voice-123",
       outputFormat: "pcm",
+      sampleRateHz: 24000,
       signal: abortController.signal,
       onChunk: () => {},
     });
@@ -523,6 +524,7 @@ describe("synthesizeAndEmit (streaming)", () => {
       useCase: "message-playback",
       voiceId: "voice-123",
       outputFormat: "pcm",
+      sampleRateHz: 24000,
       signal: abortController.signal,
     });
   });
@@ -637,6 +639,7 @@ describe("synthesizeAndEmit (buffer)", () => {
       text: "hello",
       useCase: "phone-call",
       voiceId: "voice-123",
+      sampleRateHz: 16000,
       onChunk: () => {},
     });
 
@@ -645,6 +648,7 @@ describe("synthesizeAndEmit (buffer)", () => {
       useCase: "phone-call",
       voiceId: "voice-123",
       outputFormat: undefined,
+      sampleRateHz: 16000,
       signal: undefined,
     });
   });

--- a/assistant/src/tts/synthesis-stream.ts
+++ b/assistant/src/tts/synthesis-stream.ts
@@ -50,6 +50,9 @@ export interface SynthesisEmitOptions {
   /** Output-encoding hint forwarded on the provider request (e.g. `"pcm"`). */
   outputFormat?: TtsSynthesisRequest["outputFormat"];
 
+  /** Preferred PCM sample rate in Hz, forwarded on the provider request. */
+  sampleRateHz?: number;
+
   /** Abort signal forwarded to the provider and checked before each emit. */
   signal?: AbortSignal;
 
@@ -99,6 +102,7 @@ export async function synthesizeAndEmit(
     useCase: options.useCase,
     voiceId: options.voiceId,
     outputFormat: options.outputFormat,
+    sampleRateHz: options.sampleRateHz,
     signal,
   };
 

--- a/assistant/src/tts/types.ts
+++ b/assistant/src/tts/types.ts
@@ -104,6 +104,14 @@ export interface TtsSynthesisRequest {
    * actual format of the returned audio.
    */
   outputFormat?: "pcm";
+
+  /**
+   * Optional preferred output sample rate in Hz, meaningful with
+   * `outputFormat: "pcm"`. Providers pick the nearest rate they support;
+   * callers must not assume the hint was honoured exactly and should rely
+   * on provider-documented behavior (see each provider's format mapping).
+   */
+  sampleRateHz?: number;
 }
 
 /** Output of a completed TTS synthesis call. */


### PR DESCRIPTION
## Summary
- Adds optional `sampleRateHz` to `TtsSynthesisRequest` so PCM callers can request a preferred output rate
- Forwards the hint through `synthesizeAndEmit` (`SynthesisEmitOptions`)
- Test coverage for both streaming and buffer paths

Part of plan: voice-tts-streaming-latency.md (PR 1 of 8)