### PR TITLE
fix: default-provider-aware model implication + gateway predicate consolidation

### DIFF
--- a/assistant/src/__tests__/anthropic-gateway-shared.test.ts
+++ b/assistant/src/__tests__/anthropic-gateway-shared.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  isAnthropicDelegatingGateway,
   isAnthropicModel,
   retagDelegateError,
   toAnthropicMessagesBaseURL,
@@ -38,66 +39,76 @@ describe("toAnthropicMessagesBaseURL", () => {
   });
 });
 
+describe("isAnthropicDelegatingGateway", () => {
+  test("true for the gateways that front Anthropic's Messages API", () => {
+    expect(isAnthropicDelegatingGateway("openrouter")).toBe(true);
+    expect(isAnthropicDelegatingGateway("vercel-ai-gateway")).toBe(true);
+  });
+
+  test("false for other providers", () => {
+    expect(isAnthropicDelegatingGateway("anthropic")).toBe(false);
+    expect(isAnthropicDelegatingGateway("openai")).toBe(false);
+  });
+});
+
 describe("retagDelegateError", () => {
-  const providerNames = ["openrouter", "vercel-ai-gateway"] as const;
+  // The provider name is opaque to retagDelegateError; one gateway name
+  // exercises the full behavior.
+  const providerName = "vercel-ai-gateway";
 
-  for (const providerName of providerNames) {
-    describe(providerName, () => {
-      test("re-tags a delegate ProviderError, preserving metadata", () => {
-        const inner = new ProviderError("rate limited", "anthropic", 429, {
-          retryAfterMs: 1_500,
-          abortReason: "test-abort",
-        });
-
-        let caught: unknown;
-        try {
-          retagDelegateError(inner, providerName);
-        } catch (error) {
-          caught = error;
-        }
-
-        expect(caught).toBeInstanceOf(ProviderError);
-        const err = caught as ProviderError;
-        expect(err.provider).toBe(providerName);
-        expect(err.message).toBe("rate limited");
-        expect(err.statusCode).toBe(429);
-        expect(err.retryAfterMs).toBe(1_500);
-        expect(err.abortReason).toBe("test-abort");
-        expect(err.cause).toBe(inner);
-      });
-
-      test("re-tags a delegate ContextOverflowError, preserving token counts", () => {
-        const inner = new ContextOverflowError(
-          "context overflow",
-          "anthropic",
-          { actualTokens: 250_000, maxTokens: 200_000, statusCode: 400 },
-        );
-
-        let caught: unknown;
-        try {
-          retagDelegateError(inner, providerName);
-        } catch (error) {
-          caught = error;
-        }
-
-        expect(caught).toBeInstanceOf(ContextOverflowError);
-        const err = caught as ContextOverflowError;
-        expect(err.provider).toBe(providerName);
-        expect(err.actualTokens).toBe(250_000);
-        expect(err.maxTokens).toBe(200_000);
-        expect(err.statusCode).toBe(400);
-        expect(err.cause).toBe(inner);
-      });
-
-      test("rethrows an already-tagged error unchanged", () => {
-        const inner = new ProviderError("boom", providerName, 500);
-        expect(() => retagDelegateError(inner, providerName)).toThrow(inner);
-      });
-
-      test("rethrows non-provider errors unchanged", () => {
-        const inner = new Error("plain failure");
-        expect(() => retagDelegateError(inner, providerName)).toThrow(inner);
-      });
+  test("re-tags a delegate ProviderError, preserving metadata", () => {
+    const inner = new ProviderError("rate limited", "anthropic", 429, {
+      retryAfterMs: 1_500,
+      abortReason: "test-abort",
     });
-  }
+
+    let caught: unknown;
+    try {
+      retagDelegateError(inner, providerName);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(ProviderError);
+    const err = caught as ProviderError;
+    expect(err.provider).toBe(providerName);
+    expect(err.message).toBe("rate limited");
+    expect(err.statusCode).toBe(429);
+    expect(err.retryAfterMs).toBe(1_500);
+    expect(err.abortReason).toBe("test-abort");
+    expect(err.cause).toBe(inner);
+  });
+
+  test("re-tags a delegate ContextOverflowError, preserving token counts", () => {
+    const inner = new ContextOverflowError("context overflow", "anthropic", {
+      actualTokens: 250_000,
+      maxTokens: 200_000,
+      statusCode: 400,
+    });
+
+    let caught: unknown;
+    try {
+      retagDelegateError(inner, providerName);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(ContextOverflowError);
+    const err = caught as ContextOverflowError;
+    expect(err.provider).toBe(providerName);
+    expect(err.actualTokens).toBe(250_000);
+    expect(err.maxTokens).toBe(200_000);
+    expect(err.statusCode).toBe(400);
+    expect(err.cause).toBe(inner);
+  });
+
+  test("rethrows an already-tagged error unchanged", () => {
+    const inner = new ProviderError("boom", providerName, 500);
+    expect(() => retagDelegateError(inner, providerName)).toThrow(inner);
+  });
+
+  test("rethrows non-provider errors unchanged", () => {
+    const inner = new Error("plain failure");
+    expect(() => retagDelegateError(inner, providerName)).toThrow(inner);
+  });
 });

--- a/assistant/src/__tests__/llm-resolver.test.ts
+++ b/assistant/src/__tests__/llm-resolver.test.ts
@@ -88,6 +88,76 @@ describe("resolveCallSiteConfig", () => {
     expect(resolved.effort).toBe("low");
   });
 
+  test("model-only override of a shared gateway model keeps a vercel-ai-gateway default provider", () => {
+    // `anthropic/claude-opus-4.8` is listed by both openrouter and
+    // vercel-ai-gateway; the applicable default provider serves it, so no
+    // provider is implied and the default wins.
+    const llm = LLMSchema.parse({
+      default: {
+        ...fullDefault,
+        provider: "vercel-ai-gateway",
+        model: "anthropic/claude-sonnet-4.6",
+      },
+      callSites: {
+        memoryExtraction: { model: "anthropic/claude-opus-4.8" },
+      },
+    });
+
+    const resolved = resolveCallSiteConfig("memoryExtraction", llm);
+
+    expect(resolved.provider).toBe("vercel-ai-gateway");
+    expect(resolved.model).toBe("anthropic/claude-opus-4.8");
+  });
+
+  test("model-only override of a shared gateway model keeps an openrouter default provider", () => {
+    const llm = LLMSchema.parse({
+      default: {
+        ...fullDefault,
+        provider: "openrouter",
+        model: "anthropic/claude-sonnet-4.6",
+      },
+      callSites: {
+        memoryExtraction: { model: "anthropic/claude-opus-4.8" },
+      },
+    });
+
+    const resolved = resolveCallSiteConfig("memoryExtraction", llm);
+
+    expect(resolved.provider).toBe("openrouter");
+    expect(resolved.model).toBe("anthropic/claude-opus-4.8");
+  });
+
+  test("model-only override of a gateway model with a non-serving default implies the catalog owner", () => {
+    // Anthropic's own catalog uses bare slugs, so it does not serve
+    // `anthropic/claude-sonnet-4.6` — the catalog owner (openrouter, the
+    // earliest entry listing it) is implied.
+    const llm = LLMSchema.parse({
+      default: fullDefault,
+      callSites: {
+        memoryExtraction: { model: "anthropic/claude-sonnet-4.6" },
+      },
+    });
+
+    const resolved = resolveCallSiteConfig("memoryExtraction", llm);
+
+    expect(resolved.provider).toBe("openrouter");
+    expect(resolved.model).toBe("anthropic/claude-sonnet-4.6");
+  });
+
+  test("model unique to vercel-ai-gateway implies vercel-ai-gateway", () => {
+    const llm = LLMSchema.parse({
+      default: fullDefault,
+      callSites: {
+        memoryExtraction: { model: "openai/gpt-5.5-pro" },
+      },
+    });
+
+    const resolved = resolveCallSiteConfig("memoryExtraction", llm);
+
+    expect(resolved.provider).toBe("vercel-ai-gateway");
+    expect(resolved.model).toBe("openai/gpt-5.5-pro");
+  });
+
   test("unknown model-only override preserves inherited provider", () => {
     const llm = LLMSchema.parse({
       default: {

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 
-import { getCatalogProviderForModel } from "../providers/model-catalog.js";
+import {
+  getCatalogProviderForModel,
+  isModelInCatalog,
+} from "../providers/model-catalog.js";
 import { CALL_SITE_DEFAULTS } from "./call-site-defaults.js";
 import { getEffectiveProfile } from "./default-profile-catalog.js";
 import {
@@ -201,9 +204,7 @@ export function resolveCallSiteConfig(
     );
   }
 
-  const resolved = finalize(
-    deepMerge(...layers.map(withImpliedProviderForKnownModel)),
-  );
+  const resolved = finalize(deepMerge(...withImpliedProviders(layers)));
   // `logitBias` is profile-scoped: the winning profile is its only source.
   // Overwrite — or clear — whatever the deep-merge may have copied from a
   // non-profile layer (`llm.default` or a call-site fragment), so a preset set
@@ -403,18 +404,41 @@ function effectiveDefault(
   return dflt;
 }
 
-function withImpliedProviderForKnownModel(source: Mergeable): Mergeable {
-  if (source.provider !== undefined) return source;
-  const model = source.model;
-  if (typeof model !== "string" || model.length === 0) return source;
-
-  const provider = getCatalogProviderForModel(model);
-  if (provider === undefined) return source;
-
-  return {
-    ...source,
-    provider,
-  };
+/**
+ * Stamp a catalog-implied provider onto model-only layers whose model the
+ * provider applicable at that point in the merge does not serve. Layers are
+ * scanned in merge order (low → high precedence), tracking the provider the
+ * merged config would carry at each layer: when that provider already lists
+ * the layer's model in its own catalog, no implication is needed and the
+ * layer stays provider-less so the lower-precedence provider wins. Models
+ * unknown to the catalog never imply a provider.
+ */
+function withImpliedProviders(layers: Mergeable[]): Mergeable[] {
+  let applicableProvider: string | undefined;
+  return layers.map((layer) => {
+    if (layer.provider !== undefined) {
+      if (typeof layer.provider === "string") {
+        applicableProvider = layer.provider;
+      }
+      return layer;
+    }
+    const model = layer.model;
+    if (typeof model !== "string" || model.length === 0) {
+      return layer;
+    }
+    if (
+      applicableProvider !== undefined &&
+      isModelInCatalog(applicableProvider, model)
+    ) {
+      return layer;
+    }
+    const provider = getCatalogProviderForModel(model);
+    if (provider === undefined) {
+      return layer;
+    }
+    applicableProvider = provider;
+    return { ...layer, provider };
+  });
 }
 
 /**

--- a/assistant/src/plugin-api/vision-support.ts
+++ b/assistant/src/plugin-api/vision-support.ts
@@ -97,7 +97,7 @@ function resolveEntryVision(
   const model = entry.model ?? llm.default?.model;
 
   // Infer provider from model when missing (mirrors the resolver's
-  // withImpliedProviderForKnownModel).
+  // withImpliedProviders).
   const effectiveProvider =
     provider ??
     (typeof model === "string" ? getCatalogProviderForModel(model) : undefined);

--- a/assistant/src/providers/anthropic-gateway-shared.ts
+++ b/assistant/src/providers/anthropic-gateway-shared.ts
@@ -14,6 +14,16 @@ export function isAnthropicModel(model: string): boolean {
   return model.startsWith("anthropic/");
 }
 
+// Gateways that front Anthropic's Messages API for anthropic/* models.
+const ANTHROPIC_DELEGATING_GATEWAYS = new Set([
+  "openrouter",
+  "vercel-ai-gateway",
+]);
+
+export function isAnthropicDelegatingGateway(provider: string): boolean {
+  return ANTHROPIC_DELEGATING_GATEWAYS.has(provider);
+}
+
 // The Anthropic SDK appends `/v1/messages` to its configured baseURL, so we
 // strip the trailing `/v1` segment from the OpenAI-compat base before handing
 // it to the SDK.

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -6,6 +6,10 @@ import { getProviderKeyAsync } from "../security/secure-keys.js";
 import { ProviderNotConfiguredError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import {
+  isAnthropicDelegatingGateway,
+  isAnthropicModel,
+} from "./anthropic-gateway-shared.js";
+import {
   buildProviderAdapter,
   createAdapterFromConnection,
 } from "./inference/adapter-factory.js";
@@ -116,10 +120,7 @@ export function isNativeWebSearchCapableProvider(
   if (NATIVE_WEB_SEARCH_PROVIDER_IDS.has(providerName)) {
     return true;
   }
-  if (
-    (providerName === "openrouter" || providerName === "vercel-ai-gateway") &&
-    model.startsWith("anthropic/")
-  ) {
+  if (isAnthropicDelegatingGateway(providerName) && isAnthropicModel(model)) {
     return true;
   }
   return false;

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -13,6 +13,10 @@ import {
   isRetryableNetworkError,
   sleep,
 } from "../util/retry.js";
+import {
+  isAnthropicDelegatingGateway,
+  isAnthropicModel,
+} from "./anthropic-gateway-shared.js";
 import { resolveLogitBiasPreset } from "./inference/logit-bias.js";
 import { isAdaptiveThinkingOnlyModel } from "./model-catalog.js";
 import {
@@ -186,9 +190,11 @@ function isRetryableError(error: unknown): boolean {
  * temperature ≠ 1, top_p) apply exactly to these requests.
  */
 function targetsAnthropicWire(providerName: string, model: string): boolean {
-  if (providerName === "anthropic") return true;
-  if (providerName === "openrouter" || providerName === "vercel-ai-gateway") {
-    return model.startsWith("anthropic/");
+  if (providerName === "anthropic") {
+    return true;
+  }
+  if (isAnthropicDelegatingGateway(providerName)) {
+    return isAnthropicModel(model);
   }
   return false;
 }

--- a/assistant/src/util/pricing.ts
+++ b/assistant/src/util/pricing.ts
@@ -1,4 +1,5 @@
 import type { ModelPricingOverride } from "../config/schema.js";
+import { isAnthropicDelegatingGateway } from "../providers/anthropic-gateway-shared.js";
 import type {
   CatalogModel,
   CatalogModelPricing,
@@ -150,14 +151,10 @@ export function usesAnthropicPricingRules(
   provider: string,
   model: string,
 ): boolean {
-  if (provider === "anthropic") return true;
-  if (
-    (provider === "openrouter" || provider === "vercel-ai-gateway") &&
-    isAnthropicModelId(model)
-  ) {
+  if (provider === "anthropic") {
     return true;
   }
-  return false;
+  return isAnthropicDelegatingGateway(provider) && isAnthropicModelId(model);
 }
 
 /**
@@ -394,10 +391,7 @@ export function resolvePricingForUsage(
   // up against the Anthropic catalog using the normalized bare slug. Both
   // gateways bill these calls at Anthropic's rates and the underlying Messages
   // API response includes Anthropic's cache- and speed-metadata fields.
-  if (
-    (provider === "openrouter" || provider === "vercel-ai-gateway") &&
-    isAnthropicModelId(model)
-  ) {
+  if (isAnthropicDelegatingGateway(provider) && isAnthropicModelId(model)) {
     const pricing = findPricing("anthropic", normalizeAnthropicModelId(model));
     if (pricing) {
       return {

--- a/assistant/src/workspace/adaptive-thinking-repair.ts
+++ b/assistant/src/workspace/adaptive-thinking-repair.ts
@@ -32,7 +32,7 @@ import { getCatalogProviderForModel } from "../providers/model-catalog.js";
 //   - Resolve to a non-Anthropic provider (adaptive thinking is
 //     Anthropic-specific). Effective provider is the profile's explicit
 //     `provider`; otherwise the provider implied by a known catalog `model`
-//     (mirroring the resolver's withImpliedProviderForKnownModel); otherwise
+//     (mirroring the resolver's withImpliedProviders); otherwise
 //     llm.default.provider — with a completely absent llm.default.provider
 //     treated as Anthropic, matching migration 052's own `?? "anthropic"`
 //     default. This keeps the legacy non-Anthropic empty `{}` shells seeded by

--- a/assistant/src/workspace/migrations/097-enable-adaptive-thinking-managed-profiles.ts
+++ b/assistant/src/workspace/migrations/097-enable-adaptive-thinking-managed-profiles.ts
@@ -25,7 +25,7 @@ import type { WorkspaceMigration } from "./types.js";
 //   - Resolve to a non-Anthropic provider (adaptive thinking is
 //     Anthropic-specific). Effective provider is the profile's explicit
 //     `provider`; otherwise the provider implied by a known Claude `model`
-//     (mirroring the resolver's withImpliedProviderForKnownModel); otherwise
+//     (mirroring the resolver's withImpliedProviders); otherwise
 //     llm.default.provider — with a completely absent llm.default.provider
 //     treated as Anthropic, matching migration 052's own `?? "anthropic"`
 //     default. This keeps the legacy non-Anthropic empty `{}` shells seeded by


### PR DESCRIPTION
## Summary
Round-2 review fixes for vercel-ai-gateway-provider.md.

- llm-resolver: model-only config layers no longer get an implied provider when the applicable provider already serves the model — vercel-ai-gateway users keep their default instead of being rerouted to openrouter on shared model IDs
- retry.ts: braces-rule fix in targetsAnthropicWire
- anthropic-gateway-shared.ts now owns isAnthropicDelegatingGateway; retry/registry/pricing use it (and isAnthropicModel) instead of repeated literals