### PR TITLE
refactor(plugins): scope the hook cache key by owner kind; drop dead collectUserHooks

### DIFF
--- a/assistant/src/__tests__/mtime-cache.test.ts
+++ b/assistant/src/__tests__/mtime-cache.test.ts
@@ -262,7 +262,7 @@ describe("plugin mtime cache (per-surface)", () => {
 
     expect(
       _inspectHookCacheForTests().find((key) =>
-        key.startsWith("deletable-plugin/"),
+        key.startsWith("plugin:deletable-plugin/"),
       ),
     ).toBeUndefined();
   });
@@ -479,6 +479,34 @@ describe("workspace hooks (<workspace>/hooks/)", () => {
     const hooks = await getUserHooksFor("post-tool-use");
     expect(hooks).toHaveLength(1);
     expect(getCachedUserTools()).toHaveLength(0);
+  });
+
+  test("a plugin named like the workspace owner does not collide with it", async () => {
+    // Load-time discovery doesn't reject a plugin whose manifest name equals
+    // the synthetic workspace owner. The cache key is scoped by owner kind, so
+    // `plugin:__workspace__/…` and `workspace:__workspace__/…` stay distinct
+    // and both hooks run.
+    const dir = freshPluginDir("shadow");
+    writePackageJson(dir, { ...SIMPLE_PKG, name: "__workspace__" });
+    writeHook(
+      dir,
+      "pre-model-call",
+      `export default () => ({ from: "plugin" });`,
+    );
+    writeWorkspaceHook(
+      "pre-model-call",
+      `export default () => ({ from: "workspace" });`,
+    );
+
+    await populateCacheAtBoot();
+
+    const hooks = await getUserHooksFor("pre-model-call");
+    expect(hooks).toHaveLength(2);
+    const froms = hooks.map(
+      (fn) => (fn as unknown as () => { from: string })().from,
+    );
+    // Plugin runs first (install-date order), workspace last.
+    expect(froms).toEqual(["plugin", "workspace"]);
   });
 
   // NB: each test below uses a distinct hook event name so the workspace

--- a/assistant/src/__tests__/plugin-effective-enabled-set.test.ts
+++ b/assistant/src/__tests__/plugin-effective-enabled-set.test.ts
@@ -10,8 +10,9 @@
  *  - `getHooksFor(name, { conversationId })` resolves the conversation's scope
  *    and excludes in-process default-plugin hooks outside it; omitting the
  *    conversationId imposes no restriction.
- *  - `collectUserHooks(name, dirs, set)` excludes user-land plugin hooks outside
- *    the set, while standalone workspace hooks (not owned by a plugin) still run.
+ *  - `collectUserHookEntries(name, dirs, set)` excludes user-land plugin hooks
+ *    outside the set, while standalone workspace hooks (not owned by a plugin)
+ *    still run.
  *
  * The per-chat scope layers on top of (does not replace) the global
  * `.disabled` sentinel check — a plugin excluded by either is excluded.
@@ -35,7 +36,7 @@ mock.module("../daemon/conversation-plugin-scope.js", () => ({
 }));
 
 import {
-  collectUserHooks,
+  collectUserHookEntries,
   resetHookCacheForTests,
 } from "../hooks/hook-loader.js";
 import { getHooksFor } from "../hooks/registry.js";
@@ -136,7 +137,7 @@ describe("getHooksFor per-chat plugin scope (in-process default hooks)", () => {
   });
 });
 
