### PR TITLE
refactor(plugins): kind-scope the activation table; reuse the owner-kind enum

### DIFF
--- a/assistant/src/hooks/hook-loader.ts
+++ b/assistant/src/hooks/hook-loader.ts
@@ -56,6 +56,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 
+import type { HookEventOwner } from "../api/events/hook-event.js";
 import { getConfig } from "../config/loader.js";
 import { HOOKS } from "../plugin-api/constants.js";
 import type {
@@ -84,11 +85,13 @@ const log = getLogger("hook-loader");
 export const WORKSPACE_HOOKS_OWNER = "__workspace__";
 
 /**
- * Whether a hook's owner is a user plugin or the standalone workspace surface.
- * Threaded into the cache key so the two owner namespaces can't collide even if
- * a plugin's manifest name happens to equal {@link WORKSPACE_HOOKS_OWNER}.
+ * Whether a hook's owner is a user plugin or the standalone workspace surface —
+ * the `kind` of a {@link HookEventOwner}, reused so this stays a single source
+ * of truth. Threaded into the cache key so the two owner namespaces can't
+ * collide even if a plugin's manifest name happens to equal
+ * {@link WORKSPACE_HOOKS_OWNER}.
  */
-type HookOwnerKind = "plugin" | "workspace";
+export type HookOwnerKind = HookEventOwner["kind"];
 
 /**
  * Per-hook resolution memo keyed by `${kind}:${ownerName}/${hookName}`. The key

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -38,6 +38,7 @@ import {
   collectUserHookEntries,
   evictHooksForOwner,
   hasWorkspaceHooks,
+  type HookOwnerKind,
   resetHookCacheForTests,
   runInitHook,
   runShutdownHook,
@@ -444,7 +445,7 @@ async function reconcileWorkspaceHooks(
   }
   const reason: ShutdownReason = after === undefined ? "uninstall" : "reload";
   const activeIdx = activatedPlugins.findIndex(
-    (p) => p.name === WORKSPACE_HOOKS_OWNER,
+    (p) => p.kind === "workspace" && p.name === WORKSPACE_HOOKS_OWNER,
   );
   if (activeIdx >= 0) {
     await runShutdownHook(
@@ -459,7 +460,7 @@ async function reconcileWorkspaceHooks(
   sweepModules(before, after);
   if (after !== undefined) {
     await runInitHook(WORKSPACE_HOOKS_OWNER);
-    activatedPlugins.push({ name: WORKSPACE_HOOKS_OWNER });
+    activatedPlugins.push({ kind: "workspace", name: WORKSPACE_HOOKS_OWNER });
     log.info("workspace hooks reloaded");
   }
 }
@@ -762,8 +763,13 @@ async function evictAll(): Promise<void> {
  * runtime uninstall/disable tears a single entry down via
  * {@link deactivatePlugin}; at daemon shutdown the owners' `shutdown` hooks
  * fire through the unified `runHook(HOOKS.SHUTDOWN)` pipeline.
+ *
+ * Entries carry their owner {@link HookOwnerKind} so lookups are scoped by
+ * `(kind, name)`: a plugin and the workspace pseudo-owner can share a name
+ * (a hand-installed plugin named {@link WORKSPACE_HOOKS_OWNER}), and matching on
+ * name alone would splice the wrong record.
  */
-const activatedPlugins: Array<{ name: string }> = [];
+const activatedPlugins: Array<{ kind: HookOwnerKind; name: string }> = [];
 
 /**
  * Names in {@link activatedPlugins}, kept as a set for O(1) membership and —
@@ -822,7 +828,7 @@ async function activatePlugin(
   // Run the `init` hook if present.
   await runInitHook(pluginName, pluginDir);
 
-  activatedPlugins.push({ name: pluginName });
+  activatedPlugins.push({ kind: "plugin", name: pluginName });
 }
 
 /**
@@ -840,7 +846,9 @@ async function deactivatePlugin(
     return;
   }
   activatedNames.delete(pluginName);
-  const idx = activatedPlugins.findIndex((p) => p.name === pluginName);
+  const idx = activatedPlugins.findIndex(
+    (p) => p.kind === "plugin" && p.name === pluginName,
+  );
   if (idx >= 0) {
     activatedPlugins.splice(idx, 1);
   }
@@ -902,7 +910,7 @@ export async function populateCacheAtBoot(
   // an empty/absent directory adds no shutdown work.
   if (hasWorkspaceHooks()) {
     await runInitHook(WORKSPACE_HOOKS_OWNER);
-    activatedPlugins.push({ name: WORKSPACE_HOOKS_OWNER });
+    activatedPlugins.push({ kind: "workspace", name: WORKSPACE_HOOKS_OWNER });
   }
 
   // Boot is self-sufficient (the scan above never waits on the monitor);


### PR DESCRIPTION
## Prompt / plan

The two review comments from #37351.

**1. Kind-scope `activatedPlugins` (codex P2, confirmed).** #37351 scoped the hook *cache* key by owner kind but left the activation table keyed by name only. `activatedPlugins` holds both plugins and the workspace pseudo-owner, so a hand-installed plugin named `__workspace__` makes `findIndex(p => p.name === …)` match — and splice — the wrong record, corrupting teardown bookkeeping across later reloads. Entries now carry their `kind`, and the deactivate/reconcile lookups match on `(kind, name)`.

  `activatedNames` (the synchronous double-activation guard) stays name-only on purpose: only `activatePlugin` writes it and only for plugins, so the workspace owner never enters it and there's nothing to collide with.

**2. Reuse the owner-kind enum.** `HookOwnerKind` now aliases `HookEventOwner["kind"]` instead of re-spelling the `"plugin" | "workspace"` union, so there's a single source of truth; it's exported so the cache and the activation table share the one type.

## Test plan

- `bun test` per-file: `mtime-cache.test.ts` (31), `hook-live-reload.test.ts` (6), `plugin-effective-enabled-set.test.ts` (5), `plugin-config-data-migration.test.ts` (6), `user-plugin-loader.test.ts` (5) — all pass.
- `bunx eslint` (0 errors), `bunx prettier --check` (clean), `tsc --noEmit` (exit 0); pre-push hook green.

**On test coverage for #1:** the corruption is internal to `activatedPlugins` and has no external observable today — hook resolution reads `discoveredPluginDirs`, and `shutdown` reads the (already kind-scoped) cache, so neither is affected by the array drift. Rather than expose the internal array purely to assert on it, I relied on the existing `a plugin named like the workspace owner does not collide with it` test (added in #37351) to cover the observable resolution + shutdown paths. Happy to add a test-only inspector if you'd prefer explicit coverage.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SquRHbAZqYMwNqDD7SNcNP)_