### PR TITLE
feat(assistant): add vercel-ai-gateway model-intent picks

### DIFF
--- a/assistant/src/__tests__/model-intents.test.ts
+++ b/assistant/src/__tests__/model-intents.test.ts
@@ -39,6 +39,24 @@ describe("model intents", () => {
     );
   });
 
+  test("resolves intents for vercel-ai-gateway", () => {
+    expect(resolveModelIntent("vercel-ai-gateway", "balanced")).toBe(
+      "anthropic/claude-sonnet-4.6",
+    );
+    expect(resolveModelIntent("vercel-ai-gateway", "latency-optimized")).toBe(
+      "anthropic/claude-haiku-4.5",
+    );
+    expect(resolveModelIntent("vercel-ai-gateway", "quality-optimized")).toBe(
+      "anthropic/claude-fable-5",
+    );
+    expect(resolveModelIntent("vercel-ai-gateway", "vision-optimized")).toBe(
+      "anthropic/claude-opus-4.6",
+    );
+    expect(getProviderDefaultModel("vercel-ai-gateway")).toBe(
+      "anthropic/claude-sonnet-4.6",
+    );
+  });
+
   test("uses GPT-5.5 as the OpenAI provider default", () => {
     expect(getProviderDefaultModel("openai")).toBe("gpt-5.5");
   });

--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -46,6 +46,12 @@ const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
     "quality-optimized": "anthropic/claude-fable-5",
     "vision-optimized": "anthropic/claude-opus-4.6",
   },
+  "vercel-ai-gateway": {
+    balanced: "anthropic/claude-sonnet-4.6",
+    "latency-optimized": "anthropic/claude-haiku-4.5",
+    "quality-optimized": "anthropic/claude-fable-5",
+    "vision-optimized": "anthropic/claude-opus-4.6",
+  },
 };
 
 const FALLBACK_DEFAULT_MODEL = "claude-opus-4-8";


### PR DESCRIPTION
## Summary
- Adds PROVIDER_MODEL_INTENTS entry for vercel-ai-gateway (balanced/latency/quality/vision picks from the registered catalog models)
- Extends model-intents tests to cover the new provider

Part of plan: vercel-ai-gateway-provider.md (PR 5 of 7)