### PR TITLE
fix(onboarding): full-size window, no Electron step resume, instant local adopt

### DIFF
--- a/clients/macos/src/main/main-window.test.ts
+++ b/clients/macos/src/main/main-window.test.ts
@@ -475,20 +475,18 @@ describe("installMainWindow", () => {
 });
 
 describe("onboarding window sizing", () => {
-  test("creates a 440×660 default-size but still resizable window when onboarding is active", () => {
+  test("creates the window at the main-app size even when onboarding is active", () => {
     onboardingActive = true;
     ensureVisible();
     const win = constructed[0];
     if (!win) throw new Error("expected a window");
-    expect(win.opts.width).toBe(440);
-    expect(win.opts.height).toBe(660);
-    expect(win.opts.useContentSize).toBe(true);
-    // The 440×660 default is also the floor, so the chrome-less flow can't
-    // be dragged below its content.
-    expect(win.opts.minWidth).toBe(440);
-    expect(win.opts.minHeight).toBe(660);
-    // Onboarding is the default size only — the window stays resizable
-    // (no `resizable: false` opt), so it inherits the Electron default.
+    // Onboarding shares the main-app sizing: restored bounds and the
+    // 800×600 floor — no compact 440×660 layout anymore.
+    expect(win.opts.width).toBe(1280);
+    expect(win.opts.height).toBe(800);
+    expect(win.opts.useContentSize).toBeUndefined();
+    expect(win.opts.minWidth).toBe(800);
+    expect(win.opts.minHeight).toBe(600);
     expect(win.opts.resizable).toBeUndefined();
     expect(win.stub.isResizable()).toBe(true);
   });
@@ -510,7 +508,7 @@ describe("onboarding window sizing", () => {
     expect(win.opts.fullscreen).toBeUndefined();
   });
 
-  test("setOnboarding(true) shrinks an existing main window to the default", () => {
+  test("setOnboarding(true) persists the mode without resizing the window", () => {
     onboardingActive = false;
     ensureVisible();
     const win = constructed[0];
@@ -519,15 +517,14 @@ describe("onboarding window sizing", () => {
     setOnboarding(true);
 
     expect(writeOnboardingActiveMock).toHaveBeenCalledWith(true);
-    expect(win.stub.setContentSize).toHaveBeenCalledWith(440, 660);
-    // Entering onboarding clamps the minimum to the compact content size.
-    expect(win.stub.setMinimumSize).toHaveBeenCalledWith(440, 660);
-    expect(win.stub.center).toHaveBeenCalled();
-    // The window stays resizable across the transition — never locked.
+    // Onboarding shares the main-app sizing — no shrink, no floor swap.
+    expect(win.stub.setContentSize).not.toHaveBeenCalled();
+    expect(win.stub.setMinimumSize).not.toHaveBeenCalled();
+    expect(win.stub.setBounds).not.toHaveBeenCalled();
     expect(win.stub.setResizable).not.toHaveBeenCalled();
   });
 
-  test("setOnboarding(false) grows an existing onboarding window to the main bounds", () => {
+  test("setOnboarding(false) persists the mode without resizing the window", () => {
     onboardingActive = true;
     ensureVisible();
     const win = constructed[0];
@@ -536,9 +533,9 @@ describe("onboarding window sizing", () => {
     setOnboarding(false);
 
     expect(writeOnboardingActiveMock).toHaveBeenCalledWith(false);
-    expect(win.stub.setBounds).toHaveBeenCalledWith({ width: 1280, height: 800 });
-    // Leaving onboarding swaps the compact floor for the 800×600 main floor.
-    expect(win.stub.setMinimumSize).toHaveBeenCalledWith(800, 600);
+    expect(win.stub.setContentSize).not.toHaveBeenCalled();
+    expect(win.stub.setMinimumSize).not.toHaveBeenCalled();
+    expect(win.stub.setBounds).not.toHaveBeenCalled();
     expect(win.stub.setResizable).not.toHaveBeenCalled();
   });
 
@@ -576,7 +573,9 @@ describe("onboarding window sizing", () => {
     );
 
     expect(writeOnboardingActiveMock).toHaveBeenCalledWith(true);
-    expect(win.stub.setContentSize).toHaveBeenCalledWith(440, 660);
+    // Mode change repositions the traffic lights; sizing is untouched.
+    expect(win.stub.setWindowButtonPosition).toHaveBeenCalledWith(null);
+    expect(win.stub.setContentSize).not.toHaveBeenCalled();
   });
 
   test("centres the macOS traffic lights for a main-app window on creation", () => {
@@ -651,18 +650,16 @@ describe("maximized default", () => {
     expect(win.opts.fullscreen).toBeUndefined();
   });
 
-  test("setOnboarding(false) applies the work-area bounds without entering fullscreen", () => {
+  test("constructs at the work-area bounds when onboarding is active too", () => {
     onboardingActive = true;
+    restoredBounds = { x: 0, y: 25, width: 1512, height: 944 };
     ensureVisible();
     const win = constructed[0];
     if (!win) throw new Error("expected a window");
-    restoredBounds = { x: 0, y: 25, width: 1512, height: 944 };
 
-    setOnboarding(false);
-
-    expect(win.stub.setBounds).toHaveBeenCalledWith({ width: 1512, height: 944 });
-    expect(win.stub.setPosition).toHaveBeenCalledWith(0, 25);
-    expect(win.stub.setFullScreen).not.toHaveBeenCalled();
+    expect(win.opts.width).toBe(1512);
+    expect(win.opts.height).toBe(944);
+    expect(win.opts.fullscreen).toBeUndefined();
   });
 });
 
@@ -675,16 +672,17 @@ describe("fullscreen session restore", () => {
     expect(win.opts.fullscreen).toBe(true);
   });
 
-  test("never constructs the compact onboarding window fullscreen", () => {
+  test("restores a saved fullscreen session even when onboarding is active", () => {
     restoredBounds = { width: 1280, height: 800, fullscreen: true };
     onboardingActive = true;
     ensureVisible();
     const win = constructed[0];
     if (!win) throw new Error("expected a window");
-    expect(win.opts.fullscreen).toBeUndefined();
+    // Onboarding shares the main-app sizing, fullscreen included.
+    expect(win.opts.fullscreen).toBe(true);
   });
 
-  test("setOnboarding(true) on a fullscreen window leaves fullscreen and defers the shrink", () => {
+  test("setOnboarding never touches fullscreen state", () => {
     restoredBounds = { width: 1280, height: 800, fullscreen: true };
     ensureVisible();
     const win = constructed[0];
@@ -692,57 +690,11 @@ describe("fullscreen session restore", () => {
     expect(win.stub.isFullScreen()).toBe(true);
 
     setOnboarding(true);
-
-    expect(win.stub.setFullScreen).toHaveBeenCalledWith(false);
-    // Geometry changes are ignored mid-transition, so nothing is applied
-    // until `leave-full-screen` lands.
-    expect(win.stub.setContentSize).not.toHaveBeenCalled();
-    expect(win.stub.setMinimumSize).not.toHaveBeenCalled();
-
-    win.stub.emit("leave-full-screen");
-    expect(win.stub.setMinimumSize).toHaveBeenCalledWith(440, 660);
-    expect(win.stub.setContentSize).toHaveBeenCalledWith(440, 660);
-    expect(win.stub.center).toHaveBeenCalled();
-  });
-
-  test("drops the deferred shrink when the mode flips back to main before leave-full-screen lands", () => {
-    restoredBounds = { width: 1280, height: 800, fullscreen: true };
-    ensureVisible();
-    const win = constructed[0];
-    if (!win) throw new Error("expected a window");
-
-    setOnboarding(true);
-    setOnboarding(false);
-    win.stub.setContentSize.mockClear();
-
-    win.stub.emit("leave-full-screen");
-    expect(win.stub.setContentSize).not.toHaveBeenCalled();
-  });
-
-  test("setOnboarding(false) re-enters fullscreen when the restored state calls for it", () => {
-    onboardingActive = true;
-    ensureVisible();
-    const win = constructed[0];
-    if (!win) throw new Error("expected a window");
-    restoredBounds = { width: 1280, height: 800, fullscreen: true };
-
-    setOnboarding(false);
-
-    // Windowed geometry is applied first — it's the rectangle the user
-    // lands on when exiting fullscreen.
-    expect(win.stub.setBounds).toHaveBeenCalledWith({ width: 1280, height: 800 });
-    expect(win.stub.setFullScreen).toHaveBeenCalledWith(true);
-  });
-
-  test("setOnboarding(false) stays windowed when the restored state is windowed", () => {
-    onboardingActive = true;
-    ensureVisible();
-    const win = constructed[0];
-    if (!win) throw new Error("expected a window");
-
     setOnboarding(false);
 
     expect(win.stub.setFullScreen).not.toHaveBeenCalled();
+    expect(win.stub.setContentSize).not.toHaveBeenCalled();
+    expect(win.stub.setBounds).not.toHaveBeenCalled();
   });
 });
 

--- a/clients/macos/src/main/main-window.ts
+++ b/clients/macos/src/main/main-window.ts
@@ -15,27 +15,16 @@ import {
   writeOnboardingActive,
 } from "./window-state";
 
-// Default *and* minimum content-area size of the onboarding flow. Width
-// mirrors the macOS Swift client's onboarding window
-// (`OnboardingWindow.swift`: `contentRect` == `contentMinSize` == 440×630);
-// height runs 30px taller by design choice so the step content breathes.
-// Applied as the *content* size (`useContentSize`) so the usable area matches
-// the Swift app's `.fullSizeContentView` content rect rather than including
-// the Electron title bar. The window stays resizable larger, but the same
-// dimensions are also the minimum so the chrome-less flow can't be dragged
-// below its content.
-const ONBOARDING_CONTENT_SIZE = { width: 440, height: 660 } as const;
-
 // Default state for the main window once onboarding is done: maximized — a
 // normal window filling the display's work area, deliberately NOT native
 // macOS fullscreen. Applies only until a real session is persisted; after
 // that, `window-state` restores whatever bounds/mode the user left.
 const MAIN_DEFAULT_STATE = "maximized";
 
-// Minimum size for the main-app window, mirroring the macOS Swift client's
-// main window (`MainWindow.swift`: `contentMinSize` 800×600). The window can't
-// be dragged below this — unlike the compact onboarding floor, this is the
-// roomy desktop floor the chat layout (sidebar rail + content) needs.
+// Minimum size for the window in every mode (onboarding included), mirroring
+// the macOS Swift client's main window (`MainWindow.swift`: `contentMinSize`
+// 800×600). The window can't be dragged below this — the roomy desktop floor
+// the chat layout (sidebar rail + content) needs.
 const MAIN_MIN_SIZE = { width: 800, height: 600 } as const;
 
 // Fallback main-window title before the renderer publishes the assistant's
@@ -73,22 +62,6 @@ const applyTrafficLightPosition = (
   win.setWindowButtonPosition(
     compact ? null : { ...MAIN_TRAFFIC_LIGHT_POSITION },
   );
-};
-
-// Shrink the window to the compact onboarding layout. Lower the floor before
-// shrinking: `setContentSize` clamps to the current minimum, so the 800×600
-// main floor must drop to 440×660 first or the window wouldn't actually
-// shrink.
-const applyOnboardingContentSize = (win: BrowserWindow): void => {
-  win.setMinimumSize(
-    ONBOARDING_CONTENT_SIZE.width,
-    ONBOARDING_CONTENT_SIZE.height,
-  );
-  win.setContentSize(
-    ONBOARDING_CONTENT_SIZE.width,
-    ONBOARDING_CONTENT_SIZE.height,
-  );
-  win.center();
 };
 
 /**
@@ -204,32 +177,19 @@ const createMainWindow = (): BrowserWindow => {
   // Vite's `base`; see `getRendererRootUrl`.
   const loadTarget = getRendererRootUrl(app.isPackaged);
 
-  // Onboarding opens at the 440×660 default; otherwise restore the user's
+  // Onboarding and the main app share the same sizing: restore the user's
   // saved main-app state — which defaults to maximized (work-area bounds)
   // when nothing has been persisted yet. A saved fullscreen session's
   // `fullscreen` flag rides the spread into the `BrowserWindow` constructor.
-  // Both layouts are resizable larger, but each carries its own minimum
-  // (`minWidth`/`minHeight`): the compact onboarding flow can't be dragged
-  // below its 440×660 content, and the main app can't be dragged below
-  // 800×600 (mirroring the Swift client's `contentMinSize`).
-  // The persisted flag lets a relaunch *during* onboarding rebuild the small
-  // window directly (no flash); the absent-flag default is `false` (open large) so we
-  // never cramp the `/account/*` screens that render outside RootLayout —
-  // a brand-new user entering onboarding briefly sees large then the
-  // renderer's `setOnboarding` reconcile shrinks it.
+  // The window can't be dragged below the 800×600 floor (mirroring the Swift
+  // client's `contentMinSize`). The persisted onboarding flag now only drives
+  // the traffic-light position (compact surfaces have no inline title bar).
   const onboardingActive = readOnboardingActive();
-  const sizing = onboardingActive
-    ? {
-        ...ONBOARDING_CONTENT_SIZE,
-        minWidth: ONBOARDING_CONTENT_SIZE.width,
-        minHeight: ONBOARDING_CONTENT_SIZE.height,
-        useContentSize: true,
-      }
-    : {
-        ...restoreBounds("main", MAIN_DEFAULT_STATE),
-        minWidth: MAIN_MIN_SIZE.width,
-        minHeight: MAIN_MIN_SIZE.height,
-      };
+  const sizing = {
+    ...restoreBounds("main", MAIN_DEFAULT_STATE),
+    minWidth: MAIN_MIN_SIZE.width,
+    minHeight: MAIN_MIN_SIZE.height,
+  };
 
   const win = createWindow({
     // `titleBarStyle: "hidden"` removes the native title bar chrome and its
@@ -256,12 +216,10 @@ const createMainWindow = (): BrowserWindow => {
   // sync as the user crosses between compact and main surfaces.
   applyTrafficLightPosition(win, onboardingActive);
 
-  // Persist bounds only when NOT in onboarding mode. Both layouts are
-  // resizable, so resize events fire in either mode — but the small
-  // onboarding default must not be saved as the user's "main" size, or
-  // their next post-onboarding launch would come up tiny. The mode flag
-  // (not resizability, which no longer distinguishes them) is the gate.
-  trackWindowState("main", win, () => !readOnboardingActive());
+  // Both modes share the main-app sizing now, so bounds are persisted
+  // unconditionally — a resize during onboarding is a legitimate "main"
+  // size and should survive the transition and the next launch.
+  trackWindowState("main", win);
 
   // Readiness resolves only after BOTH the renderer has loaded AND
   // the window has shown + focused. Per-window state keyed via
@@ -393,26 +351,13 @@ export const dispatchToMain = (command: VellumCommand): void => {
 };
 
 /**
- * Switch the main window between the onboarding layout (440×660 default and
- * minimum) and the main-app layout (restored bounds, 800×600 minimum). Both
- * resize larger freely; the difference is the default/restored size and which
- * floor applies. Persists the mode so the next launch's window is constructed
- * at the right size, then resizes the current window (and swaps the minimum)
- * if the mode actually changed.
- *
- * The mode of record is the persisted flag (read before the write), not
- * resizability — both layouts are resizable now, so `isResizable()` can no
- * longer distinguish them. Writing the flag *before* the resize means
- * `window-state`'s persistence gate (`!readOnboardingActive()`) already
- * reflects the new mode when the programmatic resize fires its event:
- * the entry shrink is skipped, the exit restore is captured under "main".
+ * Switch the main window between the onboarding and main-app layouts. Both
+ * share the same sizing (restored bounds, 800×600 minimum) — the only
+ * per-mode difference left is the traffic-light position, since the inline
+ * title bar exists only on the main-app surface. The mode is persisted so
+ * the next launch positions the traffic lights without a flicker.
  * Re-asserting the current mode (the renderer fires this on every
  * navigation) is a cheap no-op past the early return.
- *
- * Native fullscreen is handled on both transitions: entering onboarding
- * leaves fullscreen first (a restored fullscreen session, or a green-button
- * press at the pre-onboarding `/account/*` screens), and leaving onboarding
- * re-enters it when the saved session being restored was fullscreen.
  */
 export const setOnboarding = (active: boolean): void => {
   const wasActive = readOnboardingActive();
@@ -425,39 +370,6 @@ export const setOnboarding = (active: boolean): void => {
   // Re-centre (or reset) the traffic lights to match the layout we're moving
   // into — the inline title bar exists only on the main-app surface.
   applyTrafficLightPosition(win, active);
-
-  if (active) {
-    if (win.isFullScreen()) {
-      // macOS ignores geometry changes while in (or animating out of)
-      // fullscreen, so leave fullscreen first and defer the shrink until
-      // the transition lands. The mode re-check guards the rare flip back
-      // to main before `leave-full-screen` fires.
-      win.once("leave-full-screen", () => {
-        if (win.isDestroyed() || !readOnboardingActive()) return;
-        applyOnboardingContentSize(win);
-      });
-      win.setFullScreen(false);
-    } else {
-      applyOnboardingContentSize(win);
-    }
-  } else {
-    // Swap the onboarding floor for the roomier 800×600 main-app floor.
-    win.setMinimumSize(MAIN_MIN_SIZE.width, MAIN_MIN_SIZE.height);
-    const bounds = restoreBounds("main", MAIN_DEFAULT_STATE);
-    win.setBounds({ width: bounds.width, height: bounds.height });
-    if (bounds.x !== undefined && bounds.y !== undefined) {
-      win.setPosition(bounds.x, bounds.y);
-    } else {
-      win.center();
-    }
-    if (bounds.fullscreen) {
-      // Enter fullscreen only after the windowed geometry above is applied —
-      // it becomes the rectangle the user lands on when exiting fullscreen.
-      // Entering (never forcing an exit) keeps a mid-onboarding green-button
-      // press intact when the saved state happens to be windowed.
-      win.setFullScreen(true);
-    }
-  }
 };
 
 /**
@@ -478,9 +390,9 @@ export const installMainWindow = (): void => {
     await ensureVisible();
   });
 
-  // Renderer-driven onboarding-window sizing. The renderer is the only
-  // side that knows whether the current route is an onboarding step, so it
-  // toggles the 440×630 onboarding default on/off as the user navigates.
+  // Renderer-driven onboarding mode. The renderer is the only side that
+  // knows whether the current route is an onboarding step, so it toggles
+  // the mode (traffic-light position) on/off as the user navigates.
   handle(
     "vellum:mainWindow:setOnboarding",
     z.tuple([z.boolean()]),

--- a/clients/web/src/domains/onboarding/research-onboarding-persistence.test.ts
+++ b/clients/web/src/domains/onboarding/research-onboarding-persistence.test.ts
@@ -84,6 +84,43 @@ describe("read/write/clear round-trip", () => {
   });
 });
 
+describe("Electron host", () => {
+  // The desktop app must start onboarding fresh on every launch: reads and
+  // writes are no-ops, but clear stays live so completion/retire can still
+  // remove a snapshot written by an older build (or the web host).
+  const vellumBridge = { platform: "electron" } as unknown as Window["vellum"];
+
+  beforeEach(() => {
+    window.vellum = vellumBridge;
+  });
+
+  afterEach(() => {
+    delete window.vellum;
+  });
+
+  test("never writes a snapshot", () => {
+    writeResearchSnapshot(USER, baseSnapshot());
+    expect(localStorage.getItem(`research_onboarding:${USER}`)).toBeNull();
+  });
+
+  test("never reads a snapshot, even one written by an older build", () => {
+    localStorage.setItem(
+      `research_onboarding:${USER}`,
+      JSON.stringify(baseSnapshot()),
+    );
+    expect(readResearchSnapshot(USER)).toBeNull();
+  });
+
+  test("clear still removes a stale snapshot", () => {
+    localStorage.setItem(
+      `research_onboarding:${USER}`,
+      JSON.stringify(baseSnapshot()),
+    );
+    clearResearchSnapshot(USER);
+    expect(localStorage.getItem(`research_onboarding:${USER}`)).toBeNull();
+  });
+});
+
 describe("resolveResumeStep", () => {
   test("jumps straight to suggestions once research finished", () => {
     const snapshot = baseSnapshot({

--- a/clients/web/src/domains/onboarding/research-onboarding-persistence.ts
+++ b/clients/web/src/domains/onboarding/research-onboarding-persistence.ts
@@ -24,7 +24,17 @@
  * Best-effort: `localStorage` can throw under privacy modes / quota, so every
  * access is guarded and a failure just degrades to the old restart-at-form
  * behavior.
+ *
+ * Web-only: inside the Electron host, read/write are no-ops so every app
+ * launch starts onboarding fresh. The refresh-resilience exists for the
+ * browser, where a stray reload mid-flow is easy; the desktop app has no
+ * reload affordance, and resuming a half-finished journey from a previous
+ * launch caused confusing states. `clearResearchSnapshot` stays live on both
+ * platforms so completion/retire still removes any snapshot an older build
+ * may have written.
  */
+
+import { isElectron } from "@/runtime/is-electron";
 
 import type { ResearchStatus } from "@/domains/onboarding/research-runner";
 import type { ResearchOnboardingValues } from "@/domains/onboarding/screens/research-onboarding-screen";
@@ -95,6 +105,8 @@ function storageKey(userId: string | null): string | null {
 export function readResearchSnapshot(
   userId: string | null,
 ): ResearchOnboardingSnapshot | null {
+  // Desktop app: never resume — each launch starts onboarding fresh.
+  if (isElectron()) return null;
   const key = storageKey(userId);
   if (!key) return null;
   try {
@@ -111,6 +123,8 @@ export function writeResearchSnapshot(
   userId: string | null,
   snapshot: ResearchOnboardingSnapshot,
 ): void {
+  // Desktop app: don't persist steps — nothing should survive a relaunch.
+  if (isElectron()) return;
   const key = storageKey(userId);
   if (!key) return;
   try {

--- a/clients/web/src/domains/onboarding/use-background-hatch.test.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.test.ts
@@ -47,8 +47,16 @@ mock.module("@/lib/sentry/capture-error", () => ({
   captureError: () => {},
 }));
 const probeLocalGatewayReadyMock = mock(async (): Promise<boolean> => true);
+// The lockfile registry the adopt fast-path resolves against. Tests seed it
+// with the entries their scenario expects; ids not present fall through to
+// list-based discovery.
+let lockfileEntries: Record<string, { assistantId: string }> = {};
+const getLockfileAssistantMock = mock(
+  (id: string): { assistantId: string } | undefined => lockfileEntries[id],
+);
 mock.module("@/lib/local-mode", () => ({
   probeLocalGatewayReady: probeLocalGatewayReadyMock,
+  getLockfileAssistant: getLockfileAssistantMock,
 }));
 mock.module("@/utils/api-errors", () => ({
   extractErrorMessage: (e: unknown, _r: unknown, fallback?: string) =>
@@ -69,10 +77,12 @@ beforeEach(() => {
     data: { id: "ast-research", status: "active", is_local: false } as never,
   };
   healthzResult = { ok: true, status: 200, data: {} as never };
+  lockfileEntries = {};
   hatchAssistantMock.mockClear();
   getAssistantMock.mockClear();
   getAssistantHealthzMock.mockClear();
   probeLocalGatewayReadyMock.mockClear();
+  getLockfileAssistantMock.mockClear();
 });
 
 describe("useBackgroundHatch", () => {
@@ -131,11 +141,14 @@ describe("useBackgroundHatch", () => {
     expect(getAssistantMock).not.toHaveBeenCalled();
   });
 
-  test("adoptExisting skips the managed hatch and adopts the live assistant", async () => {
-    // A local-hosting onboarding provisions the assistant in the hatching screen
-    // before the research flow mounts, so the background hatch must skip the
-    // managed `hatchAssistant()` and discover the already-active assistant via
-    // getAssistant().
+  test("adopting a lockfile-known id settles ready immediately, with no discovery", async () => {
+    // The hatching screen provisioned this assistant in the foreground and
+    // verified gateway readiness before handing off, so a live lockfile entry
+    // for the handed-off id is adopted as ready outright — no managed hatch,
+    // no getAssistant poll (which could wedge on the platform when the gateway
+    // token isn't observable yet), no readyz probe, no "Waking up" gate.
+    lockfileEntries["ast-research"] = { assistantId: "ast-research" };
+
     const { result } = renderHook(() =>
       useBackgroundHatch({
         adoptExisting: true,
@@ -148,15 +161,28 @@ describe("useBackgroundHatch", () => {
     });
 
     await waitFor(() => expect(result.current.ready).toBe(true));
-    // No managed hatch when adopting…
+    expect(result.current.assistantId).toBe("ast-research");
     expect(hatchAssistantMock).not.toHaveBeenCalled();
-    // …the existing assistant is discovered via getAssistant, pinned to the
-    // id the hatching screen handed off…
-    expect(getAssistantMock).toHaveBeenCalledWith("ast-research");
-    // …readiness is verified against the LOCAL gateway's /readyz (the
-    // assistant-scoped healthz SDK call doesn't resolve against a local
-    // gateway) — this also covers session-based adopts that never passed
-    // through the hatching screen's own readyz poll…
+    expect(getAssistantMock).not.toHaveBeenCalled();
+    expect(probeLocalGatewayReadyMock).not.toHaveBeenCalled();
+    expect(getAssistantHealthzMock).not.toHaveBeenCalled();
+  });
+
+  test("session-fallback adopt (no handed-off id) still discovers and probes readyz", async () => {
+    // A refresh / direct visit adopts on session evidence alone — a cached
+    // gateway token proves nothing about the gateway process still being
+    // alive, so discovery and the local readyz probe must still run.
+    const { result } = renderHook(() =>
+      useBackgroundHatch({ adoptExisting: true }),
+    );
+
+    act(() => {
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(hatchAssistantMock).not.toHaveBeenCalled();
+    expect(getAssistantMock).toHaveBeenCalledWith(undefined);
     expect(probeLocalGatewayReadyMock).toHaveBeenCalled();
     expect(getAssistantHealthzMock).not.toHaveBeenCalled();
     expect(result.current.assistantId).toBe("ast-research");

--- a/clients/web/src/domains/onboarding/use-background-hatch.ts
+++ b/clients/web/src/domains/onboarding/use-background-hatch.ts
@@ -11,7 +11,7 @@ import {
   resolveAssistantLifecycleState,
   shouldRecoverFromHatchFailure,
 } from "@/assistant/lifecycle";
-import { probeLocalGatewayReady } from "@/lib/local-mode";
+import { getLockfileAssistant, probeLocalGatewayReady } from "@/lib/local-mode";
 import { captureError } from "@/lib/sentry/capture-error";
 import { extractErrorMessage } from "@/utils/api-errors";
 
@@ -129,6 +129,28 @@ export function useBackgroundHatch(
     const timedOut = () => Date.now() - startMs >= MAX_HATCH_WAIT_MS;
 
     void (async () => {
+      // 0. Adopt straight from the lockfile when the handed-off id resolves.
+      //
+      // The hatching screen provisioned this assistant in the FOREGROUND and
+      // polled the local gateway's readyz before navigating here, so a live
+      // lockfile entry for the handed-off id means there is nothing left to
+      // discover or wait for — adopt it as ready outright. Re-running
+      // discovery (platform getAssistant + gateway probe) is not just wasted
+      // work: at mount the gateway token / selection may not be observable
+      // yet, in which case getAssistant misses its lockfile short-circuit and
+      // polls the PLATFORM for an assistant that only exists locally,
+      // stranding the flow on the "Waking up" gate until timeout. A stale id
+      // (retired between the handoff and here) has no lockfile entry and
+      // falls through to the discovery + readyz path below.
+      if (adoptExisting && adoptAssistantId) {
+        const adopted = getLockfileAssistant(adoptAssistantId);
+        if (adopted) {
+          setAssistantId(adopted.assistantId);
+          settleReady(adopted.assistantId);
+          return;
+        }
+      }
+
       // 1. Hatch (managed/platform). 201 = newly created, 200 = existing.
       //
       // A local-hosting onboarding skips this: the assistant is provisioned in


### PR DESCRIPTION
## Summary

Three fixes for desktop (local) onboarding:

### 1. Onboarding opens at the main-app window size
The Electron window used to open onboarding in a compact 440×660 layout, then grow after onboarding. It now uses the main-app sizing from the start — restored bounds (maximized work-area default on a fresh install) with the 800×600 floor. `setOnboarding` no longer resizes or juggles fullscreen; the only per-mode difference left is the traffic-light position (onboarding surfaces have no inline title bar). Window bounds are persisted in both modes since they now share a layout.

### 2. Onboarding steps no longer resume across app launches on Electron (web unchanged)
The research-onboarding flow snapshots its journey to `localStorage` so a browser refresh can resume mid-flow. On the desktop app there's no reload affordance, and resuming a half-finished journey from a previous launch caused confusing states. Reads/writes are now gated to web only; `clearResearchSnapshot` stays live on both platforms so completion/retire still removes any snapshot an older build (or the web host) wrote.

### 3. Local onboarding no longer hangs on "Waking up"
On local setups the hatching screen provisions the assistant in the foreground, verifies the gateway's `/readyz`, and hands off with `?hosting=local&assistant=<id>` — yet `useBackgroundHatch` re-ran full discovery before flipping `ready`, and the "Let's chat tomorrow" step gates on that. If the gateway token/selection wasn't observable yet at mount, `getAssistant` missed its lockfile short-circuit and polled the **platform** for an assistant that only exists locally — stranding the flow on the "Waking up" gate until the 5-minute timeout. The adopt path now resolves the handed-off id against the lockfile synchronously and settles ready immediately. A stale id (no lockfile entry) still falls back to discovery, and session-fallback adopts (refresh / direct visit) still run discovery + the readyz probe.

## Testing

- `clients/macos`: `main-window.test.ts` (43) rewritten for the unified sizing; all dependent main-process suites (window-state, dock, tray, menu, deep-links, command-palette, file-open, native-auth, notifications) pass.
- `clients/web`: `research-onboarding-persistence.test.ts` (14, incl. 3 new Electron-gate tests), `use-background-hatch.test.ts` (7, incl. rewritten explicit-handoff + new session-fallback case), `adopt-existing-assistant.test.ts` (5), `retire-service.test.ts` (9) — all pass.
- Type checks clean in both packages; lint 0 errors.
- QA'd live against the local dev stack (vel up): fresh Electron launch opens onboarding maximized, restarts don't resume steps, and the local flow reaches the calendar step without the "Waking up" gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)