### PR TITLE
marketplace: rename motion-animations to motion-design

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -150,15 +150,15 @@
       "license": "MIT"
     },
     {
-      "name": "motion-animations",
+      "name": "motion-design",
       "source": {
         "source": "github",
-        "repo": "vellum-ai/motion-animations",
-        "ref": "09dd03adc8e921118eb327484e59b665248416d2"
+        "repo": "vellum-ai/motion-design",
+        "ref": "9cdc798c26e0141dcdf6887d7707559c38bfe00e"
       },
       "description": "Teaches the assistant to build polished UI animations with Motion (motion.dev) for React: animated product mockups, chat replays, typing effects, and staggered reveals, with a complete animated chat example included.",
       "category": "creative",
-      "homepage": "https://github.com/vellum-ai/motion-animations",
+      "homepage": "https://github.com/vellum-ai/motion-design",
       "license": "MIT"
     }
   ]


### PR DESCRIPTION
## What

Renames the `motion-animations` marketplace entry to **`motion-design`**, following the plugin repo rename.

- **Repo:** https://github.com/vellum-ai/motion-design (renamed from motion-animations; GitHub redirects the old URL)
- **New pinned commit:** `9cdc798c26e0141dcdf6887d7707559c38bfe00e` (the rename commit: package name, skill directory, SKILL.md display name, README all updated to motion-design)

## Notes

- Follow-up to #37334, which added the entry under the old name.
- Anyone who installed as `motion-animations` can reinstall by the new name; the old install keeps working since the pinned SHA is unchanged in content except naming.
