### PR TITLE
refactor(tools): eject tools/types.ts from the daemon core import cycle

### DIFF
--- a/assistant/src/__tests__/approval-routes-http.test.ts
+++ b/assistant/src/__tests__/approval-routes-http.test.ts
@@ -8,7 +8,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { Conversation } from "../daemon/conversation.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
-import type { SecretPromptResult } from "../permissions/secret-prompter.js";
+import type { SecretPromptResult } from "../permissions/secret-prompt-types.js";
 
 mock.module("../util/logger.js", () => ({
   getLogger: () =>

--- a/assistant/src/__tests__/credential-prompt-route.test.ts
+++ b/assistant/src/__tests__/credential-prompt-route.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { SlackChannelConfigResult } from "../daemon/handlers/config-slack-channel.js";
-import type { SecretPromptResult } from "../permissions/secret-prompter.js";
+import type { SecretPromptResult } from "../permissions/secret-prompt-types.js";
 
 // ---------------------------------------------------------------------------
 // Mutable mock state (closed over by the mock factories below)

--- a/assistant/src/__tests__/require-fresh-approval.test.ts
+++ b/assistant/src/__tests__/require-fresh-approval.test.ts
@@ -20,10 +20,10 @@ import {
 } from "bun:test";
 
 import { RiskLevel, type ScopeOption } from "../permissions/types.js";
+import type { ToolPermissionPromptEvent } from "../tools/tool-types.js";
 import type {
   ToolExecutionResult,
   ToolLifecycleEvent,
-  ToolPermissionPromptEvent,
 } from "../tools/types.js";
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/secret-response-routing.test.ts
+++ b/assistant/src/__tests__/secret-response-routing.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { SecretRequestEvent } from "../api/events/secret-request.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
-import type { SecretPromptResult } from "../permissions/secret-prompter.js";
+import type { SecretPromptResult } from "../permissions/secret-prompt-types.js";
 
 let broadcastedMessages: ServerMessage[] = [];
 mock.module("../runtime/assistant-event-hub.js", () => ({

--- a/assistant/src/__tests__/verification-control-plane-policy.test.ts
+++ b/assistant/src/__tests__/verification-control-plane-policy.test.ts
@@ -8,10 +8,10 @@ import {
   test,
 } from "bun:test";
 
+import type { ToolPermissionDeniedEvent } from "../tools/tool-types.js";
 import type {
   ToolExecutionResult,
   ToolLifecycleEvent,
-  ToolPermissionDeniedEvent,
 } from "../tools/types.js";
 
 // -- Module mocks (must precede real imports) --

--- a/assistant/src/credential-execution/prompted-credential.ts
+++ b/assistant/src/credential-execution/prompted-credential.ts
@@ -18,7 +18,7 @@ import {
   type SlackChannelConfigResult,
 } from "../daemon/handlers/config-slack-channel.js";
 import { syncManualTokenConnection } from "../oauth/manual-token-connection.js";
-import type { SecretDelivery } from "../permissions/secret-prompter.js";
+import type { SecretDelivery } from "../permissions/secret-prompt-types.js";
 import { credentialKey } from "../security/credential-key.js";
 import { setSecureKeyAsync } from "../security/secure-keys.js";
 import { credentialBroker } from "../tools/credentials/broker.js";

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -41,10 +41,12 @@ import {
   resolveSkillExecuteInput,
 } from "../tools/skills/execute.js";
 import { resolveToolInvocationAlias } from "../tools/tool-name-aliases.js";
+import type {
+  ProxyApprovalCallback,
+  ProxyApprovalRequest,
+} from "../tools/tool-types.js";
 import {
   isDiskPressureCleanupToolName,
-  type ProxyApprovalCallback,
-  type ProxyApprovalRequest,
   type ToolContext,
   type ToolExecutionResult,
   type ToolLifecycleEventHandler,

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -9,7 +9,7 @@ import type {
 import { ConfirmationDecisionSchema } from "../../api/responses/conversation-message.js";
 import { getConfig } from "../../config/loader.js";
 import type { LLMCallSite, Speed } from "../../config/schemas/llm.js";
-import type { SecretPromptResult } from "../../permissions/secret-prompter.js";
+import type { SecretPromptResult } from "../../permissions/secret-prompt-types.js";
 import { isPlaceholderSentinelText } from "../../providers/placeholder-sentinels.js";
 import { broadcastMessage } from "../../runtime/assistant-event-hub.js";
 import type { AuthContext } from "../../runtime/auth/types.js";

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -4,7 +4,7 @@ import { getConfig } from "../config/loader.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { redactSensitiveFields } from "../security/redaction.js";
-import type { ExecutionTarget } from "../tools/types.js";
+import type { ExecutionTarget } from "../tools/tool-types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import type { AllowlistOption, ScopeOption, UserDecision } from "./types.js";

--- a/assistant/src/permissions/secret-prompt-types.ts
+++ b/assistant/src/permissions/secret-prompt-types.ts
@@ -1,0 +1,23 @@
+/**
+ * Result vocabulary for a secret prompt: how the value is delivered and the
+ * outcome of the prompt. Kept in a leaf module (no runtime dependencies) so
+ * type-only consumers can reference the shapes without importing the prompter
+ * implementation and its daemon-internal dependencies.
+ */
+
+export type SecretDelivery = "store" | "transient_send";
+
+export interface SecretPromptResult {
+  value: string | null;
+  delivery: SecretDelivery;
+  /** When set, the prompt could not be delivered and the value is null due to a delivery failure (not user cancellation). */
+  error?: "unsupported_channel";
+  /**
+   * Why `value` is null. `"cancelled"` = the user explicitly dismissed the
+   * prompt (a valid flow, not a failure); `"timed_out"` = no response within
+   * the permission-timeout window. Only meaningful when `value` is null and
+   * `error` is unset. Lets callers distinguish a deliberate cancel from a
+   * genuine failure instead of treating both as an error.
+   */
+  reason?: "cancelled" | "timed_out";
+}

--- a/assistant/src/permissions/secret-prompter.ts
+++ b/assistant/src/permissions/secret-prompter.ts
@@ -6,27 +6,14 @@ import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
+import type {
+  SecretDelivery,
+  SecretPromptResult,
+} from "./secret-prompt-types.js";
 
 type SecretRequestMessage = Extract<ServerMessage, { type: "secret_request" }>;
 
 const log = getLogger("secret-prompter");
-
-export type SecretDelivery = "store" | "transient_send";
-
-export interface SecretPromptResult {
-  value: string | null;
-  delivery: SecretDelivery;
-  /** When set, the prompt could not be delivered and the value is null due to a delivery failure (not user cancellation). */
-  error?: "unsupported_channel";
-  /**
-   * Why `value` is null. `"cancelled"` = the user explicitly dismissed the
-   * prompt (a valid flow, not a failure); `"timed_out"` = no response within
-   * the permission-timeout window. Only meaningful when `value` is null and
-   * `error` is unset. Lets callers distinguish a deliberate cancel from a
-   * genuine failure instead of treating both as an error.
-   */
-  reason?: "cancelled" | "timed_out";
-}
 
 export interface SecretPrompterChannelContext {
   /** The channel the conversation was initiated from (e.g. "slack", "macos"). */

--- a/assistant/src/plugin-api/types.ts
+++ b/assistant/src/plugin-api/types.ts
@@ -24,12 +24,12 @@ export type {
   StopContext,
   UserPromptSubmitContext,
 } from "../hooks/types.js";
+export { RiskLevel } from "../tools/tool-types.js";
 export type {
   ToolContext,
   ToolDefinition,
   ToolExecutionResult,
 } from "../tools/types.js";
-export { RiskLevel } from "../tools/types.js";
 
 // ─── Hook function ───────────────────────────────────────────────────────────
 

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -13,7 +13,7 @@ import { findConversation } from "../../daemon/conversation-registry.js";
 import type {
   SecretDelivery,
   SecretPromptResult,
-} from "../../permissions/secret-prompter.js";
+} from "../../permissions/secret-prompt-types.js";
 import type { UserDecision } from "../../permissions/types.js";
 import { getConversationByKey } from "../../persistence/conversation-key-store.js";
 import { getLogger } from "../../util/logger.js";

--- a/assistant/src/tools/execution-target.ts
+++ b/assistant/src/tools/execution-target.ts
@@ -1,4 +1,4 @@
-import type { ExecutionTarget } from "./types.js";
+import type { ExecutionTarget } from "./tool-types.js";
 
 export interface ManifestOverride {
   risk: "low" | "medium" | "high";

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -21,7 +21,7 @@ import { resolveCapabilities } from "../runtime/capabilities.js";
 import { getLogger } from "../util/logger.js";
 import { buildPolicyContext } from "./policy-context.js";
 import { isSideEffectTool } from "./side-effects.js";
-import type { ExecutionTarget } from "./types.js";
+import type { ExecutionTarget } from "./tool-types.js";
 import type { Tool, ToolContext, ToolLifecycleEvent } from "./types.js";
 
 const log = getLogger("permission-checker");

--- a/assistant/src/tools/skills/skill-script-runner.ts
+++ b/assistant/src/tools/skills/skill-script-runner.ts
@@ -2,11 +2,8 @@ import { basename, join, resolve } from "node:path";
 
 import { bundledToolRegistry } from "../../config/bundled-tool-registry.js";
 import { computeSkillVersionHash } from "../../skills/version-hash.js";
-import type {
-  ExecutionTarget,
-  ToolContext,
-  ToolExecutionResult,
-} from "../types.js";
+import type { ExecutionTarget } from "../tool-types.js";
+import type { ToolContext, ToolExecutionResult } from "../types.js";
 import { runSkillToolScriptSandbox } from "./sandbox-runner.js";
 import type { SkillToolScript } from "./script-contract.js";
 

--- a/assistant/src/tools/skills/skill-tool-factory.ts
+++ b/assistant/src/tools/skills/skill-tool-factory.ts
@@ -5,12 +5,8 @@ import {
   coerceStringNumbers,
   validateInputAgainstSchema,
 } from "../../skills/validate-input.js";
-import type {
-  ExecutionTarget,
-  Tool,
-  ToolContext,
-  ToolExecutionResult,
-} from "../types.js";
+import type { ExecutionTarget } from "../tool-types.js";
+import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
 import { runSkillToolScript } from "./skill-script-runner.js";
 
 const riskMap: Record<SkillToolEntry["risk"], RiskLevel> = {

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -31,8 +31,8 @@ import {
   formatShellOutput,
   MAX_OUTPUT_LENGTH,
 } from "../shared/shell-output.js";
+import type { ProxyEnvVars } from "../tool-types.js";
 import type {
-  ProxyEnvVars,
   ToolContext,
   ToolDefinition,
   ToolExecutionResult,

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -23,8 +23,8 @@ import { getAllTools, getTool, getToolOwner } from "./registry.js";
 import { isSideEffectTool } from "./side-effects.js";
 import { summarizeToolInput } from "./tool-input-summary.js";
 import { suggestToolName } from "./tool-name-aliases.js";
+import type { ExecutionTarget } from "./tool-types.js";
 import {
-  type ExecutionTarget,
   isDiskPressureCleanupToolName,
   type OwnerInfo,
   type Tool,

--- a/assistant/src/tools/tool-defaults.ts
+++ b/assistant/src/tools/tool-defaults.ts
@@ -11,12 +11,8 @@
  */
 
 import { resolveExecutionTarget } from "./execution-target.js";
-import type {
-  RiskLevel,
-  Tool,
-  ToolDefinition,
-  ToolExecutionResult,
-} from "./types.js";
+import type { RiskLevel } from "./tool-types.js";
+import type { Tool, ToolDefinition, ToolExecutionResult } from "./types.js";
 
 /**
  * Default values applied by `finalizeTool` when the author omits a field.

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -4,9 +4,9 @@ import { z } from "zod";
 import type { InterfaceId } from "../channels/types.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.js";
-import type { SecretPromptResult } from "../permissions/secret-prompter.js";
+import type { SecretPromptResult } from "../permissions/secret-prompt-types.js";
 import type { ContentBlock } from "../providers/types.js";
-import type { TrustClass } from "../runtime/actor-trust-resolver.js";
+import type { TrustClass } from "../runtime/trust-class.js";
 import type { UsageAttributionSnapshot } from "../usage/attribution.js";
 import type {
   DiffInfo,
@@ -36,45 +36,22 @@ export function isDiskPressureCleanupToolName(name: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
-// Re-exports + concrete overlays for types that live in
-// ./tool-types.js.
+// Concrete overlays for types that live in ./tool-types.js.
 //
-// The canonical declarations live in the neutral leaf module
-// `./tool-types.js`. This file preserves existing import paths
-// (`"../tools/types.js"`) so all callers keep resolving.
-//
-// Pure re-exports below cover types the contracts package could declare
-// without any assistant-side references. The remaining interfaces (`Tool`,
-// `ToolContext`, `ToolExecutionResult`, `ToolExecutedEvent`,
-// `ToolLifecycleEvent`, `ToolLifecycleEventHandler`, `ProxyToolResolver`)
-// reference daemon-internal types (CES client, host-proxy classes,
-// `ContentBlock`, `ApprovalRequired`, `TrustClass`, `InterfaceId`,
+// The canonical declarations live in the neutral leaf module `./tool-types.js`.
+// The interfaces below (`Tool`, `ToolContext`, `ToolExecutionResult`,
+// `ToolExecutedEvent`, `ToolLifecycleEvent`, `ToolLifecycleEventHandler`,
+// `ProxyToolResolver`) reference daemon-internal types (CES client, host-proxy
+// classes, `ContentBlock`, `ApprovalRequired`, `TrustClass`, `InterfaceId`,
 // `SecretPromptResult`, `UsageAttributionSnapshot`) that can't move into a
-// neutral package. For those,
-// the contracts version uses opaque placeholders (`unknown`, broadened
-// `string`) and the assistant redeclares the interface here with the
-// concrete types. The two sides are structurally independent — no
-// inheritance, no intersection — which avoids TypeScript's contravariance
-// mismatches on lifecycle-event handlers.
-// `ToolExecutionErrorEvent` is the exception: its contracts fields are all
-// concrete, so the assistant overlay simply extends it with the
-// daemon-internal telemetry fields.
+// neutral package. For those, the contracts version uses opaque placeholders
+// (`unknown`, broadened `string`) and the assistant redeclares the interface
+// here with the concrete types. The two sides are structurally independent —
+// no inheritance, no intersection — which avoids TypeScript's contravariance
+// mismatches on lifecycle-event handlers. `ToolExecutionErrorEvent` is the
+// exception: its contracts fields are all concrete, so the assistant overlay
+// simply extends it with the daemon-internal telemetry fields.
 // ---------------------------------------------------------------------------
-
-export type {
-  DiffInfo,
-  ErrorCategory,
-  ExecutionTarget,
-  ProxyApprovalCallback,
-  ProxyApprovalRequest,
-  ProxyEnvVars,
-  SensitiveOutputBinding,
-  SensitiveOutputKind,
-  ToolExecutionStartEvent,
-  ToolPermissionDeniedEvent,
-  ToolPermissionPromptEvent,
-} from "./tool-types.js";
-export { RiskLevel } from "./tool-types.js";
 
 // ---------------------------------------------------------------------------
 // Assistant-side concrete overlays

--- a/assistant/src/tools/workspace-tools/loader.ts
+++ b/assistant/src/tools/workspace-tools/loader.ts
@@ -93,12 +93,8 @@ import {
   unregisterWorkspaceTool,
 } from "../registry.js";
 import { finalizeTool } from "../tool-defaults.js";
-import type {
-  RiskLevel,
-  Tool,
-  ToolDefinition,
-  ToolExecutionResult,
-} from "../types.js";
+import type { RiskLevel } from "../tool-types.js";
+import type { Tool, ToolDefinition, ToolExecutionResult } from "../types.js";
 
 const log = getLogger("workspace-tool-loader");
 

--- a/assistant/src/workflows/capabilities.test.ts
+++ b/assistant/src/workflows/capabilities.test.ts
@@ -8,12 +8,8 @@ import {
   registerWorkspaceTools,
 } from "../tools/registry.js";
 import { isSideEffectTool } from "../tools/side-effects.js";
-import type {
-  ExecutionTarget,
-  Tool,
-  ToolContext,
-  ToolExecutionResult,
-} from "../tools/types.js";
+import type { ExecutionTarget } from "../tools/tool-types.js";
+import type { Tool, ToolContext, ToolExecutionResult } from "../tools/types.js";
 import {
   CapabilityManifestSchema,
   CapabilityResolutionError,


### PR DESCRIPTION
## Prompt / plan

First real cut into the daemon **core** SCC. `tools/types.ts` is imported by ~197 core files, yet it was itself trapped in the giant cycle by just **two type-only back-edges** into heavy core modules. Cutting them is the single highest-leverage move available, and the two types belong in their own leaf files anyway.

**1. `SecretPromptResult` (+ `SecretDelivery`)** — defined in the heavy `permissions/secret-prompter.ts` (which imports the message protocol, event hub, etc.). Moved both into a new leaf `permissions/secret-prompt-types.ts`; the prompter and all type-only consumers now import from the leaf.

**2. `TrustClass`** — already lives in the leaf `runtime/trust-class.ts`, but `tools/types.ts` imported it via the heavy `runtime/actor-trust-resolver.ts` (which re-exports it). Repointed to the leaf.

With both edges cut, `tools/types.ts` has no import into the core and drops out of the SCC.

**Re-export cleanup** — also removed the compat re-export block that mirrored `./tool-types.js` through `tools/types.ts` (the canonical declarations already live in that neutral leaf) and repointed every consumer of the re-exported names (`RiskLevel`, `ExecutionTarget`, `ProxyEnvVars`, `ProxyApprovalCallback`/`Request`, `ToolPermissionDenied`/`PromptEvent`) to import from `tools/tool-types.js` directly. `plugin-api/types.ts`'s public `RiskLevel` re-export was repointed to the canonical source (kept — it's the intentional plugin-API surface).

**Result (full-graph SCC, measured before/after):** the core drops **479 → 367 files (−112)** from cutting those two type imports — the leverage the hub analysis predicted. `tools/types.ts` is out of every cycle. Two smaller pre-existing sub-cycles (`config/skills ↔ skills/tool-manifest` and `daemon/message-protocol ↔ message-types/subagents ↔ subagent/types`) are now *visible* as their own isolated SCCs — they were masked inside the blob, not introduced here (good future targets).

## Test plan

- `bunx madge` full-graph SCC: core **479 → 367**; `tools/types.ts` no longer in any cycle.
- `bunx tsc --noEmit` — clean (0 errors). *(Caught a real miss mid-review: consumers inside `tools/` import the re-exported names via relative `./types.js`, which the first grep sweep missed — tsc surfaced all 9, now repointed.)*
- `bun test` on the affected suites, run individually (these files carry cross-file `mock.module` pollution when batched — true on `main` too): secret/approval/credential routes, capabilities, permission checker, tool-executor, registry, workspace-tool-loader, skill-tool-factory, plugin-api-tool-definition — all green.
- Pre-commit + pre-push hooks (prettier, eslint, tsc) all green.

<!-- No new routes added; CLI verb checklist not applicable. -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01EWL4FYZVRGkJkMwL46PY3m)_