### PR TITLE
fix(onboarding): never show the managed wake gate over a pre-hatched local assistant

### DIFF
--- a/clients/web/src/assistant/retire-service.test.ts
+++ b/clients/web/src/assistant/retire-service.test.ts
@@ -41,6 +41,16 @@ mock.module("@/stores/organization-store", () => ({
     getState: () => ({ currentOrganizationId: "org-test" }),
   },
 }));
+mock.module("@/stores/auth-store", () => ({
+  useAuthStore: {
+    getState: () => ({ user: { id: "user-1" } }),
+  },
+}));
+
+const clearResearchSnapshotMock = mock((_userId: string | null) => {});
+mock.module("@/domains/onboarding/research-onboarding-persistence", () => ({
+  clearResearchSnapshot: clearResearchSnapshotMock,
+}));
 
 mock.module("@/lib/navigation/navigation-resolver", () => ({
   resolveNavigation: (
@@ -98,6 +108,7 @@ beforeEach(() => {
   retireLocalAssistantMock.mockClear();
   syncPlatformAssistantsToLockfileMock.mockClear();
   removeMock.mockClear();
+  clearResearchSnapshotMock.mockClear();
 });
 
 afterEach(() => {
@@ -120,6 +131,35 @@ describe("retireAssistant", () => {
     if (outcome.ok) {
       expect(outcome.nextRoute).toBe("/assistant/onboarding/privacy");
     }
+  });
+
+  test("a successful retire drops the research-onboarding resume snapshot", async () => {
+    // GIVEN a platform-hosted target
+    lockfileAssistants = [{ assistantId: "p1", cloud: "vellum" }];
+    storeAssistants = [{ id: "p1" }];
+
+    // WHEN retiring it
+    const outcome = await retireAssistant("p1");
+
+    // THEN the saved onboarding journey is discarded — a later onboarding must
+    // start at the form, not resume the retired assistant's run deep in the
+    // flow (e.g. straight onto the wake gate).
+    expect(outcome.ok).toBe(true);
+    expect(clearResearchSnapshotMock).toHaveBeenCalledWith("user-1");
+  });
+
+  test("a failed retire keeps the research-onboarding resume snapshot", async () => {
+    // GIVEN the platform delete fails terminally
+    lockfileAssistants = [{ assistantId: "p1", cloud: "vellum" }];
+    storeAssistants = [{ id: "p1" }];
+    retireByIdResult = { ok: false, status: 500, error: { detail: "boom" } };
+
+    // WHEN retiring it
+    const outcome = await retireAssistant("p1");
+
+    // THEN the journey survives — the assistant still exists.
+    expect(outcome.ok).toBe(false);
+    expect(clearResearchSnapshotMock).not.toHaveBeenCalled();
   });
 
   test("local assistant in local mode routes through the local retire", async () => {

--- a/clients/web/src/assistant/retire-service.ts
+++ b/clients/web/src/assistant/retire-service.ts
@@ -8,6 +8,8 @@ import {
 } from "@/lib/local-mode";
 import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
 import { buildNavigationState } from "@/lib/navigation/build-state";
+import { clearResearchSnapshot } from "@/domains/onboarding/research-onboarding-persistence";
+import { useAuthStore } from "@/stores/auth-store";
 import { useOrganizationStore } from "@/stores/organization-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { routes } from "@/utils/routes";
@@ -93,6 +95,11 @@ export async function retireAssistant(
     }
 
     useResolvedAssistantsStore.getState().remove(assistantId);
+    // Retiring ends any in-flight onboarding journey with it: drop the
+    // research-onboarding resume snapshot so the next onboarding starts at the
+    // form instead of resuming the retired assistant's run deep in the flow
+    // (e.g. straight onto the wake gate).
+    clearResearchSnapshot(useAuthStore.getState().user?.id ?? null);
     return { ok: true, nextRoute: getPostRetireRoute() };
   } catch {
     return { ok: false, error: "Failed to retire assistant." };

--- a/clients/web/src/domains/onboarding/adopt-existing-assistant.test.ts
+++ b/clients/web/src/domains/onboarding/adopt-existing-assistant.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for the research flow's adopt-vs-managed-hatch decision. The explicit
+ * hosting choice must win when present; a missing query string must fall back
+ * to the live-session signal so a pre-hatched local assistant is never routed
+ * onto the managed hatch (which gates the flow on a wake that never ends
+ * against a local gateway).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { shouldAdoptExistingAssistant } from "./adopt-existing-assistant";
+
+describe("shouldAdoptExistingAssistant", () => {
+  test("platform (non-local) builds always run the managed hatch", () => {
+    for (const hostingParam of [null, "local", "docker", "vellum-cloud"]) {
+      expect(
+        shouldAdoptExistingAssistant({
+          hostingParam,
+          localMode: false,
+          gatewayAuthSession: false,
+        }),
+      ).toBe(false);
+    }
+  });
+
+  test("explicit local/docker hosting adopts the foreground-hatched assistant", () => {
+    for (const hostingParam of ["local", "docker"]) {
+      expect(
+        shouldAdoptExistingAssistant({
+          hostingParam,
+          localMode: true,
+          gatewayAuthSession: false,
+        }),
+      ).toBe(true);
+    }
+  });
+
+  test("explicit vellum-cloud hosting runs the managed hatch even over a live local session", () => {
+    // The desktop app can onboard a managed assistant while still holding a
+    // gateway session from a previous local one — the explicit choice wins.
+    expect(
+      shouldAdoptExistingAssistant({
+        hostingParam: "vellum-cloud",
+        localMode: true,
+        gatewayAuthSession: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("no hosting param with a live local session adopts the connected assistant", () => {
+    // A refresh or back-navigation that lost the query string must not strand
+    // a pre-hatched local assistant behind the managed wake gate.
+    expect(
+      shouldAdoptExistingAssistant({
+        hostingParam: null,
+        localMode: true,
+        gatewayAuthSession: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("no hosting param and no local session runs the managed hatch", () => {
+    // Desktop app connected to a Vellum-Cloud assistant (platform session):
+    // the managed hatch resolves that existing assistant.
+    expect(
+      shouldAdoptExistingAssistant({
+        hostingParam: null,
+        localMode: true,
+        gatewayAuthSession: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/clients/web/src/domains/onboarding/adopt-existing-assistant.ts
+++ b/clients/web/src/domains/onboarding/adopt-existing-assistant.ts
@@ -1,0 +1,34 @@
+/**
+ * Decide whether the research-onboarding flow ADOPTS an already-provisioned
+ * local assistant instead of running the managed background hatch.
+ *
+ * The explicit `?hosting` choice wins when present: local/docker hosting means
+ * the hatching screen provisioned the assistant in the foreground, and
+ * "vellum-cloud" means a managed hatch is wanted even though the desktop
+ * build reports local mode. When the param is absent (a refresh that lost the
+ * query string, a back-navigation from the check-in overlay, a direct visit),
+ * fall back to the app's own state: a live gateway-auth session in a
+ * local-mode build IS a connected local assistant, and running the managed
+ * hatch against it would strand the flow on a "Waking up" gate for an
+ * assistant that is already up.
+ */
+export function shouldAdoptExistingAssistant({
+  hostingParam,
+  localMode,
+  gatewayAuthSession,
+}: {
+  /** The research route's `?hosting` value, or null when absent. */
+  hostingParam: string | null;
+  /** Build-time local mode (`isLocalMode()`). */
+  localMode: boolean;
+  /** A live local gateway session exists (`isGatewayAuthMode()`). */
+  gatewayAuthSession: boolean;
+}): boolean {
+  if (!localMode) {
+    return false;
+  }
+  if (hostingParam !== null) {
+    return hostingParam !== "vellum-cloud";
+  }
+  return gatewayAuthSession;
+}

--- a/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -223,6 +223,28 @@ mock.module("@/lib/local-mode", () => ({
   primeLocalGatewayConnection: async () => {},
   primeLocalGatewayConnectionWithRepair: async () => {},
   getLocalGatewayUrl: () => localGatewayUrlValue,
+  // Mirrors the real probe against the mocked gateway URL, so tests that stub
+  // `globalThis.fetch` keep driving the readyz loop the same way.
+  probeLocalGatewayReady: async () => {
+    if (!localGatewayUrlValue) {
+      return false;
+    }
+    try {
+      const res = await fetch(`${localGatewayUrlValue}/readyz`);
+      if (!res.ok) {
+        return false;
+      }
+      const body: unknown = await res.json();
+      return (
+        body !== null &&
+        typeof body === "object" &&
+        "status" in body &&
+        (body as { status?: unknown }).status === "ok"
+      );
+    } catch {
+      return false;
+    }
+  },
 }));
 
 mock.module("@/runtime/local-mode-host", () => ({

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -19,7 +19,7 @@ import {
     writeSelectedVersion,
 } from "@/domains/onboarding/prefs";
 import { applyPendingProviderKey } from "@/domains/onboarding/provider-key";
-import { getLocalGatewayUrl, getPlatformRuntimeUrl, isLocalMode, loadLockfile, primeLocalGatewayConnection, saveLockfileAssistant } from "@/lib/local-mode";
+import { getPlatformRuntimeUrl, isLocalMode, loadLockfile, primeLocalGatewayConnection, probeLocalGatewayReady, saveLockfileAssistant } from "@/lib/local-mode";
 import { clearGatewayToken } from "@/lib/auth/gateway-session";
 import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
 import { buildNavigationState } from "@/lib/navigation/build-state";
@@ -350,27 +350,11 @@ export function HatchingScreen() {
           transitionPhase("connecting");
           let gatewayReady = false;
           while (!cancelled && !gatewayReady) {
-            const gatewayUrl = getLocalGatewayUrl();
-            if (gatewayUrl) {
-              try {
-                const res = await fetch(`${gatewayUrl}/readyz`);
-                if (res.ok) {
-                  const body: unknown = await res.json();
-                  if (
-                    body &&
-                    typeof body === "object" &&
-                    "status" in body &&
-                    body.status === "ok"
-                  ) {
-                    clearGatewayToken();
-                    await primeLocalGatewayConnection();
-                    gatewayReady = true;
-                    break;
-                  }
-                }
-              } catch {
-                // Gateway not ready yet
-              }
+            if (await probeLocalGatewayReady()) {
+              clearGatewayToken();
+              await primeLocalGatewayConnection();
+              gatewayReady = true;
+              break;
             }
             if (Date.now() - pollStartMs >= MAX_HATCH_WAIT_MS) {
               // The hatch succeeded but the gateway never went healthy. We never

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -21,6 +21,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
 import { lifecycleService } from "@/assistant/lifecycle-service";
+import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
 import { isLocalMode } from "@/lib/local-mode";
 import { useAuthStore } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
@@ -35,6 +36,7 @@ import {
   buildResearchPrompt,
   type ResearchSubject,
 } from "@/domains/onboarding/research-prompt";
+import { shouldAdoptExistingAssistant } from "@/domains/onboarding/adopt-existing-assistant";
 import { useBackgroundHatch } from "@/domains/onboarding/use-background-hatch";
 import { useResearchRunner } from "@/domains/onboarding/research-runner";
 import { sendResearchCorrection } from "@/domains/onboarding/send-research-correction";
@@ -220,14 +222,17 @@ export function ResearchOnboardingRoute() {
   // called on submit and internally awaits the hatch.
   // A local-hosting onboarding (hosting=local/docker) already provisioned its
   // assistant in the hatching screen, so the background hatch ADOPTS it rather
-  // than running a managed hatch. Vellum-Cloud onboarding (no / "vellum-cloud"
-  // hosting) still runs the managed hatch. `isLocalMode()` alone can't tell
-  // these apart — it's a build-time value that's true for the whole desktop app,
-  // including its Vellum-Cloud path — so we key on the chosen hosting.
+  // than running a managed hatch; when the query string is missing, a live
+  // gateway-auth session is the same evidence (see
+  // `shouldAdoptExistingAssistant`). Vellum-Cloud onboarding runs the managed
+  // hatch.
   const [searchParams] = useSearchParams();
   const hostingParam = searchParams.get("hosting");
-  const adoptExistingAssistant =
-    isLocalMode() && hostingParam !== null && hostingParam !== "vellum-cloud";
+  const adoptExistingAssistant = shouldAdoptExistingAssistant({
+    hostingParam,
+    localMode: isLocalMode(),
+    gatewayAuthSession: isGatewayAuthMode(),
+  });
   // The hatching screen names the assistant it provisioned in the `assistant`
   // param, pinning adoption to that exact one — a stale selection or leftover
   // lockfile entries from previous sessions can't answer for it.

--- a/clients/web/src/domains/onboarding/use-background-hatch.test.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.test.ts
@@ -46,6 +46,10 @@ mock.module("@/assistant/api", () => ({
 mock.module("@/lib/sentry/capture-error", () => ({
   captureError: () => {},
 }));
+const probeLocalGatewayReadyMock = mock(async (): Promise<boolean> => true);
+mock.module("@/lib/local-mode", () => ({
+  probeLocalGatewayReady: probeLocalGatewayReadyMock,
+}));
 mock.module("@/utils/api-errors", () => ({
   extractErrorMessage: (e: unknown, _r: unknown, fallback?: string) =>
     e &&
@@ -68,6 +72,7 @@ beforeEach(() => {
   hatchAssistantMock.mockClear();
   getAssistantMock.mockClear();
   getAssistantHealthzMock.mockClear();
+  probeLocalGatewayReadyMock.mockClear();
 });
 
 describe("useBackgroundHatch", () => {
@@ -148,9 +153,11 @@ describe("useBackgroundHatch", () => {
     // …the existing assistant is discovered via getAssistant, pinned to the
     // id the hatching screen handed off…
     expect(getAssistantMock).toHaveBeenCalledWith("ast-research");
-    // …and the assistant-scoped healthz is SKIPPED (the hatching screen already
-    // confirmed the local gateway's /readyz, and that SDK call doesn't resolve
-    // against a local gateway anyway).
+    // …readiness is verified against the LOCAL gateway's /readyz (the
+    // assistant-scoped healthz SDK call doesn't resolve against a local
+    // gateway) — this also covers session-based adopts that never passed
+    // through the hatching screen's own readyz poll…
+    expect(probeLocalGatewayReadyMock).toHaveBeenCalled();
     expect(getAssistantHealthzMock).not.toHaveBeenCalled();
     expect(result.current.assistantId).toBe("ast-research");
   });

--- a/clients/web/src/domains/onboarding/use-background-hatch.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.ts
@@ -11,6 +11,7 @@ import {
   resolveAssistantLifecycleState,
   shouldRecoverFromHatchFailure,
 } from "@/assistant/lifecycle";
+import { probeLocalGatewayReady } from "@/lib/local-mode";
 import { captureError } from "@/lib/sentry/capture-error";
 import { extractErrorMessage } from "@/utils/api-errors";
 
@@ -200,15 +201,27 @@ export function useBackgroundHatch(
         await sleep(POLL_INTERVAL_MS);
       }
 
-      // 3. Poll healthz until the daemon is reachable, then mark ready.
+      // 3. Poll until the assistant's runtime is reachable, then mark ready.
       //
-      // Skipped when adopting an already-hatched local assistant: the hatching
-      // screen already polled the local gateway's `/readyz` before handing off
-      // here, so it's known reachable — and the assistant-scoped
-      // `getAssistantHealthz()` SDK call doesn't resolve against a local gateway
-      // (it needs a guardian-token-authed `/v1/assistants/{id}/healthz`), so
-      // running it here would spin to the timeout on a healthy assistant.
-      if (!adoptExisting) {
+      // Adopting a local assistant checks the LOCAL gateway's `/readyz`
+      // (gateway + upstream daemon) — the assistant-scoped
+      // `getAssistantHealthz()` SDK call doesn't resolve against a local
+      // gateway (it needs a guardian-token-authed
+      // `/v1/assistants/{id}/healthz`), so it would spin to the timeout on a
+      // healthy assistant. The readyz check matters even though the hatching
+      // screen polls it before handing off: an adopt can also start from a
+      // session-based fallback (refresh / direct visit with no query string),
+      // where a cached gateway token proves nothing about the gateway process
+      // still being alive.
+      if (adoptExisting) {
+        while (!(await probeLocalGatewayReady())) {
+          if (timedOut()) {
+            settleError(TIMEOUT_ERROR);
+            return;
+          }
+          await sleep(POLL_INTERVAL_MS);
+        }
+      } else {
         while (true) {
           try {
             const health = await getAssistantHealthz(activeAssistantId);

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -469,6 +469,34 @@ export function getLocalGatewayUrl(
   return gatewayProxyUrl(gatewayPort);
 }
 
+/**
+ * One-shot probe of the local gateway's `/readyz` (which reports gateway AND
+ * upstream daemon readiness). True only when the gateway answers
+ * `{ status: "ok" }`; false when the gateway URL is unresolvable, the request
+ * fails, or the gateway is up but not yet ready.
+ */
+export async function probeLocalGatewayReady(): Promise<boolean> {
+  const gatewayUrl = getLocalGatewayUrl();
+  if (!gatewayUrl) {
+    return false;
+  }
+  try {
+    const res = await fetch(`${gatewayUrl}/readyz`);
+    if (!res.ok) {
+      return false;
+    }
+    const body: unknown = await res.json();
+    return (
+      body !== null &&
+      typeof body === "object" &&
+      "status" in body &&
+      body.status === "ok"
+    );
+  } catch {
+    return false;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Gateway connection setup
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-ups to #37142 from local QA — three fixes to the research-onboarding flow's adopt/resume behavior:

1. **Adopt a live local assistant when the query params are lost.** Entering `/assistant/onboarding/research` without its query string (back-nav from the check-in overlay, refresh, direct visit) flipped a local session onto the managed hatch path, stranding the flow on "Waking up" against an assistant that was already hatched. When `?hosting` is absent the decision now falls back to app state: a live gateway-auth session in a local-mode build is a connected local assistant. Explicit `?hosting` still wins (including `vellum-cloud`). Pure `shouldAdoptExistingAssistant()` helper + unit tests.
2. **Verify local gateway readiness before adopting** *(addresses the Codex P2 review finding)*. The adopt path skipped all readiness checks on the assumption the hatching screen had just confirmed `/readyz`; session-based adopts never passed through that screen, and a cached token proves nothing about the gateway process. Adopt now polls the local gateway's `/readyz` before settling ready, via a probe helper shared with the hatching screen.
3. **Drop the research resume snapshot on retire.** The page-refresh resume snapshot was only cleared on flow completion, so retiring an assistant made the next onboarding resume the retired assistant's journey deep in the flow — landing straight on a loading/wake gate. The retire service now clears it for all retire paths (settings, tray, teleport).

`tsc` clean, changed-file eslint 0 errors, unit tests added for all three behaviors.

Note: #37335 touches the same lines in the route (helper extraction); whichever merges second needs a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)