### PR TITLE
refactor(tts): extract speakable-segment boundary logic from live-voice-session into tts/speakable-segments

### DIFF
--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -20,6 +20,7 @@ import type {
   StreamingTranscriber,
   SttStreamServerEvent,
 } from "../stt/types.js";
+import { extractSpeakableSegments } from "../tts/speakable-segments.js";
 import type {
   LiveVoiceAudioArchiveResult,
   LiveVoiceAudioArchiveRole,
@@ -54,9 +55,6 @@ type LiveVoiceSessionState =
   | "failed"
   | "closed";
 
-const LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD = 180;
-const SENTENCE_ENDING_PUNCTUATION = new Set([".", "!", "?"]);
-const TRAILING_SENTENCE_PUNCTUATION = new Set(['"', "'", ")", "]"]);
 // Cap on audio buffered while a server-VAD utterance waits for its
 // transcriber (PCM16 mono seconds; oldest chunks are dropped past the cap).
 const SERVER_VAD_PENDING_AUDIO_MAX_SECONDS = 10;
@@ -1596,81 +1594,6 @@ async function defaultArchiveLiveVoiceAudio(
   return input.role === "user"
     ? linkLiveVoiceUserUtteranceAudioToMessage(input)
     : linkLiveVoiceAssistantResponseAudioToMessage(input);
-}
-
-function extractSpeakableSegments(
-  text: string,
-  force: boolean,
-): { segments: string[]; remainder: string } {
-  const segments: string[] = [];
-  let remainder = text;
-
-  while (remainder.length > 0) {
-    const boundary = findSpeakableBoundary(remainder);
-    if (boundary === null) break;
-
-    const segment = remainder.slice(0, boundary).trim();
-    if (segment.length > 0) {
-      segments.push(segment);
-    }
-    remainder = remainder.slice(boundary);
-  }
-
-  if (force) {
-    const segment = remainder.trim();
-    if (segment.length > 0) {
-      segments.push(segment);
-    }
-    remainder = "";
-  }
-
-  return { segments, remainder };
-}
-
-function findSpeakableBoundary(text: string): number | null {
-  for (let index = 0; index < text.length; index += 1) {
-    const char = text[index];
-    if (char === "\n") return index + 1;
-    if (!char || !SENTENCE_ENDING_PUNCTUATION.has(char)) continue;
-
-    let boundary = index + 1;
-    while (
-      boundary < text.length &&
-      TRAILING_SENTENCE_PUNCTUATION.has(text[boundary] ?? "")
-    ) {
-      boundary += 1;
-    }
-
-    if (boundary === text.length || isWhitespace(text[boundary] ?? "")) {
-      return boundary;
-    }
-  }
-
-  if (text.length < LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD) {
-    return null;
-  }
-
-  const preferredBoundary = findLastWhitespaceBoundary(
-    text,
-    LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD,
-  );
-  return preferredBoundary ?? LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD;
-}
-
-function findLastWhitespaceBoundary(
-  text: string,
-  maxLength: number,
-): number | null {
-  for (let index = maxLength; index > Math.floor(maxLength * 0.6); index -= 1) {
-    if (isWhitespace(text[index] ?? "")) {
-      return index + 1;
-    }
-  }
-  return null;
-}
-
-function isWhitespace(value: string): boolean {
-  return /\s/.test(value);
 }
 
 function toSeedMarks(stashed: StashedMetricsMarks): LiveVoiceTurnSeedMarks {

--- a/assistant/src/tts/__tests__/speakable-segments.test.ts
+++ b/assistant/src/tts/__tests__/speakable-segments.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD,
+  extractSpeakableSegments,
+} from "../speakable-segments.js";
+
+describe("extractSpeakableSegments", () => {
+  test("splits complete sentences and keeps the trailing fragment as remainder", () => {
+    const { segments, remainder } = extractSpeakableSegments(
+      "Hello there. How are you? Still typ",
+      false,
+    );
+
+    expect(segments).toEqual(["Hello there.", "How are you?"]);
+    expect(remainder).toBe(" Still typ");
+  });
+
+  test("includes trailing quotes and brackets in the sentence segment", () => {
+    const { segments, remainder } = extractSpeakableSegments(
+      'She said "stop!") And then',
+      false,
+    );
+
+    expect(segments).toEqual(['She said "stop!")']);
+    expect(remainder).toBe(" And then");
+  });
+
+  test("does not split at punctuation followed by non-whitespace", () => {
+    const { segments, remainder } = extractSpeakableSegments(
+      "Version 3.5 is out",
+      false,
+    );
+
+    expect(segments).toEqual([]);
+    expect(remainder).toBe("Version 3.5 is out");
+  });
+
+  test("treats a newline as a segment boundary", () => {
+    const { segments, remainder } = extractSpeakableSegments(
+      "First line\nsecond line still going",
+      false,
+    );
+
+    expect(segments).toEqual(["First line"]);
+    expect(remainder).toBe("second line still going");
+  });
+
+  test("returns punctuation at end-of-text as a complete segment", () => {
+    const { segments, remainder } = extractSpeakableSegments(
+      "All done here.",
+      false,
+    );
+
+    expect(segments).toEqual(["All done here."]);
+    expect(remainder).toBe("");
+  });
+
+  test("sub-threshold text without a boundary yields no segments until forced", () => {
+    const text = "still waiting for a sentence to finish";
+
+    const unforced = extractSpeakableSegments(text, false);
+    expect(unforced.segments).toEqual([]);
+    expect(unforced.remainder).toBe(text);
+
+    const forced = extractSpeakableSegments(text, true);
+    expect(forced.segments).toEqual([text]);
+    expect(forced.remainder).toBe("");
+  });
+
+  test("force skips whitespace-only remainders", () => {
+    const { segments, remainder } = extractSpeakableSegments("   ", true);
+
+    expect(segments).toEqual([]);
+    expect(remainder).toBe("");
+  });
+
+  test("over-threshold text splits at the last whitespace before the threshold", () => {
+    const text = "steady ".repeat(40);
+
+    const { segments, remainder } = extractSpeakableSegments(text, false);
+
+    expect(segments).toHaveLength(1);
+    const segment = segments[0] ?? "";
+    expect(segment.length).toBeLessThanOrEqual(
+      DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD,
+    );
+    expect(segment.endsWith("steady")).toBe(true);
+    expect(remainder.startsWith("steady")).toBe(true);
+    // No text is lost across the split.
+    expect(`${segment} ${remainder}`).toBe(text);
+  });
+
+  test("over-threshold text without whitespace splits at the threshold exactly", () => {
+    const text = "x".repeat(DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD + 20);
+
+    const { segments, remainder } = extractSpeakableSegments(text, false);
+
+    expect(segments).toEqual([
+      "x".repeat(DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD),
+    ]);
+    expect(remainder).toBe("x".repeat(20));
+  });
+
+  test("charThreshold option overrides the default split length", () => {
+    const text = "alpha beta gamma delta epsilon";
+
+    const { segments, remainder } = extractSpeakableSegments(text, false, {
+      charThreshold: 12,
+    });
+
+    expect(segments).toEqual(["alpha beta", "gamma delta"]);
+    expect(remainder).toBe("epsilon");
+  });
+
+  test("charThreshold defaulting matches the exported constant", () => {
+    const text = "y".repeat(DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD - 1);
+
+    const belowDefault = extractSpeakableSegments(text, false);
+    expect(belowDefault.segments).toEqual([]);
+
+    const explicitDefault = extractSpeakableSegments(text, false, {
+      charThreshold: DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD,
+    });
+    expect(explicitDefault.segments).toEqual([]);
+  });
+});

--- a/assistant/src/tts/speakable-segments.ts
+++ b/assistant/src/tts/speakable-segments.ts
@@ -1,0 +1,100 @@
+/**
+ * Speakable-segment extraction for streaming TTS.
+ *
+ * Splits an incrementally-growing text buffer into complete, speakable
+ * segments (sentences or newline-bounded lines) plus a remainder to keep
+ * buffering. Callers feed LLM deltas in and synthesize each returned segment
+ * as soon as it is complete, so speech starts before the full response lands.
+ */
+
+export const DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD = 180;
+
+const SENTENCE_ENDING_PUNCTUATION = new Set([".", "!", "?"]);
+const TRAILING_SENTENCE_PUNCTUATION = new Set(['"', "'", ")", "]"]);
+
+export interface ExtractSpeakableSegmentsOptions {
+  /**
+   * Max characters buffered before a segment is force-split at the last
+   * whitespace boundary. Defaults to
+   * {@link DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD}.
+   */
+  charThreshold?: number;
+}
+
+export function extractSpeakableSegments(
+  text: string,
+  force: boolean,
+  options?: ExtractSpeakableSegmentsOptions,
+): { segments: string[]; remainder: string } {
+  const charThreshold =
+    options?.charThreshold ?? DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD;
+  const segments: string[] = [];
+  let remainder = text;
+
+  while (remainder.length > 0) {
+    const boundary = findSpeakableBoundary(remainder, charThreshold);
+    if (boundary === null) break;
+
+    const segment = remainder.slice(0, boundary).trim();
+    if (segment.length > 0) {
+      segments.push(segment);
+    }
+    remainder = remainder.slice(boundary);
+  }
+
+  if (force) {
+    const segment = remainder.trim();
+    if (segment.length > 0) {
+      segments.push(segment);
+    }
+    remainder = "";
+  }
+
+  return { segments, remainder };
+}
+
+function findSpeakableBoundary(
+  text: string,
+  charThreshold: number,
+): number | null {
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (char === "\n") return index + 1;
+    if (!char || !SENTENCE_ENDING_PUNCTUATION.has(char)) continue;
+
+    let boundary = index + 1;
+    while (
+      boundary < text.length &&
+      TRAILING_SENTENCE_PUNCTUATION.has(text[boundary] ?? "")
+    ) {
+      boundary += 1;
+    }
+
+    if (boundary === text.length || isWhitespace(text[boundary] ?? "")) {
+      return boundary;
+    }
+  }
+
+  if (text.length < charThreshold) {
+    return null;
+  }
+
+  const preferredBoundary = findLastWhitespaceBoundary(text, charThreshold);
+  return preferredBoundary ?? charThreshold;
+}
+
+function findLastWhitespaceBoundary(
+  text: string,
+  maxLength: number,
+): number | null {
+  for (let index = maxLength; index > Math.floor(maxLength * 0.6); index -= 1) {
+    if (isWhitespace(text[index] ?? "")) {
+      return index + 1;
+    }
+  }
+  return null;
+}
+
+function isWhitespace(value: string): boolean {
+  return /\s/.test(value);
+}


### PR DESCRIPTION
## Summary
- Moves `extractSpeakableSegments` and its boundary helpers from `live-voice-session.ts` into a new shared `tts/speakable-segments.ts` module
- Adds an optional `charThreshold` option (default preserves existing behavior)
- Direct unit tests for the segmentation module

Part of plan: voice-tts-streaming-latency.md (PR 5 of 8)