### PR TITLE
feat(assistant): add VercelAIGatewayProvider client

### DIFF
--- a/assistant/src/__tests__/vercel-ai-gateway-provider.test.ts
+++ b/assistant/src/__tests__/vercel-ai-gateway-provider.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from "bun:test";
+
+import type { AnthropicProvider } from "../providers/anthropic/client.js";
+import type { Message } from "../providers/types.js";
+import { ContextOverflowError } from "../providers/types.js";
+import {
+  toAnthropicMessagesBaseURL,
+  VercelAIGatewayProvider,
+} from "../providers/vercel-ai-gateway/client.js";
+import { ProviderError } from "../util/errors.js";
+
+const DEFAULT_BASE_URL = "https://ai-gateway.vercel.sh/v1";
+
+function resolvedBaseURL(provider: VercelAIGatewayProvider): string {
+  return (provider as unknown as { resolvedBaseURL: string }).resolvedBaseURL;
+}
+
+function stubAnthropicInner(
+  provider: VercelAIGatewayProvider,
+  sendMessage: AnthropicProvider["sendMessage"],
+): void {
+  (
+    provider as unknown as { anthropicInner: AnthropicProvider }
+  ).anthropicInner = { sendMessage } as unknown as AnthropicProvider;
+}
+
+const USER_MESSAGE: Message[] = [
+  { role: "user", content: [{ type: "text", text: "hello" }] },
+];
+
+describe("VercelAIGatewayProvider", () => {
+  describe("constructor baseURL resolution", () => {
+    test("defaults to the Vercel AI Gateway base URL", () => {
+      const provider = new VercelAIGatewayProvider(
+        "fake-key",
+        "openai/gpt-5.5",
+      );
+      expect(resolvedBaseURL(provider)).toBe(DEFAULT_BASE_URL);
+    });
+
+    test("an explicit baseURL option wins", () => {
+      const provider = new VercelAIGatewayProvider(
+        "fake-key",
+        "openai/gpt-5.5",
+        { baseURL: "https://proxy.example.com/v1" },
+      );
+      expect(resolvedBaseURL(provider)).toBe("https://proxy.example.com/v1");
+    });
+
+    test("a blank baseURL falls back to the default", () => {
+      const provider = new VercelAIGatewayProvider(
+        "fake-key",
+        "openai/gpt-5.5",
+        { baseURL: "   " },
+      );
+      expect(resolvedBaseURL(provider)).toBe(DEFAULT_BASE_URL);
+    });
+  });
+
+  describe("toAnthropicMessagesBaseURL", () => {
+    test("strips a trailing /v1", () => {
+      expect(toAnthropicMessagesBaseURL("https://ai-gateway.vercel.sh/v1")).toBe(
+        "https://ai-gateway.vercel.sh",
+      );
+    });
+
+    test("strips a trailing /v1/", () => {
+      expect(
+        toAnthropicMessagesBaseURL("https://ai-gateway.vercel.sh/v1/"),
+      ).toBe("https://ai-gateway.vercel.sh");
+    });
+
+    test("leaves URLs without a /v1 suffix untouched", () => {
+      expect(toAnthropicMessagesBaseURL("https://ai-gateway.vercel.sh")).toBe(
+        "https://ai-gateway.vercel.sh",
+      );
+    });
+  });
+
+  describe("tokenEstimationProvider", () => {
+    test("returns anthropic for anthropic/* default models", () => {
+      const provider = new VercelAIGatewayProvider(
+        "fake-key",
+        "anthropic/claude-opus-4.8",
+      );
+      expect(provider.tokenEstimationProvider).toBe("anthropic");
+    });
+
+    test("returns vercel-ai-gateway otherwise", () => {
+      const provider = new VercelAIGatewayProvider(
+        "fake-key",
+        "openai/gpt-5.5",
+      );
+      expect(provider.tokenEstimationProvider).toBe("vercel-ai-gateway");
+    });
+  });
+
+  describe("delegate error re-tagging", () => {
+    test("rethrows a delegate ProviderError tagged with vercel-ai-gateway", async () => {
+      const provider = new VercelAIGatewayProvider(
+        "fake-key",
+        "anthropic/claude-opus-4.8",
+      );
+      const inner = new ProviderError("rate limited", "anthropic", 429, {
+        retryAfterMs: 1_500,
+      });
+      stubAnthropicInner(provider, async () => {
+        throw inner;
+      });
+
+      let caught: unknown;
+      try {
+        await provider.sendMessage(USER_MESSAGE);
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toBeInstanceOf(ProviderError);
+      const err = caught as ProviderError;
+      expect(err.provider).toBe("vercel-ai-gateway");
+      expect(err.message).toBe("rate limited");
+      expect(err.statusCode).toBe(429);
+      expect(err.retryAfterMs).toBe(1_500);
+      expect(err.cause).toBe(inner);
+    });
+
+    test("rethrows a delegate ContextOverflowError preserving token counts", async () => {
+      const provider = new VercelAIGatewayProvider(
+        "fake-key",
+        "anthropic/claude-opus-4.8",
+      );
+      const inner = new ContextOverflowError("context overflow", "anthropic", {
+        actualTokens: 250_000,
+        maxTokens: 200_000,
+        statusCode: 400,
+      });
+      stubAnthropicInner(provider, async () => {
+        throw inner;
+      });
+
+      let caught: unknown;
+      try {
+        await provider.sendMessage(USER_MESSAGE);
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toBeInstanceOf(ContextOverflowError);
+      const err = caught as ContextOverflowError;
+      expect(err.provider).toBe("vercel-ai-gateway");
+      expect(err.actualTokens).toBe(250_000);
+      expect(err.maxTokens).toBe(200_000);
+      expect(err.statusCode).toBe(400);
+      expect(err.cause).toBe(inner);
+    });
+  });
+});

--- a/assistant/src/__tests__/vercel-ai-gateway-provider.test.ts
+++ b/assistant/src/__tests__/vercel-ai-gateway-provider.test.ts
@@ -95,6 +95,34 @@ describe("VercelAIGatewayProvider", () => {
     });
   });
 
