### PR TITLE
fix(tts): require non-whitespace content edges for italic spans in sanitizeForTts

### DIFF
--- a/assistant/src/calls/__tests__/tts-text-sanitizer.test.ts
+++ b/assistant/src/calls/__tests__/tts-text-sanitizer.test.ts
@@ -67,6 +67,28 @@ describe("sanitizeForTts", () => {
       expect(sanitizeForTts("5 * 3 = 15")).toBe("5 * 3 = 15");
     });
 
+    test("preserves multiple arithmetic asterisks in one sentence", () => {
+      expect(sanitizeForTts("5 * 3 is 15 and 4 * 2 is 8")).toBe(
+        "5 * 3 is 15 and 4 * 2 is 8",
+      );
+    });
+
+    test("strips italic whose content contains internal spaces", () => {
+      expect(sanitizeForTts("Hello *wide world* there")).toBe(
+        "Hello wide world there",
+      );
+    });
+
+    test("does not treat whitespace-padded asterisks as italic", () => {
+      expect(sanitizeForTts("Some * italic. still* done.")).toBe(
+        "Some * italic. still* done.",
+      );
+    });
+
+    test("does not treat whitespace-padded underscores as italic", () => {
+      expect(sanitizeForTts("a _ b and c_ d")).toBe("a _ b and c_ d");
+    });
+
     test("preserves identifiers with underscores", () => {
       expect(sanitizeForTts("The my_var variable")).toBe(
         "The my_var variable",

--- a/assistant/src/calls/tts-text-sanitizer.ts
+++ b/assistant/src/calls/tts-text-sanitizer.ts
@@ -55,9 +55,11 @@ export function sanitizeForTts(text: string): string {
   result = result.replace(/^[-*]\s+/gm, "");
 
   // 7. Italic: *text* or _text_ → text
-  //    Word-boundary-aware to preserve arithmetic like `5 * 3` and identifiers like `my_var`.
-  result = result.replace(/(?<!\w)\*([^*]+)\*(?!\w)/g, "$1");
-  result = result.replace(/(?<!\w)_([^_]+)_(?!\w)/g, "$1");
+  //    Word-boundary-aware with non-whitespace content edges, so arithmetic
+  //    like `5 * 3 and 4 * 2` and identifiers like `my_var` survive. Mirrors
+  //    the open-span rule in tts/speakable-segments.ts.
+  result = result.replace(/(?<!\w)\*([^\s*](?:[^*]*[^\s*])?)\*(?!\w)/g, "$1");
+  result = result.replace(/(?<!\w)_([^\s_](?:[^_]*[^\s_])?)_(?!\w)/g, "$1");
 
   // 8. Emojis: strip extended pictographic characters, variation selectors,
   //    zero-width joiners, skin tone modifiers, and regional indicator symbols (flags).

--- a/assistant/src/tts/__tests__/speakable-segments.test.ts
+++ b/assistant/src/tts/__tests__/speakable-segments.test.ts
@@ -274,6 +274,19 @@ describe("extractSpeakableSegments", () => {
       expect(remainder).toBe(" And more after it");
     });
 
+    test("whitespace-padded asterisks do not suppress sentence boundaries", () => {
+      // The sanitizer does not treat `* italic. still*` as an emphasis span
+      // either, so splitting here keeps segment-level and whole-text
+      // sanitization in agreement.
+      const { segments, remainder } = extractSpeakableSegments(
+        "Some * italic. still* done. And the next sentence keeps going",
+        false,
+      );
+
+      expect(segments).toEqual(["Some * italic.", "still* done."]);
+      expect(remainder).toBe(" And the next sentence keeps going");
+    });
+
     test("does not split at a clause boundary inside an open italic span", () => {
       const { segments, remainder } = extractSpeakableSegments(
         "*italic text that keeps going, more* and then.",


### PR DESCRIPTION
Round-3 review fix for the voice-tts-latency plan, addressing the Codex P2 on #37360 ([comment](https://github.com/vellum-ai/vellum-assistant/pull/37360#discussion_r3537545649)).

## Problem

`sanitizeForTts`'s italic rule (`(?<!\w)\*([^*]+)\*(?!\w)`) accepted spans whose content starts or ends with whitespace, while the speakable-segment span tracker from #37360 (correctly) does not. Two consequences:

1. **Whole-text vs per-segment disagreement** — for lax input like `Some * italic. still* done.`, whole-text sanitization stripped the asterisks but the segmenter split at the period, so per-segment sanitization left literal `*` to be spoken.
2. **Arithmetic mangling** — `The result of 5 * 3 is 15 and 4 * 2 is 8.` had ` 3 is 15 and 4 ` treated as an italic span, stripping both asterisks and contradicting the sanitizer's own "preserves arithmetic" contract (pre-existing bug, also on main).

## Fix

Tighten the italic and underscore rules to require non-whitespace content edges (CommonMark-style flanking), mirroring the segment tracker's rule. Whitespace-padded markers are no longer treated as emphasis by either component, so segment-level and whole-text sanitization now agree, and multi-asterisk arithmetic survives.

Verified by direct execution: all repro cases now produce identical whole-text and per-segment output; real emphasis (`*world*`, `*wide world*`, `_world_`) still stripped; `my_var` still preserved.

## Tests

- Sanitizer: multiple arithmetic asterisks, internal-space italic content, whitespace-padded `*` and `_` non-spans.
- Segmenter: whitespace-padded asterisks do not suppress sentence boundaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)