### PR TITLE
refactor(assistant): extract shared anthropic-gateway helpers

### DIFF
--- a/assistant/src/__tests__/anthropic-gateway-shared.test.ts
+++ b/assistant/src/__tests__/anthropic-gateway-shared.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isAnthropicModel,
+  retagDelegateError,
+  toAnthropicMessagesBaseURL,
+} from "../providers/anthropic-gateway-shared.js";
+import { ContextOverflowError } from "../providers/types.js";
+import { ProviderError } from "../util/errors.js";
+
+describe("isAnthropicModel", () => {
+  test("true for anthropic/-prefixed models", () => {
+    expect(isAnthropicModel("anthropic/claude-opus-4.8")).toBe(true);
+  });
+
+  test("false otherwise", () => {
+    expect(isAnthropicModel("openai/gpt-5.5")).toBe(false);
+  });
+});
+
+describe("toAnthropicMessagesBaseURL", () => {
+  test("strips a trailing /v1", () => {
+    expect(toAnthropicMessagesBaseURL("https://ai-gateway.vercel.sh/v1")).toBe(
+      "https://ai-gateway.vercel.sh",
+    );
+  });
+
+  test("strips a trailing /v1/", () => {
+    expect(toAnthropicMessagesBaseURL("https://openrouter.ai/api/v1/")).toBe(
+      "https://openrouter.ai/api",
+    );
+  });
+
+  test("leaves URLs without a /v1 suffix untouched", () => {
+    expect(toAnthropicMessagesBaseURL("https://ai-gateway.vercel.sh")).toBe(
+      "https://ai-gateway.vercel.sh",
+    );
+  });
+});
+
+describe("retagDelegateError", () => {
+  const providerNames = ["openrouter", "vercel-ai-gateway"] as const;
+
+  for (const providerName of providerNames) {
+    describe(providerName, () => {
+      test("re-tags a delegate ProviderError, preserving metadata", () => {
+        const inner = new ProviderError("rate limited", "anthropic", 429, {
+          retryAfterMs: 1_500,
+          abortReason: "test-abort",
+        });
+
+        let caught: unknown;
+        try {
+          retagDelegateError(inner, providerName);
+        } catch (error) {
+          caught = error;
+        }
+
+        expect(caught).toBeInstanceOf(ProviderError);
+        const err = caught as ProviderError;
+        expect(err.provider).toBe(providerName);
+        expect(err.message).toBe("rate limited");
+        expect(err.statusCode).toBe(429);
+        expect(err.retryAfterMs).toBe(1_500);
+        expect(err.abortReason).toBe("test-abort");
+        expect(err.cause).toBe(inner);
+      });
+
+      test("re-tags a delegate ContextOverflowError, preserving token counts", () => {
+        const inner = new ContextOverflowError(
+          "context overflow",
+          "anthropic",
+          { actualTokens: 250_000, maxTokens: 200_000, statusCode: 400 },
+        );
+
+        let caught: unknown;
+        try {
+          retagDelegateError(inner, providerName);
+        } catch (error) {
+          caught = error;
+        }
+
+        expect(caught).toBeInstanceOf(ContextOverflowError);
+        const err = caught as ContextOverflowError;
+        expect(err.provider).toBe(providerName);
+        expect(err.actualTokens).toBe(250_000);
+        expect(err.maxTokens).toBe(200_000);
+        expect(err.statusCode).toBe(400);
+        expect(err.cause).toBe(inner);
+      });
+
+      test("rethrows an already-tagged error unchanged", () => {
+        const inner = new ProviderError("boom", providerName, 500);
+        expect(() => retagDelegateError(inner, providerName)).toThrow(inner);
+      });
+
+      test("rethrows non-provider errors unchanged", () => {
+        const inner = new Error("plain failure");
+        expect(() => retagDelegateError(inner, providerName)).toThrow(inner);
+      });
+    });
+  }
+});

--- a/assistant/src/__tests__/vercel-ai-gateway-provider.test.ts
+++ b/assistant/src/__tests__/vercel-ai-gateway-provider.test.ts
@@ -3,10 +3,7 @@ import { describe, expect, test } from "bun:test";
 import type { AnthropicProvider } from "../providers/anthropic/client.js";
 import type { Message } from "../providers/types.js";
 import { ContextOverflowError } from "../providers/types.js";
-import {
-  toAnthropicMessagesBaseURL,
-  VercelAIGatewayProvider,
-} from "../providers/vercel-ai-gateway/client.js";
+import { VercelAIGatewayProvider } from "../providers/vercel-ai-gateway/client.js";
 import { ProviderError } from "../util/errors.js";
 
 const DEFAULT_BASE_URL = "https://ai-gateway.vercel.sh/v1";
