### PR TITLE
fix(context): keep image blocks away from catalog text-only models

### DIFF
--- a/assistant/src/__tests__/compactor-image-retention-vision-gate.test.ts
+++ b/assistant/src/__tests__/compactor-image-retention-vision-gate.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of [
+    "info",
+    "warn",
+    "error",
+    "debug",
+    "trace",
+    "fatal",
+    "silent",
+    "child",
+  ]) {
+    stub[m] = m === "child" ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeLoggerStub(),
+}));
+
+// The gate resolves the compaction call site to an effective model and checks
+// the catalog's vision flag. Pin the resolved model per test; the resolver's
+// own precedence rules are covered by its own tests.
+let resolvedModel = "claude-opus-4-8";
+mock.module("../config/llm-resolver.js", () => ({
+  resolveCallSiteConfig: () => ({ model: resolvedModel }),
+  resolveDefaultProfileKey: () => null,
+  resolveProfilelessModelKey: () => null,
+}));
+
+const ATTACHMENT_IMAGE_DATA = Buffer.from("retained-image-bytes");
+
+mock.module("../persistence/conversation-crud.js", () => ({
+  setConversationProcessingStartedAt: () => {},
+  isConversationProcessing: () => false,
+  getMessages: () => [
+    { id: "row-1", role: "user", createdAt: 1_750_000_000_000 },
+  ],
+  reserveMessage: mock(async () => ({ id: "msg-reserve" })),
+}));
+
+mock.module("../persistence/attachments-store.js", () => ({
+  getAttachmentMetadataForMessage: (messageId: string) =>
+    messageId === "row-1"
+      ? [{ id: "att-1", kind: "image", originalFilename: "mockup.png" }]
+      : [],
+  getAttachmentContent: (attachmentId: string) =>
+    attachmentId === "att-1" ? ATTACHMENT_IMAGE_DATA : null,
+}));
+
+// Pass the image through untouched so the assertion can match on its bytes.
+mock.module("../agent/image-optimize.js", () => ({
+  optimizeImageForTransport: (data: string, mediaType: string) => ({
+    data,
+    mediaType,
+  }),
+}));
+
+import { runAssistantDrivenCompaction } from "../context/compactor.js";
+import type { Message, Provider } from "../providers/types.js";
+
+const TAIL_TIMESTAMP =
+  "2026-05-21 (Thursday) 10:00:00 -05:00 (America/Chicago)";
+
+// The model answers with a retention request for the manifest image.
+const compactionResponseRetainingImage = `
+<compaction_result>
+<summary>
+Earlier turns summarized here.
+</summary>
+
+<key_state>
+- Nothing critical pending.
+</key_state>
+
+<retained_images>
+<image file="mockup.png" />
+</retained_images>
+
+<tail_start timestamp="${TAIL_TIMESTAMP}" preview="tail anchor message" />
+</compaction_result>
+`;
+
+const messages = (): Message[] => [
+  {
+    role: "user",
+    content: [{ type: "text", text: "here is a mockup to work from" }],
+  },
+  {
+    role: "assistant",
+    content: [{ type: "text", text: "working on it" }],
+  },
+  {
+    role: "user",
+    content: [
+      {
+        type: "text",
+        text: `<turn_context>\ncurrent_time: ${TAIL_TIMESTAMP}\n</turn_context>\ntail anchor message`,
+      },
+    ],
+  },
+];
+
+function recordingProvider(sink: { sent: Message[] }): Provider {
+  return {
+    name: "mock-provider",
+    sendMessage: async (msgs: Message[]) => {
+      sink.sent = msgs;
+      return {
+        content: [{ type: "text", text: compactionResponseRetainingImage }],
+        model: resolvedModel,
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: "end_turn",
+      };
+    },
+  };
+}
+
+async function runCompaction(sink: { sent: Message[] }) {
+  return runAssistantDrivenCompaction({
+    conversationId: "conv-vision-gate",
+    messages: messages(),
+    provider: recordingProvider(sink),
+    systemPrompt: "system",
+    compaction: { enabled: true, autoThreshold: 0.7 },
+    maxInputTokens: 100000,
+    previousEstimatedInputTokens: 90000,
+    // Guardian trust so the manifest walk sees the row without provenance
+    // filtering — this test exercises the vision gate, not trust filtering.
+    actorTrustClass: "guardian",
+  });
+}
+
+function findImageBlocks(rebuilt: Message[]): unknown[] {
+  return rebuilt.flatMap((m) => m.content.filter((b) => b.type === "image"));
+}
+
+beforeEach(() => {
+  resolvedModel = "claude-opus-4-8";
+});
+
+// Retained images are re-attached to the rebuilt history as raw image blocks.
+// A model the catalog marks text-only rejects the whole next request over a
+// single image block, and the compacted context persists — so retention must
+// be disabled for those models at both ends: the manifest offered to the
+// summarizer and the hydration of whatever it asks for anyway.
+describe("compaction image retention — model vision gate", () => {
+  test("vision-capable model: manifest is offered and retained images are hydrated", async () => {
+    const sink = { sent: [] as Message[] };
+    const result = await runCompaction(sink);
+
+    expect(result.compacted).toBe(true);
+    const instruction = JSON.stringify(sink.sent.at(-1));
+    expect(instruction).toContain("mockup.png");
+
+    const imageBlocks = findImageBlocks(result.messages);
+    expect(imageBlocks).toHaveLength(1);
+    expect(JSON.stringify(result.messages)).toContain(
+      ATTACHMENT_IMAGE_DATA.toString("base64"),
+    );
+  });
+
+  test("catalog text-only model: no manifest is offered and retention requests are dropped", async () => {
+    resolvedModel = "accounts/fireworks/models/glm-5p2";
+    const sink = { sent: [] as Message[] };
+    const result = await runCompaction(sink);
+
+    expect(result.compacted).toBe(true);
+
+    // The instruction tells the model retention is unavailable instead of
+    // listing images.
+    const instruction = JSON.stringify(sink.sent.at(-1));
+    expect(instruction).not.toContain("mockup.png");
+    expect(instruction).toContain("image retention unavailable");
+
+    // Even though the model asked for the image anyway, nothing is hydrated.
+    expect(findImageBlocks(result.messages)).toHaveLength(0);
+    expect(JSON.stringify(result.messages)).not.toContain(
+      ATTACHMENT_IMAGE_DATA.toString("base64"),
+    );
+  });
+
+  test("model unknown to the catalog: retention stays enabled (fail open)", async () => {
+    resolvedModel = "some-uncataloged-model";
+    const sink = { sent: [] as Message[] };
+    const result = await runCompaction(sink);
+
+    expect(result.compacted).toBe(true);
+    expect(JSON.stringify(sink.sent.at(-1))).toContain("mockup.png");
+    expect(findImageBlocks(result.messages)).toHaveLength(1);
+  });
+});

