### PR TITLE
fix(web): stop sharing ChannelPanel between the assistant contact card and the Channels tab

### DIFF
--- a/clients/web/src/domains/chat/components/chat-content-layout.tsx
+++ b/clients/web/src/domains/chat/components/chat-content-layout.tsx
@@ -193,7 +193,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
 
   // -------------------------------------------------------------------------
   // Mobile fallback: side-drawer panels don't render on narrow viewports, so
-  // redirect to the Contacts page with the Slack channel pre-expanded.
+  // redirect to the Channels tab with the channel's setup form pre-opened.
   // -------------------------------------------------------------------------
 
   useEffect(() => {
@@ -201,7 +201,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
     if (mainView !== "channel-setup" || !activeChannelSetup) return;
     const channel = activeChannelSetup.channel;
     // This close is a hand-off, not a dismissal: setup continues on the
-    // Contacts page, which runs standalone and cannot auto-notify on
+    // Channels page, which runs standalone and cannot auto-notify on
     // completion. Signal the hand-off so the assistant switches to the
     // "tell me when you're done" flow instead of waiting for a
     // wizard-closed notification that will never come. Fired before the
@@ -209,7 +209,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
     // viewports) can never race it.
     void notifyChannelSetupHandedOff(activeChannelSetup);
     useViewerStore.getState().closeChannelSetup();
-    navigate(`${routes.contacts.root}?setup=${channel}`);
+    navigate(`${routes.channels}?setup=${channel}`);
   }, [isMobile, mainView, activeChannelSetup, navigate]);
 
   // -------------------------------------------------------------------------

