### PR TITLE
feat(plugins): add polyglot to the marketplace

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -172,6 +172,18 @@
       "category": "hobby",
       "homepage": "https://github.com/vellum-ai/astrology-horoscope",
       "license": "MIT"
+    },
+    {
+      "name": "polyglot",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/polyglot",
+        "ref": "a792cc6b8334e661d969f2966930941e77ce2a65"
+      },
+      "description": "Ambient language acquisition through your assistant. Three graduated modes (practice, ambient, immersive) weave a target language into your real conversations, with SM-2 spaced repetition, error-pattern tracking, and CEFR level history.",
+      "category": "education",
+      "homepage": "https://github.com/vellum-ai/polyglot",
+      "license": "MIT"
     }
   ]
 }


### PR DESCRIPTION
## What

Registers the **polyglot** plugin in `plugins/marketplace.json`, pinned to [`vellum-ai/polyglot@a792cc6`](https://github.com/vellum-ai/polyglot/commit/a792cc6b8334e661d969f2966930941e77ce2a65).

Ambient language acquisition through the assistant — learn a language woven into your real conversations rather than in a separate app. Three graduated modes:

- **Practice** (default) — dedicated sessions that use the learner's own life as material
- **Ambient** — the language is woven into normal conversations at increasing density as competency grows
- **Immersive** — the assistant responds primarily in the target language

Uses SM-2 spaced repetition, tracks error patterns over time, and keeps CEFR level history. All learner state lives in the plugin's own `data/` directory (gitignored in the source repo).

Composition: 6 hooks (init, user-prompt-submit, pre/post-model-call, stop, conversation-deleted), 5 tools (assess, flashcard, practice, progress, translate_ctx), 4 skills (onboarding, practice-session, ambient-mode, immersive-mode). No runtime dependencies — pure TypeScript against `@vellumai/plugin-api`.

## Shape

Standard marketplace pattern: external repo + SHA-pinned entry, no in-repo copy. Category `education`, license MIT.

## Verification (risk: low)

- `tsc --strict` (bundler resolution, `.ts` specifiers) — clean.
- Runtime smoke test under Bun: `init` loads config + creates default learner state; `polyglot_progress.execute` returns a report; the `user-prompt-submit` hook runs without throwing.
- Secret/PII scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)