### PR TITLE
feat(tts): Deepgram PCM honors sampleRateHz hint with supported-rate clamp

### DIFF
--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -443,7 +443,10 @@ describe("ElevenLabs TTS provider adapter", () => {
     });
 
     await expect(
-      provider.synthesizeStream!(makeRequest({ outputFormat: "pcm" }), () => {}),
+      provider.synthesizeStream!(
+        makeRequest({ outputFormat: "pcm" }),
+        () => {},
+      ),
     ).rejects.toMatchObject({
       name: "ElevenLabsTtsError",
       code: "ELEVENLABS_TTS_STREAM_TIMEOUT",
@@ -472,8 +475,9 @@ describe("ElevenLabs TTS provider adapter", () => {
     });
 
     await expect(
-      provider.synthesizeStream!(makeRequest({ outputFormat: "pcm" }), (chunk) =>
-        received.push(chunk),
+      provider.synthesizeStream!(
+        makeRequest({ outputFormat: "pcm" }),
+        (chunk) => received.push(chunk),
       ),
     ).rejects.toMatchObject({
       name: "ElevenLabsTtsError",
@@ -1132,6 +1136,76 @@ describe("Deepgram TTS provider adapter", () => {
     expect(capturedUrl).toContain("container=none");
     expect(capturedUrl).toContain("sample_rate=16000");
     expect(result.contentType).toBe("audio/pcm");
+  });
+
+  test("pcm request honors a supported sampleRateHz hint", async () => {
+    const audioPayload = new Uint8Array([0x00, 0x01, 0x02]);
+    let capturedUrl = "";
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      capturedUrl = typeof input === "string" ? input : input.toString();
+      return new Response(audioPayload, { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const provider = createDeepgramProvider();
+    await provider.synthesize(
+      makeRequest({ outputFormat: "pcm", sampleRateHz: 24_000 }),
+    );
+
+    expect(capturedUrl).toContain("encoding=linear16");
+    expect(capturedUrl).toContain("container=none");
+    expect(capturedUrl).toContain("sample_rate=24000");
+  });
+
+  test("pcm request clamps an unsupported sampleRateHz hint to the nearest supported rate", async () => {
+    const audioPayload = new Uint8Array([0x00, 0x01, 0x02]);
+    let capturedUrl = "";
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      capturedUrl = typeof input === "string" ? input : input.toString();
+      return new Response(audioPayload, { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const provider = createDeepgramProvider();
+
+    await provider.synthesize(
+      makeRequest({ outputFormat: "pcm", sampleRateHz: 44_100 }),
+    );
+    expect(capturedUrl).toContain("sample_rate=48000");
+
+    // Tie between 8000 and 16000 prefers the higher rate.
+    await provider.synthesize(
+      makeRequest({ outputFormat: "pcm", sampleRateHz: 12_000 }),
+    );
+    expect(capturedUrl).toContain("sample_rate=16000");
+  });
+
+  // -- Output sample rate probe ---------------------------------------------
+
+  test("resolveOutputSampleRateHz returns the clamped rate for pcm requests", () => {
+    const provider = createDeepgramProvider();
+    expect(
+      provider.resolveOutputSampleRateHz!(
+        makeRequest({ outputFormat: "pcm", sampleRateHz: 44_100 }),
+      ),
+    ).toBe(48_000);
+  });
+
+  test("resolveOutputSampleRateHz defaults to 16 kHz for hint-less pcm requests", () => {
+    const provider = createDeepgramProvider();
+    expect(
+      provider.resolveOutputSampleRateHz!(makeRequest({ outputFormat: "pcm" })),
+    ).toBe(16_000);
+  });
+
+  test("resolveOutputSampleRateHz returns undefined for non-pcm requests", () => {
+    const provider = createDeepgramProvider();
+    expect(provider.resolveOutputSampleRateHz!(makeRequest())).toBeUndefined();
+    expect(
+      provider.resolveOutputSampleRateHz!(
+        makeRequest({ sampleRateHz: 24_000 }),
+      ),
+    ).toBeUndefined();
   });
 
   test("translates wav config format to linear16 encoding with container=wav", async () => {

--- a/assistant/src/tts/providers/deepgram-provider.ts
+++ b/assistant/src/tts/providers/deepgram-provider.ts
@@ -53,6 +53,22 @@ export class DeepgramTtsError extends Error {
 
 const DEEPGRAM_API_BASE = "https://api.deepgram.com";
 
+/**
+ * Sample rate for PCM requests that carry no `sampleRateHz` hint. The
+ * media-stream transcoder assumes headerless PCM is 16 kHz (the
+ * ElevenLabs/Deepgram/xAI convention) and downsamples to 8 kHz telephony.
+ */
+const DEFAULT_PCM_SAMPLE_RATE_HZ = 16_000;
+
+/**
+ * Sample rates Deepgram's linear16 encoding accepts. Per
+ * https://developers.deepgram.com/docs/tts-media-output-settings
+ * these are 8/16/24/32/48 kHz (22.05 and 44.1 kHz are not supported).
+ */
+const SUPPORTED_PCM_SAMPLE_RATES_HZ = [
+  8_000, 16_000, 24_000, 32_000, 48_000,
+] as const;
+
 /** Map from Deepgram encoding names to MIME content types. */
 const FORMAT_CONTENT_TYPE: Record<string, string> = {
   mp3: "audio/mpeg",
@@ -77,16 +93,46 @@ interface DeepgramOutputParams {
   contentTypeKey: string;
 }
 
+/** Nearest Deepgram-supported PCM sample rate to `hintHz`; ties prefer the higher rate. */
+function nearestSupportedPcmSampleRateHz(hintHz: number): number {
+  return SUPPORTED_PCM_SAMPLE_RATES_HZ.reduce((best, rate) => {
+    const bestDelta = Math.abs(best - hintHz);
+    const delta = Math.abs(rate - hintHz);
+    if (delta < bestDelta || (delta === bestDelta && rate > best)) {
+      return rate;
+    }
+    return best;
+  });
+}
+
+/**
+ * Actual PCM output sample rate for a request. A PCM request's hint is clamped
+ * to the nearest Deepgram-supported rate (e.g. 44.1 kHz → 48 kHz) so the same
+ * value is both sent to the API and reported to callers; non-PCM formats carry
+ * their rate in the container and report undefined.
+ */
+function resolvePcmOutputSampleRateHz(
+  request: TtsSynthesisRequest,
+): number | undefined {
+  if (request.outputFormat !== "pcm") {
+    return undefined;
+  }
+  return nearestSupportedPcmSampleRateHz(
+    request.sampleRateHz ?? DEFAULT_PCM_SAMPLE_RATE_HZ,
+  );
+}
+
 /**
  * Resolve the Deepgram output encoding, container, and sample rate based on
  * the synthesis request and provider config.
  *
  * **PCM path** (`outputFormat: "pcm"`):
  *   The media-stream transport needs raw headerless PCM for mu-law transcoding.
- *   We request `encoding=linear16&container=none&sample_rate=16000` — 16-bit
- *   signed little-endian at 16 kHz with no WAV header. This matches the
- *   ElevenLabs `pcm_16000` convention and the downstream
- *   `audioBufferToFrames` expectation (16 kHz -> 8 kHz downsample).
+ *   We request `encoding=linear16&container=none` — 16-bit signed
+ *   little-endian with no WAV header — at the request's `sampleRateHz` hint
+ *   clamped to the nearest Deepgram-supported rate, defaulting to 16 kHz when
+ *   no hint is given. An explicit `sample_rate` is always sent to avoid
+ *   Deepgram's 24 kHz default.
  *
  * **WAV path** (`config.format === "wav"`):
  *   Deepgram treats WAV as a container, not an encoding. We translate to
@@ -103,7 +149,7 @@ function resolveOutputParams(
     return {
       encoding: "linear16",
       container: "none",
-      sample_rate: 16_000,
+      sample_rate: resolvePcmOutputSampleRateHz(request),
       contentTypeKey: "linear16",
     };
   }
@@ -128,6 +174,7 @@ export function createDeepgramProvider(): TtsProvider {
   return {
     id: "deepgram",
     capabilities,
+    resolveOutputSampleRateHz: resolvePcmOutputSampleRateHz,
 
     async synthesize(
       request: TtsSynthesisRequest,


### PR DESCRIPTION
## Summary
- Deepgram PCM requests now honor the `sampleRateHz` hint, clamped to the nearest linear16-supported rate (8/16/24/32/48 kHz; ties prefer higher)
- Adds the `resolveOutputSampleRateHz` probe so streaming callers label chunks with the true output rate
- No-hint behavior unchanged (16 kHz)

Part of plan: deepgram-streaming-pcm.md (PR 1 of 2)