### PR TITLE
fix(tts): fish-audio streams raw PCM at the requested sample rate instead of 8 kHz WAV

### DIFF
--- a/assistant/src/calls/__tests__/fish-audio-client.test.ts
+++ b/assistant/src/calls/__tests__/fish-audio-client.test.ts
@@ -70,4 +70,16 @@ describe("synthesizeWithFishAudio request body", () => {
     const body = JSON.parse(capturedBody);
     expect("sample_rate" in body).toBe(false);
   });
+
+  test("passes pcm format and sample_rate through to the request body", async () => {
+    await synthesizeWithFishAudio(
+      "hello",
+      { ...config, format: "pcm" },
+      { sampleRate: 24000 },
+    );
+
+    const body = JSON.parse(capturedBody);
+    expect(body.format).toBe("pcm");
+    expect(body.sample_rate).toBe(24000);
+  });
 });

--- a/assistant/src/calls/fish-audio-client.ts
+++ b/assistant/src/calls/fish-audio-client.ts
@@ -5,6 +5,15 @@ import { getLogger } from "../util/logger.js";
 
 const log = getLogger("fish-audio-client");
 
+/**
+ * Config accepted by the synthesis client. Widens the user-facing format
+ * union with `"pcm"` (raw 16-bit LE, no container), which PCM-requesting
+ * callers substitute internally — it is not part of the config schema.
+ */
+export type FishAudioSynthesisConfig = Omit<FishAudioConfig, "format"> & {
+  format: FishAudioConfig["format"] | "pcm";
+};
+
 /** Timeout waiting for the first chunk from Fish Audio (ms). */
 const FIRST_CHUNK_TIMEOUT_MS = 10_000;
 
@@ -32,7 +41,7 @@ interface SynthesizeOptions {
  */
 export async function synthesizeWithFishAudio(
   text: string,
-  config: FishAudioConfig,
+  config: FishAudioSynthesisConfig,
   options?: SynthesizeOptions,
 ): Promise<Buffer> {
   const apiKey = await getSecureKeyAsync(

--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -483,6 +483,7 @@ describe("Fish Audio TTS provider adapter", () => {
       "mp3",
       "wav",
       "opus",
+      "pcm",
     ]);
   });
 
@@ -529,28 +530,73 @@ describe("Fish Audio TTS provider adapter", () => {
     );
   });
 
