### PR TITLE
feat(calls): sentence-bounded streaming TTS in MediaStreamOutput

### DIFF
--- a/assistant/src/__tests__/media-stream-output.test.ts
+++ b/assistant/src/__tests__/media-stream-output.test.ts
@@ -29,7 +29,10 @@ mock.module("../calls/resolve-call-tts-provider.js", () => ({
   })),
 }));
 
-import { mulawToPcm16 } from "../calls/media-stream-audio-transcode.js";
+import {
+  mulawToPcm16,
+  pcm16ToMulaw,
+} from "../calls/media-stream-audio-transcode.js";
 import { MediaStreamOutput } from "../calls/media-stream-output.js";
 import { resolveCallTtsProvider } from "../calls/resolve-call-tts-provider.js";
 
@@ -142,6 +145,39 @@ function concatMulawPayloads(sent: string[]): Buffer {
       .filter((s) => JSON.parse(s).event === "media")
       .map((s) => Buffer.from(JSON.parse(s).media.payload, "base64")),
   );
+}
+
+/** Number of media frames among the sent messages. */
+function countMediaFrames(sent: string[]): number {
+  return sent.filter((s) => JSON.parse(s).event === "media").length;
+}
+
+/** Encode samples as a raw PCM16 LE buffer. */
+function pcm16Buffer(samples: number[]): Buffer {
+  const buf = Buffer.alloc(samples.length * 2);
+  for (let i = 0; i < samples.length; i++) {
+    buf.writeInt16LE(samples[i], i * 2);
+  }
+  return buf;
+}
+
+/** Keep every other PCM16 sample (16 kHz -> 8 kHz decimation). */
+function decimateByTwo(pcm: Buffer): Buffer {
+  const outCount = Math.floor(pcm.length / 2 / 2);
+  const out = Buffer.alloc(outCount * 2);
+  for (let i = 0; i < outCount; i++) {
+    out.writeInt16LE(pcm.readInt16LE(i * 4), i * 2);
+  }
+  return out;
+}
+
+/** Install a resolveCallTtsProvider mock returning the given provider. */
+function useProvider(provider: unknown): void {
+  mockResolveCallTtsProvider.mockImplementation(() => ({
+    provider,
+    useSynthesizedPath: false,
+    audioFormat: "wav" as const,
+  }));
 }
 
 /** Count sign changes in a PCM16 LE buffer (proxy for tone frequency). */
