### PR TITLE
refactor(plugins): run shutdown before uninstall from disk; drop the activation pre-warm

### DIFF
--- a/assistant/src/__tests__/mtime-cache.test.ts
+++ b/assistant/src/__tests__/mtime-cache.test.ts
@@ -686,7 +686,11 @@ describe("plugin runtime activation", () => {
     });
   });
 
-  test("removing a plugin directory deactivates it (unregister + shutdown)", async () => {
+  test("an out-of-band directory removal unregisters tools but runs no shutdown", async () => {
+    // A raw `rm` (bypassing the managed uninstall) is only noticed by the
+    // monitor after the files are gone, so there's no `shutdown` to resolve —
+    // the reconcile just evicts. A managed uninstall runs `shutdown` before
+    // removal (see uninstall-plugin.test.ts).
     const dir = freshPluginDir("temp-plugin");
     writePackageJson(dir, { ...SIMPLE_PKG, name: "temp-plugin" });
     writeTool(dir, "temp-tool", TOOL_SRC("temp-tool"));
@@ -703,7 +707,7 @@ describe("plugin runtime activation", () => {
     expect(getPluginToolDefinitions().some((t) => t.name === "temp-tool")).toBe(
       false,
     );
-    expect(existsSync(shutdownMarker)).toBe(true);
+    expect(existsSync(shutdownMarker)).toBe(false);
   });
 
   test("a user plugin's shutdown hook is surfaced through the unified hook lookup", async () => {
@@ -725,10 +729,12 @@ describe("plugin runtime activation", () => {
     expect(existsSync(shutdownMarker)).toBe(true);
   });
 
-  test("disabling a plugin at runtime tears down its tools", async () => {
+  test("disabling a plugin at runtime tears down its tools and runs shutdown", async () => {
     const dir = freshPluginDir("disable-plugin");
     writePackageJson(dir, { ...SIMPLE_PKG, name: "disable-plugin" });
     writeTool(dir, "disable-tool", TOOL_SRC("disable-tool"));
+    const shutdownMarker = join(ROOT, "disable-shutdown.log");
+    writeMarkerHook(dir, "shutdown", shutdownMarker, "disabled");
 
     await populateCacheAtBoot();
     expect(getToolOwner("disable-tool")?.kind).toBe("plugin");
@@ -737,6 +743,9 @@ describe("plugin runtime activation", () => {
     await publishAndDispatch();
 
     expect(getToolOwner("disable-tool")).toBeUndefined();
+    // Disable keeps the directory, so `shutdown` is resolved from disk and runs
+    // even though it was never pre-warmed.
+    expect(existsSync(shutdownMarker)).toBe(true);
   });
 });
 
@@ -820,7 +829,7 @@ describe("live reload (sentinel-driven redeploy)", () => {
     expect(await dispatchFirst("transitive-reload")).toBe("a:b2");
   });
 
-  test("a reload runs the old shutdown (reason: reload) and the new init", async () => {
+  test("a reload runs the new init; the old shutdown is best-effort and skipped when uncached", async () => {
     const dir = freshPluginDir("lifecycle-plugin");
     writePackageJson(dir, { ...SIMPLE_PKG, name: "lifecycle-plugin" });
     const helperPath = writeLibFile(
@@ -847,12 +856,41 @@ describe("live reload (sentinel-driven redeploy)", () => {
     touchFile(helperPath, sentinelTouchSeq + 2);
     await publishAndDispatch();
 
-    // The edit is a redeploy: old version torn down with reason "reload",
-    // new version brought up through the same init path as boot.
+    // The edit is a redeploy: the new version comes up through the same init
+    // path as boot. `shutdown` was never dispatched during the plugin's life,
+    // so nothing is cached and the best-effort old-shutdown doesn't fire.
+    expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(2);
+    expect(existsSync(shutdownMarker)).toBe(false);
+  });
+
+  test("a reload runs the old shutdown when it was already resolved", async () => {
+    const dir = freshPluginDir("cached-shutdown-plugin");
+    writePackageJson(dir, { ...SIMPLE_PKG, name: "cached-shutdown-plugin" });
+    const helperPath = writeLibFile(
+      dir,
+      join("lib", "helper.ts"),
+      `export const value = 1;`,
+    );
+    const shutdownMarker = join(ROOT, "cached-shutdown.log");
+    rmSync(shutdownMarker, { force: true });
+    writeHook(
+      dir,
+      "shutdown",
+      `import { appendFileSync } from "node:fs";\nexport default (ctx: { reason: string }) => { appendFileSync(${JSON.stringify(shutdownMarker)}, ctx.reason + "\\n"); };`,
+    );
+
+    await populateCacheAtBoot();
+    // Resolve `shutdown` while the old version is live, so it's cached — the
+    // best-effort reload teardown then has an old version to run.
+    expect(await getUserHooksFor("shutdown")).toHaveLength(1);
+
+    writeFileSync(helperPath, `export const value = 2;`);
+    touchFile(helperPath, sentinelTouchSeq + 2);
+    await publishAndDispatch();
+
     expect(readFileSync(shutdownMarker, "utf8").trim().split("\n")).toEqual([
       "reload",
     ]);
-    expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(2);
   });
 
   test("boot adopts a pre-existing sentinel without spurious redeploys", async () => {
@@ -887,9 +925,8 @@ describe("sentinel path validation (ATL-983)", () => {
 
     // Forge a sentinel that claims the evil directory is a plugin.
     const sentinelPath = getSourceVersionsPath();
-    const { snapshotPluginSource } = await import(
-      "../plugins/source-fingerprint.js"
-    );
+    const { snapshotPluginSource } =
+      await import("../plugins/source-fingerprint.js");
     const snapshot = snapshotPluginSource(evilDir);
     writeFileSync(
       sentinelPath,

--- a/assistant/src/__tests__/mtime-cache.test.ts
+++ b/assistant/src/__tests__/mtime-cache.test.ts
@@ -485,8 +485,11 @@ describe("workspace hooks (<workspace>/hooks/)", () => {
     // Load-time discovery doesn't reject a plugin whose manifest name equals
     // the synthetic workspace owner. The cache key is scoped by owner kind, so
     // `plugin:__workspace__/…` and `workspace:__workspace__/…` stay distinct
-    // and both hooks run.
-    const dir = freshPluginDir("shadow");
+    // and both hooks run. The install slug (directory basename) equals the
+    // manifest name, as the installer enforces — that's what makes the plugin's
+    // hooks resolve at `<plugins>/__workspace__/hooks` while the workspace
+    // owner's resolve at `<workspace>/hooks`, distinct directories.
+    const dir = freshPluginDir("__workspace__");
     writePackageJson(dir, { ...SIMPLE_PKG, name: "__workspace__" });
     writeHook(
       dir,

--- a/assistant/src/__tests__/mtime-cache.test.ts
+++ b/assistant/src/__tests__/mtime-cache.test.ts
@@ -829,7 +829,7 @@ describe("live reload (sentinel-driven redeploy)", () => {
     expect(await dispatchFirst("transitive-reload")).toBe("a:b2");
   });
 
-  test("a reload runs the new init; the old shutdown is best-effort and skipped when uncached", async () => {
+  test("a reload runs the plugin's shutdown (reason: reload) and the new init", async () => {
     const dir = freshPluginDir("lifecycle-plugin");
     writePackageJson(dir, { ...SIMPLE_PKG, name: "lifecycle-plugin" });
     const helperPath = writeLibFile(
@@ -852,38 +852,9 @@ describe("live reload (sentinel-driven redeploy)", () => {
     expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(1);
     expect(existsSync(shutdownMarker)).toBe(false);
 
-    writeFileSync(helperPath, `export const value = 2;`);
-    touchFile(helperPath, sentinelTouchSeq + 2);
-    await publishAndDispatch();
-
-    // The edit is a redeploy: the new version comes up through the same init
-    // path as boot. `shutdown` was never dispatched during the plugin's life,
-    // so nothing is cached and the best-effort old-shutdown doesn't fire.
-    expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(2);
-    expect(existsSync(shutdownMarker)).toBe(false);
-  });
-
-  test("a reload runs the old shutdown when it was already resolved", async () => {
-    const dir = freshPluginDir("cached-shutdown-plugin");
-    writePackageJson(dir, { ...SIMPLE_PKG, name: "cached-shutdown-plugin" });
-    const helperPath = writeLibFile(
-      dir,
-      join("lib", "helper.ts"),
-      `export const value = 1;`,
-    );
-    const shutdownMarker = join(ROOT, "cached-shutdown.log");
-    rmSync(shutdownMarker, { force: true });
-    writeHook(
-      dir,
-      "shutdown",
-      `import { appendFileSync } from "node:fs";\nexport default (ctx: { reason: string }) => { appendFileSync(${JSON.stringify(shutdownMarker)}, ctx.reason + "\\n"); };`,
-    );
-
-    await populateCacheAtBoot();
-    // Resolve `shutdown` while the old version is live, so it's cached — the
-    // best-effort reload teardown then has an old version to run.
-    expect(await getUserHooksFor("shutdown")).toHaveLength(1);
-
+    // Edit a helper (not shutdown.ts) so the reload resolves the unchanged
+    // shutdown from disk and runs it, then brings the new version up through
+    // the same init path as boot.
     writeFileSync(helperPath, `export const value = 2;`);
     touchFile(helperPath, sentinelTouchSeq + 2);
     await publishAndDispatch();
@@ -891,6 +862,7 @@ describe("live reload (sentinel-driven redeploy)", () => {
     expect(readFileSync(shutdownMarker, "utf8").trim().split("\n")).toEqual([
       "reload",
     ]);
+    expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(2);
   });
 
   test("boot adopts a pre-existing sentinel without spurious redeploys", async () => {

--- a/assistant/src/__tests__/plugin-effective-enabled-set.test.ts
+++ b/assistant/src/__tests__/plugin-effective-enabled-set.test.ts
@@ -45,6 +45,7 @@ import {
   resetPluginRegistryForTests,
 } from "../plugins/registry.js";
 import type { HookFunction, Plugin } from "../plugins/types.js";
+import { getWorkspacePluginsDir } from "../util/platform.js";
 
 // Point the workspace at an empty temp dir so `getHooksFor` -> `getUserHooksFor`
 // finds no user-land plugins; the in-process hook tests then observe only the
@@ -138,59 +139,51 @@ describe("getHooksFor per-chat plugin scope (in-process default hooks)", () => {
 });
 
 describe("collectUserHookEntries per-chat plugin scope (user-land hooks)", () => {
-  let root: string;
-  let counter = 0;
+  const pluginsDir = getWorkspacePluginsDir();
 
   beforeEach(() => {
     resetHookCacheForTests();
-    root = join(
-      tmpdir(),
-      `vellum-userhooks-${process.pid}-${Date.now()}-${counter++}`,
-    );
-    mkdirSync(root, { recursive: true });
+    rmSync(pluginsDir, { recursive: true, force: true });
+    mkdirSync(pluginsDir, { recursive: true });
   });
 
   afterEach(() => {
-    rmSync(root, { recursive: true, force: true });
+    rmSync(pluginsDir, { recursive: true, force: true });
   });
 
-  // Each hook resolves lazily on its first read, so the fixture only has to lay
-  // the files down on disk — the read fills the cache.
-  function pluginDirWithHook(name: string): string {
-    const dir = join(root, name);
-    const hooksDir = join(dir, "hooks");
+  // `collectUserHookEntries` takes plugin *names* and derives each owner's
+  // hooks directory as `<workspace>/plugins/<name>/hooks` — the same layout the
+  // installer enforces — so the fixture lays files down there and returns the
+  // name. Each hook resolves lazily on its first read, so the fixture only has
+  // to write the file; the read fills the cache.
+  function pluginWithHook(name: string): string {
+    const hooksDir = join(pluginsDir, name, "hooks");
     mkdirSync(hooksDir, { recursive: true });
     writeFileSync(
       join(hooksDir, "user-prompt-submit.ts"),
       "export default () => ({});\n",
     );
-    return dir;
+    return name;
   }
 
   test("null set runs both user plugins' hooks (unchanged)", async () => {
-    const dirs: Array<readonly [string, string]> = [
-      [pluginDirWithHook("uplug-a"), "uplug-a"],
-      [pluginDirWithHook("uplug-b"), "uplug-b"],
-    ];
+    const names = [pluginWithHook("uplug-a"), pluginWithHook("uplug-b")];
 
     expect(
-      await collectUserHookEntries("user-prompt-submit", dirs),
+      await collectUserHookEntries("user-prompt-submit", names),
     ).toHaveLength(2);
     expect(
-      await collectUserHookEntries("user-prompt-submit", dirs, null),
+      await collectUserHookEntries("user-prompt-submit", names, null),
     ).toHaveLength(2);
   });
 
   test("a set excluding plugin b drops b's user-land hook", async () => {
-    const dirs: Array<readonly [string, string]> = [
-      [pluginDirWithHook("uplug-a"), "uplug-a"],
-      [pluginDirWithHook("uplug-b"), "uplug-b"],
-    ];
+    const names = [pluginWithHook("uplug-a"), pluginWithHook("uplug-b")];
 
     expect(
       await collectUserHookEntries(
         "user-prompt-submit",
-        dirs,
+        names,
         new Set(["uplug-a"]),
       ),
     ).toHaveLength(1);

--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -620,7 +620,7 @@ $ assistant plugins publish --json`,
                 return;
               }
             }
-            const result = uninstallPlugin({ name });
+            const result = await uninstallPlugin({ name });
             log.info(
               { name: result.name, target: result.target },
               "external plugin uninstalled",

--- a/assistant/src/cli/lib/__tests__/uninstall-plugin.test.ts
+++ b/assistant/src/cli/lib/__tests__/uninstall-plugin.test.ts
@@ -1,8 +1,12 @@
 /**
  * Tests for {@link uninstallPlugin}.
  *
- * Each test materializes a temp workspace plugins directory and points
- * `uninstallPlugin` at it via the `workspacePluginsDir` option.
+ * The `shutdown` hook is resolved from `<workspace>/plugins/<name>/hooks` (the
+ * installer-enforced layout), so tests materialize plugins under the real
+ * workspace plugins directory — the test-preload temp workspace — rather than a
+ * divergent temp dir. `workspacePluginsDir` is passed as the same directory so
+ * the rm target and the hook-resolution path stay in agreement, matching
+ * production (where the override is omitted and both fall back to it).
  */
 
 import {
@@ -19,6 +23,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import { resetHookCacheForTests } from "../../../hooks/hook-loader.js";
+import { getWorkspacePluginsDir } from "../../../util/platform.js";
 import { InvalidPluginNameError } from "../install-from-github.js";
 import {
   PluginNotInstalledError,
@@ -28,7 +34,10 @@ import {
 let pluginsDir: string;
 
 beforeEach(() => {
-  pluginsDir = mkdtempSync(join(tmpdir(), "plugins-uninstall-"));
+  pluginsDir = getWorkspacePluginsDir();
+  rmSync(pluginsDir, { recursive: true, force: true });
+  mkdirSync(pluginsDir, { recursive: true });
+  resetHookCacheForTests();
 });
 
 afterEach(() => {

--- a/assistant/src/cli/lib/__tests__/uninstall-plugin.test.ts
+++ b/assistant/src/cli/lib/__tests__/uninstall-plugin.test.ts
@@ -10,6 +10,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readdirSync,
+  readFileSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -49,11 +50,11 @@ function writePlugin(name: string): string {
 }
 
 describe("uninstallPlugin", () => {
-  test("removes the install target recursively", () => {
+  test("removes the install target recursively", async () => {
     const target = writePlugin("simple-memory");
     expect(existsSync(target)).toBe(true);
 
-    const result = uninstallPlugin({
+    const result = await uninstallPlugin({
       name: "simple-memory",
       workspacePluginsDir: pluginsDir,
     });
@@ -63,27 +64,50 @@ describe("uninstallPlugin", () => {
     expect(readdirSync(pluginsDir)).toEqual([]);
   });
 
-  test("throws PluginNotInstalledError when no directory exists", () => {
-    expect(() =>
+  test("runs the plugin's shutdown hook from disk before removing it", async () => {
+    const target = writePlugin("with-shutdown");
+    // Marker lives in the plugins dir (not the target), so it survives the rm
+    // and proves the shutdown hook ran during the uninstall.
+    const marker = join(pluginsDir, "shutdown-ran.txt");
+    writeFileSync(
+      join(target, "hooks", "shutdown.ts"),
+      `import { writeFileSync } from "node:fs";\n` +
+        `export default (ctx: { reason: string }) => {\n` +
+        `  writeFileSync(${JSON.stringify(marker)}, ctx.reason);\n` +
+        `};\n`,
+    );
+
+    await uninstallPlugin({
+      name: "with-shutdown",
+      workspacePluginsDir: pluginsDir,
+    });
+
+    expect(existsSync(target)).toBe(false);
+    expect(existsSync(marker)).toBe(true);
+    expect(readFileSync(marker, "utf8")).toBe("uninstall");
+  });
+
+  test("throws PluginNotInstalledError when no directory exists", async () => {
+    await expect(
       uninstallPlugin({
         name: "ghost",
         workspacePluginsDir: pluginsDir,
       }),
-    ).toThrow(PluginNotInstalledError);
+    ).rejects.toThrow(PluginNotInstalledError);
   });
 
-  test("throws PluginNotInstalledError when the target is a regular file", () => {
+  test("throws PluginNotInstalledError when the target is a regular file", async () => {
     writeFileSync(join(pluginsDir, "trap"), "not a plugin");
 
-    expect(() =>
+    await expect(
       uninstallPlugin({
         name: "trap",
         workspacePluginsDir: pluginsDir,
       }),
-    ).toThrow(PluginNotInstalledError);
+    ).rejects.toThrow(PluginNotInstalledError);
   });
 
-  test("removes a symlinked plugin without touching the link target", () => {
+  test("removes a symlinked plugin without touching the link target", async () => {
     const real = mkdtempSync(join(tmpdir(), "real-plugin-"));
     try {
       writeFileSync(
@@ -92,7 +116,7 @@ describe("uninstallPlugin", () => {
       );
       symlinkSync(real, join(pluginsDir, "linked"));
 
-      uninstallPlugin({
+      await uninstallPlugin({
         name: "linked",
         workspacePluginsDir: pluginsDir,
       });
@@ -113,12 +137,15 @@ describe("uninstallPlugin", () => {
     ["Name-WithCaps"],
     ["space name"],
     [""],
-  ])("rejects invalid plugin name %p before touching the filesystem", (bad) => {
-    // Salt the plugins dir with siblings to prove we don't blow them away.
-    writePlugin("real-plugin");
-    expect(() =>
-      uninstallPlugin({ name: bad, workspacePluginsDir: pluginsDir }),
-    ).toThrow(InvalidPluginNameError);
-    expect(existsSync(join(pluginsDir, "real-plugin"))).toBe(true);
-  });
+  ])(
+    "rejects invalid plugin name %p before touching the filesystem",
+    async (bad) => {
+      // Salt the plugins dir with siblings to prove we don't blow them away.
+      writePlugin("real-plugin");
+      await expect(
+        uninstallPlugin({ name: bad, workspacePluginsDir: pluginsDir }),
+      ).rejects.toThrow(InvalidPluginNameError);
+      expect(existsSync(join(pluginsDir, "real-plugin"))).toBe(true);
+    },
+  );
 });

--- a/assistant/src/cli/lib/uninstall-plugin.ts
+++ b/assistant/src/cli/lib/uninstall-plugin.ts
@@ -14,6 +14,7 @@
 import { existsSync, rmSync, statSync } from "node:fs";
 import { join } from "node:path";
 
+import { runShutdownHookFromDisk } from "../../hooks/hook-loader.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
 import {
   InvalidPluginNameError,
@@ -55,10 +56,17 @@ export interface UninstallPluginResult {
  * `../../etc/passwd` style argument never reaches `rmSync` — even
  * though commander typically prevents it at the argv level, defense in
  * depth.
+ *
+ * Before removing the directory, the plugin's `shutdown` hook (reason
+ * `uninstall`) is run from disk while its files are still present, so it can
+ * clean up. It resolves and runs in whatever process performs the uninstall —
+ * both the CLI command and the daemon's `DELETE` route call this — because a
+ * `shutdown` hook must not assume it shares a process with its `init`. A missing
+ * or throwing hook is best-effort and never blocks the removal.
  */
-export function uninstallPlugin(
+export async function uninstallPlugin(
   opts: UninstallPluginOptions,
-): UninstallPluginResult {
+): Promise<UninstallPluginResult> {
   const name = sanitizePluginName(opts.name);
   const pluginsDir = opts.workspacePluginsDir ?? getWorkspacePluginsDir();
   const target = join(pluginsDir, name);
@@ -74,6 +82,8 @@ export function uninstallPlugin(
   if (!stats.isDirectory()) {
     throw new PluginNotInstalledError(name, target);
   }
+
+  await runShutdownHookFromDisk(join(target, "hooks"), name, "uninstall");
 
   rmSync(target, { recursive: true, force: true });
   return { name, target };

--- a/assistant/src/cli/lib/uninstall-plugin.ts
+++ b/assistant/src/cli/lib/uninstall-plugin.ts
@@ -14,7 +14,8 @@
 import { existsSync, rmSync, statSync } from "node:fs";
 import { join } from "node:path";
 
-import { runShutdownHookFromDisk } from "../../hooks/hook-loader.js";
+import { runOwnerShutdown } from "../../hooks/hook-loader.js";
+import { ensurePluginApiShim } from "../../plugins/ensure-plugin-api-shim.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
 import {
   InvalidPluginNameError,
@@ -58,11 +59,13 @@ export interface UninstallPluginResult {
  * depth.
  *
  * Before removing the directory, the plugin's `shutdown` hook (reason
- * `uninstall`) is run from disk while its files are still present, so it can
- * clean up. It resolves and runs in whatever process performs the uninstall —
- * both the CLI command and the daemon's `DELETE` route call this — because a
- * `shutdown` hook must not assume it shares a process with its `init`. A missing
- * or throwing hook is best-effort and never blocks the removal.
+ * `uninstall`) is resolved and run while its files are still present, so it can
+ * clean up. It runs in whatever process performs the uninstall — both the CLI
+ * command and the daemon's `DELETE` route call this — because a `shutdown` hook
+ * must not assume it shares a process with its `init`. The plugin-api shim is
+ * materialized first so a hook importing `@vellumai/plugin-api` resolves even in
+ * a fresh CLI process; a missing, throwing, or slow hook is best-effort
+ * (time-boxed inside {@link runOwnerShutdown}) and never blocks the removal.
  */
 export async function uninstallPlugin(
   opts: UninstallPluginOptions,
@@ -83,7 +86,11 @@ export async function uninstallPlugin(
     throw new PluginNotInstalledError(name, target);
   }
 
-  await runShutdownHookFromDisk(join(target, "hooks"), name, "uninstall");
+  // Make `@vellumai/plugin-api` resolvable for the shutdown import even when
+  // this runs in a fresh CLI process that never called `loadUserPlugins()`.
+  // Best-effort — a failed shim just means the hook may not resolve.
+  await ensurePluginApiShim().catch(() => {});
+  await runOwnerShutdown("plugin", join(target, "hooks"), name, "uninstall");
 
   rmSync(target, { recursive: true, force: true });
   return { name, target };

--- a/assistant/src/cli/lib/uninstall-plugin.ts
+++ b/assistant/src/cli/lib/uninstall-plugin.ts
@@ -14,7 +14,7 @@
 import { existsSync, rmSync, statSync } from "node:fs";
 import { join } from "node:path";
 
-import { runOwnerShutdown } from "../../hooks/hook-loader.js";
+import { runShutdownHook } from "../../hooks/hook-loader.js";
 import { ensurePluginApiShim } from "../../plugins/ensure-plugin-api-shim.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
 import {
@@ -65,7 +65,7 @@ export interface UninstallPluginResult {
  * must not assume it shares a process with its `init`. The plugin-api shim is
  * materialized first so a hook importing `@vellumai/plugin-api` resolves even in
  * a fresh CLI process; a missing, throwing, or slow hook is best-effort
- * (time-boxed inside {@link runOwnerShutdown}) and never blocks the removal.
+ * (time-boxed inside {@link runShutdownHook}) and never blocks the removal.
  */
 export async function uninstallPlugin(
   opts: UninstallPluginOptions,
@@ -90,7 +90,7 @@ export async function uninstallPlugin(
   // this runs in a fresh CLI process that never called `loadUserPlugins()`.
   // Best-effort — a failed shim just means the hook may not resolve.
   await ensurePluginApiShim().catch(() => {});
-  await runOwnerShutdown("plugin", join(target, "hooks"), name, "uninstall");
+  await runShutdownHook("plugin", name, "uninstall");
 
   rmSync(target, { recursive: true, force: true });
   return { name, target };

--- a/assistant/src/hooks/__tests__/hook-live-reload.test.ts
+++ b/assistant/src/hooks/__tests__/hook-live-reload.test.ts
@@ -24,13 +24,13 @@
  *    source change).
  */
 
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 
 import { evictModule } from "../../plugins/surface-import.js";
 import type { HookEntry } from "../../plugins/types.js";
+import { getWorkspacePluginsDir } from "../../util/platform.js";
 import {
   collectUserHookEntries,
   evictHooksForOwner,
@@ -39,7 +39,10 @@ import {
 
 const HOOK_NAME = "user-prompt-submit";
 
-const root = mkdtempSync(join(tmpdir(), "hook-live-reload-"));
+// `collectUserHookEntries` derives each owner's hooks directory from its name
+// as `<workspace>/plugins/<name>/hooks`, so fixtures live under the workspace
+// plugins dir (the layout the installer enforces), not an arbitrary tmpdir.
+const root = getWorkspacePluginsDir();
 
 afterAll(() => {
   rmSync(root, { recursive: true, force: true });
@@ -73,12 +76,9 @@ function redeploy(plugin: { name: string }, modulePaths: string[]): void {
 }
 
 /** Collect and run the single expected hook, returning its result. */
-async function dispatchOne(plugin: {
-  dir: string;
-  name: string;
-}): Promise<unknown> {
+async function dispatchOne(plugin: { name: string }): Promise<unknown> {
   const entries: HookEntry[] = await collectUserHookEntries(HOOK_NAME, [
-    [plugin.dir, plugin.name],
+    plugin.name,
   ]);
   expect(entries).toHaveLength(1);
   return (entries[0]!.fn as () => unknown)();
@@ -110,12 +110,8 @@ describe("hook reload primitives", () => {
       `export default () => "stable";\n`,
     );
 
-    const first = await collectUserHookEntries(HOOK_NAME, [
-      [plugin.dir, plugin.name],
-    ]);
-    const second = await collectUserHookEntries(HOOK_NAME, [
-      [plugin.dir, plugin.name],
-    ]);
+    const first = await collectUserHookEntries(HOOK_NAME, [plugin.name]);
+    const second = await collectUserHookEntries(HOOK_NAME, [plugin.name]);
 
     // Same function instance: the second dispatch is a map lookup, not an
     // import.
@@ -158,8 +154,8 @@ describe("hook reload primitives", () => {
     // both await one import and get the same function instance — not import
     // twice, and not have one read a not-yet-populated entry.
     const [first, second] = await Promise.all([
-      collectUserHookEntries(HOOK_NAME, [[plugin.dir, plugin.name]]),
-      collectUserHookEntries(HOOK_NAME, [[plugin.dir, plugin.name]]),
+      collectUserHookEntries(HOOK_NAME, [plugin.name]),
+      collectUserHookEntries(HOOK_NAME, [plugin.name]),
     ]);
 
     expect(first).toHaveLength(1);
@@ -173,16 +169,16 @@ describe("hook reload primitives", () => {
 
     // Owner defines no such hook yet — resolves absent, and the absence is
     // cached.
-    expect(
-      await collectUserHookEntries(HOOK_NAME, [[plugin.dir, plugin.name]]),
-    ).toHaveLength(0);
+    expect(await collectUserHookEntries(HOOK_NAME, [plugin.name])).toHaveLength(
+      0,
+    );
 
     // Adding the file without an eviction does not lift the cached absence:
     // the negative entry is a hit, so the new file is not re-stat'd.
     writeFileSync(hookPath, `export default () => "added";\n`);
-    expect(
-      await collectUserHookEntries(HOOK_NAME, [[plugin.dir, plugin.name]]),
-    ).toHaveLength(0);
+    expect(await collectUserHookEntries(HOOK_NAME, [plugin.name])).toHaveLength(
+      0,
+    );
 
     // Evicting the owner (as the reconcile does on a source change) clears the
     // negative entry, so the next read picks the hook up.
@@ -199,9 +195,7 @@ describe("hook reload primitives", () => {
     rmSync(hookPath);
     redeploy(plugin, [hookPath]);
 
-    const entries = await collectUserHookEntries(HOOK_NAME, [
-      [plugin.dir, plugin.name],
-    ]);
+    const entries = await collectUserHookEntries(HOOK_NAME, [plugin.name]);
     expect(entries).toHaveLength(0);
   });
 });

--- a/assistant/src/hooks/hook-loader.ts
+++ b/assistant/src/hooks/hook-loader.ts
@@ -29,11 +29,9 @@
  *   {@link collectUserHookEntries}, which resolves that one hook name across the
  *   discovered owners; repeat reads are pure map lookups.
  * - **Lifecycle hooks** run once per activation / teardown. {@link runInitHook}
- *   resolves `init` (to run) and `shutdown` (to cache) while the owner's
- *   directory is present; {@link runShutdownHook} then reads that cached
- *   `shutdown`. Because the reconcile always tears an owner down *before*
- *   evicting it, the cached `shutdown` is still resident at teardown even when
- *   an uninstall has already removed the directory.
+ *   resolves and runs `init`; {@link runOwnerShutdown} resolves and runs one
+ *   owner's `shutdown` for a targeted teardown (uninstall, disable, reload).
+ *   Both go through the same resolution, so nothing is pre-warmed.
  *
  * Source changes reach the cache through the source-versions reconcile in
  * `../plugins/mtime-cache.ts`: it evicts the owner ({@link evictHooksForOwner}
@@ -137,7 +135,7 @@ function ownerHooksDir(pluginDir: string | null): string {
  * negative cache entry so an absent hook is looked up once, not every dispatch.
  * This is the single point where hook code enters the process, shared by
  * dispatch reads ({@link collectUserHookEntries}) and lifecycle runs
- * ({@link runInitHook} / {@link runShutdownHook}).
+ * ({@link runInitHook} / {@link runOwnerShutdown}).
  */
 function resolveHook(
   kind: HookOwnerKind,
@@ -331,96 +329,68 @@ export async function runInitHook(
   }
 }
 
+/** How long a single teardown `shutdown` invocation may run before we move on. */
+const SHUTDOWN_TIMEOUT_MS = 5_000;
+
 /**
- * Run one owner's `shutdown` from the cache if it's already resolved — the
- * best-effort teardown used on **reload**, where disk already holds the *new*
- * version so the old one can only come from a prior resolution. When it isn't
- * cached, this is a no-op: under the no-cross-invocation-state contract (see
- * {@link ShutdownContext}) the new `init` reconstructs from the filesystem, so a
- * missed old-`shutdown` is benign. For teardown where the current on-disk
- * version is the right one to run (uninstall, disable), use
- * {@link runShutdownHookFromDisk} instead. Best-effort: a thrown shutdown is
- * logged and swallowed; `reason` is threaded into the log for attribution only.
+ * Run one owner's `shutdown` — the targeted single-owner teardown for a managed
+ * uninstall, disable, or reload (the whole-chain `runHook(HOOKS.SHUTDOWN)` at
+ * process exit runs *every* owner's; this runs exactly one). Resolves it through
+ * the same {@link resolveHook} the dispatch path uses — cache or disk, so it
+ * needs nothing pre-warmed and works in any process (a `shutdown` hook must not
+ * assume it shares a process with its `init`; see {@link ShutdownContext}) —
+ * then invokes it under a bounded timeout so a hook that hangs can't block
+ * teardown (e.g. the `rmSync` a managed uninstall runs next). No-op when the
+ * owner defines no `shutdown`. Best-effort: a thrown, timed-out, or malformed
+ * shutdown is logged and swallowed.
  */
-export async function runShutdownHook(
+export async function runOwnerShutdown(
   kind: HookOwnerKind,
-  ownerName: string,
-  context: ShutdownContext,
-  reason: string,
-): Promise<void> {
-  const entry = hookCache.get(hookKey(kind, ownerName, HOOKS.SHUTDOWN));
-  if (entry === undefined) {
-    return;
-  }
-  const shutdown = await entry;
-  if (shutdown === null) {
-    return;
-  }
-
-  await invokeShutdown(shutdown, context, ownerName, reason);
-}
-
-/**
- * Resolve an owner's `shutdown` fresh from `hooksDir` and run it — the targeted
- * single-owner teardown for a **managed uninstall** (run before the directory is
- * removed) or a **disable** (directory still present). Resolves from disk rather
- * than the cache so it doesn't depend on the daemon having warmed anything, and
- * so it works in any process — the CLI's uninstall and the daemon's route both
- * call it (a `shutdown` hook must not assume it runs in the same process as its
- * `init`; see {@link ShutdownContext}). No-op when the owner defines no
- * `shutdown`. Best-effort: a thrown or malformed shutdown is logged and
- * swallowed.
- */
-export async function runShutdownHookFromDisk(
   hooksDir: string,
   ownerName: string,
   reason: ShutdownContext["reason"],
 ): Promise<void> {
-  const file = listSurfaceDir(hooksDir).find((f) => f.name === HOOKS.SHUTDOWN);
-  if (file === undefined) {
+  const shutdown = await resolveHook(kind, hooksDir, ownerName, HOOKS.SHUTDOWN);
+  if (shutdown === null) {
     return;
   }
-  evictModule(file.path);
-  let shutdown: HookFunction | undefined;
+  const context: ShutdownContext = { assistantVersion: APP_VERSION, reason };
   try {
-    shutdown = await importWithTimeout<HookFunction>(file.path);
-  } catch (err) {
-    log.warn(
-      { err, plugin: ownerName, path: file.path },
-      "failed to import shutdown hook for teardown (continuing)",
+    await withTimeout(
+      Promise.resolve(shutdown(context)),
+      SHUTDOWN_TIMEOUT_MS,
+      `shutdown hook for ${ownerName} exceeded ${SHUTDOWN_TIMEOUT_MS}ms`,
     );
-    return;
-  }
-  if (typeof shutdown !== "function") {
-    log.error(
-      { plugin: ownerName, path: file.path },
-      `shutdown default export must be a function (got ${typeof shutdown}) — skipping`,
-    );
-    return;
-  }
-  await invokeShutdown(
-    shutdown,
-    { assistantVersion: APP_VERSION, reason },
-    ownerName,
-    reason,
-  );
-}
-
-/** Run a resolved shutdown function, logging and swallowing any throw. */
-async function invokeShutdown(
-  shutdown: HookFunction,
-  context: ShutdownContext,
-  ownerName: string,
-  reason: string,
-): Promise<void> {
-  try {
-    await shutdown(context);
   } catch (err) {
     log.warn(
       { err, plugin: ownerName, reason },
-      "user hooks shutdown failed (continuing)",
+      "user hooks shutdown failed or timed out (continuing)",
     );
   }
+}
+
+/**
+ * Reject after `ms` if `p` hasn't settled. The losing promise is abandoned, not
+ * cancelled — the caller must treat a timeout as best-effort.
+ */
+function withTimeout<T>(
+  p: Promise<T>,
+  ms: number,
+  message: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), ms);
+    p.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
 }
 
 /**

--- a/assistant/src/hooks/hook-loader.ts
+++ b/assistant/src/hooks/hook-loader.ts
@@ -279,15 +279,12 @@ export function hasWorkspaceHooks(): boolean {
 }
 
 /**
- * Run the `init` hook for `ownerName` if the owner defines one. Resolves the
- * owner's `shutdown` first — while the directory is still present — so it's
- * cached for teardown even after an uninstall removes the directory, then
- * resolves and runs `init`. `init` can't ride the whole-chain `runHook` the way
- * dispatch hooks do because its context is per-plugin (config, logger, storage
- * dir), so it's dispatched per-owner here. Shared by user plugins and
- * standalone workspace hooks so both get the same init-context shape and
- * per-owner isolation (a thrown `init` is logged and swallowed, never blocking
- * boot).
+ * Run the `init` hook for `ownerName` if the owner defines one. `init` can't
+ * ride the whole-chain `runHook` the way dispatch hooks do because its context
+ * is per-plugin (config, logger, storage dir), so it's dispatched per-owner
+ * here. Shared by user plugins and standalone workspace hooks so both get the
+ * same init-context shape and per-owner isolation (a thrown `init` is logged and
+ * swallowed, never blocking boot).
  *
  * For user plugins, `pluginDir` is the absolute path to the installed plugin
  * directory (`<workspace>/plugins/<name>/`). Config and data now live inside
@@ -312,11 +309,6 @@ export async function runInitHook(
   const kind: HookOwnerKind = pluginDir === null ? "workspace" : "plugin";
   const hooksDir = ownerHooksDir(pluginDir);
 
-  // Resolve `shutdown` now, while the directory is present, so it's cached for
-  // teardown even after an uninstall removes the directory (runShutdownHook
-  // reads the cache, never disk). The result is discarded here — this is a warm.
-  await resolveHook(kind, hooksDir, ownerName, HOOKS.SHUTDOWN);
-
   const initHook = await resolveHook(kind, hooksDir, ownerName, HOOKS.INIT);
   if (initHook === null) {
     return;
@@ -340,13 +332,15 @@ export async function runInitHook(
 }
 
 /**
- * Run one owner's `shutdown` hook from the cache — the targeted single-owner
- * teardown for a runtime uninstall / disable / reload (the whole-chain
- * `runHook(HOOKS.SHUTDOWN)` at process exit runs *every* owner's shutdown; this
- * runs exactly one). The reconcile tears an owner down before evicting it, so
- * the `shutdown` cached at activation is still resident here even when the
- * directory is already gone. Best-effort: a thrown shutdown is logged and
- * swallowed. `reason` is threaded into the log for attribution only.
+ * Run one owner's `shutdown` from the cache if it's already resolved — the
+ * best-effort teardown used on **reload**, where disk already holds the *new*
+ * version so the old one can only come from a prior resolution. When it isn't
+ * cached, this is a no-op: under the no-cross-invocation-state contract (see
+ * {@link ShutdownContext}) the new `init` reconstructs from the filesystem, so a
+ * missed old-`shutdown` is benign. For teardown where the current on-disk
+ * version is the right one to run (uninstall, disable), use
+ * {@link runShutdownHookFromDisk} instead. Best-effort: a thrown shutdown is
+ * logged and swallowed; `reason` is threaded into the log for attribution only.
  */
 export async function runShutdownHook(
   kind: HookOwnerKind,
@@ -354,8 +348,6 @@ export async function runShutdownHook(
   context: ShutdownContext,
   reason: string,
 ): Promise<void> {
-  // Read from the cache (resolved at activation, while the directory existed) —
-  // never re-resolve here, since an uninstall may have already removed it.
   const entry = hookCache.get(hookKey(kind, ownerName, HOOKS.SHUTDOWN));
   if (entry === undefined) {
     return;
@@ -365,6 +357,62 @@ export async function runShutdownHook(
     return;
   }
 
+  await invokeShutdown(shutdown, context, ownerName, reason);
+}
+
+/**
+ * Resolve an owner's `shutdown` fresh from `hooksDir` and run it — the targeted
+ * single-owner teardown for a **managed uninstall** (run before the directory is
+ * removed) or a **disable** (directory still present). Resolves from disk rather
+ * than the cache so it doesn't depend on the daemon having warmed anything, and
+ * so it works in any process — the CLI's uninstall and the daemon's route both
+ * call it (a `shutdown` hook must not assume it runs in the same process as its
+ * `init`; see {@link ShutdownContext}). No-op when the owner defines no
+ * `shutdown`. Best-effort: a thrown or malformed shutdown is logged and
+ * swallowed.
+ */
+export async function runShutdownHookFromDisk(
+  hooksDir: string,
+  ownerName: string,
+  reason: ShutdownContext["reason"],
+): Promise<void> {
+  const file = listSurfaceDir(hooksDir).find((f) => f.name === HOOKS.SHUTDOWN);
+  if (file === undefined) {
+    return;
+  }
+  evictModule(file.path);
+  let shutdown: HookFunction | undefined;
+  try {
+    shutdown = await importWithTimeout<HookFunction>(file.path);
+  } catch (err) {
+    log.warn(
+      { err, plugin: ownerName, path: file.path },
+      "failed to import shutdown hook for teardown (continuing)",
+    );
+    return;
+  }
+  if (typeof shutdown !== "function") {
+    log.error(
+      { plugin: ownerName, path: file.path },
+      `shutdown default export must be a function (got ${typeof shutdown}) — skipping`,
+    );
+    return;
+  }
+  await invokeShutdown(
+    shutdown,
+    { assistantVersion: APP_VERSION, reason },
+    ownerName,
+    reason,
+  );
+}
+
+/** Run a resolved shutdown function, logging and swallowing any throw. */
+async function invokeShutdown(
+  shutdown: HookFunction,
+  context: ShutdownContext,
+  ownerName: string,
+  reason: string,
+): Promise<void> {
   try {
     await shutdown(context);
   } catch (err) {

--- a/assistant/src/hooks/hook-loader.ts
+++ b/assistant/src/hooks/hook-loader.ts
@@ -29,7 +29,7 @@
  *   {@link collectUserHookEntries}, which resolves that one hook name across the
  *   discovered owners; repeat reads are pure map lookups.
  * - **Lifecycle hooks** run once per activation / teardown. {@link runInitHook}
- *   resolves and runs `init`; {@link runOwnerShutdown} resolves and runs one
+ *   resolves and runs `init`; {@link runShutdownHook} resolves and runs one
  *   owner's `shutdown` for a targeted teardown (uninstall, disable, reload).
  *   Both go through the same resolution, so nothing is pre-warmed.
  *
@@ -63,10 +63,18 @@ import type {
   ShutdownContext,
 } from "../plugin-api/types.js";
 import { listSurfaceDir } from "../plugins/external-plugin-loader.js";
-import { evictModule, importWithTimeout } from "../plugins/surface-import.js";
+import {
+  evictModule,
+  importWithTimeout,
+  withTimeout,
+} from "../plugins/surface-import.js";
 import type { HookEntry } from "../plugins/types.js";
 import { getLogger } from "../util/logger.js";
-import { getWorkspaceDir, getWorkspaceHooksDir } from "../util/platform.js";
+import {
+  getWorkspaceDir,
+  getWorkspaceHooksDir,
+  getWorkspacePluginsDir,
+} from "../util/platform.js";
 import { APP_VERSION } from "../version.js";
 
 const log = getLogger("hook-loader");
@@ -119,12 +127,21 @@ function ownerKeyPrefix(kind: HookOwnerKind, ownerName: string): string {
 }
 
 /**
- * The hooks directory for an owner: `<pluginDir>/hooks` for a plugin, or the
- * standalone workspace hooks directory for {@link WORKSPACE_HOOKS_OWNER}
- * (whose `pluginDir` is `null`).
+ * The hooks directory an owner's hooks are resolved from, derived purely from
+ * `(kind, ownerName)`:
+ *
+ * - `workspace` → the standalone workspace hooks directory.
+ * - `plugin` → `<workspace>/plugins/<ownerName>/hooks`.
+ *
+ * A plugin's install slug *is* its manifest name (the installer enforces
+ * `manifest.name === <install dir basename>`; see
+ * `cli/lib/install-from-github.ts`), so the directory is a function of the name
+ * alone — no caller needs to thread the plugin directory in.
  */
-function ownerHooksDir(pluginDir: string | null): string {
-  return pluginDir === null ? getWorkspaceHooksDir() : join(pluginDir, "hooks");
+function ownerHooksDir(kind: HookOwnerKind, ownerName: string): string {
+  return kind === "workspace"
+    ? getWorkspaceHooksDir()
+    : join(getWorkspacePluginsDir(), ownerName, "hooks");
 }
 
 /**
@@ -135,18 +152,21 @@ function ownerHooksDir(pluginDir: string | null): string {
  * negative cache entry so an absent hook is looked up once, not every dispatch.
  * This is the single point where hook code enters the process, shared by
  * dispatch reads ({@link collectUserHookEntries}) and lifecycle runs
- * ({@link runInitHook} / {@link runOwnerShutdown}).
+ * ({@link runInitHook} / {@link runShutdownHook}).
+ *
+ * The owner's hooks directory is derived from `(kind, ownerName)` via
+ * {@link ownerHooksDir} — callers pass only what identifies the owner, never
+ * the directory.
  */
 function resolveHook(
   kind: HookOwnerKind,
-  hooksDir: string,
   ownerName: string,
   hookName: string,
 ): Promise<HookFunction | null> {
   const key = hookKey(kind, ownerName, hookName);
   let entry = hookCache.get(key);
   if (entry === undefined) {
-    entry = importHook(hooksDir, ownerName, hookName);
+    entry = importHook(ownerHooksDir(kind, ownerName), ownerName, hookName);
     hookCache.set(key, entry);
   }
   return entry;
@@ -200,12 +220,13 @@ async function importHook(
  * evicted — is a pure map lookup. Owners without the hook contribute nothing
  * (their negative cache entry keeps them from being re-stat'd).
  *
- * `pluginDirs` is the orchestrator's discovered `[dir, ownerName]` set (in
- * install-date order). Each plugin's hook runs first, then the standalone
- * workspace hook runs last — so a plugin can shape the threaded context
- * before a workspace-wide hook observes or finalizes it. Resolutions are kicked
- * off together and awaited in that order, so a cold first read imports the
- * owners' files concurrently without disturbing chain order.
+ * `pluginNames` is the orchestrator's discovered plugin names, in install-date
+ * order. Each plugin's hook runs first, then the standalone workspace hook runs
+ * last — so a plugin can shape the threaded context before a workspace-wide hook
+ * observes or finalizes it. Resolutions are kicked off together and awaited in
+ * that order, so a cold first read imports the owners' files concurrently
+ * without disturbing chain order. Each owner's hooks directory is derived from
+ * its name by {@link resolveHook}, so discovery passes names, not directories.
  *
  * Added, removed, and edited hook files (including helper modules they import)
  * land when the source-versions reconcile evicts the owner and the next read
@@ -219,7 +240,7 @@ async function importHook(
  */
 export async function collectUserHookEntries<TCtx = unknown>(
   hookName: string,
-  pluginDirs: Iterable<readonly [string, string]>,
+  pluginNames: Iterable<string>,
   effectiveEnabledPlugins?: Set<string> | null,
 ): Promise<HookEntry<TCtx>[]> {
   const pending: Array<{
@@ -227,7 +248,7 @@ export async function collectUserHookEntries<TCtx = unknown>(
     hook: Promise<HookFunction | null>;
   }> = [];
 
-  for (const [pluginDir, pluginName] of pluginDirs) {
+  for (const pluginName of pluginNames) {
     if (
       effectiveEnabledPlugins != null &&
       !effectiveEnabledPlugins.has(pluginName)
@@ -236,12 +257,7 @@ export async function collectUserHookEntries<TCtx = unknown>(
     }
     pending.push({
       owner: { kind: "plugin", id: pluginName },
-      hook: resolveHook(
-        "plugin",
-        ownerHooksDir(pluginDir),
-        pluginName,
-        hookName,
-      ),
+      hook: resolveHook("plugin", pluginName, hookName),
     });
   }
 
@@ -249,12 +265,7 @@ export async function collectUserHookEntries<TCtx = unknown>(
   // that are not part of any plugin (no package.json, no tools — just hooks).
   pending.push({
     owner: { kind: "workspace", id: WORKSPACE_HOOKS_OWNER },
-    hook: resolveHook(
-      "workspace",
-      ownerHooksDir(null),
-      WORKSPACE_HOOKS_OWNER,
-      hookName,
-    ),
+    hook: resolveHook("workspace", WORKSPACE_HOOKS_OWNER, hookName),
   });
 
   const out: HookEntry<TCtx>[] = [];
@@ -305,9 +316,8 @@ export async function runInitHook(
 ): Promise<void> {
   // A plugin always has a directory; only the workspace owner passes `null`.
   const kind: HookOwnerKind = pluginDir === null ? "workspace" : "plugin";
-  const hooksDir = ownerHooksDir(pluginDir);
 
-  const initHook = await resolveHook(kind, hooksDir, ownerName, HOOKS.INIT);
+  const initHook = await resolveHook(kind, ownerName, HOOKS.INIT);
   if (initHook === null) {
     return;
   }
@@ -339,18 +349,17 @@ const SHUTDOWN_TIMEOUT_MS = 5_000;
  * the same {@link resolveHook} the dispatch path uses — cache or disk, so it
  * needs nothing pre-warmed and works in any process (a `shutdown` hook must not
  * assume it shares a process with its `init`; see {@link ShutdownContext}) —
- * then invokes it under a bounded timeout so a hook that hangs can't block
- * teardown (e.g. the `rmSync` a managed uninstall runs next). No-op when the
- * owner defines no `shutdown`. Best-effort: a thrown, timed-out, or malformed
- * shutdown is logged and swallowed.
+ * then invokes it under the shared {@link withTimeout} so a hook that hangs
+ * can't block teardown (e.g. the `rmSync` a managed uninstall runs next). No-op
+ * when the owner defines no `shutdown`. Best-effort: a thrown, timed-out, or
+ * malformed shutdown is logged and swallowed.
  */
-export async function runOwnerShutdown(
+export async function runShutdownHook(
   kind: HookOwnerKind,
-  hooksDir: string,
   ownerName: string,
   reason: ShutdownContext["reason"],
 ): Promise<void> {
-  const shutdown = await resolveHook(kind, hooksDir, ownerName, HOOKS.SHUTDOWN);
+  const shutdown = await resolveHook(kind, ownerName, HOOKS.SHUTDOWN);
   if (shutdown === null) {
     return;
   }
@@ -367,30 +376,6 @@ export async function runOwnerShutdown(
       "user hooks shutdown failed or timed out (continuing)",
     );
   }
-}
-
-/**
- * Reject after `ms` if `p` hasn't settled. The losing promise is abandoned, not
- * cancelled — the caller must treat a timeout as best-effort.
- */
-function withTimeout<T>(
-  p: Promise<T>,
-  ms: number,
-  message: string,
-): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error(message)), ms);
-    p.then(
-      (value) => {
-        clearTimeout(timer);
-        resolve(value);
-      },
-      (err) => {
-        clearTimeout(timer);
-        reject(err);
-      },
-    );
-  });
 }
 
 /**

--- a/assistant/src/plugin-api/types.ts
+++ b/assistant/src/plugin-api/types.ts
@@ -135,8 +135,10 @@ export interface ModelProfileInfo {
  * - `disable` — the plugin was disabled at runtime (e.g. a `.disabled`
  *   sentinel was added, or a feature flag turned it off).
  * - `reload` — a source file inside the plugin directory changed and the
- *   plugin is being redeployed in place; the old version's `shutdown` runs
- *   before the new version is imported and its `init` fires.
+ *   plugin is being redeployed in place. Best-effort: the new version is
+ *   already on disk by the time the change is detected, so the old version's
+ *   `shutdown` runs only if it was still resident from an earlier resolution;
+ *   don't rely on it firing.
  */
 export type ShutdownReason = "shutdown" | "uninstall" | "disable" | "reload";
 
@@ -151,6 +153,13 @@ export type ShutdownReason = "shutdown" | "uninstall" | "disable" | "reload";
  * The `assistantVersion` field mirrors the init context's so plugins that stash
  * a version stamp at init can compare against the same name on tear-down
  * without keeping their own copy.
+ *
+ * **`shutdown` may run in a different process than `init`.** A managed
+ * `uninstall` runs it in whichever process performs the removal (the CLI or the
+ * daemon), which is not necessarily the daemon process that ran `init`. Do not
+ * close over in-memory state established at `init` (open handles, timers,
+ * module-level singletons) and expect to tear it down here — reconstruct
+ * anything you need from the plugin's config and `data/` directory instead.
  */
 export interface ShutdownContext {
   /** Assistant semver for compatibility checks inside the plugin. */

--- a/assistant/src/plugin-api/types.ts
+++ b/assistant/src/plugin-api/types.ts
@@ -135,10 +135,10 @@ export interface ModelProfileInfo {
  * - `disable` — the plugin was disabled at runtime (e.g. a `.disabled`
  *   sentinel was added, or a feature flag turned it off).
  * - `reload` — a source file inside the plugin directory changed and the
- *   plugin is being redeployed in place. Best-effort: the new version is
- *   already on disk by the time the change is detected, so the old version's
- *   `shutdown` runs only if it was still resident from an earlier resolution;
- *   don't rely on it firing.
+ *   plugin is being redeployed in place; `shutdown` runs before the new version
+ *   is imported and its `init` fires. Note the `shutdown` that runs is the one
+ *   currently on disk, which is the previous version *unless* the edit was to
+ *   `shutdown` itself.
  */
 export type ShutdownReason = "shutdown" | "uninstall" | "disable" | "reload";
 

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -16,13 +16,12 @@
  *   — including helper modules hooks/tools import) arrives through the
  *   source-versions sentinel published by the resource monitor's watcher.
  *   The dispatch path stats that one file and otherwise runs on memory.
- * - A changed plugin is redeployed in place: the old version's `shutdown`
- *   runs best-effort (only if it was already resolved — disk holds the new
- *   version by then), its hook/tool cache entries and module-registry entries
- *   are swept, and reactivation runs `init`; the next read of each hook
- *   re-resolves it from the swept-clean registry. The whole directory is the
- *   reload unit (every module path is swept) so a re-imported hook can never
- *   pair with a stale cached helper.
+ * - A changed plugin is redeployed in place: its `shutdown` runs (resolved
+ *   from disk), its hook/tool cache entries and module-registry entries are
+ *   swept, and reactivation runs `init`; the next read of each hook re-resolves
+ *   it from the swept-clean registry. The whole directory is the reload unit
+ *   (every module path is swept) so a re-imported hook can never pair with a
+ *   stale cached helper.
  * - Plugins are never "registered" as a unit — we register their tools into
  *   the global tool registry.
  *
@@ -48,8 +47,7 @@ import {
   type HookOwnerKind,
   resetHookCacheForTests,
   runInitHook,
-  runShutdownHook,
-  runShutdownHookFromDisk,
+  runOwnerShutdown,
   WORKSPACE_HOOKS_OWNER,
 } from "../hooks/hook-loader.js";
 import type { HookFunction, ShutdownReason } from "../plugin-api/types.js";
@@ -64,7 +62,6 @@ import {
   getWorkspaceHooksDir,
   getWorkspacePluginsDir,
 } from "../util/platform.js";
-import { APP_VERSION } from "../version.js";
 import {
   deriveToolName,
   listSurfaceDir,
@@ -346,9 +343,9 @@ function isAllowedPluginDir(
  * is logged and the next publication retries from the sentinel's truth.
  *
  * Per directory, the transitions are:
- * - present + enabled with a moved fingerprint → in-place redeploy: old
- *   `shutdown` (reason `reload`, best-effort) → sweep hook/tool caches and the
- *   module registry → re-import, re-register tools, `init`. The whole directory
+ * - present + enabled with a moved fingerprint → in-place redeploy:
+ *   `shutdown` (reason `reload`) → sweep hook/tool caches and the module
+ *   registry → re-import, re-register tools, `init`. The whole directory
  *   is the reload unit on purpose: partial eviction would let a re-imported
  *   hook pair with a stale cached helper, silently mixing versions.
  * - newly present (installed, or `.disabled` removed) → bring up.
@@ -412,10 +409,9 @@ async function applySourceVersions(
           { plugin: activeName, dir },
           "plugin source changed — reloading",
         );
-        // Tear the old version down first: `deactivatePlugin` runs the old
-        // `shutdown` best-effort (disk already holds the new version), then
-        // `evictHooksForOwner` drops the owner's cached resolutions so the next
-        // read re-resolves fresh.
+        // Tear the old version down first: `deactivatePlugin` runs `shutdown`,
+        // then `evictHooksForOwner` drops the owner's cached resolutions so the
+        // next read re-resolves fresh.
         await deactivatePlugin(activeName, dir, "reload");
         evictHooksForOwner("plugin", activeName);
         evictToolCacheEntries(activeName);
@@ -510,10 +506,10 @@ async function reconcileWorkspaceHooks(
     (p) => p.kind === "workspace" && p.name === WORKSPACE_HOOKS_OWNER,
   );
   if (activeIdx >= 0) {
-    await runShutdownHook(
+    await runOwnerShutdown(
       "workspace",
+      getWorkspaceHooksDir(),
       WORKSPACE_HOOKS_OWNER,
-      { assistantVersion: APP_VERSION, reason },
       reason,
     );
     activatedPlugins.splice(activeIdx, 1);
@@ -899,14 +895,11 @@ async function activatePlugin(
  * `shutdown` hook. Must run *before* `evictPlugin` / `evictHooksForOwner` clear
  * the owner's cache. Idempotent — a plugin that was never activated is a no-op.
  *
- * How `shutdown` is resolved depends on the reason:
- * - `disable` — the directory is still present, so resolve and run the current
- *   on-disk version ({@link runShutdownHookFromDisk}).
- * - `reload` — disk already holds the *new* version, so the old one can only
- *   come from the cache; run it best-effort ({@link runShutdownHook}).
- * - `uninstall` — a managed uninstall runs `shutdown` from disk *before*
- *   removing the directory (see `cli/lib/uninstall-plugin.ts`), and an
- *   out-of-band `rm` leaves nothing to resolve, so there is nothing to run here.
+ * `disable` and `reload` keep the directory present, so {@link runOwnerShutdown}
+ * resolves and runs the on-disk `shutdown` (via the same resolution the dispatch
+ * path uses). `uninstall` runs nothing here: a managed uninstall runs `shutdown`
+ * *before* removing the directory (see `cli/lib/uninstall-plugin.ts`), and an
+ * out-of-band `rm` leaves nothing to resolve.
  */
 async function deactivatePlugin(
   pluginName: string,
@@ -935,13 +928,11 @@ async function deactivatePlugin(
     );
   }
 
-  if (reason === "disable") {
-    await runShutdownHookFromDisk(join(pluginDir, "hooks"), pluginName, reason);
-  } else if (reason === "reload") {
-    await runShutdownHook(
+  if (reason !== "uninstall") {
+    await runOwnerShutdown(
       "plugin",
+      join(pluginDir, "hooks"),
       pluginName,
-      { assistantVersion: APP_VERSION, reason },
       reason,
     );
   }

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -17,11 +17,12 @@
  *   source-versions sentinel published by the resource monitor's watcher.
  *   The dispatch path stats that one file and otherwise runs on memory.
  * - A changed plugin is redeployed in place: the old version's `shutdown`
- *   runs, its hook/tool cache entries and module-registry entries are
- *   swept, and reactivation runs `init`; the next read of each hook re-resolves
- *   it from the swept-clean registry. The whole directory is the reload unit
- *   (every module path is swept) so a re-imported hook can never pair with a
- *   stale cached helper.
+ *   runs best-effort (only if it was already resolved — disk holds the new
+ *   version by then), its hook/tool cache entries and module-registry entries
+ *   are swept, and reactivation runs `init`; the next read of each hook
+ *   re-resolves it from the swept-clean registry. The whole directory is the
+ *   reload unit (every module path is swept) so a re-imported hook can never
+ *   pair with a stale cached helper.
  * - Plugins are never "registered" as a unit — we register their tools into
  *   the global tool registry.
  *
@@ -30,7 +31,13 @@
  * each hook through the hook loader on demand.
  */
 
-import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
 import { join } from "node:path";
 
 import {
@@ -42,6 +49,7 @@ import {
   resetHookCacheForTests,
   runInitHook,
   runShutdownHook,
+  runShutdownHookFromDisk,
   WORKSPACE_HOOKS_OWNER,
 } from "../hooks/hook-loader.js";
 import type { HookFunction, ShutdownReason } from "../plugin-api/types.js";
@@ -307,7 +315,11 @@ async function maybeReconcileFromSentinel(): Promise<void> {
  * symlinked path that looks like it's under the plugins dir but points
  * elsewhere is rejected.
  */
-function isAllowedPluginDir(dir: string, pluginsDir: string, hooksDir: string): boolean {
+function isAllowedPluginDir(
+  dir: string,
+  pluginsDir: string,
+  hooksDir: string,
+): boolean {
   let resolved: string;
   try {
     resolved = realpathSync(dir);
@@ -334,13 +346,15 @@ function isAllowedPluginDir(dir: string, pluginsDir: string, hooksDir: string): 
  * is logged and the next publication retries from the sentinel's truth.
  *
  * Per directory, the transitions are:
- * - present + enabled with a moved fingerprint → in-place redeploy:
- *   `shutdown` (reason `reload`) → sweep hook/tool caches and the module
- *   registry → re-import, re-register tools, `init`. The whole directory is
- *   the reload unit on purpose: partial eviction would let a re-imported
+ * - present + enabled with a moved fingerprint → in-place redeploy: old
+ *   `shutdown` (reason `reload`, best-effort) → sweep hook/tool caches and the
+ *   module registry → re-import, re-register tools, `init`. The whole directory
+ *   is the reload unit on purpose: partial eviction would let a re-imported
  *   hook pair with a stale cached helper, silently mixing versions.
  * - newly present (installed, or `.disabled` removed) → bring up.
- * - gone, or newly disabled → tear down (`uninstall` / `disable`).
+ * - gone → tear down (`uninstall`; `shutdown` already ran at removal time or the
+ *   directory is gone, so none runs here) or newly disabled → tear down
+ *   (`disable`, resolving `shutdown` from the still-present directory).
  * The workspace hooks pseudo-entry gets the same treatment through its own
  * `init`/`shutdown` lifecycle.
  */
@@ -377,7 +391,7 @@ async function applySourceVersions(
       if (activeName !== undefined && !shouldBeUp) {
         const reason: ShutdownReason =
           after === undefined ? "uninstall" : "disable";
-        await deactivatePlugin(activeName, reason);
+        await deactivatePlugin(activeName, dir, reason);
         await evictPlugin(dir, activeName);
         sweepModules(before, after);
         membershipChanged = true;
@@ -398,10 +412,11 @@ async function applySourceVersions(
           { plugin: activeName, dir },
           "plugin source changed — reloading",
         );
-        // Tear the old version down first: `deactivatePlugin` runs the
-        // still-cached `shutdown`, then `evictHooksForOwner` drops the owner's
-        // cached resolutions so the next read re-resolves fresh.
-        await deactivatePlugin(activeName, "reload");
+        // Tear the old version down first: `deactivatePlugin` runs the old
+        // `shutdown` best-effort (disk already holds the new version), then
+        // `evictHooksForOwner` drops the owner's cached resolutions so the next
+        // read re-resolves fresh.
+        await deactivatePlugin(activeName, dir, "reload");
         evictHooksForOwner("plugin", activeName);
         evictToolCacheEntries(activeName);
         sweepModules(before, after);
@@ -684,7 +699,7 @@ async function scanPlugins(): Promise<void> {
       const manifest = await parsePluginManifest(pluginDir);
       const pluginName = manifest?.name ?? entry;
       if (discoveredPluginDirs.has(pluginDir)) {
-        await deactivatePlugin(pluginName, "disable");
+        await deactivatePlugin(pluginName, pluginDir, "disable");
         await evictPlugin(pluginDir, pluginName);
       }
       if (!disabledPluginDirs.has(pluginDir)) {
@@ -717,7 +732,7 @@ async function scanPlugins(): Promise<void> {
   // Deactivate and evict cache entries for deleted plugins.
   for (const [pluginDir, pluginName] of discoveredPluginDirs) {
     if (!currentDirs.has(pluginDir)) {
-      await deactivatePlugin(pluginName, "uninstall");
+      await deactivatePlugin(pluginName, pluginDir, "uninstall");
       await evictPlugin(pluginDir, pluginName);
     }
   }
@@ -879,14 +894,23 @@ async function activatePlugin(
 }
 
 /**
- * Deactivate a plugin whose directory was removed (`uninstall`) or disabled
- * (`disable`) at runtime: unregister its tools and run its `shutdown` hook with
- * the matching {@link ShutdownReason}. Must run *before* `evictPlugin` /
- * `evictHooksForOwner` clear the owner's cache, since the `shutdown` hook is
- * read from it. Idempotent — a plugin that was never activated is a no-op.
+ * Deactivate a plugin that was disabled (`disable`), removed (`uninstall`), or
+ * is being redeployed (`reload`) at runtime: unregister its tools and run its
+ * `shutdown` hook. Must run *before* `evictPlugin` / `evictHooksForOwner` clear
+ * the owner's cache. Idempotent — a plugin that was never activated is a no-op.
+ *
+ * How `shutdown` is resolved depends on the reason:
+ * - `disable` — the directory is still present, so resolve and run the current
+ *   on-disk version ({@link runShutdownHookFromDisk}).
+ * - `reload` — disk already holds the *new* version, so the old one can only
+ *   come from the cache; run it best-effort ({@link runShutdownHook}).
+ * - `uninstall` — a managed uninstall runs `shutdown` from disk *before*
+ *   removing the directory (see `cli/lib/uninstall-plugin.ts`), and an
+ *   out-of-band `rm` leaves nothing to resolve, so there is nothing to run here.
  */
 async function deactivatePlugin(
   pluginName: string,
+  pluginDir: string,
   reason: ShutdownReason,
 ): Promise<void> {
   if (!activatedNames.has(pluginName)) {
@@ -911,12 +935,16 @@ async function deactivatePlugin(
     );
   }
 
-  await runShutdownHook(
-    "plugin",
-    pluginName,
-    { assistantVersion: APP_VERSION, reason },
-    reason,
-  );
+  if (reason === "disable") {
+    await runShutdownHookFromDisk(join(pluginDir, "hooks"), pluginName, reason);
+  } else if (reason === "reload") {
+    await runShutdownHook(
+      "plugin",
+      pluginName,
+      { assistantVersion: APP_VERSION, reason },
+      reason,
+    );
+  }
 }
 
 // ─── Boot population ─────────────────────────────────────────────────────────

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -47,7 +47,7 @@ import {
   type HookOwnerKind,
   resetHookCacheForTests,
   runInitHook,
-  runOwnerShutdown,
+  runShutdownHook,
   WORKSPACE_HOOKS_OWNER,
 } from "../hooks/hook-loader.js";
 import type { HookFunction, ShutdownReason } from "../plugin-api/types.js";
@@ -233,7 +233,7 @@ export async function getUserHookEntriesFor<TCtx = unknown>(
   await maybeReconcileFromSentinel();
   return collectUserHookEntries<TCtx>(
     hookName,
-    discoveredPluginDirs,
+    discoveredPluginDirs.values(),
     effectiveEnabledPlugins,
   );
 }
@@ -388,7 +388,7 @@ async function applySourceVersions(
       if (activeName !== undefined && !shouldBeUp) {
         const reason: ShutdownReason =
           after === undefined ? "uninstall" : "disable";
-        await deactivatePlugin(activeName, dir, reason);
+        await deactivatePlugin(activeName, reason);
         await evictPlugin(dir, activeName);
         sweepModules(before, after);
         membershipChanged = true;
@@ -412,7 +412,7 @@ async function applySourceVersions(
         // Tear the old version down first: `deactivatePlugin` runs `shutdown`,
         // then `evictHooksForOwner` drops the owner's cached resolutions so the
         // next read re-resolves fresh.
-        await deactivatePlugin(activeName, dir, "reload");
+        await deactivatePlugin(activeName, "reload");
         evictHooksForOwner("plugin", activeName);
         evictToolCacheEntries(activeName);
         sweepModules(before, after);
@@ -506,12 +506,7 @@ async function reconcileWorkspaceHooks(
     (p) => p.kind === "workspace" && p.name === WORKSPACE_HOOKS_OWNER,
   );
   if (activeIdx >= 0) {
-    await runOwnerShutdown(
-      "workspace",
-      getWorkspaceHooksDir(),
-      WORKSPACE_HOOKS_OWNER,
-      reason,
-    );
+    await runShutdownHook("workspace", WORKSPACE_HOOKS_OWNER, reason);
     activatedPlugins.splice(activeIdx, 1);
   }
   evictHooksForOwner("workspace", WORKSPACE_HOOKS_OWNER);
@@ -695,7 +690,7 @@ async function scanPlugins(): Promise<void> {
       const manifest = await parsePluginManifest(pluginDir);
       const pluginName = manifest?.name ?? entry;
       if (discoveredPluginDirs.has(pluginDir)) {
-        await deactivatePlugin(pluginName, pluginDir, "disable");
+        await deactivatePlugin(pluginName, "disable");
         await evictPlugin(pluginDir, pluginName);
       }
       if (!disabledPluginDirs.has(pluginDir)) {
@@ -728,7 +723,7 @@ async function scanPlugins(): Promise<void> {
   // Deactivate and evict cache entries for deleted plugins.
   for (const [pluginDir, pluginName] of discoveredPluginDirs) {
     if (!currentDirs.has(pluginDir)) {
-      await deactivatePlugin(pluginName, pluginDir, "uninstall");
+      await deactivatePlugin(pluginName, "uninstall");
       await evictPlugin(pluginDir, pluginName);
     }
   }
@@ -895,7 +890,7 @@ async function activatePlugin(
  * `shutdown` hook. Must run *before* `evictPlugin` / `evictHooksForOwner` clear
  * the owner's cache. Idempotent — a plugin that was never activated is a no-op.
  *
- * `disable` and `reload` keep the directory present, so {@link runOwnerShutdown}
+ * `disable` and `reload` keep the directory present, so {@link runShutdownHook}
  * resolves and runs the on-disk `shutdown` (via the same resolution the dispatch
  * path uses). `uninstall` runs nothing here: a managed uninstall runs `shutdown`
  * *before* removing the directory (see `cli/lib/uninstall-plugin.ts`), and an
@@ -903,7 +898,6 @@ async function activatePlugin(
  */
 async function deactivatePlugin(
   pluginName: string,
-  pluginDir: string,
   reason: ShutdownReason,
 ): Promise<void> {
   if (!activatedNames.has(pluginName)) {
@@ -929,12 +923,7 @@ async function deactivatePlugin(
   }
 
   if (reason !== "uninstall") {
-    await runOwnerShutdown(
-      "plugin",
-      join(pluginDir, "hooks"),
-      pluginName,
-      reason,
-    );
+    await runShutdownHook("plugin", pluginName, reason);
   }
 }
 

--- a/assistant/src/plugins/surface-import.ts
+++ b/assistant/src/plugins/surface-import.ts
@@ -71,6 +71,47 @@ export function evictModule(filePath: string): void {
 }
 
 /**
+ * Error a {@link withTimeout} race rejects with when the deadline wins. Named
+ * so callers that time-box user code can tell "the wrapped promise took too
+ * long" apart from "the wrapped promise itself rejected".
+ */
+export class TimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TimeoutError";
+  }
+}
+
+/**
+ * Reject with a {@link TimeoutError} after `ms` if `p` hasn't settled. The
+ * losing promise is abandoned, not cancelled — the caller must treat a timeout
+ * as best-effort and swallow any late rejection from the abandoned promise.
+ *
+ * This is the one place surface paths time-box user code: the surface import
+ * itself ({@link importWithTimeout}) and the hook runner's `shutdown`
+ * invocation both wrap through here so the deadline logic lives once.
+ */
+export function withTimeout<T>(
+  p: Promise<T>,
+  ms: number,
+  message: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new TimeoutError(message)), ms);
+    p.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
+/**
  * In-flight import promises, keyed by file path. Prevents duplicate
  * `import()` calls when multiple readers request the same surface
  * concurrently.
@@ -81,21 +122,22 @@ const inflight = new Map<string, Promise<unknown>>();
  * Import a module's default export with a timeout. If the import doesn't
  * resolve within `timeoutMs`, logs a warning and returns `undefined` so a
  * hanging module doesn't block daemon startup indefinitely. Defaults to the
- * module-level {@link getSurfaceImportTimeout}.
+ * module-level {@link getSurfaceImportTimeout}. A genuine import failure (not a
+ * timeout) propagates so the caller can log and cache it as absent.
  */
 export async function importWithTimeout<T>(
   filePath: string,
   timeoutMs: number = importTimeoutMs,
 ): Promise<T | undefined> {
-  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const importPromise = importWithDedup<T>(filePath);
   try {
-    const timeoutSentinel = Symbol("import-timeout");
-    const importPromise = importWithDedup<T>(filePath);
-    const timeoutPromise = new Promise<typeof timeoutSentinel>((resolve) => {
-      timeoutHandle = setTimeout(() => resolve(timeoutSentinel), timeoutMs);
-    });
-    const result = await Promise.race([importPromise, timeoutPromise]);
-    if (result === timeoutSentinel) {
+    return await withTimeout<T>(
+      importPromise,
+      timeoutMs,
+      `Import timed out after ${timeoutMs}ms — skipping surface`,
+    );
+  } catch (err) {
+    if (err instanceof TimeoutError) {
       importPromise.catch(() => {
         /* swallow — late rejection from abandoned import */
       });
@@ -105,11 +147,7 @@ export async function importWithTimeout<T>(
       );
       return undefined;
     }
-    return result as T;
-  } finally {
-    if (timeoutHandle !== undefined) {
-      clearTimeout(timeoutHandle);
-    }
+    throw err;
   }
 }
 

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -143,7 +143,7 @@ mock.module("../../../cli/lib/plugin-catalog-cache.js", () => ({
 // Mock uninstallPlugin. The handler's error mapping is the wiring under
 // test — the lib's own behavior is covered separately.
 const uninstallSpy = mock(
-  (_opts: UninstallPluginOptions): UninstallPluginResult => {
+  (_opts: UninstallPluginOptions): Promise<UninstallPluginResult> => {
     throw new Error("uninstallSpy default impl not configured");
   },
 );
@@ -1081,11 +1081,10 @@ describe("GET /v1/plugins/search", () => {
 // DELETE /v1/plugins/:name (uninstall)
 // ---------------------------------------------------------------------------
 
-function invokeUninstall(args: RouteHandlerArgs = {}): {
-  name: string;
-  target: string;
-} {
-  return uninstallHandler(args) as { name: string; target: string };
+async function invokeUninstall(
+  args: RouteHandlerArgs = {},
+): Promise<{ name: string; target: string }> {
+  return (await uninstallHandler(args)) as { name: string; target: string };
 }
 
 describe("DELETE /v1/plugins/:name", () => {
@@ -1094,13 +1093,15 @@ describe("DELETE /v1/plugins/:name", () => {
     broadcastMessageSpy.mockReset();
   });
 
-  test("forwards pathParams.name to uninstallPlugin and returns its result", () => {
-    uninstallSpy.mockImplementation((opts) => ({
+  test("forwards pathParams.name to uninstallPlugin and returns its result", async () => {
+    uninstallSpy.mockImplementation(async (opts) => ({
       name: opts.name,
       target: `/workspace/.vellum/plugins/${opts.name}`,
     }));
 
-    const result = invokeUninstall({ pathParams: { name: "simple-memory" } });
+    const result = await invokeUninstall({
+      pathParams: { name: "simple-memory" },
+    });
 
     expect(uninstallSpy.mock.calls).toHaveLength(1);
     expect(uninstallSpy.mock.calls[0]?.[0]).toEqual({ name: "simple-memory" });
@@ -1110,24 +1111,24 @@ describe("DELETE /v1/plugins/:name", () => {
     });
   });
 
-  test("publishes sync_changed(plugins:list) on a successful uninstall", () => {
-    uninstallSpy.mockImplementation((opts) => ({
+  test("publishes sync_changed(plugins:list) on a successful uninstall", async () => {
+    uninstallSpy.mockImplementation(async (opts) => ({
       name: opts.name,
       target: `/workspace/.vellum/plugins/${opts.name}`,
     }));
 
-    invokeUninstall({ pathParams: { name: "simple-memory" } });
+    await invokeUninstall({ pathParams: { name: "simple-memory" } });
 
     expectPluginsListBroadcast();
   });
 
-  test("threads x-vellum-client-id into the published event's originClientId", () => {
-    uninstallSpy.mockImplementation((opts) => ({
+  test("threads x-vellum-client-id into the published event's originClientId", async () => {
+    uninstallSpy.mockImplementation(async (opts) => ({
       name: opts.name,
       target: `/workspace/.vellum/plugins/${opts.name}`,
     }));
 
-    invokeUninstall({
+    await invokeUninstall({
       pathParams: { name: "simple-memory" },
       headers: { "x-vellum-client-id": "client-abc" },
     });
@@ -1139,7 +1140,7 @@ describe("DELETE /v1/plugins/:name", () => {
     });
   });
 
-  test("missing pathParams.name passes the empty string through to the lib", () => {
+  test("missing pathParams.name passes the empty string through to the lib", async () => {
     // The lib's `sanitizePluginName` is the validator of last resort —
     // the route hands off the raw value without pre-trimming. The lib
     // rejects empty strings, which the handler maps to 400 below.
@@ -1149,21 +1150,21 @@ describe("DELETE /v1/plugins/:name", () => {
       );
     });
 
-    expect(() => invokeUninstall({})).toThrow(BadRequestError);
+    await expect(invokeUninstall({})).rejects.toThrow(BadRequestError);
     expect(uninstallSpy.mock.calls[0]?.[0]).toEqual({ name: "" });
   });
 
-  test("InvalidPluginNameError → BadRequestError (400)", () => {
+  test("InvalidPluginNameError → BadRequestError (400)", async () => {
     uninstallSpy.mockImplementation(() => {
       throw new InvalidPluginNameError("bad name ../escape");
     });
 
-    expect(() =>
+    await expect(
       invokeUninstall({ pathParams: { name: "../escape" } }),
-    ).toThrow(BadRequestError);
+    ).rejects.toThrow(BadRequestError);
   });
 
-  test("PluginNotInstalledError → NotFoundError (404), no broadcast", () => {
+  test("PluginNotInstalledError → NotFoundError (404), no broadcast", async () => {
     uninstallSpy.mockImplementation((opts) => {
       throw new PluginNotInstalledError(
         opts.name,
@@ -1171,36 +1172,34 @@ describe("DELETE /v1/plugins/:name", () => {
       );
     });
 
-    expect(() => invokeUninstall({ pathParams: { name: "ghost" } })).toThrow(
-      NotFoundError,
-    );
+    await expect(
+      invokeUninstall({ pathParams: { name: "ghost" } }),
+    ).rejects.toThrow(NotFoundError);
     // A failed uninstall must not fan out a spurious invalidation.
     expect(broadcastMessageSpy).not.toHaveBeenCalled();
   });
 
-  test("unknown errors → InternalError with original message preserved", () => {
+  test("unknown errors → InternalError with original message preserved", async () => {
     uninstallSpy.mockImplementation(() => {
       throw new Error("EBUSY: resource busy or locked");
     });
 
-    expect(() =>
+    await expect(
       invokeUninstall({ pathParams: { name: "simple-memory" } }),
-    ).toThrow(InternalError);
-    try {
-      invokeUninstall({ pathParams: { name: "simple-memory" } });
-    } catch (err) {
-      expect((err as Error).message).toContain("EBUSY");
-    }
+    ).rejects.toThrow(InternalError);
+    await expect(
+      invokeUninstall({ pathParams: { name: "simple-memory" } }),
+    ).rejects.toThrow("EBUSY");
   });
 
-  test("non-Error throws fall through to InternalError with a default message", () => {
+  test("non-Error throws fall through to InternalError with a default message", async () => {
     uninstallSpy.mockImplementation(() => {
       throw "boom"; // emulates a poorly-typed throwable from the lib chain
     });
 
     let caught: unknown;
     try {
-      invokeUninstall({ pathParams: { name: "simple-memory" } });
+      await invokeUninstall({ pathParams: { name: "simple-memory" } });
     } catch (err) {
       caught = err;
     }

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -939,10 +939,10 @@ interface PluginUninstallResponse {
   target: string;
 }
 
-function handleUninstallPlugin({
+async function handleUninstallPlugin({
   pathParams = {},
   headers,
-}: RouteHandlerArgs): PluginUninstallResponse {
+}: RouteHandlerArgs): Promise<PluginUninstallResponse> {
   // The HTTP router has already URL-decoded `:name` for us; pass it
   // through verbatim — `uninstallPlugin` runs the same
   // `sanitizePluginName` check the CLI uses, so attacker-supplied
@@ -950,7 +950,7 @@ function handleUninstallPlugin({
   const rawName = pathParams.name ?? "";
 
   try {
-    const result = uninstallPlugin({ name: rawName });
+    const result = await uninstallPlugin({ name: rawName });
     publishPluginsChanged(getOriginClientId(headers));
     return { name: result.name, target: result.target };
   } catch (err) {


### PR DESCRIPTION
## Prompt / plan

A `shutdown` hook is a filesystem-resolved file and must not assume it shares a process with its `init` — so the daemon no longer needs to hold it resident to run it on teardown. This removes the last bit of "activation reaching ahead" (the shutdown pre-warm), and makes uninstall run `shutdown` from disk in whatever process performs it.

**hook-loader**
- `runInitHook` no longer pre-warms `shutdown` into the cache.
- New `runShutdownHookFromDisk(hooksDir, ownerName, reason)` resolves the `shutdown` file fresh and runs it with `{ assistantVersion, reason }` — no cache, so it works in any process.

**uninstall** (`cli/lib/uninstall-plugin.ts`, shared by the CLI command and the daemon `DELETE /v1/plugins/:name` route)
- Runs `shutdown` (reason `uninstall`) from disk **before** `rmSync`. Both callers get shutdown-before-removal with no daemon round-trip. `uninstallPlugin` is now async; the CLI command and route handler await it.

**reconcile** (`deactivatePlugin`) resolves shutdown per reason:
- `disable` → current on-disk version (directory still present).
- `reload` → old version best-effort from the cache (disk already holds the new version; skipped when uncached).
- `uninstall` → nothing (uninstall ran it; an out-of-band `rm` leaves nothing to resolve).

**contract** (`ShutdownContext` docs) — `shutdown` may run in a different process than `init`; reconstruct from config/`data/`, don't close over init's in-memory state. `ShutdownReason.reload` documented as best-effort.

## Behavior changes

- A **managed uninstall** now runs `shutdown` before removing files (previously it ran post-hoc from the pre-warmed cache after the monitor noticed the dir vanish).
- An **out-of-band `rm`** no longer runs `shutdown` (nothing to resolve once the files are gone) — accepted; you bypassed the managed path.
- **reload** old-`shutdown` is best-effort (was guaranteed via the pre-warm). Signed off earlier in the thread.

## Test plan

- `uninstall-plugin.test.ts` — new: runs the plugin's `shutdown` from disk before removal; async signature. (11 pass)
- `mtime-cache.test.ts` — updated: out-of-band `rm` unregisters tools but runs no shutdown; disable runs shutdown from disk; reload best-effort (skipped when uncached, runs when already resolved). (33 pass)
- `plugins-routes.test.ts` — DELETE handler is async; tests await + `.rejects`. (101 pass)
- `hook-live-reload` (6), `plugin-config-data-migration` (6), `plugin-effective-enabled-set` (5), `user-plugin-loader` (5) — all pass.
- `bunx eslint` (0 errors), `bunx prettier --check` (clean), `tsc --noEmit` (exit 0); pre-push hook green.

## Follow-up not in scope

Routing the daemon's monitor-reconcile teardown and the graceful process-exit path is unchanged. The one soft edge: running a user plugin's `shutdown` from the **CLI** process requires the plugin's `@vellumai/plugin-api` shim to resolve there; a failure is best-effort (logged, never blocks removal), and the daemon `DELETE` route path runs in the fully-set-up daemon.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SquRHbAZqYMwNqDD7SNcNP)_