### PR TITLE
fix(toast): truly center toasts on mobile viewports (iOS)

### DIFF
--- a/packages/design-library/src/components/toast.tsx
+++ b/packages/design-library/src/components/toast.tsx
@@ -216,12 +216,28 @@ const toast = Object.assign(
 function Toaster() {
   return (
     <div data-slot="toaster">
+      {/* Sonner's ≤600px media query drops the translateX centering and
+          anchors toasts at `left: 0; right: 0` inside an offset container,
+          and it reads `mobileOffset` (not `offset`) there. Zero the side
+          offsets so the container spans the viewport, and let the auto
+          margins center the fixed-width toast; the maxWidth clamp keeps
+          16px gutters on screens narrower than the toast. */}
       <SonnerToaster
         position="bottom-center"
         offset="24px"
+        mobileOffset={{
+          left: 0,
+          right: 0,
+          bottom:
+            "calc(24px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)))",
+        }}
         toastOptions={{
           unstyled: true,
-          style: { width: "356px" },
+          style: {
+            width: "356px",
+            maxWidth: "calc(100vw - 32px)",
+            marginInline: "auto",
+          },
         }}
       />
     </div>


### PR DESCRIPTION
Summary:
Follow-up to #37382 — the bottom-center toast positioning never actually applied on iOS. sonner ships a hard-coded `@media (max-width: 600px)` branch that drops the `translateX(-50%)` centering and left-anchors toasts inside an offset container, and it reads `mobileOffset` (default 16px) instead of `offset` there. Combined with our fixed inline `width: 356px`, toasts rendered left-pinned on iPhones (16px left / 58px right gap on a Pro Max), ignored the intended 24px bottom offset, and sat in the home-indicator zone (the Capacitor shell uses `contentInset: "never"`).

## Root cause

- **Desktop (>600px)**: sonner centers `bottom-center` via `left: 50%; transform: translateX(-50%)` — worked as intended.
- **Mobile (≤600px, every iPhone in portrait)**: sonner's own CSS (`styles.css:425-459`) sets `transform: none`, anchors the toaster at `left: var(--mobile-offset-left); width: 100%`, and expects each toast to stretch (`left: 0; right: 0; width: calc(100% - 32px)`). Our `toastOptions.style.width: 356px` (required because `unstyled: true` removes sonner's width rule) overrides the stretch; the over-constrained box (`left: 0; right: 0; width: 356px`) drops `right` per CSS 2.1 §10.3.7 and pins the toast left.
- The `offset` prop only sets desktop variables; mobile reads `--mobile-offset-*` (16px defaults), so the 24px bottom offset from 02ecf6b100 silently never applied on mobile either.
- Ruled out: single Toaster mount (`providers.tsx`), no transformed ancestors (fixed-positioning intact), no app CSS touching `[data-sonner-toaster]`, correct viewport meta, iOS loads the same deployed SPA. This is purely sonner's opinionated mobile branch vs. our fixed width.

## What changed

`packages/design-library/src/components/toast.tsx` (Toaster only):

- `mobileOffset={{ left: 0, right: 0, bottom: calc(24px + safe-area) }}` — zeroing the side offsets makes the toaster span the full viewport (centering against an offset container is otherwise 16px off-center); the bottom entry makes the intended 24px offset apply on mobile and clears the iOS home indicator via the repo's layered `var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))` pattern (same as `bottom-sheet.tsx`; the Capacitor shell injects the var via `native-safe-area.ts`, browsers fall back to `env()`, desktop resolves 0).
- `marginInline: "auto"` on the toast — with mobile's `left: 0; right: 0` + fixed width, auto margins split the slack equally → true centering (community-converged fix from sonner issue #4; #67/#678/#682 confirm no first-party API exists). On desktop the toast has no left/right constraints, so margins resolve to 0 — byte-for-byte unchanged.
- `maxWidth: calc(100vw - 32px)` — keeps 16px gutters on devices narrower than 388px (previously the 356px toast ran to within 3px of an iPhone SE's right edge).

Only documented sonner props + standard box-model CSS — no `!important`, no duplication of sonner's 600px breakpoint, survives library upgrades.

## Verification (Storybook + Playwright, measured `getBoundingClientRect`)

| Viewport | Before (left/right gap) | After (left/right gap) | Bottom offset |
|---|---|---|---|
| 430px (Pro Max) | 16 / 58 — left-pinned | **37 / 37** | 16 → **24** |
| 393px (iPhone 16) | 16 / 21 | **18.5 / 18.5** | 16 → **24** |
| 375px (SE) | 16 / 3 — near-overflow | **16 / 16** (width clamps to 343) | 16 → **24** |
| 1280px (desktop) | 462 / 462 | **462 / 462 — unchanged**, translateX centering still active | 24 → 24 |

Probes: simulated the Capacitor safe-area bridge (`--safe-area-inset-bottom: 34px` on `<html>`) → bottom gap 58 = 24 + 34, centering intact; stacked 3 toasts → symmetric gaps at every stack depth. Typecheck + prettier clean.

## Risk

Shared design-library component — affects all toasts on web/macOS/iOS. Desktop is provably unchanged (auto margins resolve to 0 without `left`/`right`; the clamp can't bind above 600px); the only visual deltas are on ≤600px viewports and all three are the intended fix. Swipe-to-dismiss and stack expansion use transforms, independent of margins.

## Alternatives rejected

- Accepting sonner's native full-width mobile toast: breaks the 356px Figma spec, and with `unstyled: true` desktop would lose its width entirely.
- `mobileOffset: { left: "calc(50vw - 178px)", ... }`: couples offset to width, goes negative below 388px.
- Flex-centering the toaster: documented broken <600px (sonner issue #4 thread).
- CSS `!important` re-asserting the transform: must also patch expanded/swipe states, fights upgrades.
- Overriding `--mobile-offset-*` via the `style` prop: silently ignored — sonner merges its offset vars after yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
