### PR TITLE
fix(calls): skip fallback re-speak after mid-stream audio, share the telephony fallback-provider guard

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -3074,6 +3074,7 @@ describe("call-controller", () => {
     onSynthesizeStream?: (
       text: string,
       request: import("../tts/types.js").TtsSynthesisRequest,
+      onChunk: (chunk: Buffer) => void,
     ) => Promise<void>;
   }): { synthesizedTexts: string[] } {
     const cfg = loadConfig();
@@ -3093,7 +3094,7 @@ describe("call-controller", () => {
       },
       async synthesizeStream(request, onChunk) {
         synthesizedTexts.push(request.text);
-        await opts?.onSynthesizeStream?.(request.text, request);
+        await opts?.onSynthesizeStream?.(request.text, request, onChunk);
         onChunk(Buffer.from(`audio:${request.text}`));
         return {
           audio: Buffer.from(`audio:${request.text}`),
@@ -3341,14 +3342,50 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
+  test("synthesized provider: a mid-stream failure after the play URL went out is not re-sent natively; later segments take the native route", async () => {
+    const { synthesizedTexts } = registerFishAudioSegmentRecorder({
+      onSynthesizeStream: async (_text, _request, onChunk) => {
+        onChunk(Buffer.from("partial-audio"));
+        // Let the queued emit flush so the play URL goes out before the
+        // failure lands (mirrors a real mid-stream stall).
+        await new Promise((r) => setTimeout(r, 0));
+        throw new Error("fish-audio mid-stream failure");
+      },
+    });
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["First part is done. ", "Second part is done."]),
+    );
+    const { relay, controller } = setupController();
+
+    await controller.handleCallerUtterance("Hi");
+
+    // The failed segment's truncated audio already played, so its text is
+    // never re-sent as native tokens; later segments still take the
+    // native route.
+    expect(synthesizedTexts).toEqual(["First part is done."]);
+    expect(relay.sentPlayUrls.length).toBe(1);
+    const tokenTexts = relay.sentTokens
+      .filter((t) => t.token.length > 0)
+      .map((t) => t.token);
+    expect(tokenTexts).toEqual(["Second part is done. "]);
+    const lastToken = relay.sentTokens[relay.sentTokens.length - 1];
+    expect(lastToken).toEqual({ token: "", last: true });
+
+    controller.destroy();
+  });
+
   // ── Per-segment fallback on WAV-requiring transports ────────────────
 
   /**
    * Register a failing fish-audio primary and a recording elevenlabs
    * fallback, with fish-audio configured as the active provider. Used by
-   * the WAV-transport segment-fallback tests.
+   * the WAV-transport segment-fallback tests. With
+   * `fishEmitsChunkBeforeFailing`, the primary emits one audio chunk (so
+   * the play URL reaches the transport) before failing mid-stream.
    */
-  function registerWavFallbackProviders(): {
+  function registerWavFallbackProviders(opts?: {
+    fishEmitsChunkBeforeFailing?: boolean;
+  }): {
     fishTexts: string[];
     fallbackTexts: string[];
   } {
@@ -3384,8 +3421,15 @@ describe("call-controller", () => {
       async synthesize() {
         throw new Error("fish-audio synth failure");
       },
-      async synthesizeStream(request) {
+      async synthesizeStream(request, onChunk) {
         fishTexts.push(request.text);
+        if (opts?.fishEmitsChunkBeforeFailing) {
+          onChunk(Buffer.from("partial-fish-audio"));
+          // Let the queued emit flush so the play URL reaches the
+          // transport before the failure lands (mirrors a real
+          // mid-stream stall).
+          await new Promise((r) => setTimeout(r, 0));
+        }
         throw new Error("fish-audio stream failure");
       },
     };
@@ -3415,6 +3459,33 @@ describe("call-controller", () => {
     ]);
     expect(relay.sentPlayUrls.length).toBe(2);
     // No text routes through native tokens on a WAV transport.
+    expect(relay.sentTokens.filter((t) => t.token.length > 0)).toEqual([]);
+    const lastToken = relay.sentTokens[relay.sentTokens.length - 1];
+    expect(lastToken).toEqual({ token: "", last: true });
+
+    controller.destroy();
+  });
+
+  test("WAV transport: a mid-stream failure after audio reached the caller is not re-spoken, but later segments use the fallback", async () => {
+    const { fishTexts, fallbackTexts } = registerWavFallbackProviders({
+      fishEmitsChunkBeforeFailing: true,
+    });
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["First part is done. ", "Second part is done."]),
+    );
+    const { relay, controller } = setupController(undefined, {
+      requiresWavAudio: true,
+    });
+
+    await controller.handleCallerUtterance("Hi");
+
+    // The failed segment's play URL already went out — the caller heard
+    // its truncated audio, so a fallback re-synthesis would speak the
+    // whole segment a second time. Only later segments route through
+    // the fallback provider.
+    expect(fishTexts).toEqual(["First part is done."]);
+    expect(fallbackTexts).toEqual(["Second part is done."]);
+    expect(relay.sentPlayUrls.length).toBe(2);
     expect(relay.sentTokens.filter((t) => t.token.length > 0)).toEqual([]);
     const lastToken = relay.sentTokens[relay.sentTokens.length - 1];
     expect(lastToken).toEqual({ token: "", last: true });

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -19,7 +19,7 @@ import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
-import { getCatalogProvider, getTtsProvider } from "../tts/provider-catalog.js";
+import { getCatalogProvider } from "../tts/provider-catalog.js";
 import { extractSpeakableSegments } from "../tts/speakable-segments.js";
 import {
   type AudioStoreSink,
@@ -57,7 +57,7 @@ import { finalizeCall } from "./finalize-call.js";
 import { sendGuardianExpiryNotices } from "./guardian-action-sweep.js";
 import { dispatchGuardianQuestion } from "./guardian-dispatch.js";
 import {
-  findPlayableTelephonyTtsFallback,
+  findPlayableTelephonyTtsFallbackProvider,
   resolveCallTtsProvider,
 } from "./resolve-call-tts-provider.js";
 import type { PromptSpeakerContext } from "./speaker-identification.js";
@@ -79,16 +79,13 @@ import {
 
 const log = getLogger("call-controller");
 
-/** Look up a registered provider, returning null instead of throwing. */
-function lookupRegisteredTtsProvider(id: string): TtsProvider | null {
-  try {
-    return getTtsProvider(id);
-  } catch {
-    return null;
-  }
-}
-
 type ControllerState = "idle" | "processing" | "speaking";
+
+/** Outcome of one segment's synthesis attempt. */
+type SegmentSynthesisStatus =
+  | "ok"
+  | "failed-before-audio"
+  | "failed-after-audio";
 
 /**
  * Tracks a pending guardian input request independently of the controller's
@@ -702,11 +699,8 @@ export class CallController {
       segment: string,
     ): Promise<void> => {
       if (wavFallbackProvider === undefined) {
-        const fallbackId =
-          await findPlayableTelephonyTtsFallback(failedProviderId);
-        wavFallbackProvider = fallbackId
-          ? lookupRegisteredTtsProvider(fallbackId)
-          : null;
+        wavFallbackProvider =
+          await findPlayableTelephonyTtsFallbackProvider(failedProviderId);
         if (wavFallbackProvider) {
           log.warn(
             {
@@ -722,14 +716,16 @@ export class CallController {
           );
         }
       }
-      if (!wavFallbackProvider || !this.isCurrentRun(runVersion)) return;
-      const fallbackFailed = await this.synthesizeAndStreamAudio(
+      if (!wavFallbackProvider || !this.isCurrentRun(runVersion)) {
+        return;
+      }
+      const fallbackStatus = await this.synthesizeAndStreamAudio(
         wavFallbackProvider,
         segment,
         runVersion,
         audioFormat,
       );
-      if (fallbackFailed) {
+      if (fallbackStatus !== "ok") {
         // The fallback provider is failing too — stop retrying.
         wavFallbackProvider = null;
       }
@@ -744,15 +740,27 @@ export class CallController {
           if (!this.isCurrentRun(runVersion) || synthesisFailure) return;
           try {
             if (!synthesisFellBack) {
-              synthesisFellBack = await this.synthesizeAndStreamAudio(
+              const status = await this.synthesizeAndStreamAudio(
                 ttsProvider,
                 segment,
                 runVersion,
                 audioFormat,
               );
-              if (!synthesisFellBack || !this.transport.requiresWavAudio) {
-                // Success, abort, or the failed segment's text already
-                // went out as native tokens inside synthesizeAndStreamAudio.
+              if (status === "ok") {
+                return;
+              }
+              synthesisFellBack = true;
+              if (!this.transport.requiresWavAudio) {
+                // synthesizeAndStreamAudio already handled the failed
+                // segment: its text went out as native tokens, or its
+                // partially-played audio stands.
+                return;
+              }
+              if (status === "failed-after-audio") {
+                // The segment's play URL already reached the caller, so
+                // the truncated audio stands — a fallback re-synthesis
+                // would speak the whole segment a second time. Later
+                // segments still route through the fallback provider.
                 return;
               }
             } else if (!this.transport.requiresWavAudio) {
@@ -943,22 +951,24 @@ export class CallController {
    * Synthesize text via a streaming TTS provider and forward audio chunks
    * to Twilio through the audio store / play-URL mechanism.
    *
-   * @returns `true` when provider synthesis failed on a provider whose
-   *   catalog entry allows fallback. On transports that accept text
-   *   tokens the failed text has already been sent natively (unless its
-   *   play URL was already delivered); on WAV-requiring transports
-   *   nothing was sent — the caller owns the fallback-provider retry.
-   *   Callers keep subsequent segments off the failed provider so text
-   *   is never spoken out of order. `false` on success or abort.
-   *   Rethrows when the provider's catalog entry has
-   *   `allowNativeFallback: false`.
+   * @returns `"ok"` on success or abort. On a handled provider failure,
+   *   `"failed-before-audio"` when the segment's play URL never went out:
+   *   on transports that accept text tokens the failed text has already
+   *   been sent natively; on WAV-requiring transports nothing was sent —
+   *   the caller owns the fallback-provider retry. `"failed-after-audio"`
+   *   when the provider failed mid-stream after the play URL was
+   *   delivered: the caller hears the truncated audio and nothing more is
+   *   sent for this segment on either transport — re-speaking it would
+   *   duplicate what already played. Callers keep subsequent segments off
+   *   the failed provider so text is never spoken out of order. Rethrows
+   *   when the provider's catalog entry has `allowNativeFallback: false`.
    */
   private async synthesizeAndStreamAudio(
     provider: TtsProvider,
     text: string,
     runVersion: number,
     format: "mp3" | "wav" | "opus" = "mp3",
-  ): Promise<boolean> {
+  ): Promise<SegmentSynthesisStatus> {
     let sink: AudioStoreSink | null = null;
     let playUrlSent = false;
     const abortController = new AbortController();
@@ -1008,7 +1018,7 @@ export class CallController {
           { provider: provider.id },
           "TTS synthesis aborted (barge-in)",
         );
-        return false;
+        return "ok";
       } else {
         // Extract error class and code for diagnosable log entries.
         const errName = err instanceof Error ? err.name : String(err);
@@ -1053,7 +1063,7 @@ export class CallController {
           // the segment was trimmed at extraction.
           this.transport.sendTextToken(`${text} `, false);
         }
-        return true;
+        return playUrlSent ? "failed-after-audio" : "failed-before-audio";
       }
     } finally {
       // Identity-guarded: a late-finishing stale segment must not clear a
@@ -1063,7 +1073,7 @@ export class CallController {
       }
       sink?.finalize();
     }
-    return false;
+    return "ok";
   }
 
   /**

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -15,7 +15,7 @@
  *   via `sendPlayUrl()`.
  */
 
-import { getCatalogProvider, getTtsProvider } from "../tts/provider-catalog.js";
+import { getCatalogProvider } from "../tts/provider-catalog.js";
 import {
   type AudioStoreSink,
   createAudioStoreSink,
@@ -25,7 +25,7 @@ import type { TtsProvider, TtsProviderId } from "../tts/types.js";
 import { getLogger } from "../util/logger.js";
 import type { CallTransport } from "./call-transport.js";
 import {
-  findPlayableTelephonyTtsFallback,
+  findPlayableTelephonyTtsFallbackProvider,
   resolveCallTtsProvider,
 } from "./resolve-call-tts-provider.js";
 
@@ -182,12 +182,9 @@ async function synthesizeAndPlay(
       // back through the same synthesis path, so retry once with a
       // playable fallback provider before degrading to end-of-turn only.
       if (!isFallbackRetry) {
-        const fallbackId = await findPlayableTelephonyTtsFallback(
-          provider.id as TtsProviderId,
+        const fallbackProvider = await findPlayableTelephonyTtsFallbackProvider(
+          provider.id,
         );
-        const fallbackProvider = fallbackId
-          ? lookupRegisteredProvider(fallbackId)
-          : null;
         if (fallbackProvider) {
           log.warn(
             {
@@ -253,14 +250,5 @@ async function synthesizeAndPlay(
     relay.sendTextToken(text, true);
   } finally {
     sink?.finalize();
-  }
-}
-
-/** Look up a registered provider, returning null instead of throwing. */
-function lookupRegisteredProvider(id: string): TtsProvider | null {
-  try {
-    return getTtsProvider(id);
-  } catch {
-    return null;
   }
 }

--- a/assistant/src/calls/resolve-call-tts-provider.ts
+++ b/assistant/src/calls/resolve-call-tts-provider.ts
@@ -199,3 +199,23 @@ export async function findPlayableTelephonyTtsFallback(
   }
   return null;
 }
+
+/**
+ * Resolve {@link findPlayableTelephonyTtsFallback} to a registered
+ * provider instance. Returns `null` when no playable fallback exists or
+ * the winning candidate is not registered in the provider registry.
+ * Callers own retry semantics and logging.
+ */
+export async function findPlayableTelephonyTtsFallbackProvider(
+  excludeProviderId?: string,
+): Promise<TtsProvider | null> {
+  const fallbackId = await findPlayableTelephonyTtsFallback(excludeProviderId);
+  if (!fallbackId) {
+    return null;
+  }
+  try {
+    return getTtsProvider(fallbackId);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
Fixes round-2 review gaps for voice-tts-streaming-latency.md.

- `synthesizeAndStreamAudio` now distinguishes failed-before-audio from failed-after-audio; a segment whose play URL already reached the caller is not re-spoken by the WAV fallback (subsequent segments still route through it)
- Extracts the shared telephony fallback-provider resolution+guard into `resolve-call-tts-provider.ts`, deduplicating call-controller and call-speech-output