### PR TITLE
feat(channels): rename Capabilities → Assistant Access, add tier legend, behavior-framed copy

### DIFF
--- a/clients/web/src/domains/contacts/components/slack-channel-list.stories.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-list.stories.tsx
@@ -65,13 +65,13 @@ export const Empty: Story = {
 };
 
 /**
- * `eng-releases` starts overridden to the Standard tier — the row badge
- * reads "Standard • custom" and expanding it shows the custom-access
+ * `eng-releases` starts overridden to the Conservative tier — the row badge
+ * reads "Conservative • custom" and expanding it shows the custom-access
  * callout with Reset to default (mirrors the ticket mockup's `releases`).
  */
 export const OverriddenChannel: Story = {
   args: {
-    tierOverrides: { C003: "standard" },
+    tierOverrides: { C003: "low" },
     onTierChange: () => {},
     onTierReset: () => {},
   },

--- a/clients/web/src/domains/contacts/components/slack-channel-list.stories.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-list.stories.tsx
@@ -66,7 +66,7 @@ export const Empty: Story = {
 
 /**
  * `eng-releases` starts overridden to the Standard tier — the row badge
- * reads "Standard • custom" and expanding it shows the custom-capabilities
+ * reads "Standard • custom" and expanding it shows the custom-access
  * callout with Reset to default (mirrors the ticket mockup's `releases`).
  */
 export const OverriddenChannel: Story = {

--- a/clients/web/src/domains/contacts/components/slack-channel-list.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-list.tsx
@@ -4,8 +4,8 @@ import { useMemo, useState } from "react";
 import { cn } from "@vellumai/design-library";
 import { Button } from "@vellumai/design-library/components/button";
 import { Card } from "@vellumai/design-library/components/card";
+import { Collapsible } from "@vellumai/design-library/components/collapsible";
 import { Input } from "@vellumai/design-library/components/input";
-import { ListRow } from "@vellumai/design-library/components/list-row";
 import { Tag } from "@vellumai/design-library/components/tag";
 import { Typography } from "@vellumai/design-library/components/typography";
 import { VirtualList } from "@vellumai/design-library/components/virtual-list";
@@ -94,10 +94,6 @@ export function slackChannelMetaLabel(channel: SlackChannel): string | null {
     : `${channel.memberCount} members`;
 }
 
-/** Shared timing for the accordion region and the caret rotation. */
-const ACCORDION_TRANSITION =
-  "duration-[280ms] ease-[cubic-bezier(0.32,0.72,0,1)]";
-
 const CHANNEL_KIND_FILTERS: {
   value: SlackRoomKind | null;
   label: string;
@@ -159,7 +155,7 @@ const EMPTY_PENDING_IDS: ReadonlySet<string> = new Set();
  * Presence channel list for the Slack sub-tab: every Slack channel the
  * assistant is a member of, with a per-row resolved-access badge. Rows
  * expand inline (single-open accordion; "Expand all" switches to multi-open)
- * to configure the channel's two override axes. Search and the kind chips
+ * to configure the channel's Assistant Access tier. Search and the kind chips
  * narrow the list client-side; the membership filter itself is server-side
  * (`?memberOnly=true`) with no toggle.
  */
@@ -181,18 +177,15 @@ export function SlackChannelList({
   const [openIds, setOpenIds] = useState<ReadonlySet<string>>(new Set());
   const [multiOpen, setMultiOpen] = useState(false);
 
-  const toggleRow = (id: string) => {
+  // Radix reports the full next open-set; outside "Expand all" mode the
+  // single-open rule keeps only the newly opened row.
+  const handleOpenChange = (next: string[]) => {
     setOpenIds((prev) => {
       if (multiOpen) {
-        const next = new Set(prev);
-        if (next.has(id)) {
-          next.delete(id);
-        } else {
-          next.add(id);
-        }
-        return next;
+        return new Set(next);
       }
-      return prev.has(id) ? new Set() : new Set([id]);
+      const added = next.find((id) => !prev.has(id));
+      return added ? new Set([added]) : new Set<string>();
     });
   };
 
@@ -318,48 +311,54 @@ export function SlackChannelList({
                 >
                   No channels match.
                 </Typography>
-              ) : visibleChannels.length > VIRTUALIZE_THRESHOLD ? (
-                // Virtuoso sizes its scroller to 100% of the wrapper, so the
-                // fixed height lives on the wrapper, not the list itself.
-                <div className="h-96">
-                  <VirtualList
-                    items={visibleChannels}
-                    computeItemKey={(_, channel) => channel.id}
-                    itemContent={(_, channel) => (
+              ) : (
+                <Collapsible.Root
+                  type="multiple"
+                  value={[...openIds]}
+                  onValueChange={handleOpenChange}
+                >
+                  {visibleChannels.length > VIRTUALIZE_THRESHOLD ? (
+                    // Virtuoso sizes its scroller to 100% of the wrapper, so
+                    // the fixed height lives on the wrapper, not the list.
+                    <div className="h-96">
+                      <VirtualList
+                        items={visibleChannels}
+                        computeItemKey={(_, channel) => channel.id}
+                        itemContent={(_, channel) => (
+                          <SlackChannelRow
+                            channel={channel}
+                            open={openIds.has(channel.id)}
+                            pending={pendingChannelIds.has(channel.id)}
+                            overridesLoading={tierOverridesLoading}
+                            overridesError={tierOverridesError}
+                            tierOverride={tierOverrides?.[channel.id]}
+                            onTierChange={(tier) =>
+                              onTierChange?.(channel.id, tier)
+                            }
+                            onReset={() => onTierReset?.(channel.id)}
+                          />
+                        )}
+                        className="h-full"
+                      />
+                    </div>
+                  ) : (
+                    visibleChannels.map((channel) => (
                       <SlackChannelRow
+                        key={channel.id}
                         channel={channel}
                         open={openIds.has(channel.id)}
                         pending={pendingChannelIds.has(channel.id)}
                         overridesLoading={tierOverridesLoading}
                         overridesError={tierOverridesError}
-                        onToggle={() => toggleRow(channel.id)}
                         tierOverride={tierOverrides?.[channel.id]}
                         onTierChange={(tier) =>
                           onTierChange?.(channel.id, tier)
                         }
                         onReset={() => onTierReset?.(channel.id)}
                       />
-                    )}
-                    className="h-full"
-                  />
-                </div>
-              ) : (
-                <div className="flex flex-col">
-                  {visibleChannels.map((channel) => (
-                    <SlackChannelRow
-                      key={channel.id}
-                      channel={channel}
-                      open={openIds.has(channel.id)}
-                      pending={pendingChannelIds.has(channel.id)}
-                      overridesLoading={tierOverridesLoading}
-                      overridesError={tierOverridesError}
-                      onToggle={() => toggleRow(channel.id)}
-                      tierOverride={tierOverrides?.[channel.id]}
-                      onTierChange={(tier) => onTierChange?.(channel.id, tier)}
-                      onReset={() => onTierReset?.(channel.id)}
-                    />
-                  ))}
-                </div>
+                    ))
+                  )}
+                </Collapsible.Root>
               )}
               <Typography
                 as="p"
@@ -387,7 +386,6 @@ function SlackChannelRow({
   pending,
   overridesLoading,
   overridesError,
-  onToggle,
   tierOverride,
   onTierChange,
   onReset,
@@ -397,7 +395,6 @@ function SlackChannelRow({
   pending: boolean;
   overridesLoading: boolean;
   overridesError: boolean;
-  onToggle: () => void;
   tierOverride: SlackCapabilityTier | undefined;
   onTierChange: (tier: SlackCapabilityTier) => void;
   onReset: () => void;
@@ -412,62 +409,57 @@ function SlackChannelRow({
   const settings = resolveChannelTier(tierOverride);
   const tierMeta = CAPABILITY_TIER_META[settings.tier];
   return (
-    <div className="[&+&]:border-t [&+&]:border-[var(--border-base)]">
-      <ListRow
-        leading={<Icon className="h-4 w-4 text-[var(--content-tertiary)]" />}
-        title={channel.name}
-        onClick={onToggle}
-        contentAriaLabel={`${channel.name} — ${open ? "collapse" : "expand"} channel settings`}
-        showChevron={false}
-        selected={open}
-        className={
-          open ? "shadow-[inset_3px_0_0_0_var(--content-default)]" : undefined
-        }
-        trailing={
-          <>
-            {pending ? (
-              <span className="text-body-small-default text-[color:var(--content-tertiary)]">
-                Saving…
-              </span>
-            ) : metaLabel != null ? (
-              <span className="text-body-small-default text-[color:var(--content-tertiary)]">
-                {metaLabel}
-              </span>
-            ) : null}
-            <Tag tone={tierMeta.tone}>
-              {tierMeta.label}
-              {settings.overridden ? " • custom" : ""}
-            </Tag>
-            <ChevronDown
-              aria-hidden="true"
-              className={cn(
-                "h-4 w-4 text-[var(--content-tertiary)] transition-transform",
-                ACCORDION_TRANSITION,
-                open && "rotate-180",
-              )}
-            />
-          </>
-        }
-      />
-      <div
+    <Collapsible.Item
+      value={channel.id}
+      className="[&+&]:border-t [&+&]:border-[var(--border-base)]"
+    >
+      <Collapsible.Trigger
+        aria-label={`${channel.name} — ${open ? "collapse" : "expand"} channel settings`}
         className={cn(
-          "grid transition-[grid-template-rows]",
-          ACCORDION_TRANSITION,
-          open ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+          "group gap-3 rounded-md px-2 py-3 transition-colors",
+          "hover:bg-[var(--surface-hover)]",
+          "data-[state=open]:bg-[var(--surface-active)]",
+          "data-[state=open]:shadow-[inset_3px_0_0_0_var(--content-default)]",
         )}
       >
-        <div className="min-h-0 overflow-hidden" inert={!open}>
-          <SlackChannelOverridePanel
-            channelName={channel.name}
-            kindLabel={kind}
-            settings={settings}
-            loading={overridesLoading}
-            error={overridesError}
-            onTierChange={onTierChange}
-            onReset={onReset}
+        <Icon
+          aria-hidden="true"
+          className="h-4 w-4 shrink-0 text-[var(--content-tertiary)]"
+        />
+        <span className="min-w-0 flex-1 truncate text-left text-body-medium-default text-[var(--content-default)]">
+          {channel.name}
+        </span>
+        <span className="flex shrink-0 items-center gap-4">
+          {pending ? (
+            <span className="text-body-small-default text-[color:var(--content-tertiary)]">
+              Saving…
+            </span>
+          ) : metaLabel != null ? (
+            <span className="text-body-small-default text-[color:var(--content-tertiary)]">
+              {metaLabel}
+            </span>
+          ) : null}
+          <Tag tone={tierMeta.tone}>
+            {tierMeta.label}
+            {settings.overridden ? " • custom" : ""}
+          </Tag>
+          <ChevronDown
+            aria-hidden="true"
+            className="h-4 w-4 text-[var(--content-tertiary)] transition-transform group-data-[state=open]:rotate-180"
           />
-        </div>
-      </div>
-    </div>
+        </span>
+      </Collapsible.Trigger>
+      <Collapsible.Content>
+        <SlackChannelOverridePanel
+          channelName={channel.name}
+          kindLabel={kind}
+          settings={settings}
+          loading={overridesLoading}
+          error={overridesError}
+          onTierChange={onTierChange}
+          onReset={onReset}
+        />
+      </Collapsible.Content>
+    </Collapsible.Item>
   );
 }

--- a/clients/web/src/domains/contacts/components/slack-channel-list.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-list.tsx
@@ -12,6 +12,7 @@ import { VirtualList } from "@vellumai/design-library/components/virtual-list";
 
 import { EmptyState } from "@/components/empty-state";
 import { SlackChannelOverridePanel } from "@/domains/contacts/components/slack-channel-override-panel";
+import { SlackChannelTierLegend } from "@/domains/contacts/components/slack-channel-tier-legend";
 import {
   CAPABILITY_TIER_META,
   resolveChannelTier,
@@ -308,6 +309,7 @@ export function SlackChannelList({
                   {multiOpen ? "Collapse all" : "Expand all"}
                 </Button>
               </div>
+              <SlackChannelTierLegend assistantName={assistantDisplayName} />
               {visibleChannels.length === 0 ? (
                 <Typography
                   as="span"

--- a/clients/web/src/domains/contacts/components/slack-channel-override-panel.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-override-panel.tsx
@@ -14,7 +14,7 @@ import {
 export interface SlackChannelOverridePanelProps {
   /** Row's channel name, for accessible control labels. */
   channelName: string;
-  /** Lowercase room-type word for the custom-capabilities callout copy. */
+  /** Lowercase room-type word for the custom-access callout copy. */
   kindLabel: "public" | "private";
   settings: SlackChannelTierSettings;
   /**
@@ -29,11 +29,12 @@ export interface SlackChannelOverridePanelProps {
 }
 
 /**
- * Expanded-row settings for one Slack channel: the capabilities tier
+ * Expanded-row settings for one Slack channel: the Assistant Access tier
  * (the only per-room knob — reach is baked into the channel type, with no
- * per-room control), with a custom-capabilities callout + reset when the
- * tier diverges from the channel-type default. Persists as channel-ID
- * cells via the gateway SDK.
+ * per-room control), with a custom-access callout + reset when the tier
+ * diverges from the channel-type default. Per-tier descriptions live in
+ * the list's one-time legend ({@link SlackChannelTierLegend}), not here.
+ * Persists as channel-ID cells via the gateway SDK.
  */
 export function SlackChannelOverridePanel({
   channelName,
@@ -48,16 +49,16 @@ export function SlackChannelOverridePanel({
   const tierItems = CAPABILITY_TIER_VALUES.map((tier) => ({
     value: tier,
     label: CAPABILITY_TIER_META[tier].label,
+    sublabel: CAPABILITY_TIER_META[tier].sublabel,
     disabled: unavailable,
   }));
-  const tierMeta = CAPABILITY_TIER_META[settings.tier];
 
   return (
     <div className="flex flex-col gap-3 px-2 pt-1 pb-4">
       {settings.overridden ? (
         <Notice
           tone="warning"
-          title="Custom capabilities."
+          title="Custom access."
           className="border-dashed"
           actions={
             <Button
@@ -79,7 +80,7 @@ export function SlackChannelOverridePanel({
           variant="body-small-emphasised"
           className="text-[color:var(--content-secondary)]"
         >
-          Capabilities
+          Assistant Access
         </Typography>
         {loading ? (
           <Typography
@@ -113,26 +114,8 @@ export function SlackChannelOverridePanel({
         items={tierItems}
         value={settings.tier}
         onChange={onTierChange}
-        ariaLabel={`Capabilities in ${channelName}`}
+        ariaLabel={`Assistant Access in ${channelName}`}
       />
-      <Typography
-        as="p"
-        variant="body-small-default"
-        className="text-[color:var(--content-tertiary)]"
-      >
-        {settings.overridden ? (
-          <>
-            {tierMeta.label} — {tierMeta.sublabel}. {tierMeta.description}
-          </>
-        ) : (
-          // Without a persisted cell the runtime falls through to the
-          // global auto-approve setting; the tier copy would overclaim.
-          <>
-            No channel override — this channel follows your global
-            auto-approve setting. Pick a tier to set one.
-          </>
-        )}
-      </Typography>
     </div>
   );
 }

--- a/clients/web/src/domains/contacts/components/slack-channel-tier-legend.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-tier-legend.tsx
@@ -16,48 +16,60 @@ const TONE_DOT_COLOR: Record<TagTone, string> = {
   positive: "var(--system-positive-strong)",
   negative: "var(--system-negative-strong)",
   warning: "var(--system-mid-strong)",
+  info: "var(--system-info-strong)",
   neutral: "var(--content-secondary)",
 };
 
 /**
  * Per-tier help copy, framed around behavior toward the people in the
- * channel: who the assistant can respond to, and what it may run when
- * responding. Lives here rather than in `CAPABILITY_TIER_META` because it
- * interpolates the assistant's name and (for full access) links out to the
- * Privacy settings page.
+ * channel: what the assistant does on its own when responding, and what
+ * waits for the owner. Lives here rather than in `CAPABILITY_TIER_META`
+ * because it interpolates the assistant's name and (for full access) links
+ * out to the Privacy settings page.
+ *
+ * Grounded in the approval-policy decision order
+ * (`assistant/src/permissions/approval-policy.ts`): a channel cell replaces
+ * the global threshold for this channel, deny trust rules block at every
+ * threshold, and at `none` every tool call prompts (it isn't a tool ban).
  */
 function tierDescription(
   tier: SlackCapabilityTier,
   assistantName: string,
 ): ReactNode {
   switch (tier) {
-    case "strict":
+    case "none":
       return (
         <>
-          {assistantName} can respond to messages in this channel, but won’t
-          run tools or take actions when doing so.
+          {assistantName} replies in this channel, but every action waits for
+          your approval first.
         </>
       );
-    case "standard":
+    case "low":
       return (
         <>
-          {assistantName} can respond to messages in this channel and run
-          safe, read-only tools when doing so. Anything that writes, sends, or
-          spends waits for your approval.
+          {assistantName} replies and runs safe, read-only tools on its own.
+          Anything that writes, sends, or spends asks first.
         </>
       );
-    case "full_access":
+    case "medium":
       return (
         <>
-          {assistantName} can respond to messages in this channel and run any
-          tool it has access to when doing so. Your{" "}
+          {assistantName} also acts in its own workspace, like editing files.
+          Riskier actions still ask first.
+        </>
+      );
+    case "high":
+      return (
+        <>
+          {assistantName} runs any tool it has access to without asking.
+          Anything you’ve blocked in{" "}
           <Link
             to={routes.settings.privacy}
             className="text-[var(--content-link)] underline hover:text-[var(--content-link-hover)]"
           >
-            Trust Rules and Risk Tolerance
+            Trust Rules
           </Link>{" "}
-          still apply.
+          stays blocked.
         </>
       );
   }
@@ -69,9 +81,9 @@ export interface SlackChannelTierLegendProps {
 }
 
 /**
- * One-time Assistant Access legend above the channel rows: all three tiers
- * with their behavior descriptions, so the expanded rows don't repeat the
- * same paragraph per channel.
+ * One-time Assistant Access legend above the channel rows: every tier with
+ * its behavior description, so the expanded rows don't repeat the same
+ * paragraph per channel.
  */
 export function SlackChannelTierLegend({
   assistantName,
@@ -85,7 +97,7 @@ export function SlackChannelTierLegend({
       >
         Assistant Access levels
       </Typography>
-      <div className="grid gap-x-8 gap-y-4 sm:grid-cols-3">
+      <div className="grid gap-x-8 gap-y-4 sm:grid-cols-2 lg:grid-cols-4">
         {CAPABILITY_TIER_VALUES.map((tier) => {
           const meta = CAPABILITY_TIER_META[tier];
           return (

--- a/clients/web/src/domains/contacts/components/slack-channel-tier-legend.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-tier-legend.tsx
@@ -1,0 +1,116 @@
+import type { ReactNode } from "react";
+import { Link } from "react-router";
+
+import type { TagTone } from "@vellumai/design-library/components/tag";
+import { Typography } from "@vellumai/design-library/components/typography";
+
+import {
+  CAPABILITY_TIER_META,
+  CAPABILITY_TIER_VALUES,
+  type SlackCapabilityTier,
+} from "@/domains/contacts/slack-channel-overrides";
+import { routes } from "@/utils/routes";
+
+/** Dot accent per tier tone — mirrors the Tag component's icon accents. */
+const TONE_DOT_COLOR: Record<TagTone, string> = {
+  positive: "var(--system-positive-strong)",
+  negative: "var(--system-negative-strong)",
+  warning: "var(--system-mid-strong)",
+  neutral: "var(--content-secondary)",
+};
+
+/**
+ * Per-tier help copy, framed around behavior toward the people in the
+ * channel: who the assistant can respond to, and what it may run when
+ * responding. Lives here rather than in `CAPABILITY_TIER_META` because it
+ * interpolates the assistant's name and (for full access) links out to the
+ * Privacy settings page.
+ */
+function tierDescription(
+  tier: SlackCapabilityTier,
+  assistantName: string,
+): ReactNode {
+  switch (tier) {
+    case "strict":
+      return (
+        <>
+          {assistantName} can respond to messages in this channel, but won’t
+          run tools or take actions when doing so.
+        </>
+      );
+    case "standard":
+      return (
+        <>
+          {assistantName} can respond to messages in this channel and run
+          safe, read-only tools when doing so. Anything that writes, sends, or
+          spends waits for your approval.
+        </>
+      );
+    case "full_access":
+      return (
+        <>
+          {assistantName} can respond to messages in this channel and run any
+          tool it has access to when doing so. Your{" "}
+          <Link
+            to={routes.settings.privacy}
+            className="text-[var(--content-link)] underline hover:text-[var(--content-link-hover)]"
+          >
+            Trust Rules and Risk Tolerance
+          </Link>{" "}
+          still apply.
+        </>
+      );
+  }
+}
+
+export interface SlackChannelTierLegendProps {
+  /** Trimmed assistant name with a "your assistant" fallback, for copy. */
+  assistantName: string;
+}
+
+/**
+ * One-time Assistant Access legend above the channel rows: all three tiers
+ * with their behavior descriptions, so the expanded rows don't repeat the
+ * same paragraph per channel.
+ */
+export function SlackChannelTierLegend({
+  assistantName,
+}: SlackChannelTierLegendProps) {
+  return (
+    <div className="flex flex-col gap-3 rounded-lg bg-[var(--surface-active)] p-4">
+      <Typography
+        as="h4"
+        variant="label-small-default"
+        className="uppercase tracking-wider text-[color:var(--content-tertiary)]"
+      >
+        Assistant Access levels
+      </Typography>
+      <div className="grid gap-x-8 gap-y-4 sm:grid-cols-3">
+        {CAPABILITY_TIER_VALUES.map((tier) => {
+          const meta = CAPABILITY_TIER_META[tier];
+          return (
+            <div key={tier} className="flex flex-col gap-1.5">
+              <span className="flex items-center gap-1.5">
+                <span
+                  aria-hidden="true"
+                  className="h-1.5 w-1.5 rounded-full"
+                  style={{ backgroundColor: TONE_DOT_COLOR[meta.tone] }}
+                />
+                <Typography as="span" variant="body-small-emphasised">
+                  {meta.label}
+                </Typography>
+              </span>
+              <Typography
+                as="p"
+                variant="body-small-default"
+                className="text-[color:var(--content-tertiary)]"
+              >
+                {tierDescription(tier, assistantName)}
+              </Typography>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/clients/web/src/domains/contacts/components/slack-channel-tier-legend.tsx
+++ b/clients/web/src/domains/contacts/components/slack-channel-tier-legend.tsx
@@ -31,6 +31,10 @@ const TONE_DOT_COLOR: Record<TagTone, string> = {
  * (`assistant/src/permissions/approval-policy.ts`): a channel cell replaces
  * the global threshold for this channel, deny trust rules block at every
  * threshold, and at `none` every tool call prompts (it isn't a tool ban).
+ * Sensitive tools sit above the threshold entirely — for non-guardian
+ * actors they always escalate to the owner without a scoped grant
+ * (`assistant/src/tools/tool-approval-handler.ts`), so the full-access
+ * copy keeps that caveat.
  */
 function tierDescription(
   tier: SlackCapabilityTier,
@@ -62,7 +66,8 @@ function tierDescription(
       return (
         <>
           {assistantName} runs any tool it has access to without asking.
-          Anything you’ve blocked in{" "}
+          Sensitive tools still come to you first, and anything you’ve
+          blocked in{" "}
           <Link
             to={routes.settings.privacy}
             className="text-[var(--content-link)] underline hover:text-[var(--content-link-hover)]"

--- a/clients/web/src/domains/contacts/hooks/use-channel-permission-overrides.ts
+++ b/clients/web/src/domains/contacts/hooks/use-channel-permission-overrides.ts
@@ -3,7 +3,6 @@ import { useMemo } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
-  CAPABILITY_TIER_THRESHOLDS,
   CHANNEL_TIER_CONTACT_TYPES,
   tierOverridesFromCells,
   type SlackCapabilityTier,
@@ -47,7 +46,7 @@ function cellsForTier(
   return CHANNEL_TIER_CONTACT_TYPES.map((contactType) => ({
     selector: { scope: "channel" as const, adapter, channelExternalId },
     contactType,
-    threshold: CAPABILITY_TIER_THRESHOLDS[tier],
+    threshold: tier,
   }));
 }
 

--- a/clients/web/src/domains/contacts/slack-channel-overrides.test.ts
+++ b/clients/web/src/domains/contacts/slack-channel-overrides.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
+import { THRESHOLD_PRESETS } from "@/utils/threshold-presets";
+
 import {
   CAPABILITY_TIER_META,
-  CAPABILITY_TIER_THRESHOLDS,
+  CAPABILITY_TIER_VALUES,
   resolveChannelTier,
-  tierFromThreshold,
   tierOverridesFromCells,
   type ChannelTierCell,
 } from "./slack-channel-overrides";
@@ -12,40 +13,57 @@ import {
 describe("resolveChannelTier", () => {
   test("no cell resolves the presentation default, not an override", () => {
     expect(resolveChannelTier(undefined)).toEqual({
-      tier: "full_access",
+      tier: "high",
       overridden: false,
     });
   });
 
   test("a persisted cell flags the row as custom", () => {
-    expect(resolveChannelTier("standard")).toEqual({
-      tier: "standard",
+    expect(resolveChannelTier("low")).toEqual({
+      tier: "low",
       overridden: true,
     });
   });
 
-  test("a full_access cell is still an override — it pins the channel above the global cascade", () => {
-    expect(resolveChannelTier("full_access")).toEqual({
-      tier: "full_access",
+  test("a high cell is still an override — it pins the channel above the global cascade", () => {
+    expect(resolveChannelTier("high")).toEqual({
+      tier: "high",
       overridden: true,
     });
   });
 });
 
-describe("tier ↔ threshold mapping", () => {
-  test("write mapping covers every tier", () => {
-    expect(CAPABILITY_TIER_THRESHOLDS).toEqual({
-      strict: "none",
-      standard: "low",
-      full_access: "high",
-    });
+describe("tier ↔ preset parity", () => {
+  test("tiers are the global presets' thresholds, in preset order", () => {
+    expect(CAPABILITY_TIER_VALUES).toEqual(
+      THRESHOLD_PRESETS.map((preset) => preset.riskThreshold),
+    );
   });
 
-  test("read mapping inverts writes and folds medium into standard", () => {
-    expect(tierFromThreshold("none")).toBe("strict");
-    expect(tierFromThreshold("low")).toBe("standard");
-    expect(tierFromThreshold("medium")).toBe("standard");
-    expect(tierFromThreshold("high")).toBe("full_access");
+  test("labels come from the matching global preset — no redefined names", () => {
+    for (const preset of THRESHOLD_PRESETS) {
+      expect(CAPABILITY_TIER_META[preset.riskThreshold].label).toBe(
+        preset.label,
+      );
+    }
+  });
+});
+
+describe("CAPABILITY_TIER_META", () => {
+  test("tones follow the existing status mapping", () => {
+    expect(CAPABILITY_TIER_META.none.tone).toBe("negative");
+    expect(CAPABILITY_TIER_META.low.tone).toBe("warning");
+    expect(CAPABILITY_TIER_META.medium.tone).toBe("info");
+    expect(CAPABILITY_TIER_META.high.tone).toBe("positive");
+  });
+
+  test("sublabels use the behavior framing, not tool inventory", () => {
+    expect(CAPABILITY_TIER_META.none.sublabel).toBe("ask before every action");
+    expect(CAPABILITY_TIER_META.low.sublabel).toBe(
+      "safe actions, ask for the rest",
+    );
+    expect(CAPABILITY_TIER_META.medium.sublabel).toBe("workspace actions too");
+    expect(CAPABILITY_TIER_META.high.sublabel).toBe("acts freely");
   });
 });
 
@@ -65,12 +83,15 @@ describe("tierOverridesFromCells", () => {
     threshold: overrides.threshold ?? "low",
   });
 
-  test("maps channel-scope cells for the adapter to tiers", () => {
+  test("maps channel-scope cells for the adapter to their thresholds", () => {
     const overrides = tierOverridesFromCells(
-      [cell({ channelExternalId: "C1", threshold: "low" })],
+      [
+        cell({ channelExternalId: "C1", threshold: "low" }),
+        cell({ channelExternalId: "C2", threshold: "medium" }),
+      ],
       "slack",
     );
-    expect(overrides).toEqual({ C1: "standard" });
+    expect(overrides).toEqual({ C1: "low", C2: "medium" });
   });
 
   test("ignores other scopes and other adapters", () => {
@@ -101,28 +122,6 @@ describe("tierOverridesFromCells", () => {
       ],
       "slack",
     );
-    expect(overrides).toEqual({ C1: "full_access" });
-  });
-});
-
-describe("CAPABILITY_TIER_META", () => {
-  test("strict and full access reuse the threshold-preset labels", () => {
-    expect(CAPABILITY_TIER_META.strict.label).toBe("Strict");
-    expect(CAPABILITY_TIER_META.full_access.label).toBe("Full access");
-    expect(CAPABILITY_TIER_META.standard.label).toBe("Standard");
-  });
-
-  test("tones follow the existing status mapping", () => {
-    expect(CAPABILITY_TIER_META.strict.tone).toBe("negative");
-    expect(CAPABILITY_TIER_META.standard.tone).toBe("warning");
-    expect(CAPABILITY_TIER_META.full_access.tone).toBe("positive");
-  });
-
-  test("sublabels use the behavior framing, not tool inventory", () => {
-    expect(CAPABILITY_TIER_META.strict.sublabel).toBe("read + reply only");
-    expect(CAPABILITY_TIER_META.standard.sublabel).toBe(
-      "safe actions, ask for the rest",
-    );
-    expect(CAPABILITY_TIER_META.full_access.sublabel).toBe("acts freely");
+    expect(overrides).toEqual({ C1: "high" });
   });
 });

--- a/clients/web/src/domains/contacts/slack-channel-overrides.test.ts
+++ b/clients/web/src/domains/contacts/slack-channel-overrides.test.ts
@@ -117,4 +117,12 @@ describe("CAPABILITY_TIER_META", () => {
     expect(CAPABILITY_TIER_META.standard.tone).toBe("warning");
     expect(CAPABILITY_TIER_META.full_access.tone).toBe("positive");
   });
+
+  test("sublabels use the behavior framing, not tool inventory", () => {
+    expect(CAPABILITY_TIER_META.strict.sublabel).toBe("read + reply only");
+    expect(CAPABILITY_TIER_META.standard.sublabel).toBe(
+      "safe actions, ask for the rest",
+    );
+    expect(CAPABILITY_TIER_META.full_access.sublabel).toBe("acts freely");
+  });
 });

--- a/clients/web/src/domains/contacts/slack-channel-overrides.ts
+++ b/clients/web/src/domains/contacts/slack-channel-overrides.ts
@@ -1,6 +1,7 @@
 /**
  * Per-channel capabilities-tier model for the Slack channel list's
- * expandable rows. Capabilities is the only per-room knob, and the list is
+ * expandable rows ("Assistant Access" in user-facing copy). The tier is
+ * the only per-room knob, and the list is
  * rooms only (channels and group DMs): admission — who can reach the
  * assistant — is a channel-type concern handled by the trust floors, and
  * how the assistant interacts with an individual person is contact-list
@@ -32,33 +33,30 @@ export type SlackCapabilityTier = (typeof CAPABILITY_TIER_VALUES)[number];
 
 interface CapabilityTierMeta {
   label: string;
-  /** Short qualifier shown with the tier in pickers and help copy. */
+  /**
+   * Short qualifier shown under the label in the tier picker. The full
+   * per-tier description lives in the one-time legend
+   * (`SlackChannelTierLegend`) — it needs the assistant name and a settings
+   * link, so it can't be a static string here.
+   */
   sublabel: string;
-  /** One-line help text for the selected tier. */
-  description: string;
   tone: TagTone;
 }
 
 export const CAPABILITY_TIER_META: Record<SlackCapabilityTier, CapabilityTierMeta> = {
   strict: {
     label: presetFromThreshold("none").label,
-    sublabel: "ask before every action",
-    description:
-      "Nothing is auto-approved — every tool call from this channel asks first.",
+    sublabel: "read + reply only",
     tone: "negative",
   },
   standard: {
     label: "Standard",
-    sublabel: "reply + safe tools",
-    description:
-      "Safe, low-risk tools are auto-approved; anything sensitive still asks.",
+    sublabel: "safe actions, ask for the rest",
     tone: "warning",
   },
   full_access: {
     label: presetFromThreshold("high").label,
-    sublabel: "all tools",
-    description:
-      "All tools auto-approve in this channel, even when the global setting is stricter. Sensitive-tool protections still apply.",
+    sublabel: "acts freely",
     tone: "positive",
   },
 };

--- a/clients/web/src/domains/contacts/slack-channel-overrides.ts
+++ b/clients/web/src/domains/contacts/slack-channel-overrides.ts
@@ -1,13 +1,18 @@
 /**
- * Per-channel capabilities-tier model for the Slack channel list's
- * expandable rows ("Assistant Access" in user-facing copy). The tier is
- * the only per-room knob, and the list is
+ * Per-channel Assistant Access model for the Slack channel list's
+ * expandable rows. The tier is the only per-room knob, and the list is
  * rooms only (channels and group DMs): admission — who can reach the
  * assistant — is a channel-type concern handled by the trust floors, and
  * how the assistant interacts with an individual person is contact-list
  * territory, so 1:1 DMs carry no room settings.
  *
- * Tiers persist as channel-ID-tier cells in the gateway's
+ * The tier axis is not its own vocabulary: a channel tier IS a
+ * {@link RiskThreshold}, the same value the global Assistant Access
+ * presets ({@link THRESHOLD_PRESETS}) read and write, and it carries the
+ * same preset name everywhere it appears. This module adds only the
+ * channel-surface presentation (picker sublabels, badge tones).
+ *
+ * Tiers persist as channel-ID cells in the gateway's
  * `channel_permission_overrides` matrix (one cell per non-guardian
  * contact-type; see {@link CHANNEL_TIER_CONTACT_TYPES}).
  */
@@ -15,23 +20,22 @@ import type { TagTone } from "@vellumai/design-library/components/tag";
 
 import {
   presetFromThreshold,
+  THRESHOLD_PRESETS,
   type RiskThreshold,
 } from "@/utils/threshold-presets";
 
 /**
- * Three-level capabilities tier shown on the row badge and the segmented
- * picker. `strict` and `full_access` carry the same labels as the matching
- * threshold presets; `standard` is the tier axis's intermediate level.
+ * A channel's Assistant Access tier — the persisted risk threshold itself,
+ * not a parallel enum.
  */
-export const CAPABILITY_TIER_VALUES = [
-  "strict",
-  "standard",
-  "full_access",
-] as const;
+export type SlackCapabilityTier = RiskThreshold;
 
-export type SlackCapabilityTier = (typeof CAPABILITY_TIER_VALUES)[number];
+/** Picker/legend order: the global presets' own order (Strict → Full access). */
+export const CAPABILITY_TIER_VALUES: readonly SlackCapabilityTier[] =
+  THRESHOLD_PRESETS.map((preset) => preset.riskThreshold);
 
 interface CapabilityTierMeta {
+  /** Preset name, straight from the matching global Assistant Access preset. */
   label: string;
   /**
    * Short qualifier shown under the label in the tier picker. The full
@@ -44,48 +48,27 @@ interface CapabilityTierMeta {
 }
 
 export const CAPABILITY_TIER_META: Record<SlackCapabilityTier, CapabilityTierMeta> = {
-  strict: {
+  none: {
     label: presetFromThreshold("none").label,
-    sublabel: "read + reply only",
+    sublabel: "ask before every action",
     tone: "negative",
   },
-  standard: {
-    label: "Standard",
+  low: {
+    label: presetFromThreshold("low").label,
     sublabel: "safe actions, ask for the rest",
     tone: "warning",
   },
-  full_access: {
+  medium: {
+    label: presetFromThreshold("medium").label,
+    sublabel: "workspace actions too",
+    tone: "info",
+  },
+  high: {
     label: presetFromThreshold("high").label,
     sublabel: "acts freely",
     tone: "positive",
   },
 };
-
-/** Threshold written to each contact-type cell when a tier is chosen. */
-export const CAPABILITY_TIER_THRESHOLDS: Record<
-  SlackCapabilityTier,
-  RiskThreshold
-> = {
-  strict: "none",
-  standard: "low",
-  full_access: "high",
-};
-
-/**
- * Inverse presentation mapping for cells written elsewhere: "medium"
- * (Relaxed — no tier equivalent) reads as the intermediate tier.
- */
-export function tierFromThreshold(
-  threshold: RiskThreshold,
-): SlackCapabilityTier {
-  if (threshold === "none") {
-    return "strict";
-  }
-  if (threshold === "high") {
-    return "full_access";
-  }
-  return "standard";
-}
 
 /**
  * Contact types a channel-tier write fans out to: everyone except the
@@ -113,7 +96,7 @@ export interface ChannelTierCell {
 }
 
 /**
- * Channel-ID-tier cells → per-channel tier map for one adapter. The
+ * Channel-ID cells → per-channel tier map for one adapter. The
  * trusted_contact cell is the representative when contact-type cells
  * diverge (the write path keeps all non-guardian cells aligned).
  */
@@ -134,7 +117,7 @@ export function tierOverridesFromCells(
       continue;
     }
     if (cell.contactType === "trusted_contact" || !(channelId in overrides)) {
-      overrides[channelId] = tierFromThreshold(cell.threshold);
+      overrides[channelId] = cell.threshold;
     }
   }
   return overrides;
@@ -154,7 +137,7 @@ export interface SlackChannelTierSettings {
 }
 
 /** Presentation default for rooms with no persisted cell. */
-export const DEFAULT_CHANNEL_TIER: SlackCapabilityTier = "full_access";
+export const DEFAULT_CHANNEL_TIER: SlackCapabilityTier = "high";
 
 /** Resolves the row's tier from a persisted cell, if any. */
 export function resolveChannelTier(

--- a/packages/design-library/src/components/segment-control.test.tsx
+++ b/packages/design-library/src/components/segment-control.test.tsx
@@ -116,6 +116,55 @@ describe("SegmentControl text-mode (non-icon-only) geometry is unchanged", () =>
   });
 });
 
+describe("SegmentControl sublabels", () => {
+  const sublabelItems: SegmentControlItem<ThemeValue>[] = [
+    { value: "light", label: "Light", sublabel: "bright and clear" },
+    { value: "dark", label: "Dark" },
+    { value: "system", label: "System" },
+  ];
+
+  test("renders the sublabel under the label when provided", () => {
+    const html = renderToStaticMarkup(
+      <SegmentControl
+        items={sublabelItems}
+        value="light"
+        onChange={() => {}}
+        ariaLabel="Theme"
+      />,
+    );
+    expect(html).toContain("bright and clear");
+    expect(html).toContain("flex-col");
+  });
+
+  test("items without a sublabel keep the single-line rendering", () => {
+    const html = renderToStaticMarkup(
+      <SegmentControl
+        items={textItems}
+        value="light"
+        onChange={() => {}}
+        ariaLabel="Theme"
+      />,
+    );
+    expect(html).not.toContain("flex-col");
+  });
+
+  test("iconOnly mode ignores sublabels", () => {
+    const html = renderToStaticMarkup(
+      <SegmentControl
+        items={sublabelItems.map((item, i) => ({
+          ...item,
+          icon: iconItems[i]!.icon,
+        }))}
+        value="light"
+        onChange={() => {}}
+        iconOnly
+        ariaLabel="Theme"
+      />,
+    );
+    expect(html).not.toContain("bright and clear");
+  });
+});
+
 describe("SegmentControl selection behavior", () => {
   test("clicking a non-active segment resolves to the new value", () => {
     expect(resolveSegmentSelection(iconItems, "light", "dark")).toBe("dark");

--- a/packages/design-library/src/components/segment-control.tsx
+++ b/packages/design-library/src/components/segment-control.tsx
@@ -6,6 +6,8 @@ import { cn } from "../utils/cn";
 export interface SegmentControlItem<T extends string> {
   value: T;
   label: string;
+  /** Optional second line under the label (ignored in `iconOnly` mode). */
+  sublabel?: string;
   icon?: ReactNode;
   disabled?: boolean;
 }
@@ -154,7 +156,17 @@ export function SegmentControl<T extends string>({
             )}
           >
             {item.icon}
-            {!iconOnly && item.label}
+            {!iconOnly &&
+              (item.sublabel != null ? (
+                <span className="flex flex-col items-center gap-0.5">
+                  <span>{item.label}</span>
+                  <span className="text-body-small-default text-[var(--content-tertiary)]">
+                    {item.sublabel}
+                  </span>
+                </span>
+              ) : (
+                item.label
+              ))}
           </Button>
         );
       })}

--- a/packages/design-library/src/components/tag.tsx
+++ b/packages/design-library/src/components/tag.tsx
@@ -28,6 +28,7 @@ const tagVariants = cva(
         positive: "bg-[var(--system-positive-weak)]",
         negative: "bg-[var(--system-negative-weak)]",
         warning: "bg-[var(--system-mid-weak)]",
+        info: "bg-[var(--system-info-weak)]",
         neutral: "bg-[var(--tag-bg-neutral)]",
       },
     },
@@ -50,6 +51,7 @@ const TONE_ICON_COLOR: Record<TagTone, string> = {
   positive: "var(--system-positive-strong)",
   negative: "var(--system-negative-strong)",
   warning: "var(--system-mid-strong)",
+  info: "var(--system-info-strong)",
   neutral: "var(--content-secondary)",
 };
 


### PR DESCRIPTION
<!-- PR title format: type(scope): description -->

## Prompt / plan

Implements [LUM-2735](https://linear.app/vellum/issue/LUM-2735/featweb-slack-channel-access-rename-capabilities-assistant-access) (supersedes LUM-2733), plus two follow-on decisions made during review: full preset parity for the channel tiers, and [LUM-2737](https://linear.app/vellum/issue/LUM-2737/refactorweb-migrate-slack-channel-list-accordion-to-design-library) (accordion → design-library `Collapsible`).

1. **Rename** — all user-visible "Capabilities" strings on the Slack channel list become "Assistant Access" (expanded-panel header, picker aria label, "Custom access." callout). No hardcoded assistant name or route strings anywhere: copy uses the existing `assistantDisplayName` binding, the settings link uses `routes.settings.privacy`.
2. **Legend** — a one-time "Assistant Access levels" legend renders between the toolbar and the rows (`slack-channel-tier-legend.tsx`): tone dot + preset label + behavior-framed description per tier; 4-across on wide, 2-up, then single column on narrow. Copy is fact-checked against `assistant/src/permissions/approval-policy.ts` + `gateway-threshold-reader.ts`: a channel cell replaces the global threshold; deny Trust Rules block at every threshold (so the full-access entry claims only "blocked in Trust Rules stays blocked", linking Trust Rules to Privacy settings); Strict means every action prompts, not a tool ban.
3. **Tier ↔ preset unification** — the channel tier is now literally the `RiskThreshold` the global Assistant Access presets read and write (`SlackCapabilityTier = RiskThreshold`). The parallel 3-value enum, `CAPABILITY_TIER_THRESHOLDS` map, and `tierFromThreshold()` inverse are deleted; labels come from `THRESHOLD_PRESETS`, so all four options (Strict / Conservative / Relaxed / Full access) carry the same names as the composer menu and Risk Tolerance settings, and nothing is representable in one surface but not the other. Only channel-specific presentation (picker sublabels, badge tones) stays local. `Tag` gains an `info` tone from the existing `--system-info-*` tokens for the Relaxed badge.
4. **Per-row description removed; picker sublabels added** — the expanded panel keeps the tier picker + overridden/default pill; `SegmentControlItem` learns an optional backwards-compatible `sublabel`.
5. **Accordion migration (LUM-2737)** — the hand-rolled grid-rows accordion is replaced with the design library's `Collapsible` (Radix Accordion), matching every other expandable surface in the app. Single controlled Root preserves single-open behavior, "Expand all" multi-open, and the virtualized >100-row branch.

📸 Screenshots (also attached to LUM-2735): [legend + expanded row after parity](https://uploads.linear.app/854629f9-2829-4be0-bb64-a004bf516cbd/e2fefe95-7991-48bc-9b69-6d39c4adc17c/10c89c98-32ea-43dd-90a4-d86d91880d15) · [initial 3-tier version](https://uploads.linear.app/854629f9-2829-4be0-bb64-a004bf516cbd/47f86afb-9ebe-4ffe-81c5-c94c5f6f98c6/0ad291a8-edb1-4f80-b299-1e94b07ddef2) — cc @ashlee

Note: existing persisted channel cells are unaffected — cells always stored `RiskThreshold` values; only the client-side representation unified. A `medium` cell (previously displayed as "Standard") now displays correctly as Relaxed.

## Test plan

- `bun test` on `slack-channel-overrides.test.ts` (10 pass — includes a parity test asserting tiers/labels come from `THRESHOLD_PRESETS`, not redefined) and `slack-channel-list.test.ts` (13 pass).
- Full design-library suite (158 pass) incl. new `SegmentControl` sublabel cases; `bunx tsc --noEmit` in both packages; repo pre-commit lint/typecheck hooks green.
- Manual: Storybook `Contacts/SlackChannelList` — legend renders once above the rows; expanded overridden row shows "Custom access." callout, 4-segment picker with sublabels, "Conservative • custom" badge; accordion expand/collapse works on the Radix animation; Trust Rules link resolves to `/assistant/settings/privacy`.
- CI note: first run failed in runner setup (apt mirror `packages.microsoft.com` clearsign error while installing browsers — never reached lint/tests); retriggered via empty commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015T1Srp5ZAqi9yNJnpjddBz