### PR TITLE
fix(tts): only count plausible emphasis delimiters in speakable-segment span tracking

### DIFF
--- a/assistant/src/tts/__tests__/speakable-segments.test.ts
+++ b/assistant/src/tts/__tests__/speakable-segments.test.ts
@@ -243,6 +243,71 @@ describe("extractSpeakableSegments", () => {
       expect(remainder).toBe("");
     });
 
+    test("a lone arithmetic asterisk does not suppress sentence boundaries", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "The result of 5 * 3 is 15. And the next sentence keeps going",
+        false,
+      );
+
+      expect(segments).toEqual(["The result of 5 * 3 is 15."]);
+      expect(remainder).toBe(" And the next sentence keeps going");
+    });
+
+    test("a lone arithmetic asterisk does not suppress eager clause boundaries", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "The result of 5 * 3 is 15, and here is even more",
+        false,
+        { eager: true },
+      );
+
+      expect(segments).toEqual(["The result of 5 * 3 is 15,"]);
+      expect(remainder).toBe(" and here is even more");
+    });
+
+    test("a line-start bullet asterisk does not suppress sentence boundaries", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "* bullet item with words. And more after it",
+        false,
+      );
+
+      expect(segments).toEqual(["* bullet item with words."]);
+      expect(remainder).toBe(" And more after it");
+    });
+
+    test("does not split at a clause boundary inside an open italic span", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "*italic text that keeps going, more* and then.",
+        false,
+        { eager: true },
+      );
+
+      expect(segments).toEqual([
+        "*italic text that keeps going, more* and then.",
+      ]);
+      expect(remainder).toBe("");
+    });
+
+    test("a short italic span with a comma stays intact in eager mode", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "*italic, text* more.",
+        false,
+        { eager: true },
+      );
+
+      expect(segments).toEqual(["*italic, text* more."]);
+      expect(remainder).toBe("");
+    });
+
+    test("an unpaired bold marker still defers sentence boundaries", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "**important note. still inside the span",
+        false,
+      );
+
+      expect(segments).toEqual([]);
+      expect(remainder).toBe("**important note. still inside the span");
+    });
+
     test("an open span still flushes at the length-threshold hard cap", () => {
       const text = `**${"steady ".repeat(40)}`;
 

--- a/assistant/src/tts/speakable-segments.ts
+++ b/assistant/src/tts/speakable-segments.ts
@@ -70,42 +70,72 @@ function findSpeakableBoundary(
   charThreshold: number,
   eager: boolean,
 ): number | null {
+  // Inline-span state (backtick / `**` / `*`), accumulated over the scan. A
+  // boundary inside an open span would split the span across segments, and
+  // per-segment sanitization would leave an unbalanced marker to be spoken.
+  let inBacktick = false;
+  let inBold = false;
+  let inItalic = false;
+  let skipSpanChar = false;
+
   for (let index = 0; index < text.length; index += 1) {
     const char = text[index];
-    if (char === "\n") {
-      return index + 1;
-    }
     if (!char) {
       continue;
     }
+    if (char === "\n") {
+      return index + 1;
+    }
+
+    const inOpenSpan = inBacktick || inBold || inItalic;
 
     if (
+      !inOpenSpan &&
       eager &&
       EAGER_CLAUSE_PUNCTUATION.has(char) &&
       index >= EAGER_MIN_CLAUSE_PREFIX_CHARS &&
-      isWhitespace(text[index + 1] ?? "") &&
-      !hasOpenInlineSpan(text.slice(0, index))
+      isWhitespace(text[index + 1] ?? "")
     ) {
       return index + 1;
     }
 
-    if (!SENTENCE_ENDING_PUNCTUATION.has(char)) {
-      continue;
+    if (!inOpenSpan && SENTENCE_ENDING_PUNCTUATION.has(char)) {
+      let boundary = index + 1;
+      while (
+        boundary < text.length &&
+        TRAILING_SENTENCE_PUNCTUATION.has(text[boundary] ?? "")
+      ) {
+        boundary += 1;
+      }
+      if (boundary === text.length || isWhitespace(text[boundary] ?? "")) {
+        return boundary;
+      }
     }
 
-    let boundary = index + 1;
-    while (
-      boundary < text.length &&
-      TRAILING_SENTENCE_PUNCTUATION.has(text[boundary] ?? "")
-    ) {
-      boundary += 1;
-    }
-
-    if (
-      (boundary === text.length || isWhitespace(text[boundary] ?? "")) &&
-      !hasOpenInlineSpan(text.slice(0, index))
-    ) {
-      return boundary;
+    if (skipSpanChar) {
+      skipSpanChar = false;
+    } else if (char === "`") {
+      inBacktick = !inBacktick;
+    } else if (char === "*") {
+      const prev = text[index - 1];
+      const next = text[index + 1];
+      if (next === "*") {
+        inBold = !inBold;
+        skipSpanChar = true;
+      } else if (inItalic) {
+        // Mirrors the TTS sanitizer's word-boundary-aware italic rule: a
+        // closer needs non-whitespace before it and no word char after, so
+        // arithmetic like `5 * 3` and bullet markers never toggle parity.
+        if (prev !== undefined && !isWhitespace(prev) && !isWordChar(next)) {
+          inItalic = false;
+        }
+      } else if (
+        !isWordChar(prev) &&
+        next !== undefined &&
+        !isWhitespace(next)
+      ) {
+        inItalic = true;
+      }
     }
   }
 
@@ -119,29 +149,8 @@ function findSpeakableBoundary(
   return preferredBoundary ?? charThreshold;
 }
 
-/**
- * Whether the text ends inside an open `**`, `*`, or backtick span. A
- * boundary there would split the span across segments, and per-segment
- * sanitization would leave an unbalanced marker to be spoken.
- */
-function hasOpenInlineSpan(prefix: string): boolean {
-  let backticks = 0;
-  let bold = 0;
-  let italic = 0;
-  for (let index = 0; index < prefix.length; index += 1) {
-    const char = prefix[index];
-    if (char === "`") {
-      backticks += 1;
-    } else if (char === "*") {
-      if (prefix[index + 1] === "*") {
-        bold += 1;
-        index += 1;
-      } else {
-        italic += 1;
-      }
-    }
-  }
-  return backticks % 2 === 1 || bold % 2 === 1 || italic % 2 === 1;
+function isWordChar(value: string | undefined): boolean {
+  return value !== undefined && /\w/.test(value);
 }
 
 function findLastWhitespaceBoundary(


### PR DESCRIPTION
## Summary
Fixes a round-2 review gap for voice-tts-streaming-latency.md.

- A lone arithmetic `*` (e.g. "5 * 3") no longer flips span parity and defer boundaries to the hard cap — delimiter counting now mirrors the TTS sanitizer's word-boundary intent
- Span parity is accumulated in the existing forward scan (removes the per-candidate prefix rescan)