### PR TITLE
refactor(contacts): retire misnamed write-helpers and the vestigial local Contact.role

### DIFF
--- a/assistant/src/__tests__/actor-trust-resolver-address-fallback.test.ts
+++ b/assistant/src/__tests__/actor-trust-resolver-address-fallback.test.ts
@@ -84,7 +84,6 @@ function makeContact(
     id: CONTACT_ID,
     displayName: "Patrick Test",
     notes: null,
-    role,
     contactType: "human" as const,
     userFile: null,
     createdAt: 0,

--- a/assistant/src/__tests__/contact-store-user-file.test.ts
+++ b/assistant/src/__tests__/contact-store-user-file.test.ts
@@ -57,7 +57,6 @@ describe("upsertContact user_file selection", () => {
   test("assigns a fresh slug per contact; principalId is gateway-owned and no longer groups siblings locally", () => {
     const primary = upsertContact({
       displayName: "Chris",
-      role: "guardian",
       channels: [
         {
           type: "vellum",
@@ -72,7 +71,6 @@ describe("upsertContact user_file selection", () => {
     // (collision-incremented) slug. Sibling grouping is owned by the gateway.
     const slack = upsertContact({
       displayName: "chris",
-      role: "guardian",
       channels: [
         {
           type: "slack",
@@ -88,7 +86,6 @@ describe("upsertContact user_file selection", () => {
   test("generates a slug from the display name for a brand-new contact", () => {
     const contact = upsertContact({
       displayName: "Alice",
-      role: "contact",
       channels: [
         {
           type: "slack",
@@ -103,7 +100,6 @@ describe("upsertContact user_file selection", () => {
   test("still auto-increments when principalId is not set and displayName collides", () => {
     const first = upsertContact({
       displayName: "Bob",
-      role: "contact",
       channels: [
         {
           type: "slack",
@@ -114,7 +110,6 @@ describe("upsertContact user_file selection", () => {
     });
     const second = upsertContact({
       displayName: "Bob",
-      role: "contact",
       channels: [
         {
           type: "slack",
@@ -137,7 +132,6 @@ describe("upsertContact user_file selection", () => {
 
     const contact = upsertContact({
       displayName: "Legacy",
-      role: "guardian",
       channels: [
         {
           type: "phone",

--- a/assistant/src/__tests__/invite-routes-http.test.ts
+++ b/assistant/src/__tests__/invite-routes-http.test.ts
@@ -119,7 +119,7 @@ await initializeDb();
 
 /** Create a throwaway contact and return its ID, for use as the invite's contactId. */
 function createTargetContact(displayName = "Test Contact"): string {
-  return upsertContact({ displayName, role: "contact" }).id;
+  return upsertContact({ displayName }).id;
 }
 
 function resetTables() {

--- a/assistant/src/__tests__/trusted-contact-verification.test.ts
+++ b/assistant/src/__tests__/trusted-contact-verification.test.ts
@@ -24,10 +24,7 @@ mock.module("../util/logger.js", () => ({
 
 import type { ChannelId } from "../channels/types.js";
 import { findContactChannel } from "../contacts/contact-store.js";
-import {
-  revokeMember,
-  upsertContactChannel,
-} from "../contacts/contacts-write.js";
+import { upsertContactChannel } from "../contacts/contacts-write.js";
 import type { ChannelStatus } from "../contacts/types.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
@@ -303,7 +300,7 @@ describe("trusted contact verification → member activation", () => {
     expect(otherChannel).toBeNull();
   });
 
-  test("revokeMember resolves the member identity without mutating local ACL", () => {
+  test("re-verification re-upserts the same identity row (revoke is gateway-owned)", () => {
     // Create a member identity row.
     const member = upsertContactChannel({
       sourceChannel: "telegram",
@@ -311,14 +308,10 @@ describe("trusted contact verification → member activation", () => {
       externalChatId: "chat-revoked",
       displayName: "Revoked User",
     });
+    expect(member).not.toBeNull();
 
-    // The local revoke is a pure resolver now — the gateway owns the ACL
-    // downgrade; revokeMember returns the resolved native contact/channel.
-    const revoked = revokeMember(member!.channel.id);
-    expect(revoked).not.toBeNull();
-    expect(revoked!.channel.id).toBe(member!.channel.id);
-
-    // Re-upsert on the same identity is idempotent on the identity row.
+    // The ACL downgrade lives on the gateway; the local identity row is
+    // untouched by a revoke, so re-verification re-upserts the same row.
     const session = createOutboundSession({
       channel: "telegram",
       expectedExternalUserId: "user-revoked",

--- a/assistant/src/a2a/__tests__/e2e-a2a-channel.test.ts
+++ b/assistant/src/a2a/__tests__/e2e-a2a-channel.test.ts
@@ -173,7 +173,6 @@ describe("e2e: trusted contact setup", () => {
     upsertContact({
       displayName: "Peer Assistant",
       contactType: "assistant",
-      role: "contact",
       channels: [
         {
           type: "a2a",

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -14,7 +14,6 @@ import type {
   AssistantContactMetadata,
   Contact,
   ContactChannel,
-  ContactRole,
   ContactType,
   ContactWithChannels,
 } from "./types.js";
@@ -94,9 +93,6 @@ function parseContact(row: typeof contacts.$inferSelect): Contact {
     id: row.id,
     displayName: row.displayName,
     notes: row.notes,
-    // gateway-owned; the serve layer stamps the real role from the gateway
-    // guardian id set.
-    role: "contact",
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
     contactType: row.contactType,
@@ -159,9 +155,6 @@ export function getContact(id: string): ContactWithChannels | null {
   return withChannels(parseContact(row));
 }
 
-/** @deprecated Use {@link getContact} directly. */
-export const getContactInternal = getContact;
-
 /** INFO-only contact fields, joined locally by contact ID. */
 export interface ContactInfo {
   notes: string | null;
@@ -200,7 +193,6 @@ export function upsertContact(params: {
   id?: string;
   displayName: string;
   notes?: string | null;
-  role?: ContactRole;
   contactType?: ContactType;
   userFile?: string | null;
   /** userFile to seed ONLY when inserting a new contact; ignored on update so
@@ -260,7 +252,7 @@ export function upsertContact(params: {
       }
 
       notifyContactsChanged();
-      return { ...getContactInternal(contactId)!, created: false };
+      return { ...getContact(contactId)!, created: false };
     }
   }
 
@@ -287,7 +279,7 @@ export function upsertContact(params: {
 
         syncChannels(contactId, canonicalChannels, now);
         notifyContactsChanged();
-        return { ...getContactInternal(contactId)!, created: false };
+        return { ...getContact(contactId)!, created: false };
       }
     }
   }
@@ -322,7 +314,7 @@ export function upsertContact(params: {
   }
 
   notifyContactsChanged();
-  return { ...getContactInternal(contactId)!, created: true };
+  return { ...getContact(contactId)!, created: true };
 }
 
 /**
@@ -337,8 +329,9 @@ export function deleteContact(id: string): void {
 
 /**
  * Add new channels to a contact without removing existing ones.
- * When a channel already exists (same type+address), updates access/verification
- * fields if provided. Skips channels owned by a different contact.
+ * When a channel already exists (same type+address), refreshes its identity
+ * fields (address casing, isPrimary, externalChatId) if provided. Skips
+ * channels owned by a different contact unless reassignment is requested.
  */
 function syncChannels(
   contactId: string,
@@ -512,7 +505,7 @@ export function searchContacts(params: {
     const results: ContactWithChannels[] = [];
     for (const id of contactIds) {
       if (results.length >= limit) break;
-      const contact = getContactInternal(id);
+      const contact = getContact(id);
       if (
         contact &&
         (!params.contactType || contact.contactType === params.contactType) &&
@@ -541,7 +534,7 @@ export function searchContacts(params: {
     const results: ContactWithChannels[] = [];
     for (const id of contactIds) {
       if (results.length >= limit) break;
-      const contact = getContactInternal(id);
+      const contact = getContact(id);
       if (
         contact &&
         (!params.contactType || contact.contactType === params.contactType)
@@ -588,7 +581,7 @@ export function searchContacts(params: {
     const results: ContactWithChannels[] = [];
     for (const id of contactIds) {
       if (results.length >= limit) break;
-      const contact = getContactInternal(id);
+      const contact = getContact(id);
       if (contact) {
         results.push(contact);
       }
@@ -697,7 +690,7 @@ export function mergeContacts(
   });
 
   notifyContactsChanged();
-  return getContactInternal(keepId)!;
+  return getContact(keepId)!;
 }
 
 /**
@@ -960,7 +953,7 @@ export function findContactByAddress(
     .get();
 
   if (!channel) return null;
-  return getContactInternal(channel.contactId);
+  return getContact(channel.contactId);
 }
 
 /**
@@ -986,7 +979,7 @@ function findContactByChannelExternalChatId(
     .orderBy(desc(contactChannels.updatedAt), desc(contactChannels.createdAt))
     .get();
   if (!channel) return null;
-  return getContactInternal(channel.contactId);
+  return getContact(channel.contactId);
 }
 
 /**
@@ -1032,20 +1025,18 @@ export function findContactChannel(params: {
 }
 
 /**
- * Heal a guardian channel's identity address when the JWT principal no longer
- * matches the stored guardian binding after a DB reset. The principalId ACL
- * column is gateway-owned and no longer written here; only the channel identity
- * address is repaired.
+ * Repair a channel's identity address, e.g. when a guardian JWT principal no
+ * longer matches the stored channel address after a DB reset. Identity-only:
+ * the principalId ACL column is gateway-owned.
  *
  * Returns false if the update would violate the unique (type, address)
- * constraint on contact_channels — e.g. when the incoming principal already
+ * constraint on contact_channels — e.g. when the incoming address already
  * exists on another channel record (a revoked former guardian entry).
- * In that case the heal is skipped and trust stays `unknown`.
+ * In that case the repair is skipped and trust stays `unknown`.
  */
-export function updateContactPrincipalAndChannel(
-  _contactId: string,
+export function repairChannelAddress(
   channelId: string,
-  newPrincipalId: string,
+  newAddress: string,
 ): boolean {
   const db = getDb();
   const now = Date.now();
@@ -1058,7 +1049,7 @@ export function updateContactPrincipalAndChannel(
   if (!channel) return false;
 
   // Guard: check if another channel row holds this canonical identity.
-  const conflicting = findConflictingChannel(db, channel.type, newPrincipalId);
+  const conflicting = findConflictingChannel(db, channel.type, newAddress);
 
   if (conflicting && conflicting.id !== channelId) {
     return false;
@@ -1066,7 +1057,7 @@ export function updateContactPrincipalAndChannel(
 
   db.update(contactChannels)
     .set({
-      address: newPrincipalId,
+      address: newAddress,
       updatedAt: now,
     })
     .where(eq(contactChannels.id, channelId))

--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -8,9 +8,7 @@
 
 import {
   findContactChannel,
-  getChannelById,
   getContact,
-  getContactInternal,
   upsertContact,
 } from "./contact-store.js";
 import type { ContactType, ContactWriteResult } from "./types.js";
@@ -125,24 +123,4 @@ export function upsertContactChannel(params: {
   }
 
   return null;
-}
-
-/**
- * Resolve the native contact/channel for a member id. The ACL downgrade is
- * gateway-owned (relayed via mark_channel_revoked); this no longer mutates
- * local status. The memberId may be a plain channel ID (internal callers) or a
- * composite contactId:channelId (from the API response format).
- */
-export function revokeMember(memberId: string): ContactWriteResult | null {
-  const channelId = memberId.includes(":") ? memberId.split(":")[1] : memberId;
-
-  const channelRow = getChannelById(channelId);
-  if (!channelRow) return null;
-
-  const contact = getContactInternal(channelRow.contactId);
-  if (!contact) return null;
-  const channel = contact.channels.find((ch) => ch.id === channelId);
-  if (!channel) return null;
-
-  return { contact, channel };
 }

--- a/assistant/src/contacts/guardian-contact-reader.ts
+++ b/assistant/src/contacts/guardian-contact-reader.ts
@@ -2,8 +2,9 @@
  * Daemon-side reader for the guardian contact id(s), sourced from the gateway
  * DB (source of truth) via the `get_guardian_contact` IPC.
  *
- * Lets contact-serve paths determine the guardian without reading the local
- * `contacts.role` column. Result is cached with a short TTL.
+ * Lets contact-serve paths determine the guardian without any local role
+ * state (the local contact shape carries none). Result is cached with a
+ * short TTL.
  *
  * FAIL-SOFT: a cache miss or IPC error returns an empty set and logs a warning;
  * this never throws (it runs on contact-serve paths).

--- a/assistant/src/contacts/member-write-relay.ts
+++ b/assistant/src/contacts/member-write-relay.ts
@@ -14,8 +14,7 @@ import {
 
 import { log } from "../daemon/handlers/shared.js";
 import { ipcCallPersistent } from "../ipc/gateway-client.js";
-import { findContactChannel } from "./contact-store.js";
-import { revokeMember, upsertContactChannel } from "./contacts-write.js";
+import { upsertContactChannel } from "./contacts-write.js";
 import type { ContactWriteResult } from "./types.js";
 
 // ── Activate ─────────────────────────────────────────────────────────
@@ -161,8 +160,7 @@ export interface BlockSenderChannelParams {
  * status, and `mark_channel_revoked` is idempotent (already-revoked →
  * didWrite:false) and refuses to downgrade a guardian channel. Fails closed —
  * a relay failure surfaces as `revoked: false` so callers never report a block
- * the gateway did not persist. The assistant-DB status update is a best-effort
- * mirror.
+ * the gateway did not persist.
  */
 export async function blockSenderChannel(
   params: BlockSenderChannelParams,
@@ -207,21 +205,6 @@ export async function blockSenderChannel(
     return { revoked: false };
   }
 
-  // Best-effort local mirror so the Contacts page reflects the downgrade.
-  // Resolved by logical (type, address) key — the local mirror row's id is
-  // not guaranteed to match the gateway channel id.
-  try {
-    const local = findContactChannel({
-      channelType: params.sourceChannel,
-      address: params.externalUserId,
-    });
-    if (local) {
-      revokeMember(local.channel.id);
-    }
-  } catch {
-    // The local row may not exist for a brand-new sender; the gateway
-    // outcome stands.
-  }
   return { revoked: true };
 }
 

--- a/assistant/src/contacts/types.ts
+++ b/assistant/src/contacts/types.ts
@@ -1,3 +1,5 @@
+/** Gateway-sourced: carried on trust verdicts and stamped at the serve layer,
+ *  never persisted on the local {@link Contact}. */
 export type ContactRole = "guardian" | "contact";
 
 export type ContactType = "human" | "assistant";
@@ -30,7 +32,6 @@ export interface Contact {
   displayName: string;
   /** Free-text notes about this contact (e.g. relationship, communication preferences). */
   notes: string | null;
-  role: ContactRole;
   createdAt: number;
   updatedAt: number;
   contactType: ContactType;

--- a/assistant/src/daemon/handlers/config-a2a.ts
+++ b/assistant/src/daemon/handlers/config-a2a.ts
@@ -151,7 +151,6 @@ export function createA2AInvite(params: {
   const contact = upsertContact({
     displayName: "Pending A2A invite",
     contactType: "assistant",
-    role: "contact",
   });
 
   // 4. Create the invite
@@ -211,7 +210,6 @@ export function completeA2AInvite(params: {
     id: invite.contactId,
     displayName: params.acceptor.displayName,
     contactType: "assistant",
-    role: "contact",
     channels: [
       {
         type: "a2a",
@@ -273,7 +271,6 @@ export function redeemA2AInvite(params: {
   const contact = upsertContact({
     displayName: params.sender.displayName,
     contactType: "assistant",
-    role: "contact",
     channels: [
       {
         type: "a2a",

--- a/assistant/src/runtime/__tests__/guardian-vellum-migration.test.ts
+++ b/assistant/src/runtime/__tests__/guardian-vellum-migration.test.ts
@@ -6,10 +6,9 @@
  * (`getGuardianDelivery`/`guardianForChannel`) supplies the authoritative
  * principal, the local-mirror heal target is resolved via
  * `findContactByAddress` (keyed on the gateway guardian's channel address) and
- * written via `updateContactPrincipalAndChannel` (the real
- * `healGuardianBindingDrift` drives this), and the local trust resolver
- * (`resolveTrustContext`) closes the loop. Heal invocations are observed via
- * the contact-store write mock.
+ * written via `repairChannelAddress` (the real `healGuardianBindingDrift`
+ * drives this), and the local trust resolver (`resolveTrustContext`) closes
+ * the loop. Heal invocations are observed via the contact-store write mock.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -30,7 +29,7 @@ mock.module("../../contacts/guardian-delivery-reader.js", () => ({
 
 // Local mirror the real heal repairs. `findContactByAddress` returns the local
 // contact (with its vellum channel) the heal writes to;
-// `updateContactPrincipalAndChannel` records heal writes.
+// `repairChannelAddress` records heal writes.
 let mockLocalContact: {
   id: string;
   channels: Array<{ id: string; type: string }>;
@@ -39,11 +38,7 @@ const healWrites: Array<{ principalId: string }> = [];
 
 mock.module("../../contacts/contact-store.js", () => ({
   findContactByAddress: () => mockLocalContact,
-  updateContactPrincipalAndChannel: (
-    _contactId: string,
-    _channelId: string,
-    principalId: string,
-  ) => {
+  repairChannelAddress: (_channelId: string, principalId: string) => {
     healWrites.push({ principalId });
     return true;
   },

--- a/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
+++ b/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
@@ -480,7 +480,6 @@ describe("toTrustContext member grounding", () => {
       id: "contact-1",
       displayName: "Frank",
       notes: null,
-      role: "contact",
       createdAt: 0,
       updatedAt: 0,
       contactType: "human",

--- a/assistant/src/runtime/guardian-vellum-migration.ts
+++ b/assistant/src/runtime/guardian-vellum-migration.ts
@@ -10,7 +10,7 @@
 import type { ChannelId } from "../channels/types.js";
 import {
   findContactByAddress,
-  updateContactPrincipalAndChannel,
+  repairChannelAddress,
 } from "../contacts/contact-store.js";
 import {
   getGuardianDelivery,
@@ -76,11 +76,7 @@ export async function healGuardianBindingDrift(
   );
   if (!localContact || !localChannel) return false;
 
-  const updated = updateContactPrincipalAndChannel(
-    localContact.id,
-    localChannel.id,
-    incomingPrincipalId,
-  );
+  const updated = repairChannelAddress(localChannel.id, incomingPrincipalId);
 
   if (!updated) {
     log.warn(

--- a/assistant/src/runtime/routes/__tests__/channel-verification-revoke.test.ts
+++ b/assistant/src/runtime/routes/__tests__/channel-verification-revoke.test.ts
@@ -103,17 +103,6 @@ mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
   }),
 }));
 
-// Guard: the contact-channel ACL write moves to the gateway relay and must
-// never run locally.
-const localAclWrite = mock(() => {
-  throw new Error("local ACL write must not happen on relayed revoke");
-});
-const actualContactsWrite = await import("../../../contacts/contacts-write.js");
-mock.module("../../../contacts/contacts-write.js", () => ({
-  ...actualContactsWrite,
-  revokeMember: localAclWrite,
-}));
-
 // Contact-change notification — fired explicitly on relay success so open
 // client views stop showing the channel as active after the gateway
 // dual-writes it to "revoked".
@@ -157,7 +146,6 @@ describe("verification revoke relay", () => {
     ipcCallPersistentMock.mockClear();
     cancelOutboundMock.mockClear();
     revokePendingSessionsMock.mockClear();
-    localAclWrite.mockClear();
     notifyContactsChangedMock.mockClear();
   });
 
@@ -180,9 +168,6 @@ describe("verification revoke relay", () => {
     // Session teardown stays assistant-side.
     expect(cancelOutboundMock).toHaveBeenCalledTimes(1);
     expect(revokePendingSessionsMock).toHaveBeenCalledTimes(1);
-
-    // The contact-channel ACL write does not fall back to the assistant.
-    expect(localAclWrite).not.toHaveBeenCalled();
 
     // Invalidation emitted explicitly on relay success.
     expect(notifyContactsChangedMock).toHaveBeenCalledTimes(1);
@@ -259,7 +244,6 @@ describe("verification revoke relay", () => {
     // Session teardown ran before the relay rejected.
     expect(cancelOutboundMock).toHaveBeenCalledTimes(1);
     expect(revokePendingSessionsMock).toHaveBeenCalledTimes(1);
-    expect(localAclWrite).not.toHaveBeenCalled();
   });
 
   test("no binding present: tears down sessions and skips the relay", async () => {

--- a/assistant/src/runtime/routes/__tests__/contact-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/contact-routes.test.ts
@@ -81,13 +81,12 @@ const { handleListContacts, handleGetContact, ROUTES } =
 
 // Daemon-native contact: INFO is hydrated locally; channel-level ACL fields
 // (status/policy/verification) are gateway-owned and absent on native reads.
-// The fixture's `role` is ignored — the serve layer derives role from the
-// gateway guardian id set.
+// `role` is likewise absent — the serve layer derives it from the gateway
+// guardian id set.
 const nativeContact = {
   id: "ct_2",
   displayName: "Bob",
   notes: null,
-  role: "contact",
   contactType: "human",
   lastInteraction: 4200,
   interactionCount: 4,

--- a/assistant/src/runtime/routes/__tests__/global-search-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/global-search-routes.test.ts
@@ -33,7 +33,6 @@ function makeContact(
     id: "ct_1",
     displayName: "Alice",
     notes: null,
-    role: "contact",
     createdAt: 1,
     updatedAt: 1,
     contactType: "human",

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -87,7 +87,7 @@ function withGuardianNameOverride<
 
 /**
  * Stamp `role` from the gateway guardian id set on DAEMON-NATIVE reads, whose
- * `role` is the neutral `"contact"` default (search / contactType-filtered).
+ * local contact shape carries no role (search / contactType-filtered).
  * Fail-soft: empty set → everyone is `"contact"`.
  *
  * NOT applied to gateway-relayed reads (`contacts_list_rich`/`_get_rich`),
@@ -95,10 +95,10 @@ function withGuardianNameOverride<
  * stale/empty 30s id-set cache DOWNGRADE a freshly-rebound guardian to
  * `"contact"` during a rebind.
  */
-function withGatewayRole<T extends { id: string; role: string }>(
+function withGatewayRole<T extends { id: string }>(
   contact: T,
   guardianIds: ReadonlySet<string>,
-): T {
+): T & { role: ContactRole } {
   return {
     ...contact,
     role: guardianIds.has(contact.id) ? "guardian" : "contact",
@@ -118,6 +118,13 @@ function withChannelCompat<T extends { channels: { address: string }[] }>(
   };
 }
 
+interface PreparableContact {
+  id: string;
+  displayName: string;
+  contactType?: string | null;
+  channels: { address: string }[];
+}
+
 /** Compose the response transforms, then apply the guardian display-name
  * override (keyed off the role that's correct for this path) and the channel
  * compat field. Also coerces nullable gateway-sourced fields to their DB
@@ -128,25 +135,27 @@ function withChannelCompat<T extends { channels: { address: string }[] }>(
  *   - omitted (gateway-relayed reads): TRUST the gateway-sourced `role` already
  *     on the `ContactRead`. Never re-derive — a stale/empty id-set cache must
  *     not downgrade a relayed guardian to `"contact"`.
- *   - provided (daemon-native reads): role is the neutral `"contact"` default,
+ *   - provided (daemon-native reads): the local contact shape carries no role,
  *     so derive it from the gateway guardian id set.
  */
-function prepareContactResponse<
-  T extends {
-    id: string;
-    role: string;
-    displayName: string;
-    contactType?: string | null;
-    channels: { address: string }[];
-  },
->(contact: T, guardianIds?: ReadonlySet<string>): T {
+function prepareContactResponse<T extends PreparableContact & { role: string }>(
+  contact: T,
+): T;
+function prepareContactResponse<T extends PreparableContact>(
+  contact: T,
+  guardianIds: ReadonlySet<string>,
+): T & { role: ContactRole };
+function prepareContactResponse(
+  contact: PreparableContact & { role?: string },
+  guardianIds?: ReadonlySet<string>,
+) {
   const coerced =
     contact.contactType == null
-      ? { ...contact, contactType: "human" as T["contactType"] }
+      ? { ...contact, contactType: "human" }
       : contact;
   const withRole = guardianIds
     ? withGatewayRole(coerced, guardianIds)
-    : coerced;
+    : (coerced as PreparableContact & { role: string });
   return withChannelCompat(withGuardianNameOverride(withRole));
 }
 

--- a/assistant/src/runtime/trust-verdict-consumer.ts
+++ b/assistant/src/runtime/trust-verdict-consumer.ts
@@ -249,7 +249,6 @@ function memberRecordFromVerdict(
     id: member.contactId,
     displayName: member.displayName ?? "",
     notes: null,
-    role,
     createdAt: 0,
     updatedAt: 0,
     contactType: "human",


### PR DESCRIPTION
## Summary
- revokeMember (pure resolver) and updateContactPrincipalAndChannel renamed to what they do; dead param + deprecated alias removed
- Local Contact.role removed (hardcoded vestige); role lives on the serve-layer shape populated from the gateway
- Pure rename/type moves — zero behavior change

Part of plan: acl-hardening-sweep.md (PR 15 of 18)