--- a/clients/web/src/domains/contacts/channels-page.tsx
+++ b/clients/web/src/domains/contacts/channels-page.tsx
@@ -19,9 +19,9 @@ export interface ChannelsPageProps {
  * manages how and where the assistant can be reached. Rendered as its own tab
  * in the About Assistant nav (`/assistant/channels`): a page-level subtitle
  * above the tabbed content (the nav's tab already reads "Channels", so the
- * page repeats no heading). The Contacts page's assistant detail renders the
- * same tabs boxed as a card (`AssistantChannelsDetail`); both compose
- * `useAssistantChannels`.
+ * page repeats no heading). The Contacts page's assistant detail
+ * (`AssistantChannelsDetail`) shows only a connect/disconnect summary of the
+ * same channels; management stays here.
  */
 export function ChannelsPage({
   assistantId,

--- a/clients/web/src/domains/contacts/components/assistant-channels-detail.stories.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-detail.stories.tsx
@@ -1,15 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
-
 import { AssistantChannelsDetail } from "./assistant-channels-detail";
 
 /**
  * The assistant's entry in the Contacts detail pane: identity header card +
- * boxed "Channels" card. The standalone Channels tab composition lives in
- * `assistant-channels-list.stories.tsx`. The card renders the shared
- * `AssistantChannelsList`, whose layout is gated on `channel-trust-floors`
- * (sub-tabs on, accordion off).
+ * a boxed "Channels" card with one connect/disconnect row per adapter.
+ * Channel management (credential forms, trust floors, Slack settings) lives
+ * in the standalone Channels tab — see `assistant-channels-list.stories.tsx`.
  */
 const meta: Meta<typeof AssistantChannelsDetail> = {
   title: "Contacts/AssistantChannelsDetail",
@@ -21,24 +18,15 @@ const meta: Meta<typeof AssistantChannelsDetail> = {
       { key: "telegram", status: "not_configured" },
       { key: "phone", status: "not_configured" },
     ],
-    onSetup: () => {},
+    onConnect: () => {},
     onDisconnect: () => {},
-    onSaveTelegramToken: async () => {},
-    onSaveSlackConfig: () => {},
-    onSaveTwilioCredentials: async () => {},
   },
   decorators: [
-    (Story) => {
-      useAssistantFeatureFlagStore.setState({
-        channelTrustFloors: true,
-        hasHydrated: true,
-      });
-      return (
-        <div style={{ maxWidth: 800, margin: "2rem auto" }}>
-          <Story />
-        </div>
-      );
-    },
+    (Story) => (
+      <div style={{ maxWidth: 800, margin: "2rem auto" }}>
+        <Story />
+      </div>
+    ),
   ],
 };
 
@@ -48,15 +36,13 @@ type Story = StoryObj<typeof AssistantChannelsDetail>;
 
 export const ContactsDetailView: Story = {};
 
-/** The accordion layout rendered while `channel-trust-floors` is off. */
-export const ContactsDetailViewLegacy: Story = {
-  decorators: [
-    (Story) => {
-      useAssistantFeatureFlagStore.setState({
-        channelTrustFloors: false,
-        hasHydrated: true,
-      });
-      return <Story />;
-    },
-  ],
+/** Every adapter connected, each with its handle and disconnect action. */
+export const AllConnected: Story = {
+  args: {
+    channels: [
+      { key: "slack", status: "ready", address: "@example-assistant" },
+      { key: "telegram", status: "ready", address: "@example_assistant_bot" },
+      { key: "phone", status: "ready", address: "+1 (555) 555-0142" },
+    ],
+  },
 };

--- a/clients/web/src/domains/contacts/components/assistant-channels-detail.test.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-detail.test.tsx
@@ -45,6 +45,62 @@ describe("assistant channels surfaces", () => {
     expect(document.body.textContent).toContain("Slack");
   });
 
+  test("the Contacts detail view is a plain connect/disconnect list, not the Channels-tab panel", () => {
+    // Regardless of the channel-trust-floors flag, the contact card renders
+    // one row per adapter — never the sub-tabs, trust-floor dropdown, Slack
+    // settings card, or channel list (those live in the Channels tab).
+    setTabbedLayout(true);
+    render(
+      <AssistantChannelsDetail
+        assistantName="Vex"
+        channels={CHANNELS}
+        onConnect={() => {}}
+        onDisconnect={() => {}}
+      />,
+    );
+    expect(document.querySelector('[data-slot="tabs"]')).toBeNull();
+    expect(document.body.textContent).not.toContain("Who can message");
+    expect(document.body.textContent).not.toContain("Thread Behavior");
+    expect(document.body.textContent).not.toContain("Share Connection Link");
+
+    // Connected Slack: handle + chip + destructive disconnect.
+    expect(document.body.textContent).toContain("@vex");
+    expect(document.body.textContent).toContain("Connected");
+    expect(document.body.textContent).toContain("Disconnect");
+
+    // Disconnected Telegram/Phone: a Connect affordance, no credential forms.
+    const connectButtons = Array.from(
+      document.querySelectorAll("button"),
+    ).filter((b) => b.textContent?.trim() === "Connect");
+    expect(connectButtons).toHaveLength(2);
+    expect(document.body.textContent).not.toContain("Bot Token");
+  });
+
+  test("disconnecting from the contact card asks for confirmation first", () => {
+    const disconnected: string[] = [];
+    render(
+      <AssistantChannelsDetail
+        assistantName="Vex"
+        channels={CHANNELS}
+        onDisconnect={(key) => disconnected.push(key)}
+      />,
+    );
+
+    const disconnectButton = Array.from(
+      document.querySelectorAll("button"),
+    ).find((b) => b.textContent?.trim() === "Disconnect");
+    expect(disconnectButton).toBeDefined();
+    fireEvent.click(disconnectButton!);
+    expect(disconnected).toEqual([]);
+
+    const confirmButton = document.querySelector<HTMLButtonElement>(
+      "[data-confirm-dialog-confirm]",
+    );
+    expect(confirmButton).not.toBeNull();
+    fireEvent.click(confirmButton!);
+    expect(disconnected).toEqual(["slack"]);
+  });
+
   test("the bare channel list (standalone Channels tab) has no identity card", () => {
     render(<AssistantChannelsList assistantName="Vex" channels={CHANNELS} />);
     expect(document.body.textContent).not.toContain("Vex (Your Assistant)");

--- a/clients/web/src/domains/contacts/components/assistant-channels-detail.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-detail.tsx
@@ -1,24 +1,27 @@
 import { DetailCard } from "@/components/detail-card";
 import { assistantDisplayName } from "@/domains/contacts/assistant-display-name";
-import { AssistantChannelsList, type AssistantChannelsListProps } from "@/domains/contacts/components/assistant-channels-list";
+import {
+    AssistantContactChannels,
+    type AssistantContactChannelsProps,
+} from "@/domains/contacts/components/assistant-contact-channels";
 import { ContactTypeBadge } from "@/domains/contacts/components/contact-type-badge";
-import { ShareConnectionLinkButton } from "@/domains/contacts/components/share-connection-link-button";
 
-interface AssistantChannelsDetailProps extends AssistantChannelsListProps {
-  onGenerateInviteLink?: () => void;
+interface AssistantChannelsDetailProps extends AssistantContactChannelsProps {
+  assistantName: string;
 }
 
 /**
  * The assistant's entry in the Contacts detail pane: the contact-style
- * identity header card followed by the channel sub-tabs in a "Channels" card.
- * The standalone Channels tab renders the same `AssistantChannelsList`
- * under its own page subtitle instead.
+ * identity header card followed by a per-adapter connected/disconnected
+ * summary in a "Channels" card. Channel management — credential forms,
+ * trust floors, Slack settings — lives in the standalone Channels tab
+ * (`AssistantChannelsList`), not here.
  */
 export function AssistantChannelsDetail({
-  onGenerateInviteLink,
-  ...listProps
+  assistantName,
+  ...channelsProps
 }: AssistantChannelsDetailProps) {
-  const displayName = assistantDisplayName(listProps.assistantName);
+  const displayName = assistantDisplayName(assistantName);
 
   return (
     <div className="flex flex-col gap-6">
@@ -30,12 +33,10 @@ export function AssistantChannelsDetail({
 
       <DetailCard
         title="Channels"
-        subtitle={`Manage where ${displayName} can be reached.`}
+        subtitle={`Where ${displayName} can be reached.`}
       >
-        <AssistantChannelsList {...listProps} />
+        <AssistantContactChannels {...channelsProps} />
       </DetailCard>
-
-      {onGenerateInviteLink ? <ShareConnectionLinkButton onClick={onGenerateInviteLink} /> : null}
     </div>
   );
 }

--- a/clients/web/src/domains/contacts/components/assistant-contact-channels.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-contact-channels.tsx
@@ -1,0 +1,132 @@
+import { CheckCircle } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@vellumai/design-library/components/button";
+import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
+
+import type { AssistantChannelState, SetupChannelId } from "@/domains/contacts/types";
+import { ChannelIcon, getChannelLabel } from "@/utils/channel-presentation";
+
+export interface AssistantContactChannelsProps {
+  channels: AssistantChannelState[];
+  /** Channel with a disconnect in flight; disables that row's actions. */
+  pendingChannelKey?: SetupChannelId | null;
+  onConnect?: (channelKey: SetupChannelId) => void;
+  onDisconnect?: (channelKey: SetupChannelId) => void;
+}
+
+/**
+ * Connected/disconnected summary of the assistant's own outbound channels,
+ * for its entry in the Contacts detail pane: one row per adapter with a
+ * Connect / Disconnect action. Mirrors the row shape of the human contact
+ * detail's `ContactChannelsSection`. Everything richer — credential forms,
+ * trust floors, Slack settings, the channel list — lives in the Channels
+ * tab's `AssistantChannelsList`.
+ */
+export function AssistantContactChannels({
+  channels,
+  pendingChannelKey = null,
+  onConnect,
+  onDisconnect,
+}: AssistantContactChannelsProps) {
+  const [pendingDisconnect, setPendingDisconnect] = useState<SetupChannelId | null>(null);
+
+  return (
+    <>
+      <div className="flex flex-col">
+        {channels.map((channel, index) => (
+          <div key={channel.key}>
+            {index > 0 ? (
+              <div
+                className="border-t"
+                style={{ borderColor: "var(--border-base)" }}
+              />
+            ) : null}
+            <ChannelRow
+              channel={channel}
+              pending={pendingChannelKey === channel.key}
+              onConnect={onConnect ? () => onConnect(channel.key) : undefined}
+              onDisconnect={
+                onDisconnect ? () => setPendingDisconnect(channel.key) : undefined
+              }
+            />
+          </div>
+        ))}
+      </div>
+
+      <ConfirmDialog
+        open={pendingDisconnect !== null}
+        title={`Disconnect ${pendingDisconnect ? getChannelLabel(pendingDisconnect) : ""}?`}
+        message="This clears the stored credentials for this channel. You can reconnect later."
+        confirmLabel="Disconnect"
+        destructive
+        onConfirm={() => {
+          if (pendingDisconnect && onDisconnect) {
+            onDisconnect(pendingDisconnect);
+          }
+          setPendingDisconnect(null);
+        }}
+        onCancel={() => setPendingDisconnect(null)}
+      />
+    </>
+  );
+}
+
+interface ChannelRowProps {
+  channel: AssistantChannelState;
+  pending: boolean;
+  onConnect?: () => void;
+  onDisconnect?: () => void;
+}
+
+function ChannelRow({ channel, pending, onConnect, onDisconnect }: ChannelRowProps) {
+  const connected = channel.status === "ready";
+
+  return (
+    <div className="flex items-center gap-3 py-4">
+      <ChannelIcon
+        channelId={channel.key}
+        className="h-4 w-4 shrink-0 text-[color:var(--content-secondary)]"
+      />
+      <span
+        className="text-body-medium-default"
+        style={{ color: "var(--content-default)" }}
+      >
+        {getChannelLabel(channel.key)}
+      </span>
+      {connected && channel.address ? (
+        <span
+          className="truncate text-body-medium-lighter"
+          style={{ color: "var(--content-tertiary)" }}
+        >
+          {channel.address}
+        </span>
+      ) : null}
+      <div className="ml-auto flex shrink-0 items-center gap-2">
+        {connected ? (
+          <>
+            <span className="inline-flex items-center gap-1 h-8 px-2.5 rounded-md whitespace-nowrap select-none text-body-small-emphasised leading-none bg-[var(--content-default)] text-[var(--surface-base)]">
+              <CheckCircle className="h-3 w-3" />
+              Connected
+            </span>
+            <Button
+              variant="danger"
+              onClick={onDisconnect}
+              disabled={!onDisconnect || pending}
+            >
+              {pending ? "Disconnecting…" : "Disconnect"}
+            </Button>
+          </>
+        ) : (
+          <Button
+            variant="outlined"
+            onClick={onConnect}
+            disabled={!onConnect || pending}
+          >
+            Connect
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/clients/web/src/domains/contacts/contacts-page.test.tsx
+++ b/clients/web/src/domains/contacts/contacts-page.test.tsx
@@ -13,7 +13,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 
 import { ApiError } from "@/utils/api-errors";
 import type { ContactPayload } from "@/domains/contacts/types";
@@ -162,12 +162,24 @@ afterEach(() => {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("ContactsPage guardian auto-selection", () => {
-  test("?setup= deep link suppresses guardian auto-select", async () => {
+describe("ContactsPage legacy setup deep link", () => {
+  test("?setup= deep link redirects to the Channels tab with the param intact", async () => {
+    // Old builds' mobile chat handoff (and saved links) pointed channel
+    // setup at this page; the credential forms now live only on the
+    // Channels tab, so the page must forward the link there.
+    function ChannelsMarker() {
+      const location = useLocation();
+      return createElement(
+        "div",
+        { "data-testid": "channels-page" },
+        location.search,
+      );
+    }
+
     render(
       createElement(
         MemoryRouter,
-        { initialEntries: ["/contacts?setup=slack"] },
+        { initialEntries: ["/assistant/contacts?setup=slack"] },
         createElement(
           QueryClientProvider,
           {
@@ -175,28 +187,27 @@ describe("ContactsPage guardian auto-selection", () => {
               defaultOptions: { queries: { retry: false } },
             }),
           },
-          createElement(ContactsPage, { assistantId: "asst-1" }),
+          createElement(
+            Routes,
+            null,
+            createElement(Route, {
+              path: "/assistant/contacts",
+              element: createElement(ContactsPage, { assistantId: "asst-1" }),
+            }),
+            createElement(Route, {
+              path: "/assistant/channels",
+              element: createElement(ChannelsMarker),
+            }),
+          ),
         ),
       ),
     );
 
-    // Wait for the guardian data to load (contactsGetOptions resolves).
     await waitFor(() => {
-      // The "Channels" heading is part of AssistantChannelsDetail which renders
-      // only when selection.kind === "assistant". If guardian auto-selected,
-      // this would not be in the document.
-      expect(
-        document.querySelector('[data-testid="channels-detail"]') ??
-          document.body.textContent?.includes("Channels"),
-      ).toBeTruthy();
+      const marker = document.querySelector('[data-testid="channels-page"]');
+      expect(marker).not.toBeNull();
+      expect(marker!.textContent).toBe("?setup=slack");
     });
-
-    // The name input (from guardian detail) should NOT be rendered because
-    // guardian auto-selection was suppressed.
-    const nameInput = document.querySelector<HTMLInputElement>(
-      'input[placeholder="Your name"]',
-    );
-    expect(nameInput).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/contacts/contacts-page.tsx
+++ b/clients/web/src/domains/contacts/contacts-page.tsx
@@ -462,9 +462,10 @@ export function ContactsPage({
           selection.contactId === deletingContactId) ? (
           <AssistantChannelsDetail
             assistantName={assistantName}
-            onGenerateInviteLink={a2aChannel ? inviteDialog.open : undefined}
-            initialChannel={setupChannel}
-            {...channelsController}
+            channels={channelsController.channels}
+            pendingChannelKey={channelsController.pendingChannelKey}
+            onConnect={channelsController.onSetup}
+            onDisconnect={channelsController.onDisconnect}
           />
         ) : optimisticContact ? (
           optimisticContact.role === "guardian" ? (

--- a/clients/web/src/domains/contacts/contacts-page.tsx
+++ b/clients/web/src/domains/contacts/contacts-page.tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Navigate, useSearchParams } from "react-router";
 
 import { toast } from "@vellumai/design-library/components/toast";
 
@@ -19,6 +20,7 @@ import {
     verifyContactChannel,
 } from "@/domains/contacts/contacts-gateway";
 import {
+    isSetupChannelId,
     type ChannelInfo,
     type ContactChannelPayload,
     type ContactPayload,
@@ -38,10 +40,10 @@ import { assistantDisplayName } from "@/domains/contacts/assistant-display-name"
 import { useAssistantChannels } from "@/domains/contacts/hooks/use-assistant-channels";
 import { useChannelProvenance } from "@/domains/contacts/hooks/use-channel-provenance";
 import { useInviteLinkDialog } from "@/domains/contacts/hooks/use-invite-link-dialog";
-import { useSetupChannelParam } from "@/domains/contacts/hooks/use-setup-channel-param";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { toastOnError } from "@/utils/mutation-error";
+import { routes } from "@/utils/routes";
 
 /**
  * Hardcoded fallback for assistants that don't expose
@@ -104,7 +106,14 @@ export function ContactsPage({
   const a2aChannel = useAssistantFeatureFlagStore.use.a2aChannel();
   const identityName = useAssistantIdentityStore.use.name();
   const queryClient = useQueryClient();
-  const setupChannel = useSetupChannelParam();
+  // Legacy `?setup=<channel>` deep link. Setup used to continue on this
+  // page's assistant detail card; the credential forms now live only on the
+  // Channels tab, so the param is forwarded there (see the redirect below)
+  // instead of being consumed via `useSetupChannelParam`.
+  const [searchParams] = useSearchParams();
+  const rawSetupParam = searchParams.get("setup");
+  const setupChannel =
+    rawSetupParam && isSetupChannelId(rawSetupParam) ? rawSetupParam : null;
 
   const [selection, setSelection] = useState<ContactSelection>({
     kind: "assistant",
@@ -410,6 +419,14 @@ export function ContactsPage({
   // ---------------------------------------------------------------------------
   // Render
   // ---------------------------------------------------------------------------
+
+  // Old builds' mobile chat handoff (and saved links) deep-linked channel
+  // setup to this page. The forms it targeted moved to the Channels tab,
+  // so forward the link there rather than stranding it on the assistant
+  // card's plain connect/disconnect list.
+  if (setupChannel) {
+    return <Navigate to={`${routes.channels}?setup=${setupChannel}`} replace />;
+  }
 
   const contactsListProps = {
     loading: contactsQuery.isLoading,


### PR DESCRIPTION
## Prompt / plan

LUM-2726 — the assistant's entry in Contacts (About Assistant → Contacts → assistant entry) rendered the full `AssistantChannelsList` (the same component the top-level Channels tab uses), leaking the new Slack sub-tabs, the "Who can message" trust-floor dropdown, the Slack settings card, the channel list, and Share Connection Link into the contact card.

Plan:
- Add `AssistantContactChannels`, a simple per-adapter connected/disconnected list mirroring the row shape of the human contact detail's `ContactChannelsSection`: adapter icon + name, `Connected` chip with the handle when connected, right-aligned **Disconnect** (destructive, confirm-first) when connected / **Connect** when not. Connect reuses the existing guided-setup conversation handler (`useAssistantChannels.onSetup`).
- Mount it in `AssistantChannelsDetail` in place of `AssistantChannelsList`. The Channels tab's mount (`ChannelsPage` → `AssistantChannelsList` → `ChannelPanel`) is untouched — all flag-gated channel-list work (LUM-2725) continues there.
- Since the contact card no longer hosts the credential forms, the mobile chat-drawer setup handoff now deep-links to `/assistant/channels?setup=<channel>` (where the forms live) instead of `/assistant/contacts?setup=<channel>`. This matches where the provenance pill already links.

## Test plan

- New unit tests in `assistant-channels-detail.test.tsx`: the contact card renders connect/disconnect rows with no tabs, no trust-floor dropdown, no thread behavior, no Share Connection Link, no credential forms; disconnect requires confirmation before firing. Existing `AssistantChannelsList` tests unchanged and passing.
- `bun test src/domains/contacts/...` — 12 pass, 0 fail.
- `bunx tsc --noEmit` and `eslint` on changed files — clean (pre-existing `curly` warnings only).
- Storybook stories updated for the new card (mixed and all-connected states).

## CLI verb checklist

No new IPC routes — web client only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AeQcbjaRAZbTwapKWZRezL)_