### PR TITLE
refactor: break the remaining isolated import cycles via leaf extraction

### DIFF
--- a/assistant/src/cli/lib/__tests__/diff-plugin.test.ts
+++ b/assistant/src/cli/lib/__tests__/diff-plugin.test.ts
@@ -18,11 +18,8 @@ import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { diffPlugin, PluginDiffUnavailableError } from "../diff-plugin.js";
-import {
-  type FetchLike,
-  type GitRunner,
-  PluginNotFoundError,
-} from "../install-from-github.js";
+import type { FetchLike } from "../fetch-like.js";
+import { type GitRunner, PluginNotFoundError } from "../install-from-github.js";
 import { PluginNotInstalledError } from "../uninstall-plugin.js";
 
 const SHA_A = "a".repeat(40);

--- a/assistant/src/cli/lib/__tests__/inspect-plugin.test.ts
+++ b/assistant/src/cli/lib/__tests__/inspect-plugin.test.ts
@@ -13,11 +13,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import type { FetchLike } from "../fetch-like.js";
 import {
   inspectPlugin,
   PluginInspectNotFoundError,
 } from "../inspect-plugin.js";
-import type { FetchLike } from "../install-from-github.js";
 import { computeFingerprint } from "../plugin-fingerprint.js";
 
 const SHA_A = "a".repeat(40);

