### PR TITLE
fix: voice version-skew tolerance + strict shared verdict usability (review round 1)

### DIFF
--- a/assistant/src/__tests__/call-setup-flow-midcall-trust.test.ts
+++ b/assistant/src/__tests__/call-setup-flow-midcall-trust.test.ts
@@ -3,9 +3,10 @@
  * re-resolution used after verification/activation on a phone call.
  *
  * The gateway verdict is the sole trust source: a usable verdict (including
- * memberless unknown and memberful blocked/revoked) is consumed directly; a
- * missing/failed/member-unresolvable verdict throws, and the flow's caller
- * keeps the setup-time trust. Local `resolveActorTrust` is never consulted.
+ * memberless unknown and memberful blocked/revoked) is consumed directly; an
+ * unusable verdict (missing, failed, member-unresolvable, memberless guardian
+ * claim) throws, and the flow's caller keeps the setup-time trust. Local
+ * `resolveActorTrust` is never consulted.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -24,7 +25,6 @@ const realInboundTrustReader = {
 };
 mock.module("../calls/inbound-trust-reader.js", () => ({
   ...realInboundTrustReader,
-  getInboundTrustVerdict: async () => mockVerdict,
   getPhoneCallerVerdict: async () => mockVerdict,
 }));
 
@@ -67,11 +67,17 @@ beforeEach(() => {
 
 describe("resolveMidCallTrustContext", () => {
   test("usable guardian verdict re-resolves trust from the gateway verdict", async () => {
+    // Guardian verdicts carry a same-channel member row — a memberless
+    // guardian claim is contradictory and unusable (asserted below).
     mockVerdict = {
       trustClass: "guardian",
       canonicalSenderId: FROM_NUMBER,
       guardianExternalUserId: FROM_NUMBER,
       guardianPrincipalId: FROM_NUMBER,
+      contactId: "ct_g",
+      channelId: "ch_g",
+      status: "active",
+      policy: "allow",
     };
 
     const context = await resolveMidCallTrustContext("self", FROM_NUMBER);
@@ -80,6 +86,20 @@ describe("resolveMidCallTrustContext", () => {
     expect(context.sourceChannel).toBe("phone");
     expect(context.trustClass).toBe("guardian");
     expect(context.guardianExternalUserId).toBe(FROM_NUMBER);
+  });
+
+  test("memberless guardian claim is contradictory and throws with no local fallback", async () => {
+    mockVerdict = {
+      trustClass: "guardian",
+      canonicalSenderId: FROM_NUMBER,
+      guardianExternalUserId: FROM_NUMBER,
+      guardianPrincipalId: FROM_NUMBER,
+    };
+
+    await expect(
+      resolveMidCallTrustContext("self", FROM_NUMBER),
+    ).rejects.toThrow(/verdict unavailable/);
+    expect(localResolutions).toBe(0);
   });
 
   test("usable trusted-contact member verdict is consumed directly", async () => {

--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -233,7 +233,6 @@ const mockReadPhoneCallerTrust = jest.fn(
 );
 mock.module("../calls/inbound-trust-reader.js", () => ({
   readPhoneCallerTrust: mockReadPhoneCallerTrust,
-  getInboundTrustVerdict: mockGetInboundTrustVerdict,
   getPhoneCallerVerdict: (otherPartyNumber: string | undefined) =>
     mockGetInboundTrustVerdict({
       channelType: "phone",
@@ -1572,7 +1571,7 @@ describe("media-stream setup outcome scenarios", () => {
       // no controller, finalization ran.
       expect(speakSystemPrompt).toHaveBeenCalledWith(
         expect.anything(),
-        "The assistant can't take calls right now. Please try again later.",
+        "The assistant is unable to take this call right now. Please try again later.",
       );
       expect(updateCallSession).toHaveBeenCalledWith(
         "call-floor-unavail-1",
@@ -1758,10 +1757,10 @@ describe("media-stream setup outcome scenarios", () => {
   });
 
   // ── Gateway trust verdict ──────────────────────────────────────────
-  // handleStart fetches getInboundTrustVerdict for the inbound caller and
-  // threads it into routeSetup, so the media-stream transport enforces
-  // the gateway ACL. routeSetup itself decides verdict-vs-local; these
-  // tests assert the verdict is fetched and passed.
+  // handleStart awaits readPhoneCallerTrust for the inbound caller and
+  // threads the verdict into routeSetup, so the media-stream transport
+  // enforces the gateway ACL. routeSetup itself decides verdict-vs-local;
+  // these tests assert the verdict is fetched and passed.
 
   describe("gateway trust verdict", () => {
     test("fetches the inbound caller's verdict and threads it into routeSetup", async () => {

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -119,10 +119,6 @@ mock.module("../calls/channel-admission-reader.js", () => ({
 let mockInboundVerdict: unknown = null;
 let lastInboundVerdictArgs: Record<string, unknown> | null = null;
 mock.module("../calls/inbound-trust-reader.js", () => ({
-  getInboundTrustVerdict: async (args: Record<string, unknown>) => {
-    lastInboundVerdictArgs = args;
-    return mockInboundVerdict;
-  },
   getPhoneCallerVerdict: async (otherPartyNumber: string | undefined) => {
     lastInboundVerdictArgs = {
       channelType: "phone",

--- a/assistant/src/calls/__tests__/call-setup-router.test.ts
+++ b/assistant/src/calls/__tests__/call-setup-router.test.ts
@@ -184,7 +184,8 @@ beforeEach(() => {
 });
 
 // ---------------------------------------------------------------------------
-// Fail-closed verdict source: missing/failed/member-unresolvable verdicts deny
+// Fail-closed verdict source: missing/failed/member-unresolvable verdicts —
+// plus unrecognized trust classes and memberless guardian claims — deny
 // inbound (no stranger-lane side effects, no verification-read IPC) and abort
 // outbound setup loudly.
 // ---------------------------------------------------------------------------
@@ -225,6 +226,20 @@ describe("routeSetup — unusable verdict fails closed", () => {
           status: "active",
           policy: "bogus",
         }),
+      },
+      {
+        name: "unrecognized trust class (version skew)",
+        verdict: makeVerdict({
+          trustClass: "superadmin" as TrustVerdict["trustClass"],
+          canonicalSenderId: "+12025550142",
+        }),
+      },
+      {
+        // Contradictory: the gateway proves guardian identity via a
+        // same-channel member row, so a memberless guardian claim must
+        // never confer guardian capabilities (or even a normal_call).
+        name: "memberless guardian claim",
+        verdict: makeVerdict({ trustClass: "guardian" }),
       },
     ];
 

--- a/assistant/src/calls/__tests__/inbound-trust-reader.test.ts
+++ b/assistant/src/calls/__tests__/inbound-trust-reader.test.ts
@@ -4,7 +4,9 @@
  * The combined read reports `{ ok: false }` on ANY failure (transport
  * failure, undefined, malformed shape, thrown error); the consumer decides
  * fail-open vs fail-closed. These tests pin that contract, the envelope's
- * admission-policy passthrough, and the forwarded method + params.
+ * admission-policy passthrough, the pre-envelope-gateway fallback (absent
+ * `admissionPolicy` key → standalone policy read, fail-closed composition),
+ * and the forwarded method + params.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -36,13 +38,14 @@ mock.module("../../ipc/gateway-client.js", () => ({
 
 import type { TrustVerdict } from "@vellumai/gateway-client";
 
+import { _clearCacheForTesting } from "../channel-admission-reader.js";
 import {
-  getInboundTrustVerdict,
   readInboundTrust,
   readPhoneCallerTrust,
 } from "../inbound-trust-reader.js";
 
 const METHOD = "resolve_inbound_trust";
+const FALLBACK_METHOD = "get_channel_admission_policy";
 
 const VALID_VERDICT = {
   trustClass: "trusted_contact",
@@ -54,6 +57,7 @@ const VALID_VERDICT = {
 beforeEach(() => {
   ipcHandlers.clear();
   ipcCallLog.length = 0;
+  _clearCacheForTesting();
 });
 
 describe("readInboundTrust", () => {
@@ -75,7 +79,7 @@ describe("readInboundTrust", () => {
     });
   });
 
-  test("an explicit null admission policy is a successful read (admit, no enforcement)", async () => {
+  test("an explicit null admission policy is a successful read (admit, no enforcement) — no fallback read", async () => {
     ipcHandlers.set(METHOD, () => ({
       verdict: VALID_VERDICT,
       admissionPolicy: null,
@@ -88,6 +92,9 @@ describe("readInboundTrust", () => {
       verdict: VALID_VERDICT,
       admissionPolicy: null,
     });
+    expect(
+      ipcCallLog.some((c) => c.method === FALLBACK_METHOD),
+    ).toBe(false);
   });
 
   test("forwards the correct method, params, and timeout to ipcCall", async () => {
@@ -124,11 +131,40 @@ describe("readInboundTrust", () => {
     });
   });
 
-  test("returns { ok: false } when the admission policy field is missing", async () => {
+  test("absent admission policy key (pre-envelope gateway) keeps the verdict and reads the policy via the fallback", async () => {
     ipcHandlers.set(METHOD, () => ({ verdict: VALID_VERDICT }));
+    ipcHandlers.set(FALLBACK_METHOD, () => ({ policy: "trusted_contacts" }));
+
+    const result = await readInboundTrust({ channelType: "telegram" });
+
+    expect(result).toEqual({
+      ok: true,
+      verdict: VALID_VERDICT,
+      admissionPolicy: "trusted_contacts",
+    });
+    const fallbackCall = ipcCallLog.find((c) => c.method === FALLBACK_METHOD);
+    expect(fallbackCall?.params).toEqual({ channelType: "telegram" });
+  });
+
+  test("absent admission policy key with an explicit-null fallback answer admits with no enforcement", async () => {
+    ipcHandlers.set(METHOD, () => ({ verdict: VALID_VERDICT }));
+    ipcHandlers.set(FALLBACK_METHOD, () => ({ policy: null }));
+
+    expect(await readInboundTrust({ channelType: "telegram" })).toEqual({
+      ok: true,
+      verdict: VALID_VERDICT,
+      admissionPolicy: null,
+    });
+  });
+
+  test("absent admission policy key + failed fallback read composes fail-closed ({ ok: false })", async () => {
+    ipcHandlers.set(METHOD, () => ({ verdict: VALID_VERDICT }));
+    ipcHandlers.set(FALLBACK_METHOD, () => undefined);
+
     expect(await readInboundTrust({ channelType: "telegram" })).toEqual({
       ok: false,
     });
+    expect(ipcCallLog.some((c) => c.method === FALLBACK_METHOD)).toBe(true);
   });
 
   test("returns { ok: false } for an out-of-vocabulary admission policy", async () => {
@@ -195,25 +231,3 @@ describe("readPhoneCallerTrust", () => {
   });
 });
 
-describe("getInboundTrustVerdict", () => {
-  test("returns the gateway-resolved verdict on a valid response", async () => {
-    ipcHandlers.set(METHOD, () => ({
-      verdict: VALID_VERDICT,
-      admissionPolicy: null,
-    }));
-
-    const verdict = await getInboundTrustVerdict({
-      channelType: "telegram",
-      actorExternalId: "U_MEMBER",
-    });
-
-    expect(verdict).toEqual(VALID_VERDICT);
-  });
-
-  test("returns null on any read failure", async () => {
-    ipcHandlers.set(METHOD, () => undefined);
-    expect(
-      await getInboundTrustVerdict({ channelType: "telegram" }),
-    ).toBeNull();
-  });
-});

--- a/assistant/src/calls/call-setup-router.ts
+++ b/assistant/src/calls/call-setup-router.ts
@@ -28,6 +28,10 @@ import {
 import { getLogger } from "../util/logger.js";
 import { getActiveVoiceInvite } from "./gateway-invite-reader.js";
 import type { CallSession } from "./types.js";
+import {
+  TRUST_UNAVAILABLE_DENY_MESSAGE,
+  unresolvedActorTrust,
+} from "./unresolved-caller-trust.js";
 
 const log = getLogger("call-setup-router");
 
@@ -105,28 +109,6 @@ export interface SetupResolved {
   actorTrust: ActorTrustContext;
 }
 
-/**
- * Minimal unknown-trust context for the fail-closed deny, where no verdict
- * is available to build real trust from.
- */
-function unresolvedActorTrust(otherPartyNumber: string): ActorTrustContext {
-  return {
-    canonicalSenderId: otherPartyNumber || null,
-    guardianBindingMatch: null,
-    memberRecord: null,
-    trustClass: "unknown",
-    actorMetadata: {
-      identifier: otherPartyNumber || undefined,
-      displayName: undefined,
-      senderDisplayName: undefined,
-      memberDisplayName: undefined,
-      username: undefined,
-      channel: "phone",
-      trustStatus: "unknown",
-    },
-  };
-}
-
 // ── Router ───────────────────────────────────────────────────────────
 
 /**
@@ -166,8 +148,7 @@ export async function routeSetup(ctx: SetupContext): Promise<{
     return {
       outcome: {
         action: "deny",
-        message:
-          "The assistant is unable to take this call right now. Please try again later.",
+        message: TRUST_UNAVAILABLE_DENY_MESSAGE,
         logReason: `Inbound voice ACL: trust verdict unavailable (${reason}) — fail-closed deny`,
       },
       resolved: {
@@ -282,8 +263,8 @@ export async function routeSetup(ctx: SetupContext): Promise<{
   // verification challenge is in flight. While active, the floor IS the access
   // decision: an admitted caller bypasses the legacy identity flows
   // (unverified_caller / name_capture) and connects directly. When inactive
-  // (null policy, flag off, exempt channel, reader failed open, or a pending
-  // challenge), those legacy flows are preserved unchanged.
+  // (null policy, flag off, exempt channel, or a pending challenge), those
+  // legacy flows are preserved unchanged.
   const floorActive = ctx.admissionPolicy != null && !pendingChallenge;
 
   // Inbound admission floor verdict; defaults to admitted when inactive.

--- a/assistant/src/calls/inbound-trust-reader.ts
+++ b/assistant/src/calls/inbound-trust-reader.ts
@@ -8,8 +8,12 @@
  * {@link readInboundTrust} reports `{ ok: false }` on ANY failure (transport
  * failure, `undefined`, malformed shape, or thrown error); an explicit
  * `admissionPolicy: null` on a successful read is the gateway's "no
- * enforcement configured" answer, distinct from an unreachable gateway. The
- * caller owns the deny policy; this reader only reports.
+ * enforcement configured" answer, distinct from an unreachable gateway. An
+ * ABSENT `admissionPolicy` key (pre-envelope gateway, version skew) keeps the
+ * verdict and resolves the policy via the standalone
+ * `get_channel_admission_policy` read instead — fail-closed composition, so a
+ * failed fallback read is still `{ ok: false }`. The caller owns the deny
+ * policy; this reader only reports.
  */
 
 import {
@@ -21,6 +25,7 @@ import {
 import type { ChannelId } from "../channels/types.js";
 import { ipcCall } from "../ipc/gateway-client.js";
 import { setMemberVerdict } from "../runtime/member-verdict-cache.js";
+import { getChannelAdmissionPolicy } from "./channel-admission-reader.js";
 
 // Short IPC timeout so the read resolves promptly rather than stalling call
 // setup on a gateway that accepts the socket but hangs.
@@ -57,6 +62,22 @@ export async function readInboundTrust(input: {
     // readers (access-request callback handoff) can resolve the member later
     // without a gateway read.
     setMemberVerdict(input.channelType, input.actorExternalId, parsed.data.verdict);
+
+    // ABSENT envelope key (pre-envelope gateway): keep the verdict and read
+    // the policy standalone. Distinct from an explicit `null`, which is the
+    // gateway's "no enforcement" answer and needs no fallback.
+    if (parsed.data.admissionPolicy === undefined) {
+      const fallback = await getChannelAdmissionPolicy(input.channelType);
+      if (!fallback.ok) {
+        return { ok: false };
+      }
+      return {
+        ok: true,
+        verdict: parsed.data.verdict,
+        admissionPolicy: fallback.policy,
+      };
+    }
+
     return {
       ok: true,
       verdict: parsed.data.verdict,
@@ -65,15 +86,6 @@ export async function readInboundTrust(input: {
   } catch {
     return { ok: false };
   }
-}
-
-/** Verdict-only surface for callers that don't consume the admission policy. */
-export async function getInboundTrustVerdict(input: {
-  channelType: ChannelId;
-  actorExternalId?: string;
-}): Promise<TrustVerdict | null> {
-  const result = await readInboundTrust(input);
-  return result.ok ? result.verdict : null;
 }
 
 /**

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -44,7 +44,6 @@ import { revokeScopedApprovalGrantsForContext } from "../approvals/scoped-approv
 import { getAssistantName } from "../daemon/identity-helpers.js";
 import { addMessage } from "../persistence/conversation-crud.js";
 import { resolveGuardianName } from "../prompts/user-reference.js";
-import type { ActorTrustContext } from "../runtime/actor-trust-resolver.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getLogger } from "../util/logger.js";
 import { CallController } from "./call-controller.js";
@@ -81,6 +80,10 @@ import {
   type MediaStreamSttSessionCallbacks,
   type MediaStreamSttSessionConfig,
 } from "./media-stream-stt-session.js";
+import {
+  TRUST_UNAVAILABLE_DENY_MESSAGE,
+  unresolvedActorTrust,
+} from "./unresolved-caller-trust.js";
 
 const log = getLogger("media-stream-server");
 const UUID_SHAPED_NAME =
@@ -106,41 +109,24 @@ function resolveAssistantLabel(): string | null {
  * Deny routing for an inbound call whose combined trust-verdict +
  * admission-floor read failed (gateway unreachable / malformed answer).
  * Mirrors the router's floor-deny outcome shape so the setup flow runs the
- * standard deny teardown (denial copy + hangup). Trust is stamped `unknown`:
- * with no gateway answer the caller cannot be vetted.
+ * standard deny teardown (denial copy + hangup). Trust is stamped `unknown`
+ * via the shared builder: with no gateway answer the caller cannot be vetted.
  */
 function admissionUnavailableDeny(otherPartyNumber: string): {
   outcome: SetupOutcome;
   resolved: SetupResolved;
 } {
-  const actorTrust: ActorTrustContext = {
-    canonicalSenderId: null,
-    guardianBindingMatch: null,
-    guardianPrincipalId: undefined,
-    memberRecord: null,
-    trustClass: "unknown",
-    actorMetadata: {
-      identifier: otherPartyNumber || undefined,
-      displayName: undefined,
-      senderDisplayName: undefined,
-      memberDisplayName: undefined,
-      username: undefined,
-      channel: "phone",
-      trustStatus: "unknown",
-    },
-  };
   return {
     outcome: {
       action: "deny",
-      message:
-        "The assistant can't take calls right now. Please try again later.",
+      message: TRUST_UNAVAILABLE_DENY_MESSAGE,
       logReason: "Inbound voice admission floor: gateway unreachable",
     },
     resolved: {
       assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
       isInbound: true,
       otherPartyNumber,
-      actorTrust,
+      actorTrust: unresolvedActorTrust(otherPartyNumber),
     },
   };
 }

--- a/assistant/src/calls/unresolved-caller-trust.ts
+++ b/assistant/src/calls/unresolved-caller-trust.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared fail-closed deny pieces for an inbound caller the gateway could not
+ * vouch for — an unreachable gateway (media-stream server) or an unusable
+ * trust verdict (setup router). Both deny lanes speak the same copy and stamp
+ * the same unknown-trust context.
+ */
+
+import type { ActorTrustContext } from "../runtime/actor-trust-resolver.js";
+
+/** Single user-facing copy for the gateway-unavailable inbound deny. */
+export const TRUST_UNAVAILABLE_DENY_MESSAGE =
+  "The assistant is unable to take this call right now. Please try again later.";
+
+/**
+ * Minimal unknown-trust context for the fail-closed deny, where no verdict
+ * is available to build real trust from.
+ */
+export function unresolvedActorTrust(
+  otherPartyNumber: string,
+): ActorTrustContext {
+  return {
+    canonicalSenderId: otherPartyNumber || null,
+    guardianBindingMatch: null,
+    memberRecord: null,
+    trustClass: "unknown",
+    actorMetadata: {
+      identifier: otherPartyNumber || undefined,
+      displayName: undefined,
+      senderDisplayName: undefined,
+      memberDisplayName: undefined,
+      username: undefined,
+      channel: "phone",
+      trustStatus: "unknown",
+    },
+  };
+}

--- a/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
+++ b/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
@@ -17,6 +17,7 @@ import {
   verdictHasMemberIdentity,
   verdictMemberFromVerdict,
   verdictMemberUnresolvable,
+  verdictUsability,
 } from "../trust-verdict-consumer.js";
 
 const CONV = "conv-123";
@@ -719,5 +720,78 @@ describe("verdict predicates", () => {
         canonicalSenderId: "u-1",
       } satisfies TrustVerdict),
     ).toBe(false);
+  });
+});
+
+describe("verdictUsability", () => {
+  test("missing / resolutionFailed / member-unresolvable are unusable with their reasons", () => {
+    expect(verdictUsability(null)).toEqual({
+      usable: false,
+      reason: "missing",
+    });
+    expect(verdictUsability(undefined)).toEqual({
+      usable: false,
+      reason: "missing",
+    });
+    expect(
+      verdictUsability({
+        trustClass: "unknown",
+        canonicalSenderId: null,
+        resolutionFailed: true,
+      } satisfies TrustVerdict),
+    ).toEqual({ usable: false, reason: "resolution failed" });
+    expect(
+      verdictUsability({
+        trustClass: "trusted_contact",
+        canonicalSenderId: "u-1",
+        contactId: "contact-1",
+        channelId: "channel-1",
+        policy: "allow",
+      } satisfies TrustVerdict),
+    ).toEqual({ usable: false, reason: "member unresolvable" });
+  });
+
+  test("unrecognized trust class (version skew) is unusable", () => {
+    expect(
+      verdictUsability({
+        trustClass: "superadmin" as TrustVerdict["trustClass"],
+        canonicalSenderId: "u-1",
+      }),
+    ).toEqual({ usable: false, reason: "unrecognized trust class" });
+  });
+
+  test("memberless guardian claim is contradictory and unusable", () => {
+    expect(
+      verdictUsability({
+        trustClass: "guardian",
+        canonicalSenderId: "u-g",
+        guardianExternalUserId: "u-g",
+        guardianPrincipalId: "p-1",
+      } satisfies TrustVerdict),
+    ).toEqual({ usable: false, reason: "guardian without member" });
+  });
+
+  test("memberful guardian and memberless stranger verdicts are usable", () => {
+    const guardian = {
+      trustClass: "guardian",
+      canonicalSenderId: "u-g",
+      contactId: "contact-g",
+      channelId: "channel-g",
+      status: "active",
+      policy: "allow",
+    } satisfies TrustVerdict;
+    expect(verdictUsability(guardian)).toEqual({
+      usable: true,
+      verdict: guardian,
+    });
+
+    const stranger = {
+      trustClass: "unknown",
+      canonicalSenderId: "u-2",
+    } satisfies TrustVerdict;
+    expect(verdictUsability(stranger)).toEqual({
+      usable: true,
+      verdict: stranger,
+    });
   });
 });

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -11,7 +11,6 @@ import type {
   SourceMetadata,
   TrustVerdict,
 } from "@vellumai/gateway-client";
-import { isTrustClass } from "@vellumai/gateway-client";
 
 import type { VerificationSessionWire } from "../../../channels/gateway-verification-sessions.js";
 import {
@@ -33,7 +32,10 @@ import {
 } from "../../access-request-helper.js";
 import { deliverChannelReply } from "../../gateway-client.js";
 import type { VerdictMember } from "../../trust-verdict-consumer.js";
-import { verdictMemberFromVerdict } from "../../trust-verdict-consumer.js";
+import {
+  verdictMemberFromVerdict,
+  verdictUsability,
+} from "../../trust-verdict-consumer.js";
 
 const log = getLogger("runtime-http");
 
@@ -207,59 +209,58 @@ export async function enforceIngressAcl(
   // Slack message timestamp for permalink construction.
   const messageTs = sourceMetadata?.messageId ?? undefined;
 
-  // Absent verdict = gateway could not vouch for this actor → fail-closed deny.
-  // A PRESENT verdict with no member (stranger) still flows through the
-  // stranger lane below; only a missing verdict short-circuits here.
-  const verdict = sourceMetadata?.trustVerdict;
-  if (verdict == null) {
-    log.info(
-      { sourceChannel, externalUserId: canonicalSenderId },
-      "Ingress ACL: absent trust verdict, denying fail-closed",
-    );
+  // The shared usability predicate is the fail-closed gate: an unusable
+  // verdict soft-denies with NO stranger-lane side effects (no access-request
+  // card, no verification challenge, no canned reply) — never fail-stranger.
+  // A PRESENT memberless stranger verdict is usable and flows through the
+  // stranger lane below. The switch preserves this stage's per-reason log
+  // lines; TEXT does not fall back to local ACL reads, the sender can retry.
+  const usability = verdictUsability(sourceMetadata?.trustVerdict);
+  if (!usability.usable) {
+    switch (usability.reason) {
+      case "missing":
+        log.info(
+          { sourceChannel, externalUserId: canonicalSenderId },
+          "Ingress ACL: absent trust verdict, denying fail-closed",
+        );
+        break;
+      case "resolution failed":
+        log.warn(
+          { sourceChannel, externalUserId: canonicalSenderId },
+          "Ingress ACL: gateway trust resolution failed, denying fail-closed",
+        );
+        break;
+      case "member unresolvable":
+        log.info(
+          { sourceChannel, externalUserId: canonicalSenderId },
+          "Ingress ACL: member verdict with unresolvable ACL, denying fail-closed",
+        );
+        break;
+      case "unrecognized trust class":
+        log.warn(
+          {
+            sourceChannel,
+            externalUserId: canonicalSenderId,
+            trustClass: sourceMetadata?.trustVerdict?.trustClass,
+          },
+          "Ingress ACL: unrecognized trust class on verdict, denying fail-safe",
+        );
+        break;
+      case "guardian without member":
+        log.warn(
+          { sourceChannel, externalUserId: canonicalSenderId },
+          "Ingress ACL: guardian verdict without a member row, denying fail-safe",
+        );
+        break;
+    }
     return failClosedDeny();
   }
-
-  // Gateway attempted resolution but failed (DB error) → fail-closed deny,
-  // distinct from an absent verdict and from a real stranger. TEXT does not
-  // fall back to local ACL reads; the sender can retry.
-  if (verdict.resolutionFailed === true) {
-    log.warn(
-      { sourceChannel, externalUserId: canonicalSenderId },
-      "Ingress ACL: gateway trust resolution failed, denying fail-closed",
-    );
-    return failClosedDeny();
-  }
+  const { verdict } = usability;
 
   // Member resolved from the gateway verdict (ACL + identity only); null for a
   // stranger verdict, which falls through to the non-member deny lane.
   const resolvedMember: VerdictMember | null =
     verdictMemberFromVerdict(verdict);
-
-  // A verdict carrying member identity but no resolvable member
-  // (malformed/unknown ACL) fails closed, not treated as a stranger.
-  if (!resolvedMember && (verdict.contactId || verdict.channelId)) {
-    log.info(
-      { sourceChannel, externalUserId: canonicalSenderId },
-      "Ingress ACL: member verdict with unresolvable ACL, denying fail-closed",
-    );
-    return failClosedDeny();
-  }
-
-  // An unrecognized trust class is an unresolvable verdict (version skew,
-  // malformed payload), not a stranger. Fail safe: soft-deny with no
-  // stranger-lane side effects (no access-request card, no verification
-  // challenge, no canned reply) — never fail-stranger.
-  if (!isTrustClass(verdict.trustClass)) {
-    log.warn(
-      {
-        sourceChannel,
-        externalUserId: canonicalSenderId,
-        trustClass: verdict.trustClass,
-      },
-      "Ingress ACL: unrecognized trust class on verdict, denying fail-safe",
-    );
-    return failClosedDeny();
-  }
 
   // ── Guardian short-circuit ──
   // A verdict classified `guardian` is admitted even when its same-channel
@@ -269,18 +270,9 @@ export async function enforceIngressAcl(
   // gates below — those would misroute the guardian into the stranger lane
   // and fire an access request at the guardian themselves.
   if (verdict.trustClass === "guardian") {
-    // The gateway proves guardian identity via a same-channel member row
-    // (the active binding address, or a row belonging to the guardian
-    // contact), so every guardian verdict carries a resolvable member row.
-    // A guardian verdict WITHOUT one is contradictory — cross-channel
-    // address collisions are not identity proofs and must never confer
-    // guardian capabilities. Fail safe: soft-deny with no stranger-lane
-    // side effects.
+    // verdictUsability guarantees guardian verdicts carry a resolvable
+    // member row; narrow for TS.
     if (!resolvedMember) {
-      log.warn(
-        { sourceChannel, externalUserId: canonicalSenderId },
-        "Ingress ACL: guardian verdict without a member row, denying fail-safe",
-      );
       return failClosedDeny();
     }
 

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
@@ -17,8 +17,7 @@
  * `sourceMetadata`; a missing/failed/contradictory verdict fails closed to
  * `unknown` (drop). Reactions never drive an agent turn.
  */
-import type { SourceMetadata, TrustVerdict } from "@vellumai/gateway-client";
-import { isTrustClass } from "@vellumai/gateway-client";
+import type { SourceMetadata } from "@vellumai/gateway-client";
 
 import type { ChannelId, InterfaceId } from "../../../channels/types.js";
 import { getDiskPressureStatus } from "../../../daemon/disk-pressure-guard.js";
@@ -40,8 +39,7 @@ import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../assistant-scope.js";
 import type { ApprovalConversationGenerator } from "../../http-types.js";
 import {
   actorTrustContextFromVerdict,
-  verdictMemberFromVerdict,
-  verdictMemberUnresolvable,
+  verdictUsability,
 } from "../../trust-verdict-consumer.js";
 import { handleGuardianReplyIntercept } from "./guardian-reply-intercept.js";
 
@@ -89,25 +87,6 @@ export function parseSlackReactionCallbackData(
   return { op, emoji };
 }
 
-/**
- * The gateway-stamped verdict, or `null` when it can't be trusted: missing,
- * `resolutionFailed`, an unrecognized trust class, a partial member ACL, or a
- * memberless guardian claim (contradictory — the gateway proves guardian
- * identity via a same-channel member row). Matches acl-enforcement's
- * fail-closed posture; the caller treats `null` as `unknown` and drops.
- */
-function usableReactionVerdict(
-  verdict: TrustVerdict | undefined,
-): TrustVerdict | null {
-  if (!verdict || verdict.resolutionFailed === true) return null;
-  if (!isTrustClass(verdict.trustClass)) return null;
-  if (verdictMemberUnresolvable(verdict)) return null;
-  if (verdict.trustClass === "guardian" && !verdictMemberFromVerdict(verdict)) {
-    return null;
-  }
-  return verdict;
-}
-
 export interface ReactionInterceptParams {
   /** The reaction callbackData (`reaction:<emoji>` / `reaction_removed:<emoji>`). */
   callbackData: string;
@@ -153,11 +132,13 @@ export async function handleSlackReactionIntercept(
   } = params;
 
   // Classify the reactor from the gateway-stamped verdict — the same source
-  // acl-enforcement reads. No local resolver, cache warm, or IPC reads; only
-  // the trust class / guardian principal matter for a reaction.
-  const verdict = usableReactionVerdict(sourceMetadata?.trustVerdict);
-  const trustCtx = verdict
-    ? actorTrustContextFromVerdict(verdict, {
+  // acl-enforcement reads, gated by the same shared usability predicate. No
+  // local resolver, cache warm, or IPC reads; only the trust class / guardian
+  // principal matter for a reaction. An unusable verdict fails closed: the
+  // caller treats `null` as `unknown` and drops.
+  const usability = verdictUsability(sourceMetadata?.trustVerdict);
+  const trustCtx = usability.usable
+    ? actorTrustContextFromVerdict(usability.verdict, {
         sourceChannel,
         conversationExternalId,
         actorUsername,

--- a/assistant/src/runtime/trust-verdict-consumer.ts
+++ b/assistant/src/runtime/trust-verdict-consumer.ts
@@ -10,6 +10,7 @@
  */
 
 import type { TrustVerdict } from "@vellumai/gateway-client";
+import { isTrustClass } from "@vellumai/gateway-client";
 
 import type { ChannelId } from "../channels/types.js";
 import { channelStatusToMemberStatus } from "../contacts/member-status.js";
@@ -126,7 +127,7 @@ export function verdictHasMemberIdentity(verdict: TrustVerdict): boolean {
 /**
  * True when the verdict claims a member identity but that member can't be
  * resolved (partial/mixed-version verdict). Such a verdict is unusable —
- * callers fall back to local resolution.
+ * consumers fail closed (deny), never falling back to local resolution.
  */
 export function verdictMemberUnresolvable(verdict: TrustVerdict): boolean {
   return (
@@ -135,17 +136,29 @@ export function verdictMemberUnresolvable(verdict: TrustVerdict): boolean {
   );
 }
 
+/** Machine-readable cause for an unusable verdict; consumers switch on it. */
+export type VerdictUnusableReason =
+  | "missing"
+  | "resolution failed"
+  | "member unresolvable"
+  | "unrecognized trust class"
+  | "guardian without member";
+
 /**
  * Classify whether a verdict can serve as a trust source. Unusable when
- * missing, `resolutionFailed`, or claiming a member whose ACL can't be
- * reassembled; consumers fail closed on those. A memberless stranger verdict
- * is usable.
+ * missing, `resolutionFailed`, claiming a member whose ACL can't be
+ * reassembled, carrying an out-of-contract trust class (version skew,
+ * malformed payload), or claiming `guardian` without a member row
+ * (contradictory — the gateway proves guardian identity via a same-channel
+ * member row, so cross-channel address collisions must never confer guardian
+ * capabilities). Consumers fail closed on all of those. A memberless stranger
+ * verdict is usable.
  */
 export function verdictUsability(
   verdict: TrustVerdict | null | undefined,
 ):
   | { usable: true; verdict: TrustVerdict }
-  | { usable: false; reason: string } {
+  | { usable: false; reason: VerdictUnusableReason } {
   if (verdict == null) {
     return { usable: false, reason: "missing" };
   }
@@ -154,6 +167,12 @@ export function verdictUsability(
   }
   if (verdictMemberUnresolvable(verdict)) {
     return { usable: false, reason: "member unresolvable" };
+  }
+  if (!isTrustClass(verdict.trustClass)) {
+    return { usable: false, reason: "unrecognized trust class" };
+  }
+  if (verdict.trustClass === "guardian" && !verdictMemberFromVerdict(verdict)) {
+    return { usable: false, reason: "guardian without member" };
   }
   return { usable: true, verdict };
 }

--- a/packages/gateway-client/src/__tests__/trust-verdict-contract.test.ts
+++ b/packages/gateway-client/src/__tests__/trust-verdict-contract.test.ts
@@ -151,10 +151,12 @@ describe("ResolveInboundTrustResponseSchema", () => {
     expect(parsed.admissionPolicy).toBeNull();
   });
 
-  test("rejects a missing admission policy field", () => {
-    expect(() =>
-      ResolveInboundTrustResponseSchema.parse({ verdict: fullVerdict }),
-    ).toThrow();
+  test("tolerates an absent admission policy field (pre-envelope gateway)", () => {
+    const parsed = ResolveInboundTrustResponseSchema.parse({
+      verdict: fullVerdict,
+    });
+    expect(parsed.verdict).toEqual(fullVerdict);
+    expect(parsed.admissionPolicy).toBeUndefined();
   });
 
   test("rejects an out-of-vocabulary admission policy", () => {

--- a/packages/gateway-client/src/trust-verdict-contract.ts
+++ b/packages/gateway-client/src/trust-verdict-contract.ts
@@ -142,11 +142,14 @@ export type ResolveInboundTrustRequest = z.infer<
  * an ENVELOPE field, not a {@link TrustVerdictSchema} field: the verdict is
  * also stamped on every text relay's `sourceMetadata`, which must not carry
  * this voice-setup-only companion. `admissionPolicy: null` is the gateway's
- * explicit "no enforcement configured" answer (an admit).
+ * explicit "no enforcement configured" answer (an admit). The key is nullish
+ * for version skew: a pre-envelope gateway answers `{ verdict }` only, and a
+ * valid verdict must not be discarded over the missing companion — the
+ * consumer falls back to the standalone admission-policy read.
  */
 export const ResolveInboundTrustResponseSchema = z.object({
   verdict: TrustVerdictSchema,
-  admissionPolicy: AdmissionPolicySchema.nullable(),
+  admissionPolicy: AdmissionPolicySchema.nullish(),
 });
 
 export type ResolveInboundTrustResponse = z.infer<


### PR DESCRIPTION
## Summary
Fixes self-review gaps for acl-hardening-sweep.md: admissionPolicy envelope key is nullish with a reader fallback (no voice outage against a pre-branch gateway), verdictUsability gains the unrecognized-trustClass + memberless-guardian checks and all three consumers share it (voice no longer fail-open on skewed classes), the gateway-unavailable deny context/copy is single-sourced, dead getInboundTrustVerdict pruned, fail-open comment residue fixed