### PR TITLE
fix(sidebar): dont mark first item active on mobile menu root

### DIFF
--- a/clients/web/src/components/sidebar-tree.tsx
+++ b/clients/web/src/components/sidebar-tree.tsx
@@ -2,6 +2,7 @@ import { ChevronRight, type LucideIcon } from "lucide-react";
 import { Fragment } from "react";
 import { useLocation, useNavigate } from "react-router";
 
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { SideMenu } from "@vellumai/design-library";
 
 export interface SidebarItem {
@@ -31,6 +32,7 @@ export function SidebarTree({
 }: SidebarTreeProps) {
   const { pathname } = useLocation();
   const navigate = useNavigate();
+  const isMobile = useIsMobile();
 
   const renderItem = (item: SidebarItem, isLast: boolean, isIndexItem: boolean) => {
     const { href, onSelect } = item;
@@ -38,7 +40,7 @@ export function SidebarTree({
       href != null &&
       (pathname === href ||
         pathname.startsWith(href + "/") ||
-        (isIndexItem && indexPath != null && pathname === indexPath));
+        (!isMobile && isIndexItem && indexPath != null && pathname === indexPath));
     return (
       <Fragment key={item.id}>
         <SideMenu.Item


### PR DESCRIPTION
## Problem

Figma annotation (node 6626-6728): **"Coming back from the pages leaves the active state on the button"**

On mobile, when navigating to a sub-page (e.g. Emails) and returning to the menu, the first sidebar item (e.g. Usage) appears stuck in active/selected state.

## Root Cause

`SidebarTree` marks the first item as active whenever `pathname === indexPath` via the `isIndexItem` condition:

```js
const isActive =
  href != null &&
  (pathname === href ||
    pathname.startsWith(href + "/") ||
    (isIndexItem && indexPath != null && pathname === indexPath));
```

This is correct on **desktop** — `SidebarShell` renders the sidebar and content side-by-side, and the index route (e.g. `/assistant/logs`) renders the first item's page content. Highlighting the first item communicates "you are here."

On **mobile**, `SidebarShell` shows only the sidebar menu on the index route (the `<main>` content area is `hidden` when `isMenuRoute` is true). The user is looking at a menu, not at the first item's page. When they navigate to a sub-page and come back, the first item lights up again — looking stuck.

## Fix

Guard the `isIndexItem` condition with `!isMobile`:

```js
(!isMobile && isIndexItem && indexPath != null && pathname === indexPath)
```

On mobile, items only go active when `pathname === href` — which only happens on sub-pages where the sidebar is already hidden. So no item highlights on the mobile menu root.

## Scope

- **1 file changed:** `clients/web/src/components/sidebar-tree.tsx`
- **Desktop behavior unchanged** — `useIsMobile()` returns false above 768px, so the `!isMobile` guard is a no-op
- **Settings page also affected** — same `SidebarTree` component, same `indexPath` pattern. The "General" item will no longer highlight on the mobile settings menu root
- Uses existing `useIsMobile()` hook (66 existing uses in the codebase)

## What I chose NOT to do

- **CSS-only fix (`max-md:`)**: The active state is computed in JS and passed as a prop to `SideMenu.Item`. There's no CSS class to override — the `active` boolean drives the styling. A JS guard is the correct layer.
- **Reworking SidebarShell to not pass indexPath on mobile**: The `indexPath` prop serves the desktop index-route case. Removing it would break desktop. The guard is cleaner.

## Testing

⚠️ No build tooling available in the container (no tsc/vitest). Type safety verified by code review — `useIsMobile()` returns `boolean`, combined with `&&` in an existing boolean expression. Needs CI + manual mobile verification.

**Manual test steps:**
1. Open the app on mobile (or narrow viewport < 768px)
2. Navigate to `/assistant/logs` — no item should be highlighted
3. Tap "Emails", go to the Emails page, tap back — no item should be highlighted on the menu
4. Repeat on desktop (> 768px) — "Usage" should highlight on `/assistant/logs` (unchanged behavior)