### PR TITLE
feat(live-voice): flush the first TTS segment at a clause boundary so speech starts sooner

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
@@ -205,6 +205,50 @@ describe("LiveVoiceSession TTS", () => {
     });
   });
 
+  test("flushes the first segment of a turn eagerly at a clause boundary", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const ttsTexts: string[] = [];
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      ttsTexts.push(options.text);
+      options.onAudioChunk(makeTtsChunk(`audio:${options.text}`));
+      return makeTtsResult(options.text);
+    });
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(
+      makeTextDelta("Sure, I can help with that, and here is more text to say."),
+    );
+    await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
+
+    // The opening clause flushes at the comma past the prefix floor instead
+    // of waiting for the sentence; the remainder follows sentence rules.
+    expect(ttsTexts).toEqual([
+      "Sure, I can help with that,",
+      "and here is more text to say.",
+    ]);
+
+    // Subsequent text in the same turn is not eagerly clause-split.
+    callbacks?.assistant_text_delta?.(
+      makeTextDelta(" Later we can dig into the details, if you want more"),
+    );
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(ttsTexts).toEqual([
+      "Sure, I can help with that,",
+      "and here is more text to say.",
+      "Later we can dig into the details, if you want more",
+    ]);
+  });
+
   test("forwards non-PCM TTS chunk content type unchanged", async () => {
     let callbacks: VoiceTurnCallbacks | undefined;
     const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
@@ -231,7 +275,7 @@ describe("LiveVoiceSession TTS", () => {
     });
   });
 
