### PR TITLE
fix: extend anthropic-wire guards, catalog inference, and usage pricing to vercel-ai-gateway

### DIFF
--- a/assistant/src/__tests__/llm-catalog-parity.test.ts
+++ b/assistant/src/__tests__/llm-catalog-parity.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
 import {
+  getCatalogProviderForModel,
   isModelInCatalog,
   PROVIDER_CATALOG,
 } from "../providers/model-catalog.js";
@@ -464,6 +465,25 @@ describe("LLM catalog parity: daemon vs client", () => {
         }
       }
     }
+  });
+
+  test("getCatalogProviderForModel breaks shared-ID ties by catalog order", () => {
+    // OpenRouter and the Vercel AI Gateway both list this ID; OpenRouter comes
+    // first in PROVIDER_CATALOG, so model→provider inference must keep
+    // returning "openrouter" for configs that predate the gateway.
+    expect(getCatalogProviderForModel("anthropic/claude-sonnet-4.6")).toBe(
+      "openrouter",
+    );
+  });
+
+  test("getCatalogProviderForModel resolves gateway-unique IDs", () => {
+    expect(getCatalogProviderForModel("xai/grok-4.3")).toBe(
+      "vercel-ai-gateway",
+    );
+  });
+
+  test("getCatalogProviderForModel returns undefined for unknown IDs", () => {
+    expect(getCatalogProviderForModel("unknown/model")).toBeUndefined();
   });
 
   test("Gemini 2.5 Pro catalog context matches provider limits", () => {

--- a/assistant/src/__tests__/pricing.test.ts
+++ b/assistant/src/__tests__/pricing.test.ts
@@ -876,6 +876,65 @@ describe("Anthropic models on OpenRouter", () => {
   });
 });
 
