### PR TITLE
feat(skills): record source conversation lineage in install-meta for retrospective-authored skills

### DIFF
--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -50,8 +50,10 @@ function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
 }
 
 /** A retrospective-pass tool context (assistant-authored scaffolds). */
-function makeRetrospectiveContext(): ToolContext {
-  return makeContext({ requestOrigin: "memory_retrospective" });
+function makeRetrospectiveContext(
+  overrides: Partial<ToolContext> = {},
+): ToolContext {
+  return makeContext({ requestOrigin: "memory_retrospective", ...overrides });
 }
 
 function installMetaFor(skillId: string) {
@@ -824,6 +826,133 @@ describe("scaffold_managed_skill tool", () => {
         ),
       ),
     ).toBe(true);
+  });
+
+  // ── Conversation lineage (retrospective-authored skills) ───────────────────
+
+  test("retrospective scaffold records source + retrospective conversation lineage", async () => {
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "lineage-skill",
+        name: "Lineage Skill",
+        description: "Distilled from an observed procedure",
+        body_markdown: "Do the procedure.",
+      },
+      makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
+      {
+        getConversation: (id) =>
+          id === "retro-run-conv"
+            ? { forkParentConversationId: "source-conv" }
+            : null,
+      },
+    );
+
+    expect(result.isError).toBe(false);
+    const meta = installMetaFor("lineage-skill");
+    expect(meta?.author).toBe("assistant");
+    expect(meta?.sourceConversationId).toBe("source-conv");
+    expect(meta?.retrospectiveConversationId).toBe("retro-run-conv");
+  });
+
+  test("user scaffold records no conversation lineage and never looks up the conversation", async () => {
+    const lookup = mock(() => ({ forkParentConversationId: "source-conv" }));
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "user-no-lineage",
+        name: "User No Lineage",
+        description: "Authored interactively",
+        body_markdown: "Do the thing.",
+      },
+      makeContext(),
+      { getConversation: lookup },
+    );
+
+    expect(result.isError).toBe(false);
+    const meta = installMetaFor("user-no-lineage");
+    expect(meta?.author).toBe("user");
+    expect("sourceConversationId" in meta!).toBe(false);
+    expect("retrospectiveConversationId" in meta!).toBe(false);
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  test("retrospective scaffold with no resolvable parent still succeeds and omits the source lineage", async () => {
+    // Two unresolvable shapes: the conversation row is gone entirely, or it
+    // exists but is not a fork (null parent).
+    const cases = [
+      { skillId: "orphan-no-row", lookup: () => null },
+      {
+        skillId: "orphan-no-parent",
+        lookup: () => ({ forkParentConversationId: null }),
+      },
+    ];
+
+    for (const { skillId, lookup } of cases) {
+      const result = await executeScaffoldManagedSkill(
+        {
+          skill_id: skillId,
+          name: "Orphan Lineage",
+          description: "Parent not resolvable",
+          body_markdown: "Do the procedure.",
+        },
+        makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
+        { getConversation: lookup },
+      );
+
+      expect(result.isError).toBe(false);
+      const meta = installMetaFor(skillId);
+      expect(meta?.author).toBe("assistant");
+      expect("sourceConversationId" in meta!).toBe(false);
+      // The authoring conversation is still known — the breadcrumb persists.
+      expect(meta?.retrospectiveConversationId).toBe("retro-run-conv");
+    }
+  });
+
+  test("a throwing conversation lookup never fails the retrospective scaffold", async () => {
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "lookup-throws",
+        name: "Lookup Throws",
+        description: "DB unavailable during lineage resolution",
+        body_markdown: "Do the procedure.",
+      },
+      makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
+      {
+        getConversation: () => {
+          throw new Error("db unavailable");
+        },
+      },
+    );
+
+    expect(result.isError).toBe(false);
+    const meta = installMetaFor("lookup-throws");
+    expect(meta?.author).toBe("assistant");
+    expect("sourceConversationId" in meta!).toBe(false);
+    expect(meta?.retrospectiveConversationId).toBe("retro-run-conv");
+  });
+
+  test("retrospective scaffold with no conversationId on the context omits all lineage", async () => {
+    const lookup = mock(() => ({ forkParentConversationId: "source-conv" }));
+    const context = makeRetrospectiveContext();
+    // Some runtime callers construct a partial context without a conversation.
+    delete (context as { conversationId?: string }).conversationId;
+
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "no-conversation",
+        name: "No Conversation",
+        description: "Context carries no conversation id",
+        body_markdown: "Do the procedure.",
+      },
+      context,
+      { getConversation: lookup },
+    );
+
+    expect(result.isError).toBe(false);
+    const meta = installMetaFor("no-conversation");
+    expect(meta?.author).toBe("assistant");
+    expect("sourceConversationId" in meta!).toBe(false);
+    expect("retrospectiveConversationId" in meta!).toBe(false);
+    expect(lookup).not.toHaveBeenCalled();
   });
 
   // ── Ownership backstop: never shadow/overwrite a non-managed skill ─────────

