### PR TITLE
feat(gateway): vellum bootstrap refuses to mint a divergent principal over evidence of a prior guardian

### DIFF
--- a/clients/web/src/domains/remote-web/pairing-page.test.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.test.tsx
@@ -26,6 +26,16 @@ const createRemoteWebPairingChallengeMock = mock(
   }),
 );
 
+class MockRemoteWebPairingError extends Error {
+  readonly status: number;
+  readonly code: string | null;
+  constructor(status: number, message: string, code: string | null = null) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+}
+
 mock.module("@/lib/auth/remote-gateway-session", () => ({
   activateRemoteGatewaySession: () => {},
   createRemoteWebPairingChallenge: createRemoteWebPairingChallengeMock,
@@ -37,13 +47,7 @@ mock.module("@/lib/auth/remote-gateway-session", () => ({
       userCode: url.searchParams.get("userCode"),
     };
   },
-  RemoteWebPairingError: class RemoteWebPairingError extends Error {
-    readonly status: number;
-    constructor(status: number, message: string) {
-      super(message);
-      this.status = status;
-    }
-  },
+  RemoteWebPairingError: MockRemoteWebPairingError,
 }));
 
 const { RemoteWebPairingPage } =
@@ -132,5 +136,51 @@ describe("RemoteWebPairingPage", () => {
         "created-device",
       );
     });
+  });
+
+  test("surfaces guardian-repair guidance on a repair-required exchange failure", async () => {
+    remoteGatewayMode = true;
+    exchangeRemoteWebPairingTokenMock.mockImplementationOnce(async () => {
+      throw new MockRemoteWebPairingError(
+        503,
+        "Pairing token exchange failed: 503",
+        "GUARDIAN_REPAIR_REQUIRED",
+      );
+    });
+
+    render(
+      <MemoryRouter
+        initialEntries={["/assistant/pair?deviceCode=device-1&userCode=ABCD"]}
+      >
+        <RemoteWebPairingPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Pairing failed")).not.toBeNull();
+    expect(screen.getByText(/trust database needs repair/)).not.toBeNull();
+    expect(screen.getByText(/retry this same pairing link/)).not.toBeNull();
+    expect(screen.queryByText(/starting a new pairing/)).toBeNull();
+  });
+
+  test("keeps new-pairing guidance for other exchange failures", async () => {
+    remoteGatewayMode = true;
+    exchangeRemoteWebPairingTokenMock.mockImplementationOnce(async () => {
+      throw new MockRemoteWebPairingError(
+        503,
+        "Pairing token exchange failed: 503",
+      );
+    });
+
+    render(
+      <MemoryRouter
+        initialEntries={["/assistant/pair?deviceCode=device-1&userCode=ABCD"]}
+      >
+        <RemoteWebPairingPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Pairing failed")).not.toBeNull();
+    expect(screen.getByText(/Try starting a new pairing/)).not.toBeNull();
+    expect(screen.queryByText(/trust database needs repair/)).toBeNull();
   });
 });

--- a/clients/web/src/domains/remote-web/pairing-page.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.tsx
@@ -164,6 +164,19 @@ export function RemoteWebPairingPage() {
           setState({ kind: "expired" });
           return;
         }