+describe("Anthropic models on the Vercel AI Gateway", () => {
+  test("prices anthropic/claude-opus-4.6 at Opus 4.6 rates", () => {
+    const result = resolvePricing(
+      "vercel-ai-gateway",
+      "anthropic/claude-opus-4.6",
+      1_000_000,
+      1_000_000,
+    );
+    expect(result.pricingStatus).toBe("priced");
+    expect(result.estimatedCostUsd).toBe(5 + 25);
+  });
+
+  test("prices bare claude-opus-4-6 slug returned unprefixed", () => {
+    const result = resolvePricing(
+      "vercel-ai-gateway",
+      "claude-opus-4-6-20260205",
+      1_000_000,
+      1_000_000,
+    );
+    expect(result.pricingStatus).toBe("priced");
+    expect(result.estimatedCostUsd).toBe(5 + 25);
+  });
+
+  test("returns unpriced for unknown anthropic model on the gateway", () => {
+    const result = resolvePricing(
+      "vercel-ai-gateway",
+      "anthropic/claude-neptune-99",
+      1_000_000,
+      1_000_000,
+    );
+    expect(result.pricingStatus).toBe("unpriced");
+    expect(result.estimatedCostUsd).toBeNull();
+  });
+
+  test("applies Anthropic cache discounts for prompt-cache reads via the gateway", () => {
+    const usage: PricingUsage = {
+      directInputTokens: 0,
+      outputTokens: 0,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 1_000_000,
+      anthropicCacheCreation: null,
+    };
+    const gateway = resolvePricingForUsage(
+      "vercel-ai-gateway",
+      "anthropic/claude-opus-4.6",
+      usage,
+    );
+    const direct = resolvePricingForUsage(
+      "anthropic",
+      "claude-opus-4-6",
+      usage,
+    );
+
+    expect(gateway.pricingStatus).toBe("priced");
+    expect(gateway.estimatedCostUsd).toBeCloseTo(5 * 0.1, 10);
+    expect(gateway.estimatedCostUsd).toBe(direct.estimatedCostUsd);
+  });
+});
+
 describe("usesAnthropicPricingRules", () => {
   test("returns true for direct Anthropic", () => {
     expect(usesAnthropicPricingRules("anthropic", "claude-opus-4-6")).toBe(

--- a/assistant/src/__tests__/retry-thinking-tool-choice.test.ts
+++ b/assistant/src/__tests__/retry-thinking-tool-choice.test.ts
@@ -246,6 +246,48 @@ describe("retry normalization: thinking + forced tool_choice", () => {
     expect(lastConfig()?.thinking).toEqual({ type: "adaptive" });
   });
 
+  test("strips thinking for vercel-ai-gateway with anthropic model and forced tool_choice", async () => {
+    setLlmConfig({
+      default: {
+        provider: "vercel-ai-gateway",
+        model: "anthropic/claude-opus-4.6",
+        thinking: { enabled: true },
+      },
+      // Disable the catalog default so resolution lands on llm.default.
+      profiles: { "cost-optimized": { source: "managed", status: "disabled" } },
+    });
+    const { provider, lastConfig } = makePipeline("vercel-ai-gateway");
+    await provider.sendMessage([userMessage], {
+      config: {
+        callSite: "memoryExtraction",
+        tool_choice: { type: "tool", name: "extract_graph_diff" },
+      },
+    });
+    expect(lastConfig()?.thinking).toBeUndefined();
+  });
+
+  test("preserves thinking for vercel-ai-gateway with non-anthropic model and forced tool_choice", async () => {
+    setLlmConfig({
+      default: {
+        provider: "vercel-ai-gateway",
+        model: "xai/grok-4.3",
+        thinking: { enabled: true },
+      },
+      // Disable the catalog default so resolution lands on llm.default.
+      profiles: { "cost-optimized": { source: "managed", status: "disabled" } },
+    });
+    const { provider, lastConfig } = makePipeline("vercel-ai-gateway");
+    await provider.sendMessage([userMessage], {
+      config: {
+        callSite: "memoryExtraction",
+        tool_choice: { type: "tool", name: "extract_graph_diff" },
+      },
+    });
+    // Non-Anthropic gateway models don't share Anthropic's wire constraint —
+    // the guard must not strip thinking for them
+    expect(lastConfig()?.thinking).toEqual({ type: "adaptive" });
+  });
+
   test("does not strip thinking for non-thinking-aware providers", async () => {
     // For non-thinking-aware providers, thinking is already stripped by the
     // earlier provider check — this test ensures the tool_choice check

--- a/assistant/src/providers/__tests__/retry-callsite.test.ts
+++ b/assistant/src/providers/__tests__/retry-callsite.test.ts
@@ -825,6 +825,58 @@ describe("RetryProvider — thinking/temperature conflict guard", () => {
     expect(config.temperature).toBe(0.7);
   });
 
+  test("drops temperature for Vercel AI Gateway when fronting an `anthropic/*` model", async () => {
+    setLlmConfig({
+      default: {
+        provider: "vercel-ai-gateway",
+        model: "anthropic/claude-opus-4.6",
+        thinking: { enabled: true, streamThinking: true },
+      },
+      callSites: { mainAgent: {} },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("vercel-ai-gateway", (options) => {
+        seen = options;
+      }),
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: { callSite: "mainAgent", temperature: 0.7 },
+    });
+
+    const config = seen?.config as Record<string, unknown>;
+    expect(config.model).toBe("anthropic/claude-opus-4.6");
+    expect(config.temperature).toBeUndefined();
+  });
+
+  test("preserves temperature for Vercel AI Gateway when fronting a non-Anthropic model", async () => {
+    setLlmConfig({
+      default: {
+        provider: "vercel-ai-gateway",
+        model: "xai/grok-4.3",
+        thinking: { enabled: true, streamThinking: true },
+      },
+      callSites: { mainAgent: {} },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("vercel-ai-gateway", (options) => {
+        seen = options;
+      }),
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: { callSite: "mainAgent", temperature: 0.7 },
+    });
+
+    const config = seen?.config as Record<string, unknown>;
+    expect(config.model).toBe("xai/grok-4.3");
+    expect(config.temperature).toBe(0.7);
+  });
+
   test("guard does not fire when thinking has already been stripped by forced tool_choice", async () => {
     // `retry.ts` strips `thinking` when forced `tool_choice: { type: "tool" }`
     // is set on Anthropic — the guard runs after that step, so by the time
@@ -920,6 +972,60 @@ describe("RetryProvider — thinking/top_p conflict guard", () => {
     const config = seen?.config as Record<string, unknown>;
     expect(config.model).toBe("anthropic/claude-opus-4-7");
     expect(config.top_p).toBeUndefined();
+  });
+
+  test("drops top_p for Vercel AI Gateway when fronting an `anthropic/*` model", async () => {
+    setLlmConfig({
+      default: {
+        provider: "vercel-ai-gateway",
+        model: "anthropic/claude-opus-4.6",
+        thinking: { enabled: true, streamThinking: true },
+        topP: 0.9,
+      },
+      callSites: { mainAgent: {} },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("vercel-ai-gateway", (options) => {
+        seen = options;
+      }),
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    const config = seen?.config as Record<string, unknown>;
+    expect(config.model).toBe("anthropic/claude-opus-4.6");
+    expect(config.top_p).toBeUndefined();
+  });
+
+  test("preserves top_p for Vercel AI Gateway when fronting a non-Anthropic model", async () => {
+    setLlmConfig({
+      default: {
+        provider: "vercel-ai-gateway",
+        model: "xai/grok-4.3",
+        thinking: { enabled: true, streamThinking: true },
+        topP: 0.9,
+      },
+      callSites: { mainAgent: {} },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("vercel-ai-gateway", (options) => {
+        seen = options;
+      }),
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    const config = seen?.config as Record<string, unknown>;
+    expect(config.model).toBe("xai/grok-4.3");
+    expect(config.top_p).toBe(0.9);
   });
 
   test("preserves top_p when thinking is enabled on a non-Anthropic provider (fireworks)", async () => {

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1670,14 +1670,16 @@ export function isModelInCatalog(provider: string, modelId: string): boolean {
   return entry?.models.some((m) => m.id === modelId) ?? false;
 }
 
-/** Return the unique catalog provider that owns a model ID, if known. */
+/**
+ * Return the catalog provider that owns a model ID, if known. When multiple
+ * providers list the same ID (e.g. OpenRouter and the Vercel AI Gateway share
+ * `anthropic/*` IDs), the earliest entry in PROVIDER_CATALOG order wins.
+ */
 export function getCatalogProviderForModel(
   modelId: string,
 ): string | undefined {
-  const matches = PROVIDER_CATALOG.filter((p) =>
-    p.models.some((m) => m.id === modelId),
-  );
-  return matches.length === 1 ? matches[0]?.id : undefined;
+  return PROVIDER_CATALOG.find((p) => p.models.some((m) => m.id === modelId))
+    ?.id;
 }
 
 /**

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -59,9 +59,11 @@ const DISABLED_THINKING_USES_EFFORT_PROVIDERS = new Set([
 
 /**
  * Providers that consume the `thinking` config. Anthropic uses it directly on
- * the wire; OpenRouter and the Vercel AI Gateway either forward it to their
- * Anthropic-compatible paths or translate it for OpenAI-compat calls;
- * Gemini reads `thinking.level` to populate `thinkingConfig.thinkingLevel`.
+ * the wire; OpenRouter forwards it on its Anthropic delegate path and
+ * translates it into `reasoning` for OpenAI-compat calls; the Vercel AI
+ * Gateway consumes it only on its `anthropic/*` delegate path (no wire effect
+ * for its other models); Gemini reads `thinking.level` to populate
+ * `thinkingConfig.thinkingLevel`.
  */
 const THINKING_AWARE_PROVIDERS = new Set([
   "anthropic",
@@ -175,6 +177,20 @@ function isRetryableError(error: unknown): boolean {
   if (isRetryableStreamError(error)) return true;
   if (isRetryableTransportAbort(error)) return true;
   return isRetryableNetworkError(error);
+}
+
+/**
+ * Whether the request lands on Anthropic's Messages API wire: direct Anthropic
+ * calls, plus OpenRouter / Vercel AI Gateway calls that delegate `anthropic/*`
+ * models to it. Anthropic's thinking wire constraints (forced tool_choice,
+ * temperature ≠ 1, top_p) apply exactly to these requests.
+ */
+function targetsAnthropicWire(providerName: string, model: string): boolean {
+  if (providerName === "anthropic") return true;
+  if (providerName === "openrouter" || providerName === "vercel-ai-gateway") {
+    return model.startsWith("anthropic/");
+  }
+  return false;
 }
 
 /**
@@ -412,35 +428,31 @@ function normalizeSendMessageOptions(
     }
   }
 
-  // Anthropic (and OpenRouter fronting Anthropic) rejects requests that
+  // Anthropic (and the gateways fronting Anthropic) rejects requests that
   // combine extended thinking with forced tool use (`tool_choice.type` of
   // `"tool"` or `"any"`).  Strip thinking when both are present so the
   // request doesn't fail with a 400 "Thinking may not be enabled when
   // tool_choice forces tool use."  `tool_choice: { type: "auto" }` is
   // compatible with thinking and left untouched.
   //
-  // For OpenRouter, only strip when routing to an `anthropic/*` model —
-  // non-Anthropic reasoning models (e.g. xAI Grok) translate `thinking`
-  // into OpenRouter's `reasoning` parameter via `buildExtraCreateParams`
-  // and may support reasoning with forced tool_choice.
+  // For OpenRouter and the Vercel AI Gateway, only strip when routing to an
+  // `anthropic/*` model — non-Anthropic reasoning models don't share this
+  // wire constraint (e.g. OpenRouter translates `thinking` into its
+  // `reasoning` parameter via `buildExtraCreateParams` and may support
+  // reasoning with forced tool_choice).
   const isThinkingForcedToolConflict = (() => {
     if (nextConfig.thinking == null) return false;
     if (isThinkingConfigDisabled(nextConfig.thinking)) return false;
     const tc = nextConfig.tool_choice as Record<string, unknown> | undefined;
     if (tc == null || (tc.type !== "tool" && tc.type !== "any")) return false;
-    if (providerName === "anthropic") return true;
-    if (providerName === "openrouter") {
-      const model =
-        typeof nextConfig.model === "string" ? nextConfig.model : "";
-      return model.startsWith("anthropic/");
-    }
-    return false;
+    const model = typeof nextConfig.model === "string" ? nextConfig.model : "";
+    return targetsAnthropicWire(providerName, model);
   })();
   if (isThinkingForcedToolConflict) {
     delete nextConfig.thinking;
   }
 
-  // Anthropic (and OpenRouter fronting Anthropic) rejects requests that
+  // Anthropic (and the gateways fronting Anthropic) rejects requests that
   // combine extended thinking with `temperature` ≠ 1. From the API:
   //   "`temperature` may only be set to 1 when thinking is enabled or in
   //   adaptive mode."
@@ -457,9 +469,10 @@ function normalizeSendMessageOptions(
   //
   // Scope:
   // - Anthropic: always.
-  // - OpenRouter fronting `anthropic/*`: same wire constraint applies.
+  // - OpenRouter / Vercel AI Gateway fronting `anthropic/*`: same wire
+  //   constraint applies.
   // - Other providers: not our problem here (e.g. OpenAI reasoning models
-  //   strip `temperature` upstream; non-Anthropic OpenRouter reasoning
+  //   strip `temperature` upstream; non-Anthropic gateway reasoning
   //   models don't have this exact constraint).
   //
   // Anthropic applies the same constraint family to `top_p` (see the `top_p`
@@ -479,13 +492,7 @@ function normalizeSendMessageOptions(
         return false;
       }
     }
-    if (providerName === "anthropic") {
-      return true;
-    }
-    if (providerName === "openrouter") {
-      return model.startsWith("anthropic/");
-    }
-    return false;
+    return targetsAnthropicWire(providerName, model);
   })();
   const isThinkingTemperatureConflict = (() => {
     if (!isThinkingEnabledOnAnthropicWire) {
@@ -514,7 +521,7 @@ function normalizeSendMessageOptions(
     delete nextConfig.temperature;
   }
 
-  // Anthropic (and OpenRouter fronting Anthropic) also rejects requests that
+  // Anthropic (and the gateways fronting Anthropic) also rejects requests that
   // combine extended thinking with *any* `top_p` modification. Unlike
   // `temperature` there is no "=== 1 is fine" exception — when thinking is
   // enabled the request must not set `top_p` at all. Drop it with a warn log

--- a/assistant/src/util/pricing.ts
+++ b/assistant/src/util/pricing.ts
@@ -390,11 +390,14 @@ export function resolvePricingForUsage(
   model: string,
   usage: PricingUsage,
 ): PricingResult {
-  // Anthropic models routed through OpenRouter: look up against the Anthropic
-  // catalog using the normalized bare slug. OpenRouter bills these calls at
-  // Anthropic's rates and the underlying Messages API response includes
-  // Anthropic's cache- and speed-metadata fields.
-  if (provider === "openrouter" && isAnthropicModelId(model)) {
+  // Anthropic models routed through OpenRouter or the Vercel AI Gateway: look
+  // up against the Anthropic catalog using the normalized bare slug. Both
+  // gateways bill these calls at Anthropic's rates and the underlying Messages
+  // API response includes Anthropic's cache- and speed-metadata fields.
+  if (
+    (provider === "openrouter" || provider === "vercel-ai-gateway") &&
+    isAnthropicModelId(model)
+  ) {
     const pricing = findPricing("anthropic", normalizeAnthropicModelId(model));
     if (pricing) {
       return {


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for vercel-ai-gateway-provider.md.

- retry.ts: thinking×tool_choice and thinking×temperature/top_p wire guards now cover vercel-ai-gateway anthropic/* (prevents Anthropic 400s)
- model-catalog.ts: getCatalogProviderForModel breaks multi-provider ties by catalog order (restores openrouter inference for 8 shared model IDs)
- pricing.ts: bare-slug anthropic response models resolve to Anthropic catalog pricing for the gateway
- retry.ts: corrected THINKING_AWARE_PROVIDERS comment (gateway consumes thinking only on the anthropic delegate path)