### PR TITLE
docs: require explicit manual confirmation before cutting or promoting a release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,10 @@ The Capacitor iOS source-of-truth lives in [`clients/ios/`](./clients/ios/) and 
 
 TestFlight builds are produced by the `release-ios.yaml` reusable workflow in this repo. Both `dev-release.yaml` and `release.yml` call it as a same-repo `uses:` job with `{ environment, version }` inputs. The workflow runs on `macos-15`, installs web dependencies, runs `cap sync ios`, generates the Xcode project via XcodeGen, archives, signs, and uploads to TestFlight.
 
+## Cutting Releases
+
+**Never cut or promote a release automatically — always get explicit manual confirmation from the user first.** This applies to both release steps: dispatching `create-release-branch.yml` (branch cut + staging bake) and dispatching `release.yml` on a `release/v<X.Y.Z>` branch (production deploy). An explicit user request for the release in the current conversation counts as confirmation; otherwise ask and wait. Never dispatch either workflow as a side effect of other work (merging PRs, completing a plan, scheduled or autonomous agent runs), and standing authorizations (e.g. auto-merge) do not extend to releases. The scheduled Tue/Fri branch cut is the only sanctioned automation; production promotion is always a deliberate human action. Process details: `/release` (`.claude/skills/release/SKILL.md`).
+
 ## Testing
 
 The full test suite is large and will hang or timeout if run unscoped. **Never run `bun test` without specifying file paths.**


### PR DESCRIPTION
## Summary
- Add a **Cutting Releases** section to `AGENTS.md` (and `CLAUDE.md` via symlink): agents must never dispatch `create-release-branch.yml` (branch cut + staging bake) or `release.yml` on a `release/v<X.Y.Z>` branch (production) without explicit manual confirmation from the user first.
- An explicit user request in the current conversation counts as confirmation; releases must never happen as a side effect of other work (merging PRs, completing a plan, scheduled/autonomous runs), and standing authorizations like auto-merge do not extend to releases. The scheduled Tue/Fri branch cut remains the only sanctioned automation.

## Original prompt
Sidd asked to update AGENTS.md with an instruction that a release is never cut automatically — a manual confirmation is always required first. The new section codifies as a project-wide agent rule the confirmation gate the `/release` skill already applies, covering both release steps (staging branch cut and production dispatch).