### PR TITLE
feat(web): add Vercel AI Gateway to onboarding provider picker

### DIFF
--- a/clients/web/src/domains/onboarding/provider-catalog.ts
+++ b/clients/web/src/domains/onboarding/provider-catalog.ts
@@ -10,6 +10,7 @@ export type OnboardingProviderId =
   | "ollama"
   | "fireworks"
   | "openrouter"
+  | "vercel-ai-gateway"
   | "openai-compatible";
 
 export interface OnboardingProvider {
@@ -119,6 +120,41 @@ export const ONBOARDING_PROVIDERS: readonly OnboardingProvider[] = [
         displayName: "DeepSeek R1",
         contextWindowTokens: 163_840,
         maxOutputTokens: 32_000,
+      },
+    ],
+  },
+  {
+    id: "vercel-ai-gateway",
+    displayName: "Vercel AI Gateway",
+    apiKeyPlaceholder: "vck_...",
+    docsUrl:
+      "https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai-gateway%2Fapi-keys&title=AI+Gateway+API+Keys",
+    requiresKey: true,
+    defaultModel: "anthropic/claude-sonnet-4.6",
+    models: [
+      {
+        id: "anthropic/claude-sonnet-4.6",
+        displayName: "Claude Sonnet 4.6",
+        contextWindowTokens: 1_000_000,
+        maxOutputTokens: 64_000,
+      },
+      {
+        id: "anthropic/claude-opus-4.8",
+        displayName: "Claude Opus 4.8",
+        contextWindowTokens: 1_000_000,
+        maxOutputTokens: 128_000,
+      },
+      {
+        id: "xai/grok-4.3",
+        displayName: "Grok 4.3",
+        contextWindowTokens: 1_000_000,
+        maxOutputTokens: 16_000,
+      },
+      {
+        id: "deepseek/deepseek-v4-flash",
+        displayName: "DeepSeek V4 Flash",
+        contextWindowTokens: 1_048_576,
+        maxOutputTokens: 384_000,
       },
     ],
   },

--- a/clients/web/src/domains/onboarding/provider-key.test.ts
+++ b/clients/web/src/domains/onboarding/provider-key.test.ts
@@ -170,4 +170,63 @@ describe("pending provider key", () => {
     });
     expect(peekPendingProviderKey()).toBeNull();
   });
+
+  test("applies a Vercel AI Gateway API key, connection, and profile with model metadata", async () => {
+    // GIVEN a Vercel AI Gateway provider key with no selected model
+    setPendingProviderKey({
+      provider: "vercel-ai-gateway",
+      key: "vck_test",
+    });
+
+    // WHEN the pending key is applied
+    await applyPendingProviderKey("local-3");
+
+    // THEN the API key is stored
+    expect(secretsPostMock).toHaveBeenCalledWith({
+      path: { assistant_id: "local-3" },
+      body: {
+        type: "api_key",
+        name: "vercel-ai-gateway",
+        value: "vck_test",
+      },
+      throwOnError: false,
+    });
+    // AND the provider connection is created with API-key auth
+    expect(inferenceProviderconnectionsPostMock).toHaveBeenCalledWith({
+      path: { assistant_id: "local-3" },
+      body: {
+        name: "vercel-ai-gateway",
+        provider: "vercel-ai-gateway",
+        auth: {
+          type: "api_key",
+          credential: "credential/vercel-ai-gateway/api_key",
+        },
+      },
+      throwOnError: false,
+    });
+    // AND the profile falls back to the catalog default model with its metadata
+    expect(configLlmProfilesByNamePutMock).toHaveBeenCalledWith({
+      path: { assistant_id: "local-3", name: "custom-balanced" },
+      body: {
+        provider: "vercel-ai-gateway",
+        model: "anthropic/claude-sonnet-4.6",
+        provider_connection: "vercel-ai-gateway",
+        source: "user",
+        label: "Balanced",
+        description: "Good balance of quality, cost, and speed",
+        maxTokens: 64_000,
+        contextWindow: { maxInputTokens: 1_000_000 },
+        effort: "high",
+        thinking: { enabled: true, streamThinking: true },
+      },
+      throwOnError: false,
+    });
+    // AND the profile is activated
+    expect(configPatchMock).toHaveBeenCalledWith({
+      path: { assistant_id: "local-3" },
+      body: { llm: { activeProfile: "custom-balanced" } },
+      throwOnError: false,
+    });
+    expect(peekPendingProviderKey()).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- Adds vercel-ai-gateway to the onboarding OnboardingProviderId union and ONBOARDING_PROVIDERS list (mirrors the OpenRouter entry)
- Extends onboarding provider-key tests for the new provider

Part of plan: vercel-ai-gateway-provider.md (PR 7 of 7)