### PR TITLE
feat(web): thinking/effort visibility for Vercel AI Gateway models

### DIFF
--- a/clients/web/src/domains/settings/ai/profile-param-visibility.test.ts
+++ b/clients/web/src/domains/settings/ai/profile-param-visibility.test.ts
@@ -67,6 +67,40 @@ describe("resolveProfileParamVisibility", () => {
     expect(vis.thinking).toBe(false);
   });
 
+  test("vercel-ai-gateway anthropic sonnet/opus enable thinking and effort", () => {
+    for (const model of ["anthropic/claude-sonnet-4.6", "anthropic/claude-opus-4.8"]) {
+      const vis = resolveProfileParamVisibility("vercel-ai-gateway", model);
+      expect(vis.thinking).toBe(true);
+      expect(vis.effort).toBe(true);
+    }
+  });
+
+  test("vercel-ai-gateway anthropic haiku supports thinking but not effort", () => {
+    const vis = resolveProfileParamVisibility("vercel-ai-gateway", "anthropic/claude-haiku-4.5");
+    expect(vis.thinking).toBe(true);
+    expect(vis.effort).toBe(false);
+  });
+
+  test("vercel-ai-gateway anthropic fable hides the thinking toggle but keeps effort", () => {
+    const vis = resolveProfileParamVisibility("vercel-ai-gateway", "anthropic/claude-fable-5");
+    expect(vis.effort).toBe(true);
+    expect(vis.thinking).toBe(false);
+  });
+
+  test("vercel-ai-gateway non-anthropic catalog reasoning model gets thinking with effort following", () => {
+    // xai/grok-4.3 is supportsThinking in the catalog; effort follows thinking
+    // for non-anthropic gateway models (same rule as openrouter).
+    const vis = resolveProfileParamVisibility("vercel-ai-gateway", "xai/grok-4.3");
+    expect(vis.thinking).toBe(true);
+    expect(vis.effort).toBe(true);
+  });
+
+  test("vercel-ai-gateway unknown non-anthropic model gets no thinking or effort", () => {
+    const vis = resolveProfileParamVisibility("vercel-ai-gateway", "mistral/mistral-large");
+    expect(vis.thinking).toBe(false);
+    expect(vis.effort).toBe(false);
+  });
+
   test("together MiniMax M3 enables effort and topP", () => {
     const vis = resolveProfileParamVisibility("together", "MiniMaxAI/MiniMax-M3");
     // Together is an OpenAI-compatible endpoint whose chat-completions client
@@ -121,6 +155,11 @@ describe("modelSupportsThinking", () => {
     expect(modelSupportsThinking("minimax", "minimax-m3")).toBe(true);
     expect(modelSupportsThinking("minimax", "MiniMax-M2.7")).toBe(true);
     expect(modelSupportsThinking("minimax", "minimax-unknown")).toBe(false);
+  });
+
+  test("vercel-ai-gateway falls back to the anthropic/ prefix heuristic off-catalog", () => {
+    expect(modelSupportsThinking("vercel-ai-gateway", "anthropic/claude-next")).toBe(true);
+    expect(modelSupportsThinking("vercel-ai-gateway", "mistral/mistral-large")).toBe(false);
   });
 });
 

--- a/clients/web/src/domains/settings/ai/profile-param-visibility.ts
+++ b/clients/web/src/domains/settings/ai/profile-param-visibility.ts
@@ -35,7 +35,8 @@ function isOpenAIGPT5Family(modelId: string): boolean {
   return modelId === "gpt-5" || modelId.startsWith("gpt-5.") || modelId.startsWith("gpt-5-");
 }
 
-function isOpenRouterAnthropicModel(modelId: string): boolean {
+/** OpenRouter and Vercel AI Gateway both vendor-prefix Anthropic models. */
+function isVendorPrefixedAnthropicModel(modelId: string): boolean {
   return modelId.startsWith("anthropic/");
 }
 
@@ -63,7 +64,7 @@ function isAdaptiveThinkingOnlyModel(provider: string, modelId: string): boolean
 
 function knownOpenRouterReasoningModel(modelId: string): boolean {
   return (
-    isOpenRouterAnthropicModel(modelId) ||
+    isVendorPrefixedAnthropicModel(modelId) ||
     modelId.startsWith("x-ai/grok-4") ||
     modelId.startsWith("deepseek/deepseek-r1") ||
     modelId === "qwen/qwen3.5-plus-02-15" ||
@@ -114,6 +115,7 @@ export function modelSupportsThinking(provider: string, modelId: string): boolea
 
   if (provider === "anthropic") return true;
   if (provider === "openrouter") return knownOpenRouterReasoningModel(modelId);
+  if (provider === "vercel-ai-gateway") return isVendorPrefixedAnthropicModel(modelId);
   return false;
 }
 
@@ -124,8 +126,8 @@ function supportsEffort(provider: string, modelId: string, supportsThinking: boo
   if (provider === "openai") {
     return isOpenAIGPT5Family(modelId);
   }
-  if (provider === "openrouter") {
-    if (isOpenRouterAnthropicModel(modelId)) {
+  if (provider === "openrouter" || provider === "vercel-ai-gateway") {
+    if (isVendorPrefixedAnthropicModel(modelId)) {
       return !modelId.includes("haiku") && supportsThinking;
     }
     return supportsThinking;
@@ -174,7 +176,7 @@ export function resolveProfileParamVisibility(
   const providerId = provider.toLowerCase();
   const modelId = model.toLowerCase();
   const usesAnthropicWire =
-    providerId === "anthropic" || (providerId === "openrouter" && isOpenRouterAnthropicModel(modelId));
+    providerId === "anthropic" || (providerId === "openrouter" && isVendorPrefixedAnthropicModel(modelId));
   const supportsThinkingResult = modelSupportsThinking(providerId, modelId);
 
   return {
@@ -186,7 +188,9 @@ export function resolveProfileParamVisibility(
     temperature: usesAnthropicWire,
     topP: supportsTopP(providerId, usesAnthropicWire),
     thinking:
-      (providerId === "anthropic" || providerId === "openrouter") &&
+      (providerId === "anthropic" ||
+        providerId === "openrouter" ||
+        providerId === "vercel-ai-gateway") &&
       supportsThinkingResult &&
       !isAdaptiveThinkingOnlyModel(providerId, modelId),
     thinkingLevel: providerId === "gemini" && supportsThinkingResult,


### PR DESCRIPTION
## Summary
- Generalizes the anthropic-prefix helper (isOpenRouterAnthropicModel → isVendorPrefixedAnthropicModel) shared by both gateways
- Adds vercel-ai-gateway branches to modelSupportsThinking and supportsEffort mirroring OpenRouter
- Mirrors the OpenRouter test cases for the new provider

Part of plan: vercel-ai-gateway-provider.md (PR 6 of 7)