-  test("flushes long assistant text as a conservative TTS segment before completion", async () => {
+  test("flushes long unpunctuated assistant text before completion at the eager threshold", async () => {
     let callbacks: VoiceTurnCallbacks | undefined;
     const ttsTexts: string[] = [];
     const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
@@ -252,9 +296,11 @@ describe("LiveVoiceSession TTS", () => {
     callbacks?.assistant_text_delta?.(makeTextDelta("steady ".repeat(32)));
     await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
 
+    // The turn's first segment splits at the eager threshold; the rest stays
+    // buffered under sentence rules until more text or completion arrives.
     expect(ttsTexts).toHaveLength(1);
-    expect(ttsTexts[0]?.length).toBeGreaterThan(100);
-    expect(ttsTexts[0]?.length).toBeLessThanOrEqual(181);
+    expect(ttsTexts[0]?.length).toBeGreaterThan(30);
+    expect(ttsTexts[0]?.length).toBeLessThanOrEqual(60);
     expect(frames.some((frame) => frame.type === "tts_done")).toBe(false);
   });
 

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -163,6 +163,9 @@ interface ActiveAssistantTurn {
   ttsAudioStarted: boolean;
   finalized: boolean;
   ttsBuffer: string;
+  // A non-empty speakable segment reached the TTS queue — gates the eager
+  // first-segment flush that trades clause quality for speech onset.
+  ttsSegmentEnqueued: boolean;
   ttsQueue: Promise<void>;
   assistantMessageId: string | null;
   assistantAudioChunks: Buffer[];
@@ -861,6 +864,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       ttsAudioStarted: false,
       finalized: false,
       ttsBuffer: "",
+      ttsSegmentEnqueued: false,
       ttsQueue: Promise.resolve(),
       assistantMessageId: null,
       assistantAudioChunks: [],
@@ -1095,6 +1099,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     const { segments, remainder } = extractSpeakableSegments(
       activeTurn.ttsBuffer,
       force,
+      // Eager until the first segment is enqueued: the opening clause flushes
+      // early so speech onset does not wait for a full sentence.
+      { eager: !activeTurn.ttsSegmentEnqueued },
     );
     activeTurn.ttsBuffer = remainder;
 
@@ -1114,6 +1121,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     const streamTtsAudio = this.streamTtsAudio;
     if (activeTurn?.token !== token || !streamTtsAudio) return;
 
+    activeTurn.ttsSegmentEnqueued = true;
     activeTurn.ttsQueue = activeTurn.ttsQueue
       .catch(() => {})
       .then(async () => {

--- a/assistant/src/tts/__tests__/speakable-segments.test.ts
+++ b/assistant/src/tts/__tests__/speakable-segments.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD,
+  EAGER_SPEAKABLE_SEGMENT_CHAR_THRESHOLD,
   extractSpeakableSegments,
 } from "../speakable-segments.js";
 
@@ -111,6 +112,99 @@ describe("extractSpeakableSegments", () => {
 
     expect(segments).toEqual(["alpha beta", "gamma delta"]);
     expect(remainder).toBe("epsilon");
+  });
+
+  describe("eager mode", () => {
+    test("splits at a comma once enough text precedes it", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "Sure, I can help with that, and here is more",
+        false,
+        { eager: true },
+      );
+
+      expect(segments).toEqual(["Sure, I can help with that,"]);
+      expect(remainder).toBe(" and here is more");
+    });
+
+    test("splits at semicolons and colons past the prefix floor", () => {
+      const { segments } = extractSpeakableSegments(
+        "Here is what I found today; there is more coming",
+        false,
+        { eager: true },
+      );
+
+      expect(segments).toEqual(["Here is what I found today;"]);
+    });
+
+    test("a short clause like 'Sure, ' does not flush on its own", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "Sure, ",
+        false,
+        { eager: true },
+      );
+
+      expect(segments).toEqual([]);
+      expect(remainder).toBe("Sure, ");
+    });
+
+    test("clause punctuation at end-of-text keeps buffering", () => {
+      const text = "Sure, I can help with that,";
+
+      const { segments, remainder } = extractSpeakableSegments(text, false, {
+        eager: true,
+      });
+
+      expect(segments).toEqual([]);
+      expect(remainder).toBe(text);
+    });
+
+    test("uses the lower char threshold to split without punctuation", () => {
+      const text = "word ".repeat(20);
+
+      const { segments } = extractSpeakableSegments(text, false, {
+        eager: true,
+      });
+
+      expect(segments.length).toBeGreaterThan(0);
+      const segment = segments[0] ?? "";
+      expect(segment.length).toBeLessThanOrEqual(
+        EAGER_SPEAKABLE_SEGMENT_CHAR_THRESHOLD,
+      );
+      expect(segment.endsWith("word")).toBe(true);
+    });
+
+    test("charThreshold option overrides the eager default", () => {
+      const text = "word ".repeat(20);
+
+      const { segments } = extractSpeakableSegments(text, false, {
+        eager: true,
+        charThreshold: 30,
+      });
+
+      expect(segments[0]?.length).toBeLessThanOrEqual(30);
+    });
+
+    test("eagerness applies only to the first segment of a call", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "Sure, I can help with that, and after that we can keep going, with more",
+        false,
+        { eager: true },
+      );
+
+      expect(segments).toEqual(["Sure, I can help with that,"]);
+      expect(remainder).toBe(
+        " and after that we can keep going, with more",
+      );
+    });
+
+    test("non-eager extraction ignores clause punctuation", () => {
+      const text = "Sure, I can help with that, and here is more";
+
+      const { segments, remainder } = extractSpeakableSegments(text, false);
+
+      expect(segments).toEqual([]);
+      expect(remainder).toBe(text);
+    });
   });
 
   test("charThreshold defaulting matches the exported constant", () => {

--- a/assistant/src/tts/speakable-segments.ts
+++ b/assistant/src/tts/speakable-segments.ts
@@ -8,17 +8,33 @@
  */
 
 export const DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD = 180;
+export const EAGER_SPEAKABLE_SEGMENT_CHAR_THRESHOLD = 60;
 
 const SENTENCE_ENDING_PUNCTUATION = new Set([".", "!", "?"]);
 const TRAILING_SENTENCE_PUNCTUATION = new Set(['"', "'", ")", "]"]);
+const EAGER_CLAUSE_PUNCTUATION = new Set([",", ";", ":"]);
+// A clause boundary only counts in eager mode once this much text precedes
+// it — "Sure, " alone would be a one-word blip.
+const EAGER_MIN_CLAUSE_PREFIX_CHARS = 24;
 
 export interface ExtractSpeakableSegmentsOptions {
   /**
    * Max characters buffered before a segment is force-split at the last
    * whitespace boundary. Defaults to
-   * {@link DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD}.
+   * {@link DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD}
+   * ({@link EAGER_SPEAKABLE_SEGMENT_CHAR_THRESHOLD} when `eager`).
    */
   charThreshold?: number;
+  /**
+   * Trade segment quality for onset latency: clause punctuation (`,` `;` `:`)
+   * followed by whitespace also ends a segment once at least
+   * ~24 chars precede it, and the default char threshold drops to
+   * {@link EAGER_SPEAKABLE_SEGMENT_CHAR_THRESHOLD}. Applies only until the
+   * first segment of the call is found — later segments keep full-sentence
+   * rules. The caller decides when to stop passing `eager` (typically after
+   * the first segment is enqueued).
+   */
+  eager?: boolean;
 }
 
 export function extractSpeakableSegments(
@@ -26,18 +42,25 @@ export function extractSpeakableSegments(
   force: boolean,
   options?: ExtractSpeakableSegmentsOptions,
 ): { segments: string[]; remainder: string } {
-  const charThreshold =
-    options?.charThreshold ?? DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD;
+  let eager = options?.eager ?? false;
   const segments: string[] = [];
   let remainder = text;
 
   while (remainder.length > 0) {
-    const boundary = findSpeakableBoundary(remainder, charThreshold);
-    if (boundary === null) break;
+    const charThreshold =
+      options?.charThreshold ??
+      (eager
+        ? EAGER_SPEAKABLE_SEGMENT_CHAR_THRESHOLD
+        : DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD);
+    const boundary = findSpeakableBoundary(remainder, charThreshold, eager);
+    if (boundary === null) {
+      break;
+    }
 
     const segment = remainder.slice(0, boundary).trim();
     if (segment.length > 0) {
       segments.push(segment);
+      eager = false;
     }
     remainder = remainder.slice(boundary);
   }
@@ -56,11 +79,29 @@ export function extractSpeakableSegments(
 function findSpeakableBoundary(
   text: string,
   charThreshold: number,
+  eager: boolean,
 ): number | null {
   for (let index = 0; index < text.length; index += 1) {
     const char = text[index];
-    if (char === "\n") return index + 1;
-    if (!char || !SENTENCE_ENDING_PUNCTUATION.has(char)) continue;
+    if (char === "\n") {
+      return index + 1;
+    }
+    if (!char) {
+      continue;
+    }
+
+    if (
+      eager &&
+      EAGER_CLAUSE_PUNCTUATION.has(char) &&
+      index >= EAGER_MIN_CLAUSE_PREFIX_CHARS &&
+      isWhitespace(text[index + 1] ?? "")
+    ) {
+      return index + 1;
+    }
+
+    if (!SENTENCE_ENDING_PUNCTUATION.has(char)) {
+      continue;
+    }
 
     let boundary = index + 1;
     while (


### PR DESCRIPTION
## Summary
- Adds eager mode to `extractSpeakableSegments`: clause punctuation (`,` `;` `:`) past a 24-char floor, or 60 chars, ends the first segment
- Live-voice applies eager mode only until the turn's first segment is enqueued, so speech onset no longer waits for a full sentence
- Unit + session-level test coverage

Part of plan: voice-tts-streaming-latency.md (PR 6 of 8)