### PR TITLE
refactor(daemon): break lifecycle↔shutdown-handlers import cycle

### DIFF
--- a/assistant/src/__tests__/disk-pressure-lifecycle.test.ts
+++ b/assistant/src/__tests__/disk-pressure-lifecycle.test.ts
@@ -99,7 +99,7 @@ mock.module("../util/logger.js", () =>
 const {
   startDiskPressureGuardForLifecycle,
   stopDiskPressureGuardForLifecycle,
-} = await import("../daemon/lifecycle.js");
+} = await import("../daemon/disk-pressure-guard-lifecycle.js");
 
 async function flushStartupSample(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 0));

--- a/assistant/src/daemon/disk-pressure-guard-lifecycle.ts
+++ b/assistant/src/daemon/disk-pressure-guard-lifecycle.ts
@@ -1,0 +1,64 @@
+/**
+ * Disk-pressure guard wiring for the daemon lifecycle.
+ *
+ * Starts the guard at boot and defers the first full sample onto a macrotask so
+ * it never blocks startup, and stops the guard (cancelling any pending deferred
+ * sample) on shutdown.
+ */
+import { getLogger } from "../util/logger.js";
+import {
+  evaluateDiskPressureNow,
+  startDiskPressureGuard,
+  stopDiskPressureGuard,
+} from "./disk-pressure-guard.js";
+
+const log = getLogger("disk-pressure-guard-lifecycle");
+
+let diskPressureStartupSampleTimer: ReturnType<typeof setTimeout> | null = null;
+
+function runDeferredDiskPressureStartupSample(): void {
+  diskPressureStartupSampleTimer = null;
+  try {
+    const status = evaluateDiskPressureNow();
+    if (status.error) {
+      log.warn(
+        { error: status.error },
+        "Disk pressure guard sample failed during startup — continuing unlocked",
+      );
+    }
+  } catch (err) {
+    log.warn(
+      { err },
+      "Disk pressure guard failed during startup — continuing unlocked",
+    );
+  }
+}
+
+export function startDiskPressureGuardForLifecycle(): void {
+  try {
+    const startedStatus = startDiskPressureGuard();
+    if (!startedStatus.enabled) {
+      return;
+    }
+    if (!diskPressureStartupSampleTimer) {
+      diskPressureStartupSampleTimer = setTimeout(
+        runDeferredDiskPressureStartupSample,
+        0,
+      );
+      (diskPressureStartupSampleTimer as { unref?: () => void }).unref?.();
+    }
+  } catch (err) {
+    log.warn(
+      { err },
+      "Disk pressure guard failed during startup — continuing unlocked",
+    );
+  }
+}
+
+export function stopDiskPressureGuardForLifecycle(): void {
+  if (diskPressureStartupSampleTimer) {
+    clearTimeout(diskPressureStartupSampleTimer);
+    diskPressureStartupSampleTimer = null;
+  }
+  stopDiskPressureGuard();
+}

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -71,11 +71,7 @@ import {
   setDbReady,
   setStartupComplete,
 } from "./daemon-readiness.js";
-import {
-  evaluateDiskPressureNow,
-  startDiskPressureGuard,
-  stopDiskPressureGuard,
-} from "./disk-pressure-guard.js";
+import { startDiskPressureGuardForLifecycle } from "./disk-pressure-guard-lifecycle.js";
 import { startEventLoopWatchdog } from "./event-loop-watchdog.js";
 import { initializePlugins } from "./external-plugins-bootstrap.js";
 import { backfillSlackInjectionTemplates } from "./handlers/config-slack-channel.js";
@@ -91,57 +87,9 @@ import { installShutdownHandlers } from "./shutdown-handlers.js";
 import { broadcastDaemonStatus } from "./status.js";
 
 const log = getLogger("lifecycle");
-let diskPressureStartupSampleTimer: ReturnType<typeof setTimeout> | null = null;
 
 function loadDotEnv(): void {
   dotenvConfig({ path: getDotEnvPath(), quiet: true });
-}
-
-function runDeferredDiskPressureStartupSample(): void {
-  diskPressureStartupSampleTimer = null;
-  try {
-    const status = evaluateDiskPressureNow();
-    if (status.error) {
-      log.warn(
-        { error: status.error },
-        "Disk pressure guard sample failed during startup — continuing unlocked",
-      );
-    }
-  } catch (err) {
-    log.warn(
-      { err },
-      "Disk pressure guard failed during startup — continuing unlocked",
-    );
-  }
-}
-
-export function startDiskPressureGuardForLifecycle(): void {
-  try {
-    const startedStatus = startDiskPressureGuard();
-    if (!startedStatus.enabled) {
-      return;
-    }
-    if (!diskPressureStartupSampleTimer) {
-      diskPressureStartupSampleTimer = setTimeout(
-        runDeferredDiskPressureStartupSample,
-        0,
-      );
-      (diskPressureStartupSampleTimer as { unref?: () => void }).unref?.();
-    }
-  } catch (err) {
-    log.warn(
-      { err },
-      "Disk pressure guard failed during startup — continuing unlocked",
-    );
-  }
-}
-
-export function stopDiskPressureGuardForLifecycle(): void {
-  if (diskPressureStartupSampleTimer) {
-    clearTimeout(diskPressureStartupSampleTimer);
-    diskPressureStartupSampleTimer = null;
-  }
-  stopDiskPressureGuard();
 }
 
 // Entry point for the daemon process itself
