### PR TITLE
feat(tts): Deepgram chunk-streaming synthesis (true streaming PCM provider)

### DIFF
--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -197,6 +197,15 @@ function mockFetchError(status: number, body: string): void {
   ) as unknown as typeof globalThis.fetch;
 }
 
+function streamOf(...parts: Uint8Array[]): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const part of parts) controller.enqueue(part);
+      controller.close();
+    },
+  });
+}
+
 // ===========================================================================
 // ElevenLabs provider adapter
 // ===========================================================================
@@ -394,15 +403,6 @@ describe("ElevenLabs TTS provider adapter", () => {
   });
 
   // -- Streaming -------------------------------------------------------------
-
-  function streamOf(...parts: Uint8Array[]): ReadableStream<Uint8Array> {
-    return new ReadableStream<Uint8Array>({
-      start(controller) {
-        for (const part of parts) controller.enqueue(part);
-        controller.close();
-      },
-    });
-  }
 
   test("synthesizeStream reads chunks from the /stream endpoint and concatenates them", async () => {
     const part1 = new Uint8Array([0x01, 0x02]);
@@ -1073,14 +1073,20 @@ describe("Deepgram TTS provider adapter", () => {
     expect(provider.id).toBe("deepgram");
   });
 
-  test("advertises mp3, wav, opus format support without streaming", () => {
+  test("advertises mp3, wav, opus, pcm format support with streaming", () => {
     const provider = createDeepgramProvider();
-    expect(provider.capabilities.supportsStreaming).toBe(false);
+    expect(provider.capabilities.supportsStreaming).toBe(true);
     expect(provider.capabilities.supportedFormats).toEqual([
       "mp3",
       "wav",
       "opus",
+      "pcm",
     ]);
+  });
+
+  test("implements synthesizeStream", () => {
+    const provider = createDeepgramProvider();
+    expect(typeof provider.synthesizeStream).toBe("function");
   });
 
   // -- Request mapping -----------------------------------------------------
@@ -1243,6 +1249,165 @@ describe("Deepgram TTS provider adapter", () => {
     expect(capturedUrl).toContain("model=aura-luna-en");
   });
 
+  // -- Streaming -------------------------------------------------------------
+
+  test("synthesizeStream reads chunks from /v1/speak and concatenates them", async () => {
+    const part1 = new Uint8Array([0x01, 0x02]);
+    const part2 = new Uint8Array([0x03]);
+    const part3 = new Uint8Array([0x04, 0x05]);
+    let capturedUrl = "";
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      capturedUrl = typeof input === "string" ? input : input.toString();
+      return new Response(streamOf(part1, part2, part3), { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const received: Uint8Array[] = [];
+    const provider = createDeepgramProvider();
+    const result = await provider.synthesizeStream!(
+      makeRequest({ outputFormat: "pcm" }),
+      (chunk) => received.push(chunk),
+    );
+
+    expect(capturedUrl).toContain("/v1/speak");
+    expect(capturedUrl).toContain("encoding=linear16");
+    expect(capturedUrl).toContain("container=none");
+    expect(capturedUrl).toContain("sample_rate=");
+    expect(received).toEqual([part1, part2, part3]);
+    expect(result.audio).toEqual(Buffer.from([0x01, 0x02, 0x03, 0x04, 0x05]));
+    expect(result.contentType).toBe("audio/pcm");
+  });
+
+  test("synthesizeStream rejects after the first-chunk timeout when the stream never produces audio", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response(new ReadableStream<Uint8Array>({ start() {} }), {
+          status: 200,
+        }),
+    ) as unknown as typeof globalThis.fetch;
+
+    const provider = createDeepgramProvider({
+      firstChunkTimeoutMs: 20,
+      idleTimeoutMs: 20,
+    });
+
+    await expect(
+      provider.synthesizeStream!(
+        makeRequest({ outputFormat: "pcm" }),
+        () => {},
+      ),
+    ).rejects.toMatchObject({
+      name: "DeepgramTtsError",
+      code: "DEEPGRAM_TTS_STREAM_TIMEOUT",
+      message: expect.stringContaining("timed out after 20ms"),
+    });
+  });
+
+  test("synthesizeStream rejects after the idle timeout when the stream stalls mid-stream", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new Uint8Array([0x01, 0x02]));
+              // Never enqueue again and never close — a mid-stream stall.
+            },
+          }),
+          { status: 200 },
+        ),
+    ) as unknown as typeof globalThis.fetch;
+
+    const received: Uint8Array[] = [];
+    const provider = createDeepgramProvider({
+      firstChunkTimeoutMs: 1_000,
+      idleTimeoutMs: 20,
+    });
+
+    await expect(
+      provider.synthesizeStream!(
+        makeRequest({ outputFormat: "pcm" }),
+        (chunk) => received.push(chunk),
+      ),
+    ).rejects.toMatchObject({
+      name: "DeepgramTtsError",
+      code: "DEEPGRAM_TTS_STREAM_TIMEOUT",
+    });
+    expect(received).toHaveLength(1);
+  });
+
+  test("synthesizeStream throws DEEPGRAM_TTS_EMPTY_RESPONSE on null body", async () => {
+    globalThis.fetch = mock(
+      async () => new Response(null, { status: 200 }),
+    ) as unknown as typeof globalThis.fetch;
+
+    const provider = createDeepgramProvider();
+
+    try {
+      await provider.synthesizeStream!(makeRequest(), () => {});
+      throw new Error("Expected synthesizeStream to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(DeepgramTtsError);
+      expect((err as DeepgramTtsError).code).toBe(
+        "DEEPGRAM_TTS_EMPTY_RESPONSE",
+      );
+    }
+  });
+
+  test("synthesizeStream throws DEEPGRAM_TTS_EMPTY_RESPONSE on zero-byte stream", async () => {
+    globalThis.fetch = mock(
+      async () => new Response(streamOf(), { status: 200 }),
+    ) as unknown as typeof globalThis.fetch;
+
+    const provider = createDeepgramProvider();
+
+    try {
+      await provider.synthesizeStream!(makeRequest(), () => {});
+      throw new Error("Expected synthesizeStream to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(DeepgramTtsError);
+      expect((err as DeepgramTtsError).code).toBe(
+        "DEEPGRAM_TTS_EMPTY_RESPONSE",
+      );
+    }
+  });
+
+  test("synthesizeStream throws DEEPGRAM_TTS_HTTP_ERROR on non-200 response", async () => {
+    mockFetchError(429, "Rate limit exceeded");
+
+    const provider = createDeepgramProvider();
+
+    try {
+      await provider.synthesizeStream!(makeRequest(), () => {});
+      throw new Error("Expected synthesizeStream to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(DeepgramTtsError);
+      expect((err as DeepgramTtsError).code).toBe("DEEPGRAM_TTS_HTTP_ERROR");
+      expect((err as DeepgramTtsError).statusCode).toBe(429);
+    }
+  });
+
+  test("synthesizeStream propagates AbortError unmodified", async () => {
+    globalThis.fetch = mock(async () => {
+      const abortError = new Error("The operation was aborted");
+      abortError.name = "AbortError";
+      throw abortError;
+    }) as unknown as typeof globalThis.fetch;
+
+    const controller = new AbortController();
+    const provider = createDeepgramProvider();
+
+    try {
+      await provider.synthesizeStream!(
+        makeRequest({ signal: controller.signal }),
+        () => {},
+      );
+      throw new Error("Expected synthesizeStream to throw");
+    } catch (err) {
+      expect(err).not.toBeInstanceOf(DeepgramTtsError);
+      expect((err as Error).name).toBe("AbortError");
+    }
+  });
+
   // -- Content type / format -----------------------------------------------
 
   test("returns audio/mpeg content type for mp3 format", async () => {
@@ -1254,6 +1419,18 @@ describe("Deepgram TTS provider adapter", () => {
 
     expect(result.contentType).toBe("audio/mpeg");
     expect(result.audio.byteLength).toBeGreaterThan(0);
+  });
+
+  test("synthesizeStream resolves audio/mpeg content type for mp3 format", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response(streamOf(new Uint8Array([0x49])), { status: 200 }),
+    ) as unknown as typeof globalThis.fetch;
+
+    const provider = createDeepgramProvider();
+    const result = await provider.synthesizeStream!(makeRequest(), () => {});
+
+    expect(result.contentType).toBe("audio/mpeg");
   });
 
   // -- Required config validation ------------------------------------------

--- a/assistant/src/tts/__tests__/provider-catalog.test.ts
+++ b/assistant/src/tts/__tests__/provider-catalog.test.ts
@@ -181,14 +181,15 @@ describe("Deepgram catalog entry", () => {
     expect(entry.callMode).toBe("synthesized-play");
   });
 
-  test("does not support streaming", () => {
-    expect(entry.capabilities.supportsStreaming).toBe(false);
+  test("supports streaming", () => {
+    expect(entry.capabilities.supportsStreaming).toBe(true);
   });
 
-  test("supports mp3, wav, and opus formats", () => {
+  test("supports mp3, wav, opus, and pcm formats", () => {
     expect(entry.capabilities.supportedFormats).toContain("mp3");
     expect(entry.capabilities.supportedFormats).toContain("wav");
     expect(entry.capabilities.supportedFormats).toContain("opus");
+    expect(entry.capabilities.supportedFormats).toContain("pcm");
   });
 
   test("plays over media-stream via PCM output", () => {

--- a/assistant/src/tts/providers/deepgram-provider.ts
+++ b/assistant/src/tts/providers/deepgram-provider.ts
@@ -2,9 +2,12 @@
  * Deepgram TTS provider adapter.
  *
  * Wraps the Deepgram REST text-to-speech API (`/v1/speak`) behind the uniform
- * {@link TtsProvider} interface. Reads the API key from the secure credential
- * store using the shared `deepgram` bare key (shared with STT) and the model
- * configuration from `services.tts.providers.deepgram` config section.
+ * {@link TtsProvider} interface. The endpoint streams its body natively via
+ * chunked transfer, so `synthesizeStream` forwards audio chunks as they
+ * arrive from the same URL that `synthesize` buffers. Reads the API key from
+ * the secure credential store using the shared `deepgram` bare key (shared
+ * with STT) and the model configuration from `services.tts.providers.deepgram`
+ * config section.
  */
 
 import { getConfig } from "../../config/loader.js";
@@ -12,6 +15,7 @@ import type { TtsDeepgramProviderConfig } from "../../config/schemas/tts.js";
 import { getProviderKeyAsync } from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
 import type { TtsProviderDefinition } from "../provider-definition.js";
+import { readChunkedBody } from "../stream-read.js";
 import type {
   TtsProvider,
   TtsProviderCapabilities,
@@ -29,7 +33,8 @@ export type DeepgramTtsErrorCode =
   | "DEEPGRAM_TTS_NO_API_KEY"
   | "DEEPGRAM_TTS_HTTP_ERROR"
   | "DEEPGRAM_TTS_EMPTY_RESPONSE"
-  | "DEEPGRAM_TTS_REQUEST_FAILED";
+  | "DEEPGRAM_TTS_REQUEST_FAILED"
+  | "DEEPGRAM_TTS_STREAM_TIMEOUT";
 
 export class DeepgramTtsError extends Error {
   readonly code: DeepgramTtsErrorCode;
@@ -165,104 +170,157 @@ function resolveOutputParams(
   return { encoding: config.format, contentTypeKey: config.format };
 }
 
-export function createDeepgramProvider(): TtsProvider {
+/**
+ * Resolve credentials and config, build the `/v1/speak` URL, and issue the
+ * Deepgram TTS HTTP request. Shared by `synthesize` and `synthesizeStream` —
+ * Deepgram's single endpoint streams its body natively, so both paths hit the
+ * same URL. Throws on missing credentials and non-OK responses; resolves with
+ * the OK response and the resolved content type.
+ */
+async function performTtsRequest(
+  request: TtsSynthesisRequest,
+): Promise<{ response: Response; contentType: string }> {
+  const apiKey = await getProviderKeyAsync("deepgram");
+  if (!apiKey) {
+    throw new DeepgramTtsError(
+      "DEEPGRAM_TTS_NO_API_KEY",
+      "Deepgram API key not configured. " +
+        "Add it in Settings → Voice or via: assistant keys set deepgram <key>",
+    );
+  }
+
+  const config = getConfig().services.tts.providers.deepgram;
+  const outputParams = resolveOutputParams(request, config);
+  const model = config.model;
+
+  const params = new URLSearchParams({
+    model,
+    encoding: outputParams.encoding,
+  });
+  if (outputParams.container) {
+    params.set("container", outputParams.container);
+  }
+  if (outputParams.sample_rate != null) {
+    params.set("sample_rate", String(outputParams.sample_rate));
+  }
+  const url = `${DEEPGRAM_API_BASE}/v1/speak?${params.toString()}`;
+
+  log.info(
+    {
+      model,
+      encoding: outputParams.encoding,
+      container: outputParams.container,
+      textLength: request.text.length,
+    },
+    "Starting Deepgram TTS synthesis",
+  );
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Token ${apiKey}`,
+      },
+      body: JSON.stringify({ text: request.text }),
+      signal: request.signal,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") throw err;
+    throw new DeepgramTtsError(
+      "DEEPGRAM_TTS_REQUEST_FAILED",
+      `Deepgram TTS request failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "");
+    throw new DeepgramTtsError(
+      "DEEPGRAM_TTS_HTTP_ERROR",
+      `Deepgram TTS returned ${response.status}: ${errorText}`,
+      response.status,
+    );
+  }
+
+  const contentType =
+    FORMAT_CONTENT_TYPE[outputParams.contentTypeKey] ?? "audio/mpeg";
+
+  return { response, contentType };
+}
+
+/** Stream-stall timeouts, injectable for tests. */
+export interface DeepgramStreamTimeouts {
+  firstChunkTimeoutMs?: number;
+  idleTimeoutMs?: number;
+}
+
+/**
+ * Issue the TTS request and consume the response into a complete result.
+ * The streaming path forwards chunks via `onChunk` as they arrive, guarded
+ * by first-chunk/idle stall timeouts; the buffer path reads the whole body.
+ */
+async function performSynthesis(
+  request: TtsSynthesisRequest,
+  options: {
+    stream: boolean;
+    onChunk?: (chunk: Uint8Array) => void;
+  } & DeepgramStreamTimeouts,
+): Promise<TtsSynthesisResult> {
+  const { response, contentType } = await performTtsRequest(request);
+
+  let audio: Buffer;
+  if (options.stream) {
+    if (!response.body) {
+      throw new DeepgramTtsError(
+        "DEEPGRAM_TTS_EMPTY_RESPONSE",
+        "Deepgram streaming TTS returned no response body",
+      );
+    }
+    audio = await readChunkedBody(response.body, {
+      onChunk: options.onChunk,
+      firstChunkTimeoutMs: options.firstChunkTimeoutMs,
+      idleTimeoutMs: options.idleTimeoutMs,
+      makeTimeoutError: (timeoutMs) =>
+        new DeepgramTtsError(
+          "DEEPGRAM_TTS_STREAM_TIMEOUT",
+          `Deepgram streaming TTS read timed out after ${timeoutMs}ms`,
+        ),
+    });
+  } else {
+    audio = Buffer.from(await response.arrayBuffer());
+  }
+
+  if (audio.byteLength === 0) {
+    throw new DeepgramTtsError(
+      "DEEPGRAM_TTS_EMPTY_RESPONSE",
+      "Deepgram TTS returned an empty audio response",
+    );
+  }
+
+  log.debug(
+    { bytes: audio.byteLength, stream: options.stream },
+    "Deepgram TTS synthesis complete",
+  );
+
+  return { audio, contentType };
+}
+
+export function createDeepgramProvider(
+  streamTimeouts: DeepgramStreamTimeouts = {},
+): TtsProvider {
   const capabilities: TtsProviderCapabilities = {
-    supportsStreaming: false,
-    supportedFormats: ["mp3", "wav", "opus"],
+    supportsStreaming: true,
+    supportedFormats: ["mp3", "wav", "opus", "pcm"],
   };
 
   return {
     id: "deepgram",
     capabilities,
     resolveOutputSampleRateHz: resolvePcmOutputSampleRateHz,
-
-    async synthesize(
-      request: TtsSynthesisRequest,
-    ): Promise<TtsSynthesisResult> {
-      const apiKey = await getProviderKeyAsync("deepgram");
-      if (!apiKey) {
-        throw new DeepgramTtsError(
-          "DEEPGRAM_TTS_NO_API_KEY",
-          "Deepgram API key not configured. " +
-            "Add it in Settings → Voice or via: assistant keys set deepgram <key>",
-        );
-      }
-
-      const config = getConfig().services.tts.providers.deepgram;
-      const outputParams = resolveOutputParams(request, config);
-      const model = config.model;
-
-      const params = new URLSearchParams({
-        model,
-        encoding: outputParams.encoding,
-      });
-      if (outputParams.container) {
-        params.set("container", outputParams.container);
-      }
-      if (outputParams.sample_rate != null) {
-        params.set("sample_rate", String(outputParams.sample_rate));
-      }
-      const url = `${DEEPGRAM_API_BASE}/v1/speak?${params.toString()}`;
-
-      log.info(
-        {
-          model,
-          encoding: outputParams.encoding,
-          container: outputParams.container,
-          textLength: request.text.length,
-        },
-        "Starting Deepgram TTS synthesis",
-      );
-
-      let response: Response;
-      try {
-        response = await fetch(url, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Token ${apiKey}`,
-          },
-          body: JSON.stringify({ text: request.text }),
-          signal: request.signal,
-        });
-      } catch (err) {
-        if (err instanceof Error && err.name === "AbortError") throw err;
-        throw new DeepgramTtsError(
-          "DEEPGRAM_TTS_REQUEST_FAILED",
-          `Deepgram TTS request failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-
-      if (!response.ok) {
-        const errorText = await response.text().catch(() => "");
-        throw new DeepgramTtsError(
-          "DEEPGRAM_TTS_HTTP_ERROR",
-          `Deepgram TTS returned ${response.status}: ${errorText}`,
-          response.status,
-        );
-      }
-
-      const arrayBuffer = await response.arrayBuffer();
-      if (arrayBuffer.byteLength === 0) {
-        throw new DeepgramTtsError(
-          "DEEPGRAM_TTS_EMPTY_RESPONSE",
-          "Deepgram TTS returned an empty audio response",
-        );
-      }
-
-      const contentType =
-        FORMAT_CONTENT_TYPE[outputParams.contentTypeKey] ?? "audio/mpeg";
-
-      log.debug(
-        { bytes: arrayBuffer.byteLength },
-        "Deepgram TTS synthesis complete",
-      );
-
-      return {
-        audio: Buffer.from(arrayBuffer),
-        contentType,
-      };
-    },
+    synthesize: (request) => performSynthesis(request, { stream: false }),
+    synthesizeStream: (request, onChunk) =>
+      performSynthesis(request, { stream: true, onChunk, ...streamTimeouts }),
   };
 }
 
@@ -291,8 +349,8 @@ export const deepgramTtsProviderDefinition: TtsProviderDefinition = {
   callMode: "synthesized-play",
   allowNativeFallback: false,
   capabilities: {
-    supportsStreaming: false,
-    supportedFormats: ["mp3", "wav", "opus"],
+    supportsStreaming: true,
+    supportedFormats: ["mp3", "wav", "opus", "pcm"],
   },
   // The adapter honours the PCM hint via `linear16` + `container=none`.
   mediaStreamPlayback: { outputFormat: "pcm" },


### PR DESCRIPTION
## Summary
- Deepgram TTS now streams audio chunks from /v1/speak via the shared readChunkedBody reader (first-chunk/idle stall timeouts, DEEPGRAM_TTS_STREAM_TIMEOUT)
- supportsStreaming flipped on adapter + catalog definition; pcm added to supportedFormats
- Phone/hands-free segments with Deepgram start playing on the first chunk instead of after full-segment synthesis

Part of plan: deepgram-streaming-pcm.md (PR 2 of 2)