### PR TITLE
fix(plugins): realpath sentinel allowlist roots; fix workspace-hook test isolation

### DIFF
--- a/assistant/src/__tests__/mtime-cache.test.ts
+++ b/assistant/src/__tests__/mtime-cache.test.ts
@@ -512,7 +512,12 @@ describe("workspace hooks (<workspace>/hooks/)", () => {
   // NB: each test below uses a distinct hook event name so the workspace
   // hook file path is unique and each test stays independent of the cache
   // state its siblings leave behind (the plugin tests get the same isolation
-  // from a fresh plugin directory per test).
+  // from a fresh plugin directory per test). A test that must reuse an event
+  // name another test already imported cannot rely on a boot scan alone:
+  // Bun's module registry serves the previous compile of an already-imported
+  // path, and only the publish path's in-place redeploy sweeps the registry.
+  // Such a test edits the file after boot and publishes, like the ordering
+  // test below.
   test("plugin hooks run before the workspace hook for the same event", async () => {
     const dir = freshPluginDir("ordering-plugin");
     writePackageJson(dir, { ...SIMPLE_PKG, name: "ordering-plugin" });
@@ -521,12 +526,20 @@ describe("workspace hooks (<workspace>/hooks/)", () => {
       "pre-model-call",
       `export default () => ({ tag: "plugin" });`,
     );
+    const hookFile = join(WORKSPACE_HOOKS_DIR, "pre-model-call.ts");
     writeWorkspaceHook(
       "pre-model-call",
-      `export default () => ({ tag: "workspace" });`,
+      `export default () => ({ tag: "stale" });`,
     );
 
     await populateCacheAtBoot();
+
+    // The collision test above already imported this workspace hook path, so
+    // reach the current version through an edit + publish (in-place redeploy
+    // sweeps the module registry) rather than the boot scan.
+    writeFileSync(hookFile, `export default () => ({ tag: "workspace" });`);
+    touchFile(hookFile);
+    publishSourceChanges();
 
     const hooks = await getUserHooksFor("pre-model-call");
     expect(hooks).toHaveLength(2);
@@ -887,9 +900,8 @@ describe("sentinel path validation (ATL-983)", () => {
 
     // Forge a sentinel that claims the evil directory is a plugin.
     const sentinelPath = getSourceVersionsPath();
-    const { snapshotPluginSource } = await import(
-      "../plugins/source-fingerprint.js"
-    );
+    const { snapshotPluginSource } =
+      await import("../plugins/source-fingerprint.js");
     const snapshot = snapshotPluginSource(evilDir);
     writeFileSync(
       sentinelPath,

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -30,7 +30,13 @@
  * each hook through the hook loader on demand.
  */
 
-import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
 import { join } from "node:path";
 
 import {
@@ -307,7 +313,11 @@ async function maybeReconcileFromSentinel(): Promise<void> {
  * symlinked path that looks like it's under the plugins dir but points
  * elsewhere is rejected.
  */
-function isAllowedPluginDir(dir: string, pluginsDir: string, hooksDir: string): boolean {
+function isAllowedPluginDir(
+  dir: string,
+  pluginsDir: string,
+  hooksDir: string,
+): boolean {
   let resolved: string;
   try {
     resolved = realpathSync(dir);
@@ -318,13 +328,29 @@ function isAllowedPluginDir(dir: string, pluginsDir: string, hooksDir: string): 
     // directory.
     return true;
   }
-  const normalizedPluginsDir = pluginsDir + "/";
-  const normalizedHooksDir = hooksDir + "/";
+  // Resolve the allowed roots the same way as the candidate, or the check
+  // breaks whenever the workspace path contains a symlinked segment (e.g.
+  // macOS's /var → /private/var): the candidate resolves to the physical
+  // path while the configured root keeps the symlinked spelling, and every
+  // legitimate directory is rejected. An unresolvable root keeps its
+  // configured spelling — nothing under it can exist to import anyway.
+  let resolvedPluginsDir: string;
+  try {
+    resolvedPluginsDir = realpathSync(pluginsDir);
+  } catch {
+    resolvedPluginsDir = pluginsDir;
+  }
+  let resolvedHooksDir: string;
+  try {
+    resolvedHooksDir = realpathSync(hooksDir);
+  } catch {
+    resolvedHooksDir = hooksDir;
+  }
   return (
-    resolved === pluginsDir ||
-    resolved.startsWith(normalizedPluginsDir) ||
-    resolved === hooksDir ||
-    resolved.startsWith(normalizedHooksDir)
+    resolved === resolvedPluginsDir ||
+    resolved.startsWith(resolvedPluginsDir + "/") ||
+    resolved === resolvedHooksDir ||
+    resolved.startsWith(resolvedHooksDir + "/")
   );
 }
 


### PR DESCRIPTION
## Problem

Two independent issues surfaced while running `mtime-cache.test.ts` on macOS (found while working on #37418; both pre-exist on `main`):

**1. Production bug — sentinel path validation breaks under symlinked workspace paths.** `isAllowedPluginDir` (added in ATL-983 / #37343) realpath-resolves the candidate directory but compares it against the configured plugins/hooks roots verbatim. When the workspace path contains a symlinked segment — macOS `/var` → `/private/var` (which includes anything under `os.tmpdir()`), or a symlinked home directory — the resolved candidate never prefix-matches the unresolved root. Every legitimate sentinel entry is rejected as out-of-bounds and **published plugin changes are silently skipped: live plugin reload stops working**. On `main`, 8 of the 32 mtime-cache tests fail on macOS because of this. Fix: resolve the roots with the same `realpathSync` before comparing; an unresolvable root keeps its configured spelling (nothing under it can exist to import). The security posture is unchanged — both sides of the comparison are now physical paths.

**2. Flaky test — workspace-hook ordering test reads a sibling's compiled module.** The "plugin hooks run before the workspace hook for the same event" test reuses the `pre-model-call` workspace hook path that the collision test above it already imported, violating the suite's own NB isolation rule. A boot scan can't observe the rewrite (Bun's module registry serves the previous compile of an already-imported path), so the test read the sibling's `{ from: ... }` module and its `tag` assertion failed. Fixed by routing the rewrite through the publish path — whose in-place redeploy sweeps the module registry — mirroring the passing edited-workspace-hook test, and extending the NB comment with the constraint.

## Tests

- `mtime-cache.test.ts`: 32/32 pass across 5 consecutive runs (was 23/32 on `main` on macOS).
- Adjacent suites green: `app-source-watcher`, `plugin-source-watch`, `app-dir-path-guard`, `conversation-tool-setup-app-refresh`.
- `tsgo --noEmit` clean, lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->