### PR TITLE
refactor(providers): break inference↔registry import cycle

### DIFF
--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -122,7 +122,6 @@ mock.module("../providers/inference/connections.js", () => ({
   createConnection: () => ({ ok: false, error: { code: "already_exists" } }),
   getConnection: () => null,
   VELLUM_MANAGED_CONNECTION_NAME: "vellum",
-  PROVIDERS_REQUIRING_BASE_URL_AND_MODELS: new Set(["openai-compatible"]),
 }));
 
 import { ROUTES } from "../runtime/routes/conversation-query-routes.js";

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -1,9 +1,9 @@
 import type { DrizzleDb } from "../persistence/db-connection.js";
+import { PROVIDERS_REQUIRING_BASE_URL_AND_MODELS } from "../providers/inference/auth.js";
 import {
   createConnection,
   getConnection,
   MANAGED_CONNECTION_NAMES,
-  PROVIDERS_REQUIRING_BASE_URL_AND_MODELS,
   VELLUM_MANAGED_CONNECTION_NAME,
 } from "../providers/inference/connections.js";
 import { PROVIDER_CATALOG } from "../providers/model-catalog.js";

--- a/assistant/src/providers/inference/auth.ts
+++ b/assistant/src/providers/inference/auth.ts
@@ -102,6 +102,15 @@ export const ConnectionModelSchema = z
   .meta({ id: "ConnectionModel" });
 export type ConnectionModel = z.infer<typeof ConnectionModelSchema>;
 
+/**
+ * Providers whose connections require an explicit `baseUrl` and non-empty
+ * `models` list (openai-compatible endpoints have no fixed upstream, so the
+ * user must supply both). Every other provider derives these from its catalog
+ * entry and rejects a client-supplied `baseUrl`.
+ */
+export const PROVIDERS_REQUIRING_BASE_URL_AND_MODELS: ReadonlySet<string> =
+  new Set(["openai-compatible"]);
+
 // ---------------------------------------------------------------------------
 // Full connection shape used by CRUD layer
 // ---------------------------------------------------------------------------

--- a/assistant/src/providers/inference/backfill.ts
+++ b/assistant/src/providers/inference/backfill.ts
@@ -22,10 +22,10 @@ import type { DrizzleDb } from "../../persistence/db-connection.js";
 import { credentialKey } from "../../security/credential-key.js";
 import { getLogger } from "../../util/logger.js";
 import { MANAGED_ROUTABLE_PROVIDERS } from "../vellum-model-routing.js";
+import { PROVIDERS_REQUIRING_BASE_URL_AND_MODELS } from "./auth.js";
 import {
   createConnection,
   getConnection,
-  PROVIDERS_REQUIRING_BASE_URL_AND_MODELS,
   seedCanonicalConnections,
   VELLUM_MANAGED_CONNECTION_NAME,
 } from "./connections.js";

--- a/assistant/src/providers/inference/connections.ts
+++ b/assistant/src/providers/inference/connections.ts
@@ -14,6 +14,7 @@ import {
   type ConnectionProvider,
   ConnectionProviderSchema,
   type ProviderConnection,
+  PROVIDERS_REQUIRING_BASE_URL_AND_MODELS,
   VALID_CONNECTION_PROVIDERS,
 } from "./auth.js";
 
@@ -32,9 +33,6 @@ function parseModelsColumn(raw: string | null): ConnectionModel[] | null {
     return null;
   }
 }
-
-export const PROVIDERS_REQUIRING_BASE_URL_AND_MODELS: ReadonlySet<string> =
-  new Set(["openai-compatible"]);
 
 // ---------------------------------------------------------------------------
 // Read

--- a/assistant/src/providers/inference/resolve-auth.ts
+++ b/assistant/src/providers/inference/resolve-auth.ts
@@ -15,8 +15,11 @@ import {
   buildManagedBaseUrl,
   resolveManagedProxyContext,
 } from "../platform-proxy/context.js";
