### PR TITLE
feat(web): render skill_card chat surface for retrospective-authored skills

### DIFF
--- a/clients/web/src/domains/chat/components/surfaces/skill-created-card.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/skill-created-card.test.tsx
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router";
+
+import { SkillCreatedCard } from "@/domains/chat/components/surfaces/skill-created-card";
+import { SurfaceRouter } from "@/domains/chat/components/surfaces/surface-router";
+import type { Surface } from "@/domains/chat/types/types";
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeSurface(overrides: Partial<Surface> = {}): Surface {
+  return {
+    surfaceId: "skill-card-conv-xyz",
+    surfaceType: "skill_card",
+    title: "New skill learned",
+    display: "inline",
+    data: {
+      skills: [
+        {
+          skillId: "skill-1",
+          name: "Weekly report digest",
+          description: "Compile the weekly report from the usual sources.",
+          emoji: "📊",
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+/** Exposes the router's current URL so tests can assert navigation. */
+function LocationProbe() {
+  const location = useLocation();
+  return (
+    <div data-testid="location">{`${location.pathname}${location.search}`}</div>
+  );
+}
+
+function renderCard(surface: Surface) {
+  return render(
+    <MemoryRouter initialEntries={["/assistant/conversations/conv-xyz"]}>
+      <SkillCreatedCard surface={surface} onAction={() => {}} />
+      <LocationProbe />
+    </MemoryRouter>,
+  );
+}
+
+describe("SkillCreatedCard", () => {
+  test("renders the header, subline, and a skill row", () => {
+    const { getByText, getByRole } = renderCard(makeSurface());
+
+    expect(getByText("New skill learned")).toBeTruthy();
+    expect(
+      getByText("Saved to your skills from this conversation's work"),
+    ).toBeTruthy();
+    expect(getByText("Weekly report digest")).toBeTruthy();
+    expect(
+      getByText("Compile the weekly report from the usual sources."),
+    ).toBeTruthy();
+    expect(getByText("📊")).toBeTruthy();
+    expect(getByRole("button", { name: "View" })).toBeTruthy();
+  });
+
+  test("renders multiple skills as stacked rows in a single card", () => {
+    const { container, getByText, getAllByRole } = renderCard(
+      makeSurface({
+        data: {
+          skills: [
+            { skillId: "skill-1", name: "Skill one", description: "First" },
+            { skillId: "skill-2", name: "Skill two", description: "Second" },
+          ],
+        },
+      }),
+    );
+
+    expect(getByText("Skill one")).toBeTruthy();
+    expect(getByText("Skill two")).toBeTruthy();
+    expect(getAllByRole("button", { name: "View" })).toHaveLength(2);
+    // One card (SurfaceContainer), not one per skill.
+    expect(container.querySelectorAll(".rounded-lg")).toHaveLength(1);
+  });
+
+  test("View navigates to the Skills tab deep-link for the clicked skill", () => {
+    const { getAllByRole, getByTestId } = renderCard(
+      makeSurface({
+        data: {
+          skills: [
+            { skillId: "skill-1", name: "Skill one" },
+            { skillId: "skill-2", name: "Skill two" },
+          ],
+        },
+      }),
+    );
+
+    fireEvent.click(getAllByRole("button", { name: "View" })[1]!);
+
+    expect(getByTestId("location").textContent).toBe(
+      "/assistant/skills?skill=skill-2",
+    );
+  });
+
+  test("falls back to the Brain icon when a skill has no emoji", () => {
+    const { container } = renderCard(
+      makeSurface({
+        data: {
+          skills: [{ skillId: "skill-1", name: "No emoji", emoji: null }],
+        },
+      }),
+    );
+
+    expect(container.innerHTML).toContain("lucide-brain");
+  });
+
+  test("renders nothing when data.skills is missing", () => {
+    const { queryByText } = renderCard(makeSurface({ data: {} }));
+
+    expect(queryByText("New skill learned")).toBeNull();
+  });
+
+  test("renders nothing when data.skills is malformed", () => {
+    const { queryByText } = renderCard(
+      makeSurface({ data: { skills: "not-an-array" } }),
+    );
+
+    expect(queryByText("New skill learned")).toBeNull();
+  });
+
+  test("drops entries without a usable skillId or name but keeps valid ones", () => {
+    const { getByText, queryByText, getAllByRole } = renderCard(
+      makeSurface({
+        data: {
+          skills: [
+            { skillId: "skill-1", name: "Valid skill" },
+            { name: "Missing id" },
+            { skillId: "skill-3", name: 42 },
+            "junk",
+          ],
+        },
+      }),
+    );
+
+    expect(getByText("Valid skill")).toBeTruthy();
+    expect(queryByText("Missing id")).toBeNull();
+    expect(getAllByRole("button", { name: "View" })).toHaveLength(1);
+  });
+});
+
+describe("SurfaceRouter", () => {
+  test("routes skill_card surfaces", () => {
+    const { queryByText, getByText } = render(
+      <MemoryRouter>
+        <SurfaceRouter surface={makeSurface()} onAction={() => {}} />
+      </MemoryRouter>,
+    );
+
+    expect(queryByText("Unsupported surface type: skill_card")).toBeNull();
+    expect(getByText("Weekly report digest")).toBeTruthy();
+  });
+});

--- a/clients/web/src/domains/chat/components/surfaces/skill-created-card.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/skill-created-card.test.tsx
@@ -60,11 +60,13 @@ describe("SkillCreatedCard", () => {
       getByText("Compile the weekly report from the usual sources."),
     ).toBeTruthy();
     expect(getByText("📊")).toBeTruthy();
-    expect(getByRole("button", { name: "View" })).toBeTruthy();
+    expect(
+      getByRole("button", { name: "View Weekly report digest" }),
+    ).toBeTruthy();
   });
 
   test("renders multiple skills as stacked rows in a single card", () => {
-    const { container, getByText, getAllByRole } = renderCard(
+    const { container, getByText, getByRole } = renderCard(
       makeSurface({
         data: {
           skills: [
@@ -77,13 +79,15 @@ describe("SkillCreatedCard", () => {
 
     expect(getByText("Skill one")).toBeTruthy();
     expect(getByText("Skill two")).toBeTruthy();
-    expect(getAllByRole("button", { name: "View" })).toHaveLength(2);
+    // Each row's action carries a skill-specific accessible name.
+    expect(getByRole("button", { name: "View Skill one" })).toBeTruthy();
+    expect(getByRole("button", { name: "View Skill two" })).toBeTruthy();
     // One card (SurfaceContainer), not one per skill.
     expect(container.querySelectorAll(".rounded-lg")).toHaveLength(1);
   });
 
   test("View navigates to the Skills tab deep-link for the clicked skill", () => {
-    const { getAllByRole, getByTestId } = renderCard(
+    const { getByRole, getByTestId } = renderCard(
       makeSurface({
         data: {
           skills: [
@@ -94,7 +98,7 @@ describe("SkillCreatedCard", () => {
       }),
     );
 
-    fireEvent.click(getAllByRole("button", { name: "View" })[1]!);
+    fireEvent.click(getByRole("button", { name: "View Skill two" }));
 
     expect(getByTestId("location").textContent).toBe(
       "/assistant/skills?skill=skill-2",
@@ -143,7 +147,7 @@ describe("SkillCreatedCard", () => {
 
     expect(getByText("Valid skill")).toBeTruthy();
     expect(queryByText("Missing id")).toBeNull();
-    expect(getAllByRole("button", { name: "View" })).toHaveLength(1);
+    expect(getAllByRole("button", { name: /^View / })).toHaveLength(1);
   });
 });
 

--- a/clients/web/src/domains/chat/components/surfaces/skill-created-card.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/skill-created-card.tsx
@@ -67,8 +67,7 @@ export function SkillCreatedCard({ surface, onAction }: SkillCreatedCardProps) {
   const navigate = useNavigate();
   const skills = parseSkills(surface.data.skills);
 
-  // Single navigation target for every row so a later change (e.g. an
-  // in-chat skill detail sidepanel) rewires the card in one place.
+  // Every row deep-links to the Skills tab with the clicked skill selected.
   const handleView = (skillId: string) => {
     navigate(`${routes.skills}?skill=${encodeURIComponent(skillId)}`);
   };
@@ -110,6 +109,7 @@ export function SkillCreatedCard({ surface, onAction }: SkillCreatedCardProps) {
             <Button
               variant="outlined"
               size="compact"
+              aria-label={`View ${skill.name}`}
               onClick={() => handleView(skill.skillId)}
             >
               View

--- a/clients/web/src/domains/chat/components/surfaces/skill-created-card.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/skill-created-card.tsx
@@ -1,0 +1,122 @@
+import { Brain } from "lucide-react";
+import { useNavigate } from "react-router";
+
+import { Button } from "@vellumai/design-library";
+import type { Surface } from "@/domains/chat/types/types";
+
+import { SurfaceContainer } from "@/domains/chat/components/surfaces/surface-container";
+import {
+  filterRecords,
+  str,
+} from "@/domains/chat/components/surfaces/surface-parse-helpers";
+import { routes } from "@/utils/routes";
+
+/**
+ * Card copy lives here as the single source so a design copy swap is a
+ * one-line change. The subline is static because the card can arrive long
+ * after the triggering work (the retrospective runs in the background).
+ */
+const SKILL_CARD_FALLBACK_TITLE = "New skill learned";
+const SKILL_CARD_SUBLINE = "Saved to your skills from this conversation's work";
+
+interface SkillCardEntry {
+  skillId: string;
+  name: string;
+  description?: string;
+  emoji?: string;
+}
+
+interface SkillCreatedCardProps {
+  surface: Surface;
+  onAction: (
+    surfaceId: string,
+    actionId: string,
+    data?: Record<string, unknown>,
+  ) => void | Promise<void>;
+}
+
+/**
+ * Narrow the untyped `data.skills` payload to renderable entries. Entries
+ * missing a usable `skillId` or `name` are dropped rather than crashing the
+ * card; a malformed or absent list yields `[]` (the card renders nothing).
+ */
+function parseSkills(skills: unknown): SkillCardEntry[] {
+  return filterRecords(skills).flatMap((entry) => {
+    const skillId = str(entry.skillId);
+    const name = str(entry.name);
+    if (!skillId || !name) {
+      return [];
+    }
+    return [
+      {
+        skillId,
+        name,
+        description: str(entry.description),
+        emoji: str(entry.emoji),
+      },
+    ];
+  });
+}
+
+/**
+ * Static in-chat card announcing skills the memory retrospective authored
+ * from this conversation's work. One card batches all skills from a single
+ * retrospective run as stacked rows; each row deep-links to the skill.
+ */
+export function SkillCreatedCard({ surface, onAction }: SkillCreatedCardProps) {
+  const navigate = useNavigate();
+  const skills = parseSkills(surface.data.skills);
+
+  // Single navigation target for every row so a later change (e.g. an
+  // in-chat skill detail sidepanel) rewires the card in one place.
+  const handleView = (skillId: string) => {
+    navigate(`${routes.skills}?skill=${encodeURIComponent(skillId)}`);
+  };
+
+  if (skills.length === 0) {
+    return null;
+  }
+
+  return (
+    <SurfaceContainer surface={surface} onAction={onAction} hideTitle>
+      <h3 className="text-title-small text-[var(--content-strong)]">
+        {surface.title ?? SKILL_CARD_FALLBACK_TITLE}
+      </h3>
+      <p className="mt-0.5 text-body-small-default text-[var(--content-quiet)]">
+        {SKILL_CARD_SUBLINE}
+      </p>
+
+      <div className="mt-3 divide-y divide-[var(--border-base)]">
+        {skills.map((skill) => (
+          <div
+            key={skill.skillId}
+            className="flex items-center gap-3 py-2.5 first:pt-0 last:pb-0"
+          >
+            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-[var(--tag-bg-neutral)] text-body-large-default">
+              {skill.emoji ?? (
+                <Brain className="h-4 w-4 text-[var(--content-tertiary)]" />
+              )}
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-body-medium-default text-[var(--content-strong)]">
+                {skill.name}
+              </div>
+              {skill.description && (
+                <p className="truncate text-body-small-default text-[var(--content-tertiary)]">
+                  {skill.description}
+                </p>
+              )}
+            </div>
+            <Button
+              variant="outlined"
+              size="compact"
+              onClick={() => handleView(skill.skillId)}
+            >
+              View
+            </Button>
+          </div>
+        ))}
+      </div>
+    </SurfaceContainer>
+  );
+}

--- a/clients/web/src/domains/chat/components/surfaces/surface-router.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/surface-router.tsx
@@ -16,6 +16,7 @@ import { FileUploadSurface } from "@/domains/chat/components/surfaces/file-uploa
 import { FormSurface } from "@/domains/chat/components/surfaces/form-surface";
 import { ListSurface } from "@/domains/chat/components/surfaces/list-surface";
 import { OAuthConnectSurface } from "@/domains/chat/components/surfaces/oauth-connect-surface";
+import { SkillCreatedCard } from "@/domains/chat/components/surfaces/skill-created-card";
 import { SurfaceContainer } from "@/domains/chat/components/surfaces/surface-container";
 import { TableSurface } from "@/domains/chat/components/surfaces/table-surface";
 import { TaskPreferencesSurface } from "@/domains/chat/components/surfaces/task-preferences-surface";
@@ -131,6 +132,9 @@ export function SurfaceRouter({
           onOpenDocument={onOpenDocument}
         />
       );
+
+    case "skill_card":
+      return <SkillCreatedCard surface={surface} onAction={onAction} />;
 
     default:
       // Fallback card for unsupported surface types


### PR DESCRIPTION
## Summary
- New SkillCreatedCard surface component (skill emoji, name, description, View button; batches multiple skills as rows)
- Registered skill_card in SurfaceRouter; static card, not added to INHERENTLY_INTERACTIVE_SURFACE_TYPES
- View currently deep-links to the Skills tab; a later PR rewires it to the in-chat sidepanel

Part of plan: skill-surfacing-v1.md (PR 4 of 8)