### PR TITLE
fix(tts): report actual provider sample rate, share the stream reader with stall timeouts

### DIFF
--- a/assistant/src/calls/fish-audio-client.ts
+++ b/assistant/src/calls/fish-audio-client.ts
@@ -1,6 +1,7 @@
 import type { FishAudioConfig } from "../config/schemas/fish-audio.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { readChunkedBody } from "../tts/stream-read.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("fish-audio-client");
@@ -13,12 +14,6 @@ const log = getLogger("fish-audio-client");
 export type FishAudioSynthesisConfig = Omit<FishAudioConfig, "format"> & {
   format: FishAudioConfig["format"] | "pcm";
 };
-
-/** Timeout waiting for the first chunk from Fish Audio (ms). */
-const FIRST_CHUNK_TIMEOUT_MS = 10_000;
-
-/** Timeout waiting between consecutive chunks (ms). */
-const IDLE_TIMEOUT_MS = 5_000;
 
 // ---------------------------------------------------------------------------
 // Fish Audio REST API (POST /v1/tts)
@@ -95,47 +90,12 @@ export async function synthesizeWithFishAudio(
     throw new Error("Fish Audio API returned no body");
   }
 
-  const chunks: Uint8Array[] = [];
-  const reader = response.body.getReader();
-  let isFirstChunk = true;
+  const audio = await readChunkedBody(response.body, {
+    onChunk: options?.onChunk,
+    makeTimeoutError: (timeoutMs) =>
+      new Error(`Fish Audio read timed out after ${timeoutMs}ms`),
+  });
 
-  try {
-    while (true) {
-      const timeoutMs = isFirstChunk ? FIRST_CHUNK_TIMEOUT_MS : IDLE_TIMEOUT_MS;
-      let timerId: ReturnType<typeof setTimeout>;
-      const timeout = new Promise<never>((_, reject) => {
-        timerId = setTimeout(
-          () => reject(new Error(`Fish Audio read timed out after ${timeoutMs}ms`)),
-          timeoutMs,
-        );
-      });
-      let done: boolean;
-      let value: Uint8Array | undefined;
-      try {
-        ({ done, value } = await Promise.race([reader.read(), timeout]));
-      } finally {
-        clearTimeout(timerId!);
-      }
-      if (done) break;
-      if (value) {
-        isFirstChunk = false;
-        chunks.push(value);
-        options?.onChunk?.(value);
-      }
-    }
-  } catch (err) {
-    try { await reader.cancel(); } catch { /* Ignore cancellation errors */ }
-    throw err;
-  }
-
-  const totalLength = chunks.reduce((sum, c) => sum + c.byteLength, 0);
-  const merged = new Uint8Array(totalLength);
-  let offset = 0;
-  for (const chunk of chunks) {
-    merged.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-
-  log.debug({ bytes: totalLength }, "Fish Audio synthesis complete");
-  return Buffer.from(merged);
+  log.debug({ bytes: audio.byteLength }, "Fish Audio synthesis complete");
+  return audio;
 }

--- a/assistant/src/live-voice/__tests__/live-voice-tts.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {
   _resetTtsProviderOverridesForTests,
@@ -16,6 +16,17 @@ import type {
 } from "../live-voice-tts.js";
 
 let config = makeConfig();
+
+// Real-catalog tests exercise the actual provider adapters, which read
+// credentials and config through these modules.
+mock.module("../../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async () => "test-api-key",
+  getProviderKeyAsync: async () => "test-api-key",
+}));
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => config,
+  loadConfig: () => config,
+}));
 
 const { LiveVoiceTtsError, streamLiveVoiceTtsAudio } =
   await import("../live-voice-tts.js");
@@ -314,6 +325,93 @@ describe("streamLiveVoiceTtsAudio", () => {
       chunks: 0,
       bytes: 0,
     });
