### PR TITLE
chore(plugins): bump polyglot pin to lazy-load state fix

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -178,7 +178,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/polyglot",
-        "ref": "a792cc6b8334e661d969f2966930941e77ce2a65"
+        "ref": "ab607b7c60b64b0ac5c6bf01609840a004cfd002"
       },
       "description": "Ambient language acquisition through your assistant. Three graduated modes (practice, ambient, immersive) weave a target language into your real conversations, with SM-2 spaced repetition, error-pattern tracking, and CEFR level history.",
       "category": "education",


### PR DESCRIPTION
Bumps the `polyglot` marketplace pin from `a792cc6` → `ab607b7` (vellum-ai/polyglot#1, merged).

## Why

The pinned version had an initialization bug: every polyglot tool (`assess`, `practice`, `translate_ctx`, `flashcard`, `progress`) depended on a module-level singleton that only the init hook populated, and threw `[ERROR] Polyglot not initialized` when a tool executed in a module instance where init never ran. A user who installed polyglot mid-conversation and said *"I want to learn Spanish"* burned an entire turn (~20 tool calls) with the assistant unable to recover — disable/enable and uninstall/reinstall all failed because none re-run init in the tool's module instance.

The new pin makes `getConfig()`/`getState()` lazy-load from disk on first access, so tools work regardless of init timing. See vellum-ai/polyglot#1 for the full RCA and verification.

Only `polyglot.source.ref` changes; the catalog serves the pinned commit, not `main`, so this bump is required for the fix to reach users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)