### PR TITLE
fix(release): staging Web SPA deploy was always skipped by implicit success()

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1823,10 +1823,17 @@ jobs:
   # release failed to register; on production runs the SPA ships LAST,
   # after the GitHub Release is published and the release is registered
   # with the platform.
+  #
+  # Both `if` conditions MUST use the `always() && !cancelled()` + explicit
+  # per-need result checks pattern: register-release sits downstream of the
+  # production-only `release` and `push-dockerhub-image` jobs, which are
+  # skipped on staging runs. A skipped job anywhere in the transitive needs
+  # chain makes the implicit `success()` false — so a plain `if` here would
+  # skip the deploy even though every direct need succeeded.
   deploy-web-spa-staging:
     name: Deploy Web SPA (staging)
     needs: [extract-version, ci-assistant, ci-cli, ci-gateway, ci-credential-executor, ci-web, register-release]
-    if: ${{ needs.extract-version.outputs.is_staging == 'true' }}
+    if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging == 'true' && needs.extract-version.result == 'success' && needs.ci-assistant.result == 'success' && needs.ci-cli.result == 'success' && needs.ci-gateway.result == 'success' && needs.ci-credential-executor.result == 'success' && needs.ci-web.result == 'success' && needs.register-release.result == 'success' }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary
- `deploy-web-spa-staging` was skipped on every staging release (e.g. [Release v0.10.7](https://github.com/vellum-ai/vellum-assistant/actions/runs/28868132306)): its plain `if: is_staging == 'true'` gains an implicit `success()`, and job-level `success()` is false when any job in the **transitive** needs chain was skipped. `register-release` sits downstream of the production-only `release` and `push-dockerhub-image` jobs, which are always skipped on staging runs — so the deploy skipped even though every direct need succeeded.
- Switch the condition to the `always() && !cancelled()` + explicit per-need `result == 'success'` checks pattern already used by `deploy-web-spa-production`, and document the gotcha above both jobs.
- The job has never run since it landed in #37222; the staging SPA bucket is still serving the pre-#37222 bundle until the next staging release (or a re-run) picks this up.

## Original prompt
User asked why the Web SPA was not deployed to staging in the v0.10.7 release run. Investigation traced it to the skip-propagation trap above (all direct needs green, `is_staging=true`, job still skipped), and the user asked to fix it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->