### PR TITLE
feat(web): expandable-row per-channel capabilities — rooms only

### DIFF
--- a/clients/web/src/domains/contacts/channels-page.tsx
+++ b/clients/web/src/domains/contacts/channels-page.tsx
@@ -52,6 +52,7 @@ export function ChannelsPage({
 
       <DetailCard>
         <AssistantChannelsList
+          assistantId={assistantId}
           assistantName={displayName}
           initialChannel={setupChannel}
           {...channelsController}

--- a/clients/web/src/domains/contacts/components/assistant-channels-detail.test.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-detail.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
 import { AssistantChannelsDetail } from "@/domains/contacts/components/assistant-channels-detail";
@@ -21,6 +22,27 @@ function setTabbedLayout(enabled: boolean) {
     channelTrustFloors: enabled,
     hasHydrated: true,
   });
+}
+
+
+// The tabbed layout's Slack panel owns its own queries
+// (`SlackChannelSection`), so list renders need a QueryClient. Queries fail
+// fast (retry off, no server) and the panel shows its error state, which
+// these layout assertions don't depend on.
+function renderList(extraProps: { initialChannel?: "slack" | "telegram" | "phone" } = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AssistantChannelsList
+        assistantId="assistant-1"
+        assistantName="Vex"
+        channels={CHANNELS}
+        {...extraProps}
+      />
+    </QueryClientProvider>,
+  );
 }
 
 beforeEach(() => {
@@ -102,7 +124,7 @@ describe("assistant channels surfaces", () => {
   });
 
   test("the bare channel list (standalone Channels tab) has no identity card", () => {
-    render(<AssistantChannelsList assistantName="Vex" channels={CHANNELS} />);
+    renderList();
     expect(document.body.textContent).not.toContain("Vex (Your Assistant)");
     expect(document.body.textContent).toContain("Slack");
     expect(document.body.textContent).toContain("Telegram");
@@ -110,7 +132,7 @@ describe("assistant channels surfaces", () => {
 
   test("channel-trust-floors off renders the accordion rows", () => {
     setTabbedLayout(false);
-    render(<AssistantChannelsList assistantName="Vex" channels={CHANNELS} />);
+    renderList();
     expect(document.body.textContent).toContain("Phone Calling");
     // Accordion rows surface per-channel Set up buttons inline.
     expect(document.body.textContent).toContain("Set up");
@@ -119,7 +141,7 @@ describe("assistant channels surfaces", () => {
 
   test("channel-trust-floors on renders the adapter sub-tabs", () => {
     setTabbedLayout(true);
-    render(<AssistantChannelsList assistantName="Vex" channels={CHANNELS} />);
+    renderList();
     expect(document.querySelector('[data-slot="tabs"]')).not.toBeNull();
     expect(document.body.textContent).toContain("Phone");
     expect(document.body.textContent).not.toContain("Phone Calling");
@@ -133,7 +155,7 @@ describe("assistant channels surfaces", () => {
       channelTrustFloors: false,
       hasHydrated: false,
     });
-    render(<AssistantChannelsList assistantName="Vex" channels={CHANNELS} />);
+    renderList();
     expect(document.body.textContent).toContain("Loading…");
     expect(document.body.textContent).not.toContain("Slack");
   });
@@ -143,13 +165,13 @@ describe("assistant channels surfaces", () => {
       channelTrustFloors: true,
       hasHydrated: false,
     });
-    render(<AssistantChannelsList assistantName="Vex" channels={CHANNELS} />);
+    renderList();
     expect(document.querySelector('[data-slot="tabs"]')).not.toBeNull();
   });
 
   test("disconnected tab swaps the empty state for the manual form on request", () => {
     setTabbedLayout(true);
-    render(<AssistantChannelsList assistantName="Vex" channels={CHANNELS} />);
+    renderList();
 
     const telegramTab = Array.from(
       document.querySelectorAll('[data-slot="tabs-trigger"]'),
@@ -176,13 +198,7 @@ describe("assistant channels surfaces", () => {
     // continue credential entry here — it must land on the form, not the
     // empty state whose Set up button would start another conversation.
     setTabbedLayout(true);
-    render(
-      <AssistantChannelsList
-        assistantName="Vex"
-        channels={CHANNELS}
-        initialChannel="telegram"
-      />,
-    );
+    renderList({ initialChannel: "telegram" });
     expect(document.body.textContent).toContain("Bot Token");
     expect(document.body.textContent).not.toContain("Telegram isn't connected");
   });

--- a/clients/web/src/domains/contacts/components/assistant-channels-list.stories.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-list.stories.tsx
@@ -1,4 +1,5 @@
 import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { DetailCard } from "@/components/detail-card";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
@@ -24,10 +25,23 @@ const withLayoutFlag = (tabbed: boolean): Decorator => {
   };
 };
 
+// The Slack panel owns its own queries (`SlackChannelSection`), so stories
+// need a QueryClient. Requests fail in Storybook (no daemon), so the Slack
+// tab's channel list renders its error state; the list's full visuals live
+// in the SlackChannelList stories, which mock data via props.
+const withQueryClient: Decorator = (Story) => (
+  <QueryClientProvider
+    client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+  >
+    <Story />
+  </QueryClientProvider>
+);
+
 const meta: Meta<typeof AssistantChannelsList> = {
   title: "Contacts/AssistantChannelsList",
   component: AssistantChannelsList,
   args: {
+    assistantId: "assistant-1",
     assistantName: "Example Assistant",
     channels: [
       { key: "slack", status: "ready", address: "@example-assistant" },
@@ -41,6 +55,7 @@ const meta: Meta<typeof AssistantChannelsList> = {
     onSaveTwilioCredentials: async () => {},
   },
   decorators: [
+    withQueryClient,
     withLayoutFlag(true),
     (Story) => (
       <div
@@ -78,38 +93,6 @@ export const ChannelsTabSlackConnected: Story = {
     onSlackThreadModeChange: () => {},
     channelPolicies: { slack: "trusted_contacts" },
     onChannelPolicyChange: () => {},
-    slackChannels: [
-      {
-        id: "C001",
-        name: "general",
-        type: "channel",
-        isPrivate: false,
-        isMember: true,
-        memberCount: 42,
-        topic: null,
-        imageUrl: null,
-      },
-      {
-        id: "C002",
-        name: "leadership",
-        type: "channel",
-        isPrivate: true,
-        isMember: true,
-        memberCount: 4,
-        topic: null,
-        imageUrl: null,
-      },
-      {
-        id: "D001",
-        name: "Alice",
-        type: "dm",
-        isPrivate: true,
-        isMember: true,
-        memberCount: null,
-        topic: null,
-        imageUrl: null,
-      },
-    ],
   },
 };
 

--- a/clients/web/src/domains/contacts/components/assistant-channels-list.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-list.tsx
@@ -13,9 +13,9 @@ import { Typography } from "@vellumai/design-library/components/typography";
 import { EmptyState } from "@/components/empty-state";
 import { assistantDisplayName as toAssistantDisplayName } from "@/domains/contacts/assistant-display-name";
 import { SlackChannelCard } from "@/domains/contacts/components/slack-channel-card";
-import { SlackChannelList } from "@/domains/contacts/components/slack-channel-list";
+import { SlackChannelSection } from "@/domains/contacts/components/slack-channel-section";
 import { SlackSetupWizard, type SlackThreadMode, type MutationStatus } from "@/components/slack-setup-wizard";
-import type { AssistantChannelState, SetupChannelId, SlackChannel } from "@/domains/contacts/types";
+import type { AssistantChannelState, SetupChannelId } from "@/domains/contacts/types";
 import {
   ADMISSION_POLICY_DEFAULT,
   ADMISSION_POLICY_VALUES,
@@ -63,20 +63,13 @@ const POLICY_CONFIRMATIONS: Partial<
 };
 
 export interface AssistantChannelsListProps {
+  /** Needed by the Slack sub-tab's channel list, which owns its own data. */
+  assistantId: string;
   assistantName: string;
   channels: AssistantChannelState[];
   pendingChannelKey?: ChannelKey | null;
   slackThreadMode?: SlackThreadMode;
   slackThreadModePending?: boolean;
-  /** Member-only Slack channel list for the Slack sub-tab's presence list. */
-  slackChannels?: SlackChannel[];
-  slackChannelsLoading?: boolean;
-  slackChannelsError?: boolean;
-  /**
-   * Verified-contact lookup for the Slack DM rows' resolved-access badges
-   * (see `buildVerifiedSlackContactNames`).
-   */
-  slackVerifiedDmContactNames?: ReadonlySet<string>;
   /**
    * Per-channel admission floor, keyed by channel. Omit (or pass no
    * `onChannelPolicyChange`) to hide the trust-floor control entirely — used
@@ -145,15 +138,12 @@ const CHANNEL_META: Record<
  * for disconnected channels, off → the accordion rows.
  */
 export function AssistantChannelsList({
+  assistantId,
   assistantName,
   channels,
   pendingChannelKey = null,
   slackThreadMode,
   slackThreadModePending = false,
-  slackChannels,
-  slackChannelsLoading = false,
-  slackChannelsError = false,
-  slackVerifiedDmContactNames,
   channelPolicies,
   policySavingKey = null,
   policiesLoading = false,
@@ -248,6 +238,7 @@ export function AssistantChannelsList({
             <Tabs.Panel key={channel.key} value={channel.key} className="pt-4">
               <ChannelPanel
                 channel={channel}
+                assistantId={assistantId}
                 assistantName={assistantName}
                 assistantDisplayName={displayName}
                 pending={pendingChannelKey === channel.key}
@@ -263,10 +254,6 @@ export function AssistantChannelsList({
                 slackThreadMode={slackThreadMode}
                 slackThreadModePending={slackThreadModePending}
                 onSlackThreadModeChange={onSlackThreadModeChange}
-                slackChannels={slackChannels}
-                slackChannelsLoading={slackChannelsLoading}
-                slackChannelsError={slackChannelsError}
-                slackVerifiedDmContactNames={slackVerifiedDmContactNames}
                 onSaveTwilioCredentials={onSaveTwilioCredentials}
                 policy={channelPolicies?.[channel.key]}
                 policySaving={policySavingKey === channel.key}
@@ -375,6 +362,7 @@ export function AssistantChannelsList({
 
 interface ChannelPanelProps {
   channel: AssistantChannelState;
+  assistantId: string;
   assistantName: string;
   /** Trimmed assistant name with a "your assistant" fallback, for copy. */
   assistantDisplayName: string;
@@ -394,10 +382,6 @@ interface ChannelPanelProps {
   slackThreadMode?: SlackThreadMode;
   slackThreadModePending?: boolean;
   onSlackThreadModeChange?: (mode: SlackThreadMode) => void;
-  slackChannels?: SlackChannel[];
-  slackChannelsLoading?: boolean;
-  slackChannelsError?: boolean;
-  slackVerifiedDmContactNames?: ReadonlySet<string>;
   onSaveTwilioCredentials?: (accountSid: string, authToken: string) => Promise<void>;
   policy?: AdmissionPolicy;
   policySaving?: boolean;
@@ -408,6 +392,7 @@ interface ChannelPanelProps {
 
 function ChannelPanel({
   channel,
+  assistantId,
   assistantName,
   assistantDisplayName,
   pending,
@@ -421,10 +406,6 @@ function ChannelPanel({
   slackThreadMode,
   slackThreadModePending = false,
   onSlackThreadModeChange,
-  slackChannels,
-  slackChannelsLoading = false,
-  slackChannelsError = false,
-  slackVerifiedDmContactNames,
   onSaveTwilioCredentials,
   policy,
   policySaving = false,
@@ -527,13 +508,10 @@ function ChannelPanel({
       ) : null}
 
       {channel.key === "slack" && connected ? (
-        <SlackChannelList
+        <SlackChannelSection
+          assistantId={assistantId}
           assistantDisplayName={assistantDisplayName}
           slackHandle={channel.address}
-          channels={slackChannels}
-          loading={slackChannelsLoading}
-          error={slackChannelsError}
-          verifiedDmContactNames={slackVerifiedDmContactNames}
         />
       ) : null}
 

--- a/clients/web/src/domains/contacts/components/assistant-channels-list.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-list.tsx
@@ -512,6 +512,7 @@ function ChannelPanel({
           assistantId={assistantId}
           assistantDisplayName={assistantDisplayName}
           slackHandle={channel.address}
+          admissionPolicy={policy}
         />
       ) : null}
 

--- a/clients/web/src/domains/contacts/components/slack-channel-list.stories.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-list.stories.tsx
@@ -17,7 +17,10 @@ function makeChannel(overrides: Partial<SlackChannel> & Pick<SlackChannel, "id" 
   };
 }
 
-/** A mix of public channels, private channels, and DMs, all member-only. */
+/**
+ * A mix of public channels, private channels, group DMs, and 1:1 DMs — the
+ * list renders rooms only, so the 1:1 DM rows stay hidden.
+ */
 const MIXED_CHANNELS: SlackChannel[] = [
   makeChannel({ id: "C001", name: "general", memberCount: 42 }),
   makeChannel({ id: "C002", name: "engineering", memberCount: 18 }),
@@ -37,9 +40,6 @@ const meta: Meta<typeof SlackChannelList> = {
     assistantDisplayName: "Example Assistant",
     slackHandle: "@example-assistant",
     channels: MIXED_CHANNELS,
-    // Alice is a verified contact, so her DM resolves "Full access";
-    // Bob's DM resolves "Strict".
-    verifiedDmContactNames: new Set(["alice"]),
   },
   decorators: [
     (Story) => (

--- a/clients/web/src/domains/contacts/components/slack-channel-list.stories.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-list.stories.tsx
@@ -64,6 +64,25 @@ export const Empty: Story = {
   },
 };
 
+/**
+ * `eng-releases` starts overridden to the Standard tier — the row badge
+ * reads "Standard • custom" and expanding it shows the custom-capabilities
+ * callout with Reset to default (mirrors the ticket mockup's `releases`).
+ */
+export const OverriddenChannel: Story = {
+  args: {
+    tierOverrides: { C003: "standard" },
+    onTierChange: () => {},
+    onTierReset: () => {},
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByLabelText("eng-releases — expand channel settings"),
+    );
+  },
+};
+
 /** Search-as-you-type narrows rows by channel name. */
 export const SearchFiltering: Story = {
   play: async ({ canvasElement }) => {

--- a/clients/web/src/domains/contacts/components/slack-channel-list.test.ts
+++ b/clients/web/src/domains/contacts/components/slack-channel-list.test.ts
@@ -1,13 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
-import type { ContactPayload, SlackChannel } from "@/domains/contacts/types";
+import type { SlackChannel } from "@/domains/contacts/types";
 
 import {
-  buildVerifiedSlackContactNames,
   classifySlackChannelKind,
   countSlackChannelKinds,
   filterSlackChannels,
-  isVerifiedSlackDm,
+  roomsOnly,
   slackChannelMetaLabel,
 } from "./slack-channel-list";
 
@@ -25,33 +24,6 @@ function makeChannel(
   };
 }
 
-function makeContact(
-  displayName: string,
-  channels: Partial<ContactPayload["channels"][number]>[],
-): ContactPayload {
-  return {
-    id: `contact-${displayName}`,
-    displayName,
-    role: "contact",
-    contactType: "human",
-    interactionCount: 0,
-    createdAt: 0,
-    updatedAt: 0,
-    channels: channels.map((overrides, index) => ({
-      id: `ch-${displayName}-${index}`,
-      contactId: `contact-${displayName}`,
-      type: "slack",
-      address: `U${index}`,
-      isPrimary: index === 0,
-      externalUserId: null,
-      lastSeenAt: null,
-      interactionCount: null,
-      lastInteraction: null,
-      ...overrides,
-    })),
-  };
-}
-
 const general = makeChannel({ id: "C1", name: "general" });
 const leadership = makeChannel({ id: "C2", name: "leadership", isPrivate: true });
 const dmAlice = makeChannel({ id: "D1", name: "Alice", type: "dm" });
@@ -61,7 +33,7 @@ const groupDm = makeChannel({
   type: "group",
   isPrivate: true,
 });
-const CHANNELS = [leadership, dmAlice, general, groupDm];
+const ROOMS = [leadership, general, groupDm];
 
 describe("classifySlackChannelKind", () => {
   test("public channels", () => {
@@ -81,10 +53,18 @@ describe("classifySlackChannelKind", () => {
   });
 });
 
+describe("roomsOnly", () => {
+  test("keeps channels and group DMs, drops 1:1 DMs", () => {
+    expect(roomsOnly([general, dmAlice, groupDm]).map((c) => c.id)).toEqual([
+      "C1",
+      "G1",
+    ]);
+  });
+});
+
 describe("filterSlackChannels", () => {
   test("no filters returns everything sorted by name", () => {
-    expect(filterSlackChannels(CHANNELS, "", null).map((c) => c.id)).toEqual([
-      "D1",
+    expect(filterSlackChannels(ROOMS, "", null).map((c) => c.id)).toEqual([
       "G1",
       "C1",
       "C2",
@@ -93,32 +73,32 @@ describe("filterSlackChannels", () => {
 
   test("kind filter narrows to one category", () => {
     expect(
-      filterSlackChannels(CHANNELS, "", "private").map((c) => c.id),
+      filterSlackChannels(ROOMS, "", "private").map((c) => c.id),
     ).toEqual(["G1", "C2"]);
-    expect(filterSlackChannels(CHANNELS, "", "dm").map((c) => c.id)).toEqual([
-      "D1",
+    expect(filterSlackChannels(ROOMS, "", "public").map((c) => c.id)).toEqual([
+      "C1",
     ]);
   });
 
   test("search is case-insensitive and trims whitespace", () => {
     expect(
-      filterSlackChannels(CHANNELS, "  LEAD ", null).map((c) => c.id),
+      filterSlackChannels(ROOMS, "  LEAD ", null).map((c) => c.id),
     ).toEqual(["C2"]);
   });
 
   test("search and kind filter compose", () => {
     expect(
-      filterSlackChannels(CHANNELS, "alice", "private").map((c) => c.id),
+      filterSlackChannels(ROOMS, "alice", "private").map((c) => c.id),
     ).toEqual(["G1"]);
   });
 });
 
 describe("countSlackChannelKinds", () => {
-  test("counts every kind, independent of search", () => {
-    expect(countSlackChannelKinds(CHANNELS)).toEqual({
+  test("counts every room kind, independent of search", () => {
+    expect(countSlackChannelKinds(ROOMS)).toEqual({
       public: 1,
       private: 2,
-      dm: 1,
+      dm: 0,
     });
   });
 
@@ -128,11 +108,7 @@ describe("countSlackChannelKinds", () => {
 });
 
 describe("slackChannelMetaLabel", () => {
-  test("DMs read as direct messages", () => {
-    expect(slackChannelMetaLabel(dmAlice)).toBe("Direct message");
-  });
-
-  test("channels show a pluralized member count", () => {
+  test("rooms show a pluralized member count", () => {
     expect(
       slackChannelMetaLabel(makeChannel({ id: "C9", name: "x", memberCount: 24 })),
     ).toBe("24 members");
@@ -143,44 +119,5 @@ describe("slackChannelMetaLabel", () => {
 
   test("no member count yields no label", () => {
     expect(slackChannelMetaLabel(general)).toBeNull();
-  });
-});
-
-describe("buildVerifiedSlackContactNames", () => {
-  test("collects normalized names of contacts with a verified Slack channel", () => {
-    const contacts = [
-      makeContact("  Alice ", [{ status: "verified" }]),
-      makeContact("Bob", [{ status: "active", verifiedAt: 123 }]),
-      makeContact("Mallory", [{ status: "active" }]),
-    ];
-    expect(buildVerifiedSlackContactNames(contacts)).toEqual(
-      new Set(["alice", "bob"]),
-    );
-  });
-
-  test("ignores verified channels of other types", () => {
-    const contacts = [
-      makeContact("Carol", [{ type: "telegram", status: "verified" }]),
-    ];
-    expect(buildVerifiedSlackContactNames(contacts)).toEqual(new Set());
-  });
-});
-
-describe("isVerifiedSlackDm", () => {
-  const verified = new Set(["alice"]);
-
-  test("true only for DMs whose peer name matches (case-insensitive)", () => {
-    expect(isVerifiedSlackDm(dmAlice, verified)).toBe(true);
-    expect(
-      isVerifiedSlackDm(makeChannel({ id: "D2", name: "ALICE", type: "dm" }), verified),
-    ).toBe(true);
-    expect(
-      isVerifiedSlackDm(makeChannel({ id: "D3", name: "Mallory", type: "dm" }), verified),
-    ).toBe(false);
-  });
-
-  test("false for channels and group DMs regardless of names", () => {
-    expect(isVerifiedSlackDm(general, verified)).toBe(false);
-    expect(isVerifiedSlackDm(groupDm, verified)).toBe(false);
   });
 });

--- a/clients/web/src/domains/contacts/components/slack-channel-list.test.ts
+++ b/clients/web/src/domains/contacts/components/slack-channel-list.test.ts
@@ -2,14 +2,12 @@ import { describe, expect, test } from "bun:test";
 
 import type { ContactPayload, SlackChannel } from "@/domains/contacts/types";
 
-import { presetFromThreshold } from "@/utils/threshold-presets";
-
 import {
   buildVerifiedSlackContactNames,
   classifySlackChannelKind,
   countSlackChannelKinds,
   filterSlackChannels,
-  resolveSlackChannelThreshold,
+  isVerifiedSlackDm,
   slackChannelMetaLabel,
 } from "./slack-channel-list";
 
@@ -168,31 +166,21 @@ describe("buildVerifiedSlackContactNames", () => {
   });
 });
 
-describe("resolveSlackChannelThreshold", () => {
+describe("isVerifiedSlackDm", () => {
   const verified = new Set(["alice"]);
 
-  test("public and private channels resolve the Full access threshold", () => {
-    expect(resolveSlackChannelThreshold(general, new Set())).toBe("high");
-    expect(resolveSlackChannelThreshold(leadership, new Set())).toBe("high");
-    expect(resolveSlackChannelThreshold(groupDm, new Set())).toBe("high");
+  test("true only for DMs whose peer name matches (case-insensitive)", () => {
+    expect(isVerifiedSlackDm(dmAlice, verified)).toBe(true);
+    expect(
+      isVerifiedSlackDm(makeChannel({ id: "D2", name: "ALICE", type: "dm" }), verified),
+    ).toBe(true);
+    expect(
+      isVerifiedSlackDm(makeChannel({ id: "D3", name: "Mallory", type: "dm" }), verified),
+    ).toBe(false);
   });
 
-  test("DMs with verified contacts resolve the Full access threshold", () => {
-    expect(resolveSlackChannelThreshold(dmAlice, verified)).toBe("high");
-  });
-
-  test("DM name matching is case-insensitive", () => {
-    const dm = makeChannel({ id: "D2", name: "ALICE", type: "dm" });
-    expect(resolveSlackChannelThreshold(dm, verified)).toBe("high");
-  });
-
-  test("DMs with unverified contacts resolve the Strict threshold", () => {
-    const dm = makeChannel({ id: "D3", name: "Mallory", type: "dm" });
-    expect(resolveSlackChannelThreshold(dm, verified)).toBe("none");
-  });
-
-  test("resolved thresholds present via the shared preset labels", () => {
-    expect(presetFromThreshold("high").label).toBe("Full access");
-    expect(presetFromThreshold("none").label).toBe("Strict");
+  test("false for channels and group DMs regardless of names", () => {
+    expect(isVerifiedSlackDm(general, verified)).toBe(false);
+    expect(isVerifiedSlackDm(groupDm, verified)).toBe(false);
   });
 });

--- a/clients/web/src/domains/contacts/components/slack-channel-list.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-list.tsx
@@ -1,7 +1,8 @@
-import { Hash, Lock, Search, User } from "lucide-react";
+import { ChevronDown, Hash, Lock, Search, User } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { cn } from "@vellumai/design-library";
+import { Button } from "@vellumai/design-library/components/button";
 import { Card } from "@vellumai/design-library/components/card";
 import { Input } from "@vellumai/design-library/components/input";
 import { ListRow } from "@vellumai/design-library/components/list-row";
@@ -9,15 +10,15 @@ import { Tag } from "@vellumai/design-library/components/tag";
 import { Typography } from "@vellumai/design-library/components/typography";
 import { VirtualList } from "@vellumai/design-library/components/virtual-list";
 
-import type { TagTone } from "@vellumai/design-library/components/tag";
-
 import { EmptyState } from "@/components/empty-state";
 import { isVerifiedContactChannel } from "@/domains/contacts/components/contact-channels-section";
-import type { ContactPayload, SlackChannel } from "@/domains/contacts/types";
+import { SlackChannelOverridePanel } from "@/domains/contacts/components/slack-channel-override-panel";
 import {
-  presetFromThreshold,
-  type RiskThreshold,
-} from "@/utils/threshold-presets";
+  CAPABILITY_TIER_META,
+  resolveChannelTier,
+  type SlackCapabilityTier,
+} from "@/domains/contacts/slack-channel-overrides";
+import type { ContactPayload, SlackChannel } from "@/domains/contacts/types";
 
 /**
  * How a channel presents in the filter chips. Mirrors the conversation-type
@@ -111,32 +112,22 @@ export function buildVerifiedSlackContactNames(
 }
 
 /**
- * The Slack adapter's per-row resolved auto-approve threshold, rendered via
- * the shared threshold presets ("high" → Full access, "none" → Strict).
- * Derived from channel type + contact trust class: public/private channels
- * and group DMs resolve "high"; 1:1 DMs resolve "high" only when the peer is
- * a verified contact. Resolved matrix cells (`channel_permission_overrides`)
- * are not consulted.
+ * Whether a DM row's peer is a verified contact — the contact-trust input
+ * to the channel-type defaults. Always false for non-DM rows.
  */
-export function resolveSlackChannelThreshold(
+export function isVerifiedSlackDm(
   channel: SlackChannel,
   verifiedDmContactNames: ReadonlySet<string>,
-): RiskThreshold {
-  if (classifySlackChannelKind(channel) !== "dm") {
-    return "high";
-  }
-  return verifiedDmContactNames.has(normalizeSlackDmName(channel.name))
-    ? "high"
-    : "none";
+): boolean {
+  return (
+    classifySlackChannelKind(channel) === "dm" &&
+    verifiedDmContactNames.has(normalizeSlackDmName(channel.name))
+  );
 }
 
-/** Badge tone per resolved threshold: permissive reads green, locked-down red. */
-const THRESHOLD_TAG_TONES: Record<RiskThreshold, TagTone> = {
-  none: "negative",
-  low: "warning",
-  medium: "warning",
-  high: "positive",
-};
+/** Shared timing for the accordion region and the caret rotation. */
+const ACCORDION_TRANSITION =
+  "duration-[280ms] ease-[cubic-bezier(0.32,0.72,0,1)]";
 
 const CHANNEL_KIND_FILTERS: {
   value: SlackChannelKind | null;
@@ -178,15 +169,34 @@ export interface SlackChannelListProps {
    * absent (contacts still loading).
    */
   verifiedDmContactNames?: ReadonlySet<string>;
+  /**
+   * Persisted capabilities-tier override per channel id (from the gateway's
+   * channel-permission cells). Channels absent from the map use the
+   * channel-type default.
+   */
+  tierOverrides?: Record<string, SlackCapabilityTier>;
+  /**
+   * True until persisted overrides have loaded — expanded rows hold their
+   * tier picker disabled so stored overrides can't be misread as defaults.
+   */
+  tierOverridesLoading?: boolean;
+  /** Channels with a tier write in flight — the row shows a saving hint. */
+  pendingChannelIds?: ReadonlySet<string>;
+  onTierChange?: (channelId: string, tier: SlackCapabilityTier) => void;
+  /** Deletes the channel's persisted cells so the default wins again. */
+  onTierReset?: (channelId: string) => void;
 }
 
 const EMPTY_VERIFIED_NAMES: ReadonlySet<string> = new Set();
+const EMPTY_PENDING_IDS: ReadonlySet<string> = new Set();
 
 /**
  * Presence channel list for the Slack sub-tab: every Slack channel the
- * assistant is a member of, with a per-row resolved-access badge. Search and
- * the kind chips narrow the list client-side; the membership filter itself
- * is server-side (`?memberOnly=true`) with no toggle.
+ * assistant is a member of, with a per-row resolved-access badge. Rows
+ * expand inline (single-open accordion; "Expand all" switches to multi-open)
+ * to configure the channel's two override axes. Search and the kind chips
+ * narrow the list client-side; the membership filter itself is server-side
+ * (`?memberOnly=true`) with no toggle.
  */
 export function SlackChannelList({
   assistantDisplayName,
@@ -195,9 +205,41 @@ export function SlackChannelList({
   loading = false,
   error = false,
   verifiedDmContactNames = EMPTY_VERIFIED_NAMES,
+  tierOverrides,
+  tierOverridesLoading = false,
+  pendingChannelIds = EMPTY_PENDING_IDS,
+  onTierChange,
+  onTierReset,
 }: SlackChannelListProps) {
   const [search, setSearch] = useState("");
   const [kindFilter, setKindFilter] = useState<SlackChannelKind | null>(null);
+  const [openIds, setOpenIds] = useState<ReadonlySet<string>>(new Set());
+  const [multiOpen, setMultiOpen] = useState(false);
+
+  const toggleRow = (id: string) => {
+    setOpenIds((prev) => {
+      if (multiOpen) {
+        const next = new Set(prev);
+        if (next.has(id)) {
+          next.delete(id);
+        } else {
+          next.add(id);
+        }
+        return next;
+      }
+      return prev.has(id) ? new Set() : new Set([id]);
+    });
+  };
+
+  const toggleExpandAll = () => {
+    if (multiOpen) {
+      setMultiOpen(false);
+      setOpenIds(new Set());
+    } else {
+      setMultiOpen(true);
+      setOpenIds(new Set((channels ?? []).map((channel) => channel.id)));
+    }
+  };
 
   const allChannels = channels ?? [];
   const visibleChannels = useMemo(
@@ -298,6 +340,9 @@ export function SlackChannelList({
                     );
                   })}
                 </div>
+                <Button type="button" variant="outlined" onClick={toggleExpandAll}>
+                  {multiOpen ? "Collapse all" : "Expand all"}
+                </Button>
               </div>
               {visibleChannels.length === 0 ? (
                 <Typography
@@ -318,6 +363,15 @@ export function SlackChannelList({
                       <SlackChannelRow
                         channel={channel}
                         verifiedDmContactNames={verifiedDmContactNames}
+                        open={openIds.has(channel.id)}
+                        pending={pendingChannelIds.has(channel.id)}
+                        overridesLoading={tierOverridesLoading}
+                        onToggle={() => toggleRow(channel.id)}
+                        tierOverride={tierOverrides?.[channel.id]}
+                        onTierChange={(tier) =>
+                          onTierChange?.(channel.id, tier)
+                        }
+                        onReset={() => onTierReset?.(channel.id)}
                       />
                     )}
                     className="h-full"
@@ -330,6 +384,13 @@ export function SlackChannelList({
                       key={channel.id}
                       channel={channel}
                       verifiedDmContactNames={verifiedDmContactNames}
+                      open={openIds.has(channel.id)}
+                      pending={pendingChannelIds.has(channel.id)}
+                      overridesLoading={tierOverridesLoading}
+                      onToggle={() => toggleRow(channel.id)}
+                      tierOverride={tierOverrides?.[channel.id]}
+                      onTierChange={(tier) => onTierChange?.(channel.id, tier)}
+                      onReset={() => onTierReset?.(channel.id)}
                     />
                   ))}
                 </div>
@@ -357,30 +418,86 @@ export function SlackChannelList({
 function SlackChannelRow({
   channel,
   verifiedDmContactNames,
+  open,
+  pending,
+  overridesLoading,
+  onToggle,
+  tierOverride,
+  onTierChange,
+  onReset,
 }: {
   channel: SlackChannel;
   verifiedDmContactNames: ReadonlySet<string>;
+  open: boolean;
+  pending: boolean;
+  overridesLoading: boolean;
+  onToggle: () => void;
+  tierOverride: SlackCapabilityTier | undefined;
+  onTierChange: (tier: SlackCapabilityTier) => void;
+  onReset: () => void;
 }) {
   const kind = classifySlackChannelKind(channel);
   const Icon = CHANNEL_KIND_ICONS[kind];
-  const threshold = resolveSlackChannelThreshold(channel, verifiedDmContactNames);
   const metaLabel = slackChannelMetaLabel(channel);
+  const dmVerified = isVerifiedSlackDm(channel, verifiedDmContactNames);
+  const settings = resolveChannelTier(kind, dmVerified, tierOverride);
+  const tierMeta = CAPABILITY_TIER_META[settings.tier];
   return (
-    <ListRow
-      leading={<Icon className="h-4 w-4 text-[var(--content-tertiary)]" />}
-      title={channel.name}
-      trailing={
-        <>
-          {metaLabel != null ? (
-            <span className="text-body-small-default text-[color:var(--content-tertiary)]">
-              {metaLabel}
-            </span>
-          ) : null}
-          <Tag tone={THRESHOLD_TAG_TONES[threshold]}>
-            {presetFromThreshold(threshold).label}
-          </Tag>
-        </>
-      }
-    />
+    <div className="[&+&]:border-t [&+&]:border-[var(--border-base)]">
+      <ListRow
+        leading={<Icon className="h-4 w-4 text-[var(--content-tertiary)]" />}
+        title={channel.name}
+        onClick={onToggle}
+        contentAriaLabel={`${channel.name} — ${open ? "collapse" : "expand"} channel settings`}
+        showChevron={false}
+        selected={open}
+        className={
+          open ? "shadow-[inset_3px_0_0_0_var(--content-default)]" : undefined
+        }
+        trailing={
+          <>
+            {pending ? (
+              <span className="text-body-small-default text-[color:var(--content-tertiary)]">
+                Saving…
+              </span>
+            ) : metaLabel != null ? (
+              <span className="text-body-small-default text-[color:var(--content-tertiary)]">
+                {metaLabel}
+              </span>
+            ) : null}
+            <Tag tone={tierMeta.tone}>
+              {tierMeta.label}
+              {settings.overridden ? " • custom" : ""}
+            </Tag>
+            <ChevronDown
+              aria-hidden="true"
+              className={cn(
+                "h-4 w-4 text-[var(--content-tertiary)] transition-transform",
+                ACCORDION_TRANSITION,
+                open && "rotate-180",
+              )}
+            />
+          </>
+        }
+      />
+      <div
+        className={cn(
+          "grid transition-[grid-template-rows]",
+          ACCORDION_TRANSITION,
+          open ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+        )}
+      >
+        <div className="min-h-0 overflow-hidden" inert={!open}>
+          <SlackChannelOverridePanel
+            channelName={channel.name}
+            kindLabel={kind === "dm" ? "DM" : kind}
+            settings={settings}
+            loading={overridesLoading}
+            onTierChange={onTierChange}
+            onReset={onReset}
+          />
+        </div>
+      </div>
+    </div>
   );
 }

--- a/clients/web/src/domains/contacts/components/slack-channel-list.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-list.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, Hash, Lock, Search, User } from "lucide-react";
+import { ChevronDown, Hash, Lock, Search } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { cn } from "@vellumai/design-library";
@@ -11,14 +11,14 @@ import { Typography } from "@vellumai/design-library/components/typography";
 import { VirtualList } from "@vellumai/design-library/components/virtual-list";
 
 import { EmptyState } from "@/components/empty-state";
-import { isVerifiedContactChannel } from "@/domains/contacts/components/contact-channels-section";
 import { SlackChannelOverridePanel } from "@/domains/contacts/components/slack-channel-override-panel";
 import {
   CAPABILITY_TIER_META,
   resolveChannelTier,
   type SlackCapabilityTier,
 } from "@/domains/contacts/slack-channel-overrides";
-import type { ContactPayload, SlackChannel } from "@/domains/contacts/types";
+import type { SlackChannel } from "@/domains/contacts/types";
+import type { AdmissionPolicy } from "@/lib/channel-admission-policy/types";
 
 /**
  * How a channel presents in the filter chips. Mirrors the conversation-type
@@ -34,6 +34,20 @@ export function classifySlackChannelKind(channel: SlackChannel): SlackChannelKin
     return "dm";
   }
   return channel.isPrivate ? "private" : "public";
+}
+
+/** Room kinds the presence list renders — 1:1 DMs are person-scoped, not rooms. */
+export type SlackRoomKind = Exclude<SlackChannelKind, "dm">;
+
+/**
+ * The presence list is rooms only: channels and group DMs. 1:1 DMs are
+ * person-scoped — how the assistant interacts with a person lives on their
+ * contact, not on a room row.
+ */
+export function roomsOnly(channels: SlackChannel[]): SlackChannel[] {
+  return channels.filter(
+    (channel) => classifySlackChannelKind(channel) !== "dm",
+  );
 }
 
 /**
@@ -70,14 +84,8 @@ export function countSlackChannelKinds(
   return counts;
 }
 
-/**
- * Right-aligned row metadata: DMs read "Direct message", everything else
- * shows its member count when Slack reports one.
- */
+/** Right-aligned row metadata: the member count, when Slack reports one. */
 export function slackChannelMetaLabel(channel: SlackChannel): string | null {
-  if (classifySlackChannelKind(channel) === "dm") {
-    return "Direct message";
-  }
   if (channel.memberCount == null) {
     return null;
   }
@@ -86,63 +94,22 @@ export function slackChannelMetaLabel(channel: SlackChannel): string | null {
     : `${channel.memberCount} members`;
 }
 
-function normalizeSlackDmName(name: string): string {
-  return name.trim().toLowerCase();
-}
-
-/**
- * Normalized display names of contacts with a verified Slack channel — the
- * lookup behind the DM rows' resolved-access badges. Matching is by display
- * name because the channel list exposes each DM peer's Slack display name
- * but not their Slack user id.
- */
-export function buildVerifiedSlackContactNames(
-  contacts: ContactPayload[],
-): Set<string> {
-  const names = new Set<string>();
-  for (const contact of contacts) {
-    const hasVerifiedSlack = contact.channels.some(
-      (channel) => channel.type === "slack" && isVerifiedContactChannel(channel),
-    );
-    if (hasVerifiedSlack) {
-      names.add(normalizeSlackDmName(contact.displayName));
-    }
-  }
-  return names;
-}
-
-/**
- * Whether a DM row's peer is a verified contact — the contact-trust input
- * to the channel-type defaults. Always false for non-DM rows.
- */
-export function isVerifiedSlackDm(
-  channel: SlackChannel,
-  verifiedDmContactNames: ReadonlySet<string>,
-): boolean {
-  return (
-    classifySlackChannelKind(channel) === "dm" &&
-    verifiedDmContactNames.has(normalizeSlackDmName(channel.name))
-  );
-}
-
 /** Shared timing for the accordion region and the caret rotation. */
 const ACCORDION_TRANSITION =
   "duration-[280ms] ease-[cubic-bezier(0.32,0.72,0,1)]";
 
 const CHANNEL_KIND_FILTERS: {
-  value: SlackChannelKind | null;
+  value: SlackRoomKind | null;
   label: string;
 }[] = [
   { value: null, label: "All" },
   { value: "public", label: "Public" },
   { value: "private", label: "Private" },
-  { value: "dm", label: "DMs" },
 ];
 
-const CHANNEL_KIND_ICONS: Record<SlackChannelKind, typeof Hash> = {
+const CHANNEL_KIND_ICONS: Record<SlackRoomKind, typeof Hash> = {
   public: Hash,
   private: Lock,
-  dm: User,
 };
 
 /**
@@ -164,12 +131,6 @@ export interface SlackChannelListProps {
   loading?: boolean;
   error?: boolean;
   /**
-   * Lookup for the DM rows' resolved-access badges (see
-   * {@link buildVerifiedSlackContactNames}). DMs resolve strict while it is
-   * absent (contacts still loading).
-   */
-  verifiedDmContactNames?: ReadonlySet<string>;
-  /**
    * Persisted capabilities-tier override per channel id (from the gateway's
    * channel-permission cells). Channels absent from the map use the
    * channel-type default.
@@ -185,9 +146,10 @@ export interface SlackChannelListProps {
   onTierChange?: (channelId: string, tier: SlackCapabilityTier) => void;
   /** Deletes the channel's persisted cells so the default wins again. */
   onTierReset?: (channelId: string) => void;
+  /** Slack trust floor, shown read-only in expanded rows. */
+  admissionPolicy?: AdmissionPolicy;
 }
 
-const EMPTY_VERIFIED_NAMES: ReadonlySet<string> = new Set();
 const EMPTY_PENDING_IDS: ReadonlySet<string> = new Set();
 
 /**
@@ -204,15 +166,15 @@ export function SlackChannelList({
   channels,
   loading = false,
   error = false,
-  verifiedDmContactNames = EMPTY_VERIFIED_NAMES,
   tierOverrides,
   tierOverridesLoading = false,
   pendingChannelIds = EMPTY_PENDING_IDS,
   onTierChange,
   onTierReset,
+  admissionPolicy,
 }: SlackChannelListProps) {
   const [search, setSearch] = useState("");
-  const [kindFilter, setKindFilter] = useState<SlackChannelKind | null>(null);
+  const [kindFilter, setKindFilter] = useState<SlackRoomKind | null>(null);
   const [openIds, setOpenIds] = useState<ReadonlySet<string>>(new Set());
   const [multiOpen, setMultiOpen] = useState(false);
 
@@ -237,18 +199,18 @@ export function SlackChannelList({
       setOpenIds(new Set());
     } else {
       setMultiOpen(true);
-      setOpenIds(new Set((channels ?? []).map((channel) => channel.id)));
+      setOpenIds(new Set(allChannels.map((channel) => channel.id)));
     }
   };
 
-  const allChannels = channels ?? [];
+  const allChannels = useMemo(() => roomsOnly(channels ?? []), [channels]);
   const visibleChannels = useMemo(
-    () => filterSlackChannels(channels ?? [], search, kindFilter),
-    [channels, search, kindFilter],
+    () => filterSlackChannels(allChannels, search, kindFilter),
+    [allChannels, search, kindFilter],
   );
   const kindCounts = useMemo(
-    () => countSlackChannelKinds(channels ?? []),
-    [channels],
+    () => countSlackChannelKinds(allChannels),
+    [allChannels],
   );
 
   const handle = slackHandle ?? `@${assistantDisplayName}`;
@@ -362,7 +324,6 @@ export function SlackChannelList({
                     itemContent={(_, channel) => (
                       <SlackChannelRow
                         channel={channel}
-                        verifiedDmContactNames={verifiedDmContactNames}
                         open={openIds.has(channel.id)}
                         pending={pendingChannelIds.has(channel.id)}
                         overridesLoading={tierOverridesLoading}
@@ -372,6 +333,8 @@ export function SlackChannelList({
                           onTierChange?.(channel.id, tier)
                         }
                         onReset={() => onTierReset?.(channel.id)}
+                        assistantDisplayName={assistantDisplayName}
+                        admissionPolicy={admissionPolicy}
                       />
                     )}
                     className="h-full"
@@ -383,7 +346,6 @@ export function SlackChannelList({
                     <SlackChannelRow
                       key={channel.id}
                       channel={channel}
-                      verifiedDmContactNames={verifiedDmContactNames}
                       open={openIds.has(channel.id)}
                       pending={pendingChannelIds.has(channel.id)}
                       overridesLoading={tierOverridesLoading}
@@ -391,6 +353,8 @@ export function SlackChannelList({
                       tierOverride={tierOverrides?.[channel.id]}
                       onTierChange={(tier) => onTierChange?.(channel.id, tier)}
                       onReset={() => onTierReset?.(channel.id)}
+                      assistantDisplayName={assistantDisplayName}
+                      admissionPolicy={admissionPolicy}
                     />
                   ))}
                 </div>
@@ -417,7 +381,6 @@ export function SlackChannelList({
 
 function SlackChannelRow({
   channel,
-  verifiedDmContactNames,
   open,
   pending,
   overridesLoading,
@@ -425,9 +388,10 @@ function SlackChannelRow({
   tierOverride,
   onTierChange,
   onReset,
+  assistantDisplayName,
+  admissionPolicy,
 }: {
   channel: SlackChannel;
-  verifiedDmContactNames: ReadonlySet<string>;
   open: boolean;
   pending: boolean;
   overridesLoading: boolean;
@@ -435,12 +399,17 @@ function SlackChannelRow({
   tierOverride: SlackCapabilityTier | undefined;
   onTierChange: (tier: SlackCapabilityTier) => void;
   onReset: () => void;
+  assistantDisplayName: string;
+  admissionPolicy: AdmissionPolicy | undefined;
 }) {
   const kind = classifySlackChannelKind(channel);
+  // Rows are rooms only ({@link roomsOnly}); a 1:1 DM row is unreachable.
+  if (kind === "dm") {
+    return null;
+  }
   const Icon = CHANNEL_KIND_ICONS[kind];
   const metaLabel = slackChannelMetaLabel(channel);
-  const dmVerified = isVerifiedSlackDm(channel, verifiedDmContactNames);
-  const settings = resolveChannelTier(kind, dmVerified, tierOverride);
+  const settings = resolveChannelTier(tierOverride);
   const tierMeta = CAPABILITY_TIER_META[settings.tier];
   return (
     <div className="[&+&]:border-t [&+&]:border-[var(--border-base)]">
@@ -490,7 +459,9 @@ function SlackChannelRow({
         <div className="min-h-0 overflow-hidden" inert={!open}>
           <SlackChannelOverridePanel
             channelName={channel.name}
-            kindLabel={kind === "dm" ? "DM" : kind}
+            kindLabel={kind}
+            assistantDisplayName={assistantDisplayName}
+            admissionPolicy={admissionPolicy}
             settings={settings}
             loading={overridesLoading}
             onTierChange={onTierChange}

--- a/clients/web/src/domains/contacts/components/slack-channel-override-panel.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-override-panel.tsx
@@ -10,12 +10,25 @@ import {
   type SlackCapabilityTier,
   type SlackChannelTierSettings,
 } from "@/domains/contacts/slack-channel-overrides";
+import {
+  getPolicyDescriptions,
+  POLICY_LABELS,
+  type AdmissionPolicy,
+} from "@/lib/channel-admission-policy/types";
 
 export interface SlackChannelOverridePanelProps {
   /** Row's channel name, for accessible control labels. */
   channelName: string;
-  /** Lowercase channel-type word for the custom-capabilities callout copy. */
-  kindLabel: "public" | "private" | "DM";
+  /** Lowercase room-type word for the custom-capabilities callout copy. */
+  kindLabel: "public" | "private";
+  /** Trimmed assistant name with a "your assistant" fallback, for copy. */
+  assistantDisplayName: string;
+  /**
+   * The Slack trust floor, shown read-only so the row answers "who can
+   * reach the assistant here". Admission is a channel-type setting — the
+   * control lives in the "Who can message" dropdown, not per room.
+   */
+  admissionPolicy?: AdmissionPolicy;
   settings: SlackChannelTierSettings;
   /**
    * True until persisted overrides have loaded — the picker holds disabled
@@ -35,6 +48,8 @@ export interface SlackChannelOverridePanelProps {
 export function SlackChannelOverridePanel({
   channelName,
   kindLabel,
+  assistantDisplayName,
+  admissionPolicy,
   settings,
   loading = false,
   onTierChange,
@@ -49,6 +64,35 @@ export function SlackChannelOverridePanel({
 
   return (
     <div className="flex flex-col gap-3 px-2 pt-1 pb-4">
+      {admissionPolicy ? (
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center justify-between gap-2">
+            <Typography
+              as="span"
+              variant="body-small-emphasised"
+              className="text-[color:var(--content-secondary)]"
+            >
+              Who can reach {assistantDisplayName} here
+            </Typography>
+            <Typography
+              as="span"
+              variant="body-small-default"
+              className="text-[color:var(--content-tertiary)]"
+            >
+              {POLICY_LABELS[admissionPolicy]} — all of Slack
+            </Typography>
+          </div>
+          <Typography
+            as="p"
+            variant="body-small-default"
+            className="text-[color:var(--content-tertiary)]"
+          >
+            {getPolicyDescriptions(assistantDisplayName)[admissionPolicy]}{" "}
+            Set once for all Slack channels in “Who can message{" "}
+            {assistantDisplayName}” above.
+          </Typography>
+        </div>
+      ) : null}
       {settings.overridden ? (
         <Notice
           tone="warning"

--- a/clients/web/src/domains/contacts/components/slack-channel-override-panel.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-override-panel.tsx
@@ -1,0 +1,109 @@
+import { Button } from "@vellumai/design-library/components/button";
+import { Notice } from "@vellumai/design-library/components/notice";
+import { SegmentControl } from "@vellumai/design-library/components/segment-control";
+import { Tag } from "@vellumai/design-library/components/tag";
+import { Typography } from "@vellumai/design-library/components/typography";
+
+import {
+  CAPABILITY_TIER_META,
+  CAPABILITY_TIER_VALUES,
+  type SlackCapabilityTier,
+  type SlackChannelTierSettings,
+} from "@/domains/contacts/slack-channel-overrides";
+
+export interface SlackChannelOverridePanelProps {
+  /** Row's channel name, for accessible control labels. */
+  channelName: string;
+  /** Lowercase channel-type word for the custom-capabilities callout copy. */
+  kindLabel: "public" | "private" | "DM";
+  settings: SlackChannelTierSettings;
+  /**
+   * True until persisted overrides have loaded — the picker holds disabled
+   * so a stored tier can't be misread (and overwritten) as the default.
+   */
+  loading?: boolean;
+  onTierChange: (tier: SlackCapabilityTier) => void;
+  onReset: () => void;
+}
+
+/**
+ * Expanded-row settings for one Slack channel: the capabilities tier
+ * (the only per-room knob — admission is a channel-type concern), with a
+ * custom-capabilities callout + reset when the tier diverges from the
+ * channel-type default. Persists as channel-ID cells via the gateway SDK.
+ */
+export function SlackChannelOverridePanel({
+  channelName,
+  kindLabel,
+  settings,
+  loading = false,
+  onTierChange,
+  onReset,
+}: SlackChannelOverridePanelProps) {
+  const tierItems = CAPABILITY_TIER_VALUES.map((tier) => ({
+    value: tier,
+    label: CAPABILITY_TIER_META[tier].label,
+    disabled: loading,
+  }));
+  const tierMeta = CAPABILITY_TIER_META[settings.tier];
+
+  return (
+    <div className="flex flex-col gap-3 px-2 pt-1 pb-4">
+      {settings.overridden ? (
+        <Notice
+          tone="warning"
+          title="Custom capabilities."
+          className="border-dashed"
+          actions={
+            <Button type="button" variant="outlined" onClick={onReset}>
+              Reset to default
+            </Button>
+          }
+        >
+          This channel isn’t using the {kindLabel} default.
+        </Notice>
+      ) : null}
+      <div className="flex items-center justify-between gap-2">
+        <Typography
+          as="span"
+          variant="body-small-emphasised"
+          className="text-[color:var(--content-secondary)]"
+        >
+          Capabilities
+        </Typography>
+        {loading ? (
+          <Typography
+            as="span"
+            variant="body-small-default"
+            className="text-[color:var(--content-tertiary)]"
+          >
+            Loading…
+          </Typography>
+        ) : settings.overridden ? (
+          <Tag tone="warning">overridden</Tag>
+        ) : (
+          <Typography
+            as="span"
+            variant="body-small-default"
+            className="text-[color:var(--content-tertiary)]"
+          >
+            default
+          </Typography>
+        )}
+      </div>
+      <SegmentControl<SlackCapabilityTier>
+        items={tierItems}
+        value={settings.tier}
+        onChange={onTierChange}
+        ariaLabel={`Capabilities in ${channelName}`}
+      />
+      <Typography
+        as="p"
+        variant="body-small-default"
+        className="text-[color:var(--content-tertiary)]"
+      >
+        {tierMeta.label} — {tierMeta.sublabel}. {tierMeta.description}
+      </Typography>
+    </div>
+  );
+}

--- a/clients/web/src/domains/contacts/components/slack-channel-section.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-section.tsx
@@ -1,12 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
 
-import {
-  buildVerifiedSlackContactNames,
-  SlackChannelList,
-} from "@/domains/contacts/components/slack-channel-list";
+import { SlackChannelList } from "@/domains/contacts/components/slack-channel-list";
 import { useChannelPermissionOverrides } from "@/domains/contacts/hooks/use-channel-permission-overrides";
 import { memberSlackChannelsOptions } from "@/domains/contacts/slack-channels-query";
-import { contactsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
+import type { AdmissionPolicy } from "@/lib/channel-admission-policy/types";
 
 export interface SlackChannelSectionProps {
   assistantId: string;
@@ -14,32 +11,26 @@ export interface SlackChannelSectionProps {
   assistantDisplayName: string;
   /** The assistant's Slack handle for the `/invite` and `/remove` hints. */
   slackHandle?: string;
+  /** Slack trust floor, shown read-only in expanded rows. */
+  admissionPolicy?: AdmissionPolicy;
 }
 
 /**
- * Data container for the Slack sub-tab's channel list: the member-only
- * channels query, the verified-contact lookup behind DM badges, and the
- * per-channel capabilities-tier persistence. Mounts only while Slack is
- * connected (the panel renders it conditionally), so the queries need no
- * connection gate of their own.
+ * Data container for the Slack sub-tab's room list: the member-only
+ * channels query and the per-channel capabilities-tier persistence. Mounts
+ * only while Slack is connected (the panel renders it conditionally), so
+ * the queries need no connection gate of their own.
  */
 export function SlackChannelSection({
   assistantId,
   assistantDisplayName,
   slackHandle,
+  admissionPolicy,
 }: SlackChannelSectionProps) {
   const channelsQuery = useQuery({
     ...memberSlackChannelsOptions(assistantId),
     enabled: Boolean(assistantId),
     select: (data) => data.channels,
-  });
-
-  // Verified-contact lookup for the DM rows' badges. Shares the contacts
-  // cache with the Contacts page (same key, own select).
-  const verifiedContactsQuery = useQuery({
-    ...contactsGetOptions({ path: { assistant_id: assistantId } }),
-    enabled: Boolean(assistantId),
-    select: (data) => buildVerifiedSlackContactNames(data.contacts),
   });
 
   const overrides = useChannelPermissionOverrides({
@@ -54,12 +45,12 @@ export function SlackChannelSection({
       channels={channelsQuery.data}
       loading={channelsQuery.isPending}
       error={channelsQuery.isError}
-      verifiedDmContactNames={verifiedContactsQuery.data}
       tierOverrides={overrides.tierOverrides}
       tierOverridesLoading={overrides.isLoading}
       pendingChannelIds={overrides.pendingChannelIds}
       onTierChange={overrides.onTierChange}
       onTierReset={overrides.onTierReset}
+      admissionPolicy={admissionPolicy}
     />
   );
 }

--- a/clients/web/src/domains/contacts/components/slack-channel-section.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-section.tsx
@@ -1,0 +1,65 @@
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  buildVerifiedSlackContactNames,
+  SlackChannelList,
+} from "@/domains/contacts/components/slack-channel-list";
+import { useChannelPermissionOverrides } from "@/domains/contacts/hooks/use-channel-permission-overrides";
+import { memberSlackChannelsOptions } from "@/domains/contacts/slack-channels-query";
+import { contactsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
+
+export interface SlackChannelSectionProps {
+  assistantId: string;
+  /** Trimmed assistant name with a "your assistant" fallback, for copy. */
+  assistantDisplayName: string;
+  /** The assistant's Slack handle for the `/invite` and `/remove` hints. */
+  slackHandle?: string;
+}
+
+/**
+ * Data container for the Slack sub-tab's channel list: the member-only
+ * channels query, the verified-contact lookup behind DM badges, and the
+ * per-channel capabilities-tier persistence. Mounts only while Slack is
+ * connected (the panel renders it conditionally), so the queries need no
+ * connection gate of their own.
+ */
+export function SlackChannelSection({
+  assistantId,
+  assistantDisplayName,
+  slackHandle,
+}: SlackChannelSectionProps) {
+  const channelsQuery = useQuery({
+    ...memberSlackChannelsOptions(assistantId),
+    enabled: Boolean(assistantId),
+    select: (data) => data.channels,
+  });
+
+  // Verified-contact lookup for the DM rows' badges. Shares the contacts
+  // cache with the Contacts page (same key, own select).
+  const verifiedContactsQuery = useQuery({
+    ...contactsGetOptions({ path: { assistant_id: assistantId } }),
+    enabled: Boolean(assistantId),
+    select: (data) => buildVerifiedSlackContactNames(data.contacts),
+  });
+
+  const overrides = useChannelPermissionOverrides({
+    assistantId,
+    adapter: "slack",
+  });
+
+  return (
+    <SlackChannelList
+      assistantDisplayName={assistantDisplayName}
+      slackHandle={slackHandle}
+      channels={channelsQuery.data}
+      loading={channelsQuery.isPending}
+      error={channelsQuery.isError}
+      verifiedDmContactNames={verifiedContactsQuery.data}
+      tierOverrides={overrides.tierOverrides}
+      tierOverridesLoading={overrides.isLoading}
+      pendingChannelIds={overrides.pendingChannelIds}
+      onTierChange={overrides.onTierChange}
+      onTierReset={overrides.onTierReset}
+    />
+  );
+}

--- a/clients/web/src/domains/contacts/hooks/use-assistant-channels.ts
+++ b/clients/web/src/domains/contacts/hooks/use-assistant-channels.ts
@@ -3,7 +3,6 @@ import { useCallback, useMemo } from "react";
 
 import type { SlackThreadMode } from "@/components/slack-setup-wizard";
 import type { AssistantChannelsListProps } from "@/domains/contacts/components/assistant-channels-list";
-import { buildVerifiedSlackContactNames } from "@/domains/contacts/components/slack-channel-list";
 import { useChannelTrustFloors } from "@/domains/contacts/hooks/use-channel-trust-floors";
 import {
   SETUP_CHANNEL_IDS,
@@ -11,11 +10,10 @@ import {
   type ChannelReadinessSnapshot,
   type SetupChannelId,
 } from "@/domains/contacts/types";
-import { memberSlackChannelsOptions, memberSlackChannelsQueryKey } from "@/domains/contacts/slack-channels-query";
+import { memberSlackChannelsQueryKey } from "@/domains/contacts/slack-channels-query";
 import {
   channelsReadinessGetOptions,
   channelsReadinessGetQueryKey,
-  contactsGetOptions,
   integrationsSlackChannelConfigGetOptions,
   integrationsSlackChannelConfigGetQueryKey,
   integrationsSlackChannelConfigPatchMutation,
@@ -47,11 +45,12 @@ export interface UseAssistantChannelsOptions {
 /**
  * Everything `AssistantChannelsList` needs except the page-specific bits —
  * spread the controller straight into the component. Derived from the list's
- * own props so the two can't drift.
+ * own props so the two can't drift. The Slack sub-tab's channel list owns
+ * its own data (`SlackChannelSection`), so nothing list-related lives here.
  */
 export type AssistantChannelsController = Omit<
   AssistantChannelsListProps,
-  "assistantName" | "initialChannel"
+  "assistantId" | "assistantName" | "initialChannel"
 >;
 
 /**
@@ -94,21 +93,6 @@ export function useAssistantChannels({
     ...integrationsSlackChannelConfigGetOptions(pathOpts),
     enabled: slackConnected,
     select: (data: IntegrationsSlackChannelConfigGetResponse) => data.threadMode,
-  });
-
-  // Presence-only channel list for the Slack sub-tab.
-  const slackChannelsQuery = useQuery({
-    ...memberSlackChannelsOptions(assistantId),
-    enabled: slackConnected,
-    select: (data) => data.channels,
-  });
-
-  // Verified-contact lookup behind the DM rows' resolved-access badges.
-  // Shares the contacts cache with the Contacts page (same key, own select).
-  const verifiedSlackContactsQuery = useQuery({
-    ...contactsGetOptions(pathOpts),
-    enabled: slackConnected,
-    select: (data) => buildVerifiedSlackContactNames(data.contacts),
   });
 
   // Per-channel trust floors (admission policy), shown inline on each connected
@@ -219,10 +203,6 @@ export function useAssistantChannels({
       : null,
     slackThreadMode: slackConfigQuery.data,
     slackThreadModePending: slackThreadModeMutation.isPending,
-    slackChannels: slackChannelsQuery.data,
-    slackChannelsLoading: slackChannelsQuery.isPending,
-    slackChannelsError: slackChannelsQuery.isError,
-    slackVerifiedDmContactNames: verifiedSlackContactsQuery.data,
     channelPolicies: channelTrustFloors.policies,
     policySavingKey: channelTrustFloors.savingKey,
     policiesLoading: channelTrustFloors.isLoading,

--- a/clients/web/src/domains/contacts/hooks/use-channel-permission-overrides.ts
+++ b/clients/web/src/domains/contacts/hooks/use-channel-permission-overrides.ts
@@ -1,0 +1,225 @@
+import { useMemo } from "react";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  CAPABILITY_TIER_THRESHOLDS,
+  CHANNEL_TIER_CONTACT_TYPES,
+  tierOverridesFromCells,
+  type SlackCapabilityTier,
+} from "@/domains/contacts/slack-channel-overrides";
+import {
+  assistantChannelPermissionOverridesListOptions,
+  assistantChannelPermissionOverridesListQueryKey,
+} from "@/generated/gateway/@tanstack/react-query.gen";
+import {
+  assistantChannelPermissionOverrideDelete,
+  assistantChannelPermissionOverrideSet,
+} from "@/generated/gateway/sdk.gen";
+import type { AssistantChannelPermissionOverridesListResponse } from "@/generated/gateway/types.gen";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
+import { toastOnError } from "@/utils/mutation-error";
+
+type CellList = AssistantChannelPermissionOverridesListResponse;
+type Cell = CellList["cells"][number];
+type WireCell = Omit<Cell, "updatedAt">;
+
+export interface ChannelPermissionOverridesController {
+  /** Persisted tier per channel external id, or `undefined` while the feature is off. */
+  tierOverrides?: Record<string, SlackCapabilityTier>;
+  /** Channels with a cell write/delete in flight. */
+  pendingChannelIds: ReadonlySet<string>;
+  /** True until the cells have loaded at least once. */
+  isLoading: boolean;
+  isError: boolean;
+  /** Persist a tier as channel-ID cells, or `undefined` when the feature is off. */
+  onTierChange?: (channelExternalId: string, tier: SlackCapabilityTier) => void;
+  /** Delete the channel's cells so the next cascade tier up wins. */
+  onTierReset?: (channelExternalId: string) => void;
+}
+
+/** One channel-ID cell per non-guardian contact-type for the chosen tier. */
+function cellsForTier(
+  adapter: string,
+  channelExternalId: string,
+  tier: SlackCapabilityTier,
+): WireCell[] {
+  return CHANNEL_TIER_CONTACT_TYPES.map((contactType) => ({
+    selector: { scope: "channel" as const, adapter, channelExternalId },
+    contactType,
+    threshold: CAPABILITY_TIER_THRESHOLDS[tier],
+  }));
+}
+
+function isChannelCell(
+  cell: Cell,
+  adapter: string,
+  channelExternalId: string,
+): boolean {
+  return (
+    cell.selector.scope === "channel" &&
+    cell.selector.adapter === adapter &&
+    cell.selector.channelExternalId === channelExternalId
+  );
+}
+
+/**
+ * Per-channel capabilities-tier persistence for a channel adapter's room
+ * list: reads the gateway's channel-permission cells and writes/deletes
+ * channel-ID-tier cells (one per non-guardian contact-type). Optimistic —
+ * the cell cache is patched immediately, rolled back and toasted on
+ * failure, and revalidated on settle. Reads the `channelTrustFloors` flag
+ * itself; when off it returns no overrides and no handlers.
+ *
+ * The adapter is a parameter so Telegram/Phone room lists reuse this hook
+ * unchanged when they land.
+ */
+export function useChannelPermissionOverrides({
+  assistantId,
+  adapter,
+}: {
+  assistantId: string;
+  adapter: string;
+}): ChannelPermissionOverridesController {
+  const queryClient = useQueryClient();
+  const enabled = useAssistantFeatureFlagStore.use.channelTrustFloors();
+
+  const pathOptions = useMemo(
+    () => ({ path: { assistant_id: assistantId } }),
+    [assistantId],
+  );
+  const queryKey = useMemo(
+    () => assistantChannelPermissionOverridesListQueryKey(pathOptions),
+    [pathOptions],
+  );
+
+  const query = useQuery({
+    ...assistantChannelPermissionOverridesListOptions(pathOptions),
+    enabled: enabled && Boolean(assistantId),
+    select: (data) => tierOverridesFromCells(data.cells, adapter),
+  });
+
+  // Optimistically replace the channel's cells in the cached list, snapshot
+  // for rollback, and revalidate after the server settles either way.
+  const applyOptimistic = (
+    channelExternalId: string,
+    nextCells: WireCell[],
+  ): { previous: CellList | undefined } => {
+    const previous = queryClient.getQueryData<CellList>(queryKey);
+    const stampedAt = Date.now();
+    queryClient.setQueryData<CellList>(queryKey, (old) => ({
+      cells: [
+        ...(old?.cells ?? []).filter(
+          (cell) => !isChannelCell(cell, adapter, channelExternalId),
+        ),
+        ...nextCells.map((cell) => ({ ...cell, updatedAt: stampedAt })),
+      ],
+    }));
+    return { previous };
+  };
+
+  const setMutation = useMutation({
+    mutationFn: async ({
+      channelExternalId,
+      tier,
+    }: {
+      channelExternalId: string;
+      tier: SlackCapabilityTier;
+    }) => {
+      await Promise.all(
+        cellsForTier(adapter, channelExternalId, tier).map((cell) =>
+          assistantChannelPermissionOverrideSet({
+            ...pathOptions,
+            body: cell,
+            throwOnError: true,
+          }),
+        ),
+      );
+    },
+    onMutate: ({ channelExternalId, tier }) =>
+      applyOptimistic(
+        channelExternalId,
+        cellsForTier(adapter, channelExternalId, tier),
+      ),
+    onError: (err, _vars, context) => {
+      queryClient.setQueryData(queryKey, context?.previous);
+      toastOnError("Failed to save channel settings")(err);
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey }),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async ({
+      channelExternalId,
+    }: {
+      channelExternalId: string;
+    }) => {
+      await Promise.all(
+        CHANNEL_TIER_CONTACT_TYPES.map((contactType) =>
+          assistantChannelPermissionOverrideDelete({
+            ...pathOptions,
+            body: {
+              selector: {
+                scope: "channel" as const,
+                adapter,
+                channelExternalId,
+              },
+              contactType,
+            },
+            throwOnError: true,
+          }),
+        ),
+      );
+    },
+    onMutate: ({ channelExternalId }) =>
+      applyOptimistic(channelExternalId, []),
+    onError: (err, _vars, context) => {
+      queryClient.setQueryData(queryKey, context?.previous);
+      toastOnError("Failed to reset channel settings")(err);
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey }),
+  });
+
+  const pendingChannelIds = useMemo(() => {
+    const ids = new Set<string>();
+    if (setMutation.isPending && setMutation.variables) {
+      ids.add(setMutation.variables.channelExternalId);
+    }
+    if (deleteMutation.isPending && deleteMutation.variables) {
+      ids.add(deleteMutation.variables.channelExternalId);
+    }
+    return ids;
+  }, [
+    setMutation.isPending,
+    setMutation.variables,
+    deleteMutation.isPending,
+    deleteMutation.variables,
+  ]);
+
+  if (!enabled) {
+    return {
+      tierOverrides: undefined,
+      pendingChannelIds: new Set(),
+      isLoading: false,
+      isError: false,
+      onTierChange: undefined,
+      onTierReset: undefined,
+    };
+  }
+
+  return {
+    tierOverrides: query.data,
+    pendingChannelIds,
+    isLoading: query.isPending,
+    isError: query.isError,
+    onTierChange: (channelExternalId, tier) =>
+      setMutation.mutate({ channelExternalId, tier }),
+    onTierReset: (channelExternalId) => {
+      // Skip the round-trip when nothing is persisted for the channel.
+      if (query.data?.[channelExternalId] === undefined) {
+        return;
+      }
+      deleteMutation.mutate({ channelExternalId });
+    },
+  };
+}

--- a/clients/web/src/domains/contacts/slack-channel-overrides.test.ts
+++ b/clients/web/src/domains/contacts/slack-channel-overrides.test.ts
@@ -3,43 +3,30 @@ import { describe, expect, test } from "bun:test";
 import {
   CAPABILITY_TIER_META,
   CAPABILITY_TIER_THRESHOLDS,
-  defaultChannelTier,
   resolveChannelTier,
   tierFromThreshold,
   tierOverridesFromCells,
   type ChannelTierCell,
 } from "./slack-channel-overrides";
 
-describe("defaultChannelTier", () => {
-  test("public and private channels default to full access", () => {
-    expect(defaultChannelTier("public", false)).toBe("full_access");
-    expect(defaultChannelTier("private", false)).toBe("full_access");
-  });
-
-  test("DMs default by contact trust: verified full access, unverified strict", () => {
-    expect(defaultChannelTier("dm", true)).toBe("full_access");
-    expect(defaultChannelTier("dm", false)).toBe("strict");
-  });
-});
-
 describe("resolveChannelTier", () => {
-  test("no override resolves the default with no divergence", () => {
-    expect(resolveChannelTier("public", false, undefined)).toEqual({
+  test("no override resolves the room default with no divergence", () => {
+    expect(resolveChannelTier(undefined)).toEqual({
       tier: "full_access",
       overridden: false,
     });
   });
 
   test("a diverging override flags the row as custom", () => {
-    expect(resolveChannelTier("public", false, "standard")).toEqual({
+    expect(resolveChannelTier("standard")).toEqual({
       tier: "standard",
       overridden: true,
     });
   });
 
   test("a persisted cell matching the default is not flagged", () => {
-    expect(resolveChannelTier("dm", false, "strict")).toEqual({
-      tier: "strict",
+    expect(resolveChannelTier("full_access")).toEqual({
+      tier: "full_access",
       overridden: false,
     });
   });

--- a/clients/web/src/domains/contacts/slack-channel-overrides.test.ts
+++ b/clients/web/src/domains/contacts/slack-channel-overrides.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  CAPABILITY_TIER_META,
+  CAPABILITY_TIER_THRESHOLDS,
+  defaultChannelTier,
+  resolveChannelTier,
+  tierFromThreshold,
+  tierOverridesFromCells,
+  type ChannelTierCell,
+} from "./slack-channel-overrides";
+
+describe("defaultChannelTier", () => {
+  test("public and private channels default to full access", () => {
+    expect(defaultChannelTier("public", false)).toBe("full_access");
+    expect(defaultChannelTier("private", false)).toBe("full_access");
+  });
+
+  test("DMs default by contact trust: verified full access, unverified strict", () => {
+    expect(defaultChannelTier("dm", true)).toBe("full_access");
+    expect(defaultChannelTier("dm", false)).toBe("strict");
+  });
+});
+
+describe("resolveChannelTier", () => {
+  test("no override resolves the default with no divergence", () => {
+    expect(resolveChannelTier("public", false, undefined)).toEqual({
+      tier: "full_access",
+      overridden: false,
+    });
+  });
+
+  test("a diverging override flags the row as custom", () => {
+    expect(resolveChannelTier("public", false, "standard")).toEqual({
+      tier: "standard",
+      overridden: true,
+    });
+  });
+
+  test("a persisted cell matching the default is not flagged", () => {
+    expect(resolveChannelTier("dm", false, "strict")).toEqual({
+      tier: "strict",
+      overridden: false,
+    });
+  });
+});
+
+describe("tier ↔ threshold mapping", () => {
+  test("write mapping covers every tier", () => {
+    expect(CAPABILITY_TIER_THRESHOLDS).toEqual({
+      strict: "none",
+      standard: "low",
+      full_access: "high",
+    });
+  });
+
+  test("read mapping inverts writes and folds medium into standard", () => {
+    expect(tierFromThreshold("none")).toBe("strict");
+    expect(tierFromThreshold("low")).toBe("standard");
+    expect(tierFromThreshold("medium")).toBe("standard");
+    expect(tierFromThreshold("high")).toBe("full_access");
+  });
+});
+
+describe("tierOverridesFromCells", () => {
+  const cell = (
+    overrides: Partial<ChannelTierCell["selector"]> & {
+      contactType?: string;
+      threshold?: ChannelTierCell["threshold"];
+    },
+  ): ChannelTierCell => ({
+    selector: {
+      scope: overrides.scope ?? "channel",
+      adapter: overrides.adapter ?? "slack",
+      channelExternalId: overrides.channelExternalId,
+    },
+    contactType: overrides.contactType ?? "trusted_contact",
+    threshold: overrides.threshold ?? "low",
+  });
+
+  test("maps channel-scope cells for the adapter to tiers", () => {
+    const overrides = tierOverridesFromCells(
+      [cell({ channelExternalId: "C1", threshold: "low" })],
+      "slack",
+    );
+    expect(overrides).toEqual({ C1: "standard" });
+  });
+
+  test("ignores other scopes and other adapters", () => {
+    const overrides = tierOverridesFromCells(
+      [
+        cell({ scope: "adapter" }),
+        cell({ scope: "channel_type" }),
+        cell({ channelExternalId: "C1", adapter: "telegram" }),
+      ],
+      "slack",
+    );
+    expect(overrides).toEqual({});
+  });
+
+  test("trusted_contact is the representative when cells diverge", () => {
+    const overrides = tierOverridesFromCells(
+      [
+        cell({
+          channelExternalId: "C1",
+          contactType: "unknown",
+          threshold: "none",
+        }),
+        cell({
+          channelExternalId: "C1",
+          contactType: "trusted_contact",
+          threshold: "high",
+        }),
+      ],
+      "slack",
+    );
+    expect(overrides).toEqual({ C1: "full_access" });
+  });
+});
+
+describe("CAPABILITY_TIER_META", () => {
+  test("strict and full access reuse the threshold-preset labels", () => {
+    expect(CAPABILITY_TIER_META.strict.label).toBe("Strict");
+    expect(CAPABILITY_TIER_META.full_access.label).toBe("Full access");
+    expect(CAPABILITY_TIER_META.standard.label).toBe("Standard");
+  });
+
+  test("tones follow the existing status mapping", () => {
+    expect(CAPABILITY_TIER_META.strict.tone).toBe("negative");
+    expect(CAPABILITY_TIER_META.standard.tone).toBe("warning");
+    expect(CAPABILITY_TIER_META.full_access.tone).toBe("positive");
+  });
+});

--- a/clients/web/src/domains/contacts/slack-channel-overrides.ts
+++ b/clients/web/src/domains/contacts/slack-channel-overrides.ts
@@ -1,0 +1,171 @@
+/**
+ * Per-channel capabilities-tier model for the Slack channel list's
+ * expandable rows. Capabilities is the only per-room knob: the tier
+ * persists as channel-ID-tier cells in the gateway's
+ * `channel_permission_overrides` matrix (one cell per non-guardian
+ * contact-type; see {@link CHANNEL_TIER_CONTACT_TYPES}). Admission — who
+ * can reach the assistant — is a channel-type concern handled by the trust
+ * floors and has no per-room control.
+ */
+import type { TagTone } from "@vellumai/design-library/components/tag";
+
+import type { SlackChannelKind } from "@/domains/contacts/components/slack-channel-list";
+import {
+  presetFromThreshold,
+  type RiskThreshold,
+} from "@/utils/threshold-presets";
+
+/**
+ * Three-level capabilities tier shown on the row badge and the segmented
+ * picker. `strict` and `full_access` carry the same labels as the matching
+ * threshold presets; `standard` is the tier axis's intermediate level.
+ */
+export const CAPABILITY_TIER_VALUES = [
+  "strict",
+  "standard",
+  "full_access",
+] as const;
+
+export type SlackCapabilityTier = (typeof CAPABILITY_TIER_VALUES)[number];
+
+interface CapabilityTierMeta {
+  label: string;
+  /** Short qualifier shown with the tier in pickers and help copy. */
+  sublabel: string;
+  /** One-line help text for the selected tier. */
+  description: string;
+  tone: TagTone;
+}
+
+export const CAPABILITY_TIER_META: Record<SlackCapabilityTier, CapabilityTierMeta> = {
+  strict: {
+    label: presetFromThreshold("none").label,
+    sublabel: "read + reply only",
+    description: "Read and reply only — no tools run from this channel.",
+    tone: "negative",
+  },
+  standard: {
+    label: "Standard",
+    sublabel: "reply + safe tools",
+    description: "Reply and safe tools. Sensitive tools require approval.",
+    tone: "warning",
+  },
+  full_access: {
+    label: presetFromThreshold("high").label,
+    sublabel: "all tools",
+    description: "All tools the assistant has access to, within global gating.",
+    tone: "positive",
+  },
+};
+
+/** Threshold written to each contact-type cell when a tier is chosen. */
+export const CAPABILITY_TIER_THRESHOLDS: Record<
+  SlackCapabilityTier,
+  RiskThreshold
+> = {
+  strict: "none",
+  standard: "low",
+  full_access: "high",
+};
+
+/**
+ * Inverse presentation mapping for cells written elsewhere: "medium"
+ * (Relaxed — no tier equivalent) reads as the intermediate tier.
+ */
+export function tierFromThreshold(
+  threshold: RiskThreshold,
+): SlackCapabilityTier {
+  if (threshold === "none") {
+    return "strict";
+  }
+  if (threshold === "high") {
+    return "full_access";
+  }
+  return "standard";
+}
+
+/**
+ * Contact types a channel-tier write fans out to: everyone except the
+ * guardian — room-level posture never restricts the guardian (same rule as
+ * the m0012 Slack-profile migration).
+ */
+export const CHANNEL_TIER_CONTACT_TYPES = [
+  "trusted_contact",
+  "unverified_contact",
+  "unknown",
+] as const;
+
+/**
+ * Structural view of a matrix cell as the generated gateway SDK returns it —
+ * kept structural so this module stays free of generated-type imports.
+ */
+export interface ChannelTierCell {
+  selector: {
+    scope: string;
+    adapter?: string;
+    channelExternalId?: string;
+  };
+  contactType: string;
+  threshold: RiskThreshold;
+}
+
+/**
+ * Channel-ID-tier cells → per-channel tier map for one adapter. The
+ * trusted_contact cell is the representative when contact-type cells
+ * diverge (the write path keeps all non-guardian cells aligned).
+ */
+export function tierOverridesFromCells(
+  cells: ChannelTierCell[],
+  adapter: string,
+): Record<string, SlackCapabilityTier> {
+  const overrides: Record<string, SlackCapabilityTier> = {};
+  for (const cell of cells) {
+    if (
+      cell.selector.scope !== "channel" ||
+      cell.selector.adapter !== adapter
+    ) {
+      continue;
+    }
+    const channelId = cell.selector.channelExternalId;
+    if (!channelId) {
+      continue;
+    }
+    if (cell.contactType === "trusted_contact" || !(channelId in overrides)) {
+      overrides[channelId] = tierFromThreshold(cell.threshold);
+    }
+  }
+  return overrides;
+}
+
+/** The row's resolved tier plus whether it diverges from the default. */
+export interface SlackChannelTierSettings {
+  tier: SlackCapabilityTier;
+  overridden: boolean;
+}
+
+/**
+ * Channel-type-appropriate default tier: full access everywhere except DMs
+ * with unverified contacts, which default to strict.
+ */
+export function defaultChannelTier(
+  kind: SlackChannelKind,
+  dmVerified: boolean,
+): SlackCapabilityTier {
+  return kind === "dm" && !dmVerified ? "strict" : "full_access";
+}
+
+/**
+ * Applies a persisted tier override (possibly absent) on top of the
+ * channel-type default. A tier counts as overridden only when it diverges
+ * from the default — a persisted cell that matches the default is not
+ * flagged.
+ */
+export function resolveChannelTier(
+  kind: SlackChannelKind,
+  dmVerified: boolean,
+  override: SlackCapabilityTier | undefined,
+): SlackChannelTierSettings {
+  const defaultTier = defaultChannelTier(kind, dmVerified);
+  const tier = override ?? defaultTier;
+  return { tier, overridden: tier !== defaultTier };
+}

--- a/clients/web/src/domains/contacts/slack-channel-overrides.ts
+++ b/clients/web/src/domains/contacts/slack-channel-overrides.ts
@@ -1,15 +1,17 @@
 /**
  * Per-channel capabilities-tier model for the Slack channel list's
- * expandable rows. Capabilities is the only per-room knob: the tier
- * persists as channel-ID-tier cells in the gateway's
+ * expandable rows. Capabilities is the only per-room knob, and the list is
+ * rooms only (channels and group DMs): admission — who can reach the
+ * assistant — is a channel-type concern handled by the trust floors, and
+ * how the assistant interacts with an individual person is contact-list
+ * territory, so 1:1 DMs carry no room settings.
+ *
+ * Tiers persist as channel-ID-tier cells in the gateway's
  * `channel_permission_overrides` matrix (one cell per non-guardian
- * contact-type; see {@link CHANNEL_TIER_CONTACT_TYPES}). Admission — who
- * can reach the assistant — is a channel-type concern handled by the trust
- * floors and has no per-room control.
+ * contact-type; see {@link CHANNEL_TIER_CONTACT_TYPES}).
  */
 import type { TagTone } from "@vellumai/design-library/components/tag";
 
-import type { SlackChannelKind } from "@/domains/contacts/components/slack-channel-list";
 import {
   presetFromThreshold,
   type RiskThreshold,
@@ -143,29 +145,17 @@ export interface SlackChannelTierSettings {
   overridden: boolean;
 }
 
-/**
- * Channel-type-appropriate default tier: full access everywhere except DMs
- * with unverified contacts, which default to strict.
- */
-export function defaultChannelTier(
-  kind: SlackChannelKind,
-  dmVerified: boolean,
-): SlackCapabilityTier {
-  return kind === "dm" && !dmVerified ? "strict" : "full_access";
-}
+/** Every room defaults to full access; anything else is an override. */
+export const DEFAULT_CHANNEL_TIER: SlackCapabilityTier = "full_access";
 
 /**
- * Applies a persisted tier override (possibly absent) on top of the
- * channel-type default. A tier counts as overridden only when it diverges
- * from the default — a persisted cell that matches the default is not
- * flagged.
+ * Applies a persisted tier override (possibly absent) on top of the room
+ * default. A tier counts as overridden only when it diverges — a persisted
+ * cell that matches the default is not flagged.
  */
 export function resolveChannelTier(
-  kind: SlackChannelKind,
-  dmVerified: boolean,
   override: SlackCapabilityTier | undefined,
 ): SlackChannelTierSettings {
-  const defaultTier = defaultChannelTier(kind, dmVerified);
-  const tier = override ?? defaultTier;
-  return { tier, overridden: tier !== defaultTier };
+  const tier = override ?? DEFAULT_CHANNEL_TIER;
+  return { tier, overridden: tier !== DEFAULT_CHANNEL_TIER };
 }


### PR DESCRIPTION
## Prompt / plan

Second of two PRs for [LUM-2727](https://linear.app/vellum/issue/LUM-2727/channels-tab-expandable-row-per-channel-override-ux-who-can-reach), now rebased onto `main` after the gateway cells surface (#37385) merged. Companion daemon change also merged: #37395 (presence list is rooms only server-side).

Two design corrections from the original ticket, both guardian-confirmed:

1. **Capabilities is the only per-room knob.** The per-room "Who Can Reach" dropdown was cut — admission is a channel-type concern (trust floors), not a room concern.
2. **The list is rooms only.** 1:1 DMs are person-scoped — how the assistant interacts with a person is contact-list territory — so DM rows are gone entirely (`roomsOnly()`), which also deletes the display-name contact-matching heuristic both review bots flagged on LUM-2725, the DMs chip, and the DM tier defaults (every room defaults to Full access).

What each row now answers, per the guardian's clarity bar:

- **Collapsed**: room name + member count + resolved capabilities badge (Full access green / Standard amber / Strict tomato, `• custom` when overridden).
- **Expanded**: a read-only **"Who can reach [assistant] here"** line derived from the live Slack trust floor (label + plain-English description + pointer to the "Who can message" control that owns it), then the **Capabilities** tier picker (`SegmentControl`) with per-tier help, `default`/`overridden` hint, and the dashed custom-capabilities callout with **Reset to default** when overridden.
- **Interaction**: single-open accordion (`grid-template-rows 0fr→1fr`, 280ms `cubic-bezier(0.32,0.72,0,1)`), Expand all/Collapse all toggle, open-row tint + inset border + rotating caret, collapsed panels `inert`.

Persistence: tier writes go through the generated gateway SDK as **channel-ID-tier cells**, one per non-guardian contact-type (m0012 precedent), thresholds `none`/`low`/`high`; **reset deletes the cells** so the next cascade tier wins. Optimistic with rollback + toast; per-row "Saving…"; picker held disabled until cells load. `useChannelPermissionOverrides({ assistantId, adapter })` keeps the adapter a parameter for future Telegram/Phone room lists. `SlackChannelSection` colocates the sub-tab's data, shedding the Slack list props from the `AssistantChannelsList` controller.

## Test plan

- `bun test` — 35 pass across `slack-channel-overrides.test.ts` (resolve/divergence, tier↔threshold maps, cells→tier mapping), `slack-channel-list.test.ts` (rooms-only, filtering, counts, meta labels), `assistant-channels-detail.test.tsx`, `contacts-page.test.tsx`.
- `bunx tsc --noEmit` + eslint clean (pre-commit).
- Storybook: `OverriddenChannel` mirrors the mockup's `releases`; fixtures include 1:1 DMs to demonstrate they stay hidden.

Known trade-off: the 3-cell fan-out per tier write is non-atomic (settle-refetch reconciles); a batch endpoint is the fix if it ever matters.

## CLI verb checklist

No new routes — web-client-only change (gateway surface is #37385, daemon change is #37395).

Part of LUM-2727

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gthC8b9mWi9v3DFQH8xtw