+  describe("supportsNativeWebSearch", () => {
+    test("true when enabled and the default model is anthropic/*", () => {
+      const provider = new VercelAIGatewayProvider(
+        "fake-key",
+        "anthropic/claude-opus-4.8",
+        { useNativeWebSearch: true },
+      );
+      expect(provider.supportsNativeWebSearch).toBe(true);
+    });
+
+    test("false for a non-anthropic model even when enabled", () => {
+      const provider = new VercelAIGatewayProvider(
+        "fake-key",
+        "openai/gpt-5.5",
+        { useNativeWebSearch: true },
+      );
+      expect(provider.supportsNativeWebSearch).toBe(false);
+    });
+
+    test("false when disabled, even for an anthropic model", () => {
+      const provider = new VercelAIGatewayProvider(
+        "fake-key",
+        "anthropic/claude-opus-4.8",
+      );
+      expect(provider.supportsNativeWebSearch).toBe(false);
+    });
+  });
+
   describe("delegate error re-tagging", () => {
     test("rethrows a delegate ProviderError tagged with vercel-ai-gateway", async () => {
       const provider = new VercelAIGatewayProvider(

--- a/assistant/src/providers/vercel-ai-gateway/client.ts
+++ b/assistant/src/providers/vercel-ai-gateway/client.ts
@@ -73,9 +73,10 @@ export class VercelAIGatewayProvider extends OpenAIChatCompletionsProvider {
     return isAnthropicModel(this.defaultModel) ? "anthropic" : this.name;
   }
 
-  /** See {@link Provider.supportsNativeWebSearch}. Set per model at construction. */
+  // Native web search is only wired through the Anthropic Messages delegate;
+  // the OpenAI-compat path has no native search tool mapping.
   get supportsNativeWebSearch(): boolean {
-    return this.useNativeWebSearch;
+    return this.useNativeWebSearch && isAnthropicModel(this.defaultModel);
   }
 
   override async sendMessage(

--- a/assistant/src/providers/vercel-ai-gateway/client.ts
+++ b/assistant/src/providers/vercel-ai-gateway/client.ts
@@ -1,0 +1,139 @@
+import { ProviderError } from "../../util/errors.js";
+import { AnthropicProvider } from "../anthropic/client.js";
+import { OpenAIChatCompletionsProvider } from "../openai/chat-completions-provider.js";
+import type {
+  Message,
+  ProviderResponse,
+  SendMessageOptions,
+} from "../types.js";
+import { ContextOverflowError, isContextOverflowError } from "../types.js";
+
+export interface VercelAIGatewayProviderOptions {
+  apiKey?: string;
+  baseURL?: string;
+  streamTimeoutMs?: number;
+  useNativeWebSearch?: boolean;
+}
+
+const DEFAULT_VERCEL_AI_GATEWAY_BASE_URL = "https://ai-gateway.vercel.sh/v1";
+
+// Models prefixed `anthropic/` are routed through the gateway's
+// Anthropic-compatible Messages API at `<root>/v1/messages` so that
+// Anthropic-native features — extended thinking, prompt caching, cache TTL,
+// output_config — work without lossy translation through the OpenAI chat
+// completions compatibility layer. The Anthropic SDK appends `/v1/messages` to
+// its configured baseURL, so we strip the trailing `/v1` segment from the
+// OpenAI-compat base before handing it to the SDK.
+function isAnthropicModel(model: string): boolean {
+  return model.startsWith("anthropic/");
+}
+
+export function toAnthropicMessagesBaseURL(baseURL: string): string {
+  return baseURL.replace(/\/v1\/?$/, "");
+}
+
+export class VercelAIGatewayProvider extends OpenAIChatCompletionsProvider {
+  private readonly gatewayApiKey: string;
+  private readonly defaultModel: string;
+  private readonly resolvedBaseURL: string;
+  private readonly providerStreamTimeoutMs: number | undefined;
+  private readonly useNativeWebSearch: boolean;
+  private anthropicInner: AnthropicProvider | undefined;
+
+  constructor(
+    apiKey: string,
+    model: string,
+    options: VercelAIGatewayProviderOptions = {},
+  ) {
+    const baseURL =
+      options.baseURL?.trim() || DEFAULT_VERCEL_AI_GATEWAY_BASE_URL;
+    super(apiKey, model, {
+      baseURL,
+      providerName: "vercel-ai-gateway",
+      providerLabel: "Vercel AI Gateway",
+      streamTimeoutMs: options.streamTimeoutMs,
+      // Vercel's OpenAI-compat endpoint streams reasoning text in
+      // `delta.reasoning` (see its Advanced Configuration docs).
+      assistantReasoningField: "reasoning",
+      backfillEmptyAssistantContent: true,
+    });
+    this.gatewayApiKey = apiKey;
+    this.defaultModel = model;
+    this.resolvedBaseURL = baseURL;
+    this.providerStreamTimeoutMs = options.streamTimeoutMs;
+    this.useNativeWebSearch = options.useNativeWebSearch ?? false;
+  }
+
+  // When routing to an `anthropic/*` model, actual API calls hit the Anthropic
+  // Messages endpoint, which charges for images using dimension-based pricing
+  // (~width*height/750 tokens) rather than the generic `base64/4` heuristic.
+  // Expose this so the local token estimator picks the matching rules and
+  // `shouldCompact()` doesn't over-count image tokens by ~100×.
+  get tokenEstimationProvider(): string {
+    return isAnthropicModel(this.defaultModel) ? "anthropic" : this.name;
+  }
+
+  /** See {@link Provider.supportsNativeWebSearch}. Set per model at construction. */
+  get supportsNativeWebSearch(): boolean {
+    return this.useNativeWebSearch;
+  }
+
+  override async sendMessage(
+    messages: Message[],
+    options?: SendMessageOptions,
+  ): Promise<ProviderResponse> {
+    const effectiveModel = this.resolveEffectiveModel(options);
+    try {
+      if (isAnthropicModel(effectiveModel)) {
+        return await this.getAnthropicInner().sendMessage(messages, options);
+      }
+      return await super.sendMessage(messages, options);
+    } catch (error) {
+      // Re-tag delegate-thrown ContextOverflowError so the outer provider name
+      // matches the configured provider ("vercel-ai-gateway"). This keeps
+      // downstream error reporting and metrics attribution accurate, while
+      // preserving the actualTokens/maxTokens extracted by the delegate.
+      if (isContextOverflowError(error) && error.provider !== this.name) {
+        throw new ContextOverflowError(error.message, this.name, {
+          actualTokens: error.actualTokens,
+          maxTokens: error.maxTokens,
+          statusCode: error.statusCode,
+          cause: error,
+        });
+      }
+      if (error instanceof ProviderError && error.provider !== this.name) {
+        throw new ProviderError(error.message, this.name, error.statusCode, {
+          cause: error.cause ?? error,
+          retryAfterMs: error.retryAfterMs,
+          abortReason: error.abortReason,
+        });
+      }
+      throw error;
+    }
+  }
+
+  private resolveEffectiveModel(options?: SendMessageOptions): string {
+    const config = options?.config as Record<string, unknown> | undefined;
+    const override =
+      typeof config?.model === "string" && config.model.trim().length > 0
+        ? config.model.trim()
+        : undefined;
+    return override ?? this.defaultModel;
+  }
+
+  private getAnthropicInner(): AnthropicProvider {
+    if (!this.anthropicInner) {
+      this.anthropicInner = new AnthropicProvider(
+        this.gatewayApiKey,
+        this.defaultModel,
+        {
+          baseURL: toAnthropicMessagesBaseURL(this.resolvedBaseURL),
+          streamTimeoutMs: this.providerStreamTimeoutMs,
+          authToken: this.gatewayApiKey,
+          useNativeWebSearch: this.useNativeWebSearch,
+        },
+      );
+    }
+    return this.anthropicInner;
+  }
+}


### PR DESCRIPTION
## Summary
- New standalone VercelAIGatewayProvider extending OpenAIChatCompletionsProvider (OpenAI-compat path at https://ai-gateway.vercel.sh/v1)
- Delegates anthropic/* models to AnthropicProvider via the gateway's Messages API path, with provider-name re-tagging on delegate errors
- Unit tests mirroring the OpenRouter probe-subclass pattern

Part of plan: vercel-ai-gateway-provider.md (PR 1 of 7)