--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -124,7 +124,7 @@ function compactionModelSupportsImages(
       getConfig().llm,
       overrideProfile ? { overrideProfile } : {},
     );
-    return getCatalogModelVision(resolved.model) !== false;
+    return getCatalogModelVision(resolved.model, resolved.provider) !== false;
   } catch {
     return true;
   }

--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -19,6 +19,8 @@
  * `compacted: false` — never silently lose messages.
  */
 import { optimizeImageForTransport } from "../agent/image-optimize.js";
+import { resolveCallSiteConfig } from "../config/llm-resolver.js";
+import { getConfig } from "../config/loader.js";
 import type { CompactionConfig } from "../config/schemas/compaction.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { filterMessagesForUntrustedActor } from "../daemon/message-provenance.js";
@@ -28,6 +30,7 @@ import {
 } from "../persistence/attachments-store.js";
 import { getMessages } from "../persistence/conversation-crud.js";
 import { recordRequestLog } from "../persistence/llm-request-log-store.js";
+import { getCatalogModelVision } from "../providers/model-catalog.js";
 import type {
   ContentBlock,
   ImageContent,
@@ -98,6 +101,32 @@ function recordCompactionRequestLog(
       { err, conversationId },
       "Failed to persist compaction LLM request log (non-fatal)",
     );
+  }
+}
+
+/**
+ * Whether the model the compacted context is rebuilt for accepts image input.
+ *
+ * Resolves `mainAgent` + the conversation's override profile — the same
+ * inputs the compaction `sendMessage` (and the agent's next turn) resolve —
+ * and checks the catalog's vision flag for the resolved model. Only an
+ * explicit catalog `supportsVision: false` disables retention; unknown models
+ * fail open so uncataloged setups keep today's behavior. Resolution errors
+ * also fail open — a config problem surfaces on the provider call itself, not
+ * here.
+ */
+function compactionModelSupportsImages(
+  overrideProfile: string | null | undefined,
+): boolean {
+  try {
+    const resolved = resolveCallSiteConfig(
+      COMPACTION_CALL_SITE,
+      getConfig().llm,
+      overrideProfile ? { overrideProfile } : {},
+    );
+    return getCatalogModelVision(resolved.model) !== false;
+  } catch {
+    return true;
   }
 }
 
