### PR TITLE
feat(telemetry): add explicit shell field to client metadata

### DIFF
--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -548,6 +548,7 @@ describe("HTTP POST /v1/messages client metadata headers", () => {
     "x-vellum-browser-family": "safari",
     "x-vellum-browser-version": "17",
     "x-vellum-client-os": "ios",
+    "x-vellum-client-shell": "capacitor",
     "x-vellum-interface-version": "1.2.3",
   };
 
@@ -582,6 +583,7 @@ describe("HTTP POST /v1/messages client metadata headers", () => {
         browser_family: "safari",
         browser_version: "17",
         os: "ios",
+        shell: "capacitor",
         interface_version: "1.2.3",
       },
     });
@@ -620,6 +622,7 @@ describe("HTTP POST /v1/messages client metadata headers", () => {
         browser_family: "safari",
         browser_version: "17",
         os: "ios",
+        shell: "capacitor",
         interface_version: "1.2.3",
       },
     });

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -170,7 +170,8 @@ export const messageMetadataSchema = z
      * by `persistQueuedMessageBody` — the transport `userMessageInterface` is
      * "web" for the web, iOS, and macOS apps alike, so this is the only
      * per-platform attribution. `browser_family` / `browser_version` /
-     * `interface_version` (and an `os` override) come from the sanitized
+     * `shell` ("electron" | "capacitor" | "browser") / `interface_version`
+     * (and an `os` override) come from the sanitized
      * `x-vellum-*` client-metadata headers read by `handleSendMessage`
      * (see `@vellumai/service-contracts/client-metadata`). Forwarded
      * verbatim onto `TurnTelemetryEvent.client` for downstream analytics.

--- a/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -350,6 +350,7 @@ mock.module("@/runtime/platform-detection", () => ({
   // this onboarding test doesn't exercise the OS/browser surface, so stub
   // the web defaults to keep the partial module mock complete.
   detectClientOs: () => "web",
+  detectClientShell: () => "browser",
   detectBrowserInfo: () => ({}),
 }));
 

--- a/clients/web/src/lib/telemetry/client-identity.test.ts
+++ b/clients/web/src/lib/telemetry/client-identity.test.ts
@@ -142,6 +142,7 @@ describe("client-identity", () => {
         "x-vellum-browser-family",
         "x-vellum-browser-version",
         "x-vellum-client-os",
+        "x-vellum-client-shell",
         "x-vellum-interface-version",
       ]);
       expect(headers["X-Vellum-Client-Id"]).toBe(mod.getClientId());
@@ -155,6 +156,7 @@ describe("client-identity", () => {
       expect(headers["x-vellum-browser-family"]).toBe("safari");
       expect(headers["x-vellum-browser-version"]).toBe("17");
       expect(headers["x-vellum-client-os"]).toBe("ios");
+      expect(headers["x-vellum-client-shell"]).toBe("browser");
       expect(headers["x-vellum-interface-version"]).toBe("1.2.3");
       // Never the raw user-agent string, in any header.
       expect(JSON.stringify(headers)).not.toContain("Mozilla");
@@ -183,6 +185,7 @@ describe("client-identity", () => {
       "X-Vellum-Client-Id",
       "X-Vellum-Interface-Id",
       "x-vellum-client-os",
+      "x-vellum-client-shell",
     ]);
     expect(headers["x-vellum-client-os"]).toBe("web");
   });
@@ -209,6 +212,7 @@ describe("client-identity", () => {
       "X-Vellum-Client-Id",
       "X-Vellum-Interface-Id",
       "x-vellum-client-os",
+      "x-vellum-client-shell",
     ]);
     expect(headers["x-vellum-client-os"]).toBe("ios");
   });

