### PR TITLE
fix(onboarding): skip calendar check-in steps on local onboarding, fix managed OAuth start for local assistants

### DIFF
--- a/clients/web/src/domains/onboarding/hooks/use-google-calendar-connect.test.ts
+++ b/clients/web/src/domains/onboarding/hooks/use-google-calendar-connect.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for the check-in calendar connect hook, focused on platform-identity
+ * resolution: a locally-hatched assistant is known to the platform by its own
+ * platform UUID, so the managed OAuth start must be called with the RESOLVED
+ * id — passing the local id 404s and the onError handler closes the popup the
+ * moment it opened (a visible flicker).
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { renderHook, act, waitFor } from "@testing-library/react";
+
+const startOAuthMutate = mock(
+  (
+    _vars: unknown,
+    _handlers?: { onSuccess?: (data: unknown) => void; onError?: () => void },
+  ) => {},
+);
+mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
+  useAssistantsOauthStartCreateMutation: () => ({
+    mutate: startOAuthMutate,
+    isPending: false,
+  }),
+  assistantsOauthConnectionsListOptions: (opts: unknown) => ({
+    queryKey: ["oauth-connections", opts],
+    queryFn: async () => [],
+  }),
+}));
+
+let resolvedPlatformId = "11111111-2222-4333-8444-555555555555";
+let resolveShouldThrow = false;
+const resolveMock = mock(async (id: string): Promise<string> => {
+  if (resolveShouldThrow) throw new Error("identity resolution failed");
+  return id === "vellum-local-assistant" ? resolvedPlatformId : id;
+});
+mock.module("@/lib/local-platform-identity", () => ({
+  resolveLocalAssistantPlatformIdentity: resolveMock,
+}));
+
+mock.module("@/runtime/native-auth", () => ({
+  useIsNativePlatform: () => false,
+}));
+mock.module("@/hooks/use-oauth-complete-deep-link-listener", () => ({
+  useOAuthCompleteDeepLinkListener: () => {},
+}));
+mock.module("@/runtime/browser", () => ({
+  openUrl: async () => {},
+  openUrlFinishedListener: () => () => {},
+}));
+mock.module("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ fetchQuery: async () => [] }),
+}));
+
+const { useGoogleCalendarConnect } = await import(
+  "./use-google-calendar-connect"
+);
+
+// The hook opens a blank popup synchronously before the async identity
+// resolution; stub a minimal Window the flow can point at Google later.
+interface StubPopup {
+  closed: boolean;
+  close: () => void;
+  location: { href: string };
+}
+let popupStub: StubPopup;
+
+beforeEach(() => {
+  resolveShouldThrow = false;
+  resolvedPlatformId = "11111111-2222-4333-8444-555555555555";
+  startOAuthMutate.mockClear();
+  resolveMock.mockClear();
+  popupStub = {
+    closed: false,
+    close: () => {
+      popupStub.closed = true;
+    },
+    location: { href: "" },
+  };
+  window.open = (() => popupStub) as unknown as typeof window.open;
+});
+
+describe("useGoogleCalendarConnect", () => {
+  test("starts OAuth with the RESOLVED platform assistant id, not the local id", async () => {
+    const { result } = renderHook(() =>
+      useGoogleCalendarConnect({
+        assistantId: "vellum-local-assistant",
+        onConnect: () => {},
+      }),
+    );
+
+    act(() => {
+      result.current.handleConnect();
+    });
+
+    await waitFor(() => expect(startOAuthMutate).toHaveBeenCalledTimes(1));
+    const vars = startOAuthMutate.mock.calls[0]?.[0] as {
+      path: { assistant_id: string; provider: string };
+    };
+    expect(resolveMock).toHaveBeenCalledWith("vellum-local-assistant");
+    expect(vars.path.assistant_id).toBe(resolvedPlatformId);
+    expect(vars.path.provider).toBe("google");
+    // The popup stays open, waiting for the connect URL.
+    expect(popupStub.closed).toBe(false);
+  });
+
+  test("a platform assistant id passes through the resolver unchanged", async () => {
+    const platformId = "99999999-8888-4777-8666-555555555555";
+    const { result } = renderHook(() =>
+      useGoogleCalendarConnect({
+        assistantId: platformId,
+        onConnect: () => {},
+      }),
+    );
+
+    act(() => {
+      result.current.handleConnect();
+    });
+
+    await waitFor(() => expect(startOAuthMutate).toHaveBeenCalledTimes(1));
+    const vars = startOAuthMutate.mock.calls[0]?.[0] as {
+      path: { assistant_id: string };
+    };
+    expect(vars.path.assistant_id).toBe(platformId);
+  });
+
+  test("failed identity resolution closes the popup and never starts OAuth", async () => {
+    resolveShouldThrow = true;
+    const { result } = renderHook(() =>
+      useGoogleCalendarConnect({
+        assistantId: "vellum-local-assistant",
+        onConnect: () => {},
+      }),
+    );
+
+    act(() => {
+      result.current.handleConnect();
+    });
+
+    await waitFor(() => expect(popupStub.closed).toBe(true));
+    expect(startOAuthMutate).not.toHaveBeenCalled();
+    expect(result.current.oauthInProgress).toBe(false);
+  });
+});

