### PR TITLE
feat(assistant): redact Vercel AI Gateway API keys (vck_...)

### DIFF
--- a/assistant/src/__tests__/secret-patterns.test.ts
+++ b/assistant/src/__tests__/secret-patterns.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+import { PREFIX_PATTERNS } from "../security/secret-patterns.js";
+
+function matchingLabels(text: string): string[] {
+  return PREFIX_PATTERNS.filter((p) => p.regex.test(text)).map((p) => p.label);
+}
+
+describe("Vercel AI Gateway API Key", () => {
+  test("matches a vck_ key as exactly one pattern", () => {
+    expect(matchingLabels(`vck_${"a".repeat(32)}`)).toEqual([
+      "Vercel AI Gateway API Key",
+    ]);
+  });
+
+  test("does not match a short vck_ string", () => {
+    expect(matchingLabels("vck_abc")).toEqual([]);
+  });
+});
+
+describe("OpenRouter API Key", () => {
+  test("matches an sk-or-v1- key", () => {
+    expect(matchingLabels(`sk-or-v1-${"a".repeat(40)}`)).toEqual([
+      "OpenRouter API Key",
+    ]);
+  });
+});

--- a/assistant/src/security/secret-patterns.ts
+++ b/assistant/src/security/secret-patterns.ts
@@ -125,6 +125,9 @@ export const PREFIX_PATTERNS: SecretPrefixPattern[] = [
   // -- OpenRouter --
   { label: "OpenRouter API Key", regex: /sk-or-v1-[A-Za-z0-9\-_]{40,}/ },
 
+  // -- Vercel AI Gateway --
+  { label: "Vercel AI Gateway API Key", regex: /vck_[A-Za-z0-9\-_]{24,}/ },
+
   // -- Fireworks --
   { label: "Fireworks API Key", regex: /fw_[A-Za-z0-9]{32,}/ },
 


### PR DESCRIPTION
## Summary
- Adds a vck_ secret-redaction pattern for Vercel AI Gateway API keys
- Adds a minimal secret-patterns test covering the new pattern plus an OpenRouter regression case

Part of plan: vercel-ai-gateway-provider.md (PR 2 of 7)