### PR TITLE
fix(onboarding): stop the first greeting racing the personality rewrite

### DIFF
--- a/clients/web/src/domains/onboarding/apply-personality.test.ts
+++ b/clients/web/src/domains/onboarding/apply-personality.test.ts
@@ -2,11 +2,17 @@
  * Tests for the personality system-message builder — the load-bearing mapping
  * from the five 0–100 sliders to the nine named trait scores. Must reproduce
  * the agreed template wording exactly (the assistant parses these lines).
+ * Also covers the rewrite-turn settle decision, which gates the "Let's chat"
+ * handoff: settling early would let the first greeting race the identity
+ * rewrite.
  */
 
 import { describe, expect, test } from "bun:test";
 
-import { buildPersonalityMessage } from "./apply-personality";
+import {
+  buildPersonalityMessage,
+  shouldSettlePersonalityPoll,
+} from "./apply-personality";
 
 describe("buildPersonalityMessage", () => {
   test("reproduces the template scores from the matching slider values", () => {
@@ -65,5 +71,93 @@ describe("buildPersonalityMessage", () => {
     const msg = buildPersonalityMessage({ "companion-coworker": 140 });
     expect(msg).toContain("Coworker (0-100): 100");
     expect(msg).toContain("Companion (0-100): 0");
+  });
+
+  test("states the chosen assistant name outright when one was picked", () => {
+    const msg = buildPersonalityMessage({}, "Alice", "Quill");
+    // The rewrite conversation's system prompt can predate the name landing in
+    // IDENTITY.md, so the message itself must carry the authoritative name…
+    expect(msg).toContain("Your name is Quill.");
+    // …pinned to the exact field-line format the onboarding name-seeder's
+    // regex matches.
+    expect(msg).toContain("Write exactly `- **Name:** Quill` in IDENTITY.md");
+    expect(msg).toContain("do not rename yourself or invent a different name");
+    // The generic keep-your-name wording is replaced, not duplicated.
+    expect(msg).not.toContain("Keep your existing name exactly as it is");
+  });
+
+  test("keeps the carry-your-name-through wording when no name was picked", () => {
+    const msg = buildPersonalityMessage({}, "Alice");
+    expect(msg).toContain("Keep your existing name exactly as it is");
+    expect(msg).toContain("Do not rename yourself");
+    expect(msg).not.toContain("Your name is");
+  });
+
+  test("ignores a whitespace-only assistant name", () => {
+    const msg = buildPersonalityMessage({}, "Alice", "   ");
+    expect(msg).toContain("Keep your existing name exactly as it is");
+    expect(msg).not.toContain("Your name is");
+  });
+});
+
+describe("shouldSettlePersonalityPoll", () => {
+  test("does not settle while the daemon reports the turn mid-flight", () => {
+    // The regression: the rewrite emits a stable "rewriting now…" preamble and
+    // then spends tens of seconds on file_write calls. Text-stability alone
+    // settled here and released the chat handoff before IDENTITY.md was
+    // written.
+    expect(
+      shouldSettlePersonalityPoll({
+        processing: true,
+        hasReply: true,
+        stableReads: 5,
+      }),
+    ).toBe(false);
+  });
+
+  test("settles once the daemon reports the turn finished and a reply exists", () => {
+    expect(
+      shouldSettlePersonalityPoll({
+        processing: false,
+        hasReply: true,
+        stableReads: 0,
+      }),
+    ).toBe(true);
+  });
+
+  test("does not settle on processing:false before the turn has produced a reply", () => {
+    // A just-posted message can still be queued — `processing` is false until
+    // the turn actually starts, so the flag alone would settle instantly.
+    expect(
+      shouldSettlePersonalityPoll({
+        processing: false,
+        hasReply: false,
+        stableReads: 0,
+      }),
+    ).toBe(false);
+  });
+
+  test("falls back to text-stability when the daemon omits the flag", () => {
+    expect(
+      shouldSettlePersonalityPoll({
+        processing: undefined,
+        hasReply: true,
+        stableReads: 2,
+      }),
+    ).toBe(true);
+    expect(
+      shouldSettlePersonalityPoll({
+        processing: undefined,
+        hasReply: true,
+        stableReads: 1,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSettlePersonalityPoll({
+        processing: undefined,
+        hasReply: false,
+        stableReads: 2,
+      }),
+    ).toBe(false);
   });
 });

--- a/clients/web/src/domains/onboarding/apply-personality.ts
+++ b/clients/web/src/domains/onboarding/apply-personality.ts
@@ -49,8 +49,35 @@ const AXIS = {
 /** Poll cadence + ceiling while waiting for the rewrite turn to land. */
 const POLL_INTERVAL_MS = 1500;
 const MAX_POLL_MS = 120_000;
-/** Consecutive identical assistant reads that mark the rewrite turn settled. */
+/**
+ * Consecutive identical assistant reads that mark the rewrite turn settled —
+ * fallback only, for daemons that predate the `processing` flag.
+ */
 const STABLE_READS_TO_SETTLE = 2;
+
+/**
+ * Decide whether the rewrite turn is finished. The daemon's `processing` flag
+ * is authoritative (`true` while the turn is mid-flight), so prefer it: the
+ * rewrite typically emits a "rewriting now…" preamble and then spends most of
+ * the turn on file_write calls, during which the visible text is stable —
+ * text-stability alone settles ~3s into a turn that runs for tens of seconds,
+ * releasing the chat handoff before IDENTITY.md is actually written. The
+ * `hasReply` guard keeps a still-queued turn (`processing` not yet flipped on)
+ * from reading as already finished. Older daemons omit the flag; fall back to
+ * text-stability there.
+ */
+export function shouldSettlePersonalityPoll({
+  processing,
+  hasReply,
+  stableReads,
+}: {
+  processing: boolean | undefined;
+  hasReply: boolean;
+  stableReads: number;
+}): boolean {
+  if (processing !== undefined) return !processing && hasReply;
+  return hasReply && stableReads >= STABLE_READS_TO_SETTLE;
+}
 
 const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
@@ -65,6 +92,7 @@ const clamp = (n: number): number => Math.max(0, Math.min(100, Math.round(n)));
 export function buildPersonalityMessage(
   values: Record<string, number>,
   userName?: string,
+  assistantName?: string,
 ): string {
   const v = (id: string): number => clamp(values[id] ?? 50);
   const companionCoworker = v(AXIS.companionCoworker); // 100 = Coworker
@@ -73,6 +101,16 @@ export function buildPersonalityMessage(
   const politeUnfiltered = v(AXIS.politeUnfiltered); // 100 = Unfiltered
 
   const who = userName?.trim() || "The user";
+  // The name instruction must be unambiguous: the rewrite conversation's
+  // system prompt may have been snapshotted before the chosen name landed in
+  // IDENTITY.md, so "keep your existing name" alone would read a placeholder
+  // and invite the model to invent one. When the user picked a name, state it
+  // outright; either way, pin the `- **Name:** …` line format so the
+  // onboarding name-seeder's regex keeps matching on later rewrites.
+  const chosenName = assistantName?.trim();
+  const nameInstruction = chosenName
+    ? `Your name is ${chosenName}. Write exactly \`- **Name:** ${chosenName}\` in IDENTITY.md — do not rename yourself or invent a different name, even if the file currently shows a placeholder or a different name. This changes your personality, not who you are.`
+    : `Keep your existing name exactly as it is — this changes your personality, not who you are. Do not rename yourself, and if your name is already set, carry it through verbatim (don't treat it as a placeholder to fill). Whatever the name ends up being, keep it on IDENTITY.md's \`- **Name:** …\` line.`;
   return `<system-message>
 ${who} wants to customize your personality.
 This is what they want you to be:
@@ -90,7 +128,7 @@ Rewrite your own identity files (IDENTITY.md and SOUL.md) to reflect your new pe
 
 Overwrite each file completely with file_write: write the whole file fresh in one pass. This is a from-scratch rewrite, not an edit — do not append to what's already there, do not patch individual lines, and leave none of the current default wording behind. Fill in every IDENTITY.md placeholder (the _(not yet chosen)_ / _(not yet established)_ fields).
 
-Keep your existing name exactly as it is — this changes your personality, not who you are. Do not rename yourself, and if your name is already set, carry it through verbatim (don't treat it as a placeholder to fill).
+${nameInstruction}
 
 Each rewritten file must still be complete: SOUL.md keeps everything you operate by — how you use memory, your boundaries, your compliance stance — re-expressed in your new voice rather than dropped. When you finish, both files should read top-to-bottom as this new personality, with nothing left in the generic default voice.
 </system-message>`;
@@ -124,6 +162,12 @@ export interface ApplyPersonalityOptions {
   values: Record<string, number>;
   /** The user's name, woven into the system-message. */
   userName?: string;
+  /**
+   * The assistant name picked on the face screen. Passed through so the
+   * rewrite writes the chosen name instead of trusting its (possibly stale)
+   * system-prompt copy of IDENTITY.md.
+   */
+  assistantName?: string;
 }
 
 /**
@@ -134,6 +178,7 @@ export async function applyPersonality({
   awaitAssistantId,
   values,
   userName,
+  assistantName,
 }: ApplyPersonalityOptions): Promise<void> {
   let assistantId: string | undefined;
   let conversationId: string | undefined;
@@ -150,7 +195,7 @@ export async function applyPersonality({
 
     const body: MessagesPostData["body"] = {
       conversationId,
-      content: buildPersonalityMessage(values, userName),
+      content: buildPersonalityMessage(values, userName, assistantName),
       sourceChannel: "vellum",
       interface: "vellum",
       clientMessageId: crypto.randomUUID(),
@@ -163,7 +208,10 @@ export async function applyPersonality({
     if (!posted.response?.ok) return;
 
     // Let the rewrite turn run before hiding the thread — archiving mid-turn
-    // could drop the identity edits. Settle once the reply stops changing.
+    // could drop the identity edits, and the chat handoff awaits this promise
+    // so the first greeting must not start until the identity files are
+    // written. Settle on the daemon's turn-completion flag (see
+    // `shouldSettlePersonalityPoll`).
     const deadline = Date.now() + MAX_POLL_MS;
     let lastText = "";
     let stableReads = 0;
@@ -178,7 +226,15 @@ export async function applyPersonality({
       if (text) {
         stableReads = text === lastText ? stableReads + 1 : 0;
         lastText = text;
-        if (stableReads >= STABLE_READS_TO_SETTLE) break;
+      }
+      if (
+        shouldSettlePersonalityPoll({
+          processing: listed.data?.processing,
+          hasReply: text.length > 0,
+          stableReads,
+        })
+      ) {
+        break;
       }
     }
   } catch (err) {

--- a/clients/web/src/domains/onboarding/lets-chat-kickoff.test.ts
+++ b/clients/web/src/domains/onboarding/lets-chat-kickoff.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Tests for the hidden "Let's chat" kickoff builder. The greeting turn is
+ * forbidden from reading files, so the chosen assistant name must ride the
+ * kickoff message itself — otherwise a slow or failed personality rewrite
+ * leaves the model free to invent a name for its first words to the user.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { buildLetsChatKickoffMessage } from "./lets-chat-kickoff";
+
+describe("buildLetsChatKickoffMessage", () => {
+  test("carries the chosen assistant name into the kickoff", () => {
+    const msg = buildLetsChatKickoffMessage("Quill");
+    expect(msg).toContain("Your name is Quill — introduce yourself as Quill.");
+    expect(msg).toContain("You're about to begin your first conversation.");
+    expect(msg).toContain("don't use `recall` or read any files");
+  });
+
+  test("omits the name line when no name was picked", () => {
+    for (const name of [undefined, "", "   "]) {
+      const msg = buildLetsChatKickoffMessage(name);
+      expect(msg).not.toContain("Your name is");
+      expect(msg).toContain("You're about to begin your first conversation.");
+    }
+  });
+
+  test("trims the picked name", () => {
+    const msg = buildLetsChatKickoffMessage("  Luna ");
+    expect(msg).toContain("Your name is Luna — introduce yourself as Luna.");
+  });
+});

--- a/clients/web/src/domains/onboarding/lets-chat-kickoff.ts
+++ b/clients/web/src/domains/onboarding/lets-chat-kickoff.ts
@@ -1,0 +1,22 @@
+/**
+ * Hidden kickoff sent on the user's behalf when they hit "Let's chat" at the
+ * end of the personality-onboarding flow. It drives the assistant's first
+ * reply but renders no user bubble, so the chat opens with the assistant
+ * proactively greeting the user in the persona they just configured.
+ *
+ * The greeting turn is told not to read any files, so its only sources of
+ * identity are the system prompt and this message. The chosen assistant name
+ * rides the message itself as a backstop: if the personality rewrite timed
+ * out or IDENTITY.md's name is still a placeholder when the turn's system
+ * prompt is built, the model would otherwise invent a name for its very first
+ * words to the user.
+ */
+export function buildLetsChatKickoffMessage(assistantName?: string): string {
+  const name = assistantName?.trim();
+  const nameLine = name
+    ? `\nYour name is ${name} — introduce yourself as ${name}.`
+    : "";
+  return `You're about to begin your first conversation.${nameLine}
+Respond with a warm and engaging greeting. Be interesting, be real. This is your chance to get to know and impress the user.
+Keep it short! For this opening greeting only, don't use \`recall\` or read any files — just say hello. (This applies to the greeting alone; use your tools normally for everything the user asks afterward.)`;
+}

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -39,6 +39,7 @@ import { useBackgroundHatch } from "@/domains/onboarding/use-background-hatch";
 import { useResearchRunner } from "@/domains/onboarding/research-runner";
 import { sendResearchCorrection } from "@/domains/onboarding/send-research-correction";
 import { applyPersonality } from "@/domains/onboarding/apply-personality";
+import { buildLetsChatKickoffMessage } from "@/domains/onboarding/lets-chat-kickoff";
 import {
   clearResearchSnapshot,
   readResearchSnapshot,
@@ -81,16 +82,6 @@ import {
   OnboardingStageSizeProvider,
   useElementSize,
 } from "@/domains/onboarding/hooks/use-onboarding-stage-size";
-
-/**
- * Hidden kickoff sent on the user's behalf when they hit "Let's chat" at the
- * end of the personality-onboarding flow. It drives the assistant's first reply
- * but renders no user bubble, so the chat opens with the assistant proactively
- * greeting the user in the persona they just configured.
- */
-const LETS_CHAT_KICKOFF_MESSAGE = `You're about to begin your first conversation.
-Respond with a warm and engaging greeting. Be interesting, be real. This is your chance to get to know and impress the user.
-Keep it short! For this opening greeting only, don't use \`recall\` or read any files — just say hello. (This applies to the greeting alone; use your tools normally for everything the user asks afterward.)`;
 
 /** Build the research subject from the collected form values. */
 function researchSubjectFrom(values: ResearchOnboardingValues): ResearchSubject {
@@ -505,9 +496,12 @@ export function ResearchOnboardingRoute() {
       researchCorrectionRef.current,
       personalityAppliedRef.current,
     ]);
-    enterAssistant(formValues, faceValues, LETS_CHAT_KICKOFF_MESSAGE, {
-      hidden: true,
-    });
+    enterAssistant(
+      formValues,
+      faceValues,
+      buildLetsChatKickoffMessage(faceValues?.name),
+      { hidden: true },
+    );
   }
 
   function handleFormSubmit(values: ResearchOnboardingValues) {
@@ -646,6 +640,7 @@ export function ResearchOnboardingRoute() {
                   awaitAssistantId: awaitHatchReady,
                   values: personalityValues,
                   userName: formValues?.firstName?.trim() || undefined,
+                  assistantName: faceValues?.name?.trim() || undefined,
                 }).finally(() => setPersonalityPending(false));
                 setPersonalityLocked(true);
               }


### PR DESCRIPTION
## Problem

~28% of new users (36/126 kickoffs in the sampled window) get their first-ever greeting from an assistant using the wrong name — invented ("Trix"), the face-picker default ("Ziggy"), or contradicting what IDENTITY.md says, followed by visible self-flagellation in later chats.

Three writers race on IDENTITY.md's Name field:

1. **The personality rewrite** (`apply-personality.ts`) — its side conversation's system-prompt snapshot is taken before the chosen name is on disk, so the prompt's contradictory pair ("fill every placeholder" vs "keep your existing name") resolves to *inventing* a name, and its from-scratch `file_write` lands last, clobbering the correct name.
2. **`persistOnboardingArtifacts`** (daemon) — correctly writes the face-picker name when the kickoff message arrives, but is then overwritten by (1) finishing late.
3. **The kickoff greeting turn** — told "don't read any files, be interesting, be real", so a placeholder Name at snapshot time yields an invented greeting name.

The client already sequences the handoff (`finishAndEnterChat` awaits the rewrite promise), but `applyPersonality` settled on **two stable reads of the latest assistant text** — satisfied ~3s into a 30–60s turn by the model's "rewriting now…" preamble, long before any `file_write` ran.

## Fix

- **Settle on the daemon's authoritative turn flag**: the `messagesGet` response already carries `processing: boolean` (backed by the persisted `processing_started_at` column). The poll now settles on `processing === false` plus a has-reply guard (a still-queued turn also reports `false`), keeping text-stability only as a fallback for older daemons that omit the field — field absence is itself the version gate.
- **Give the rewrite the authoritative name**: `buildPersonalityMessage` now takes the face-picker name and instructs "Write exactly `- **Name:** X`" instead of the contradictory pair. This also makes a late rewrite idempotent with the daemon's name write instead of a clobber, and pins the field-line format the daemon's name-seeder regex matches.
- **Carry the name in the kickoff itself**: the hidden "Let's chat" message now includes "Your name is X — introduce yourself as X", so every degraded path (rewrite timeout, credit exhaustion, old daemon) still greets correctly.

## Notes

- Stacked on #37142 (`feat/local-mode-research-onboarding`) — this touches the same route file.
- One correction to the original analysis: personas are **not** frozen at AgentLoop construction; `syncLoopSystemPrompt()` rebuilds before every turn. The race is purely about what's on disk when each turn's snapshot is taken.
- The settle decision is extracted into a pure `shouldSettlePersonalityPoll` helper (mirroring `shouldSettleResearchPoll`), with a regression test for the exact failure (stable preamble text while `processing: true` must not settle).

## Testing

- `bun test src/domains/onboarding/apply-personality.test.ts src/domains/onboarding/lets-chat-kickoff.test.ts` — 13 pass.
- `bunx tsc --noEmit` clean; production build succeeds; eslint: no errors (only the repo-wide pre-existing `curly` warnings).
- Full onboarding-folder run shows 11 failures in unrelated files (`connect-recovery-dialog`, `privacy-screen`) that reproduce identically on the unmodified tree — pre-existing cross-file pollution in bun's single-process run, they pass in isolation.
- Manual QA still pending: run onboarding end-to-end with a custom name and confirm the "Let's chat" hold + greeting name; degraded-path check by killing the rewrite turn mid-flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)