-describe("collectUserHooks per-chat plugin scope (user-land hooks)", () => {
+describe("collectUserHookEntries per-chat plugin scope (user-land hooks)", () => {
   let root: string;
   let counter = 0;
 
@@ -153,8 +154,8 @@ describe("collectUserHooks per-chat plugin scope (user-land hooks)", () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  // Dispatch hooks import lazily on the first `collectUserHooks` read, so the
-  // fixture only has to lay the files down on disk — the read fills the cache.
+  // Each hook resolves lazily on its first read, so the fixture only has to lay
+  // the files down on disk — the read fills the cache.
   function pluginDirWithHook(name: string): string {
     const dir = join(root, name);
     const hooksDir = join(dir, "hooks");
@@ -172,9 +173,11 @@ describe("collectUserHooks per-chat plugin scope (user-land hooks)", () => {
       [pluginDirWithHook("uplug-b"), "uplug-b"],
     ];
 
-    expect(await collectUserHooks("user-prompt-submit", dirs)).toHaveLength(2);
     expect(
-      await collectUserHooks("user-prompt-submit", dirs, null),
+      await collectUserHookEntries("user-prompt-submit", dirs),
+    ).toHaveLength(2);
+    expect(
+      await collectUserHookEntries("user-prompt-submit", dirs, null),
     ).toHaveLength(2);
   });
 
@@ -185,7 +188,11 @@ describe("collectUserHooks per-chat plugin scope (user-land hooks)", () => {
     ];
 
     expect(
-      await collectUserHooks("user-prompt-submit", dirs, new Set(["uplug-a"])),
+      await collectUserHookEntries(
+        "user-prompt-submit",
+        dirs,
+        new Set(["uplug-a"]),
+      ),
     ).toHaveLength(1);
   });
 });

--- a/assistant/src/hooks/__tests__/hook-live-reload.test.ts
+++ b/assistant/src/hooks/__tests__/hook-live-reload.test.ts
@@ -66,7 +66,7 @@ function makePlugin(): { dir: string; hooksDir: string; name: string } {
  * from disk.
  */
 function redeploy(plugin: { name: string }, modulePaths: string[]): void {
-  evictHooksForOwner(plugin.name);
+  evictHooksForOwner("plugin", plugin.name);
   for (const path of modulePaths) {
     evictModule(path);
   }
@@ -186,7 +186,7 @@ describe("hook reload primitives", () => {
 
     // Evicting the owner (as the reconcile does on a source change) clears the
     // negative entry, so the next read picks the hook up.
-    evictHooksForOwner(plugin.name);
+    evictHooksForOwner("plugin", plugin.name);
     expect(await dispatchOne(plugin)).toBe("added");
   });
 

--- a/assistant/src/hooks/hook-loader.ts
+++ b/assistant/src/hooks/hook-loader.ts
@@ -42,8 +42,8 @@
  *
  * Plugin *discovery* (which plugin directories exist, in what order) lives in
  * `../plugins/mtime-cache.ts`; the orchestrator there passes the discovered
- * directories into {@link collectUserHooks}. Keeping discovery out of this
- * module lets it sit below the plugin cache with no import cycle.
+ * directories into {@link collectUserHookEntries}. Keeping discovery out of
+ * this module lets it sit below the plugin cache with no import cycle.
  */
 
 import {
@@ -84,20 +84,37 @@ const log = getLogger("hook-loader");
 export const WORKSPACE_HOOKS_OWNER = "__workspace__";
 
 /**
- * Per-hook resolution memo keyed by `${ownerName}/${hookName}`. The key
- * includes the owner (plugin name, or {@link WORKSPACE_HOOKS_OWNER}) so hooks
- * from different owners don't collide. Each value is the promise that resolved
- * (or is resolving) that one hook: it settles to the imported function, or to
- * `null` when the owner doesn't define it (a negative cache entry). Storing the
+ * Whether a hook's owner is a user plugin or the standalone workspace surface.
+ * Threaded into the cache key so the two owner namespaces can't collide even if
+ * a plugin's manifest name happens to equal {@link WORKSPACE_HOOKS_OWNER}.
+ */
+type HookOwnerKind = "plugin" | "workspace";
+
+/**
+ * Per-hook resolution memo keyed by `${kind}:${ownerName}/${hookName}`. The key
+ * includes the owner kind and name (plugin name, or {@link WORKSPACE_HOOKS_OWNER})
+ * so hooks from different owners — even a plugin and the workspace that share a
+ * name — never collide. Each value is the promise that resolved (or is
+ * resolving) that one hook: it settles to the imported function, or to `null`
+ * when the owner doesn't define it (a negative cache entry). Storing the
  * promise, not the settled value, means concurrent first-readers of the same
  * hook share one import. An index over the filesystem, never the source of
  * truth.
  */
 const hookCache = new Map<string, Promise<HookFunction | null>>();
 
-/** Cache key for a hook: `${ownerName}/${hookName}`. */
-function hookKey(ownerName: string, hookName: string): string {
-  return `${ownerName}/${hookName}`;
+/** Cache key for a hook: `${kind}:${ownerName}/${hookName}`. */
+function hookKey(
+  kind: HookOwnerKind,
+  ownerName: string,
+  hookName: string,
+): string {
+  return `${kind}:${ownerName}/${hookName}`;
+}
+
+/** Key prefix for every hook owned by `(kind, ownerName)`. */
+function ownerKeyPrefix(kind: HookOwnerKind, ownerName: string): string {
+  return `${kind}:${ownerName}/`;
 }
 
 /**
@@ -120,11 +137,12 @@ function ownerHooksDir(pluginDir: string | null): string {
  * ({@link runInitHook} / {@link runShutdownHook}).
  */
 function resolveHook(
+  kind: HookOwnerKind,
   hooksDir: string,
   ownerName: string,
   hookName: string,
 ): Promise<HookFunction | null> {
-  const key = hookKey(ownerName, hookName);
+  const key = hookKey(kind, ownerName, hookName);
   let entry = hookCache.get(key);
   if (entry === undefined) {
     entry = importHook(hooksDir, ownerName, hookName);
@@ -217,7 +235,12 @@ export async function collectUserHookEntries<TCtx = unknown>(
     }
     pending.push({
       owner: { kind: "plugin", id: pluginName },
-      hook: resolveHook(ownerHooksDir(pluginDir), pluginName, hookName),
+      hook: resolveHook(
+        "plugin",
+        ownerHooksDir(pluginDir),
+        pluginName,
+        hookName,
+      ),
     });
   }
 
@@ -225,7 +248,12 @@ export async function collectUserHookEntries<TCtx = unknown>(
   // that are not part of any plugin (no package.json, no tools — just hooks).
   pending.push({
     owner: { kind: "workspace", id: WORKSPACE_HOOKS_OWNER },
-    hook: resolveHook(ownerHooksDir(null), WORKSPACE_HOOKS_OWNER, hookName),
+    hook: resolveHook(
+      "workspace",
+      ownerHooksDir(null),
+      WORKSPACE_HOOKS_OWNER,
+      hookName,
+    ),
   });
 
   const out: HookEntry<TCtx>[] = [];
@@ -236,24 +264,6 @@ export async function collectUserHookEntries<TCtx = unknown>(
     }
   }
   return out;
-}
-
-/**
- * {@link collectUserHookEntries} without owner attribution — returns just the
- * hook functions in the same order. For callers that only dispatch the chain
- * and don't attribute per-hook side effects.
- */
-export async function collectUserHooks<TCtx = unknown>(
-  hookName: string,
-  pluginDirs: Iterable<readonly [string, string]>,
-  effectiveEnabledPlugins?: Set<string> | null,
-): Promise<HookFunction<TCtx>[]> {
-  const entries = await collectUserHookEntries<TCtx>(
-    hookName,
-    pluginDirs,
-    effectiveEnabledPlugins,
-  );
-  return entries.map((e) => e.fn);
 }
 
 /**
@@ -295,14 +305,16 @@ export async function runInitHook(
   ownerName: string,
   pluginDir: string | null = null,
 ): Promise<void> {
+  // A plugin always has a directory; only the workspace owner passes `null`.
+  const kind: HookOwnerKind = pluginDir === null ? "workspace" : "plugin";
   const hooksDir = ownerHooksDir(pluginDir);
 
   // Resolve `shutdown` now, while the directory is present, so it's cached for
   // teardown even after an uninstall removes the directory (runShutdownHook
   // reads the cache, never disk). The result is discarded here — this is a warm.
-  await resolveHook(hooksDir, ownerName, HOOKS.SHUTDOWN);
+  await resolveHook(kind, hooksDir, ownerName, HOOKS.SHUTDOWN);
 
-  const initHook = await resolveHook(hooksDir, ownerName, HOOKS.INIT);
+  const initHook = await resolveHook(kind, hooksDir, ownerName, HOOKS.INIT);
   if (initHook === null) {
     return;
   }
@@ -334,13 +346,14 @@ export async function runInitHook(
  * swallowed. `reason` is threaded into the log for attribution only.
  */
 export async function runShutdownHook(
+  kind: HookOwnerKind,
   ownerName: string,
   context: ShutdownContext,
   reason: string,
 ): Promise<void> {
   // Read from the cache (resolved at activation, while the directory existed) —
   // never re-resolve here, since an uninstall may have already removed it.
-  const entry = hookCache.get(hookKey(ownerName, HOOKS.SHUTDOWN));
+  const entry = hookCache.get(hookKey(kind, ownerName, HOOKS.SHUTDOWN));
   if (entry === undefined) {
     return;
   }
@@ -360,12 +373,16 @@ export async function runShutdownHook(
 }
 
 /**
- * Evict every cached resolution owned by `ownerName` — positive and negative —
- * so the next read re-resolves fresh. Called by the reconcile after the owner's
- * `shutdown` has already run. No-op when the owner has no cached state.
+ * Evict every cached resolution owned by `(kind, ownerName)` — positive and
+ * negative — so the next read re-resolves fresh. Called by the reconcile after
+ * the owner's `shutdown` has already run. No-op when the owner has no cached
+ * state.
  */
-export function evictHooksForOwner(ownerName: string): void {
-  const prefix = `${ownerName}/`;
+export function evictHooksForOwner(
+  kind: HookOwnerKind,
+  ownerName: string,
+): void {
+  const prefix = ownerKeyPrefix(kind, ownerName);
   for (const key of hookCache.keys()) {
     if (key.startsWith(prefix)) {
       hookCache.delete(key);
@@ -380,7 +397,7 @@ export function evictHooksForOwner(ownerName: string): void {
  */
 export function clearPluginHooks(): void {
   for (const key of hookCache.keys()) {
-    if (!key.startsWith(`${WORKSPACE_HOOKS_OWNER}/`)) {
+    if (key.startsWith("plugin:")) {
       hookCache.delete(key);
     }
   }

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -354,7 +354,7 @@ async function applySourceVersions(
         // still-cached `shutdown`, then `evictHooksForOwner` drops the owner's
         // cached resolutions so the next read re-resolves fresh.
         await deactivatePlugin(activeName, "reload");
-        evictHooksForOwner(activeName);
+        evictHooksForOwner("plugin", activeName);
         evictToolCacheEntries(activeName);
         sweepModules(before, after);
         // Re-read the manifest — the edit may have renamed the plugin (or
@@ -448,13 +448,14 @@ async function reconcileWorkspaceHooks(
   );
   if (activeIdx >= 0) {
     await runShutdownHook(
+      "workspace",
       WORKSPACE_HOOKS_OWNER,
       { assistantVersion: APP_VERSION, reason },
       reason,
     );
     activatedPlugins.splice(activeIdx, 1);
   }
-  evictHooksForOwner(WORKSPACE_HOOKS_OWNER);
+  evictHooksForOwner("workspace", WORKSPACE_HOOKS_OWNER);
   sweepModules(before, after);
   if (after !== undefined) {
     await runInitHook(WORKSPACE_HOOKS_OWNER);
@@ -716,7 +717,7 @@ async function evictPlugin(
   pluginName: string,
 ): Promise<void> {
   // Evict hooks (owned by the hook loader).
-  evictHooksForOwner(pluginName);
+  evictHooksForOwner("plugin", pluginName);
 
   // Evict tools.
   evictToolCacheEntries(pluginName);
@@ -856,6 +857,7 @@ async function deactivatePlugin(
   }
 
   await runShutdownHook(
+    "plugin",
     pluginName,
     { assistantVersion: APP_VERSION, reason },
     reason,


### PR DESCRIPTION
## Prompt / plan

Follow-up to #37339, addressing review feedback.

**1. Owner-type in the hook key (collision fix).** At **load time**, a plugin's manifest name is only validated as non-empty — the kebab-case `^[a-z0-9]…` rule lives only in the publish CLI. So a hand-installed plugin whose stripped name equals the synthetic workspace owner (`__workspace__`) would share a cache key with the workspace surface and collide. The key is now `${kind}:${ownerName}/${hookName}`, with `kind` (`"plugin"` | `"workspace"`) threaded from each call site's **structural** source — a plugin always has a directory; the workspace owner passes `null` — rather than derived from the name. So the two namespaces can't collide even when the names match.

**2. Remove dead `collectUserHooks`.** Nothing in production called it (`getUserHooksFor` maps `getUserHookEntriesFor` itself). Removed; the one test that used it now drives `collectUserHookEntries`.

The reconcile call sites (`evictHooksForOwner`, `runShutdownHook`) now pass their owner kind explicitly, and `runInitHook` derives it from whether a plugin directory was supplied.

## Test plan

- New test `a plugin named like the workspace owner does not collide with it` (`mtime-cache.test.ts`): a plugin whose manifest name is `__workspace__` and a workspace hook of the same event both run, in the right order — the exact case the typed key fixes.
- `bun test` per-file: `mtime-cache.test.ts` (31), `hook-live-reload.test.ts` (6), `plugin-effective-enabled-set.test.ts` (5), `plugin-config-data-migration.test.ts` (6), `user-plugin-loader.test.ts` (5) — all pass.
- `bunx eslint` (0 errors), `bunx prettier --check` (clean), `tsc --noEmit` (exit 0); pre-push hook green.

## Not included here

Two review threads I'm deferring, with reasoning posted inline on #37339:

- **"Cold hooks unpinned until the sentinel reloads"** — I read this as a transient within the sentinel's eventual-consistency window that self-heals on the next reconcile, not a regression worth re-introducing whole-owner pinning for. Left a detailed reply; happy to add a documenting test if you want it pinned.
- **"Hook-read methods should live in hook-loader, not mtime-cache"** — agreed directionally, but the naive move creates a hook-loader ↔ mtime-cache import cycle (hook-loader would need mtime-cache's discovery + reconcile). It's entangled with removing the activation lifecycle, so I want to fold it into that exploration rather than force a cycle here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SquRHbAZqYMwNqDD7SNcNP)_