### PR TITLE
refactor(tts): single source of truth for actual output sample rate

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-tts.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts.test.ts
@@ -348,7 +348,6 @@ describe("streamLiveVoiceTtsAudio", () => {
         return {
           audio: Buffer.from("pcm-one!"),
           contentType: "audio/pcm",
-          sampleRateHz: 16_000,
         };
       },
     });

--- a/assistant/src/live-voice/live-voice-tts.ts
+++ b/assistant/src/live-voice/live-voice-tts.ts
@@ -93,7 +93,7 @@ export async function streamLiveVoiceTtsAudio(
     sampleRateHz: requestedSampleRate,
     signal: options.signal,
   });
-  let sampleRate = providerSampleRate ?? requestedSampleRate;
+  const sampleRate = providerSampleRate ?? requestedSampleRate;
   if (sampleRate !== requestedSampleRate) {
     log.warn(
       { provider: providerId, requestedSampleRate, sampleRate },
@@ -171,24 +171,6 @@ export async function streamLiveVoiceTtsAudio(
       );
     }
     const contentType = result.contentType || chunkContentType;
-
-    // Late correction for providers that report the actual rate only on the
-    // completed result: it relabels the buffered emit below and the returned
-    // result (already-streamed frames keep their up-front label).
-    if (
-      isPositiveFiniteNumber(result.sampleRateHz) &&
-      result.sampleRateHz !== sampleRate
-    ) {
-      log.warn(
-        {
-          provider: providerId,
-          labeledSampleRate: sampleRate,
-          sampleRate: result.sampleRateHz,
-        },
-        "TTS provider reported a different output sample rate on the completed result",
-      );
-      sampleRate = result.sampleRateHz;
-    }
 
     // An abort mid-stream resolves without throwing; skip the buffered emit
     // so a truncated payload is never delivered after cancellation.

--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -343,7 +343,6 @@ describe("ElevenLabs TTS provider adapter", () => {
 
     expect(capturedUrl).toContain("output_format=pcm_24000");
     expect(result.contentType).toBe("audio/pcm");
-    expect(result.sampleRateHz).toBe(24000);
   });
 
   test("pcm output without sampleRateHz defaults to pcm_16000", async () => {
@@ -376,17 +375,6 @@ describe("ElevenLabs TTS provider adapter", () => {
     );
 
     expect(capturedUrl).toContain("output_format=pcm_16000");
-  });
-
-  test("pcm request at an unsupported 48000 Hz reports the actual 16000 Hz output rate", async () => {
-    mockFetchReturning(new Uint8Array([0x00, 0x01]));
-
-    const provider = createElevenLabsProvider();
-    const result = await provider.synthesize(
-      makeRequest({ outputFormat: "pcm", sampleRateHz: 48000 }),
-    );
-
-    expect(result.sampleRateHz).toBe(16000);
   });
 
   test("resolveOutputSampleRateHz reports the actual PCM rate without synthesis", () => {
@@ -439,7 +427,6 @@ describe("ElevenLabs TTS provider adapter", () => {
     expect(received).toEqual([part1, part2]);
     expect(result.audio).toEqual(Buffer.from([0x01, 0x02, 0x03]));
     expect(result.contentType).toBe("audio/pcm");
-    expect(result.sampleRateHz).toBe(16000);
   });
 
   test("synthesizeStream rejects after the first-chunk timeout when the stream never produces audio", async () => {
@@ -611,7 +598,7 @@ describe("ElevenLabs TTS provider adapter", () => {
 
   // -- Content type / format -----------------------------------------------
 
-  test("returns audio/mpeg content type for mp3 format without a sample rate", async () => {
+  test("returns audio/mpeg content type for mp3 format", async () => {
     const audioPayload = new Uint8Array([0x49, 0x44, 0x33]);
     mockFetchReturning(audioPayload);
 
@@ -620,7 +607,6 @@ describe("ElevenLabs TTS provider adapter", () => {
 
     expect(result.contentType).toBe("audio/mpeg");
     expect(result.audio.byteLength).toBeGreaterThan(0);
-    expect(result.sampleRateHz).toBeUndefined();
   });
 
   // -- Required config validation ------------------------------------------
@@ -850,12 +836,11 @@ describe("Fish Audio TTS provider adapter", () => {
       16000,
     );
     expect(result.contentType).toBe("audio/pcm");
-    expect(result.sampleRateHz).toBe(16000);
   });
 
   test("pcm output request honors the sampleRateHz hint", async () => {
     const provider = createFishAudioProvider();
-    const result = await provider.synthesize(
+    await provider.synthesize(
       makeRequest({ outputFormat: "pcm", sampleRateHz: 24000 }),
     );
 
@@ -864,7 +849,6 @@ describe("Fish Audio TTS provider adapter", () => {
     expect((options as { sampleRate?: number } | undefined)?.sampleRate).toBe(
       24000,
     );
-    expect(result.sampleRateHz).toBe(24000);
   });
 
   test("synthesizeStream pcm output request maps to raw pcm honoring the hint", async () => {
@@ -880,7 +864,6 @@ describe("Fish Audio TTS provider adapter", () => {
       24000,
     );
     expect(result.contentType).toBe("audio/pcm");
-    expect(result.sampleRateHz).toBe(24000);
   });
 
   test("resolveOutputSampleRateHz passes the pcm hint through and is undefined otherwise", () => {
@@ -964,12 +947,11 @@ describe("Fish Audio TTS provider adapter", () => {
     expect(result.contentType).toBe("audio/mpeg");
   });
 
-  test("returns audio/wav content type for wav format without a sample rate", async () => {
+  test("returns audio/wav content type for wav format", async () => {
     mockFishAudioConfig.format = "wav";
     const provider = createFishAudioProvider();
     const result = await provider.synthesize(makeRequest());
     expect(result.contentType).toBe("audio/wav");
-    expect(result.sampleRateHz).toBeUndefined();
   });
 
   test("returns audio/opus content type for opus format", async () => {

--- a/assistant/src/tts/__tests__/synthesis-stream.test.ts
+++ b/assistant/src/tts/__tests__/synthesis-stream.test.ts
@@ -30,7 +30,6 @@ interface StreamingFakeOptions {
   /** Awaited after all chunks are delivered, before the stream resolves. */
   resolveGate?: Promise<void>;
   contentType?: string;
-  sampleRateHz?: number;
 }
 
 function makeStreamingProvider(
@@ -57,7 +56,6 @@ function makeStreamingProvider(
       return {
         audio: Buffer.concat(chunks),
         contentType: options.contentType ?? "audio/mpeg",
-        sampleRateHz: options.sampleRateHz,
       };
     },
   };
@@ -66,7 +64,6 @@ function makeStreamingProvider(
 function makeBufferProvider(
   audio: Buffer,
   contentType = "audio/mpeg",
-  sampleRateHz?: number,
 ): TtsProvider & { requests: TtsSynthesisRequest[] } {
   const requests: TtsSynthesisRequest[] = [];
   return {
@@ -75,7 +72,7 @@ function makeBufferProvider(
     requests,
     async synthesize(request): Promise<TtsSynthesisResult> {
       requests.push(request);
-      return { audio, contentType, sampleRateHz };
+      return { audio, contentType };
     },
   };
 }
@@ -506,22 +503,6 @@ describe("synthesizeAndEmit (streaming)", () => {
     ]);
   });
 
-  test("passes the provider-reported sampleRateHz through on the result", async () => {
-    const provider = makeStreamingProvider([bytes("a")], {
-      contentType: "audio/pcm",
-      sampleRateHz: 24000,
-    });
-
-    const result = await synthesizeAndEmit({
-      provider,
-      text: "hello",
-      useCase: "phone-call",
-      onChunk: () => {},
-    });
-
-    expect(result.sampleRateHz).toBe(24000);
-  });
-
   test("passes text/useCase/voiceId/outputFormat/sampleRateHz/signal through on the request", async () => {
     const provider = makeStreamingProvider([bytes("a")]);
     const abortController = new AbortController();
@@ -571,26 +552,8 @@ describe("synthesizeAndEmit (buffer)", () => {
     expect(result).toEqual({
       emittedChunks: 1,
       contentType: "audio/wav",
-      sampleRateHz: undefined,
       stopped: false,
     });
-  });
-
-  test("passes the provider-reported sampleRateHz through on the result", async () => {
-    const provider = makeBufferProvider(
-      Buffer.from("abc"),
-      "audio/pcm",
-      16000,
-    );
-
-    const result = await synthesizeAndEmit({
-      provider,
-      text: "hello",
-      useCase: "phone-call",
-      onChunk: () => {},
-    });
-
-    expect(result.sampleRateHz).toBe(16000);
   });
 
   test("throws on an empty audio payload", async () => {

--- a/assistant/src/tts/providers/elevenlabs-provider.ts
+++ b/assistant/src/tts/providers/elevenlabs-provider.ts
@@ -204,13 +204,13 @@ function pcmFormatSampleRateHz(outputFormat: string): number | undefined {
  * Resolve credentials and config, build the request body, and issue the
  * ElevenLabs TTS HTTP request. Shared by `synthesize` (buffer endpoint) and
  * `synthesizeStream` (`/stream` endpoint). Throws on missing credentials and
- * non-OK responses; resolves with the OK response and the resolved output
- * format and content type.
+ * non-OK responses; resolves with the OK response and the resolved content
+ * type.
  */
 async function performTtsRequest(
   request: TtsSynthesisRequest,
   { stream }: { stream: boolean },
-): Promise<{ response: Response; outputFormat: string; contentType: string }> {
+): Promise<{ response: Response; contentType: string }> {
   const apiKey = await getSecureKeyAsync(
     credentialKey("elevenlabs", "api_key"),
   );
@@ -289,7 +289,7 @@ async function performTtsRequest(
     );
   }
 
-  return { response, outputFormat, contentType };
+  return { response, contentType };
 }
 
 /** Stream-stall timeouts, injectable for tests. */
@@ -310,10 +310,9 @@ async function performSynthesis(
     onChunk?: (chunk: Uint8Array) => void;
   } & ElevenLabsStreamTimeouts,
 ): Promise<TtsSynthesisResult> {
-  const { response, outputFormat, contentType } = await performTtsRequest(
-    request,
-    { stream: options.stream },
-  );
+  const { response, contentType } = await performTtsRequest(request, {
+    stream: options.stream,
+  });
 
   let audio: Buffer;
   if (options.stream) {
@@ -349,11 +348,7 @@ async function performSynthesis(
     "ElevenLabs TTS synthesis complete",
   );
 
-  return {
-    audio,
-    contentType,
-    sampleRateHz: pcmFormatSampleRateHz(outputFormat),
-  };
+  return { audio, contentType };
 }
 
 export function createElevenLabsProvider(

--- a/assistant/src/tts/providers/fish-audio-provider.ts
+++ b/assistant/src/tts/providers/fish-audio-provider.ts
@@ -148,7 +148,7 @@ async function performSynthesis(
 
   const contentType = FORMAT_CONTENT_TYPE[effectiveFormat] ?? "audio/mpeg";
 
-  return { audio, contentType, sampleRateHz };
+  return { audio, contentType };
 }
 
 export function createFishAudioProvider(): TtsProvider {

--- a/assistant/src/tts/synthesis-stream.ts
+++ b/assistant/src/tts/synthesis-stream.ts
@@ -77,13 +77,6 @@ export interface SynthesisEmitResult {
   contentType: string;
 
   /**
-   * Provider-reported actual output sample rate in Hz, passed through from
-   * {@link TtsSynthesisResult.sampleRateHz}. Undefined when the provider
-   * does not report one (non-PCM output).
-   */
-  sampleRateHz?: number;
-
-  /**
    * `true` when emission was halted by an aborted `signal` or an
    * `isCurrent()` staleness flip — the silent-resolve path. Callers use
    * this instead of re-probing the signal after resolve.
@@ -182,7 +175,6 @@ export async function synthesizeAndEmit(
     return {
       emittedChunks,
       contentType: result.contentType,
-      sampleRateHz: result.sampleRateHz,
       stopped: shouldStop(),
     };
   }
@@ -200,7 +192,6 @@ export async function synthesizeAndEmit(
   return {
     emittedChunks,
     contentType: result.contentType,
-    sampleRateHz: result.sampleRateHz,
     stopped: shouldStop(),
   };
 }

--- a/assistant/src/tts/types.ts
+++ b/assistant/src/tts/types.ts
@@ -121,15 +121,6 @@ export interface TtsSynthesisResult {
 
   /** MIME type of the returned audio (e.g. `"audio/mpeg"`, `"audio/wav"`). */
   contentType: string;
-
-  /**
-   * Actual output sample rate in Hz of the returned audio, when the provider
-   * knows it (raw PCM output). Undefined for container/compressed formats
-   * whose rate is carried in the payload (mp3/wav/opus). May differ from the
-   * request's `sampleRateHz` hint when the provider cannot honour it exactly —
-   * callers that label raw PCM with a rate must use this over the hint.
-   */
-  sampleRateHz?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -210,11 +201,12 @@ export interface TtsProvider {
    * Actual PCM output sample rate in Hz that synthesizing `request` will
    * produce, when deterministically known before synthesis begins.
    *
-   * Streaming callers that label emitted chunks with a rate use this so the
-   * first chunk — delivered before the final {@link TtsSynthesisResult}
-   * resolves — carries the provider's true output rate rather than the
-   * request's `sampleRateHz` hint. Returns `undefined` for non-PCM output
-   * or when the rate is not known up-front.
+   * This up-front probe is the single source of truth for the actual output
+   * rate — {@link TtsSynthesisResult} carries no rate. Streaming callers that
+   * label emitted chunks with a rate use this so the first chunk — delivered
+   * before the final result resolves — carries the provider's true output
+   * rate rather than the request's `sampleRateHz` hint. Returns `undefined`
+   * for non-PCM output or when the rate is not known up-front.
    */
   resolveOutputSampleRateHz?(request: TtsSynthesisRequest): number | undefined;
 


### PR DESCRIPTION
## Summary
Fixes a round-2 review gap for voice-tts-streaming-latency.md.

- Drops the result-side `sampleRateHz` channel (and its never-firing late-correction branch in live-voice) — `resolveOutputSampleRateHz` is the single source of truth for actual PCM output rate
- Providers keep their deterministic rate probes; live-voice labeling behavior unchanged