### PR TITLE
refactor(plugins): resolve user hooks per (owner, hookName) on demand

### DIFF
--- a/assistant/src/hooks/__tests__/hook-live-reload.test.ts
+++ b/assistant/src/hooks/__tests__/hook-live-reload.test.ts
@@ -1,11 +1,10 @@
 /**
  * Pins the eviction primitives hook live-reload is built on, driven through
- * the production import machinery (`preImportHooksDir` →
- * `collectUserHookEntries`), one layer below the sentinel-driven reconcile
- * that orchestrates them in production (see `../../plugins/mtime-cache.ts`
- * and its end-to-end suite).
+ * the production resolution path (`resolveHook` behind `collectUserHookEntries`),
+ * one layer below the sentinel-driven reconcile that orchestrates them in
+ * production (see `../../plugins/mtime-cache.ts` and its end-to-end suite).
  *
- * Two invariants live here:
+ * Three invariants live here:
  *
  * 1. **The Bun primitive.** Deleting a file's `require.cache` entry makes
  *    the next dynamic `import()` re-evaluate it from disk. This is
@@ -14,10 +13,15 @@
  *    Bun upgrade that breaks it must fail here rather than silently degrade
  *    hook edits back to restart-required.
  *
- * 2. **Whole-owner eviction.** Evicting only a hook's own module re-binds
+ * 2. **Whole-plugin module sweep.** Evicting only a hook's own module re-binds
  *    the re-imported hook to its stale cached helpers. The reconcile sweeps
  *    every path in the plugin for exactly this reason, and this suite pins
  *    the failure mode that rule prevents.
+ *
+ * 3. **Negative caching.** A hook an owner doesn't define resolves to a cached
+ *    absence, so it is stat'd once rather than re-stat'd every dispatch; the
+ *    absence only lifts when the owner is evicted (as the reconcile does on a
+ *    source change).
  */
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -30,7 +34,6 @@ import type { HookEntry } from "../../plugins/types.js";
 import {
   collectUserHookEntries,
   evictHooksForOwner,
-  preImportHooksDir,
   resetHookCacheForTests,
 } from "../hook-loader.js";
 
@@ -58,18 +61,15 @@ function makePlugin(): { dir: string; hooksDir: string; name: string } {
 }
 
 /**
- * Redeploy an owner's hooks the way the reconcile does: drop its cache
- * entries, sweep the given module paths, and re-import from disk.
+ * Redeploy an owner's hooks the way the reconcile does: drop its cached
+ * resolutions and sweep the given module paths. The next read re-resolves
+ * from disk.
  */
