### PR TITLE
feat(channels): consolidate Slack sub-tab top matter into one connection card

### DIFF
--- a/clients/web/src/components/slack-setup-wizard.stories.tsx
+++ b/clients/web/src/components/slack-setup-wizard.stories.tsx
@@ -37,11 +37,3 @@ export const Step3InstallAndConnect: Story = {
     },
   },
 };
-
-export const ConnectedThreadBehavior: Story = {
-  args: {
-    connected: true,
-    threadMode: "mention_then_thread",
-    onThreadModeChange: () => {},
-  },
-};

--- a/clients/web/src/components/slack-setup-wizard.tsx
+++ b/clients/web/src/components/slack-setup-wizard.tsx
@@ -1,11 +1,9 @@
 import { ClipboardCopy, ExternalLink, Plus } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { Button, Input, Radio, RadioGroup, Stepper, type StepperStep, Typography } from "@vellumai/design-library";
+import { Button, Input, Stepper, type StepperStep, Typography } from "@vellumai/design-library";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { buildSlackManifestUrl } from "@/utils/slack-manifest";
-
-export type SlackThreadMode = "mention_only" | "mention_then_thread";
 
 export type MutationStatus = "idle" | "pending" | "success" | "error";
 
@@ -21,22 +19,20 @@ const WIZARD_STEPS: StepperStep[] = [
 export interface SlackSetupWizardProps {
   assistantName: string;
   initialStepId?: WizardStepId;
-  connected?: boolean;
-  threadMode?: SlackThreadMode;
-  threadModePending?: boolean;
-  onThreadModeChange?: (mode: SlackThreadMode) => void;
   onSave?: (botToken: string, appToken: string) => void;
   saveStatus?: MutationStatus;
   saveError?: string | null;
 }
 
+/**
+ * Three-step guided setup for connecting a Slack app: create the app from
+ * a manifest, generate the app-level token, then install and paste the bot
+ * token. Settings for an already-connected Slack (thread behavior) live in
+ * `SlackThreadBehavior`.
+ */
 export function SlackSetupWizard({
   assistantName,
   initialStepId = "create-app",
-  connected = false,
-  threadMode,
-  threadModePending = false,
-  onThreadModeChange,
   onSave,
   saveStatus = "idle",
   saveError = null,
@@ -81,39 +77,6 @@ export function SlackSetupWizard({
       setStepId(WIZARD_STEP_IDS[next]);
     }
   }, [stepIndex]);
-
-  if (connected) {
-    return (
-      <div data-slot="slack-setup-wizard">
-        <div className="flex flex-col gap-3">
-          <Typography
-            as="span"
-            variant="body-small-emphasised"
-            className="text-[color:var(--content-secondary)]"
-          >
-            Thread Behavior
-          </Typography>
-          <RadioGroup<SlackThreadMode>
-            value={threadMode ?? "mention_then_thread"}
-            onValueChange={(next) => onThreadModeChange?.(next)}
-            disabled={threadModePending || !onThreadModeChange}
-            aria-label="Slack thread behavior"
-          >
-            <Radio<SlackThreadMode>
-              value="mention_only"
-              label="Mentions only"
-              helperText="Bot only responds when @mentioned."
-            />
-            <Radio<SlackThreadMode>
-              value="mention_then_thread"
-              label="Follow threads after first mention"
-              helperText="After an @mention in a thread, bot listens to all subsequent replies."
-            />
-          </RadioGroup>
-        </div>
-      </div>
-    );
-  }
 
   return (
     <div data-slot="slack-setup-wizard">

--- a/clients/web/src/domains/contacts/channels-page.tsx
+++ b/clients/web/src/domains/contacts/channels-page.tsx
@@ -28,9 +28,6 @@ export function ChannelsPage({
   onStartSetupConversation,
 }: ChannelsPageProps) {
   const a2aChannel = useAssistantFeatureFlagStore.use.a2aChannel();
-  // The Channels-tab restructure (sub-tabs + promoted subtitle) ships with
-  // the channel-trust-floors arc; off keeps the titled card + accordion.
-  const tabbedLayout = useAssistantFeatureFlagStore.use.channelTrustFloors();
   const identityName = useAssistantIdentityStore.use.name();
   const setupChannel = useSetupChannelParam();
   const inviteDialog = useInviteLinkDialog(assistantId);
@@ -46,7 +43,6 @@ export function ChannelsPage({
     <div className="flex flex-col gap-6">
       <DetailCard
         showBorder={false}
-        title={tabbedLayout ? undefined : "Channels"}
         subtitle={`Manage where ${displayName} can be reached.`}
       />
 

--- a/clients/web/src/domains/contacts/components/assistant-channels-detail.test.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-detail.test.tsx
@@ -1,12 +1,14 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
 import { AssistantChannelsDetail } from "@/domains/contacts/components/assistant-channels-detail";
-import { AssistantChannelsList } from "@/domains/contacts/components/assistant-channels-list";
+import {
+  AssistantChannelsList,
+  type AssistantChannelsListProps,
+} from "@/domains/contacts/components/assistant-channels-list";
 import type { AssistantChannelState } from "@/domains/contacts/types";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 const CHANNELS: AssistantChannelState[] = [
   { key: "slack", status: "ready", address: "@vex" },
@@ -14,22 +16,10 @@ const CHANNELS: AssistantChannelState[] = [
   { key: "phone", status: "not_configured" },
 ];
 
-// Flag values are only authoritative once /feature-flags has hydrated;
-// pre-hydration the list renders a loading placeholder instead of
-// committing to a layout (see the hydration gate in AssistantChannelsList).
-function setTabbedLayout(enabled: boolean) {
-  useAssistantFeatureFlagStore.setState({
-    channelTrustFloors: enabled,
-    hasHydrated: true,
-  });
-}
-
-
-// The tabbed layout's Slack panel owns its own queries
-// (`SlackChannelSection`), so list renders need a QueryClient. Queries fail
-// fast (retry off, no server) and the panel shows its error state, which
-// these layout assertions don't depend on.
-function renderList(extraProps: { initialChannel?: "slack" | "telegram" | "phone" } = {}) {
+// The Slack panel owns its own queries (`SlackChannelSection`), so list
+// renders need a QueryClient. Queries fail fast (retry off, no server) and
+// the panel shows its error state, which these assertions don't depend on.
+function renderList(extraProps: Partial<AssistantChannelsListProps> = {}) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
@@ -45,16 +35,8 @@ function renderList(extraProps: { initialChannel?: "slack" | "telegram" | "phone
   );
 }
 
-beforeEach(() => {
-  setTabbedLayout(false);
-});
-
 afterEach(() => {
   cleanup();
-  useAssistantFeatureFlagStore.setState({
-    channelTrustFloors: false,
-    hasHydrated: false,
-  });
 });
 
 describe("assistant channels surfaces", () => {
@@ -68,10 +50,9 @@ describe("assistant channels surfaces", () => {
   });
 
   test("the Contacts detail view is a plain connect/disconnect list, not the Channels-tab panel", () => {
-    // Regardless of the channel-trust-floors flag, the contact card renders
-    // one row per adapter — never the sub-tabs, trust-floor dropdown, Slack
-    // settings card, or channel list (those live in the Channels tab).
-    setTabbedLayout(true);
+    // The contact card renders one row per adapter — never the sub-tabs,
+    // trust-floor dropdown, Slack cards, or channel list (those live in the
+    // Channels tab).
     render(
       <AssistantChannelsDetail
         assistantName="Vex"
@@ -85,7 +66,7 @@ describe("assistant channels surfaces", () => {
     expect(document.body.textContent).not.toContain("Thread Behavior");
     expect(document.body.textContent).not.toContain("Share Connection Link");
 
-    // Connected Slack: handle + chip + destructive disconnect.
+    // Connected Slack: handle + chip + disconnect.
     expect(document.body.textContent).toContain("@vex");
     expect(document.body.textContent).toContain("Connected");
     expect(document.body.textContent).toContain("Disconnect");
@@ -130,17 +111,7 @@ describe("assistant channels surfaces", () => {
     expect(document.body.textContent).toContain("Telegram");
   });
 
-  test("channel-trust-floors off renders the accordion rows", () => {
-    setTabbedLayout(false);
-    renderList();
-    expect(document.body.textContent).toContain("Phone Calling");
-    // Accordion rows surface per-channel Set up buttons inline.
-    expect(document.body.textContent).toContain("Set up");
-    expect(document.querySelector('[data-slot="tabs"]')).toBeNull();
-  });
-
-  test("channel-trust-floors on renders the adapter sub-tabs", () => {
-    setTabbedLayout(true);
+  test("renders the adapter sub-tabs", () => {
     renderList();
     expect(document.querySelector('[data-slot="tabs"]')).not.toBeNull();
     expect(document.body.textContent).toContain("Phone");
@@ -150,27 +121,64 @@ describe("assistant channels surfaces", () => {
     expect(document.body.textContent).toContain("Disconnect");
   });
 
-  test("renders a loading placeholder while a false flag is unhydrated", () => {
-    useAssistantFeatureFlagStore.setState({
-      channelTrustFloors: false,
-      hasHydrated: false,
+  test("the Slack sub-tab consolidates connection state into a single card", () => {
+    renderList({
+      onDisconnect: () => {},
+      channelPolicies: { slack: "trusted_contacts" },
+      onChannelPolicyChange: () => {},
     });
-    renderList();
-    expect(document.body.textContent).toContain("Loading…");
-    expect(document.body.textContent).not.toContain("Slack");
+
+    // Card header row: @handle + Connected chip + Disconnect; card body:
+    // the Thread Behavior radios.
+    expect(document.body.textContent).toContain("@vex");
+    expect(document.body.textContent).toContain("Connected");
+    expect(document.body.textContent).toContain("Disconnect");
+    expect(document.body.textContent).toContain("Thread Behavior");
+
+    // No trust-floor dropdown even with a policy handler wired — Slack has
+    // no channel-wide floor control. And no duplicated wrapper header or
+    // "Connected as" subline.
+    expect(document.body.textContent).not.toContain("Who can message");
+    expect(document.body.textContent).not.toContain("Slack settings");
+    expect(document.body.textContent).not.toContain("Connected as");
   });
 
-  test("an unhydrated true flag (env override) renders the tabs immediately", () => {
-    useAssistantFeatureFlagStore.setState({
-      channelTrustFloors: true,
-      hasHydrated: false,
+  test("the Slack Disconnect affordance is low-weight but still confirms first", () => {
+    const disconnected: string[] = [];
+    renderList({ onDisconnect: (key) => disconnected.push(key) });
+
+    const disconnectButton = Array.from(
+      document.querySelectorAll("button"),
+    ).find((b) => b.textContent?.trim() === "Disconnect");
+    expect(disconnectButton).toBeDefined();
+    // Ghost weight, not the destructive filled variant.
+    expect(disconnectButton!.className).not.toContain("system-negative");
+
+    fireEvent.click(disconnectButton!);
+    expect(disconnected).toEqual([]);
+
+    const confirmButton = document.querySelector<HTMLButtonElement>(
+      "[data-confirm-dialog-confirm]",
+    );
+    expect(confirmButton).not.toBeNull();
+    fireEvent.click(confirmButton!);
+    expect(disconnected).toEqual(["slack"]);
+  });
+
+  test("connected Telegram keeps the trust-floor dropdown", () => {
+    renderList({
+      channels: [
+        { key: "telegram", status: "ready", address: "@vex_bot" },
+        { key: "slack", status: "ready", address: "@vex" },
+        { key: "phone", status: "not_configured" },
+      ],
+      channelPolicies: { telegram: "trusted_contacts" },
+      onChannelPolicyChange: () => {},
     });
-    renderList();
-    expect(document.querySelector('[data-slot="tabs"]')).not.toBeNull();
+    expect(document.body.textContent).toContain("Who can message Vex");
   });
 
   test("disconnected tab swaps the empty state for the manual form on request", () => {
-    setTabbedLayout(true);
     renderList();
 
     const telegramTab = Array.from(
@@ -197,7 +205,6 @@ describe("assistant channels surfaces", () => {
     // The mobile chat-drawer handoff navigates to `?setup=<channel>` to
     // continue credential entry here — it must land on the form, not the
     // empty state whose Set up button would start another conversation.
-    setTabbedLayout(true);
     renderList({ initialChannel: "telegram" });
     expect(document.body.textContent).toContain("Bot Token");
     expect(document.body.textContent).not.toContain("Telegram isn't connected");

--- a/clients/web/src/domains/contacts/components/assistant-channels-list.stories.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-list.stories.tsx
@@ -2,7 +2,6 @@ import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { DetailCard } from "@/components/detail-card";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 import { AssistantChannelsList } from "./assistant-channels-list";
 
@@ -10,21 +9,10 @@ import { AssistantChannelsList } from "./assistant-channels-list";
  * The standalone Channels tab composition (`ChannelsPage` minus its data
  * wiring): a borderless page subtitle, then the channel sub-tabs in a card —
  * matching the sibling About Assistant tabs rather than the boxed
- * "Channels" card used inside the Contacts detail view.
- *
- * The layout is gated on the `channel-trust-floors` flag: sub-tabs when on,
- * the accordion rows when off (see the Legacy story).
+ * "Channels" card used inside the Contacts detail view. (The Channels tab
+ * itself is gated on the `channel-trust-floors` flag in the About
+ * Assistant nav.)
  */
-const withLayoutFlag = (tabbed: boolean): Decorator => {
-  return (Story) => {
-    useAssistantFeatureFlagStore.setState({
-      channelTrustFloors: tabbed,
-      hasHydrated: true,
-    });
-    return <Story />;
-  };
-};
-
 // The Slack panel owns its own queries (`SlackChannelSection`), so stories
 // need a QueryClient. Requests fail in Storybook (no daemon), so the Slack
 // tab's channel list renders its error state; the list's full visuals live
@@ -56,7 +44,6 @@ const meta: Meta<typeof AssistantChannelsList> = {
   },
   decorators: [
     withQueryClient,
-    withLayoutFlag(true),
     (Story) => (
       <div
         style={{
@@ -85,7 +72,13 @@ type Story = StoryObj<typeof AssistantChannelsList>;
 
 export const ChannelsTab: Story = {};
 
-/** Connected Slack tab with the trust-floor control, as after a `?setup=slack` deep link. */
+/**
+ * Connected Slack tab: the consolidated connection card (logo, @handle,
+ * Connected chip, low-weight Disconnect) with Thread Behavior in the body,
+ * over the channel presence list. Slack shows no trust-floor dropdown even
+ * with a policy handler wired — its floors are managed per conversation
+ * type.
+ */
 export const ChannelsTabSlackConnected: Story = {
   args: {
     initialChannel: "slack",
@@ -93,6 +86,17 @@ export const ChannelsTabSlackConnected: Story = {
     onSlackThreadModeChange: () => {},
     channelPolicies: { slack: "trusted_contacts" },
     onChannelPolicyChange: () => {},
+  },
+};
+
+/** Disconnected Slack tab: the setup wizard in the "Slack setup" card. */
+export const ChannelsTabSlackDisconnected: Story = {
+  args: {
+    channels: [
+      { key: "slack", status: "not_configured" },
+      { key: "telegram", status: "not_configured" },
+      { key: "phone", status: "not_configured" },
+    ],
   },
 };
 
@@ -127,9 +131,4 @@ export const ChannelsTabTelegramSetupHandoff: Story = {
   args: {
     initialChannel: "telegram",
   },
-};
-
-/** The accordion layout rendered while `channel-trust-floors` is off. */
-export const LegacyAccordion: Story = {
-  decorators: [withLayoutFlag(false)],
 };

--- a/clients/web/src/domains/contacts/components/assistant-channels-list.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-list.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle, ChevronDown, ChevronRight } from "lucide-react";
+import { CheckCircle } from "lucide-react";
 import { useState } from "react";
 
 import { Button } from "@vellumai/design-library/components/button";
@@ -14,7 +14,9 @@ import { EmptyState } from "@/components/empty-state";
 import { assistantDisplayName as toAssistantDisplayName } from "@/domains/contacts/assistant-display-name";
 import { SlackChannelCard } from "@/domains/contacts/components/slack-channel-card";
 import { SlackChannelSection } from "@/domains/contacts/components/slack-channel-section";
-import { SlackSetupWizard, type SlackThreadMode, type MutationStatus } from "@/components/slack-setup-wizard";
+import { SlackConnectionCard } from "@/domains/contacts/components/slack-connection-card";
+import { SlackThreadBehavior, type SlackThreadMode } from "@/domains/contacts/components/slack-thread-behavior";
+import { SlackSetupWizard, type MutationStatus } from "@/components/slack-setup-wizard";
 import type { AssistantChannelState, SetupChannelId } from "@/domains/contacts/types";
 import {
   ADMISSION_POLICY_DEFAULT,
@@ -23,7 +25,6 @@ import {
   POLICY_LABELS,
   type AdmissionPolicy,
 } from "@/lib/channel-admission-policy/types";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { ChannelIcon, getChannelLabel } from "@/utils/channel-presentation";
 
 type ChannelKey = SetupChannelId;
@@ -72,8 +73,9 @@ export interface AssistantChannelsListProps {
   slackThreadModePending?: boolean;
   /**
    * Per-channel admission floor, keyed by channel. Omit (or pass no
-   * `onChannelPolicyChange`) to hide the trust-floor control entirely — used
-   * when the `channelTrustFloors` flag is off.
+   * `onChannelPolicyChange`) to hide the trust-floor control entirely —
+   * `useChannelTrustFloors` does so while the `channelTrustFloors` flag is
+   * off.
    */
   channelPolicies?: Partial<Record<ChannelKey, AdmissionPolicy>>;
   policySavingKey?: ChannelKey | null;
@@ -89,8 +91,8 @@ export interface AssistantChannelsListProps {
   onSlackThreadModeChange?: (mode: SlackThreadMode) => void;
   onSaveTwilioCredentials?: (accountSid: string, authToken: string) => Promise<void>;
   /**
-   * Pre-open a channel on mount (e.g. from a `?setup=slack` deep-link):
-   * selects its tab in the tabbed layout, expands its row in the accordion.
+   * Pre-select a channel's sub-tab on mount (e.g. from a `?setup=slack`
+   * deep-link) and open its manual credential form.
    */
   initialChannel?: ChannelKey | null;
 }
@@ -98,9 +100,15 @@ export interface AssistantChannelsListProps {
 const CHANNEL_META: Record<
   ChannelKey,
   {
-    /** Row label in the accordion layout; also the disconnect-dialog subject. */
+    /** The disconnect-dialog subject ("Disconnect {label}?"). */
     label: string;
     disconnectMessage: string;
+    /**
+     * Whether a connected channel surfaces the "Who can message" trust-floor
+     * dropdown. Slack has none: its admission floors are managed per
+     * conversation type (DMs vs. channels), with no channel-wide knob.
+     */
+    hasTrustFloorControl: boolean;
     /** One-line pitch for the disconnected empty state. Slack has none — its disconnected state is the setup wizard. */
     disconnectedPitch?: (displayName: string) => string;
   }
@@ -109,11 +117,13 @@ const CHANNEL_META: Record<
     label: "Slack",
     disconnectMessage:
       "This clears the stored Slack bot and app tokens for this assistant. You can reconnect later.",
+    hasTrustFloorControl: false,
   },
   telegram: {
     label: "Telegram",
     disconnectMessage:
       "This clears the stored Telegram bot token for this assistant. You can reconnect later.",
+    hasTrustFloorControl: true,
     disconnectedPitch: (displayName) =>
       `Connect a Telegram bot so ${displayName} can send and receive messages on Telegram.`,
   },
@@ -121,21 +131,19 @@ const CHANNEL_META: Record<
     label: "Phone Calling",
     disconnectMessage:
       "This clears the stored Twilio credentials for this assistant. You can reconnect later.",
+    hasTrustFloorControl: true,
     disconnectedPitch: (displayName) =>
       `Connect your Twilio account so ${displayName} can make and answer phone calls.`,
   },
 };
 
 /**
- * The Slack/Telegram/Phone channel sections plus their disconnect and
- * trust-floor confirmation dialogs. Owns which section is open and which
- * confirmations are pending; the queries and mutations behind the props live
- * in `useAssistantChannels`. Rendered by both mount points — the Channels
- * tab (in a card) and the Contacts assistant detail.
- *
- * Layout is gated on the `channel-trust-floors` flag (the Channels-tab
- * restructure ships with that arc): on → adapter sub-tabs with empty states
- * for disconnected channels, off → the accordion rows.
+ * The Slack/Telegram/Phone adapter sub-tabs plus their disconnect and
+ * trust-floor confirmation dialogs, rendered by the Channels tab
+ * (`ChannelsPage`). Owns which sub-tab is active and which confirmations
+ * are pending; the queries and mutations behind the props live in
+ * `useAssistantChannels`. The `channel-trust-floors` flag gates the
+ * Channels tab itself (in `IntelligenceLayout`), not anything in here.
  */
 export function AssistantChannelsList({
   assistantId,
@@ -159,14 +167,9 @@ export function AssistantChannelsList({
   onSaveTwilioCredentials,
   initialChannel = null,
 }: AssistantChannelsListProps) {
-  const tabbedLayout = useAssistantFeatureFlagStore.use.channelTrustFloors();
-  const flagsHydrated = useAssistantFeatureFlagStore.use.hasHydrated();
   const [pendingDisconnect, setPendingDisconnect] = useState<ChannelKey | null>(null);
   const [activeChannel, setActiveChannel] = useState<ChannelKey>(
     () => initialChannel ?? channels[0]?.key ?? "slack",
-  );
-  const [expandedChannels, setExpandedChannels] = useState<Set<ChannelKey>>(
-    () => initialChannel ? new Set([initialChannel]) : new Set(),
   );
   // Floor confirmation: non-null while a floor in POLICY_CONFIRMATIONS awaits
   // the user's go-ahead before persisting.
@@ -191,112 +194,29 @@ export function AssistantChannelsList({
     onChannelPolicyChange?.(channelKey, next);
   };
 
-  const toggleExpanded = (key: ChannelKey) => {
-    setExpandedChannels((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) {
-        next.delete(key);
-      } else {
-        next.add(key);
-      }
-      return next;
-    });
-  };
-
-  // A `false` flag before /feature-flags hydrates is the registry default,
-  // not the real value — committing to the accordion and swapping to the
-  // tabs after hydration would unmount the credential forms and discard
-  // anything mid-entry. Treat the window as loading instead; a `true`
-  // (env override) is already definitive. Same pattern as `InspectPage`.
-  if (!tabbedLayout && !flagsHydrated) {
-    return (
-      <Typography
-        as="span"
-        variant="body-small-default"
-        className="text-[color:var(--content-tertiary)]"
-      >
-        Loading…
-      </Typography>
-    );
-  }
-
   return (
     <div className="flex flex-col">
-      {tabbedLayout ? (
-        <Tabs.Root
-          value={activeChannel}
-          onValueChange={(value) => setActiveChannel(value as ChannelKey)}
-        >
-          <Tabs.List>
-            {channels.map((channel) => (
-              <Tabs.Trigger key={channel.key} value={channel.key}>
-                {getChannelLabel(channel.key)}
-              </Tabs.Trigger>
-            ))}
-          </Tabs.List>
+      <Tabs.Root
+        value={activeChannel}
+        onValueChange={(value) => setActiveChannel(value as ChannelKey)}
+      >
+        <Tabs.List>
           {channels.map((channel) => (
-            <Tabs.Panel key={channel.key} value={channel.key} className="pt-4">
-              <ChannelPanel
-                channel={channel}
-                assistantId={assistantId}
-                assistantName={assistantName}
-                assistantDisplayName={displayName}
-                pending={pendingChannelKey === channel.key}
-                initialManualEntry={initialChannel === channel.key}
-                onSetup={onSetup ? () => onSetup(channel.key) : undefined}
-                onDisconnect={
-                  onDisconnect ? () => setPendingDisconnect(channel.key) : undefined
-                }
-                onSaveTelegramToken={onSaveTelegramToken}
-                onSaveSlackConfig={onSaveSlackConfig}
-                slackSaveStatus={slackSaveStatus}
-                slackSaveError={slackSaveError}
-                slackThreadMode={slackThreadMode}
-                slackThreadModePending={slackThreadModePending}
-                onSlackThreadModeChange={onSlackThreadModeChange}
-                onSaveTwilioCredentials={onSaveTwilioCredentials}
-                policy={channelPolicies?.[channel.key]}
-                policySaving={policySavingKey === channel.key}
-                policyLoading={policiesLoading}
-                policyError={policiesError}
-                onPolicyChange={
-                  onChannelPolicyChange
-                    ? (next) => handlePolicyChange(channel.key, next)
-                    : undefined
-                }
-              />
-            </Tabs.Panel>
+            <Tabs.Trigger key={channel.key} value={channel.key}>
+              {getChannelLabel(channel.key)}
+            </Tabs.Trigger>
           ))}
-        </Tabs.Root>
-      ) : (
-        channels.map((channel, index) => (
-          <div key={channel.key}>
-            {index > 0 ? (
-              <div
-                className="border-t"
-                style={{ borderColor: "var(--border-base)" }}
-              />
-            ) : null}
-            <ChannelRow
+        </Tabs.List>
+        {channels.map((channel) => (
+          <Tabs.Panel key={channel.key} value={channel.key} className="pt-4">
+            <ChannelPanel
               channel={channel}
+              assistantId={assistantId}
               assistantName={assistantName}
               assistantDisplayName={displayName}
               pending={pendingChannelKey === channel.key}
-              expanded={expandedChannels.has(channel.key)}
-              onToggleExpand={() => toggleExpanded(channel.key)}
-              onSetup={
-                channel.key === "slack"
-                  ? () => {
-                      setExpandedChannels((prev) => {
-                        const next = new Set(prev);
-                        next.add(channel.key);
-                        return next;
-                      });
-                    }
-                  : onSetup
-                    ? () => onSetup(channel.key)
-                    : undefined
-              }
+              initialManualEntry={initialChannel === channel.key}
+              onSetup={onSetup ? () => onSetup(channel.key) : undefined}
               onDisconnect={
                 onDisconnect ? () => setPendingDisconnect(channel.key) : undefined
               }
@@ -318,9 +238,9 @@ export function AssistantChannelsList({
                   : undefined
               }
             />
-          </div>
-        ))
-      )}
+          </Tabs.Panel>
+        ))}
+      </Tabs.Root>
 
       <ConfirmDialog
         open={pendingDisconnect !== null}
@@ -357,7 +277,7 @@ export function AssistantChannelsList({
 }
 
 // ---------------------------------------------------------------------------
-// Channel Panel (tabbed layout)
+// Channel Panel
 // ---------------------------------------------------------------------------
 
 interface ChannelPanelProps {
@@ -423,7 +343,9 @@ function ChannelPanel({
 
   return (
     <div className="flex flex-col gap-4">
-      {connected ? (
+      {/* Slack renders no standalone connection row — connected Slack's
+          connection state lives in the consolidated card's header below. */}
+      {channel.key !== "slack" && connected ? (
         <div className="flex items-center gap-3">
           <Tag tone="positive" leftIcon={<CheckCircle />}>
             Connected
@@ -477,7 +399,7 @@ function ChannelPanel({
         />
       ) : null}
 
-      {connected && onPolicyChange ? (
+      {connected && meta.hasTrustFloorControl && onPolicyChange ? (
         <ChannelTrustFloorSection
           assistantDisplayName={assistantDisplayName}
           policy={policy}
@@ -493,18 +415,28 @@ function ChannelPanel({
       ) : null}
 
       {channel.key === "slack" ? (
-        <SlackChannelCard assistantName={assistantName} connected={connected}>
-          <SlackSetupWizard
-            assistantName={assistantName}
-            connected={connected}
-            onSave={onSaveSlackConfig}
-            saveStatus={slackSaveStatus}
-            saveError={slackSaveError}
-            threadMode={slackThreadMode}
-            threadModePending={slackThreadModePending}
-            onThreadModeChange={onSlackThreadModeChange}
-          />
-        </SlackChannelCard>
+        connected ? (
+          <SlackConnectionCard
+            slackHandle={channel.address}
+            disconnectPending={pending}
+            onDisconnect={onDisconnect}
+          >
+            <SlackThreadBehavior
+              threadMode={slackThreadMode}
+              threadModePending={slackThreadModePending}
+              onThreadModeChange={onSlackThreadModeChange}
+            />
+          </SlackConnectionCard>
+        ) : (
+          <SlackChannelCard>
+            <SlackSetupWizard
+              assistantName={assistantName}
+              onSave={onSaveSlackConfig}
+              saveStatus={slackSaveStatus}
+              saveError={slackSaveError}
+            />
+          </SlackChannelCard>
+        )
       ) : null}
 
       {channel.key === "slack" && connected ? (
@@ -512,171 +444,11 @@ function ChannelPanel({
           assistantId={assistantId}
           assistantDisplayName={assistantDisplayName}
           slackHandle={channel.address}
-          admissionPolicy={policy}
         />
       ) : null}
 
       {channel.key === "phone" && showCredentialForm ? (
         <TwilioCredentialEntry onSave={onSaveTwilioCredentials} />
-      ) : null}
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Channel Row (accordion layout, `channel-trust-floors` off)
-// ---------------------------------------------------------------------------
-
-interface ChannelRowProps {
-  channel: AssistantChannelState;
-  assistantName: string;
-  /** Trimmed assistant name with a "your assistant" fallback, for copy. */
-  assistantDisplayName: string;
-  pending: boolean;
-  expanded: boolean;
-  onToggleExpand: () => void;
-  onSetup?: () => void;
-  onDisconnect?: () => void;
-  onSaveTelegramToken?: (botToken: string) => Promise<void>;
-  onSaveSlackConfig?: (botToken: string, appToken: string) => void;
-  slackSaveStatus?: MutationStatus;
-  slackSaveError?: string | null;
-  slackThreadMode?: SlackThreadMode;
-  slackThreadModePending?: boolean;
-  onSlackThreadModeChange?: (mode: SlackThreadMode) => void;
-  onSaveTwilioCredentials?: (accountSid: string, authToken: string) => Promise<void>;
-  policy?: AdmissionPolicy;
-  policySaving?: boolean;
-  policyLoading?: boolean;
-  policyError?: boolean;
-  onPolicyChange?: (policy: AdmissionPolicy) => void;
-}
-
-function ChannelRow({
-  channel,
-  assistantName,
-  assistantDisplayName,
-  pending,
-  expanded,
-  onToggleExpand,
-  onSetup,
-  onDisconnect,
-  onSaveTelegramToken,
-  onSaveSlackConfig,
-  slackSaveStatus,
-  slackSaveError,
-  slackThreadMode,
-  slackThreadModePending = false,
-  onSlackThreadModeChange,
-  onSaveTwilioCredentials,
-  policy,
-  policySaving = false,
-  policyLoading = false,
-  policyError = false,
-  onPolicyChange,
-}: ChannelRowProps) {
-  const meta = CHANNEL_META[channel.key];
-  const connected = channel.status === "ready";
-
-  return (
-    <div className="flex flex-col gap-2 py-4">
-      <div className="flex items-center gap-3">
-        <button
-          type="button"
-          className="flex shrink-0 items-center justify-center"
-          onClick={onToggleExpand}
-          style={{ color: "var(--content-secondary)" }}
-        >
-          {expanded ? (
-            <ChevronDown className="h-4 w-4" />
-          ) : (
-            <ChevronRight className="h-4 w-4" />
-          )}
-        </button>
-        <span
-          className="text-body-medium-default"
-          style={{ color: "var(--content-default)" }}
-        >
-          {meta.label}
-        </span>
-        {channel.address ? (
-          <span className="text-body-medium-lighter" style={{ color: "var(--content-tertiary)" }}>
-            {channel.address}
-          </span>
-        ) : null}
-        <div className="ml-auto flex items-center gap-2">
-          {connected ? (
-            <>
-              <span className="inline-flex items-center gap-1 h-8 px-2.5 rounded-md whitespace-nowrap select-none text-body-small-emphasised leading-none bg-[var(--content-default)] text-[var(--surface-base)]">
-                <CheckCircle className="h-3 w-3" />
-                Connected
-              </span>
-              <Button
-                type="button"
-                variant="danger"
-                onClick={onDisconnect}
-                disabled={!onDisconnect || pending}
-              >
-                {pending ? "Disconnecting…" : "Disconnect"}
-              </Button>
-            </>
-          ) : (
-            <Button
-              type="button"
-              variant="outlined"
-              onClick={onSetup}
-              disabled={!onSetup || pending}
-            >
-              {pending ? "Opening…" : "Set up"}
-            </Button>
-          )}
-        </div>
-      </div>
-
-      {expanded ? (
-        <div className={connected ? "flex flex-col gap-4" : undefined}>
-          {connected && onPolicyChange ? (
-            <div className="pl-7">
-              <ChannelTrustFloorSection
-                assistantDisplayName={assistantDisplayName}
-                policy={policy}
-                saving={policySaving}
-                loading={policyLoading}
-                error={policyError}
-                onChange={onPolicyChange}
-              />
-            </div>
-          ) : null}
-
-          {channel.key === "telegram" ? (
-            <div className="pl-7">
-              <TelegramCredentialEntry onSave={onSaveTelegramToken} />
-            </div>
-          ) : null}
-
-          {channel.key === "slack" ? (
-            <div className="pl-7">
-              <SlackChannelCard assistantName={assistantName} connected={connected}>
-                <SlackSetupWizard
-                  assistantName={assistantName}
-                  connected={connected}
-                  onSave={onSaveSlackConfig}
-                  saveStatus={slackSaveStatus}
-                  saveError={slackSaveError}
-                  threadMode={slackThreadMode}
-                  threadModePending={slackThreadModePending}
-                  onThreadModeChange={onSlackThreadModeChange}
-                />
-              </SlackChannelCard>
-            </div>
-          ) : null}
-
-          {channel.key === "phone" ? (
-            <div className="pl-7">
-              <TwilioCredentialEntry onSave={onSaveTwilioCredentials} />
-            </div>
-          ) : null}
-        </div>
       ) : null}
     </div>
   );

--- a/clients/web/src/domains/contacts/components/slack-channel-card.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-card.tsx
@@ -6,12 +6,14 @@ import { Typography } from "@vellumai/design-library/components/typography";
 import { publicAsset } from "@/utils/public-asset";
 
 interface SlackChannelCardProps {
-  assistantName: string;
-  connected?: boolean;
   children: ReactNode;
 }
 
-export function SlackChannelCard({ assistantName, connected = false, children }: SlackChannelCardProps) {
+/**
+ * The "Slack setup" card wrapping the setup wizard for a disconnected
+ * Slack. A connected Slack renders `SlackConnectionCard` instead.
+ */
+export function SlackChannelCard({ children }: SlackChannelCardProps) {
   return (
     <Card.Root>
       <Card.Header>
@@ -21,17 +23,9 @@ export function SlackChannelCard({ assistantName, connected = false, children }:
             alt=""
             className="size-8 rounded-lg bg-[var(--surface-sunken)] p-1"
           />
-          <div className="flex flex-col">
-            <Typography as="span" variant="body-medium-default">
-              {connected ? "Slack settings" : "Slack setup"}
-            </Typography>
-            {connected ? (
-              <span className="flex items-center gap-1.5 text-body-small-default text-[var(--content-secondary)]">
-                <span className="size-2 rounded-full bg-[var(--system-positive-strong)]" />
-                Connected as {assistantName}
-              </span>
-            ) : null}
-          </div>
+          <Typography as="span" variant="body-medium-default">
+            Slack setup
+          </Typography>
         </div>
       </Card.Header>
       <Card.Body>{children}</Card.Body>

--- a/clients/web/src/domains/contacts/components/slack-channel-list.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-list.tsx
@@ -18,7 +18,6 @@ import {
   type SlackCapabilityTier,
 } from "@/domains/contacts/slack-channel-overrides";
 import type { SlackChannel } from "@/domains/contacts/types";
-import type { AdmissionPolicy } from "@/lib/channel-admission-policy/types";
 
 /**
  * How a channel presents in the filter chips. Mirrors the conversation-type
@@ -151,8 +150,6 @@ export interface SlackChannelListProps {
   onTierChange?: (channelId: string, tier: SlackCapabilityTier) => void;
   /** Deletes the channel's persisted cells so the default wins again. */
   onTierReset?: (channelId: string) => void;
-  /** Slack trust floor, shown read-only in expanded rows. */
-  admissionPolicy?: AdmissionPolicy;
 }
 
 const EMPTY_PENDING_IDS: ReadonlySet<string> = new Set();
@@ -177,7 +174,6 @@ export function SlackChannelList({
   pendingChannelIds = EMPTY_PENDING_IDS,
   onTierChange,
   onTierReset,
-  admissionPolicy,
 }: SlackChannelListProps) {
   const [search, setSearch] = useState("");
   const [kindFilter, setKindFilter] = useState<SlackRoomKind | null>(null);
@@ -340,8 +336,6 @@ export function SlackChannelList({
                           onTierChange?.(channel.id, tier)
                         }
                         onReset={() => onTierReset?.(channel.id)}
-                        assistantDisplayName={assistantDisplayName}
-                        admissionPolicy={admissionPolicy}
                       />
                     )}
                     className="h-full"
@@ -361,8 +355,6 @@ export function SlackChannelList({
                       tierOverride={tierOverrides?.[channel.id]}
                       onTierChange={(tier) => onTierChange?.(channel.id, tier)}
                       onReset={() => onTierReset?.(channel.id)}
-                      assistantDisplayName={assistantDisplayName}
-                      admissionPolicy={admissionPolicy}
                     />
                   ))}
                 </div>
@@ -397,8 +389,6 @@ function SlackChannelRow({
   tierOverride,
   onTierChange,
   onReset,
-  assistantDisplayName,
-  admissionPolicy,
 }: {
   channel: SlackChannel;
   open: boolean;
@@ -409,8 +399,6 @@ function SlackChannelRow({
   tierOverride: SlackCapabilityTier | undefined;
   onTierChange: (tier: SlackCapabilityTier) => void;
   onReset: () => void;
-  assistantDisplayName: string;
-  admissionPolicy: AdmissionPolicy | undefined;
 }) {
   const kind = classifySlackChannelKind(channel);
   // Rows are rooms only ({@link roomsOnly}); a 1:1 DM row is unreachable.
@@ -470,8 +458,6 @@ function SlackChannelRow({
           <SlackChannelOverridePanel
             channelName={channel.name}
             kindLabel={kind}
-            assistantDisplayName={assistantDisplayName}
-            admissionPolicy={admissionPolicy}
             settings={settings}
             loading={overridesLoading}
             error={overridesError}

--- a/clients/web/src/domains/contacts/components/slack-channel-override-panel.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-override-panel.tsx
@@ -10,25 +10,12 @@ import {
   type SlackCapabilityTier,
   type SlackChannelTierSettings,
 } from "@/domains/contacts/slack-channel-overrides";
-import {
-  getPolicyDescriptions,
-  POLICY_LABELS,
-  type AdmissionPolicy,
-} from "@/lib/channel-admission-policy/types";
 
 export interface SlackChannelOverridePanelProps {
   /** Row's channel name, for accessible control labels. */
   channelName: string;
   /** Lowercase room-type word for the custom-capabilities callout copy. */
   kindLabel: "public" | "private";
-  /** Trimmed assistant name with a "your assistant" fallback, for copy. */
-  assistantDisplayName: string;
-  /**
-   * The Slack trust floor, shown read-only so the row answers "who can
-   * reach the assistant here". Admission is a channel-type setting — the
-   * control lives in the "Who can message" dropdown, not per room.
-   */
-  admissionPolicy?: AdmissionPolicy;
   settings: SlackChannelTierSettings;
   /**
    * True until persisted overrides have loaded — the picker holds disabled
@@ -43,15 +30,14 @@ export interface SlackChannelOverridePanelProps {
 
 /**
  * Expanded-row settings for one Slack channel: the capabilities tier
- * (the only per-room knob — admission is a channel-type concern), with a
- * custom-capabilities callout + reset when the tier diverges from the
- * channel-type default. Persists as channel-ID cells via the gateway SDK.
+ * (the only per-room knob — reach is baked into the channel type, with no
+ * per-room control), with a custom-capabilities callout + reset when the
+ * tier diverges from the channel-type default. Persists as channel-ID
+ * cells via the gateway SDK.
  */
 export function SlackChannelOverridePanel({
   channelName,
   kindLabel,
-  assistantDisplayName,
-  admissionPolicy,
   settings,
   loading = false,
   error = false,
@@ -68,35 +54,6 @@ export function SlackChannelOverridePanel({
 
   return (
     <div className="flex flex-col gap-3 px-2 pt-1 pb-4">
-      {admissionPolicy ? (
-        <div className="flex flex-col gap-1">
-          <div className="flex items-center justify-between gap-2">
-            <Typography
-              as="span"
-              variant="body-small-emphasised"
-              className="text-[color:var(--content-secondary)]"
-            >
-              Who can reach {assistantDisplayName} here
-            </Typography>
-            <Typography
-              as="span"
-              variant="body-small-default"
-              className="text-[color:var(--content-tertiary)]"
-            >
-              {POLICY_LABELS[admissionPolicy]} — all of Slack
-            </Typography>
-          </div>
-          <Typography
-            as="p"
-            variant="body-small-default"
-            className="text-[color:var(--content-tertiary)]"
-          >
-            {getPolicyDescriptions(assistantDisplayName)[admissionPolicy]}{" "}
-            Set once for all Slack channels in “Who can message{" "}
-            {assistantDisplayName}” above.
-          </Typography>
-        </div>
-      ) : null}
       {settings.overridden ? (
         <Notice
           tone="warning"

--- a/clients/web/src/domains/contacts/components/slack-channel-section.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-section.tsx
@@ -3,7 +3,6 @@ import { useQuery } from "@tanstack/react-query";
 import { SlackChannelList } from "@/domains/contacts/components/slack-channel-list";
 import { useChannelPermissionOverrides } from "@/domains/contacts/hooks/use-channel-permission-overrides";
 import { memberSlackChannelsOptions } from "@/domains/contacts/slack-channels-query";
-import type { AdmissionPolicy } from "@/lib/channel-admission-policy/types";
 
 export interface SlackChannelSectionProps {
   assistantId: string;
@@ -11,8 +10,6 @@ export interface SlackChannelSectionProps {
   assistantDisplayName: string;
   /** The assistant's Slack handle for the `/invite` and `/remove` hints. */
   slackHandle?: string;
-  /** Slack trust floor, shown read-only in expanded rows. */
-  admissionPolicy?: AdmissionPolicy;
 }
 
 /**
@@ -25,7 +22,6 @@ export function SlackChannelSection({
   assistantId,
   assistantDisplayName,
   slackHandle,
-  admissionPolicy,
 }: SlackChannelSectionProps) {
   const channelsQuery = useQuery({
     ...memberSlackChannelsOptions(assistantId),
@@ -51,7 +47,6 @@ export function SlackChannelSection({
       pendingChannelIds={overrides.pendingChannelIds}
       onTierChange={overrides.onTierChange}
       onTierReset={overrides.onTierReset}
-      admissionPolicy={admissionPolicy}
     />
   );
 }

--- a/clients/web/src/domains/contacts/components/slack-connection-card.tsx
+++ b/clients/web/src/domains/contacts/components/slack-connection-card.tsx
@@ -1,0 +1,66 @@
+import { CheckCircle } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { Button } from "@vellumai/design-library/components/button";
+import { Card } from "@vellumai/design-library/components/card";
+import { Tag } from "@vellumai/design-library/components/tag";
+import { Typography } from "@vellumai/design-library/components/typography";
+
+import { publicAsset } from "@/utils/public-asset";
+
+interface SlackConnectionCardProps {
+  /** The assistant's Slack @handle, when known. */
+  slackHandle?: string;
+  /** Disconnect in flight; disables the button and swaps its label. */
+  disconnectPending?: boolean;
+  onDisconnect?: () => void;
+  children: ReactNode;
+}
+
+/**
+ * The consolidated card for a connected Slack on the Channels tab: one
+ * header row with the Slack logo, @handle, Connected chip, and a
+ * right-aligned low-weight Disconnect affordance (the caller confirms
+ * before disconnecting), with the Slack settings as the body. A
+ * disconnected Slack renders `SlackChannelCard` + `SlackSetupWizard`
+ * instead.
+ */
+export function SlackConnectionCard({
+  slackHandle,
+  disconnectPending = false,
+  onDisconnect,
+  children,
+}: SlackConnectionCardProps) {
+  return (
+    <Card.Root>
+      <Card.Header>
+        <div className="flex items-center gap-3">
+          <img
+            src={publicAsset("/images/integrations/slack.svg")}
+            alt=""
+            className="size-8 rounded-lg bg-[var(--surface-sunken)] p-1"
+          />
+          {slackHandle ? (
+            <Typography as="span" variant="body-medium-default">
+              {slackHandle}
+            </Typography>
+          ) : null}
+          <Tag tone="positive" leftIcon={<CheckCircle />}>
+            Connected
+          </Tag>
+          <div className="ml-auto">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onDisconnect}
+              disabled={!onDisconnect || disconnectPending}
+            >
+              {disconnectPending ? "Disconnecting…" : "Disconnect"}
+            </Button>
+          </div>
+        </div>
+      </Card.Header>
+      <Card.Body>{children}</Card.Body>
+    </Card.Root>
+  );
+}

--- a/clients/web/src/domains/contacts/components/slack-thread-behavior.stories.tsx
+++ b/clients/web/src/domains/contacts/components/slack-thread-behavior.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { SlackThreadBehavior } from "./slack-thread-behavior";
+
+const meta: Meta<typeof SlackThreadBehavior> = {
+  title: "Contacts/SlackThreadBehavior",
+  component: SlackThreadBehavior,
+  args: {
+    threadMode: "mention_then_thread",
+    onThreadModeChange: () => {},
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 800, margin: "2rem auto" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SlackThreadBehavior>;
+
+export const ThreadBehavior: Story = {};
+
+/** A thread-mode write in flight disables the radios. */
+export const SavePending: Story = {
+  args: {
+    threadModePending: true,
+  },
+};

--- a/clients/web/src/domains/contacts/components/slack-thread-behavior.tsx
+++ b/clients/web/src/domains/contacts/components/slack-thread-behavior.tsx
@@ -1,0 +1,51 @@
+import { Radio, RadioGroup } from "@vellumai/design-library/components/radio";
+import { Typography } from "@vellumai/design-library/components/typography";
+
+export type SlackThreadMode = "mention_only" | "mention_then_thread";
+
+interface SlackThreadBehaviorProps {
+  threadMode?: SlackThreadMode;
+  threadModePending?: boolean;
+  onThreadModeChange?: (mode: SlackThreadMode) => void;
+}
+
+/**
+ * Thread Behavior setting for a connected Slack channel: whether the
+ * assistant only answers @mentions or follows a thread after its first
+ * mention. Rendered inside the connected Slack card on the Channels tab;
+ * setup for a disconnected Slack lives in `SlackSetupWizard`.
+ */
+export function SlackThreadBehavior({
+  threadMode,
+  threadModePending = false,
+  onThreadModeChange,
+}: SlackThreadBehaviorProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      <Typography
+        as="span"
+        variant="body-small-emphasised"
+        className="text-[color:var(--content-secondary)]"
+      >
+        Thread Behavior
+      </Typography>
+      <RadioGroup<SlackThreadMode>
+        value={threadMode ?? "mention_then_thread"}
+        onValueChange={(next) => onThreadModeChange?.(next)}
+        disabled={threadModePending || !onThreadModeChange}
+        aria-label="Slack thread behavior"
+      >
+        <Radio<SlackThreadMode>
+          value="mention_only"
+          label="Mentions only"
+          helperText="Bot only responds when @mentioned."
+        />
+        <Radio<SlackThreadMode>
+          value="mention_then_thread"
+          label="Follow threads after first mention"
+          helperText="After an @mention in a thread, bot listens to all subsequent replies."
+        />
+      </RadioGroup>
+    </div>
+  );
+}

--- a/clients/web/src/domains/contacts/hooks/use-assistant-channels.ts
+++ b/clients/web/src/domains/contacts/hooks/use-assistant-channels.ts
@@ -1,8 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
 
-import type { SlackThreadMode } from "@/components/slack-setup-wizard";
 import type { AssistantChannelsListProps } from "@/domains/contacts/components/assistant-channels-list";
+import type { SlackThreadMode } from "@/domains/contacts/components/slack-thread-behavior";
 import { useChannelTrustFloors } from "@/domains/contacts/hooks/use-channel-trust-floors";
 import {
   SETUP_CHANNEL_IDS,


### PR DESCRIPTION
## Prompt / plan

Closes LUM-2729 — Channels tab (Slack sub-tab): consolidate top matter into a single connection card.

Rebased onto main after #37391/#37402 (single commit; the branch history's merge commit and interim states are squashed away).

- **Delete the "Who can message" trust-floor dropdown from the Slack sub-tab.** Reach is managed per channel type with no user-facing knob on this surface (Jul 6 decision). The dropdown renders only for channels that declare one via `CHANNEL_META.hasTrustFloorControl` (Telegram, Phone keep it). The shared `ChannelTrustFloorSection`, trust-floor query, and `channel-trust-floors` flag are untouched.
- **Delete the room override panel's read-only reach block too** (per design review): it rendered channel-type-scoped information at channel-ID altitude and pointed at the removed dropdown. The `admissionPolicy` prop chain (`ChannelPanel` → `SlackChannelSection` → `SlackChannelList` → `SlackChannelOverridePanel`) goes with it; expanded rows are Capabilities-only, matching the updated mockup. #37402's error-guard and copy changes in those files are preserved.
- **Merge the three top-of-tab blocks** (connection row + "Slack settings" card wrapper + Thread Behavior radios) into one `SlackConnectionCard`: header row is Slack logo · `@handle` · Connected chip · right-aligned Disconnect; body is the Thread Behavior radios. The duplicated "Connected as [assistant]" subline is gone.
- **Disconnect styling** moves from destructive-red filled to ghost weight. Behavior unchanged — it still opens the confirm dialog (which keeps its red confirm action).
- **No layout fork inside the page.** The flag-off accordion layout was vestigial (`AssistantChannelsList`'s only mount is `ChannelsPage`, and the flag gates the Channels tab itself in `IntelligenceLayout`); it's deleted and the list no longer reads the flag.
- **Component seams re-cut so the setup wizard is unaffected:** `SlackSetupWizard`'s `connected` branch (Thread Behavior radios) moved to a new `SlackThreadBehavior` component; `SlackChannelCard` is now purely the disconnected "Slack setup" wrapper.

Out of scope, unchanged: room list behavior (LUM-2727 / #37402), Telegram/Phone sub-tabs, connection flow, thread-behavior semantics.

## Test plan

- `bun test` on `assistant-channels-detail.test.tsx`, `slack-channel-list.test.ts`, `slack-channel-overrides.test.ts` — 33 pass, including: the consolidated card renders with no "Who can message"/"Slack settings"/"Connected as"; the ghost Disconnect still confirms before firing; connected Telegram keeps the trust-floor dropdown.
- `bunx tsc --noEmit` and `eslint` clean.
- Verified visually in Storybook via headless Chromium on the rebased tree: consolidated connected card, confirm-on-disconnect dialog, disconnected Slack tab (wizard card), and the expanded room row showing Capabilities only (no reach block) with #37402's no-cell fall-through copy intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGzMXbka4pBv6SqWfaQDcJ