### PR TITLE
fix(web): hold tier picker disabled on override load errors; accurate tier copy

### DIFF
--- a/clients/web/src/domains/contacts/components/slack-channel-list.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-list.tsx
@@ -141,6 +141,11 @@ export interface SlackChannelListProps {
    * tier picker disabled so stored overrides can't be misread as defaults.
    */
   tierOverridesLoading?: boolean;
+  /**
+   * True when persisted overrides failed to load. The picker stays disabled
+   * — writing over unknown stored cells could silently clobber them.
+   */
+  tierOverridesError?: boolean;
   /** Channels with a tier write in flight — the row shows a saving hint. */
   pendingChannelIds?: ReadonlySet<string>;
   onTierChange?: (channelId: string, tier: SlackCapabilityTier) => void;
@@ -168,6 +173,7 @@ export function SlackChannelList({
   error = false,
   tierOverrides,
   tierOverridesLoading = false,
+  tierOverridesError = false,
   pendingChannelIds = EMPTY_PENDING_IDS,
   onTierChange,
   onTierReset,
@@ -327,6 +333,7 @@ export function SlackChannelList({
                         open={openIds.has(channel.id)}
                         pending={pendingChannelIds.has(channel.id)}
                         overridesLoading={tierOverridesLoading}
+                        overridesError={tierOverridesError}
                         onToggle={() => toggleRow(channel.id)}
                         tierOverride={tierOverrides?.[channel.id]}
                         onTierChange={(tier) =>
@@ -349,6 +356,7 @@ export function SlackChannelList({
                       open={openIds.has(channel.id)}
                       pending={pendingChannelIds.has(channel.id)}
                       overridesLoading={tierOverridesLoading}
+                      overridesError={tierOverridesError}
                       onToggle={() => toggleRow(channel.id)}
                       tierOverride={tierOverrides?.[channel.id]}
                       onTierChange={(tier) => onTierChange?.(channel.id, tier)}
@@ -384,6 +392,7 @@ function SlackChannelRow({
   open,
   pending,
   overridesLoading,
+  overridesError,
   onToggle,
   tierOverride,
   onTierChange,
@@ -395,6 +404,7 @@ function SlackChannelRow({
   open: boolean;
   pending: boolean;
   overridesLoading: boolean;
+  overridesError: boolean;
   onToggle: () => void;
   tierOverride: SlackCapabilityTier | undefined;
   onTierChange: (tier: SlackCapabilityTier) => void;
@@ -464,6 +474,7 @@ function SlackChannelRow({
             admissionPolicy={admissionPolicy}
             settings={settings}
             loading={overridesLoading}
+            error={overridesError}
             onTierChange={onTierChange}
             onReset={onReset}
           />

--- a/clients/web/src/domains/contacts/components/slack-channel-override-panel.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-override-panel.tsx
@@ -35,6 +35,8 @@ export interface SlackChannelOverridePanelProps {
    * so a stored tier can't be misread (and overwritten) as the default.
    */
   loading?: boolean;
+  /** True when overrides failed to load; the picker stays disabled. */
+  error?: boolean;
   onTierChange: (tier: SlackCapabilityTier) => void;
   onReset: () => void;
 }
@@ -52,13 +54,15 @@ export function SlackChannelOverridePanel({
   admissionPolicy,
   settings,
   loading = false,
+  error = false,
   onTierChange,
   onReset,
 }: SlackChannelOverridePanelProps) {
+  const unavailable = loading || error;
   const tierItems = CAPABILITY_TIER_VALUES.map((tier) => ({
     value: tier,
     label: CAPABILITY_TIER_META[tier].label,
-    disabled: loading,
+    disabled: unavailable,
   }));
   const tierMeta = CAPABILITY_TIER_META[settings.tier];
 
@@ -122,6 +126,14 @@ export function SlackChannelOverridePanel({
             className="text-[color:var(--content-tertiary)]"
           >
             Loading…
+          </Typography>
+        ) : error ? (
+          <Typography
+            as="span"
+            variant="body-small-default"
+            className="text-[color:var(--content-negative)]"
+          >
+            Couldn’t load — try reopening this page
           </Typography>
         ) : settings.overridden ? (
           <Tag tone="warning">overridden</Tag>

--- a/clients/web/src/domains/contacts/components/slack-channel-override-panel.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-override-panel.tsx
@@ -103,7 +103,12 @@ export function SlackChannelOverridePanel({
           title="Custom capabilities."
           className="border-dashed"
           actions={
-            <Button type="button" variant="outlined" onClick={onReset}>
+            <Button
+              type="button"
+              variant="outlined"
+              onClick={onReset}
+              disabled={unavailable}
+            >
               Reset to default
             </Button>
           }
@@ -158,7 +163,18 @@ export function SlackChannelOverridePanel({
         variant="body-small-default"
         className="text-[color:var(--content-tertiary)]"
       >
-        {tierMeta.label} — {tierMeta.sublabel}. {tierMeta.description}
+        {settings.explicit ? (
+          <>
+            {tierMeta.label} — {tierMeta.sublabel}. {tierMeta.description}
+          </>
+        ) : (
+          // Without a persisted cell the runtime falls through to the
+          // global auto-approve setting; the tier copy would overclaim.
+          <>
+            No channel override — this channel follows your global
+            auto-approve setting. Pick a tier to set one.
+          </>
+        )}
       </Typography>
     </div>
   );

--- a/clients/web/src/domains/contacts/components/slack-channel-override-panel.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-override-panel.tsx
@@ -163,7 +163,7 @@ export function SlackChannelOverridePanel({
         variant="body-small-default"
         className="text-[color:var(--content-tertiary)]"
       >
-        {settings.explicit ? (
+        {settings.overridden ? (
           <>
             {tierMeta.label} — {tierMeta.sublabel}. {tierMeta.description}
           </>

--- a/clients/web/src/domains/contacts/components/slack-channel-section.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-section.tsx
@@ -47,6 +47,7 @@ export function SlackChannelSection({
       error={channelsQuery.isError}
       tierOverrides={overrides.tierOverrides}
       tierOverridesLoading={overrides.isLoading}
+      tierOverridesError={overrides.isError}
       pendingChannelIds={overrides.pendingChannelIds}
       onTierChange={overrides.onTierChange}
       onTierReset={overrides.onTierReset}

--- a/clients/web/src/domains/contacts/slack-channel-overrides.test.ts
+++ b/clients/web/src/domains/contacts/slack-channel-overrides.test.ts
@@ -13,6 +13,7 @@ describe("resolveChannelTier", () => {
   test("no override resolves the room default with no divergence", () => {
     expect(resolveChannelTier(undefined)).toEqual({
       tier: "full_access",
+      explicit: false,
       overridden: false,
     });
   });
@@ -20,6 +21,7 @@ describe("resolveChannelTier", () => {
   test("a diverging override flags the row as custom", () => {
     expect(resolveChannelTier("standard")).toEqual({
       tier: "standard",
+      explicit: true,
       overridden: true,
     });
   });
@@ -27,6 +29,7 @@ describe("resolveChannelTier", () => {
   test("a persisted cell matching the default is not flagged", () => {
     expect(resolveChannelTier("full_access")).toEqual({
       tier: "full_access",
+      explicit: true,
       overridden: false,
     });
   });

--- a/clients/web/src/domains/contacts/slack-channel-overrides.test.ts
+++ b/clients/web/src/domains/contacts/slack-channel-overrides.test.ts
@@ -10,27 +10,24 @@ import {
 } from "./slack-channel-overrides";
 
 describe("resolveChannelTier", () => {
-  test("no override resolves the room default with no divergence", () => {
+  test("no cell resolves the presentation default, not an override", () => {
     expect(resolveChannelTier(undefined)).toEqual({
       tier: "full_access",
-      explicit: false,
       overridden: false,
     });
   });
 
-  test("a diverging override flags the row as custom", () => {
+  test("a persisted cell flags the row as custom", () => {
     expect(resolveChannelTier("standard")).toEqual({
       tier: "standard",
-      explicit: true,
       overridden: true,
     });
   });
 
-  test("a persisted cell matching the default is not flagged", () => {
+  test("a full_access cell is still an override — it pins the channel above the global cascade", () => {
     expect(resolveChannelTier("full_access")).toEqual({
       tier: "full_access",
-      explicit: true,
-      overridden: false,
+      overridden: true,
     });
   });
 });

--- a/clients/web/src/domains/contacts/slack-channel-overrides.ts
+++ b/clients/web/src/domains/contacts/slack-channel-overrides.ts
@@ -142,9 +142,16 @@ export function tierOverridesFromCells(
   return overrides;
 }
 
-/** The row's resolved tier plus whether it diverges from the default. */
+/** The row's resolved tier plus how it was determined. */
 export interface SlackChannelTierSettings {
   tier: SlackCapabilityTier;
+  /**
+   * True when a persisted cell backs the tier. Without a cell the runtime
+   * falls through to the global auto-approve setting — the tier is what the
+   * room defaults to, not an active channel override.
+   */
+  explicit: boolean;
+  /** True when the tier diverges from the room default. */
   overridden: boolean;
 }
 
@@ -160,5 +167,9 @@ export function resolveChannelTier(
   override: SlackCapabilityTier | undefined,
 ): SlackChannelTierSettings {
   const tier = override ?? DEFAULT_CHANNEL_TIER;
-  return { tier, overridden: tier !== DEFAULT_CHANNEL_TIER };
+  return {
+    tier,
+    explicit: override !== undefined,
+    overridden: tier !== DEFAULT_CHANNEL_TIER,
+  };
 }

--- a/clients/web/src/domains/contacts/slack-channel-overrides.ts
+++ b/clients/web/src/domains/contacts/slack-channel-overrides.ts
@@ -142,34 +142,28 @@ export function tierOverridesFromCells(
   return overrides;
 }
 
-/** The row's resolved tier plus how it was determined. */
+/** The row's resolved tier plus whether a persisted cell backs it. */
 export interface SlackChannelTierSettings {
   tier: SlackCapabilityTier;
   /**
-   * True when a persisted cell backs the tier. Without a cell the runtime
-   * falls through to the global auto-approve setting — the tier is what the
-   * room defaults to, not an active channel override.
+   * True when a persisted cell backs the tier. A cell is an override by
+   * existing: it pins the channel above the global auto-approve cascade
+   * even when its tier matches the room default, so it must stay visible
+   * (badge, callout, reset). Without a cell the runtime falls through to
+   * the global setting.
    */
-  explicit: boolean;
-  /** True when the tier diverges from the room default. */
   overridden: boolean;
 }
 
-/** Every room defaults to full access; anything else is an override. */
+/** Presentation default for rooms with no persisted cell. */
 export const DEFAULT_CHANNEL_TIER: SlackCapabilityTier = "full_access";
 
-/**
- * Applies a persisted tier override (possibly absent) on top of the room
- * default. A tier counts as overridden only when it diverges — a persisted
- * cell that matches the default is not flagged.
- */
+/** Resolves the row's tier from a persisted cell, if any. */
 export function resolveChannelTier(
   override: SlackCapabilityTier | undefined,
 ): SlackChannelTierSettings {
-  const tier = override ?? DEFAULT_CHANNEL_TIER;
   return {
-    tier,
-    explicit: override !== undefined,
-    overridden: tier !== DEFAULT_CHANNEL_TIER,
+    tier: override ?? DEFAULT_CHANNEL_TIER,
+    overridden: override !== undefined,
   };
 }

--- a/clients/web/src/domains/contacts/slack-channel-overrides.ts
+++ b/clients/web/src/domains/contacts/slack-channel-overrides.ts
@@ -42,7 +42,7 @@ interface CapabilityTierMeta {
 export const CAPABILITY_TIER_META: Record<SlackCapabilityTier, CapabilityTierMeta> = {
   strict: {
     label: presetFromThreshold("none").label,
-    sublabel: "read + reply only",
+    sublabel: "ask before every action",
     description:
       "Nothing is auto-approved — every tool call from this channel asks first.",
     tone: "negative",

--- a/clients/web/src/domains/contacts/slack-channel-overrides.ts
+++ b/clients/web/src/domains/contacts/slack-channel-overrides.ts
@@ -43,19 +43,22 @@ export const CAPABILITY_TIER_META: Record<SlackCapabilityTier, CapabilityTierMet
   strict: {
     label: presetFromThreshold("none").label,
     sublabel: "read + reply only",
-    description: "Read and reply only — no tools run from this channel.",
+    description:
+      "Nothing is auto-approved — every tool call from this channel asks first.",
     tone: "negative",
   },
   standard: {
     label: "Standard",
     sublabel: "reply + safe tools",
-    description: "Reply and safe tools. Sensitive tools require approval.",
+    description:
+      "Safe, low-risk tools are auto-approved; anything sensitive still asks.",
     tone: "warning",
   },
   full_access: {
     label: presetFromThreshold("high").label,
     sublabel: "all tools",
-    description: "All tools the assistant has access to, within global gating.",
+    description:
+      "All tools auto-approve in this channel, even when the global setting is stricter. Sensitive-tool protections still apply.",
     tone: "positive",
   },
 };


### PR DESCRIPTION
## Prompt / plan

Follow-up to #37391, closing out the two Codex P2s that Vex's merging review filed as "follow-up owed" (the fix commit raced the merge — it was pushed as #37391 was being merged, so it missed the squash).

- **P2-1 (error state)**: `overrides.isError` is now forwarded through `SlackChannelSection` → `SlackChannelList` → the row panel. On a failed cells GET, the tier picker stays disabled and the field hint shows "Couldn't load — try reopening this page" — same hazard guard as the loading hold, so unknown persisted cells can't be silently clobbered by a write over a default that isn't real.
- **P2-2 (copy accuracy)**: tier help text now states enforcement truthfully. A channel cell *overrides* the global auto-approve setting rather than being capped by it, so Full access reads "All tools auto-approve in this channel, even when the global setting is stricter. Sensitive-tool protections still apply." Strict's "no tools run" also corrected to "Nothing is auto-approved — every tool call from this channel asks first" (tools still run with approval), and Standard tightened to match.

No Linear follow-up tickets needed — this PR is the follow-up.

## Test plan

- `bunx tsc --noEmit` + eslint clean (pre-commit); `bun test` on the contacts-domain suites — 33 pass.
- Error path: with the cells query failing, expanded rows render the disabled picker + error hint; tier writes unreachable.

## CLI verb checklist

No new routes — web-client-only change.

Part of LUM-2727

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gthC8b9mWi9v3DFQH8xtw

---
_Generated by [Claude Code](https://claude.ai/code/session_012gthC8b9mWi9v3DFQH8xtw)_