+        if (
+          err instanceof RemoteWebPairingError &&
+          err.code === "GUARDIAN_REPAIR_REQUIRED"
+        ) {
+          // A new pairing would hit the same failure; the approved code stays
+          // exchangeable after guardian repair, so point at repair + retry.
+          setState({
+            kind: "error",
+            message:
+              "The assistant's trust database needs repair. Run guardian repair on the machine hosting the assistant, then retry this same pairing link — the code stays valid.",
+          });
+          return;
+        }
         setState({
           kind: "error",
           message:

--- a/clients/web/src/lib/auth/gateway-session.ts
+++ b/clients/web/src/lib/auth/gateway-session.ts
@@ -8,12 +8,14 @@ import type { LockfileAssistant } from "@/runtime/local-mode-host";
 /**
  * Thrown when the gateway `/auth/token` mint rejects the request, carrying the
  * response `status` so callers can branch on the failure class. A `401` means
- * the gateway refused the guardian token itself — most often an
- * `invalid_signature` after the gateway restarted with a different signing key
- * than the on-disk guardian token was leased against — which a guardian
- * re-provision (`wake --repair-guardian`) fixes by re-leasing against the
- * running gateway. A `403` is a loopback/Origin boundary refusal that repair
- * can't change, and `5xx`/network failures are transient.
+ * the gateway refused to mint against the presented guardian identity — most
+ * often an `invalid_signature` after the gateway restarted with a different
+ * signing key than the on-disk guardian token was leased against, or a
+ * `guardian_repair_required` refusal after the gateway DB lost its guardian
+ * rows — which a guardian re-provision (`wake --repair-guardian`) fixes by
+ * re-leasing against the running gateway. A `403` is a loopback/Origin
+ * boundary refusal that repair can't change, and `5xx`/network failures are
+ * transient.
  *
  * Distinct from {@link GuardianTokenError} (thrown by `fetchGuardianTokenHost`
  * when the guardian token is missing/unrefreshable on disk): this is the

--- a/clients/web/src/lib/auth/remote-gateway-session.test.ts
+++ b/clients/web/src/lib/auth/remote-gateway-session.test.ts
@@ -143,6 +143,30 @@ describe("remote gateway token exchange", () => {
     );
     expect(error).toBeInstanceOf(RemoteWebPairingError);
     expect((error as RemoteWebPairingError).status).toBe(502);
+    expect((error as RemoteWebPairingError).code).toBeNull();
+  });
+
+  test("surfaces the error body code on a repair-required token-exchange failure", async () => {
+    globalThis.fetch = mock(async () =>
+      Response.json(
+        {
+          error: {
+            code: "GUARDIAN_REPAIR_REQUIRED",
+            message: "gateway guardian binding is missing",
+          },
+        },
+        { status: 503 },
+      ),
+    ) as unknown as typeof fetch;
+
+    const error = await exchangeRemoteWebPairingToken("device-code").catch(
+      (e: unknown) => e,
+    );
+    expect(error).toBeInstanceOf(RemoteWebPairingError);
+    expect((error as RemoteWebPairingError).status).toBe(503);
+    expect((error as RemoteWebPairingError).code).toBe(
+      "GUARDIAN_REPAIR_REQUIRED",
+    );
   });
 
   test("posts the device code with cookie credentials", async () => {

--- a/clients/web/src/lib/auth/remote-gateway-session.ts
+++ b/clients/web/src/lib/auth/remote-gateway-session.ts
@@ -62,12 +62,19 @@ export type RemoteWebPairingTokenResult =
 
 export class RemoteWebPairingError extends Error {
   readonly status: number;
+  readonly code: string | null;
 
-  constructor(status: number, message: string) {
+  constructor(status: number, message: string, code: string | null = null) {
     super(message);
     this.name = "RemoteWebPairingError";
     this.status = status;
+    this.code = code;
   }
+}
+
+function errorBodyCode(body: unknown): string | null {
+  const code = (body as { error?: { code?: unknown } } | null)?.error?.code;
+  return typeof code === "string" ? code : null;
 }
 
 function stringParam(
@@ -285,6 +292,7 @@ export async function exchangeRemoteWebPairingToken(
     throw new RemoteWebPairingError(
       response.status,
       `Pairing token exchange failed: ${response.status}`,
+      errorBodyCode(body),
     );
   }
 

--- a/gateway/src/__tests__/actor-token-revocation.test.ts
+++ b/gateway/src/__tests__/actor-token-revocation.test.ts
@@ -275,7 +275,7 @@ describe("/auth/token revocation", () => {
     expect(isActorTokenRevoked(derivedJwt, actorClaims)).toBe(true);
   });
 
-  test("fails closed with 503 when guardian rows are lost over evidence (no divergent mint)", async () => {
+  test("fails closed with a repairable 401 when guardian rows are lost over evidence (no divergent mint)", async () => {
     const { handleCreateToken } = await import("../http/routes/auth-token.js");
     const { bustGuardianIntegrityCache } =
       await import("../auth/guardian-integrity.js");
@@ -318,7 +318,8 @@ describe("/auth/token revocation", () => {
         makeLoopbackServer(),
       );
 
-      expect(res.status).toBe(503);
+      // 401 is the status clients already treat as guardian-repairable.
+      expect(res.status).toBe(401);
       expect(await res.json()).toEqual({ error: "guardian_repair_required" });
       // No divergent principal row was minted.
       expect(getGatewayDb().select().from(contacts).all()).toHaveLength(0);

--- a/gateway/src/__tests__/actor-token-revocation.test.ts
+++ b/gateway/src/__tests__/actor-token-revocation.test.ts
@@ -274,6 +274,63 @@ describe("/auth/token revocation", () => {
     expect(isActorTokenRevoked(sourceJwt, actorClaims)).toBe(true);
     expect(isActorTokenRevoked(derivedJwt, actorClaims)).toBe(true);
   });
+
+  test("fails closed with 503 when guardian rows are lost over evidence (no divergent mint)", async () => {
+    const { handleCreateToken } = await import("../http/routes/auth-token.js");
+    const { bustGuardianIntegrityCache } =
+      await import("../auth/guardian-integrity.js");
+    const {
+      resetGuardianIntegrityReporterForTesting,
+      setGuardianIntegrityReporterOverridesForTesting,
+    } = await import("../guardian-integrity-reporter.js");
+    const { contacts } = await import("../db/schema.js");
+
+    // Unrecorded (compatibility) source token: the handler falls back to
+    // ensureVellumGuardianBinding. A residual actor-token row for another
+    // device is evidence of prior onboarding with no guardian contact row,
+    // so the fallback mint must refuse rather than diverge.
+    insertTokenRecord("residual-evidence-token", "active");
+    const jwt = mintToken({
+      aud: "vellum-gateway",
+      sub: ACTOR_SUB,
+      scope_profile: "actor_client_v1",
+      policy_epoch: CURRENT_POLICY_EPOCH,
+      ttlSeconds: 3600,
+    });
+
+    bustGuardianIntegrityCache();
+    setGuardianIntegrityReporterOverridesForTesting({
+      fetchImpl: async () => new Response("{}"),
+      mintToken: () => "svc-token",
+      baseUrl: "http://127.0.0.1:7821",
+      log: { error: () => {}, warn: () => {} },
+    });
+
+    try {
+      const res = await handleCreateToken(
+        new Request("http://127.0.0.1:7830/auth/token", {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${jwt}`,
+            origin: "http://localhost:3000",
+          },
+        }),
+        makeLoopbackServer(),
+      );
+
+      expect(res.status).toBe(503);
+      expect(await res.json()).toEqual({ error: "guardian_repair_required" });
+      // No divergent principal row was minted.
+      expect(getGatewayDb().select().from(contacts).all()).toHaveLength(0);
+      // No token minted or recorded beyond the seeded evidence row.
+      expect(
+        getGatewayDb().select().from(actorTokenRecords).all(),
+      ).toHaveLength(1);
+    } finally {
+      resetGuardianIntegrityReporterForTesting();
+      bustGuardianIntegrityCache();
+    }
+  });
 });
 
 describe("m0004 token-hash index migration", () => {

--- a/gateway/src/__tests__/guardian-bootstrap-lookups.test.ts
+++ b/gateway/src/__tests__/guardian-bootstrap-lookups.test.ts
@@ -2,7 +2,12 @@
  * Tests for guardian-bootstrap guardian lookups
  * (findVellumGuardian + findGuardianForChannelActor), which read the gateway
  * DB directly, plus the resolve-or-mint path in resolveOrCreateVellumGuardian
- * (via ensureVellumGuardianBinding / bootstrapGuardian).
+ * (via ensureVellumGuardianBinding / bootstrapGuardian) and its divergent
+ * re-mint guard (evidence of a prior guardian refuses the implicit mint).
+ *
+ * The guardian-integrity reporter is silenced/observed via its test-only
+ * overrides, and the integrity cache is busted between tests — same seam
+ * conventions as the guardian-integrity test trio (no mock.module).
  *
  * Guardian rows are seeded ONLY in the gateway DB. By default the assistant
  * DB proxy is swapped for a backend that throws, proving the lookups never
@@ -20,6 +25,7 @@ import {
   expect,
   beforeAll,
   beforeEach,
+  afterEach,
   afterAll,
   mock,
 } from "bun:test";
@@ -63,14 +69,26 @@ import {
   findGuardianForChannelActor,
   ensureVellumGuardianBinding,
   bootstrapGuardian,
+  VellumGuardianMintRefusedError,
 } from "../auth/guardian-bootstrap.js";
+import { bustGuardianIntegrityCache } from "../auth/guardian-integrity.js";
 import { initSigningKey } from "../auth/token-service.js";
 import {
   initGatewayDb,
   getGatewayDb,
   resetGatewayDb,
 } from "../db/connection.js";
-import { contacts, contactChannels } from "../db/schema.js";
+import {
+  contacts,
+  contactChannels,
+  actorTokenRecords,
+  actorRefreshTokenRecords,
+} from "../db/schema.js";
+import {
+  resetGuardianIntegrityReporterForTesting,
+  setGuardianIntegrityReporterOverridesForTesting,
+} from "../guardian-integrity-reporter.js";
+import { seedActorToken, seedContact } from "./helpers/contact-fixtures.js";
 
 // Initialize signing key so bootstrapGuardian's JWT minting works.
 initSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long"));
@@ -147,11 +165,36 @@ beforeAll(async () => {
   await initGatewayDb();
 });
 
+// Captured missing-guardian reporter detail payloads (via the log override).
+const reportCalls: Record<string, unknown>[] = [];
+
 beforeEach(() => {
   const db = getGatewayDb();
   db.delete(contactChannels).run();
   db.delete(contacts).run();
+  // Token rows are guardian-integrity evidence; bootstrapGuardian tests mint
+  // them, so clear between tests to keep the evidence signals deterministic.
+  db.delete(actorTokenRecords).run();
+  db.delete(actorRefreshTokenRecords).run();
+  bustGuardianIntegrityCache();
   assistantBackend = throwingBackend;
+  reportCalls.length = 0;
+  resetGuardianIntegrityReporterForTesting();
+  setGuardianIntegrityReporterOverridesForTesting({
+    fetchImpl: async () => new Response("{}"),
+    mintToken: () => "svc-token",
+    baseUrl: "http://127.0.0.1:7821",
+    log: {
+      error: (detail) => {
+        reportCalls.push(detail);
+      },
+      warn: () => {},
+    },
+  });
+});
+
+afterEach(() => {
+  resetGuardianIntegrityReporterForTesting();
 });
 
 afterAll(() => {
@@ -326,6 +369,7 @@ describe("resolve-or-mint (resolveOrCreateVellumGuardian)", () => {
 
     expect(result.guardianPrincipalId).toBe("principal-existing");
     expect(result.isNew).toBe(false);
+    expect(result.mintedOverPriorEvidence).toBe(false);
     expect(result.accessToken).toBeTruthy();
     expect(result.refreshToken).toBeTruthy();
   });
@@ -340,5 +384,89 @@ describe("resolve-or-mint (resolveOrCreateVellumGuardian)", () => {
 
     expect(result.guardianPrincipalId).toMatch(/^vellum-principal-/);
     expect(result.isNew).toBe(true);
+    expect(result.mintedOverPriorEvidence).toBe(false);
+  });
+
+  test("startup backfill refuses to mint over contact evidence and fires the reporter", async () => {
+    seedContact({ id: "invited-contact" });
+
+    // Throwing assistant backend stays installed: the refusal must happen
+    // before any mint/mirror write. The rejection is an ordinary Error —
+    // post-assistant-ready wraps the backfill in try/catch, so boot
+    // continues degraded instead of crashing.
+    await expect(ensureVellumGuardianBinding()).rejects.toBeInstanceOf(
+      VellumGuardianMintRefusedError,
+    );
+
+    expect(gatewayVellumGuardians()).toHaveLength(0);
+    const contactRows = getGatewayDb().select().from(contacts).all();
+    expect(contactRows).toHaveLength(1); // no new principal row minted
+    expect(reportCalls).toEqual([
+      { has_contacts: true, has_actor_tokens: false },
+    ]);
+  });
+
+  test("startup backfill refuses to mint over actor-token evidence (guardian rows lost)", async () => {
+    seedActorToken();
+
+    await expect(ensureVellumGuardianBinding()).rejects.toBeInstanceOf(
+      VellumGuardianMintRefusedError,
+    );
+
+    expect(gatewayVellumGuardians()).toHaveLength(0);
+    expect(getGatewayDb().select().from(contacts).all()).toHaveLength(0);
+    expect(reportCalls).toEqual([
+      { has_contacts: false, has_actor_tokens: true },
+    ]);
+  });
+
+  test("refuses when a guardian contact exists but the vellum binding is inactive — no missing-guardian report", async () => {
+    seedGuardianChannel({
+      type: "vellum",
+      address: "vellum-principal-stale",
+      status: "revoked",
+      principalId: "principal-stale",
+    });
+
+    await expect(ensureVellumGuardianBinding()).rejects.toBeInstanceOf(
+      VellumGuardianMintRefusedError,
+    );
+
+    // Integrity state is "ok" (a guardian row exists), so the
+    // missing-guardian reporter stays quiet; the refusal is still logged.
+    expect(reportCalls).toHaveLength(0);
+  });
+
+  test("startup backfill recovers once the guardian is re-seeded", async () => {
+    seedActorToken();
+    await expect(ensureVellumGuardianBinding()).rejects.toBeInstanceOf(
+      VellumGuardianMintRefusedError,
+    );
+
+    seedGuardianChannel({
+      type: "vellum",
+      address: "vellum-principal-reseeded",
+      principalId: "principal-reseeded",
+    });
+
+    expect(await ensureVellumGuardianBinding()).toBe("principal-reseeded");
+  });
+
+  test("bootstrapGuardian (guardian init) mints over evidence with the returned flag set", async () => {
+    assistantBackend = makeAssistantBackend();
+    seedContact({ id: "invited-contact" });
+
+    const result = await bootstrapGuardian({
+      platform: "macos",
+      deviceId: "device-1",
+    });
+
+    expect(result.guardianPrincipalId).toMatch(/^vellum-principal-/);
+    expect(result.isNew).toBe(true);
+    expect(result.mintedOverPriorEvidence).toBe(true);
+    expect(gatewayVellumGuardians()).toHaveLength(1);
+    // The sanctioned recovery path warns locally; it is not a
+    // missing-guardian integrity report.
+    expect(reportCalls).toHaveLength(0);
   });
 });

--- a/gateway/src/__tests__/remote-web-pairing-token.test.ts
+++ b/gateway/src/__tests__/remote-web-pairing-token.test.ts
@@ -39,6 +39,12 @@ const {
   resetRemoteWebPairingChallengesForTests,
   setRemoteWebPairingChallengeNowForTests,
 } = await import("../remote-web/pairing-challenge-store.js");
+const { bustGuardianIntegrityCache } =
+  await import("../auth/guardian-integrity.js");
+const {
+  resetGuardianIntegrityReporterForTesting,
+  setGuardianIntegrityReporterOverridesForTesting,
+} = await import("../guardian-integrity-reporter.js");
 
 const GUARDIAN_ID = "guardian-001";
 const PUBLIC_BASE_URL = "https://paired.example.com";
@@ -603,6 +609,76 @@ describe("remote web pairing token exchange", () => {
     expect(setCookies(retry)).toHaveLength(1);
     expect(activeTokens()).toHaveLength(1);
     expect(activeRefreshTokens()).toHaveLength(1);
+  });
+
+  test("guardian mint refusal fails closed with 503 and releases the approved code", async () => {
+    const challenge = createRemoteWebPairingChallenge(PUBLIC_BASE_URL);
+    expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
+      "approved",
+    );
+
+    // Guardian rows lost, but a residual non-guardian contact is evidence of
+    // prior onboarding — the fallback mint must refuse rather than diverge.
+    clearGatewayGuardian();
+    const now = Date.now();
+    getGatewayDb()
+      .insert(contacts)
+      .values({
+        id: "contact-invited",
+        displayName: "invited",
+        role: "contact",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    bustGuardianIntegrityCache();
+    setGuardianIntegrityReporterOverridesForTesting({
+      fetchImpl: async () => new Response("{}"),
+      mintToken: () => "svc-token",
+      baseUrl: "http://127.0.0.1:7821",
+      log: { error: () => {}, warn: () => {} },
+    });
+
+    try {
+      const res = await handleRemoteWebPairingToken(
+        makeTokenRequest({ deviceCode: challenge.deviceCode }),
+      );
+
+      expect(res.status).toBe(503);
+      expect(await res.json()).toEqual({
+        error: {
+          code: "GUARDIAN_REPAIR_REQUIRED",
+          message:
+            "gateway guardian binding is missing over evidence of prior onboarding — repair via guardian init, then retry pairing",
+        },
+      });
+      expect(setCookies(res)).toHaveLength(0);
+      expect(activeTokens()).toHaveLength(0);
+      expect(activeRefreshTokens()).toHaveLength(0);
+      // No divergent principal was minted.
+      expect(
+        getGatewayDb()
+          .select()
+          .from(contacts)
+          .where(eq(contacts.role, "guardian"))
+          .all(),
+      ).toHaveLength(0);
+      expect(getGatewayDb().select().from(contacts).all()).toHaveLength(1);
+      // The approved code was released, so pairing succeeds after repair.
+      expect(
+        getRemoteWebPairingChallengeForTests(challenge.userCode)?.status,
+      ).toBe("approved");
+
+      seedGatewayGuardian();
+      const retry = await handleRemoteWebPairingToken(
+        makeTokenRequest({ deviceCode: challenge.deviceCode }),
+      );
+      expect(retry.status).toBe(200);
+      expect(activeTokens()).toHaveLength(1);
+    } finally {
+      resetGuardianIntegrityReporterForTesting();
+      bustGuardianIntegrityCache();
+    }
   });
 
   test("expired device code does not mint credentials", async () => {

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -839,8 +839,10 @@ async function resolveOrCreateVellumGuardian(options: {
  * Ensure a vellum guardian binding exists, returning its principalId.
  * Resolves from the gateway DB, minting a fresh principal on a miss — unless
  * the DB carries evidence of a prior guardian, in which case it throws
- * {@link VellumGuardianMintRefusedError} (callers degrade; startup backfill
- * is wrapped non-fatally in post-assistant-ready).
+ * {@link VellumGuardianMintRefusedError}. Every caller must handle that
+ * refusal explicitly: the startup backfill degrades boot non-fatally
+ * (post-assistant-ready), and the /auth/token + remote-web pairing routes
+ * map it to a 503 repair-required response.
  *
  * Called during gateway startup to backfill existing installations.
  */

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -24,7 +24,11 @@ import { ipcCallAssistant } from "../ipc/assistant-client.js";
 import { getLogger } from "../logger.js";
 import { deleteContactIfOrphaned } from "../verification/contact-helpers.js";
 
-import { bustGuardianIntegrityCache } from "./guardian-integrity.js";
+import {
+  bustGuardianIntegrityCache,
+  guardianIntegrityState,
+  hasEvidenceOfPriorGuardian,
+} from "./guardian-integrity.js";
 import { CURRENT_POLICY_EPOCH } from "./policy.js";
 import { mintToken } from "./token-service.js";
 
@@ -64,6 +68,24 @@ export interface GuardianBootstrapResult {
   refreshTokenExpiresAt: number;
   refreshAfter: number;
   isNew: boolean;
+  /** True when the mint overrode evidence of a prior guardian (re-pair). */
+  mintedOverPriorEvidence: boolean;
+}
+
+/**
+ * Thrown when a vellum guardian mint is refused: the gateway DB has no active
+ * vellum guardian binding but carries evidence of prior onboarding, so a mint
+ * would permanently diverge from prior clients' tokens. Recovery is the
+ * explicit /v1/guardian/init flow.
+ */
+export class VellumGuardianMintRefusedError extends Error {
+  constructor() {
+    super(
+      "refusing to mint a vellum guardian principal: the gateway DB has " +
+        "evidence of a prior guardian — re-pair via guardian init to recover",
+    );
+    this.name = "VellumGuardianMintRefusedError";
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -751,10 +773,20 @@ async function fetchPlatformOwnerDisplayName(): Promise<string | null> {
  *
  * Shared by ensureVellumGuardianBinding + bootstrapGuardian. `isNew` is true
  * only on the mint path.
+ *
+ * A gateway miss with evidence of a prior guardian (guardian-integrity.ts)
+ * means the guardian rows were lost, not that this is a fresh install — a
+ * mint there would permanently diverge from prior clients' tokens. Only the
+ * explicit operator-driven guardian init may mint over evidence
+ * (`allowMintWithEvidence`); implicit paths throw
+ * {@link VellumGuardianMintRefusedError} instead.
  */
-async function resolveOrCreateVellumGuardian(): Promise<{
+async function resolveOrCreateVellumGuardian(options: {
+  allowMintWithEvidence: boolean;
+}): Promise<{
   guardianPrincipalId: string;
   isNew: boolean;
+  mintedOverPriorEvidence: boolean;
 }> {
   const gw = await findVellumGuardian();
   if (gw) {
@@ -762,7 +794,27 @@ async function resolveOrCreateVellumGuardian(): Promise<{
       { guardianPrincipalId: gw.principalId },
       "Vellum guardian binding already exists",
     );
-    return { guardianPrincipalId: gw.principalId, isNew: false };
+    return {
+      guardianPrincipalId: gw.principalId,
+      isNew: false,
+      mintedOverPriorEvidence: false,
+    };
+  }
+
+  const priorEvidence = hasEvidenceOfPriorGuardian();
+  if (priorEvidence && !options.allowMintWithEvidence) {
+    // Fires the missing-guardian reporter (error log + telemetry,
+    // rate-limited there) when the DB is truly guardian-less.
+    guardianIntegrityState();
+    log.error(
+      "no active vellum guardian binding but the gateway DB carries evidence of prior onboarding — refusing to mint a divergent principal; re-pair via guardian init to recover",
+    );
+    throw new VellumGuardianMintRefusedError();
+  }
+  if (priorEvidence) {
+    log.warn(
+      "minting a fresh vellum guardian principal over evidence of a prior guardian — prior clients' tokens will not match",
+    );
   }
 
   // No gateway guardian — mint a fresh principal.
@@ -776,18 +828,26 @@ async function resolveOrCreateVellumGuardian(): Promise<{
     verifiedVia: "bootstrap",
     ...(displayName ? { displayName } : {}),
   });
-  return { guardianPrincipalId, isNew: true };
+  return {
+    guardianPrincipalId,
+    isNew: true,
+    mintedOverPriorEvidence: priorEvidence,
+  };
 }
 
 /**
  * Ensure a vellum guardian binding exists, returning its principalId.
- * Resolves from the gateway DB, minting a fresh principal on a miss (see
- * resolveOrCreateVellumGuardian).
+ * Resolves from the gateway DB, minting a fresh principal on a miss — unless
+ * the DB carries evidence of a prior guardian, in which case it throws
+ * {@link VellumGuardianMintRefusedError} (callers degrade; startup backfill
+ * is wrapped non-fatally in post-assistant-ready).
  *
  * Called during gateway startup to backfill existing installations.
  */
 export async function ensureVellumGuardianBinding(): Promise<string> {
-  const { guardianPrincipalId } = await resolveOrCreateVellumGuardian();
+  const { guardianPrincipalId } = await resolveOrCreateVellumGuardian({
+    allowMintWithEvidence: false,
+  });
   return guardianPrincipalId;
 }
 
@@ -802,8 +862,11 @@ export async function bootstrapGuardian(params: {
   platform: string;
   deviceId: string;
 }): Promise<GuardianBootstrapResult> {
-  // 1. Resolve (or mint) the guardian principal.
-  const { guardianPrincipalId, isNew } = await resolveOrCreateVellumGuardian();
+  // 1. Resolve (or mint) the guardian principal. Guardian init is the
+  //    sanctioned operator-driven recovery path, so it may mint over evidence
+  //    of a prior guardian (loud warn inside).
+  const { guardianPrincipalId, isNew, mintedOverPriorEvidence } =
+    await resolveOrCreateVellumGuardian({ allowMintWithEvidence: true });
 
   // 2. Revoke existing credentials for this device and mint a fresh pair.
   const pair = mintAndRecordDeviceBoundTokenPair({
@@ -813,7 +876,12 @@ export async function bootstrapGuardian(params: {
   });
 
   log.info(
-    { platform: params.platform, guardianPrincipalId, isNew },
+    {
+      platform: params.platform,
+      guardianPrincipalId,
+      isNew,
+      mintedOverPriorEvidence,
+    },
     "Guardian bootstrap completed",
   );
 
@@ -825,5 +893,6 @@ export async function bootstrapGuardian(params: {
     refreshTokenExpiresAt: pair.refreshTokenExpiresAt,
     refreshAfter: pair.refreshAfter,
     isNew,
+    mintedOverPriorEvidence,
   };
 }

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -841,8 +841,9 @@ async function resolveOrCreateVellumGuardian(options: {
  * the DB carries evidence of a prior guardian, in which case it throws
  * {@link VellumGuardianMintRefusedError}. Every caller must handle that
  * refusal explicitly: the startup backfill degrades boot non-fatally
- * (post-assistant-ready), and the /auth/token + remote-web pairing routes
- * map it to a 503 repair-required response.
+ * (post-assistant-ready), /auth/token maps it to a repairable 401
+ * (`guardian_repair_required`), and the remote-web pairing route to a 503
+ * (its 401 is claimed by invalid device codes).
  *
  * Called during gateway startup to backfill existing installations.
  */

--- a/gateway/src/http/routes/auth-token.ts
+++ b/gateway/src/http/routes/auth-token.ts
@@ -6,7 +6,10 @@ import {
   actorTokenRecordHash,
   isActorTokenRevoked,
 } from "../../auth/actor-token-revocation.js";
-import { ensureVellumGuardianBinding } from "../../auth/guardian-bootstrap.js";
+import {
+  ensureVellumGuardianBinding,
+  VellumGuardianMintRefusedError,
+} from "../../auth/guardian-bootstrap.js";
 import { CURRENT_POLICY_EPOCH } from "../../auth/policy.js";
 import { mintToken, verifyToken } from "../../auth/token-service.js";
 import { getGatewayDb } from "../../db/connection.js";
@@ -135,8 +138,26 @@ export async function handleCreateToken(
   }
 
   const sourceRecord = findSourceActorTokenRecord(bearerToken);
-  const guardianPrincipalId =
-    sourceRecord?.guardianPrincipalId ?? (await ensureVellumGuardianBinding());
+  let guardianPrincipalId = sourceRecord?.guardianPrincipalId;
+  if (!guardianPrincipalId) {
+    try {
+      guardianPrincipalId = await ensureVellumGuardianBinding();
+    } catch (err) {
+      // Guardian rows lost but the DB shows prior onboarding: minting here
+      // would diverge from prior clients' tokens. Fail closed with an
+      // explicit repair-required response instead of an unhandled 500.
+      if (err instanceof VellumGuardianMintRefusedError) {
+        log.error(
+          "Token create refused: guardian binding missing over evidence of prior onboarding — repair via guardian init",
+        );
+        return Response.json(
+          { error: "guardian_repair_required" },
+          { status: 503 },
+        );
+      }
+      throw err;
+    }
+  }
 
   const token = mintToken({
     aud: "vellum-gateway",

--- a/gateway/src/http/routes/auth-token.ts
+++ b/gateway/src/http/routes/auth-token.ts
@@ -144,15 +144,16 @@ export async function handleCreateToken(
       guardianPrincipalId = await ensureVellumGuardianBinding();
     } catch (err) {
       // Guardian rows lost but the DB shows prior onboarding: minting here
-      // would diverge from prior clients' tokens. Fail closed with an
-      // explicit repair-required response instead of an unhandled 500.
+      // would diverge from prior clients' tokens. Fail closed as a 401 — the
+      // status the web client treats as repairable — so callers offer the
+      // guardian re-init flow instead of dead-ending on a generic retry.
       if (err instanceof VellumGuardianMintRefusedError) {
         log.error(
           "Token create refused: guardian binding missing over evidence of prior onboarding — repair via guardian init",
         );
         return Response.json(
           { error: "guardian_repair_required" },
-          { status: 503 },
+          { status: 401 },
         );
       }
       throw err;

--- a/gateway/src/http/routes/remote-web-pairing-token.ts
+++ b/gateway/src/http/routes/remote-web-pairing-token.ts
@@ -102,6 +102,9 @@ export async function handleRemoteWebPairingToken(
       // Guardian rows lost but the DB shows prior onboarding: minting here
       // would diverge from prior clients' tokens. Fail closed with an
       // explicit repair-required response instead of an unhandled 500.
+      // Stays 503 (unlike /auth/token's repairable 401): 401 here means
+      // invalid/expired device code, and the released code stays
+      // exchangeable after guardian repair.
       return jsonError(
         "GUARDIAN_REPAIR_REQUIRED",
         "gateway guardian binding is missing over evidence of prior onboarding — repair via guardian init, then retry pairing",

--- a/gateway/src/http/routes/remote-web-pairing-token.ts
+++ b/gateway/src/http/routes/remote-web-pairing-token.ts
@@ -2,6 +2,7 @@ import {
   ensureVellumGuardianBinding,
   getExternalAssistantId,
   mintAndRecordBrowserTokenPair,
+  VellumGuardianMintRefusedError,
 } from "../../auth/guardian-bootstrap.js";
 import {
   claimRemoteWebPairingChallengeExchange,
@@ -94,7 +95,19 @@ export async function handleRemoteWebPairingToken(
       browserRefreshCookiePath: refreshCookiePath,
     });
   } catch (err) {
+    // Release so the approved code stays exchangeable after the failure is
+    // repaired (mint refusal) or retried (transient DB error).
     releaseRemoteWebPairingChallengeExchange(deviceCode);
+    if (err instanceof VellumGuardianMintRefusedError) {
+      // Guardian rows lost but the DB shows prior onboarding: minting here
+      // would diverge from prior clients' tokens. Fail closed with an
+      // explicit repair-required response instead of an unhandled 500.
+      return jsonError(
+        "GUARDIAN_REPAIR_REQUIRED",
+        "gateway guardian binding is missing over evidence of prior onboarding — repair via guardian init, then retry pairing",
+        503,
+      );
+    }
     throw err;
   }
   completeRemoteWebPairingChallengeExchange(deviceCode);


### PR DESCRIPTION
## Summary
- Startup backfill no longer mints a fresh vellum principal when evidence of a prior guardian exists (the mint converted a recoverable outage into permanent divergence); boot continues degraded + loud
- Explicit /v1/guardian/init keeps minting as the sanctioned recovery path, with a loud warn
- Fresh-install hatch byte-identical

Part of plan: acl-hardening-sweep.md (PR 4 of 18)