### PR TITLE
docs(db-proxy): banners + allowlist describe the migrations-only bridge end state

### DIFF
--- a/assistant/src/ipc/routes/db-proxy.ts
+++ b/assistant/src/ipc/routes/db-proxy.ts
@@ -1,24 +1,18 @@
 /**
- * ⚠️  TEMPORARY HACK — DO NOT EXTEND ⚠️
- *
- * IPC route that lets the gateway execute raw SQL against the assistant's
- * SQLite database. This exists solely because the gateway and assistant run
- * in separate containers on platform pods, and cross-container SQLite file
- * access causes database corruption (fcntl locks are not shared across
- * mount namespaces).
+ * IPC route that lets gateway one-time data migrations execute raw SQL
+ * against the assistant's SQLite database. Migrations (m0002, m0010, m0014,
+ * et al.) need raw read/drop access to legacy assistant tables on first boot
+ * of upgraded installs, and cross-container SQLite file access corrupts the
+ * DB on platform pods (fcntl locks are not shared across mount namespaces) —
+ * so they go through this route.
  *
  * This route is intentionally NOT in the shared ROUTES array — it is a
  * private implementation detail between the gateway and assistant IPC
  * servers and must not be discoverable by clients or the OpenAPI spec.
  *
- * The gateway callers are pinned by an allowlist guard
- * (gateway `__tests__/db-proxy-allowlist.test.ts`): the contact-merge
- * identity-mirror cluster (pending a merge-shaped op), residual raw-SQL
- * contact reads in `verification/contact-helpers.ts` (deferred cleanup),
- * and one-time data migrations. Slated for removal once the contact-merge
- * cluster gets typed mirror ops.
- *
- * Tracking: ATL-XXX (gateway security migration)
+ * No runtime feature may use this surface: gateway callers are pinned to the
+ * proxy module (`db/assistant-db-proxy.ts`) plus `db/data-migrations/` by
+ * the allowlist guard (gateway `__tests__/db-proxy-allowlist.test.ts`).
  */
 
 import { getSqlite } from "../../persistence/db-connection.js";

--- a/gateway/src/__tests__/db-proxy-allowlist.test.ts
+++ b/gateway/src/__tests__/db-proxy-allowlist.test.ts
@@ -4,33 +4,22 @@ import { join, sep } from "node:path";
 
 /**
  * db_proxy surface guard: the assistant-DB proxy (`assistant-db-proxy.ts` +
- * the daemon-side `db-proxy` route) is a temporary raw-SQL bridge, slated for
- * removal once its last callers get typed ops. This source scan
- * fails if any gateway file OUTSIDE the allowlist imports the proxy or names
- * the raw-SQL bridge method (`db_proxy`), so the surface can only shrink,
- * never grow.
- *
- * The proxy currently serves two groups (the allowlist below):
- *   1. The contact dual-write cluster (`contact-store.ts`,
- *      `dualWriteContactToAssistantDb`) — pending its typed replacement; the
- *      merge mirror is already the typed `contacts_mirror_merge_contact` op.
- *   2. Data migrations — one-time backfills that legitimately touch the
- *      assistant DB broadly.
+ * the daemon-side `db-proxy` route) is a data-migrations-only bridge.
+ * Gateway one-time migrations (m0002/m0010/m0014 et al.) need raw read/drop
+ * access to the assistant DB on first boot of upgraded installs; no runtime
+ * feature may use this surface. This source scan fails if any gateway file
+ * OUTSIDE the proxy module and `db/data-migrations/` imports the proxy or
+ * names the raw-SQL bridge method (`db_proxy`).
  */
 
-// Relative to GATEWAY_SRC (POSIX-separated). Every entry is a sanctioned
-// db_proxy caller; new callers must NOT be added — drain them instead.
+// Relative to GATEWAY_SRC (POSIX-separated). New entries must NOT be added.
 const ALLOWLIST = new Set<string>([
   // The proxy definition itself (calls ipcCallAssistant("db_proxy")).
   "db/assistant-db-proxy.ts",
-
-  // contact-store.ts is drained: its merge + upsert mirrors are typed ops
-  // (`contacts_mirror_merge_contact` / `contacts_mirror_upsert_full`). The
-  // migrations-only banner rewrite lands in the follow-up PR.
 ]);
 
-// Data migrations run one-time backfills through the same proxy and touch
-// contacts/channels/invites broadly. Allowed wholesale by directory prefix.
+// One-time data migrations legitimately touch the assistant DB broadly.
+// Allowed wholesale by directory prefix.
 const ALLOWED_DIR_PREFIX = "db/data-migrations/";
 
 const GATEWAY_SRC = join(import.meta.dirname!, "..");

--- a/gateway/src/db/assistant-db-proxy.ts
+++ b/gateway/src/db/assistant-db-proxy.ts
@@ -1,22 +1,15 @@
 /**
- * ⚠️  TEMPORARY HACK — DO NOT EXTEND ⚠️
+ * Data-migrations-only bridge for executing SQL against the assistant's
+ * SQLite database via IPC. Gateway one-time data migrations (m0002, m0010,
+ * m0014, et al.) need raw read/drop access to the assistant DB on first boot
+ * of upgraded installs, and direct cross-container file access corrupts the
+ * DB on platform pods (fcntl locks are not shared across mount namespaces +
+ * a SQLite WAL-reset bug in ≤3.51.2) — so migrations reach the assistant DB
+ * only through this route.
  *
- * Proxy for executing SQL against the assistant's SQLite database via IPC.
- * Direct cross-container file access corrupts the DB on platform pods (fcntl
- * locks are not shared across mount namespaces + a SQLite WAL-reset bug in
- * ≤3.51.2), so the gateway reaches the assistant DB only through this route.
- *
- * The caller allowlist is pinned by `__tests__/db-proxy-allowlist.test.ts`.
- * The surface serves exactly three groups:
- *   (a) the contact-merge identity-mirror cluster in `db/contact-store.ts` —
- *       pending a merge-shaped op that expresses a notes-only survivor UPDATE
- *       and a resolved-slug dual-write INSERT the typed mirror ops cannot,
- *   (b) data migrations (one-time backfills and drops), and
- *   (c) residual raw-SQL contact reads in `verification/contact-helpers.ts`
- *       (deferred cleanup).
- *
- * NOT a general-purpose query layer. Slated for removal once the
- * contact-merge cluster gets typed mirror ops.
+ * No runtime feature may use this surface. The caller allowlist — this
+ * module plus `db/data-migrations/` — is enforced by
+ * `__tests__/db-proxy-allowlist.test.ts`.
  */
 
 import { ipcCallAssistant } from "../ipc/assistant-client.js";


### PR DESCRIPTION
## Summary
- db_proxy banners (both ends) + allowlist test header rewritten to the permanent end state: a data-migrations-only bridge
- ATL-XXX placeholder replaced with a pointer to the allowlist test as the enforcement mechanism

Part of plan: acl-hardening-sweep.md (PR 14 of 18)