-import type { Auth, ResolvedAuth } from "./auth.js";
-import { PROVIDERS_REQUIRING_BASE_URL_AND_MODELS } from "./connections.js";
+import {
+  type Auth,
+  PROVIDERS_REQUIRING_BASE_URL_AND_MODELS,
+  type ResolvedAuth,
+} from "./auth.js";
 
 const log = getLogger("resolve-auth");
 

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -82,12 +82,12 @@ import { getMemoryRecallLogByMessageIds } from "../../plugins/defaults/memory/me
 import { getMemoryV2ActivationLogByMessageIds } from "../../plugins/defaults/memory/memory-v2-activation-log-store.js";
 import { MEMORY_V2_CONSOLIDATION_SOURCE } from "../../plugins/defaults/memory/v2/constants.js";
 import { getMemoryV3SelectionForInspectorByMessageIds } from "../../plugins/defaults/memory/v3/selection-log-store.js";
+import { PROVIDERS_REQUIRING_BASE_URL_AND_MODELS } from "../../providers/inference/auth.js";
 import {
   createConnection,
   getConnection,
   LEGACY_MANAGED_CONNECTION_NAMES,
   listConnections,
-  PROVIDERS_REQUIRING_BASE_URL_AND_MODELS,
   VELLUM_MANAGED_CONNECTION_NAME,
 } from "../../providers/inference/connections.js";
 import { PROVIDER_CATALOG } from "../../providers/model-catalog.js";

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -19,6 +19,7 @@ import {
   ConnectionModelSchema,
   ConnectionProviderSchema,
   ProviderConnectionSchema,
+  PROVIDERS_REQUIRING_BASE_URL_AND_MODELS,
   VALID_CONNECTION_PROVIDERS,
 } from "../../providers/inference/auth.js";
 import {
@@ -28,7 +29,6 @@ import {
   LEGACY_MANAGED_CONNECTION_NAMES,
   listConnections,
   MANAGED_CONNECTION_NAMES,
-  PROVIDERS_REQUIRING_BASE_URL_AND_MODELS,
   updateConnection,
 } from "../../providers/inference/connections.js";
 import {


### PR DESCRIPTION
## Prompt / plan

Now that `lint:circular` (madge) is load-bearing in CI, we're resolving the remaining import cycles in `/assistant`. madge reports 421 cyclic *paths*, but structurally those collapse to **11 independent tangles**: one giant 384-file daemon "core" SCC plus 10 small, self-contained cycles.

This PR tackles the most tractable high-value one: the providers inference/auth cluster.

**Why this one:** unlike most of the small cycles it's built entirely from *eager* top-level imports, so it's a genuine module-init footgun rather than just a linter flag; it's fully isolated from the 384-file core; and the fix is a single leaf extraction that serves as a template for three sibling SCCs (`llm-usage-store`, `llm-request-log-source`, `embeddings`) with the same "hub + satellites both import back from the hub" shape.

**The change:** `resolve-auth.ts` imported the pure-data constant `PROVIDERS_REQUIRING_BASE_URL_AND_MODELS` from `connections.ts`, and that was the sole back-edge closing the cycle:

```
connections → registry → resolve-auth → connections
```

The constant is moved into `providers/inference/auth.ts` — already the connection-vocabulary leaf (`VALID_CONNECTION_PROVIDERS`, `ProviderConnection`, the connection schemas) that every member of the cluster imports, and whose own deps (`model-catalog`, `vellum-model-routing`) don't reach back into the cluster, so it introduces no new edge. All consumers (`connections`, `resolve-auth`, `backfill`, `seed-inference-profiles`, and the two route modules) now import it from `auth.ts`.

madge circular chains: **421 → 420**; the providers SCC is eliminated entirely (0 cycles now touch `connections` / `resolve-auth` / `registry`).

## Test plan

- `bun run lint:circular` — providers SCC gone; no cycle touches `connections`/`resolve-auth`/`registry`.
- `bunx tsc --noEmit` — clean (0 errors in `assistant/src`).
- `bun test src/__tests__/managed-profile-guard.test.ts` — 57/57 pass (this suite mocks `connections.js`; the now-dead mock property for the moved constant was removed).
- Pre-commit + pre-push hooks (prettier, eslint, tsc) all green.
- The 5 failures in `src/providers/__tests__/` are pre-existing on the base commit (unrelated DB/model-data setup in this environment), not introduced here.

<!-- No new routes added; CLI verb checklist not applicable. -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01EWL4FYZVRGkJkMwL46PY3m)_