--- a/assistant/src/cli/lib/__tests__/install-from-github.test.ts
+++ b/assistant/src/cli/lib/__tests__/install-from-github.test.ts
@@ -22,8 +22,8 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import type { FetchLike } from "../fetch-like.js";
 import {
-  type FetchLike,
   type GitRunner,
   installPlugin,
   InvalidPluginNameError,

--- a/assistant/src/cli/lib/__tests__/plugin-details.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-details.test.ts
@@ -15,7 +15,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import type { FetchLike } from "../install-from-github.js";
+import type { FetchLike } from "../fetch-like.js";
 import {
   getPluginDetails,
   PluginDetailsNotFoundError,

--- a/assistant/src/cli/lib/__tests__/plugin-marketplace.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-marketplace.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import type { FetchLike } from "../install-from-github.js";
+import type { FetchLike } from "../fetch-like.js";
 import {
   fetchMarketplaceEntries,
   type MarketplaceEntry,

--- a/assistant/src/cli/lib/__tests__/plugin-pin-history.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-pin-history.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import type { FetchLike } from "../install-from-github.js";
+import type { FetchLike } from "../fetch-like.js";
 import {
   listPinHistory,
   resolvePinToMarketplaceCommit,

--- a/assistant/src/cli/lib/__tests__/search-plugins.test.ts
+++ b/assistant/src/cli/lib/__tests__/search-plugins.test.ts
@@ -9,9 +9,9 @@
 
 import { describe, expect, test } from "bun:test";
 
+import type { FetchLike } from "../fetch-like.js";
 import { MarketplaceFetchError } from "../plugin-marketplace.js";
 import {
-  type FetchLike,
   InvalidSearchPatternError,
   PluginCatalogUnavailableError,
   searchPlugins,

--- a/assistant/src/cli/lib/__tests__/upgrade-plugin.test.ts
+++ b/assistant/src/cli/lib/__tests__/upgrade-plugin.test.ts
@@ -21,8 +21,8 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import type { FetchLike } from "../fetch-like.js";
 import {
-  type FetchLike,
   type GitRunner,
   PluginSourceUnavailableError,
 } from "../install-from-github.js";

--- a/assistant/src/cli/lib/diff-plugin.ts
+++ b/assistant/src/cli/lib/diff-plugin.ts
@@ -40,9 +40,9 @@ import { createTwoFilesPatch } from "diff";
 
 import { PRESERVED_ENTRIES } from "../../plugins/plugin-tree-walk.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
+import type { FetchLike } from "./fetch-like.js";
 import {
   DEFAULT_PLUGIN_REF,
-  type FetchLike,
   type GitRunner,
   materializePluginTree,
   type PluginFetchSource,

--- a/assistant/src/cli/lib/fetch-like.ts
+++ b/assistant/src/cli/lib/fetch-like.ts
@@ -1,0 +1,11 @@
+/**
+ * Minimal `fetch` shape used by the plugin CLI helpers.
+ *
+ * Narrower than `typeof fetch` because Bun's `fetch` carries a `preconnect`
+ * static these callers do not need — pinning to the wider type would force
+ * every caller to construct a fully-featured Bun fetch.
+ */
+export type FetchLike = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;

--- a/assistant/src/cli/lib/inspect-plugin.ts
+++ b/assistant/src/cli/lib/inspect-plugin.ts
@@ -17,9 +17,9 @@
  */
 
 import { PRESERVED_ENTRIES } from "../../plugins/plugin-tree-walk.js";
+import type { FetchLike } from "./fetch-like.js";
 import {
   DEFAULT_PLUGIN_REF,
-  type FetchLike,
   type InstallMeta,
   readInstallMeta,
   sanitizePluginName,

--- a/assistant/src/cli/lib/install-from-github.ts
+++ b/assistant/src/cli/lib/install-from-github.ts
@@ -42,6 +42,7 @@ import { promisify } from "node:util";
 import { PRESERVED_ENTRIES } from "../../plugins/plugin-tree-walk.js";
 import { ensureBun } from "../../util/bun-runtime.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
+import type { FetchLike } from "./fetch-like.js";
 import {
   computeContentHash,
   computeFingerprint,
@@ -79,18 +80,6 @@ interface GitHubContentEntry {
   readonly size: number;
   readonly download_url: string | null;
 }
-
-/**
- * Minimal `fetch` shape used by this module.
- *
- * Narrower than `typeof fetch` because Bun's `fetch` carries a `preconnect`
- * static that this module does not need — pinning to the wider type would
- * force every caller to construct a fully-featured Bun fetch.
- */
-export type FetchLike = (
-  input: RequestInfo | URL,
-  init?: RequestInit,
-) => Promise<Response>;
 
 /**
  * Runs a `git` subcommand in `cwd` and resolves its stdout. Injected so tests

--- a/assistant/src/cli/lib/plugin-details.ts
+++ b/assistant/src/cli/lib/plugin-details.ts
@@ -28,9 +28,9 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { getWorkspacePluginsDir } from "../../util/platform.js";
+import type { FetchLike } from "./fetch-like.js";
 import {
   DEFAULT_PLUGIN_REF,
-  type FetchLike,
   sanitizePluginName,
 } from "./install-from-github.js";
 import { parsePluginArtifact, type PluginArtifact } from "./plugin-artifact.js";

--- a/assistant/src/cli/lib/plugin-marketplace.ts
+++ b/assistant/src/cli/lib/plugin-marketplace.ts
@@ -25,10 +25,7 @@
 
 import { z } from "zod";
 
-// Type-only import: keeps the dependency direction one-way at runtime
-// (install-from-github resolves sources *through* this module) while still
-// sharing the injected-`fetch` shape.
-import type { FetchLike } from "./install-from-github.js";
+import type { FetchLike } from "./fetch-like.js";
 
 /** Canonical location of the marketplace manifest. */
 const MARKETPLACE_SOURCE_OWNER = "vellum-ai";

--- a/assistant/src/cli/lib/plugin-pin-history.ts
+++ b/assistant/src/cli/lib/plugin-pin-history.ts
@@ -22,7 +22,8 @@
  * sibling plugin libraries.
  */
 
-import { type FetchLike, sanitizePluginName } from "./install-from-github.js";
+import type { FetchLike } from "./fetch-like.js";
+import { sanitizePluginName } from "./install-from-github.js";
 import {
   fetchMarketplaceEntries,
   MARKETPLACE_MANIFEST_LOCATION,

--- a/assistant/src/cli/lib/search-plugins.ts
+++ b/assistant/src/cli/lib/search-plugins.ts
@@ -16,17 +16,13 @@
  * retry-decorated client, or a test fixture).
  */
 
-import type { FetchLike } from "./install-from-github.js";
+import type { FetchLike } from "./fetch-like.js";
 import { DEFAULT_PLUGIN_REF } from "./install-from-github.js";
 import {
   fetchMarketplaceEntries,
   type MarketplaceEntry,
   MarketplaceFetchError,
 } from "./plugin-marketplace.js";
-
-// Re-export the dep-injection type so callers can grab everything they need
-// from one module rather than reaching into `install-from-github.js`.
-export type { FetchLike } from "./install-from-github.js";
 
 /** Options that control the search. */
 export interface SearchPluginsOptions {

--- a/assistant/src/cli/lib/upgrade-plugin.ts
+++ b/assistant/src/cli/lib/upgrade-plugin.ts
@@ -34,6 +34,7 @@ import { dirname, join } from "node:path";
 
 import { PRESERVED_ENTRIES } from "../../plugins/plugin-tree-walk.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
+import type { FetchLike } from "./fetch-like.js";
 import {
   inspectPlugin,
   type PluginInspection,
@@ -43,7 +44,6 @@ import {
 } from "./inspect-plugin.js";
 import {
   DEFAULT_PLUGIN_REF,
-  type FetchLike,
   finalizeStagedInstall,
   type GitRunner,
   installPlugin,

--- a/assistant/src/monitoring/__tests__/resource-sampler.test.ts
+++ b/assistant/src/monitoring/__tests__/resource-sampler.test.ts
@@ -6,10 +6,8 @@
 
 import { describe, expect, test } from "bun:test";
 
-import {
-  computeSampleDeltas,
-  type ResourceSample,
-} from "../resource-sampler.js";
+import type { ResourceSample } from "../resource-sample-types.js";
+import { computeSampleDeltas } from "../resource-sampler.js";
 
 function makeSample(overrides: Partial<ResourceSample>): ResourceSample {
   return {

--- a/assistant/src/monitoring/__tests__/stall-capture.test.ts
+++ b/assistant/src/monitoring/__tests__/stall-capture.test.ts
@@ -11,7 +11,7 @@ import { beforeEach, describe, expect, test } from "bun:test";
 
 import { getMonitoringDataDir } from "../../util/platform.js";
 import { getDaemonHeartbeatPath } from "../daemon-heartbeat.js";
-import type { ResourceSample } from "../resource-sampler.js";
+import type { ResourceSample } from "../resource-sample-types.js";
 import {
   createStallCaptureMonitor,
   findRecentStallCapture,

--- a/assistant/src/monitoring/resource-sample-types.ts
+++ b/assistant/src/monitoring/resource-sample-types.ts
@@ -1,0 +1,71 @@
+/**
+ * The resource-sample shape captured by the monitor (`resource-sampler.ts`),
+ * consumed by the stall-capture monitor (`stall-capture.ts`) and rendered by
+ * the monitoring routes: a point-in-time snapshot of cgroup memory/CPU, disk,
+ * and the conversations mid-turn at capture time.
+ */
+import type { ContainerCpuStat } from "../util/cgroup-cpu.js";
+import type {
+  ContainerMemoryEvents,
+  ContainerMemoryStat,
+  ContainerReclaimCounters,
+} from "../util/cgroup-memory.js";
+import type { ActiveConversation } from "./active-conversations.js";
+
+export interface ResourceSampleMemory {
+  currentBytes: number;
+  limitBytes: number | null;
+  peakBytes: number | null;
+  /** current / limit, or null when the limit is unknown. */
+  ratio: number | null;
+}
+
+export interface ResourceSampleDisk {
+  path: string;
+  usedMb: number;
+  totalMb: number;
+  freeMb: number;
+}
+
+/**
+ * Counter increases since the previous sample. The cumulative since-boot
+ * counters answer "has this ever happened"; the deltas are what turn a stall
+ * into a timeline — a burst of `reclaim.pgscanDirect` across a few samples *is*
+ * the synchronous-reclaim stall, invisible in the cumulative totals.
+ */
+export interface ResourceSampleDeltas {
+  events: ContainerMemoryEvents | null;
+  reclaim: ContainerReclaimCounters | null;
+  cpu: ContainerCpuStat | null;
+}
+
+export interface ResourceSample {
+  ts: number;
+  memory: ResourceSampleMemory | null;
+  /**
+   * memory.stat breakdown (anon / file / kernel / slab, plus the derived
+   * unevictable vs reclaimable split). `memory.currentBytes` alone cannot say
+   * whether the cgroup is filling with process heap or with droppable cache.
+   */
+  memoryStat: ContainerMemoryStat | null;
+  /** Cumulative reclaim/thrash counters from memory.stat (since boot). */
+  reclaim: ContainerReclaimCounters | null;
+  /**
+   * Cumulative cpu.stat counters (since boot). A rising `throttledUsec` delta
+   * means the container hit its CPU quota and the kernel paused its threads —
+   * indistinguishable from a busy event loop without this.
+   */
+  cpu: ContainerCpuStat | null;
+  events: ContainerMemoryEvents | null;
+  /** Since the previous sample; null on the monitor's first sample. */
+  deltas: ResourceSampleDeltas | null;
+  disk: ResourceSampleDisk | null;
+  /**
+   * Conversations mid-turn per the daemon's persisted
+   * `conversations.processing_started_at` flag, so a spike in the timeline
+   * names what was running. The live flag is nulled when a turn ends, so only
+   * this sampling-time capture preserves the correlation for post-mortems.
+   * Null when nothing is processing or the database is unavailable.
+   */
+  activeConversations: ActiveConversation[] | null;
+}

--- a/assistant/src/monitoring/resource-sampler.ts
+++ b/assistant/src/monitoring/resource-sampler.ts
@@ -20,14 +20,8 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import type { MonitoringConfig } from "../config/schemas/monitoring.js";
+import { getContainerCpuStat } from "../util/cgroup-cpu.js";
 import {
-  type ContainerCpuStat,
-  getContainerCpuStat,
-} from "../util/cgroup-cpu.js";
-import {
-  type ContainerMemoryEvents,
-  type ContainerMemoryStat,
-  type ContainerReclaimCounters,
   getContainerMemoryEvents,
   getContainerMemoryLimitBytes,
   getContainerMemoryPeakBytes,
@@ -41,13 +35,15 @@ import { getDiskUsageInfo } from "../util/disk-usage.js";
 import { getLogger } from "../util/logger.js";
 import { getMonitoringDataDir } from "../util/platform.js";
 import { buildProcessTree, listProcesses } from "../util/process-tree.js";
-import {
-  type ActiveConversation,
-  readActiveConversations,
-} from "./active-conversations.js";
+import { readActiveConversations } from "./active-conversations.js";
 import { getTrackedDataFiles, readFileResidency } from "./page-cache.js";
 import { topProcessesByMemory } from "./process-memory.js";
 import { prunePrefixedJsonFiles } from "./prune-snapshots.js";
+import type {
+  ResourceSample,
+  ResourceSampleDeltas,
+  ResourceSampleMemory,
+} from "./resource-sample-types.js";
 import { SampleRingBuffer } from "./sample-ring-buffer.js";
 import { topSlabCaches } from "./slabinfo.js";
 import { createStallCaptureMonitor } from "./stall-capture.js";
@@ -69,64 +65,6 @@ const SNAPSHOT_KINDS = {
 } as const;
 
 type SnapshotKind = keyof typeof SNAPSHOT_KINDS;
-
-export interface ResourceSampleMemory {
-  currentBytes: number;
-  limitBytes: number | null;
-  peakBytes: number | null;
-  /** current / limit, or null when the limit is unknown. */
-  ratio: number | null;
-}
-
-export interface ResourceSampleDisk {
-  path: string;
-  usedMb: number;
-  totalMb: number;
-  freeMb: number;
-}
-
-/**
- * Counter increases since the previous sample. The cumulative since-boot
- * counters answer "has this ever happened"; the deltas are what turn a stall
- * into a timeline — a burst of `reclaim.pgscanDirect` across a few samples *is*
- * the synchronous-reclaim stall, invisible in the cumulative totals.
- */
-export interface ResourceSampleDeltas {
-  events: ContainerMemoryEvents | null;
-  reclaim: ContainerReclaimCounters | null;
-  cpu: ContainerCpuStat | null;
-}
-
-export interface ResourceSample {
-  ts: number;
-  memory: ResourceSampleMemory | null;
-  /**
-   * memory.stat breakdown (anon / file / kernel / slab, plus the derived
-   * unevictable vs reclaimable split). `memory.currentBytes` alone cannot say
-   * whether the cgroup is filling with process heap or with droppable cache.
-   */
-  memoryStat: ContainerMemoryStat | null;
-  /** Cumulative reclaim/thrash counters from memory.stat (since boot). */
-  reclaim: ContainerReclaimCounters | null;
-  /**
-   * Cumulative cpu.stat counters (since boot). A rising `throttledUsec` delta
-   * means the container hit its CPU quota and the kernel paused its threads —
-   * indistinguishable from a busy event loop without this.
-   */
-  cpu: ContainerCpuStat | null;
-  events: ContainerMemoryEvents | null;
-  /** Since the previous sample; null on the monitor's first sample. */
-  deltas: ResourceSampleDeltas | null;
-  disk: ResourceSampleDisk | null;
-  /**
-   * Conversations mid-turn per the daemon's persisted
-   * `conversations.processing_started_at` flag, so a spike in the timeline
-   * names what was running. The live flag is nulled when a turn ends, so only
-   * this sampling-time capture preserves the correlation for post-mortems.
-   * Null when nothing is processing or the database is unavailable.
-   */
-  activeConversations: ActiveConversation[] | null;
-}
 
 /** Per-counter increases from `prev` to `current`. */
 export function computeSampleDeltas(

--- a/assistant/src/monitoring/stall-capture.ts
+++ b/assistant/src/monitoring/stall-capture.ts
@@ -23,7 +23,7 @@ import { getLogger } from "../util/logger.js";
 import { getMonitoringDataDir } from "../util/platform.js";
 import { readDaemonHeartbeat } from "./daemon-heartbeat.js";
 import { prunePrefixedJsonFiles } from "./prune-snapshots.js";
-import type { ResourceSample } from "./resource-sampler.js";
+import type { ResourceSample } from "./resource-sample-types.js";
 
 const log = getLogger("stall-capture");
 

--- a/assistant/src/plugins/defaults/memory/v2/harness/harness-types.ts
+++ b/assistant/src/plugins/defaults/memory/v2/harness/harness-types.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared types for the memory comparison harness, referenced by both the
+ * retriever seam (`retriever.ts`) and the descent tracing (`trace.ts`).
+ */
+
+/** Optional cost accounting for a single retrieval. */
+export interface RetrievalCost {
+  inputTokens?: number;
+  outputTokens?: number;
+  usd?: number;
+  ms?: number;
+}

--- a/assistant/src/plugins/defaults/memory/v2/harness/retriever.ts
+++ b/assistant/src/plugins/defaults/memory/v2/harness/retriever.ts
@@ -12,6 +12,7 @@
 import type { AssistantConfig } from "../../../../../config/types.js";
 import type { RouterTurnPair } from "../router.js";
 import type { EverInjectedEntry } from "../types.js";
+import type { RetrievalCost } from "./harness-types.js";
 import type { DescentTrace } from "./trace.js";
 
 /**
@@ -32,14 +33,6 @@ export interface RetrievalInput {
   priorEverInjected: readonly EverInjectedEntry[];
   config: AssistantConfig;
   signal?: AbortSignal;
-}
-
-/** Optional cost accounting for a single retrieval. */
-export interface RetrievalCost {
-  inputTokens?: number;
-  outputTokens?: number;
-  usd?: number;
-  ms?: number;
 }
 
 /** What a retriever returns for one turn. */

--- a/assistant/src/plugins/defaults/memory/v2/harness/trace.ts
+++ b/assistant/src/plugins/defaults/memory/v2/harness/trace.ts
@@ -8,7 +8,7 @@
  * high-level skip is observable rather than silent.
  */
 
-import type { RetrievalCost } from "./retriever.js";
+import type { RetrievalCost } from "./harness-types.js";
 
 /** A scout lane's contribution on one pass. */
 export interface ScoutResult {

--- a/assistant/src/runtime/http-router-types.ts
+++ b/assistant/src/runtime/http-router-types.ts
@@ -1,0 +1,119 @@
+/**
+ * HTTP route definition vocabulary for the runtime HTTP server: the shape of a
+ * route entry (`HTTPRouteDefinition`), the per-handler context (`RouteContext`),
+ * and the OpenAPI metadata types that hang off them. Consumed by the router
+ * (`http-router.ts`) and the transport adapter (`routes/http-adapter.ts`).
+ */
+
+import type { z } from "zod";
+
+import type { RoutePolicy } from "./auth/route-policy.js";
+import type { AuthContext } from "./auth/types.js";
+import type {
+  RouteLoggingConfig,
+  RoutePathParam,
+  RouteRequestBody,
+  RouteResponseBody,
+} from "./routes/types.js";
+
+/** Extracted parameters from parameterized route matches. */
+export type RouteParams = Record<string, string>;
+
+/** The context available to every route handler. */
+export interface RouteContext {
+  req: Request;
+  url: URL;
+  server: ReturnType<typeof Bun.serve>;
+  authContext: AuthContext;
+  params: RouteParams;
+}
+
+/** Schema for an OpenAPI query parameter. */
+export interface RouteQueryParam {
+  name: string;
+  /** OpenAPI-style JSON Schema type (e.g. "string", "integer"). Defaults to "string". */
+  type?: string;
+  required?: boolean;
+  description?: string;
+  /** Inline JSON Schema for the parameter (overrides `type` when present). */
+  schema?: Record<string, unknown>;
+}
+
+/** Zod schema used to describe a request or response body.
+ * The generate-openapi script converts these to JSON Schema via z.toJSONSchema(). */
+export type RouteBodySchema = z.ZodType;
+
+/**
+ * Description for a non-200 response variant. Used when an endpoint has
+ * meaningful alternate response shapes that clients should handle (e.g.
+ * 502 `fetch_failed` on POST /v1/migrations/import when the URL body path
+ * can't reach the upstream bundle host).
+ */
+export interface RouteAdditionalResponse {
+  description: string;
+  /** Zod schema or plain JSON Schema fragment. */
+  schema?: RouteBodySchema | Record<string, unknown>;
+}
+
+/**
+ * A single route entry in the declarative table.
+ *
+ * - `endpoint`: The endpoint pattern after `/v1/`. Use `:paramName` for
+ *   single-segment params (e.g. `calls/:id/cancel`) or `:paramName*` for
+ *   catch-all params that match across slashes (e.g. `interfaces/:path*`).
+ * - `method`: HTTP method (GET, POST, DELETE, PATCH, PUT).
+ * - `handler`: Async function that produces the Response.
+ * - `policy`: Scope + principal-type policy for this route, or `null`
+ *   when the route is intentionally unprotected. See
+ *   `runtime/auth/route-policy.ts` for the type.
+ */
+export interface HTTPRouteDefinition {
+  endpoint: string;
+  method: string;
+  handler: (ctx: RouteContext) => Promise<Response> | Response;
+  policy: RoutePolicy | null;
+
+  /** Stable identifier used as the IPC method name when served over both transports. */
+  operationId?: string;
+
+  /** Typed path parameter constraints. When a param has `type: "uuid"`,
+   *  the compiled regex narrows the capture group so it only matches
+   *  UUID-shaped segments, preventing shadowing of literal sub-routes. */
+  pathParams?: RoutePathParam[];
+
+  // -- OpenAPI metadata (optional) ------------------------------------------
+  /** Short summary shown next to the operation in generated docs. */
+  summary?: string;
+  /** Longer description (Markdown-safe) for the operation. */
+  description?: string;
+  /** Grouping tags (e.g. "secrets", "identity"). Auto-derived from the route module filename when omitted. */
+  tags?: string[];
+  /** Query parameter definitions for the operation. */
+  queryParams?: RouteQueryParam[];
+  /**
+   * Request body for POST/PUT/PATCH/DELETE. A bare Zod schema is advertised
+   * as `application/json`; use the `{ contentType, schema }` form for non-JSON
+   * bodies (e.g. a raw `application/octet-stream` upload).
+   */
+  requestBody?: RouteRequestBody;
+  /**
+   * Success response body. A bare Zod schema is advertised as
+   * `application/json`; use the `{ contentType, schema }` form for non-JSON
+   * responses (e.g. a binary `application/octet-stream` download).
+   */
+  responseBody?: RouteResponseBody;
+  /**
+   * HTTP status code for the documented success response. Defaults to 200.
+   * Set to "202" for async endpoints that enqueue a job and return
+   * immediately — this keeps the generated OpenAPI spec aligned with the
+   * handler's actual `status:` value.
+   */
+  responseStatus?: string;
+  /** Additional response codes documented in the generated OpenAPI spec. */
+  additionalResponses?: Record<string, RouteAdditionalResponse>;
+  /**
+   * Per-route request-log control. See `RouteLoggingConfig` in `routes/types.ts`.
+   * When omitted, the route uses the default log-every-request behavior.
+   */
+  logging?: RouteLoggingConfig;
+}

--- a/assistant/src/runtime/http-router.ts
+++ b/assistant/src/runtime/http-router.ts
@@ -10,127 +10,14 @@
  * `normalizeEndpointForPolicy`.
  */
 
-import type { z } from "zod";
-
-import type { RoutePolicy } from "./auth/route-policy.js";
 import { enforcePolicy } from "./auth/route-policy.js";
 import type { AuthContext } from "./auth/types.js";
 import { httpError } from "./http-errors.js";
+import type { HTTPRouteDefinition, RouteParams } from "./http-router-types.js";
 import { withErrorHandling } from "./middleware/error-handler.js";
 import { routeDefinitionsToHTTPRoutes } from "./routes/http-adapter.js";
 import { ROUTES } from "./routes/index.js";
-import type {
-  RouteLoggingConfig,
-  RoutePathParam,
-  RouteRequestBody,
-  RouteResponseBody,
-} from "./routes/types.js";
-
-// ---------------------------------------------------------------------------
-// Route definition types
-// ---------------------------------------------------------------------------
-
-/** Extracted parameters from parameterized route matches. */
-export type RouteParams = Record<string, string>;
-
-/** The context available to every route handler. */
-export interface RouteContext {
-  req: Request;
-  url: URL;
-  server: ReturnType<typeof Bun.serve>;
-  authContext: AuthContext;
-  params: RouteParams;
-}
-
-/** Schema for an OpenAPI query parameter. */
-export interface RouteQueryParam {
-  name: string;
-  /** OpenAPI-style JSON Schema type (e.g. "string", "integer"). Defaults to "string". */
-  type?: string;
-  required?: boolean;
-  description?: string;
-  /** Inline JSON Schema for the parameter (overrides `type` when present). */
-  schema?: Record<string, unknown>;
-}
-
-/** Zod schema used to describe a request or response body.
- * The generate-openapi script converts these to JSON Schema via z.toJSONSchema(). */
-export type RouteBodySchema = z.ZodType;
-
-/**
- * Description for a non-200 response variant. Used when an endpoint has
- * meaningful alternate response shapes that clients should handle (e.g.
- * 502 `fetch_failed` on POST /v1/migrations/import when the URL body path
- * can't reach the upstream bundle host).
- */
-export interface RouteAdditionalResponse {
-  description: string;
-  /** Zod schema or plain JSON Schema fragment. */
-  schema?: RouteBodySchema | Record<string, unknown>;
-}
-
-/**
- * A single route entry in the declarative table.
- *
- * - `endpoint`: The endpoint pattern after `/v1/`. Use `:paramName` for
- *   single-segment params (e.g. `calls/:id/cancel`) or `:paramName*` for
- *   catch-all params that match across slashes (e.g. `interfaces/:path*`).
- * - `method`: HTTP method (GET, POST, DELETE, PATCH, PUT).
- * - `handler`: Async function that produces the Response.
- * - `policy`: Scope + principal-type policy for this route, or `null`
- *   when the route is intentionally unprotected. See
- *   `runtime/auth/route-policy.ts` for the type.
- */
-export interface HTTPRouteDefinition {
-  endpoint: string;
-  method: string;
-  handler: (ctx: RouteContext) => Promise<Response> | Response;
-  policy: RoutePolicy | null;
-
-  /** Stable identifier used as the IPC method name when served over both transports. */
-  operationId?: string;
-
-  /** Typed path parameter constraints. When a param has `type: "uuid"`,
-   *  the compiled regex narrows the capture group so it only matches
-   *  UUID-shaped segments, preventing shadowing of literal sub-routes. */
-  pathParams?: RoutePathParam[];
-
-  // -- OpenAPI metadata (optional) ------------------------------------------
-  /** Short summary shown next to the operation in generated docs. */
-  summary?: string;
-  /** Longer description (Markdown-safe) for the operation. */
-  description?: string;
-  /** Grouping tags (e.g. "secrets", "identity"). Auto-derived from the route module filename when omitted. */
-  tags?: string[];
-  /** Query parameter definitions for the operation. */
-  queryParams?: RouteQueryParam[];
-  /**
-   * Request body for POST/PUT/PATCH/DELETE. A bare Zod schema is advertised
-   * as `application/json`; use the `{ contentType, schema }` form for non-JSON
-   * bodies (e.g. a raw `application/octet-stream` upload).
-   */
-  requestBody?: RouteRequestBody;
-  /**
-   * Success response body. A bare Zod schema is advertised as
-   * `application/json`; use the `{ contentType, schema }` form for non-JSON
-   * responses (e.g. a binary `application/octet-stream` download).
-   */
-  responseBody?: RouteResponseBody;
-  /**
-   * HTTP status code for the documented success response. Defaults to 200.
-   * Set to "202" for async endpoints that enqueue a job and return
-   * immediately — this keeps the generated OpenAPI spec aligned with the
-   * handler's actual `status:` value.
-   */
-  responseStatus?: string;
-  /** Additional response codes documented in the generated OpenAPI spec. */
-  additionalResponses?: Record<string, RouteAdditionalResponse>;
-  /**
-   * Per-route request-log control. See `RouteLoggingConfig` in `routes/types.ts`.
-   * When omitted, the route uses the default log-every-request behavior.
-   */
-  logging?: RouteLoggingConfig;
-}
+import type { RouteLoggingConfig } from "./routes/types.js";
 
 // ---------------------------------------------------------------------------
 // Compiled route — internal representation with pre-built regex

--- a/assistant/src/runtime/routes/__tests__/monitoring-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/monitoring-routes.test.ts
@@ -14,7 +14,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import * as actualLoader from "../../../config/loader.js";
-import type { ResourceSample } from "../../../monitoring/resource-sampler.js";
+import type { ResourceSample } from "../../../monitoring/resource-sample-types.js";
 import { getMonitoringPidPath } from "../../../util/platform.js";
 
 class FakeSpawnError extends Error {}

--- a/assistant/src/runtime/routes/http-adapter.ts
+++ b/assistant/src/runtime/routes/http-adapter.ts
@@ -6,7 +6,7 @@
 import { requireBoundGuardian } from "../auth/require-bound-guardian.js";
 import type { HttpErrorCode } from "../http-errors.js";
 import { httpError } from "../http-errors.js";
-import type { HTTPRouteDefinition } from "../http-router.js";
+import type { HTTPRouteDefinition } from "../http-router-types.js";
 import { RouteError } from "./errors.js";
 import type { ResponseHeaderArgs, RouteDefinition } from "./types.js";
 import { RouteResponse } from "./types.js";

--- a/assistant/src/runtime/routes/monitoring-routes.ts
+++ b/assistant/src/runtime/routes/monitoring-routes.ts
@@ -18,7 +18,7 @@ import {
   spawnMonitoringWorkerProcess,
   stopMonitoringWorkerProcess,
 } from "../../monitoring/control.js";
-import type { ResourceSample } from "../../monitoring/resource-sampler.js";
+import type { ResourceSample } from "../../monitoring/resource-sample-types.js";
 import { SampleRingBuffer } from "../../monitoring/sample-ring-buffer.js";
 import { getLogger } from "../../util/logger.js";
 import {


### PR DESCRIPTION
## Prompt / plan

Final pass on the import-cycle cleanup. This clears the remaining isolated strongly-connected components in one PR. Each is the same "type-only back-edge → extract to a leaf" shape; two of them (`http-router`, `resource-sampler`) drag a small *cluster* of sibling types that had to move together, the other two are single types. No runtime behavior changes — all pure type relocation.

**1. `runtime/http-router` ↔ `routes/http-adapter`** — the adapter imported `HTTPRouteDefinition` back from the router. Moved the HTTP route-definition vocabulary (`HTTPRouteDefinition`, `RouteContext`, `RouteParams`, `RouteQueryParam`, `RouteBodySchema`, `RouteAdditionalResponse`) into `runtime/http-router-types.ts`; the router and adapter both import from the leaf. Now-unused type imports in the router were pruned.

**2. `monitoring/resource-sampler` ↔ `monitoring/stall-capture`** — stall-capture imported the `ResourceSample` type back from resource-sampler. Moved the sample vocabulary (`ResourceSample` + `ResourceSampleMemory`/`ResourceSampleDisk`/`ResourceSampleDeltas`) into `monitoring/resource-sample-types.ts`; resource-sampler, stall-capture, and the monitoring route import from the leaf.

**3. `cli/lib/install-from-github` ↔ `cli/lib/plugin-marketplace`** — plugin-marketplace imported the `FetchLike` type back from the 1.5k-line install-from-github module. `FetchLike` is a generic injected-fetch shape used across seven `cli/lib` modules, so it moved into `cli/lib/fetch-like.ts` and every importer (plus tests) was repointed — also gets it out of the giant module. Removed a stale re-export from `search-plugins.ts`.

**4. memory-v2 harness `retriever` ↔ `trace`** — mutual type import. Moved `RetrievalCost` into a `harness-types.ts` leaf so `trace` no longer imports `retriever`. Note: `retriever` itself stays in the daemon **core** SCC via `router.ts` (a larger, separate cycle), but the direct `retriever↔trace` back-edge is gone and `trace` is now cycle-free.

**Result (verified against `main` back-to-back with madge):** isolated circular SCCs **4 → 0**. `main` had SCC sizes `[392, 2, 2, 2]`; this branch has `[391]` — the three isolated pairs are eliminated, and the core actually shrank by one (the `retriever↔trace` cut pushed `trace` out of it). The only strongly-connected component left is the daemon core. All moved symbols are imported directly from the leaves — no re-export shims.

## Test plan

- `bunx madge --circular` — 0 cycles touch `http-router`, `http-adapter`, `resource-sampler`, `stall-capture`, `install-from-github`, `plugin-marketplace`, or `trace`; only the daemon-core SCC remains.
- `bunx tsc --noEmit` — clean (0 errors).
- `bun test` across the touched areas — all green:
  - cli plugin lib + monitoring suites — 200/200
  - http-adapter / harness compare/metrics/runner — 19/19
  - the five repointed test files (diff/upgrade-plugin, resource-sampler, stall-capture, monitoring-routes) — 46/46
- Pre-commit + pre-push hooks (prettier, eslint, tsc) all green.

<!-- No new routes added; CLI verb checklist not applicable. -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01EWL4FYZVRGkJkMwL46PY3m)_