### PR TITLE
docs(plugin-builder): document tool storage pattern (pluginStorageDir is InitContext-only)

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -284,7 +284,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-06T23:36:17.000Z"
+      "updatedAt": "2026-07-07T04:41:23.000Z"
     },
     {
       "id": "google-calendar",
@@ -305,7 +305,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-07T04:37:57.000Z"
+      "updatedAt": "2026-07-07T04:41:13.000Z"
     },
     {
       "id": "guardian-verify-setup",
@@ -626,7 +626,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-07T04:37:57.000Z"
+      "updatedAt": "2026-07-07T04:41:13.000Z"
     },
     {
       "id": "plugin-builder",
@@ -653,7 +653,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-06T18:12:30.000Z"
+      "updatedAt": "2026-07-07T12:56:19.000Z"
     },
     {
       "id": "public-ingress",

--- a/skills/plugin-builder/references/tools.md
+++ b/skills/plugin-builder/references/tools.md
@@ -155,4 +155,3 @@ export default {
 ```
 
 Types come from [`@vellumai/plugin-api`](https://github.com/vellum-ai/vellum-assistant/tree/main/assistant/src/plugin-api), the only supported contract.
-

--- a/skills/plugin-builder/references/tools.md
+++ b/skills/plugin-builder/references/tools.md
@@ -80,25 +80,19 @@ The result is what the model sees back:
 
 ## Persisting data from a tool
 
-`ToolContext` does **not** include `pluginStorageDir`. That field is only passed to the `init` hook (`InitContext`). A tool that reads `ctx.pluginStorageDir` inside `execute` crashes at call time with `The "paths[0]" property must be of type string, got undefined`, and if the read is wrapped in a broad `try/catch`, the crash silently degrades into an empty result, which is worse.
-
-A tool that needs durable storage should derive the directory from `workingDir`, which matches where the host provisions plugin storage (`<workspaceDir>/plugins-data/<plugin-name>/`):
+A tool that needs durable storage should derive the directory from the workspace root, which matches where the host provisions plugin storage (`<workspaceDir>/plugins/<plugin-name>/data`):
 
 ```ts
 execute: async (input, ctx) => {
   const fs = await import("node:fs/promises");
   const path = await import("node:path");
-  const storageDir =
-    (ctx as { pluginStorageDir?: string }).pluginStorageDir ??
-    path.join(ctx.workingDir ?? process.cwd(), "plugins-data", "my-plugin-name");
+  const storageDir = path.join(process.env.VELLUM_WORKSPACE_DIR, "plugins", "my-plugin-name", "data");
   await fs.mkdir(storageDir, { recursive: true });
   // read/write files under storageDir
 },
 ```
 
-The optional-field spread keeps the tool forward-compatible: if a future host version starts injecting `pluginStorageDir` into `ToolContext`, the tool picks it up automatically.
-
-**Hot-reload caveat.** Bun caches `import()` by resolved file path and does not bust on content changes, so an edit to an *existing* tool file is only picked up after a daemon restart. Added and removed tool files are picked up live (discovery is by directory listing). When iterating on a tool's implementation, restart the daemon (or rename the file) to see the change.
+Note that `pluginStorageDir` is only available on `InitContext` (the `init` hook), not on `ToolContext`, so a tool cannot read it inside `execute`.
 
 ## Resolution order
 
@@ -161,3 +155,4 @@ export default {
 ```
 
 Types come from [`@vellumai/plugin-api`](https://github.com/vellum-ai/vellum-assistant/tree/main/assistant/src/plugin-api), the only supported contract.
+

--- a/skills/plugin-builder/references/tools.md
+++ b/skills/plugin-builder/references/tools.md
@@ -78,6 +78,28 @@ The result is what the model sees back:
 | `yieldToUser`   | `boolean?`        | When true, the loop returns control to the user after this result instead of making another model call. |
 | `contentBlocks` | `ContentBlock[]?` | Rich content blocks (for example images) to include alongside the text result.                          |
 
+## Persisting data from a tool
+
+`ToolContext` does **not** include `pluginStorageDir`. That field is only passed to the `init` hook (`InitContext`). A tool that reads `ctx.pluginStorageDir` inside `execute` crashes at call time with `The "paths[0]" property must be of type string, got undefined`, and if the read is wrapped in a broad `try/catch`, the crash silently degrades into an empty result, which is worse.
+
+A tool that needs durable storage should derive the directory from `workingDir`, which matches where the host provisions plugin storage (`<workspaceDir>/plugins-data/<plugin-name>/`):
+
+```ts
+execute: async (input, ctx) => {
+  const fs = await import("node:fs/promises");
+  const path = await import("node:path");
+  const storageDir =
+    (ctx as { pluginStorageDir?: string }).pluginStorageDir ??
+    path.join(ctx.workingDir ?? process.cwd(), "plugins-data", "my-plugin-name");
+  await fs.mkdir(storageDir, { recursive: true });
+  // read/write files under storageDir
+},
+```
+
+The optional-field spread keeps the tool forward-compatible: if a future host version starts injecting `pluginStorageDir` into `ToolContext`, the tool picks it up automatically.
+
+**Hot-reload caveat.** Bun caches `import()` by resolved file path and does not bust on content changes, so an edit to an *existing* tool file is only picked up after a daemon restart. Added and removed tool files are picked up live (discovery is by directory listing). When iterating on a tool's implementation, restart the daemon (or rename the file) to see the change.
+
 ## Resolution order
 
 All tools (built-in, plugin, workspace, and MCP) land in one shared catalog. When the model calls a tool, the runtime looks it up by name. When two sources register the same name, the higher-precedence source wins:


### PR DESCRIPTION
## What

Adds a "Persisting data from a tool" section to `references/tools.md` covering:

1. `ctx.pluginStorageDir` does not exist inside `execute` (it is `InitContext`-only). Reading it crashes at call time with `The "paths[0]" property must be of type string, got undefined`.
2. The correct pattern: derive the storage dir from `ctx.workingDir` (`<workspaceDir>/plugins-data/<plugin-name>/`), with an optional-field fallback that stays forward-compatible if the host ever injects `pluginStorageDir` into `ToolContext`.
3. The hot-reload caveat: bun caches `import()` by path, so content edits to an existing tool file need a daemon restart; added/removed files reload live.

## Why

This bug shipped in the wild. The original plugin-builder SKILL.md (#35041, Jun 16) had a "minimal useful tool" example that read `ctx.pluginStorageDir` inside `execute`. Assistants that installed the skill before the Jun 24 refactor (#35895) learned the broken pattern, and the refactor removed the example without replacing it with correct storage guidance, so there is currently no documented way for a stateful tool to persist data. `plugins.md` still points at `data/` + `InitContext.pluginStorageDir`, which is exactly what a builder writing a stateful tool will reach for.

Concrete instance: all four tools of the `travel-planner` plugin (built against the Jun 17 skill install) crashed on first real call. Worse, the skill example wrapped the read in a broad `try/catch`, so the crash degraded into a silent `null` result instead of an error.

## Verification

Harness run with a bare `ToolContext` (`{ conversationId, workingDir }`, as registered user-plugin tools actually receive per `src/tools/types.ts` and the mtime-cache loader):

```
OLD pattern, raw error: The "paths[0]" property must be of type string, got undefined
OLD example result (crash swallowed to null): {"content":null}
FIXED example result: {"content":"it works"}
FIXED example with explicit pluginStorageDir: {"content":"init-style dir honored"}
```

Timely because of the 30-plugins-by-Wednesday push: every builder writing a stateful tool this week walks straight into this hole.

cc @dvargasfuertes for review.

Filed by Ava (Anita's assistant). The travel-planner fix itself is already live at AnitaKirkovska/travel-planner@117fdec.