### PR TITLE
refactor(calls): collapse the voice-setup gateway fan-out onto the trust-verdict IPC

### DIFF
--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -176,35 +176,33 @@ mock.module("../calls/call-setup-router.js", () => ({
   }),
 }));
 
-// Mock the channel admission reader. handleStart awaits this before routing;
-// tests override mockAdmissionPolicy to exercise floor enforcement, or set
-// mockAdmissionUnavailable to exercise the fail-closed deny (the reader
-// resolves { ok: false } when the gateway is unreachable). Returning a
-// resolved promise introduces a microtask hop, so tests await
+// Mock the inbound trust reader. handleStart awaits the combined
+// verdict + admission-policy read (one gateway round-trip) and threads both
+// into routeSetup so the media-stream transport enforces the gateway ACL and
+// the admission floor. Tests override mockInboundVerdict /
+// mockAdmissionPolicy, or set mockTrustReadUnavailable to exercise the
+// fail-closed deny ({ ok: false } when the gateway is unreachable).
+// Returning a resolved promise introduces a microtask hop, so tests await
 // session.whenSetupSettled() after sending the start frame.
-let mockAdmissionPolicy: unknown = null;
-let mockAdmissionUnavailable = false;
-// Optional gate: when set, getChannelAdmissionPolicy awaits this promise before
-// resolving, letting a test dispose the session mid-read (simulating a WS close
-// while the admission IPC read is pending).
-let mockAdmissionGate: Promise<void> | null = null;
-const mockGetChannelAdmissionPolicy = jest.fn(async () => {
-  if (mockAdmissionGate) {await mockAdmissionGate;}
-  return mockAdmissionUnavailable
-    ? { ok: false as const }
-    : { ok: true as const, policy: mockAdmissionPolicy };
+//
+// The default verdict carries the guardian label the gateway stamps for the
+// phone channel; setup-flow copy reads it via the primed displayName.
+const defaultInboundVerdict = () => ({
+  trustClass: "unknown",
+  canonicalSenderId: null,
+  guardianDisplayName: "Alex",
 });
-mock.module("../calls/channel-admission-reader.js", () => ({
-  getChannelAdmissionPolicy: mockGetChannelAdmissionPolicy,
-}));
-
-// Mock the inbound trust reader. handleStart awaits this and threads the
-// verdict into routeSetup so the media-stream transport enforces the
-// gateway ACL. Tests override mockInboundVerdict.
-// The optional gate lets a test hold mid-setup trust re-resolution open
-// (the setup flow's default resolver reads the verdict first) so it can
-// deliver transcripts during the deferral window.
-let mockInboundVerdict: unknown = null;
+let mockAdmissionPolicy: unknown = null;
+let mockTrustReadUnavailable = false;
+// Optional gate: when set, the trust read awaits this promise before
+// resolving, letting a test dispose the session mid-read (simulating a WS
+// close while the gateway IPC read is pending) or deliver frames during the
+// setup-routing window.
+let mockTrustReadGate: Promise<void> | null = null;
+// The verdict gate lets a test hold mid-setup trust RE-resolution open (the
+// setup flow's default resolver reads the verdict) so it can deliver
+// transcripts during the deferral window.
+let mockInboundVerdict: unknown = defaultInboundVerdict();
 let mockVerdictGate: Promise<void> | null = null;
 const mockGetInboundTrustVerdict = jest.fn(
   async (_args?: Record<string, unknown>) => {
@@ -214,7 +212,27 @@ const mockGetInboundTrustVerdict = jest.fn(
     return mockInboundVerdict;
   },
 );
+const mockReadPhoneCallerTrust = jest.fn(
+  async (otherPartyNumber: string | undefined) => {
+    if (mockTrustReadGate) {
+      await mockTrustReadGate;
+    }
+    if (mockTrustReadUnavailable) {
+      return { ok: false as const };
+    }
+    const verdict = await mockGetInboundTrustVerdict({
+      channelType: "phone",
+      actorExternalId: otherPartyNumber || undefined,
+    });
+    return {
+      ok: true as const,
+      verdict,
+      admissionPolicy: mockAdmissionPolicy,
+    };
+  },
+);
 mock.module("../calls/inbound-trust-reader.js", () => ({
+  readPhoneCallerTrust: mockReadPhoneCallerTrust,
   getInboundTrustVerdict: mockGetInboundTrustVerdict,
   getPhoneCallerVerdict: (otherPartyNumber: string | undefined) =>
     mockGetInboundTrustVerdict({
@@ -283,12 +301,17 @@ mock.module("../calls/call-constants.js", () => ({
   getEndCallListenWindowMs: jest.fn(() => 15_000),
 }));
 
-// Guardian delivery reader (IPC-backed): label priming + cache warming.
+// Guardian delivery reader (IPC-backed). The setup path no longer reads it —
+// the guardian label comes off the verdict — so tests assert these stay
+// uncalled during handleStart; the mock also keeps transitive importers off
+// the real IPC.
+const mockGetGuardianDelivery = jest.fn(async () => [
+  { channelType: "phone", status: "active", displayName: "Alex" },
+]);
+const mockGetGuardianDeliveryFresh = jest.fn(async () => []);
 mock.module("../contacts/guardian-delivery-reader.js", () => ({
-  getGuardianDelivery: jest.fn(async () => [
-    { channelType: "phone", status: "active", displayName: "Alex" },
-  ]),
-  getGuardianDeliveryFresh: jest.fn(async () => []),
+  getGuardianDelivery: mockGetGuardianDelivery,
+  getGuardianDeliveryFresh: mockGetGuardianDeliveryFresh,
   peekCachedGuardianDelivery: jest.fn(() => null),
   voiceGuardianDisplayName: jest.fn(() => "Alex"),
   guardianForChannel: jest.fn(),
@@ -547,13 +570,15 @@ beforeEach(() => {
   (postPointerMessageSafe as jest.Mock).mockClear();
   (routeSetup as jest.Mock).mockClear();
   mockRouteSetupError = null;
-  mockGetChannelAdmissionPolicy.mockClear();
+  mockReadPhoneCallerTrust.mockClear();
   mockAdmissionPolicy = null;
-  mockAdmissionUnavailable = false;
-  mockAdmissionGate = null;
+  mockTrustReadUnavailable = false;
+  mockTrustReadGate = null;
   mockGetInboundTrustVerdict.mockClear();
-  mockInboundVerdict = null;
+  mockInboundVerdict = defaultInboundVerdict();
   mockVerdictGate = null;
+  mockGetGuardianDelivery.mockClear();
+  mockGetGuardianDeliveryFresh.mockClear();
   mockAddMessage.mockClear();
   mockAttemptVerificationCode.mockClear();
   mockVerificationResult = {
@@ -1380,12 +1405,13 @@ describe("media-stream setup outcome scenarios", () => {
   // The phone channel is no longer exempt from per-channel admission, so the
   // trust floor must be enforced on this transport too — not just the
   // gateway's no_one kill switch. handleStart resolves the phone admission
-  // policy and threads it into routeSetup; a floor-denied caller (e.g.
-  // guardian_only vs a trusted_contact) produces a `deny` outcome here, which
-  // speaks a denial + tears down and never starts a normal call.
+  // policy (riding the caller-trust verdict read — one gateway round-trip)
+  // and threads it into routeSetup; a floor-denied caller (e.g. guardian_only
+  // vs a trusted_contact) produces a `deny` outcome here, which speaks a
+  // denial + tears down and never starts a normal call.
 
   describe("admission floor enforcement", () => {
-    test("resolves the phone admission policy and threads it into routeSetup", async () => {
+    test("resolves the phone admission policy on the single trust read and threads it into routeSetup", async () => {
       mockAdmissionPolicy = "guardian_only";
 
       const mockWs = createMockWs();
@@ -1406,7 +1432,13 @@ describe("media-stream setup outcome scenarios", () => {
       session.handleMessage(makeStartMessage());
       await session.whenSetupSettled();
 
-      expect(mockGetChannelAdmissionPolicy).toHaveBeenCalledWith("phone");
+      // Exactly one gateway read on the setup path: the combined verdict +
+      // admission-policy IPC. No separate guardian display-name prime or
+      // delivery cache warm.
+      expect(mockReadPhoneCallerTrust).toHaveBeenCalledTimes(1);
+      expect(mockReadPhoneCallerTrust).toHaveBeenCalledWith("+14155550000");
+      expect(mockGetGuardianDelivery).not.toHaveBeenCalled();
+      expect(mockGetGuardianDeliveryFresh).not.toHaveBeenCalled();
       expect(routeSetup).toHaveBeenCalledWith(
         expect.objectContaining({
           callSessionId: "call-floor-thread-1",
@@ -1513,7 +1545,7 @@ describe("media-stream setup outcome scenarios", () => {
     });
 
     test("unreachable gateway fails closed — inbound setup denied without routing", async () => {
-      mockAdmissionUnavailable = true;
+      mockTrustReadUnavailable = true;
 
       const mockWs = createMockWs();
       mockSessions.set("call-floor-unavail-1", {
@@ -1533,9 +1565,8 @@ describe("media-stream setup outcome scenarios", () => {
       session.handleMessage(makeStartMessage());
       await session.whenSetupSettled();
 
-      // Fail closed promptly: no routing, no verdict read.
+      // Fail closed promptly: no routing.
       expect(routeSetup).not.toHaveBeenCalled();
-      expect(mockGetInboundTrustVerdict).not.toHaveBeenCalled();
 
       // Standard deny teardown: unavailable copy spoken, session failed,
       // no controller, finalization ran.
@@ -1559,7 +1590,7 @@ describe("media-stream setup outcome scenarios", () => {
     });
 
     test("unreachable gateway does not affect an outbound call (admission not consulted)", async () => {
-      mockAdmissionUnavailable = true;
+      mockTrustReadUnavailable = true;
       mockRouteSetupResult = {
         outcome: { action: "normal_call", isInbound: false },
         resolved: {
@@ -1590,9 +1621,10 @@ describe("media-stream setup outcome scenarios", () => {
       await session.whenSetupSettled();
 
       // Outbound routes normally; the failed read degrades to a null policy
-      // (the router ignores admission on outbound).
+      // and a null verdict (the router ignores admission on outbound and owns
+      // the missing-verdict abort posture).
       expect(routeSetup).toHaveBeenCalledWith(
-        expect.objectContaining({ admissionPolicy: null }),
+        expect.objectContaining({ admissionPolicy: null, verdict: null }),
       );
       expect(registerCallController).toHaveBeenCalledWith(
         "call-outbound-unavail-1",
@@ -1650,10 +1682,10 @@ describe("media-stream setup outcome scenarios", () => {
     });
 
     test("a DTMF digit received during setup routing is dropped", async () => {
-      // Gate the admission read so setupRouting is still true when the DTMF
-      // frame arrives (simulating a digit during the admission IPC read).
+      // Gate the trust read so setupRouting is still true when the DTMF
+      // frame arrives (simulating a digit during the gateway IPC read).
       let releaseGate!: () => void;
-      mockAdmissionGate = new Promise<void>((resolve) => {
+      mockTrustReadGate = new Promise<void>((resolve) => {
         releaseGate = resolve;
       });
 
@@ -1671,7 +1703,7 @@ describe("media-stream setup outcome scenarios", () => {
       const session = new MediaStreamCallSession(mockWs.ws, "call-dtmf-drop-1");
       session.handleMessage(makeStartMessage());
 
-      // DTMF arrives while the admission read is still pending.
+      // DTMF arrives while the trust read is still pending.
       session.handleMessage(makeDtmfMessage("5"));
 
       releaseGate();
@@ -1688,11 +1720,11 @@ describe("media-stream setup outcome scenarios", () => {
       expect(mockHandleCallerUtterance).not.toHaveBeenCalled();
     });
 
-    test("session disposed during the admission read aborts setup — no controller, no greeting", async () => {
-      // Gate the admission read so the session can be disposed (as the WS
+    test("session disposed during the trust read aborts setup — no controller, no greeting", async () => {
+      // Gate the trust read so the session can be disposed (as the WS
       // close handler does) while handleStart is awaiting it.
       let releaseGate!: () => void;
-      mockAdmissionGate = new Promise<void>((resolve) => {
+      mockTrustReadGate = new Promise<void>((resolve) => {
         releaseGate = resolve;
       });
 
@@ -1713,7 +1745,7 @@ describe("media-stream setup outcome scenarios", () => {
       // Twilio closes the WebSocket mid-read: the server disposes the session.
       session.destroy();
 
-      // Now let the admission read resolve and setup routing resume.
+      // Now let the trust read resolve and setup routing resume.
       releaseGate();
       await session.whenSetupSettled();
 

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -130,6 +130,17 @@ mock.module("../calls/inbound-trust-reader.js", () => ({
     };
     return mockInboundVerdict;
   },
+  readPhoneCallerTrust: async (otherPartyNumber: string | undefined) => {
+    lastInboundVerdictArgs = {
+      channelType: "phone",
+      actorExternalId: otherPartyNumber || undefined,
+    };
+    return {
+      ok: true as const,
+      verdict: mockInboundVerdict,
+      admissionPolicy: mockAdmissionPolicy,
+    };
+  },
 }));
 
 // Mock the STT+TTS credential-readiness preflight consulted at TwiML time.

--- a/assistant/src/calls/__tests__/inbound-trust-reader.test.ts
+++ b/assistant/src/calls/__tests__/inbound-trust-reader.test.ts
@@ -1,10 +1,10 @@
 /**
  * Tests for the gateway-backed per-actor inbound trust reader.
  *
- * The reader returns `null` on ANY failure (transport failure, undefined,
- * malformed shape, thrown error); the Combo 9/10 consumer decides fail-open
- * vs fail-closed. These tests pin that contract plus the forwarded method +
- * params.
+ * The combined read reports `{ ok: false }` on ANY failure (transport
+ * failure, undefined, malformed shape, thrown error); the consumer decides
+ * fail-open vs fail-closed. These tests pin that contract, the envelope's
+ * admission-policy passthrough, and the forwarded method + params.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -36,7 +36,11 @@ mock.module("../../ipc/gateway-client.js", () => ({
 
 import type { TrustVerdict } from "@vellumai/gateway-client";
 
-import { getInboundTrustVerdict } from "../inbound-trust-reader.js";
+import {
+  getInboundTrustVerdict,
+  readInboundTrust,
+  readPhoneCallerTrust,
+} from "../inbound-trust-reader.js";
 
 const METHOD = "resolve_inbound_trust";
 
@@ -47,14 +51,156 @@ const VALID_VERDICT = {
   status: "active",
 } satisfies TrustVerdict;
 
-describe("getInboundTrustVerdict", () => {
-  beforeEach(() => {
-    ipcHandlers.clear();
-    ipcCallLog.length = 0;
+beforeEach(() => {
+  ipcHandlers.clear();
+  ipcCallLog.length = 0;
+});
+
+describe("readInboundTrust", () => {
+  test("returns the verdict and admission policy on a valid response", async () => {
+    ipcHandlers.set(METHOD, () => ({
+      verdict: VALID_VERDICT,
+      admissionPolicy: "guardian_only",
+    }));
+
+    const result = await readInboundTrust({
+      channelType: "telegram",
+      actorExternalId: "U_MEMBER",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      verdict: VALID_VERDICT,
+      admissionPolicy: "guardian_only",
+    });
   });
 
-  test("returns the gateway-resolved verdict on a valid response", async () => {
+  test("an explicit null admission policy is a successful read (admit, no enforcement)", async () => {
+    ipcHandlers.set(METHOD, () => ({
+      verdict: VALID_VERDICT,
+      admissionPolicy: null,
+    }));
+
+    const result = await readInboundTrust({ channelType: "telegram" });
+
+    expect(result).toEqual({
+      ok: true,
+      verdict: VALID_VERDICT,
+      admissionPolicy: null,
+    });
+  });
+
+  test("forwards the correct method, params, and timeout to ipcCall", async () => {
+    ipcHandlers.set(METHOD, () => ({
+      verdict: VALID_VERDICT,
+      admissionPolicy: null,
+    }));
+
+    const input = {
+      channelType: "telegram" as const,
+      actorExternalId: "U_MEMBER",
+    };
+    await readInboundTrust(input);
+
+    const call = ipcCallLog.find((c) => c.method === METHOD);
+    expect(call?.params).toEqual(input);
+    expect(call?.timeoutMs).toBe(2_000);
+  });
+
+  test("returns { ok: false } when IPC transport fails (undefined)", async () => {
+    ipcHandlers.set(METHOD, () => undefined);
+    expect(await readInboundTrust({ channelType: "telegram" })).toEqual({
+      ok: false,
+    });
+  });
+
+  test("returns { ok: false } for a malformed verdict shape", async () => {
+    ipcHandlers.set(METHOD, () => ({
+      verdict: { trustClass: "bogus" },
+      admissionPolicy: null,
+    }));
+    expect(await readInboundTrust({ channelType: "telegram" })).toEqual({
+      ok: false,
+    });
+  });
+
+  test("returns { ok: false } when the admission policy field is missing", async () => {
     ipcHandlers.set(METHOD, () => ({ verdict: VALID_VERDICT }));
+    expect(await readInboundTrust({ channelType: "telegram" })).toEqual({
+      ok: false,
+    });
+  });
+
+  test("returns { ok: false } for an out-of-vocabulary admission policy", async () => {
+    ipcHandlers.set(METHOD, () => ({
+      verdict: VALID_VERDICT,
+      admissionPolicy: "everyone",
+    }));
+    expect(await readInboundTrust({ channelType: "telegram" })).toEqual({
+      ok: false,
+    });
+  });
+
+  test("returns { ok: false } when the verdict field is missing", async () => {
+    ipcHandlers.set(METHOD, () => ({ admissionPolicy: null }));
+    expect(await readInboundTrust({ channelType: "telegram" })).toEqual({
+      ok: false,
+    });
+  });
+
+  test("returns { ok: false } when the IPC call throws", async () => {
+    ipcHandlers.set(METHOD, () => {
+      throw new Error("socket exploded");
+    });
+    expect(await readInboundTrust({ channelType: "telegram" })).toEqual({
+      ok: false,
+    });
+  });
+});
+
+describe("readPhoneCallerTrust", () => {
+  test("reads the phone channel keyed by the caller number", async () => {
+    ipcHandlers.set(METHOD, () => ({
+      verdict: VALID_VERDICT,
+      admissionPolicy: "trusted_contacts",
+    }));
+
+    const result = await readPhoneCallerTrust("+15555550100");
+
+    expect(result).toEqual({
+      ok: true,
+      verdict: VALID_VERDICT,
+      admissionPolicy: "trusted_contacts",
+    });
+    const call = ipcCallLog.find((c) => c.method === METHOD);
+    expect(call?.params).toEqual({
+      channelType: "phone",
+      actorExternalId: "+15555550100",
+    });
+  });
+
+  test("an empty caller number normalizes to an absent actorExternalId", async () => {
+    ipcHandlers.set(METHOD, () => ({
+      verdict: VALID_VERDICT,
+      admissionPolicy: null,
+    }));
+
+    await readPhoneCallerTrust("");
+
+    const call = ipcCallLog.find((c) => c.method === METHOD);
+    expect(call?.params).toEqual({
+      channelType: "phone",
+      actorExternalId: undefined,
+    });
+  });
+});
+
+describe("getInboundTrustVerdict", () => {
+  test("returns the gateway-resolved verdict on a valid response", async () => {
+    ipcHandlers.set(METHOD, () => ({
+      verdict: VALID_VERDICT,
+      admissionPolicy: null,
+    }));
 
     const verdict = await getInboundTrustVerdict({
       channelType: "telegram",
@@ -64,45 +210,8 @@ describe("getInboundTrustVerdict", () => {
     expect(verdict).toEqual(VALID_VERDICT);
   });
 
-  test("forwards the correct method, params, and timeout to ipcCall", async () => {
-    ipcHandlers.set(METHOD, () => ({ verdict: VALID_VERDICT }));
-
-    const input = {
-      channelType: "telegram" as const,
-      actorExternalId: "U_MEMBER",
-    };
-    await getInboundTrustVerdict(input);
-
-    const call = ipcCallLog.find((c) => c.method === METHOD);
-    expect(call?.params).toEqual(input);
-    expect(call?.timeoutMs).toBe(2_000);
-  });
-
-  test("returns null when IPC transport fails (undefined)", async () => {
+  test("returns null on any read failure", async () => {
     ipcHandlers.set(METHOD, () => undefined);
-    expect(
-      await getInboundTrustVerdict({ channelType: "telegram" }),
-    ).toBeNull();
-  });
-
-  test("returns null for a malformed verdict shape", async () => {
-    ipcHandlers.set(METHOD, () => ({ verdict: { trustClass: "bogus" } }));
-    expect(
-      await getInboundTrustVerdict({ channelType: "telegram" }),
-    ).toBeNull();
-  });
-
-  test("returns null when the verdict field is missing", async () => {
-    ipcHandlers.set(METHOD, () => ({}));
-    expect(
-      await getInboundTrustVerdict({ channelType: "telegram" }),
-    ).toBeNull();
-  });
-
-  test("returns null when the IPC call throws", async () => {
-    ipcHandlers.set(METHOD, () => {
-      throw new Error("socket exploded");
-    });
     expect(
       await getInboundTrustVerdict({ channelType: "telegram" }),
     ).toBeNull();

--- a/assistant/src/calls/inbound-trust-reader.ts
+++ b/assistant/src/calls/inbound-trust-reader.ts
@@ -1,18 +1,21 @@
 /**
- * Gateway-backed per-actor inbound trust verdict reader.
+ * Gateway-backed per-actor inbound trust reader.
  *
- * Resolves the inbound sender's {@link TrustVerdict} from the gateway via the
- * `resolve_inbound_trust` IPC route. Unlike the channel-admission reader this
- * is per-actor, NOT per-channel, so there is NO caching.
+ * Resolves the inbound sender's {@link TrustVerdict} — and, on the same
+ * `resolve_inbound_trust` round-trip, the channel's admission policy — from
+ * the gateway. Per-actor, NOT per-channel, so there is NO caching.
  *
- * Returns `null` on ANY failure (transport failure, `undefined`, malformed
- * shape, or thrown error). The caller owns the deny policy (fail-open vs
- * fail-closed); this reader only reports the verdict or `null`.
+ * {@link readInboundTrust} reports `{ ok: false }` on ANY failure (transport
+ * failure, `undefined`, malformed shape, or thrown error); an explicit
+ * `admissionPolicy: null` on a successful read is the gateway's "no
+ * enforcement configured" answer, distinct from an unreachable gateway. The
+ * caller owns the deny policy; this reader only reports.
  */
 
 import {
+  type AdmissionPolicy,
+  ResolveInboundTrustResponseSchema,
   type TrustVerdict,
-  TrustVerdictSchema,
 } from "@vellumai/gateway-client";
 
 import type { ChannelId } from "../channels/types.js";
@@ -23,40 +26,69 @@ import { setMemberVerdict } from "../runtime/member-verdict-cache.js";
 // setup on a gateway that accepts the socket but hangs.
 const TRUST_IPC_TIMEOUT_MS = 2_000;
 
+/**
+ * Combined verdict + admission-policy read result. `{ ok: false }` means the
+ * gateway was unreachable or answered with a malformed shape.
+ */
+export type InboundTrustReadResult =
+  | { ok: true; verdict: TrustVerdict; admissionPolicy: AdmissionPolicy | null }
+  | { ok: false };
+
+export async function readInboundTrust(input: {
+  channelType: ChannelId;
+  actorExternalId?: string;
+}): Promise<InboundTrustReadResult> {
+  try {
+    const result = await ipcCall(
+      "resolve_inbound_trust",
+      input,
+      TRUST_IPC_TIMEOUT_MS,
+    );
+    if (!result) return { ok: false };
+
+    const parsed = ResolveInboundTrustResponseSchema.safeParse(result);
+    if (!parsed.success) return { ok: false };
+
+    // Single choke point: warm the member-verdict cache so the sync trust
+    // fallback resolves the member without a local ACL read.
+    setMemberVerdict(input.channelType, input.actorExternalId, parsed.data.verdict);
+    return {
+      ok: true,
+      verdict: parsed.data.verdict,
+      admissionPolicy: parsed.data.admissionPolicy,
+    };
+  } catch {
+    return { ok: false };
+  }
+}
+
+/** Verdict-only surface for callers that don't consume the admission policy. */
 export async function getInboundTrustVerdict(input: {
   channelType: ChannelId;
   actorExternalId?: string;
 }): Promise<TrustVerdict | null> {
-  try {
-    const result = (await ipcCall(
-      "resolve_inbound_trust",
-      input,
-      TRUST_IPC_TIMEOUT_MS,
-    )) as { verdict?: unknown } | null | undefined;
-
-    if (!result) return null;
-
-    const parsed = TrustVerdictSchema.safeParse(result.verdict);
-    if (!parsed.success) return null;
-
-    // Single choke point: warm the member-verdict cache so the sync trust
-    // fallback resolves the member without a local ACL read.
-    setMemberVerdict(input.channelType, input.actorExternalId, parsed.data);
-    return parsed.data;
-  } catch {
-    return null;
-  }
+  const result = await readInboundTrust(input);
+  return result.ok ? result.verdict : null;
 }
 
 /**
- * Resolve the verdict for a phone caller by their external number. Callers
- * compute `otherPartyNumber` from their own transport-specific direction.
+ * Combined verdict + admission-policy read for a phone caller by their
+ * external number. Callers compute `otherPartyNumber` from their own
+ * transport-specific direction.
  */
-export function getPhoneCallerVerdict(
+export function readPhoneCallerTrust(
   otherPartyNumber: string | undefined,
-): Promise<TrustVerdict | null> {
-  return getInboundTrustVerdict({
+): Promise<InboundTrustReadResult> {
+  return readInboundTrust({
     channelType: "phone",
     actorExternalId: otherPartyNumber || undefined,
   });
+}
+
+/** Verdict-only variant of {@link readPhoneCallerTrust}. */
+export async function getPhoneCallerVerdict(
+  otherPartyNumber: string | undefined,
+): Promise<TrustVerdict | null> {
+  const result = await readPhoneCallerTrust(otherPartyNumber);
+  return result.ok ? result.verdict : null;
 }

--- a/assistant/src/calls/inbound-trust-reader.ts
+++ b/assistant/src/calls/inbound-trust-reader.ts
@@ -44,10 +44,14 @@ export async function readInboundTrust(input: {
       input,
       TRUST_IPC_TIMEOUT_MS,
     );
-    if (!result) return { ok: false };
+    if (!result) {
+      return { ok: false };
+    }
 
     const parsed = ResolveInboundTrustResponseSchema.safeParse(result);
-    if (!parsed.success) return { ok: false };
+    if (!parsed.success) {
+      return { ok: false };
+    }
 
     // Single choke point: warm the member-verdict cache so the sync trust
     // fallback resolves the member without a local ACL read.

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -41,11 +41,6 @@
 import type { ServerWebSocket } from "bun";
 
 import { revokeScopedApprovalGrantsForContext } from "../approvals/scoped-approval-grants.js";
-import {
-  getGuardianDelivery,
-  getGuardianDeliveryFresh,
-  voiceGuardianDisplayName,
-} from "../contacts/guardian-delivery-reader.js";
 import { getAssistantName } from "../daemon/identity-helpers.js";
 import { addMessage } from "../persistence/conversation-crud.js";
 import { resolveGuardianName } from "../prompts/user-reference.js";
@@ -76,9 +71,8 @@ import {
   recordCallEvent,
   updateCallSession,
 } from "./call-store.js";
-import { getChannelAdmissionPolicy } from "./channel-admission-reader.js";
 import { finalizeCall } from "./finalize-call.js";
-import { getPhoneCallerVerdict } from "./inbound-trust-reader.js";
+import { readPhoneCallerTrust } from "./inbound-trust-reader.js";
 import { MediaStreamOutput } from "./media-stream-output.js";
 import { parseMediaStreamFrame } from "./media-stream-parser.js";
 import type { MediaStreamStartEvent } from "./media-stream-protocol.js";
@@ -109,11 +103,11 @@ function resolveAssistantLabel(): string | null {
 }
 
 /**
- * Deny routing for an inbound call whose admission floor could not be read
- * (gateway unreachable / malformed answer). Mirrors the router's floor-deny
- * outcome shape so the setup flow runs the standard deny teardown (denial
- * copy + hangup). Trust is stamped `unknown`: with no gateway answer the
- * caller cannot be vetted.
+ * Deny routing for an inbound call whose combined trust-verdict +
+ * admission-floor read failed (gateway unreachable / malformed answer).
+ * Mirrors the router's floor-deny outcome shape so the setup flow runs the
+ * standard deny teardown (denial copy + hangup). Trust is stamped `unknown`:
+ * with no gateway answer the caller cannot be vetted.
  */
 function admissionUnavailableDeny(otherPartyNumber: string): {
   outcome: SetupOutcome;
@@ -182,22 +176,23 @@ export class MediaStreamCallSession {
    * instead of the controller while set.
    */
   private setupFlow: CallSetupFlow | null = null;
-  /** Guardian displayName primed from the gateway binding during setup. */
+  /** Guardian displayName primed from the setup trust verdict. */
   private primedGuardianDisplayName: string | undefined;
   private streamSid: string | null = null;
   private callSid: string | null = null;
   private disposed = false;
   // True from the synchronous start of handleStart until setup routing
-  // completes. Resolving the admission floor yields the event loop, so
-  // transcripts/barge-in arriving in this window are ignored — a denied or
-  // not-yet-authorized caller's speech is never persisted before the floor
-  // and trust ACL are applied. The controller-existence checks below also
-  // gate persistence, but this guard makes the intent explicit and covers
-  // the brief async window before the controller is created.
+  // completes. Resolving the trust verdict + admission floor yields the
+  // event loop, so transcripts/barge-in arriving in this window are ignored
+  // — a denied or not-yet-authorized caller's speech is never persisted
+  // before the floor and trust ACL are applied. The controller-existence
+  // checks below also gate persistence, but this guard makes the intent
+  // explicit and covers the brief async window before the controller is
+  // created.
   private setupRouting = false;
   // Resolves when the async setup routing kicked off by the `start` frame
   // settles. Exposed via whenSetupSettled() for deterministic test awaiting,
-  // since handleStart now yields on the admission-policy read.
+  // since handleStart yields on the gateway trust read.
   private setupSettled: Promise<void> = Promise.resolve();
 
   // ── Operational diagnostics counters ──────────────────────────────
@@ -278,9 +273,10 @@ export class MediaStreamCallSession {
     // Intercept `start` to bootstrap the session before forwarding.
     const parseResult = parseMediaStreamFrame(raw);
     if (parseResult.ok && parseResult.event.event === "start") {
-      // handleStart resolves the admission floor asynchronously; the
-      // setupRouting guard set synchronously at its top ensures inbound
-      // frames forwarded below are ignored until routing completes.
+      // handleStart resolves the trust verdict + admission floor
+      // asynchronously; the setupRouting guard set synchronously at its top
+      // ensures inbound frames forwarded below are ignored until routing
+      // completes.
       this.setupSettled = this.handleStart(parseResult.event).catch((err) =>
         this.handleSetupFailure(err),
       );
@@ -423,7 +419,7 @@ export class MediaStreamCallSession {
 
   private async handleStart(event: MediaStreamStartEvent): Promise<void> {
     // Enter the setup-pending window synchronously, before any await. The
-    // admission-policy read below yields the event loop, so frames forwarded
+    // gateway trust read below yields the event loop, so frames forwarded
     // to the STT session can produce transcripts/barge-in before routing
     // completes — those are dropped while setupRouting is true.
     this.setupRouting = true;
@@ -469,66 +465,53 @@ export class MediaStreamCallSession {
     const isInbound = session?.initiatedFromConversationId == null;
     const otherPartyNumber = isInbound ? from : to;
 
-    // Resolve the phone channel's inbound admission floor so the trust floor
-    // (e.g. guardian_only) is enforced on this transport too — not just the
-    // gateway webhook's no_one kill switch. The reader fails closed by
-    // contract: an unreachable gateway denies inbound setup below rather
-    // than admitting unvetted callers past the floor.
-    //
-    // Concurrently, prime the guardian displayName used by setup-flow copy
-    // and warm the phone-channel guardian-delivery cache for setup-flow
-    // label resolution (gateway-side binding writes don't invalidate the
-    // daemon cache, so read fresh). All three are independent IPC reads on
-    // different cache keys.
-    const [admissionRead] = await Promise.all([
-      getChannelAdmissionPolicy("phone"),
-      this.primeGuardianDisplayName(),
-      getGuardianDeliveryFresh({ channelTypes: ["phone"] }),
-    ]);
+    // Single gateway round-trip for caller trust: the verdict (this
+    // transport's sole caller-trust source) rides with the phone channel's
+    // inbound admission floor, so the trust floor (e.g. guardian_only) is
+    // enforced here too — not just the gateway webhook's no_one kill switch.
+    // The read fails closed: an unreachable gateway denies inbound setup
+    // below rather than admitting unvetted callers past the floor.
+    const trustRead = await readPhoneCallerTrust(otherPartyNumber);
 
-    // The admission-policy read above yields the event loop; if Twilio closed
-    // the WebSocket meanwhile, the close handler will have called destroy().
+    // The trust read above yields the event loop; if Twilio closed the
+    // WebSocket meanwhile, the close handler will have called destroy().
     // Abort setup so we don't create a controller or speak on a disposed
     // session.
-    if (this.abortIfDisposed("admission read")) {
+    if (this.abortIfDisposed("trust read")) {
       return;
     }
 
     let routed: { outcome: SetupOutcome; resolved: SetupResolved };
-    if (isInbound && !admissionRead.ok) {
-      // Fail closed: with no gateway answer the floor cannot be enforced, so
-      // the caller cannot be vetted. Outbound calls never consult admission
-      // and route normally below.
+    if (isInbound && !trustRead.ok) {
+      // Fail closed: with no gateway answer neither the floor nor the caller
+      // trust can be resolved, so the caller cannot be vetted.
       log.warn(
         { callSessionId: this.callSessionId, from },
-        "Inbound voice admission floor unavailable — denying call setup",
+        "Inbound voice trust/admission read unavailable — denying call setup",
       );
       routed = admissionUnavailableDeny(otherPartyNumber);
     } else {
-      // Gateway-verdict caller trust so this transport enforces the gateway
-      // ACL. The reader returns null on failure; routeSetup fails closed on a
-      // missing/failed verdict (inbound deny, outbound setup-failure
-      // teardown).
-      const verdict = await getPhoneCallerVerdict(otherPartyNumber);
+      // Guardian displayName for setup-flow copy comes off the verdict (the
+      // gateway stamps the channel's guardian binding label independent of
+      // who is calling); absent → the default guardian reference.
+      const verdict = trustRead.ok ? trustRead.verdict : null;
+      this.primedGuardianDisplayName = verdict?.guardianDisplayName;
 
-      // The verdict read above yields the event loop; abort if the session was
-      // disposed meanwhile, matching the admission-read guard above.
-      if (this.abortIfDisposed("verdict read")) {
-        return;
-      }
-
+      // routeSetup fails closed on a missing/failed verdict (inbound deny,
+      // outbound setup-failure teardown). Outbound calls never consult
+      // admission, so a failed read degrades to a null policy here.
       routed = await routeSetup({
         callSessionId: this.callSessionId,
         session: session ?? null,
         from,
         to,
         customParameters: event.start.customParameters,
-        admissionPolicy: admissionRead.ok ? admissionRead.policy : null,
+        admissionPolicy: trustRead.ok ? trustRead.admissionPolicy : null,
         verdict,
       });
 
       // routeSetup can yield the event loop (gateway voice-invite read); abort
-      // if the session was disposed meanwhile, matching the guards above.
+      // if the session was disposed meanwhile, matching the guard above.
       if (this.abortIfDisposed("setup routing")) {
         return;
       }
@@ -721,16 +704,6 @@ export class MediaStreamCallSession {
           "Failed to start call flow after setup completion",
         );
       });
-  }
-
-  /**
-   * Prime the guardian displayName from the gateway binding so the
-   * synchronous setup-flow label path can read it without an IPC
-   * round-trip.
-   */
-  private async primeGuardianDisplayName(): Promise<void> {
-    const list = await getGuardianDelivery();
-    this.primedGuardianDisplayName = voiceGuardianDisplayName(list);
   }
 
   // ── Finalization helpers for early-teardown paths ─────────────────

--- a/gateway/src/ipc/__tests__/trust-verdict-handlers.test.ts
+++ b/gateway/src/ipc/__tests__/trust-verdict-handlers.test.ts
@@ -2,12 +2,30 @@
  * Tests for the `resolve_inbound_trust` IPC route.
  *
  * Seeds the gateway ACL DB directly (contacts + contact_channels) and invokes
- * the route handler with params, asserting the returned `{ verdict }` matches
- * the resolver output for guardian / member / unknown actors.
+ * the route handler with params, asserting the returned verdict matches the
+ * resolver output for guardian / member / unknown actors and that the
+ * envelope carries the channel admission policy from the same store
+ * `get_channel_admission_policy` reads.
  */
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { AdmissionPolicy } from "@vellumai/gateway-client";
 
 await import("../../__tests__/test-preload.js");
+
+// Leak-safe snapshot-spread delegating mock: only resolveAdmissionPolicy is
+// overridden, and it delegates to a per-test implementation.
+const actualAdmissionPolicyCache = await import(
+  "../../risk/admission-policy-cache.js"
+);
+let resolveAdmissionPolicyImpl: (channelType: string) => AdmissionPolicy | null =
+  () => null;
+mock.module("../../risk/admission-policy-cache.js", () => ({
+  ...actualAdmissionPolicyCache,
+  resolveAdmissionPolicy: (channelType: string) =>
+    resolveAdmissionPolicyImpl(channelType),
+}));
+
 const { initGatewayDb, resetGatewayDb, getGatewayDb } = await import(
   "../../db/connection.js"
 );
@@ -77,6 +95,7 @@ beforeEach(async () => {
   await initGatewayDb();
   getGatewayDb().delete(gwContactChannels).run();
   getGatewayDb().delete(gwContacts).run();
+  resolveAdmissionPolicyImpl = () => null;
 });
 
 afterEach(() => {
@@ -89,7 +108,7 @@ describe("resolve_inbound_trust route", () => {
     expect(route.schema).toBeDefined();
   });
 
-  test("guardian actor → { verdict } matching the resolver output", async () => {
+  test("guardian actor → verdict matching the resolver output", async () => {
     insertContact({
       id: "c-guardian",
       displayName: "The Guardian",
@@ -147,10 +166,42 @@ describe("resolve_inbound_trust route", () => {
     ).toBeUndefined();
   });
 
-  test("resolver throw → resolutionFailed sentinel verdict", async () => {
+  test("response envelope carries the channel's resolved admission policy", async () => {
+    resolveAdmissionPolicyImpl = (channelType) =>
+      channelType === CHANNEL ? "guardian_only" : null;
+
+    const result = (await route.handler({
+      channelType: CHANNEL,
+      actorExternalId: "U_STRANGER",
+    })) as { admissionPolicy: unknown };
+
+    expect(result.admissionPolicy).toBe("guardian_only");
+  });
+
+  test("no-enforcement channel → explicit null admission policy on the envelope", async () => {
+    const result = (await route.handler({
+      channelType: CHANNEL,
+      actorExternalId: "U_STRANGER",
+    })) as { admissionPolicy: unknown };
+
+    expect(result.admissionPolicy).toBeNull();
+  });
+
+  test("a thrown admission-policy read fails the whole call (fail closed, no fabricated null)", async () => {
+    resolveAdmissionPolicyImpl = () => {
+      throw new Error("admission cache not initialized");
+    };
+
+    expect(
+      route.handler({ channelType: CHANNEL, actorExternalId: "U_STRANGER" }),
+    ).rejects.toThrow("admission cache not initialized");
+  });
+
+  test("resolver throw → resolutionFailed sentinel verdict, policy still carried", async () => {
     // Drop the gateway DB connection so resolveTrustVerdict's getGatewayDb()
     // throws.
     resetGatewayDb();
+    resolveAdmissionPolicyImpl = () => "trusted_contacts";
 
     const params = { channelType: CHANNEL, actorExternalId: "U_STRANGER" };
     const result = (await route.handler(params)) as {
@@ -159,11 +210,13 @@ describe("resolve_inbound_trust route", () => {
         canonicalSenderId: string | null;
         resolutionFailed?: boolean;
       };
+      admissionPolicy: unknown;
     };
 
     expect(result.verdict.resolutionFailed).toBe(true);
     expect(result.verdict.trustClass).toBe("unknown");
     expect(result.verdict.canonicalSenderId).toBe("U_STRANGER");
+    expect(result.admissionPolicy).toBe("trusted_contacts");
   });
 
   test("resolver throw with whitespace-only actor id → sentinel canonicalSenderId is null", async () => {

--- a/gateway/src/ipc/trust-verdict-handlers.ts
+++ b/gateway/src/ipc/trust-verdict-handlers.ts
@@ -2,10 +2,11 @@
  * IPC route definitions for gateway-owned per-actor trust verdict reads.
  *
  * Exposes `resolve_inbound_trust` to the assistant daemon over the IPC socket.
- * Resolves the per-actor {@link TrustVerdict} from the gateway ACL DB. This is
- * deliberately a SEPARATE method from `get_channel_admission_policy`: the
- * admission read is channel-scoped + TTL-cached, while this verdict is
- * per-actor and must not share that cache or widen that response.
+ * Resolves the per-actor {@link TrustVerdict} from the gateway ACL DB and
+ * carries the channel's admission policy alongside it as an ENVELOPE field
+ * (resolved from the same store `get_channel_admission_policy` reads), so
+ * voice setup needs a single gateway round-trip. The policy stays off the
+ * shared verdict schema — the verdict is also stamped on every text relay.
  */
 
 import {
@@ -13,6 +14,7 @@ import {
   ResolveInboundTrustRequestSchema,
 } from "@vellumai/gateway-client";
 
+import { resolveAdmissionPolicy } from "../risk/admission-policy-cache.js";
 import { resolveTrustVerdict } from "../risk/trust-verdict-resolver.js";
 import { canonicalSenderIdFor } from "../verification/identity.js";
 import type { IpcRoute } from "./server.js";
@@ -23,17 +25,20 @@ export const trustVerdictRoutes: IpcRoute[] = [
     schema: ResolveInboundTrustRequestSchema,
     handler: async (params?: Record<string, unknown>) => {
       const input = ResolveInboundTrustRequestSchema.parse(params);
-      try {
-        return { verdict: await resolveTrustVerdict(input) };
-      } catch {
-        // Sentinel lets the daemon distinguish a resolver failure from a real
-        // stranger.
-        return {
-          verdict: makeResolutionFailedVerdict(
-            canonicalSenderIdFor(input.channelType, input.actorExternalId),
-          ),
-        };
-      }
+      // Sentinel lets the daemon distinguish a resolver failure from a real
+      // stranger.
+      const verdict = await resolveTrustVerdict(input).catch(() =>
+        makeResolutionFailedVerdict(
+          canonicalSenderIdFor(input.channelType, input.actorExternalId),
+        ),
+      );
+      // A thrown admission read propagates and fails the whole IPC call: the
+      // daemon must deny fail-closed rather than admit on a fabricated null
+      // ("no enforcement") policy.
+      return {
+        verdict,
+        admissionPolicy: resolveAdmissionPolicy(input.channelType),
+      };
     },
   },
 ];

--- a/packages/gateway-client/src/__tests__/trust-verdict-contract.test.ts
+++ b/packages/gateway-client/src/__tests__/trust-verdict-contract.test.ts
@@ -9,6 +9,7 @@ import { SourceMetadataSchema } from "../inbound-contract.js";
 import {
   makeResolutionFailedVerdict,
   makeUnauthenticatedSenderVerdict,
+  ResolveInboundTrustResponseSchema,
   TrustVerdictSchema,
   type TrustVerdict,
 } from "../trust-verdict-contract.js";
@@ -127,5 +128,41 @@ describe("SourceMetadataSchema trustVerdict back-compat", () => {
   test("round-trips a payload carrying trustVerdict", () => {
     const parsed = SourceMetadataSchema.parse({ trustVerdict: fullVerdict });
     expect(parsed.trustVerdict).toEqual(fullVerdict);
+  });
+});
+
+describe("ResolveInboundTrustResponseSchema", () => {
+  test("round-trips a verdict with an admission policy", () => {
+    const parsed = ResolveInboundTrustResponseSchema.parse({
+      verdict: fullVerdict,
+      admissionPolicy: "guardian_only",
+    });
+    expect(parsed).toEqual({
+      verdict: fullVerdict,
+      admissionPolicy: "guardian_only",
+    });
+  });
+
+  test("accepts an explicit null admission policy (no enforcement)", () => {
+    const parsed = ResolveInboundTrustResponseSchema.parse({
+      verdict: fullVerdict,
+      admissionPolicy: null,
+    });
+    expect(parsed.admissionPolicy).toBeNull();
+  });
+
+  test("rejects a missing admission policy field", () => {
+    expect(() =>
+      ResolveInboundTrustResponseSchema.parse({ verdict: fullVerdict }),
+    ).toThrow();
+  });
+
+  test("rejects an out-of-vocabulary admission policy", () => {
+    expect(() =>
+      ResolveInboundTrustResponseSchema.parse({
+        verdict: fullVerdict,
+        admissionPolicy: "everyone",
+      }),
+    ).toThrow();
   });
 });

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -81,6 +81,7 @@ export {
   makeResolutionFailedVerdict,
   makeUnauthenticatedSenderVerdict,
   ResolveInboundTrustRequestSchema,
+  ResolveInboundTrustResponseSchema,
   TRUST_CLASS_VALUES,
   TrustClassSchema,
   TrustVerdictSchema,
@@ -88,6 +89,7 @@ export {
 
 export type {
   ResolveInboundTrustRequest,
+  ResolveInboundTrustResponse,
   TrustClass,
   TrustVerdict,
 } from "./trust-verdict-contract.js";

--- a/packages/gateway-client/src/trust-verdict-contract.ts
+++ b/packages/gateway-client/src/trust-verdict-contract.ts
@@ -16,6 +16,8 @@
 
 import { z } from "zod";
 
+import { AdmissionPolicySchema } from "./admission-policy-contract.js";
+
 /**
  * Verification-purpose trust classification. Mirrors the daemon's
  * `TrustClass` union (`actor-trust-resolver.ts`), ordered most- to
@@ -124,8 +126,7 @@ export function makeUnauthenticatedSenderVerdict(
 
 /**
  * IPC request for `resolve_inbound_trust`. Per-actor identity keys the
- * gateway resolver needs to classify the inbound sender. The response reuses
- * {@link TrustVerdictSchema}.
+ * gateway resolver needs to classify the inbound sender.
  */
 export const ResolveInboundTrustRequestSchema = z.object({
   channelType: z.string().min(1),
@@ -134,4 +135,20 @@ export const ResolveInboundTrustRequestSchema = z.object({
 
 export type ResolveInboundTrustRequest = z.infer<
   typeof ResolveInboundTrustRequestSchema
+>;
+
+/**
+ * IPC response for `resolve_inbound_trust`. The channel admission policy is
+ * an ENVELOPE field, not a {@link TrustVerdictSchema} field: the verdict is
+ * also stamped on every text relay's `sourceMetadata`, which must not carry
+ * this voice-setup-only companion. `admissionPolicy: null` is the gateway's
+ * explicit "no enforcement configured" answer (an admit).
+ */
+export const ResolveInboundTrustResponseSchema = z.object({
+  verdict: TrustVerdictSchema,
+  admissionPolicy: AdmissionPolicySchema.nullable(),
+});
+
+export type ResolveInboundTrustResponse = z.infer<
+  typeof ResolveInboundTrustResponseSchema
 >;


### PR DESCRIPTION
## Summary
- resolve_inbound_trust response carries the channel admission policy; media-stream setup drops the separate admission read
- Guardian display/delivery hints read from the verdict where possible
- Fail-closed posture preserved end to end; voice setup now makes at most 2 gateway reads (was 4)

## Envelope decision
The admission policy rides the IPC RESPONSE envelope (`ResolveInboundTrustResponseSchema`), not `TrustVerdictSchema` — the verdict is also stamped on every text relay's `sourceMetadata`, which must not carry voice-setup-only data. `assistant/openapi.yaml` regenerated with zero diff, confirming text stamps are unchanged.

## Fan-out collapse (4 reads → 1)
- `get_channel_admission_policy` (PR-1 reader): dropped on this path — the policy rides the verdict read, resolved gateway-side from the same store. The reader module stays functional; the voice path was its only production caller.
- `resolve_inbound_trust`: the single remaining read (`readPhoneCallerTrust`).
- Guardian display-name prime (`getGuardianDelivery`): replaced by `verdict.guardianDisplayName` (channel-scoped guardian binding label, stamped independent of the caller). Absent → default guardian reference, same degradation PR 5 accepted for text deny copy.
- `getGuardianDeliveryFresh({phone})` cache warm: deleted — its only remaining phone-key consumers were the persona-resolver userFile fallback hint (primary branch resolves via the verdict-populated `guardianExternalUserId`) and `resolveActorTrust`, which left the voice path in PR 2. Nothing downstream needs the full fresh delivery list on this path.

## Fail-closed composition
- Combined read fails + inbound → `admissionUnavailableDeny` (PR-1 posture, standard deny teardown)
- Combined read fails + outbound → null verdict → router's loud abort → `handleSetupFailure` (PR-2 posture)
- Explicit `admissionPolicy: null` on a successful read still admits with no enforcement
- A thrown gateway-side admission resolution fails the whole IPC call (no fabricated null policy)

Part of plan: acl-hardening-sweep.md (PR 7 of 18)