### PR TITLE
feat(live-voice): request provider PCM at the session sample rate so tts_audio frames stream per chunk

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-tts.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts.test.ts
@@ -67,6 +67,7 @@ describe("streamLiveVoiceTtsAudio", () => {
         voiceId: undefined,
         signal: undefined,
         outputFormat: undefined,
+        sampleRateHz: 24_000,
       },
     ]);
     expect(frames).toEqual([
@@ -152,10 +153,68 @@ describe("streamLiveVoiceTtsAudio", () => {
         onChunk: (chunk: Uint8Array) => void,
       ): Promise<TtsSynthesisResult> {
         requests.push(request);
-        onChunk(Buffer.from("pcm-one"));
-        onChunk(Buffer.from("pcm-two"));
+        onChunk(Buffer.from("pcm-one!"));
+        onChunk(Buffer.from("pcm-two!"));
         return {
-          audio: Buffer.from("pcm-onepcm-two"),
+          audio: Buffer.from("pcm-one!pcm-two!"),
+          contentType: "audio/pcm",
+        };
+      },
+    });
+
+    const frames: LiveVoiceTtsAudioChunk[] = [];
+    const result = await streamLiveVoiceTtsAudio({
+      config,
+      text: "hello from live voice",
+      outputFormat: "pcm",
+      sampleRate: 16_000,
+      onAudioChunk: (chunk) => frames.push(chunk),
+    });
+
+    expect(requests[0]?.outputFormat).toBe("pcm");
+    expect(requests[0]?.sampleRateHz).toBe(16_000);
+    expect(frames).toEqual([
+      {
+        type: "tts_audio",
+        contentType: "audio/pcm",
+        sampleRate: 16_000,
+        dataBase64: Buffer.from("pcm-one!").toString("base64"),
+      },
+      {
+        type: "tts_audio",
+        contentType: "audio/pcm",
+        sampleRate: 16_000,
+        dataBase64: Buffer.from("pcm-two!").toString("base64"),
+      },
+    ]);
+    expect(result).toEqual({
+      provider: "elevenlabs",
+      contentType: "audio/pcm",
+      sampleRate: 16_000,
+      chunks: 2,
+      bytes: Buffer.byteLength("pcm-one!pcm-two!"),
+    });
+  });
+
+  test("carries a trailing odd byte into the next PCM chunk to keep frames sample-aligned", async () => {
+    config = makeConfig({ provider: "elevenlabs" });
+    _setTtsProviderForTests({
+      id: "elevenlabs",
+      capabilities: {
+        supportsStreaming: true,
+        supportedFormats: ["mp3", "pcm"],
+      },
+      async synthesize(): Promise<TtsSynthesisResult> {
+        throw new Error("buffered synthesis should not be used");
+      },
+      async synthesizeStream(
+        _request: TtsSynthesisRequest,
+        onChunk: (chunk: Uint8Array) => void,
+      ): Promise<TtsSynthesisResult> {
+        onChunk(Buffer.from([1, 2, 3]));
+        onChunk(Buffer.from([4, 5, 6, 7, 8]));
+        return {
+          audio: Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]),
           contentType: "audio/pcm",
         };
       },
@@ -169,28 +228,48 @@ describe("streamLiveVoiceTtsAudio", () => {
       onAudioChunk: (chunk) => frames.push(chunk),
     });
 
-    expect(requests[0]?.outputFormat).toBe("pcm");
-    expect(frames).toEqual([
-      {
-        type: "tts_audio",
-        contentType: "audio/pcm",
-        sampleRate: 24_000,
-        dataBase64: Buffer.from("pcm-one").toString("base64"),
-      },
-      {
-        type: "tts_audio",
-        contentType: "audio/pcm",
-        sampleRate: 24_000,
-        dataBase64: Buffer.from("pcm-two").toString("base64"),
-      },
+    expect(frames.map((frame) => frame.dataBase64)).toEqual([
+      Buffer.from([1, 2]).toString("base64"),
+      Buffer.from([3, 4, 5, 6, 7, 8]).toString("base64"),
     ]);
-    expect(result).toEqual({
-      provider: "elevenlabs",
-      contentType: "audio/pcm",
-      sampleRate: 24_000,
-      chunks: 2,
-      bytes: Buffer.byteLength("pcm-onepcm-two"),
+    expect(result).toMatchObject({ chunks: 2, bytes: 8 });
+  });
+
+  test("drops a dangling final odd byte instead of emitting a torn PCM sample", async () => {
+    config = makeConfig({ provider: "elevenlabs" });
+    _setTtsProviderForTests({
+      id: "elevenlabs",
+      capabilities: {
+        supportsStreaming: true,
+        supportedFormats: ["mp3", "pcm"],
+      },
+      async synthesize(): Promise<TtsSynthesisResult> {
+        throw new Error("buffered synthesis should not be used");
+      },
+      async synthesizeStream(
+        _request: TtsSynthesisRequest,
+        onChunk: (chunk: Uint8Array) => void,
+      ): Promise<TtsSynthesisResult> {
+        onChunk(Buffer.from([1, 2, 3]));
+        return {
+          audio: Buffer.from([1, 2, 3]),
+          contentType: "audio/pcm",
+        };
+      },
     });
+
+    const frames: LiveVoiceTtsAudioChunk[] = [];
+    const result = await streamLiveVoiceTtsAudio({
+      config,
+      text: "hello from live voice",
+      outputFormat: "pcm",
+      onAudioChunk: (chunk) => frames.push(chunk),
+    });
+
+    expect(frames.map((frame) => frame.dataBase64)).toEqual([
+      Buffer.from([1, 2]).toString("base64"),
+    ]);
+    expect(result).toMatchObject({ chunks: 1, bytes: 2 });
   });
 
   test("skips the buffered non-PCM emit when the signal aborts mid-stream", async () => {

--- a/assistant/src/live-voice/live-voice-tts.ts
+++ b/assistant/src/live-voice/live-voice-tts.ts
@@ -7,6 +7,9 @@ import type {
   TtsSynthesisRequest,
   TtsUseCase,
 } from "../tts/types.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("live-voice-tts");
 
 export const DEFAULT_LIVE_VOICE_TTS_SAMPLE_RATE = 24_000;
 
@@ -102,6 +105,19 @@ export async function streamLiveVoiceTtsAudio(
   // compressed formats (mp3/wav/opus) are only playable as a whole payload.
   const bufferedAudio: Buffer[] = [];
 
+  // Provider chunks can split a 16-bit PCM sample across chunk boundaries;
+  // a trailing odd byte is carried into the next chunk to keep frames aligned.
+  let pcm16Carry: Buffer | undefined;
+  const alignPcm16 = (audio: Buffer): Buffer => {
+    const combined = pcm16Carry ? Buffer.concat([pcm16Carry, audio]) : audio;
+    const alignedLength = combined.byteLength & ~1;
+    pcm16Carry =
+      alignedLength < combined.byteLength
+        ? combined.subarray(alignedLength)
+        : undefined;
+    return combined.subarray(0, alignedLength);
+  };
+
   try {
     const result = await synthesizeAndEmit({
       provider,
@@ -109,15 +125,28 @@ export async function streamLiveVoiceTtsAudio(
       useCase: options.useCase ?? "phone-call",
       voiceId: options.voiceId,
       outputFormat: options.outputFormat,
+      sampleRateHz: sampleRate,
       signal: options.signal,
       onChunk: (chunk) => {
         if (canStreamChunks) {
-          emitAudioFrame(chunk.contentType || chunkContentType, chunk.audio);
+          emitAudioFrame(
+            chunk.contentType || chunkContentType,
+            alignPcm16(chunk.audio),
+          );
         } else {
           bufferedAudio.push(chunk.audio);
         }
       },
     });
+
+    // A dangling final byte is malformed provider output — drop it rather
+    // than emit a torn sample.
+    if (pcm16Carry) {
+      log.debug(
+        { provider: providerId },
+        "Dropping trailing odd byte from PCM16 TTS stream",
+      );
+    }
     const contentType = result.contentType || chunkContentType;
 
     // An abort mid-stream resolves without throwing; skip the buffered emit


### PR DESCRIPTION
## Summary
- Passes the resolved session sample rate to the TTS provider via `sampleRateHz` so streamed PCM matches the labeled frame rate
- Adds a PCM16 odd-byte carry so chunk boundaries can't split a sample
- Test coverage for per-chunk emission, rate forwarding, alignment, and the buffered non-PCM fallback

Part of plan: voice-tts-streaming-latency.md (PR 4 of 8)