--- a/assistant/src/skills/install-meta.ts
+++ b/assistant/src/skills/install-meta.ts
@@ -29,6 +29,14 @@ export interface SkillInstallMeta {
   // skills are eligible for the usage-based prune; "user" and untagged skills
   // are protected. Set by install/scaffold callers, never defaulted here.
   author?: "assistant" | "user";
+  // Conversation whose trace the retrospective distilled this skill from (the
+  // fork's parent). The durable lineage record for retrospective-authored
+  // skills.
+  sourceConversationId?: string;
+  // Retrospective background (fork) conversation that authored this skill.
+  // That conversation is GC'd once superseded, so this id is a debugging
+  // breadcrumb only — `sourceConversationId` is the durable lineage.
+  retrospectiveConversationId?: string;
   // Day-granularity stamp of the last time the skill was loaded (ISO 8601).
   // Stamped by `touchSkillLastUsed` on the managed-skill activation path; the
   // usage-based prune reads its date portion as the last-used signal.

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -217,6 +217,10 @@ interface CreateManagedSkillParams {
   version?: string;
   contactId?: string;
   author?: "assistant" | "user";
+  // Conversation lineage for retrospective-authored skills — see the field
+  // docs on `SkillInstallMeta` (install-meta.ts).
+  sourceConversationId?: string;
+  retrospectiveConversationId?: string;
   files?: Array<{ path: string; content: string }>;
 }
 
@@ -315,6 +319,12 @@ export function createManagedSkill(
     ...(params.version ? { version: params.version } : {}),
     ...(params.contactId ? { installedBy: params.contactId } : {}),
     ...(params.author ? { author: params.author } : {}),
+    ...(params.sourceConversationId
+      ? { sourceConversationId: params.sourceConversationId }
+      : {}),
+    ...(params.retrospectiveConversationId
+      ? { retrospectiveConversationId: params.retrospectiveConversationId }
+      : {}),
   });
 
   // Clean up legacy version.json if present (superseded by install-meta.json)

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import type { SkillSource } from "../../config/skills.js";
 import { loadSkillCatalog } from "../../config/skills.js";
 import { refreshSkillCapabilityMemories } from "../../daemon/skill-memory-refresh.js";
+import { getConversation } from "../../persistence/conversation-crud.js";
 import { MEMORY_RETROSPECTIVE_ORIGIN } from "../../plugins/defaults/memory/memory-retrospective-constants.js";
 import { readInstallMeta } from "../../skills/install-meta.js";
 import {
@@ -57,14 +58,19 @@ function normalizeOptionalStringArray(
  * Core execution logic for scaffold_managed_skill.
  * Exported so bundled-skill executors and tests can call it directly.
  *
- * `deps` injects the catalog seam so the ownership backstop's non-managed
- * collision check can be exercised without standing up a real bundled/plugin
- * catalog.
+ * `deps` injects the catalog and conversation-lookup seams so the ownership
+ * backstop's non-managed collision check and the lineage resolution can be
+ * exercised without standing up a real bundled/plugin catalog or a live DB.
  */
 export async function executeScaffoldManagedSkill(
   input: Record<string, unknown>,
   context: ToolContext,
-  deps: { loadCatalog?: () => { id: string; source: SkillSource }[] } = {},
+  deps: {
+    loadCatalog?: () => { id: string; source: SkillSource }[];
+    getConversation?: (
+      id: string,
+    ) => { forkParentConversationId: string | null } | null;
+  } = {},
 ): Promise<ToolExecutionResult> {
   const skillId = input.skill_id;
   if (typeof skillId !== "string" || !skillId.trim()) {
@@ -230,6 +236,25 @@ export async function executeScaffoldManagedSkill(
     }
   }
 
+  // Conversation lineage (retrospective origin only). The retrospective runs
+  // in a background fork of the conversation it distilled the procedure from,
+  // so the fork's parent is this skill's durable source conversation.
+  // Resolution is best-effort: a missing or unresolvable parent must never
+  // fail the scaffold.
+  let sourceConversationId: string | undefined;
+  let retrospectiveConversationId: string | undefined;
+  if (fromRetrospective && context.conversationId) {
+    retrospectiveConversationId = context.conversationId;
+    try {
+      const lookupConversation = deps.getConversation ?? getConversation;
+      sourceConversationId =
+        lookupConversation(context.conversationId)?.forkParentConversationId ??
+        undefined;
+    } catch {
+      // Lineage stays unset; the scaffold itself still proceeds.
+    }
+  }
+
   const result = createManagedSkill({
     id,
     name: sanitizeFrontmatterValue(name),
@@ -246,6 +271,8 @@ export async function executeScaffoldManagedSkill(
     category,
     files,
     author,
+    sourceConversationId,
+    retrospectiveConversationId,
   });
 
   if (!result.created) {


### PR DESCRIPTION
## Summary
- Adds optional sourceConversationId / retrospectiveConversationId to SkillInstallMeta
- Retrospective-origin scaffold_managed_skill resolves the fork's parent conversation and persists both ids; user scaffolds are unchanged
- Closes the lineage gap: which conversation a retrospective-authored skill was distilled from is now durable on disk

Part of plan: skill-surfacing-v1.md (PR 2 of 8)