@@ -54,26 +51,6 @@ describe("VercelAIGatewayProvider", () => {
         { baseURL: "   " },
       );
       expect(resolvedBaseURL(provider)).toBe(DEFAULT_BASE_URL);
-    });
-  });
-
-  describe("toAnthropicMessagesBaseURL", () => {
-    test("strips a trailing /v1", () => {
-      expect(toAnthropicMessagesBaseURL("https://ai-gateway.vercel.sh/v1")).toBe(
-        "https://ai-gateway.vercel.sh",
-      );
-    });
-
-    test("strips a trailing /v1/", () => {
-      expect(
-        toAnthropicMessagesBaseURL("https://ai-gateway.vercel.sh/v1/"),
-      ).toBe("https://ai-gateway.vercel.sh");
-    });
-
-    test("leaves URLs without a /v1 suffix untouched", () => {
-      expect(toAnthropicMessagesBaseURL("https://ai-gateway.vercel.sh")).toBe(
-        "https://ai-gateway.vercel.sh",
-      );
     });
   });
 

--- a/assistant/src/providers/anthropic-gateway-shared.ts
+++ b/assistant/src/providers/anthropic-gateway-shared.ts
@@ -1,0 +1,48 @@
+// Shared helpers for OpenAI-compat gateway providers (OpenRouter, Vercel AI
+// Gateway) that delegate `anthropic/*` models to the gateway's
+// Anthropic-compatible Messages API.
+
+import { ProviderError } from "../util/errors.js";
+import { ContextOverflowError, isContextOverflowError } from "./types.js";
+
+// Models prefixed `anthropic/` are routed through the gateway's
+// Anthropic-compatible Messages API at `<root>/v1/messages` so that
+// Anthropic-native features — extended thinking, prompt caching, cache TTL,
+// output_config — work without lossy translation through the OpenAI chat
+// completions compatibility layer.
+export function isAnthropicModel(model: string): boolean {
+  return model.startsWith("anthropic/");
+}
+
+// The Anthropic SDK appends `/v1/messages` to its configured baseURL, so we
+// strip the trailing `/v1` segment from the OpenAI-compat base before handing
+// it to the SDK.
+export function toAnthropicMessagesBaseURL(baseURL: string): string {
+  return baseURL.replace(/\/v1\/?$/, "");
+}
+
+// Re-tag delegate-thrown errors so the outer provider name matches the
+// configured provider. This keeps downstream error reporting and metrics
+// attribution accurate, while preserving the actualTokens/maxTokens extracted
+// by the delegate.
+export function retagDelegateError(
+  error: unknown,
+  providerName: string,
+): never {
+  if (isContextOverflowError(error) && error.provider !== providerName) {
+    throw new ContextOverflowError(error.message, providerName, {
+      actualTokens: error.actualTokens,
+      maxTokens: error.maxTokens,
+      statusCode: error.statusCode,
+      cause: error,
+    });
+  }
+  if (error instanceof ProviderError && error.provider !== providerName) {
+    throw new ProviderError(error.message, providerName, error.statusCode, {
+      cause: error.cause ?? error,
+      retryAfterMs: error.retryAfterMs,
+      abortReason: error.abortReason,
+    });
+  }
+  throw error;
+}

--- a/assistant/src/providers/openrouter/client.ts
+++ b/assistant/src/providers/openrouter/client.ts
@@ -1,5 +1,9 @@
-import { ProviderError } from "../../util/errors.js";
 import { AnthropicProvider } from "../anthropic/client.js";
