### PR TITLE
Real-time TTS streaming for hands-free voice and phone calls

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -3197,6 +3197,23 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
+  test("synthesized provider: markdown spanning delta boundaries is stripped before synthesis", async () => {
+    const { synthesizedTexts } = registerFishAudioSegmentRecorder();
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["This is **very", " important**. Please note it."]),
+    );
+    const { controller } = setupController();
+
+    await controller.handleCallerUtterance("Hi");
+
+    expect(synthesizedTexts).toEqual([
+      "This is very important.",
+      "Please note it.",
+    ]);
+
+    controller.destroy();
+  });
+
   test("synthesized provider: barge-in mid-turn stops subsequent segment synthesis", async () => {
     let releaseFirst: (() => void) | undefined;
     const firstGate = new Promise<void>((r) => {

--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -92,9 +92,19 @@ mock.module("../config/loader.js", () => {
 
 // ── Credential mock (prevents real key lookups) ──────────────────────
 
+// Provider API keys resolve by default so telephony playability checks
+// (WAV-transport tests) can select providers; tests can narrow the
+// resolvable set. Reset to null (all resolve) in beforeEach.
+let mockResolvableProviderKeys: ((service: string) => string | null) | null =
+  null;
+
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async () => null,
   getSecureKey: () => null,
+  getProviderKeyAsync: async (service: string) =>
+    mockResolvableProviderKeys
+      ? mockResolvableProviderKeys(service)
+      : "test-key",
 }));
 
 mock.module("../security/credential-key.js", () => ({
@@ -398,6 +408,8 @@ function setupController(
   opts?: {
     assistantId?: string;
     trustContext?: import("../daemon/trust-context.js").TrustContext;
+    /** Simulate the media-stream transport's WAV requirement. */
+    requiresWavAudio?: boolean;
   },
 ) {
   ensureConversation("conv-ctrl-test");
@@ -410,6 +422,9 @@ function setupController(
   });
   updateCallSession(session.id, { status: "in_progress" });
   const transport = createMockTransport();
+  if (opts?.requiresWavAudio) {
+    Object.assign(transport, { requiresWavAudio: true });
+  }
   const controller = new CallController(session.id, transport, task ?? null, {
     assistantId: opts?.assistantId,
     trustContext: opts?.trustContext,
@@ -483,6 +498,7 @@ describe("call-controller", () => {
     cfg.services.tts.provider = "elevenlabs";
     cfg.services.tts.providers["fish-audio"].referenceId = "";
     cfg.ingress.publicBaseUrl = "https://generic.example.com";
+    mockResolvableProviderKeys = null;
     // Reset TTS provider registry to ensure clean state
     registerTestTtsProviders();
   });
@@ -3311,11 +3327,121 @@ describe("call-controller", () => {
       .filter((t) => t.token.length > 0)
       .map((t) => t.token);
     expect(tokenTexts).toEqual([
+      "First part is done. ",
+      "Second part is done. ",
+    ]);
+    // Trimmed segments carry a separator so back-to-back tokens never
+    // fuse into "…done.Second part…".
+    expect(tokenTexts.join("")).toContain("done. Second");
+    expect(relay.sentPlayUrls.length).toBe(0);
+    // End-of-turn still fires after the chain drains.
+    const lastToken = relay.sentTokens[relay.sentTokens.length - 1];
+    expect(lastToken).toEqual({ token: "", last: true });
+
+    controller.destroy();
+  });
+
+  // ── Per-segment fallback on WAV-requiring transports ────────────────
+
+  /**
+   * Register a failing fish-audio primary and a recording elevenlabs
+   * fallback, with fish-audio configured as the active provider. Used by
+   * the WAV-transport segment-fallback tests.
+   */
+  function registerWavFallbackProviders(): {
+    fishTexts: string[];
+    fallbackTexts: string[];
+  } {
+    const cfg = loadConfig();
+    cfg.services.tts.provider = "fish-audio";
+    cfg.services.tts.providers["fish-audio"].referenceId = "fish-ref-123";
+
+    _resetTtsProviderOverridesForTests();
+    const fallbackTexts: string[] = [];
+    const elevenlabs: TtsProvider = {
+      id: "elevenlabs",
+      capabilities: {
+        supportsStreaming: false,
+        supportedFormats: ["mp3", "wav", "opus"],
+      },
+      async synthesize(request) {
+        fallbackTexts.push(request.text);
+        return {
+          audio: Buffer.from("fallback-audio"),
+          contentType: "audio/pcm",
+        };
+      },
+    };
+    _setTtsProviderForTests(elevenlabs);
+
+    const fishTexts: string[] = [];
+    const fishAudioFailing: TtsProvider = {
+      id: "fish-audio",
+      capabilities: {
+        supportsStreaming: true,
+        supportedFormats: ["mp3", "wav", "opus"],
+      },
+      async synthesize() {
+        throw new Error("fish-audio synth failure");
+      },
+      async synthesizeStream(request) {
+        fishTexts.push(request.text);
+        throw new Error("fish-audio stream failure");
+      },
+    };
+    _setTtsProviderForTests(fishAudioFailing);
+
+    return { fishTexts, fallbackTexts };
+  }
+
+  test("WAV transport: a failed segment and the rest of the turn synthesize via a playable fallback provider", async () => {
+    const { fishTexts, fallbackTexts } = registerWavFallbackProviders();
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["First part is done. ", "Second part is done."]),
+    );
+    const { relay, controller } = setupController(undefined, {
+      requiresWavAudio: true,
+    });
+
+    await controller.handleCallerUtterance("Hi");
+
+    // The primary provider is tried once; the failed segment and all
+    // subsequent segments retry through the fallback provider, so the
+    // caller hears the whole turn instead of partial speech then silence.
+    expect(fishTexts).toEqual(["First part is done."]);
+    expect(fallbackTexts).toEqual([
       "First part is done.",
       "Second part is done.",
     ]);
+    expect(relay.sentPlayUrls.length).toBe(2);
+    // No text routes through native tokens on a WAV transport.
+    expect(relay.sentTokens.filter((t) => t.token.length > 0)).toEqual([]);
+    const lastToken = relay.sentTokens[relay.sentTokens.length - 1];
+    expect(lastToken).toEqual({ token: "", last: true });
+
+    controller.destroy();
+  });
+
+  test("WAV transport: when no playable fallback exists, failed segments are skipped and end-of-turn still fires", async () => {
+    // Only fish-audio's key resolves, so the fallback scan finds nothing.
+    mockResolvableProviderKeys = (service) =>
+      service === "fish-audio" ? "test-key" : null;
+    const { fishTexts, fallbackTexts } = registerWavFallbackProviders();
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["First part is done. ", "Second part is done."]),
+    );
+    const { relay, controller } = setupController(undefined, {
+      requiresWavAudio: true,
+    });
+
+    await controller.handleCallerUtterance("Hi");
+
+    expect(fishTexts).toEqual(["First part is done."]);
+    expect(fallbackTexts).toEqual([]);
     expect(relay.sentPlayUrls.length).toBe(0);
-    // End-of-turn still fires after the chain drains.
+    // Native tokens are never used on a WAV transport, and the turn
+    // still closes with the end-of-turn signal.
+    expect(relay.sentTokens.filter((t) => t.token.length > 0)).toEqual([]);
     const lastToken = relay.sentTokens[relay.sentTokens.length - 1];
     expect(lastToken).toEqual({ token: "", last: true });
 
@@ -3665,6 +3791,56 @@ describe("call-controller", () => {
 
       controller.destroy();
       await turnPromise.catch(() => {});
+    });
+
+    test("buffering transport: a caller utterance during processing cancels the transport's pending speech", async () => {
+      let releaseTurn!: () => void;
+      const completeGate = new Promise<void>((r) => {
+        releaseTurn = r;
+      });
+      let turnCalls = 0;
+      mockStartVoiceTurn.mockImplementation(
+        async (opts: {
+          onTextDelta: (t: string) => void;
+          onComplete: () => void;
+          signal?: AbortSignal;
+        }) => {
+          turnCalls++;
+          if (turnCalls === 1) {
+            opts.onTextDelta("Queued sentence one. Queued sentence two.");
+            opts.signal?.addEventListener("abort", () => releaseTurn());
+            await completeGate;
+            opts.onComplete();
+            return { turnId: "run-cancel-1", abort: () => releaseTurn() };
+          }
+          opts.onTextDelta("Second turn reply.");
+          opts.onComplete();
+          return { turnId: "run-cancel-2", abort: () => {} };
+        },
+      );
+
+      const { relay, controller } = setupController();
+      let cancelledPendingSpeech = 0;
+      // Buffering transport: audio never starts, so the first turn stays
+      // in `processing` with its sentences already queued for synthesis.
+      relay.setAudioStartCallback = () => {};
+      relay.cancelPendingSpeech = () => {
+        cancelledPendingSpeech++;
+      };
+
+      const turn1 = controller.handleCallerUtterance("Hi");
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      expect(controller.getState()).toBe("processing");
+      expect(cancelledPendingSpeech).toBe(0);
+
+      // The caller speaks again before any audio played — the aborted
+      // turn's queued speech must be cancelled so it cannot play over
+      // the new turn.
+      await controller.handleCallerUtterance("Actually, wait");
+      expect(cancelledPendingSpeech).toBeGreaterThan(0);
+
+      await turn1.catch(() => {});
+      controller.destroy();
     });
 
     test("buffering transport: stale audio-start signal from a superseded run does not flip state", async () => {

--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -3052,6 +3052,276 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
+  // ── Incremental per-segment synthesis (synthesized-play path) ───────
+
+  function registerFishAudioSegmentRecorder(opts?: {
+    onSynthesizeStream?: (
+      text: string,
+      request: import("../tts/types.js").TtsSynthesisRequest,
+    ) => Promise<void>;
+  }): { synthesizedTexts: string[] } {
+    const cfg = loadConfig();
+    cfg.services.tts.provider = "fish-audio";
+    cfg.services.tts.providers["fish-audio"].referenceId = "fish-ref-123";
+
+    _resetTtsProviderOverridesForTests();
+    const synthesizedTexts: string[] = [];
+    const fishAudioStreaming: TtsProvider = {
+      id: "fish-audio",
+      capabilities: {
+        supportsStreaming: true,
+        supportedFormats: ["mp3", "wav", "opus"],
+      },
+      async synthesize() {
+        return { audio: Buffer.from("audio"), contentType: "audio/mpeg" };
+      },
+      async synthesizeStream(request, onChunk) {
+        synthesizedTexts.push(request.text);
+        await opts?.onSynthesizeStream?.(request.text, request);
+        onChunk(Buffer.from(`audio:${request.text}`));
+        return {
+          audio: Buffer.from(`audio:${request.text}`),
+          contentType: "audio/mpeg",
+        };
+      },
+    };
+    _setTtsProviderForTests(fishAudioStreaming);
+    return { synthesizedTexts };
+  }
+
+  test("synthesized provider: segments synthesize during the stream — first play URL before turn completion", async () => {
+    const { synthesizedTexts } = registerFishAudioSegmentRecorder();
+    const { relay, controller } = setupController();
+
+    let playUrlsAtTurnCompletion = -1;
+    mockStartVoiceTurn.mockImplementation(
+      async (opts: {
+        onTextDelta: (t: string) => void;
+        onComplete: () => void;
+      }) => {
+        opts.onTextDelta("First sentence done. ");
+        // The first segment's play URL must reach the transport while the
+        // LLM turn is still streaming.
+        await pollUntil(() => relay.sentPlayUrls.length > 0);
+        opts.onTextDelta("Second sentence follows.");
+        playUrlsAtTurnCompletion = relay.sentPlayUrls.length;
+        opts.onComplete();
+        return { turnId: "run-incremental", abort: () => {} };
+      },
+    );
+
+    await controller.handleCallerUtterance("Hi");
+
+    expect(playUrlsAtTurnCompletion).toBe(1);
+    expect(synthesizedTexts).toEqual([
+      "First sentence done.",
+      "Second sentence follows.",
+    ]);
+    expect(relay.sentPlayUrls.length).toBe(2);
+    // End-of-turn signal fires only after the synthesis chain drains.
+    const lastToken = relay.sentTokens[relay.sentTokens.length - 1];
+    expect(lastToken).toEqual({ token: "", last: true });
+
+    controller.destroy();
+  });
+
+  test("synthesized provider: segments synthesize serially in order even when the first is slow", async () => {
+    const events: string[] = [];
+    registerFishAudioSegmentRecorder({
+      onSynthesizeStream: async (text) => {
+        events.push(`start:${text}`);
+        if (text.startsWith("One")) {
+          await new Promise((r) => setTimeout(r, 20));
+        }
+        events.push(`emit:${text}`);
+      },
+    });
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["One is here. ", "Two is here."]),
+    );
+    const { relay, controller } = setupController();
+
+    await controller.handleCallerUtterance("Hi");
+
+    // Serialized chain: the second segment must not start until the first
+    // finished, so play URLs hit the transport FIFO in segment order.
+    expect(events).toEqual([
+      "start:One is here.",
+      "emit:One is here.",
+      "start:Two is here.",
+      "emit:Two is here.",
+    ]);
+    expect(relay.sentPlayUrls.length).toBe(2);
+
+    controller.destroy();
+  });
+
+  test("synthesized provider: a control marker spanning delta boundaries is never synthesized", async () => {
+    const { synthesizedTexts } = registerFishAudioSegmentRecorder();
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn([
+        "Let me check that for you. [ASK_GUARD",
+        "IAN: What time works?] One moment.",
+      ]),
+    );
+    const { session, controller } = setupController();
+
+    await controller.handleCallerUtterance("Hi");
+
+    expect(synthesizedTexts).toEqual([
+      "Let me check that for you.",
+      "One moment.",
+    ]);
+    // The consultation is still dispatched from the full response text.
+    expect(getPendingQuestion(session.id)?.questionText).toBe(
+      "What time works?",
+    );
+
+    controller.destroy();
+  });
+
+  test("synthesized provider: barge-in mid-turn stops subsequent segment synthesis", async () => {
+    let releaseFirst: (() => void) | undefined;
+    const firstGate = new Promise<void>((r) => {
+      releaseFirst = r;
+    });
+    const { synthesizedTexts } = registerFishAudioSegmentRecorder({
+      // Block the first segment mid-synthesis (ignoring the abort signal)
+      // so the barge-in lands while later segments are still queued.
+      onSynthesizeStream: () => firstGate,
+    });
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["One is done. ", "Two is done. ", "Three is done."]),
+    );
+    const { relay, controller } = setupController();
+
+    const turn = controller.handleCallerUtterance("Hi");
+    await pollUntil(() => synthesizedTexts.length === 1);
+
+    controller.handleInterrupt();
+    releaseFirst?.();
+    await turn;
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Queued segments never synthesize after the barge-in, and the aborted
+    // first segment's late audio never reaches the caller.
+    expect(synthesizedTexts).toEqual(["One is done."]);
+    expect(relay.sentPlayUrls.length).toBe(0);
+
+    controller.destroy();
+  });
+
+  test("synthesized provider: a late-finishing stale segment neither clobbers the new turn's abort handle nor emits audio", async () => {
+    let releaseStale: (() => void) | undefined;
+    const staleGate = new Promise<void>((r) => {
+      releaseStale = r;
+    });
+    let newTurnAborted = false;
+    const { synthesizedTexts } = registerFishAudioSegmentRecorder({
+      onSynthesizeStream: async (text, request) => {
+        if (text.startsWith("Old")) {
+          // Stale turn's provider ignores the abort and finishes late.
+          await staleGate;
+          return;
+        }
+        // New turn's provider hangs until its own abort signal fires.
+        await new Promise<void>((resolve) => {
+          request.signal?.addEventListener(
+            "abort",
+            () => {
+              newTurnAborted = true;
+              resolve();
+            },
+            { once: true },
+          );
+        });
+        const err = new Error("aborted");
+        err.name = "AbortError";
+        throw err;
+      },
+    });
+    let voiceTurnCalls = 0;
+    mockStartVoiceTurn.mockImplementation(
+      async (opts: { onTextDelta: (t: string) => void }) => {
+        voiceTurnCalls++;
+        opts.onTextDelta(
+          voiceTurnCalls === 1 ? "Old news here. " : "New reply here. ",
+        );
+        // Hold the turn open; barge-in resolves it via the abort listener.
+        return { turnId: `run-clobber-${voiceTurnCalls}`, abort: () => {} };
+      },
+    );
+    const { relay, controller } = setupController();
+
+    const turn1 = controller.handleCallerUtterance("Hi");
+    let turn1Settled = false;
+    void turn1.finally(() => {
+      turn1Settled = true;
+    });
+    await pollUntil(() => synthesizedTexts.length === 1);
+
+    // Barge-in while the first segment's synthesis is still in flight.
+    controller.handleInterrupt();
+
+    // The stale run drains its chain before settling, so the interrupted
+    // turn stays pending until its hung segment resolves.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(turn1Settled).toBe(false);
+
+    // Start the next turn while the stale segment is still in flight.
+    const turn2 = controller.handleUserInstruction("follow up");
+    await pollUntil(() => synthesizedTexts.length === 2);
+
+    // The stale segment finishes late — after the new turn registered its
+    // own abort handle.
+    releaseStale?.();
+    await turn1;
+
+    // A barge-in on the NEW turn must still abort its in-flight synthesis:
+    // the stale segment's completion must not have cleared the handle.
+    controller.handleInterrupt();
+    await pollUntil(() => newTurnAborted);
+    await turn2;
+
+    expect(synthesizedTexts).toEqual(["Old news here.", "New reply here."]);
+    // Neither the stale segment's late chunk nor the aborted new segment
+    // ever reaches the caller.
+    expect(relay.sentPlayUrls.length).toBe(0);
+
+    controller.destroy();
+  });
+
+  test("synthesized provider: after a segment synthesis failure, remaining segments take the native fallback in order", async () => {
+    const { synthesizedTexts } = registerFishAudioSegmentRecorder({
+      onSynthesizeStream: async () => {
+        throw new Error("fish-audio stream failure");
+      },
+    });
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["First part is done. ", "Second part is done."]),
+    );
+    const { relay, controller } = setupController();
+
+    await controller.handleCallerUtterance("Hi");
+
+    // Only the first segment attempts synthesis; the rest short-circuit to
+    // the native route so text is never dropped, duplicated, or reordered.
+    expect(synthesizedTexts).toEqual(["First part is done."]);
+    const tokenTexts = relay.sentTokens
+      .filter((t) => t.token.length > 0)
+      .map((t) => t.token);
+    expect(tokenTexts).toEqual([
+      "First part is done.",
+      "Second part is done.",
+    ]);
+    expect(relay.sentPlayUrls.length).toBe(0);
+    // End-of-turn still fires after the chain drains.
+    const lastToken = relay.sentTokens[relay.sentTokens.length - 1];
+    expect(lastToken).toEqual({ token: "", last: true });
+
+    controller.destroy();
+  });
+
   // ── TTS provider abstraction: interruption behavior ─────────────────
 
   test("handleInterrupt: cancels synthesis abort controller for native provider path", async () => {

--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -3074,6 +3074,7 @@ describe("call-controller", () => {
     onSynthesizeStream?: (
       text: string,
       request: import("../tts/types.js").TtsSynthesisRequest,
+      onChunk: (chunk: Buffer) => void,
     ) => Promise<void>;
   }): { synthesizedTexts: string[] } {
     const cfg = loadConfig();
@@ -3093,7 +3094,7 @@ describe("call-controller", () => {
       },
       async synthesizeStream(request, onChunk) {
         synthesizedTexts.push(request.text);
-        await opts?.onSynthesizeStream?.(request.text, request);
+        await opts?.onSynthesizeStream?.(request.text, request, onChunk);
         onChunk(Buffer.from(`audio:${request.text}`));
         return {
           audio: Buffer.from(`audio:${request.text}`),
@@ -3341,14 +3342,50 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
+  test("synthesized provider: a mid-stream failure after the play URL went out is not re-sent natively; later segments take the native route", async () => {
+    const { synthesizedTexts } = registerFishAudioSegmentRecorder({
+      onSynthesizeStream: async (_text, _request, onChunk) => {
+        onChunk(Buffer.from("partial-audio"));
+        // Let the queued emit flush so the play URL goes out before the
+        // failure lands (mirrors a real mid-stream stall).
+        await new Promise((r) => setTimeout(r, 0));
+        throw new Error("fish-audio mid-stream failure");
+      },
+    });
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["First part is done. ", "Second part is done."]),
+    );
+    const { relay, controller } = setupController();
+
+    await controller.handleCallerUtterance("Hi");
+
+    // The failed segment's truncated audio already played, so its text is
+    // never re-sent as native tokens; later segments still take the
+    // native route.
+    expect(synthesizedTexts).toEqual(["First part is done."]);
+    expect(relay.sentPlayUrls.length).toBe(1);
+    const tokenTexts = relay.sentTokens
+      .filter((t) => t.token.length > 0)
+      .map((t) => t.token);
+    expect(tokenTexts).toEqual(["Second part is done. "]);
+    const lastToken = relay.sentTokens[relay.sentTokens.length - 1];
+    expect(lastToken).toEqual({ token: "", last: true });
+
+    controller.destroy();
+  });
+
   // ── Per-segment fallback on WAV-requiring transports ────────────────
 
   /**
    * Register a failing fish-audio primary and a recording elevenlabs
    * fallback, with fish-audio configured as the active provider. Used by
-   * the WAV-transport segment-fallback tests.
+   * the WAV-transport segment-fallback tests. With
+   * `fishEmitsChunkBeforeFailing`, the primary emits one audio chunk (so
+   * the play URL reaches the transport) before failing mid-stream.
    */
-  function registerWavFallbackProviders(): {
+  function registerWavFallbackProviders(opts?: {
+    fishEmitsChunkBeforeFailing?: boolean;
+  }): {
     fishTexts: string[];
     fallbackTexts: string[];
   } {
@@ -3384,8 +3421,15 @@ describe("call-controller", () => {
       async synthesize() {
         throw new Error("fish-audio synth failure");
       },
-      async synthesizeStream(request) {
+      async synthesizeStream(request, onChunk) {
         fishTexts.push(request.text);
+        if (opts?.fishEmitsChunkBeforeFailing) {
+          onChunk(Buffer.from("partial-fish-audio"));
+          // Let the queued emit flush so the play URL reaches the
+          // transport before the failure lands (mirrors a real
+          // mid-stream stall).
+          await new Promise((r) => setTimeout(r, 0));
+        }
         throw new Error("fish-audio stream failure");
       },
     };
@@ -3415,6 +3459,33 @@ describe("call-controller", () => {
     ]);
     expect(relay.sentPlayUrls.length).toBe(2);
     // No text routes through native tokens on a WAV transport.
+    expect(relay.sentTokens.filter((t) => t.token.length > 0)).toEqual([]);
+    const lastToken = relay.sentTokens[relay.sentTokens.length - 1];
+    expect(lastToken).toEqual({ token: "", last: true });
+
+    controller.destroy();
+  });
+
+  test("WAV transport: a mid-stream failure after audio reached the caller is not re-spoken, but later segments use the fallback", async () => {
+    const { fishTexts, fallbackTexts } = registerWavFallbackProviders({
+      fishEmitsChunkBeforeFailing: true,
+    });
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["First part is done. ", "Second part is done."]),
+    );
+    const { relay, controller } = setupController(undefined, {
+      requiresWavAudio: true,
+    });
+
+    await controller.handleCallerUtterance("Hi");
+
+    // The failed segment's play URL already went out — the caller heard
+    // its truncated audio, so a fallback re-synthesis would speak the
+    // whole segment a second time. Only later segments route through
+    // the fallback provider.
+    expect(fishTexts).toEqual(["First part is done."]);
+    expect(fallbackTexts).toEqual(["Second part is done."]);
+    expect(relay.sentPlayUrls.length).toBe(2);
     expect(relay.sentTokens.filter((t) => t.token.length > 0)).toEqual([]);
     const lastToken = relay.sentTokens[relay.sentTokens.length - 1];
     expect(lastToken).toEqual({ token: "", last: true });

--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -2965,6 +2965,108 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
+  test("synthesized provider: a turn error cancels the queued synthesis chain so no stale speech follows the recovery prompt", async () => {
+    const cfg = loadConfig();
+    cfg.services.tts.provider = "fish-audio";
+    cfg.services.tts.providers["fish-audio"].referenceId = "fish-ref-123";
+
+    _resetTtsProviderOverridesForTests();
+    // elevenlabs present so a native fallback route exists for fish-audio.
+    const elevenlabs: TtsProvider = {
+      id: "elevenlabs",
+      capabilities: { supportsStreaming: false, supportedFormats: ["mp3"] },
+      async synthesize() {
+        return { audio: Buffer.from(""), contentType: "audio/mpeg" };
+      },
+    };
+    _setTtsProviderForTests(elevenlabs);
+
+    // Slow provider: blocks until the test releases it, but honors the
+    // abort signal like real providers do.
+    let releaseSynth: (() => void) | undefined;
+    const synthGate = new Promise<void>((resolve) => {
+      releaseSynth = resolve;
+    });
+    let synthStartedResolve: (() => void) | undefined;
+    const synthStarted = new Promise<void>((resolve) => {
+      synthStartedResolve = resolve;
+    });
+    let providerSawAbort = false;
+    const fishAudioSlow: TtsProvider = {
+      id: "fish-audio",
+      capabilities: {
+        supportsStreaming: true,
+        supportedFormats: ["mp3", "wav", "opus"],
+      },
+      async synthesize() {
+        return { audio: Buffer.from("x"), contentType: "audio/mpeg" };
+      },
+      async synthesizeStream(request, onChunk) {
+        synthStartedResolve?.();
+        await new Promise<void>((resolve, reject) => {
+          const abortErr = new Error("aborted");
+          abortErr.name = "AbortError";
+          if (request.signal?.aborted) {
+            providerSawAbort = true;
+            reject(abortErr);
+            return;
+          }
+          request.signal?.addEventListener(
+            "abort",
+            () => {
+              providerSawAbort = true;
+              reject(abortErr);
+            },
+            { once: true },
+          );
+          void synthGate.then(resolve);
+        });
+        onChunk(Buffer.from("stale-partial-answer-audio"));
+        return {
+          audio: Buffer.from("stale-partial-answer-audio"),
+          contentType: "audio/mpeg",
+        };
+      },
+    };
+    _setTtsProviderForTests(fishAudioSlow);
+
+    // Emit a speakable segment, then error the turn once that segment's
+    // synthesis is in flight — the run is never superseded, so only the
+    // turn-error cancellation keeps the chain from speaking.
+    mockStartVoiceTurn.mockImplementation(
+      async (opts: {
+        onTextDelta: (text: string) => void;
+        onError: (msg: string) => void;
+      }) => {
+        opts.onTextDelta("Partial answer for the caller. And more");
+        void synthStarted.then(() => {
+          opts.onError("voice pipeline failure");
+        });
+        return { turnId: "run-err-synth", abort: () => {} };
+      },
+    );
+
+    const { relay, controller } = setupController();
+
+    await controller.handleCallerUtterance("Hi");
+
+    // The in-flight segment was aborted and the recovery message spoken.
+    expect(providerSawAbort).toBe(true);
+    const spoken = relay.sentTokens.map((t) => t.token).join("");
+    expect(spoken).toContain("technical issue");
+    expect(controller.getState()).toBe("idle");
+
+    // Releasing the slow provider must not surface the cancelled chain's
+    // play URL or native-fallback text after the recovery prompt.
+    releaseSynth?.();
+    await new Promise((r) => setTimeout(r, 30));
+    expect(relay.sentPlayUrls.length).toBe(0);
+    const allText = relay.sentTokens.map((t) => t.token).join("");
+    expect(allText).not.toContain("Partial answer for the caller");
+
+    controller.destroy();
+  });
+
   test("Deepgram selected path resolves useSynthesizedPath to true", async () => {
     const cfg = loadConfig();
     cfg.services.tts.provider = "deepgram";

--- a/assistant/src/__tests__/media-stream-output.test.ts
+++ b/assistant/src/__tests__/media-stream-output.test.ts
@@ -29,7 +29,14 @@ mock.module("../calls/resolve-call-tts-provider.js", () => ({
   })),
 }));
 
-import { mulawToPcm16 } from "../calls/media-stream-audio-transcode.js";
+// Pre-load the module processSynthesizeItem imports dynamically, so the
+// first synthesize item doesn't pay module-load latency mid-test.
+await import("../tts/synthesis-stream.js");
+
+import {
+  mulawToPcm16,
+  pcm16ToMulaw,
+} from "../calls/media-stream-audio-transcode.js";
 import { MediaStreamOutput } from "../calls/media-stream-output.js";
 import { resolveCallTtsProvider } from "../calls/resolve-call-tts-provider.js";
 
@@ -78,10 +85,27 @@ function createMockWs() {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Wait for async playback queue to drain. */
-async function drain(): Promise<void> {
-  // Allow microtasks and the drain loop to run
-  await new Promise((resolve) => setTimeout(resolve, 10));
+/**
+ * Wait for async playback to progress. With `until`, polls (up to 2 s) for
+ * the condition so assertions don't race the queue on slow CI machines;
+ * without it, a single fixed tick (for negative assertions).
+ */
+async function drain(until?: () => boolean): Promise<void> {
+  const deadline = Date.now() + 2000;
+  for (;;) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    if (!until || until() || Date.now() > deadline) return;
+  }
+}
+
+/** True when a sent message with the given event type exists. */
+function hasEvent(sent: string[], event: string): boolean {
+  return sent.some((s) => JSON.parse(s).event === event);
+}
+
+/** Number of mark messages among the sent messages. */
+function countMarks(sent: string[]): number {
+  return sent.filter((s) => JSON.parse(s).event === "mark").length;
 }
 
 /** Generate a minimal valid WAV buffer with PCM data. */
@@ -144,6 +168,52 @@ function concatMulawPayloads(sent: string[]): Buffer {
   );
 }
 
+/** Number of media frames among the sent messages. */
+function countMediaFrames(sent: string[]): number {
+  return sent.filter((s) => JSON.parse(s).event === "media").length;
+}
+
+/** Encode samples as a raw PCM16 LE buffer. */
+function pcm16Buffer(samples: number[]): Buffer {
+  const buf = Buffer.alloc(samples.length * 2);
+  for (let i = 0; i < samples.length; i++) {
+    buf.writeInt16LE(samples[i], i * 2);
+  }
+  return buf;
+}
+
+/** Keep every other PCM16 sample (16 kHz -> 8 kHz decimation). */
+function decimateByTwo(pcm: Buffer): Buffer {
+  const outCount = Math.floor(pcm.length / 2 / 2);
+  const out = Buffer.alloc(outCount * 2);
+  for (let i = 0; i < outCount; i++) {
+    out.writeInt16LE(pcm.readInt16LE(i * 4), i * 2);
+  }
+  return out;
+}
+
+/** Outputs created during the current test, closed in afterEach. */
+const activeOutputs: MediaStreamOutput[] = [];
+
+/** Construct a MediaStreamOutput tracked for afterEach teardown. */
+function makeOutput(
+  ws: import("bun").ServerWebSocket<unknown>,
+  streamSid: string,
+): MediaStreamOutput {
+  const output = new MediaStreamOutput(ws, streamSid);
+  activeOutputs.push(output);
+  return output;
+}
+
+/** Install a resolveCallTtsProvider mock returning the given provider. */
+function useProvider(provider: unknown): void {
+  mockResolveCallTtsProvider.mockImplementation(() => ({
+    provider,
+    useSynthesizedPath: false,
+    audioFormat: "wav" as const,
+  }));
+}
+
 /** Count sign changes in a PCM16 LE buffer (proxy for tone frequency). */
 function countZeroCrossings(pcm: Buffer): number {
   const samples = Math.floor(pcm.length / 2);
@@ -162,6 +232,13 @@ function countZeroCrossings(pcm: Buffer): number {
 // ---------------------------------------------------------------------------
 
 afterEach(() => {
+  // Close every output so an in-flight synthesize item from a slow test
+  // bails on its staleness check instead of calling the next test's
+  // (re-)mocked provider.
+  for (const output of activeOutputs) {
+    output.markClosed();
+  }
+  activeOutputs.length = 0;
   mockSynthesize.mockReset();
   // Restore the default resolveCallTtsProvider mock
   mockResolveCallTtsProvider.mockImplementation(() => ({
@@ -185,11 +262,11 @@ describe("MediaStreamOutput", () => {
       });
 
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.sendTextToken("hello ", false);
       output.sendTextToken("world", true);
 
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
 
       // Should have sent media frames (from synthesis) and a mark
       const events = sent.map((s) => JSON.parse(s).event);
@@ -203,10 +280,10 @@ describe("MediaStreamOutput", () => {
 
     test("empty token with last: true sends only end-of-turn mark (no synthesis)", async () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.sendTextToken("", true);
 
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
 
       // Should send only a mark, no media frames
       expect(sent).toHaveLength(1);
@@ -220,7 +297,7 @@ describe("MediaStreamOutput", () => {
 
     test("non-last tokens accumulate without sending", () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.sendTextToken("hello ", false);
       output.sendTextToken("world ", false);
       expect(sent).toHaveLength(0);
@@ -228,7 +305,7 @@ describe("MediaStreamOutput", () => {
 
     test("does not send when closed", () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.endSession();
       output.sendTextToken("hello", true);
       expect(sent).toHaveLength(0);
@@ -238,7 +315,7 @@ describe("MediaStreamOutput", () => {
   describe("CallTransport interface — sendPlayUrl", () => {
     test("enqueues a fetch-url item in the playback queue", () => {
       const { ws } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.sendPlayUrl("https://example.com/audio.mp3");
       // The queue should have one item (the fetch will fail since
       // there's no real server, but the enqueueing is synchronous)
@@ -247,7 +324,7 @@ describe("MediaStreamOutput", () => {
 
     test("does not enqueue when closed", () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.endSession();
       output.sendPlayUrl("https://example.com/audio.mp3");
       expect(sent).toHaveLength(0);
@@ -257,7 +334,7 @@ describe("MediaStreamOutput", () => {
   describe("CallTransport interface — endSession", () => {
     test("closes the WebSocket with code 1000", () => {
       const mock = createMockWs();
-      const output = new MediaStreamOutput(mock.ws, "stream-1");
+      const output = makeOutput(mock.ws, "stream-1");
       output.endSession("test-reason");
       expect(mock.closed).toBe(true);
       expect(mock.closeCode).toBe(1000);
@@ -266,7 +343,7 @@ describe("MediaStreamOutput", () => {
 
     test("uses default reason when none provided", () => {
       const mock = createMockWs();
-      const output = new MediaStreamOutput(mock.ws, "stream-1");
+      const output = makeOutput(mock.ws, "stream-1");
       output.endSession();
       expect(mock.closed).toBe(true);
       expect(mock.closeReason).toBe("session-ended");
@@ -274,7 +351,7 @@ describe("MediaStreamOutput", () => {
 
     test("is idempotent", () => {
       const mock = createMockWs();
-      const output = new MediaStreamOutput(mock.ws, "stream-1");
+      const output = makeOutput(mock.ws, "stream-1");
       output.endSession("first");
       // Second call should not throw (ws.close would throw on already-closed)
       output.endSession("second");
@@ -285,7 +362,7 @@ describe("MediaStreamOutput", () => {
   describe("sendAudioPayload", () => {
     test("sends a media command with the base64 payload", () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      const output = makeOutput(ws, "MZ-stream-1");
       output.sendAudioPayload("dGVzdA==");
 
       expect(sent).toHaveLength(1);
@@ -299,7 +376,7 @@ describe("MediaStreamOutput", () => {
 
     test("does not send when closed", () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      const output = makeOutput(ws, "MZ-stream-1");
       output.endSession();
       output.sendAudioPayload("dGVzdA==");
       // Only the close would have happened, no media sent
@@ -310,7 +387,7 @@ describe("MediaStreamOutput", () => {
   describe("sendMark", () => {
     test("sends a mark command with the given name", () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      const output = makeOutput(ws, "MZ-stream-1");
       output.sendMark("end-of-turn");
 
       expect(sent).toHaveLength(1);
@@ -324,7 +401,7 @@ describe("MediaStreamOutput", () => {
 
     test("does not send when closed", () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      const output = makeOutput(ws, "MZ-stream-1");
       output.endSession();
       output.sendMark("end-of-turn");
       expect(sent).toHaveLength(0);
@@ -334,7 +411,7 @@ describe("MediaStreamOutput", () => {
   describe("clearAudio — barge-in", () => {
     test("sends a clear command to Twilio", () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      const output = makeOutput(ws, "MZ-stream-1");
       output.clearAudio();
 
       expect(sent).toHaveLength(1);
@@ -359,7 +436,7 @@ describe("MediaStreamOutput", () => {
       );
 
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      const output = makeOutput(ws, "MZ-stream-1");
 
       // Queue synthesis
       output.sendTextToken("hello world", true);
@@ -379,7 +456,7 @@ describe("MediaStreamOutput", () => {
 
     test("does not send when closed", () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      const output = makeOutput(ws, "MZ-stream-1");
       output.endSession();
       output.clearAudio();
       expect(sent).toHaveLength(0);
@@ -389,7 +466,7 @@ describe("MediaStreamOutput", () => {
   describe("clearBufferedAudio — rejected barge-in", () => {
     test("sends a clear command to Twilio", () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      const output = makeOutput(ws, "MZ-stream-1");
       output.clearBufferedAudio();
 
       expect(sent).toHaveLength(1);
@@ -413,12 +490,12 @@ describe("MediaStreamOutput", () => {
       );
 
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      const output = makeOutput(ws, "MZ-stream-1");
 
       output.sendTextToken("hello world", true);
       output.clearBufferedAudio();
 
-      await new Promise((resolve) => setTimeout(resolve, 60));
+      await drain(() => hasEvent(sent, "media"));
 
       // Unlike clearAudio, the in-flight synthesis is not aborted:
       // its frames go out once ready.
@@ -439,7 +516,7 @@ describe("MediaStreamOutput", () => {
       );
 
       const { ws } = createMockWs();
-      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      const output = makeOutput(ws, "MZ-stream-1");
 
       let fired = 0;
       output.setAudioStartCallback(() => {
@@ -448,14 +525,14 @@ describe("MediaStreamOutput", () => {
       output.sendTextToken("hello world", true);
       output.clearBufferedAudio();
 
-      await new Promise((resolve) => setTimeout(resolve, 60));
+      await drain(() => fired === 1);
 
       expect(fired).toBe(1);
     });
 
     test("does not send when closed", () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "MZ-stream-1");
+      const output = makeOutput(ws, "MZ-stream-1");
       output.endSession();
       output.clearBufferedAudio();
       expect(sent).toHaveLength(0);
@@ -477,7 +554,7 @@ describe("MediaStreamOutput", () => {
       });
 
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
 
       let fired = 0;
       let mediaSentWhenFired = -1;
@@ -489,7 +566,7 @@ describe("MediaStreamOutput", () => {
       });
 
       output.sendTextToken("hello world", true);
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
 
       const mediaMessages = sent.filter((s) => JSON.parse(s).event === "media");
       expect(mediaMessages.length).toBeGreaterThan(1);
@@ -504,25 +581,25 @@ describe("MediaStreamOutput", () => {
         contentType: "audio/wav",
       });
 
-      const { ws } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
 
       let fired = 0;
       output.setAudioStartCallback(() => fired++);
 
       output.sendTextToken("first", true);
-      await drain();
+      await drain(() => countMarks(sent) >= 1);
       expect(fired).toBe(1);
 
       // Second item without re-arming — signal already consumed.
       output.sendTextToken("second", true);
-      await drain();
+      await drain(() => countMarks(sent) >= 2);
       expect(fired).toBe(1);
 
       // Re-armed — fires again for the next item.
       output.setAudioStartCallback(() => fired++);
       output.sendTextToken("third", true);
-      await drain();
+      await drain(() => countMarks(sent) >= 3);
       expect(fired).toBe(2);
     });
 
@@ -540,7 +617,7 @@ describe("MediaStreamOutput", () => {
       );
 
       const { ws } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
 
       let fired = 0;
       output.setAudioStartCallback(() => fired++);
@@ -553,14 +630,14 @@ describe("MediaStreamOutput", () => {
     });
 
     test("an empty end-of-turn (mark only) does not fire the signal", async () => {
-      const { ws } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
 
       let fired = 0;
       output.setAudioStartCallback(() => fired++);
 
       output.sendTextToken("", true);
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
       expect(fired).toBe(0);
     });
   });
@@ -573,8 +650,8 @@ describe("MediaStreamOutput", () => {
         contentType: "audio/wav",
       });
 
-      const { ws } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
 
       // Tokens buffered mid-turn; a barge-in signal the controller ignores
       // (turn still processing) flushes queued audio but must not truncate
@@ -582,7 +659,7 @@ describe("MediaStreamOutput", () => {
       output.sendTextToken("hello ", false);
       output.clearAudio();
       output.sendTextToken("world", true);
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
 
       expect(mockSynthesize).toHaveBeenCalledTimes(1);
       expect(mockSynthesize.mock.calls[0][0].text).toBe("hello world");
@@ -590,12 +667,12 @@ describe("MediaStreamOutput", () => {
 
     test("discardPendingText drops accumulated text so no synthesis occurs", async () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
 
       output.sendTextToken("stale partial response", false);
       output.discardPendingText();
       output.sendTextToken("", true);
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
 
       expect(mockSynthesize).not.toHaveBeenCalled();
       // Only the end-of-turn mark goes out.
@@ -607,7 +684,7 @@ describe("MediaStreamOutput", () => {
   describe("setStreamSid / getStreamSid", () => {
     test("updates the stream SID used in subsequent commands", () => {
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "old-sid");
+      const output = makeOutput(ws, "old-sid");
       expect(output.getStreamSid()).toBe("old-sid");
 
       output.setStreamSid("new-sid");
@@ -622,7 +699,7 @@ describe("MediaStreamOutput", () => {
   describe("markClosed", () => {
     test("transitions to closed state without sending a close frame", () => {
       const mock = createMockWs();
-      const output = new MediaStreamOutput(mock.ws, "stream-1");
+      const output = makeOutput(mock.ws, "stream-1");
       output.markClosed();
       expect(mock.closed).toBe(false); // WebSocket not actually closed
       output.sendAudioPayload("dGVzdA=="); // Should be suppressed
@@ -639,7 +716,7 @@ describe("MediaStreamOutput", () => {
         close() {},
       } as unknown as import("bun").ServerWebSocket<unknown>;
 
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       // Should not throw
       expect(() => output.sendAudioPayload("dGVzdA==")).not.toThrow();
     });
@@ -652,7 +729,7 @@ describe("MediaStreamOutput", () => {
         },
       } as unknown as import("bun").ServerWebSocket<unknown>;
 
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       // Should not throw
       expect(() => output.endSession()).not.toThrow();
     });
@@ -671,10 +748,10 @@ describe("MediaStreamOutput", () => {
       });
 
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.sendTextToken("test synthesis", true);
 
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
 
       // Should have sent at least one media frame and an end-of-turn mark
       const mediaMessages = sent.filter((s) => JSON.parse(s).event === "media");
@@ -693,7 +770,7 @@ describe("MediaStreamOutput", () => {
 
     test("getPlaybackQueueLength reflects queue state", () => {
       const { ws } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       // Initially empty
       expect(output.getPlaybackQueueLength()).toBe(0);
     });
@@ -721,10 +798,10 @@ describe("MediaStreamOutput", () => {
       });
 
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.sendTextToken("test", true);
 
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
 
       // The audioBufferToFrames magic-byte detection should detect mp3
       // sync bytes when format is "wav" and return silence (no media
@@ -754,10 +831,10 @@ describe("MediaStreamOutput", () => {
       });
 
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.sendTextToken("test", true);
 
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
 
       // processSynthesizeItem derives actualFormat from content-type:
       // "audio/pcm" -> "pcm". audioBufferToFrames handles raw PCM by
@@ -789,10 +866,10 @@ describe("MediaStreamOutput", () => {
       });
 
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.sendTextToken("test", true);
 
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
 
       // processSynthesizeItem detects "audio/x-raw" -> "pcm" format.
       // audioBufferToFrames converts raw PCM to mu-law frames.
@@ -818,9 +895,9 @@ describe("MediaStreamOutput", () => {
         contentType: "audio/wav",
       });
       const { ws, sent } = createMockWs();
-      const output = new MediaStreamOutput(ws, "stream-1");
+      const output = makeOutput(ws, "stream-1");
       output.sendTextToken("test", true);
-      await drain();
+      await drain(() => hasEvent(sent, "mark"));
       return sent;
     }
 
@@ -880,6 +957,215 @@ describe("MediaStreamOutput", () => {
       const wav = makeWavBuffer(interleaved, { sampleRate: 8000, channels: 2 });
       const sent = await synthesizeWav(wav);
       // One channel of 400 samples -> 400 mu-law bytes.
+      expect(totalMulawBytes(sent)).toBe(400);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Incremental sentence-bounded synthesis
+  // ---------------------------------------------------------------------------
+
+  describe("incremental sentence-bounded synthesis", () => {
+    test("complete sentences synthesize and play before last: true arrives", async () => {
+      const wav = makeWavBuffer(sineSamples(400, 440, 8000));
+      mockSynthesize.mockResolvedValue({
+        audio: wav,
+        contentType: "audio/wav",
+      });
+
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+
+      output.sendTextToken("First sentence. Sec", false);
+      await drain(() => countMediaFrames(sent) > 0);
+
+      // The completed first sentence synthesizes (and its frames go out)
+      // while the turn is still streaming.
+      expect(mockSynthesize).toHaveBeenCalledTimes(1);
+      expect(mockSynthesize.mock.calls[0][0].text).toBe("First sentence.");
+      expect(countMediaFrames(sent)).toBeGreaterThan(0);
+
+      output.sendTextToken("ond sentence.", true);
+      await drain(() => hasEvent(sent, "mark"));
+
+      expect(mockSynthesize).toHaveBeenCalledTimes(2);
+      expect(mockSynthesize.mock.calls[1][0].text).toBe("Second sentence.");
+    });
+
+    test("end-of-turn mark follows the final segment's frames", async () => {
+      const wav = makeWavBuffer(sineSamples(400, 440, 8000));
+      mockSynthesize.mockResolvedValue({
+        audio: wav,
+        contentType: "audio/wav",
+      });
+
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("One. Two.", true);
+      await drain(() => hasEvent(sent, "mark"));
+
+      expect(mockSynthesize).toHaveBeenCalledTimes(2);
+      const events = sent.map((s) => JSON.parse(s).event);
+      const markIndex = events.indexOf("mark");
+      const lastMediaIndex = events.lastIndexOf("media");
+      expect(lastMediaIndex).toBeGreaterThanOrEqual(0);
+      expect(markIndex).toBeGreaterThan(lastMediaIndex);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Streaming PCM synthesis (incremental transcode)
+  // ---------------------------------------------------------------------------
+
+  describe("streaming PCM synthesis", () => {
+    test("frames are sent before the provider stream completes", async () => {
+      let releaseStream!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        releaseStream = resolve;
+      });
+      // 640 samples at 16 kHz -> 320 samples at 8 kHz = two whole frames.
+      const chunk = pcm16Buffer(sineSamples(640, 440, 16000));
+      useProvider({
+        id: "streaming-pcm",
+        capabilities: { supportsStreaming: true, supportedFormats: ["pcm"] },
+        synthesize: jest.fn(),
+        async synthesizeStream(
+          _request: unknown,
+          onChunk: (c: Uint8Array) => void,
+        ) {
+          onChunk(chunk);
+          await gate;
+          onChunk(chunk);
+          return {
+            audio: Buffer.concat([chunk, chunk]),
+            contentType: "audio/pcm",
+          };
+        },
+      });
+
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("Hello there.", true);
+      await drain(() => countMediaFrames(sent) >= 2);
+
+      // First chunk's frames went out while the stream is still open,
+      // and the end-of-turn mark has not been sent yet.
+      const framesBefore = countMediaFrames(sent);
+      expect(framesBefore).toBe(2);
+      expect(sent.some((s) => JSON.parse(s).event === "mark")).toBe(false);
+
+      releaseStream();
+      await drain(() => hasEvent(sent, "mark"));
+
+      expect(countMediaFrames(sent)).toBe(4);
+      expect(sent.some((s) => JSON.parse(s).event === "mark")).toBe(true);
+    });
+
+    test("odd-byte and partial-frame chunk boundaries produce well-formed frames", async () => {
+      // 800 samples at 16 kHz (1600 bytes), split at deliberately awkward
+      // boundaries: odd bytes, non-frame-aligned sizes.
+      const full = pcm16Buffer(sineSamples(800, 440, 16000));
+      const cuts = [0, 3, 251, 640, 1001, full.length];
+      const chunks = cuts
+        .slice(0, -1)
+        .map((start, i) => full.subarray(start, cuts[i + 1]));
+      useProvider({
+        id: "streaming-pcm",
+        capabilities: { supportsStreaming: true, supportedFormats: ["pcm"] },
+        synthesize: jest.fn(),
+        async synthesizeStream(
+          _request: unknown,
+          onChunk: (c: Uint8Array) => void,
+        ) {
+          for (const c of chunks) {
+            onChunk(c);
+          }
+          return { audio: full, contentType: "audio/pcm" };
+        },
+      });
+
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("Test.", true);
+      await drain(() => hasEvent(sent, "mark"));
+
+      // The concatenated mu-law output must be byte-identical to a
+      // whole-buffer transcode: no dropped or torn samples at chunk seams.
+      const expected = pcm16ToMulaw(decimateByTwo(full));
+      expect(expected.length).toBe(400);
+      expect(concatMulawPayloads(sent).equals(expected)).toBe(true);
+    });
+
+    test("playbackVersion bump mid-stream stops further frames", async () => {
+      let releaseStream!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        releaseStream = resolve;
+      });
+      const chunk = pcm16Buffer(sineSamples(640, 440, 16000));
+      useProvider({
+        id: "streaming-pcm",
+        capabilities: { supportsStreaming: true, supportedFormats: ["pcm"] },
+        synthesize: jest.fn(),
+        async synthesizeStream(
+          _request: unknown,
+          onChunk: (c: Uint8Array) => void,
+        ) {
+          onChunk(chunk);
+          await gate;
+          // Stale chunk emitted after barge-in must never become frames.
+          onChunk(chunk);
+          return {
+            audio: Buffer.concat([chunk, chunk]),
+            contentType: "audio/pcm",
+          };
+        },
+      });
+
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("Hello there.", true);
+      await drain(() => countMediaFrames(sent) > 0);
+
+      const framesBefore = countMediaFrames(sent);
+      expect(framesBefore).toBeGreaterThan(0);
+
+      output.clearAudio();
+      releaseStream();
+      await drain();
+
+      expect(countMediaFrames(sent)).toBe(framesBefore);
+    });
+
+    test("streaming provider without PCM support falls back to the whole-buffer path", async () => {
+      const wav = makeWavBuffer(sineSamples(400, 440, 8000));
+      const half = Math.floor(wav.length / 2);
+      let midStreamFrames = -1;
+      const sentRef: { sent: string[] } = { sent: [] };
+      useProvider({
+        id: "streaming-wav",
+        capabilities: { supportsStreaming: true, supportedFormats: ["wav"] },
+        synthesize: jest.fn(),
+        async synthesizeStream(
+          _request: unknown,
+          onChunk: (c: Uint8Array) => void,
+        ) {
+          onChunk(wav.subarray(0, half));
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          midStreamFrames = countMediaFrames(sentRef.sent);
+          onChunk(wav.subarray(half));
+          return { audio: wav, contentType: "audio/wav" };
+        },
+      });
+
+      const { ws, sent } = createMockWs();
+      sentRef.sent = sent;
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("Hello.", true);
+      await drain(() => hasEvent(sent, "mark"));
+
+      // Nothing streamed mid-flight; the whole accumulated WAV is
+      // transcoded once at the end.
+      expect(midStreamFrames).toBe(0);
       expect(totalMulawBytes(sent)).toBe(400);
     });
   });

--- a/assistant/src/__tests__/media-stream-output.test.ts
+++ b/assistant/src/__tests__/media-stream-output.test.ts
@@ -29,10 +29,6 @@ mock.module("../calls/resolve-call-tts-provider.js", () => ({
   })),
 }));
 
-// Pre-load the module processSynthesizeItem imports dynamically, so the
-// first synthesize item doesn't pay module-load latency mid-test.
-await import("../tts/synthesis-stream.js");
-
 import {
   mulawToPcm16,
   pcm16ToMulaw,
@@ -98,14 +94,9 @@ async function drain(until?: () => boolean): Promise<void> {
   }
 }
 
-/** True when a sent message with the given event type exists. */
-function hasEvent(sent: string[], event: string): boolean {
-  return sent.some((s) => JSON.parse(s).event === event);
-}
-
-/** Number of mark messages among the sent messages. */
-function countMarks(sent: string[]): number {
-  return sent.filter((s) => JSON.parse(s).event === "mark").length;
+/** Number of sent messages with the given event type. */
+function countEvents(sent: string[], event: string): number {
+  return sent.filter((s) => JSON.parse(s).event === event).length;
 }
 
 /** Generate a minimal valid WAV buffer with PCM data. */
@@ -166,11 +157,6 @@ function concatMulawPayloads(sent: string[]): Buffer {
       .filter((s) => JSON.parse(s).event === "media")
       .map((s) => Buffer.from(JSON.parse(s).media.payload, "base64")),
   );
-}
-
-/** Number of media frames among the sent messages. */
-function countMediaFrames(sent: string[]): number {
-  return sent.filter((s) => JSON.parse(s).event === "media").length;
 }
 
 /** Encode samples as a raw PCM16 LE buffer. */
@@ -266,7 +252,7 @@ describe("MediaStreamOutput", () => {
       output.sendTextToken("hello ", false);
       output.sendTextToken("world", true);
 
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
       // Should have sent media frames (from synthesis) and a mark
       const events = sent.map((s) => JSON.parse(s).event);
@@ -283,7 +269,7 @@ describe("MediaStreamOutput", () => {
       const output = makeOutput(ws, "stream-1");
       output.sendTextToken("", true);
 
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
       // Should send only a mark, no media frames
       expect(sent).toHaveLength(1);
@@ -495,7 +481,7 @@ describe("MediaStreamOutput", () => {
       output.sendTextToken("hello world", true);
       output.clearBufferedAudio();
 
-      await drain(() => hasEvent(sent, "media"));
+      await drain(() => countEvents(sent, "media") > 0);
 
       // Unlike clearAudio, the in-flight synthesis is not aborted:
       // its frames go out once ready.
@@ -539,6 +525,62 @@ describe("MediaStreamOutput", () => {
     });
   });
 
+  describe("cancelPendingSpeech — turn abort", () => {
+    test("queued-but-unplayed synthesis never produces frames; the next turn plays normally", async () => {
+      const wav = makeWavBuffer(sineSamples(400, 440, 8000));
+      // Slow synthesis so the abort lands while the first segment is
+      // in flight and the second is still queued.
+      mockSynthesize.mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(
+              () => resolve({ audio: wav, contentType: "audio/wav" }),
+              200,
+            ),
+          ),
+      );
+
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "MZ-stream-1");
+
+      // Aborted turn: first segment in flight, second still queued.
+      output.sendTextToken("Sentence one. Sentence two.", true);
+      await drain(() => mockSynthesize.mock.calls.length === 1);
+      expect(output.getPlaybackQueueLength()).toBeGreaterThan(0);
+
+      output.cancelPendingSpeech();
+
+      // Twilio's buffered audio was flushed too.
+      expect(countEvents(sent, "clear")).toBe(1);
+
+      // Next turn: fast synthesis so its audio goes out.
+      mockSynthesize.mockResolvedValue({
+        audio: wav,
+        contentType: "audio/wav",
+      });
+      output.sendTextToken("Next turn reply.", true);
+      await drain(() => countEvents(sent, "mark") > 0);
+
+      // The aborted turn's queued segment never synthesized, its
+      // in-flight segment produced no frames, and the next turn's
+      // audio is the only audio sent.
+      const synthesizedTexts = mockSynthesize.mock.calls.map(
+        (c) => (c[0] as { text: string }).text,
+      );
+      expect(synthesizedTexts).toEqual(["Sentence one.", "Next turn reply."]);
+      expect(countEvents(sent, "media")).toBeGreaterThan(0);
+      expect(totalMulawBytes(sent)).toBe(400);
+    });
+
+    test("does not send when closed", () => {
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "MZ-stream-1");
+      output.endSession();
+      output.cancelPendingSpeech();
+      expect(sent).toHaveLength(0);
+    });
+  });
+
   describe("audio-start signal", () => {
     function makePlayableWav(): Buffer {
       const samples = Array.from({ length: 400 }, (_, i) =>
@@ -566,7 +608,7 @@ describe("MediaStreamOutput", () => {
       });
 
       output.sendTextToken("hello world", true);
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
       const mediaMessages = sent.filter((s) => JSON.parse(s).event === "media");
       expect(mediaMessages.length).toBeGreaterThan(1);
@@ -588,18 +630,18 @@ describe("MediaStreamOutput", () => {
       output.setAudioStartCallback(() => fired++);
 
       output.sendTextToken("first", true);
-      await drain(() => countMarks(sent) >= 1);
+      await drain(() => countEvents(sent, "mark") >= 1);
       expect(fired).toBe(1);
 
       // Second item without re-arming — signal already consumed.
       output.sendTextToken("second", true);
-      await drain(() => countMarks(sent) >= 2);
+      await drain(() => countEvents(sent, "mark") >= 2);
       expect(fired).toBe(1);
 
       // Re-armed — fires again for the next item.
       output.setAudioStartCallback(() => fired++);
       output.sendTextToken("third", true);
-      await drain(() => countMarks(sent) >= 3);
+      await drain(() => countEvents(sent, "mark") >= 3);
       expect(fired).toBe(2);
     });
 
@@ -637,7 +679,7 @@ describe("MediaStreamOutput", () => {
       output.setAudioStartCallback(() => fired++);
 
       output.sendTextToken("", true);
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
       expect(fired).toBe(0);
     });
   });
@@ -659,7 +701,7 @@ describe("MediaStreamOutput", () => {
       output.sendTextToken("hello ", false);
       output.clearAudio();
       output.sendTextToken("world", true);
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
       expect(mockSynthesize).toHaveBeenCalledTimes(1);
       expect(mockSynthesize.mock.calls[0][0].text).toBe("hello world");
@@ -672,7 +714,7 @@ describe("MediaStreamOutput", () => {
       output.sendTextToken("stale partial response", false);
       output.discardPendingText();
       output.sendTextToken("", true);
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
       expect(mockSynthesize).not.toHaveBeenCalled();
       // Only the end-of-turn mark goes out.
@@ -751,7 +793,7 @@ describe("MediaStreamOutput", () => {
       const output = makeOutput(ws, "stream-1");
       output.sendTextToken("test synthesis", true);
 
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
       // Should have sent at least one media frame and an end-of-turn mark
       const mediaMessages = sent.filter((s) => JSON.parse(s).event === "media");
@@ -801,7 +843,7 @@ describe("MediaStreamOutput", () => {
       const output = makeOutput(ws, "stream-1");
       output.sendTextToken("test", true);
 
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
       // The audioBufferToFrames magic-byte detection should detect mp3
       // sync bytes when format is "wav" and return silence (no media
@@ -834,7 +876,7 @@ describe("MediaStreamOutput", () => {
       const output = makeOutput(ws, "stream-1");
       output.sendTextToken("test", true);
 
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
       // processSynthesizeItem derives actualFormat from content-type:
       // "audio/pcm" -> "pcm". audioBufferToFrames handles raw PCM by
@@ -869,7 +911,7 @@ describe("MediaStreamOutput", () => {
       const output = makeOutput(ws, "stream-1");
       output.sendTextToken("test", true);
 
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
       // processSynthesizeItem detects "audio/x-raw" -> "pcm" format.
       // audioBufferToFrames converts raw PCM to mu-law frames.
@@ -897,7 +939,7 @@ describe("MediaStreamOutput", () => {
       const { ws, sent } = createMockWs();
       const output = makeOutput(ws, "stream-1");
       output.sendTextToken("test", true);
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
       return sent;
     }
 
@@ -977,16 +1019,16 @@ describe("MediaStreamOutput", () => {
       const output = makeOutput(ws, "stream-1");
 
       output.sendTextToken("First sentence. Sec", false);
-      await drain(() => countMediaFrames(sent) > 0);
+      await drain(() => countEvents(sent, "media") > 0);
 
       // The completed first sentence synthesizes (and its frames go out)
       // while the turn is still streaming.
       expect(mockSynthesize).toHaveBeenCalledTimes(1);
       expect(mockSynthesize.mock.calls[0][0].text).toBe("First sentence.");
-      expect(countMediaFrames(sent)).toBeGreaterThan(0);
+      expect(countEvents(sent, "media")).toBeGreaterThan(0);
 
       output.sendTextToken("ond sentence.", true);
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
       expect(mockSynthesize).toHaveBeenCalledTimes(2);
       expect(mockSynthesize.mock.calls[1][0].text).toBe("Second sentence.");
@@ -1002,7 +1044,7 @@ describe("MediaStreamOutput", () => {
       const { ws, sent } = createMockWs();
       const output = makeOutput(ws, "stream-1");
       output.sendTextToken("One. Two.", true);
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
       expect(mockSynthesize).toHaveBeenCalledTimes(2);
       const events = sent.map((s) => JSON.parse(s).event);
@@ -1046,18 +1088,18 @@ describe("MediaStreamOutput", () => {
       const { ws, sent } = createMockWs();
       const output = makeOutput(ws, "stream-1");
       output.sendTextToken("Hello there.", true);
-      await drain(() => countMediaFrames(sent) >= 2);
+      await drain(() => countEvents(sent, "media") >= 2);
 
       // First chunk's frames went out while the stream is still open,
       // and the end-of-turn mark has not been sent yet.
-      const framesBefore = countMediaFrames(sent);
+      const framesBefore = countEvents(sent, "media");
       expect(framesBefore).toBe(2);
       expect(sent.some((s) => JSON.parse(s).event === "mark")).toBe(false);
 
       releaseStream();
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
-      expect(countMediaFrames(sent)).toBe(4);
+      expect(countEvents(sent, "media")).toBe(4);
       expect(sent.some((s) => JSON.parse(s).event === "mark")).toBe(true);
     });
 
@@ -1087,7 +1129,7 @@ describe("MediaStreamOutput", () => {
       const { ws, sent } = createMockWs();
       const output = makeOutput(ws, "stream-1");
       output.sendTextToken("Test.", true);
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
       // The concatenated mu-law output must be byte-identical to a
       // whole-buffer transcode: no dropped or torn samples at chunk seams.
@@ -1124,16 +1166,16 @@ describe("MediaStreamOutput", () => {
       const { ws, sent } = createMockWs();
       const output = makeOutput(ws, "stream-1");
       output.sendTextToken("Hello there.", true);
-      await drain(() => countMediaFrames(sent) > 0);
+      await drain(() => countEvents(sent, "media") > 0);
 
-      const framesBefore = countMediaFrames(sent);
+      const framesBefore = countEvents(sent, "media");
       expect(framesBefore).toBeGreaterThan(0);
 
       output.clearAudio();
       releaseStream();
       await drain();
 
-      expect(countMediaFrames(sent)).toBe(framesBefore);
+      expect(countEvents(sent, "media")).toBe(framesBefore);
     });
 
     test("streaming provider without PCM support falls back to the whole-buffer path", async () => {
@@ -1151,7 +1193,7 @@ describe("MediaStreamOutput", () => {
         ) {
           onChunk(wav.subarray(0, half));
           await new Promise((resolve) => setTimeout(resolve, 5));
-          midStreamFrames = countMediaFrames(sentRef.sent);
+          midStreamFrames = countEvents(sentRef.sent, "media");
           onChunk(wav.subarray(half));
           return { audio: wav, contentType: "audio/wav" };
         },
@@ -1161,7 +1203,7 @@ describe("MediaStreamOutput", () => {
       sentRef.sent = sent;
       const output = makeOutput(ws, "stream-1");
       output.sendTextToken("Hello.", true);
-      await drain(() => hasEvent(sent, "mark"));
+      await drain(() => countEvents(sent, "mark") > 0);
 
       // Nothing streamed mid-flight; the whole accumulated WAV is
       // transcoded once at the end.

--- a/assistant/src/__tests__/telephony-tts-guard.test.ts
+++ b/assistant/src/__tests__/telephony-tts-guard.test.ts
@@ -9,8 +9,9 @@
  *    resolving into guaranteed media-stream silence.
  * 3. `speakSystemPrompt` on a WAV-requiring transport — synthesis failure
  *    retries once via the fallback provider before degrading to an
- *    end-of-turn-only signal; aborted synthesis short-circuits with no
- *    fallback and no end-of-turn token.
+ *    end-of-turn-only signal; a mid-stream failure after the play URL went
+ *    out skips all fallback (the truncated prompt stands); aborted
+ *    synthesis short-circuits with no fallback and no end-of-turn token.
  *
  * The provider catalog, config loader, credential store, provider registry,
  * audio store, and ingress URL modules are all mocked so the tests exercise
@@ -235,6 +236,22 @@ function registerStubProvider(
     id,
     capabilities: { supportsStreaming: false, supportedFormats: ["mp3"] },
     synthesize,
+  };
+  registeredProviders.set(id, provider);
+  return provider;
+}
+
+function registerStreamingStubProvider(
+  id: string,
+  synthesizeStream: NonNullable<TtsProvider["synthesizeStream"]>,
+): TtsProvider {
+  const provider: TtsProvider = {
+    id,
+    capabilities: { supportsStreaming: true, supportedFormats: ["mp3"] },
+    synthesize: async () => {
+      throw new Error("buffer path should not be used");
+    },
+    synthesizeStream,
   };
   registeredProviders.set(id, provider);
   return provider;
@@ -527,6 +544,81 @@ describe("speakSystemPrompt on a WAV-requiring transport", () => {
     expect(deepgramSynthesize).toHaveBeenCalledTimes(1);
     expect(elevenlabsSynthesize).toHaveBeenCalledTimes(1);
     expect(sentPlayUrls.length).toBe(0);
+    expect(sentTokens).toEqual([{ token: "", last: true }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// speakSystemPrompt — mid-stream failure after audio started skips fallback
+// ---------------------------------------------------------------------------
+
+describe("speakSystemPrompt mid-stream failure after audio started", () => {
+  /** Streaming stub that emits one chunk, lets it flush, then fails. */
+  function failAfterFirstChunk(): NonNullable<TtsProvider["synthesizeStream"]> {
+    return async (_request, emit) => {
+      emit(Buffer.from("pcm-chunk"));
+      // Let the queued emit flush so the play URL goes out before the failure.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      throw new Error("stream died mid-flight");
+    };
+  }
+
+  test("WAV transport: skips the fallback retry — the truncated prompt stands", async () => {
+    testConfig.services.tts.provider = "deepgram";
+    storedKeys["deepgram"] = "dg-key";
+    storedKeys["elevenlabs"] = "el-key";
+
+    const deepgramStream = jest.fn(failAfterFirstChunk());
+    const elevenlabsSynthesize = jest.fn(async () => {
+      return { audio: Buffer.from("pcm-bytes"), contentType: "audio/pcm" };
+    });
+    registerStreamingStubProvider("deepgram", deepgramStream);
+    registerStubProvider("elevenlabs", elevenlabsSynthesize);
+
+    const { relay, sentTokens, sentPlayUrls } = createRelay(true);
+    await speakSystemPrompt(relay, "Your verification code is 123456.");
+
+    expect(deepgramStream).toHaveBeenCalledTimes(1);
+    expect(elevenlabsSynthesize).not.toHaveBeenCalled();
+    expect(sentPlayUrls.length).toBe(1);
+    expect(sentTokens).toEqual([{ token: "", last: true }]);
+  });
+
+  test("non-WAV transport: skips the native text fallback — no full-prompt re-speak", async () => {
+    testConfig.services.tts.provider = "fish-audio";
+    testConfig.services.tts.providers["fish-audio"].referenceId = "ref-123";
+
+    const fishStream = jest.fn(failAfterFirstChunk());
+    registerStreamingStubProvider("fish-audio", fishStream);
+
+    const { relay, sentTokens, sentPlayUrls } = createRelay(false);
+    await speakSystemPrompt(relay, "You have a new message.");
+
+    expect(fishStream).toHaveBeenCalledTimes(1);
+    expect(sentPlayUrls.length).toBe(1);
+    expect(sentTokens).toEqual([{ token: "", last: true }]);
+  });
+
+  test("streaming failure before any chunk still retries the fallback provider", async () => {
+    testConfig.services.tts.provider = "deepgram";
+    storedKeys["deepgram"] = "dg-key";
+    storedKeys["elevenlabs"] = "el-key";
+
+    const deepgramStream = jest.fn(async () => {
+      throw new Error("stream refused before first chunk");
+    });
+    const elevenlabsSynthesize = jest.fn(async () => {
+      return { audio: Buffer.from("pcm-bytes"), contentType: "audio/pcm" };
+    });
+    registerStreamingStubProvider("deepgram", deepgramStream);
+    registerStubProvider("elevenlabs", elevenlabsSynthesize);
+
+    const { relay, sentTokens, sentPlayUrls } = createRelay(true);
+    await speakSystemPrompt(relay, "Your verification code is 123456.");
+
+    expect(deepgramStream).toHaveBeenCalledTimes(1);
+    expect(elevenlabsSynthesize).toHaveBeenCalledTimes(1);
+    expect(sentPlayUrls.length).toBe(1);
     expect(sentTokens).toEqual([{ token: "", last: true }]);
   });
 });

--- a/assistant/src/calls/__tests__/fish-audio-client.test.ts
+++ b/assistant/src/calls/__tests__/fish-audio-client.test.ts
@@ -70,4 +70,16 @@ describe("synthesizeWithFishAudio request body", () => {
     const body = JSON.parse(capturedBody);
     expect("sample_rate" in body).toBe(false);
   });
+
+  test("passes pcm format and sample_rate through to the request body", async () => {
+    await synthesizeWithFishAudio(
+      "hello",
+      { ...config, format: "pcm" },
+      { sampleRate: 24000 },
+    );
+
+    const body = JSON.parse(capturedBody);
+    expect(body.format).toBe("pcm");
+    expect(body.sample_rate).toBe(24000);
+  });
 });

--- a/assistant/src/calls/__tests__/tts-text-sanitizer.test.ts
+++ b/assistant/src/calls/__tests__/tts-text-sanitizer.test.ts
@@ -67,6 +67,28 @@ describe("sanitizeForTts", () => {
       expect(sanitizeForTts("5 * 3 = 15")).toBe("5 * 3 = 15");
     });
 
+    test("preserves multiple arithmetic asterisks in one sentence", () => {
+      expect(sanitizeForTts("5 * 3 is 15 and 4 * 2 is 8")).toBe(
+        "5 * 3 is 15 and 4 * 2 is 8",
+      );
+    });
+
+    test("strips italic whose content contains internal spaces", () => {
+      expect(sanitizeForTts("Hello *wide world* there")).toBe(
+        "Hello wide world there",
+      );
+    });
+
+    test("does not treat whitespace-padded asterisks as italic", () => {
+      expect(sanitizeForTts("Some * italic. still* done.")).toBe(
+        "Some * italic. still* done.",
+      );
+    });
+
+    test("does not treat whitespace-padded underscores as italic", () => {
+      expect(sanitizeForTts("a _ b and c_ d")).toBe("a _ b and c_ d");
+    });
+
     test("preserves identifiers with underscores", () => {
       expect(sanitizeForTts("The my_var variable")).toBe(
         "The my_var variable",

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -735,7 +735,13 @@ export class CallController {
       ttsProvider: TtsProvider,
       segments: string[],
     ): void => {
-      for (const segment of segments) {
+      for (const rawSegment of segments) {
+        // Sanitized per segment (not per delta) so markdown spanning deltas
+        // is stripped before the text reaches any TTS route.
+        const segment = sanitizeForTts(rawSegment).trim();
+        if (segment.length === 0) {
+          continue;
+        }
         synthesisChain = synthesisChain.then(async () => {
           if (!this.isCurrentRun(runVersion) || synthesisFailure) return;
           try {
@@ -780,10 +786,10 @@ export class CallController {
 
     /** Emit a chunk of safe text to the appropriate TTS backend. */
     const emitSafeChunk = (safeText: string): void => {
-      const cleaned = sanitizeForTts(safeText);
-      if (cleaned.length === 0) return;
       if (synthProvider) {
-        pendingSynthText += cleaned;
+        // Boundary detection runs on raw text; each extracted segment is
+        // sanitized inside enqueueSynthesisSegments.
+        pendingSynthText += safeText;
         const { segments, remainder } = extractSpeakableSegments(
           pendingSynthText,
           false,
@@ -791,6 +797,8 @@ export class CallController {
         pendingSynthText = remainder;
         enqueueSynthesisSegments(synthProvider, segments);
       } else {
+        const cleaned = sanitizeForTts(safeText);
+        if (cleaned.length === 0) return;
         this.beginSpeakingOnAudioStart(runVersion);
         this.transport.sendTextToken(cleaned, false);
       }

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -19,7 +19,7 @@ import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
-import { getCatalogProvider, getTtsProvider } from "../tts/provider-catalog.js";
+import { getCatalogProvider } from "../tts/provider-catalog.js";
 import { extractSpeakableSegments } from "../tts/speakable-segments.js";
 import {
   type AudioStoreSink,
@@ -57,7 +57,7 @@ import { finalizeCall } from "./finalize-call.js";
 import { sendGuardianExpiryNotices } from "./guardian-action-sweep.js";
 import { dispatchGuardianQuestion } from "./guardian-dispatch.js";
 import {
-  findPlayableTelephonyTtsFallback,
+  findPlayableTelephonyTtsFallbackProvider,
   resolveCallTtsProvider,
 } from "./resolve-call-tts-provider.js";
 import type { PromptSpeakerContext } from "./speaker-identification.js";
@@ -79,16 +79,13 @@ import {
 
 const log = getLogger("call-controller");
 
-/** Look up a registered provider, returning null instead of throwing. */
-function lookupRegisteredTtsProvider(id: string): TtsProvider | null {
-  try {
-    return getTtsProvider(id);
-  } catch {
-    return null;
-  }
-}
-
 type ControllerState = "idle" | "processing" | "speaking";
+
+/** Outcome of one segment's synthesis attempt. */
+type SegmentSynthesisStatus =
+  | "ok"
+  | "failed-before-audio"
+  | "failed-after-audio";
 
 /**
  * Tracks a pending guardian input request independently of the controller's
@@ -702,11 +699,8 @@ export class CallController {
       segment: string,
     ): Promise<void> => {
       if (wavFallbackProvider === undefined) {
-        const fallbackId =
-          await findPlayableTelephonyTtsFallback(failedProviderId);
-        wavFallbackProvider = fallbackId
-          ? lookupRegisteredTtsProvider(fallbackId)
-          : null;
+        wavFallbackProvider =
+          await findPlayableTelephonyTtsFallbackProvider(failedProviderId);
         if (wavFallbackProvider) {
           log.warn(
             {
@@ -722,14 +716,16 @@ export class CallController {
           );
         }
       }
-      if (!wavFallbackProvider || !this.isCurrentRun(runVersion)) return;
-      const fallbackFailed = await this.synthesizeAndStreamAudio(
+      if (!wavFallbackProvider || !this.isCurrentRun(runVersion)) {
+        return;
+      }
+      const fallbackStatus = await this.synthesizeAndStreamAudio(
         wavFallbackProvider,
         segment,
         runVersion,
         audioFormat,
       );
-      if (fallbackFailed) {
+      if (fallbackStatus !== "ok") {
         // The fallback provider is failing too — stop retrying.
         wavFallbackProvider = null;
       }
@@ -744,15 +740,27 @@ export class CallController {
           if (!this.isCurrentRun(runVersion) || synthesisFailure) return;
           try {
             if (!synthesisFellBack) {
-              synthesisFellBack = await this.synthesizeAndStreamAudio(
+              const status = await this.synthesizeAndStreamAudio(
                 ttsProvider,
                 segment,
                 runVersion,
                 audioFormat,
               );
-              if (!synthesisFellBack || !this.transport.requiresWavAudio) {
-                // Success, abort, or the failed segment's text already
-                // went out as native tokens inside synthesizeAndStreamAudio.
+              if (status === "ok") {
+                return;
+              }
+              synthesisFellBack = true;
+              if (!this.transport.requiresWavAudio) {
+                // synthesizeAndStreamAudio already handled the failed
+                // segment: its text went out as native tokens, or its
+                // partially-played audio stands.
+                return;
+              }
+              if (status === "failed-after-audio") {
+                // The segment's play URL already reached the caller, so
+                // the truncated audio stands — a fallback re-synthesis
+                // would speak the whole segment a second time. Later
+                // segments still route through the fallback provider.
                 return;
               }
             } else if (!this.transport.requiresWavAudio) {
@@ -943,22 +951,24 @@ export class CallController {
    * Synthesize text via a streaming TTS provider and forward audio chunks
    * to Twilio through the audio store / play-URL mechanism.
    *
-   * @returns `true` when provider synthesis failed on a provider whose
-   *   catalog entry allows fallback. On transports that accept text
-   *   tokens the failed text has already been sent natively (unless its
-   *   play URL was already delivered); on WAV-requiring transports
-   *   nothing was sent — the caller owns the fallback-provider retry.
-   *   Callers keep subsequent segments off the failed provider so text
-   *   is never spoken out of order. `false` on success or abort.
-   *   Rethrows when the provider's catalog entry has
-   *   `allowNativeFallback: false`.
+   * @returns `"ok"` on success or abort. On a handled provider failure,
+   *   `"failed-before-audio"` when the segment's play URL never went out:
+   *   on transports that accept text tokens the failed text has already
+   *   been sent natively; on WAV-requiring transports nothing was sent —
+   *   the caller owns the fallback-provider retry. `"failed-after-audio"`
+   *   when the provider failed mid-stream after the play URL was
+   *   delivered: the caller hears the truncated audio and nothing more is
+   *   sent for this segment on either transport — re-speaking it would
+   *   duplicate what already played. Callers keep subsequent segments off
+   *   the failed provider so text is never spoken out of order. Rethrows
+   *   when the provider's catalog entry has `allowNativeFallback: false`.
    */
   private async synthesizeAndStreamAudio(
     provider: TtsProvider,
     text: string,
     runVersion: number,
     format: "mp3" | "wav" | "opus" = "mp3",
-  ): Promise<boolean> {
+  ): Promise<SegmentSynthesisStatus> {
     let sink: AudioStoreSink | null = null;
     let playUrlSent = false;
     const abortController = new AbortController();
@@ -1008,7 +1018,7 @@ export class CallController {
           { provider: provider.id },
           "TTS synthesis aborted (barge-in)",
         );
-        return false;
+        return "ok";
       } else {
         // Extract error class and code for diagnosable log entries.
         const errName = err instanceof Error ? err.name : String(err);
@@ -1053,7 +1063,7 @@ export class CallController {
           // the segment was trimmed at extraction.
           this.transport.sendTextToken(`${text} `, false);
         }
-        return true;
+        return playUrlSent ? "failed-after-audio" : "failed-before-audio";
       }
     } finally {
       // Identity-guarded: a late-finishing stale segment must not clear a
@@ -1063,7 +1073,7 @@ export class CallController {
       }
       sink?.finalize();
     }
-    return false;
+    return "ok";
   }
 
   /**

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -19,7 +19,7 @@ import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
-import { getCatalogProvider } from "../tts/provider-catalog.js";
+import { getCatalogProvider, getTtsProvider } from "../tts/provider-catalog.js";
 import { extractSpeakableSegments } from "../tts/speakable-segments.js";
 import {
   type AudioStoreSink,
@@ -56,7 +56,10 @@ import type { CallTransport } from "./call-transport.js";
 import { finalizeCall } from "./finalize-call.js";
 import { sendGuardianExpiryNotices } from "./guardian-action-sweep.js";
 import { dispatchGuardianQuestion } from "./guardian-dispatch.js";
-import { resolveCallTtsProvider } from "./resolve-call-tts-provider.js";
+import {
+  findPlayableTelephonyTtsFallback,
+  resolveCallTtsProvider,
+} from "./resolve-call-tts-provider.js";
 import type { PromptSpeakerContext } from "./speaker-identification.js";
 import { sanitizeForTts } from "./tts-text-sanitizer.js";
 import {
@@ -75,6 +78,15 @@ import {
 } from "./voice-session-bridge.js";
 
 const log = getLogger("call-controller");
+
+/** Look up a registered provider, returning null instead of throwing. */
+function lookupRegisteredTtsProvider(id: string): TtsProvider | null {
+  try {
+    return getTtsProvider(id);
+  } catch {
+    return null;
+  }
+}
 
 type ControllerState = "idle" | "processing" | "speaking";
 
@@ -517,10 +529,12 @@ export class CallController {
       this.activeSynthesisAbort.abort();
       this.activeSynthesisAbort = null;
     }
-    // Drop the aborted turn's unsent buffered text on transports that
-    // accumulate tokens (media-stream), so it cannot leak into the next
-    // turn's synthesis.
+    // Drop the aborted turn's unsent buffered text and cancel its queued /
+    // in-flight speech on transports that hold either (media-stream), so
+    // the aborted turn neither leaks text into the next turn's synthesis
+    // nor plays stale audio over it.
     this.transport.discardPendingText?.();
+    this.transport.cancelPendingSpeech?.();
   }
 
   private formatCallerUtterance(
@@ -666,13 +680,60 @@ export class CallController {
     const synthProvider = useSynthesizedPath ? provider : null;
     let pendingSynthText = "";
     let synthesisChain: Promise<void> = Promise.resolve();
-    // After a segment falls back to native tokens, the rest of the turn
-    // stays on the native route so text is never spoken out of order.
+    // After a segment fails, the rest of the turn stays off the primary
+    // provider so text is never spoken out of order: non-WAV transports
+    // send native tokens; WAV-requiring transports (media-stream) retry
+    // through a playable fallback provider.
     let synthesisFellBack = false;
+    // Fallback provider for WAV-requiring transports, resolved once per
+    // turn. `undefined` = not yet resolved; `null` = none available (or
+    // the fallback failed too) — affected segments are skipped.
+    let wavFallbackProvider: TtsProvider | null | undefined;
     // Non-recoverable failure (allowNativeFallback: false providers):
     // remaining segments are skipped and the error rethrows after the
     // chain drains so the outer handler speaks the generic recovery copy.
     let synthesisFailure: { err: unknown } | undefined;
+
+    // WAV-requiring transports re-synthesize native tokens through the
+    // same failing provider path, so a failed segment (and the rest of
+    // the turn) is spoken through a playable fallback provider instead.
+    const speakSegmentViaWavFallback = async (
+      failedProviderId: string,
+      segment: string,
+    ): Promise<void> => {
+      if (wavFallbackProvider === undefined) {
+        const fallbackId =
+          await findPlayableTelephonyTtsFallback(failedProviderId);
+        wavFallbackProvider = fallbackId
+          ? lookupRegisteredTtsProvider(fallbackId)
+          : null;
+        if (wavFallbackProvider) {
+          log.warn(
+            {
+              provider: failedProviderId,
+              fallbackProvider: wavFallbackProvider.id,
+            },
+            "Speaking remaining TTS segments via fallback provider",
+          );
+        } else {
+          log.error(
+            { provider: failedProviderId },
+            "No playable fallback TTS provider — skipping failed segments",
+          );
+        }
+      }
+      if (!wavFallbackProvider || !this.isCurrentRun(runVersion)) return;
+      const fallbackFailed = await this.synthesizeAndStreamAudio(
+        wavFallbackProvider,
+        segment,
+        runVersion,
+        audioFormat,
+      );
+      if (fallbackFailed) {
+        // The fallback provider is failing too — stop retrying.
+        wavFallbackProvider = null;
+      }
+    };
 
     const enqueueSynthesisSegments = (
       ttsProvider: TtsProvider,
@@ -681,20 +742,27 @@ export class CallController {
       for (const segment of segments) {
         synthesisChain = synthesisChain.then(async () => {
           if (!this.isCurrentRun(runVersion) || synthesisFailure) return;
-          if (synthesisFellBack) {
-            if (!this.transport.requiresWavAudio) {
-              this.beginSpeakingOnAudioStart(runVersion);
-              this.transport.sendTextToken(segment, false);
-            }
-            return;
-          }
           try {
-            synthesisFellBack = await this.synthesizeAndStreamAudio(
-              ttsProvider,
-              segment,
-              runVersion,
-              audioFormat,
-            );
+            if (!synthesisFellBack) {
+              synthesisFellBack = await this.synthesizeAndStreamAudio(
+                ttsProvider,
+                segment,
+                runVersion,
+                audioFormat,
+              );
+              if (!synthesisFellBack || !this.transport.requiresWavAudio) {
+                // Success, abort, or the failed segment's text already
+                // went out as native tokens inside synthesizeAndStreamAudio.
+                return;
+              }
+            } else if (!this.transport.requiresWavAudio) {
+              // Native route. Segments are trimmed, so restore the
+              // inter-segment separator.
+              this.beginSpeakingOnAudioStart(runVersion);
+              this.transport.sendTextToken(`${segment} `, false);
+              return;
+            }
+            await speakSegmentViaWavFallback(ttsProvider.id, segment);
           } catch (err) {
             synthesisFailure = { err };
           }
@@ -875,10 +943,14 @@ export class CallController {
    * Synthesize text via a streaming TTS provider and forward audio chunks
    * to Twilio through the audio store / play-URL mechanism.
    *
-   * @returns `true` when provider synthesis failed and the text took the
-   *   native-token fallback route — callers keep subsequent segments on
-   *   the same route so text is never spoken out of order. `false` on
-   *   success or abort. Rethrows when the provider's catalog entry has
+   * @returns `true` when provider synthesis failed on a provider whose
+   *   catalog entry allows fallback. On transports that accept text
+   *   tokens the failed text has already been sent natively (unless its
+   *   play URL was already delivered); on WAV-requiring transports
+   *   nothing was sent — the caller owns the fallback-provider retry.
+   *   Callers keep subsequent segments off the failed provider so text
+   *   is never spoken out of order. `false` on success or abort.
+   *   Rethrows when the provider's catalog entry has
    *   `allowNativeFallback: false`.
    */
   private async synthesizeAndStreamAudio(
@@ -977,7 +1049,9 @@ export class CallController {
           this.isCurrentRun(runVersion)
         ) {
           this.beginSpeakingOnAudioStart(runVersion);
-          this.transport.sendTextToken(text, false);
+          // Trailing space restores the inter-segment separator lost when
+          // the segment was trimmed at extraction.
+          this.transport.sendTextToken(`${text} `, false);
         }
         return true;
       }

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -469,10 +469,7 @@ export class CallController {
     this.endCallListenTimer = null;
     this.llmRunVersion++;
     this.abortCurrentTurn();
-    if (this.activeSynthesisAbort) {
-      this.activeSynthesisAbort.abort();
-      this.activeSynthesisAbort = null;
-    }
+    this.abortActiveSynthesis();
     this.currentTurnPromise = null;
     unregisterCallController(this.callSessionId);
 
@@ -522,16 +519,21 @@ export class CallController {
     this.abortController = new AbortController();
     // Abort any in-flight synthesized-TTS playback too, so a superseded or
     // torn-down turn's audio isn't streamed to the caller after they move on.
-    if (this.activeSynthesisAbort) {
-      this.activeSynthesisAbort.abort();
-      this.activeSynthesisAbort = null;
-    }
+    this.abortActiveSynthesis();
     // Drop the aborted turn's unsent buffered text and cancel its queued /
     // in-flight speech on transports that hold either (media-stream), so
     // the aborted turn neither leaks text into the next turn's synthesis
     // nor plays stale audio over it.
     this.transport.discardPendingText?.();
     this.transport.cancelPendingSpeech?.();
+  }
+
+  /** Abort and clear the in-flight synthesized-TTS segment, if any. */
+  private abortActiveSynthesis(): void {
+    if (this.activeSynthesisAbort) {
+      this.activeSynthesisAbort.abort();
+      this.activeSynthesisAbort = null;
+    }
   }
 
   private formatCallerUtterance(
@@ -690,6 +692,9 @@ export class CallController {
     // remaining segments are skipped and the error rethrows after the
     // chain drains so the outer handler speaks the generic recovery copy.
     let synthesisFailure: { err: unknown } | undefined;
+    // Turn errored while still current — isCurrentRun can't catch this, so
+    // chain links check it to keep stale speech off the recovery prompt.
+    let synthesisCancelled = false;
 
     // WAV-requiring transports re-synthesize native tokens through the
     // same failing provider path, so a failed segment (and the rest of
@@ -716,7 +721,11 @@ export class CallController {
           );
         }
       }
-      if (!wavFallbackProvider || !this.isCurrentRun(runVersion)) {
+      if (
+        !wavFallbackProvider ||
+        synthesisCancelled ||
+        !this.isCurrentRun(runVersion)
+      ) {
         return;
       }
       const fallbackStatus = await this.synthesizeAndStreamAudio(
@@ -743,7 +752,13 @@ export class CallController {
           continue;
         }
         synthesisChain = synthesisChain.then(async () => {
-          if (!this.isCurrentRun(runVersion) || synthesisFailure) return;
+          if (
+            !this.isCurrentRun(runVersion) ||
+            synthesisFailure ||
+            synthesisCancelled
+          ) {
+            return;
+          }
           try {
             if (!synthesisFellBack) {
               const status = await this.synthesizeAndStreamAudio(
@@ -902,7 +917,20 @@ export class CallController {
     // inside the Promise constructor before this await adds its handler.
     // The await below still re-throws, caught by the outer try-catch.
     turnComplete.catch(() => {});
-    await turnComplete;
+    try {
+      await turnComplete;
+    } catch (err) {
+      // Cancel and settle this turn's synthesis before the error reaches
+      // the outer handler, so no straggling segment plays the partial
+      // answer over the recovery prompt. While this run is current no
+      // newer run's synthesis can be in flight, so the abort is safe.
+      if (this.isCurrentRun(runVersion)) {
+        synthesisCancelled = true;
+        this.abortActiveSynthesis();
+      }
+      await synthesisChain.catch(() => {});
+      throw err;
+    }
     if (!this.isCurrentRun(runVersion)) {
       // Superseded mid-stream (barge-in): drain the segment chain — queued
       // links short-circuit on staleness — so this turn's synthesis fully

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -20,6 +20,7 @@ import type { TrustContext } from "../daemon/trust-context.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
 import { getCatalogProvider } from "../tts/provider-catalog.js";
+import { extractSpeakableSegments } from "../tts/speakable-segments.js";
 import {
   type AudioStoreSink,
   createAudioStoreSink,
@@ -639,10 +640,10 @@ export class CallController {
   ): Promise<string> {
     // Resolve the active TTS provider through the global abstraction.
     // The catalog's callMode determines the call path: synthesized-play
-    // providers buffer text, synthesize via provider API, and stream
-    // audio chunks to Twilio via play-URL. Native-twilio providers
-    // stream text tokens through the transport, which re-synthesizes
-    // them via daemon TTS on media-stream.
+    // providers synthesize each speakable segment via the provider API as
+    // the LLM streams, playing audio chunks to Twilio via play-URL.
+    // Native-twilio providers stream text tokens through the transport,
+    // which re-synthesizes them via daemon TTS on media-stream.
     //
     // When the transport requires WAV (media-stream), request WAV so
     // the audio store entry and any downstream fetch/transcode receives
@@ -658,16 +659,61 @@ export class CallController {
     let ttsBuffer = "";
     let fullResponseText = "";
 
-    // When using the synthesized path, we accumulate all text and synthesize
-    // the complete response at the end of the turn (better prosody).
-    let synthesizedTextBuffer = "";
+    // Synthesized path: text is split at speakable boundaries as it streams
+    // and each segment is synthesized while the LLM keeps generating. The
+    // chain serializes segments so play URLs reach the transport in order
+    // (transport FIFO gives gapless playback).
+    const synthProvider = useSynthesizedPath ? provider : null;
+    let pendingSynthText = "";
+    let synthesisChain: Promise<void> = Promise.resolve();
+    // After a segment falls back to native tokens, the rest of the turn
+    // stays on the native route so text is never spoken out of order.
+    let synthesisFellBack = false;
+    // Non-recoverable failure (allowNativeFallback: false providers):
+    // remaining segments are skipped and the error rethrows after the
+    // chain drains so the outer handler speaks the generic recovery copy.
+    let synthesisFailure: { err: unknown } | undefined;
+
+    const enqueueSynthesisSegments = (
+      ttsProvider: TtsProvider,
+      segments: string[],
+    ): void => {
+      for (const segment of segments) {
+        synthesisChain = synthesisChain.then(async () => {
+          if (!this.isCurrentRun(runVersion) || synthesisFailure) return;
+          if (synthesisFellBack) {
+            if (!this.transport.requiresWavAudio) {
+              this.beginSpeakingOnAudioStart(runVersion);
+              this.transport.sendTextToken(segment, false);
+            }
+            return;
+          }
+          try {
+            synthesisFellBack = await this.synthesizeAndStreamAudio(
+              ttsProvider,
+              segment,
+              runVersion,
+              audioFormat,
+            );
+          } catch (err) {
+            synthesisFailure = { err };
+          }
+        });
+      }
+    };
 
     /** Emit a chunk of safe text to the appropriate TTS backend. */
     const emitSafeChunk = (safeText: string): void => {
       const cleaned = sanitizeForTts(safeText);
       if (cleaned.length === 0) return;
-      if (useSynthesizedPath) {
-        synthesizedTextBuffer += cleaned;
+      if (synthProvider) {
+        pendingSynthText += cleaned;
+        const { segments, remainder } = extractSpeakableSegments(
+          pendingSynthText,
+          false,
+        );
+        pendingSynthText = remainder;
+        enqueueSynthesisSegments(synthProvider, segments);
       } else {
         this.beginSpeakingOnAudioStart(runVersion);
         this.transport.sendTextToken(cleaned, false);
@@ -773,7 +819,13 @@ export class CallController {
     // The await below still re-throws, caught by the outer try-catch.
     turnComplete.catch(() => {});
     await turnComplete;
-    if (!this.isCurrentRun(runVersion)) return fullResponseText;
+    if (!this.isCurrentRun(runVersion)) {
+      // Superseded mid-stream (barge-in): drain the segment chain — queued
+      // links short-circuit on staleness — so this turn's synthesis fully
+      // settles instead of racing the next turn.
+      await synthesisChain.catch(() => {});
+      return fullResponseText;
+    }
 
     // Final sweep: strip any remaining control markers from the buffer
     ttsBuffer = stripInternalSpeechMarkers(ttsBuffer);
@@ -781,24 +833,19 @@ export class CallController {
       emitSafeChunk(ttsBuffer);
     }
 
-    // Synthesized-play path: when the active provider supports streaming,
-    // synthesize the complete response text via the provider's streaming
-    // API. The full text gives the provider better context for prosody
-    // and intonation. Audio streams back via chunked transfer encoding
-    // and is forwarded to Twilio as it arrives.
-    const sanitizedSynthText = sanitizeForTts(synthesizedTextBuffer.trim());
-    if (useSynthesizedPath && provider && sanitizedSynthText.length > 0) {
-      if (!this.isCurrentRun(runVersion)) return fullResponseText;
-      // Do NOT flip to `speaking` here — provider synthesis latency (or the
-      // no-audio fallback window) would still be silent. The transition happens
-      // inside synthesizeAndStreamAudio when the play URL / first audio chunk
-      // (or native fallback token) is actually emitted.
-      await this.synthesizeAndStreamAudio(
-        provider,
-        sanitizedSynthText,
-        runVersion,
-        audioFormat,
-      );
+    // Synthesized path: force-extract whatever never reached a speakable
+    // boundary, then drain the chain so every segment's audio (or its
+    // native fallback) is enqueued before the end-of-turn signal. The
+    // `speaking` flip happens inside synthesizeAndStreamAudio when the
+    // play URL / first audio chunk (or native fallback token) is actually
+    // emitted — never here, where provider latency would still be silent.
+    if (synthProvider) {
+      const { segments } = extractSpeakableSegments(pendingSynthText, true);
+      enqueueSynthesisSegments(synthProvider, segments);
+      await synthesisChain;
+      if (synthesisFailure) {
+        throw synthesisFailure.err;
+      }
     }
 
     // Synthesized playback (and its native fallback) can await provider
@@ -827,13 +874,19 @@ export class CallController {
   /**
    * Synthesize text via a streaming TTS provider and forward audio chunks
    * to Twilio through the audio store / play-URL mechanism.
+   *
+   * @returns `true` when provider synthesis failed and the text took the
+   *   native-token fallback route — callers keep subsequent segments on
+   *   the same route so text is never spoken out of order. `false` on
+   *   success or abort. Rethrows when the provider's catalog entry has
+   *   `allowNativeFallback: false`.
    */
   private async synthesizeAndStreamAudio(
     provider: TtsProvider,
     text: string,
     runVersion: number,
     format: "mp3" | "wav" | "opus" = "mp3",
-  ): Promise<void> {
+  ): Promise<boolean> {
     let sink: AudioStoreSink | null = null;
     let playUrlSent = false;
     const abortController = new AbortController();
@@ -883,6 +936,7 @@ export class CallController {
           { provider: provider.id },
           "TTS synthesis aborted (barge-in)",
         );
+        return false;
       } else {
         // Extract error class and code for diagnosable log entries.
         const errName = err instanceof Error ? err.name : String(err);
@@ -925,11 +979,17 @@ export class CallController {
           this.beginSpeakingOnAudioStart(runVersion);
           this.transport.sendTextToken(text, false);
         }
+        return true;
       }
     } finally {
-      this.activeSynthesisAbort = null;
+      // Identity-guarded: a late-finishing stale segment must not clear a
+      // newer turn's abort handle.
+      if (this.activeSynthesisAbort === abortController) {
+        this.activeSynthesisAbort = null;
+      }
       sink?.finalize();
     }
+    return false;
   }
 
   /**

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -15,7 +15,7 @@
  *   via `sendPlayUrl()`.
  */
 
-import { getCatalogProvider, getTtsProvider } from "../tts/provider-catalog.js";
+import { getCatalogProvider } from "../tts/provider-catalog.js";
 import {
   type AudioStoreSink,
   createAudioStoreSink,
@@ -25,7 +25,7 @@ import type { TtsProvider, TtsProviderId } from "../tts/types.js";
 import { getLogger } from "../util/logger.js";
 import type { CallTransport } from "./call-transport.js";
 import {
-  findPlayableTelephonyTtsFallback,
+  findPlayableTelephonyTtsFallbackProvider,
   resolveCallTtsProvider,
 } from "./resolve-call-tts-provider.js";
 
@@ -182,12 +182,9 @@ async function synthesizeAndPlay(
       // back through the same synthesis path, so retry once with a
       // playable fallback provider before degrading to end-of-turn only.
       if (!isFallbackRetry) {
-        const fallbackId = await findPlayableTelephonyTtsFallback(
-          provider.id as TtsProviderId,
+        const fallbackProvider = await findPlayableTelephonyTtsFallbackProvider(
+          provider.id,
         );
-        const fallbackProvider = fallbackId
-          ? lookupRegisteredProvider(fallbackId)
-          : null;
         if (fallbackProvider) {
           log.warn(
             {
@@ -253,14 +250,5 @@ async function synthesizeAndPlay(
     relay.sendTextToken(text, true);
   } finally {
     sink?.finalize();
-  }
-}
-
-/** Look up a registered provider, returning null instead of throwing. */
-function lookupRegisteredProvider(id: string): TtsProvider | null {
-  try {
-    return getTtsProvider(id);
-  } catch {
-    return null;
   }
 }

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -83,7 +83,13 @@ export async function speakSystemPrompt(
  * Synthesize text via a streaming TTS provider and send the play URL
  * to the transport.
  *
- * On synthesis failure the behavior depends on the transport:
+ * A failure after the play URL has gone out (streaming provider died
+ * mid-stream) sends only the end-of-turn signal on every transport: the
+ * caller already heard the truncated prompt, and any fallback would
+ * re-speak it in full.
+ *
+ * On synthesis failure before any audio the behavior depends on the
+ * transport:
  * - WAV-requiring transports (media-stream) retry once with a playable
  *   fallback provider — native token TTS cannot rescue the prompt there
  *   because text tokens are themselves synthesized via the same provider
@@ -109,6 +115,7 @@ async function synthesizeAndPlay(
   isFallbackRetry = false,
 ): Promise<void> {
   let sink: AudioStoreSink | null = null;
+  let playUrlSent = false;
   try {
     // When format is WAV (media-stream transport), request raw PCM from
     // the provider so the audio bytes match the store's content-type.
@@ -124,7 +131,10 @@ async function synthesizeAndPlay(
     const storeFormat = outputFormat ? "pcm" : format;
     sink = createAudioStoreSink({
       format: storeFormat,
-      onPlayUrl: (url) => relay.sendPlayUrl(url),
+      onPlayUrl: (url) => {
+        relay.sendPlayUrl(url);
+        playUrlSent = true;
+      },
     });
 
     const result = await synthesizeAndEmit({
@@ -176,6 +186,17 @@ async function synthesizeAndPlay(
       err instanceof Error && "code" in err
         ? (err as Error & { code?: string }).code
         : undefined;
+
+    // The caller already heard the truncated prompt — any fallback would
+    // re-speak it in full (mirrors call-controller's failed-after-audio).
+    if (playUrlSent) {
+      log.warn(
+        { err, provider: provider.id, errName, errCode },
+        "System prompt TTS synthesis failed after audio started — skipping fallback to avoid re-speaking the prompt",
+      );
+      relay.sendTextToken("", true);
+      return;
+    }
 
     if (relay.requiresWavAudio) {
       // WAV-requiring transport (media-stream): native token TTS routes

--- a/assistant/src/calls/call-transport.ts
+++ b/assistant/src/calls/call-transport.ts
@@ -60,4 +60,15 @@ export interface CallTransport {
    * synthesis. Transports that don't buffer text may omit this.
    */
   discardPendingText?(): void;
+
+  /**
+   * Cancel queued and in-flight speech playback held by the transport,
+   * including any audio already buffered downstream (e.g. by Twilio).
+   *
+   * Called by the controller when it aborts an in-flight turn so speech
+   * the aborted turn queued for synthesis or playback never plays over
+   * the next turn. Transports that emit speech synchronously may omit
+   * this.
+   */
+  cancelPendingSpeech?(): void;
 }

--- a/assistant/src/calls/fish-audio-client.ts
+++ b/assistant/src/calls/fish-audio-client.ts
@@ -5,6 +5,15 @@ import { getLogger } from "../util/logger.js";
 
 const log = getLogger("fish-audio-client");
 
+/**
+ * Config accepted by the synthesis client. Widens the user-facing format
+ * union with `"pcm"` (raw 16-bit LE, no container), which PCM-requesting
+ * callers substitute internally — it is not part of the config schema.
+ */
+export type FishAudioSynthesisConfig = Omit<FishAudioConfig, "format"> & {
+  format: FishAudioConfig["format"] | "pcm";
+};
+
 /** Timeout waiting for the first chunk from Fish Audio (ms). */
 const FIRST_CHUNK_TIMEOUT_MS = 10_000;
 
@@ -32,7 +41,7 @@ interface SynthesizeOptions {
  */
 export async function synthesizeWithFishAudio(
   text: string,
-  config: FishAudioConfig,
+  config: FishAudioSynthesisConfig,
   options?: SynthesizeOptions,
 ): Promise<Buffer> {
   const apiKey = await getSecureKeyAsync(

--- a/assistant/src/calls/fish-audio-client.ts
+++ b/assistant/src/calls/fish-audio-client.ts
@@ -1,6 +1,7 @@
 import type { FishAudioConfig } from "../config/schemas/fish-audio.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { readChunkedBody } from "../tts/stream-read.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("fish-audio-client");
@@ -13,12 +14,6 @@ const log = getLogger("fish-audio-client");
 export type FishAudioSynthesisConfig = Omit<FishAudioConfig, "format"> & {
   format: FishAudioConfig["format"] | "pcm";
 };
-
-/** Timeout waiting for the first chunk from Fish Audio (ms). */
-const FIRST_CHUNK_TIMEOUT_MS = 10_000;
-
-/** Timeout waiting between consecutive chunks (ms). */
-const IDLE_TIMEOUT_MS = 5_000;
 
 // ---------------------------------------------------------------------------
 // Fish Audio REST API (POST /v1/tts)
@@ -95,47 +90,12 @@ export async function synthesizeWithFishAudio(
     throw new Error("Fish Audio API returned no body");
   }
 
-  const chunks: Uint8Array[] = [];
-  const reader = response.body.getReader();
-  let isFirstChunk = true;
+  const audio = await readChunkedBody(response.body, {
+    onChunk: options?.onChunk,
+    makeTimeoutError: (timeoutMs) =>
+      new Error(`Fish Audio read timed out after ${timeoutMs}ms`),
+  });
 
-  try {
-    while (true) {
-      const timeoutMs = isFirstChunk ? FIRST_CHUNK_TIMEOUT_MS : IDLE_TIMEOUT_MS;
-      let timerId: ReturnType<typeof setTimeout>;
-      const timeout = new Promise<never>((_, reject) => {
-        timerId = setTimeout(
-          () => reject(new Error(`Fish Audio read timed out after ${timeoutMs}ms`)),
-          timeoutMs,
-        );
-      });
-      let done: boolean;
-      let value: Uint8Array | undefined;
-      try {
-        ({ done, value } = await Promise.race([reader.read(), timeout]));
-      } finally {
-        clearTimeout(timerId!);
-      }
-      if (done) break;
-      if (value) {
-        isFirstChunk = false;
-        chunks.push(value);
-        options?.onChunk?.(value);
-      }
-    }
-  } catch (err) {
-    try { await reader.cancel(); } catch { /* Ignore cancellation errors */ }
-    throw err;
-  }
-
-  const totalLength = chunks.reduce((sum, c) => sum + c.byteLength, 0);
-  const merged = new Uint8Array(totalLength);
-  let offset = 0;
-  for (const chunk of chunks) {
-    merged.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-
-  log.debug({ bytes: totalLength }, "Fish Audio synthesis complete");
-  return Buffer.from(merged);
+  log.debug({ bytes: audio.byteLength }, "Fish Audio synthesis complete");
+  return audio;
 }

--- a/assistant/src/calls/media-stream-audio-transcode.ts
+++ b/assistant/src/calls/media-stream-audio-transcode.ts
@@ -26,7 +26,7 @@
  * 8000 samples/sec * 0.020 sec = 160 samples per frame.
  * Each mu-law sample is 1 byte, so each frame is 160 bytes.
  */
-const MULAW_FRAME_SIZE = 160;
+export const MULAW_FRAME_SIZE = 160;
 
 /**
  * Bias constant used in the linear-to-mu-law compression formula

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -29,11 +29,14 @@
  *
  * - `clearAudio()` — Clears any queued outbound audio (barge-in),
  *   flushes the internal playback queue, and aborts in-flight synthesis.
+ *   Also exposed to the call controller as `cancelPendingSpeech()` so an
+ *   aborted turn's queued speech never plays over the next turn.
  */
 
 import type { ServerWebSocket } from "bun";
 
 import { extractSpeakableSegments } from "../tts/speakable-segments.js";
+import { synthesizeAndEmit } from "../tts/synthesis-stream.js";
 import { getLogger } from "../util/logger.js";
 import type { CallTransport } from "./call-transport.js";
 import {
@@ -47,6 +50,7 @@ import type {
   MediaStreamSendMarkCommand,
   MediaStreamSendMediaCommand,
 } from "./media-stream-protocol.js";
+import { resolveCallTtsProvider } from "./resolve-call-tts-provider.js";
 
 const log = getLogger("media-stream-output");
 
@@ -209,6 +213,16 @@ export class MediaStreamOutput implements CallTransport {
    */
   discardPendingText(): void {
     this.textBuffer = "";
+  }
+
+  /**
+   * Cancel queued and in-flight speech playback, including audio Twilio
+   * has already buffered. The call controller invokes this when it
+   * aborts an in-flight turn so speech the aborted turn queued for
+   * synthesis never plays over the next turn.
+   */
+  cancelPendingSpeech(): void {
+    this.clearAudio();
   }
 
   /**
@@ -489,8 +503,6 @@ export class MediaStreamOutput implements CallTransport {
     this.activePlaybackAbort = abortController;
 
     try {
-      const { resolveCallTtsProvider } =
-        await import("./resolve-call-tts-provider.js");
       // Request WAV so audioBufferToFrames gets PCM it can transcode
       // to mu-law. Compressed formats (mp3, opus) would be sent as raw
       // bytes and produce garbled audio.
@@ -509,7 +521,6 @@ export class MediaStreamOutput implements CallTransport {
         return;
       }
 
-      const { synthesizeAndEmit } = await import("../tts/synthesis-stream.js");
       const isCurrent = (): boolean =>
         version === this.playbackVersion && !this.isClosed();
 

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -7,11 +7,12 @@
  *
  * The media-stream transport operates on raw audio frames:
  *
- * - `sendTextToken()` — Accumulates text tokens and, on `last: true`,
- *   synthesizes the accumulated text via the configured TTS provider,
- *   transcodes the resulting audio to mu-law 8 kHz, and streams it as
- *   media frames to Twilio. An empty token with `last: true` sends an
- *   end-of-turn mark without synthesizing.
+ * - `sendTextToken()` — Accumulates text tokens, extracts complete
+ *   speakable segments as they form, and synthesizes each segment via
+ *   the configured TTS provider, transcoding the resulting audio to
+ *   mu-law 8 kHz media frames for Twilio. On `last: true` the remaining
+ *   text is flushed as a final segment followed by an end-of-turn mark.
+ *   An empty token with `last: true` sends only the mark.
  *
  * - `sendPlayUrl()` — Fetches audio from the given URL, transcodes it
  *   to mu-law 8 kHz, and streams the resulting frames to Twilio.
@@ -32,10 +33,12 @@
 
 import type { ServerWebSocket } from "bun";
 
+import { extractSpeakableSegments } from "../tts/speakable-segments.js";
 import { getLogger } from "../util/logger.js";
 import type { CallTransport } from "./call-transport.js";
 import {
   chunkMulawToBase64Frames,
+  MULAW_FRAME_SIZE,
   pcm16ToMulaw,
   resamplePcm16,
 } from "./media-stream-audio-transcode.js";
@@ -49,6 +52,14 @@ const log = getLogger("media-stream-output");
 
 /** Twilio media streams consume 8 kHz mono mu-law. */
 const TELEPHONY_SAMPLE_RATE_HZ = 8000;
+
+/**
+ * PCM sample rate requested from streaming-capable providers. Deterministic
+ * across providers (ElevenLabs maps the hint to `pcm_16000`; fish-audio
+ * honours it directly), so the incremental transcode can hard-wire its
+ * downsample ratio to the telephony rate.
+ */
+const STREAMING_PCM_SAMPLE_RATE_HZ = 16_000;
 
 /**
  * Keep every `factor`-th 16-bit LE sample. Cheap decimation (no anti-alias
@@ -96,7 +107,10 @@ export class MediaStreamOutput implements CallTransport {
   private ws: ServerWebSocket<unknown>;
   private state: MediaStreamOutputState = "connected";
 
-  /** Accumulated text from sendTextToken calls before the final `last: true`. */
+  /**
+   * Text accumulated from sendTextToken calls that has not yet formed a
+   * complete speakable segment.
+   */
   private textBuffer = "";
 
   /** FIFO queue of playback items awaiting delivery. */
@@ -134,27 +148,33 @@ export class MediaStreamOutput implements CallTransport {
   // ── CallTransport interface ─────────────────────────────────────────
 
   /**
-   * Accumulate text tokens for TTS synthesis. When `last` is true, the
-   * accumulated text is queued for synthesis and delivery as media frames.
+   * Accumulate text tokens for TTS synthesis. Each complete speakable
+   * segment (sentence or newline-bounded line) is queued for synthesis
+   * as soon as it forms, so speech starts before the turn completes.
+   * When `last` is true, the remaining text is force-flushed as a final
+   * segment.
    *
    * An empty token with `last: true` signals end-of-turn without TTS:
    * a mark is sent so the session transitions from "assistant speaking"
    * to "caller speaking".
    */
   sendTextToken(token: string, last: boolean): void {
-    if (this.state === "closed") return;
+    if (this.state === "closed") {
+      return;
+    }
 
     this.textBuffer += token;
 
+    const { segments, remainder } = extractSpeakableSegments(
+      this.textBuffer,
+      last,
+    );
+    this.textBuffer = remainder;
+    for (const segment of segments) {
+      this.enqueuePlayback({ type: "synthesize", text: segment });
+    }
+
     if (last) {
-      const text = this.textBuffer.trim();
-      this.textBuffer = "";
-
-      if (text.length > 0) {
-        // Queue synthesis of the accumulated text.
-        this.enqueuePlayback({ type: "synthesize", text });
-      }
-
       // Always send an end-of-turn mark so the media-stream server
       // can detect turn boundaries.
       this.enqueuePlayback({ type: "mark", name: "end-of-turn" });
@@ -456,7 +476,10 @@ export class MediaStreamOutput implements CallTransport {
 
   /**
    * Synthesize text via the TTS provider and send resulting audio as
-   * mu-law frames. Falls back to a silent frame if synthesis fails.
+   * mu-law frames. PCM-capable providers are transcoded incrementally —
+   * each streamed chunk becomes frames as it arrives — while other
+   * providers accumulate into the whole-buffer conversion path. Falls
+   * back to a silent frame if synthesis fails.
    */
   private async processSynthesizeItem(
     text: string,
@@ -482,21 +505,108 @@ export class MediaStreamOutput implements CallTransport {
         return;
       }
 
-      if (version !== this.playbackVersion || this.isClosed()) return;
+      if (version !== this.playbackVersion || this.isClosed()) {
+        return;
+      }
+
+      const { synthesizeAndEmit } = await import("../tts/synthesis-stream.js");
+      const isCurrent = (): boolean =>
+        version === this.playbackVersion && !this.isClosed();
+
+      // PCM-capable providers honour `outputFormat: "pcm"` at the requested
+      // sample rate, so their chunks can be transcoded to mu-law frames as
+      // they arrive. Other providers accumulate below and go through the
+      // whole-buffer content-type sniffing path.
+      const streamsPcm = provider.capabilities.supportedFormats.includes("pcm");
+      const bufferedChunks: Buffer[] = [];
+
+      // Chunk boundaries can split a 16-bit sample or a decimation pair;
+      // the unprocessable tail (< 4 bytes) carries into the next chunk so
+      // sample alignment and decimation phase stay stable across chunks.
+      let pcmCarry: Buffer | undefined;
+      // Mu-law bytes short of a whole 20 ms frame, carried likewise.
+      let mulawCarry: Buffer = Buffer.alloc(0);
+
+      const sendMulaw = (mulaw: Buffer, flushPartialFrame: boolean): void => {
+        mulawCarry =
+          mulawCarry.length > 0 ? Buffer.concat([mulawCarry, mulaw]) : mulaw;
+        const sendableBytes = flushPartialFrame
+          ? mulawCarry.length
+          : mulawCarry.length - (mulawCarry.length % MULAW_FRAME_SIZE);
+        if (sendableBytes === 0) {
+          return;
+        }
+        const frames = chunkMulawToBase64Frames(
+          mulawCarry.subarray(0, sendableBytes),
+        );
+        mulawCarry = mulawCarry.subarray(sendableBytes);
+        this.sendFrames(frames);
+      };
 
       // Synthesize the text. Request PCM output so the media-stream
       // transport receives raw samples it can transcode to mu-law.
       // Providers that support it (e.g. ElevenLabs pcm_16000) will
       // return raw PCM; others fall back to their default format and
       // the content-type sniffing below handles the mismatch.
-      const result = await provider.synthesize({
+      const result = await synthesizeAndEmit({
+        provider,
         text,
         useCase: "phone-call",
         outputFormat: "pcm",
+        sampleRateHz: STREAMING_PCM_SAMPLE_RATE_HZ,
         signal: abortController.signal,
+        isCurrent,
+        onChunk: (chunk) => {
+          if (!streamsPcm) {
+            bufferedChunks.push(chunk.audio);
+            return;
+          }
+          if (!isCurrent()) {
+            return;
+          }
+          const combined = pcmCarry
+            ? Buffer.concat([pcmCarry, chunk.audio])
+            : chunk.audio;
+          // 4 bytes = two 16 kHz samples = one 8 kHz output sample.
+          const usableBytes = combined.length & ~3;
+          pcmCarry =
+            usableBytes < combined.length
+              ? combined.subarray(usableBytes)
+              : undefined;
+          if (usableBytes === 0) {
+            return;
+          }
+          const pcm8k = this.pcm16ToTelephonyRate(
+            combined.subarray(0, usableBytes),
+            STREAMING_PCM_SAMPLE_RATE_HZ,
+          );
+          sendMulaw(pcm16ToMulaw(pcm8k), false);
+        },
       });
 
-      if (version !== this.playbackVersion || this.isClosed()) return;
+      if (!isCurrent()) {
+        return;
+      }
+
+      if (streamsPcm) {
+        if (pcmCarry) {
+          // A sub-sample tail is malformed provider output; decimation
+          // would drop it anyway.
+          log.debug(
+            { streamSid: this.streamSid, carryBytes: pcmCarry.length },
+            "Dropping sub-sample tail from PCM16 TTS stream",
+          );
+        }
+        // Flush the final partial frame — the whole-buffer path sends a
+        // short trailing frame the same way.
+        sendMulaw(Buffer.alloc(0), true);
+        return;
+      }
+
+      // A stopped stream means partial audio; never send a truncated buffer.
+      if (result.stopped) {
+        return;
+      }
 
       // Derive the format from the provider's actual content type rather
       // than the declared audioFormat. The declared format may not match
@@ -515,8 +625,13 @@ export class MediaStreamOutput implements CallTransport {
                   result.contentType.includes("x-raw")
                 ? "pcm"
                 : audioFormat; // fall back to declared format for unknown types
-      const frames = this.audioBufferToFrames(result.audio, actualFormat);
-      if (version !== this.playbackVersion || this.isClosed()) return;
+      const frames = this.audioBufferToFrames(
+        Buffer.concat(bufferedChunks),
+        actualFormat,
+      );
+      if (!isCurrent()) {
+        return;
+      }
 
       this.sendFrames(frames);
     } catch (err) {

--- a/assistant/src/calls/resolve-call-tts-provider.ts
+++ b/assistant/src/calls/resolve-call-tts-provider.ts
@@ -199,3 +199,23 @@ export async function findPlayableTelephonyTtsFallback(
   }
   return null;
 }
+
+/**
+ * Resolve {@link findPlayableTelephonyTtsFallback} to a registered
+ * provider instance. Returns `null` when no playable fallback exists or
+ * the winning candidate is not registered in the provider registry.
+ * Callers own retry semantics and logging.
+ */
+export async function findPlayableTelephonyTtsFallbackProvider(
+  excludeProviderId?: string,
+): Promise<TtsProvider | null> {
+  const fallbackId = await findPlayableTelephonyTtsFallback(excludeProviderId);
+  if (!fallbackId) {
+    return null;
+  }
+  try {
+    return getTtsProvider(fallbackId);
+  } catch {
+    return null;
+  }
+}

--- a/assistant/src/calls/tts-text-sanitizer.ts
+++ b/assistant/src/calls/tts-text-sanitizer.ts
@@ -55,9 +55,11 @@ export function sanitizeForTts(text: string): string {
   result = result.replace(/^[-*]\s+/gm, "");
 
   // 7. Italic: *text* or _text_ → text
-  //    Word-boundary-aware to preserve arithmetic like `5 * 3` and identifiers like `my_var`.
-  result = result.replace(/(?<!\w)\*([^*]+)\*(?!\w)/g, "$1");
-  result = result.replace(/(?<!\w)_([^_]+)_(?!\w)/g, "$1");
+  //    Word-boundary-aware with non-whitespace content edges, so arithmetic
+  //    like `5 * 3 and 4 * 2` and identifiers like `my_var` survive. Mirrors
+  //    the open-span rule in tts/speakable-segments.ts.
+  result = result.replace(/(?<!\w)\*([^\s*](?:[^*]*[^\s*])?)\*(?!\w)/g, "$1");
+  result = result.replace(/(?<!\w)_([^\s_](?:[^_]*[^\s_])?)_(?!\w)/g, "$1");
 
   // 8. Emojis: strip extended pictographic characters, variation selectors,
   //    zero-width joiners, skin tone modifiers, and regional indicator symbols (flags).

--- a/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
@@ -205,6 +205,50 @@ describe("LiveVoiceSession TTS", () => {
     });
   });
 
+  test("flushes the first segment of a turn eagerly at a clause boundary", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const ttsTexts: string[] = [];
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      ttsTexts.push(options.text);
+      options.onAudioChunk(makeTtsChunk(`audio:${options.text}`));
+      return makeTtsResult(options.text);
+    });
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(
+      makeTextDelta("Sure, I can help with that, and here is more text to say."),
+    );
+    await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
+
+    // The opening clause flushes at the comma past the prefix floor instead
+    // of waiting for the sentence; the remainder follows sentence rules.
+    expect(ttsTexts).toEqual([
+      "Sure, I can help with that,",
+      "and here is more text to say.",
+    ]);
+
+    // Subsequent text in the same turn is not eagerly clause-split.
+    callbacks?.assistant_text_delta?.(
+      makeTextDelta(" Later we can dig into the details, if you want more"),
+    );
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(ttsTexts).toEqual([
+      "Sure, I can help with that,",
+      "and here is more text to say.",
+      "Later we can dig into the details, if you want more",
+    ]);
+  });
+
   test("forwards non-PCM TTS chunk content type unchanged", async () => {
     let callbacks: VoiceTurnCallbacks | undefined;
     const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
@@ -231,7 +275,7 @@ describe("LiveVoiceSession TTS", () => {
     });
   });
 
-  test("flushes long assistant text as a conservative TTS segment before completion", async () => {
+  test("flushes long unpunctuated assistant text before completion at the eager threshold", async () => {
     let callbacks: VoiceTurnCallbacks | undefined;
     const ttsTexts: string[] = [];
     const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
@@ -252,9 +296,11 @@ describe("LiveVoiceSession TTS", () => {
     callbacks?.assistant_text_delta?.(makeTextDelta("steady ".repeat(32)));
     await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
 
+    // The turn's first segment splits at the eager threshold; the rest stays
+    // buffered under sentence rules until more text or completion arrives.
     expect(ttsTexts).toHaveLength(1);
-    expect(ttsTexts[0]?.length).toBeGreaterThan(100);
-    expect(ttsTexts[0]?.length).toBeLessThanOrEqual(181);
+    expect(ttsTexts[0]?.length).toBeGreaterThan(30);
+    expect(ttsTexts[0]?.length).toBeLessThanOrEqual(60);
     expect(frames.some((frame) => frame.type === "tts_done")).toBe(false);
   });
 

--- a/assistant/src/live-voice/__tests__/live-voice-tts.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts.test.ts
@@ -348,7 +348,6 @@ describe("streamLiveVoiceTtsAudio", () => {
         return {
           audio: Buffer.from("pcm-one!"),
           contentType: "audio/pcm",
-          sampleRateHz: 16_000,
         };
       },
     });

--- a/assistant/src/live-voice/__tests__/live-voice-tts.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {
   _resetTtsProviderOverridesForTests,
@@ -16,6 +16,17 @@ import type {
 } from "../live-voice-tts.js";
 
 let config = makeConfig();
+
+// Real-catalog tests exercise the actual provider adapters, which read
+// credentials and config through these modules.
+mock.module("../../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async () => "test-api-key",
+  getProviderKeyAsync: async () => "test-api-key",
+}));
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => config,
+  loadConfig: () => config,
+}));
 
 const { LiveVoiceTtsError, streamLiveVoiceTtsAudio } =
   await import("../live-voice-tts.js");
@@ -314,6 +325,93 @@ describe("streamLiveVoiceTtsAudio", () => {
       chunks: 0,
       bytes: 0,
     });
+  });
+
+  test("labels frames with the provider-reported output rate when the requested rate is not honoured", async () => {
+    config = makeConfig({ provider: "elevenlabs" });
+    _setTtsProviderForTests({
+      id: "elevenlabs",
+      capabilities: {
+        supportsStreaming: true,
+        supportedFormats: ["mp3", "pcm"],
+      },
+      resolveOutputSampleRateHz: () => 16_000,
+      async synthesize(): Promise<TtsSynthesisResult> {
+        throw new Error("buffered synthesis should not be used");
+      },
+      async synthesizeStream(
+        request: TtsSynthesisRequest,
+        onChunk: (chunk: Uint8Array) => void,
+      ): Promise<TtsSynthesisResult> {
+        expect(request.sampleRateHz).toBe(48_000);
+        onChunk(Buffer.from("pcm-one!"));
+        return {
+          audio: Buffer.from("pcm-one!"),
+          contentType: "audio/pcm",
+          sampleRateHz: 16_000,
+        };
+      },
+    });
+
+    const frames: LiveVoiceTtsAudioChunk[] = [];
+    const result = await streamLiveVoiceTtsAudio({
+      config,
+      text: "hello from live voice",
+      outputFormat: "pcm",
+      sampleRate: 48_000,
+      onAudioChunk: (chunk) => frames.push(chunk),
+    });
+
+    expect(frames.map((frame) => frame.sampleRate)).toEqual([16_000]);
+    expect(result.sampleRate).toBe(16_000);
+  });
+
+  test("resolves ElevenLabs streaming through the real catalog adapter", async () => {
+    // No _setTtsProviderForTests override: this exercises the real catalog
+    // provider lookup and must not throw LIVE_VOICE_TTS_STREAMING_UNAVAILABLE.
+    config = makeConfig({ provider: "elevenlabs" });
+    const originalFetch = globalThis.fetch;
+    let capturedUrl = "";
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      capturedUrl = typeof input === "string" ? input : input.toString();
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new Uint8Array([0x01, 0x02, 0x03, 0x04]));
+            controller.close();
+          },
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof globalThis.fetch;
+
+    try {
+      const frames: LiveVoiceTtsAudioChunk[] = [];
+      const result = await streamLiveVoiceTtsAudio({
+        config,
+        text: "hello from live voice",
+        outputFormat: "pcm",
+        sampleRate: 24_000,
+        onAudioChunk: (chunk) => frames.push(chunk),
+      });
+
+      expect(capturedUrl).toContain("/stream?output_format=pcm_24000");
+      expect(result).toMatchObject({
+        provider: "elevenlabs",
+        contentType: "audio/pcm",
+        sampleRate: 24_000,
+      });
+      expect(frames).toEqual([
+        {
+          type: "tts_audio",
+          contentType: "audio/pcm",
+          sampleRate: 24_000,
+          dataBase64: Buffer.from([0x01, 0x02, 0x03, 0x04]).toString("base64"),
+        },
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   test("returns a typed configuration error for a non-streaming provider", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-tts.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts.test.ts
@@ -67,6 +67,7 @@ describe("streamLiveVoiceTtsAudio", () => {
         voiceId: undefined,
         signal: undefined,
         outputFormat: undefined,
+        sampleRateHz: 24_000,
       },
     ]);
     expect(frames).toEqual([
@@ -152,10 +153,68 @@ describe("streamLiveVoiceTtsAudio", () => {
         onChunk: (chunk: Uint8Array) => void,
       ): Promise<TtsSynthesisResult> {
         requests.push(request);
-        onChunk(Buffer.from("pcm-one"));
-        onChunk(Buffer.from("pcm-two"));
+        onChunk(Buffer.from("pcm-one!"));
+        onChunk(Buffer.from("pcm-two!"));
         return {
-          audio: Buffer.from("pcm-onepcm-two"),
+          audio: Buffer.from("pcm-one!pcm-two!"),
+          contentType: "audio/pcm",
+        };
+      },
+    });
+
+    const frames: LiveVoiceTtsAudioChunk[] = [];
+    const result = await streamLiveVoiceTtsAudio({
+      config,
+      text: "hello from live voice",
+      outputFormat: "pcm",
+      sampleRate: 16_000,
+      onAudioChunk: (chunk) => frames.push(chunk),
+    });
+
+    expect(requests[0]?.outputFormat).toBe("pcm");
+    expect(requests[0]?.sampleRateHz).toBe(16_000);
+    expect(frames).toEqual([
+      {
+        type: "tts_audio",
+        contentType: "audio/pcm",
+        sampleRate: 16_000,
+        dataBase64: Buffer.from("pcm-one!").toString("base64"),
+      },
+      {
+        type: "tts_audio",
+        contentType: "audio/pcm",
+        sampleRate: 16_000,
+        dataBase64: Buffer.from("pcm-two!").toString("base64"),
+      },
+    ]);
+    expect(result).toEqual({
+      provider: "elevenlabs",
+      contentType: "audio/pcm",
+      sampleRate: 16_000,
+      chunks: 2,
+      bytes: Buffer.byteLength("pcm-one!pcm-two!"),
+    });
+  });
+
+  test("carries a trailing odd byte into the next PCM chunk to keep frames sample-aligned", async () => {
+    config = makeConfig({ provider: "elevenlabs" });
+    _setTtsProviderForTests({
+      id: "elevenlabs",
+      capabilities: {
+        supportsStreaming: true,
+        supportedFormats: ["mp3", "pcm"],
+      },
+      async synthesize(): Promise<TtsSynthesisResult> {
+        throw new Error("buffered synthesis should not be used");
+      },
+      async synthesizeStream(
+        _request: TtsSynthesisRequest,
+        onChunk: (chunk: Uint8Array) => void,
+      ): Promise<TtsSynthesisResult> {
+        onChunk(Buffer.from([1, 2, 3]));
+        onChunk(Buffer.from([4, 5, 6, 7, 8]));
+        return {
+          audio: Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]),
           contentType: "audio/pcm",
         };
       },
@@ -169,28 +228,48 @@ describe("streamLiveVoiceTtsAudio", () => {
       onAudioChunk: (chunk) => frames.push(chunk),
     });
 
-    expect(requests[0]?.outputFormat).toBe("pcm");
-    expect(frames).toEqual([
-      {
-        type: "tts_audio",
-        contentType: "audio/pcm",
-        sampleRate: 24_000,
-        dataBase64: Buffer.from("pcm-one").toString("base64"),
-      },
-      {
-        type: "tts_audio",
-        contentType: "audio/pcm",
-        sampleRate: 24_000,
-        dataBase64: Buffer.from("pcm-two").toString("base64"),
-      },
+    expect(frames.map((frame) => frame.dataBase64)).toEqual([
+      Buffer.from([1, 2]).toString("base64"),
+      Buffer.from([3, 4, 5, 6, 7, 8]).toString("base64"),
     ]);
-    expect(result).toEqual({
-      provider: "elevenlabs",
-      contentType: "audio/pcm",
-      sampleRate: 24_000,
-      chunks: 2,
-      bytes: Buffer.byteLength("pcm-onepcm-two"),
+    expect(result).toMatchObject({ chunks: 2, bytes: 8 });
+  });
+
+  test("drops a dangling final odd byte instead of emitting a torn PCM sample", async () => {
+    config = makeConfig({ provider: "elevenlabs" });
+    _setTtsProviderForTests({
+      id: "elevenlabs",
+      capabilities: {
+        supportsStreaming: true,
+        supportedFormats: ["mp3", "pcm"],
+      },
+      async synthesize(): Promise<TtsSynthesisResult> {
+        throw new Error("buffered synthesis should not be used");
+      },
+      async synthesizeStream(
+        _request: TtsSynthesisRequest,
+        onChunk: (chunk: Uint8Array) => void,
+      ): Promise<TtsSynthesisResult> {
+        onChunk(Buffer.from([1, 2, 3]));
+        return {
+          audio: Buffer.from([1, 2, 3]),
+          contentType: "audio/pcm",
+        };
+      },
     });
+
+    const frames: LiveVoiceTtsAudioChunk[] = [];
+    const result = await streamLiveVoiceTtsAudio({
+      config,
+      text: "hello from live voice",
+      outputFormat: "pcm",
+      onAudioChunk: (chunk) => frames.push(chunk),
+    });
+
+    expect(frames.map((frame) => frame.dataBase64)).toEqual([
+      Buffer.from([1, 2]).toString("base64"),
+    ]);
+    expect(result).toMatchObject({ chunks: 1, bytes: 2 });
   });
 
   test("skips the buffered non-PCM emit when the signal aborts mid-stream", async () => {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -20,6 +20,7 @@ import type {
   StreamingTranscriber,
   SttStreamServerEvent,
 } from "../stt/types.js";
+import { extractSpeakableSegments } from "../tts/speakable-segments.js";
 import type {
   LiveVoiceAudioArchiveResult,
   LiveVoiceAudioArchiveRole,
@@ -54,9 +55,6 @@ type LiveVoiceSessionState =
   | "failed"
   | "closed";
 
-const LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD = 180;
-const SENTENCE_ENDING_PUNCTUATION = new Set([".", "!", "?"]);
-const TRAILING_SENTENCE_PUNCTUATION = new Set(['"', "'", ")", "]"]);
 // Cap on audio buffered while a server-VAD utterance waits for its
 // transcriber (PCM16 mono seconds; oldest chunks are dropped past the cap).
 const SERVER_VAD_PENDING_AUDIO_MAX_SECONDS = 10;
@@ -1596,81 +1594,6 @@ async function defaultArchiveLiveVoiceAudio(
   return input.role === "user"
     ? linkLiveVoiceUserUtteranceAudioToMessage(input)
     : linkLiveVoiceAssistantResponseAudioToMessage(input);
-}
-
-function extractSpeakableSegments(
-  text: string,
-  force: boolean,
-): { segments: string[]; remainder: string } {
-  const segments: string[] = [];
-  let remainder = text;
-
-  while (remainder.length > 0) {
-    const boundary = findSpeakableBoundary(remainder);
-    if (boundary === null) break;
-
-    const segment = remainder.slice(0, boundary).trim();
-    if (segment.length > 0) {
-      segments.push(segment);
-    }
-    remainder = remainder.slice(boundary);
-  }
-
-  if (force) {
-    const segment = remainder.trim();
-    if (segment.length > 0) {
-      segments.push(segment);
-    }
-    remainder = "";
-  }
-
-  return { segments, remainder };
-}
-
-function findSpeakableBoundary(text: string): number | null {
-  for (let index = 0; index < text.length; index += 1) {
-    const char = text[index];
-    if (char === "\n") return index + 1;
-    if (!char || !SENTENCE_ENDING_PUNCTUATION.has(char)) continue;
-
-    let boundary = index + 1;
-    while (
-      boundary < text.length &&
-      TRAILING_SENTENCE_PUNCTUATION.has(text[boundary] ?? "")
-    ) {
-      boundary += 1;
-    }
-
-    if (boundary === text.length || isWhitespace(text[boundary] ?? "")) {
-      return boundary;
-    }
-  }
-
-  if (text.length < LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD) {
-    return null;
-  }
-
-  const preferredBoundary = findLastWhitespaceBoundary(
-    text,
-    LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD,
-  );
-  return preferredBoundary ?? LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD;
-}
-
-function findLastWhitespaceBoundary(
-  text: string,
-  maxLength: number,
-): number | null {
-  for (let index = maxLength; index > Math.floor(maxLength * 0.6); index -= 1) {
-    if (isWhitespace(text[index] ?? "")) {
-      return index + 1;
-    }
-  }
-  return null;
-}
-
-function isWhitespace(value: string): boolean {
-  return /\s/.test(value);
 }
 
 function toSeedMarks(stashed: StashedMetricsMarks): LiveVoiceTurnSeedMarks {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -163,6 +163,9 @@ interface ActiveAssistantTurn {
   ttsAudioStarted: boolean;
   finalized: boolean;
   ttsBuffer: string;
+  // A non-empty speakable segment reached the TTS queue — gates the eager
+  // first-segment flush that trades clause quality for speech onset.
+  ttsSegmentEnqueued: boolean;
   ttsQueue: Promise<void>;
   assistantMessageId: string | null;
   assistantAudioChunks: Buffer[];
@@ -861,6 +864,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       ttsAudioStarted: false,
       finalized: false,
       ttsBuffer: "",
+      ttsSegmentEnqueued: false,
       ttsQueue: Promise.resolve(),
       assistantMessageId: null,
       assistantAudioChunks: [],
@@ -1095,6 +1099,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     const { segments, remainder } = extractSpeakableSegments(
       activeTurn.ttsBuffer,
       force,
+      // Eager until the first segment is enqueued: the opening clause flushes
+      // early so speech onset does not wait for a full sentence.
+      { eager: !activeTurn.ttsSegmentEnqueued },
     );
     activeTurn.ttsBuffer = remainder;
 
@@ -1114,6 +1121,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     const streamTtsAudio = this.streamTtsAudio;
     if (activeTurn?.token !== token || !streamTtsAudio) return;
 
+    activeTurn.ttsSegmentEnqueued = true;
     activeTurn.ttsQueue = activeTurn.ttsQueue
       .catch(() => {})
       .then(async () => {

--- a/assistant/src/live-voice/live-voice-tts.ts
+++ b/assistant/src/live-voice/live-voice-tts.ts
@@ -76,7 +76,30 @@ export async function streamLiveVoiceTtsAudio(
 ): Promise<LiveVoiceTtsResult> {
   const { provider, providerId, providerConfig } =
     await resolveLiveVoiceStreamingTtsProvider(options.config);
-  const sampleRate = resolveSampleRate(options.sampleRate, providerConfig);
+  const useCase = options.useCase ?? "phone-call";
+  const requestedSampleRate = resolveSampleRate(
+    options.sampleRate,
+    providerConfig,
+  );
+  // Frames are labeled with the provider's actual output rate: the streaming
+  // path emits chunks before the synthesis result resolves, so the rate must
+  // be known up-front — a rate hint the provider cannot honour would
+  // otherwise mislabel the audio and play at the wrong speed.
+  const providerSampleRate = provider.resolveOutputSampleRateHz?.({
+    text: options.text,
+    useCase,
+    voiceId: options.voiceId,
+    outputFormat: options.outputFormat,
+    sampleRateHz: requestedSampleRate,
+    signal: options.signal,
+  });
+  let sampleRate = providerSampleRate ?? requestedSampleRate;
+  if (sampleRate !== requestedSampleRate) {
+    log.warn(
+      { provider: providerId, requestedSampleRate, sampleRate },
+      "TTS provider output sample rate differs from the requested rate; labeling audio with the provider rate",
+    );
+  }
   const chunkContentType = resolveChunkContentType(
     provider,
     providerConfig,
@@ -122,10 +145,10 @@ export async function streamLiveVoiceTtsAudio(
     const result = await synthesizeAndEmit({
       provider,
       text: options.text,
-      useCase: options.useCase ?? "phone-call",
+      useCase,
       voiceId: options.voiceId,
       outputFormat: options.outputFormat,
-      sampleRateHz: sampleRate,
+      sampleRateHz: requestedSampleRate,
       signal: options.signal,
       onChunk: (chunk) => {
         if (canStreamChunks) {
@@ -148,6 +171,24 @@ export async function streamLiveVoiceTtsAudio(
       );
     }
     const contentType = result.contentType || chunkContentType;
+
+    // Late correction for providers that report the actual rate only on the
+    // completed result: it relabels the buffered emit below and the returned
+    // result (already-streamed frames keep their up-front label).
+    if (
+      isPositiveFiniteNumber(result.sampleRateHz) &&
+      result.sampleRateHz !== sampleRate
+    ) {
+      log.warn(
+        {
+          provider: providerId,
+          labeledSampleRate: sampleRate,
+          sampleRate: result.sampleRateHz,
+        },
+        "TTS provider reported a different output sample rate on the completed result",
+      );
+      sampleRate = result.sampleRateHz;
+    }
 
     // An abort mid-stream resolves without throwing; skip the buffered emit
     // so a truncated payload is never delivered after cancellation.

--- a/assistant/src/live-voice/live-voice-tts.ts
+++ b/assistant/src/live-voice/live-voice-tts.ts
@@ -7,6 +7,9 @@ import type {
   TtsSynthesisRequest,
   TtsUseCase,
 } from "../tts/types.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("live-voice-tts");
 
 export const DEFAULT_LIVE_VOICE_TTS_SAMPLE_RATE = 24_000;
 
@@ -102,6 +105,19 @@ export async function streamLiveVoiceTtsAudio(
   // compressed formats (mp3/wav/opus) are only playable as a whole payload.
   const bufferedAudio: Buffer[] = [];
 
+  // Provider chunks can split a 16-bit PCM sample across chunk boundaries;
+  // a trailing odd byte is carried into the next chunk to keep frames aligned.
+  let pcm16Carry: Buffer | undefined;
+  const alignPcm16 = (audio: Buffer): Buffer => {
+    const combined = pcm16Carry ? Buffer.concat([pcm16Carry, audio]) : audio;
+    const alignedLength = combined.byteLength & ~1;
+    pcm16Carry =
+      alignedLength < combined.byteLength
+        ? combined.subarray(alignedLength)
+        : undefined;
+    return combined.subarray(0, alignedLength);
+  };
+
   try {
     const result = await synthesizeAndEmit({
       provider,
@@ -109,15 +125,28 @@ export async function streamLiveVoiceTtsAudio(
       useCase: options.useCase ?? "phone-call",
       voiceId: options.voiceId,
       outputFormat: options.outputFormat,
+      sampleRateHz: sampleRate,
       signal: options.signal,
       onChunk: (chunk) => {
         if (canStreamChunks) {
-          emitAudioFrame(chunk.contentType || chunkContentType, chunk.audio);
+          emitAudioFrame(
+            chunk.contentType || chunkContentType,
+            alignPcm16(chunk.audio),
+          );
         } else {
           bufferedAudio.push(chunk.audio);
         }
       },
     });
+
+    // A dangling final byte is malformed provider output — drop it rather
+    // than emit a torn sample.
+    if (pcm16Carry) {
+      log.debug(
+        { provider: providerId },
+        "Dropping trailing odd byte from PCM16 TTS stream",
+      );
+    }
     const contentType = result.contentType || chunkContentType;
 
     // An abort mid-stream resolves without throwing; skip the buffered emit

--- a/assistant/src/live-voice/live-voice-tts.ts
+++ b/assistant/src/live-voice/live-voice-tts.ts
@@ -93,7 +93,7 @@ export async function streamLiveVoiceTtsAudio(
     sampleRateHz: requestedSampleRate,
     signal: options.signal,
   });
-  let sampleRate = providerSampleRate ?? requestedSampleRate;
+  const sampleRate = providerSampleRate ?? requestedSampleRate;
   if (sampleRate !== requestedSampleRate) {
     log.warn(
       { provider: providerId, requestedSampleRate, sampleRate },
@@ -171,24 +171,6 @@ export async function streamLiveVoiceTtsAudio(
       );
     }
     const contentType = result.contentType || chunkContentType;
-
-    // Late correction for providers that report the actual rate only on the
-    // completed result: it relabels the buffered emit below and the returned
-    // result (already-streamed frames keep their up-front label).
-    if (
-      isPositiveFiniteNumber(result.sampleRateHz) &&
-      result.sampleRateHz !== sampleRate
-    ) {
-      log.warn(
-        {
-          provider: providerId,
-          labeledSampleRate: sampleRate,
-          sampleRate: result.sampleRateHz,
-        },
-        "TTS provider reported a different output sample rate on the completed result",
-      );
-      sampleRate = result.sampleRateHz;
-    }
 
     // An abort mid-stream resolves without throwing; skip the buffered emit
     // so a truncated payload is never delivered after cancellation.

--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -343,7 +343,6 @@ describe("ElevenLabs TTS provider adapter", () => {
 
     expect(capturedUrl).toContain("output_format=pcm_24000");
     expect(result.contentType).toBe("audio/pcm");
-    expect(result.sampleRateHz).toBe(24000);
   });
 
   test("pcm output without sampleRateHz defaults to pcm_16000", async () => {
@@ -376,17 +375,6 @@ describe("ElevenLabs TTS provider adapter", () => {
     );
 
     expect(capturedUrl).toContain("output_format=pcm_16000");
-  });
-
-  test("pcm request at an unsupported 48000 Hz reports the actual 16000 Hz output rate", async () => {
-    mockFetchReturning(new Uint8Array([0x00, 0x01]));
-
-    const provider = createElevenLabsProvider();
-    const result = await provider.synthesize(
-      makeRequest({ outputFormat: "pcm", sampleRateHz: 48000 }),
-    );
-
-    expect(result.sampleRateHz).toBe(16000);
   });
 
   test("resolveOutputSampleRateHz reports the actual PCM rate without synthesis", () => {
@@ -439,7 +427,6 @@ describe("ElevenLabs TTS provider adapter", () => {
     expect(received).toEqual([part1, part2]);
     expect(result.audio).toEqual(Buffer.from([0x01, 0x02, 0x03]));
     expect(result.contentType).toBe("audio/pcm");
-    expect(result.sampleRateHz).toBe(16000);
   });
 
   test("synthesizeStream rejects after the first-chunk timeout when the stream never produces audio", async () => {
@@ -611,7 +598,7 @@ describe("ElevenLabs TTS provider adapter", () => {
 
   // -- Content type / format -----------------------------------------------
 
-  test("returns audio/mpeg content type for mp3 format without a sample rate", async () => {
+  test("returns audio/mpeg content type for mp3 format", async () => {
     const audioPayload = new Uint8Array([0x49, 0x44, 0x33]);
     mockFetchReturning(audioPayload);
 
@@ -620,7 +607,6 @@ describe("ElevenLabs TTS provider adapter", () => {
 
     expect(result.contentType).toBe("audio/mpeg");
     expect(result.audio.byteLength).toBeGreaterThan(0);
-    expect(result.sampleRateHz).toBeUndefined();
   });
 
   // -- Required config validation ------------------------------------------
@@ -850,12 +836,11 @@ describe("Fish Audio TTS provider adapter", () => {
       16000,
     );
     expect(result.contentType).toBe("audio/pcm");
-    expect(result.sampleRateHz).toBe(16000);
   });
 
   test("pcm output request honors the sampleRateHz hint", async () => {
     const provider = createFishAudioProvider();
-    const result = await provider.synthesize(
+    await provider.synthesize(
       makeRequest({ outputFormat: "pcm", sampleRateHz: 24000 }),
     );
 
@@ -864,7 +849,6 @@ describe("Fish Audio TTS provider adapter", () => {
     expect((options as { sampleRate?: number } | undefined)?.sampleRate).toBe(
       24000,
     );
-    expect(result.sampleRateHz).toBe(24000);
   });
 
   test("synthesizeStream pcm output request maps to raw pcm honoring the hint", async () => {
@@ -880,7 +864,6 @@ describe("Fish Audio TTS provider adapter", () => {
       24000,
     );
     expect(result.contentType).toBe("audio/pcm");
-    expect(result.sampleRateHz).toBe(24000);
   });
 
   test("resolveOutputSampleRateHz passes the pcm hint through and is undefined otherwise", () => {
@@ -964,12 +947,11 @@ describe("Fish Audio TTS provider adapter", () => {
     expect(result.contentType).toBe("audio/mpeg");
   });
 
-  test("returns audio/wav content type for wav format without a sample rate", async () => {
+  test("returns audio/wav content type for wav format", async () => {
     mockFishAudioConfig.format = "wav";
     const provider = createFishAudioProvider();
     const result = await provider.synthesize(makeRequest());
     expect(result.contentType).toBe("audio/wav");
-    expect(result.sampleRateHz).toBeUndefined();
   });
 
   test("returns audio/opus content type for opus format", async () => {

--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -838,7 +838,7 @@ describe("Fish Audio TTS provider adapter", () => {
     expect(result.contentType).toBe("audio/pcm");
   });
 
-  test("pcm output request honors the sampleRateHz hint", async () => {
+  test("pcm output request honors a supported sampleRateHz hint", async () => {
     const provider = createFishAudioProvider();
     await provider.synthesize(
       makeRequest({ outputFormat: "pcm", sampleRateHz: 24000 }),
@@ -848,6 +848,19 @@ describe("Fish Audio TTS provider adapter", () => {
     expect((config as { format: string }).format).toBe("pcm");
     expect((options as { sampleRate?: number } | undefined)?.sampleRate).toBe(
       24000,
+    );
+  });
+
+  test("pcm output request clamps an unsupported sampleRateHz hint to the nearest supported rate", async () => {
+    const provider = createFishAudioProvider();
+    await provider.synthesize(
+      makeRequest({ outputFormat: "pcm", sampleRateHz: 48000 }),
+    );
+
+    const [, config, options] = mockSynthesizeWithFishAudio.mock.calls[0]!;
+    expect((config as { format: string }).format).toBe("pcm");
+    expect((options as { sampleRate?: number } | undefined)?.sampleRate).toBe(
+      44100,
     );
   });
 
@@ -866,14 +879,19 @@ describe("Fish Audio TTS provider adapter", () => {
     expect(result.contentType).toBe("audio/pcm");
   });
 
-  test("resolveOutputSampleRateHz passes the pcm hint through and is undefined otherwise", () => {
+  test("resolveOutputSampleRateHz clamps unsupported pcm hints and is undefined otherwise", () => {
     const provider = createFishAudioProvider();
 
     expect(
       provider.resolveOutputSampleRateHz!(
         makeRequest({ outputFormat: "pcm", sampleRateHz: 48000 }),
       ),
-    ).toBe(48000);
+    ).toBe(44100);
+    expect(
+      provider.resolveOutputSampleRateHz!(
+        makeRequest({ outputFormat: "pcm", sampleRateHz: 24000 }),
+      ),
+    ).toBe(24000);
     expect(
       provider.resolveOutputSampleRateHz!(makeRequest({ outputFormat: "pcm" })),
     ).toBe(16000);

--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -708,6 +708,7 @@ describe("Fish Audio TTS provider adapter", () => {
       "mp3",
       "wav",
       "opus",
+      "pcm",
     ]);
   });
 
@@ -754,28 +755,73 @@ describe("Fish Audio TTS provider adapter", () => {
     );
   });
 
-  test("pcm output request maps to wav format at 8 kHz", async () => {
+  test("pcm output request maps to raw pcm format at the 16 kHz default", async () => {
     const provider = createFishAudioProvider();
-    await provider.synthesize(makeRequest({ outputFormat: "pcm" }));
+    const result = await provider.synthesize(
+      makeRequest({ outputFormat: "pcm" }),
+    );
 
     const [, config, options] = mockSynthesizeWithFishAudio.mock.calls[0]!;
-    expect((config as { format: string }).format).toBe("wav");
+    expect((config as { format: string }).format).toBe("pcm");
     expect((options as { sampleRate?: number } | undefined)?.sampleRate).toBe(
-      8000,
+      16000,
+    );
+    expect(result.contentType).toBe("audio/pcm");
+  });
+
+  test("pcm output request honors the sampleRateHz hint", async () => {
+    const provider = createFishAudioProvider();
+    await provider.synthesize(
+      makeRequest({ outputFormat: "pcm", sampleRateHz: 24000 }),
+    );
+
+    const [, config, options] = mockSynthesizeWithFishAudio.mock.calls[0]!;
+    expect((config as { format: string }).format).toBe("pcm");
+    expect((options as { sampleRate?: number } | undefined)?.sampleRate).toBe(
+      24000,
     );
   });
 
-  test("synthesizeStream pcm output request maps to wav format at 8 kHz", async () => {
+  test("synthesizeStream pcm output request maps to raw pcm honoring the hint", async () => {
     const provider = createFishAudioProvider();
-    await provider.synthesizeStream!(
-      makeRequest({ outputFormat: "pcm" }),
+    const result = await provider.synthesizeStream!(
+      makeRequest({ outputFormat: "pcm", sampleRateHz: 24000 }),
       () => {},
     );
 
     const [, config, options] = mockSynthesizeWithFishAudio.mock.calls[0]!;
-    expect((config as { format: string }).format).toBe("wav");
+    expect((config as { format: string }).format).toBe("pcm");
     expect((options as { sampleRate?: number } | undefined)?.sampleRate).toBe(
-      8000,
+      24000,
+    );
+    expect(result.contentType).toBe("audio/pcm");
+  });
+
+  test("synthesizeStream pcm chunks pass through raw with no RIFF header", async () => {
+    const rawPcm = new Uint8Array([0x01, 0x00, 0x02, 0x00, 0x03, 0x00]);
+    mockSynthesizeWithFishAudio.mockImplementationOnce(
+      async (_text, _config, options) => {
+        options?.onChunk?.(rawPcm);
+        return Buffer.from(rawPcm);
+      },
+    );
+
+    const chunks: Uint8Array[] = [];
+    const provider = createFishAudioProvider();
+    await provider.synthesizeStream!(
+      makeRequest({ outputFormat: "pcm" }),
+      (chunk) => chunks.push(chunk),
+    );
+
+    const [, config, options] = mockSynthesizeWithFishAudio.mock.calls[0]!;
+    expect((config as { format: string }).format).toBe("pcm");
+    expect((options as { sampleRate?: number } | undefined)?.sampleRate).toBe(
+      16000,
+    );
+    // Chunks are forwarded verbatim — raw PCM, no WAV container.
+    expect(chunks).toEqual([rawPcm]);
+    expect(Buffer.from(chunks[0]!).subarray(0, 4).toString("ascii")).not.toBe(
+      "RIFF",
     );
   });
 

--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -209,10 +209,15 @@ describe("ElevenLabs TTS provider adapter", () => {
     expect(provider.id).toBe("elevenlabs");
   });
 
-  test("advertises mp3 and pcm format support without streaming", () => {
+  test("advertises mp3 and pcm format support with streaming", () => {
     const provider = createElevenLabsProvider();
-    expect(provider.capabilities.supportsStreaming).toBe(false);
+    expect(provider.capabilities.supportsStreaming).toBe(true);
     expect(provider.capabilities.supportedFormats).toEqual(["mp3", "pcm"]);
+  });
+
+  test("implements synthesizeStream", () => {
+    const provider = createElevenLabsProvider();
+    expect(typeof provider.synthesizeStream).toBe("function");
   });
 
   // -- Request mapping -----------------------------------------------------
@@ -300,6 +305,226 @@ describe("ElevenLabs TTS provider adapter", () => {
 
     const body = JSON.parse(capturedBody);
     expect(body.model_id).toBe("eleven_turbo_v2_5");
+  });
+
+  test("synthesize defaults to eleven_multilingual_v2 model", async () => {
+    const audioPayload = new Uint8Array([0x49, 0x44, 0x33]);
+    let capturedBody = "";
+
+    globalThis.fetch = mock(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedBody = init?.body as string;
+        return new Response(audioPayload, { status: 200 });
+      },
+    ) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider();
+    await provider.synthesize(makeRequest());
+
+    const body = JSON.parse(capturedBody);
+    expect(body.model_id).toBe("eleven_multilingual_v2");
+  });
+
+  // -- PCM sample-rate mapping ----------------------------------------------
+
+  test("pcm output with sampleRateHz 24000 requests pcm_24000", async () => {
+    const audioPayload = new Uint8Array([0x00, 0x01]);
+    let capturedUrl = "";
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      capturedUrl = typeof input === "string" ? input : input.toString();
+      return new Response(audioPayload, { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider();
+    const result = await provider.synthesize(
+      makeRequest({ outputFormat: "pcm", sampleRateHz: 24000 }),
+    );
+
+    expect(capturedUrl).toContain("output_format=pcm_24000");
+    expect(result.contentType).toBe("audio/pcm");
+  });
+
+  test("pcm output without sampleRateHz defaults to pcm_16000", async () => {
+    const audioPayload = new Uint8Array([0x00, 0x01]);
+    let capturedUrl = "";
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      capturedUrl = typeof input === "string" ? input : input.toString();
+      return new Response(audioPayload, { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider();
+    await provider.synthesize(makeRequest({ outputFormat: "pcm" }));
+
+    expect(capturedUrl).toContain("output_format=pcm_16000");
+  });
+
+  test("pcm output with unmatched sampleRateHz falls back to pcm_16000", async () => {
+    const audioPayload = new Uint8Array([0x00, 0x01]);
+    let capturedUrl = "";
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      capturedUrl = typeof input === "string" ? input : input.toString();
+      return new Response(audioPayload, { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider();
+    await provider.synthesize(
+      makeRequest({ outputFormat: "pcm", sampleRateHz: 8000 }),
+    );
+
+    expect(capturedUrl).toContain("output_format=pcm_16000");
+  });
+
+  // -- Streaming -------------------------------------------------------------
+
+  function streamOf(...parts: Uint8Array[]): ReadableStream<Uint8Array> {
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const part of parts) controller.enqueue(part);
+        controller.close();
+      },
+    });
+  }
+
+  test("synthesizeStream reads chunks from the /stream endpoint and concatenates them", async () => {
+    const part1 = new Uint8Array([0x01, 0x02]);
+    const part2 = new Uint8Array([0x03]);
+    let capturedUrl = "";
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      capturedUrl = typeof input === "string" ? input : input.toString();
+      return new Response(streamOf(part1, part2), { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const received: Uint8Array[] = [];
+    const provider = createElevenLabsProvider();
+    const result = await provider.synthesizeStream!(
+      makeRequest({ outputFormat: "pcm" }),
+      (chunk) => received.push(chunk),
+    );
+
+    expect(capturedUrl).toContain(
+      "/v1/text-to-speech/test-voice-id/stream?output_format=pcm_16000",
+    );
+    expect(received).toEqual([part1, part2]);
+    expect(result.audio).toEqual(Buffer.from([0x01, 0x02, 0x03]));
+    expect(result.contentType).toBe("audio/pcm");
+  });
+
+  test("synthesizeStream defaults to eleven_flash_v2_5 model", async () => {
+    let capturedBody = "";
+
+    globalThis.fetch = mock(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedBody = init?.body as string;
+        return new Response(streamOf(new Uint8Array([0x01])), { status: 200 });
+      },
+    ) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider();
+    await provider.synthesizeStream!(makeRequest(), () => {});
+
+    const body = JSON.parse(capturedBody);
+    expect(body.model_id).toBe("eleven_flash_v2_5");
+  });
+
+  test("synthesizeStream respects configured voiceModelId over flash default", async () => {
+    mockElevenLabsConfig.voiceModelId = "eleven_turbo_v2_5";
+    let capturedBody = "";
+
+    globalThis.fetch = mock(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedBody = init?.body as string;
+        return new Response(streamOf(new Uint8Array([0x01])), { status: 200 });
+      },
+    ) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider();
+    await provider.synthesizeStream!(makeRequest(), () => {});
+
+    const body = JSON.parse(capturedBody);
+    expect(body.model_id).toBe("eleven_turbo_v2_5");
+  });
+
+  test("synthesizeStream throws ELEVENLABS_TTS_EMPTY_RESPONSE on null body", async () => {
+    globalThis.fetch = mock(
+      async () => new Response(null, { status: 200 }),
+    ) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider();
+
+    try {
+      await provider.synthesizeStream!(makeRequest(), () => {});
+      throw new Error("Expected synthesizeStream to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ElevenLabsTtsError);
+      expect((err as ElevenLabsTtsError).code).toBe(
+        "ELEVENLABS_TTS_EMPTY_RESPONSE",
+      );
+    }
+  });
+
+  test("synthesizeStream throws ELEVENLABS_TTS_EMPTY_RESPONSE on zero-byte stream", async () => {
+    globalThis.fetch = mock(
+      async () => new Response(streamOf(), { status: 200 }),
+    ) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider();
+
+    try {
+      await provider.synthesizeStream!(makeRequest(), () => {});
+      throw new Error("Expected synthesizeStream to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ElevenLabsTtsError);
+      expect((err as ElevenLabsTtsError).code).toBe(
+        "ELEVENLABS_TTS_EMPTY_RESPONSE",
+      );
+    }
+  });
+
+  test("synthesizeStream surfaces upstream error message on HTTP error", async () => {
+    mockFetchError(
+      402,
+      JSON.stringify({ detail: { message: "Quota exceeded" } }),
+    );
+
+    const provider = createElevenLabsProvider();
+
+    try {
+      await provider.synthesizeStream!(makeRequest(), () => {});
+      throw new Error("Expected synthesizeStream to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ElevenLabsTtsError);
+      expect((err as ElevenLabsTtsError).code).toBe(
+        "ELEVENLABS_TTS_HTTP_ERROR",
+      );
+      expect((err as ElevenLabsTtsError).statusCode).toBe(402);
+      expect((err as ElevenLabsTtsError).message).toBe("Quota exceeded");
+    }
+  });
+
+  test("synthesizeStream propagates AbortError unmodified", async () => {
+    globalThis.fetch = mock(async () => {
+      const abortError = new Error("The operation was aborted");
+      abortError.name = "AbortError";
+      throw abortError;
+    }) as unknown as typeof globalThis.fetch;
+
+    const controller = new AbortController();
+    const provider = createElevenLabsProvider();
+
+    try {
+      await provider.synthesizeStream!(
+        makeRequest({ signal: controller.signal }),
+        () => {},
+      );
+      throw new Error("Expected synthesizeStream to throw");
+    } catch (err) {
+      expect(err).not.toBeInstanceOf(ElevenLabsTtsError);
+      expect((err as Error).name).toBe("AbortError");
+    }
   });
 
   // -- Content type / format -----------------------------------------------

--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -343,6 +343,7 @@ describe("ElevenLabs TTS provider adapter", () => {
 
     expect(capturedUrl).toContain("output_format=pcm_24000");
     expect(result.contentType).toBe("audio/pcm");
+    expect(result.sampleRateHz).toBe(24000);
   });
 
   test("pcm output without sampleRateHz defaults to pcm_16000", async () => {
@@ -375,6 +376,33 @@ describe("ElevenLabs TTS provider adapter", () => {
     );
 
     expect(capturedUrl).toContain("output_format=pcm_16000");
+  });
+
+  test("pcm request at an unsupported 48000 Hz reports the actual 16000 Hz output rate", async () => {
+    mockFetchReturning(new Uint8Array([0x00, 0x01]));
+
+    const provider = createElevenLabsProvider();
+    const result = await provider.synthesize(
+      makeRequest({ outputFormat: "pcm", sampleRateHz: 48000 }),
+    );
+
+    expect(result.sampleRateHz).toBe(16000);
+  });
+
+  test("resolveOutputSampleRateHz reports the actual PCM rate without synthesis", () => {
+    const provider = createElevenLabsProvider();
+
+    expect(
+      provider.resolveOutputSampleRateHz!(
+        makeRequest({ outputFormat: "pcm", sampleRateHz: 24000 }),
+      ),
+    ).toBe(24000);
+    expect(
+      provider.resolveOutputSampleRateHz!(
+        makeRequest({ outputFormat: "pcm", sampleRateHz: 48000 }),
+      ),
+    ).toBe(16000);
+    expect(provider.resolveOutputSampleRateHz!(makeRequest())).toBeUndefined();
   });
 
   // -- Streaming -------------------------------------------------------------
@@ -411,6 +439,60 @@ describe("ElevenLabs TTS provider adapter", () => {
     expect(received).toEqual([part1, part2]);
     expect(result.audio).toEqual(Buffer.from([0x01, 0x02, 0x03]));
     expect(result.contentType).toBe("audio/pcm");
+    expect(result.sampleRateHz).toBe(16000);
+  });
+
+  test("synthesizeStream rejects after the first-chunk timeout when the stream never produces audio", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response(new ReadableStream<Uint8Array>({ start() {} }), {
+          status: 200,
+        }),
+    ) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider({
+      firstChunkTimeoutMs: 20,
+      idleTimeoutMs: 20,
+    });
+
+    await expect(
+      provider.synthesizeStream!(makeRequest({ outputFormat: "pcm" }), () => {}),
+    ).rejects.toMatchObject({
+      name: "ElevenLabsTtsError",
+      code: "ELEVENLABS_TTS_STREAM_TIMEOUT",
+      message: expect.stringContaining("timed out after 20ms"),
+    });
+  });
+
+  test("synthesizeStream rejects after the idle timeout when the stream stalls mid-stream", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new Uint8Array([0x01, 0x02]));
+              // Never enqueue again and never close — a mid-stream stall.
+            },
+          }),
+          { status: 200 },
+        ),
+    ) as unknown as typeof globalThis.fetch;
+
+    const received: Uint8Array[] = [];
+    const provider = createElevenLabsProvider({
+      firstChunkTimeoutMs: 1_000,
+      idleTimeoutMs: 20,
+    });
+
+    await expect(
+      provider.synthesizeStream!(makeRequest({ outputFormat: "pcm" }), (chunk) =>
+        received.push(chunk),
+      ),
+    ).rejects.toMatchObject({
+      name: "ElevenLabsTtsError",
+      code: "ELEVENLABS_TTS_STREAM_TIMEOUT",
+    });
+    expect(received).toHaveLength(1);
   });
 
   test("synthesizeStream defaults to eleven_flash_v2_5 model", async () => {
@@ -529,7 +611,7 @@ describe("ElevenLabs TTS provider adapter", () => {
 
   // -- Content type / format -----------------------------------------------
 
-  test("returns audio/mpeg content type for mp3 format", async () => {
+  test("returns audio/mpeg content type for mp3 format without a sample rate", async () => {
     const audioPayload = new Uint8Array([0x49, 0x44, 0x33]);
     mockFetchReturning(audioPayload);
 
@@ -538,6 +620,7 @@ describe("ElevenLabs TTS provider adapter", () => {
 
     expect(result.contentType).toBe("audio/mpeg");
     expect(result.audio.byteLength).toBeGreaterThan(0);
+    expect(result.sampleRateHz).toBeUndefined();
   });
 
   // -- Required config validation ------------------------------------------
@@ -767,11 +850,12 @@ describe("Fish Audio TTS provider adapter", () => {
       16000,
     );
     expect(result.contentType).toBe("audio/pcm");
+    expect(result.sampleRateHz).toBe(16000);
   });
 
   test("pcm output request honors the sampleRateHz hint", async () => {
     const provider = createFishAudioProvider();
-    await provider.synthesize(
+    const result = await provider.synthesize(
       makeRequest({ outputFormat: "pcm", sampleRateHz: 24000 }),
     );
 
@@ -780,6 +864,7 @@ describe("Fish Audio TTS provider adapter", () => {
     expect((options as { sampleRate?: number } | undefined)?.sampleRate).toBe(
       24000,
     );
+    expect(result.sampleRateHz).toBe(24000);
   });
 
   test("synthesizeStream pcm output request maps to raw pcm honoring the hint", async () => {
@@ -795,6 +880,21 @@ describe("Fish Audio TTS provider adapter", () => {
       24000,
     );
     expect(result.contentType).toBe("audio/pcm");
+    expect(result.sampleRateHz).toBe(24000);
+  });
+
+  test("resolveOutputSampleRateHz passes the pcm hint through and is undefined otherwise", () => {
+    const provider = createFishAudioProvider();
+
+    expect(
+      provider.resolveOutputSampleRateHz!(
+        makeRequest({ outputFormat: "pcm", sampleRateHz: 48000 }),
+      ),
+    ).toBe(48000);
+    expect(
+      provider.resolveOutputSampleRateHz!(makeRequest({ outputFormat: "pcm" })),
+    ).toBe(16000);
+    expect(provider.resolveOutputSampleRateHz!(makeRequest())).toBeUndefined();
   });
 
   test("synthesizeStream pcm chunks pass through raw with no RIFF header", async () => {
@@ -864,11 +964,12 @@ describe("Fish Audio TTS provider adapter", () => {
     expect(result.contentType).toBe("audio/mpeg");
   });
 
-  test("returns audio/wav content type for wav format", async () => {
+  test("returns audio/wav content type for wav format without a sample rate", async () => {
     mockFishAudioConfig.format = "wav";
     const provider = createFishAudioProvider();
     const result = await provider.synthesize(makeRequest());
     expect(result.contentType).toBe("audio/wav");
+    expect(result.sampleRateHz).toBeUndefined();
   });
 
   test("returns audio/opus content type for opus format", async () => {

--- a/assistant/src/tts/__tests__/provider-catalog.test.ts
+++ b/assistant/src/tts/__tests__/provider-catalog.test.ts
@@ -154,14 +154,15 @@ describe("Fish Audio catalog entry", () => {
     expect(entry.capabilities.supportsStreaming).toBe(true);
   });
 
-  test("supports mp3, wav, and opus formats", () => {
+  test("supports mp3, wav, opus, and pcm formats", () => {
     expect(entry.capabilities.supportedFormats).toContain("mp3");
     expect(entry.capabilities.supportedFormats).toContain("wav");
     expect(entry.capabilities.supportedFormats).toContain("opus");
+    expect(entry.capabilities.supportedFormats).toContain("pcm");
   });
 
-  test("plays over media-stream via WAV output", () => {
-    expect(entry.mediaStreamPlayback.outputFormat).toBe("wav");
+  test("plays over media-stream via PCM output", () => {
+    expect(entry.mediaStreamPlayback.outputFormat).toBe("pcm");
   });
 
   test("requires an API key stored under 'credential/fish-audio/api_key'", () => {

--- a/assistant/src/tts/__tests__/provider-catalog.test.ts
+++ b/assistant/src/tts/__tests__/provider-catalog.test.ts
@@ -121,12 +121,13 @@ describe("ElevenLabs catalog entry", () => {
     expect(entry.callMode).toBe("native-twilio");
   });
 
-  test("does not support streaming", () => {
-    expect(entry.capabilities.supportsStreaming).toBe(false);
+  test("supports streaming", () => {
+    expect(entry.capabilities.supportsStreaming).toBe(true);
   });
 
-  test("supports mp3 format", () => {
+  test("supports mp3 and pcm formats", () => {
     expect(entry.capabilities.supportedFormats).toContain("mp3");
+    expect(entry.capabilities.supportedFormats).toContain("pcm");
   });
 
   test("plays over media-stream via PCM output", () => {

--- a/assistant/src/tts/__tests__/speakable-segments.test.ts
+++ b/assistant/src/tts/__tests__/speakable-segments.test.ts
@@ -243,6 +243,71 @@ describe("extractSpeakableSegments", () => {
       expect(remainder).toBe("");
     });
 
+    test("a lone arithmetic asterisk does not suppress sentence boundaries", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "The result of 5 * 3 is 15. And the next sentence keeps going",
+        false,
+      );
+
+      expect(segments).toEqual(["The result of 5 * 3 is 15."]);
+      expect(remainder).toBe(" And the next sentence keeps going");
+    });
+
+    test("a lone arithmetic asterisk does not suppress eager clause boundaries", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "The result of 5 * 3 is 15, and here is even more",
+        false,
+        { eager: true },
+      );
+
+      expect(segments).toEqual(["The result of 5 * 3 is 15,"]);
+      expect(remainder).toBe(" and here is even more");
+    });
+
+    test("a line-start bullet asterisk does not suppress sentence boundaries", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "* bullet item with words. And more after it",
+        false,
+      );
+
+      expect(segments).toEqual(["* bullet item with words."]);
+      expect(remainder).toBe(" And more after it");
+    });
+
+    test("does not split at a clause boundary inside an open italic span", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "*italic text that keeps going, more* and then.",
+        false,
+        { eager: true },
+      );
+
+      expect(segments).toEqual([
+        "*italic text that keeps going, more* and then.",
+      ]);
+      expect(remainder).toBe("");
+    });
+
+    test("a short italic span with a comma stays intact in eager mode", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "*italic, text* more.",
+        false,
+        { eager: true },
+      );
+
+      expect(segments).toEqual(["*italic, text* more."]);
+      expect(remainder).toBe("");
+    });
+
+    test("an unpaired bold marker still defers sentence boundaries", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "**important note. still inside the span",
+        false,
+      );
+
+      expect(segments).toEqual([]);
+      expect(remainder).toBe("**important note. still inside the span");
+    });
+
     test("an open span still flushes at the length-threshold hard cap", () => {
       const text = `**${"steady ".repeat(40)}`;
 

--- a/assistant/src/tts/__tests__/speakable-segments.test.ts
+++ b/assistant/src/tts/__tests__/speakable-segments.test.ts
@@ -1,10 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import {
-  DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD,
-  EAGER_SPEAKABLE_SEGMENT_CHAR_THRESHOLD,
-  extractSpeakableSegments,
-} from "../speakable-segments.js";
+import { extractSpeakableSegments } from "../speakable-segments.js";
+
+const DEFAULT_CHAR_THRESHOLD = 180;
+const EAGER_CHAR_THRESHOLD = 60;
 
 describe("extractSpeakableSegments", () => {
   test("splits complete sentences and keeps the trailing fragment as remainder", () => {
@@ -76,6 +75,15 @@ describe("extractSpeakableSegments", () => {
     expect(remainder).toBe("");
   });
 
+  test("text below the 180-char threshold does not force-split", () => {
+    const text = "y".repeat(DEFAULT_CHAR_THRESHOLD - 1);
+
+    const { segments, remainder } = extractSpeakableSegments(text, false);
+
+    expect(segments).toEqual([]);
+    expect(remainder).toBe(text);
+  });
+
   test("over-threshold text splits at the last whitespace before the threshold", () => {
     const text = "steady ".repeat(40);
 
@@ -83,9 +91,7 @@ describe("extractSpeakableSegments", () => {
 
     expect(segments).toHaveLength(1);
     const segment = segments[0] ?? "";
-    expect(segment.length).toBeLessThanOrEqual(
-      DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD,
-    );
+    expect(segment.length).toBeLessThanOrEqual(DEFAULT_CHAR_THRESHOLD);
     expect(segment.endsWith("steady")).toBe(true);
     expect(remainder.startsWith("steady")).toBe(true);
     // No text is lost across the split.
@@ -93,25 +99,12 @@ describe("extractSpeakableSegments", () => {
   });
 
   test("over-threshold text without whitespace splits at the threshold exactly", () => {
-    const text = "x".repeat(DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD + 20);
+    const text = "x".repeat(DEFAULT_CHAR_THRESHOLD + 20);
 
     const { segments, remainder } = extractSpeakableSegments(text, false);
 
-    expect(segments).toEqual([
-      "x".repeat(DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD),
-    ]);
+    expect(segments).toEqual(["x".repeat(DEFAULT_CHAR_THRESHOLD)]);
     expect(remainder).toBe("x".repeat(20));
-  });
-
-  test("charThreshold option overrides the default split length", () => {
-    const text = "alpha beta gamma delta epsilon";
-
-    const { segments, remainder } = extractSpeakableSegments(text, false, {
-      charThreshold: 12,
-    });
-
-    expect(segments).toEqual(["alpha beta", "gamma delta"]);
-    expect(remainder).toBe("epsilon");
   });
 
   describe("eager mode", () => {
@@ -158,7 +151,7 @@ describe("extractSpeakableSegments", () => {
       expect(remainder).toBe(text);
     });
 
-    test("uses the lower char threshold to split without punctuation", () => {
+    test("uses the lower 60-char threshold to split without punctuation", () => {
       const text = "word ".repeat(20);
 
       const { segments } = extractSpeakableSegments(text, false, {
@@ -167,21 +160,8 @@ describe("extractSpeakableSegments", () => {
 
       expect(segments.length).toBeGreaterThan(0);
       const segment = segments[0] ?? "";
-      expect(segment.length).toBeLessThanOrEqual(
-        EAGER_SPEAKABLE_SEGMENT_CHAR_THRESHOLD,
-      );
+      expect(segment.length).toBeLessThanOrEqual(EAGER_CHAR_THRESHOLD);
       expect(segment.endsWith("word")).toBe(true);
-    });
-
-    test("charThreshold option overrides the eager default", () => {
-      const text = "word ".repeat(20);
-
-      const { segments } = extractSpeakableSegments(text, false, {
-        eager: true,
-        charThreshold: 30,
-      });
-
-      expect(segments[0]?.length).toBeLessThanOrEqual(30);
     });
 
     test("eagerness applies only to the first segment of a call", () => {
@@ -207,15 +187,71 @@ describe("extractSpeakableSegments", () => {
     });
   });
 
-  test("charThreshold defaulting matches the exported constant", () => {
-    const text = "y".repeat(DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD - 1);
+  describe("open inline spans", () => {
+    test("does not split at a clause boundary inside an open bold span", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "**bold text that keeps going, more** and then.",
+        false,
+        { eager: true },
+      );
 
-    const belowDefault = extractSpeakableSegments(text, false);
-    expect(belowDefault.segments).toEqual([]);
-
-    const explicitDefault = extractSpeakableSegments(text, false, {
-      charThreshold: DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD,
+      expect(segments).toEqual([
+        "**bold text that keeps going, more** and then.",
+      ]);
+      expect(remainder).toBe("");
     });
-    expect(explicitDefault.segments).toEqual([]);
+
+    test("does not split at a clause boundary inside an open backtick span", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "`code segment with a comma here, x` done.",
+        false,
+        { eager: true },
+      );
+
+      expect(segments).toEqual(["`code segment with a comma here, x` done."]);
+      expect(remainder).toBe("");
+    });
+
+    test("splits normally at a clause boundary after a balanced span", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "He said **wait** and more, then it continued on",
+        false,
+        { eager: true },
+      );
+
+      expect(segments).toEqual(["He said **wait** and more,"]);
+      expect(remainder).toBe(" then it continued on");
+    });
+
+    test("does not split at sentence punctuation inside an open bold span", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "**Wait. No** more.",
+        false,
+      );
+
+      expect(segments).toEqual(["**Wait. No** more."]);
+      expect(remainder).toBe("");
+    });
+
+    test("does not split at sentence punctuation inside an open italic span", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "*hold on. yes* it is done.",
+        false,
+      );
+
+      expect(segments).toEqual(["*hold on. yes* it is done."]);
+      expect(remainder).toBe("");
+    });
+
+    test("an open span still flushes at the length-threshold hard cap", () => {
+      const text = `**${"steady ".repeat(40)}`;
+
+      const { segments } = extractSpeakableSegments(text, false);
+
+      expect(segments).toHaveLength(1);
+      expect((segments[0] ?? "").length).toBeLessThanOrEqual(
+        DEFAULT_CHAR_THRESHOLD,
+      );
+    });
   });
 });

--- a/assistant/src/tts/__tests__/speakable-segments.test.ts
+++ b/assistant/src/tts/__tests__/speakable-segments.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD,
+  extractSpeakableSegments,
+} from "../speakable-segments.js";
+
+describe("extractSpeakableSegments", () => {
+  test("splits complete sentences and keeps the trailing fragment as remainder", () => {
+    const { segments, remainder } = extractSpeakableSegments(
+      "Hello there. How are you? Still typ",
+      false,
+    );
+
+    expect(segments).toEqual(["Hello there.", "How are you?"]);
+    expect(remainder).toBe(" Still typ");
+  });
+
+  test("includes trailing quotes and brackets in the sentence segment", () => {
+    const { segments, remainder } = extractSpeakableSegments(
+      'She said "stop!") And then',
+      false,
+    );
+
+    expect(segments).toEqual(['She said "stop!")']);
+    expect(remainder).toBe(" And then");
+  });
+
+  test("does not split at punctuation followed by non-whitespace", () => {
+    const { segments, remainder } = extractSpeakableSegments(
+      "Version 3.5 is out",
+      false,
+    );
+
+    expect(segments).toEqual([]);
+    expect(remainder).toBe("Version 3.5 is out");
+  });
+
+  test("treats a newline as a segment boundary", () => {
+    const { segments, remainder } = extractSpeakableSegments(
+      "First line\nsecond line still going",
+      false,
+    );
+
+    expect(segments).toEqual(["First line"]);
+    expect(remainder).toBe("second line still going");
+  });
+
+  test("returns punctuation at end-of-text as a complete segment", () => {
+    const { segments, remainder } = extractSpeakableSegments(
+      "All done here.",
+      false,
+    );
+
+    expect(segments).toEqual(["All done here."]);
+    expect(remainder).toBe("");
+  });
+
+  test("sub-threshold text without a boundary yields no segments until forced", () => {
+    const text = "still waiting for a sentence to finish";
+
+    const unforced = extractSpeakableSegments(text, false);
+    expect(unforced.segments).toEqual([]);
+    expect(unforced.remainder).toBe(text);
+
+    const forced = extractSpeakableSegments(text, true);
+    expect(forced.segments).toEqual([text]);
+    expect(forced.remainder).toBe("");
+  });
+
+  test("force skips whitespace-only remainders", () => {
+    const { segments, remainder } = extractSpeakableSegments("   ", true);
+
+    expect(segments).toEqual([]);
+    expect(remainder).toBe("");
+  });
+
+  test("over-threshold text splits at the last whitespace before the threshold", () => {
+    const text = "steady ".repeat(40);
+
+    const { segments, remainder } = extractSpeakableSegments(text, false);
+
+    expect(segments).toHaveLength(1);
+    const segment = segments[0] ?? "";
+    expect(segment.length).toBeLessThanOrEqual(
+      DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD,
+    );
+    expect(segment.endsWith("steady")).toBe(true);
+    expect(remainder.startsWith("steady")).toBe(true);
+    // No text is lost across the split.
+    expect(`${segment} ${remainder}`).toBe(text);
+  });
+
+  test("over-threshold text without whitespace splits at the threshold exactly", () => {
+    const text = "x".repeat(DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD + 20);
+
+    const { segments, remainder } = extractSpeakableSegments(text, false);
+
+    expect(segments).toEqual([
+      "x".repeat(DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD),
+    ]);
+    expect(remainder).toBe("x".repeat(20));
+  });
+
+  test("charThreshold option overrides the default split length", () => {
+    const text = "alpha beta gamma delta epsilon";
+
+    const { segments, remainder } = extractSpeakableSegments(text, false, {
+      charThreshold: 12,
+    });
+
+    expect(segments).toEqual(["alpha beta", "gamma delta"]);
+    expect(remainder).toBe("epsilon");
+  });
+
+  test("charThreshold defaulting matches the exported constant", () => {
+    const text = "y".repeat(DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD - 1);
+
+    const belowDefault = extractSpeakableSegments(text, false);
+    expect(belowDefault.segments).toEqual([]);
+
+    const explicitDefault = extractSpeakableSegments(text, false, {
+      charThreshold: DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD,
+    });
+    expect(explicitDefault.segments).toEqual([]);
+  });
+});

--- a/assistant/src/tts/__tests__/speakable-segments.test.ts
+++ b/assistant/src/tts/__tests__/speakable-segments.test.ts
@@ -274,6 +274,19 @@ describe("extractSpeakableSegments", () => {
       expect(remainder).toBe(" And more after it");
     });
 
+    test("whitespace-padded asterisks do not suppress sentence boundaries", () => {
+      // The sanitizer does not treat `* italic. still*` as an emphasis span
+      // either, so splitting here keeps segment-level and whole-text
+      // sanitization in agreement.
+      const { segments, remainder } = extractSpeakableSegments(
+        "Some * italic. still* done. And the next sentence keeps going",
+        false,
+      );
+
+      expect(segments).toEqual(["Some * italic.", "still* done."]);
+      expect(remainder).toBe(" And the next sentence keeps going");
+    });
+
     test("does not split at a clause boundary inside an open italic span", () => {
       const { segments, remainder } = extractSpeakableSegments(
         "*italic text that keeps going, more* and then.",

--- a/assistant/src/tts/__tests__/speakable-segments.test.ts
+++ b/assistant/src/tts/__tests__/speakable-segments.test.ts
@@ -287,6 +287,49 @@ describe("extractSpeakableSegments", () => {
       expect(remainder).toBe(" And the next sentence keeps going");
     });
 
+    test("does not split at sentence punctuation inside an open underscore span", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "This is _very important. Please listen_ now.",
+        false,
+      );
+
+      expect(segments).toEqual(["This is _very important. Please listen_ now."]);
+      expect(remainder).toBe("");
+    });
+
+    test("snake_case identifiers do not suppress sentence boundaries", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "Set my_var to 5. Then continue with the other_value here",
+        false,
+      );
+
+      expect(segments).toEqual(["Set my_var to 5."]);
+      expect(remainder).toBe(" Then continue with the other_value here");
+    });
+
+    test("whitespace-padded underscores do not suppress sentence boundaries", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "a _ b and c_ d happened. And the next sentence keeps going",
+        false,
+      );
+
+      expect(segments).toEqual(["a _ b and c_ d happened."]);
+      expect(remainder).toBe(" And the next sentence keeps going");
+    });
+
+    test("does not split at a clause boundary inside an open underscore span in eager mode", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "_underscored text that keeps going, more_ and then.",
+        false,
+        { eager: true },
+      );
+
+      expect(segments).toEqual([
+        "_underscored text that keeps going, more_ and then.",
+      ]);
+      expect(remainder).toBe("");
+    });
+
     test("does not split at a clause boundary inside an open italic span", () => {
       const { segments, remainder } = extractSpeakableSegments(
         "*italic text that keeps going, more* and then.",

--- a/assistant/src/tts/__tests__/speakable-segments.test.ts
+++ b/assistant/src/tts/__tests__/speakable-segments.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD,
+  EAGER_SPEAKABLE_SEGMENT_CHAR_THRESHOLD,
   extractSpeakableSegments,
 } from "../speakable-segments.js";
 
@@ -111,6 +112,99 @@ describe("extractSpeakableSegments", () => {
 
     expect(segments).toEqual(["alpha beta", "gamma delta"]);
     expect(remainder).toBe("epsilon");
+  });
+
+  describe("eager mode", () => {
+    test("splits at a comma once enough text precedes it", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "Sure, I can help with that, and here is more",
+        false,
+        { eager: true },
+      );
+
+      expect(segments).toEqual(["Sure, I can help with that,"]);
+      expect(remainder).toBe(" and here is more");
+    });
+
+    test("splits at semicolons and colons past the prefix floor", () => {
+      const { segments } = extractSpeakableSegments(
+        "Here is what I found today; there is more coming",
+        false,
+        { eager: true },
+      );
+
+      expect(segments).toEqual(["Here is what I found today;"]);
+    });
+
+    test("a short clause like 'Sure, ' does not flush on its own", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "Sure, ",
+        false,
+        { eager: true },
+      );
+
+      expect(segments).toEqual([]);
+      expect(remainder).toBe("Sure, ");
+    });
+
+    test("clause punctuation at end-of-text keeps buffering", () => {
+      const text = "Sure, I can help with that,";
+
+      const { segments, remainder } = extractSpeakableSegments(text, false, {
+        eager: true,
+      });
+
+      expect(segments).toEqual([]);
+      expect(remainder).toBe(text);
+    });
+
+    test("uses the lower char threshold to split without punctuation", () => {
+      const text = "word ".repeat(20);
+
+      const { segments } = extractSpeakableSegments(text, false, {
+        eager: true,
+      });
+
+      expect(segments.length).toBeGreaterThan(0);
+      const segment = segments[0] ?? "";
+      expect(segment.length).toBeLessThanOrEqual(
+        EAGER_SPEAKABLE_SEGMENT_CHAR_THRESHOLD,
+      );
+      expect(segment.endsWith("word")).toBe(true);
+    });
+
+    test("charThreshold option overrides the eager default", () => {
+      const text = "word ".repeat(20);
+
+      const { segments } = extractSpeakableSegments(text, false, {
+        eager: true,
+        charThreshold: 30,
+      });
+
+      expect(segments[0]?.length).toBeLessThanOrEqual(30);
+    });
+
+    test("eagerness applies only to the first segment of a call", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "Sure, I can help with that, and after that we can keep going, with more",
+        false,
+        { eager: true },
+      );
+
+      expect(segments).toEqual(["Sure, I can help with that,"]);
+      expect(remainder).toBe(
+        " and after that we can keep going, with more",
+      );
+    });
+
+    test("non-eager extraction ignores clause punctuation", () => {
+      const text = "Sure, I can help with that, and here is more";
+
+      const { segments, remainder } = extractSpeakableSegments(text, false);
+
+      expect(segments).toEqual([]);
+      expect(remainder).toBe(text);
+    });
   });
 
   test("charThreshold defaulting matches the exported constant", () => {

--- a/assistant/src/tts/__tests__/speakable-segments.test.ts
+++ b/assistant/src/tts/__tests__/speakable-segments.test.ts
@@ -364,6 +364,55 @@ describe("extractSpeakableSegments", () => {
       expect(remainder).toBe("**important note. still inside the span");
     });
 
+    test("does not split at the newline after an opening code fence", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "```ts\ncode here``` done. And more",
+        false,
+      );
+
+      expect(segments).toEqual(["```ts\ncode here``` done."]);
+      expect(remainder).toBe(" And more");
+    });
+
+    test("does not split at a newline inside an open backtick span", () => {
+      const text = "`code that spans\nlines and keeps going";
+
+      const { segments, remainder } = extractSpeakableSegments(text, false);
+
+      expect(segments).toEqual([]);
+      expect(remainder).toBe(text);
+    });
+
+    test("splits at the newline once the backtick span closes", () => {
+      const { segments, remainder } = extractSpeakableSegments(
+        "`code that spans\nlines` done\nnext line",
+        false,
+      );
+
+      expect(segments).toEqual(["`code that spans\nlines` done"]);
+      expect(remainder).toBe("next line");
+    });
+
+    test("an unclosed span with newlines still flushes when forced", () => {
+      const text = "```ts\nconst x = 1;";
+
+      const { segments, remainder } = extractSpeakableSegments(text, true);
+
+      expect(segments).toEqual([text]);
+      expect(remainder).toBe("");
+    });
+
+    test("an unclosed span with newlines still flushes at the hard cap", () => {
+      const text = `\`\`\`ts\n${"steady ".repeat(40)}`;
+
+      const { segments } = extractSpeakableSegments(text, false);
+
+      expect(segments).toHaveLength(1);
+      expect((segments[0] ?? "").length).toBeLessThanOrEqual(
+        DEFAULT_CHAR_THRESHOLD,
+      );
+    });
+
     test("an open span still flushes at the length-threshold hard cap", () => {
       const text = `**${"steady ".repeat(40)}`;
 

--- a/assistant/src/tts/__tests__/synthesis-stream.test.ts
+++ b/assistant/src/tts/__tests__/synthesis-stream.test.ts
@@ -503,7 +503,7 @@ describe("synthesizeAndEmit (streaming)", () => {
     ]);
   });
 
-  test("passes text/useCase/voiceId/outputFormat/signal through on the request", async () => {
+  test("passes text/useCase/voiceId/outputFormat/sampleRateHz/signal through on the request", async () => {
     const provider = makeStreamingProvider([bytes("a")]);
     const abortController = new AbortController();
 
@@ -513,6 +513,7 @@ describe("synthesizeAndEmit (streaming)", () => {
       useCase: "message-playback",
       voiceId: "voice-123",
       outputFormat: "pcm",
+      sampleRateHz: 24000,
       signal: abortController.signal,
       onChunk: () => {},
     });
@@ -523,6 +524,7 @@ describe("synthesizeAndEmit (streaming)", () => {
       useCase: "message-playback",
       voiceId: "voice-123",
       outputFormat: "pcm",
+      sampleRateHz: 24000,
       signal: abortController.signal,
     });
   });
@@ -637,6 +639,7 @@ describe("synthesizeAndEmit (buffer)", () => {
       text: "hello",
       useCase: "phone-call",
       voiceId: "voice-123",
+      sampleRateHz: 16000,
       onChunk: () => {},
     });
 
@@ -645,6 +648,7 @@ describe("synthesizeAndEmit (buffer)", () => {
       useCase: "phone-call",
       voiceId: "voice-123",
       outputFormat: undefined,
+      sampleRateHz: 16000,
       signal: undefined,
     });
   });

--- a/assistant/src/tts/__tests__/synthesis-stream.test.ts
+++ b/assistant/src/tts/__tests__/synthesis-stream.test.ts
@@ -30,6 +30,7 @@ interface StreamingFakeOptions {
   /** Awaited after all chunks are delivered, before the stream resolves. */
   resolveGate?: Promise<void>;
   contentType?: string;
+  sampleRateHz?: number;
 }
 
 function makeStreamingProvider(
@@ -56,6 +57,7 @@ function makeStreamingProvider(
       return {
         audio: Buffer.concat(chunks),
         contentType: options.contentType ?? "audio/mpeg",
+        sampleRateHz: options.sampleRateHz,
       };
     },
   };
@@ -64,6 +66,7 @@ function makeStreamingProvider(
 function makeBufferProvider(
   audio: Buffer,
   contentType = "audio/mpeg",
+  sampleRateHz?: number,
 ): TtsProvider & { requests: TtsSynthesisRequest[] } {
   const requests: TtsSynthesisRequest[] = [];
   return {
@@ -72,7 +75,7 @@ function makeBufferProvider(
     requests,
     async synthesize(request): Promise<TtsSynthesisResult> {
       requests.push(request);
-      return { audio, contentType };
+      return { audio, contentType, sampleRateHz };
     },
   };
 }
@@ -503,6 +506,22 @@ describe("synthesizeAndEmit (streaming)", () => {
     ]);
   });
 
+  test("passes the provider-reported sampleRateHz through on the result", async () => {
+    const provider = makeStreamingProvider([bytes("a")], {
+      contentType: "audio/pcm",
+      sampleRateHz: 24000,
+    });
+
+    const result = await synthesizeAndEmit({
+      provider,
+      text: "hello",
+      useCase: "phone-call",
+      onChunk: () => {},
+    });
+
+    expect(result.sampleRateHz).toBe(24000);
+  });
+
   test("passes text/useCase/voiceId/outputFormat/sampleRateHz/signal through on the request", async () => {
     const provider = makeStreamingProvider([bytes("a")]);
     const abortController = new AbortController();
@@ -552,8 +571,26 @@ describe("synthesizeAndEmit (buffer)", () => {
     expect(result).toEqual({
       emittedChunks: 1,
       contentType: "audio/wav",
+      sampleRateHz: undefined,
       stopped: false,
     });
+  });
+
+  test("passes the provider-reported sampleRateHz through on the result", async () => {
+    const provider = makeBufferProvider(
+      Buffer.from("abc"),
+      "audio/pcm",
+      16000,
+    );
+
+    const result = await synthesizeAndEmit({
+      provider,
+      text: "hello",
+      useCase: "phone-call",
+      onChunk: () => {},
+    });
+
+    expect(result.sampleRateHz).toBe(16000);
   });
 
   test("throws on an empty audio payload", async () => {

--- a/assistant/src/tts/__tests__/synthesis-stream.test.ts
+++ b/assistant/src/tts/__tests__/synthesis-stream.test.ts
@@ -30,7 +30,6 @@ interface StreamingFakeOptions {
   /** Awaited after all chunks are delivered, before the stream resolves. */
   resolveGate?: Promise<void>;
   contentType?: string;
-  sampleRateHz?: number;
 }
 
 function makeStreamingProvider(
@@ -57,7 +56,6 @@ function makeStreamingProvider(
       return {
         audio: Buffer.concat(chunks),
         contentType: options.contentType ?? "audio/mpeg",
-        sampleRateHz: options.sampleRateHz,
       };
     },
   };
@@ -66,7 +64,6 @@ function makeStreamingProvider(
 function makeBufferProvider(
   audio: Buffer,
   contentType = "audio/mpeg",
-  sampleRateHz?: number,
 ): TtsProvider & { requests: TtsSynthesisRequest[] } {
   const requests: TtsSynthesisRequest[] = [];
   return {
@@ -75,7 +72,7 @@ function makeBufferProvider(
     requests,
     async synthesize(request): Promise<TtsSynthesisResult> {
       requests.push(request);
-      return { audio, contentType, sampleRateHz };
+      return { audio, contentType };
     },
   };
 }
@@ -506,22 +503,6 @@ describe("synthesizeAndEmit (streaming)", () => {
     ]);
   });
 
-  test("passes the provider-reported sampleRateHz through on the result", async () => {
-    const provider = makeStreamingProvider([bytes("a")], {
-      contentType: "audio/pcm",
-      sampleRateHz: 24000,
-    });
-
-    const result = await synthesizeAndEmit({
-      provider,
-      text: "hello",
-      useCase: "phone-call",
-      onChunk: () => {},
-    });
-
-    expect(result.sampleRateHz).toBe(24000);
-  });
-
   test("passes text/useCase/voiceId/outputFormat/sampleRateHz/signal through on the request", async () => {
     const provider = makeStreamingProvider([bytes("a")]);
     const abortController = new AbortController();
@@ -571,26 +552,8 @@ describe("synthesizeAndEmit (buffer)", () => {
     expect(result).toEqual({
       emittedChunks: 1,
       contentType: "audio/wav",
-      sampleRateHz: undefined,
       stopped: false,
     });
-  });
-
-  test("passes the provider-reported sampleRateHz through on the result", async () => {
-    const provider = makeBufferProvider(
-      Buffer.from("abc"),
-      "audio/pcm",
-      16000,
-    );
-
-    const result = await synthesizeAndEmit({
-      provider,
-      text: "hello",
-      useCase: "phone-call",
-      onChunk: () => {},
-    });
-
-    expect(result.sampleRateHz).toBe(16000);
   });
 
   test("throws on an empty audio payload", async () => {

--- a/assistant/src/tts/providers/elevenlabs-provider.ts
+++ b/assistant/src/tts/providers/elevenlabs-provider.ts
@@ -204,13 +204,13 @@ function pcmFormatSampleRateHz(outputFormat: string): number | undefined {
  * Resolve credentials and config, build the request body, and issue the
  * ElevenLabs TTS HTTP request. Shared by `synthesize` (buffer endpoint) and
  * `synthesizeStream` (`/stream` endpoint). Throws on missing credentials and
- * non-OK responses; resolves with the OK response and the resolved output
- * format and content type.
+ * non-OK responses; resolves with the OK response and the resolved content
+ * type.
  */
 async function performTtsRequest(
   request: TtsSynthesisRequest,
   { stream }: { stream: boolean },
-): Promise<{ response: Response; outputFormat: string; contentType: string }> {
+): Promise<{ response: Response; contentType: string }> {
   const apiKey = await getSecureKeyAsync(
     credentialKey("elevenlabs", "api_key"),
   );
@@ -289,7 +289,7 @@ async function performTtsRequest(
     );
   }
 
-  return { response, outputFormat, contentType };
+  return { response, contentType };
 }
 
 /** Stream-stall timeouts, injectable for tests. */
@@ -310,10 +310,9 @@ async function performSynthesis(
     onChunk?: (chunk: Uint8Array) => void;
   } & ElevenLabsStreamTimeouts,
 ): Promise<TtsSynthesisResult> {
-  const { response, outputFormat, contentType } = await performTtsRequest(
-    request,
-    { stream: options.stream },
-  );
+  const { response, contentType } = await performTtsRequest(request, {
+    stream: options.stream,
+  });
 
   let audio: Buffer;
   if (options.stream) {
@@ -349,11 +348,7 @@ async function performSynthesis(
     "ElevenLabs TTS synthesis complete",
   );
 
-  return {
-    audio,
-    contentType,
-    sampleRateHz: pcmFormatSampleRateHz(outputFormat),
-  };
+  return { audio, contentType };
 }
 
 export function createElevenLabsProvider(

--- a/assistant/src/tts/providers/elevenlabs-provider.ts
+++ b/assistant/src/tts/providers/elevenlabs-provider.ts
@@ -14,6 +14,7 @@ import { credentialKey } from "../../security/credential-key.js";
 import { getSecureKeyAsync } from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
 import type { TtsProviderDefinition } from "../provider-definition.js";
+import { readChunkedBody } from "../stream-read.js";
 import type {
   TtsProvider,
   TtsProviderCapabilities,
@@ -32,7 +33,8 @@ export type ElevenLabsTtsErrorCode =
   | "ELEVENLABS_TTS_NO_VOICE_ID"
   | "ELEVENLABS_TTS_HTTP_ERROR"
   | "ELEVENLABS_TTS_EMPTY_RESPONSE"
-  | "ELEVENLABS_TTS_REQUEST_FAILED";
+  | "ELEVENLABS_TTS_REQUEST_FAILED"
+  | "ELEVENLABS_TTS_STREAM_TIMEOUT";
 
 export class ElevenLabsTtsError extends Error {
   readonly code: ElevenLabsTtsErrorCode;
@@ -191,17 +193,24 @@ function resolveOutputFormat(request: TtsSynthesisRequest): string {
   return request.useCase === "phone-call" ? "mp3_22050_32" : "mp3_44100_128";
 }
 
+/** Sample rate of a `pcm_*` output format in Hz; undefined for non-PCM formats. */
+function pcmFormatSampleRateHz(outputFormat: string): number | undefined {
+  return outputFormat.startsWith("pcm_")
+    ? Number(outputFormat.slice("pcm_".length))
+    : undefined;
+}
+
 /**
  * Resolve credentials and config, build the request body, and issue the
  * ElevenLabs TTS HTTP request. Shared by `synthesize` (buffer endpoint) and
  * `synthesizeStream` (`/stream` endpoint). Throws on missing credentials and
  * non-OK responses; resolves with the OK response and the resolved output
- * format.
+ * format and content type.
  */
 async function performTtsRequest(
   request: TtsSynthesisRequest,
   { stream }: { stream: boolean },
-): Promise<{ response: Response; outputFormat: string }> {
+): Promise<{ response: Response; outputFormat: string; contentType: string }> {
   const apiKey = await getSecureKeyAsync(
     credentialKey("elevenlabs", "api_key"),
   );
@@ -242,7 +251,7 @@ async function performTtsRequest(
     "Starting ElevenLabs TTS synthesis",
   );
 
-  const acceptType = FORMAT_CONTENT_TYPE[outputFormat] ?? "audio/mpeg";
+  const contentType = FORMAT_CONTENT_TYPE[outputFormat] ?? "audio/mpeg";
 
   let response: Response;
   try {
@@ -251,7 +260,7 @@ async function performTtsRequest(
       headers: {
         "Content-Type": "application/json",
         "xi-api-key": apiKey,
-        Accept: acceptType,
+        Accept: contentType,
       },
       body: JSON.stringify(body),
       signal: request.signal,
@@ -280,10 +289,76 @@ async function performTtsRequest(
     );
   }
 
-  return { response, outputFormat };
+  return { response, outputFormat, contentType };
 }
 
-export function createElevenLabsProvider(): TtsProvider {
+/** Stream-stall timeouts, injectable for tests. */
+export interface ElevenLabsStreamTimeouts {
+  firstChunkTimeoutMs?: number;
+  idleTimeoutMs?: number;
+}
+
+/**
+ * Issue the TTS request and consume the response into a complete result.
+ * The streaming path forwards chunks via `onChunk` as they arrive, guarded
+ * by first-chunk/idle stall timeouts; the buffer path reads the whole body.
+ */
+async function performSynthesis(
+  request: TtsSynthesisRequest,
+  options: {
+    stream: boolean;
+    onChunk?: (chunk: Uint8Array) => void;
+  } & ElevenLabsStreamTimeouts,
+): Promise<TtsSynthesisResult> {
+  const { response, outputFormat, contentType } = await performTtsRequest(
+    request,
+    { stream: options.stream },
+  );
+
+  let audio: Buffer;
+  if (options.stream) {
+    if (!response.body) {
+      throw new ElevenLabsTtsError(
+        "ELEVENLABS_TTS_EMPTY_RESPONSE",
+        "ElevenLabs streaming TTS returned no response body",
+      );
+    }
+    audio = await readChunkedBody(response.body, {
+      onChunk: options.onChunk,
+      firstChunkTimeoutMs: options.firstChunkTimeoutMs,
+      idleTimeoutMs: options.idleTimeoutMs,
+      makeTimeoutError: (timeoutMs) =>
+        new ElevenLabsTtsError(
+          "ELEVENLABS_TTS_STREAM_TIMEOUT",
+          `ElevenLabs streaming TTS read timed out after ${timeoutMs}ms`,
+        ),
+    });
+  } else {
+    audio = Buffer.from(await response.arrayBuffer());
+  }
+
+  if (audio.byteLength === 0) {
+    throw new ElevenLabsTtsError(
+      "ELEVENLABS_TTS_EMPTY_RESPONSE",
+      "ElevenLabs TTS returned an empty audio response",
+    );
+  }
+
+  log.debug(
+    { bytes: audio.byteLength, stream: options.stream },
+    "ElevenLabs TTS synthesis complete",
+  );
+
+  return {
+    audio,
+    contentType,
+    sampleRateHz: pcmFormatSampleRateHz(outputFormat),
+  };
+}
+
+export function createElevenLabsProvider(
+  streamTimeouts: ElevenLabsStreamTimeouts = {},
+): TtsProvider {
   const capabilities: TtsProviderCapabilities = {
     supportsStreaming: true,
     supportedFormats: ["mp3", "pcm"],
@@ -292,86 +367,11 @@ export function createElevenLabsProvider(): TtsProvider {
   return {
     id: "elevenlabs",
     capabilities,
-
-    async synthesize(
-      request: TtsSynthesisRequest,
-    ): Promise<TtsSynthesisResult> {
-      const { response, outputFormat } = await performTtsRequest(request, {
-        stream: false,
-      });
-
-      const arrayBuffer = await response.arrayBuffer();
-      if (arrayBuffer.byteLength === 0) {
-        throw new ElevenLabsTtsError(
-          "ELEVENLABS_TTS_EMPTY_RESPONSE",
-          "ElevenLabs TTS returned an empty audio response",
-        );
-      }
-
-      log.debug(
-        { bytes: arrayBuffer.byteLength },
-        "ElevenLabs TTS synthesis complete",
-      );
-
-      return {
-        audio: Buffer.from(arrayBuffer),
-        contentType: FORMAT_CONTENT_TYPE[outputFormat] ?? "audio/mpeg",
-      };
-    },
-
-    async synthesizeStream(
-      request: TtsSynthesisRequest,
-      onChunk: (chunk: Uint8Array) => void,
-    ): Promise<TtsSynthesisResult> {
-      const { response, outputFormat } = await performTtsRequest(request, {
-        stream: true,
-      });
-
-      if (!response.body) {
-        throw new ElevenLabsTtsError(
-          "ELEVENLABS_TTS_EMPTY_RESPONSE",
-          "ElevenLabs streaming TTS returned no response body",
-        );
-      }
-
-      const chunks: Uint8Array[] = [];
-      const reader = response.body.getReader();
-      try {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          if (value && value.byteLength > 0) {
-            chunks.push(value);
-            onChunk(value);
-          }
-        }
-      } catch (err) {
-        try {
-          await reader.cancel();
-        } catch {
-          // Ignore cancellation errors
-        }
-        throw err;
-      }
-
-      if (chunks.length === 0) {
-        throw new ElevenLabsTtsError(
-          "ELEVENLABS_TTS_EMPTY_RESPONSE",
-          "ElevenLabs TTS returned an empty audio response",
-        );
-      }
-
-      const audio = Buffer.concat(chunks);
-      log.debug(
-        { bytes: audio.byteLength },
-        "ElevenLabs streaming TTS synthesis complete",
-      );
-
-      return {
-        audio,
-        contentType: FORMAT_CONTENT_TYPE[outputFormat] ?? "audio/mpeg",
-      };
-    },
+    resolveOutputSampleRateHz: (request) =>
+      pcmFormatSampleRateHz(resolveOutputFormat(request)),
+    synthesize: (request) => performSynthesis(request, { stream: false }),
+    synthesizeStream: (request, onChunk) =>
+      performSynthesis(request, { stream: true, onChunk, ...streamTimeouts }),
   };
 }
 

--- a/assistant/src/tts/providers/elevenlabs-provider.ts
+++ b/assistant/src/tts/providers/elevenlabs-provider.ts
@@ -159,14 +159,24 @@ function resolveVoiceId(
   return voiceId;
 }
 
+/** ElevenLabs PCM output formats by exact sample rate. */
+const PCM_FORMAT_BY_SAMPLE_RATE: Record<number, string> = {
+  16000: "pcm_16000",
+  22050: "pcm_22050",
+  24000: "pcm_24000",
+  44100: "pcm_44100",
+};
+
 /**
  * Choose the ElevenLabs output format based on the use case and optional
  * format hint.
  *
  * When the caller requests `outputFormat: "pcm"` (e.g. the media-stream
- * transport which needs raw PCM for mu-law transcoding), we use `pcm_16000`
- * — 16-bit signed little-endian at 16 kHz. The media-stream transport's
- * `audioBufferToFrames` handles the 16 kHz -> 8 kHz downsample.
+ * transport which needs raw PCM for mu-law transcoding), we map the optional
+ * `sampleRateHz` hint to an exact ElevenLabs PCM format — 16-bit signed
+ * little-endian. An absent or unmatched hint defaults to `pcm_16000`, which
+ * preserves the media-stream transport's behavior (its `audioBufferToFrames`
+ * handles the 16 kHz -> 8 kHz downsample).
  *
  * Otherwise:
  * - Phone calls benefit from lower-latency, smaller payloads (mp3 at 22050/32).
@@ -174,14 +184,108 @@ function resolveVoiceId(
  */
 function resolveOutputFormat(request: TtsSynthesisRequest): string {
   if (request.outputFormat === "pcm") {
-    return "pcm_16000";
+    return (
+      PCM_FORMAT_BY_SAMPLE_RATE[request.sampleRateHz ?? 16000] ?? "pcm_16000"
+    );
   }
   return request.useCase === "phone-call" ? "mp3_22050_32" : "mp3_44100_128";
 }
 
+/**
+ * Resolve credentials and config, build the request body, and issue the
+ * ElevenLabs TTS HTTP request. Shared by `synthesize` (buffer endpoint) and
+ * `synthesizeStream` (`/stream` endpoint). Throws on missing credentials and
+ * non-OK responses; resolves with the OK response and the resolved output
+ * format.
+ */
+async function performTtsRequest(
+  request: TtsSynthesisRequest,
+  { stream }: { stream: boolean },
+): Promise<{ response: Response; outputFormat: string }> {
+  const apiKey = await getSecureKeyAsync(
+    credentialKey("elevenlabs", "api_key"),
+  );
+  if (!apiKey) {
+    throw new ElevenLabsTtsError(
+      "ELEVENLABS_TTS_NO_API_KEY",
+      "ElevenLabs API key not configured. " +
+        "Add it in Settings → Voice or via: assistant credentials set --service elevenlabs --field api_key <key>",
+    );
+  }
+
+  const config = getConfig().services.tts.providers.elevenlabs;
+  const voiceId = resolveVoiceId(request, config);
+  const outputFormat = resolveOutputFormat(request);
+
+  const url = stream
+    ? `${ELEVENLABS_API_BASE}/v1/text-to-speech/${voiceId}/stream?output_format=${outputFormat}`
+    : `${ELEVENLABS_API_BASE}/v1/text-to-speech/${voiceId}?output_format=${outputFormat}`;
+
+  // Streaming defaults to the low-latency flash model; batch keeps
+  // multilingual for quality. A configured voiceModelId always wins.
+  const defaultModelId = stream
+    ? "eleven_flash_v2_5"
+    : "eleven_multilingual_v2";
+
+  const body: Record<string, unknown> = {
+    text: request.text,
+    model_id: config.voiceModelId?.trim() || defaultModelId,
+    voice_settings: {
+      stability: config.stability,
+      similarity_boost: config.similarityBoost,
+      speed: config.speed,
+    },
+  };
+
+  log.info(
+    { voiceId, outputFormat, stream, textLength: request.text.length },
+    "Starting ElevenLabs TTS synthesis",
+  );
+
+  const acceptType = FORMAT_CONTENT_TYPE[outputFormat] ?? "audio/mpeg";
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "xi-api-key": apiKey,
+        Accept: acceptType,
+      },
+      body: JSON.stringify(body),
+      signal: request.signal,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") throw err;
+    throw new ElevenLabsTtsError(
+      "ELEVENLABS_TTS_REQUEST_FAILED",
+      `ElevenLabs TTS request failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "");
+    // Surface the upstream provider message verbatim when extractable —
+    // the daemon route wraps it with a single "TTS synthesis failed:"
+    // prefix on the way out. The HTTP status is preserved on `statusCode`
+    // and logged by the daemon, so we don't embed it in the message text.
+    const message =
+      extractElevenLabsErrorMessage(errorText) ??
+      `ElevenLabs returned HTTP ${response.status}`;
+    throw new ElevenLabsTtsError(
+      "ELEVENLABS_TTS_HTTP_ERROR",
+      message,
+      response.status,
+    );
+  }
+
+  return { response, outputFormat };
+}
+
 export function createElevenLabsProvider(): TtsProvider {
   const capabilities: TtsProviderCapabilities = {
-    supportsStreaming: false,
+    supportsStreaming: true,
     supportedFormats: ["mp3", "pcm"],
   };
 
@@ -192,75 +296,9 @@ export function createElevenLabsProvider(): TtsProvider {
     async synthesize(
       request: TtsSynthesisRequest,
     ): Promise<TtsSynthesisResult> {
-      const apiKey = await getSecureKeyAsync(
-        credentialKey("elevenlabs", "api_key"),
-      );
-      if (!apiKey) {
-        throw new ElevenLabsTtsError(
-          "ELEVENLABS_TTS_NO_API_KEY",
-          "ElevenLabs API key not configured. " +
-            "Add it in Settings → Voice or via: assistant credentials set --service elevenlabs --field api_key <key>",
-        );
-      }
-
-      const config = getConfig().services.tts.providers.elevenlabs;
-      const voiceId = resolveVoiceId(request, config);
-      const outputFormat = resolveOutputFormat(request);
-
-      const url = `${ELEVENLABS_API_BASE}/v1/text-to-speech/${voiceId}`;
-
-      const body: Record<string, unknown> = {
-        text: request.text,
-        model_id: config.voiceModelId?.trim() || "eleven_multilingual_v2",
-        voice_settings: {
-          stability: config.stability,
-          similarity_boost: config.similarityBoost,
-          speed: config.speed,
-        },
-      };
-
-      log.info(
-        { voiceId, outputFormat, textLength: request.text.length },
-        "Starting ElevenLabs TTS synthesis",
-      );
-
-      const acceptType = FORMAT_CONTENT_TYPE[outputFormat] ?? "audio/mpeg";
-
-      let response: Response;
-      try {
-        response = await fetch(`${url}?output_format=${outputFormat}`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "xi-api-key": apiKey,
-            Accept: acceptType,
-          },
-          body: JSON.stringify(body),
-          signal: request.signal,
-        });
-      } catch (err) {
-        if (err instanceof Error && err.name === "AbortError") throw err;
-        throw new ElevenLabsTtsError(
-          "ELEVENLABS_TTS_REQUEST_FAILED",
-          `ElevenLabs TTS request failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-
-      if (!response.ok) {
-        const errorText = await response.text().catch(() => "");
-        // Surface the upstream provider message verbatim when extractable —
-        // the daemon route wraps it with a single "TTS synthesis failed:"
-        // prefix on the way out. The HTTP status is preserved on `statusCode`
-        // and logged by the daemon, so we don't embed it in the message text.
-        const message =
-          extractElevenLabsErrorMessage(errorText) ??
-          `ElevenLabs returned HTTP ${response.status}`;
-        throw new ElevenLabsTtsError(
-          "ELEVENLABS_TTS_HTTP_ERROR",
-          message,
-          response.status,
-        );
-      }
+      const { response, outputFormat } = await performTtsRequest(request, {
+        stream: false,
+      });
 
       const arrayBuffer = await response.arrayBuffer();
       if (arrayBuffer.byteLength === 0) {
@@ -270,8 +308,6 @@ export function createElevenLabsProvider(): TtsProvider {
         );
       }
 
-      const contentType = FORMAT_CONTENT_TYPE[outputFormat] ?? "audio/mpeg";
-
       log.debug(
         { bytes: arrayBuffer.byteLength },
         "ElevenLabs TTS synthesis complete",
@@ -279,7 +315,61 @@ export function createElevenLabsProvider(): TtsProvider {
 
       return {
         audio: Buffer.from(arrayBuffer),
-        contentType,
+        contentType: FORMAT_CONTENT_TYPE[outputFormat] ?? "audio/mpeg",
+      };
+    },
+
+    async synthesizeStream(
+      request: TtsSynthesisRequest,
+      onChunk: (chunk: Uint8Array) => void,
+    ): Promise<TtsSynthesisResult> {
+      const { response, outputFormat } = await performTtsRequest(request, {
+        stream: true,
+      });
+
+      if (!response.body) {
+        throw new ElevenLabsTtsError(
+          "ELEVENLABS_TTS_EMPTY_RESPONSE",
+          "ElevenLabs streaming TTS returned no response body",
+        );
+      }
+
+      const chunks: Uint8Array[] = [];
+      const reader = response.body.getReader();
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (value && value.byteLength > 0) {
+            chunks.push(value);
+            onChunk(value);
+          }
+        }
+      } catch (err) {
+        try {
+          await reader.cancel();
+        } catch {
+          // Ignore cancellation errors
+        }
+        throw err;
+      }
+
+      if (chunks.length === 0) {
+        throw new ElevenLabsTtsError(
+          "ELEVENLABS_TTS_EMPTY_RESPONSE",
+          "ElevenLabs TTS returned an empty audio response",
+        );
+      }
+
+      const audio = Buffer.concat(chunks);
+      log.debug(
+        { bytes: audio.byteLength },
+        "ElevenLabs streaming TTS synthesis complete",
+      );
+
+      return {
+        audio,
+        contentType: FORMAT_CONTENT_TYPE[outputFormat] ?? "audio/mpeg",
       };
     },
   };
@@ -309,10 +399,10 @@ export const elevenLabsTtsProviderDefinition: TtsProviderDefinition = {
   callMode: "native-twilio",
   allowNativeFallback: true,
   capabilities: {
-    supportsStreaming: false,
-    supportedFormats: ["mp3"],
+    supportsStreaming: true,
+    supportedFormats: ["mp3", "pcm"],
   },
-  // The adapter honours the PCM hint via `pcm_16000` output.
+  // The adapter honours the PCM hint via sample-rate-mapped pcm_* output.
   mediaStreamPlayback: { outputFormat: "pcm" },
   secretRequirements: [
     {

--- a/assistant/src/tts/providers/fish-audio-provider.ts
+++ b/assistant/src/tts/providers/fish-audio-provider.ts
@@ -148,7 +148,7 @@ async function performSynthesis(
 
   const contentType = FORMAT_CONTENT_TYPE[effectiveFormat] ?? "audio/mpeg";
 
-  return { audio, contentType, sampleRateHz };
+  return { audio, contentType };
 }
 
 export function createFishAudioProvider(): TtsProvider {

--- a/assistant/src/tts/providers/fish-audio-provider.ts
+++ b/assistant/src/tts/providers/fish-audio-provider.ts
@@ -84,6 +84,19 @@ function resolveReferenceId(
   return referenceId;
 }
 
+/**
+ * Actual PCM output sample rate for a request. Fish Audio accepts an exact
+ * `sample_rate`, so a PCM request's hint is honoured as-is; non-PCM formats
+ * carry their rate in the container and report undefined.
+ */
+function resolvePcmOutputSampleRateHz(
+  request: TtsSynthesisRequest,
+): number | undefined {
+  return request.outputFormat === "pcm"
+    ? (request.sampleRateHz ?? DEFAULT_PCM_SAMPLE_RATE_HZ)
+    : undefined;
+}
+
 // ---------------------------------------------------------------------------
 // Provider implementation
 // ---------------------------------------------------------------------------
@@ -99,6 +112,7 @@ async function performSynthesis(
   // PCM request passes straight through at the hinted sample rate.
   const pcmRequested = request.outputFormat === "pcm";
   const effectiveFormat = pcmRequested ? "pcm" : config.format;
+  const sampleRateHz = resolvePcmOutputSampleRateHz(request);
 
   const effectiveConfig: FishAudioSynthesisConfig = {
     ...config,
@@ -122,9 +136,7 @@ async function performSynthesis(
     audio = await synthesizeWithFishAudio(request.text, effectiveConfig, {
       onChunk,
       signal: request.signal,
-      sampleRate: pcmRequested
-        ? (request.sampleRateHz ?? DEFAULT_PCM_SAMPLE_RATE_HZ)
-        : undefined,
+      sampleRate: sampleRateHz,
     });
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") throw err;
@@ -136,7 +148,7 @@ async function performSynthesis(
 
   const contentType = FORMAT_CONTENT_TYPE[effectiveFormat] ?? "audio/mpeg";
 
-  return { audio, contentType };
+  return { audio, contentType, sampleRateHz };
 }
 
 export function createFishAudioProvider(): TtsProvider {
@@ -148,6 +160,7 @@ export function createFishAudioProvider(): TtsProvider {
   return {
     id: "fish-audio",
     capabilities,
+    resolveOutputSampleRateHz: resolvePcmOutputSampleRateHz,
     synthesize: (request) => performSynthesis(request),
     synthesizeStream: (request, onChunk) => performSynthesis(request, onChunk),
   };

--- a/assistant/src/tts/providers/fish-audio-provider.ts
+++ b/assistant/src/tts/providers/fish-audio-provider.ts
@@ -34,6 +34,15 @@ const log = getLogger("tts:fish-audio");
  */
 const DEFAULT_PCM_SAMPLE_RATE_HZ = 16_000;
 
+/**
+ * PCM/WAV sample rates the Fish Audio TTS API accepts. Per
+ * https://docs.fish.audio/api-reference/endpoint/openapi-v1/text-to-speech
+ * these are 8/16/24/32/44.1 kHz (22.05 and 48 kHz are not supported).
+ */
+const SUPPORTED_PCM_SAMPLE_RATES_HZ = [
+  8_000, 16_000, 24_000, 32_000, 44_100,
+] as const;
+
 // ---------------------------------------------------------------------------
 // Error types
 // ---------------------------------------------------------------------------
@@ -84,17 +93,33 @@ function resolveReferenceId(
   return referenceId;
 }
 
+/** Nearest Fish-supported PCM sample rate to `hintHz`; ties prefer the higher rate. */
+function nearestSupportedPcmSampleRateHz(hintHz: number): number {
+  return SUPPORTED_PCM_SAMPLE_RATES_HZ.reduce((best, rate) => {
+    const bestDelta = Math.abs(best - hintHz);
+    const delta = Math.abs(rate - hintHz);
+    if (delta < bestDelta || (delta === bestDelta && rate > best)) {
+      return rate;
+    }
+    return best;
+  });
+}
+
 /**
- * Actual PCM output sample rate for a request. Fish Audio accepts an exact
- * `sample_rate`, so a PCM request's hint is honoured as-is; non-PCM formats
- * carry their rate in the container and report undefined.
+ * Actual PCM output sample rate for a request. A PCM request's hint is clamped
+ * to the nearest Fish-supported rate (e.g. 48 kHz → 44.1 kHz) so the same value
+ * is both sent to the API and reported to callers; non-PCM formats carry their
+ * rate in the container and report undefined.
  */
 function resolvePcmOutputSampleRateHz(
   request: TtsSynthesisRequest,
 ): number | undefined {
-  return request.outputFormat === "pcm"
-    ? (request.sampleRateHz ?? DEFAULT_PCM_SAMPLE_RATE_HZ)
-    : undefined;
+  if (request.outputFormat !== "pcm") {
+    return undefined;
+  }
+  return nearestSupportedPcmSampleRateHz(
+    request.sampleRateHz ?? DEFAULT_PCM_SAMPLE_RATE_HZ,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -108,8 +133,8 @@ async function performSynthesis(
   const config = getConfig().services.tts.providers["fish-audio"];
   const referenceId = resolveReferenceId(request, config);
 
-  // Fish Audio supports raw PCM (16-bit LE, no container) natively, so a
-  // PCM request passes straight through at the hinted sample rate.
+  // Fish Audio supports raw PCM (16-bit LE, no container) natively; the
+  // hinted sample rate is clamped to the nearest API-supported rate.
   const pcmRequested = request.outputFormat === "pcm";
   const effectiveFormat = pcmRequested ? "pcm" : config.format;
   const sampleRateHz = resolvePcmOutputSampleRateHz(request);

--- a/assistant/src/tts/providers/fish-audio-provider.ts
+++ b/assistant/src/tts/providers/fish-audio-provider.ts
@@ -10,7 +10,10 @@
  * client.
  */
 
-import { synthesizeWithFishAudio } from "../../calls/fish-audio-client.js";
+import {
+  type FishAudioSynthesisConfig,
+  synthesizeWithFishAudio,
+} from "../../calls/fish-audio-client.js";
 import { getConfig } from "../../config/loader.js";
 import type { TtsFishAudioProviderConfig } from "../../config/schemas/tts.js";
 import { getLogger } from "../../util/logger.js";
@@ -25,11 +28,11 @@ import type {
 const log = getLogger("tts:fish-audio");
 
 /**
- * Sample rate requested when the caller wants PCM (the phone path).
- * Twilio media streams consume 8 kHz; without this Fish defaults WAV
- * to 44.1 kHz, which the media-stream transcoder would play ~5.5x slow.
+ * Sample rate for PCM requests that carry no `sampleRateHz` hint. The
+ * media-stream transcoder assumes headerless PCM is 16 kHz (the
+ * ElevenLabs/Deepgram/xAI convention) and downsamples to 8 kHz telephony.
  */
-const TELEPHONY_SAMPLE_RATE_HZ = 8000;
+const DEFAULT_PCM_SAMPLE_RATE_HZ = 16_000;
 
 // ---------------------------------------------------------------------------
 // Error types
@@ -58,6 +61,7 @@ const FORMAT_CONTENT_TYPE: Record<string, string> = {
   mp3: "audio/mpeg",
   wav: "audio/wav",
   opus: "audio/opus",
+  pcm: "audio/pcm",
 };
 
 /**
@@ -84,111 +88,68 @@ function resolveReferenceId(
 // Provider implementation
 // ---------------------------------------------------------------------------
 
+async function performSynthesis(
+  request: TtsSynthesisRequest,
+  onChunk?: (chunk: Uint8Array) => void,
+): Promise<TtsSynthesisResult> {
+  const config = getConfig().services.tts.providers["fish-audio"];
+  const referenceId = resolveReferenceId(request, config);
+
+  // Fish Audio supports raw PCM (16-bit LE, no container) natively, so a
+  // PCM request passes straight through at the hinted sample rate.
+  const pcmRequested = request.outputFormat === "pcm";
+  const effectiveFormat = pcmRequested ? "pcm" : config.format;
+
+  const effectiveConfig: FishAudioSynthesisConfig = {
+    ...config,
+    referenceId,
+    format: effectiveFormat,
+  };
+
+  const streaming = Boolean(onChunk);
+  log.info(
+    {
+      referenceId,
+      format: effectiveFormat,
+      streaming,
+      textLength: request.text.length,
+    },
+    "Starting Fish Audio TTS synthesis",
+  );
+
+  let audio: Buffer;
+  try {
+    audio = await synthesizeWithFishAudio(request.text, effectiveConfig, {
+      onChunk,
+      signal: request.signal,
+      sampleRate: pcmRequested
+        ? (request.sampleRateHz ?? DEFAULT_PCM_SAMPLE_RATE_HZ)
+        : undefined,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") throw err;
+    throw new FishAudioTtsError(
+      "FISH_AUDIO_TTS_SYNTHESIS_FAILED",
+      `Fish Audio TTS ${streaming ? "streaming " : ""}synthesis failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const contentType = FORMAT_CONTENT_TYPE[effectiveFormat] ?? "audio/mpeg";
+
+  return { audio, contentType };
+}
+
 export function createFishAudioProvider(): TtsProvider {
   const capabilities: TtsProviderCapabilities = {
     supportsStreaming: true,
-    supportedFormats: ["mp3", "wav", "opus"],
+    supportedFormats: ["mp3", "wav", "opus", "pcm"],
   };
 
   return {
     id: "fish-audio",
     capabilities,
-
-    async synthesize(
-      request: TtsSynthesisRequest,
-    ): Promise<TtsSynthesisResult> {
-      const config = getConfig().services.tts.providers["fish-audio"];
-      const referenceId = resolveReferenceId(request, config);
-
-      // When PCM output is requested, override to WAV at 8 kHz. Fish Audio
-      // doesn't support raw PCM, but WAV gives us PCM in a container that
-      // audioBufferToFrames can extract; the explicit sample rate avoids
-      // Fish's 44.1 kHz WAV default.
-      const pcmRequested = request.outputFormat === "pcm";
-      const effectiveFormat = pcmRequested ? "wav" : config.format;
-
-      // Build an effective config with the resolved reference ID
-      // and the potentially overridden format.
-      const effectiveConfig: TtsFishAudioProviderConfig = {
-        ...config,
-        referenceId,
-        format: effectiveFormat,
-      };
-
-      log.info(
-        {
-          referenceId,
-          format: effectiveFormat,
-          textLength: request.text.length,
-        },
-        "Starting Fish Audio TTS synthesis",
-      );
-
-      let audio: Buffer;
-      try {
-        audio = await synthesizeWithFishAudio(request.text, effectiveConfig, {
-          signal: request.signal,
-          sampleRate: pcmRequested ? TELEPHONY_SAMPLE_RATE_HZ : undefined,
-        });
-      } catch (err) {
-        if (err instanceof Error && err.name === "AbortError") throw err;
-        throw new FishAudioTtsError(
-          "FISH_AUDIO_TTS_SYNTHESIS_FAILED",
-          `Fish Audio TTS synthesis failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-
-      const contentType = FORMAT_CONTENT_TYPE[effectiveFormat] ?? "audio/mpeg";
-
-      return { audio, contentType };
-    },
-
-    async synthesizeStream(
-      request: TtsSynthesisRequest,
-      onChunk: (chunk: Uint8Array) => void,
-    ): Promise<TtsSynthesisResult> {
-      const config = getConfig().services.tts.providers["fish-audio"];
-      const referenceId = resolveReferenceId(request, config);
-
-      // When PCM output is requested, override to WAV at 8 kHz (see
-      // synthesize above).
-      const pcmRequested = request.outputFormat === "pcm";
-      const effectiveFormat = pcmRequested ? "wav" : config.format;
-
-      const effectiveConfig: TtsFishAudioProviderConfig = {
-        ...config,
-        referenceId,
-        format: effectiveFormat,
-      };
-
-      log.info(
-        {
-          referenceId,
-          format: effectiveFormat,
-          textLength: request.text.length,
-        },
-        "Starting Fish Audio TTS streaming synthesis",
-      );
-
-      let audio: Buffer;
-      try {
-        audio = await synthesizeWithFishAudio(request.text, effectiveConfig, {
-          onChunk,
-          signal: request.signal,
-          sampleRate: pcmRequested ? TELEPHONY_SAMPLE_RATE_HZ : undefined,
-        });
-      } catch (err) {
-        if (err instanceof Error && err.name === "AbortError") throw err;
-        throw new FishAudioTtsError(
-          "FISH_AUDIO_TTS_SYNTHESIS_FAILED",
-          `Fish Audio TTS streaming synthesis failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-
-      const contentType = FORMAT_CONTENT_TYPE[effectiveFormat] ?? "audio/mpeg";
-
-      return { audio, contentType };
-    },
+    synthesize: (request) => performSynthesis(request),
+    synthesizeStream: (request, onChunk) => performSynthesis(request, onChunk),
   };
 }
 
@@ -218,10 +179,9 @@ export const fishAudioTtsProviderDefinition: TtsProviderDefinition = {
   allowNativeFallback: true,
   capabilities: {
     supportsStreaming: true,
-    supportedFormats: ["mp3", "wav", "opus"],
+    supportedFormats: ["mp3", "wav", "opus", "pcm"],
   },
-  // The adapter substitutes WAV for the PCM hint (no raw PCM support).
-  mediaStreamPlayback: { outputFormat: "wav" },
+  mediaStreamPlayback: { outputFormat: "pcm" },
   secretRequirements: [
     {
       credentialStoreKey: "credential/fish-audio/api_key",

--- a/assistant/src/tts/speakable-segments.ts
+++ b/assistant/src/tts/speakable-segments.ts
@@ -70,12 +70,14 @@ function findSpeakableBoundary(
   charThreshold: number,
   eager: boolean,
 ): number | null {
-  // Inline-span state (backtick / `**` / `*`), accumulated over the scan. A
-  // boundary inside an open span would split the span across segments, and
-  // per-segment sanitization would leave an unbalanced marker to be spoken.
+  // Inline-span state (backtick / `**` / `*` / `_`), accumulated over the
+  // scan. A boundary inside an open span would split the span across
+  // segments, and per-segment sanitization would leave an unbalanced marker
+  // to be spoken.
   let inBacktick = false;
   let inBold = false;
   let inItalic = false;
+  let inUnderscore = false;
   let skipSpanChar = false;
 
   for (let index = 0; index < text.length; index += 1) {
@@ -87,7 +89,7 @@ function findSpeakableBoundary(
       return index + 1;
     }
 
-    const inOpenSpan = inBacktick || inBold || inItalic;
+    const inOpenSpan = inBacktick || inBold || inItalic || inUnderscore;
 
     if (
       !inOpenSpan &&
@@ -135,6 +137,22 @@ function findSpeakableBoundary(
         !isWhitespace(next)
       ) {
         inItalic = true;
+      }
+    } else if (char === "_") {
+      // Same word-boundary rule as `*`. Since `_` neighbors in identifiers
+      // like `my_var` are word chars, they never open or close a span.
+      const prev = text[index - 1];
+      const next = text[index + 1];
+      if (inUnderscore) {
+        if (prev !== undefined && !isWhitespace(prev) && !isWordChar(next)) {
+          inUnderscore = false;
+        }
+      } else if (
+        !isWordChar(prev) &&
+        next !== undefined &&
+        !isWhitespace(next)
+      ) {
+        inUnderscore = true;
       }
     }
   }

--- a/assistant/src/tts/speakable-segments.ts
+++ b/assistant/src/tts/speakable-segments.ts
@@ -85,11 +85,11 @@ function findSpeakableBoundary(
     if (!char) {
       continue;
     }
-    if (char === "\n") {
+    const inOpenSpan = inBacktick || inBold || inItalic || inUnderscore;
+
+    if (!inOpenSpan && char === "\n") {
       return index + 1;
     }
-
-    const inOpenSpan = inBacktick || inBold || inItalic || inUnderscore;
 
     if (
       !inOpenSpan &&

--- a/assistant/src/tts/speakable-segments.ts
+++ b/assistant/src/tts/speakable-segments.ts
@@ -8,17 +8,33 @@
  */
 
 export const DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD = 180;
+export const EAGER_SPEAKABLE_SEGMENT_CHAR_THRESHOLD = 60;
 
 const SENTENCE_ENDING_PUNCTUATION = new Set([".", "!", "?"]);
 const TRAILING_SENTENCE_PUNCTUATION = new Set(['"', "'", ")", "]"]);
+const EAGER_CLAUSE_PUNCTUATION = new Set([",", ";", ":"]);
+// A clause boundary only counts in eager mode once this much text precedes
+// it — "Sure, " alone would be a one-word blip.
+const EAGER_MIN_CLAUSE_PREFIX_CHARS = 24;
 
 export interface ExtractSpeakableSegmentsOptions {
   /**
    * Max characters buffered before a segment is force-split at the last
    * whitespace boundary. Defaults to
-   * {@link DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD}.
+   * {@link DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD}
+   * ({@link EAGER_SPEAKABLE_SEGMENT_CHAR_THRESHOLD} when `eager`).
    */
   charThreshold?: number;
+  /**
+   * Trade segment quality for onset latency: clause punctuation (`,` `;` `:`)
+   * followed by whitespace also ends a segment once at least
+   * ~24 chars precede it, and the default char threshold drops to
+   * {@link EAGER_SPEAKABLE_SEGMENT_CHAR_THRESHOLD}. Applies only until the
+   * first segment of the call is found — later segments keep full-sentence
+   * rules. The caller decides when to stop passing `eager` (typically after
+   * the first segment is enqueued).
+   */
+  eager?: boolean;
 }
 
 export function extractSpeakableSegments(
@@ -26,18 +42,25 @@ export function extractSpeakableSegments(
   force: boolean,
   options?: ExtractSpeakableSegmentsOptions,
 ): { segments: string[]; remainder: string } {
-  const charThreshold =
-    options?.charThreshold ?? DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD;
+  let eager = options?.eager ?? false;
   const segments: string[] = [];
   let remainder = text;
 
   while (remainder.length > 0) {
-    const boundary = findSpeakableBoundary(remainder, charThreshold);
-    if (boundary === null) break;
+    const charThreshold =
+      options?.charThreshold ??
+      (eager
+        ? EAGER_SPEAKABLE_SEGMENT_CHAR_THRESHOLD
+        : DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD);
+    const boundary = findSpeakableBoundary(remainder, charThreshold, eager);
+    if (boundary === null) {
+      break;
+    }
 
     const segment = remainder.slice(0, boundary).trim();
     if (segment.length > 0) {
       segments.push(segment);
+      eager = false;
     }
     remainder = remainder.slice(boundary);
   }
@@ -56,11 +79,29 @@ export function extractSpeakableSegments(
 function findSpeakableBoundary(
   text: string,
   charThreshold: number,
+  eager: boolean,
 ): number | null {
   for (let index = 0; index < text.length; index += 1) {
     const char = text[index];
-    if (char === "\n") return index + 1;
-    if (!char || !SENTENCE_ENDING_PUNCTUATION.has(char)) continue;
+    if (char === "\n") {
+      return index + 1;
+    }
+    if (!char) {
+      continue;
+    }
+
+    if (
+      eager &&
+      EAGER_CLAUSE_PUNCTUATION.has(char) &&
+      index >= EAGER_MIN_CLAUSE_PREFIX_CHARS &&
+      isWhitespace(text[index + 1] ?? "")
+    ) {
+      return index + 1;
+    }
+
+    if (!SENTENCE_ENDING_PUNCTUATION.has(char)) {
+      continue;
+    }
 
     let boundary = index + 1;
     while (

--- a/assistant/src/tts/speakable-segments.ts
+++ b/assistant/src/tts/speakable-segments.ts
@@ -1,0 +1,100 @@
+/**
+ * Speakable-segment extraction for streaming TTS.
+ *
+ * Splits an incrementally-growing text buffer into complete, speakable
+ * segments (sentences or newline-bounded lines) plus a remainder to keep
+ * buffering. Callers feed LLM deltas in and synthesize each returned segment
+ * as soon as it is complete, so speech starts before the full response lands.
+ */
+
+export const DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD = 180;
+
+const SENTENCE_ENDING_PUNCTUATION = new Set([".", "!", "?"]);
+const TRAILING_SENTENCE_PUNCTUATION = new Set(['"', "'", ")", "]"]);
+
+export interface ExtractSpeakableSegmentsOptions {
+  /**
+   * Max characters buffered before a segment is force-split at the last
+   * whitespace boundary. Defaults to
+   * {@link DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD}.
+   */
+  charThreshold?: number;
+}
+
+export function extractSpeakableSegments(
+  text: string,
+  force: boolean,
+  options?: ExtractSpeakableSegmentsOptions,
+): { segments: string[]; remainder: string } {
+  const charThreshold =
+    options?.charThreshold ?? DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD;
+  const segments: string[] = [];
+  let remainder = text;
+
+  while (remainder.length > 0) {
+    const boundary = findSpeakableBoundary(remainder, charThreshold);
+    if (boundary === null) break;
+
+    const segment = remainder.slice(0, boundary).trim();
+    if (segment.length > 0) {
+      segments.push(segment);
+    }
+    remainder = remainder.slice(boundary);
+  }
+
+  if (force) {
+    const segment = remainder.trim();
+    if (segment.length > 0) {
+      segments.push(segment);
+    }
+    remainder = "";
+  }
+
+  return { segments, remainder };
+}
+
+function findSpeakableBoundary(
+  text: string,
+  charThreshold: number,
+): number | null {
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (char === "\n") return index + 1;
+    if (!char || !SENTENCE_ENDING_PUNCTUATION.has(char)) continue;
+
+    let boundary = index + 1;
+    while (
+      boundary < text.length &&
+      TRAILING_SENTENCE_PUNCTUATION.has(text[boundary] ?? "")
+    ) {
+      boundary += 1;
+    }
+
+    if (boundary === text.length || isWhitespace(text[boundary] ?? "")) {
+      return boundary;
+    }
+  }
+
+  if (text.length < charThreshold) {
+    return null;
+  }
+
+  const preferredBoundary = findLastWhitespaceBoundary(text, charThreshold);
+  return preferredBoundary ?? charThreshold;
+}
+
+function findLastWhitespaceBoundary(
+  text: string,
+  maxLength: number,
+): number | null {
+  for (let index = maxLength; index > Math.floor(maxLength * 0.6); index -= 1) {
+    if (isWhitespace(text[index] ?? "")) {
+      return index + 1;
+    }
+  }
+  return null;
+}
+
+function isWhitespace(value: string): boolean {
+  return /\s/.test(value);
+}

--- a/assistant/src/tts/speakable-segments.ts
+++ b/assistant/src/tts/speakable-segments.ts
@@ -70,42 +70,72 @@ function findSpeakableBoundary(
   charThreshold: number,
   eager: boolean,
 ): number | null {
+  // Inline-span state (backtick / `**` / `*`), accumulated over the scan. A
+  // boundary inside an open span would split the span across segments, and
+  // per-segment sanitization would leave an unbalanced marker to be spoken.
+  let inBacktick = false;
+  let inBold = false;
+  let inItalic = false;
+  let skipSpanChar = false;
+
   for (let index = 0; index < text.length; index += 1) {
     const char = text[index];
-    if (char === "\n") {
-      return index + 1;
-    }
     if (!char) {
       continue;
     }
+    if (char === "\n") {
+      return index + 1;
+    }
+
+    const inOpenSpan = inBacktick || inBold || inItalic;
 
     if (
+      !inOpenSpan &&
       eager &&
       EAGER_CLAUSE_PUNCTUATION.has(char) &&
       index >= EAGER_MIN_CLAUSE_PREFIX_CHARS &&
-      isWhitespace(text[index + 1] ?? "") &&
-      !hasOpenInlineSpan(text.slice(0, index))
+      isWhitespace(text[index + 1] ?? "")
     ) {
       return index + 1;
     }
 
-    if (!SENTENCE_ENDING_PUNCTUATION.has(char)) {
-      continue;
+    if (!inOpenSpan && SENTENCE_ENDING_PUNCTUATION.has(char)) {
+      let boundary = index + 1;
+      while (
+        boundary < text.length &&
+        TRAILING_SENTENCE_PUNCTUATION.has(text[boundary] ?? "")
+      ) {
+        boundary += 1;
+      }
+      if (boundary === text.length || isWhitespace(text[boundary] ?? "")) {
+        return boundary;
+      }
     }
 
-    let boundary = index + 1;
-    while (
-      boundary < text.length &&
-      TRAILING_SENTENCE_PUNCTUATION.has(text[boundary] ?? "")
-    ) {
-      boundary += 1;
-    }
-
-    if (
-      (boundary === text.length || isWhitespace(text[boundary] ?? "")) &&
-      !hasOpenInlineSpan(text.slice(0, index))
-    ) {
-      return boundary;
+    if (skipSpanChar) {
+      skipSpanChar = false;
+    } else if (char === "`") {
+      inBacktick = !inBacktick;
+    } else if (char === "*") {
+      const prev = text[index - 1];
+      const next = text[index + 1];
+      if (next === "*") {
+        inBold = !inBold;
+        skipSpanChar = true;
+      } else if (inItalic) {
+        // Mirrors the TTS sanitizer's word-boundary-aware italic rule: a
+        // closer needs non-whitespace before it and no word char after, so
+        // arithmetic like `5 * 3` and bullet markers never toggle parity.
+        if (prev !== undefined && !isWhitespace(prev) && !isWordChar(next)) {
+          inItalic = false;
+        }
+      } else if (
+        !isWordChar(prev) &&
+        next !== undefined &&
+        !isWhitespace(next)
+      ) {
+        inItalic = true;
+      }
     }
   }
 
@@ -119,29 +149,8 @@ function findSpeakableBoundary(
   return preferredBoundary ?? charThreshold;
 }
 
-/**
- * Whether the text ends inside an open `**`, `*`, or backtick span. A
- * boundary there would split the span across segments, and per-segment
- * sanitization would leave an unbalanced marker to be spoken.
- */
-function hasOpenInlineSpan(prefix: string): boolean {
-  let backticks = 0;
-  let bold = 0;
-  let italic = 0;
-  for (let index = 0; index < prefix.length; index += 1) {
-    const char = prefix[index];
-    if (char === "`") {
-      backticks += 1;
-    } else if (char === "*") {
-      if (prefix[index + 1] === "*") {
-        bold += 1;
-        index += 1;
-      } else {
-        italic += 1;
-      }
-    }
-  }
-  return backticks % 2 === 1 || bold % 2 === 1 || italic % 2 === 1;
+function isWordChar(value: string | undefined): boolean {
+  return value !== undefined && /\w/.test(value);
 }
 
 function findLastWhitespaceBoundary(

--- a/assistant/src/tts/speakable-segments.ts
+++ b/assistant/src/tts/speakable-segments.ts
@@ -7,8 +7,8 @@
  * as soon as it is complete, so speech starts before the full response lands.
  */
 
-export const DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD = 180;
-export const EAGER_SPEAKABLE_SEGMENT_CHAR_THRESHOLD = 60;
+const DEFAULT_CHAR_THRESHOLD = 180;
+const EAGER_CHAR_THRESHOLD = 60;
 
 const SENTENCE_ENDING_PUNCTUATION = new Set([".", "!", "?"]);
 const TRAILING_SENTENCE_PUNCTUATION = new Set(['"', "'", ")", "]"]);
@@ -19,17 +19,10 @@ const EAGER_MIN_CLAUSE_PREFIX_CHARS = 24;
 
 export interface ExtractSpeakableSegmentsOptions {
   /**
-   * Max characters buffered before a segment is force-split at the last
-   * whitespace boundary. Defaults to
-   * {@link DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD}
-   * ({@link EAGER_SPEAKABLE_SEGMENT_CHAR_THRESHOLD} when `eager`).
-   */
-  charThreshold?: number;
-  /**
    * Trade segment quality for onset latency: clause punctuation (`,` `;` `:`)
    * followed by whitespace also ends a segment once at least
-   * ~24 chars precede it, and the default char threshold drops to
-   * {@link EAGER_SPEAKABLE_SEGMENT_CHAR_THRESHOLD}. Applies only until the
+   * ~24 chars precede it, and the max buffered length before a forced split
+   * drops from 180 to 60 chars. Applies only until the
    * first segment of the call is found — later segments keep full-sentence
    * rules. The caller decides when to stop passing `eager` (typically after
    * the first segment is enqueued).
@@ -47,11 +40,7 @@ export function extractSpeakableSegments(
   let remainder = text;
 
   while (remainder.length > 0) {
-    const charThreshold =
-      options?.charThreshold ??
-      (eager
-        ? EAGER_SPEAKABLE_SEGMENT_CHAR_THRESHOLD
-        : DEFAULT_SPEAKABLE_SEGMENT_CHAR_THRESHOLD);
+    const charThreshold = eager ? EAGER_CHAR_THRESHOLD : DEFAULT_CHAR_THRESHOLD;
     const boundary = findSpeakableBoundary(remainder, charThreshold, eager);
     if (boundary === null) {
       break;
@@ -94,7 +83,8 @@ function findSpeakableBoundary(
       eager &&
       EAGER_CLAUSE_PUNCTUATION.has(char) &&
       index >= EAGER_MIN_CLAUSE_PREFIX_CHARS &&
-      isWhitespace(text[index + 1] ?? "")
+      isWhitespace(text[index + 1] ?? "") &&
+      !hasOpenInlineSpan(text.slice(0, index))
     ) {
       return index + 1;
     }
@@ -111,7 +101,10 @@ function findSpeakableBoundary(
       boundary += 1;
     }
 
-    if (boundary === text.length || isWhitespace(text[boundary] ?? "")) {
+    if (
+      (boundary === text.length || isWhitespace(text[boundary] ?? "")) &&
+      !hasOpenInlineSpan(text.slice(0, index))
+    ) {
       return boundary;
     }
   }
@@ -120,8 +113,35 @@ function findSpeakableBoundary(
     return null;
   }
 
+  // Length-threshold splits are a hard cap and must flush even inside an
+  // open span — unbalanced markers there are an accepted edge.
   const preferredBoundary = findLastWhitespaceBoundary(text, charThreshold);
   return preferredBoundary ?? charThreshold;
+}
+
+/**
+ * Whether the text ends inside an open `**`, `*`, or backtick span. A
+ * boundary there would split the span across segments, and per-segment
+ * sanitization would leave an unbalanced marker to be spoken.
+ */
+function hasOpenInlineSpan(prefix: string): boolean {
+  let backticks = 0;
+  let bold = 0;
+  let italic = 0;
+  for (let index = 0; index < prefix.length; index += 1) {
+    const char = prefix[index];
+    if (char === "`") {
+      backticks += 1;
+    } else if (char === "*") {
+      if (prefix[index + 1] === "*") {
+        bold += 1;
+        index += 1;
+      } else {
+        italic += 1;
+      }
+    }
+  }
+  return backticks % 2 === 1 || bold % 2 === 1 || italic % 2 === 1;
 }
 
 function findLastWhitespaceBoundary(

--- a/assistant/src/tts/stream-read.ts
+++ b/assistant/src/tts/stream-read.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared chunked-body reader for streaming TTS HTTP responses.
+ *
+ * Reads a fetch response body to completion, forwarding each non-empty chunk
+ * to an optional callback, and guards against stalled upstream streams with a
+ * first-chunk timeout and an idle (between-chunks) timeout. On timeout the
+ * reader is cancelled and the caller-supplied error is thrown.
+ */
+
+/** Default timeout waiting for the first chunk of a TTS stream (ms). */
+const DEFAULT_FIRST_CHUNK_TIMEOUT_MS = 10_000;
+
+/** Default timeout waiting between consecutive chunks (ms). */
+const DEFAULT_IDLE_TIMEOUT_MS = 5_000;
+
+export interface ReadChunkedBodyOptions {
+  /** Invoked with each non-empty chunk as it arrives. */
+  onChunk?: (chunk: Uint8Array) => void;
+
+  /** Timeout waiting for the first chunk (ms). */
+  firstChunkTimeoutMs?: number;
+
+  /** Timeout waiting between consecutive chunks (ms). */
+  idleTimeoutMs?: number;
+
+  /** Builds the error thrown when a read times out. */
+  makeTimeoutError: (timeoutMs: number) => Error;
+}
+
+/**
+ * Read a chunked response body to completion and return the concatenated
+ * audio. Any received chunk (even an empty one) counts as stream activity
+ * and switches from the first-chunk timeout to the idle timeout; only
+ * non-empty chunks are collected and forwarded to `onChunk`.
+ */
+export async function readChunkedBody(
+  body: ReadableStream<Uint8Array>,
+  options: ReadChunkedBodyOptions,
+): Promise<Buffer> {
+  const firstChunkTimeoutMs =
+    options.firstChunkTimeoutMs ?? DEFAULT_FIRST_CHUNK_TIMEOUT_MS;
+  const idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
+
+  const chunks: Uint8Array[] = [];
+  const reader = body.getReader();
+  let isFirstChunk = true;
+
+  try {
+    while (true) {
+      const timeoutMs = isFirstChunk ? firstChunkTimeoutMs : idleTimeoutMs;
+      let timerId: ReturnType<typeof setTimeout>;
+      const timeout = new Promise<never>((_, reject) => {
+        timerId = setTimeout(
+          () => reject(options.makeTimeoutError(timeoutMs)),
+          timeoutMs,
+        );
+      });
+      let done: boolean;
+      let value: Uint8Array | undefined;
+      try {
+        ({ done, value } = await Promise.race([reader.read(), timeout]));
+      } finally {
+        clearTimeout(timerId!);
+      }
+      if (done) {
+        break;
+      }
+      if (value) {
+        isFirstChunk = false;
+        if (value.byteLength > 0) {
+          chunks.push(value);
+          options.onChunk?.(value);
+        }
+      }
+    }
+  } catch (err) {
+    try {
+      await reader.cancel();
+    } catch {
+      // Ignore cancellation errors
+    }
+    throw err;
+  }
+
+  return Buffer.concat(chunks);
+}

--- a/assistant/src/tts/synthesis-stream.ts
+++ b/assistant/src/tts/synthesis-stream.ts
@@ -77,13 +77,6 @@ export interface SynthesisEmitResult {
   contentType: string;
 
   /**
-   * Provider-reported actual output sample rate in Hz, passed through from
-   * {@link TtsSynthesisResult.sampleRateHz}. Undefined when the provider
-   * does not report one (non-PCM output).
-   */
-  sampleRateHz?: number;
-
-  /**
    * `true` when emission was halted by an aborted `signal` or an
    * `isCurrent()` staleness flip — the silent-resolve path. Callers use
    * this instead of re-probing the signal after resolve.
@@ -182,7 +175,6 @@ export async function synthesizeAndEmit(
     return {
       emittedChunks,
       contentType: result.contentType,
-      sampleRateHz: result.sampleRateHz,
       stopped: shouldStop(),
     };
   }
@@ -200,7 +192,6 @@ export async function synthesizeAndEmit(
   return {
     emittedChunks,
     contentType: result.contentType,
-    sampleRateHz: result.sampleRateHz,
     stopped: shouldStop(),
   };
 }

--- a/assistant/src/tts/synthesis-stream.ts
+++ b/assistant/src/tts/synthesis-stream.ts
@@ -77,6 +77,13 @@ export interface SynthesisEmitResult {
   contentType: string;
 
   /**
+   * Provider-reported actual output sample rate in Hz, passed through from
+   * {@link TtsSynthesisResult.sampleRateHz}. Undefined when the provider
+   * does not report one (non-PCM output).
+   */
+  sampleRateHz?: number;
+
+  /**
    * `true` when emission was halted by an aborted `signal` or an
    * `isCurrent()` staleness flip — the silent-resolve path. Callers use
    * this instead of re-probing the signal after resolve.
@@ -175,6 +182,7 @@ export async function synthesizeAndEmit(
     return {
       emittedChunks,
       contentType: result.contentType,
+      sampleRateHz: result.sampleRateHz,
       stopped: shouldStop(),
     };
   }
@@ -192,6 +200,7 @@ export async function synthesizeAndEmit(
   return {
     emittedChunks,
     contentType: result.contentType,
+    sampleRateHz: result.sampleRateHz,
     stopped: shouldStop(),
   };
 }

--- a/assistant/src/tts/synthesis-stream.ts
+++ b/assistant/src/tts/synthesis-stream.ts
@@ -50,6 +50,9 @@ export interface SynthesisEmitOptions {
   /** Output-encoding hint forwarded on the provider request (e.g. `"pcm"`). */
   outputFormat?: TtsSynthesisRequest["outputFormat"];
 
+  /** Preferred PCM sample rate in Hz, forwarded on the provider request. */
+  sampleRateHz?: number;
+
   /** Abort signal forwarded to the provider and checked before each emit. */
   signal?: AbortSignal;
 
@@ -99,6 +102,7 @@ export async function synthesizeAndEmit(
     useCase: options.useCase,
     voiceId: options.voiceId,
     outputFormat: options.outputFormat,
+    sampleRateHz: options.sampleRateHz,
     signal,
   };
 

--- a/assistant/src/tts/types.ts
+++ b/assistant/src/tts/types.ts
@@ -104,6 +104,14 @@ export interface TtsSynthesisRequest {
    * actual format of the returned audio.
    */
   outputFormat?: "pcm";
+
+  /**
+   * Optional preferred output sample rate in Hz, meaningful with
+   * `outputFormat: "pcm"`. Providers pick the nearest rate they support;
+   * callers must not assume the hint was honoured exactly and should rely
+   * on provider-documented behavior (see each provider's format mapping).
+   */
+  sampleRateHz?: number;
 }
 
 /** Output of a completed TTS synthesis call. */

--- a/assistant/src/tts/types.ts
+++ b/assistant/src/tts/types.ts
@@ -121,6 +121,15 @@ export interface TtsSynthesisResult {
 
   /** MIME type of the returned audio (e.g. `"audio/mpeg"`, `"audio/wav"`). */
   contentType: string;
+
+  /**
+   * Actual output sample rate in Hz of the returned audio, when the provider
+   * knows it (raw PCM output). Undefined for container/compressed formats
+   * whose rate is carried in the payload (mp3/wav/opus). May differ from the
+   * request's `sampleRateHz` hint when the provider cannot honour it exactly —
+   * callers that label raw PCM with a rate must use this over the hint.
+   */
+  sampleRateHz?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -196,6 +205,18 @@ export interface TtsProvider {
 
   /** Static capability advertisement. */
   readonly capabilities: TtsProviderCapabilities;
+
+  /**
+   * Actual PCM output sample rate in Hz that synthesizing `request` will
+   * produce, when deterministically known before synthesis begins.
+   *
+   * Streaming callers that label emitted chunks with a rate use this so the
+   * first chunk — delivered before the final {@link TtsSynthesisResult}
+   * resolves — carries the provider's true output rate rather than the
+   * request's `sampleRateHz` hint. Returns `undefined` for non-PCM output
+   * or when the rate is not known up-front.
+   */
+  resolveOutputSampleRateHz?(request: TtsSynthesisRequest): number | undefined;
 
   /**
    * Synthesize text and return the complete audio buffer.

--- a/assistant/src/tts/types.ts
+++ b/assistant/src/tts/types.ts
@@ -121,15 +121,6 @@ export interface TtsSynthesisResult {
 
   /** MIME type of the returned audio (e.g. `"audio/mpeg"`, `"audio/wav"`). */
   contentType: string;
-
-  /**
-   * Actual output sample rate in Hz of the returned audio, when the provider
-   * knows it (raw PCM output). Undefined for container/compressed formats
-   * whose rate is carried in the payload (mp3/wav/opus). May differ from the
-   * request's `sampleRateHz` hint when the provider cannot honour it exactly —
-   * callers that label raw PCM with a rate must use this over the hint.
-   */
-  sampleRateHz?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -210,11 +201,12 @@ export interface TtsProvider {
    * Actual PCM output sample rate in Hz that synthesizing `request` will
    * produce, when deterministically known before synthesis begins.
    *
-   * Streaming callers that label emitted chunks with a rate use this so the
-   * first chunk — delivered before the final {@link TtsSynthesisResult}
-   * resolves — carries the provider's true output rate rather than the
-   * request's `sampleRateHz` hint. Returns `undefined` for non-PCM output
-   * or when the rate is not known up-front.
+   * This up-front probe is the single source of truth for the actual output
+   * rate — {@link TtsSynthesisResult} carries no rate. Streaming callers that
+   * label emitted chunks with a rate use this so the first chunk — delivered
+   * before the final result resolves — carries the provider's true output
+   * rate rather than the request's `sampleRateHz` hint. Returns `undefined`
+   * for non-PCM output or when the rate is not known up-front.
    */
   resolveOutputSampleRateHz?(request: TtsSynthesisRequest): number | undefined;
 


### PR DESCRIPTION
## Summary

Makes voice output feel real-time on all three surfaces by eliminating TTS buffering: ElevenLabs becomes a true streaming PCM provider (fixing hands-free hard-failing on the default config), fish-audio's fake 8 kHz-WAV "PCM" is replaced with native raw PCM at the requested rate, live-voice speaks at the first clause instead of the first sentence, and both phone-call seams (synthesized-play and native-twilio media-stream) synthesize per speakable segment during the LLM stream instead of buffering the whole response. Target achieved: time-to-first-audio ≈ (first-clause LLM time) + (first-chunk synthesis time).

## Self-review result

4 review rounds (external-feedback / plan-faithfulness / repo-integration / slop passes): 7 gaps found and fixed across 7 fix PRs, final round PASS. Highlights caught and fixed in-review: stale speech playing over the next turn after a mid-`processing` barge-in (P1), double-speak on mid-stream provider failure, sample-rate labeling that could pitch-shift future clients, sanitizer/segmenter markdown-span disagreement, stream-stall timeouts for ElevenLabs.

## PRs merged into feature branch

- #37308: feat(tts): add sampleRateHz hint to TtsSynthesisRequest and forward it through synthesizeAndEmit
- #37309: refactor(tts): extract speakable-segment boundary logic into tts/speakable-segments
- #37312: feat(tts): implement ElevenLabs synthesizeStream with chunked PCM output
- #37314: fix(tts): fish-audio streams raw PCM at the requested sample rate instead of 8 kHz WAV
- #37311: feat(live-voice): request provider PCM at the session sample rate for per-chunk tts_audio streaming
- #37313: feat(live-voice): flush the first TTS segment at a clause boundary
- #37315: feat(calls): synthesize synthesized-play TTS per speakable segment during the LLM stream
- #37316: feat(calls): sentence-bounded streaming TTS in MediaStreamOutput

### Fix PRs

- #37348: fix(tts): keep speakable-segment boundaries out of open markdown spans; drop test-only charThreshold knob
- #37352: fix(tts): report actual provider sample rate, share stream reader with stall timeouts
- #37353: fix: cancel pending media-stream speech on turn abort and add per-segment fallback retry
- #37360: fix(tts): only count plausible emphasis delimiters in speakable-segment span tracking
- #37363: refactor(tts): single source of truth for actual output sample rate
- #37364: fix(calls): skip fallback re-speak after mid-stream audio, share the telephony fallback-provider guard
- #37366: fix(tts): require non-whitespace content edges for italic spans in sanitizeForTts

## Deferred follow-ups (documented, out of scope)

- ElevenLabs WebSocket text-streaming API (would supersede sentence segmentation for ElevenLabs)
- VAD silence-threshold tuning after real-mic QA (metrics frames already measure each latency leg)
- PCM-carry helper consolidation (live-voice 2-byte vs media-stream 4-byte aligners)
- preferWav sentinel collapse + callMode split collapse (pre-existing debt)
- Real-call fish-audio PCM QA (format verified against docs.fish.audio; add to the mic/call QA matrix)

Part of plan: voice-tts-streaming-latency.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)