--- a/clients/web/src/lib/telemetry/client-identity.ts
+++ b/clients/web/src/lib/telemetry/client-identity.ts
@@ -6,6 +6,7 @@ import {
 import {
   detectBrowserInfo,
   detectClientOs,
+  detectClientShell,
 } from "@/runtime/platform-detection";
 
 let cached: string | null = null;
@@ -49,6 +50,7 @@ function getClientMetadataHeaders(): Record<string, string> {
     [CLIENT_METADATA_HEADERS.browser_family, browser.family],
     [CLIENT_METADATA_HEADERS.browser_version, browser.version],
     [CLIENT_METADATA_HEADERS.os, detectClientOs()],
+    [CLIENT_METADATA_HEADERS.shell, detectClientShell()],
     [
       CLIENT_METADATA_HEADERS.interface_version,
       import.meta.env.VITE_APP_VERSION,

--- a/clients/web/src/runtime/platform-detection.test.ts
+++ b/clients/web/src/runtime/platform-detection.test.ts
@@ -28,7 +28,9 @@ mock.module("@capacitor/core", () => ({
   Capacitor: { getPlatform: () => nativeOsPlatform },
 }));
 
-const { detectClientOs } = await import("@/runtime/platform-detection");
+const { detectClientOs, detectClientShell } = await import(
+  "@/runtime/platform-detection"
+);
 
 const ORIGINAL_UA = navigator.userAgent;
 const IPHONE_UA =
@@ -94,5 +96,29 @@ describe("detectClientOs", () => {
     nativePlatform = true;
     setUserAgent(IPHONE_UA);
     expect(detectClientOs()).toBe("macos");
+  });
+});
+
+describe("detectClientShell", () => {
+  test("returns 'electron' inside the Electron desktop shell", () => {
+    electron = true;
+    expect(detectClientShell()).toBe("electron");
+  });
+
+  test("returns 'capacitor' inside the Capacitor native shell", () => {
+    nativePlatform = true;
+    expect(detectClientShell()).toBe("capacitor");
+  });
+
+  test("returns 'browser' in a plain browser", () => {
+    expect(detectClientShell()).toBe("browser");
+  });
+
+  test("prefers 'electron' when both the Electron and native signals are present", () => {
+    // The Electron macOS shell also satisfies the native heuristics;
+    // `isElectron()` must win so it isn't reported as 'capacitor'.
+    electron = true;
+    nativePlatform = true;
+    expect(detectClientShell()).toBe("electron");
   });
 });

--- a/clients/web/src/runtime/platform-detection.ts
+++ b/clients/web/src/runtime/platform-detection.ts
@@ -149,6 +149,38 @@ export function detectClientOs(): ClientOs {
 }
 
 /**
+ * The app shell hosting this web bundle, for turn telemetry
+ * (`metadata.client.shell`). The same `clients/web` bundle runs in the
+ * Electron macOS app, the Capacitor iOS/Android native shell, and a plain
+ * browser, so the host shell is decided at runtime rather than by which build
+ * is shipped. Lets analytics distinguish the app shells directly instead of
+ * inferring them from the absence of a browser family.
+ */
+export type ClientShell = "electron" | "capacitor" | "browser";
+
+/**
+ * Detect the app shell ("electron" | "capacitor" | "browser") at runtime.
+ *
+ * Order mirrors `detectClientOs`: the Electron macOS shell also satisfies the
+ * native heuristics, so `isElectron()` is checked first or it would be
+ * misreported as `capacitor`. A native Capacitor shell (`isNativePlatform()`,
+ * true for iOS AND Android) reports `capacitor`; everything else is `browser`.
+ *
+ * Safe to call before hydration: each underlying helper falls through to
+ * `false` when `window`/`navigator` are undefined, so SSR resolves to
+ * `browser`.
+ */
+export function detectClientShell(): ClientShell {
+  if (isElectron()) {
+    return "electron";
+  }
+  if (isNativePlatform()) {
+    return "capacitor";
+  }
+  return "browser";
+}
+
+/**
  * Browser attribution for turn telemetry (`metadata.client.browser_family` /
  * `.browser_version`). Family is engine-level: Chromium derivatives without
  * their own brand entry (Opera, Brave, Arc) report as `"chrome"`.

--- a/packages/service-contracts/src/client-metadata.ts
+++ b/packages/service-contracts/src/client-metadata.ts
@@ -17,6 +17,7 @@ export const CLIENT_METADATA_HEADERS = {
   browser_family: "x-vellum-browser-family",
   browser_version: "x-vellum-browser-version",
   os: "x-vellum-client-os",
+  shell: "x-vellum-client-shell",
   interface_version: "x-vellum-interface-version",
 } as const;
 


### PR DESCRIPTION
## Summary

Adds an explicit `shell` field ("electron" | "capacitor" | "browser") to the client-metadata analytics pipeline so analytics can distinguish the app shells directly, instead of inferring an app from `browser_family` being absent.

- `packages/service-contracts`: add `shell: "x-vellum-client-shell"` to `CLIENT_METADATA_HEADERS`. The daemon route (`readClientMetadataHeaders`) iterates this map and the gateway CORS allowlist builds from `Object.values()` of it, so both pick the new field up with no edits.
- `clients/web`: add `detectClientShell()` in `platform-detection.ts` (electron → capacitor → browser precedence, mirroring `detectClientOs`) and attach it as a header candidate in `client-identity.ts`.
- `assistant`: extend the `messageMetadataSchema` `client` docstring enumeration to include `shell`.

BigQuery's client bag is permissive JSON (persisted as an untyped `record`), so no migration is needed.

Related to #36015 — follow-up building on the client-metadata plumbing merged there.

## Tests

- `cd clients/web && bun test src/lib/telemetry/client-identity.test.ts src/runtime/platform-detection.test.ts` (21 pass)
- `cd clients/web && bun test src/domains/onboarding/onboarding-lifecycle-sync.test.tsx` (run separately; 16 pass)
- `cd clients/web && bun run typecheck` (exit 0)
- `cd assistant && bun test src/__tests__/http-user-message-parity.test.ts` (19 pass)
- `cd assistant && bun run typecheck:fast` (exit 0)
- `cd gateway && bun test src/__tests__/pair-origin-allowlist.test.ts` (13 pass) && `bunx tsc --noEmit` (exit 0)
- `cd packages/service-contracts && bunx tsc --noEmit` (exit 0)
- `bunx eslint` on all changed files (0 new errors/warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->