### PR TITLE
ci(assistant): longest-first test scheduling on PR runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ node_modules
 
 # testing
 coverage/
+# Per-file test durations written by scripts/test.sh for longest-first
+# scheduling; produced/consumed in CI, never committed.
+.test-durations
 
 # next.js
 .next/

--- a/assistant/src/__tests__/scheduler-recurrence.test.ts
+++ b/assistant/src/__tests__/scheduler-recurrence.test.ts
@@ -198,7 +198,7 @@ describe("scheduler RRULE execution", () => {
 
     // runScheduleDueWorkOnce() awaits the full tick — including the run_task
     // dynamic import and processMessage — so the schedule run is recorded by the
-    // time it resolves. No fixed timeout / callback race needed.
+    // time it resolves.
     await runScheduleDueWorkOnce();
 
     // runTask renders the template, so processMessage gets the template text


### PR DESCRIPTION
Closing — deserting the durations-based scheduling approach. Ordering PR runs based on prior runs' timings introduces run-to-run nondeterminism we don't want near the release process, and the real win is making the tests genuinely fast rather than reordering them. Superseded by the "make every test file fast" work (PR 5: reducing the per-file process-isolation overhead).

The `.test-durations` gitignore and the scheduler-test comment tidy from this branch can be folded into a later cleanup if still wanted.