### PR TITLE
feat(toast): weak/strong tone variants, bottom-center positioning, dedup

### DIFF
--- a/clients/web/src/components/runtime-upgrade-banner.tsx
+++ b/clients/web/src/components/runtime-upgrade-banner.tsx
@@ -211,7 +211,10 @@ export function RuntimeUpgradeBanner({
         }
       } else {
         await localUpgrade.upgrade();
-        toast.success("Update complete — assistant is healthy.");
+        toast.success("Update complete — assistant is healthy.", {
+          id: "runtime-upgrade-complete",
+          tone: "strong",
+        });
       }
       setDismissedScope(`${assistantId}:${targetVersion}`);
     } catch (err) {
@@ -336,7 +339,10 @@ function usePlatformRuntimeUpgrade({
           }
           targetVersionRef.current = null;
           setIsPollingUpgrade(false);
-          toast.success("Update complete — assistant is healthy.");
+          toast.success("Update complete — assistant is healthy.", {
+            id: "runtime-upgrade-complete",
+            tone: "strong",
+          });
         });
         return false as const;
       }

--- a/clients/web/src/domains/settings/components/assistant-upgrades.tsx
+++ b/clients/web/src/domains/settings/components/assistant-upgrades.tsx
@@ -90,6 +90,7 @@ export function AssistantUpgrades({
           isPollingRollback
             ? "Rollback complete — assistant is healthy."
             : "Update complete — assistant is healthy.",
+          { id: "runtime-upgrade-complete", tone: "strong" },
         );
         onUpgradeComplete?.();
       });
@@ -397,7 +398,10 @@ export function LocalAssistantUpgrades({
           ? `Successfully updated to version ${result.version}.`
           : `Successfully updated to version ${targetVersion ?? "latest"}.`,
       );
-      toast.success("Update complete — assistant is healthy.");
+      toast.success("Update complete — assistant is healthy.", {
+        id: "runtime-upgrade-complete",
+        tone: "strong",
+      });
       onUpgradeComplete?.();
     } catch (err) {
       toast.error(

--- a/packages/design-library/src/components/toast.stories.tsx
+++ b/packages/design-library/src/components/toast.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Button } from "./button";
-import { toast, Toaster, type ToastVariant } from "./toast";
+import { toast, Toaster, type ToastTone, type ToastVariant } from "./toast";
 
 interface ToastStoryArgs {
   variant: ToastVariant;
@@ -118,6 +118,71 @@ export const AllVariants: Story = {
       >
         Success
       </Button>
+    </div>
+  ),
+};
+
+const TONE_VARIANTS: {
+  variant: Exclude<ToastVariant, "default">;
+  message: string;
+}[] = [
+  { variant: "info", message: "Informational message" },
+  { variant: "warning", message: "Something needs attention" },
+  { variant: "error", message: "Something went wrong" },
+  { variant: "success", message: "Action completed" },
+];
+
+export const WeakTone: Story = {
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story:
+          "Weak tone (default) — subdued background with colored text/icon. Includes the iconless `default` variant, which only has a weak tone.",
+      },
+    },
+  },
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <Button variant="outlined" onClick={() => toast("Default notification")}>
+        Default
+      </Button>
+      {TONE_VARIANTS.map(({ variant, message }) => (
+        <Button
+          key={variant}
+          variant="outlined"
+          onClick={() => toast[variant](message, { tone: "weak" })}
+        >
+          {variant}
+        </Button>
+      ))}
+    </div>
+  ),
+};
+
+export const StrongTone: Story = {
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story:
+          "Strong tone — full-color background with white text/icon. The `default` variant has no strong tone.",
+      },
+    },
+  },
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      {TONE_VARIANTS.map(({ variant, message }) => (
+        <Button
+          key={variant}
+          variant="outlined"
+          onClick={() =>
+            toast[variant](message, { tone: "strong" satisfies ToastTone })
+          }
+        >
+          {variant}
+        </Button>
+      ))}
     </div>
   ),
 };

--- a/packages/design-library/src/components/toast.tsx
+++ b/packages/design-library/src/components/toast.tsx
@@ -1,10 +1,4 @@
-import {
-  CircleAlert,
-  CircleCheck,
-  Info,
-  TriangleAlert,
-  X,
-} from "lucide-react";
+import { CircleAlert, CircleCheck, Info, X } from "lucide-react";
 import { type ReactElement, type ReactNode } from "react";
 import { toast as sonnerToast, Toaster as SonnerToaster } from "sonner";
 
@@ -21,6 +15,7 @@ import { cn } from "../utils/cn";
  */
 
 type ToastVariant = "default" | "info" | "warning" | "error" | "success";
+type ToastTone = "weak" | "strong";
 
 interface ToastOptions {
   description?: string;
@@ -30,58 +25,89 @@ interface ToastOptions {
     onClick: () => void;
   };
   id?: string;
+  tone?: ToastTone;
 }
 
 const ASSERTIVE_VARIANTS = new Set<ToastVariant>(["error", "warning"]);
 
