### PR TITLE
fix: cancel pending media-stream speech on turn abort and add per-segment fallback retry

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -92,9 +92,19 @@ mock.module("../config/loader.js", () => {
 
 // ── Credential mock (prevents real key lookups) ──────────────────────
 
+// Provider API keys resolve by default so telephony playability checks
+// (WAV-transport tests) can select providers; tests can narrow the
+// resolvable set. Reset to null (all resolve) in beforeEach.
+let mockResolvableProviderKeys: ((service: string) => string | null) | null =
+  null;
+
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async () => null,
   getSecureKey: () => null,
+  getProviderKeyAsync: async (service: string) =>
+    mockResolvableProviderKeys
+      ? mockResolvableProviderKeys(service)
+      : "test-key",
 }));
 
 mock.module("../security/credential-key.js", () => ({
@@ -398,6 +408,8 @@ function setupController(
   opts?: {
     assistantId?: string;
     trustContext?: import("../daemon/trust-context.js").TrustContext;
+    /** Simulate the media-stream transport's WAV requirement. */
+    requiresWavAudio?: boolean;
   },
 ) {
   ensureConversation("conv-ctrl-test");
@@ -410,6 +422,9 @@ function setupController(
   });
   updateCallSession(session.id, { status: "in_progress" });
   const transport = createMockTransport();
+  if (opts?.requiresWavAudio) {
+    Object.assign(transport, { requiresWavAudio: true });
+  }
   const controller = new CallController(session.id, transport, task ?? null, {
     assistantId: opts?.assistantId,
     trustContext: opts?.trustContext,
@@ -483,6 +498,7 @@ describe("call-controller", () => {
     cfg.services.tts.provider = "elevenlabs";
     cfg.services.tts.providers["fish-audio"].referenceId = "";
     cfg.ingress.publicBaseUrl = "https://generic.example.com";
+    mockResolvableProviderKeys = null;
     // Reset TTS provider registry to ensure clean state
     registerTestTtsProviders();
   });
@@ -3311,11 +3327,121 @@ describe("call-controller", () => {
       .filter((t) => t.token.length > 0)
       .map((t) => t.token);
     expect(tokenTexts).toEqual([
+      "First part is done. ",
+      "Second part is done. ",
+    ]);
+    // Trimmed segments carry a separator so back-to-back tokens never
+    // fuse into "…done.Second part…".
+    expect(tokenTexts.join("")).toContain("done. Second");
+    expect(relay.sentPlayUrls.length).toBe(0);
+    // End-of-turn still fires after the chain drains.
+    const lastToken = relay.sentTokens[relay.sentTokens.length - 1];
+    expect(lastToken).toEqual({ token: "", last: true });
+
+    controller.destroy();
+  });
+
+  // ── Per-segment fallback on WAV-requiring transports ────────────────
+
+  /**
+   * Register a failing fish-audio primary and a recording elevenlabs
+   * fallback, with fish-audio configured as the active provider. Used by
+   * the WAV-transport segment-fallback tests.
+   */
+  function registerWavFallbackProviders(): {
+    fishTexts: string[];
+    fallbackTexts: string[];
+  } {
+    const cfg = loadConfig();
+    cfg.services.tts.provider = "fish-audio";
+    cfg.services.tts.providers["fish-audio"].referenceId = "fish-ref-123";
+
+    _resetTtsProviderOverridesForTests();
+    const fallbackTexts: string[] = [];
+    const elevenlabs: TtsProvider = {
+      id: "elevenlabs",
+      capabilities: {
+        supportsStreaming: false,
+        supportedFormats: ["mp3", "wav", "opus"],
+      },
+      async synthesize(request) {
+        fallbackTexts.push(request.text);
+        return {
+          audio: Buffer.from("fallback-audio"),
+          contentType: "audio/pcm",
+        };
+      },
+    };
+    _setTtsProviderForTests(elevenlabs);
+
+    const fishTexts: string[] = [];
+    const fishAudioFailing: TtsProvider = {
+      id: "fish-audio",
+      capabilities: {
+        supportsStreaming: true,
+        supportedFormats: ["mp3", "wav", "opus"],
+      },
+      async synthesize() {
+        throw new Error("fish-audio synth failure");
+      },
+      async synthesizeStream(request) {
+        fishTexts.push(request.text);
+        throw new Error("fish-audio stream failure");
+      },
+    };
+    _setTtsProviderForTests(fishAudioFailing);
+
+    return { fishTexts, fallbackTexts };
+  }
+
+  test("WAV transport: a failed segment and the rest of the turn synthesize via a playable fallback provider", async () => {
+    const { fishTexts, fallbackTexts } = registerWavFallbackProviders();
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["First part is done. ", "Second part is done."]),
+    );
+    const { relay, controller } = setupController(undefined, {
+      requiresWavAudio: true,
+    });
+
+    await controller.handleCallerUtterance("Hi");
+
+    // The primary provider is tried once; the failed segment and all
+    // subsequent segments retry through the fallback provider, so the
+    // caller hears the whole turn instead of partial speech then silence.
+    expect(fishTexts).toEqual(["First part is done."]);
+    expect(fallbackTexts).toEqual([
       "First part is done.",
       "Second part is done.",
     ]);
+    expect(relay.sentPlayUrls.length).toBe(2);
+    // No text routes through native tokens on a WAV transport.
+    expect(relay.sentTokens.filter((t) => t.token.length > 0)).toEqual([]);
+    const lastToken = relay.sentTokens[relay.sentTokens.length - 1];
+    expect(lastToken).toEqual({ token: "", last: true });
+
+    controller.destroy();
+  });
+
+  test("WAV transport: when no playable fallback exists, failed segments are skipped and end-of-turn still fires", async () => {
+    // Only fish-audio's key resolves, so the fallback scan finds nothing.
+    mockResolvableProviderKeys = (service) =>
+      service === "fish-audio" ? "test-key" : null;
+    const { fishTexts, fallbackTexts } = registerWavFallbackProviders();
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["First part is done. ", "Second part is done."]),
+    );
+    const { relay, controller } = setupController(undefined, {
+      requiresWavAudio: true,
+    });
+
+    await controller.handleCallerUtterance("Hi");
+
+    expect(fishTexts).toEqual(["First part is done."]);
+    expect(fallbackTexts).toEqual([]);
     expect(relay.sentPlayUrls.length).toBe(0);
-    // End-of-turn still fires after the chain drains.
+    // Native tokens are never used on a WAV transport, and the turn
+    // still closes with the end-of-turn signal.
+    expect(relay.sentTokens.filter((t) => t.token.length > 0)).toEqual([]);
     const lastToken = relay.sentTokens[relay.sentTokens.length - 1];
     expect(lastToken).toEqual({ token: "", last: true });
 
@@ -3665,6 +3791,56 @@ describe("call-controller", () => {
 
       controller.destroy();
       await turnPromise.catch(() => {});
+    });
+
+    test("buffering transport: a caller utterance during processing cancels the transport's pending speech", async () => {
+      let releaseTurn!: () => void;
+      const completeGate = new Promise<void>((r) => {
+        releaseTurn = r;
+      });
+      let turnCalls = 0;
+      mockStartVoiceTurn.mockImplementation(
+        async (opts: {
+          onTextDelta: (t: string) => void;
+          onComplete: () => void;
+          signal?: AbortSignal;
+        }) => {
+          turnCalls++;
+          if (turnCalls === 1) {
+            opts.onTextDelta("Queued sentence one. Queued sentence two.");
+            opts.signal?.addEventListener("abort", () => releaseTurn());
+            await completeGate;
+            opts.onComplete();
+            return { turnId: "run-cancel-1", abort: () => releaseTurn() };
+          }
+          opts.onTextDelta("Second turn reply.");
+          opts.onComplete();
+          return { turnId: "run-cancel-2", abort: () => {} };
+        },
+      );
+
+      const { relay, controller } = setupController();
+      let cancelledPendingSpeech = 0;
+      // Buffering transport: audio never starts, so the first turn stays
+      // in `processing` with its sentences already queued for synthesis.
+      relay.setAudioStartCallback = () => {};
+      relay.cancelPendingSpeech = () => {
+        cancelledPendingSpeech++;
+      };
+
+      const turn1 = controller.handleCallerUtterance("Hi");
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      expect(controller.getState()).toBe("processing");
+      expect(cancelledPendingSpeech).toBe(0);
+
+      // The caller speaks again before any audio played — the aborted
+      // turn's queued speech must be cancelled so it cannot play over
+      // the new turn.
+      await controller.handleCallerUtterance("Actually, wait");
+      expect(cancelledPendingSpeech).toBeGreaterThan(0);
+
+      await turn1.catch(() => {});
+      controller.destroy();
     });
 
     test("buffering transport: stale audio-start signal from a superseded run does not flip state", async () => {

--- a/assistant/src/__tests__/media-stream-output.test.ts
+++ b/assistant/src/__tests__/media-stream-output.test.ts
@@ -29,10 +29,6 @@ mock.module("../calls/resolve-call-tts-provider.js", () => ({
   })),
 }));
 
-// Pre-load the module processSynthesizeItem imports dynamically, so the
-// first synthesize item doesn't pay module-load latency mid-test.
-await import("../tts/synthesis-stream.js");
-
 import {
   mulawToPcm16,
   pcm16ToMulaw,
@@ -98,14 +94,9 @@ async function drain(until?: () => boolean): Promise<void> {
   }
 }
 
-/** True when a sent message with the given event type exists. */
-function hasEvent(sent: string[], event: string): boolean {
-  return sent.some((s) => JSON.parse(s).event === event);
-}
-
-/** Number of mark messages among the sent messages. */
-function countMarks(sent: string[]): number {
-  return sent.filter((s) => JSON.parse(s).event === "mark").length;
+/** Number of sent messages with the given event type. */
+function countEvents(sent: string[], event: string): number {
+  return sent.filter((s) => JSON.parse(s).event === event).length;
 }
 
 /** Generate a minimal valid WAV buffer with PCM data. */
@@ -166,11 +157,6 @@ function concatMulawPayloads(sent: string[]): Buffer {
       .filter((s) => JSON.parse(s).event === "media")
       .map((s) => Buffer.from(JSON.parse(s).media.payload, "base64")),
   );
-}
-
-/** Number of media frames among the sent messages. */
-function countMediaFrames(sent: string[]): number {
-  return sent.filter((s) => JSON.parse(s).event === "media").length;
 }
 
 /** Encode samples as a raw PCM16 LE buffer. */
@@ -266,7 +252,7 @@ describe("MediaStreamOutput", () => {
       output.sendTextToken("hello ", false);
       output.sendTextToken("world", true);
 
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
       // Should have sent media frames (from synthesis) and a mark
       const events = sent.map((s) => JSON.parse(s).event);
@@ -283,7 +269,7 @@ describe("MediaStreamOutput", () => {
       const output = makeOutput(ws, "stream-1");
       output.sendTextToken("", true);
 
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
       // Should send only a mark, no media frames
       expect(sent).toHaveLength(1);
@@ -495,7 +481,7 @@ describe("MediaStreamOutput", () => {
       output.sendTextToken("hello world", true);
       output.clearBufferedAudio();
 
-      await drain(() => hasEvent(sent, "media"));
+      await drain(() => countEvents(sent, "media") > 0);
 
       // Unlike clearAudio, the in-flight synthesis is not aborted:
       // its frames go out once ready.
@@ -539,6 +525,62 @@ describe("MediaStreamOutput", () => {
     });
   });
 
+  describe("cancelPendingSpeech — turn abort", () => {
+    test("queued-but-unplayed synthesis never produces frames; the next turn plays normally", async () => {
+      const wav = makeWavBuffer(sineSamples(400, 440, 8000));
+      // Slow synthesis so the abort lands while the first segment is
+      // in flight and the second is still queued.
+      mockSynthesize.mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(
+              () => resolve({ audio: wav, contentType: "audio/wav" }),
+              200,
+            ),
+          ),
+      );
+
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "MZ-stream-1");
+
+      // Aborted turn: first segment in flight, second still queued.
+      output.sendTextToken("Sentence one. Sentence two.", true);
+      await drain(() => mockSynthesize.mock.calls.length === 1);
+      expect(output.getPlaybackQueueLength()).toBeGreaterThan(0);
+
+      output.cancelPendingSpeech();
+
+      // Twilio's buffered audio was flushed too.
+      expect(countEvents(sent, "clear")).toBe(1);
+
+      // Next turn: fast synthesis so its audio goes out.
+      mockSynthesize.mockResolvedValue({
+        audio: wav,
+        contentType: "audio/wav",
+      });
+      output.sendTextToken("Next turn reply.", true);
+      await drain(() => countEvents(sent, "mark") > 0);
+
+      // The aborted turn's queued segment never synthesized, its
+      // in-flight segment produced no frames, and the next turn's
+      // audio is the only audio sent.
+      const synthesizedTexts = mockSynthesize.mock.calls.map(
+        (c) => (c[0] as { text: string }).text,
+      );
+      expect(synthesizedTexts).toEqual(["Sentence one.", "Next turn reply."]);
+      expect(countEvents(sent, "media")).toBeGreaterThan(0);
+      expect(totalMulawBytes(sent)).toBe(400);
+    });
+
+    test("does not send when closed", () => {
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "MZ-stream-1");
+      output.endSession();
+      output.cancelPendingSpeech();
+      expect(sent).toHaveLength(0);
+    });
+  });
+
   describe("audio-start signal", () => {
     function makePlayableWav(): Buffer {
       const samples = Array.from({ length: 400 }, (_, i) =>
@@ -566,7 +608,7 @@ describe("MediaStreamOutput", () => {
       });
 
       output.sendTextToken("hello world", true);
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
       const mediaMessages = sent.filter((s) => JSON.parse(s).event === "media");
       expect(mediaMessages.length).toBeGreaterThan(1);
@@ -588,18 +630,18 @@ describe("MediaStreamOutput", () => {
       output.setAudioStartCallback(() => fired++);
 
       output.sendTextToken("first", true);
-      await drain(() => countMarks(sent) >= 1);
+      await drain(() => countEvents(sent, "mark") >= 1);
       expect(fired).toBe(1);
 
       // Second item without re-arming — signal already consumed.
       output.sendTextToken("second", true);
-      await drain(() => countMarks(sent) >= 2);
+      await drain(() => countEvents(sent, "mark") >= 2);
       expect(fired).toBe(1);
 
       // Re-armed — fires again for the next item.
       output.setAudioStartCallback(() => fired++);
       output.sendTextToken("third", true);
-      await drain(() => countMarks(sent) >= 3);
+      await drain(() => countEvents(sent, "mark") >= 3);
       expect(fired).toBe(2);
     });
 
@@ -637,7 +679,7 @@ describe("MediaStreamOutput", () => {
       output.setAudioStartCallback(() => fired++);
 
       output.sendTextToken("", true);
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
       expect(fired).toBe(0);
     });
   });
@@ -659,7 +701,7 @@ describe("MediaStreamOutput", () => {
       output.sendTextToken("hello ", false);
       output.clearAudio();
       output.sendTextToken("world", true);
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
       expect(mockSynthesize).toHaveBeenCalledTimes(1);
       expect(mockSynthesize.mock.calls[0][0].text).toBe("hello world");
@@ -672,7 +714,7 @@ describe("MediaStreamOutput", () => {
       output.sendTextToken("stale partial response", false);
       output.discardPendingText();
       output.sendTextToken("", true);
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
       expect(mockSynthesize).not.toHaveBeenCalled();
       // Only the end-of-turn mark goes out.
@@ -751,7 +793,7 @@ describe("MediaStreamOutput", () => {
       const output = makeOutput(ws, "stream-1");
       output.sendTextToken("test synthesis", true);
 
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
       // Should have sent at least one media frame and an end-of-turn mark
       const mediaMessages = sent.filter((s) => JSON.parse(s).event === "media");
@@ -801,7 +843,7 @@ describe("MediaStreamOutput", () => {
       const output = makeOutput(ws, "stream-1");
       output.sendTextToken("test", true);
 
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
       // The audioBufferToFrames magic-byte detection should detect mp3
       // sync bytes when format is "wav" and return silence (no media
@@ -834,7 +876,7 @@ describe("MediaStreamOutput", () => {
       const output = makeOutput(ws, "stream-1");
       output.sendTextToken("test", true);
 
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
       // processSynthesizeItem derives actualFormat from content-type:
       // "audio/pcm" -> "pcm". audioBufferToFrames handles raw PCM by
@@ -869,7 +911,7 @@ describe("MediaStreamOutput", () => {
       const output = makeOutput(ws, "stream-1");
       output.sendTextToken("test", true);
 
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
       // processSynthesizeItem detects "audio/x-raw" -> "pcm" format.
       // audioBufferToFrames converts raw PCM to mu-law frames.
@@ -897,7 +939,7 @@ describe("MediaStreamOutput", () => {
       const { ws, sent } = createMockWs();
       const output = makeOutput(ws, "stream-1");
       output.sendTextToken("test", true);
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
       return sent;
     }
 
@@ -977,16 +1019,16 @@ describe("MediaStreamOutput", () => {
       const output = makeOutput(ws, "stream-1");
 
       output.sendTextToken("First sentence. Sec", false);
-      await drain(() => countMediaFrames(sent) > 0);
+      await drain(() => countEvents(sent, "media") > 0);
 
       // The completed first sentence synthesizes (and its frames go out)
       // while the turn is still streaming.
       expect(mockSynthesize).toHaveBeenCalledTimes(1);
       expect(mockSynthesize.mock.calls[0][0].text).toBe("First sentence.");
-      expect(countMediaFrames(sent)).toBeGreaterThan(0);
+      expect(countEvents(sent, "media")).toBeGreaterThan(0);
 
       output.sendTextToken("ond sentence.", true);
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
       expect(mockSynthesize).toHaveBeenCalledTimes(2);
       expect(mockSynthesize.mock.calls[1][0].text).toBe("Second sentence.");
@@ -1002,7 +1044,7 @@ describe("MediaStreamOutput", () => {
       const { ws, sent } = createMockWs();
       const output = makeOutput(ws, "stream-1");
       output.sendTextToken("One. Two.", true);
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
       expect(mockSynthesize).toHaveBeenCalledTimes(2);
       const events = sent.map((s) => JSON.parse(s).event);
@@ -1046,18 +1088,18 @@ describe("MediaStreamOutput", () => {
       const { ws, sent } = createMockWs();
       const output = makeOutput(ws, "stream-1");
       output.sendTextToken("Hello there.", true);
-      await drain(() => countMediaFrames(sent) >= 2);
+      await drain(() => countEvents(sent, "media") >= 2);
 
       // First chunk's frames went out while the stream is still open,
       // and the end-of-turn mark has not been sent yet.
-      const framesBefore = countMediaFrames(sent);
+      const framesBefore = countEvents(sent, "media");
       expect(framesBefore).toBe(2);
       expect(sent.some((s) => JSON.parse(s).event === "mark")).toBe(false);
 
       releaseStream();
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
-      expect(countMediaFrames(sent)).toBe(4);
+      expect(countEvents(sent, "media")).toBe(4);
       expect(sent.some((s) => JSON.parse(s).event === "mark")).toBe(true);
     });
 
@@ -1087,7 +1129,7 @@ describe("MediaStreamOutput", () => {
       const { ws, sent } = createMockWs();
       const output = makeOutput(ws, "stream-1");
       output.sendTextToken("Test.", true);
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
       // The concatenated mu-law output must be byte-identical to a
       // whole-buffer transcode: no dropped or torn samples at chunk seams.
@@ -1124,16 +1166,16 @@ describe("MediaStreamOutput", () => {
       const { ws, sent } = createMockWs();
       const output = makeOutput(ws, "stream-1");
       output.sendTextToken("Hello there.", true);
-      await drain(() => countMediaFrames(sent) > 0);
+      await drain(() => countEvents(sent, "media") > 0);
 
-      const framesBefore = countMediaFrames(sent);
+      const framesBefore = countEvents(sent, "media");
       expect(framesBefore).toBeGreaterThan(0);
 
       output.clearAudio();
       releaseStream();
       await drain();
 
-      expect(countMediaFrames(sent)).toBe(framesBefore);
+      expect(countEvents(sent, "media")).toBe(framesBefore);
     });
 
     test("streaming provider without PCM support falls back to the whole-buffer path", async () => {
@@ -1151,7 +1193,7 @@ describe("MediaStreamOutput", () => {
         ) {
           onChunk(wav.subarray(0, half));
           await new Promise((resolve) => setTimeout(resolve, 5));
-          midStreamFrames = countMediaFrames(sentRef.sent);
+          midStreamFrames = countEvents(sentRef.sent, "media");
           onChunk(wav.subarray(half));
           return { audio: wav, contentType: "audio/wav" };
         },
@@ -1161,7 +1203,7 @@ describe("MediaStreamOutput", () => {
       sentRef.sent = sent;
       const output = makeOutput(ws, "stream-1");
       output.sendTextToken("Hello.", true);
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
       // Nothing streamed mid-flight; the whole accumulated WAV is
       // transcoded once at the end.

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -19,7 +19,7 @@ import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
-import { getCatalogProvider } from "../tts/provider-catalog.js";
+import { getCatalogProvider, getTtsProvider } from "../tts/provider-catalog.js";
 import { extractSpeakableSegments } from "../tts/speakable-segments.js";
 import {
   type AudioStoreSink,
@@ -56,7 +56,10 @@ import type { CallTransport } from "./call-transport.js";
 import { finalizeCall } from "./finalize-call.js";
 import { sendGuardianExpiryNotices } from "./guardian-action-sweep.js";
 import { dispatchGuardianQuestion } from "./guardian-dispatch.js";
-import { resolveCallTtsProvider } from "./resolve-call-tts-provider.js";
+import {
+  findPlayableTelephonyTtsFallback,
+  resolveCallTtsProvider,
+} from "./resolve-call-tts-provider.js";
 import type { PromptSpeakerContext } from "./speaker-identification.js";
 import { sanitizeForTts } from "./tts-text-sanitizer.js";
 import {
@@ -75,6 +78,15 @@ import {
 } from "./voice-session-bridge.js";
 
 const log = getLogger("call-controller");
+
+/** Look up a registered provider, returning null instead of throwing. */
+function lookupRegisteredTtsProvider(id: string): TtsProvider | null {
+  try {
+    return getTtsProvider(id);
+  } catch {
+    return null;
+  }
+}
 
 type ControllerState = "idle" | "processing" | "speaking";
 
@@ -517,10 +529,12 @@ export class CallController {
       this.activeSynthesisAbort.abort();
       this.activeSynthesisAbort = null;
     }
-    // Drop the aborted turn's unsent buffered text on transports that
-    // accumulate tokens (media-stream), so it cannot leak into the next
-    // turn's synthesis.
+    // Drop the aborted turn's unsent buffered text and cancel its queued /
+    // in-flight speech on transports that hold either (media-stream), so
+    // the aborted turn neither leaks text into the next turn's synthesis
+    // nor plays stale audio over it.
     this.transport.discardPendingText?.();
+    this.transport.cancelPendingSpeech?.();
   }
 
   private formatCallerUtterance(
@@ -666,13 +680,60 @@ export class CallController {
     const synthProvider = useSynthesizedPath ? provider : null;
     let pendingSynthText = "";
     let synthesisChain: Promise<void> = Promise.resolve();
-    // After a segment falls back to native tokens, the rest of the turn
-    // stays on the native route so text is never spoken out of order.
+    // After a segment fails, the rest of the turn stays off the primary
+    // provider so text is never spoken out of order: non-WAV transports
+    // send native tokens; WAV-requiring transports (media-stream) retry
+    // through a playable fallback provider.
     let synthesisFellBack = false;
+    // Fallback provider for WAV-requiring transports, resolved once per
+    // turn. `undefined` = not yet resolved; `null` = none available (or
+    // the fallback failed too) — affected segments are skipped.
+    let wavFallbackProvider: TtsProvider | null | undefined;
     // Non-recoverable failure (allowNativeFallback: false providers):
     // remaining segments are skipped and the error rethrows after the
     // chain drains so the outer handler speaks the generic recovery copy.
     let synthesisFailure: { err: unknown } | undefined;
+
+    // WAV-requiring transports re-synthesize native tokens through the
+    // same failing provider path, so a failed segment (and the rest of
+    // the turn) is spoken through a playable fallback provider instead.
+    const speakSegmentViaWavFallback = async (
+      failedProviderId: string,
+      segment: string,
+    ): Promise<void> => {
+      if (wavFallbackProvider === undefined) {
+        const fallbackId =
+          await findPlayableTelephonyTtsFallback(failedProviderId);
+        wavFallbackProvider = fallbackId
+          ? lookupRegisteredTtsProvider(fallbackId)
+          : null;
+        if (wavFallbackProvider) {
+          log.warn(
+            {
+              provider: failedProviderId,
+              fallbackProvider: wavFallbackProvider.id,
+            },
+            "Speaking remaining TTS segments via fallback provider",
+          );
+        } else {
+          log.error(
+            { provider: failedProviderId },
+            "No playable fallback TTS provider — skipping failed segments",
+          );
+        }
+      }
+      if (!wavFallbackProvider || !this.isCurrentRun(runVersion)) return;
+      const fallbackFailed = await this.synthesizeAndStreamAudio(
+        wavFallbackProvider,
+        segment,
+        runVersion,
+        audioFormat,
+      );
+      if (fallbackFailed) {
+        // The fallback provider is failing too — stop retrying.
+        wavFallbackProvider = null;
+      }
+    };
 
     const enqueueSynthesisSegments = (
       ttsProvider: TtsProvider,
@@ -681,20 +742,27 @@ export class CallController {
       for (const segment of segments) {
         synthesisChain = synthesisChain.then(async () => {
           if (!this.isCurrentRun(runVersion) || synthesisFailure) return;
-          if (synthesisFellBack) {
-            if (!this.transport.requiresWavAudio) {
-              this.beginSpeakingOnAudioStart(runVersion);
-              this.transport.sendTextToken(segment, false);
-            }
-            return;
-          }
           try {
-            synthesisFellBack = await this.synthesizeAndStreamAudio(
-              ttsProvider,
-              segment,
-              runVersion,
-              audioFormat,
-            );
+            if (!synthesisFellBack) {
+              synthesisFellBack = await this.synthesizeAndStreamAudio(
+                ttsProvider,
+                segment,
+                runVersion,
+                audioFormat,
+              );
+              if (!synthesisFellBack || !this.transport.requiresWavAudio) {
+                // Success, abort, or the failed segment's text already
+                // went out as native tokens inside synthesizeAndStreamAudio.
+                return;
+              }
+            } else if (!this.transport.requiresWavAudio) {
+              // Native route. Segments are trimmed, so restore the
+              // inter-segment separator.
+              this.beginSpeakingOnAudioStart(runVersion);
+              this.transport.sendTextToken(`${segment} `, false);
+              return;
+            }
+            await speakSegmentViaWavFallback(ttsProvider.id, segment);
           } catch (err) {
             synthesisFailure = { err };
           }
@@ -875,10 +943,14 @@ export class CallController {
    * Synthesize text via a streaming TTS provider and forward audio chunks
    * to Twilio through the audio store / play-URL mechanism.
    *
-   * @returns `true` when provider synthesis failed and the text took the
-   *   native-token fallback route — callers keep subsequent segments on
-   *   the same route so text is never spoken out of order. `false` on
-   *   success or abort. Rethrows when the provider's catalog entry has
+   * @returns `true` when provider synthesis failed on a provider whose
+   *   catalog entry allows fallback. On transports that accept text
+   *   tokens the failed text has already been sent natively (unless its
+   *   play URL was already delivered); on WAV-requiring transports
+   *   nothing was sent — the caller owns the fallback-provider retry.
+   *   Callers keep subsequent segments off the failed provider so text
+   *   is never spoken out of order. `false` on success or abort.
+   *   Rethrows when the provider's catalog entry has
    *   `allowNativeFallback: false`.
    */
   private async synthesizeAndStreamAudio(
@@ -977,7 +1049,9 @@ export class CallController {
           this.isCurrentRun(runVersion)
         ) {
           this.beginSpeakingOnAudioStart(runVersion);
-          this.transport.sendTextToken(text, false);
+          // Trailing space restores the inter-segment separator lost when
+          // the segment was trimmed at extraction.
+          this.transport.sendTextToken(`${text} `, false);
         }
         return true;
       }

--- a/assistant/src/calls/call-transport.ts
+++ b/assistant/src/calls/call-transport.ts
@@ -60,4 +60,15 @@ export interface CallTransport {
    * synthesis. Transports that don't buffer text may omit this.
    */
   discardPendingText?(): void;
+
+  /**
+   * Cancel queued and in-flight speech playback held by the transport,
+   * including any audio already buffered downstream (e.g. by Twilio).
+   *
+   * Called by the controller when it aborts an in-flight turn so speech
+   * the aborted turn queued for synthesis or playback never plays over
+   * the next turn. Transports that emit speech synchronously may omit
+   * this.
+   */
+  cancelPendingSpeech?(): void;
 }

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -29,11 +29,14 @@
  *
  * - `clearAudio()` — Clears any queued outbound audio (barge-in),
  *   flushes the internal playback queue, and aborts in-flight synthesis.
+ *   Also exposed to the call controller as `cancelPendingSpeech()` so an
+ *   aborted turn's queued speech never plays over the next turn.
  */
 
 import type { ServerWebSocket } from "bun";
 
 import { extractSpeakableSegments } from "../tts/speakable-segments.js";
+import { synthesizeAndEmit } from "../tts/synthesis-stream.js";
 import { getLogger } from "../util/logger.js";
 import type { CallTransport } from "./call-transport.js";
 import {
@@ -47,6 +50,7 @@ import type {
   MediaStreamSendMarkCommand,
   MediaStreamSendMediaCommand,
 } from "./media-stream-protocol.js";
+import { resolveCallTtsProvider } from "./resolve-call-tts-provider.js";
 
 const log = getLogger("media-stream-output");
 
@@ -209,6 +213,16 @@ export class MediaStreamOutput implements CallTransport {
    */
   discardPendingText(): void {
     this.textBuffer = "";
+  }
+
+  /**
+   * Cancel queued and in-flight speech playback, including audio Twilio
+   * has already buffered. The call controller invokes this when it
+   * aborts an in-flight turn so speech the aborted turn queued for
+   * synthesis never plays over the next turn.
+   */
+  cancelPendingSpeech(): void {
+    this.clearAudio();
   }
 
   /**
@@ -489,8 +503,6 @@ export class MediaStreamOutput implements CallTransport {
     this.activePlaybackAbort = abortController;
 
     try {
-      const { resolveCallTtsProvider } =
-        await import("./resolve-call-tts-provider.js");
       // Request WAV so audioBufferToFrames gets PCM it can transcode
       // to mu-law. Compressed formats (mp3, opus) would be sent as raw
       // bytes and produce garbled audio.
@@ -509,7 +521,6 @@ export class MediaStreamOutput implements CallTransport {
         return;
       }
 
-      const { synthesizeAndEmit } = await import("../tts/synthesis-stream.js");
       const isCurrent = (): boolean =>
         version === this.playbackVersion && !this.isClosed();
 


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for voice-tts-streaming-latency.md.

- **P1**: `abortCurrentTurn` now cancels MediaStreamOutput's queued/in-flight sentence synthesis (`cancelPendingSpeech` on the transport contract) so an aborted turn can't play stale speech over the next turn
- Failed segments on the media-stream transport now retry via `findPlayableTelephonyTtsFallback` (mirrors call-speech-output) instead of silently truncating the turn; token-fallback spacing preserved
- Hot-path dynamic import made static; test helper dedup