### PR TITLE
refactor(daemon): break sqlite-corruption-watchdog↔slow-query-log import cycle

### DIFF
--- a/assistant/src/daemon/sqlite-corruption-watchdog.ts
+++ b/assistant/src/daemon/sqlite-corruption-watchdog.ts
@@ -34,7 +34,6 @@
 
 import * as Sentry from "@sentry/node";
 
-import type { StatementErrorContext } from "../persistence/slow-query-log.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("sqlite-corruption-watchdog");
@@ -121,6 +120,20 @@ function reportCorruption(
   } catch {
     // Never let a Sentry failure escape into the calling query path.
   }
+}
+
+/** Context handed to {@link observeSqliteStatementError} for a failed execution. */
+export interface StatementErrorContext {
+  /** SQL preview (truncated) of the failing statement. */
+  sql: string;
+  /**
+   * The database file's basename (e.g. `"assistant.db"` / `"assistant-logs.db"`),
+   * derived from the `Database`'s own `filename`. Always set by the wrapper;
+   * optional only for direct callers (tests) that construct a context by hand.
+   */
+  database?: string;
+  /** Caller-supplied `.label()` attribution tag, when present. */
+  label?: string;
 }
 
 /**

--- a/assistant/src/persistence/slow-query-log.ts
+++ b/assistant/src/persistence/slow-query-log.ts
@@ -167,20 +167,6 @@ export function reportSlowQuery(event: SlowQueryEvent): void {
   log.warn(event, "Slow SQLite query blocked the event loop");
 }
 
-/** Context handed to {@link observeSqliteStatementError} for a failed execution. */
-export interface StatementErrorContext {
-  /** SQL preview (first {@link SQL_PREVIEW_MAX} chars) of the failing statement. */
-  sql: string;
-  /**
-   * The database file's basename (e.g. `"assistant.db"` / `"assistant-logs.db"`),
-   * derived from the `Database`'s own `filename`. Always set by the wrapper;
-   * optional only for direct callers (tests) that construct a context by hand.
-   */
-  database?: string;
-  /** Caller-supplied `.label()` attribution tag, when present. */
-  label?: string;
-}
-
 /** Injectable seams so the wrapper is unit-testable with a fake clock/sink. */
 export interface SlowQueryWatcherOptions {
   thresholdMs?: number;


### PR DESCRIPTION
## Prompt / plan

Next in the import-cycle cleanup. Of the five remaining isolated 2-node cycles, this one has the cleanest fix.

**The cycle:**
- `slow-query-log.ts` imports `observeSqliteStatementError` (value) from `sqlite-corruption-watchdog.ts`
- `sqlite-corruption-watchdog.ts` imported the `StatementErrorContext` type back from `slow-query-log.ts`

**The fix:** `StatementErrorContext` is the parameter contract of `observeSqliteStatementError`, so it belongs alongside that function. Moved the interface into `sqlite-corruption-watchdog.ts`. The watchdog no longer imports `slow-query-log`, and `slow-query-log`'s call site passes a plain object literal (no named-type reference), so it needs no import back — the cycle is gone with **no new module**. No other code in the repo references the type.

madge circular chains: **413 → 412**; no cycle now touches either module.

## Test plan

- `bunx madge --circular` — 412 paths, **0** touching `sqlite-corruption-watchdog.ts` / `slow-query-log.ts`.
- `bunx tsc --noEmit` — clean (0 errors).
- `bun test src/persistence/__tests__/slow-query-log.test.ts src/daemon/sqlite-corruption-watchdog.test.ts` — 23/23 pass.
- Pre-commit + pre-push hooks (prettier, eslint, tsc) all green.

<!-- No new routes added; CLI verb checklist not applicable. -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01EWL4FYZVRGkJkMwL46PY3m)_