### PR TITLE
fix(profile-modal): button sizing, remove 'Pick a provider' text, larger toggle with spacing

### DIFF
--- a/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -49,6 +49,7 @@ import type {
 import { ProviderCreateForm } from "@/domains/settings/ai/provider-create-form";
 import { useLabelKeySync } from "@/domains/settings/ai/use-label-key-sync";
 import { useActiveAssistantIsSelfHosted } from "@/hooks/use-platform-gate";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 
 // Sentinel value for the "+ Create new provider" option in the create-mode
 // Provider dropdown. Picking it mounts the inline ProviderCreateForm instead
@@ -205,6 +206,7 @@ function ProfileEditorModalInner({
   // daemon rejects for managed profiles.
   const isReadOnly = effectiveMode === "view" || isInvariant;
   const activeAssistantIsSelfHosted = useActiveAssistantIsSelfHosted();
+  const isMobile = useIsMobile();
 
   // Baseline for `hasViewModeChanges`: the enable flip is the only edit
   // read-only mode permits.
@@ -726,6 +728,7 @@ function ProfileEditorModalInner({
         checked={status === "active"}
         onChange={(v) => setStatus(v ? "active" : "disabled")}
         label="Active"
+        className="touch-mobile:mt-2 touch-mobile:[&_button]:h-7 touch-mobile:[&_button]:w-10 touch-mobile:[&_button>span]:h-6 touch-mobile:[&_button>span]:w-6"
       />
     ) : null;
 
@@ -818,7 +821,7 @@ function ProfileEditorModalInner({
           >
             Provider
           </label>
-          {providerMissing && !creatingProvider ? (
+          {providerMissing && !creatingProvider && !isMobile ? (
             <span className="rounded-full bg-[var(--surface-warning-subtle)] px-2 py-0.5 text-body-small-default text-[var(--content-warning)]">
               Pick a provider
             </span>
@@ -970,6 +973,7 @@ function ProfileEditorModalInner({
           <>
             <Button
               variant="outlined"
+              className="touch-mobile:h-10"
               onClick={onCancel}
               disabled={saving}
               data-testid="modal-cancel-btn"
@@ -978,6 +982,7 @@ function ProfileEditorModalInner({
             </Button>
             <Button
               variant="outlined"
+              className="touch-mobile:h-10"
               onClick={() => {
                 setEffectiveMode("create");
                 setKey("");
@@ -992,6 +997,7 @@ function ProfileEditorModalInner({
                 session can't round-trip a no-op write. */}
             <Button
               variant="primary"
+              className="touch-mobile:h-10"
               onClick={() => void handleSave()}
               disabled={!hasViewModeChanges || saving}
               data-testid="modal-save-btn"
@@ -1003,6 +1009,7 @@ function ProfileEditorModalInner({
           <>
             <Button
               variant="outlined"
+              className="touch-mobile:h-10"
               onClick={onCancel}
               disabled={saving}
               data-testid="modal-cancel-btn"
@@ -1011,6 +1018,7 @@ function ProfileEditorModalInner({
             </Button>
             <Button
               variant="primary"
+              className="touch-mobile:h-10"
               onClick={() => void handleSave()}
               disabled={isInvalid || saving}
               data-testid="modal-save-btn"

--- a/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -10,6 +10,7 @@ import {
 
 import { OPENAI_COMPATIBLE_PROVIDER } from "@/domains/settings/ai/constants";
 import { useSelectableCatalogProviders } from "@/domains/settings/ai/provider-availability";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import type { ConnectionModel, ConnectionProvider, ProviderConnection } from "@/generated/daemon/types.gen";
 
 const CODEX_SUBSCRIPTION_MODEL_IDS = new Set([
@@ -98,6 +99,7 @@ export function ProfileEditorProviderSection({
   connectionNotFound,
   hideProviderField = false,
 }: ProfileEditorProviderSectionProps) {
+  const isMobile = useIsMobile();
   const providerMissing = provider.length === 0;
   const providerWithoutModel = provider.length > 0 && model.length === 0;
 
@@ -256,7 +258,7 @@ export function ProfileEditorProviderSection({
             >
               Provider
             </label>
-            {providerMissing ? (
+            {providerMissing && !isMobile ? (
               <span className="rounded-full bg-[var(--surface-warning-subtle)] px-2 py-0.5 text-body-small-default text-[var(--content-warning)]">
                 Pick a provider
               </span>


### PR DESCRIPTION
## Summary

Fixes 3 UI issues from the Figma design review (node 6604-6729) on the New Profile modal. All changes are scoped to mobile (touch devices) only — desktop and macOS are unaffected.

## Changes

1. **Button should be at least 24px or 32px** — Added `touch-mobile:h-10` (40px) to all modal footer buttons (Cancel, Save, Close, Save As New). Desktop stays at `h-8` (32px). The `touch-mobile` variant targets `(width < 48rem) and (pointer: coarse)`, matching the Button component's own mobile expansion pattern for icon-only buttons.

2. **Remove the "Pick a provider" text** — Hidden on mobile via `useIsMobile()` conditional in both the create-mode (`profile-editor-modal.tsx`) and edit-mode (`profile-editor-provider-section.tsx`) provider sections. The `providerMissing` variable is preserved in both files — it still drives the desktop rendering.

3. **Switch should be a little larger and 8px further down** — Toggle sizing scaled up via `touch-mobile:` prefixed className: track `h-6 w-9` -> `h-7 w-10` (28x40px), knob `h-5 w-5` -> `h-6 w-6` (24px). Added `touch-mobile:mt-2` (8px) margin between description field and toggle. Desktop keeps the default toggle size and standard `space-y-4` gap.

## Why it's safe

- All CSS overrides use `touch-mobile:` prefix — only applies on touch devices (iOS, Android), never desktop or Electron
- "Pick a provider" conditional uses `useIsMobile()` — the codebase's standard mobile detection hook (66 uses across the codebase)
- No design library changes — toggle and button sizing are consumer-side className overrides
- `providerMissing` variable preserved in both files (still used for desktop rendering)
- Typecheck and lint pass (0 errors, only pre-existing `curly` warnings)

## What was NOT done

- No design library changes — all fixes are consumer-side overrides
- Desktop rendering is completely unchanged
- The `touch-mobile:` variant excludes narrow desktop windows (requires `pointer: coarse`)

## Figma reference

- Design review: node 6604-6729 in file `cCGBcpVDbn22kj3OPU58W8`
