### PR TITLE
fix(slack): presence channel list is rooms only — no 1:1 DMs

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -27475,8 +27475,9 @@ paths:
               - "true"
               - "false"
           description:
-            "When 'true', only return conversations the connected identity is in: channels/groups with is_member, plus
-            all DMs and group DMs"
+            "When 'true', only return rooms the connected identity is in: channels with is_member plus group DMs. 1:1
+            DMs are excluded — they are person-scoped, and Slack materializes IM rows without any conversation
+            happening."
       responses:
         "200":
           description: Successful response

--- a/assistant/src/__tests__/slack-channels-routes.test.ts
+++ b/assistant/src/__tests__/slack-channels-routes.test.ts
@@ -291,7 +291,7 @@ describe("handleListSlackChannels", () => {
     });
   });
 
-  test("memberOnly=true keeps DMs and group DMs despite missing is_member", async () => {
+  test("memberOnly=true keeps group DMs but excludes 1:1 DMs (person-scoped)", async () => {
     configureToken();
 
     listConversationsResult = {
@@ -303,31 +303,49 @@ describe("handleListSlackChannels", () => {
       ],
     };
 
-    userInfoResults.set("U1", {
-      ok: true,
-      user: {
-        id: "U1",
-        name: "alice",
-        profile: { display_name: "Alice Smith" },
-      },
-    });
-
     const result = (await handleListSlackChannels({
       queryParams: { memberOnly: "true" },
     })) as { channels: Array<Record<string, unknown>> };
 
-    expect(result.channels.map((c) => c.id)).toEqual(["G1", "D1"]);
-    expect(result.channels.every((c) => c.isMember === true)).toBe(true);
-    expect(result.channels[1]).toEqual({
-      id: "D1",
-      name: "Alice Smith",
-      type: "dm",
+    expect(result.channels.map((c) => c.id)).toEqual(["G1"]);
+    expect(result.channels[0]).toEqual({
+      id: "G1",
+      name: "group-chat",
+      type: "group",
       isPrivate: true,
       isMember: true,
       memberCount: null,
       topic: null,
       imageUrl: null,
     });
+  });
+
+  test("drops Slackbot and deleted-user IMs from the share picker path", async () => {
+    configureToken();
+
+    listConversationsResult = {
+      ok: true,
+      channels: [
+        { id: "D1", is_im: true, user: "USLACKBOT", is_private: true },
+        {
+          id: "D2",
+          is_im: true,
+          user: "U2",
+          is_private: true,
+          is_user_deleted: true,
+        },
+        { id: "D3", is_im: true, user: "U3", is_private: true },
+      ],
+    };
+    userInfoResults.set("U3", {
+      ok: true,
+      user: { id: "U3", name: "carol", profile: { display_name: "Carol" } },
+    });
+
+    const all = (await handleListSlackChannels({})) as {
+      channels: Array<Record<string, unknown>>;
+    };
+    expect(all.channels.map((c) => c.id)).toEqual(["D3"]);
   });
 
   test("omitting memberOnly returns all conversations", async () => {

--- a/assistant/src/messaging/providers/slack/conversation-utils.ts
+++ b/assistant/src/messaging/providers/slack/conversation-utils.ts
@@ -31,10 +31,13 @@ export function isPrivateConversation(
 }
 
 /**
- * Whether the connected identity is in this conversation. Slack omits
- * `is_member` on IM/MPIM rows, but `conversations.list` only returns
- * IMs/MPIMs the authenticated identity participates in, so those count
- * as member conversations.
+ * Whether the connected identity can access this conversation. Slack omits
+ * `is_member` on IM/MPIM rows; `conversations.list` only returns IMs/MPIMs
+ * the authenticated identity can post to, so those count as member
+ * conversations. Note this is access, not presence: Slack materializes IM
+ * rows without any conversation happening (Slackbot, a user opening the
+ * bot's DM tab) — surfaces that mean "an actual DM exists" must add their
+ * own history check (see the slack channels route's memberOnly path).
  */
 export function isMemberConversation(conv: SlackConversation): boolean {
   return conv.is_member === true || !!conv.is_im || !!conv.is_mpim;

--- a/assistant/src/messaging/providers/slack/types.ts
+++ b/assistant/src/messaging/providers/slack/types.ts
@@ -41,6 +41,8 @@ export interface SlackConversation {
   unread_count_display?: number;
   latest?: SlackMessage;
   user?: string;
+  /** IM rows only: the DM peer's account has been deactivated. */
+  is_user_deleted?: boolean;
 }
 
 export interface SlackConversationsListResponse extends SlackApiResponse {

--- a/assistant/src/runtime/routes/integrations/slack/channels.ts
+++ b/assistant/src/runtime/routes/integrations/slack/channels.ts
@@ -46,6 +46,19 @@ const TYPE_SORT_ORDER: Record<string, number> = {
   dm: 2,
 };
 
+/** Slackbot's fixed user id — its IM channel exists in every workspace. */
+const SLACKBOT_USER_ID = "USLACKBOT";
+
+/**
+ * IMs the assistant can neither converse in meaningfully nor post to:
+ * Slackbot (bots cannot message Slackbot) and deactivated accounts.
+ */
+function isNoiseIm(c: SlackConversation): boolean {
+  return (
+    !!c.is_im && (c.user === SLACKBOT_USER_ID || c.is_user_deleted === true)
+  );
+}
+
 export async function handleListSlackChannels({
   queryParams,
 }: RouteHandlerArgs = {}) {
@@ -70,9 +83,18 @@ export async function handleListSlackChannels({
     cursor = resp.response_metadata?.next_cursor || undefined;
   } while (cursor);
 
-  const conversations = memberOnly
-    ? allChannels.filter(isMemberConversation)
-    : allChannels;
+  // The presence list (memberOnly) is rooms only: channels and group DMs.
+  // 1:1 IMs are person-scoped, not room-scoped — the person's settings live
+  // on their contact — and Slack materializes IM rows without any
+  // conversation happening (app install, a user merely opening the bot's DM
+  // tab, Slackbot), so IM existence would overstate presence anyway. The
+  // share picker (memberOnly absent) keeps IMs — they are valid share
+  // destinations — minus the unpostable noise IMs.
+  const conversations = (
+    memberOnly
+      ? allChannels.filter((c) => !c.is_im && isMemberConversation(c))
+      : allChannels
+  ).filter((c) => !isNoiseIm(c));
 
   const dmUserIds = conversations
     .filter((c) => c.is_im && c.user)
@@ -150,7 +172,7 @@ export const ROUTES: RouteDefinition[] = [
         name: "memberOnly",
         schema: { type: "string", enum: ["true", "false"] },
         description:
-          "When 'true', only return conversations the connected identity is in: channels/groups with is_member, plus all DMs and group DMs",
+          "When 'true', only return rooms the connected identity is in: channels with is_member plus group DMs. 1:1 DMs are excluded — they are person-scoped, and Slack materializes IM rows without any conversation happening.",
       },
     ],
     responseBody: SlackChannelsListResultSchema,


### PR DESCRIPTION
## Prompt / plan

Fixes the phantom DMs on the Channels-tab presence list: a brand-new assistant showed a "Direct message" row for a dozen people who had never messaged it (including **Slackbot** — the tell). Slack materializes IM channel rows without any conversation happening (app install, a user merely opening the bot's DM tab, Slackbot's ever-present IM), so IM existence overstates presence.

The fix is a design correction rather than a filter: **1:1 DMs are person-scoped, not room-scoped** — how the assistant interacts with a person is contact-list territory, so DM rows don't belong on the "where the assistant is present" room list at all.

- **Presence path (`memberOnly=true`)**: returns rooms only — channels with `is_member` plus group DMs. No 1:1 IMs, no per-IM probing.
- **Share picker path (`memberOnly` absent)**: keeps IMs as valid share destinations, minus Slackbot (`USLACKBOT`) and deleted-user IMs, which bots cannot post to.
- `isMemberConversation()` behavior unchanged; its docstring now spells out the access-vs-presence distinction.
- `assistant/openapi.yaml` regenerated for the updated `memberOnly` description.

An earlier revision of this PR filtered DMs by probing `conversations.history(limit: 1)` per IM; superseded — with DM rows gone from the presence list entirely, the probes (and their rate-limit cost) never ship. Companion web change (rooms-only list, DM chip removed) lands in #37391.

## Test plan

- `bun test src/__tests__/slack-channels-routes.test.ts` — 8 pass: memberOnly excludes 1:1 DMs and keeps group DMs; share picker drops Slackbot/deleted-user IMs and keeps real ones; existing sorting/mapping coverage.
- `bun run typecheck:fast`, prettier, eslint — clean (pre-commit).

## CLI verb checklist

No new routes — behavior fix inside the existing `slack_channels_get` handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gthC8b9mWi9v3DFQH8xtw