### PR TITLE
test(assistant): drive scheduler tests deterministically instead of sleeping

### DIFF
--- a/assistant/src/__tests__/scheduler-recurrence.test.ts
+++ b/assistant/src/__tests__/scheduler-recurrence.test.ts
@@ -1,12 +1,4 @@
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  test,
-} from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 mock.module("../util/logger.js", () => ({
   getLogger: () =>
@@ -77,7 +69,7 @@ import {
   getSchedule,
   getScheduleRuns,
 } from "../schedule/schedule-store.js";
-import { startScheduler } from "../schedule/scheduler.js";
+import { runScheduleDueWorkOnce } from "../schedule/scheduler.js";
 import { createTask } from "../tasks/task-store.js";
 
 await initializeDb();
@@ -131,30 +123,7 @@ function buildEndedRrule(): string {
 
 // ── RRULE schedule fires through the scheduler ──────────────────────
 
-// Replace setTimeout with a zero-delay version so the 500ms scheduler
-// wait calls fire instantly instead of waiting real time.
-let origSetTimeout: typeof globalThis.setTimeout;
-
 describe("scheduler RRULE execution", () => {
-  beforeAll(() => {
-    origSetTimeout = globalThis.setTimeout;
-    globalThis.setTimeout = ((
-      fn: TimerHandler,
-      _ms?: number,
-      ...args: unknown[]
-    ) => {
-      // Use a small real delay so fire-and-forget async ticks have time to
-      // settle, while still cutting the 500ms waits down dramatically.
-      // 200ms gives headroom for the run_task path which does a dynamic
-      // import of task-runner.js on first invocation.
-      return origSetTimeout(fn, 200, ...args);
-    }) as typeof setTimeout;
-  });
-
-  afterAll(() => {
-    globalThis.setTimeout = origSetTimeout;
-  });
-
   beforeEach(() => {
     const db = getDb();
     db.run("DELETE FROM cron_runs");
@@ -192,9 +161,7 @@ describe("scheduler RRULE execution", () => {
       processedMessages.push({ conversationId, message: prompt });
     };
 
-    const scheduler = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler.stop();
+    await runScheduleDueWorkOnce();
 
     // The runner should have been invoked with the RRULE message
     expect(
@@ -225,26 +192,14 @@ describe("scheduler RRULE execution", () => {
     forceScheduleDue(schedule.id);
 
     const directCalls: { conversationId: string; message: string }[] = [];
-    let onMessage: (() => void) | undefined;
-    const messageReceived = new Promise<void>((r) => (onMessage = r));
     processMessageImpl = async (conversationId, message) => {
       directCalls.push({ conversationId, message });
-      onMessage?.();
     };
 
-    const scheduler = startScheduler();
-    // The run_task path involves a dynamic import which can take >50ms in CI,
-    // exceeding the patched setTimeout delay. Await the actual callback instead
-    // of relying on a fixed timeout.
-    await Promise.race([
-      messageReceived,
-      new Promise((r) => origSetTimeout(r, 2000)),
-    ]);
-    // Yield to the macrotask queue so all pending microtasks settle —
-    // the scheduler tick still needs to create the schedule run after
-    // processMessage returns.
-    await new Promise((r) => origSetTimeout(r, 0));
-    scheduler.stop();
+    // runScheduleDueWorkOnce() awaits the full tick — including the run_task
+    // dynamic import and processMessage — so the schedule run is recorded by the
+    // time it resolves. No fixed timeout / callback race needed.
+    await runScheduleDueWorkOnce();
 
     // runTask renders the template, so processMessage gets the template text
     const runTaskCalls = directCalls.filter(
@@ -297,9 +252,7 @@ describe("scheduler RRULE execution", () => {
     };
 
     // First tick: the expired schedule should fire its final due run
-    const scheduler1 = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler1.stop();
+    await runScheduleDueWorkOnce();
 
     // The message IS delivered once
     expect(processedMessages).toContain("Final expired run");
@@ -317,9 +270,7 @@ describe("scheduler RRULE execution", () => {
 
     // Second tick: the disabled schedule must NOT fire again
     processedMessages.length = 0;
-    const scheduler2 = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler2.stop();
+    await runScheduleDueWorkOnce();
 
     expect(processedMessages).not.toContain("Final expired run");
     // No additional runs
@@ -347,9 +298,7 @@ describe("scheduler RRULE execution", () => {
       processedMessages.push({ conversationId, message: prompt });
     };
 
-    const scheduler = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler.stop();
+    await runScheduleDueWorkOnce();
 
     // The runner should have been invoked with the cron message
     expect(processedMessages.some((m) => m.message === "Cron message")).toBe(
@@ -402,9 +351,7 @@ describe("scheduler RRULE execution", () => {
     // Force the schedule to be due
     forceScheduleDue(schedule.id);
 
-    const scheduler = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler.stop();
+    await runScheduleDueWorkOnce();
 
     // The schedule should have been claimed and nextRunAt advanced
     const after = getSchedule(schedule.id);
@@ -451,9 +398,7 @@ describe("scheduler RRULE execution", () => {
       processedMessages.push(prompt);
     };
 
-    const scheduler = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler.stop();
+    await runScheduleDueWorkOnce();
 
     expect(processedMessages).toContain("Set fire test");
 
@@ -527,9 +472,7 @@ describe("scheduler RRULE execution", () => {
         processedMessages.push(prompt);
       };
 
-      const scheduler = startScheduler();
-      await new Promise((resolve) => setTimeout(resolve, 500));
-      scheduler.stop();
+      await runScheduleDueWorkOnce();
 
       // The schedule should have fired
       expect(processedMessages).toContain("EXRULE scheduler fire");
@@ -565,9 +508,7 @@ describe("scheduler RRULE execution", () => {
     forceScheduleDue(schedule.id);
     const forcedDueAt = getSchedule(schedule.id)!.nextRunAt;
 
-    const scheduler = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler.stop();
+    await runScheduleDueWorkOnce();
 
     const after = getSchedule(schedule.id);
     expect(after).not.toBeNull();
@@ -596,9 +537,7 @@ describe("scheduler RRULE execution", () => {
       processedMessages.push({ conversationId, message: prompt });
     };
 
-    const scheduler = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler.stop();
+    await runScheduleDueWorkOnce();
 
     expect(
       processedMessages.some((m) => m.message === "Execute this once"),
@@ -627,9 +566,7 @@ describe("scheduler RRULE execution", () => {
 
     expect(getSchedule(schedule.id)!.status).toBe("active");
 
-    const scheduler = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler.stop();
+    await runScheduleDueWorkOnce();
 
     expect(notifySignalCalls).toHaveLength(1);
     expect(notifySignalCalls[0]).toMatchObject({
@@ -662,9 +599,7 @@ describe("scheduler RRULE execution", () => {
 
     runBackgroundJobShouldFail = true;
 
-    const scheduler = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler.stop();
+    await runScheduleDueWorkOnce();
 
     const after = getSchedule(schedule.id);
     expect(after).not.toBeNull();
@@ -687,9 +622,7 @@ describe("scheduler RRULE execution", () => {
 
     forceScheduleDue(schedule.id);
 
-    const scheduler = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler.stop();
+    await runScheduleDueWorkOnce();
 
     expect(notifySignalCalls).toHaveLength(1);
     expect(notifySignalCalls[0]).toMatchObject({
@@ -727,9 +660,7 @@ describe("scheduler RRULE execution", () => {
       },
     });
 
-    const scheduler = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler.stop();
+    await runScheduleDueWorkOnce();
 
     expect(notifySignalCalls).toHaveLength(1);
     expect(notifySignalCalls[0].routingIntent).toBe("all_channels");

--- a/assistant/src/__tests__/scheduler-reuse-conversation.test.ts
+++ b/assistant/src/__tests__/scheduler-reuse-conversation.test.ts
@@ -1,12 +1,4 @@
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  test,
-} from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 mock.module("../util/logger.js", () => ({
   getLogger: () =>
@@ -110,7 +102,7 @@ import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { createSchedule, getScheduleRuns } from "../schedule/schedule-store.js";
-import { startScheduler } from "../schedule/scheduler.js";
+import { runScheduleDueWorkOnce } from "../schedule/scheduler.js";
 
 await initializeDb();
 
@@ -146,26 +138,7 @@ function buildEveryMinuteRrule(dtstart: Date = new Date()): string {
   return `DTSTART:${ds}\nRRULE:FREQ=MINUTELY;INTERVAL=1`;
 }
 
-// Replace setTimeout with a zero-delay version so the 500ms scheduler
-// wait calls fire instantly instead of waiting real time.
-let origSetTimeout: typeof globalThis.setTimeout;
-
 describe("scheduler conversation reuse", () => {
-  beforeAll(() => {
-    origSetTimeout = globalThis.setTimeout;
-    globalThis.setTimeout = ((
-      fn: TimerHandler,
-      _ms?: number,
-      ...args: unknown[]
-    ) => {
-      return origSetTimeout(fn, 200, ...args);
-    }) as typeof setTimeout;
-  });
-
-  afterAll(() => {
-    globalThis.setTimeout = origSetTimeout;
-  });
-
   beforeEach(() => {
     const db = getDb();
     db.run("DELETE FROM cron_runs");
@@ -201,9 +174,7 @@ describe("scheduler conversation reuse", () => {
     // WHEN the schedule fires for the first time
     forceScheduleDue(schedule.id);
 
-    const scheduler1 = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler1.stop();
+    await runScheduleDueWorkOnce();
 
     // THEN a conversation is created and recorded
     expect(processedMessages).toHaveLength(1);
@@ -220,9 +191,7 @@ describe("scheduler conversation reuse", () => {
     forceScheduleDue(schedule.id);
     processedMessages.length = 0;
 
-    const scheduler2 = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler2.stop();
+    await runScheduleDueWorkOnce();
 
     // THEN the same conversation is reused
     expect(processedMessages).toHaveLength(1);
@@ -257,9 +226,7 @@ describe("scheduler conversation reuse", () => {
     // WHEN the schedule fires for the first time
     forceScheduleDue(schedule.id);
 
-    const scheduler1 = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler1.stop();
+    await runScheduleDueWorkOnce();
 
     expect(processedMessages).toHaveLength(1);
     const firstConversationId = processedMessages[0].conversationId;
@@ -269,9 +236,7 @@ describe("scheduler conversation reuse", () => {
     forceScheduleDue(schedule.id);
     processedMessages.length = 0;
 
-    const scheduler2 = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler2.stop();
+    await runScheduleDueWorkOnce();
 
     // THEN a fresh conversation is created instead of reusing the first
     expect(processedMessages).toHaveLength(1);
@@ -297,9 +262,7 @@ describe("scheduler conversation reuse", () => {
     // WHEN the schedule fires for the first time
     forceScheduleDue(schedule.id);
 
-    const scheduler1 = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler1.stop();
+    await runScheduleDueWorkOnce();
 
     expect(processedMessages).toHaveLength(1);
     const firstConversationId = processedMessages[0].conversationId;
@@ -308,9 +271,7 @@ describe("scheduler conversation reuse", () => {
     forceScheduleDue(schedule.id);
     processedMessages.length = 0;
 
-    const scheduler2 = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler2.stop();
+    await runScheduleDueWorkOnce();
 
     // THEN a different conversation is created
     expect(processedMessages).toHaveLength(1);
@@ -336,9 +297,7 @@ describe("scheduler conversation reuse", () => {
 
     forceScheduleDue(schedule.id);
 
-    const scheduler1 = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler1.stop();
+    await runScheduleDueWorkOnce();
 
     expect(processedMessages).toHaveLength(1);
     const firstConversationId = processedMessages[0].conversationId;
@@ -350,9 +309,7 @@ describe("scheduler conversation reuse", () => {
     forceScheduleDue(schedule.id);
     processedMessages.length = 0;
 
-    const scheduler2 = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler2.stop();
+    await runScheduleDueWorkOnce();
 
     // THEN a new conversation is created (not the deleted one)
     expect(processedMessages).toHaveLength(1);
@@ -376,9 +333,7 @@ describe("scheduler conversation reuse", () => {
     });
 
     // WHEN the schedule fires
-    const scheduler = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler.stop();
+    await runScheduleDueWorkOnce();
 
     // THEN the message is processed with a new conversation
     expect(processedMessages).toHaveLength(1);
@@ -416,9 +371,7 @@ describe("scheduler conversation reuse", () => {
       if (shouldFail) throw new Error("Simulated failure");
     };
 
-    const scheduler1 = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler1.stop();
+    await runScheduleDueWorkOnce();
 
     expect(processedMessages).toHaveLength(1);
     const successConversationId = processedMessages[0].conversationId;
@@ -428,9 +381,7 @@ describe("scheduler conversation reuse", () => {
     processedMessages.length = 0;
     shouldFail = true;
 
-    const scheduler2 = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler2.stop();
+    await runScheduleDueWorkOnce();
 
     // The failed run created a different conversation (since it failed
     // before the run could reuse — actually it does reuse the same one
@@ -442,9 +393,7 @@ describe("scheduler conversation reuse", () => {
     processedMessages.length = 0;
     shouldFail = false;
 
-    const scheduler3 = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler3.stop();
+    await runScheduleDueWorkOnce();
 
     // THEN the third run reuses the conversation from the first successful run
     // (the lookup queries for status="ok", so it picks the first run's conversation)
@@ -479,9 +428,7 @@ describe("scheduler talk-mode runner option propagation", () => {
     });
     forceScheduleDue(schedule.id);
 
-    const scheduler = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler.stop();
+    await runScheduleDueWorkOnce();
 
     expect(runBackgroundJobOptions).toHaveLength(1);
     const opts = runBackgroundJobOptions[0]!;
@@ -503,9 +450,7 @@ describe("scheduler talk-mode runner option propagation", () => {
     });
     forceScheduleDue(schedule.id);
 
-    const scheduler = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler.stop();
+    await runScheduleDueWorkOnce();
 
     expect(runBackgroundJobOptions).toHaveLength(1);
     expect(runBackgroundJobOptions[0]!.suppressFailureNotifications).toBe(
@@ -531,9 +476,7 @@ describe("scheduler talk-mode runner option propagation", () => {
     forceScheduleDue(schedule.id);
     runBackgroundJobBootstrapFails = true;
 
-    const scheduler = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler.stop();
+    await runScheduleDueWorkOnce();
 
     const runs = getScheduleRuns(schedule.id);
     expect(runs.length).toBe(1);
@@ -572,9 +515,7 @@ describe("scheduler talk-mode runner option propagation", () => {
         }
       },
     });
-    const scheduler = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler.stop();
+    await runScheduleDueWorkOnce();
     subscription.dispose();
 
     expect(sseCalls).toHaveLength(1);

--- a/assistant/src/__tests__/scheduler-wake.test.ts
+++ b/assistant/src/__tests__/scheduler-wake.test.ts
@@ -1,12 +1,4 @@
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  test,
-} from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 mock.module("../util/logger.js", () => ({
   getLogger: () =>
@@ -36,7 +28,7 @@ import { loadRawConfig, saveRawConfig } from "../config/loader.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { createSchedule } from "../schedule/schedule-store.js";
-import { startScheduler } from "../schedule/scheduler.js";
+import { runScheduleDueWorkOnce } from "../schedule/scheduler.js";
 
 await initializeDb();
 
@@ -61,26 +53,7 @@ function forceScheduleDue(scheduleId: string): void {
   ]);
 }
 
-// Replace setTimeout with a fast-forward version so the scheduler
-// wait calls fire quickly instead of waiting real time.
-let origSetTimeout: typeof globalThis.setTimeout;
-
 describe("scheduler wake mode", () => {
-  beforeAll(() => {
-    origSetTimeout = globalThis.setTimeout;
-    globalThis.setTimeout = ((
-      fn: TimerHandler,
-      _ms?: number,
-      ...args: unknown[]
-    ) => {
-      return origSetTimeout(fn, 200, ...args);
-    }) as typeof setTimeout;
-  });
-
-  afterAll(() => {
-    globalThis.setTimeout = origSetTimeout;
-  });
-
   beforeEach(() => {
     const db = getDb();
     db.run("DELETE FROM cron_runs");
@@ -105,9 +78,7 @@ describe("scheduler wake mode", () => {
     forceScheduleDue(schedule.id);
 
     // WHEN the scheduler fires
-    const scheduler = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler.stop();
+    await runScheduleDueWorkOnce();
 
     // THEN wakeAgentForOpportunity is called with the correct arguments
     expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
@@ -140,9 +111,7 @@ describe("scheduler wake mode", () => {
     forceScheduleDue(schedule.id);
 
     // WHEN the scheduler fires
-    const scheduler = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler.stop();
+    await runScheduleDueWorkOnce();
 
     // THEN wakeAgentForOpportunity is NOT called
     expect(mockWakeAgentForOpportunity).not.toHaveBeenCalled();
@@ -171,9 +140,7 @@ describe("scheduler wake mode", () => {
     forceScheduleDue(schedule.id);
 
     // WHEN the scheduler fires
-    const scheduler = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler.stop();
+    await runScheduleDueWorkOnce();
 
     // THEN the one-shot is marked as completed (status = 'fired')
     const row = getRawDb()
@@ -196,9 +163,7 @@ describe("scheduler wake mode", () => {
     forceScheduleDue(schedule.id);
 
     // WHEN the scheduler fires
-    const scheduler = startScheduler();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler.stop();
+    await runScheduleDueWorkOnce();
 
     // THEN the one-shot is reverted to 'active' for retry (failOneShot behavior)
     const row = getRawDb()
@@ -229,10 +194,8 @@ describe("scheduler wake mode", () => {
     });
     forceScheduleDue(schedule.id);
 
-    const scheduler = startScheduler();
-
-    // WHEN the first tick runs (fires immediately from startScheduler)
-    await new Promise((resolve) => origSetTimeout(resolve, 600));
+    // WHEN the first tick runs
+    await runScheduleDueWorkOnce();
 
     // THEN the job is NOT completed — it's reverted to 'active' for retry
     const rowAfterFirst = getRawDb()
@@ -241,9 +204,8 @@ describe("scheduler wake mode", () => {
     expect(rowAfterFirst?.status).toBe("active");
     expect(rowAfterFirst?.retry_count).toBe(1);
 
-    // WHEN the second tick fires (call runOnce directly to avoid waiting for setInterval)
-    await scheduler.runOnce();
-    scheduler.stop();
+    // WHEN the second tick fires
+    await runScheduleDueWorkOnce();
 
     // THEN the job IS completed (status = 'fired')
     const rowAfterSecond = getRawDb()
@@ -277,10 +239,8 @@ describe("scheduler wake mode", () => {
       schedule.id,
     ]);
 
-    // WHEN the scheduler fires (first tick runs immediately from startScheduler)
-    const scheduler = startScheduler();
-    await new Promise((resolve) => origSetTimeout(resolve, 600));
-    scheduler.stop();
+    // WHEN the scheduler fires
+    await runScheduleDueWorkOnce();
 
     // THEN the job is permanently failed (status = 'cancelled', enabled = false)
     const row = getRawDb()


### PR DESCRIPTION
## Prompt / plan

Part of the assistant unit-test runtime triage. The slowest non-DB tests are scheduler tests that burn real wall-time waiting for a fire-and-forget tick to settle. Each of these three files:

- called `startScheduler()` (the interval-based scheduler) and then `await`ed a fixed real-time sleep before asserting, and
- monkeypatched `globalThis.setTimeout` to a fixed 200ms — a process-global hack that races the async tick and forces every wait to a fixed floor no matter how fast the work actually completes.

The scheduler already exposes a deterministic entry point, `runScheduleDueWorkOnce()`, which awaits a single tick end-to-end (including the `run_task` dynamic import and `processMessage`). This PR replaces the start-and-sleep pattern with direct `await runScheduleDueWorkOnce()` calls, so each test drives exactly the ticks it needs and asserts immediately — no sleeps, no global `setTimeout` patch, no callback races.

Scope is deliberately limited to the three scheduler files that used this monkeypatch anti-pattern. The other files that patch `globalThis.setTimeout` (`conversation-queue`, `memory-jobs-worker-backoff`, `oauth2-refresh-retry`) drive different subsystems — `conversation-queue` already uses condition-polling (`waitForPendingRun`) rather than fixed sleeps — and are better handled separately.

## Test plan

- All 29 tests across the three files pass.
- Full suite (`EXCLUDE_EXPERIMENTAL=true bun run test`) green except the same pre-existing environment-only failures (egress-proxy / sandbox / avatar-state) that also fail on `main` in this environment — no new or newly-flaky failures.
- `prettier` / `eslint` / `tsc --noEmit` clean (enforced by pre-commit hook).

**Isolated timings (warm template cache):**

| File | Before | After |
|---|---|---|
| scheduler-reuse-conversation | 6.76s | 1.67s |
| scheduler-recurrence | 4.62s | 1.98s |
| scheduler-wake | 3.47s | 1.67s |

~14.8s → ~5.3s across the three files; the remainder is DB/import overhead, not waiting. Net −168 lines (three `globalThis.setTimeout` monkeypatches removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VQ5pbTnrDa963kGuz2eq7

---
_Generated by [Claude Code](https://claude.ai/code/session_019VQ5pbTnrDa963kGuz2eq7)_