+  });
+
+  test("labels frames with the provider-reported output rate when the requested rate is not honoured", async () => {
+    config = makeConfig({ provider: "elevenlabs" });
+    _setTtsProviderForTests({
+      id: "elevenlabs",
+      capabilities: {
+        supportsStreaming: true,
+        supportedFormats: ["mp3", "pcm"],
+      },
+      resolveOutputSampleRateHz: () => 16_000,
+      async synthesize(): Promise<TtsSynthesisResult> {
+        throw new Error("buffered synthesis should not be used");
+      },
+      async synthesizeStream(
+        request: TtsSynthesisRequest,
+        onChunk: (chunk: Uint8Array) => void,
+      ): Promise<TtsSynthesisResult> {
+        expect(request.sampleRateHz).toBe(48_000);
+        onChunk(Buffer.from("pcm-one!"));
+        return {
+          audio: Buffer.from("pcm-one!"),
+          contentType: "audio/pcm",
+          sampleRateHz: 16_000,
+        };
+      },
+    });
+
+    const frames: LiveVoiceTtsAudioChunk[] = [];
+    const result = await streamLiveVoiceTtsAudio({
+      config,
+      text: "hello from live voice",
+      outputFormat: "pcm",
+      sampleRate: 48_000,
+      onAudioChunk: (chunk) => frames.push(chunk),
+    });
+
+    expect(frames.map((frame) => frame.sampleRate)).toEqual([16_000]);
+    expect(result.sampleRate).toBe(16_000);
+  });
+
+  test("resolves ElevenLabs streaming through the real catalog adapter", async () => {
+    // No _setTtsProviderForTests override: this exercises the real catalog
+    // provider lookup and must not throw LIVE_VOICE_TTS_STREAMING_UNAVAILABLE.
+    config = makeConfig({ provider: "elevenlabs" });
+    const originalFetch = globalThis.fetch;
+    let capturedUrl = "";
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      capturedUrl = typeof input === "string" ? input : input.toString();
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new Uint8Array([0x01, 0x02, 0x03, 0x04]));
+            controller.close();
+          },
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof globalThis.fetch;
+
+    try {
+      const frames: LiveVoiceTtsAudioChunk[] = [];
+      const result = await streamLiveVoiceTtsAudio({
+        config,
+        text: "hello from live voice",
+        outputFormat: "pcm",
+        sampleRate: 24_000,
+        onAudioChunk: (chunk) => frames.push(chunk),
+      });
+
+      expect(capturedUrl).toContain("/stream?output_format=pcm_24000");
+      expect(result).toMatchObject({
+        provider: "elevenlabs",
+        contentType: "audio/pcm",
+        sampleRate: 24_000,
+      });
+      expect(frames).toEqual([
+        {
+          type: "tts_audio",
+          contentType: "audio/pcm",
+          sampleRate: 24_000,
+          dataBase64: Buffer.from([0x01, 0x02, 0x03, 0x04]).toString("base64"),
+        },
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   test("returns a typed configuration error for a non-streaming provider", async () => {

--- a/assistant/src/live-voice/live-voice-tts.ts
+++ b/assistant/src/live-voice/live-voice-tts.ts
@@ -76,7 +76,30 @@ export async function streamLiveVoiceTtsAudio(
 ): Promise<LiveVoiceTtsResult> {
   const { provider, providerId, providerConfig } =
     await resolveLiveVoiceStreamingTtsProvider(options.config);
-  const sampleRate = resolveSampleRate(options.sampleRate, providerConfig);
+  const useCase = options.useCase ?? "phone-call";
+  const requestedSampleRate = resolveSampleRate(
+    options.sampleRate,
+    providerConfig,
+  );
+  // Frames are labeled with the provider's actual output rate: the streaming
+  // path emits chunks before the synthesis result resolves, so the rate must
+  // be known up-front — a rate hint the provider cannot honour would
+  // otherwise mislabel the audio and play at the wrong speed.
+  const providerSampleRate = provider.resolveOutputSampleRateHz?.({
+    text: options.text,
+    useCase,
+    voiceId: options.voiceId,
+    outputFormat: options.outputFormat,
+    sampleRateHz: requestedSampleRate,
+    signal: options.signal,
+  });
+  let sampleRate = providerSampleRate ?? requestedSampleRate;
+  if (sampleRate !== requestedSampleRate) {
+    log.warn(
+      { provider: providerId, requestedSampleRate, sampleRate },
+      "TTS provider output sample rate differs from the requested rate; labeling audio with the provider rate",
+    );
+  }
   const chunkContentType = resolveChunkContentType(
     provider,
     providerConfig,
@@ -122,10 +145,10 @@ export async function streamLiveVoiceTtsAudio(
     const result = await synthesizeAndEmit({
       provider,
       text: options.text,
-      useCase: options.useCase ?? "phone-call",
+      useCase,
       voiceId: options.voiceId,
       outputFormat: options.outputFormat,
-      sampleRateHz: sampleRate,
+      sampleRateHz: requestedSampleRate,
       signal: options.signal,
       onChunk: (chunk) => {
         if (canStreamChunks) {
@@ -148,6 +171,24 @@ export async function streamLiveVoiceTtsAudio(
       );
     }
     const contentType = result.contentType || chunkContentType;
+
+    // Late correction for providers that report the actual rate only on the
+    // completed result: it relabels the buffered emit below and the returned
+    // result (already-streamed frames keep their up-front label).
+    if (
+      isPositiveFiniteNumber(result.sampleRateHz) &&
+      result.sampleRateHz !== sampleRate
+    ) {
+      log.warn(
+        {
+          provider: providerId,
+          labeledSampleRate: sampleRate,
+          sampleRate: result.sampleRateHz,
+        },
+        "TTS provider reported a different output sample rate on the completed result",
+      );
+      sampleRate = result.sampleRateHz;
+    }
 
     // An abort mid-stream resolves without throwing; skip the buffered emit
     // so a truncated payload is never delivered after cancellation.

--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -343,6 +343,7 @@ describe("ElevenLabs TTS provider adapter", () => {
 
     expect(capturedUrl).toContain("output_format=pcm_24000");
     expect(result.contentType).toBe("audio/pcm");
+    expect(result.sampleRateHz).toBe(24000);
   });
 
   test("pcm output without sampleRateHz defaults to pcm_16000", async () => {
@@ -375,6 +376,33 @@ describe("ElevenLabs TTS provider adapter", () => {
     );
 
     expect(capturedUrl).toContain("output_format=pcm_16000");
+  });
+
+  test("pcm request at an unsupported 48000 Hz reports the actual 16000 Hz output rate", async () => {
+    mockFetchReturning(new Uint8Array([0x00, 0x01]));
+
+    const provider = createElevenLabsProvider();
+    const result = await provider.synthesize(
+      makeRequest({ outputFormat: "pcm", sampleRateHz: 48000 }),
+    );
+
+    expect(result.sampleRateHz).toBe(16000);
+  });
+
+  test("resolveOutputSampleRateHz reports the actual PCM rate without synthesis", () => {
+    const provider = createElevenLabsProvider();
+
+    expect(
+      provider.resolveOutputSampleRateHz!(
+        makeRequest({ outputFormat: "pcm", sampleRateHz: 24000 }),
+      ),
+    ).toBe(24000);
+    expect(
+      provider.resolveOutputSampleRateHz!(
+        makeRequest({ outputFormat: "pcm", sampleRateHz: 48000 }),
+      ),
+    ).toBe(16000);
+    expect(provider.resolveOutputSampleRateHz!(makeRequest())).toBeUndefined();
   });
 
   // -- Streaming -------------------------------------------------------------
@@ -411,6 +439,60 @@ describe("ElevenLabs TTS provider adapter", () => {
     expect(received).toEqual([part1, part2]);
     expect(result.audio).toEqual(Buffer.from([0x01, 0x02, 0x03]));
     expect(result.contentType).toBe("audio/pcm");
+    expect(result.sampleRateHz).toBe(16000);
+  });
+
+  test("synthesizeStream rejects after the first-chunk timeout when the stream never produces audio", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response(new ReadableStream<Uint8Array>({ start() {} }), {
+          status: 200,
+        }),
+    ) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider({
+      firstChunkTimeoutMs: 20,
+      idleTimeoutMs: 20,
+    });
+
+    await expect(
+      provider.synthesizeStream!(makeRequest({ outputFormat: "pcm" }), () => {}),
+    ).rejects.toMatchObject({
+      name: "ElevenLabsTtsError",
+      code: "ELEVENLABS_TTS_STREAM_TIMEOUT",
+      message: expect.stringContaining("timed out after 20ms"),
+    });
+  });
+
+  test("synthesizeStream rejects after the idle timeout when the stream stalls mid-stream", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new Uint8Array([0x01, 0x02]));
+              // Never enqueue again and never close — a mid-stream stall.
+            },
+          }),
+          { status: 200 },
+        ),
+    ) as unknown as typeof globalThis.fetch;
+
+    const received: Uint8Array[] = [];
+    const provider = createElevenLabsProvider({
+      firstChunkTimeoutMs: 1_000,
+      idleTimeoutMs: 20,
+    });
+
+    await expect(
+      provider.synthesizeStream!(makeRequest({ outputFormat: "pcm" }), (chunk) =>
+        received.push(chunk),
+      ),
+    ).rejects.toMatchObject({
+      name: "ElevenLabsTtsError",
+      code: "ELEVENLABS_TTS_STREAM_TIMEOUT",
+    });
+    expect(received).toHaveLength(1);
   });
 
   test("synthesizeStream defaults to eleven_flash_v2_5 model", async () => {
@@ -529,7 +611,7 @@ describe("ElevenLabs TTS provider adapter", () => {
 
   // -- Content type / format -----------------------------------------------
 
-  test("returns audio/mpeg content type for mp3 format", async () => {
+  test("returns audio/mpeg content type for mp3 format without a sample rate", async () => {
     const audioPayload = new Uint8Array([0x49, 0x44, 0x33]);
     mockFetchReturning(audioPayload);
 
@@ -538,6 +620,7 @@ describe("ElevenLabs TTS provider adapter", () => {
 
     expect(result.contentType).toBe("audio/mpeg");
     expect(result.audio.byteLength).toBeGreaterThan(0);
+    expect(result.sampleRateHz).toBeUndefined();
   });
 
   // -- Required config validation ------------------------------------------
@@ -767,11 +850,12 @@ describe("Fish Audio TTS provider adapter", () => {
       16000,
     );
     expect(result.contentType).toBe("audio/pcm");
+    expect(result.sampleRateHz).toBe(16000);
   });
 
   test("pcm output request honors the sampleRateHz hint", async () => {
     const provider = createFishAudioProvider();
-    await provider.synthesize(
+    const result = await provider.synthesize(
       makeRequest({ outputFormat: "pcm", sampleRateHz: 24000 }),
     );
 
@@ -780,6 +864,7 @@ describe("Fish Audio TTS provider adapter", () => {
     expect((options as { sampleRate?: number } | undefined)?.sampleRate).toBe(
       24000,
     );
+    expect(result.sampleRateHz).toBe(24000);
   });
 
   test("synthesizeStream pcm output request maps to raw pcm honoring the hint", async () => {
@@ -795,6 +880,21 @@ describe("Fish Audio TTS provider adapter", () => {
       24000,
     );
     expect(result.contentType).toBe("audio/pcm");
+    expect(result.sampleRateHz).toBe(24000);
+  });
+
+  test("resolveOutputSampleRateHz passes the pcm hint through and is undefined otherwise", () => {
+    const provider = createFishAudioProvider();
+
+    expect(
+      provider.resolveOutputSampleRateHz!(
+        makeRequest({ outputFormat: "pcm", sampleRateHz: 48000 }),
+      ),
+    ).toBe(48000);
+    expect(
+      provider.resolveOutputSampleRateHz!(makeRequest({ outputFormat: "pcm" })),
+    ).toBe(16000);
+    expect(provider.resolveOutputSampleRateHz!(makeRequest())).toBeUndefined();
   });
 
   test("synthesizeStream pcm chunks pass through raw with no RIFF header", async () => {
@@ -864,11 +964,12 @@ describe("Fish Audio TTS provider adapter", () => {
     expect(result.contentType).toBe("audio/mpeg");
   });
 
-  test("returns audio/wav content type for wav format", async () => {
+  test("returns audio/wav content type for wav format without a sample rate", async () => {
     mockFishAudioConfig.format = "wav";
     const provider = createFishAudioProvider();
     const result = await provider.synthesize(makeRequest());
     expect(result.contentType).toBe("audio/wav");
+    expect(result.sampleRateHz).toBeUndefined();
   });
 
   test("returns audio/opus content type for opus format", async () => {

--- a/assistant/src/tts/__tests__/synthesis-stream.test.ts
+++ b/assistant/src/tts/__tests__/synthesis-stream.test.ts
@@ -30,6 +30,7 @@ interface StreamingFakeOptions {
   /** Awaited after all chunks are delivered, before the stream resolves. */
   resolveGate?: Promise<void>;
   contentType?: string;
+  sampleRateHz?: number;
 }
 
 function makeStreamingProvider(
@@ -56,6 +57,7 @@ function makeStreamingProvider(
       return {
         audio: Buffer.concat(chunks),
         contentType: options.contentType ?? "audio/mpeg",
+        sampleRateHz: options.sampleRateHz,
       };
     },
   };
@@ -64,6 +66,7 @@ function makeStreamingProvider(
 function makeBufferProvider(
   audio: Buffer,
   contentType = "audio/mpeg",
+  sampleRateHz?: number,
 ): TtsProvider & { requests: TtsSynthesisRequest[] } {
   const requests: TtsSynthesisRequest[] = [];
   return {
@@ -72,7 +75,7 @@ function makeBufferProvider(
     requests,
     async synthesize(request): Promise<TtsSynthesisResult> {
       requests.push(request);
-      return { audio, contentType };
+      return { audio, contentType, sampleRateHz };
     },
   };
 }
@@ -503,6 +506,22 @@ describe("synthesizeAndEmit (streaming)", () => {
     ]);
   });
 
+  test("passes the provider-reported sampleRateHz through on the result", async () => {
+    const provider = makeStreamingProvider([bytes("a")], {
+      contentType: "audio/pcm",
+      sampleRateHz: 24000,
+    });
+
+    const result = await synthesizeAndEmit({
+      provider,
+      text: "hello",
+      useCase: "phone-call",
+      onChunk: () => {},
+    });
+
+    expect(result.sampleRateHz).toBe(24000);
+  });
+
   test("passes text/useCase/voiceId/outputFormat/sampleRateHz/signal through on the request", async () => {
     const provider = makeStreamingProvider([bytes("a")]);
     const abortController = new AbortController();
@@ -552,8 +571,26 @@ describe("synthesizeAndEmit (buffer)", () => {
     expect(result).toEqual({
       emittedChunks: 1,
       contentType: "audio/wav",
+      sampleRateHz: undefined,
       stopped: false,
     });
+  });
+
+  test("passes the provider-reported sampleRateHz through on the result", async () => {
+    const provider = makeBufferProvider(
+      Buffer.from("abc"),
+      "audio/pcm",
+      16000,
+    );
+
+    const result = await synthesizeAndEmit({
+      provider,
+      text: "hello",
+      useCase: "phone-call",
+      onChunk: () => {},
+    });
+
+    expect(result.sampleRateHz).toBe(16000);
   });
 
   test("throws on an empty audio payload", async () => {

--- a/assistant/src/tts/providers/elevenlabs-provider.ts
+++ b/assistant/src/tts/providers/elevenlabs-provider.ts
@@ -14,6 +14,7 @@ import { credentialKey } from "../../security/credential-key.js";
 import { getSecureKeyAsync } from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
 import type { TtsProviderDefinition } from "../provider-definition.js";
+import { readChunkedBody } from "../stream-read.js";
 import type {
   TtsProvider,
   TtsProviderCapabilities,
@@ -32,7 +33,8 @@ export type ElevenLabsTtsErrorCode =
   | "ELEVENLABS_TTS_NO_VOICE_ID"
   | "ELEVENLABS_TTS_HTTP_ERROR"
   | "ELEVENLABS_TTS_EMPTY_RESPONSE"
-  | "ELEVENLABS_TTS_REQUEST_FAILED";
+  | "ELEVENLABS_TTS_REQUEST_FAILED"
+  | "ELEVENLABS_TTS_STREAM_TIMEOUT";
 
 export class ElevenLabsTtsError extends Error {
   readonly code: ElevenLabsTtsErrorCode;
@@ -191,17 +193,24 @@ function resolveOutputFormat(request: TtsSynthesisRequest): string {
   return request.useCase === "phone-call" ? "mp3_22050_32" : "mp3_44100_128";
 }
 
+/** Sample rate of a `pcm_*` output format in Hz; undefined for non-PCM formats. */
+function pcmFormatSampleRateHz(outputFormat: string): number | undefined {
+  return outputFormat.startsWith("pcm_")
+    ? Number(outputFormat.slice("pcm_".length))
+    : undefined;
+}
+
 /**
  * Resolve credentials and config, build the request body, and issue the
  * ElevenLabs TTS HTTP request. Shared by `synthesize` (buffer endpoint) and
  * `synthesizeStream` (`/stream` endpoint). Throws on missing credentials and
  * non-OK responses; resolves with the OK response and the resolved output
- * format.
+ * format and content type.
  */
 async function performTtsRequest(
   request: TtsSynthesisRequest,
   { stream }: { stream: boolean },
-): Promise<{ response: Response; outputFormat: string }> {
+): Promise<{ response: Response; outputFormat: string; contentType: string }> {
   const apiKey = await getSecureKeyAsync(
     credentialKey("elevenlabs", "api_key"),
   );
@@ -242,7 +251,7 @@ async function performTtsRequest(
     "Starting ElevenLabs TTS synthesis",
   );
 
-  const acceptType = FORMAT_CONTENT_TYPE[outputFormat] ?? "audio/mpeg";
+  const contentType = FORMAT_CONTENT_TYPE[outputFormat] ?? "audio/mpeg";
 
   let response: Response;
   try {
@@ -251,7 +260,7 @@ async function performTtsRequest(
       headers: {
         "Content-Type": "application/json",
         "xi-api-key": apiKey,
-        Accept: acceptType,
+        Accept: contentType,
       },
       body: JSON.stringify(body),
       signal: request.signal,
@@ -280,10 +289,76 @@ async function performTtsRequest(
     );
   }
 
-  return { response, outputFormat };
+  return { response, outputFormat, contentType };
 }
 
-export function createElevenLabsProvider(): TtsProvider {
+/** Stream-stall timeouts, injectable for tests. */
+export interface ElevenLabsStreamTimeouts {
+  firstChunkTimeoutMs?: number;
+  idleTimeoutMs?: number;
+}
+
+/**
+ * Issue the TTS request and consume the response into a complete result.
+ * The streaming path forwards chunks via `onChunk` as they arrive, guarded
+ * by first-chunk/idle stall timeouts; the buffer path reads the whole body.
+ */
+async function performSynthesis(
+  request: TtsSynthesisRequest,
+  options: {
+    stream: boolean;
+    onChunk?: (chunk: Uint8Array) => void;
+  } & ElevenLabsStreamTimeouts,
+): Promise<TtsSynthesisResult> {
+  const { response, outputFormat, contentType } = await performTtsRequest(
+    request,
+    { stream: options.stream },
+  );
+
+  let audio: Buffer;
+  if (options.stream) {
+    if (!response.body) {
+      throw new ElevenLabsTtsError(
+        "ELEVENLABS_TTS_EMPTY_RESPONSE",
+        "ElevenLabs streaming TTS returned no response body",
+      );
+    }
+    audio = await readChunkedBody(response.body, {
+      onChunk: options.onChunk,
+      firstChunkTimeoutMs: options.firstChunkTimeoutMs,
+      idleTimeoutMs: options.idleTimeoutMs,
+      makeTimeoutError: (timeoutMs) =>
+        new ElevenLabsTtsError(
+          "ELEVENLABS_TTS_STREAM_TIMEOUT",
+          `ElevenLabs streaming TTS read timed out after ${timeoutMs}ms`,
+        ),
+    });
+  } else {
+    audio = Buffer.from(await response.arrayBuffer());
+  }
+
+  if (audio.byteLength === 0) {
+    throw new ElevenLabsTtsError(
+      "ELEVENLABS_TTS_EMPTY_RESPONSE",
+      "ElevenLabs TTS returned an empty audio response",
+    );
+  }
+
+  log.debug(
+    { bytes: audio.byteLength, stream: options.stream },
+    "ElevenLabs TTS synthesis complete",
+  );
+
+  return {
+    audio,
+    contentType,
+    sampleRateHz: pcmFormatSampleRateHz(outputFormat),
+  };
+}
+
+export function createElevenLabsProvider(
+  streamTimeouts: ElevenLabsStreamTimeouts = {},
+): TtsProvider {
   const capabilities: TtsProviderCapabilities = {
     supportsStreaming: true,
     supportedFormats: ["mp3", "pcm"],
@@ -292,86 +367,11 @@ export function createElevenLabsProvider(): TtsProvider {
   return {
     id: "elevenlabs",
     capabilities,
-
-    async synthesize(
-      request: TtsSynthesisRequest,
-    ): Promise<TtsSynthesisResult> {
-      const { response, outputFormat } = await performTtsRequest(request, {
-        stream: false,
-      });
-
-      const arrayBuffer = await response.arrayBuffer();
-      if (arrayBuffer.byteLength === 0) {
-        throw new ElevenLabsTtsError(
-          "ELEVENLABS_TTS_EMPTY_RESPONSE",
-          "ElevenLabs TTS returned an empty audio response",
-        );
-      }
-
-      log.debug(
-        { bytes: arrayBuffer.byteLength },
-        "ElevenLabs TTS synthesis complete",
-      );
-
-      return {
-        audio: Buffer.from(arrayBuffer),
-        contentType: FORMAT_CONTENT_TYPE[outputFormat] ?? "audio/mpeg",
-      };
-    },
-
-    async synthesizeStream(
-      request: TtsSynthesisRequest,
-      onChunk: (chunk: Uint8Array) => void,
-    ): Promise<TtsSynthesisResult> {
-      const { response, outputFormat } = await performTtsRequest(request, {
-        stream: true,
-      });
-
-      if (!response.body) {
-        throw new ElevenLabsTtsError(
-          "ELEVENLABS_TTS_EMPTY_RESPONSE",
-          "ElevenLabs streaming TTS returned no response body",
-        );
-      }
-
-      const chunks: Uint8Array[] = [];
-      const reader = response.body.getReader();
-      try {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          if (value && value.byteLength > 0) {
-            chunks.push(value);
-            onChunk(value);
-          }
-        }
-      } catch (err) {
-        try {
-          await reader.cancel();
-        } catch {
-          // Ignore cancellation errors
-        }
-        throw err;
-      }
-
-      if (chunks.length === 0) {
-        throw new ElevenLabsTtsError(
-          "ELEVENLABS_TTS_EMPTY_RESPONSE",
-          "ElevenLabs TTS returned an empty audio response",
-        );
-      }
-
-      const audio = Buffer.concat(chunks);
-      log.debug(
-        { bytes: audio.byteLength },
-        "ElevenLabs streaming TTS synthesis complete",
-      );
-
-      return {
-        audio,
-        contentType: FORMAT_CONTENT_TYPE[outputFormat] ?? "audio/mpeg",
-      };
-    },
+    resolveOutputSampleRateHz: (request) =>
+      pcmFormatSampleRateHz(resolveOutputFormat(request)),
+    synthesize: (request) => performSynthesis(request, { stream: false }),
+    synthesizeStream: (request, onChunk) =>
+      performSynthesis(request, { stream: true, onChunk, ...streamTimeouts }),
   };
 }
 

--- a/assistant/src/tts/providers/fish-audio-provider.ts
+++ b/assistant/src/tts/providers/fish-audio-provider.ts
@@ -84,6 +84,19 @@ function resolveReferenceId(
   return referenceId;
 }
 
+/**
+ * Actual PCM output sample rate for a request. Fish Audio accepts an exact
+ * `sample_rate`, so a PCM request's hint is honoured as-is; non-PCM formats
+ * carry their rate in the container and report undefined.
+ */
+function resolvePcmOutputSampleRateHz(
+  request: TtsSynthesisRequest,
+): number | undefined {
+  return request.outputFormat === "pcm"
+    ? (request.sampleRateHz ?? DEFAULT_PCM_SAMPLE_RATE_HZ)
+    : undefined;
+}
+
 // ---------------------------------------------------------------------------
 // Provider implementation
 // ---------------------------------------------------------------------------
@@ -99,6 +112,7 @@ async function performSynthesis(
   // PCM request passes straight through at the hinted sample rate.
   const pcmRequested = request.outputFormat === "pcm";
   const effectiveFormat = pcmRequested ? "pcm" : config.format;
+  const sampleRateHz = resolvePcmOutputSampleRateHz(request);
 
   const effectiveConfig: FishAudioSynthesisConfig = {
     ...config,
@@ -122,9 +136,7 @@ async function performSynthesis(
     audio = await synthesizeWithFishAudio(request.text, effectiveConfig, {
       onChunk,
       signal: request.signal,
-      sampleRate: pcmRequested
-        ? (request.sampleRateHz ?? DEFAULT_PCM_SAMPLE_RATE_HZ)
-        : undefined,
+      sampleRate: sampleRateHz,
     });
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") throw err;
@@ -136,7 +148,7 @@ async function performSynthesis(
 
   const contentType = FORMAT_CONTENT_TYPE[effectiveFormat] ?? "audio/mpeg";
 
-  return { audio, contentType };
+  return { audio, contentType, sampleRateHz };
 }
 
 export function createFishAudioProvider(): TtsProvider {
@@ -148,6 +160,7 @@ export function createFishAudioProvider(): TtsProvider {
   return {
     id: "fish-audio",
     capabilities,
+    resolveOutputSampleRateHz: resolvePcmOutputSampleRateHz,
     synthesize: (request) => performSynthesis(request),
     synthesizeStream: (request, onChunk) => performSynthesis(request, onChunk),
   };

--- a/assistant/src/tts/stream-read.ts
+++ b/assistant/src/tts/stream-read.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared chunked-body reader for streaming TTS HTTP responses.
+ *
+ * Reads a fetch response body to completion, forwarding each non-empty chunk
+ * to an optional callback, and guards against stalled upstream streams with a
+ * first-chunk timeout and an idle (between-chunks) timeout. On timeout the
+ * reader is cancelled and the caller-supplied error is thrown.
+ */
+
+/** Default timeout waiting for the first chunk of a TTS stream (ms). */
+const DEFAULT_FIRST_CHUNK_TIMEOUT_MS = 10_000;
+
+/** Default timeout waiting between consecutive chunks (ms). */
+const DEFAULT_IDLE_TIMEOUT_MS = 5_000;
+
+export interface ReadChunkedBodyOptions {
+  /** Invoked with each non-empty chunk as it arrives. */
+  onChunk?: (chunk: Uint8Array) => void;
+
+  /** Timeout waiting for the first chunk (ms). */
+  firstChunkTimeoutMs?: number;
+
+  /** Timeout waiting between consecutive chunks (ms). */
+  idleTimeoutMs?: number;
+
+  /** Builds the error thrown when a read times out. */
+  makeTimeoutError: (timeoutMs: number) => Error;
+}
+
+/**
+ * Read a chunked response body to completion and return the concatenated
+ * audio. Any received chunk (even an empty one) counts as stream activity
+ * and switches from the first-chunk timeout to the idle timeout; only
+ * non-empty chunks are collected and forwarded to `onChunk`.
+ */
+export async function readChunkedBody(
+  body: ReadableStream<Uint8Array>,
+  options: ReadChunkedBodyOptions,
+): Promise<Buffer> {
+  const firstChunkTimeoutMs =
+    options.firstChunkTimeoutMs ?? DEFAULT_FIRST_CHUNK_TIMEOUT_MS;
+  const idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
+
+  const chunks: Uint8Array[] = [];
+  const reader = body.getReader();
+  let isFirstChunk = true;
+
+  try {
+    while (true) {
+      const timeoutMs = isFirstChunk ? firstChunkTimeoutMs : idleTimeoutMs;
+      let timerId: ReturnType<typeof setTimeout>;
+      const timeout = new Promise<never>((_, reject) => {
+        timerId = setTimeout(
+          () => reject(options.makeTimeoutError(timeoutMs)),
+          timeoutMs,
+        );
+      });
+      let done: boolean;
+      let value: Uint8Array | undefined;
+      try {
+        ({ done, value } = await Promise.race([reader.read(), timeout]));
+      } finally {
+        clearTimeout(timerId!);
+      }
+      if (done) {
+        break;
+      }
+      if (value) {
+        isFirstChunk = false;
+        if (value.byteLength > 0) {
+          chunks.push(value);
+          options.onChunk?.(value);
+        }
+      }
+    }
+  } catch (err) {
+    try {
+      await reader.cancel();
+    } catch {
+      // Ignore cancellation errors
+    }
+    throw err;
+  }
+
+  return Buffer.concat(chunks);
+}

--- a/assistant/src/tts/synthesis-stream.ts
+++ b/assistant/src/tts/synthesis-stream.ts
@@ -77,6 +77,13 @@ export interface SynthesisEmitResult {
   contentType: string;
 
   /**
+   * Provider-reported actual output sample rate in Hz, passed through from
+   * {@link TtsSynthesisResult.sampleRateHz}. Undefined when the provider
+   * does not report one (non-PCM output).
+   */
+  sampleRateHz?: number;
+
+  /**
    * `true` when emission was halted by an aborted `signal` or an
    * `isCurrent()` staleness flip — the silent-resolve path. Callers use
    * this instead of re-probing the signal after resolve.
@@ -175,6 +182,7 @@ export async function synthesizeAndEmit(
     return {
       emittedChunks,
       contentType: result.contentType,
+      sampleRateHz: result.sampleRateHz,
       stopped: shouldStop(),
     };
   }
@@ -192,6 +200,7 @@ export async function synthesizeAndEmit(
   return {
     emittedChunks,
     contentType: result.contentType,
+    sampleRateHz: result.sampleRateHz,
     stopped: shouldStop(),
   };
 }

--- a/assistant/src/tts/types.ts
+++ b/assistant/src/tts/types.ts
@@ -121,6 +121,15 @@ export interface TtsSynthesisResult {
 
   /** MIME type of the returned audio (e.g. `"audio/mpeg"`, `"audio/wav"`). */
   contentType: string;
+
+  /**
+   * Actual output sample rate in Hz of the returned audio, when the provider
+   * knows it (raw PCM output). Undefined for container/compressed formats
+   * whose rate is carried in the payload (mp3/wav/opus). May differ from the
+   * request's `sampleRateHz` hint when the provider cannot honour it exactly —
+   * callers that label raw PCM with a rate must use this over the hint.
+   */
+  sampleRateHz?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -196,6 +205,18 @@ export interface TtsProvider {
 
   /** Static capability advertisement. */
   readonly capabilities: TtsProviderCapabilities;
+
+  /**
+   * Actual PCM output sample rate in Hz that synthesizing `request` will
+   * produce, when deterministically known before synthesis begins.
+   *
+   * Streaming callers that label emitted chunks with a rate use this so the
+   * first chunk — delivered before the final {@link TtsSynthesisResult}
+   * resolves — carries the provider's true output rate rather than the
+   * request's `sampleRateHz` hint. Returns `undefined` for non-PCM output
+   * or when the rate is not known up-front.
+   */
+  resolveOutputSampleRateHz?(request: TtsSynthesisRequest): number | undefined;
 
   /**
    * Synthesize text and return the complete audio buffer.


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for voice-tts-streaming-latency.md.

- Providers now report the actual PCM output rate on `TtsSynthesisResult`; live-voice labels `tts_audio` frames (and archives) with it, so an unhonored rate hint can no longer cause wrong-speed playback
- Extracts a shared chunked-body reader (first-chunk + idle stall timeouts) used by both ElevenLabs and fish-audio; unifies the ElevenLabs stream/batch bodies
- Adds the real-catalog live-voice acceptance test for ElevenLabs streaming