@@ -880,6 +916,215 @@ describe("MediaStreamOutput", () => {
       const wav = makeWavBuffer(interleaved, { sampleRate: 8000, channels: 2 });
       const sent = await synthesizeWav(wav);
       // One channel of 400 samples -> 400 mu-law bytes.
+      expect(totalMulawBytes(sent)).toBe(400);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Incremental sentence-bounded synthesis
+  // ---------------------------------------------------------------------------
+
+  describe("incremental sentence-bounded synthesis", () => {
+    test("complete sentences synthesize and play before last: true arrives", async () => {
+      const wav = makeWavBuffer(sineSamples(400, 440, 8000));
+      mockSynthesize.mockResolvedValue({
+        audio: wav,
+        contentType: "audio/wav",
+      });
+
+      const { ws, sent } = createMockWs();
+      const output = new MediaStreamOutput(ws, "stream-1");
+
+      output.sendTextToken("First sentence. Sec", false);
+      await drain();
+
+      // The completed first sentence synthesizes (and its frames go out)
+      // while the turn is still streaming.
+      expect(mockSynthesize).toHaveBeenCalledTimes(1);
+      expect(mockSynthesize.mock.calls[0][0].text).toBe("First sentence.");
+      expect(countMediaFrames(sent)).toBeGreaterThan(0);
+
+      output.sendTextToken("ond sentence.", true);
+      await drain();
+
+      expect(mockSynthesize).toHaveBeenCalledTimes(2);
+      expect(mockSynthesize.mock.calls[1][0].text).toBe("Second sentence.");
+    });
+
+    test("end-of-turn mark follows the final segment's frames", async () => {
+      const wav = makeWavBuffer(sineSamples(400, 440, 8000));
+      mockSynthesize.mockResolvedValue({
+        audio: wav,
+        contentType: "audio/wav",
+      });
+
+      const { ws, sent } = createMockWs();
+      const output = new MediaStreamOutput(ws, "stream-1");
+      output.sendTextToken("One. Two.", true);
+      await drain();
+
+      expect(mockSynthesize).toHaveBeenCalledTimes(2);
+      const events = sent.map((s) => JSON.parse(s).event);
+      const markIndex = events.indexOf("mark");
+      const lastMediaIndex = events.lastIndexOf("media");
+      expect(lastMediaIndex).toBeGreaterThanOrEqual(0);
+      expect(markIndex).toBeGreaterThan(lastMediaIndex);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Streaming PCM synthesis (incremental transcode)
+  // ---------------------------------------------------------------------------
+
+  describe("streaming PCM synthesis", () => {
+    test("frames are sent before the provider stream completes", async () => {
+      let releaseStream!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        releaseStream = resolve;
+      });
+      // 640 samples at 16 kHz -> 320 samples at 8 kHz = two whole frames.
+      const chunk = pcm16Buffer(sineSamples(640, 440, 16000));
+      useProvider({
+        id: "streaming-pcm",
+        capabilities: { supportsStreaming: true, supportedFormats: ["pcm"] },
+        synthesize: jest.fn(),
+        async synthesizeStream(
+          _request: unknown,
+          onChunk: (c: Uint8Array) => void,
+        ) {
+          onChunk(chunk);
+          await gate;
+          onChunk(chunk);
+          return {
+            audio: Buffer.concat([chunk, chunk]),
+            contentType: "audio/pcm",
+          };
+        },
+      });
+
+      const { ws, sent } = createMockWs();
+      const output = new MediaStreamOutput(ws, "stream-1");
+      output.sendTextToken("Hello there.", true);
+      await drain();
+
+      // First chunk's frames went out while the stream is still open,
+      // and the end-of-turn mark has not been sent yet.
+      const framesBefore = countMediaFrames(sent);
+      expect(framesBefore).toBe(2);
+      expect(sent.some((s) => JSON.parse(s).event === "mark")).toBe(false);
+
+      releaseStream();
+      await drain();
+
+      expect(countMediaFrames(sent)).toBe(4);
+      expect(sent.some((s) => JSON.parse(s).event === "mark")).toBe(true);
+    });
+
+    test("odd-byte and partial-frame chunk boundaries produce well-formed frames", async () => {
+      // 800 samples at 16 kHz (1600 bytes), split at deliberately awkward
+      // boundaries: odd bytes, non-frame-aligned sizes.
+      const full = pcm16Buffer(sineSamples(800, 440, 16000));
+      const cuts = [0, 3, 251, 640, 1001, full.length];
+      const chunks = cuts
+        .slice(0, -1)
+        .map((start, i) => full.subarray(start, cuts[i + 1]));
+      useProvider({
+        id: "streaming-pcm",
+        capabilities: { supportsStreaming: true, supportedFormats: ["pcm"] },
+        synthesize: jest.fn(),
+        async synthesizeStream(
+          _request: unknown,
+          onChunk: (c: Uint8Array) => void,
+        ) {
+          for (const c of chunks) {
+            onChunk(c);
+          }
+          return { audio: full, contentType: "audio/pcm" };
+        },
+      });
+
+      const { ws, sent } = createMockWs();
+      const output = new MediaStreamOutput(ws, "stream-1");
+      output.sendTextToken("Test.", true);
+      await drain();
+
+      // The concatenated mu-law output must be byte-identical to a
+      // whole-buffer transcode: no dropped or torn samples at chunk seams.
+      const expected = pcm16ToMulaw(decimateByTwo(full));
+      expect(expected.length).toBe(400);
+      expect(concatMulawPayloads(sent).equals(expected)).toBe(true);
+    });
+
+    test("playbackVersion bump mid-stream stops further frames", async () => {
+      let releaseStream!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        releaseStream = resolve;
+      });
+      const chunk = pcm16Buffer(sineSamples(640, 440, 16000));
+      useProvider({
+        id: "streaming-pcm",
+        capabilities: { supportsStreaming: true, supportedFormats: ["pcm"] },
+        synthesize: jest.fn(),
+        async synthesizeStream(
+          _request: unknown,
+          onChunk: (c: Uint8Array) => void,
+        ) {
+          onChunk(chunk);
+          await gate;
+          // Stale chunk emitted after barge-in must never become frames.
+          onChunk(chunk);
+          return {
+            audio: Buffer.concat([chunk, chunk]),
+            contentType: "audio/pcm",
+          };
+        },
+      });
+
+      const { ws, sent } = createMockWs();
+      const output = new MediaStreamOutput(ws, "stream-1");
+      output.sendTextToken("Hello there.", true);
+      await drain();
+
+      const framesBefore = countMediaFrames(sent);
+      expect(framesBefore).toBeGreaterThan(0);
+
+      output.clearAudio();
+      releaseStream();
+      await drain();
+
+      expect(countMediaFrames(sent)).toBe(framesBefore);
+    });
+
+    test("streaming provider without PCM support falls back to the whole-buffer path", async () => {
+      const wav = makeWavBuffer(sineSamples(400, 440, 8000));
+      const half = Math.floor(wav.length / 2);
+      let midStreamFrames = -1;
+      const sentRef: { sent: string[] } = { sent: [] };
+      useProvider({
+        id: "streaming-wav",
+        capabilities: { supportsStreaming: true, supportedFormats: ["wav"] },
+        synthesize: jest.fn(),
+        async synthesizeStream(
+          _request: unknown,
+          onChunk: (c: Uint8Array) => void,
+        ) {
+          onChunk(wav.subarray(0, half));
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          midStreamFrames = countMediaFrames(sentRef.sent);
+          onChunk(wav.subarray(half));
+          return { audio: wav, contentType: "audio/wav" };
+        },
+      });
+
+      const { ws, sent } = createMockWs();
+      sentRef.sent = sent;
+      const output = new MediaStreamOutput(ws, "stream-1");
+      output.sendTextToken("Hello.", true);
+      await drain();
+
+      // Nothing streamed mid-flight; the whole accumulated WAV is
+      // transcoded once at the end.
+      expect(midStreamFrames).toBe(0);
       expect(totalMulawBytes(sent)).toBe(400);
     });
   });

--- a/assistant/src/__tests__/media-stream-output.test.ts
+++ b/assistant/src/__tests__/media-stream-output.test.ts
@@ -29,6 +29,10 @@ mock.module("../calls/resolve-call-tts-provider.js", () => ({
   })),
 }));
 