@@ -933,15 +962,26 @@ export async function runAssistantDrivenCompaction(
     return emptyResult(args, thresholdTokens, "no messages to compact");
   }
 
+  // Image retention only makes sense when the model consuming the compacted
+  // context accepts image input. Retained images are re-attached as raw image
+  // blocks in the rebuilt history, so a text-only model (e.g. a catalog entry
+  // with `supportsVision: false`) would have its next request rejected
+  // wholesale by the provider — and since the compacted context is persisted,
+  // every subsequent turn on that profile fails the same way. Gate on the same
+  // call-site resolution the summary call below uses.
+  const retainImages = compactionModelSupportsImages(args.overrideProfile);
+
   // Build image manifest from the DB before invoking the model so the
   // instruction message carries a faithful picture of available images.
   // Filtered by actor trust so untrusted turns never see guardian-only
-  // attachments.
-  const manifest = collectImageManifest(
-    args.conversationId,
-    args.actorTrustClass,
-  );
-  const manifestText = renderImageManifest(manifest);
+  // attachments. An empty manifest tells the model there is nothing to
+  // retain, so a text-only pass never invites retention it cannot honor.
+  const manifest = retainImages
+    ? collectImageManifest(args.conversationId, args.actorTrustClass)
+    : [];
+  const manifestText = retainImages
+    ? renderImageManifest(manifest)
+    : "(image retention unavailable: the active model does not accept image input)";
   const instruction = buildInstructionMessage(
     args.compaction.prompt ?? null,
     manifestText,
@@ -1079,11 +1119,23 @@ export async function runAssistantDrivenCompaction(
     content: [{ type: "text", text: finalSummaryText }],
   };
 
+  if (!retainImages && parsed.retainedImageFilenames.length > 0) {
+    // Belt to the empty-manifest suspenders: the model may still emit a
+    // `<retained_images>` block (e.g. hallucinated filenames). Never hydrate
+    // for a text-only model.
+    log.warn(
+      { filenames: parsed.retainedImageFilenames },
+      "Compaction requested image retention but the active model does not accept image input — dropping",
+    );
+  }
   const {
     blocks: retainedImageBlocks,
     resolved,
     missing,
-  } = buildRetainedImageBlocks(parsed.retainedImageFilenames, manifest);
+  } = buildRetainedImageBlocks(
+    retainImages ? parsed.retainedImageFilenames : [],
+    manifest,
+  );
   if (missing.length > 0) {
     log.warn(
       { missing },

--- a/assistant/src/plugin-api/vision-support.ts
+++ b/assistant/src/plugin-api/vision-support.ts
@@ -19,6 +19,7 @@
 import { getEffectiveProfile } from "../config/default-profile-catalog.js";
 import { getConfig } from "../config/loader.js";
 import {
+  getCatalogModelVision,
   getCatalogProviderForModel,
   PROVIDER_CATALOG,
 } from "../providers/model-catalog.js";
@@ -37,23 +38,12 @@ export function doesSupportVision(
   if (typeof modelOrProfile === "string") {
     // Concrete model id first, then fall back to treating it as a profile key.
     return (
-      modelVision(modelOrProfile) ?? profileVision(modelOrProfile) ?? false
+      getCatalogModelVision(modelOrProfile) ??
+      profileVision(modelOrProfile) ??
+      false
     );
   }
   return profileVision(modelOrProfile.key) ?? false;
-}
-
-/**
- * Catalog vision flag for a concrete model id, or `undefined` when the catalog
- * doesn't know the model. The same model id carries the same capability under
- * every provider that offers it, so the first catalog match wins.
- */
-function modelVision(model: string): boolean | undefined {
-  for (const provider of PROVIDER_CATALOG) {
-    const catalogModel = provider.models.find((m) => m.id === model);
-    if (catalogModel != null) return catalogModel.supportsVision ?? false;
-  }
-  return undefined;
 }
 
 /**

--- a/assistant/src/plugins/defaults/image-fallback/hooks/post-tool-use.ts
+++ b/assistant/src/plugins/defaults/image-fallback/hooks/post-tool-use.ts
@@ -11,8 +11,9 @@
  *
  * Capability is read straight off `ctx.model` — the provider-reported model id
  * for the turn that issued this tool call — so the decision tracks the model
- * that actually ran, including a text-only override. The substitution is in
- * place, so the persisted/displayed tool result carries the caption too.
+ * that actually ran, including a text-only override. The hook receives a deep
+ * clone of the tool result, so the caption reaches the provider-bound history
+ * only — the persisted/displayed tool result keeps the original image.
  */
 
 import {

--- a/assistant/src/plugins/defaults/image-fallback/src/caption-blocks.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/caption-blocks.ts
@@ -10,10 +10,13 @@
  * known location, caption it via a vision-capable profile, and swap in a
  * `[Image …]` text block.
  *
- * The substitution mutates the blocks in place, so the caption replaces the
- * image everywhere the block is referenced (the provider-bound history and the
- * persisted/displayed copy alike) — a text-only turn does not keep the raw
- * image around.
+ * The substitution mutates the blocks in place, but the hook pipeline hands
+ * each hook a deep clone of its context, so the caption reaches only the
+ * provider-bound history — the persisted/displayed tool result keeps the
+ * original image. Raw images therefore survive in durable history (clients
+ * can still render them) and can re-enter a request through paths that
+ * rebuild context from persistence (e.g. compaction); the chat-completions
+ * provider's own text-only image gate covers those.
  *
  * The caption text states up front that the model can't view images and the
  * image was auto-described to text, so the model treats the block as a derived

--- a/assistant/src/providers/__tests__/model-catalog-capability-consistency.test.ts
+++ b/assistant/src/providers/__tests__/model-catalog-capability-consistency.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+
+import { getCatalogModelVision, PROVIDER_CATALOG } from "../model-catalog.js";
+
+// Some capability lookups only hold a bare model id (e.g. a
+// provider-reported response model) and scan every provider for the first id
+// match: `getCatalogModelVision`'s fallback and
+// `isAdaptiveThinkingOnlyModel`. Those lookups are only sound while a model
+// id never appears under two providers with different values for the flags
+// they read. Capabilities that genuinely vary by serving provider (caching,
+// thinking, effort ceilings, context windows) are intentionally NOT
+// constrained here — when one of the flags below starts varying by provider,
+// every provider-agnostic consumer must switch to a (provider, model) lookup
+// before the catalog change lands.
+describe("model catalog capability consistency", () => {
+  test("a model id never carries conflicting provider-agnostic capability flags across providers", () => {
+    const seen = new Map<
+      string,
+      { provider: string; vision: boolean; adaptiveThinkingOnly: boolean }
+    >();
+    for (const provider of PROVIDER_CATALOG) {
+      for (const model of provider.models) {
+        const flags = {
+          provider: provider.id,
+          vision: model.supportsVision ?? false,
+          adaptiveThinkingOnly: model.adaptiveThinkingOnly ?? false,
+        };
+        const prior = seen.get(model.id);
+        if (prior != null) {
+          expect(
+            { id: model.id, ...flags },
+            `model id "${model.id}" is listed under both "${prior.provider}" and "${flags.provider}" with different provider-agnostic capability flags`,
+          ).toMatchObject({ id: model.id, ...prior, provider: flags.provider });
+        }
+        seen.set(model.id, flags);
+      }
+    }
+  });
+
+  test("getCatalogModelVision prefers the (provider, model) pair and falls back to a cross-provider scan", () => {
+    // Known (provider, model) pair.
+    expect(
+      getCatalogModelVision("accounts/fireworks/models/glm-5p2", "fireworks"),
+    ).toBe(false);
+    // Provider not in the catalog (e.g. a wrapper name) — id still resolves.
+    expect(
+      getCatalogModelVision(
+        "accounts/fireworks/models/glm-5p2",
+        "some-proxy-wrapper",
+      ),
+    ).toBe(false);
+    // No provider — bare-id fallback.
+    expect(getCatalogModelVision("accounts/fireworks/models/glm-5p2")).toBe(
+      false,
+    );
+    // Unknown model id — undefined regardless of provider.
+    expect(getCatalogModelVision("no-such-model", "fireworks")).toBeUndefined();
+    expect(getCatalogModelVision("no-such-model")).toBeUndefined();
+  });
+});

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1464,14 +1464,31 @@ export function getCatalogProviderForModel(
 
 /**
  * Catalog vision capability for a concrete model id, or `undefined` when no
- * catalog entry knows the model. A model id carries the same capability under
- * every provider that offers it, so the first catalog match wins. A known
- * model without the flag reports `false` — catalog entries declare vision
- * explicitly.
+ * catalog entry knows the model. A known model without the flag reports
+ * `false` — catalog entries declare vision explicitly.
+ *
+ * When `provider` is given and that provider's catalog entry lists the model,
+ * the (provider, model) pair is authoritative. Otherwise the lookup falls
+ * back to scanning every provider — callers holding only a bare model id
+ * (e.g. a provider-reported response model) rely on this, and wrapper
+ * providers whose runtime name is not a catalog id degrade to it. The
+ * fallback is only sound while a model id never appears under two providers
+ * with different vision flags; `model-catalog-capability-consistency.test.ts`
+ * enforces that.
  */
-export function getCatalogModelVision(modelId: string): boolean | undefined {
-  for (const provider of PROVIDER_CATALOG) {
-    const model = provider.models.find((m) => m.id === modelId);
+export function getCatalogModelVision(
+  modelId: string,
+  provider?: string,
+): boolean | undefined {
+  if (provider != null) {
+    const entry = PROVIDER_CATALOG.find((p) => p.id === provider);
+    const model = entry?.models.find((m) => m.id === modelId);
+    if (model != null) {
+      return model.supportsVision ?? false;
+    }
+  }
+  for (const entry of PROVIDER_CATALOG) {
+    const model = entry.models.find((m) => m.id === modelId);
     if (model != null) {
       return model.supportsVision ?? false;
     }

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1463,6 +1463,23 @@ export function getCatalogProviderForModel(
 }
 
 /**
+ * Catalog vision capability for a concrete model id, or `undefined` when no
+ * catalog entry knows the model. A model id carries the same capability under
+ * every provider that offers it, so the first catalog match wins. A known
+ * model without the flag reports `false` — catalog entries declare vision
+ * explicitly.
+ */
+export function getCatalogModelVision(modelId: string): boolean | undefined {
+  for (const provider of PROVIDER_CATALOG) {
+    const model = provider.models.find((m) => m.id === modelId);
+    if (model != null) {
+      return model.supportsVision ?? false;
+    }
+  }
+  return undefined;
+}
+
+/**
  * Whether the given model only supports adaptive (always-on) thinking, driven
  * by the `adaptiveThinkingOnly` capability in the catalog. Matches the model ID
  * across every provider (a model carries the same id under each provider it is

--- a/assistant/src/providers/openai/__tests__/chat-completions-image-input-gate.test.ts
+++ b/assistant/src/providers/openai/__tests__/chat-completions-image-input-gate.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Message } from "../../types.js";
+import { OpenAIChatCompletionsProvider } from "../chat-completions-provider.js";
+
+type MockChunk = {
+  choices: Array<{ delta: { content?: string }; finish_reason?: string }>;
+  model?: string;
+  usage?: { prompt_tokens: number; completion_tokens: number };
+};
+
+function makeStream(chunks: MockChunk[]): AsyncIterable<MockChunk> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const c of chunks) {
+        yield c;
+      }
+    },
+  };
+}
+
+function stubProvider(model: string): {
+  provider: OpenAIChatCompletionsProvider;
+  requests: Array<{ messages: unknown[] }>;
+} {
+  const provider = new OpenAIChatCompletionsProvider("test-key", model);
+  const requests: Array<{ messages: unknown[] }> = [];
+  (provider as unknown as { client: unknown }).client = {
+    chat: {
+      completions: {
+        create: async (params: { messages: unknown[] }) => {
+          requests.push(params);
+          return makeStream([
+            {
+              choices: [{ delta: { content: "ok" }, finish_reason: "stop" }],
+              model,
+              usage: { prompt_tokens: 1, completion_tokens: 1 },
+            },
+          ]);
+        },
+      },
+    },
+  };
+  return { provider, requests };
+}
+
+const IMAGE_DATA = "aGVsbG8taW1hZ2UtYnl0ZXM=";
+
+const userMessageWithImage = (): Message[] => [
+  {
+    role: "user",
+    content: [
+      { type: "text", text: "what is in this screenshot?" },
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data: IMAGE_DATA,
+        },
+      },
+    ],
+  },
+];
+
+const toolResultWithImage = (): Message[] => [
+  {
+    role: "assistant",
+    content: [{ type: "tool_use", id: "tu_1", name: "screenshot", input: {} }],
+  },
+  {
+    role: "user",
+    content: [
+      {
+        type: "tool_result",
+        tool_use_id: "tu_1",
+        content: "captured",
+        contentBlocks: [
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: IMAGE_DATA,
+            },
+          },
+        ],
+      },
+    ],
+  },
+];
+
+// A model the catalog explicitly marks `supportsVision: false` rejects the
+// whole request over a single image block (HTTP 400) — image blocks can reach
+// it through persisted history (compaction-rebuilt context, profile switch),
+// so the provider serializes them as text placeholders instead. Models the
+// catalog doesn't know keep their images: the provider decides.
+describe("chat-completions image input gate", () => {
+  // Catalog: supportsVision: false.
+  const TEXT_ONLY_MODEL = "accounts/fireworks/models/glm-5p2";
+  // Catalog: supportsVision: true.
+  const VISION_MODEL = "accounts/fireworks/models/kimi-k2p6";
+
+  test("catalog text-only model: user-message image becomes a text placeholder", async () => {
+    const { provider, requests } = stubProvider(TEXT_ONLY_MODEL);
+    await provider.sendMessage(userMessageWithImage());
+
+    const wire = JSON.stringify(requests[0].messages);
+    expect(wire).not.toContain("image_url");
+    expect(wire).not.toContain(IMAGE_DATA);
+    expect(wire).toContain(
+      "[Image omitted: this model does not accept image input]",
+    );
+  });
+
+  test("catalog text-only model: tool-result image becomes a text placeholder", async () => {
+    const { provider, requests } = stubProvider(TEXT_ONLY_MODEL);
+    await provider.sendMessage(toolResultWithImage());
+
+    const wire = JSON.stringify(requests[0].messages);
+    expect(wire).not.toContain("image_url");
+    expect(wire).not.toContain(IMAGE_DATA);
+    expect(wire).toContain(
+      "[Image omitted: this model does not accept image input]",
+    );
+  });
+
+  test("catalog vision model: image is sent as image_url", async () => {
+    const { provider, requests } = stubProvider(VISION_MODEL);
+    await provider.sendMessage(userMessageWithImage());
+
+    const wire = JSON.stringify(requests[0].messages);
+    expect(wire).toContain("image_url");
+    expect(wire).toContain(IMAGE_DATA);
+  });
+
+  test("model unknown to the catalog: image is sent as image_url (fail open)", async () => {
+    const { provider, requests } = stubProvider("some-uncataloged-model");
+    await provider.sendMessage(userMessageWithImage());
+
+    const wire = JSON.stringify(requests[0].messages);
+    expect(wire).toContain("image_url");
+    expect(wire).toContain(IMAGE_DATA);
+  });
+
+  test("per-call model override drives the gate", async () => {
+    // Provider constructed with a vision model, but the call overrides to a
+    // text-only model — the override is what goes on the wire, so it decides.
+    const { provider, requests } = stubProvider(VISION_MODEL);
+    await provider.sendMessage(userMessageWithImage(), {
+      config: { model: TEXT_ONLY_MODEL },
+    } as never);
+
+    const wire = JSON.stringify(requests[0].messages);
+    expect(wire).not.toContain("image_url");
+    expect(wire).toContain(
+      "[Image omitted: this model does not accept image input]",
+    );
+  });
+});

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -5,6 +5,7 @@ import { isAbortReason } from "../../util/abort-reasons.js";
 import { ProviderError } from "../../util/errors.js";
 import { extractRetryAfterMs } from "../../util/retry.js";
 import { escapeXmlAttr } from "../../util/xml.js";
+import { getCatalogModelVision } from "../model-catalog.js";
 import { PLACEHOLDER_EMPTY_TURN } from "../placeholder-sentinels.js";
 import { createStreamTimeout } from "../stream-timeout.js";
 import { createToolProgressEmitter } from "../tool-progress-events.js";
@@ -315,7 +316,21 @@ export class OpenAIChatCompletionsProvider implements Provider {
     const coercedObjectKeys = new Map<string, string[]>();
 
     try {
-      const openaiMessages = this.toOpenAIMessages(messages, systemPrompt);
+      // Models the catalog explicitly marks text-only reject the whole
+      // request over a single image block (HTTP 400), so their image blocks
+      // are serialized as text placeholders instead. Image blocks can reach a
+      // text-only model through persisted history — e.g. a compaction-rebuilt
+      // context or a profile switch after images entered the conversation —
+      // where no upstream hook gets another chance to strip them. Models the
+      // catalog doesn't know keep their images (fail open — the provider
+      // decides, and `detectVisionNotSupported` below classifies a rejection).
+      const supportsImageInput =
+        getCatalogModelVision(modelOverride ?? this.model) !== false;
+      const openaiMessages = this.toOpenAIMessages(
+        messages,
+        systemPrompt,
+        supportsImageInput,
+      );
 
       const params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming =
         {
@@ -804,7 +819,8 @@ export class OpenAIChatCompletionsProvider implements Provider {
   /** Convert neutral messages + system prompt to OpenAI message format. */
   private toOpenAIMessages(
     messages: Message[],
-    systemPrompt?: string,
+    systemPrompt: string | undefined,
+    supportsImageInput: boolean,
   ): OpenAI.Chat.Completions.ChatCompletionMessageParam[] {
     const result: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
 
@@ -863,7 +879,9 @@ export class OpenAIChatCompletionsProvider implements Provider {
         // message because OpenAI-compatible APIs don't support images in tool messages.
         const userContent = [...otherBlocks, ...toolResultImages];
         if (userContent.length > 0) {
-          result.push(this.toOpenAIUserMessage(userContent));
+          result.push(
+            this.toOpenAIUserMessage(userContent, supportsImageInput),
+          );
         }
       }
     }
@@ -947,6 +965,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
   /** Convert user content blocks (text, image) to an OpenAI user message. */
   private toOpenAIUserMessage(
     blocks: ContentBlock[],
+    supportsImageInput: boolean,
   ): OpenAI.Chat.Completions.ChatCompletionUserMessageParam {
     // If only a single text block, use plain string (simpler, fewer tokens)
     if (blocks.length === 1 && blocks[0].type === "text") {
@@ -960,7 +979,14 @@ export class OpenAIChatCompletionsProvider implements Provider {
           parts.push({ type: "text", text: block.text });
           break;
         case "image":
-          if (!OPENAI_SUPPORTED_IMAGE_TYPES.has(block.source.media_type)) {
+          if (!supportsImageInput) {
+            parts.push({
+              type: "text",
+              text: "[Image omitted: this model does not accept image input]",
+            });
+          } else if (
+            !OPENAI_SUPPORTED_IMAGE_TYPES.has(block.source.media_type)
+          ) {
             parts.push({
               type: "text",
               text: `[Image: ${block.source.media_type} — format not supported by this provider]`,

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -325,7 +325,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
       // catalog doesn't know keep their images (fail open — the provider
       // decides, and `detectVisionNotSupported` below classifies a rejection).
       const supportsImageInput =
-        getCatalogModelVision(modelOverride ?? this.model) !== false;
+        getCatalogModelVision(modelOverride ?? this.model, this.name) !== false;
       const openaiMessages = this.toOpenAIMessages(
         messages,
         systemPrompt,


### PR DESCRIPTION
## User feedback

> "balanced profile doesn't support images"

A conversation on the managed **balanced** profile (Fireworks GLM 5.2, catalog `supportsVision: false`) died mid-task with the non-retryable error **"This model doesn't support image input. Remove the image or switch to a vision-capable model."** — and stayed dead on every subsequent turn until the user switched to a vision-capable profile.

## Root cause

The failure fires right after a context compaction, and the chain is subtle:

1. During the conversation, `file_read` tool results carried screenshot image blocks. The **image-fallback** plugin captions those for text-only models — but the hook pipeline (`runHook`) hands every hook a **deep clone** of its context, so the caption only ever reaches the provider-bound history. The **persisted rows keep the raw images** (the plugin's doc comment claimed otherwise; corrected here). That's why the conversation ran fine for ~50 minutes with images "in" it.
2. Auto-compaction then rebuilt the context. The compactor offers the summarizer an image manifest (built from persisted attachments) and re-attaches whatever it retains as **raw image blocks** in the rebuilt history — with **no check that the consuming model accepts image input**.
3. The next main-agent call sent those raw images to Fireworks GLM 5.2 → HTTP 400 → classified as non-retryable `vision_not_supported` (`ProviderError` at `chat-completions-provider.ts:735` in the feedback logs).
4. The compacted context (summary + retained-image message) is **persisted**, so the conversation is bricked on that profile — every turn replays the images and fails again.

## Fix (two layers, one invariant: never send raw images to a catalog text-only model)

- **Compactor** (root cause): gate image retention on the vision capability of the model the compacted context is rebuilt for, resolved via the same `mainAgent` call-site + override-profile inputs the summary call itself uses. Text-only models get a "(image retention unavailable…)" manifest, and any `<retained_images>` the summarizer emits anyway is dropped before hydration.
- **Chat-completions provider** (safety net + retroactive unbrick): when the effective model is catalog-marked `supportsVision: false`, serialize image blocks as `[Image omitted: this model does not accept image input]` text placeholders instead of `image_url` parts. This rescues conversations already poisoned by a retained-image message, and covers profile switches to a text-only model after images entered history. Models unknown to the catalog keep their images (fail open — the provider decides, and `detectVisionNotSupported` still classifies a rejection).

Supporting changes:

- Extracted the catalog vision lookup into `getCatalogModelVision(modelId, provider?)` in `model-catalog.ts`; `plugin-api/vision-support.ts` now uses it instead of a private duplicate. The (provider, model) pair is authoritative when the caller knows the provider (the chat-completions gate passes the provider instance name, the compactor passes the resolved call-site provider); the cross-provider scan is only the bare-model-id fallback, and `model-catalog-capability-consistency.test.ts` guards the invariant it relies on (no model id under two providers with conflicting provider-agnostic flags).
- Corrected the image-fallback plugin doc comments that claimed the caption reaches the persisted/displayed copy.

## Tests

- `compactor-image-retention-vision-gate.test.ts`: text-only model → no manifest offered + retention requests dropped; vision model → retained image hydrated; uncataloged model → fail open.
- `chat-completions-image-input-gate.test.ts`: user-message and tool-result images become placeholders for a catalog text-only model (incl. per-call model override); `image_url` preserved for vision-capable and uncataloged models.
- Ran adjacent suites (compactor, agent-loop compaction, provider reasoning/tool-choice, image-fallback plugin, catalog parity, context normalization): all green. `tsgo --noEmit` clean, 0 lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