-async function redeploy(
-  plugin: { hooksDir: string; name: string },
-  modulePaths: string[],
-): Promise<void> {
+function redeploy(plugin: { name: string }, modulePaths: string[]): void {
   evictHooksForOwner(plugin.name);
   for (const path of modulePaths) {
     evictModule(path);
   }
-  await preImportHooksDir(plugin.hooksDir, plugin.name);
 }
 
 /** Collect and run the single expected hook, returning its result. */
@@ -89,7 +89,6 @@ describe("hook reload primitives", () => {
     const plugin = makePlugin();
     const hookPath = join(plugin.hooksDir, `${HOOK_NAME}.ts`);
     writeFileSync(hookPath, `export default () => "v1";\n`);
-    await preImportHooksDir(plugin.hooksDir, plugin.name);
     expect(await dispatchOne(plugin)).toBe("v1");
 
     // Two edit → redeploy cycles: the first proves the primitive, the
@@ -99,7 +98,7 @@ describe("hook reload primitives", () => {
         hookPath,
         `export default () => ${JSON.stringify(marker)};\n`,
       );
-      await redeploy(plugin, [hookPath]);
+      redeploy(plugin, [hookPath]);
       expect(await dispatchOne(plugin)).toBe(marker);
     }
   });
@@ -110,7 +109,6 @@ describe("hook reload primitives", () => {
       join(plugin.hooksDir, `${HOOK_NAME}.ts`),
       `export default () => "stable";\n`,
     );
-    await preImportHooksDir(plugin.hooksDir, plugin.name);
 
     const first = await collectUserHookEntries(HOOK_NAME, [
       [plugin.dir, plugin.name],
@@ -119,7 +117,8 @@ describe("hook reload primitives", () => {
       [plugin.dir, plugin.name],
     ]);
 
-    // Same function instance: dispatch is a map lookup, not an import.
+    // Same function instance: the second dispatch is a map lookup, not an
+    // import.
     expect(second[0]!.fn).toBe(first[0]!.fn);
   });
 
@@ -132,7 +131,6 @@ describe("hook reload primitives", () => {
       hookPath,
       `import { value } from "../lib/helper.ts";\nexport default () => value;\n`,
     );
-    await preImportHooksDir(plugin.hooksDir, plugin.name);
     expect(await dispatchOne(plugin)).toBe("h1");
 
     writeFileSync(helperPath, `export const value = "h2";\n`);
@@ -140,25 +138,25 @@ describe("hook reload primitives", () => {
     // Partial eviction — the hook file only. The re-evaluated hook binds to
     // the helper module still cached at h1: the version-skew failure mode
     // whole-plugin sweeping exists to prevent.
-    await redeploy(plugin, [hookPath]);
+    redeploy(plugin, [hookPath]);
     expect(await dispatchOne(plugin)).toBe("h1");
 
     // The full sweep (hook + helper, as the reconcile's eviction list would
     // carry) brings the edit through.
-    await redeploy(plugin, [hookPath, helperPath]);
+    redeploy(plugin, [hookPath, helperPath]);
     expect(await dispatchOne(plugin)).toBe("h2");
   });
 
-  test("concurrent first reads of an owner share one load, not an empty cache", async () => {
+  test("concurrent first reads of a hook share one import", async () => {
     const plugin = makePlugin();
     writeFileSync(
       join(plugin.hooksDir, `${HOOK_NAME}.ts`),
       `export default () => "shared";\n`,
     );
 
-    // Two reads race before the owner is loaded. The load memo must make the
-    // second await the first's import instead of seeing "loaded" and reading a
-    // half-filled cache — otherwise the second read returns zero hooks.
+    // Two reads race before the hook is resolved. The resolution memo must make
+    // both await one import and get the same function instance — not import
+    // twice, and not have one read a not-yet-populated entry.
     const [first, second] = await Promise.all([
       collectUserHookEntries(HOOK_NAME, [[plugin.dir, plugin.name]]),
       collectUserHookEntries(HOOK_NAME, [[plugin.dir, plugin.name]]),
@@ -169,15 +167,37 @@ describe("hook reload primitives", () => {
     expect(second[0]!.fn).toBe(first[0]!.fn);
   });
 
-  test("re-import after owner eviction drops hooks whose files are gone", async () => {
+  test("an absent hook is cached negative until the owner is evicted", async () => {
+    const plugin = makePlugin();
+    const hookPath = join(plugin.hooksDir, `${HOOK_NAME}.ts`);
+
+    // Owner defines no such hook yet — resolves absent, and the absence is
+    // cached.
+    expect(
+      await collectUserHookEntries(HOOK_NAME, [[plugin.dir, plugin.name]]),
+    ).toHaveLength(0);
+
+    // Adding the file without an eviction does not lift the cached absence:
+    // the negative entry is a hit, so the new file is not re-stat'd.
+    writeFileSync(hookPath, `export default () => "added";\n`);
+    expect(
+      await collectUserHookEntries(HOOK_NAME, [[plugin.dir, plugin.name]]),
+    ).toHaveLength(0);
+
+    // Evicting the owner (as the reconcile does on a source change) clears the
+    // negative entry, so the next read picks the hook up.
+    evictHooksForOwner(plugin.name);
+    expect(await dispatchOne(plugin)).toBe("added");
+  });
+
+  test("re-resolve after owner eviction drops hooks whose files are gone", async () => {
     const plugin = makePlugin();
     const hookPath = join(plugin.hooksDir, `${HOOK_NAME}.ts`);
     writeFileSync(hookPath, `export default () => "here";\n`);
-    await preImportHooksDir(plugin.hooksDir, plugin.name);
     expect(await dispatchOne(plugin)).toBe("here");
 
     rmSync(hookPath);
-    await redeploy(plugin, [hookPath]);
+    redeploy(plugin, [hookPath]);
 
     const entries = await collectUserHookEntries(HOOK_NAME, [
       [plugin.dir, plugin.name],

--- a/assistant/src/hooks/hook-loader.ts
+++ b/assistant/src/hooks/hook-loader.ts
@@ -15,28 +15,30 @@
  * cache here ({@link hookCache}) only saves repeat filesystem/import work — it
  * is an index over what's on disk, never the source of truth.
  *
- * An owner's hooks are imported **lazily as a unit**, the first time anything
- * reads that owner, keyed in {@link ownerLoads} by a memoized load promise.
- * Importing the whole `hooks/` directory at once means a hook the owner doesn't
- * define is a negative cache hit (an absent key), not a per-dispatch re-stat;
- * memoizing the promise means concurrent first-readers share one import instead
- * of racing. Every hook — dispatch (`user-prompt-submit`, `post-tool-use`, …)
- * *and* lifecycle (`init`, `shutdown`) — is served from this one cache:
+ * Each hook is resolved **individually, on demand**, the first time something
+ * reads that exact `(owner, hookName)` pair — never a whole directory up front.
+ * A resolution memoizes its promise in {@link hookCache}, so the entry doubles
+ * as both the cache and the in-flight de-dup (concurrent first-readers of the
+ * same hook await one import). The promise resolves to the hook function, or to
+ * `null` when the owner doesn't define that hook — a **negative cache** so a
+ * hook an owner lacks is stat'd once, not re-stat'd every dispatch. Every hook,
+ * dispatch (`user-prompt-submit`, `post-tool-use`, …) *and* lifecycle (`init`,
+ * `shutdown`), goes through the one {@link resolveHook} path:
  *
  * - **Dispatch hooks** run on the hot per-turn path via
- *   {@link collectUserHookEntries}; repeat reads are pure map lookups.
+ *   {@link collectUserHookEntries}, which resolves that one hook name across the
+ *   discovered owners; repeat reads are pure map lookups.
  * - **Lifecycle hooks** run once per activation / teardown. {@link runInitHook}
- *   triggers the lazy load (so activation warms the cache the same way a read
- *   would) and runs `init` with the owner's per-plugin context;
- *   {@link runShutdownHook} reads the same cached `shutdown`. Because the
- *   reconcile always tears an owner down *before* evicting it, the cached
- *   `shutdown` is still resident at teardown even when an uninstall has already
- *   removed the directory — no separate capture is needed.
+ *   resolves `init` (to run) and `shutdown` (to cache) while the owner's
+ *   directory is present; {@link runShutdownHook} then reads that cached
+ *   `shutdown`. Because the reconcile always tears an owner down *before*
+ *   evicting it, the cached `shutdown` is still resident at teardown even when
+ *   an uninstall has already removed the directory.
  *
  * Source changes reach the cache through the source-versions reconcile in
  * `../plugins/mtime-cache.ts`: it evicts the owner ({@link evictHooksForOwner}
- * clears the cache entries and the load memo) and sweeps the module registry,
- * so the next read re-imports fresh.
+ * drops every `(owner, *)` entry, positive and negative) and sweeps the module
+ * registry, so the next read re-resolves fresh.
  *
  * Plugin *discovery* (which plugin directories exist, in what order) lives in
  * `../plugins/mtime-cache.ts`; the orchestrator there passes the discovered
@@ -81,28 +83,17 @@ const log = getLogger("hook-loader");
  */
 export const WORKSPACE_HOOKS_OWNER = "__workspace__";
 
-/** A cached, imported hook function. */
-interface CachedHook {
-  readonly hook: HookFunction;
-}
-
 /**
- * Lazily-imported hooks keyed by `${ownerName}/${hookName}`. The key includes
- * the owner (plugin name, or {@link WORKSPACE_HOOKS_OWNER}) so hooks from
- * different owners don't collide. Populated per-owner on first read; an index
- * over the filesystem, never the source of truth.
+ * Per-hook resolution memo keyed by `${ownerName}/${hookName}`. The key
+ * includes the owner (plugin name, or {@link WORKSPACE_HOOKS_OWNER}) so hooks
+ * from different owners don't collide. Each value is the promise that resolved
+ * (or is resolving) that one hook: it settles to the imported function, or to
+ * `null` when the owner doesn't define it (a negative cache entry). Storing the
+ * promise, not the settled value, means concurrent first-readers of the same
+ * hook share one import. An index over the filesystem, never the source of
+ * truth.
  */
-const hookCache = new Map<string, CachedHook>();
-
-/**
- * Per-owner load memo: maps an owner to the promise that imports its whole
- * `hooks/` directory into {@link hookCache}. Presence means "loaded or
- * loading" — distinguishing "this owner defines no `<hookName>`" (loaded,
- * absent — a negative cache hit) from "not imported yet". Storing the promise
- * (not just a boolean) means concurrent first-readers await the same import
- * rather than one racing ahead and reading a half-filled cache.
- */
-const ownerLoads = new Map<string, Promise<void>>();
+const hookCache = new Map<string, Promise<HookFunction | null>>();
 
 /** Cache key for a hook: `${ownerName}/${hookName}`. */
 function hookKey(ownerName: string, hookName: string): string {
@@ -119,47 +110,92 @@ function ownerHooksDir(pluginDir: string | null): string {
 }
 
 /**
- * Ensure an owner's hooks are imported into {@link hookCache}, importing its
- * whole `hooks/` directory once (so absent hooks become negative cache hits).
- * The load promise is memoized in {@link ownerLoads}: the first caller starts
- * the import, concurrent callers await the same promise, and later callers are
- * no-ops until the owner is evicted. This is the single lazy fill behind both
+ * Resolve a single `(owner, hookName)` to its function, memoized in
+ * {@link hookCache}. The first caller starts the import; concurrent callers
+ * await the same promise; later callers get a pure map lookup until the owner
+ * is evicted. Resolves to `null` when the owner doesn't define the hook — a
+ * negative cache entry so an absent hook is looked up once, not every dispatch.
+ * This is the single point where hook code enters the process, shared by
  * dispatch reads ({@link collectUserHookEntries}) and lifecycle runs
- * ({@link runInitHook}).
+ * ({@link runInitHook} / {@link runShutdownHook}).
  */
-function ensureOwnerHooksLoaded(
+function resolveHook(
   hooksDir: string,
   ownerName: string,
-): Promise<void> {
-  let load = ownerLoads.get(ownerName);
-  if (load === undefined) {
-    load = preImportHooksDir(hooksDir, ownerName);
-    ownerLoads.set(ownerName, load);
+  hookName: string,
+): Promise<HookFunction | null> {
+  const key = hookKey(ownerName, hookName);
+  let entry = hookCache.get(key);
+  if (entry === undefined) {
+    entry = importHook(hooksDir, ownerName, hookName);
+    hookCache.set(key, entry);
   }
-  return load;
+  return entry;
 }
 
 /**
- * Collect every hook for a given event name across all surfaces, importing
- * each owner's dispatch hooks lazily on first read (see
- * {@link ensureOwnerHooksLoaded}). The first read of an owner does one
- * directory import; every read after that — until the owner is evicted — is a
- * pure map lookup.
+ * Import the file backing `(owner, hookName)` from `hooksDir`, or `null` when
+ * the owner doesn't define it (no matching file, a failed import, or a
+ * non-function default export). Evicts the module first so an edited file
+ * re-evaluates. Never rejects — a failure is logged and cached as `null` like a
+ * genuinely absent hook, so one bad file doesn't wedge the resolution promise.
+ */
+async function importHook(
+  hooksDir: string,
+  ownerName: string,
+  hookName: string,
+): Promise<HookFunction | null> {
+  const file = listSurfaceDir(hooksDir).find((f) => f.name === hookName);
+  if (file === undefined) {
+    return null;
+  }
+
+  // The same path may hold different content than when it was last imported
+  // (edit, reinstall at the same path); evict so the import re-evaluates from
+  // disk instead of serving Bun's cached module. No-op for a first-ever load.
+  evictModule(file.path);
+
+  try {
+    const hook = await importWithTimeout<HookFunction>(file.path);
+    if (hook === undefined || typeof hook !== "function") {
+      log.error(
+        { plugin: ownerName, hook: hookName, path: file.path },
+        `hook ${hookName} default export must be a function (got ${typeof hook}) — skipping`,
+      );
+      return null;
+    }
+    return hook;
+  } catch (err) {
+    log.error(
+      { err, plugin: ownerName, hook: hookName, path: file.path },
+      `Failed to import hook ${hookName} from ${file.path}`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Collect the hooks for one event name across all surfaces, resolving that one
+ * `(owner, hookName)` per owner via {@link resolveHook}. The first read of a
+ * given hook does one import; every read after that — until the owner is
+ * evicted — is a pure map lookup. Owners without the hook contribute nothing
+ * (their negative cache entry keeps them from being re-stat'd).
  *
  * `pluginDirs` is the orchestrator's discovered `[dir, ownerName]` set (in
  * install-date order). Each plugin's hook runs first, then the standalone
  * workspace hook runs last — so a plugin can shape the threaded context
- * before a workspace-wide hook observes or finalizes it.
+ * before a workspace-wide hook observes or finalizes it. Resolutions are kicked
+ * off together and awaited in that order, so a cold first read imports the
+ * owners' files concurrently without disturbing chain order.
  *
- * The cache holds exactly what each owner's last import saw on disk; added,
- * removed, and edited hook files (including helper modules they import) land
- * when the source-versions reconcile evicts the owner and the next read
- * re-imports.
+ * Added, removed, and edited hook files (including helper modules they import)
+ * land when the source-versions reconcile evicts the owner and the next read
+ * re-resolves.
  *
  * `effectiveEnabledPlugins` carries the per-chat plugin scope: when non-null, a
  * plugin whose name is not in the set is skipped (its hooks do not run for this
- * conversation, and its hooks are not imported). The standalone workspace hook
- * is not owned by a plugin, so it always runs. `null`/omitted means no per-chat
+ * conversation, and its hook is not imported). The standalone workspace hook is
+ * not owned by a plugin, so it always runs. `null`/omitted means no per-chat
  * restriction.
  */
 export async function collectUserHookEntries<TCtx = unknown>(
@@ -167,7 +203,10 @@ export async function collectUserHookEntries<TCtx = unknown>(
   pluginDirs: Iterable<readonly [string, string]>,
   effectiveEnabledPlugins?: Set<string> | null,
 ): Promise<HookEntry<TCtx>[]> {
-  const out: HookEntry<TCtx>[] = [];
+  const pending: Array<{
+    owner: HookEntry<TCtx>["owner"];
+    hook: Promise<HookFunction | null>;
+  }> = [];
 
   for (const [pluginDir, pluginName] of pluginDirs) {
     if (
@@ -176,27 +215,26 @@ export async function collectUserHookEntries<TCtx = unknown>(
     ) {
       continue;
     }
-    await ensureOwnerHooksLoaded(ownerHooksDir(pluginDir), pluginName);
-    const cached = hookCache.get(hookKey(pluginName, hookName));
-    if (cached !== undefined) {
-      out.push({
-        fn: cached.hook as HookFunction<TCtx>,
-        owner: { kind: "plugin", id: pluginName },
-      });
-    }
+    pending.push({
+      owner: { kind: "plugin", id: pluginName },
+      hook: resolveHook(ownerHooksDir(pluginDir), pluginName, hookName),
+    });
   }
 
   // Standalone workspace hooks: files directly under `<workspace>/hooks/`
   // that are not part of any plugin (no package.json, no tools — just hooks).
-  await ensureOwnerHooksLoaded(ownerHooksDir(null), WORKSPACE_HOOKS_OWNER);
-  const wsCached = hookCache.get(hookKey(WORKSPACE_HOOKS_OWNER, hookName));
-  if (wsCached !== undefined) {
-    out.push({
-      fn: wsCached.hook as HookFunction<TCtx>,
-      owner: { kind: "workspace", id: WORKSPACE_HOOKS_OWNER },
-    });
-  }
+  pending.push({
+    owner: { kind: "workspace", id: WORKSPACE_HOOKS_OWNER },
+    hook: resolveHook(ownerHooksDir(null), WORKSPACE_HOOKS_OWNER, hookName),
+  });
 
+  const out: HookEntry<TCtx>[] = [];
+  for (const { owner, hook } of pending) {
+    const fn = await hook;
+    if (fn !== null) {
+      out.push({ fn: fn as HookFunction<TCtx>, owner });
+    }
+  }
   return out;
 }
 
@@ -219,47 +257,6 @@ export async function collectUserHooks<TCtx = unknown>(
 }
 
 /**
- * Import every hook file under `hooksDir` into the cache, keyed by
- * `${ownerName}/${hookName}`. This is the single point where hook code
- * enters the process: it runs at owner (re)activation, and what it caches
- * is exactly what dispatch serves until the owner is next redeployed.
- * Best-effort per file: a failing or non-function import is logged and
- * skipped (the owner's other hooks still load). A missing directory yields
- * no files (handled by {@link listSurfaceDir}).
- */
-export async function preImportHooksDir(
-  hooksDir: string,
-  ownerName: string,
-): Promise<void> {
-  for (const file of listSurfaceDir(hooksDir)) {
-    const key = hookKey(ownerName, file.name);
-
-    // The same path may hold different content than when it was last
-    // imported (edit, reinstall at the same path); evict so the import
-    // below re-evaluates from disk instead of serving Bun's cached module.
-    // No-op for a first-ever load.
-    evictModule(file.path);
-
-    try {
-      const hook = await importWithTimeout<HookFunction>(file.path);
-      if (hook === undefined || typeof hook !== "function") {
-        log.error(
-          { plugin: ownerName, hook: file.name, path: file.path },
-          `hook ${file.name} default export must be a function (got ${typeof hook}) — skipping`,
-        );
-        continue;
-      }
-      hookCache.set(key, { hook });
-    } catch (err) {
-      log.error(
-        { err, plugin: ownerName, hook: file.name, path: file.path },
-        `Failed to pre-import hook ${file.name}`,
-      );
-    }
-  }
-}
-
-/**
  * Whether the standalone workspace hooks directory currently holds any hook
  * files. Used by the boot orchestrator to skip activating (and registering
  * teardown for) an empty/absent directory.
@@ -269,15 +266,15 @@ export function hasWorkspaceHooks(): boolean {
 }
 
 /**
- * Run the `init` hook for `ownerName` if the owner defines one. Triggers the
- * owner's lazy load first (the same memoized import a dispatch read would), so
- * activation warms the cache — including the `shutdown` teardown will later
- * read — instead of a separate pre-import step. `init` can't ride the
- * whole-chain `runHook` the way dispatch hooks do because its context is
- * per-plugin (config, logger, storage dir), so it's dispatched per-owner here.
- * Shared by user plugins and standalone workspace hooks so both get the same
- * init-context shape and per-owner isolation (a thrown `init` is logged and
- * swallowed, never blocking boot).
+ * Run the `init` hook for `ownerName` if the owner defines one. Resolves the
+ * owner's `shutdown` first — while the directory is still present — so it's
+ * cached for teardown even after an uninstall removes the directory, then
+ * resolves and runs `init`. `init` can't ride the whole-chain `runHook` the way
+ * dispatch hooks do because its context is per-plugin (config, logger, storage
+ * dir), so it's dispatched per-owner here. Shared by user plugins and
+ * standalone workspace hooks so both get the same init-context shape and
+ * per-owner isolation (a thrown `init` is logged and swallowed, never blocking
+ * boot).
  *
  * For user plugins, `pluginDir` is the absolute path to the installed plugin
  * directory (`<workspace>/plugins/<name>/`). Config and data now live inside
@@ -298,13 +295,15 @@ export async function runInitHook(
   ownerName: string,
   pluginDir: string | null = null,
 ): Promise<void> {
-  // Lazily import the owner's hooks (idempotent — a later dispatch read shares
-  // this same memoized load). This is what warms the cache at activation, so
-  // the owner's `shutdown` is resident for teardown even after an uninstall.
-  await ensureOwnerHooksLoaded(ownerHooksDir(pluginDir), ownerName);
+  const hooksDir = ownerHooksDir(pluginDir);
 
-  const initHookEntry = hookCache.get(hookKey(ownerName, HOOKS.INIT));
-  if (initHookEntry === undefined) {
+  // Resolve `shutdown` now, while the directory is present, so it's cached for
+  // teardown even after an uninstall removes the directory (runShutdownHook
+  // reads the cache, never disk). The result is discarded here — this is a warm.
+  await resolveHook(hooksDir, ownerName, HOOKS.SHUTDOWN);
+
+  const initHook = await resolveHook(hooksDir, ownerName, HOOKS.INIT);
+  if (initHook === null) {
     return;
   }
 
@@ -315,7 +314,7 @@ export async function runInitHook(
       pluginStorageDir: resolvePluginStorageDir(ownerName, pluginDir),
       assistantVersion: APP_VERSION,
     };
-    await initHookEntry.hook(initContext);
+    await initHook(initContext);
     log.info({ plugin: ownerName }, "user hooks initialized");
   } catch (err) {
     log.error(
@@ -339,13 +338,19 @@ export async function runShutdownHook(
   context: ShutdownContext,
   reason: string,
 ): Promise<void> {
-  const shutdownHookEntry = hookCache.get(hookKey(ownerName, HOOKS.SHUTDOWN));
-  if (shutdownHookEntry === undefined) {
+  // Read from the cache (resolved at activation, while the directory existed) —
+  // never re-resolve here, since an uninstall may have already removed it.
+  const entry = hookCache.get(hookKey(ownerName, HOOKS.SHUTDOWN));
+  if (entry === undefined) {
+    return;
+  }
+  const shutdown = await entry;
+  if (shutdown === null) {
     return;
   }
 
   try {
-    await shutdownHookEntry.hook(context);
+    await shutdown(context);
   } catch (err) {
     log.warn(
       { err, plugin: ownerName, reason },
@@ -355,8 +360,8 @@ export async function runShutdownHook(
 }
 
 /**
- * Evict every cached hook owned by `ownerName` and drop its load memo, so the
- * next read re-imports fresh. Called by the reconcile after the owner's
+ * Evict every cached resolution owned by `ownerName` — positive and negative —
+ * so the next read re-resolves fresh. Called by the reconcile after the owner's
  * `shutdown` has already run. No-op when the owner has no cached state.
  */
 export function evictHooksForOwner(ownerName: string): void {
@@ -366,11 +371,10 @@ export function evictHooksForOwner(ownerName: string): void {
       hookCache.delete(key);
     }
   }
-  ownerLoads.delete(ownerName);
 }
 
 /**
- * Evict all plugin-owned hook state while preserving standalone workspace
+ * Evict all plugin-owned resolutions while preserving standalone workspace
  * hooks. Called when the plugins directory is gone entirely: workspace hooks
  * live outside it, so the absence of any plugin must not evict them.
  */
@@ -378,11 +382,6 @@ export function clearPluginHooks(): void {
   for (const key of hookCache.keys()) {
     if (!key.startsWith(`${WORKSPACE_HOOKS_OWNER}/`)) {
       hookCache.delete(key);
-    }
-  }
-  for (const owner of ownerLoads.keys()) {
-    if (owner !== WORKSPACE_HOOKS_OWNER) {
-      ownerLoads.delete(owner);
     }
   }
 }
@@ -509,7 +508,7 @@ function ensureLegacyStorageDir(ownerName: string): string {
 
 // ─── Test hooks ──────────────────────────────────────────────────────────────
 
-/** Clear the hook cache and per-owner load memo. Test-only. */
+/** Clear the hook resolution cache. Test-only. */
 export function resetHookCacheForTests(): void {
   const isTest =
     process.env.BUN_TEST === "1" || process.env.NODE_ENV === "test";
@@ -519,7 +518,6 @@ export function resetHookCacheForTests(): void {
     );
   }
   hookCache.clear();
-  ownerLoads.clear();
 }
 
 /** Test-only: inspect the hook cache's keys. */

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -8,8 +8,8 @@
  * `../hooks/hook-loader.ts`. This module is the boot orchestrator: it scans the
  * plugins directory, registers tools, and drives each owner's `init` / `shutdown`
  * lifecycle by handing the discovered directories to the hook loader. Dispatch
- * hooks are not imported here — the hook loader fills its own cache lazily on
- * the first read that needs an owner.
+ * hooks are not imported here — the hook loader resolves each one on demand on
+ * the first read that needs it.
  *
  * - Boot does one full discovery scan; after that, every change (plugin
  *   installed, removed, disabled, or any source file inside a plugin edited
@@ -18,15 +18,16 @@
  *   The dispatch path stats that one file and otherwise runs on memory.
  * - A changed plugin is redeployed in place: the old version's `shutdown`
  *   runs, its hook/tool cache entries and module-registry entries are
- *   swept, and reactivation runs `init`, which lazily re-imports the owner's
- *   hooks from the swept-clean registry. The whole directory is the reload
- *   unit so a re-imported hook can never pair with a stale cached helper.
+ *   swept, and reactivation runs `init`; the next read of each hook re-resolves
+ *   it from the swept-clean registry. The whole directory is the reload unit
+ *   (every module path is swept) so a re-imported hook can never pair with a
+ *   stale cached helper.
  * - Plugins are never "registered" as a unit — we register their tools into
  *   the global tool registry.
  *
  * Tools are populated at boot by `loadUserPlugins()`; `getHooksFor` reads
- * hooks on every dispatch via {@link getUserHookEntriesFor}, which fills the
- * hook loader's cache on demand.
+ * hooks on every dispatch via {@link getUserHookEntriesFor}, which resolves
+ * each hook through the hook loader on demand.
  */
 
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
@@ -351,7 +352,7 @@ async function applySourceVersions(
         );
         // Tear the old version down first: `deactivatePlugin` runs the
         // still-cached `shutdown`, then `evictHooksForOwner` drops the owner's
-        // cache entries and load memo so reactivation re-imports fresh.
+        // cached resolutions so the next read re-resolves fresh.
         await deactivatePlugin(activeName, "reload");
         evictHooksForOwner(activeName);
         evictToolCacheEntries(activeName);
@@ -432,7 +433,7 @@ function sweepModules(
  * Reconcile the standalone workspace hooks pseudo-entry: same
  * shutdown → evict → sweep → init cycle a plugin gets, through the workspace
  * owner's lifecycle. Dispatch hooks are not re-imported here; the eviction
- * clears the loaded mark so the next read re-imports them fresh.
+ * drops the owner's cached resolutions so the next read re-resolves them fresh.
  */
 async function reconcileWorkspaceHooks(
   before: PluginSourceVersion | undefined,
@@ -774,12 +775,12 @@ const activatedNames = new Set<string>();
 
 /**
  * Activate a single discovered plugin: register its tools into the global tool
- * registry and run its `init` hook. Running `init` lazily imports the owner's
- * hooks (warming the cache the same way a dispatch read would), so no separate
- * pre-import step is needed. Idempotent — a plugin already activated (or
- * mid-activation) is skipped. Never throws; per-surface failures are logged and
- * the plugin still counts as activated so the shutdown teardown handles
- * whatever came up (mirrors boot semantics).
+ * registry and run its `init` hook. Running `init` also resolves the owner's
+ * `shutdown` (caching it for teardown), so no separate pre-import step is
+ * needed; dispatch hooks resolve on their first read. Idempotent — a plugin
+ * already activated (or mid-activation) is skipped. Never throws; per-surface
+ * failures are logged and the plugin still counts as activated so the shutdown
+ * teardown handles whatever came up (mirrors boot semantics).
  *
  * Called from `scanPlugins`, which runs both at boot and on every subsequent
  * scan — so a plugin whose files appear at runtime (installed via the CLI or
@@ -893,10 +894,10 @@ export async function populateCacheAtBoot(
 
   // Activate standalone workspace hooks under `<workspace>/hooks/`. These
   // carry no package.json, no tools, and no install-date ordering — just hook
-  // files. Running their `init` hook lazily imports the workspace hooks, so a
-  // workspace-wide `init`/`shutdown` lifecycle works the same way a plugin's
-  // does. Only register for teardown when at least one hook file is actually
-  // present, so an empty/absent directory adds no shutdown work.
+  // files. Running their `init` hook resolves the workspace `init`/`shutdown`,
+  // so a workspace-wide lifecycle works the same way a plugin's does. Only
+  // register for teardown when at least one hook file is actually present, so
+  // an empty/absent directory adds no shutdown work.
   if (hasWorkspaceHooks()) {
     await runInitHook(WORKSPACE_HOOKS_OWNER);
     activatedPlugins.push({ name: WORKSPACE_HOOKS_OWNER });


### PR DESCRIPTION
## Prompt / plan

Follow-up to #37327. That PR made the hook cache lazy but still loaded an owner's **whole** `hooks/` directory as a unit on first read. This drops the whole-owner load entirely: each hook resolves **individually, on demand**, the first time that exact `(owner, hookName)` pair is read.

**Design:**

- `hookCache` becomes `Map<owner/hook, Promise<HookFunction | null>>` — one entry per hook, memoizing the resolution. A settled `null` is a **negative cache** entry, so a hook an owner doesn't define is stat'd once, not re-stat'd every dispatch. The stored promise (not the settled value) also de-dups concurrent first-readers of the same hook.
- `resolveHook` (+ `importHook`) replace `ensureOwnerHooksLoaded` / `preImportHooksDir` and the `ownerLoads` memo — **one** structure instead of two.
- `collectUserHookEntries` resolves the one hook name across the discovered owners, kicking the resolutions off together and awaiting them in chain (install-date) order.
- `runInitHook` resolves `shutdown` (to cache for teardown, while the directory still exists) then `init` (to run). `runShutdownHook` reads that cached entry. The graceful `runHook(HOOKS.SHUTDOWN)` path and the targeted single-owner teardown still share one cached function instance.
- `evictHooksForOwner` / `clearPluginHooks` drop the owner's entries (positive **and** negative) so the next read re-resolves — this is what lifts a negative entry when a hook file is added.

Net effect: no directory is imported up front; a hook name that's never dispatched is never imported; an owner that doesn't define a hook costs one stat, then a map lookup.

## Test plan

- `bun test` (per-file, mirroring CI):
  - `src/hooks/__tests__/hook-live-reload.test.ts` — 6 pass. Rewritten to the resolution model (first load happens through `collectUserHookEntries`, `redeploy` = evict + module sweep). Adds **`an absent hook is cached negative until the owner is evicted`**, pinning that a file added without an eviction is not picked up (negative hit) and that `evictHooksForOwner` lifts it.
  - `src/__tests__/mtime-cache.test.ts` — 30 pass (workspace add/edit/delete, runtime activation, reload runs old shutdown + new init, uninstall runs cached shutdown).
  - `src/__tests__/plugin-effective-enabled-set.test.ts` — 5 pass
  - `src/__tests__/plugin-config-data-migration.test.ts` — 6 pass
  - `src/__tests__/user-plugin-loader.test.ts` — 5 pass
- `bunx eslint` (0 errors), `bunx prettier --check` (clean), `tsc --noEmit` (exit 0) on the changed files; pre-push hook green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SquRHbAZqYMwNqDD7SNcNP)_