### PR TITLE
feat(tts): implement ElevenLabs synthesizeStream with chunked PCM output

### DIFF
--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -209,10 +209,15 @@ describe("ElevenLabs TTS provider adapter", () => {
     expect(provider.id).toBe("elevenlabs");
   });
 
-  test("advertises mp3 and pcm format support without streaming", () => {
+  test("advertises mp3 and pcm format support with streaming", () => {
     const provider = createElevenLabsProvider();
-    expect(provider.capabilities.supportsStreaming).toBe(false);
+    expect(provider.capabilities.supportsStreaming).toBe(true);
     expect(provider.capabilities.supportedFormats).toEqual(["mp3", "pcm"]);
+  });
+
+  test("implements synthesizeStream", () => {
+    const provider = createElevenLabsProvider();
+    expect(typeof provider.synthesizeStream).toBe("function");
   });
 
   // -- Request mapping -----------------------------------------------------
@@ -300,6 +305,226 @@ describe("ElevenLabs TTS provider adapter", () => {
 
     const body = JSON.parse(capturedBody);
     expect(body.model_id).toBe("eleven_turbo_v2_5");
+  });
+
+  test("synthesize defaults to eleven_multilingual_v2 model", async () => {
+    const audioPayload = new Uint8Array([0x49, 0x44, 0x33]);
+    let capturedBody = "";
+
+    globalThis.fetch = mock(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedBody = init?.body as string;
+        return new Response(audioPayload, { status: 200 });
+      },
+    ) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider();
+    await provider.synthesize(makeRequest());
+
+    const body = JSON.parse(capturedBody);
+    expect(body.model_id).toBe("eleven_multilingual_v2");
+  });
+
+  // -- PCM sample-rate mapping ----------------------------------------------
+
+  test("pcm output with sampleRateHz 24000 requests pcm_24000", async () => {
+    const audioPayload = new Uint8Array([0x00, 0x01]);
+    let capturedUrl = "";
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      capturedUrl = typeof input === "string" ? input : input.toString();
+      return new Response(audioPayload, { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider();
+    const result = await provider.synthesize(
+      makeRequest({ outputFormat: "pcm", sampleRateHz: 24000 }),
+    );
+
+    expect(capturedUrl).toContain("output_format=pcm_24000");
+    expect(result.contentType).toBe("audio/pcm");
+  });
+
+  test("pcm output without sampleRateHz defaults to pcm_16000", async () => {
+    const audioPayload = new Uint8Array([0x00, 0x01]);
+    let capturedUrl = "";
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      capturedUrl = typeof input === "string" ? input : input.toString();
+      return new Response(audioPayload, { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider();
+    await provider.synthesize(makeRequest({ outputFormat: "pcm" }));
+
+    expect(capturedUrl).toContain("output_format=pcm_16000");
+  });
+
+  test("pcm output with unmatched sampleRateHz falls back to pcm_16000", async () => {
+    const audioPayload = new Uint8Array([0x00, 0x01]);
+    let capturedUrl = "";
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      capturedUrl = typeof input === "string" ? input : input.toString();
+      return new Response(audioPayload, { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider();
+    await provider.synthesize(
+      makeRequest({ outputFormat: "pcm", sampleRateHz: 8000 }),
+    );
+
+    expect(capturedUrl).toContain("output_format=pcm_16000");
+  });
+
+  // -- Streaming -------------------------------------------------------------
+
+  function streamOf(...parts: Uint8Array[]): ReadableStream<Uint8Array> {
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const part of parts) controller.enqueue(part);
+        controller.close();
+      },
+    });
+  }
+
+  test("synthesizeStream reads chunks from the /stream endpoint and concatenates them", async () => {
+    const part1 = new Uint8Array([0x01, 0x02]);
+    const part2 = new Uint8Array([0x03]);
+    let capturedUrl = "";
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      capturedUrl = typeof input === "string" ? input : input.toString();
+      return new Response(streamOf(part1, part2), { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const received: Uint8Array[] = [];
+    const provider = createElevenLabsProvider();
+    const result = await provider.synthesizeStream!(
+      makeRequest({ outputFormat: "pcm" }),
+      (chunk) => received.push(chunk),
+    );
+
+    expect(capturedUrl).toContain(
+      "/v1/text-to-speech/test-voice-id/stream?output_format=pcm_16000",
+    );
+    expect(received).toEqual([part1, part2]);
+    expect(result.audio).toEqual(Buffer.from([0x01, 0x02, 0x03]));
+    expect(result.contentType).toBe("audio/pcm");
+  });
+
+  test("synthesizeStream defaults to eleven_flash_v2_5 model", async () => {
+    let capturedBody = "";
+
+    globalThis.fetch = mock(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedBody = init?.body as string;
+        return new Response(streamOf(new Uint8Array([0x01])), { status: 200 });
+      },
+    ) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider();
+    await provider.synthesizeStream!(makeRequest(), () => {});
+
+    const body = JSON.parse(capturedBody);
+    expect(body.model_id).toBe("eleven_flash_v2_5");
+  });
+
+  test("synthesizeStream respects configured voiceModelId over flash default", async () => {
+    mockElevenLabsConfig.voiceModelId = "eleven_turbo_v2_5";
+    let capturedBody = "";
+
+    globalThis.fetch = mock(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedBody = init?.body as string;
+        return new Response(streamOf(new Uint8Array([0x01])), { status: 200 });
+      },
+    ) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider();
+    await provider.synthesizeStream!(makeRequest(), () => {});
+
+    const body = JSON.parse(capturedBody);
+    expect(body.model_id).toBe("eleven_turbo_v2_5");
+  });
+
+  test("synthesizeStream throws ELEVENLABS_TTS_EMPTY_RESPONSE on null body", async () => {
+    globalThis.fetch = mock(
+      async () => new Response(null, { status: 200 }),
+    ) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider();
+
+    try {
+      await provider.synthesizeStream!(makeRequest(), () => {});
+      throw new Error("Expected synthesizeStream to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ElevenLabsTtsError);
+      expect((err as ElevenLabsTtsError).code).toBe(
+        "ELEVENLABS_TTS_EMPTY_RESPONSE",
+      );
+    }
+  });
+
+  test("synthesizeStream throws ELEVENLABS_TTS_EMPTY_RESPONSE on zero-byte stream", async () => {
+    globalThis.fetch = mock(
+      async () => new Response(streamOf(), { status: 200 }),
+    ) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider();
+
+    try {
+      await provider.synthesizeStream!(makeRequest(), () => {});
+      throw new Error("Expected synthesizeStream to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ElevenLabsTtsError);
+      expect((err as ElevenLabsTtsError).code).toBe(
+        "ELEVENLABS_TTS_EMPTY_RESPONSE",
+      );
+    }
+  });
+
+  test("synthesizeStream surfaces upstream error message on HTTP error", async () => {
+    mockFetchError(
+      402,
+      JSON.stringify({ detail: { message: "Quota exceeded" } }),
+    );
+
+    const provider = createElevenLabsProvider();
+
+    try {
+      await provider.synthesizeStream!(makeRequest(), () => {});
+      throw new Error("Expected synthesizeStream to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ElevenLabsTtsError);
+      expect((err as ElevenLabsTtsError).code).toBe(
+        "ELEVENLABS_TTS_HTTP_ERROR",
+      );
+      expect((err as ElevenLabsTtsError).statusCode).toBe(402);
+      expect((err as ElevenLabsTtsError).message).toBe("Quota exceeded");
+    }
+  });
+
+  test("synthesizeStream propagates AbortError unmodified", async () => {
+    globalThis.fetch = mock(async () => {
+      const abortError = new Error("The operation was aborted");
+      abortError.name = "AbortError";
+      throw abortError;
+    }) as unknown as typeof globalThis.fetch;
+
+    const controller = new AbortController();
+    const provider = createElevenLabsProvider();
+
+    try {
+      await provider.synthesizeStream!(
+        makeRequest({ signal: controller.signal }),
+        () => {},
+      );
+      throw new Error("Expected synthesizeStream to throw");
+    } catch (err) {
+      expect(err).not.toBeInstanceOf(ElevenLabsTtsError);
+      expect((err as Error).name).toBe("AbortError");
+    }
   });
 
   // -- Content type / format -----------------------------------------------

--- a/assistant/src/tts/__tests__/provider-catalog.test.ts
+++ b/assistant/src/tts/__tests__/provider-catalog.test.ts
@@ -121,12 +121,13 @@ describe("ElevenLabs catalog entry", () => {
     expect(entry.callMode).toBe("native-twilio");
   });
 
-  test("does not support streaming", () => {
-    expect(entry.capabilities.supportsStreaming).toBe(false);
+  test("supports streaming", () => {
+    expect(entry.capabilities.supportsStreaming).toBe(true);
   });
 
-  test("supports mp3 format", () => {
+  test("supports mp3 and pcm formats", () => {
     expect(entry.capabilities.supportedFormats).toContain("mp3");
+    expect(entry.capabilities.supportedFormats).toContain("pcm");
   });
 
   test("plays over media-stream via PCM output", () => {

--- a/assistant/src/tts/providers/elevenlabs-provider.ts
+++ b/assistant/src/tts/providers/elevenlabs-provider.ts
@@ -159,14 +159,24 @@ function resolveVoiceId(
   return voiceId;
 }
 
+/** ElevenLabs PCM output formats by exact sample rate. */
+const PCM_FORMAT_BY_SAMPLE_RATE: Record<number, string> = {
+  16000: "pcm_16000",
+  22050: "pcm_22050",
+  24000: "pcm_24000",
+  44100: "pcm_44100",
+};
+
 /**
  * Choose the ElevenLabs output format based on the use case and optional
  * format hint.
  *
  * When the caller requests `outputFormat: "pcm"` (e.g. the media-stream
- * transport which needs raw PCM for mu-law transcoding), we use `pcm_16000`
- * — 16-bit signed little-endian at 16 kHz. The media-stream transport's
- * `audioBufferToFrames` handles the 16 kHz -> 8 kHz downsample.
+ * transport which needs raw PCM for mu-law transcoding), we map the optional
+ * `sampleRateHz` hint to an exact ElevenLabs PCM format — 16-bit signed
+ * little-endian. An absent or unmatched hint defaults to `pcm_16000`, which
+ * preserves the media-stream transport's behavior (its `audioBufferToFrames`
+ * handles the 16 kHz -> 8 kHz downsample).
  *
  * Otherwise:
  * - Phone calls benefit from lower-latency, smaller payloads (mp3 at 22050/32).
@@ -174,14 +184,108 @@ function resolveVoiceId(
  */
 function resolveOutputFormat(request: TtsSynthesisRequest): string {
   if (request.outputFormat === "pcm") {
-    return "pcm_16000";
+    return (
+      PCM_FORMAT_BY_SAMPLE_RATE[request.sampleRateHz ?? 16000] ?? "pcm_16000"
+    );
   }
   return request.useCase === "phone-call" ? "mp3_22050_32" : "mp3_44100_128";
 }
 
+/**
+ * Resolve credentials and config, build the request body, and issue the
+ * ElevenLabs TTS HTTP request. Shared by `synthesize` (buffer endpoint) and
+ * `synthesizeStream` (`/stream` endpoint). Throws on missing credentials and
+ * non-OK responses; resolves with the OK response and the resolved output
+ * format.
+ */
+async function performTtsRequest(
+  request: TtsSynthesisRequest,
+  { stream }: { stream: boolean },
+): Promise<{ response: Response; outputFormat: string }> {
+  const apiKey = await getSecureKeyAsync(
+    credentialKey("elevenlabs", "api_key"),
+  );
+  if (!apiKey) {
+    throw new ElevenLabsTtsError(
+      "ELEVENLABS_TTS_NO_API_KEY",
+      "ElevenLabs API key not configured. " +
+        "Add it in Settings → Voice or via: assistant credentials set --service elevenlabs --field api_key <key>",
+    );
+  }
+
+  const config = getConfig().services.tts.providers.elevenlabs;
+  const voiceId = resolveVoiceId(request, config);
+  const outputFormat = resolveOutputFormat(request);
+
+  const url = stream
+    ? `${ELEVENLABS_API_BASE}/v1/text-to-speech/${voiceId}/stream?output_format=${outputFormat}`
+    : `${ELEVENLABS_API_BASE}/v1/text-to-speech/${voiceId}?output_format=${outputFormat}`;
+
+  // Streaming defaults to the low-latency flash model; batch keeps
+  // multilingual for quality. A configured voiceModelId always wins.
+  const defaultModelId = stream
+    ? "eleven_flash_v2_5"
+    : "eleven_multilingual_v2";
+
+  const body: Record<string, unknown> = {
+    text: request.text,
+    model_id: config.voiceModelId?.trim() || defaultModelId,
+    voice_settings: {
+      stability: config.stability,
+      similarity_boost: config.similarityBoost,
+      speed: config.speed,
+    },
+  };
+
+  log.info(
+    { voiceId, outputFormat, stream, textLength: request.text.length },
+    "Starting ElevenLabs TTS synthesis",
+  );
+
+  const acceptType = FORMAT_CONTENT_TYPE[outputFormat] ?? "audio/mpeg";
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "xi-api-key": apiKey,
+        Accept: acceptType,
+      },
+      body: JSON.stringify(body),
+      signal: request.signal,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") throw err;
+    throw new ElevenLabsTtsError(
+      "ELEVENLABS_TTS_REQUEST_FAILED",
+      `ElevenLabs TTS request failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "");
+    // Surface the upstream provider message verbatim when extractable —
+    // the daemon route wraps it with a single "TTS synthesis failed:"
+    // prefix on the way out. The HTTP status is preserved on `statusCode`
+    // and logged by the daemon, so we don't embed it in the message text.
+    const message =
+      extractElevenLabsErrorMessage(errorText) ??
+      `ElevenLabs returned HTTP ${response.status}`;
+    throw new ElevenLabsTtsError(
+      "ELEVENLABS_TTS_HTTP_ERROR",
+      message,
+      response.status,
+    );
+  }
+
+  return { response, outputFormat };
+}
+
 export function createElevenLabsProvider(): TtsProvider {
   const capabilities: TtsProviderCapabilities = {
-    supportsStreaming: false,
+    supportsStreaming: true,
     supportedFormats: ["mp3", "pcm"],
   };
 
@@ -192,75 +296,9 @@ export function createElevenLabsProvider(): TtsProvider {
     async synthesize(
       request: TtsSynthesisRequest,
     ): Promise<TtsSynthesisResult> {
-      const apiKey = await getSecureKeyAsync(
-        credentialKey("elevenlabs", "api_key"),
-      );
-      if (!apiKey) {
-        throw new ElevenLabsTtsError(
-          "ELEVENLABS_TTS_NO_API_KEY",
-          "ElevenLabs API key not configured. " +
-            "Add it in Settings → Voice or via: assistant credentials set --service elevenlabs --field api_key <key>",
-        );
-      }
-
-      const config = getConfig().services.tts.providers.elevenlabs;
-      const voiceId = resolveVoiceId(request, config);
-      const outputFormat = resolveOutputFormat(request);
-
-      const url = `${ELEVENLABS_API_BASE}/v1/text-to-speech/${voiceId}`;
-
-      const body: Record<string, unknown> = {
-        text: request.text,
-        model_id: config.voiceModelId?.trim() || "eleven_multilingual_v2",
-        voice_settings: {
-          stability: config.stability,
-          similarity_boost: config.similarityBoost,
-          speed: config.speed,
-        },
-      };
-
-      log.info(
-        { voiceId, outputFormat, textLength: request.text.length },
-        "Starting ElevenLabs TTS synthesis",
-      );
-
-      const acceptType = FORMAT_CONTENT_TYPE[outputFormat] ?? "audio/mpeg";
-
-      let response: Response;
-      try {
-        response = await fetch(`${url}?output_format=${outputFormat}`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "xi-api-key": apiKey,
-            Accept: acceptType,
-          },
-          body: JSON.stringify(body),
-          signal: request.signal,
-        });
-      } catch (err) {
-        if (err instanceof Error && err.name === "AbortError") throw err;
-        throw new ElevenLabsTtsError(
-          "ELEVENLABS_TTS_REQUEST_FAILED",
-          `ElevenLabs TTS request failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-
-      if (!response.ok) {
-        const errorText = await response.text().catch(() => "");
-        // Surface the upstream provider message verbatim when extractable —
-        // the daemon route wraps it with a single "TTS synthesis failed:"
-        // prefix on the way out. The HTTP status is preserved on `statusCode`
-        // and logged by the daemon, so we don't embed it in the message text.
-        const message =
-          extractElevenLabsErrorMessage(errorText) ??
-          `ElevenLabs returned HTTP ${response.status}`;
-        throw new ElevenLabsTtsError(
-          "ELEVENLABS_TTS_HTTP_ERROR",
-          message,
-          response.status,
-        );
-      }
+      const { response, outputFormat } = await performTtsRequest(request, {
+        stream: false,
+      });
 
       const arrayBuffer = await response.arrayBuffer();
       if (arrayBuffer.byteLength === 0) {
@@ -270,8 +308,6 @@ export function createElevenLabsProvider(): TtsProvider {
         );
       }
 
-      const contentType = FORMAT_CONTENT_TYPE[outputFormat] ?? "audio/mpeg";
-
       log.debug(
         { bytes: arrayBuffer.byteLength },
         "ElevenLabs TTS synthesis complete",
@@ -279,7 +315,61 @@ export function createElevenLabsProvider(): TtsProvider {
 
       return {
         audio: Buffer.from(arrayBuffer),
-        contentType,
+        contentType: FORMAT_CONTENT_TYPE[outputFormat] ?? "audio/mpeg",
+      };
+    },
+
+    async synthesizeStream(
+      request: TtsSynthesisRequest,
+      onChunk: (chunk: Uint8Array) => void,
+    ): Promise<TtsSynthesisResult> {
+      const { response, outputFormat } = await performTtsRequest(request, {
+        stream: true,
+      });
+
+      if (!response.body) {
+        throw new ElevenLabsTtsError(
+          "ELEVENLABS_TTS_EMPTY_RESPONSE",
+          "ElevenLabs streaming TTS returned no response body",
+        );
+      }
+
+      const chunks: Uint8Array[] = [];
+      const reader = response.body.getReader();
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (value && value.byteLength > 0) {
+            chunks.push(value);
+            onChunk(value);
+          }
+        }
+      } catch (err) {
+        try {
+          await reader.cancel();
+        } catch {
+          // Ignore cancellation errors
+        }
+        throw err;
+      }
+
+      if (chunks.length === 0) {
+        throw new ElevenLabsTtsError(
+          "ELEVENLABS_TTS_EMPTY_RESPONSE",
+          "ElevenLabs TTS returned an empty audio response",
+        );
+      }
+
+      const audio = Buffer.concat(chunks);
+      log.debug(
+        { bytes: audio.byteLength },
+        "ElevenLabs streaming TTS synthesis complete",
+      );
+
+      return {
+        audio,
+        contentType: FORMAT_CONTENT_TYPE[outputFormat] ?? "audio/mpeg",
       };
     },
   };
@@ -309,10 +399,10 @@ export const elevenLabsTtsProviderDefinition: TtsProviderDefinition = {
   callMode: "native-twilio",
   allowNativeFallback: true,
   capabilities: {
-    supportsStreaming: false,
-    supportedFormats: ["mp3"],
+    supportsStreaming: true,
+    supportedFormats: ["mp3", "pcm"],
   },
-  // The adapter honours the PCM hint via `pcm_16000` output.
+  // The adapter honours the PCM hint via sample-rate-mapped pcm_* output.
   mediaStreamPlayback: { outputFormat: "pcm" },
   secretRequirements: [
     {


### PR DESCRIPTION
## Summary
- Adds `synthesizeStream` to the ElevenLabs provider using the `/stream` endpoint with incremental body reads
- Maps `sampleRateHz` to exact ElevenLabs PCM formats (default pcm_16000); streaming defaults to the low-latency `eleven_flash_v2_5` model (config `voiceModelId` always wins)
- Flips `supportsStreaming: true` so live-voice hands-free works on the default provider

Part of plan: voice-tts-streaming-latency.md (PR 2 of 8)