### PR TITLE
MFA copy: the challenge applies to all sign-ins

### DIFF
--- a/clients/web/src/domains/settings/security/security-page.tsx
+++ b/clients/web/src/domains/settings/security/security-page.tsx
@@ -29,7 +29,7 @@ export function SecurityPage() {
     <div className="space-y-4">
       <DetailCard
         title="Two-Factor Authentication"
-        subtitle="Require a code from an authenticator app when you sign in with email and password."
+        subtitle="Require a code from an authenticator app when you sign in."
       >
         {platformGate === "disabled" ? (
           <PlatformLoginNotice>

--- a/clients/web/src/domains/settings/security/two-factor-section.tsx
+++ b/clients/web/src/domains/settings/security/two-factor-section.tsx
@@ -124,7 +124,7 @@ export function TwoFactorSection() {
       <ConfirmDialog
         open={pendingDelete !== null}
         title="Remove authenticator app"
-        message="Signing in with email and password will no longer ask for a code from this app. You can set up a new authenticator app at any time."
+        message="Signing in will no longer ask for a code from this app. You can set up a new authenticator app at any time."
         confirmLabel="Remove"
         destructive
         onConfirm={() => {


### PR DESCRIPTION
QA on ATL-966 showed AuthKit challenges OAuth (Google) sign-ins too once a TOTP factor is enrolled — not just email/password as the WorkOS docs imply. Drop the password-only scoping from the Security page subtitle and the remove-factor confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)