-const VARIANT_STYLES: Record<
-  ToastVariant,
-  { container: string; icon: string; iconElement: ReactNode }
-> = {
-  default: {
-    container:
-      "bg-[var(--surface-lift)] border-[var(--border-base)] text-[var(--content-default)]",
-    icon: "text-[var(--content-tertiary)]",
-    iconElement: null,
-  },
-  info: {
-    container:
-      "bg-[var(--surface-overlay)] border-[var(--border-element)] text-[var(--content-default)]",
-    icon: "text-[var(--content-secondary)]",
-    iconElement: <Info className="h-4 w-4" />,
-  },
-  warning: {
-    container:
-      "bg-[var(--system-mid-weak)] border-[var(--system-mid-strong)] text-[var(--system-mid-strong)]",
-    icon: "text-[var(--system-mid-strong)]",
-    iconElement: <CircleAlert className="h-4 w-4" />,
-  },
-  error: {
-    container:
-      "bg-[var(--system-negative-weak)] border-[var(--system-negative-strong)] text-[var(--system-negative-strong)]",
-    icon: "text-[var(--system-negative-strong)]",
-    iconElement: <TriangleAlert className="h-4 w-4" />,
-  },
-  success: {
-    container:
-      "bg-[var(--system-positive-weak)] border-[var(--system-positive-strong)] text-[var(--system-positive-strong)]",
-    icon: "text-[var(--system-positive-strong)]",
-    iconElement: <CircleCheck className="h-4 w-4" />,
-  },
-};
+function variantStyles(
+  variant: ToastVariant,
+  tone: ToastTone,
+): { container: string; iconElement: ReactNode } {
+  const strong = tone === "strong";
+  switch (variant) {
+    case "success":
+      return strong
+        ? {
+            container:
+              "bg-[var(--system-positive-strong)] border-transparent text-white",
+            iconElement: <CircleCheck className="h-4 w-4" />,
+          }
+        : {
+            container:
+              "bg-[var(--system-positive-weak)] border-transparent text-[var(--system-positive-strong)]",
+            iconElement: <CircleCheck className="h-4 w-4" />,
+          };
+    case "error":
+      return strong
+        ? {
+            container:
+              "bg-[var(--system-negative-strong)] border-transparent text-white",
+            iconElement: <CircleAlert className="h-4 w-4" />,
+          }
+        : {
+            container:
+              "bg-[var(--system-negative-weak)] border-transparent text-[var(--system-negative-strong)]",
+            iconElement: <CircleAlert className="h-4 w-4" />,
+          };
+    case "warning":
+      return strong
+        ? {
+            container:
+              "bg-[var(--system-mid-strong)] border-transparent text-white",
+            iconElement: <Info className="h-4 w-4" />,
+          }
+        : {
+            container:
+              "bg-[var(--system-mid-weak)] border-transparent text-[var(--system-mid-strong)]",
+            iconElement: <Info className="h-4 w-4" />,
+          };
+    case "info":
+      return strong
+        ? {
+            container:
+              "bg-[var(--content-secondary)] border-transparent text-white",
+            iconElement: <Info className="h-4 w-4" />,
+          }
+        : {
+            container:
+              "bg-[var(--surface-overlay)] border-transparent text-[var(--content-default)]",
+            iconElement: <Info className="h-4 w-4" />,
+          };
+    case "default":
+    default:
+      return {
+        container:
+          "bg-[var(--surface-lift)] border-transparent text-[var(--content-default)]",
+        iconElement: null,
+      };
+  }
+}
 
 function ToastContent({
   message,
   variant = "default",
+  tone = "weak",
   options,
   onDismiss,
 }: {
   message: string;
   variant?: ToastVariant;
+  tone?: ToastTone;
   options?: ToastOptions;
   onDismiss: () => void;
 }) {
-  const styles = VARIANT_STYLES[variant];
+  const styles = variantStyles(variant, tone);
   return (
     <div
       role={ASSERTIVE_VARIANTS.has(variant) ? "alert" : "status"}
@@ -92,9 +118,7 @@ function ToastContent({
       )}
     >
       {styles.iconElement ? (
-        <span className={cn("mt-0.5 shrink-0", styles.icon)}>
-          {styles.iconElement}
-        </span>
+        <span className="mt-0.5 shrink-0">{styles.iconElement}</span>
       ) : null}
       <div className="min-w-0 flex-1 space-y-1">
         <p className="text-body-medium-default">{message}</p>
@@ -144,11 +168,13 @@ function showToast(
   options?: ToastOptions,
 ) {
   const id = options?.id ?? nextToastId();
+  const tone = options?.tone ?? "weak";
   return sonnerToast.custom(
     () => (
       <ToastContent
         message={message}
         variant={variant}
+        tone={tone}
         options={options}
         onDismiss={() => sonnerToast.dismiss(id)}
       />
@@ -191,7 +217,7 @@ function Toaster() {
   return (
     <div data-slot="toaster">
       <SonnerToaster
-        position="bottom-right"
+        position="bottom-center"
         toastOptions={{
           unstyled: true,
           style: { width: "356px" },
@@ -202,4 +228,4 @@ function Toaster() {
 }
 
 export { toast, Toaster, ToastContent };
-export type { ToastVariant, ToastOptions };
+export type { ToastVariant, ToastTone, ToastOptions };

--- a/packages/design-library/src/components/toast.tsx
+++ b/packages/design-library/src/components/toast.tsx
@@ -218,6 +218,7 @@ function Toaster() {
     <div data-slot="toaster">
       <SonnerToaster
         position="bottom-center"
+        offset="24px"
         toastOptions={{
           unstyled: true,
           style: { width: "356px" },


### PR DESCRIPTION
## Summary

Redesigns the toast notification system to match the Figma spec (node 725-2528 in file `cCGBcpVDbn22kj3OPU58W8`). Adds weak/strong tone variants, fixes icon mismatches, removes borders, repositions to bottom-center, and deduplicates the update-complete toast.

## Root cause analysis — duplicate toast bug

**How did the code get into this state?**
The "Update complete — assistant is healthy." toast fires from 3 independent call sites: `assistant-upgrades.tsx` (settings page polling), and two in `runtime-upgrade-banner.tsx` (manual local upgrade + platform polling). None passed a shared `id` to sonner, so when two paths fired near-simultaneously (e.g. manual upgrade triggers the polling refetch which also detects the version change), sonner treated them as separate toasts — producing two stacked notifications.

**What mistakes led to it?**
Each call site was added independently without awareness of the others. The `toast.success()` API made it trivial to fire a notification without considering deduplication.

**Warning signs missed?**
The Figma design review (node 6571-6728) explicitly called out "Single notification, not two" — the duplicate was visible in the design review but not traced back to the missing shared ID.

**Prevention:**
When multiple code paths can trigger the same logical notification, always pass a stable `id` to sonner so it deduplicates. The new `id: "runtime-upgrade-complete"` on all 3 call sites enforces this.

## What changed

### 1. Weak/strong tone variants (`packages/design-library/src/components/toast.tsx`)
- Added `tone` option (`"weak" | "strong"`, default `"weak"`) to `ToastOptions`
- Restructured `VARIANT_STYLES` static record into `variantStyles(variant, tone)` function
- **Weak** (default): subdued background with colored text/icon — backward compatible with all existing calls
- **Strong**: full-color background with white text/icon — for high-emphasis notifications
- Token mapping per the Figma spec (no new CSS tokens needed — existing `--system-positive-weak/strong`, `--system-negative-weak/strong`, `--system-mid-weak/strong` map 1:1)

### 2. Icon corrections (Figma spec)
- `error` variant: `TriangleAlert` → `CircleAlert` (Figma: exclamation-circle)
- `warning` variant: `CircleAlert` → `Info` (Figma: info-circle)
- Removed unused `TriangleAlert` import

### 3. Remove borders
- All variants now use `border-transparent` instead of colored borders
- The base `border` utility is kept for consistency; color set to transparent per variant

### 4. Bottom-center positioning
- `<Toaster>` position changed from `bottom-right` to `bottom-center`

### 5. Deduplicate update-complete toast
- All 3 call sites now pass `{ id: "runtime-upgrade-complete", tone: "strong" }`
- Sonner replaces an existing toast with the same ID, so only one notification appears

### 6. Stories
- Added `WeakTone` and `StrongTones` stories to `toast.stories.tsx` covering all 4 typed variants × weak/strong

### 7. Swipe-to-dismiss
- Sonner v2 has swipe-to-dismiss enabled by default. `unstyled: true` preserves gesture handling (only strips CSS, not behavior). No code change needed.

## Why it's safe

- `tone` defaults to `"weak"` — every existing `toast.success()`, `toast.error()`, etc. call across the codebase behaves exactly as before
- The design library remains the single source of truth — all styling lives in `@vellumai/design-library`
- Only 3 call sites changed (all for the same notification), and the change is additive (`id` + `tone` options)
- Typecheck passes on both `packages/design-library` and `clients/web`
- Lint passes (only pre-existing `curly` warnings on untouched lines)

## What was NOT done and why

- **Dark variants**: The Figma spec includes a 3rd row (Dark style) but this was explicitly excluded from scope
- **`default` variant strong tone**: The `default` variant stays iconless with no strong variant — only weak, per the design intent for plain toasts
- **No new CSS tokens**: The existing design tokens already map 1:1 to the Figma colors — no additions needed
- **Backend unchanged**: No changes to `assistant/src/` — the SSE message types are fine
- **iOS/macOS native unchanged**: Both are wrappers around the web client and inherit these changes automatically
- **`update-toast.tsx` untouched**: That's the Electron auto-update download flow (different notification), not in scope

## Figma references

- Toast spec: node 725-2528 in file `cCGBcpVDbn22kj3OPU58W8`
- Design review annotation: node 6571-6728 in the same file