--- a/clients/web/src/domains/onboarding/hooks/use-google-calendar-connect.ts
+++ b/clients/web/src/domains/onboarding/hooks/use-google-calendar-connect.ts
@@ -17,6 +17,7 @@
  */
 
 import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "@vellumai/design-library/components/toast";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
@@ -32,9 +33,11 @@ import {
   oauthCompletionStorageKey,
   type OAuthCompletePayload,
 } from "@/lib/auth/oauth-popup";
+import { resolveLocalAssistantPlatformIdentity } from "@/lib/local-platform-identity";
 import { openUrl, openUrlFinishedListener } from "@/runtime/browser";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import type { OAuthCompleteDeepLinkPayload } from "@/runtime/native-deep-link";
+import { extractErrorMessage } from "@/utils/api-errors";
 import { wait } from "@/utils/oauth-connection-utils";
 import { routes } from "@/utils/routes";
 
@@ -97,6 +100,13 @@ export function useGoogleCalendarConnect({
 
   const popupRef = useRef<Window | null>(null);
   const pendingRequestRef = useRef<{ requestId: string } | null>(null);
+  // The id the PLATFORM knows this assistant by. A locally-hatched assistant
+  // self-registers with the platform under its own platform UUID — the
+  // assistant-scoped OAuth endpoints 404 for the local id, so every platform
+  // call in this flow must use the resolved id. Kept outside
+  // `pendingRequestRef` because the success path clears the pending request
+  // BEFORE fetching the connection to read its granted scopes.
+  const platformAssistantIdRef = useRef<string | null>(null);
   const popupCheckIntervalRef = useRef<ReturnType<typeof setInterval> | null>(
     null,
   );
@@ -169,9 +179,13 @@ export function useGoogleCalendarConnect({
   const fetchActiveGoogleConnection =
     useCallback(async (): Promise<OAuthConnection | null> => {
       try {
+        // The raw prop id is a fallback for the platform-assistant case,
+        // where the two are identical.
+        const platformAssistantId =
+          platformAssistantIdRef.current ?? assistantId;
         const connections = await queryClient.fetchQuery({
           ...assistantsOauthConnectionsListOptions({
-            path: { assistant_id: assistantId },
+            path: { assistant_id: platformAssistantId },
           }),
           staleTime: 0,
         });
@@ -282,26 +296,76 @@ export function useGoogleCalendarConnect({
     messageListenerRef.current = handleOAuthMessage;
     storageListenerRef.current = handleOAuthStorage;
 
-    if (isNative) {
-      setOAuthInProgress(true);
-      pendingRequestRef.current = { requestId };
+    // Resolve the platform identity, then start the managed OAuth flow. For a
+    // locally-hatched assistant the resolver returns (registering on first
+    // use) the platform UUID the OAuth endpoints are scoped by — passing the
+    // local id 404s, whose onError used to close the just-opened popup after
+    // a single flicker. For platform assistants it resolves to the same id.
+    const startWithResolvedIdentity = async (
+      popup: Window | null,
+      onStartFailed: () => void,
+    ): Promise<void> => {
+      let platformAssistantId: string;
+      try {
+        platformAssistantId =
+          await resolveLocalAssistantPlatformIdentity(assistantId);
+      } catch (error) {
+        onStartFailed();
+        // Surface the reason — a local assistant with no platform link (e.g.
+        // signed out of Vellum) fails resolution before any request is made,
+        // and a silently-closing popup reads as an app bug.
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "Failed to start Google Calendar authorization.",
+        );
+        return;
+      }
+      platformAssistantIdRef.current = platformAssistantId;
       startOAuth.mutate(
         {
-          path: { assistant_id: assistantId, provider: GOOGLE_PROVIDER_KEY },
+          path: {
+            assistant_id: platformAssistantId,
+            provider: GOOGLE_PROVIDER_KEY,
+          },
           body: {
             requested_scopes: requestedScopes,
-            redirect_after_connect: `${routes.account.oauth.popupComplete}?requestId=${requestId}&native=1`,
+            redirect_after_connect: `${routes.account.oauth.popupComplete}?requestId=${requestId}${popup ? "" : "&native=1"}`,
           },
         },
         {
           onSuccess(data) {
-            void openUrl(data.connect_url);
+            if (!popup) {
+              void openUrl(data.connect_url);
+              return;
+            }
+            if (!popup.closed) {
+              popup.location.href = data.connect_url;
+            } else if (pendingRequestRef.current) {
+              onStartFailed();
+            }
           },
-          onError() {
-            clearPendingRequest();
+          onError(error) {
+            onStartFailed();
+            toast.error(
+              extractErrorMessage(
+                error,
+                undefined,
+                "Failed to start Google Calendar authorization.",
+              ),
+            );
           },
         },
       );
+    };
+
+    if (isNative) {
+      setOAuthInProgress(true);
+      pendingRequestRef.current = { requestId };
+      void startWithResolvedIdentity(null, () => {
+        clearPendingRequest();
+        removeEventListeners();
+      });
 
       window.addEventListener("message", handleOAuthMessage);
       window.addEventListener("storage", handleOAuthStorage);
@@ -394,31 +458,11 @@ export function useGoogleCalendarConnect({
       }
     }, 100);
 
-    startOAuth.mutate(
-      {
-        path: { assistant_id: assistantId, provider: GOOGLE_PROVIDER_KEY },
-        body: {
-          requested_scopes: requestedScopes,
-          redirect_after_connect: `${routes.account.oauth.popupComplete}?requestId=${requestId}`,
-        },
-      },
-      {
-        onSuccess(data) {
-          if (popupRef.current && !popupRef.current.closed) {
-            popupRef.current.location.href = data.connect_url;
-          } else if (pendingRequestRef.current) {
-            closePopupWindow();
-            clearPendingRequest();
-            removeEventListeners();
-          }
-        },
-        onError() {
-          closePopupWindow();
-          clearPendingRequest();
-          removeEventListeners();
-        },
-      },
-    );
+    void startWithResolvedIdentity(popup, () => {
+      closePopupWindow();
+      clearPendingRequest();
+      removeEventListeners();
+    });
   }, [
     assistantId,
     clearPendingRequest,

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -237,6 +237,13 @@ export function ResearchOnboardingRoute() {
   // param, pinning adoption to that exact one — a stale selection or leftover
   // lockfile entries from previous sessions can't answer for it.
   const adoptAssistantId = searchParams.get("assistant") ?? undefined;
+  // The day-2 check-in offer ("letschat" → "meeting") books through the
+  // platform's managed Google Calendar OAuth. A local-hosting onboarding can
+  // run with no platform session at all (the assistant itself is fully
+  // local), where that connect can only fail — skip the calendar steps
+  // entirely and go straight to the research reveal. Vellum-cloud onboarding
+  // keeps them: a managed hatch implies a platform session.
+  const skipCheckinSteps = adoptExistingAssistant;
   const {
     start: startHatch,
     ready: hatchReady,
@@ -313,11 +320,19 @@ export function ResearchOnboardingRoute() {
           },
           awaitHatchReady,
         );
-      setStep(resolveResumeStep(snapshot));
+      // A snapshot written before the calendar steps were dropped from the
+      // local flow (or by a signed-in web session) may resume onto them —
+      // remap to the research reveal the skip lands on.
+      const resumeStep = resolveResumeStep(snapshot);
+      setStep(
+        skipCheckinSteps && (resumeStep === "letschat" || resumeStep === "meeting")
+          ? "looking"
+          : resumeStep,
+      );
       setForwardStack([]);
     }
     setRestored(true);
-  }, [restored, userId, hydrateResearch, awaitHatchReady]);
+  }, [restored, userId, hydrateResearch, awaitHatchReady, skipCheckinSteps]);
 
   // Persist the journey as it advances so a refresh can resume it. Gated on
   // `restored` so we don't overwrite the snapshot before reading it, and only
@@ -664,7 +679,7 @@ export function ResearchOnboardingRoute() {
         )}
         {step === "integration" && (
           <IntegrationStep
-            onClaim={() => goForwardTo("letschat")}
+            onClaim={() => goForwardTo(skipCheckinSteps ? "looking" : "letschat")}
             onBumpEyes={() => setEyesBump((n) => n + 1)}
             onBack={() =>
               goBackTo(personalityEnabled ? "personality" : "different")
@@ -700,7 +715,7 @@ export function ResearchOnboardingRoute() {
         {step === "looking" && (
           <LookingYouUpStep
             onDone={() => goForwardTo(noClaims ? "suggestions" : "results")}
-            onBack={() => goBackTo("letschat")}
+            onBack={() => goBackTo(skipCheckinSteps ? "integration" : "letschat")}
             onAdvance={(i) => setEdgeAvatars(Math.min(i + 1, 4))}
             onForward={onForward}
             // Gate only on the web-search turn — the personality rewrite runs


### PR DESCRIPTION
## Summary

Local-hosting onboarding can run with **no platform session at all** (the assistant is fully local; platform calls 403 with `user_id: None`). The day-2 check-in step offers managed Google Calendar OAuth, which the platform must broker — so on a signed-out local setup the connect button could only fail. Two changes:

### 1. Local onboarding skips the calendar check-in steps
When the research flow adopts a locally-hatched assistant (`adoptExistingAssistant`), the `letschat` → `meeting` steps are skipped entirely: the integration step advances straight to the research reveal ("looking"), back-navigation from "looking" returns to "integration", and a persisted snapshot that would resume onto the removed steps is remapped. Vellum-cloud onboarding keeps the calendar steps — a managed hatch implies a platform session.

### 2. Managed OAuth start fixes in `use-google-calendar-connect` (still used by cloud onboarding)
- **Resolve the platform identity before starting OAuth.** The hook passed the raw local lockfile id to the platform's assistant-scoped OAuth start endpoint, which 404s (`POST /v1/assistants/vellum-…/oauth/google/start/ → 404`), and the mutation's `onError` closed the popup it had just opened — a visible open-and-close flicker. It now resolves via `resolveLocalAssistantPlatformIdentity()` (identity pass-through for platform UUIDs), same as the settings integrations hook.
- The post-connect connections fetch (reads granted scopes) uses the resolved id too — it had the same local-id problem and would have mis-reported a successful grant as "calendar scope missing".
- **Failures surface as an error toast** (e.g. "Sign in to Vellum and select an organization to register this local assistant.") instead of a silently closing popup.

## Signed-out local onboarding audit

Swept the rest of the flow for platform-session dependencies; everything else degrades gracefully:
- `getAssistant()`/lifecycle checks short-circuit through the lockfile in gateway-auth mode — no platform 403 loop.
- `bootstrapLocalAssistantPlatformIdentity` is fire-and-forget with a `.catch` (console.warn) — no crash on missing org.
- Consent fetch falls back to the device-cached consent; organization fetches are gated on a live platform session.
- Research turn, personality rewrite, plugin installs, provider key, and avatar seeding are all daemon-side (local), with caught/fire-and-forget error handling.

## Testing

- New `use-google-calendar-connect.test.ts`: OAuth starts with the resolved platform id (not the local id), platform ids pass through unchanged, failed resolution closes the popup without starting OAuth — 3/3.
- `research-onboarding-persistence` (14), `funnel-events` (9), `lets-chat-tomorrow-step` (6) all pass; typecheck clean; lint 0 errors.
- QA'd live on the local dev stack: local onboarding now goes integration → research reveal with no calendar step; the failure toast replaces the popup flicker for the cloud-path hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)