-  test("pcm output request maps to wav format at 8 kHz", async () => {
+  test("pcm output request maps to raw pcm format at the 16 kHz default", async () => {
     const provider = createFishAudioProvider();
-    await provider.synthesize(makeRequest({ outputFormat: "pcm" }));
+    const result = await provider.synthesize(
+      makeRequest({ outputFormat: "pcm" }),
+    );
 
     const [, config, options] = mockSynthesizeWithFishAudio.mock.calls[0]!;
-    expect((config as { format: string }).format).toBe("wav");
+    expect((config as { format: string }).format).toBe("pcm");
     expect((options as { sampleRate?: number } | undefined)?.sampleRate).toBe(
-      8000,
+      16000,
+    );
+    expect(result.contentType).toBe("audio/pcm");
+  });
+
+  test("pcm output request honors the sampleRateHz hint", async () => {
+    const provider = createFishAudioProvider();
+    await provider.synthesize(
+      makeRequest({ outputFormat: "pcm", sampleRateHz: 24000 }),
+    );
+
+    const [, config, options] = mockSynthesizeWithFishAudio.mock.calls[0]!;
+    expect((config as { format: string }).format).toBe("pcm");
+    expect((options as { sampleRate?: number } | undefined)?.sampleRate).toBe(
+      24000,
     );
   });
 
-  test("synthesizeStream pcm output request maps to wav format at 8 kHz", async () => {
+  test("synthesizeStream pcm output request maps to raw pcm honoring the hint", async () => {
     const provider = createFishAudioProvider();
-    await provider.synthesizeStream!(
-      makeRequest({ outputFormat: "pcm" }),
+    const result = await provider.synthesizeStream!(
+      makeRequest({ outputFormat: "pcm", sampleRateHz: 24000 }),
       () => {},
     );
 
     const [, config, options] = mockSynthesizeWithFishAudio.mock.calls[0]!;
-    expect((config as { format: string }).format).toBe("wav");
+    expect((config as { format: string }).format).toBe("pcm");
     expect((options as { sampleRate?: number } | undefined)?.sampleRate).toBe(
-      8000,
+      24000,
+    );
+    expect(result.contentType).toBe("audio/pcm");
+  });
+
+  test("synthesizeStream pcm chunks pass through raw with no RIFF header", async () => {
+    const rawPcm = new Uint8Array([0x01, 0x00, 0x02, 0x00, 0x03, 0x00]);
+    mockSynthesizeWithFishAudio.mockImplementationOnce(
+      async (_text, _config, options) => {
+        options?.onChunk?.(rawPcm);
+        return Buffer.from(rawPcm);
+      },
+    );
+
+    const chunks: Uint8Array[] = [];
+    const provider = createFishAudioProvider();
+    await provider.synthesizeStream!(
+      makeRequest({ outputFormat: "pcm" }),
+      (chunk) => chunks.push(chunk),
+    );
+
+    const [, config, options] = mockSynthesizeWithFishAudio.mock.calls[0]!;
+    expect((config as { format: string }).format).toBe("pcm");
+    expect((options as { sampleRate?: number } | undefined)?.sampleRate).toBe(
+      16000,
+    );
+    // Chunks are forwarded verbatim — raw PCM, no WAV container.
+    expect(chunks).toEqual([rawPcm]);
+    expect(Buffer.from(chunks[0]!).subarray(0, 4).toString("ascii")).not.toBe(
+      "RIFF",
     );
   });
 

--- a/assistant/src/tts/__tests__/provider-catalog.test.ts
+++ b/assistant/src/tts/__tests__/provider-catalog.test.ts
@@ -153,14 +153,15 @@ describe("Fish Audio catalog entry", () => {
     expect(entry.capabilities.supportsStreaming).toBe(true);
   });
 
-  test("supports mp3, wav, and opus formats", () => {
+  test("supports mp3, wav, opus, and pcm formats", () => {
     expect(entry.capabilities.supportedFormats).toContain("mp3");
     expect(entry.capabilities.supportedFormats).toContain("wav");
     expect(entry.capabilities.supportedFormats).toContain("opus");
+    expect(entry.capabilities.supportedFormats).toContain("pcm");
   });
 
-  test("plays over media-stream via WAV output", () => {
-    expect(entry.mediaStreamPlayback.outputFormat).toBe("wav");
+  test("plays over media-stream via PCM output", () => {
+    expect(entry.mediaStreamPlayback.outputFormat).toBe("pcm");
   });
 
   test("requires an API key stored under 'credential/fish-audio/api_key'", () => {

--- a/assistant/src/tts/providers/fish-audio-provider.ts
+++ b/assistant/src/tts/providers/fish-audio-provider.ts
@@ -10,7 +10,10 @@
  * client.
  */
 
-import { synthesizeWithFishAudio } from "../../calls/fish-audio-client.js";
+import {
+  type FishAudioSynthesisConfig,
+  synthesizeWithFishAudio,
+} from "../../calls/fish-audio-client.js";
 import { getConfig } from "../../config/loader.js";
 import type { TtsFishAudioProviderConfig } from "../../config/schemas/tts.js";
 import { getLogger } from "../../util/logger.js";
@@ -25,11 +28,11 @@ import type {
 const log = getLogger("tts:fish-audio");
 
 /**
- * Sample rate requested when the caller wants PCM (the phone path).
- * Twilio media streams consume 8 kHz; without this Fish defaults WAV
- * to 44.1 kHz, which the media-stream transcoder would play ~5.5x slow.
+ * Sample rate for PCM requests that carry no `sampleRateHz` hint. The
+ * media-stream transcoder assumes headerless PCM is 16 kHz (the
+ * ElevenLabs/Deepgram/xAI convention) and downsamples to 8 kHz telephony.
  */
-const TELEPHONY_SAMPLE_RATE_HZ = 8000;
+const DEFAULT_PCM_SAMPLE_RATE_HZ = 16_000;
 
 // ---------------------------------------------------------------------------
 // Error types
@@ -58,6 +61,7 @@ const FORMAT_CONTENT_TYPE: Record<string, string> = {
   mp3: "audio/mpeg",
   wav: "audio/wav",
   opus: "audio/opus",
+  pcm: "audio/pcm",
 };
 
 /**
@@ -84,111 +88,68 @@ function resolveReferenceId(
 // Provider implementation
 // ---------------------------------------------------------------------------
 
+async function performSynthesis(
+  request: TtsSynthesisRequest,
+  onChunk?: (chunk: Uint8Array) => void,
+): Promise<TtsSynthesisResult> {
+  const config = getConfig().services.tts.providers["fish-audio"];
+  const referenceId = resolveReferenceId(request, config);
+
+  // Fish Audio supports raw PCM (16-bit LE, no container) natively, so a
+  // PCM request passes straight through at the hinted sample rate.
+  const pcmRequested = request.outputFormat === "pcm";
+  const effectiveFormat = pcmRequested ? "pcm" : config.format;
+
+  const effectiveConfig: FishAudioSynthesisConfig = {
+    ...config,
+    referenceId,
+    format: effectiveFormat,
+  };
+
+  const streaming = Boolean(onChunk);
+  log.info(
+    {
+      referenceId,
+      format: effectiveFormat,
+      streaming,
+      textLength: request.text.length,
+    },
+    "Starting Fish Audio TTS synthesis",
+  );
+
+  let audio: Buffer;
+  try {
+    audio = await synthesizeWithFishAudio(request.text, effectiveConfig, {
+      onChunk,
+      signal: request.signal,
+      sampleRate: pcmRequested
+        ? (request.sampleRateHz ?? DEFAULT_PCM_SAMPLE_RATE_HZ)
+        : undefined,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") throw err;
+    throw new FishAudioTtsError(
+      "FISH_AUDIO_TTS_SYNTHESIS_FAILED",
+      `Fish Audio TTS ${streaming ? "streaming " : ""}synthesis failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const contentType = FORMAT_CONTENT_TYPE[effectiveFormat] ?? "audio/mpeg";
+
+  return { audio, contentType };
+}
+
 export function createFishAudioProvider(): TtsProvider {
   const capabilities: TtsProviderCapabilities = {
     supportsStreaming: true,
-    supportedFormats: ["mp3", "wav", "opus"],
+    supportedFormats: ["mp3", "wav", "opus", "pcm"],
   };
 
   return {
     id: "fish-audio",
     capabilities,
-
-    async synthesize(
-      request: TtsSynthesisRequest,
-    ): Promise<TtsSynthesisResult> {
-      const config = getConfig().services.tts.providers["fish-audio"];
-      const referenceId = resolveReferenceId(request, config);
-
-      // When PCM output is requested, override to WAV at 8 kHz. Fish Audio
-      // doesn't support raw PCM, but WAV gives us PCM in a container that
-      // audioBufferToFrames can extract; the explicit sample rate avoids
-      // Fish's 44.1 kHz WAV default.
-      const pcmRequested = request.outputFormat === "pcm";
-      const effectiveFormat = pcmRequested ? "wav" : config.format;
-
-      // Build an effective config with the resolved reference ID
-      // and the potentially overridden format.
-      const effectiveConfig: TtsFishAudioProviderConfig = {
-        ...config,
-        referenceId,
-        format: effectiveFormat,
-      };
-
-      log.info(
-        {
-          referenceId,
-          format: effectiveFormat,
-          textLength: request.text.length,
-        },
-        "Starting Fish Audio TTS synthesis",
-      );
-
-      let audio: Buffer;
-      try {
-        audio = await synthesizeWithFishAudio(request.text, effectiveConfig, {
-          signal: request.signal,
-          sampleRate: pcmRequested ? TELEPHONY_SAMPLE_RATE_HZ : undefined,
-        });
-      } catch (err) {
-        if (err instanceof Error && err.name === "AbortError") throw err;
-        throw new FishAudioTtsError(
-          "FISH_AUDIO_TTS_SYNTHESIS_FAILED",
-          `Fish Audio TTS synthesis failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-
-      const contentType = FORMAT_CONTENT_TYPE[effectiveFormat] ?? "audio/mpeg";
-
-      return { audio, contentType };
-    },
-
-    async synthesizeStream(
-      request: TtsSynthesisRequest,
-      onChunk: (chunk: Uint8Array) => void,
-    ): Promise<TtsSynthesisResult> {
-      const config = getConfig().services.tts.providers["fish-audio"];
-      const referenceId = resolveReferenceId(request, config);
-
-      // When PCM output is requested, override to WAV at 8 kHz (see
-      // synthesize above).
-      const pcmRequested = request.outputFormat === "pcm";
-      const effectiveFormat = pcmRequested ? "wav" : config.format;
-
-      const effectiveConfig: TtsFishAudioProviderConfig = {
-        ...config,
-        referenceId,
-        format: effectiveFormat,
-      };
-
-      log.info(
-        {
-          referenceId,
-          format: effectiveFormat,
-          textLength: request.text.length,
-        },
-        "Starting Fish Audio TTS streaming synthesis",
-      );
-
-      let audio: Buffer;
-      try {
-        audio = await synthesizeWithFishAudio(request.text, effectiveConfig, {
-          onChunk,
-          signal: request.signal,
-          sampleRate: pcmRequested ? TELEPHONY_SAMPLE_RATE_HZ : undefined,
-        });
-      } catch (err) {
-        if (err instanceof Error && err.name === "AbortError") throw err;
-        throw new FishAudioTtsError(
-          "FISH_AUDIO_TTS_SYNTHESIS_FAILED",
-          `Fish Audio TTS streaming synthesis failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-
-      const contentType = FORMAT_CONTENT_TYPE[effectiveFormat] ?? "audio/mpeg";
-
-      return { audio, contentType };
-    },
+    synthesize: (request) => performSynthesis(request),
+    synthesizeStream: (request, onChunk) => performSynthesis(request, onChunk),
   };
 }
 
@@ -218,10 +179,9 @@ export const fishAudioTtsProviderDefinition: TtsProviderDefinition = {
   allowNativeFallback: true,
   capabilities: {
     supportsStreaming: true,
-    supportedFormats: ["mp3", "wav", "opus"],
+    supportedFormats: ["mp3", "wav", "opus", "pcm"],
   },
-  // The adapter substitutes WAV for the PCM hint (no raw PCM support).
-  mediaStreamPlayback: { outputFormat: "wav" },
+  mediaStreamPlayback: { outputFormat: "pcm" },
   secretRequirements: [
     {
       credentialStoreKey: "credential/fish-audio/api_key",


### PR DESCRIPTION
## Summary
- PCM-requested fish-audio synthesis now uses `format: pcm` at `request.sampleRateHz` (verified against docs.fish.audio: `pcm` is raw 16-bit mono, no container; supported rates 8/16/24/32/44.1 kHz)
- Result contentType is `audio/pcm`, so live-voice chunk streaming engages instead of buffering whole WAV segments
- Adds `pcm` to advertised supportedFormats and flips the catalog `mediaStreamPlayback.outputFormat` to `pcm` (the WAV substitution it described no longer exists)

## Deviation from the plan
The plan specified a hint-less PCM default of 8 kHz (`TELEPHONY_SAMPLE_RATE_HZ`). That would double-speed fish audio on the phone path: the only hint-less PCM consumer is the media-stream transport, whose `audioBufferToFrames` assumes headerless PCM is **16 kHz** and decimates by 2 (the ElevenLabs `pcm_16000` convention; deepgram and xai both hard-wire `sample_rate: 16000` for exactly this reason). This PR defaults to 16 kHz instead, so the caller still hears correct 8 kHz mu-law — the plan's intent ("phone path unchanged") — while honoring explicit `sampleRateHz` hints (live-voice sends 24000 in PR 4).

Part of plan: voice-tts-streaming-latency.md (PR 3 of 8)