@@ -719,7 +667,7 @@ export async function runDaemon(): Promise<void> {
   // failure never affects startup.
   installAssistantSymlink();
 
-  startEmbeddingRuntimeManager();
+  void startEmbeddingRuntimeManager();
 
   startWorkspaceHeartbeatService();
 

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -36,8 +36,8 @@ import { stopConversationEvictor } from "./conversation-evictor.js";
 import { stopConversations } from "./conversation-store.js";
 import { cleanupPidFile, cleanupPidFileIfOwner } from "./daemon-control.js";
 import { isStartupComplete } from "./daemon-readiness.js";
+import { stopDiskPressureGuardForLifecycle } from "./disk-pressure-guard-lifecycle.js";
 import { stopEventLoopWatchdog } from "./event-loop-watchdog.js";
-import { stopDiskPressureGuardForLifecycle } from "./lifecycle.js";
 import { stopOrphanReaper } from "./orphan-reaper.js";
 
 const log = getLogger("lifecycle");

--- a/assistant/src/persistence/embeddings/embedding-backend.ts
+++ b/assistant/src/persistence/embeddings/embedding-backend.ts
@@ -235,26 +235,25 @@ export function resetLocalEmbeddingFailureState(): void {
  * embed doesn't pay the download cost inline. A no-op when the runtime is
  * already installed. Failures are swallowed with a warning: local embeddings
  * fall back to cloud backends, so a failed download must never block or crash
- * daemon startup. Returns immediately; the download proceeds on its own.
+ * daemon startup. Callers fire-and-forget; the returned promise settles when
+ * the download finishes.
  */
-export function startEmbeddingRuntimeManager(): void {
-  void (async () => {
-    try {
-      const runtimeManager = new EmbeddingRuntimeManager();
-      if (runtimeManager.isReady()) return;
-      log.info("Downloading embedding runtime in background...");
-      await runtimeManager.ensureInstalled();
-      // Reset the sticky local-backend failure flag so auto mode retries local
-      // embeddings without evicting a worker that may already be live.
-      resetLocalEmbeddingFailureState();
-      log.info("Embedding runtime download complete");
-    } catch (err) {
-      log.warn(
-        { err },
-        "Embedding runtime download failed — local embeddings will use cloud fallback",
-      );
-    }
-  })();
+export async function startEmbeddingRuntimeManager(): Promise<void> {
+  try {
+    const runtimeManager = new EmbeddingRuntimeManager();
+    if (runtimeManager.isReady()) return;
+    log.info("Downloading embedding runtime in background...");
+    await runtimeManager.ensureInstalled();
+    // Reset the sticky local-backend failure flag so auto mode retries local
+    // embeddings without evicting a worker that may already be live.
+    resetLocalEmbeddingFailureState();
+    log.info("Embedding runtime download complete");
+  } catch (err) {
+    log.warn(
+      { err },
+      "Embedding runtime download failed — local embeddings will use cloud fallback",
+    );
+  }
 }
 
 function cacheKey(provider: string, model: string, extras?: string[]): string {


### PR DESCRIPTION
## Prompt / plan

Continuing the import-cycle cleanup. After #37322 and #37324, the remaining isolated SCCs are six two-node cycles plus the 384-file daemon "core". Five of the six are the same cosmetic "type-only back-edge → extract to a leaf" shape already applied four times. This PR takes the **odd one out**: `lifecycle ↔ shutdown-handlers` is the only remaining cycle where **both** edges are eager value imports — a genuine runtime coupling in the daemon's startup/shutdown orchestration, not a linter-only flag.

**The cycle:**
- `lifecycle.ts` imports `installShutdownHandlers` from `shutdown-handlers.ts`
- `shutdown-handlers.ts` imports `stopDiskPressureGuardForLifecycle` back from `lifecycle.ts`

**The fix:** the disk-pressure guard lifecycle wiring (`start`/`stopDiskPressureGuardForLifecycle`, the deferred startup-sample timer, and its module state) is fully self-contained around `disk-pressure-guard.ts`. Moved it out of `lifecycle.ts` into a new leaf `daemon/disk-pressure-guard-lifecycle.ts`. Both `lifecycle.ts` and `shutdown-handlers.ts` now import from that leaf, so `shutdown-handlers` no longer imports `lifecycle` and the cycle is gone. `lifecycle.ts` drops its `disk-pressure-guard.ts` imports entirely (only the moved code used them).

**Carried-over review feedback from #37324:** the `startEmbeddingRuntimeManager` function (moved into `embedding-backend.ts` in that PR) wrapped its body in a redundant `void (async () => { … })()` IIFE. It's now a plain `async function`; the `lifecycle.ts` caller `void`s the returned promise to keep the fire-and-forget semantics.

madge circular chains: **415 → 414**; no cycle now touches `lifecycle.ts`, `shutdown-handlers.ts`, or the new module.

## Test plan

- `bunx madge --circular` — 414 paths, **0** containing `lifecycle.ts` / `shutdown-handlers.ts` / `disk-pressure-guard-lifecycle.ts`.
- `bunx tsc --noEmit` — clean (0 errors).
- `bun test`:
  - `disk-pressure-lifecycle.test.ts` (updated to import the two functions from the new module) — pass
  - `embedding-backend.test.ts` — pass
  - `lifecycle-docs-guard.test.ts` — pass
- Pre-commit + pre-push hooks (prettier, eslint, tsc) all green.

<!-- No new routes added; CLI verb checklist not applicable. -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01EWL4FYZVRGkJkMwL46PY3m)_