+// Pre-load the module processSynthesizeItem imports dynamically, so the
+// first synthesize item doesn't pay module-load latency mid-test.
+await import("../tts/synthesis-stream.js");
+
 import {
   mulawToPcm16,
   pcm16ToMulaw,
@@ -81,10 +85,27 @@ function createMockWs() {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Wait for async playback queue to drain. */
-async function drain(): Promise<void> {
-  // Allow microtasks and the drain loop to run
-  await new Promise((resolve) => setTimeout(resolve, 10));
+/**
+ * Wait for async playback to progress. With `until`, polls (up to 2 s) for
+ * the condition so assertions don't race the queue on slow CI machines;
+ * without it, a single fixed tick (for negative assertions).
+ */
+async function drain(until?: () => boolean): Promise<void> {
+  const deadline = Date.now() + 2000;
+  for (;;) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    if (!until || until() || Date.now() > deadline) return;
+  }
+}
+
+/** True when a sent message with the given event type exists. */
+function hasEvent(sent: string[], event: string): boolean {
+  return sent.some((s) => JSON.parse(s).event === event);
+}
+
+/** Number of mark messages among the sent messages. */
+function countMarks(sent: string[]): number {
+  return sent.filter((s) => JSON.parse(s).event === "mark").length;
 }
 
 /** Generate a minimal valid WAV buffer with PCM data. */
@@ -171,6 +192,19 @@ function decimateByTwo(pcm: Buffer): Buffer {
   return out;
 }
 
+/** Outputs created during the current test, closed in afterEach. */
+const activeOutputs: MediaStreamOutput[] = [];
+
+/** Construct a MediaStreamOutput tracked for afterEach teardown. */
+function makeOutput(
+  ws: import("bun").ServerWebSocket<unknown>,
+  streamSid: string,
+): MediaStreamOutput {
+  const output = new MediaStreamOutput(ws, streamSid);
+  activeOutputs.push(output);
+  return output;
+}
+
 /** Install a resolveCallTtsProvider mock returning the given provider. */
 function useProvider(provider: unknown): void {
   mockResolveCallTtsProvider.mockImplementation(() => ({
@@ -198,6 +232,13 @@ function countZeroCrossings(pcm: Buffer): number {
 // ---------------------------------------------------------------------------
 
 afterEach(() => {
+  // Close every output so an in-flight synthesize item from a slow test
+  // bails on its staleness check instead of calling the next test's
+  // (re-)mocked provider.
+  for (const output of activeOutputs) {
+    output.markClosed();
+  }
+  activeOutputs.length = 0;
   mockSynthesize.mockReset();
   // Restore the default resolveCallTtsProvider mock
   mockResolveCallTtsProvider.mockImplementation(() => ({
@@ -221,11 +262,11 @@ describe("MediaStreamOutput", () => {
       });
 
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.sendTextToken("hello ", false);
       output.sendTextToken("world", true);
 
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
 
       // Should have sent media frames (from synthesis) and a mark
       const events = sent.map((s) => JSON.parse(s).event);
@@ -239,10 +280,10 @@ describe("MediaStreamOutput", () => {
 
     test("empty token with last: true sends only end-of-turn mark (no synthesis)", async () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.sendTextToken("", true);
 
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
 
       // Should send only a mark, no media frames
       expect(sent).toHaveLength(1);
@@ -256,7 +297,7 @@ describe("MediaStreamOutput", () => {
 
     test("non-last tokens accumulate without sending", () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.sendTextToken("hello ", false);
       output.sendTextToken("world ", false);
       expect(sent).toHaveLength(0);
@@ -264,7 +305,7 @@ describe("MediaStreamOutput", () => {
 
     test("does not send when closed", () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.endSession();
       output.sendTextToken("hello", true);
       expect(sent).toHaveLength(0);
@@ -274,7 +315,7 @@ describe("MediaStreamOutput", () => {
   describe("CallTransport interface — sendPlayUrl", () => {
     test("enqueues a fetch-url item in the playback queue", () => {
       const { ws } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.sendPlayUrl("https://example.com/audio.mp3");
       // The queue should have one item (the fetch will fail since
       // there's no real server, but the enqueueing is synchronous)
@@ -283,7 +324,7 @@ describe("MediaStreamOutput", () => {
 
     test("does not enqueue when closed", () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.endSession();
       output.sendPlayUrl("https://example.com/audio.mp3");
       expect(sent).toHaveLength(0);
@@ -293,7 +334,7 @@ describe("MediaStreamOutput", () => {
   describe("CallTransport interface — endSession", () => {
     test("closes the WebSocket with code 1000", () => {
       const mock = createMockWs();
-      const output = new MediaStreamOutput(mock.ws, "stream-1");
+      const output = makeOutput(mock.ws, "stream-1");
       output.endSession("test-reason");
       expect(mock.closed).toBe(true);
       expect(mock.closeCode).toBe(1000);
@@ -302,7 +343,7 @@ describe("MediaStreamOutput", () => {
 
     test("uses default reason when none provided", () => {
       const mock = createMockWs();
-      const output = new MediaStreamOutput(mock.ws, "stream-1");
+      const output = makeOutput(mock.ws, "stream-1");
       output.endSession();
       expect(mock.closed).toBe(true);
       expect(mock.closeReason).toBe("session-ended");
@@ -310,7 +351,7 @@ describe("MediaStreamOutput", () => {
 
     test("is idempotent", () => {
       const mock = createMockWs();
-      const output = new MediaStreamOutput(mock.ws, "stream-1");
+      const output = makeOutput(mock.ws, "stream-1");
       output.endSession("first");
       // Second call should not throw (ws.close would throw on already-closed)
       output.endSession("second");
@@ -321,7 +362,7 @@ describe("MediaStreamOutput", () => {
   describe("sendAudioPayload", () => {
     test("sends a media command with the base64 payload", () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      const output = makeOutput(ws, "MZ-stream-1");
       output.sendAudioPayload("dGVzdA==");
 
       expect(sent).toHaveLength(1);
@@ -335,7 +376,7 @@ describe("MediaStreamOutput", () => {
 
     test("does not send when closed", () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      const output = makeOutput(ws, "MZ-stream-1");
       output.endSession();
       output.sendAudioPayload("dGVzdA==");
       // Only the close would have happened, no media sent
@@ -346,7 +387,7 @@ describe("MediaStreamOutput", () => {
   describe("sendMark", () => {
     test("sends a mark command with the given name", () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      const output = makeOutput(ws, "MZ-stream-1");
       output.sendMark("end-of-turn");
 
       expect(sent).toHaveLength(1);
@@ -360,7 +401,7 @@ describe("MediaStreamOutput", () => {
 
     test("does not send when closed", () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      const output = makeOutput(ws, "MZ-stream-1");
       output.endSession();
       output.sendMark("end-of-turn");
       expect(sent).toHaveLength(0);
@@ -370,7 +411,7 @@ describe("MediaStreamOutput", () => {
   describe("clearAudio — barge-in", () => {
     test("sends a clear command to Twilio", () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      const output = makeOutput(ws, "MZ-stream-1");
       output.clearAudio();
 
       expect(sent).toHaveLength(1);
@@ -395,7 +436,7 @@ describe("MediaStreamOutput", () => {
       );
 
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      const output = makeOutput(ws, "MZ-stream-1");
 
       // Queue synthesis
       output.sendTextToken("hello world", true);
@@ -415,7 +456,7 @@ describe("MediaStreamOutput", () => {
 
     test("does not send when closed", () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      const output = makeOutput(ws, "MZ-stream-1");
       output.endSession();
       output.clearAudio();
       expect(sent).toHaveLength(0);
@@ -425,7 +466,7 @@ describe("MediaStreamOutput", () => {
   describe("clearBufferedAudio — rejected barge-in", () => {
     test("sends a clear command to Twilio", () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      const output = makeOutput(ws, "MZ-stream-1");
       output.clearBufferedAudio();
 
       expect(sent).toHaveLength(1);
@@ -449,12 +490,12 @@ describe("MediaStreamOutput", () => {
       );
 
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      const output = makeOutput(ws, "MZ-stream-1");
 
       output.sendTextToken("hello world", true);
       output.clearBufferedAudio();
 
-      await new Promise((resolve) => setTimeout(resolve, 60));
+      await drain(() => hasEvent(sent, "media"));
 
       // Unlike clearAudio, the in-flight synthesis is not aborted:
       // its frames go out once ready.
@@ -475,7 +516,7 @@ describe("MediaStreamOutput", () => {
       );
 
       const { ws } = createMockWs();
-      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      const output = makeOutput(ws, "MZ-stream-1");
 
       let fired = 0;
       output.setAudioStartCallback(() => {
@@ -484,14 +525,14 @@ describe("MediaStreamOutput", () => {
       output.sendTextToken("hello world", true);
       output.clearBufferedAudio();
 
-      await new Promise((resolve) => setTimeout(resolve, 60));
+      await drain(() => fired === 1);
 
       expect(fired).toBe(1);
     });
 
     test("does not send when closed", () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      const output = makeOutput(ws, "MZ-stream-1");
       output.endSession();
       output.clearBufferedAudio();
       expect(sent).toHaveLength(0);
@@ -513,7 +554,7 @@ describe("MediaStreamOutput", () => {
       });
 
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
 
       let fired = 0;
       let mediaSentWhenFired = -1;
@@ -525,7 +566,7 @@ describe("MediaStreamOutput", () => {
       });
 
       output.sendTextToken("hello world", true);
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
 
       const mediaMessages = sent.filter((s) => JSON.parse(s).event === "media");
       expect(mediaMessages.length).toBeGreaterThan(1);
@@ -540,25 +581,25 @@ describe("MediaStreamOutput", () => {
         contentType: "audio/wav",
       });
 
-      const { ws } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
 
       let fired = 0;
       output.setAudioStartCallback(() => fired++);
 
       output.sendTextToken("first", true);
-      await drain();
+      await drain(() => countMarks(sent) >= 1);
       expect(fired).toBe(1);
 
       // Second item without re-arming — signal already consumed.
       output.sendTextToken("second", true);
-      await drain();
+      await drain(() => countMarks(sent) >= 2);
       expect(fired).toBe(1);
 
       // Re-armed — fires again for the next item.
       output.setAudioStartCallback(() => fired++);
       output.sendTextToken("third", true);
-      await drain();
+      await drain(() => countMarks(sent) >= 3);
       expect(fired).toBe(2);
     });
 
@@ -576,7 +617,7 @@ describe("MediaStreamOutput", () => {
       );
 
       const { ws } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
 
       let fired = 0;
       output.setAudioStartCallback(() => fired++);
@@ -589,14 +630,14 @@ describe("MediaStreamOutput", () => {
     });
 
     test("an empty end-of-turn (mark only) does not fire the signal", async () => {
-      const { ws } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
 
       let fired = 0;
       output.setAudioStartCallback(() => fired++);
 
       output.sendTextToken("", true);
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
       expect(fired).toBe(0);
     });
   });
@@ -609,8 +650,8 @@ describe("MediaStreamOutput", () => {
         contentType: "audio/wav",
       });
 
-      const { ws } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
 
       // Tokens buffered mid-turn; a barge-in signal the controller ignores
       // (turn still processing) flushes queued audio but must not truncate
@@ -618,7 +659,7 @@ describe("MediaStreamOutput", () => {
       output.sendTextToken("hello ", false);
       output.clearAudio();
       output.sendTextToken("world", true);
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
 
       expect(mockSynthesize).toHaveBeenCalledTimes(1);
       expect(mockSynthesize.mock.calls[0][0].text).toBe("hello world");
@@ -626,12 +667,12 @@ describe("MediaStreamOutput", () => {
 
     test("discardPendingText drops accumulated text so no synthesis occurs", async () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
 
       output.sendTextToken("stale partial response", false);
       output.discardPendingText();
       output.sendTextToken("", true);
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
 
       expect(mockSynthesize).not.toHaveBeenCalled();
       // Only the end-of-turn mark goes out.
@@ -643,7 +684,7 @@ describe("MediaStreamOutput", () => {
   describe("setStreamSid / getStreamSid", () => {
     test("updates the stream SID used in subsequent commands", () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "old-sid");
+      const output = makeOutput(ws, "old-sid");
       expect(output.getStreamSid()).toBe("old-sid");
 
       output.setStreamSid("new-sid");
@@ -658,7 +699,7 @@ describe("MediaStreamOutput", () => {
   describe("markClosed", () => {
     test("transitions to closed state without sending a close frame", () => {
       const mock = createMockWs();
-      const output = new MediaStreamOutput(mock.ws, "stream-1");
+      const output = makeOutput(mock.ws, "stream-1");
       output.markClosed();
       expect(mock.closed).toBe(false); // WebSocket not actually closed
       output.sendAudioPayload("dGVzdA=="); // Should be suppressed
@@ -675,7 +716,7 @@ describe("MediaStreamOutput", () => {
         close() {},
       } as unknown as import("bun").ServerWebSocket<unknown>;
 
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       // Should not throw
       expect(() => output.sendAudioPayload("dGVzdA==")).not.toThrow();
     });
@@ -688,7 +729,7 @@ describe("MediaStreamOutput", () => {
         },
       } as unknown as import("bun").ServerWebSocket<unknown>;
 
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       // Should not throw
       expect(() => output.endSession()).not.toThrow();
     });
@@ -707,10 +748,10 @@ describe("MediaStreamOutput", () => {
       });
 
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.sendTextToken("test synthesis", true);
 
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
 
       // Should have sent at least one media frame and an end-of-turn mark
       const mediaMessages = sent.filter((s) => JSON.parse(s).event === "media");
@@ -729,7 +770,7 @@ describe("MediaStreamOutput", () => {
 
     test("getPlaybackQueueLength reflects queue state", () => {
       const { ws } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       // Initially empty
       expect(output.getPlaybackQueueLength()).toBe(0);
     });
@@ -757,10 +798,10 @@ describe("MediaStreamOutput", () => {
       });
 
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.sendTextToken("test", true);
 
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
 
       // The audioBufferToFrames magic-byte detection should detect mp3
       // sync bytes when format is "wav" and return silence (no media
@@ -790,10 +831,10 @@ describe("MediaStreamOutput", () => {
       });
 
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.sendTextToken("test", true);
 
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
 
       // processSynthesizeItem derives actualFormat from content-type:
       // "audio/pcm" -> "pcm". audioBufferToFrames handles raw PCM by
@@ -825,10 +866,10 @@ describe("MediaStreamOutput", () => {
       });
 
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.sendTextToken("test", true);
 
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
 
       // processSynthesizeItem detects "audio/x-raw" -> "pcm" format.
       // audioBufferToFrames converts raw PCM to mu-law frames.
@@ -854,9 +895,9 @@ describe("MediaStreamOutput", () => {
         contentType: "audio/wav",
       });
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.sendTextToken("test", true);
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
       return sent;
     }
 
@@ -933,10 +974,10 @@ describe("MediaStreamOutput", () => {
       });
 
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
 
       output.sendTextToken("First sentence. Sec", false);
-      await drain();
+      await drain(() => countMediaFrames(sent) > 0);
 
       // The completed first sentence synthesizes (and its frames go out)
       // while the turn is still streaming.
@@ -945,7 +986,7 @@ describe("MediaStreamOutput", () => {
       expect(countMediaFrames(sent)).toBeGreaterThan(0);
 
       output.sendTextToken("ond sentence.", true);
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
 
       expect(mockSynthesize).toHaveBeenCalledTimes(2);
       expect(mockSynthesize.mock.calls[1][0].text).toBe("Second sentence.");
@@ -959,9 +1000,9 @@ describe("MediaStreamOutput", () => {
       });
 
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.sendTextToken("One. Two.", true);
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
 
       expect(mockSynthesize).toHaveBeenCalledTimes(2);
       const events = sent.map((s) => JSON.parse(s).event);
@@ -1003,9 +1044,9 @@ describe("MediaStreamOutput", () => {
       });
 
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.sendTextToken("Hello there.", true);
-      await drain();
+      await drain(() => countMediaFrames(sent) >= 2);
 
       // First chunk's frames went out while the stream is still open,
       // and the end-of-turn mark has not been sent yet.
@@ -1014,7 +1055,7 @@ describe("MediaStreamOutput", () => {
       expect(sent.some((s) => JSON.parse(s).event === "mark")).toBe(false);
 
       releaseStream();
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
 
       expect(countMediaFrames(sent)).toBe(4);
       expect(sent.some((s) => JSON.parse(s).event === "mark")).toBe(true);
@@ -1044,9 +1085,9 @@ describe("MediaStreamOutput", () => {
       });
 
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.sendTextToken("Test.", true);
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
 
       // The concatenated mu-law output must be byte-identical to a
       // whole-buffer transcode: no dropped or torn samples at chunk seams.
@@ -1081,9 +1122,9 @@ describe("MediaStreamOutput", () => {
       });
 
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.sendTextToken("Hello there.", true);
-      await drain();
+      await drain(() => countMediaFrames(sent) > 0);
 
       const framesBefore = countMediaFrames(sent);
       expect(framesBefore).toBeGreaterThan(0);
@@ -1118,9 +1159,9 @@ describe("MediaStreamOutput", () => {
 
       const { ws, sent } = createMockWs();
       sentRef.sent = sent;
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.sendTextToken("Hello.", true);
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
 
       // Nothing streamed mid-flight; the whole accumulated WAV is
       // transcoded once at the end.

--- a/assistant/src/calls/media-stream-audio-transcode.ts
+++ b/assistant/src/calls/media-stream-audio-transcode.ts
@@ -26,7 +26,7 @@
  * 8000 samples/sec * 0.020 sec = 160 samples per frame.
  * Each mu-law sample is 1 byte, so each frame is 160 bytes.
  */
-const MULAW_FRAME_SIZE = 160;
+export const MULAW_FRAME_SIZE = 160;
 
 /**
  * Bias constant used in the linear-to-mu-law compression formula

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -7,11 +7,12 @@
  *
  * The media-stream transport operates on raw audio frames:
  *
- * - `sendTextToken()` — Accumulates text tokens and, on `last: true`,
- *   synthesizes the accumulated text via the configured TTS provider,
- *   transcodes the resulting audio to mu-law 8 kHz, and streams it as
- *   media frames to Twilio. An empty token with `last: true` sends an
- *   end-of-turn mark without synthesizing.
+ * - `sendTextToken()` — Accumulates text tokens, extracts complete
+ *   speakable segments as they form, and synthesizes each segment via
+ *   the configured TTS provider, transcoding the resulting audio to
+ *   mu-law 8 kHz media frames for Twilio. On `last: true` the remaining
+ *   text is flushed as a final segment followed by an end-of-turn mark.
+ *   An empty token with `last: true` sends only the mark.
  *
  * - `sendPlayUrl()` — Fetches audio from the given URL, transcodes it
  *   to mu-law 8 kHz, and streams the resulting frames to Twilio.
@@ -32,10 +33,12 @@
 
 import type { ServerWebSocket } from "bun";
 
+import { extractSpeakableSegments } from "../tts/speakable-segments.js";
 import { getLogger } from "../util/logger.js";
 import type { CallTransport } from "./call-transport.js";
 import {
   chunkMulawToBase64Frames,
+  MULAW_FRAME_SIZE,
   pcm16ToMulaw,
   resamplePcm16,
 } from "./media-stream-audio-transcode.js";
@@ -49,6 +52,14 @@ const log = getLogger("media-stream-output");
 
 /** Twilio media streams consume 8 kHz mono mu-law. */
 const TELEPHONY_SAMPLE_RATE_HZ = 8000;
+
+/**
+ * PCM sample rate requested from streaming-capable providers. Deterministic
+ * across providers (ElevenLabs maps the hint to `pcm_16000`; fish-audio
+ * honours it directly), so the incremental transcode can hard-wire its
+ * downsample ratio to the telephony rate.
+ */
+const STREAMING_PCM_SAMPLE_RATE_HZ = 16_000;
 
 /**
  * Keep every `factor`-th 16-bit LE sample. Cheap decimation (no anti-alias
@@ -96,7 +107,10 @@ export class MediaStreamOutput implements CallTransport {
   private ws: ServerWebSocket<unknown>;
   private state: MediaStreamOutputState = "connected";
 
-  /** Accumulated text from sendTextToken calls before the final `last: true`. */
+  /**
+   * Text accumulated from sendTextToken calls that has not yet formed a
+   * complete speakable segment.
+   */
   private textBuffer = "";
 
   /** FIFO queue of playback items awaiting delivery. */
@@ -134,27 +148,33 @@ export class MediaStreamOutput implements CallTransport {
   // ── CallTransport interface ─────────────────────────────────────────
 
   /**
-   * Accumulate text tokens for TTS synthesis. When `last` is true, the
-   * accumulated text is queued for synthesis and delivery as media frames.
+   * Accumulate text tokens for TTS synthesis. Each complete speakable
+   * segment (sentence or newline-bounded line) is queued for synthesis
+   * as soon as it forms, so speech starts before the turn completes.
+   * When `last` is true, the remaining text is force-flushed as a final
+   * segment.
    *
    * An empty token with `last: true` signals end-of-turn without TTS:
    * a mark is sent so the session transitions from "assistant speaking"
    * to "caller speaking".
    */
   sendTextToken(token: string, last: boolean): void {
-    if (this.state === "closed") return;
+    if (this.state === "closed") {
+      return;
+    }
 
     this.textBuffer += token;
 
+    const { segments, remainder } = extractSpeakableSegments(
+      this.textBuffer,
+      last,
+    );
+    this.textBuffer = remainder;
+    for (const segment of segments) {
+      this.enqueuePlayback({ type: "synthesize", text: segment });
+    }
+
     if (last) {
-      const text = this.textBuffer.trim();
-      this.textBuffer = "";
-
-      if (text.length > 0) {
-        // Queue synthesis of the accumulated text.
-        this.enqueuePlayback({ type: "synthesize", text });
-      }
-
       // Always send an end-of-turn mark so the media-stream server
       // can detect turn boundaries.
       this.enqueuePlayback({ type: "mark", name: "end-of-turn" });
@@ -456,7 +476,10 @@ export class MediaStreamOutput implements CallTransport {
 
   /**
    * Synthesize text via the TTS provider and send resulting audio as
-   * mu-law frames. Falls back to a silent frame if synthesis fails.
+   * mu-law frames. PCM-capable providers are transcoded incrementally —
+   * each streamed chunk becomes frames as it arrives — while other
+   * providers accumulate into the whole-buffer conversion path. Falls
+   * back to a silent frame if synthesis fails.
    */
   private async processSynthesizeItem(
     text: string,
@@ -482,21 +505,108 @@ export class MediaStreamOutput implements CallTransport {
         return;
       }
 
-      if (version !== this.playbackVersion || this.isClosed()) return;
+      if (version !== this.playbackVersion || this.isClosed()) {
+        return;
+      }
+
+      const { synthesizeAndEmit } = await import("../tts/synthesis-stream.js");
+      const isCurrent = (): boolean =>
+        version === this.playbackVersion && !this.isClosed();
+
+      // PCM-capable providers honour `outputFormat: "pcm"` at the requested
+      // sample rate, so their chunks can be transcoded to mu-law frames as
+      // they arrive. Other providers accumulate below and go through the
+      // whole-buffer content-type sniffing path.
+      const streamsPcm = provider.capabilities.supportedFormats.includes("pcm");
+      const bufferedChunks: Buffer[] = [];
+
+      // Chunk boundaries can split a 16-bit sample or a decimation pair;
+      // the unprocessable tail (< 4 bytes) carries into the next chunk so
+      // sample alignment and decimation phase stay stable across chunks.
+      let pcmCarry: Buffer | undefined;
+      // Mu-law bytes short of a whole 20 ms frame, carried likewise.
+      let mulawCarry: Buffer = Buffer.alloc(0);
+
+      const sendMulaw = (mulaw: Buffer, flushPartialFrame: boolean): void => {
+        mulawCarry =
+          mulawCarry.length > 0 ? Buffer.concat([mulawCarry, mulaw]) : mulaw;
+        const sendableBytes = flushPartialFrame
+          ? mulawCarry.length
+          : mulawCarry.length - (mulawCarry.length % MULAW_FRAME_SIZE);
+        if (sendableBytes === 0) {
+          return;
+        }
+        const frames = chunkMulawToBase64Frames(
+          mulawCarry.subarray(0, sendableBytes),
+        );
+        mulawCarry = mulawCarry.subarray(sendableBytes);
+        this.sendFrames(frames);
+      };
 
       // Synthesize the text. Request PCM output so the media-stream
       // transport receives raw samples it can transcode to mu-law.
       // Providers that support it (e.g. ElevenLabs pcm_16000) will
       // return raw PCM; others fall back to their default format and
       // the content-type sniffing below handles the mismatch.
-      const result = await provider.synthesize({
+      const result = await synthesizeAndEmit({
+        provider,
         text,
         useCase: "phone-call",
         outputFormat: "pcm",
+        sampleRateHz: STREAMING_PCM_SAMPLE_RATE_HZ,
         signal: abortController.signal,
+        isCurrent,
+        onChunk: (chunk) => {
+          if (!streamsPcm) {
+            bufferedChunks.push(chunk.audio);
+            return;
+          }
+          if (!isCurrent()) {
+            return;
+          }
+          const combined = pcmCarry
+            ? Buffer.concat([pcmCarry, chunk.audio])
+            : chunk.audio;
+          // 4 bytes = two 16 kHz samples = one 8 kHz output sample.
+          const usableBytes = combined.length & ~3;
+          pcmCarry =
+            usableBytes < combined.length
+              ? combined.subarray(usableBytes)
+              : undefined;
+          if (usableBytes === 0) {
+            return;
+          }
+          const pcm8k = this.pcm16ToTelephonyRate(
+            combined.subarray(0, usableBytes),
+            STREAMING_PCM_SAMPLE_RATE_HZ,
+          );
+          sendMulaw(pcm16ToMulaw(pcm8k), false);
+        },
       });
 
-      if (version !== this.playbackVersion || this.isClosed()) return;
+      if (!isCurrent()) {
+        return;
+      }
+
+      if (streamsPcm) {
+        if (pcmCarry) {
+          // A sub-sample tail is malformed provider output; decimation
+          // would drop it anyway.
+          log.debug(
+            { streamSid: this.streamSid, carryBytes: pcmCarry.length },
+            "Dropping sub-sample tail from PCM16 TTS stream",
+          );
+        }
+        // Flush the final partial frame — the whole-buffer path sends a
+        // short trailing frame the same way.
+        sendMulaw(Buffer.alloc(0), true);
+        return;
+      }
+
+      // A stopped stream means partial audio; never send a truncated buffer.
+      if (result.stopped) {
+        return;
+      }
 
       // Derive the format from the provider's actual content type rather
       // than the declared audioFormat. The declared format may not match
@@ -515,8 +625,13 @@ export class MediaStreamOutput implements CallTransport {
                   result.contentType.includes("x-raw")
                 ? "pcm"
                 : audioFormat; // fall back to declared format for unknown types
-      const frames = this.audioBufferToFrames(result.audio, actualFormat);
-      if (version !== this.playbackVersion || this.isClosed()) return;
+      const frames = this.audioBufferToFrames(
+        Buffer.concat(bufferedChunks),
+        actualFormat,
+      );
+      if (!isCurrent()) {
+        return;
+      }
 
       this.sendFrames(frames);
     } catch (err) {


### PR DESCRIPTION
## Summary
- `sendTextToken` flushes speakable segments to the synthesis queue as LLM tokens arrive instead of waiting for end-of-turn
- `processSynthesizeItem` streams provider PCM chunks straight to mu-law frames (odd-byte + frame-boundary carries), falling back to the whole-buffer path for non-PCM providers
- Barge-in version checks preserved per chunk

Part of plan: voice-tts-streaming-latency.md (PR 8 of 8)