### PR TITLE
fix: reporter scaffolding dedup + export hygiene (review round 2)

### DIFF
--- a/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
+++ b/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
@@ -14,9 +14,7 @@ import { toTrustContext } from "../actor-trust-resolver.js";
 import {
   actorTrustContextFromVerdict,
   trustContextFromVerdict,
-  verdictHasMemberIdentity,
   verdictMemberFromVerdict,
-  verdictMemberUnresolvable,
   verdictUsability,
 } from "../trust-verdict-consumer.js";
 
@@ -661,65 +659,56 @@ describe("verdictMemberFromVerdict", () => {
   });
 });
 
-describe("verdict predicates", () => {
-  test("verdictHasMemberIdentity is true with contactId or channelId", () => {
+// Member-identity handling is module-private; exercised via verdictUsability's
+// "member unresolvable" reason.
+describe("verdict member-identity handling (via verdictUsability)", () => {
+  test("partial member identity (contactId or channelId alone) is member unresolvable", () => {
     expect(
-      verdictHasMemberIdentity({
+      verdictUsability({
         trustClass: "unknown",
         canonicalSenderId: "u-1",
         contactId: "contact-1",
       } satisfies TrustVerdict),
-    ).toBe(true);
+    ).toEqual({ usable: false, reason: "member unresolvable" });
     expect(
-      verdictHasMemberIdentity({
+      verdictUsability({
         trustClass: "unknown",
         canonicalSenderId: "u-1",
         channelId: "channel-1",
       } satisfies TrustVerdict),
-    ).toBe(true);
+    ).toEqual({ usable: false, reason: "member unresolvable" });
   });
 
-  test("verdictHasMemberIdentity is false for a memberless verdict", () => {
+  test("member identity with unsynthesizable ACL is member unresolvable", () => {
     expect(
-      verdictHasMemberIdentity({
-        trustClass: "unknown",
-        canonicalSenderId: "u-1",
-      } satisfies TrustVerdict),
-    ).toBe(false);
-  });
-
-  test("verdictMemberUnresolvable is true when member identity present but ACL unsynthesizable", () => {
-    expect(
-      verdictMemberUnresolvable({
+      verdictUsability({
         trustClass: "trusted_contact",
         canonicalSenderId: "u-1",
         contactId: "contact-1",
         channelId: "channel-1",
         policy: "allow",
       } satisfies TrustVerdict),
-    ).toBe(true);
+    ).toEqual({ usable: false, reason: "member unresolvable" });
   });
 
-  test("verdictMemberUnresolvable is false for a usable member verdict", () => {
-    expect(
-      verdictMemberUnresolvable({
-        trustClass: "trusted_contact",
-        canonicalSenderId: "u-1",
-        contactId: "contact-1",
-        channelId: "channel-1",
-        status: "active",
-        policy: "allow",
-      } satisfies TrustVerdict),
-    ).toBe(false);
+  test("resolvable member verdict is usable, not member unresolvable", () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-1",
+      contactId: "contact-1",
+      channelId: "channel-1",
+      status: "active",
+      policy: "allow",
+    } satisfies TrustVerdict;
+    expect(verdictUsability(verdict)).toEqual({ usable: true, verdict });
   });
 
-  test("verdictMemberUnresolvable is false for a memberless verdict", () => {
-    expect(
-      verdictMemberUnresolvable({
-        trustClass: "unknown",
-        canonicalSenderId: "u-1",
-      } satisfies TrustVerdict),
-    ).toBe(false);
+  test("memberless verdict is usable, not member unresolvable", () => {
+    const verdict = {
+      trustClass: "unknown",
+      canonicalSenderId: "u-1",
+    } satisfies TrustVerdict;
+    expect(verdictUsability(verdict)).toEqual({ usable: true, verdict });
   });
 });
 

--- a/assistant/src/runtime/trust-verdict-consumer.ts
+++ b/assistant/src/runtime/trust-verdict-consumer.ts
@@ -120,7 +120,7 @@ export function trustContextFromVerdict(
  * True when the verdict carries a member identity (contactId or channelId),
  * regardless of whether that member resolves to a usable {@link VerdictMember}.
  */
-export function verdictHasMemberIdentity(verdict: TrustVerdict): boolean {
+function verdictHasMemberIdentity(verdict: TrustVerdict): boolean {
   return !!(verdict.contactId || verdict.channelId);
 }
 
@@ -129,7 +129,7 @@ export function verdictHasMemberIdentity(verdict: TrustVerdict): boolean {
  * resolved (partial/mixed-version verdict). Such a verdict is unusable —
  * consumers fail closed (deny), never falling back to local resolution.
  */
-export function verdictMemberUnresolvable(verdict: TrustVerdict): boolean {
+function verdictMemberUnresolvable(verdict: TrustVerdict): boolean {
   return (
     verdictHasMemberIdentity(verdict) &&
     verdictMemberFromVerdict(verdict) === null

--- a/gateway/src/contacts-mirror-op-reporter.ts
+++ b/gateway/src/contacts-mirror-op-reporter.ts
@@ -6,24 +6,17 @@
 // `contacts_mirror_op_missing` watchdog telemetry event to the daemon's
 // internal telemetry route (the route predates the mirror ops, so an old
 // daemon still accepts it). Rate-limited per op per process; a lost event is
-// acceptable for a rare, high-signal check (no retry). Pattern:
-// guardian-integrity-reporter.
+// acceptable for a rare, high-signal check (no retry). Scaffolding:
+// watchdog-reporter.ts.
 
-import { loadConfig } from "./config.js";
-import type { fetchImpl } from "./fetch.js";
-import { postInternalTelemetry } from "./internal-telemetry-client.js";
 import { getLogger } from "./logger.js";
-
-const log = getLogger("contacts-mirror-op-reporter");
+import { createWatchdogReporter } from "./watchdog-reporter.js";
 
 /**
  * Watchdog `check_name` for a daemon missing a contacts mirror op. Platform
  * dashboards filter on this exact string — it is the cross-repo contract.
  */
 export const MIRROR_OP_MISSING_CHECK_NAME = "contacts_mirror_op_missing";
-
-const ROUTE_PATH = "/v1/internal/telemetry/watchdog";
-const REPORT_INTERVAL_MS = 60 * 60 * 1000;
 
 /**
  * True when a daemon IPC failure is the IPC server's unknown-method rejection
@@ -34,21 +27,12 @@ export function isUnknownIpcMethodError(err: unknown): boolean {
   return err instanceof Error && err.message.startsWith("Unknown method:");
 }
 
-type ReporterLog = {
-  error: (detail: Record<string, unknown>, msg: string) => void;
-  warn: (detail: Record<string, unknown>, msg: string) => void;
-};
-
-type ReporterOverrides = {
-  fetchImpl?: typeof fetchImpl;
-  mintToken?: () => string;
-  baseUrl?: string;
-  log?: ReporterLog;
-};
-
-let overrides: ReporterOverrides = {};
-const lastReportAtByOp = new Map<string, number>();
-let pendingRelay: Promise<unknown> = Promise.resolve();
+const reporter = createWatchdogReporter({
+  log: getLogger("contacts-mirror-op-reporter"),
+  relayFailedMessage: "mirror-op-missing telemetry relay failed (non-fatal)",
+  relayRejectedMessage:
+    "mirror-op-missing telemetry relay rejected (non-fatal)",
+});
 
 /**
  * Report a mirror op the daemon doesn't implement: error log + telemetry
@@ -59,71 +43,19 @@ export function reportMirrorOpMissing(
   op: string,
   detail: Record<string, unknown>,
 ): void {
-  const now = Date.now();
-  const last = lastReportAtByOp.get(op) ?? Number.NEGATIVE_INFINITY;
-  if (now - last < REPORT_INTERVAL_MS) {
-    return;
-  }
-  lastReportAtByOp.set(op, now);
-
-  reporterLog().error(
-    { op, ...detail },
-    "daemon does not implement this contacts mirror op — gateway write applied " +
+  reporter.report({
+    key: op,
+    checkName: MIRROR_OP_MISSING_CHECK_NAME,
+    message:
+      "daemon does not implement this contacts mirror op — gateway write applied " +
       "without the assistant mirror (divergence until the daemon updates)",
-  );
-
-  pendingRelay = relayToDaemon(op, detail).catch((err) => {
-    reporterLog().warn(
-      { op, err },
-      "mirror-op-missing telemetry relay failed (non-fatal)",
-    );
+    detail: { op, ...detail },
+    warnContext: { op },
   });
 }
 
-async function relayToDaemon(
-  op: string,
-  detail: Record<string, unknown>,
-): Promise<void> {
-  const resp = await postInternalTelemetry({
-    baseUrl: overrides.baseUrl ?? loadConfig().assistantRuntimeBaseUrl,
-    path: ROUTE_PATH,
-    body: {
-      check_name: MIRROR_OP_MISSING_CHECK_NAME,
-      detail: { op, ...detail },
-    },
-    fetchImpl: overrides.fetchImpl,
-    mintToken: overrides.mintToken,
-  });
-  if (!resp.ok) {
-    reporterLog().warn(
-      { op, status: resp.status },
-      "mirror-op-missing telemetry relay rejected (non-fatal)",
-    );
-  }
-}
-
-function reporterLog(): ReporterLog {
-  return overrides.log ?? log;
-}
-
-/**
- * Test-only: inject fetch/token/baseUrl/log so tests never touch the network
- * or the process logger.
- */
-export function setMirrorOpReporterOverridesForTesting(
-  next: ReporterOverrides,
-): void {
-  overrides = next;
-}
-
-/** Test-only: clear overrides and the rate-limit windows. */
-export function resetMirrorOpReporterForTesting(): void {
-  overrides = {};
-  lastReportAtByOp.clear();
-  pendingRelay = Promise.resolve();
-}
-
-/** Test-only: await the most recent fire-and-forget relay. */
-export function flushMirrorOpReporterForTesting(): Promise<unknown> {
-  return pendingRelay;
-}
+/** Test-only seams; see {@link createWatchdogReporter}. */
+export const setMirrorOpReporterOverridesForTesting =
+  reporter.setOverridesForTesting;
+export const resetMirrorOpReporterForTesting = reporter.resetForTesting;
+export const flushMirrorOpReporterForTesting = reporter.flushForTesting;

--- a/gateway/src/guardian-integrity-reporter.ts
+++ b/gateway/src/guardian-integrity-reporter.ts
@@ -7,14 +7,10 @@
 // directly to platform ingest — bypassing any state owned by the broken trust
 // path so the alarm cannot suppress itself. Rate-limited per check_name per
 // process; a lost event is acceptable for a rare, high-signal check (no
-// retry).
+// retry). Scaffolding: watchdog-reporter.ts.
 
-import { loadConfig } from "./config.js";
-import type { fetchImpl } from "./fetch.js";
-import { postInternalTelemetry } from "./internal-telemetry-client.js";
 import { getLogger } from "./logger.js";
-
-const log = getLogger("guardian-integrity-reporter");
+import { createWatchdogReporter } from "./watchdog-reporter.js";
 
 /**
  * Watchdog `check_name` for the missing-guardian integrity failure. Platform
@@ -30,24 +26,12 @@ export const GUARDIAN_MISSING_CHECK_NAME = "gateway_guardian_missing";
  */
 export const GUARDIAN_MINT_REFUSED_CHECK_NAME = "gateway_guardian_mint_refused";
 
-const ROUTE_PATH = "/v1/internal/telemetry/watchdog";
-const REPORT_INTERVAL_MS = 60 * 60 * 1000;
-
-type ReporterLog = {
-  error: (detail: Record<string, unknown>, msg: string) => void;
-  warn: (detail: Record<string, unknown>, msg: string) => void;
-};
-
-type ReporterOverrides = {
-  fetchImpl?: typeof fetchImpl;
-  mintToken?: () => string;
-  baseUrl?: string;
-  log?: ReporterLog;
-};
-
-let overrides: ReporterOverrides = {};
-const lastReportAtByCheck = new Map<string, number>();
-let pendingRelay: Promise<unknown> = Promise.resolve();
+const reporter = createWatchdogReporter({
+  log: getLogger("guardian-integrity-reporter"),
+  relayFailedMessage: "guardian-integrity telemetry relay failed (non-fatal)",
+  relayRejectedMessage:
+    "guardian-integrity telemetry relay rejected (non-fatal)",
+});
 
 /**
  * Report the missing-guardian state: error log + telemetry relay. Fires on
@@ -87,65 +71,17 @@ function report(
   message: string,
   detail: Record<string, unknown>,
 ): void {
-  const now = Date.now();
-  const lastReportAt =
-    lastReportAtByCheck.get(checkName) ?? Number.NEGATIVE_INFINITY;
-  if (now - lastReportAt < REPORT_INTERVAL_MS) {
-    return;
-  }
-  lastReportAtByCheck.set(checkName, now);
-
-  reporterLog().error(detail, message);
-
-  pendingRelay = relayToDaemon(checkName, detail).catch((err) => {
-    reporterLog().warn(
-      { err, checkName },
-      "guardian-integrity telemetry relay failed (non-fatal)",
-    );
+  reporter.report({
+    key: checkName,
+    checkName,
+    message,
+    detail,
+    warnContext: { checkName },
   });
 }
 
-async function relayToDaemon(
-  checkName: string,
-  detail: Record<string, unknown>,
-): Promise<void> {
-  const resp = await postInternalTelemetry({
-    baseUrl: overrides.baseUrl ?? loadConfig().assistantRuntimeBaseUrl,
-    path: ROUTE_PATH,
-    body: { check_name: checkName, detail },
-    fetchImpl: overrides.fetchImpl,
-    mintToken: overrides.mintToken,
-  });
-  if (!resp.ok) {
-    reporterLog().warn(
-      { status: resp.status, checkName },
-      "guardian-integrity telemetry relay rejected (non-fatal)",
-    );
-  }
-}
-
-function reporterLog(): ReporterLog {
-  return overrides.log ?? log;
-}
-
-/**
- * Test-only: inject fetch/token/baseUrl/log so tests never touch the network
- * or the process logger.
- */
-export function setGuardianIntegrityReporterOverridesForTesting(
-  next: ReporterOverrides,
-): void {
-  overrides = next;
-}
-
-/** Test-only: clear overrides and the rate-limit windows. */
-export function resetGuardianIntegrityReporterForTesting(): void {
-  overrides = {};
-  lastReportAtByCheck.clear();
-  pendingRelay = Promise.resolve();
-}
-
-/** Test-only: await the most recent fire-and-forget relay. */
-export function flushGuardianIntegrityReporterForTesting(): Promise<unknown> {
-  return pendingRelay;
-}
+/** Test-only seams; see {@link createWatchdogReporter}. */
+export const setGuardianIntegrityReporterOverridesForTesting =
+  reporter.setOverridesForTesting;
+export const resetGuardianIntegrityReporterForTesting = reporter.resetForTesting;
+export const flushGuardianIntegrityReporterForTesting = reporter.flushForTesting;

--- a/gateway/src/watchdog-reporter.ts
+++ b/gateway/src/watchdog-reporter.ts
@@ -1,0 +1,110 @@
+// Shared scaffolding for fail-loud watchdog reporters: per-key hourly rate
+// limiting, an error-level log, and a fire-and-forget relay to the daemon's
+// internal watchdog telemetry route. Best-effort — never throws, never blocks
+// the caller, and a lost event is acceptable for rare, high-signal checks (no
+// retry). Each reporter module owns its check names, message copy, and detail
+// shaping; this factory owns the state and transport posture.
+
+import { loadConfig } from "./config.js";
+import type { fetchImpl } from "./fetch.js";
+import { postInternalTelemetry } from "./internal-telemetry-client.js";
+
+const ROUTE_PATH = "/v1/internal/telemetry/watchdog";
+const REPORT_INTERVAL_MS = 60 * 60 * 1000;
+
+export type ReporterLog = {
+  error: (detail: Record<string, unknown>, msg: string) => void;
+  warn: (detail: Record<string, unknown>, msg: string) => void;
+};
+
+export type ReporterOverrides = {
+  fetchImpl?: typeof fetchImpl;
+  mintToken?: () => string;
+  baseUrl?: string;
+  log?: ReporterLog;
+};
+
+export type WatchdogReport = {
+  /** Rate-limit key: at most one report per key per hour per process. */
+  key: string;
+  /** Watchdog `check_name` — the cross-repo platform-dashboard contract. */
+  checkName: string;
+  /** Error-log message. */
+  message: string;
+  /** Logged with the error and sent as the relay body's `detail`. */
+  detail: Record<string, unknown>;
+  /** Merged into the non-fatal relay warn logs. */
+  warnContext: Record<string, unknown>;
+};
+
+export type WatchdogReporter = {
+  report: (args: WatchdogReport) => void;
+  /**
+   * Test-only: inject fetch/token/baseUrl/log so tests never touch the
+   * network or the process logger.
+   */
+  setOverridesForTesting: (next: ReporterOverrides) => void;
+  /** Test-only: clear overrides and the rate-limit windows. */
+  resetForTesting: () => void;
+  /** Test-only: await the most recent fire-and-forget relay. */
+  flushForTesting: () => Promise<unknown>;
+};
+
+export function createWatchdogReporter(config: {
+  log: ReporterLog;
+  relayFailedMessage: string;
+  relayRejectedMessage: string;
+}): WatchdogReporter {
+  let overrides: ReporterOverrides = {};
+  const lastReportAtByKey = new Map<string, number>();
+  let pendingRelay: Promise<unknown> = Promise.resolve();
+
+  const reporterLog = (): ReporterLog => overrides.log ?? config.log;
+
+  async function relayToDaemon(args: WatchdogReport): Promise<void> {
+    const resp = await postInternalTelemetry({
+      baseUrl: overrides.baseUrl ?? loadConfig().assistantRuntimeBaseUrl,
+      path: ROUTE_PATH,
+      body: { check_name: args.checkName, detail: args.detail },
+      fetchImpl: overrides.fetchImpl,
+      mintToken: overrides.mintToken,
+    });
+    if (!resp.ok) {
+      reporterLog().warn(
+        { status: resp.status, ...args.warnContext },
+        config.relayRejectedMessage,
+      );
+    }
+  }
+
+  return {
+    report(args: WatchdogReport): void {
+      const now = Date.now();
+      const last = lastReportAtByKey.get(args.key) ?? Number.NEGATIVE_INFINITY;
+      if (now - last < REPORT_INTERVAL_MS) {
+        return;
+      }
+      lastReportAtByKey.set(args.key, now);
+
+      reporterLog().error(args.detail, args.message);
+
+      pendingRelay = relayToDaemon(args).catch((err) => {
+        reporterLog().warn(
+          { err, ...args.warnContext },
+          config.relayFailedMessage,
+        );
+      });
+    },
+    setOverridesForTesting(next: ReporterOverrides): void {
+      overrides = next;
+    },
+    resetForTesting(): void {
+      overrides = {};
+      lastReportAtByKey.clear();
+      pendingRelay = Promise.resolve();
+    },
+    flushForTesting(): Promise<unknown> {
+      return pendingRelay;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
Final self-review residuals for acl-hardening-sweep.md: the two watchdog reporters share a createWatchdogReporter factory (a third check no longer mints a third copy; zero behavior change), and the now-internal verdict predicates are module-private