### PR TITLE
fix: mirror-op skew signal + helper consolidation (review round 1)

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -20,6 +20,10 @@ import type {
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
+type Db = ReturnType<typeof getDb>;
+/** Accepts the live connection or a transaction handle. */
+type DbOrTx = Db | Parameters<Parameters<Db["transaction"]>[0]>[0];
+
 /** Strip LIKE metacharacters so user input is matched literally.
  * SQLite has no default escape character for LIKE, so we strip rather than escape. */
 function escapeLike(value: string): string {
@@ -30,11 +34,7 @@ function escapeLike(value: string): string {
  * Find the first contact_channels row whose (type, address) matches.
  * Uses COLLATE NOCASE to find legacy lowercased rows (pre-migration 290).
  */
-function findConflictingChannel(
-  db: ReturnType<typeof getDb>,
-  type: string,
-  address: string,
-) {
+function findConflictingChannel(db: DbOrTx, type: string, address: string) {
   return db
     .select()
     .from(contactChannels)
@@ -45,6 +45,60 @@ function findConflictingChannel(
       ),
     )
     .get();
+}
+
+/** Merge notes concat: survivor notes first, donor appended with \n,
+ * empty result stored as null. */
+function concatMergedNotes(
+  keepNotes: string | null | undefined,
+  donorNotes: string | null,
+): string | null {
+  return [keepNotes ?? null, donorNotes].filter(Boolean).join("\n") || null;
+}
+
+/**
+ * Move donor channels onto the survivor, skipping any the survivor already
+ * holds by logical (type, address) key. COLLATE NOCASE catches legacy
+ * lowercased rows. `touchUpdatedAt` stamps updated_at on moved rows (the
+ * mirror op does; the local merge historically does not).
+ */
+function reparentDonorChannels(
+  tx: DbOrTx,
+  keepId: string,
+  mergeId: string,
+  touchUpdatedAt?: number,
+): void {
+  const donorChannels = tx
+    .select()
+    .from(contactChannels)
+    .where(eq(contactChannels.contactId, mergeId))
+    .all();
+
+  for (const ch of donorChannels) {
+    const exists = tx
+      .select()
+      .from(contactChannels)
+      .where(
+        and(
+          eq(contactChannels.contactId, keepId),
+          eq(contactChannels.type, ch.type),
+          sql`${contactChannels.address} = ${ch.address} COLLATE NOCASE`,
+        ),
+      )
+      .get();
+
+    if (!exists) {
+      tx.update(contactChannels)
+        .set({
+          contactId: keepId,
+          ...(touchUpdatedAt !== undefined
+            ? { updatedAt: touchUpdatedAt }
+            : {}),
+        })
+        .where(eq(contactChannels.id, ch.id))
+        .run();
+    }
+  }
 }
 
 /**
@@ -649,41 +703,14 @@ export function mergeContacts(
 
     tx.update(contacts)
       .set({
-        notes: [keep.notes, merge.notes].filter(Boolean).join("\n") || null,
+        notes: concatMergedNotes(keep.notes, merge.notes),
         updatedAt: now,
       })
       .where(eq(contacts.id, keepId))
       .run();
 
     // Move channels from donor to survivor, skipping duplicates
-    const donorChannels = tx
-      .select()
-      .from(contactChannels)
-      .where(eq(contactChannels.contactId, mergeId))
-      .all();
-
-    for (const ch of donorChannels) {
-      // COLLATE NOCASE catches legacy lowercased rows so we don't try to
-      // move a donor channel that collides with an existing survivor channel.
-      const exists = tx
-        .select()
-        .from(contactChannels)
-        .where(
-          and(
-            eq(contactChannels.contactId, keepId),
-            eq(contactChannels.type, ch.type),
-            sql`${contactChannels.address} = ${ch.address} COLLATE NOCASE`,
-          ),
-        )
-        .get();
-
-      if (!exists) {
-        tx.update(contactChannels)
-          .set({ contactId: keepId })
-          .where(eq(contactChannels.id, ch.id))
-          .run();
-      }
-    }
+    reparentDonorChannels(tx, keepId, mergeId);
 
     // Delete the donor contact (cascading deletes remaining channels)
     tx.delete(contacts).where(eq(contacts.id, mergeId)).run();
@@ -723,9 +750,7 @@ export function mergeContactMirror(params: {
       .from(contacts)
       .where(eq(contacts.id, params.keepContactId))
       .get();
-    const combined =
-      [survivor?.notes ?? null, donor.notes].filter(Boolean).join("\n") ||
-      null;
+    const combined = concatMergedNotes(survivor?.notes, donor.notes);
 
     if (survivor) {
       tx.update(contacts)
@@ -747,30 +772,7 @@ export function mergeContactMirror(params: {
     }
 
     // Move donor channels to the survivor, skipping duplicates by logical key.
-    const donorChannels = tx
-      .select()
-      .from(contactChannels)
-      .where(eq(contactChannels.contactId, params.mergeContactId))
-      .all();
-    for (const ch of donorChannels) {
-      const exists = tx
-        .select()
-        .from(contactChannels)
-        .where(
-          and(
-            eq(contactChannels.contactId, params.keepContactId),
-            eq(contactChannels.type, ch.type),
-            sql`${contactChannels.address} = ${ch.address} COLLATE NOCASE`,
-          ),
-        )
-        .get();
-      if (!exists) {
-        tx.update(contactChannels)
-          .set({ contactId: params.keepContactId, updatedAt: now })
-          .where(eq(contactChannels.id, ch.id))
-          .run();
-      }
-    }
+    reparentDonorChannels(tx, params.keepContactId, params.mergeContactId, now);
 
     // Delete the donor (cascade removes remaining duplicate channels).
     tx.delete(contacts).where(eq(contacts.id, params.mergeContactId)).run();
@@ -899,17 +901,8 @@ export function upsertContactMirrorFull(params: {
         continue;
       }
 
-      const conflict = tx
-        .select({ id: contactChannels.id })
-        .from(contactChannels)
-        .where(
-          and(
-            eq(contactChannels.type, ch.type),
-            sql`${contactChannels.address} = ${ch.address} COLLATE NOCASE`,
-          ),
-        )
-        .get();
-      if (conflict) continue;
+      // Address owned by ANOTHER contact is never stolen.
+      if (findConflictingChannel(tx, ch.type, ch.address)) continue;
 
       tx.insert(contactChannels)
         .values({

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -984,6 +984,25 @@ export const ROUTES: RouteDefinition[] = [
 // Transport-agnostic handlers (moved from HTTP-only)
 // ---------------------------------------------------------------------------
 
+/**
+ * DIVERGENCE RISK — daemon-local merge, NOT the canonical path.
+ *
+ * This executes the LOCAL `mergeContacts` (assistant DB only). The canonical
+ * merge is the gateway control plane (POST /v1/contacts/merge →
+ * contacts-control-plane-proxy.handleMergeContacts), which merges the gateway
+ * DB — the ACL source of truth — and mirrors here via
+ * `contacts_mirror_merge_contact`. A merge through THIS route leaves the
+ * gateway DB untouched: the donor contact and its ACL channel rows survive
+ * gateway-side while the assistant mirror deletes them. Gateway-fronted
+ * clients never reach this route (the control-plane route-match intercepts
+ * the path), but direct daemon callers — notably the bundled `contact_merge`
+ * tool — do.
+ *
+ * Not converted to a relay yet because no gateway IPC/SDK merge surface
+ * exists (unlike `update_contact_channel` below); relaying requires new
+ * gateway-client contracts + a gateway IPC route + a core extraction of the
+ * HTTP handler. Until then, prefer the gateway route wherever reachable.
+ */
 async function handleMergeContactsRoute(args: RouteHandlerArgs) {
   const { body } = args;
   const keepId = body?.keepId as string | undefined;

--- a/gateway/src/__tests__/contact-store-mirror-op-missing.test.ts
+++ b/gateway/src/__tests__/contact-store-mirror-op-missing.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Unknown-method escalation on the typed contacts mirror ops.
+ *
+ * An old daemon rejects `contacts_mirror_merge_contact` /
+ * `contacts_mirror_upsert_full` with "Unknown method"; the best-effort catch
+ * must NOT swallow that silently — it escalates through the mirror-op-missing
+ * reporter (error log + `contacts_mirror_op_missing` watchdog telemetry)
+ * while the gateway write still stands (no raw-SQL fallback by design). Any
+ * other IPC failure keeps the routine best-effort warn: no escalation, same
+ * gateway state.
+ */
+
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterAll,
+  afterEach,
+  mock,
+} from "bun:test";
+
+import "./test-preload.js";
+
+// ── Mocked daemon IPC (leak-safe: delegates to a mutable mock, spreads the
+// actual module so other exports stay importable across suites) ─────────────
+
+type IpcCallFn = (
+  method: string,
+  params?: Record<string, unknown>,
+) => Promise<unknown>;
+
+const ipcCalls: string[] = [];
+// Method name → error to throw whenever it is called.
+const ipcThrowOn = new Map<string, Error>();
+
+let ipcCallAssistantMock: ReturnType<typeof mock<IpcCallFn>> = mock(
+  async () => ({}),
+);
+
+const actualAssistantClient = await import("../ipc/assistant-client.js");
+mock.module("../ipc/assistant-client.js", () => ({
+  ...actualAssistantClient,
+  ipcCallAssistant: (...args: Parameters<IpcCallFn>) =>
+    ipcCallAssistantMock(...args),
+}));
+
+// ── Imports ──────────────────────────────────────────────────────────────────
+
+import { ContactStore } from "../db/contact-store.js";
+import {
+  initGatewayDb,
+  getGatewayDb,
+  resetGatewayDb,
+} from "../db/connection.js";
+import { contacts, contactChannels } from "../db/schema.js";
+import {
+  MIRROR_OP_MISSING_CHECK_NAME,
+  flushMirrorOpReporterForTesting,
+  resetMirrorOpReporterForTesting,
+  setMirrorOpReporterOverridesForTesting,
+} from "../contacts-mirror-op-reporter.js";
+
+// ── Setup ────────────────────────────────────────────────────────────────────
+
+const errorLogs: [Record<string, unknown>, string][] = [];
+const warnLogs: unknown[] = [];
+let telemetryBodies: unknown[] = [];
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
+
+beforeEach(() => {
+  const db = getGatewayDb();
+  db.delete(contactChannels).run();
+  db.delete(contacts).run();
+
+  ipcCalls.length = 0;
+  ipcThrowOn.clear();
+  ipcCallAssistantMock = mock(async (method: string) => {
+    ipcCalls.push(method);
+    const err = ipcThrowOn.get(method);
+    if (err) throw err;
+    if (method === "contacts_info_batch") return { infos: [] };
+    if (method === "contact_user_file_slugs") return { userFiles: [] };
+    return {};
+  });
+
+  errorLogs.length = 0;
+  warnLogs.length = 0;
+  telemetryBodies = [];
+  resetMirrorOpReporterForTesting();
+  setMirrorOpReporterOverridesForTesting({
+    fetchImpl: async (_url, init) => {
+      telemetryBodies.push(JSON.parse(String(init?.body)));
+      return new Response("{}");
+    },
+    mintToken: () => "svc-token",
+    baseUrl: "http://127.0.0.1:7821",
+    log: {
+      error: (detail, msg) => {
+        errorLogs.push([detail, msg]);
+      },
+      warn: (detail, msg) => {
+        warnLogs.push([detail, msg]);
+      },
+    },
+  });
+});
+
+afterEach(() => {
+  resetMirrorOpReporterForTesting();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+function seedContact(id: string) {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(contacts)
+    .values({
+      id,
+      displayName: `name-${id}`,
+      role: "contact",
+      principalId: null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function seedChannel(id: string, contactId: string) {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(contactChannels)
+    .values({
+      id,
+      contactId,
+      type: "slack" as never,
+      address: `addr-${id}`,
+      isPrimary: false,
+      status: "active",
+      policy: "allow",
+      interactionCount: 0,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function unknownMethodError(method: string): Error {
+  // Exact shape the daemon IPC server sends for an unregistered method,
+  // surfaced by ipcCallAssistant as a transport-level Error message.
+  return new Error(`Unknown method: ${method}`);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("mergeContacts — unknown mirror op escalation", () => {
+  test("unknown method → error log + telemetry; gateway merge still applied", async () => {
+    seedContact("ct_keep");
+    seedContact("ct_merge");
+    seedChannel("ch_1", "ct_merge");
+    ipcThrowOn.set(
+      "contacts_mirror_merge_contact",
+      unknownMethodError("contacts_mirror_merge_contact"),
+    );
+
+    const store = new ContactStore();
+    const result = await store.mergeContacts("ct_keep", "ct_merge");
+    await flushMirrorOpReporterForTesting();
+
+    // Gateway (source of truth) merge stands: donor gone, channel moved.
+    expect(result!.id).toBe("ct_keep");
+    const db = getGatewayDb();
+    expect(
+      db
+        .select()
+        .from(contacts)
+        .all()
+        .find((c) => c.id === "ct_merge"),
+    ).toBeUndefined();
+    expect(
+      db
+        .select()
+        .from(contactChannels)
+        .all()
+        .find((c) => c.id === "ch_1")?.contactId,
+    ).toBe("ct_keep");
+
+    // Escalated: one error log + one watchdog telemetry event.
+    expect(errorLogs.length).toBe(1);
+    expect(errorLogs[0][0]).toMatchObject({
+      op: "contacts_mirror_merge_contact",
+      keepId: "ct_keep",
+      mergeId: "ct_merge",
+    });
+    expect(telemetryBodies).toEqual([
+      {
+        check_name: MIRROR_OP_MISSING_CHECK_NAME,
+        detail: {
+          op: "contacts_mirror_merge_contact",
+          keepId: "ct_keep",
+          mergeId: "ct_merge",
+        },
+      },
+    ]);
+  });
+
+  test("other IPC failure → best-effort warn only, same gateway state", async () => {
+    seedContact("ct_keep");
+    seedContact("ct_merge");
+    seedChannel("ch_1", "ct_merge");
+    ipcThrowOn.set(
+      "contacts_mirror_merge_contact",
+      new Error("daemon unavailable"),
+    );
+
+    const store = new ContactStore();
+    const result = await store.mergeContacts("ct_keep", "ct_merge");
+    await flushMirrorOpReporterForTesting();
+
+    expect(result!.id).toBe("ct_keep");
+    expect(
+      getGatewayDb()
+        .select()
+        .from(contacts)
+        .all()
+        .find((c) => c.id === "ct_merge"),
+    ).toBeUndefined();
+
+    // No escalation: no reporter error log, no telemetry.
+    expect(errorLogs.length).toBe(0);
+    expect(telemetryBodies).toEqual([]);
+  });
+});
+
+describe("upsertContact — unknown mirror op escalation", () => {
+  test("unknown method → error log + telemetry; gateway upsert still applied", async () => {
+    ipcThrowOn.set(
+      "contacts_mirror_upsert_full",
+      unknownMethodError("contacts_mirror_upsert_full"),
+    );
+
+    const store = new ContactStore();
+    const { contact, created } = await store.upsertContact({
+      displayName: "Alice",
+      channels: [{ type: "slack", address: "U12345" }],
+    });
+    await flushMirrorOpReporterForTesting();
+
+    // Gateway write stands.
+    expect(created).toBe(true);
+    expect(
+      getGatewayDb()
+        .select()
+        .from(contacts)
+        .all()
+        .find((c) => c.id === contact.id),
+    ).toBeDefined();
+    expect(store.getChannelsForContact(contact.id)).toHaveLength(1);
+
+    expect(errorLogs.length).toBe(1);
+    expect(errorLogs[0][0]).toMatchObject({
+      op: "contacts_mirror_upsert_full",
+      contactId: contact.id,
+    });
+    expect(telemetryBodies).toEqual([
+      {
+        check_name: MIRROR_OP_MISSING_CHECK_NAME,
+        detail: { op: "contacts_mirror_upsert_full", contactId: contact.id },
+      },
+    ]);
+  });
+
+  test("other IPC failure → best-effort warn only, same gateway state", async () => {
+    ipcThrowOn.set("contacts_mirror_upsert_full", new Error("socket closed"));
+
+    const store = new ContactStore();
+    const { contact, created } = await store.upsertContact({
+      displayName: "Bob",
+      channels: [{ type: "slack", address: "U67890" }],
+    });
+    await flushMirrorOpReporterForTesting();
+
+    expect(created).toBe(true);
+    expect(store.getChannelsForContact(contact.id)).toHaveLength(1);
+    expect(errorLogs.length).toBe(0);
+    expect(telemetryBodies).toEqual([]);
+  });
+});

--- a/gateway/src/__tests__/contacts-mirror-op-reporter.test.ts
+++ b/gateway/src/__tests__/contacts-mirror-op-reporter.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Fail-loud mirror-op-missing reporter (contacts-mirror-op-reporter.ts):
+ *
+ *  - First report per op emits one error log and one telemetry relay POST with
+ *    the `contacts_mirror_op_missing` check name and `{ op, ...detail }`.
+ *  - Repeat reports for the same op inside the hourly window are dropped; a
+ *    DIFFERENT op still reports (per-op rate limit).
+ *  - Relay failures never throw out of the caller.
+ *  - `isUnknownIpcMethodError` matches only the IPC server's unknown-method
+ *    rejection shape.
+ *
+ * Logging is observed through the reporter's test-only `log` override —
+ * bun's mock.module is process-global and would leak into other test files.
+ */
+import { beforeEach, afterEach, describe, expect, test } from "bun:test";
+
+const errorLogs: unknown[] = [];
+const warnLogs: unknown[] = [];
+
+await import("./test-preload.js");
+const {
+  MIRROR_OP_MISSING_CHECK_NAME,
+  flushMirrorOpReporterForTesting,
+  isUnknownIpcMethodError,
+  reportMirrorOpMissing,
+  resetMirrorOpReporterForTesting,
+  setMirrorOpReporterOverridesForTesting,
+} = await import("../contacts-mirror-op-reporter.js");
+
+type FetchCall = { url: string; init: RequestInit };
+let fetchCalls: FetchCall[] = [];
+let fetchResult: () => Promise<Response> = async () => new Response("{}");
+
+beforeEach(() => {
+  fetchCalls = [];
+  fetchResult = async () => new Response("{}");
+  errorLogs.length = 0;
+  warnLogs.length = 0;
+  resetMirrorOpReporterForTesting();
+  setMirrorOpReporterOverridesForTesting({
+    fetchImpl: async (url, init) => {
+      fetchCalls.push({ url: String(url), init: init ?? {} });
+      return fetchResult();
+    },
+    mintToken: () => "svc-token",
+    baseUrl: "http://127.0.0.1:7821",
+    log: {
+      error: (detail, msg) => {
+        errorLogs.push([detail, msg]);
+      },
+      warn: (detail, msg) => {
+        warnLogs.push([detail, msg]);
+      },
+    },
+  });
+});
+
+afterEach(() => {
+  resetMirrorOpReporterForTesting();
+});
+
+describe("reportMirrorOpMissing", () => {
+  test("first report logs an error and relays one watchdog event", async () => {
+    reportMirrorOpMissing("contacts_mirror_merge_contact", {
+      keepId: "ct_keep",
+      mergeId: "ct_merge",
+    });
+    await flushMirrorOpReporterForTesting();
+
+    expect(errorLogs.length).toBe(1);
+    expect(fetchCalls.length).toBe(1);
+    expect(fetchCalls[0].url).toBe(
+      "http://127.0.0.1:7821/v1/internal/telemetry/watchdog",
+    );
+    const headers = fetchCalls[0].init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer svc-token");
+    expect(JSON.parse(String(fetchCalls[0].init.body))).toEqual({
+      check_name: MIRROR_OP_MISSING_CHECK_NAME,
+      detail: {
+        op: "contacts_mirror_merge_contact",
+        keepId: "ct_keep",
+        mergeId: "ct_merge",
+      },
+    });
+  });
+
+  test("repeat reports for the same op are dropped; a different op still fires", async () => {
+    reportMirrorOpMissing("contacts_mirror_merge_contact", { keepId: "a" });
+    reportMirrorOpMissing("contacts_mirror_merge_contact", { keepId: "b" });
+    reportMirrorOpMissing("contacts_mirror_upsert_full", { contactId: "c" });
+    await flushMirrorOpReporterForTesting();
+
+    expect(errorLogs.length).toBe(2);
+    expect(fetchCalls.length).toBe(2);
+  });
+
+  test("a rejected relay never throws out of the caller", async () => {
+    fetchResult = async () => {
+      throw new Error("daemon unreachable");
+    };
+
+    expect(() =>
+      reportMirrorOpMissing("contacts_mirror_upsert_full", { contactId: "x" }),
+    ).not.toThrow();
+    await flushMirrorOpReporterForTesting();
+
+    expect(errorLogs.length).toBe(1);
+    expect(warnLogs.length).toBe(1);
+  });
+
+  test("a non-ok relay response is swallowed with a warning", async () => {
+    fetchResult = async () => new Response("nope", { status: 500 });
+
+    reportMirrorOpMissing("contacts_mirror_upsert_full", { contactId: "x" });
+    await flushMirrorOpReporterForTesting();
+
+    expect(fetchCalls.length).toBe(1);
+    expect(warnLogs.length).toBe(1);
+  });
+});
+
+describe("isUnknownIpcMethodError", () => {
+  test("matches the IPC server's unknown-method rejection", () => {
+    expect(
+      isUnknownIpcMethodError(
+        new Error("Unknown method: contacts_mirror_upsert_full"),
+      ),
+    ).toBe(true);
+  });
+
+  test("does not match other failures", () => {
+    expect(isUnknownIpcMethodError(new Error("daemon unavailable"))).toBe(
+      false,
+    );
+    expect(isUnknownIpcMethodError(new Error("Connect timed out"))).toBe(false);
+    expect(isUnknownIpcMethodError("Unknown method: x")).toBe(false);
+    expect(isUnknownIpcMethodError(undefined)).toBe(false);
+  });
+});

--- a/gateway/src/contacts-mirror-op-reporter.ts
+++ b/gateway/src/contacts-mirror-op-reporter.ts
@@ -1,0 +1,129 @@
+// Fail-loud reporting for a daemon that rejects a typed contacts mirror op
+// with "Unknown method" (old daemon behind a newer gateway). The mirror ops
+// deliberately have no raw-SQL fallback, so the gateway write has already
+// applied while the assistant mirror silently missed it — divergence persists
+// until reconciliation. Emits an error-level log and relays a
+// `contacts_mirror_op_missing` watchdog telemetry event to the daemon's
+// internal telemetry route (the route predates the mirror ops, so an old
+// daemon still accepts it). Rate-limited per op per process; a lost event is
+// acceptable for a rare, high-signal check (no retry). Pattern:
+// guardian-integrity-reporter.
+
+import { loadConfig } from "./config.js";
+import type { fetchImpl } from "./fetch.js";
+import { postInternalTelemetry } from "./internal-telemetry-client.js";
+import { getLogger } from "./logger.js";
+
+const log = getLogger("contacts-mirror-op-reporter");
+
+/**
+ * Watchdog `check_name` for a daemon missing a contacts mirror op. Platform
+ * dashboards filter on this exact string — it is the cross-repo contract.
+ */
+export const MIRROR_OP_MISSING_CHECK_NAME = "contacts_mirror_op_missing";
+
+const ROUTE_PATH = "/v1/internal/telemetry/watchdog";
+const REPORT_INTERVAL_MS = 60 * 60 * 1000;
+
+/**
+ * True when a daemon IPC failure is the IPC server's unknown-method rejection
+ * (`error: "Unknown method: <m>"`, surfaced by ipcCallAssistant as an
+ * IpcTransportError carrying that message verbatim).
+ */
+export function isUnknownIpcMethodError(err: unknown): boolean {
+  return err instanceof Error && err.message.startsWith("Unknown method:");
+}
+
+type ReporterLog = {
+  error: (detail: Record<string, unknown>, msg: string) => void;
+  warn: (detail: Record<string, unknown>, msg: string) => void;
+};
+
+type ReporterOverrides = {
+  fetchImpl?: typeof fetchImpl;
+  mintToken?: () => string;
+  baseUrl?: string;
+  log?: ReporterLog;
+};
+
+let overrides: ReporterOverrides = {};
+const lastReportAtByOp = new Map<string, number>();
+let pendingRelay: Promise<unknown> = Promise.resolve();
+
+/**
+ * Report a mirror op the daemon doesn't implement: error log + telemetry
+ * relay. At most one report per op per hour per process. Fire-and-forget —
+ * never throws, never blocks the caller.
+ */
+export function reportMirrorOpMissing(
+  op: string,
+  detail: Record<string, unknown>,
+): void {
+  const now = Date.now();
+  const last = lastReportAtByOp.get(op) ?? Number.NEGATIVE_INFINITY;
+  if (now - last < REPORT_INTERVAL_MS) {
+    return;
+  }
+  lastReportAtByOp.set(op, now);
+
+  reporterLog().error(
+    { op, ...detail },
+    "daemon does not implement this contacts mirror op — gateway write applied " +
+      "without the assistant mirror (divergence until the daemon updates)",
+  );
+
+  pendingRelay = relayToDaemon(op, detail).catch((err) => {
+    reporterLog().warn(
+      { op, err },
+      "mirror-op-missing telemetry relay failed (non-fatal)",
+    );
+  });
+}
+
+async function relayToDaemon(
+  op: string,
+  detail: Record<string, unknown>,
+): Promise<void> {
+  const resp = await postInternalTelemetry({
+    baseUrl: overrides.baseUrl ?? loadConfig().assistantRuntimeBaseUrl,
+    path: ROUTE_PATH,
+    body: {
+      check_name: MIRROR_OP_MISSING_CHECK_NAME,
+      detail: { op, ...detail },
+    },
+    fetchImpl: overrides.fetchImpl,
+    mintToken: overrides.mintToken,
+  });
+  if (!resp.ok) {
+    reporterLog().warn(
+      { op, status: resp.status },
+      "mirror-op-missing telemetry relay rejected (non-fatal)",
+    );
+  }
+}
+
+function reporterLog(): ReporterLog {
+  return overrides.log ?? log;
+}
+
+/**
+ * Test-only: inject fetch/token/baseUrl/log so tests never touch the network
+ * or the process logger.
+ */
+export function setMirrorOpReporterOverridesForTesting(
+  next: ReporterOverrides,
+): void {
+  overrides = next;
+}
+
+/** Test-only: clear overrides and the rate-limit windows. */
+export function resetMirrorOpReporterForTesting(): void {
+  overrides = {};
+  lastReportAtByOp.clear();
+  pendingRelay = Promise.resolve();
+}
+
+/** Test-only: await the most recent fire-and-forget relay. */
+export function flushMirrorOpReporterForTesting(): Promise<unknown> {
+  return pendingRelay;
+}

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -14,6 +14,10 @@ import {
   emptyContactInfo,
   fetchInfoForContacts,
 } from "./contacts-info-joiner.js";
+import {
+  isUnknownIpcMethodError,
+  reportMirrorOpMissing,
+} from "../contacts-mirror-op-reporter.js";
 import { ipcCallAssistant } from "../ipc/assistant-client.js";
 import {
   fetchContactsInfoBatch,
@@ -1251,10 +1255,16 @@ export class ContactStore {
     try {
       await this.mirrorContactToAssistantDb(contactId, canonicalParams);
     } catch (err) {
-      log.warn(
-        { contactId, err },
-        "upsertContact: assistant DB mirror failed (best-effort)",
-      );
+      // Unknown method = old daemon without the typed op: the gateway write
+      // stands with no mirror and no fallback — escalate loudly.
+      if (isUnknownIpcMethodError(err)) {
+        reportMirrorOpMissing("contacts_mirror_upsert_full", { contactId });
+      } else {
+        log.warn(
+          { contactId, err },
+          "upsertContact: assistant DB mirror failed (best-effort)",
+        );
+      }
     }
 
     // ── 6. Read back full contact shape (best-effort) ─────────────────
@@ -1421,10 +1431,20 @@ export class ContactStore {
         },
       });
     } catch (err) {
-      log.warn(
-        { keepId, mergeId, err },
-        "mergeContacts: assistant DB mirror failed (best-effort)",
-      );
+      // Unknown method = old daemon without the typed op: the donor is already
+      // gone gateway-side but stays alive in the mirror, with no fallback —
+      // escalate loudly instead of the routine best-effort warn.
+      if (isUnknownIpcMethodError(err)) {
+        reportMirrorOpMissing("contacts_mirror_merge_contact", {
+          keepId,
+          mergeId,
+        });
+      } else {
+        log.warn(
+          { keepId, mergeId, err },
+          "mergeContacts: assistant DB mirror failed (best-effort)",
+        );
+      }
     }
 
     // Read back the survivor with info join.


### PR DESCRIPTION
## Summary
Fixes self-review gaps for acl-hardening-sweep.md: unknown-method on the new mirror ops now escalates to error log + telemetry (silent divergence eliminated; no raw-SQL fallback by design), mirror primitives share the in-file channel-conflict/reparent/notes helpers (zero behavior change, pins unchanged), and the daemon merge route's relationship to the gateway-native merge is resolved (relay or documented)