### PR TITLE
feat(assistant): teach retry/web-search/pricing layers about vercel-ai-gateway

### DIFF
--- a/assistant/src/__tests__/pricing.test.ts
+++ b/assistant/src/__tests__/pricing.test.ts
@@ -899,6 +899,30 @@ describe("usesAnthropicPricingRules", () => {
     expect(usesAnthropicPricingRules("openrouter", "x-ai/grok-4")).toBe(false);
   });
 
+  test("returns true for anthropic/* on the Vercel AI Gateway", () => {
+    expect(
+      usesAnthropicPricingRules(
+        "vercel-ai-gateway",
+        "anthropic/claude-sonnet-4.6",
+      ),
+    ).toBe(true);
+  });
+
+  test("returns true for bare claude-* slug on the Vercel AI Gateway", () => {
+    expect(
+      usesAnthropicPricingRules(
+        "vercel-ai-gateway",
+        "claude-opus-4-5-20250929",
+      ),
+    ).toBe(true);
+  });
+
+  test("returns false for non-Anthropic Vercel AI Gateway models", () => {
+    expect(usesAnthropicPricingRules("vercel-ai-gateway", "x-ai/grok-4")).toBe(
+      false,
+    );
+  });
+
   test("returns false for other providers", () => {
     expect(usesAnthropicPricingRules("openai", "gpt-4o")).toBe(false);
     expect(usesAnthropicPricingRules("gemini", "gemini-2.5-pro")).toBe(false);

--- a/assistant/src/providers/__tests__/registry-native-web-search.test.ts
+++ b/assistant/src/providers/__tests__/registry-native-web-search.test.ts
@@ -41,6 +41,7 @@ mock.module("../inference/adapter-factory.js", () => ({
 
 import {
   clearConnectionProviderCache,
+  isNativeWebSearchCapableProvider,
   resolveProviderFromConnection,
 } from "../registry.js";
 
@@ -118,5 +119,25 @@ describe("resolveProviderFromConnection native web search selection", () => {
         useNativeWebSearch: true,
       }),
     ]);
+  });
+});
+
+describe("isNativeWebSearchCapableProvider gateway anthropic routing", () => {
+  test("vercel-ai-gateway anthropic/* models are capable", () => {
+    expect(
+      isNativeWebSearchCapableProvider(
+        "vercel-ai-gateway",
+        "anthropic/claude-opus-4-7",
+      ),
+    ).toBe(true);
+  });
+
+  test("vercel-ai-gateway non-Anthropic models are not capable", () => {
+    expect(
+      isNativeWebSearchCapableProvider(
+        "vercel-ai-gateway",
+        "x-ai/grok-4.20-beta",
+      ),
+    ).toBe(false);
   });
 });

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -116,7 +116,10 @@ export function isNativeWebSearchCapableProvider(
   if (NATIVE_WEB_SEARCH_PROVIDER_IDS.has(providerName)) {
     return true;
   }
-  if (providerName === "openrouter" && model.startsWith("anthropic/")) {
+  if (
+    (providerName === "openrouter" || providerName === "vercel-ai-gateway") &&
+    model.startsWith("anthropic/")
+  ) {
     return true;
   }
   return false;

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -43,6 +43,7 @@ const EFFORT_SUPPORTED_PROVIDERS = new Set([
   "anthropic",
   "openai",
   "openrouter",
+  "vercel-ai-gateway",
   "fireworks",
   "together",
 ]);
@@ -58,11 +59,16 @@ const DISABLED_THINKING_USES_EFFORT_PROVIDERS = new Set([
 
 /**
  * Providers that consume the `thinking` config. Anthropic uses it directly on
- * the wire; OpenRouter either forwards it to its Anthropic-compatible path or
- * translates it into the unified `reasoning` parameter on OpenAI-compat calls;
+ * the wire; OpenRouter and the Vercel AI Gateway either forward it to their
+ * Anthropic-compatible paths or translate it for OpenAI-compat calls;
  * Gemini reads `thinking.level` to populate `thinkingConfig.thinkingLevel`.
  */
-const THINKING_AWARE_PROVIDERS = new Set(["anthropic", "openrouter", "gemini"]);
+const THINKING_AWARE_PROVIDERS = new Set([
+  "anthropic",
+  "openrouter",
+  "vercel-ai-gateway",
+  "gemini",
+]);
 
 /**
  * Providers that consume Gemini-only thinking extras (`level`,

--- a/assistant/src/util/pricing.ts
+++ b/assistant/src/util/pricing.ts
@@ -141,16 +141,22 @@ function normalizeAnthropicModelId(model: string): string {
 /**
  * Whether Anthropic's pricing rules (cache-read/write multipliers, fast-mode
  * surcharge) apply for the given provider/model. True for direct Anthropic
- * calls and for Anthropic models routed through OpenRouter — OpenRouter
- * proxies to Anthropic's Messages API, so the usage response carries the
- * same cache and speed fields and is charged at Anthropic's rates.
+ * calls and for Anthropic models routed through OpenRouter or the Vercel AI
+ * Gateway — both gateways proxy `anthropic/*` to Anthropic's Messages API, so
+ * the usage response carries the same cache and speed fields and is charged
+ * at Anthropic's rates.
  */
 export function usesAnthropicPricingRules(
   provider: string,
   model: string,
 ): boolean {
   if (provider === "anthropic") return true;
-  if (provider === "openrouter" && isAnthropicModelId(model)) return true;
+  if (
+    (provider === "openrouter" || provider === "vercel-ai-gateway") &&
+    isAnthropicModelId(model)
+  ) {
+    return true;
+  }
   return false;
 }
 


### PR DESCRIPTION
## Summary
- Adds vercel-ai-gateway to EFFORT_SUPPORTED_PROVIDERS and THINKING_AWARE_PROVIDERS in the retry layer
- Extends native-web-search capability and Anthropic pricing rules to vercel-ai-gateway anthropic/* models (mirrors OpenRouter)
- Mirrors the existing OpenRouter test cases for the new provider

Part of plan: vercel-ai-gateway-provider.md (PR 3 of 7)