### PR TITLE
refactor(onboarding): cleanup after making research onboarding the default

### DIFF
--- a/clients/web/src/domains/onboarding/onboarding-destination.ts
+++ b/clients/web/src/domains/onboarding/onboarding-destination.ts
@@ -4,8 +4,8 @@ import { routes } from "@/utils/routes";
  * Decide where the standard onboarding flow goes after the user accepts
  * consent on the privacy screen.
  *
- * The research/personality flow is now THE onboarding, but HOW the assistant is
- * provisioned differs by hosting:
+ * Every non-native user onboards through the research/personality flow, but
+ * HOW the assistant is provisioned differs by hosting:
  *
  * - **Platform / Vellum-Cloud** → straight to `/assistant/onboarding/research`,
  *   which runs its own managed background hatch and walks the user to chat.

--- a/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -223,6 +223,9 @@ mock.module("@/lib/local-mode", () => ({
   primeLocalGatewayConnection: async () => {},
   primeLocalGatewayConnectionWithRepair: async () => {},
   getLocalGatewayUrl: () => localGatewayUrlValue,
+  // Mirrors the real derivation against the mocked local-mode state.
+  isLocalHatchHosting: (hostingParam: string | null) =>
+    isLocalModeValue && hostingParam !== null && hostingParam !== "vellum-cloud",
 }));
 
 mock.module("@/runtime/local-mode-host", () => ({

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -19,7 +19,7 @@ import {
     writeSelectedVersion,
 } from "@/domains/onboarding/prefs";
 import { applyPendingProviderKey } from "@/domains/onboarding/provider-key";
-import { getLocalGatewayUrl, getPlatformRuntimeUrl, isLocalMode, loadLockfile, primeLocalGatewayConnection, saveLockfileAssistant } from "@/lib/local-mode";
+import { getLocalGatewayUrl, getPlatformRuntimeUrl, isLocalHatchHosting, isLocalMode, loadLockfile, primeLocalGatewayConnection, saveLockfileAssistant } from "@/lib/local-mode";
 import { clearGatewayToken } from "@/lib/auth/gateway-session";
 import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
 import { buildNavigationState } from "@/lib/navigation/build-state";
@@ -115,7 +115,7 @@ export function HatchingScreen() {
   const hostingParam = searchParams.get("hosting");
   const failParam = searchParams.get("fail");
   const electron = isElectron();
-  const useLocalHatch = isLocalMode() && hostingParam !== null && hostingParam !== "vellum-cloud";
+  const useLocalHatch = isLocalHatchHosting(hostingParam);
   const sessionStatus = useAuthStore.use.sessionStatus();
   // Local hatches drive `sessionStatus` themselves (`connectLocalAssistant`
   // below flips it mid-handoff), so they gate on settled-ness to keep that flip
@@ -231,12 +231,11 @@ export function HatchingScreen() {
             });
             return;
           }
-          // A local hatch feeds the research/personality flow — now THE default
+          // A local hatch feeds the research/personality flow — the default
           // onboarding. The assistant is live, so the research route adopts it
           // (its background hatch resolves the existing local assistant instead
-          // of provisioning a managed one). The legacy pre-chat funnel is
-          // retired; it only remains as a fallback for any non-local hatch that
-          // still lands here.
+          // of provisioning a managed one). The pre-chat funnel below is only a
+          // fallback for any non-local hatch that still lands here.
           if (useLocalHatch) {
             // Carry the hosting choice through so the research route's
             // background hatch ADOPTS this just-hatched local assistant instead

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -44,7 +44,12 @@ mock.module("@/runtime/is-electron", () => ({ isElectron: () => true }));
 let nativePlatform = false;
 let researchFlag = false;
 let localMode = false;
-mock.module("@/lib/local-mode", () => ({ isLocalMode: () => localMode }));
+mock.module("@/lib/local-mode", () => ({
+  isLocalMode: () => localMode,
+  // Mirrors the real derivation, against the mocked local-mode state.
+  isLocalHatchHosting: (hostingParam: string | null) =>
+    localMode && hostingParam !== null && hostingParam !== "vellum-cloud",
+}));
 mock.module("@/runtime/native-auth", () => ({
   useIsNativePlatform: () => nativePlatform,
 }));
@@ -130,7 +135,7 @@ describe("PrivacyScreen — Start navigation", () => {
     expect(emitFunnelStepCompletedMock).not.toHaveBeenCalled();
   });
 
-  test("web persists consent and advances to the research flow (now the default), preserving hosting", () => {
+  test("web persists consent and advances to the research flow, preserving hosting", () => {
     nativePlatform = false;
     searchParamsValue = new URLSearchParams("hosting=managed");
     render(<PrivacyScreen />);

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -15,7 +15,7 @@ import {
     resolveOnboardingFunnelVariant,
 } from "@/domains/onboarding/funnel-events";
 import { onboardingDestinationAfterConsent } from "@/domains/onboarding/onboarding-destination";
-import { isLocalMode } from "@/lib/local-mode";
+import { isLocalHatchHosting } from "@/lib/local-mode";
 import {
     usePrivacyConsent,
     useShareAnalytics,
@@ -86,8 +86,7 @@ export function PrivacyScreen() {
     // must run the foreground local hatch first, so it goes to `hatching`, which
     // then redirects into the research flow. Vellum-Cloud goes straight to
     // research (managed background hatch).
-    const isLocalHatch =
-      isLocalMode() && hostingParam !== null && hostingParam !== "vellum-cloud";
+    const isLocalHatch = isLocalHatchHosting(hostingParam);
     const destination = onboardingDestinationAfterConsent({
       isNative,
       isLocalHatch,

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -21,7 +21,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
 import { lifecycleService } from "@/assistant/lifecycle-service";
-import { isLocalMode } from "@/lib/local-mode";
+import { isLocalHatchHosting } from "@/lib/local-mode";
 import { useAuthStore } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
 import { preloadBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
@@ -74,7 +74,6 @@ import {
   LookingYouUpStep,
   FinishingUpStep,
   ResearchResultsStep,
-  SuggestionsStep,
   LetsChatReadyStep,
 } from "@/domains/onboarding/screens/research-result-steps";
 import { OnboardingTonedBackdrop } from "@/domains/onboarding/components/onboarding-toned-backdrop";
@@ -113,11 +112,6 @@ export function ResearchOnboardingRoute() {
     useOnboardingFocusStore.use.setPendingAvatarTraits();
   const requestSidebarCollapse =
     useOnboardingFocusStore.use.requestSidebarCollapse();
-  // Research/personality onboarding is now THE onboarding — it fully replaces
-  // the legacy pre-chat funnel and is no longer flag-gated, so the route always
-  // renders and the "Create my personality" step is always shown.
-  const personalityEnabled = true;
-
   // Sub-steps share this route: details form → avatar/name picker →
   // introduction → pitch (the "different" step, which carousels its lines to
   // the payoff) → integration → "let's chat tomorrow". The toned steps share a
@@ -221,13 +215,10 @@ export function ResearchOnboardingRoute() {
   // A local-hosting onboarding (hosting=local/docker) already provisioned its
   // assistant in the hatching screen, so the background hatch ADOPTS it rather
   // than running a managed hatch. Vellum-Cloud onboarding (no / "vellum-cloud"
-  // hosting) still runs the managed hatch. `isLocalMode()` alone can't tell
-  // these apart — it's a build-time value that's true for the whole desktop app,
-  // including its Vellum-Cloud path — so we key on the chosen hosting.
+  // hosting) runs the managed hatch (see `isLocalHatchHosting`).
   const [searchParams] = useSearchParams();
   const hostingParam = searchParams.get("hosting");
-  const adoptExistingAssistant =
-    isLocalMode() && hostingParam !== null && hostingParam !== "vellum-cloud";
+  const adoptExistingAssistant = isLocalHatchHosting(hostingParam);
   // The hatching screen names the assistant it provisioned in the `assistant`
   // param, pinning adoption to that exact one — a stale selection or leftover
   // lockfile entries from previous sessions can't answer for it.
@@ -270,8 +261,8 @@ export function ResearchOnboardingRoute() {
 
   // Landing on the form means a fresh run — clear any stale focus state left
   // behind by an abandoned previous attempt so the form itself never renders
-  // chrome-less — and kick off the background hatch (idempotent). This is now
-  // the default onboarding, so the hatch fires unconditionally on mount.
+  // chrome-less — and kick off the background hatch (idempotent) on mount:
+  // every non-native user onboards through this route, so there is no gate.
   useEffect(() => {
     exitFocus();
     setPendingAvatarTraits(null);
@@ -378,7 +369,7 @@ export function ResearchOnboardingRoute() {
         ? { resumeConversationId: researchConversationId }
         : {}),
       onConversationCreated: setResearchConversationId,
-      includeSuggestions: !personalityEnabled,
+      includeSuggestions: false,
     });
   }, [
     restored,
@@ -387,7 +378,6 @@ export function ResearchOnboardingRoute() {
     research.status,
     startResearch,
     awaitHatchReady,
-    personalityEnabled,
   ]);
 
   // If we're sitting on the results step when the research turn resolves empty
@@ -520,9 +510,9 @@ export function ResearchOnboardingRoute() {
       subject: researchSubjectFrom(values),
       conversationTitle: researchTitleFor(values),
       onConversationCreated: setResearchConversationId,
-      // The "Let's chat" final step replaces suggestions when personality
-      // onboarding is on, so don't ask the model to generate any.
-      includeSuggestions: !personalityEnabled,
+      // The "Let's chat" final step replaces suggestions, so don't ask the
+      // model to generate any.
+      includeSuggestions: false,
     });
     goForwardTo("face");
   }
@@ -617,9 +607,7 @@ export function ResearchOnboardingRoute() {
         />
         {step === "different" && (
           <PitchStep
-            onContinue={() =>
-              goForwardTo(personalityEnabled ? "personality" : "integration")
-            }
+            onContinue={() => goForwardTo("personality")}
             onBack={() => goBackTo("intro")}
             onForward={onForward}
           />
@@ -661,9 +649,7 @@ export function ResearchOnboardingRoute() {
           <IntegrationStep
             onClaim={() => goForwardTo("letschat")}
             onBumpEyes={() => setEyesBump((n) => n + 1)}
-            onBack={() =>
-              goBackTo(personalityEnabled ? "personality" : "different")
-            }
+            onBack={() => goBackTo("personality")}
             onForward={onForward}
           />
         )}
@@ -741,13 +727,13 @@ export function ResearchOnboardingRoute() {
             onForward={onForward}
           />
         )}
-        {step === "suggestions" && personalityEnabled && (
+        {step === "suggestions" && (
           <LetsChatReadyStep
             installedPlugins={research.installedPlugins}
             pluginCatalog={research.pluginCatalog}
             onStart={async () => {
               // Terminal step: the handoff leaves via enterAssistant, not
-              // goForwardTo, so emit the completion here (mirrors SuggestionsStep).
+              // goForwardTo, so emit the completion here.
               emitResearchOnboardingStepCompleted(
                 RESEARCH_ONBOARDING_FUNNEL_STEPS.suggestions,
                 { userId, outcome: "completed" },
@@ -763,46 +749,6 @@ export function ResearchOnboardingRoute() {
                 return;
               }
               await finishAndEnterChat();
-            }}
-            onBack={() => goBackTo(noClaims ? "looking" : "results")}
-            onForward={onForward}
-          />
-        )}
-        {step === "suggestions" && !personalityEnabled && (
-          <SuggestionsStep
-            suggestions={research.suggestions}
-            loading={researchLoading}
-            installedPlugins={research.installedPlugins}
-            onSuggestionClick={async (suggestion) => {
-              // Terminal step: the handoff leaves via enterAssistant, not
-              // goForwardTo, so emit the suggestions completion here (mirrors the
-              // pre-chat funnel emitting on its final step before completeFlow).
-              emitResearchOnboardingStepCompleted(
-                RESEARCH_ONBOARDING_FUNNEL_STEPS.suggestions,
-                { userId, outcome: "completed" },
-              );
-              // Wait out any background capability installs so the new chat can
-              // discover their skills (else it silently degrades to a generic
-              // prompt). Usually instant — installs kicked off while the user
-              // reviewed the results. Also wait for any removal correction to
-              // persist so rejected claims can't leak into this first chat.
-              await Promise.all([
-                research.awaitPluginInstalls(),
-                researchCorrectionRef.current,
-              ]);
-              enterAssistant(formValues, faceValues, suggestion.prompt);
-            }}
-            onSkip={async () => {
-              // "Skip to Chat" — record the suggestions step as skipped.
-              emitResearchOnboardingStepCompleted(
-                RESEARCH_ONBOARDING_FUNNEL_STEPS.suggestions,
-                { userId, outcome: "skipped" },
-              );
-              await Promise.all([
-                research.awaitPluginInstalls(),
-                researchCorrectionRef.current,
-              ]);
-              enterAssistant(formValues, faceValues, undefined, { skip: true });
             }}
             onBack={() => goBackTo(noClaims ? "looking" : "results")}
             onForward={onForward}

--- a/clients/web/src/domains/onboarding/research-prompt.ts
+++ b/clients/web/src/domains/onboarding/research-prompt.ts
@@ -76,11 +76,11 @@ Add a "plugins" array as the FIRST key in your JSON object, ${beforeKeys}: the 1
 export interface BuildResearchPromptOptions {
   /**
    * Whether to ask the model for clickable follow-up `suggestions`. The
-   * suggestions-based final step is being retired in favor of the "Let's chat"
-   * handoff (gated behind the personality-onboarding flag), which installs the
-   * picked plugins and drops the user straight into a primed chat. When false,
-   * the prompt asks for ONLY `plugins` + `claims` and omits all suggestion
-   * guidance. Defaults to true so the legacy suggestions flow is unchanged.
+   * onboarding route ends on the "Let's chat" handoff, which installs the
+   * picked plugins and drops the user straight into a primed chat — it passes
+   * false, so the prompt asks for ONLY `plugins` + `claims` and omits all
+   * suggestion guidance. Defaults to true for callers (e.g. the research mock
+   * harness) that render suggestion cards.
    */
   includeSuggestions?: boolean;
 }
@@ -117,8 +117,8 @@ export function buildResearchPrompt(
     "I'd like you to get to know me before we start working together.";
 
   // The clickable-suggestions block is optional: the "Let's chat" final step
-  // (personality-onboarding flag) installs the picked plugins and drops the
-  // user into a primed chat instead, so it asks for only `plugins` + `claims`.
+  // installs the picked plugins and drops the user into a primed chat instead,
+  // so it asks for only `plugins` + `claims`.
   const suggestionsArrayExample = includeSuggestions
     ? ` "suggestions": [ { "suggestion": "I'll find the 3 newest arXiv eval papers worth your time", "prompt": "Find me the 3 newest arXiv eval papers worth reading." }, { "suggestion": "I'll draft a crisp summary of the latest model-serving trade-offs", "prompt": "Draft me a short summary of the latest model-serving trade-offs." }, { "suggestion": "Connect GitHub and I'll triage your stalest issues", "prompt": "Connect to GitHub and triage my oldest open issues." }, { "suggestion": "I'll plan a weekend climbing trip near Boulder", "prompt": "Plan me a weekend climbing trip near Boulder." } ]`
     : "";

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -241,9 +241,9 @@ export interface StartResearchOptions {
   onConversationCreated?: (conversationId: string) => void;
   /**
    * Whether to ask the model for clickable `suggestions`. Off for the "Let's
-   * chat" final step (personality-onboarding flag), which installs the picked
-   * plugins and primes a chat instead of surfacing suggestion cards. Defaults to
-   * true so the legacy suggestions flow is unchanged.
+   * chat" final step, which installs the picked plugins and primes a chat
+   * instead of surfacing suggestion cards. Defaults to true for callers (e.g.
+   * the research mock harness) that render suggestion cards.
    */
   includeSuggestions?: boolean;
 }

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -7,17 +7,16 @@
  *   - MeetingCreatedStep   a brief "Check-in scheduled…" confirmation
  *   - LookingYouUpStep     a loading carousel ("looking you up")
  *   - ResearchResultsStep  the editable "Alright, this is what I got:" claims
- *   - SuggestionsStep      tappable suggestions that open a new chat
+ *   - LetsChatReadyStep    the plugins-ready terminal step ("Let's chat")
  *
- * Foreground only (the toned backdrop sits behind). The claims + suggestions
- * are the REAL research output — the route fires the research turn against the
- * hatched assistant (see `research-runner.ts`) and threads the parsed
- * `{ claims, suggestions }` in here. Each step falls back to a graceful
- * loading / empty presentation while the turn is still streaming.
+ * Foreground only (the toned backdrop sits behind). The claims are the REAL
+ * research output — the route fires the research turn against the hatched
+ * assistant (see `research-runner.ts`) and threads the parsed claims in here.
+ * Each step falls back to a graceful loading / empty presentation while the
+ * turn is still streaming.
  */
 
 import {
-  Fragment,
   useEffect,
   useLayoutEffect,
   useRef,
@@ -29,23 +28,18 @@ import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
 import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
-import {
-  toneForBg,
-  useOnboardingTone,
-  type OnboardingTone,
-} from "@/domains/onboarding/onboarding-tone";
+import { toneForBg } from "@/domains/onboarding/onboarding-tone";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 import {
   pluginDisplayName,
   type ResearchFact,
-  type ResearchSuggestion,
 } from "@/utils/research-facts";
 
 // Once the calendar step blends the background to black, every step from there
 // on sits on a constant dark surface — so their text/UI must be a constant
 // light tone, NOT one derived from the chosen avatar color (a light avatar like
 // yellow would otherwise render dark text, invisible on black). The avatar color
-// is still used where it's intentional (e.g. the plugin pills).
+// is still used where it's intentional (e.g. the flying heading avatar).
 const DARK_TONE = toneForBg("#17191C");
 
 function useViewportSize() {
@@ -517,62 +511,8 @@ export function ResearchResultsStep({
 }
 
 // ---------------------------------------------------------------------------
-// Suggestions
+// Heading-avatar flight (shared by the terminal step)
 // ---------------------------------------------------------------------------
-
-/**
- * Generic fallbacks shown only if the research turn produced no suggestions
- * (failure / sparse subject) so the step is never empty once it's done loading.
- * Each pairs the assistant-voiced card text with the user-voiced prompt sent on
- * click.
- */
-const FALLBACK_SUGGESTIONS: ResearchSuggestion[] = [
-  {
-    suggestion: "I'll pull together a quick brief on what's new in your field",
-    prompt: "Give me a quick brief on what's new in my field right now.",
-  },
-  {
-    suggestion: "I'll send a weekly briefing on news in your space",
-    prompt: "Set up a weekly briefing on news in my space.",
-  },
-  {
-    suggestion: "I'll help you get on top of your week",
-    prompt: "Help me get on top of my week.",
-  },
-  {
-    suggestion: "I'll draft something from a few rough notes",
-    prompt: "Draft something from a few rough notes I'll give you.",
-  },
-];
-
-/** A plugin name rendered as a pill tinted with the chosen avatar's color. */
-function PluginPill({ label, tone }: { label: string; tone: OnboardingTone }) {
-  return (
-    <span
-      className="inline-flex items-center whitespace-nowrap rounded-full px-2.5 py-[3px] text-[12px] font-medium align-middle"
-      style={{ backgroundColor: tone.bg, color: tone.fg }}
-    >
-      {label}
-    </span>
-  );
-}
-
-/** Interleave plugin pills with readable connectors: "A", "A and B", "A, B, and C". */
-function joinPills(labels: string[], tone: OnboardingTone) {
-  return labels.map((label, i) => {
-    let connector = "";
-    if (i > 0) {
-      const isLast = i === labels.length - 1;
-      connector = isLast ? (labels.length === 2 ? " and " : ", and ") : ", ";
-    }
-    return (
-      <Fragment key={label}>
-        {connector}
-        <PluginPill label={label} tone={tone} />
-      </Fragment>
-    );
-  });
-}
 
 /** Avatar box size — the same at the heading and where it lands by the note. */
 const HEADING_AVATAR = 64;
@@ -581,57 +521,11 @@ const NOTE_AVATAR = HEADING_AVATAR;
 type Anchor = { x: number; y: number };
 
 /**
- * The "already set up …" confirmation line. No avatar of its own — it just
- * reserves a small landing slot (`slotRef`) for the single avatar that flies
- * down from the heading — and names the installed plugins as avatar-tinted
- * pills.
- */
-function PluginSetupNote({
-  pluginLabels,
-  tone,
-  pillTone,
-  reduce,
-  slotRef,
-  revealed,
-}: {
-  pluginLabels: string[];
-  /** Surface tone for the line's text (constant light on the dark surface). */
-  tone: OnboardingTone;
-  /** Avatar tone for the pills (their fill + contrast text). */
-  pillTone: OnboardingTone;
-  reduce: boolean | null;
-  slotRef: React.RefObject<HTMLDivElement | null>;
-  /** True once the avatar has landed — the text only appears then. */
-  revealed: boolean;
-}) {
-  const plural = pluginLabels.length > 1;
-  return (
-    <div className="mt-12 flex items-center gap-3">
-      <div
-        ref={slotRef}
-        className="shrink-0"
-        style={{ width: NOTE_AVATAR, height: NOTE_AVATAR }}
-      />
-      <motion.p
-        className="text-[14px]"
-        style={{ color: tone.fg }}
-        initial={false}
-        animate={{ opacity: revealed ? 1 : 0, x: revealed ? 0 : -6 }}
-        transition={reduce ? { duration: 0 } : { duration: 0.35 }}
-      >
-        Already set up the {joinPills(pluginLabels, pillTone)} plugin{plural ? "s" : ""}{" "}
-        to help with your work
-      </motion.p>
-    </div>
-  );
-}
-
-/**
  * The chosen avatar as a single overlay that rests over the heading and — once
  * the plugin note is present and the layout has settled — flies down along a
  * curved arc to the note's landing slot and stays there (shrinking from the
  * heading size to the note size). Positions are measured from the slots so the
- * flight tracks the real layout as suggestions stream in.
+ * flight tracks the real layout as content reflows.
  */
 function FlyingHeadingAvatar({
   head,
@@ -681,205 +575,19 @@ function FlyingHeadingAvatar({
   );
 }
 
-export function SuggestionsStep({
-  suggestions,
-  loading,
-  installedPlugins = [],
-  onSuggestionClick,
-  onSkip,
-  onBack,
-  onForward,
-}: {
-  /** Parsed research suggestions (streams in; may be empty while running). */
-  suggestions: ResearchSuggestion[];
-  /** True while the research turn is still streaming. */
-  loading: boolean;
-  /**
-   * Capabilities installed for the assistant this run (from the model's
-   * persona-level `plugins` picks, already catalog-gated). Surfaced as a small
-   * confirmation note; empty when none were set up.
-   */
-  installedPlugins?: string[];
-  /** Opens the chat on the clicked suggestion (sends its user-voiced prompt). */
-  onSuggestionClick: (suggestion: ResearchSuggestion) => void;
-  /** Skips the suggestions and drops the user straight into a blank chat. */
-  onSkip: () => void;
-  onBack: () => void;
-  /** Redo into the next step — only set when the user has stepped back. */
-  onForward?: () => void;
-}) {
-  // Constant dark surface for the UI; the avatar tone is only for the pills.
-  const tone = DARK_TONE;
-  const avatarTone = useOnboardingTone();
-  const reduce = useReducedMotion();
-  // Show real suggestions as they arrive; only fall back once the turn settles
-  // with nothing, so we never flash generic prompts over an in-flight result.
-  const items =
-    suggestions.length > 0
-      ? suggestions
-      : loading
-        ? []
-        : FALLBACK_SUGGESTIONS;
-
-  const pluginLabels = installedPlugins
-    .map(pluginDisplayName)
-    .filter((label) => label.length > 0);
-  const hasNote = pluginLabels.length > 0;
-
-  // A single avatar starts over the heading slot and flies down to the note's
-  // landing slot. We measure both slot centers (relative to the column) so the
-  // flight follows the real layout as suggestions stream in and reflow.
-  const columnRef = useRef<HTMLDivElement>(null);
-  const headSlotRef = useRef<HTMLDivElement>(null);
-  const noteSlotRef = useRef<HTMLDivElement>(null);
-  const [anchors, setAnchors] = useState<{ head: Anchor; note?: Anchor } | null>(
-    null,
-  );
-  const [flown, setFlown] = useState(false);
-  const [landed, setLanded] = useState(false);
-
-  useLayoutEffect(() => {
-    const measure = () => {
-      const col = columnRef.current;
-      const head = headSlotRef.current;
-      if (!col || !head) return;
-      const c = col.getBoundingClientRect();
-      const center = (r: DOMRect): Anchor => ({
-        x: r.left - c.left + r.width / 2,
-        y: r.top - c.top + r.height / 2,
-      });
-      const note = noteSlotRef.current;
-      setAnchors({
-        head: center(head.getBoundingClientRect()),
-        note: note ? center(note.getBoundingClientRect()) : undefined,
-      });
-    };
-    measure();
-    window.addEventListener("resize", measure);
-    return () => window.removeEventListener("resize", measure);
-    // Intentionally not re-measuring on `flown`: the head anchor must stay at
-    // its pre-collapse position so the flight starts from where the avatar sat.
-  }, [items.length, hasNote]);
-
-  // Fly down the moment we have the data: as soon as the note slot is measured.
-  const noteY = anchors?.note?.y;
-  useEffect(() => {
-    if (!hasNote || noteY === undefined || flown) return;
-    setFlown(true);
-  }, [hasNote, noteY, flown]);
-
-  return (
-    <div className="absolute inset-0 z-10" style={{ color: tone.fg }}>
-      <OnboardingTopBar onBack={onBack} onNext={onForward} />
-
-      <div
-        ref={columnRef}
-        className="absolute left-1/2 top-[14%] sm:top-[26%] z-10 flex w-full max-w-xl -translate-x-1/2 flex-col px-6"
-      >
-        <div className="flex items-center">
-          {/*
-            Empty slot the flying avatar rests over. Once the avatar departs
-            (`flown`), it collapses its width + right margin so the title slides
-            smoothly to left-aligned.
-          */}
-          <motion.div
-            ref={headSlotRef}
-            className="shrink-0"
-            style={{ height: HEADING_AVATAR }}
-            initial={false}
-            animate={
-              flown
-                ? { width: 0, marginRight: 0 }
-                : { width: HEADING_AVATAR, marginRight: 12 }
-            }
-            transition={reduce ? { duration: 0 } : { duration: 0.5, ease: "easeInOut" }}
-          />
-          <h1 className="text-[2.2rem] leading-none" style={{ fontFamily: "var(--font-serif)" }}>
-            Here&rsquo;s what we could do first
-          </h1>
-        </div>
-        <p className="mb-7 mt-2 text-[15px]" style={{ color: tone.fgMuted }}>
-          {items.length > 0 ? (
-            <>
-              Pick one to jump in — or start your own thing.{" "}
-              <button
-                type="button"
-                onClick={onSkip}
-                className="cursor-pointer underline underline-offset-2 transition-opacity hover:opacity-80"
-                style={{ color: tone.fg }}
-              >
-                Skip to Chat
-              </button>
-            </>
-          ) : (
-            "Putting together a few ideas…"
-          )}
-        </p>
-
-        <div className="flex flex-col gap-3">
-          {items.map((s, i) => (
-            <motion.button
-              key={`${i}-${s.suggestion}`}
-              type="button"
-              onClick={() => onSuggestionClick(s)}
-              initial={reduce ? false : { opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={
-                reduce ? { duration: 0 } : { duration: 0.3, delay: i * 0.06 }
-              }
-              className="cursor-pointer rounded-2xl px-5 py-4 text-left text-[15px] transition-transform duration-150 hover:scale-[1.01] active:scale-[0.99]"
-              style={{
-                backgroundColor: tone.isLight
-                  ? "rgba(0,0,0,0.06)"
-                  : "rgba(255,255,255,0.1)",
-              }}
-            >
-              <span>{s.suggestion}</span>
-            </motion.button>
-          ))}
-        </div>
-
-        {hasNote && (
-          <PluginSetupNote
-            pluginLabels={pluginLabels}
-            tone={tone}
-            pillTone={avatarTone}
-            reduce={reduce}
-            slotRef={noteSlotRef}
-            revealed={landed}
-          />
-        )}
-
-        {anchors && (
-          <FlyingHeadingAvatar
-            head={anchors.head}
-            note={anchors.note}
-            flyToNote={flown && hasNote && anchors.note !== undefined}
-            reduce={reduce}
-            onLanded={() => setLanded(true)}
-          />
-        )}
-      </div>
-    </div>
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Let's chat (plugins-ready terminal step)
 // ---------------------------------------------------------------------------
 
 /**
- * Terminal step for the personality-onboarding flow (replaces SuggestionsStep
- * when that flag is on). The suggestions idea is retired: instead this confirms
- * the capabilities already set up for the assistant — chosen from the user's
- * role, hobby, and what the web research surfaced — and offers a single "Let's
- * chat" button. Clicking primes a fresh chat with a hidden kickoff message so
- * the assistant opens by proactively greeting the user in the persona they just
- * configured.
+ * Terminal step of the research-onboarding flow. Confirms the capabilities
+ * already set up for the assistant — chosen from the user's role, hobby, and
+ * what the web research surfaced — and offers a single "Let's chat" button.
+ * Clicking primes a fresh chat with a hidden kickoff message so the assistant
+ * opens by proactively greeting the user in the persona they just configured.
  *
- * Reuses SuggestionsStep's plugin choreography: one avatar rests over the
- * heading and flies down to land beside the "already set up …" note once the
- * installed plugins are known.
+ * One avatar rests over the heading and flies down to land beside the
+ * "already set up …" note once the installed plugins are known.
  */
 export function LetsChatReadyStep({
   installedPlugins = [],

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -371,14 +371,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "personality-onboarding",
-      "scope": "client",
-      "key": "personality-onboarding",
-      "label": "Personality onboarding step (spike)",
-      "description": "Spike: show the \"Create my personality\" trait-slider step in the research-onboarding flow (between the pitch and the integration step). On continue it applies the sliders to the assistant's persona on a throwaway side conversation. When off, the step is skipped entirely. Off by default; enable locally via the feature-flags panel.",
-      "defaultEnabled": false
-    },
-    {
       "id": "channel-trust-floors",
       "scope": "assistant",
       "key": "channel-trust-floors",

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -128,6 +128,22 @@ export function isLocalMode(): boolean {
   return !PLATFORM_MODE_TRUTHY.has(raw.toLowerCase());
 }
 
+/**
+ * Whether an onboarding run with this `?hosting` choice provisions its
+ * assistant via the FOREGROUND local hatch (hosting=local/docker in a
+ * local-mode build) rather than the managed platform hatch. Keyed on the
+ * chosen hosting, not just `isLocalMode()`: that is a build-time value, true
+ * for the whole desktop app — including its Vellum-Cloud path, which needs
+ * the managed hatch. The single source of truth for the privacy screen's
+ * routing, the hatching screen's hatch kind, and the research route's
+ * adopt-vs-hatch decision.
+ */
+export function isLocalHatchHosting(hostingParam: string | null): boolean {
+  return (
+    isLocalMode() && hostingParam !== null && hostingParam !== "vellum-cloud"
+  );
+}
+
 export function isPlatformDisabled(): boolean {
   const config = getInjectedConfig();
   if (config?.disablePlatform != null) return !!config.disablePlatform;

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -371,14 +371,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "personality-onboarding",
-      "scope": "client",
-      "key": "personality-onboarding",
-      "label": "Personality onboarding step (spike)",
-      "description": "Spike: show the \"Create my personality\" trait-slider step in the research-onboarding flow (between the pitch and the integration step). On continue it applies the sliders to the assistant's persona on a throwaway side conversation. When off, the step is skipped entirely. Off by default; enable locally via the feature-flags panel.",
-      "defaultEnabled": false
-    },
-    {
       "id": "channel-trust-floors",
       "scope": "assistant",
       "key": "channel-trust-floors",


### PR DESCRIPTION
Follow-up cleanup from the review of #37142 (stacked on that branch; findings that didn't need to block it). Four pieces:

1. **Drop `personalityEnabled` and the dead suggestions UI.** The constant was hardcoded `true`, leaving ~45 lines of one-way branches — including a `SuggestionsStep` render block that could never render. Branches collapsed; `SuggestionsStep` and its orphaned helpers (`FALLBACK_SUGGESTIONS`, `PluginPill`, `joinPills`, `PluginSetupNote`) deleted. `includeSuggestions` stays on the runner/prompt — the research mock harness still renders suggestion cards.
2. **Remove the dead `personality-onboarding` flag.** Zero reads remain anywhere (unlike `research-onboarding`, which the mock harness still reads). Registry entry removed and bundled copies re-synced. ⚠️ Platform-side Terraform definition in `vellum-assistant-platform` can be retired in a follow-up.
3. **Extract `isLocalHatchHosting()`.** The `isLocalMode() && hostingParam !== "vellum-cloud"` fork was written out identically in the privacy screen, hatching screen, and research route; it now has one definition in `lib/local-mode` that all three import.
4. **Reword migration-narrative comments** ("now THE onboarding", "(now the default)") to present-tense behavior, per the style guide's no-migration-history rule.

`tsc` clean, changed-file eslint 0 errors, all onboarding tests pass in isolation (`bun test <file>`; the combined single-process run has pre-existing `mock.module` bleed, which is why CI uses `test:ci`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)