### PR TITLE
refactor(contacts): typed full-upsert mirror op replaces dualWriteContactToAssistantDb

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -789,8 +789,7 @@ export function mergeContactMirror(params: {
 
 /**
  * Full identity-mirror upsert for the gateway's `contacts_mirror_upsert_full`
- * op — the typed replacement for the gateway's raw dual-write SQL. One
- * transaction; semantics are byte-faithful to the raw writes it replaces:
+ * op. One transaction:
  *
  * - Existing contact: sparse omit-to-preserve UPDATE — only provided fields
  *   change (a partial upsert can't clobber notes/contact_type or revert a

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -788,6 +788,156 @@ export function mergeContactMirror(params: {
 }
 
 /**
+ * Full identity-mirror upsert for the gateway's `contacts_mirror_upsert_full`
+ * op — the typed replacement for the gateway's raw dual-write SQL. One
+ * transaction; semantics are byte-faithful to the raw writes it replaces:
+ *
+ * - Existing contact: sparse omit-to-preserve UPDATE — only provided fields
+ *   change (a partial upsert can't clobber notes/contact_type or revert a
+ *   curated display name).
+ * - Missing contact: INSERT with a generated collision-free user_file slug
+ *   (display name falls back to the first channel address, then "Unknown").
+ * - `assistant_contact_metadata` is upserted only for assistant-type contacts.
+ * - Channels: an existing (type, address NOCASE) row on this contact gets an
+ *   omit-to-preserve external_chat_id refresh; an address owned by ANOTHER
+ *   contact is skipped (never stolen); a new row adopts the gateway-minted
+ *   channel id so both stores share one canonical id.
+ */
+export function upsertContactMirrorFull(params: {
+  contactId: string;
+  displayName?: string;
+  notes?: string | null;
+  contactType?: ContactType;
+  assistantMetadata?: {
+    species: string;
+    metadata?: Record<string, unknown> | null;
+  };
+  channels?: {
+    id?: string;
+    type: string;
+    address: string;
+    isPrimary?: boolean;
+    externalChatId?: string | null;
+  }[];
+}): void {
+  const db = getDb();
+
+  db.transaction((tx) => {
+    const now = Date.now();
+    const existing = tx
+      .select()
+      .from(contacts)
+      .where(eq(contacts.id, params.contactId))
+      .get();
+
+    if (existing) {
+      const updateSet: Record<string, unknown> = { updatedAt: now };
+      if (params.displayName !== undefined) {
+        updateSet.displayName = params.displayName;
+      }
+      if (params.notes !== undefined) updateSet.notes = params.notes;
+      if (params.contactType !== undefined) {
+        updateSet.contactType = params.contactType;
+      }
+      tx.update(contacts)
+        .set(updateSet)
+        .where(eq(contacts.id, params.contactId))
+        .run();
+    } else {
+      const displayName =
+        params.displayName ?? params.channels?.[0]?.address ?? "Unknown";
+      tx.insert(contacts)
+        .values({
+          id: params.contactId,
+          displayName,
+          notes: params.notes ?? null,
+          contactType: params.contactType ?? "human",
+          userFile: generateUserFileSlug(displayName),
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run();
+    }
+
+    if (params.contactType === "assistant" && params.assistantMetadata) {
+      const metadataJson =
+        params.assistantMetadata.metadata != null
+          ? JSON.stringify(params.assistantMetadata.metadata)
+          : null;
+      tx.insert(assistantContactMetadata)
+        .values({
+          contactId: params.contactId,
+          species: params.assistantMetadata.species,
+          metadata: metadataJson,
+        })
+        .onConflictDoUpdate({
+          target: assistantContactMetadata.contactId,
+          set: {
+            species: params.assistantMetadata.species,
+            metadata: metadataJson,
+          },
+        })
+        .run();
+    }
+
+    for (const ch of params.channels ?? []) {
+      const existingCh = tx
+        .select()
+        .from(contactChannels)
+        .where(
+          and(
+            eq(contactChannels.contactId, params.contactId),
+            eq(contactChannels.type, ch.type),
+            sql`${contactChannels.address} = ${ch.address} COLLATE NOCASE`,
+          ),
+        )
+        .get();
+
+      if (existingCh) {
+        // Omit-to-preserve external_chat_id; is_primary is never rewritten on
+        // an existing channel (matches the raw dual-write this op replaces).
+        const updateSet: Record<string, unknown> = { updatedAt: now };
+        if (ch.externalChatId !== undefined) {
+          updateSet.externalChatId = ch.externalChatId;
+        }
+        tx.update(contactChannels)
+          .set(updateSet)
+          .where(eq(contactChannels.id, existingCh.id))
+          .run();
+        continue;
+      }
+
+      const conflict = tx
+        .select({ id: contactChannels.id })
+        .from(contactChannels)
+        .where(
+          and(
+            eq(contactChannels.type, ch.type),
+            sql`${contactChannels.address} = ${ch.address} COLLATE NOCASE`,
+          ),
+        )
+        .get();
+      if (conflict) continue;
+
+      tx.insert(contactChannels)
+        .values({
+          id: ch.id ?? uuid(),
+          contactId: params.contactId,
+          type: ch.type,
+          address: ch.address,
+          isPrimary: ch.isPrimary ?? false,
+          externalChatId: ch.externalChatId ?? null,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run();
+    }
+  });
+
+  notifyContactsChanged();
+}
+
+/**
  * Find a contact by a specific channel address. Returns null if not found.
  * Canonicalizes the address before querying. Uses COLLATE NOCASE to match
  * legacy lowercased rows that migration 290 couldn't restore.

--- a/assistant/src/ipc/routes/__tests__/contacts-mirror-ipc-routes.test.ts
+++ b/assistant/src/ipc/routes/__tests__/contacts-mirror-ipc-routes.test.ts
@@ -9,6 +9,7 @@ import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
 
 const upsertContactChannelCalls: unknown[] = [];
 const upsertContactCalls: unknown[] = [];
+const upsertContactMirrorFullCalls: unknown[] = [];
 const deleteContactCalls: unknown[] = [];
 const mergeContactMirrorCalls: unknown[] = [];
 
@@ -59,6 +60,12 @@ mock.module("../../../contacts/contact-store.js", () => ({
     if (!mockActive) {return realContactStore.deleteContact(...args);}
     deleteContactCalls.push(args[0]);
   },
+  upsertContactMirrorFull: (
+    ...args: Parameters<typeof realContactStore.upsertContactMirrorFull>
+  ) => {
+    if (!mockActive) {return realContactStore.upsertContactMirrorFull(...args);}
+    upsertContactMirrorFullCalls.push(args[0]);
+  },
   mergeContactMirror: (
     ...args: Parameters<typeof realContactStore.mergeContactMirror>
   ) => {
@@ -84,6 +91,7 @@ const {
   CONTACTS_MIRROR_IPC_METHODS,
   handleContactsMirrorUpsertChannel,
   handleContactsMirrorUpsertContact,
+  handleContactsMirrorUpsertFull,
   handleContactsMirrorDeleteContact,
   handleContactsMirrorMergeContact,
   handleContactsMirrorApply,
@@ -97,6 +105,7 @@ const { routeDefinitionsToIpcMethods } = await import("../route-adapter.js");
 const MIRROR_OPERATION_IDS = [
   "contacts_mirror_upsert_channel",
   "contacts_mirror_upsert_contact",
+  "contacts_mirror_upsert_full",
   "contacts_mirror_delete_contact",
   "contacts_mirror_merge_contact",
   "contacts_mirror_apply",
@@ -280,6 +289,50 @@ describe("contacts_mirror_upsert_contact", () => {
   test("rejects a body missing contactId/displayName", () => {
     expect(() =>
       handleContactsMirrorUpsertContact({ body: { contactId: "co-1" } }),
+    ).toThrow();
+  });
+});
+
+describe("contacts_mirror_upsert_full", () => {
+  test("delegates the parsed params to the transactional full-upsert primitive", () => {
+    upsertContactMirrorFullCalls.length = 0;
+    const result = handleContactsMirrorUpsertFull({
+      body: {
+        contactId: "co-full",
+        contactType: "assistant",
+        notes: null,
+        assistantMetadata: { species: "vellum", metadata: { assistantId: "a1" } },
+        channels: [
+          { id: "gw-ch-1", type: "email", address: "a@x.com", isPrimary: true },
+        ],
+      },
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(upsertContactMirrorFullCalls).toEqual([
+      {
+        contactId: "co-full",
+        // displayName omitted → sparse update preserves the mirror's name.
+        displayName: undefined,
+        contactType: "assistant",
+        notes: null,
+        assistantMetadata: { species: "vellum", metadata: { assistantId: "a1" } },
+        channels: [
+          {
+            id: "gw-ch-1",
+            type: "email",
+            address: "a@x.com",
+            isPrimary: true,
+            externalChatId: undefined,
+          },
+        ],
+      },
+    ]);
+  });
+
+  test("rejects a body missing contactId", () => {
+    expect(() =>
+      handleContactsMirrorUpsertFull({ body: { displayName: "X" } }),
     ).toThrow();
   });
 });

--- a/assistant/src/ipc/routes/__tests__/contacts-mirror-upsert-full.test.ts
+++ b/assistant/src/ipc/routes/__tests__/contacts-mirror-upsert-full.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Full identity-mirror upsert IPC (`contacts_mirror_upsert_full`) against the
+ * REAL assistant DB. Pins the semantics of the gateway raw dual-write it
+ * replaces (`dualWriteContactToAssistantDb`): sparse omit-to-preserve contact
+ * update, slug-resolved user_file on create, assistant_contact_metadata
+ * upsert (assistant-type only), channel conflict-skip + gateway-id adoption,
+ * omit-to-preserve external_chat_id — plus the new guarantee: one transaction
+ * (induced-failure rollback).
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { getSqlite } from "../../../persistence/db-connection.js";
+import { initializeDb } from "../../../persistence/db-init.js";
+import { handleContactsMirrorUpsertFull } from "../contacts-mirror-ipc-routes.js";
+
+await initializeDb();
+
+function seedContact(
+  id: string,
+  opts: {
+    displayName?: string;
+    notes?: string | null;
+    userFile?: string | null;
+    contactType?: string;
+  } = {},
+): void {
+  getSqlite()
+    .prepare(
+      "INSERT INTO contacts (id, display_name, notes, user_file, contact_type, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .run(
+      id,
+      opts.displayName ?? `name-${id}`,
+      opts.notes ?? null,
+      opts.userFile ?? null,
+      opts.contactType ?? "human",
+      100,
+      100,
+    );
+}
+
+function seedChannel(
+  id: string,
+  contactId: string,
+  opts: {
+    type?: string;
+    address?: string;
+    isPrimary?: number;
+    externalChatId?: string | null;
+  } = {},
+): void {
+  getSqlite()
+    .prepare(
+      "INSERT INTO contact_channels (id, contact_id, type, address, is_primary, external_chat_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .run(
+      id,
+      contactId,
+      opts.type ?? "slack",
+      opts.address ?? `addr-${id}`,
+      opts.isPrimary ?? 0,
+      opts.externalChatId ?? null,
+      100,
+    );
+}
+
+type ContactRow = {
+  display_name: string;
+  notes: string | null;
+  user_file: string | null;
+  contact_type: string;
+};
+
+function contactRow(id: string): ContactRow | null {
+  return (
+    (getSqlite()
+      .prepare(
+        "SELECT display_name, notes, user_file, contact_type FROM contacts WHERE id = ?",
+      )
+      .get(id) as ContactRow | undefined) ?? null
+  );
+}
+
+type ChannelRow = {
+  id: string;
+  contact_id: string;
+  is_primary: number;
+  external_chat_id: string | null;
+};
+
+function channelByAddress(type: string, address: string): ChannelRow | null {
+  return (
+    (getSqlite()
+      .prepare(
+        "SELECT id, contact_id, is_primary, external_chat_id FROM contact_channels WHERE type = ? AND address = ? COLLATE NOCASE",
+      )
+      .get(type, address) as ChannelRow | undefined) ?? null
+  );
+}
+
+function metadataRow(
+  contactId: string,
+): { species: string; metadata: string | null } | null {
+  return (
+    (getSqlite()
+      .prepare(
+        "SELECT species, metadata FROM assistant_contact_metadata WHERE contact_id = ?",
+      )
+      .get(contactId) as { species: string; metadata: string | null } | undefined) ??
+    null
+  );
+}
+
+function upsertFull(body: Record<string, unknown>): unknown {
+  return handleContactsMirrorUpsertFull({ body });
+}
+
+describe("contacts_mirror_upsert_full", () => {
+  beforeEach(() => {
+    const sqlite = getSqlite();
+    sqlite.exec("DELETE FROM assistant_contact_metadata");
+    sqlite.exec("DELETE FROM contact_channels");
+    sqlite.exec("DELETE FROM contacts");
+  });
+
+  // ── Sparse contact update (omit-to-preserve) ──────────────────────────
+
+  test("sparse update touches only provided fields — omitted ones preserved", () => {
+    seedContact("co-1", {
+      displayName: "Curated Name",
+      notes: "old notes",
+      userFile: "curated.md",
+      contactType: "assistant",
+    });
+
+    expect(upsertFull({ contactId: "co-1", notes: "new notes" })).toEqual({
+      ok: true,
+    });
+
+    expect(contactRow("co-1")).toEqual({
+      display_name: "Curated Name",
+      notes: "new notes",
+      user_file: "curated.md",
+      contact_type: "assistant",
+    });
+  });
+
+  test("displayName-only update preserves notes and never rewrites user_file", () => {
+    seedContact("co-1", { notes: "keep me", userFile: "keep.md" });
+
+    upsertFull({ contactId: "co-1", displayName: "Renamed" });
+
+    const row = contactRow("co-1");
+    expect(row?.display_name).toBe("Renamed");
+    expect(row?.notes).toBe("keep me");
+    expect(row?.user_file).toBe("keep.md");
+  });
+
+  test("explicit null notes clears them (null ≠ omitted)", () => {
+    seedContact("co-1", { notes: "to be cleared" });
+    upsertFull({ contactId: "co-1", notes: null });
+    expect(contactRow("co-1")?.notes).toBeNull();
+  });
+
+  // ── Create path (slug-resolved user_file) ─────────────────────────────
+
+  test("create inserts the full row with a generated user_file slug", () => {
+    upsertFull({
+      contactId: "co-new",
+      displayName: "Alice Smith",
+      notes: "n",
+    });
+
+    expect(contactRow("co-new")).toEqual({
+      display_name: "Alice Smith",
+      notes: "n",
+      user_file: "alice-smith.md",
+      contact_type: "human",
+    });
+  });
+
+  test("create slug is collision-suffixed against existing user_files", () => {
+    seedContact("co-a", { userFile: "alice-smith.md" });
+    upsertFull({ contactId: "co-new", displayName: "Alice Smith" });
+    expect(contactRow("co-new")?.user_file).toBe("alice-smith-2.md");
+  });
+
+  test("create display name falls back to first channel address, then 'Unknown'", () => {
+    upsertFull({
+      contactId: "co-ch",
+      channels: [{ type: "email", address: "a@x.com" }],
+    });
+    expect(contactRow("co-ch")?.display_name).toBe("a@x.com");
+
+    upsertFull({ contactId: "co-bare" });
+    expect(contactRow("co-bare")?.display_name).toBe("Unknown");
+  });
+
+  // ── assistant_contact_metadata upsert ─────────────────────────────────
+
+  test("metadata upsert: insert then conflict-update, assistant contactType only", () => {
+    upsertFull({
+      contactId: "co-bot",
+      displayName: "Bot",
+      contactType: "assistant",
+      assistantMetadata: { species: "vellum", metadata: { assistantId: "a1" } },
+    });
+    expect(metadataRow("co-bot")).toEqual({
+      species: "vellum",
+      metadata: JSON.stringify({ assistantId: "a1" }),
+    });
+
+    // Second call updates in place (ON CONFLICT DO UPDATE).
+    upsertFull({
+      contactId: "co-bot",
+      contactType: "assistant",
+      assistantMetadata: { species: "vellum", metadata: { assistantId: "a2" } },
+    });
+    expect(metadataRow("co-bot")).toEqual({
+      species: "vellum",
+      metadata: JSON.stringify({ assistantId: "a2" }),
+    });
+  });
+
+  test("metadata is gated on contactType 'assistant' — ignored otherwise", () => {
+    upsertFull({
+      contactId: "co-human",
+      displayName: "Human",
+      contactType: "human",
+      assistantMetadata: { species: "vellum" },
+    });
+    expect(metadataRow("co-human")).toBeNull();
+
+    // Omitted contactType is not "assistant" either.
+    upsertFull({
+      contactId: "co-omit",
+      displayName: "Omit",
+      assistantMetadata: { species: "vellum" },
+    });
+    expect(metadataRow("co-omit")).toBeNull();
+  });
+
+  test("null metadata blob is stored as SQL NULL", () => {
+    upsertFull({
+      contactId: "co-bot",
+      displayName: "Bot",
+      contactType: "assistant",
+      assistantMetadata: { species: "openclaw", metadata: null },
+    });
+    expect(metadataRow("co-bot")).toEqual({ species: "openclaw", metadata: null });
+  });
+
+  // ── Channel sync ──────────────────────────────────────────────────────
+
+  test("new channel adopts the gateway-minted id; without one a uuid is minted", () => {
+    seedContact("co-1");
+
+    upsertFull({
+      contactId: "co-1",
+      channels: [
+        { id: "gw-ch-1", type: "email", address: "adopt@x.com", isPrimary: true },
+        { type: "email", address: "minted@x.com" },
+      ],
+    });
+
+    const adopted = channelByAddress("email", "adopt@x.com");
+    expect(adopted?.id).toBe("gw-ch-1");
+    expect(adopted?.is_primary).toBe(1);
+
+    const minted = channelByAddress("email", "minted@x.com");
+    expect(minted?.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    expect(minted?.is_primary).toBe(0);
+  });
+
+  test("conflict-skip: an address owned by another contact is never stolen", () => {
+    seedContact("co-1");
+    seedContact("co-other");
+    seedChannel("ch-other", "co-other", {
+      type: "email",
+      address: "Taken@X.com",
+    });
+
+    // Case-insensitive match — the mirror must skip, not reassign or dupe.
+    upsertFull({
+      contactId: "co-1",
+      channels: [{ id: "gw-new", type: "email", address: "taken@x.com" }],
+    });
+
+    const row = channelByAddress("email", "taken@x.com");
+    expect(row?.id).toBe("ch-other");
+    expect(row?.contact_id).toBe("co-other");
+  });
+
+  test("existing channel: external_chat_id is omit-to-preserve, explicit null clears", () => {
+    seedContact("co-1");
+    seedChannel("ch-1", "co-1", {
+      type: "telegram",
+      address: "tg-1",
+      externalChatId: "chat-9",
+    });
+
+    // Omitted → preserved.
+    upsertFull({
+      contactId: "co-1",
+      channels: [{ type: "telegram", address: "tg-1" }],
+    });
+    expect(channelByAddress("telegram", "tg-1")?.external_chat_id).toBe("chat-9");
+
+    // Provided → overwritten.
+    upsertFull({
+      contactId: "co-1",
+      channels: [{ type: "telegram", address: "tg-1", externalChatId: "chat-10" }],
+    });
+    expect(channelByAddress("telegram", "tg-1")?.external_chat_id).toBe("chat-10");
+
+    // Explicit null → cleared.
+    upsertFull({
+      contactId: "co-1",
+      channels: [{ type: "telegram", address: "tg-1", externalChatId: null }],
+    });
+    expect(channelByAddress("telegram", "tg-1")?.external_chat_id).toBeNull();
+  });
+
+  test("existing channel: is_primary is never rewritten (raw dual-write parity)", () => {
+    seedContact("co-1");
+    seedChannel("ch-1", "co-1", {
+      type: "email",
+      address: "p@x.com",
+      isPrimary: 1,
+    });
+
+    upsertFull({
+      contactId: "co-1",
+      channels: [{ type: "email", address: "p@x.com", isPrimary: false }],
+    });
+
+    expect(channelByAddress("email", "p@x.com")?.is_primary).toBe(1);
+  });
+
+  // ── Validation + atomicity ────────────────────────────────────────────
+
+  test("rejects a body missing contactId", () => {
+    expect(() => upsertFull({ displayName: "No Id" })).toThrow();
+  });
+
+  test("rolls back the WHOLE upsert when a late channel step fails", () => {
+    seedContact("co-1", { displayName: "Before" });
+    seedContact("co-other");
+    // A row already holding the gateway id under a DIFFERENT (type, address):
+    // the INSERT collides on the primary key and must abort the transaction.
+    seedChannel("gw-dup", "co-other", { type: "slack", address: "elsewhere" });
+
+    expect(() =>
+      upsertFull({
+        contactId: "co-1",
+        displayName: "After",
+        channels: [{ id: "gw-dup", type: "email", address: "fresh@x.com" }],
+      }),
+    ).toThrow();
+
+    // Nothing applied — the contact rename rolled back with the channel.
+    expect(contactRow("co-1")?.display_name).toBe("Before");
+    expect(channelByAddress("email", "fresh@x.com")).toBeNull();
+  });
+});

--- a/assistant/src/ipc/routes/contacts-mirror-ipc-routes.ts
+++ b/assistant/src/ipc/routes/contacts-mirror-ipc-routes.ts
@@ -17,6 +17,7 @@ import {
   deleteContact,
   mergeContactMirror,
   upsertContact,
+  upsertContactMirrorFull,
 } from "../../contacts/contact-store.js";
 import { upsertContactChannel } from "../../contacts/contacts-write.js";
 import { getDb } from "../../persistence/db-connection.js";
@@ -148,6 +149,48 @@ function applyDeleteContact(
   deleteContact(params.contactId);
 }
 
+const UpsertFullChannelSchema = z.object({
+  // Gateway-minted channel id, adopted on INSERT so both stores share one
+  // canonical id for the same logical channel; omit to mint one.
+  id: z.string().min(1).optional(),
+  type: z.string().min(1),
+  address: z.string().min(1),
+  isPrimary: z.boolean().optional(),
+  // Omit to preserve an existing channel's external_chat_id; explicit null
+  // clears it; a new channel defaults to null.
+  externalChatId: z.string().nullable().optional(),
+});
+
+const UpsertFullParamsSchema = z.object({
+  contactId: z.string().min(1),
+  // Sparse: omitted on update preserves the mirror's name; a create falls
+  // back to the first channel address, then "Unknown".
+  displayName: z.string().optional(),
+  contactType: ContactTypeSchema.optional(),
+  notes: z.string().nullable().optional(),
+  assistantMetadata: z
+    .object({
+      species: z.string().min(1),
+      metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+    })
+    .optional(),
+  channels: z.array(UpsertFullChannelSchema).optional(),
+});
+
+/**
+ * Full contact + channels identity-mirror upsert — the typed replacement for
+ * the gateway's raw dual-write (`dualWriteContactToAssistantDb`). One daemon
+ * transaction; sparse omit-to-preserve update, slug-resolved user_file on
+ * create, assistant_contact_metadata upsert, and channel conflict-skip /
+ * gateway-id-adoption sync (see `upsertContactMirrorFull`).
+ */
+export function handleContactsMirrorUpsertFull({
+  body = {},
+}: RouteHandlerArgs) {
+  upsertContactMirrorFull(UpsertFullParamsSchema.parse(body));
+  return { ok: true };
+}
+
 const MergeContactParamsSchema = z.object({
   keepContactId: z.string().min(1),
   mergeContactId: z.string().min(1),
@@ -230,6 +273,7 @@ export const CONTACTS_MIRROR_IPC_METHODS: Record<
 > = {
   contacts_mirror_upsert_channel: handleContactsMirrorUpsertChannel,
   contacts_mirror_upsert_contact: handleContactsMirrorUpsertContact,
+  contacts_mirror_upsert_full: handleContactsMirrorUpsertFull,
   contacts_mirror_delete_contact: handleContactsMirrorDeleteContact,
   contacts_mirror_merge_contact: handleContactsMirrorMergeContact,
   contacts_mirror_apply: handleContactsMirrorApply,

--- a/assistant/src/ipc/routes/contacts-mirror-ipc-routes.ts
+++ b/assistant/src/ipc/routes/contacts-mirror-ipc-routes.ts
@@ -178,10 +178,9 @@ const UpsertFullParamsSchema = z.object({
 });
 
 /**
- * Full contact + channels identity-mirror upsert — the typed replacement for
- * the gateway's raw dual-write (`dualWriteContactToAssistantDb`). One daemon
- * transaction; sparse omit-to-preserve update, slug-resolved user_file on
- * create, assistant_contact_metadata upsert, and channel conflict-skip /
+ * Full contact + channels identity-mirror upsert. One daemon transaction;
+ * sparse omit-to-preserve update, slug-resolved user_file on create,
+ * assistant_contact_metadata upsert, and channel conflict-skip /
  * gateway-id-adoption sync (see `upsertContactMirrorFull`).
  */
 export function handleContactsMirrorUpsertFull({

--- a/gateway/src/__tests__/contact-prompt-submit.test.ts
+++ b/gateway/src/__tests__/contact-prompt-submit.test.ts
@@ -5,11 +5,12 @@
  * - Guardian prompts always bind to the existing guardian contact.
  * - Guardian prompts conflict (409) when the channel belongs to another contact.
  * - Non-guardian prompts create or reuse contacts via channel lookup.
- * - All writes are dual-written to the gateway DB.
+ * - The gateway DB is the source of truth; the assistant identity mirror is
+ *   driven over typed `contacts_mirror_*` IPC ops (asserted by payload — the
+ *   daemon-side write semantics are pinned in the daemon's mirror suites).
  */
 import {
   afterAll,
-  afterEach,
   beforeAll,
   beforeEach,
   describe,
@@ -18,41 +19,26 @@ import {
   spyOn,
   test,
 } from "bun:test";
-import { Database } from "bun:sqlite";
 
 import { initSigningKey } from "../auth/token-service.js";
 
 initSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long-xx"));
 
 // ---------------------------------------------------------------------------
-// Mock assistant DB proxy with a real in-memory SQLite.
+// Mock IPC so mirror ops + resolve_contact_prompt don't dial a real socket.
+// Method name → error to throw on the next call to it (mirror-failure tests).
 // ---------------------------------------------------------------------------
 
-let testAssistantDb: Database | null = null;
+const ipcThrowOn = new Map<string, Error>();
 
-mock.module("../db/assistant-db-proxy.js", () => ({
-  async assistantDbQuery(sql: string, bind?: any[]) {
-    if (!testAssistantDb) throw new Error("test assistant DB not initialized");
-    const stmt = testAssistantDb.prepare(sql);
-    return bind ? stmt.all(...bind) : stmt.all();
-  },
-
-  async assistantDbRun(sql: string, bind?: any[]) {
-    if (!testAssistantDb) throw new Error("test assistant DB not initialized");
-    const stmt = testAssistantDb.prepare(sql);
-    const result = bind ? stmt.run(...bind) : stmt.run();
-    return {
-      changes: result.changes,
-      lastInsertRowid: Number(result.lastInsertRowid),
-    };
-  },
-}));
-
-// ---------------------------------------------------------------------------
-// Mock IPC so resolve_contact_prompt doesn't try to dial a real socket.
-// ---------------------------------------------------------------------------
-
-const ipcMock = mock(async () => ({ resolved: true }));
+const ipcMock = mock(async (method: string) => {
+  const err = ipcThrowOn.get(method);
+  if (err) {
+    ipcThrowOn.delete(method);
+    throw err;
+  }
+  return { resolved: true };
+});
 
 // Spread the actual module so untouched exports (IpcHandlerError,
 // IpcTransportError, ipcSuggestTrustRule) stay importable by later-loaded
@@ -75,52 +61,6 @@ const { contactChannels: gwContactChannels, contacts: gwContacts } =
   await import("../db/schema.js");
 const { ContactStore } = await import("../db/contact-store.js");
 const { eq } = await import("drizzle-orm");
-
-// ---------------------------------------------------------------------------
-// Schema helpers
-// ---------------------------------------------------------------------------
-
-function initAssistantDb(): Database {
-  const db = new Database(":memory:");
-  db.exec("PRAGMA foreign_keys=ON");
-  db.exec(`
-    CREATE TABLE contacts (
-      id TEXT PRIMARY KEY,
-      display_name TEXT NOT NULL,
-      notes TEXT,
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL,
-      role TEXT NOT NULL DEFAULT 'contact',
-      principal_id TEXT,
-      user_file TEXT,
-      contact_type TEXT NOT NULL DEFAULT 'human'
-    )
-  `);
-  db.exec(`
-    CREATE TABLE contact_channels (
-      id TEXT PRIMARY KEY,
-      contact_id TEXT NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
-      type TEXT NOT NULL,
-      address TEXT NOT NULL,
-      is_primary INTEGER NOT NULL DEFAULT 0,
-      external_user_id TEXT,
-      external_chat_id TEXT,
-      status TEXT NOT NULL DEFAULT 'unverified',
-      policy TEXT NOT NULL DEFAULT 'allow',
-      verified_at INTEGER,
-      verified_via TEXT,
-      invite_id TEXT,
-      revoked_reason TEXT,
-      blocked_reason TEXT,
-      updated_at INTEGER,
-      created_at INTEGER NOT NULL
-    )
-  `);
-  db.exec(
-    `CREATE UNIQUE INDEX idx_contact_channels_type_address ON contact_channels(type, address)`,
-  );
-  return db;
-}
 
 // ---------------------------------------------------------------------------
 // Request factory
@@ -181,17 +121,12 @@ afterAll(() => {
 });
 
 beforeEach(() => {
-  testAssistantDb = initAssistantDb();
   ipcMock.mockClear();
+  ipcThrowOn.clear();
 
   const gwDb = getGatewayDb();
   gwDb.delete(gwContactChannels).run();
   gwDb.delete(gwContacts).run();
-});
-
-afterEach(() => {
-  testAssistantDb?.close();
-  testAssistantDb = null;
 });
 
 // ---------------------------------------------------------------------------
@@ -199,9 +134,9 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("handleContactPromptSubmit", () => {
-  // Seed a guardian contact into BOTH the gateway DB (source of truth) and the
-  // assistant DB mirror. The handler resolves the guardian from the gateway DB;
-  // the assistant row keeps the FK for the best-effort channel mirror.
+  // Seed a guardian contact into the gateway DB (source of truth). The
+  // assistant identity mirror is not modeled here — mirror writes are
+  // asserted as typed IPC payloads.
   function seedGuardian(id = "guardian-1", name = "Vargas"): void {
     const now = Date.now();
     getGatewayDb()
@@ -214,11 +149,6 @@ describe("handleContactPromptSubmit", () => {
         updatedAt: now,
       })
       .run();
-    testAssistantDb!.run(
-      `INSERT INTO contacts (id, display_name, role, contact_type, created_at, updated_at)
-       VALUES (?, ?, 'guardian', 'human', ?, ?)`,
-      [id, name, now, now],
-    );
   }
 
   test("guardian prompt — binds channel to existing gateway guardian, role preserved", async () => {
@@ -365,11 +295,8 @@ describe("handleContactPromptSubmit", () => {
     expect(gwChannels[0].id).toBe("chan-other");
     expect(gwChannels[0].contactId).toBe("other-1");
 
-    // No assistant-DB channel write occurred for that address either.
-    const asChannels = testAssistantDb!
-      .prepare(`SELECT id FROM contact_channels WHERE address = ?`)
-      .all("+12125550123") as { id: string }[];
-    expect(asChannels).toHaveLength(0);
+    // No mirror op fired either — the conflict aborts before any upsert.
+    expect(callsFor(ipcMock, "contacts_mirror_upsert_full")).toHaveLength(0);
 
     // IPC should have been called with an error so the CLI doesn't hang.
     expect(ipcMock).toHaveBeenCalledTimes(1);
@@ -381,31 +308,24 @@ describe("handleContactPromptSubmit", () => {
     expectNoEmit(ipcMock);
   });
 
-  test("guardian prompt — accepted even when assistant-DB mirror throws (gateway-first)", async () => {
+  test("guardian prompt — accepted even when the mirror op throws (gateway-first)", async () => {
     seedGuardian();
 
-    // Make the best-effort assistant-DB mirror fail. The gateway-first write
+    // Make the best-effort typed mirror op fail. The gateway-first write
     // must still succeed and the request still be accepted.
-    const realDb = testAssistantDb!;
-    testAssistantDb = {
-      prepare() {
-        throw new Error("assistant DB mirror unavailable");
-      },
-    } as unknown as Database;
+    ipcThrowOn.set(
+      "contacts_mirror_upsert_full",
+      new Error("assistant DB mirror unavailable"),
+    );
 
-    let res: Response;
-    try {
-      res = await handleContactPromptSubmit(
-        makeRequest({
-          requestId: "req-mirror-g",
-          address: "+12125550124",
-          channelType: "phone",
-          role: "guardian",
-        }),
-      );
-    } finally {
-      testAssistantDb = realDb;
-    }
+    const res = await handleContactPromptSubmit(
+      makeRequest({
+        requestId: "req-mirror-g",
+        address: "+12125550124",
+        channelType: "phone",
+        role: "guardian",
+      }),
+    );
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as Record<string, unknown>;
@@ -503,14 +423,13 @@ describe("handleContactPromptSubmit", () => {
     expectEmittedContactsChanged(ipcMock);
   });
 
-  test("non-guardian prompt — mirrors the new channel into the post-317 assistant DB (no dropped-column write)", async () => {
-    // Regression: the assistant DB dropped interaction_count/last_seen_at/
-    // last_interaction (migration 317). The dual-write mirror INSERT must write
-    // only surviving columns; a dropped-column reference would throw and be
-    // swallowed by the best-effort catch, silently stranding the mirror row.
+  test("non-guardian prompt — one contacts_mirror_upsert_full op carries the gateway contact + channel ids", async () => {
+    // The identity mirror is ONE typed transactional op; it must ship the
+    // just-written gateway ids so the daemon-side rows adopt them (daemon
+    // write semantics pinned in contacts-mirror-upsert-full.test.ts).
     const res = await handleContactPromptSubmit(
       makeRequest({
-        requestId: "req-mirror-317",
+        requestId: "req-mirror-op",
         address: "carol@example.com",
         channelType: "email",
         role: "trusted-contact",
@@ -527,51 +446,39 @@ describe("handleContactPromptSubmit", () => {
       .all();
     expect(gwChannelRows).toHaveLength(1);
 
-    // The mirror INSERT succeeded against the post-317 schema: the assistant DB
-    // has the channel row under the same gateway contact + channel id.
-    const asChannels = testAssistantDb!
-      .prepare(
-        `SELECT id, contact_id AS contactId, type, address, is_primary AS isPrimary
-           FROM contact_channels WHERE address = ?`,
-      )
-      .all("carol@example.com") as {
-      id: string;
-      contactId: string;
+    const mirror = callsFor(ipcMock, "contacts_mirror_upsert_full");
+    expect(mirror).toHaveLength(1);
+    expect(mirror[0].body.contactId).toBe(gwChannelRows[0].contactId);
+    const channels = mirror[0].body.channels as {
+      id?: string;
       type: string;
       address: string;
-      isPrimary: number;
+      isPrimary?: boolean;
     }[];
-    expect(asChannels).toHaveLength(1);
-    expect(asChannels[0].id).toBe(gwChannelRows[0].id);
-    expect(asChannels[0].contactId).toBe(gwChannelRows[0].contactId);
-    expect(asChannels[0].type).toBe("email");
-    expect(asChannels[0].isPrimary).toBe(1);
+    expect(channels).toHaveLength(1);
+    expect(channels[0].id).toBe(gwChannelRows[0].id);
+    expect(channels[0].type).toBe("email");
+    expect(channels[0].address).toBe("carol@example.com");
+    expect(channels[0].isPrimary).toBe(true);
   });
 
-  test("non-guardian prompt — accepted even when assistant-DB mirror throws (gateway-first)", async () => {
-    // Make the best-effort assistant-DB mirror fail. The gateway-first write
+  test("non-guardian prompt — accepted even when the mirror op throws (gateway-first)", async () => {
+    // Make the best-effort typed mirror op fail. The gateway-first write
     // must still succeed and the request still be accepted.
-    const realDb = testAssistantDb!;
-    testAssistantDb = {
-      prepare() {
-        throw new Error("assistant DB mirror unavailable");
-      },
-    } as unknown as Database;
+    ipcThrowOn.set(
+      "contacts_mirror_upsert_full",
+      new Error("assistant DB mirror unavailable"),
+    );
 
-    let res: Response;
-    try {
-      res = await handleContactPromptSubmit(
-        makeRequest({
-          requestId: "req-mirror",
-          address: "bob@example.com",
-          channelType: "email",
-          role: "trusted-contact",
-          displayName: "Bob",
-        }),
-      );
-    } finally {
-      testAssistantDb = realDb;
-    }
+    const res = await handleContactPromptSubmit(
+      makeRequest({
+        requestId: "req-mirror",
+        address: "bob@example.com",
+        channelType: "email",
+        role: "trusted-contact",
+        displayName: "Bob",
+      }),
+    );
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as Record<string, unknown>;
@@ -691,25 +598,8 @@ describe("handleContactPromptSubmit", () => {
     expect(gwContactRows[0].displayName).toBe("Alice");
   });
 
-  test("gateway DB receives dual-write for new contact and channel", async () => {
-    const now = Date.now();
-    testAssistantDb!.run(
-      `INSERT INTO contacts (id, display_name, role, contact_type, created_at, updated_at)
-       VALUES ('guardian-1', 'Vargas', 'guardian', 'human', ?, ?)`,
-      [now, now],
-    );
-
-    // Also seed guardian in gateway DB so FK is satisfied.
-    getGatewayDb()
-      .insert(gwContacts)
-      .values({
-        id: "guardian-1",
-        displayName: "Vargas",
-        role: "guardian",
-        createdAt: now,
-        updatedAt: now,
-      })
-      .run();
+  test("gateway DB receives the new channel bound to the existing guardian", async () => {
+    seedGuardian();
 
     await handleContactPromptSubmit(
       makeRequest({
@@ -729,12 +619,13 @@ describe("handleContactPromptSubmit", () => {
     expect(gwChannels[0].contactId).toBe("guardian-1");
   });
 
-  test("guardian prompt — reuse path heals the assistant-DB mirror channel", async () => {
+  test("guardian prompt — reuse path fires the mirror-heal upsert op with the existing channel id", async () => {
     const now = Date.now();
     seedGuardian();
-    // Gateway channel already bound to the guardian (the reuse precondition),
-    // but the assistant-DB mirror has NO channel row — simulating a mirror that
-    // was unavailable when the channel was first bound.
+    // Gateway channel already bound to the guardian (the reuse precondition).
+    // The reuse path still runs upsertContact so a mirror that missed the
+    // original bind is healed by the typed op (daemon-side upsert pinned in
+    // contacts-mirror-upsert-full.test.ts).
     getGatewayDb()
       .insert(gwContactChannels)
       .values({
@@ -750,13 +641,6 @@ describe("handleContactPromptSubmit", () => {
         updatedAt: now,
       })
       .run();
-
-    // Precondition: assistant mirror has no channel for this address.
-    expect(
-      testAssistantDb!
-        .prepare(`SELECT id FROM contact_channels WHERE address = ?`)
-        .all("+15551112222"),
-    ).toHaveLength(0);
 
     const res = await handleContactPromptSubmit(
       makeRequest({
@@ -780,13 +664,14 @@ describe("handleContactPromptSubmit", () => {
     expect(gwChannels).toHaveLength(1);
     expect(gwChannels[0].id).toBe("chan-reuse");
 
-    // The reuse path called upsertContact, which healed the assistant-DB
-    // mirror: a channel row for the address now exists under the guardian.
-    const asChannels = testAssistantDb!
-      .prepare(`SELECT contact_id FROM contact_channels WHERE address = ?`)
-      .all("+15551112222") as { contact_id: string }[];
-    expect(asChannels).toHaveLength(1);
-    expect(asChannels[0].contact_id).toBe("guardian-1");
+    // The mirror-heal op targets the guardian and ships the existing gateway
+    // channel id for daemon-side id alignment.
+    const mirror = callsFor(ipcMock, "contacts_mirror_upsert_full");
+    expect(mirror).toHaveLength(1);
+    expect(mirror[0].body.contactId).toBe("guardian-1");
+    const channels = mirror[0].body.channels as { id?: string }[];
+    expect(channels).toHaveLength(1);
+    expect(channels[0].id).toBe("chan-reuse");
 
     const ipcCall = resolveCall(ipcMock);
     expect(ipcCall.body.channelId).toBe("chan-reuse");
@@ -857,7 +742,7 @@ describe("handleContactPromptSubmit", () => {
     expectEmittedContactsChanged(ipcMock);
   });
 
-  test("guardian bootstrap-create — gateway is authoritative; assistant mirror row exists without ACL role", async () => {
+  test("guardian bootstrap-create — gateway is authoritative; no ACL role crosses the mirror ops", async () => {
     const res = await handleContactPromptSubmit(
       makeRequest({
         requestId: "req-boot-role",
@@ -879,13 +764,17 @@ describe("handleContactPromptSubmit", () => {
       .all();
     expect(gwGuardians).toHaveLength(1);
 
-    // Assistant mirror is an identity mirror only — the row exists but no ACL
-    // role is written through, so it falls back to the schema default 'contact'.
-    const asContacts = testAssistantDb!
-      .prepare(`SELECT role FROM contacts WHERE id = ?`)
-      .all(gwGuardians[0].id) as { role: string }[];
-    expect(asContacts).toHaveLength(1);
-    expect(asContacts[0].role).toBe("contact");
+    // The identity mirror carries no ACL role: neither the contact-create op
+    // nor the channel-bind op includes one.
+    const mirrorBodies = [
+      ...callsFor(ipcMock, "contacts_mirror_upsert_contact"),
+      ...callsFor(ipcMock, "contacts_mirror_upsert_full"),
+    ];
+    expect(mirrorBodies.length).toBeGreaterThanOrEqual(1);
+    for (const call of mirrorBodies) {
+      expect(call.body.contactId).toBe(gwGuardians[0].id);
+      expect("role" in call.body).toBe(false);
+    }
   });
 
   test("non-guardian prompt — 500 + daemon error when channel can't be resolved (no empty channelId)", async () => {

--- a/gateway/src/__tests__/db-proxy-allowlist.test.ts
+++ b/gateway/src/__tests__/db-proxy-allowlist.test.ts
@@ -24,9 +24,9 @@ const ALLOWLIST = new Set<string>([
   // The proxy definition itself (calls ipcCallAssistant("db_proxy")).
   "db/assistant-db-proxy.ts",
 
-  // Contact dual-write cluster (dualWriteContactToAssistantDb) — the last raw
-  // writes in the file; the merge mirror is now a typed transactional op.
-  "db/contact-store.ts",
+  // contact-store.ts is drained: its merge + upsert mirrors are typed ops
+  // (`contacts_mirror_merge_contact` / `contacts_mirror_upsert_full`). The
+  // migrations-only banner rewrite lands in the follow-up PR.
 ]);
 
 // Data migrations run one-time backfills through the same proxy and touch

--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -343,9 +343,9 @@ describe("IPC contact routes", () => {
   // create_contact (gateway DB source of truth via ContactStore.upsertContact)
   // -------------------------------------------------------------------------
   //
-  // No assistant daemon runs in these tests, so the best-effort assistant-DB
-  // dual-write inside upsertContact soft-fails. The gateway write still
-  // succeeds and { contactId, channelId } is returned regardless.
+  // No assistant daemon runs in these tests: the best-effort typed mirror op
+  // inside upsertContact resolves against the mocked IPC client. The gateway
+  // write succeeds and { contactId, channelId } is returned regardless.
 
   test("create_contact writes the gateway DB contacts + contact_channels rows", async () => {
     await startServerAndConnect();
@@ -592,10 +592,11 @@ describe("IPC contact routes", () => {
     expect(store.getContact("rename-c1")!.displayName).toBe("New Name");
   });
 
-  test("create_contact retry does not overwrite the assistant-DB display_name when omitted", async () => {
-    // Gap A: the gateway row exists with a stale name; the assistant DB holds
-    // the user's current (different) name. A retry WITHOUT displayName must
-    // leave the assistant-DB name untouched — the UPDATE must omit display_name.
+  test("create_contact retry omits displayName from the mirror op when not supplied", async () => {
+    // Gap A: the gateway row exists with a stale name; the assistant mirror
+    // may hold the user's current (different) name. A retry WITHOUT
+    // displayName must keep the mirror op sparse — no displayName key — so
+    // the daemon-side omit-to-preserve update can't revert the mirror's name.
     const db = getGatewayDb();
     const now = Date.now();
     db.insert(contacts)
@@ -622,17 +623,13 @@ describe("IPC contact routes", () => {
       })
       .run();
 
-    // Assistant DB has the contact (so the mirror takes the UPDATE branch).
-    assistantDbQueryMock = mock(async (sql: string) => {
-      if (sql.includes("FROM contacts WHERE id = ?")) {
-        return [{ userFile: "current-name.md" }];
-      }
-      return [];
-    });
-    const runCalls: { sql: string; bind?: unknown[] }[] = [];
-    assistantDbRunMock = mock(async (sql: string, bind?: unknown[]) => {
-      runCalls.push({ sql, bind });
-      return { changes: 1, lastInsertRowid: 0 };
+    const ipcCalls: { method: string; body?: Record<string, unknown> }[] = [];
+    ipcCallAssistantMock = mock(async (method, params) => {
+      ipcCalls.push({
+        method,
+        body: params?.body as Record<string, unknown> | undefined,
+      });
+      return {};
     });
 
     await startServerAndConnect();
@@ -643,13 +640,16 @@ describe("IPC contact routes", () => {
 
     expect(res.error).toBeUndefined();
 
-    // The assistant-DB contact UPDATE must NOT touch display_name.
-    const contactUpdate = runCalls.find(
-      (c) =>
-        c.sql.includes("UPDATE contacts") && c.sql.includes("WHERE id = ?"),
+    const mirror = ipcCalls.filter(
+      (c) => c.method === "contacts_mirror_upsert_full",
     );
-    expect(contactUpdate).toBeDefined();
-    expect(contactUpdate!.sql).not.toContain("display_name");
+    expect(mirror).toHaveLength(1);
+    // undefined = omitted: JSON serialization drops it on the wire, and the
+    // daemon's sparse update only applies fields that are !== undefined.
+    expect(mirror[0].body!.displayName).toBeUndefined();
+    // The existing gateway channel id ships for daemon-side id alignment.
+    const channels = mirror[0].body!.channels as { id?: string }[];
+    expect(channels[0].id).toBe("stale-ch1");
 
     // The gateway row's stale name is likewise preserved (omit-to-preserve).
     expect(new ContactStore(db).getContact("stale-c1")!.displayName).toBe(
@@ -657,11 +657,12 @@ describe("IPC contact routes", () => {
     );
   });
 
-  test("upsertContact with an explicit id does NOT retarget another contact's metadata", async () => {
-    // Update path (Problem 2): an edit carries a channel whose (type,address)
-    // is owned by a DIFFERENT assistant contact. The assistant mirror must
-    // target the provided id — never the other contact — matching the gateway
-    // syncChannels skip-on-cross-contact behavior.
+  test("upsertContact with an explicit id keys the mirror op to that id (no retargeting)", async () => {
+    // Update path (Problem 2): the mirror op must always target the provided
+    // gateway id — never another contact — matching the gateway syncChannels
+    // skip-on-cross-contact behavior. The daemon-side conflict-skip for a
+    // channel owned by a different mirror contact is pinned in the daemon's
+    // contacts-mirror-upsert-full suite.
     const db = getGatewayDb();
     const now = Date.now();
     db.insert(contacts)
@@ -675,25 +676,13 @@ describe("IPC contact routes", () => {
       })
       .run();
 
-    // The assistant DB reports the channel is owned by "other-contact" and the
-    // edited contact already exists by id.
-    assistantDbQueryMock = mock(async (sql: string, bind?: unknown[]) => {
-      if (
-        sql.includes("FROM contact_channels cc") &&
-        sql.includes("WHERE cc.type = ?")
-      ) {
-        return [{ contactId: "other-contact", displayName: "Other" }];
-      }
-      if (sql.includes("FROM contacts WHERE id = ?")) {
-        if (bind?.[0] === "edit-me") return [{ userFile: "edit-me.md" }];
-        return [];
-      }
-      return [];
-    });
-    const runCalls: { sql: string; bind?: unknown[] }[] = [];
-    assistantDbRunMock = mock(async (sql: string, bind?: unknown[]) => {
-      runCalls.push({ sql, bind });
-      return { changes: 1, lastInsertRowid: 0 };
+    const ipcCalls: { method: string; body?: Record<string, unknown> }[] = [];
+    ipcCallAssistantMock = mock(async (method, params) => {
+      ipcCalls.push({
+        method,
+        body: params?.body as Record<string, unknown> | undefined,
+      });
+      return {};
     });
 
     const store = new ContactStore(db);
@@ -703,14 +692,13 @@ describe("IPC contact routes", () => {
       channels: [{ type: "email", address: "shared@example.com" }],
     });
 
-    // The assistant contact UPDATE targets the provided id, never "other-contact".
-    const contactUpdate = runCalls.find(
-      (c) =>
-        c.sql.includes("UPDATE contacts") && c.sql.includes("WHERE id = ?"),
+    const mirror = ipcCalls.filter(
+      (c) => c.method === "contacts_mirror_upsert_full",
     );
-    expect(contactUpdate).toBeDefined();
-    expect(contactUpdate!.bind?.at(-1)).toBe("edit-me");
-    expect(runCalls.some((c) => c.bind?.includes("other-contact"))).toBe(false);
+    expect(mirror).toHaveLength(1);
+    expect(mirror[0].body!.contactId).toBe("edit-me");
+    expect(mirror[0].body!.displayName).toBe("New Name");
+    expect(JSON.stringify(mirror[0].body)).not.toContain("other-contact");
   });
 
   test("upsertContact read-back sources ACL from the gateway DB, not assistant defaults", async () => {

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -7,11 +7,6 @@ import {
   type ContactRead,
 } from "@vellumai/gateway-client/gateway-ipc-contracts";
 
-import {
-  type SqliteValue,
-  assistantDbQuery,
-  assistantDbRun,
-} from "./assistant-db-proxy.js";
 import { type GatewayDb, getGatewayDb } from "./connection.js";
 import { contacts, contactChannels, ingressInvites } from "./schema.js";
 import {
@@ -1078,23 +1073,23 @@ export class ContactStore {
   }
 
   // ---------------------------------------------------------------------------
-  // Upsert (gateway DB + assistant DB dual-write)
+  // Upsert (gateway DB + typed assistant mirror)
   // ---------------------------------------------------------------------------
 
   /**
-   * Upsert a contact + channels in the gateway DB and dual-write the same
-   * change to the assistant DB (best-effort).
+   * Upsert a contact + channels in the gateway DB and mirror the same change
+   * to the assistant DB via the typed `contacts_mirror_upsert_full` op
+   * (best-effort).
    *
    * Resolution order (mirrors the assistant's upsertContact):
    *  1. Match by `params.id` if provided.
    *  2. Match by (type, address) on a provided channel in the gateway DB.
-   *  3. Create: adopt an existing assistant-DB contact id for the same channel
-   *     (canonical-id heal), else mint a fresh id.
+   *  3. Create: mint a fresh id.
    *
-   * Steps 2 and 3 (channel-match + assistant-id adoption) run on the create
-   * path only — when no explicit `id` is supplied. An explicit id is an update
-   * and keys the gateway row + assistant mirror to that id directly, so an edit
-   * can't retarget another contact's metadata.
+   * Step 2 runs on the create path only — when no explicit `id` is supplied.
+   * An explicit id is an update and keys the gateway row + assistant mirror
+   * to that id directly, so an edit can't retarget another contact's
+   * metadata.
    *
    * Channel sync follows the same no-reassignment path: existing channels
    * on the same contact are updated; conflicting channels on a different
@@ -1103,11 +1098,11 @@ export class ContactStore {
    * The gateway DB is the source of truth for auth/authz fields (id,
    * displayName, role, principalId). The assistant DB receives a mirrored
    * write for the assistant-only columns (notes, userFile, contactType,
-   * assistantContactMetadata) plus a copy of the channel rows. The
-   * assistant-DB dual-write is best-effort: failures are logged but do not
-   * fail the call. The returned `contact` shape is read back from the
-   * assistant DB when available, falling back to a synthetic shape built
-   * from the gateway row on any read-back failure.
+   * assistantContactMetadata) plus a copy of the channel rows. The mirror is
+   * best-effort: failures are logged but do not fail the call. The returned
+   * `contact` shape is read back with the info overlay when available,
+   * falling back to a synthetic shape built from the gateway row on any
+   * read-back failure.
    *
    * SECURITY: `role` and `principalId` are intentionally NOT accepted as
    * inputs. They are auth/authz fields owned by guardian-bootstrap (raw
@@ -1152,8 +1147,8 @@ export class ContactStore {
     let created = false;
 
     // Canonicalize all channel addresses up front so every downstream path
-    // (gateway DB, assistant DB dual-write, conflict checks) uses the
-    // canonical form.
+    // (gateway DB, assistant mirror op, conflict checks) uses the canonical
+    // form.
     const canonicalChannels = params.channels?.map((ch) => ({
       ...ch,
       address: canonicalizeInboundIdentity(ch.type, ch.address) ?? ch.address,
@@ -1249,16 +1244,16 @@ export class ContactStore {
       this.syncChannels(contactId, canonicalChannels, now);
     }
 
-    // ── 5. Dual-write to assistant DB (best-effort) ───────────────────
+    // ── 5. Mirror to assistant DB (best-effort typed op) ──────────────
     const canonicalParams = canonicalChannels
       ? { ...params, channels: canonicalChannels }
       : params;
     try {
-      await this.dualWriteContactToAssistantDb(contactId, canonicalParams, now);
+      await this.mirrorContactToAssistantDb(contactId, canonicalParams);
     } catch (err) {
       log.warn(
         { contactId, err },
-        "upsertContact: assistant DB dual-write failed (best-effort)",
+        "upsertContact: assistant DB mirror failed (best-effort)",
       );
     }
 
@@ -1528,172 +1523,58 @@ export class ContactStore {
   }
 
   // ---------------------------------------------------------------------------
-  // Assistant DB dual-write
+  // Assistant DB identity mirror
   // ---------------------------------------------------------------------------
 
   /**
-   * Mirror the contact + channels write to the assistant DB.
+   * Mirror the contact + channels write to the assistant DB via ONE typed
+   * transactional daemon op (`contacts_mirror_upsert_full`).
    *
-   * - For an existing contact, build a dynamic SET clause that only touches
-   *   fields the caller explicitly provided. Without this guard, a partial
-   *   upsert (e.g. `{displayName: "X"}`) would clobber `notes`, `role`,
-   *   `contact_type`, and `principal_id` to default values — silently losing
-   *   data that the assistant DB may have but the gateway DB doesn't carry.
-   *
-   * - For a new contact, INSERT the full row with a freshly resolved
-   *   `user_file` slug.
-   *
-   * - For each channel: UPDATE if a row already exists on the same contact;
-   *   otherwise INSERT (skipping addresses claimed by a different contact).
+   * The mirror always targets the gateway contactId — the SAME id the gateway
+   * row + channels were written under — so an edit can't retarget another
+   * contact's metadata. Write semantics live daemon-side and match the raw
+   * dual-write this replaced: sparse omit-to-preserve contact update,
+   * slug-resolved `user_file` on create, `assistant_contact_metadata` upsert,
+   * and per-channel conflict-skip sync.
    */
-  private async dualWriteContactToAssistantDb(
+  private async mirrorContactToAssistantDb(
     contactId: string,
     params: Parameters<ContactStore["upsertContact"]>[0],
-    now: number,
   ): Promise<void> {
-    // The mirror always targets the gateway contactId — the SAME id the gateway
-    // row + channels were written under. On create, any assistant-only contact
-    // was already adopted onto this id in upsertContact, so both DBs converge.
-    // On update (explicit id), this matches syncChannels' skip-on-cross-contact
-    // behavior so an edit can't retarget another contact's metadata.
-    const existing = await assistantDbQuery<{ userFile: string | null }>(
-      "SELECT user_file AS userFile FROM contacts WHERE id = ?",
-      [contactId],
-    );
+    const channels = params.channels?.map((ch) => {
+      // Ship the just-written gateway channel id so the mirror adopts it and
+      // both stores share one canonical id for the same logical channel. A
+      // gateway conflict-skip leaves it undefined (the daemon mints one).
+      const gatewayChannel = this.db
+        .select({ id: contactChannels.id })
+        .from(contactChannels)
+        .where(
+          and(
+            eq(contactChannels.contactId, contactId),
+            eq(contactChannels.type, ch.type),
+            sql`${contactChannels.address} = ${ch.address} COLLATE NOCASE`,
+          ),
+        )
+        .get();
+      return {
+        id: gatewayChannel?.id,
+        type: ch.type,
+        address: ch.address,
+        isPrimary: ch.isPrimary,
+        externalChatId: ch.externalChatId,
+      };
+    });
 
-    if (existing.length) {
-      // Dynamic SET clause: only touch fields the caller actually provided.
-      // role / principal_id are intentionally never updated from this path —
-      // they're not in the params surface and the assistant DB already holds
-      // the values written by guardian-bootstrap. display_name is
-      // omit-to-preserve so a sparse upsert can't revert a custom name.
-      const setParts: string[] = ["updated_at = ?"];
-      const setParams: SqliteValue[] = [now];
-
-      if (params.displayName !== undefined) {
-        setParts.push("display_name = ?");
-        setParams.push(params.displayName);
-      }
-      if (params.notes !== undefined) {
-        setParts.push("notes = ?");
-        setParams.push(params.notes ?? null);
-      }
-      if (params.contactType !== undefined) {
-        setParts.push("contact_type = ?");
-        setParams.push(params.contactType);
-      }
-      setParams.push(contactId);
-
-      await assistantDbRun(
-        `UPDATE contacts SET ${setParts.join(", ")} WHERE id = ?`,
-        setParams,
-      );
-    } else {
-      const displayName =
-        params.displayName ?? params.channels?.[0]?.address ?? "Unknown";
-      const userFile = await this.resolveAssistantUserFileSlug(
-        displayName,
-        null,
-      );
-      await assistantDbRun(
-        `INSERT INTO contacts
-           (id, display_name, notes, contact_type,
-            user_file, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`,
-        [
-          contactId,
-          displayName,
-          params.notes ?? null,
-          params.contactType ?? "human",
-          userFile,
-          now,
-          now,
-        ],
-      );
-    }
-
-    // Assistant contact metadata (assistant-type contacts only).
-    if (params.contactType === "assistant" && params.assistantMetadata) {
-      await assistantDbRun(
-        `INSERT INTO assistant_contact_metadata (contact_id, species, metadata)
-         VALUES (?, ?, ?)
-         ON CONFLICT(contact_id) DO UPDATE SET
-           species  = excluded.species,
-           metadata = excluded.metadata`,
-        [
-          contactId,
-          params.assistantMetadata.species,
-          params.assistantMetadata.metadata != null
-            ? JSON.stringify(params.assistantMetadata.metadata)
-            : null,
-        ],
-      );
-    }
-
-    // Sync channels to the assistant DB.
-    for (const ch of params.channels ?? []) {
-      const existingCh = await assistantDbQuery<{ id: string }>(
-        "SELECT id FROM contact_channels WHERE contact_id = ? AND type = ? AND address = ? COLLATE NOCASE",
-        [contactId, ch.type, ch.address],
-      );
-
-      if (existingCh.length) {
-        // Omit-to-preserve: only overwrite external_chat_id when the caller
-        // supplied one, mirroring syncChannels (gateway DB). A sparse upsert
-        // (no externalChatId) must not clear an existing delivery chat id.
-        const setParts: string[] = ["updated_at = ?"];
-        const setParams: SqliteValue[] = [now];
-        if (ch.externalChatId !== undefined) {
-          setParts.push("external_chat_id = ?");
-          setParams.push(ch.externalChatId);
-        }
-        setParams.push(existingCh[0].id);
-        await assistantDbRun(
-          `UPDATE contact_channels SET ${setParts.join(", ")} WHERE id = ?`,
-          setParams,
-        );
-      } else {
-        // Skip if an address conflict exists on a different contact.
-        const conflict = await assistantDbQuery<{ id: string }>(
-          "SELECT id FROM contact_channels WHERE type = ? AND address = ? COLLATE NOCASE",
-          [ch.type, ch.address],
-        );
-        if (conflict.length) continue;
-
-        // Reuse the gateway channel ID so assistant and gateway channel rows
-        // share the same UUID for the same logical channel.
-        const gatewayChannel = this.db
-          .select({ id: contactChannels.id })
-          .from(contactChannels)
-          .where(
-            and(
-              eq(contactChannels.contactId, contactId),
-              eq(contactChannels.type, ch.type),
-              sql`${contactChannels.address} = ${ch.address} COLLATE NOCASE`,
-            ),
-          )
-          .get();
-        const channelId = gatewayChannel?.id ?? crypto.randomUUID();
-
-        await assistantDbRun(
-          `INSERT INTO contact_channels
-             (id, contact_id, type, address, is_primary,
-              external_chat_id,
-              created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-          [
-            channelId,
-            contactId,
-            ch.type,
-            ch.address,
-            ch.isPrimary ? 1 : 0,
-            ch.externalChatId ?? null,
-            now,
-            now,
-          ],
-        );
-      }
-    }
+    await ipcCallAssistant("contacts_mirror_upsert_full", {
+      body: {
+        contactId,
+        displayName: params.displayName,
+        contactType: params.contactType,
+        notes: params.notes,
+        assistantMetadata: params.assistantMetadata,
+        channels,
+      },
+    });
   }
 
   /**

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -1018,10 +1018,10 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
     /**
      * POST /v1/contacts — gateway-native contact upsert.
      *
-     * Writes to BOTH the gateway DB (auth/authz fields: id, displayName, role,
-     * principalId + channels) and the assistant DB (all fields including notes,
-     * userFile, contactType) so the daemon stays in sync during the migration
-     * transition period.
+     * Writes the gateway DB (auth/authz fields: id, displayName, role,
+     * principalId + channels) and mirrors the identity/info fields (notes,
+     * userFile, contactType, assistantMetadata) to the assistant DB via the
+     * typed `contacts_mirror_upsert_full` op (best-effort).
      *
      * Resolution order mirrors the assistant's upsertContact:
      *  1. Match by `body.id` if provided.
@@ -1207,7 +1207,7 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
         }
       }
 
-      // ── Service-layer write (gateway DB + assistant DB dual-write) ───
+      // ── Service-layer write (gateway DB + typed assistant mirror) ────
       //
       // SECURITY: `role` and `principalId` are auth/authz fields. They are
       // NEVER read from the request body. The route is protected by generic


### PR DESCRIPTION
## Summary
- Daemon mirror upsert op extended (sparse displayName, assistant_contact_metadata, explicit userFile, channel conflict-skip/id-adoption sync)
- Gateway upsertContact flips onto it; dualWriteContactToAssistantDb deleted — contact-store has zero raw assistant-DB SQL
- Old write semantics pinned by tests before the flip

Part of plan: acl-hardening-sweep.md (PR 13 of 18)