### PR TITLE
fix(web): correct param visibility and onboarding context defaults for vercel-ai-gateway

### DIFF
--- a/clients/web/src/domains/onboarding/provider-catalog.ts
+++ b/clients/web/src/domains/onboarding/provider-catalog.ts
@@ -131,29 +131,31 @@ export const ONBOARDING_PROVIDERS: readonly OnboardingProvider[] = [
       "https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai-gateway%2Fapi-keys&title=AI+Gateway+API+Keys",
     requiresKey: true,
     defaultModel: "anthropic/claude-sonnet-4.6",
+    // Context windows are capped at 200k (like the OpenRouter entry) so
+    // onboarding never opts new users into Anthropic long-context pricing.
     models: [
       {
         id: "anthropic/claude-sonnet-4.6",
         displayName: "Claude Sonnet 4.6",
-        contextWindowTokens: 1_000_000,
+        contextWindowTokens: 200_000,
         maxOutputTokens: 64_000,
       },
       {
         id: "anthropic/claude-opus-4.8",
         displayName: "Claude Opus 4.8",
-        contextWindowTokens: 1_000_000,
+        contextWindowTokens: 200_000,
         maxOutputTokens: 128_000,
       },
       {
         id: "xai/grok-4.3",
         displayName: "Grok 4.3",
-        contextWindowTokens: 1_000_000,
+        contextWindowTokens: 200_000,
         maxOutputTokens: 16_000,
       },
       {
         id: "deepseek/deepseek-v4-flash",
         displayName: "DeepSeek V4 Flash",
-        contextWindowTokens: 1_048_576,
+        contextWindowTokens: 200_000,
         maxOutputTokens: 384_000,
       },
     ],

--- a/clients/web/src/domains/onboarding/provider-key.test.ts
+++ b/clients/web/src/domains/onboarding/provider-key.test.ts
@@ -215,7 +215,7 @@ describe("pending provider key", () => {
         label: "Balanced",
         description: "Good balance of quality, cost, and speed",
         maxTokens: 64_000,
-        contextWindow: { maxInputTokens: 1_000_000 },
+        contextWindow: { maxInputTokens: 200_000 },
         effort: "high",
         thinking: { enabled: true, streamThinking: true },
       },

--- a/clients/web/src/domains/settings/ai/profile-param-visibility.test.ts
+++ b/clients/web/src/domains/settings/ai/profile-param-visibility.test.ts
@@ -32,6 +32,12 @@ describe("resolveProfileParamVisibility", () => {
       resolveProfileParamVisibility("fireworks", "accounts/fireworks/models/minimax-m3").topP,
     ).toBe(true);
     expect(resolveProfileParamVisibility("openrouter", "anthropic/claude-fable-5").topP).toBe(true);
+    expect(
+      resolveProfileParamVisibility("vercel-ai-gateway", "anthropic/claude-fable-5").topP,
+    ).toBe(true);
+    // Non-anthropic gateway models ride the OpenAI-compat chat-completions
+    // client, which forwards top_p.
+    expect(resolveProfileParamVisibility("vercel-ai-gateway", "xai/grok-4.3").topP).toBe(true);
     expect(resolveProfileParamVisibility("together", "MiniMaxAI/MiniMax-M3").topP).toBe(true);
     // Custom OpenAI-compatible connections route through the OpenAI adapter,
     // which forwards top_p — so the control must be visible for them too.
@@ -67,11 +73,15 @@ describe("resolveProfileParamVisibility", () => {
     expect(vis.thinking).toBe(false);
   });
 
-  test("vercel-ai-gateway anthropic sonnet/opus enable thinking and effort", () => {
+  test("vercel-ai-gateway anthropic sonnet/opus enable thinking, effort, and temperature", () => {
     for (const model of ["anthropic/claude-sonnet-4.6", "anthropic/claude-opus-4.8"]) {
       const vis = resolveProfileParamVisibility("vercel-ai-gateway", model);
       expect(vis.thinking).toBe(true);
       expect(vis.effort).toBe(true);
+      // anthropic/* gateway models ride the Anthropic Messages wire, which
+      // forwards temperature — same as their openrouter twins.
+      expect(vis.temperature).toBe(true);
+      expect(vis.topP).toBe(true);
     }
   });
 
@@ -87,12 +97,15 @@ describe("resolveProfileParamVisibility", () => {
     expect(vis.thinking).toBe(false);
   });
 
-  test("vercel-ai-gateway non-anthropic catalog reasoning model gets thinking with effort following", () => {
-    // xai/grok-4.3 is supportsThinking in the catalog; effort follows thinking
-    // for non-anthropic gateway models (same rule as openrouter).
+  test("vercel-ai-gateway non-anthropic catalog reasoning model gets effort but no thinking toggle", () => {
+    // xai/grok-4.3 is supportsThinking in the catalog, so effort is exposed
+    // (reasoning_effort works on the OpenAI-compat path) — but the thinking
+    // toggle is hidden because that path has no thinking translation.
     const vis = resolveProfileParamVisibility("vercel-ai-gateway", "xai/grok-4.3");
-    expect(vis.thinking).toBe(true);
+    expect(vis.thinking).toBe(false);
     expect(vis.effort).toBe(true);
+    // Non-anthropic gateway models don't ride the Anthropic wire.
+    expect(vis.temperature).toBe(false);
   });
 
   test("vercel-ai-gateway unknown non-anthropic model gets no thinking or effort", () => {

--- a/clients/web/src/domains/settings/ai/profile-param-visibility.ts
+++ b/clients/web/src/domains/settings/ai/profile-param-visibility.ts
@@ -155,6 +155,7 @@ const TOP_P_OPENAI_COMPAT_PROVIDERS = new Set([
   "ollama",
   "openrouter",
   "together",
+  "vercel-ai-gateway",
 ]);
 
 /**
@@ -176,7 +177,9 @@ export function resolveProfileParamVisibility(
   const providerId = provider.toLowerCase();
   const modelId = model.toLowerCase();
   const usesAnthropicWire =
-    providerId === "anthropic" || (providerId === "openrouter" && isVendorPrefixedAnthropicModel(modelId));
+    providerId === "anthropic" ||
+    ((providerId === "openrouter" || providerId === "vercel-ai-gateway") &&
+      isVendorPrefixedAnthropicModel(modelId));
   const supportsThinkingResult = modelSupportsThinking(providerId, modelId);
 
   return {
@@ -187,10 +190,12 @@ export function resolveProfileParamVisibility(
     verbosity: providerId === "openai" && isOpenAIGPT5Family(modelId),
     temperature: usesAnthropicWire,
     topP: supportsTopP(providerId, usesAnthropicWire),
+    // Gateway thinking is anthropic/*-only: the OpenAI-compat path has no
+    // thinking translation (effort still works there via reasoning_effort).
     thinking:
       (providerId === "anthropic" ||
         providerId === "openrouter" ||
-        providerId === "vercel-ai-gateway") &&
+        (providerId === "vercel-ai-gateway" && isVendorPrefixedAnthropicModel(modelId))) &&
       supportsThinkingResult &&
       !isAdaptiveThinkingOnlyModel(providerId, modelId),
     thinkingLevel: providerId === "gemini" && supportsThinkingResult,


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for vercel-ai-gateway-provider.md.

- usesAnthropicWire + TOP_P_OPENAI_COMPAT_PROVIDERS now cover vercel-ai-gateway (temperature/topP controls show correctly)
- Thinking toggle gated to anthropic/* models for the gateway (the OpenAI-compat path has no thinking translation; effort still exposed)
- Onboarding context windows mirror the OpenRouter entry's 200k defaults instead of opting new users into 1M long-context pricing