+import {
+  isAnthropicModel,
+  retagDelegateError,
+  toAnthropicMessagesBaseURL,
+} from "../anthropic-gateway-shared.js";
 import {
   clampReasoningEffort,
   EFFORT_TO_REASONING_EFFORT,
@@ -11,10 +15,8 @@ import type {
   ProviderResponse,
   SendMessageOptions,
 } from "../types.js";
-import { ContextOverflowError, isContextOverflowError } from "../types.js";
 
 export interface OpenRouterProviderOptions {
-  apiKey?: string;
   baseURL?: string;
   streamTimeoutMs?: number;
   useNativeWebSearch?: boolean;
@@ -26,22 +28,6 @@ const OPENROUTER_APP_ATTRIBUTION_HEADERS = {
   "X-OpenRouter-Title": "Vellum Assistant",
   "X-OpenRouter-Categories": "personal-agent,cli-agent",
 };
-
-// Models on OpenRouter prefixed `anthropic/` are routed through OpenRouter's
-// Anthropic-compatible Messages API at `<root>/v1/messages` (where `<root>` is
-// the OpenRouter API root, e.g. `https://openrouter.ai/api`) so that
-// Anthropic-native features — extended thinking, prompt caching, cache TTL,
-// output_config — work without lossy translation through the OpenAI chat
-// completions compatibility layer. The Anthropic SDK appends `/v1/messages` to
-// its configured baseURL, so we strip the trailing `/v1` segment from the
-// OpenAI-compat base before handing it to the SDK.
-function isAnthropicModel(model: string): boolean {
-  return model.startsWith("anthropic/");
-}
-
-function toAnthropicMessagesBaseURL(openRouterBaseURL: string): string {
-  return openRouterBaseURL.replace(/\/v1\/?$/, "");
-}
 
 /**
  * Extract the normalized `openrouter.only` list from a per-call config. Returns
@@ -159,26 +145,7 @@ export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
       }
       return await super.sendMessage(messages, options);
     } catch (error) {
-      // Re-tag delegate-thrown ContextOverflowError so the outer provider name
-      // matches the configured provider ("openrouter"). This keeps downstream
-      // error reporting and metrics attribution accurate, while preserving the
-      // actualTokens/maxTokens extracted by the delegate.
-      if (isContextOverflowError(error) && error.provider !== this.name) {
-        throw new ContextOverflowError(error.message, this.name, {
-          actualTokens: error.actualTokens,
-          maxTokens: error.maxTokens,
-          statusCode: error.statusCode,
-          cause: error,
-        });
-      }
-      if (error instanceof ProviderError && error.provider !== this.name) {
-        throw new ProviderError(error.message, this.name, error.statusCode, {
-          cause: error.cause ?? error,
-          retryAfterMs: error.retryAfterMs,
-          abortReason: error.abortReason,
-        });
-      }
-      throw error;
+      retagDelegateError(error, this.name);
     }
   }
 

--- a/assistant/src/providers/vercel-ai-gateway/client.ts
+++ b/assistant/src/providers/vercel-ai-gateway/client.ts
@@ -1,36 +1,23 @@
-import { ProviderError } from "../../util/errors.js";
 import { AnthropicProvider } from "../anthropic/client.js";
+import {
+  isAnthropicModel,
+  retagDelegateError,
+  toAnthropicMessagesBaseURL,
+} from "../anthropic-gateway-shared.js";
 import { OpenAIChatCompletionsProvider } from "../openai/chat-completions-provider.js";
 import type {
   Message,
   ProviderResponse,
   SendMessageOptions,
 } from "../types.js";
-import { ContextOverflowError, isContextOverflowError } from "../types.js";
 
 export interface VercelAIGatewayProviderOptions {
-  apiKey?: string;
   baseURL?: string;
   streamTimeoutMs?: number;
   useNativeWebSearch?: boolean;
 }
 
 const DEFAULT_VERCEL_AI_GATEWAY_BASE_URL = "https://ai-gateway.vercel.sh/v1";
-
-// Models prefixed `anthropic/` are routed through the gateway's
-// Anthropic-compatible Messages API at `<root>/v1/messages` so that
-// Anthropic-native features — extended thinking, prompt caching, cache TTL,
-// output_config — work without lossy translation through the OpenAI chat
-// completions compatibility layer. The Anthropic SDK appends `/v1/messages` to
-// its configured baseURL, so we strip the trailing `/v1` segment from the
-// OpenAI-compat base before handing it to the SDK.
-function isAnthropicModel(model: string): boolean {
-  return model.startsWith("anthropic/");
-}
-
-export function toAnthropicMessagesBaseURL(baseURL: string): string {
-  return baseURL.replace(/\/v1\/?$/, "");
-}
 
 export class VercelAIGatewayProvider extends OpenAIChatCompletionsProvider {
   private readonly gatewayApiKey: string;
@@ -90,26 +77,7 @@ export class VercelAIGatewayProvider extends OpenAIChatCompletionsProvider {
       }
       return await super.sendMessage(messages, options);
     } catch (error) {
-      // Re-tag delegate-thrown ContextOverflowError so the outer provider name
-      // matches the configured provider ("vercel-ai-gateway"). This keeps
-      // downstream error reporting and metrics attribution accurate, while
-      // preserving the actualTokens/maxTokens extracted by the delegate.
-      if (isContextOverflowError(error) && error.provider !== this.name) {
-        throw new ContextOverflowError(error.message, this.name, {
-          actualTokens: error.actualTokens,
-          maxTokens: error.maxTokens,
-          statusCode: error.statusCode,
-          cause: error,
-        });
-      }
-      if (error instanceof ProviderError && error.provider !== this.name) {
-        throw new ProviderError(error.message, this.name, error.statusCode, {
-          cause: error.cause ?? error,
-          retryAfterMs: error.retryAfterMs,
-          abortReason: error.abortReason,
-        });
-      }
-      throw error;
+      retagDelegateError(error, this.name);
     }
   }
 


### PR DESCRIPTION
## Summary
Fixes a reuse gap identified during plan review for vercel-ai-gateway-provider.md.

- New anthropic-gateway-shared.ts owns isAnthropicModel, toAnthropicMessagesBaseURL, and retagDelegateError; both gateway clients import them (previously verbatim-duplicated, tested on only one copy)
- Drops the dead apiKey? field from both gateway option interfaces
- Shared tests cover the re-tag invariant for both providers