### PR TITLE
fix: guardian-integrity telemetry gaps (review round 1)

### DIFF
--- a/gateway/src/__tests__/guardian-bootstrap-lookups.test.ts
+++ b/gateway/src/__tests__/guardian-bootstrap-lookups.test.ts
@@ -165,7 +165,8 @@ beforeAll(async () => {
   await initGatewayDb();
 });
 
-// Captured missing-guardian reporter detail payloads (via the log override).
+// Captured guardian-integrity reporter detail payloads (via the log
+// override): missing-guardian and mint-refused reports both land here.
 const reportCalls: Record<string, unknown>[] = [];
 
 beforeEach(() => {
@@ -403,6 +404,7 @@ describe("resolve-or-mint (resolveOrCreateVellumGuardian)", () => {
     expect(contactRows).toHaveLength(1); // no new principal row minted
     expect(reportCalls).toEqual([
       { has_contacts: true, has_actor_tokens: false },
+      { integrity_state: "missing_guardian" },
     ]);
   });
 
@@ -417,10 +419,11 @@ describe("resolve-or-mint (resolveOrCreateVellumGuardian)", () => {
     expect(getGatewayDb().select().from(contacts).all()).toHaveLength(0);
     expect(reportCalls).toEqual([
       { has_contacts: false, has_actor_tokens: true },
+      { integrity_state: "missing_guardian" },
     ]);
   });
 
-  test("refuses when a guardian contact exists but the vellum binding is inactive — no missing-guardian report", async () => {
+  test("refuses when a guardian contact exists but the vellum binding is inactive — mint-refused report fires", async () => {
     seedGuardianChannel({
       type: "vellum",
       address: "vellum-principal-stale",
@@ -433,8 +436,9 @@ describe("resolve-or-mint (resolveOrCreateVellumGuardian)", () => {
     );
 
     // Integrity state is "ok" (a guardian row exists), so the
-    // missing-guardian reporter stays quiet; the refusal is still logged.
-    expect(reportCalls).toHaveLength(0);
+    // missing-guardian reporter stays quiet — but the refusal must not be
+    // telemetry-silent: the mint-refused report fires with the state.
+    expect(reportCalls).toEqual([{ integrity_state: "ok" }]);
   });
 
   test("startup backfill recovers once the guardian is re-seeded", async () => {

--- a/gateway/src/__tests__/post-assistant-ready-deferred.test.ts
+++ b/gateway/src/__tests__/post-assistant-ready-deferred.test.ts
@@ -17,6 +17,9 @@
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { sql } from "drizzle-orm";
+
+import "./test-preload.js";
 
 type HealthResponder = () => unknown;
 
@@ -40,6 +43,19 @@ const {
   runDeferredTasksWhenAssistantReady,
   waitForAssistant,
 } = await import("../post-assistant-ready.js");
+const { initGatewayDb, getGatewayDb, resetGatewayDb } = await import(
+  "../db/connection.js"
+);
+const { contacts, contactChannels } = await import("../db/schema.js");
+const { MIGRATIONS } = await import("../db/data-migrations/index.js");
+const { bustGuardianIntegrityCache } = await import(
+  "../auth/guardian-integrity.js"
+);
+const {
+  resetGuardianIntegrityReporterForTesting,
+  setGuardianIntegrityReporterOverridesForTesting,
+} = await import("../guardian-integrity-reporter.js");
+const { seedContact } = await import("./helpers/contact-fixtures.js");
 
 const MIGRATING_HEALTH = {
   status: "MIGRATING",
@@ -101,6 +117,44 @@ describe("runDeferredTasksWhenAssistantReady", () => {
     expect(ready).toBe(false);
     // Nowhere near the 5-minute deadline (or even one 2s poll interval).
     expect(Date.now() - started).toBeLessThan(1_500);
+  });
+
+  test("real deferred run resolves when the guardian backfill refuses to mint", async () => {
+    await initGatewayDb();
+    try {
+      // Pre-record every data-migration key so the real executor's migration
+      // step no-ops against the test DB — the refusing guardian backfill is
+      // the code under test.
+      for (const { key } of MIGRATIONS) {
+        getGatewayDb().run(
+          sql`INSERT OR IGNORE INTO one_time_migrations (key, ran_at) VALUES (${key}, ${Date.now()})`,
+        );
+      }
+      // Evidence of prior onboarding with no guardian row →
+      // ensureVellumGuardianBinding throws VellumGuardianMintRefusedError.
+      seedContact({ id: "invited-contact" });
+      bustGuardianIntegrityCache();
+      setGuardianIntegrityReporterOverridesForTesting({
+        fetchImpl: async () => new Response("{}"),
+        mintToken: () => "svc-token",
+        baseUrl: "http://127.0.0.1:7821",
+        log: { error: () => {}, warn: () => {} },
+      });
+      resetPostAssistantReadyForTest(); // restore the REAL executor
+
+      // The refusal is warn-and-continue inside the executor: the deferred
+      // run resolves instead of rejecting or crashing boot.
+      await runDeferredTasksWhenAssistantReady(5);
+
+      // Refused, not minted: no vellum guardian binding appeared.
+      expect(
+        getGatewayDb().select().from(contactChannels).all(),
+      ).toHaveLength(0);
+      expect(getGatewayDb().select().from(contacts).all()).toHaveLength(1);
+    } finally {
+      resetGuardianIntegrityReporterForTesting();
+      resetGatewayDb();
+    }
   });
 
   test("stops polling immediately once the tasks have run elsewhere", async () => {

--- a/gateway/src/__tests__/trust-verdict-resolver-guardian-integrity.test.ts
+++ b/gateway/src/__tests__/trust-verdict-resolver-guardian-integrity.test.ts
@@ -4,15 +4,16 @@
  *  - Onboarded-evidence DB with zero guardian rows → every `unknown`
  *    classification carries `resolutionFailed: true` (consumers fail closed).
  *  - Non-unknown classifications (e.g. an intact trusted contact) are never
- *    stamped by the integrity check.
+ *    stamped by the integrity check, but they still evaluate the state — the
+ *    fail-loud reporter fires on member traffic too, not just strangers.
  *  - Fresh install and healthy (guardian present) install → verdicts
  *    unchanged, no `resolutionFailed`.
  *  - A thrown integrity check degrades to the plain unknown verdict — no
  *    crash, no stamp.
  *
- * The fail-loud reporter is silenced through its test-only overrides so no
- * relay or log leaves the test process (bun's mock.module is process-global
- * and would leak into other test files).
+ * The fail-loud reporter is silenced/observed through its test-only overrides
+ * so no relay or log leaves the test process (bun's mock.module is
+ * process-global and would leak into other test files).
  */
 import { beforeEach, afterEach, describe, expect, test } from "bun:test";
 import { sql } from "drizzle-orm";
@@ -71,6 +72,9 @@ function insertChannel(args: {
     .run();
 }
 
+// Captured reporter detail payloads (via the log-override seam).
+const reportCalls: Record<string, unknown>[] = [];
+
 beforeEach(async () => {
   resetGatewayDb();
   await initGatewayDb();
@@ -79,12 +83,18 @@ beforeEach(async () => {
   getGatewayDb().delete(actorTokenRecords).run();
   getGatewayDb().delete(actorRefreshTokenRecords).run();
   bustGuardianIntegrityCache();
+  reportCalls.length = 0;
   resetGuardianIntegrityReporterForTesting();
   setGuardianIntegrityReporterOverridesForTesting({
     fetchImpl: async () => new Response("{}"),
     mintToken: () => "svc-token",
     baseUrl: "http://127.0.0.1:7821",
-    log: { error: () => {}, warn: () => {} },
+    log: {
+      error: (detail) => {
+        reportCalls.push(detail);
+      },
+      warn: () => {},
+    },
   });
 });
 
@@ -125,7 +135,7 @@ describe("missing-guardian state (evidence, zero guardian rows)", () => {
     expect(verdict.resolutionFailed).toBe(true);
   });
 
-  test("intact trusted contact still classifies without a stamp", async () => {
+  test("intact trusted contact classifies without a stamp but fires the reporter", async () => {
     seedContact({ id: "c1" });
     insertChannel({ id: "ch1", contactId: "c1", address: "U_MEMBER" });
 
@@ -134,8 +144,13 @@ describe("missing-guardian state (evidence, zero guardian rows)", () => {
       actorExternalId: "U_MEMBER",
     });
 
+    // Member admission is unchanged — no resolutionFailed on the verdict —
+    // but detection is traffic-independent: member traffic alone reports.
     expect(verdict.trustClass).toBe("trusted_contact");
     expect(verdict.resolutionFailed).toBeUndefined();
+    expect(reportCalls).toEqual([
+      { has_contacts: true, has_actor_tokens: false },
+    ]);
   });
 });
 
@@ -164,6 +179,7 @@ describe("healthy and fresh installs are unaffected", () => {
 
     expect(verdict.trustClass).toBe("guardian");
     expect(verdict.resolutionFailed).toBeUndefined();
+    expect(reportCalls).toHaveLength(0);
   });
 
   test("fresh empty DB: stranger stays plain unknown", async () => {
@@ -174,6 +190,7 @@ describe("healthy and fresh installs are unaffected", () => {
 
     expect(verdict.trustClass).toBe("unknown");
     expect(verdict.resolutionFailed).toBeUndefined();
+    expect(reportCalls).toHaveLength(0);
   });
 });
 

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -20,6 +20,7 @@ import {
 import { readCredential } from "../credential-reader.js";
 import { credentialKey } from "../credential-key.js";
 import { arePlatformFeaturesEnabled } from "../feature-flag-resolver.js";
+import { reportGuardianMintRefused } from "../guardian-integrity-reporter.js";
 import { ipcCallAssistant } from "../ipc/assistant-client.js";
 import { getLogger } from "../logger.js";
 import { deleteContactIfOrphaned } from "../verification/contact-helpers.js";
@@ -804,8 +805,19 @@ async function resolveOrCreateVellumGuardian(options: {
   const priorEvidence = hasEvidenceOfPriorGuardian();
   if (priorEvidence && !options.allowMintWithEvidence) {
     // Fires the missing-guardian reporter (error log + telemetry,
-    // rate-limited there) when the DB is truly guardian-less.
-    guardianIntegrityState();
+    // rate-limited there) when the DB is truly guardian-less. The state is
+    // `ok` when a guardian contact row survives with a lost/inactive vellum
+    // binding, so the refusal reports under its own check_name either way —
+    // clients see guardian_repair_required 401s and that must never be
+    // telemetry-silent. Best-effort: the refusal itself must not depend on
+    // the integrity check.
+    let integrityState = "unavailable";
+    try {
+      integrityState = guardianIntegrityState();
+    } catch {
+      // Reported as "unavailable"; refusal proceeds regardless.
+    }
+    reportGuardianMintRefused({ integrity_state: integrityState });
     log.error(
       "no active vellum guardian binding but the gateway DB carries evidence of prior onboarding — refusing to mint a divergent principal; re-pair via guardian init to recover",
     );

--- a/gateway/src/guardian-integrity-reporter.ts
+++ b/gateway/src/guardian-integrity-reporter.ts
@@ -1,10 +1,13 @@
-// Fail-loud reporting for a gateway DB that has lost its guardian rows while
-// carrying evidence of prior onboarding (see auth/guardian-integrity.ts).
-// Emits an error-level log and relays a `gateway_guardian_missing` watchdog
+// Fail-loud reporting for guardian-integrity failures: a gateway DB that has
+// lost its guardian rows while carrying evidence of prior onboarding
+// (`gateway_guardian_missing`, see auth/guardian-integrity.ts) and a refused
+// vellum-guardian mint (`gateway_guardian_mint_refused`, see
+// auth/guardian-bootstrap.ts). Emits an error-level log and relays a watchdog
 // telemetry event to the daemon's internal telemetry route, which POSTs it
 // directly to platform ingest — bypassing any state owned by the broken trust
-// path so the alarm cannot suppress itself. Rate-limited per process; a lost
-// event is acceptable for a rare, high-signal check (no retry).
+// path so the alarm cannot suppress itself. Rate-limited per check_name per
+// process; a lost event is acceptable for a rare, high-signal check (no
+// retry).
 
 import { loadConfig } from "./config.js";
 import type { fetchImpl } from "./fetch.js";
@@ -18,6 +21,14 @@ const log = getLogger("guardian-integrity-reporter");
  * dashboards filter on this exact string — it is the cross-repo contract.
  */
 export const GUARDIAN_MISSING_CHECK_NAME = "gateway_guardian_missing";
+
+/**
+ * Watchdog `check_name` for a refused vellum-guardian mint (evidence of a
+ * prior guardian, no active vellum binding). Fires even when the integrity
+ * state is `ok` — a guardian contact row can be intact while the vellum
+ * binding is lost/inactive, and clients see `guardian_repair_required` 401s.
+ */
+export const GUARDIAN_MINT_REFUSED_CHECK_NAME = "gateway_guardian_mint_refused";
 
 const ROUTE_PATH = "/v1/internal/telemetry/watchdog";
 const REPORT_INTERVAL_MS = 60 * 60 * 1000;
@@ -35,7 +46,7 @@ type ReporterOverrides = {
 };
 
 let overrides: ReporterOverrides = {};
-let lastReportAt = Number.NEGATIVE_INFINITY;
+const lastReportAtByCheck = new Map<string, number>();
 let pendingRelay: Promise<unknown> = Promise.resolve();
 
 /**
@@ -45,38 +56,70 @@ let pendingRelay: Promise<unknown> = Promise.resolve();
  * re-fire it). Fire-and-forget — never throws, never blocks the caller.
  */
 export function reportMissingGuardian(detail: Record<string, unknown>): void {
+  report(
+    GUARDIAN_MISSING_CHECK_NAME,
+    "gateway DB has no guardian rows but evidence of prior onboarding — " +
+      "trust verdicts will fail closed until the guardian is re-seeded",
+    detail,
+  );
+}
+
+/**
+ * Report a refused vellum-guardian mint: error log + telemetry relay. Same
+ * per-check rate limiting and fire-and-forget semantics as
+ * {@link reportMissingGuardian}; the sibling check_name distinguishes the
+ * vellum-binding-lost-but-contact-intact refusal, which the missing-guardian
+ * state check cannot see.
+ */
+export function reportGuardianMintRefused(
+  detail: Record<string, unknown>,
+): void {
+  report(
+    GUARDIAN_MINT_REFUSED_CHECK_NAME,
+    "refused to mint a vellum guardian principal over evidence of a prior " +
+      "guardian — clients get guardian_repair_required until re-pair",
+    detail,
+  );
+}
+
+function report(
+  checkName: string,
+  message: string,
+  detail: Record<string, unknown>,
+): void {
   const now = Date.now();
+  const lastReportAt =
+    lastReportAtByCheck.get(checkName) ?? Number.NEGATIVE_INFINITY;
   if (now - lastReportAt < REPORT_INTERVAL_MS) {
     return;
   }
-  lastReportAt = now;
+  lastReportAtByCheck.set(checkName, now);
 
-  reporterLog().error(
-    detail,
-    "gateway DB has no guardian rows but evidence of prior onboarding — " +
-      "trust verdicts will fail closed until the guardian is re-seeded",
-  );
+  reporterLog().error(detail, message);
 
-  pendingRelay = relayToDaemon(detail).catch((err) => {
+  pendingRelay = relayToDaemon(checkName, detail).catch((err) => {
     reporterLog().warn(
-      { err },
-      "guardian-missing telemetry relay failed (non-fatal)",
+      { err, checkName },
+      "guardian-integrity telemetry relay failed (non-fatal)",
     );
   });
 }
 
-async function relayToDaemon(detail: Record<string, unknown>): Promise<void> {
+async function relayToDaemon(
+  checkName: string,
+  detail: Record<string, unknown>,
+): Promise<void> {
   const resp = await postInternalTelemetry({
     baseUrl: overrides.baseUrl ?? loadConfig().assistantRuntimeBaseUrl,
     path: ROUTE_PATH,
-    body: { check_name: GUARDIAN_MISSING_CHECK_NAME, detail },
+    body: { check_name: checkName, detail },
     fetchImpl: overrides.fetchImpl,
     mintToken: overrides.mintToken,
   });
   if (!resp.ok) {
     reporterLog().warn(
-      { status: resp.status },
-      "guardian-missing telemetry relay rejected (non-fatal)",
+      { status: resp.status, checkName },
+      "guardian-integrity telemetry relay rejected (non-fatal)",
     );
   }
 }
@@ -95,10 +138,10 @@ export function setGuardianIntegrityReporterOverridesForTesting(
   overrides = next;
 }
 
-/** Test-only: clear overrides and the rate-limit window. */
+/** Test-only: clear overrides and the rate-limit windows. */
 export function resetGuardianIntegrityReporterForTesting(): void {
   overrides = {};
-  lastReportAt = Number.NEGATIVE_INFINITY;
+  lastReportAtByCheck.clear();
   pendingRelay = Promise.resolve();
 }
 

--- a/gateway/src/risk/trust-verdict-resolver.ts
+++ b/gateway/src/risk/trust-verdict-resolver.ts
@@ -207,18 +207,23 @@ export async function resolveTrustVerdict(
   const verdict: TrustVerdict = { trustClass, canonicalSenderId };
 
   // A gateway DB that has lost its guardian rows (but shows evidence of prior
-  // onboarding) misclassifies every sender as a plain stranger. Stamp
-  // `resolutionFailed` so consumers fail closed with no stranger-lane side
-  // effects. Best-effort: a thrown integrity check degrades to the plain
-  // unknown verdict rather than breaking resolution.
-  if (trustClass === "unknown") {
-    try {
-      if (guardianIntegrityState() === "missing_guardian") {
-        verdict.resolutionFailed = true;
-      }
-    } catch {
-      // Plain unknown verdict; integrity detection must never break resolution.
+  // onboarding) misclassifies every sender as a plain stranger. Evaluate the
+  // integrity state (TTL-cached) on EVERY resolve so detection/reporting is
+  // traffic-independent — intact contact rows classify members normally and
+  // would otherwise keep the fail-loud reporter silent until a stranger
+  // messages. Only `unknown` classifications get the `resolutionFailed` stamp
+  // (consumers fail closed with no stranger-lane side effects); member
+  // admission is unchanged. Best-effort: a thrown integrity check degrades to
+  // the plain verdict rather than breaking resolution.
+  try {
+    if (
+      guardianIntegrityState() === "missing_guardian" &&
+      trustClass === "unknown"
+    ) {
+      verdict.resolutionFailed = true;
     }
+  } catch {
+    // Plain verdict; integrity detection must never break resolution.
   }
 
   // Session-presence stamp (channel-scoped): lets the daemon's deny branches


### PR DESCRIPTION
## Summary
Fixes self-review gaps for acl-hardening-sweep.md: integrity detection no longer depends on stranger traffic (state evaluated every resolve; resolutionFailed stamp still unknown-scoped), the vellum-binding-lost-but-contact-intact mint refusal now emits telemetry, and the refusing-boot-completes posture is pinned by test