### PR TITLE
feat(telemetry): stamp explicit turn outcomes (batched/failed/cancelled) on turn events

### DIFF
--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -213,6 +213,12 @@ mock.module("../persistence/conversation-queries.js", () => ({
   listConversations: () => [],
 }));
 
+const mockStampTurnOutcome = mock(() => {});
+
+mock.module("../telemetry/turn-outcome.js", () => ({
+  stampTurnOutcome: mockStampTurnOutcome,
+}));
+
 let linkAttachmentShouldThrow = false;
 let mockAttachmentIdCounter = 0;
 
@@ -974,6 +980,61 @@ describe("Conversation message queue", () => {
 describe("Batched drain", () => {
   beforeEach(() => {
     pendingRuns = [];
+  });
+
+  test("stamps coalesced heads `batched` pointing at the batch-final turn", async () => {
+    mockStampTurnOutcome.mockClear();
+    const addMessagesBefore = capturedAddMessages.length;
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+
+    // Start an in-flight turn so the next two messages queue behind it.
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      requestId: "req-1",
+    });
+    await waitForPendingRun(1);
+
+    conversation.enqueueMessage({
+      content: "msg-2",
+      onEvent: () => {},
+      requestId: "req-2",
+    });
+    conversation.enqueueMessage({
+      content: "msg-3",
+      onEvent: () => {},
+      requestId: "req-3",
+    });
+
+    // Resolve msg-1 → the queued pair drains as one coalesced batch.
+    await resolveRun(0);
+    await p1;
+    await waitForPendingRun(2);
+
+    const batchUserIds = capturedAddMessages
+      .slice(addMessagesBefore)
+      .filter(
+        (m) =>
+          m.role === "user" &&
+          (m.content.includes("msg-2") || m.content.includes("msg-3")),
+      )
+      .map((m) => m.id);
+    expect(batchUserIds).toHaveLength(2);
+
+    // Exactly the head is stamped, pointing at the batch-final member. The
+    // final member (whose window carries the shared response) is unstamped,
+    // and the earlier single-message turn (msg-1) is never stamped.
+    expect(mockStampTurnOutcome).toHaveBeenCalledTimes(1);
+    expect(mockStampTurnOutcome).toHaveBeenCalledWith(
+      batchUserIds[0],
+      "batched",
+      { batchedInto: batchUserIds[1] },
+    );
+
+    await resolveRun(1);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockStampTurnOutcome).toHaveBeenCalledTimes(1);
   });
 
   test("mixed-interface queue splits into multiple batches at each interface boundary", async () => {

--- a/assistant/src/__tests__/turn-events-store.test.ts
+++ b/assistant/src/__tests__/turn-events-store.test.ts
@@ -22,6 +22,7 @@ import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { messages } from "../persistence/schema/index.js";
 import { queryUnreportedTurnEvents } from "../telemetry/turn-events-store.js";
+import { stampTurnOutcome } from "../telemetry/turn-outcome.js";
 
 await initializeDb();
 
@@ -259,5 +260,54 @@ describe("queryUnreportedTurnEvents", () => {
     expect(byId[legacyMsg.id].interfaceId).toBeNull();
     expect(byId[legacyMsg.id].channelId).toBeNull();
     expect(byId[legacyMsg.id].clientMetadata).toBeNull();
+  });
+
+  test("projects turn-outcome stamps from messages.metadata", async () => {
+    const conv = createConversation({ conversationType: "standard" });
+    const head = await addMessage(conv.id, "user", "first of a burst", {
+      metadata: { userMessageInterface: "web", userMessageChannel: "vellum" },
+    });
+    const final = await addMessage(conv.id, "user", "second of a burst");
+    const failed = await addMessage(conv.id, "user", "doomed turn");
+    const cancelled = await addMessage(conv.id, "user", "stopped turn");
+    const normal = await addMessage(conv.id, "user", "replied turn");
+
+    stampTurnOutcome(head.id, "batched", { batchedInto: final.id });
+    stampTurnOutcome(failed.id, "failed", {
+      failureCode: "PROVIDER_RATE_LIMIT",
+    });
+    stampTurnOutcome(cancelled.id, "cancelled");
+
+    const events = queryUnreportedTurnEvents(0, undefined, 100);
+    const byId = Object.fromEntries(events.map((e) => [e.id, e]));
+
+    expect(byId[head.id].outcome).toBe("batched");
+    expect(byId[head.id].batchedInto).toBe(final.id);
+    expect(byId[head.id].failureCode).toBeNull();
+    // The stamp shallow-merges into existing metadata: attribution keys
+    // written at persist time survive.
+    expect(byId[head.id].interfaceId).toBe("web");
+    expect(byId[head.id].channelId).toBe("vellum");
+
+    expect(byId[failed.id].outcome).toBe("failed");
+    expect(byId[failed.id].failureCode).toBe("PROVIDER_RATE_LIMIT");
+    expect(byId[failed.id].batchedInto).toBeNull();
+
+    expect(byId[cancelled.id].outcome).toBe("cancelled");
+    expect(byId[cancelled.id].batchedInto).toBeNull();
+    expect(byId[cancelled.id].failureCode).toBeNull();
+
+    // Unstamped turns (normal replies, pre-stamping rows) project null for
+    // all three outcome fields.
+    expect(byId[normal.id].outcome).toBeNull();
+    expect(byId[normal.id].batchedInto).toBeNull();
+    expect(byId[normal.id].failureCode).toBeNull();
+
+    // The batch-final turn itself carries no stamp.
+    expect(byId[final.id].outcome).toBeNull();
+  });
+
+  test("stampTurnOutcome never throws, even for a nonexistent message id", () => {
+    expect(() => stampTurnOutcome("no-such-message", "failed")).not.toThrow();
   });
 });

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -168,6 +168,13 @@ export interface EventHandlerState {
   readonly exchangeRawResponses: unknown[];
   model: string;
   providerErrorUserMessage: string | null;
+  /**
+   * Stable classified code of the most recent provider error
+   * (`classifyConversationError(...).code`). Carried into the turn's
+   * telemetry outcome stamp when the loop terminates on the provider-error
+   * path.
+   */
+  providerErrorCode: string | null;
   persistProviderErrorAsAssistantMessage: boolean;
   lastAssistantMessageId: string | undefined;
   /**
@@ -382,6 +389,7 @@ export function createEventHandlerState(): EventHandlerState {
     exchangeRawResponses: [],
     model: "",
     providerErrorUserMessage: null,
+    providerErrorCode: null,
     persistProviderErrorAsAssistantMessage: false,
     lastAssistantMessageId: undefined,
     assistantRowAwaitingFinalization: false,
@@ -1850,6 +1858,7 @@ function handleError(
     buildConversationErrorMessage(deps.ctx.conversationId, classified),
   );
   state.providerErrorUserMessage = classified.userMessage;
+  state.providerErrorCode = classified.code;
   state.persistProviderErrorAsAssistantMessage =
     shouldPersistProviderErrorAsAssistantMessage(classified);
 }

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1102,12 +1102,19 @@ export async function runAgentLoopImpl(
         new Error("context_length_exceeded"),
         { phase: "agent_loop" },
       );
+      // Exhausted-overflow exit: the reduction ladder is spent and the turn
+      // ends without a real reply, so label it failed for telemetry.
+      abnormalOutcome = { outcome: "failed", failureCode: classified.code };
       onEvent(buildConversationErrorMessage(ctx.conversationId, classified));
     } else if (
       overflowTerminalReason === "budget_yield_unrecovered" &&
       !abortController.signal.aborted
     ) {
       budgetYieldClassification = budgetYieldUnrecoveredClassification();
+      abnormalOutcome = {
+        outcome: "failed",
+        failureCode: budgetYieldClassification.code,
+      };
       onEvent(
         buildConversationErrorMessage(
           ctx.conversationId,

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -610,6 +610,13 @@ export async function runAgentLoopImpl(
   try {
     if (diskPressureDecision.action === "block") {
       const message = formatDiskPressureBlockedMessage();
+      // The user message is already persisted, so this turn will be reported
+      // by the telemetry scan; label it failed (the early return still runs
+      // the `finally`, which stamps `abnormalOutcome`).
+      abnormalOutcome = {
+        outcome: "failed",
+        failureCode: DISK_PRESSURE_ERROR_CODE,
+      };
       rlog.warn(
         { reason: diskPressureDecision.reason },
         "Blocked turn during disk pressure cleanup mode",

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -68,6 +68,7 @@ import { resolveCapabilities } from "../runtime/capabilities.js";
 import { enqueueAutoAnalysisOnCompaction } from "../runtime/services/auto-analysis-enqueue.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
 import type { ActivationMomentParam } from "../telemetry/activation-funnel.js";
+import { stampTurnOutcome } from "../telemetry/turn-outcome.js";
 import type { UsageActor } from "../usage/actors.js";
 import { getLogger } from "../util/logger.js";
 import { timeAgo } from "../util/time.js";
@@ -571,6 +572,17 @@ export async function runAgentLoopImpl(
   const state = createEventHandlerState();
   let persistedErrorAssistantMessage = false;
   let deletedReservedAssistantMessage = false;
+  // Abnormal turn outcome for telemetry, stamped onto the user-message row in
+  // the `finally` (before processing clears, so the reporter's settled-turn
+  // barrier guarantees the stamp ships with the turn event). Unset = the turn
+  // replied normally and carries no stamp.
+  let abnormalOutcome:
+    | { outcome: "failed" | "cancelled"; failureCode?: string }
+    | undefined;
+  // True once a replied terminal SSE (message_complete / generation_handoff)
+  // has been emitted. Guards the catch block: an error thrown afterwards
+  // (deferred turn-tail bookkeeping) must not relabel a visibly-replied turn.
+  let turnReplied = false;
 
   const publishLoopMessagesChanged = (): void => {
     if (
@@ -1229,6 +1241,15 @@ export async function runAgentLoopImpl(
       !abortController.signal.aborted &&
       !yieldedForHandoff
     ) {
+      // The turn is terminating on the provider-error path: its only
+      // assistant output (if any) is the synthetic error message persisted
+      // below. Label the turn `failed` for telemetry either way.
+      abnormalOutcome = {
+        outcome: "failed",
+        ...(state.providerErrorCode
+          ? { failureCode: state.providerErrorCode }
+          : {}),
+      };
       // Drop any reservation stranded by the failed LLM call. The B3
       // pre-allocation path reserves an empty assistant row at
       // `llm_call_started`; when the call exits through the provider-error
@@ -1363,6 +1384,7 @@ export async function runAgentLoopImpl(
     // so the client can re-enable the UI without delay. Disk sync and the rest
     // of the bookkeeping run in `runDeferredTurnTail` after this SSE.
     if (abortController.signal.aborted) {
+      abnormalOutcome = { outcome: "cancelled" };
       ctx.emitActivityState("idle", "generation_cancelled", {
         anchor: "global",
         requestId: reqId,
@@ -1397,6 +1419,7 @@ export async function runAgentLoopImpl(
 
       // Re-check: the user may have cancelled during attachment resolution
       if (abortController.signal.aborted) {
+        abnormalOutcome = { outcome: "cancelled" };
         ctx.emitActivityState("idle", "generation_cancelled", {
           anchor: "global",
           requestId: reqId,
@@ -1407,6 +1430,7 @@ export async function runAgentLoopImpl(
         });
         publishLoopMessagesChanged();
       } else if (yieldedForHandoff) {
+        turnReplied = true;
         onEvent({
           type: "generation_handoff",
           conversationId: ctx.conversationId,
@@ -1424,6 +1448,7 @@ export async function runAgentLoopImpl(
         });
         publishLoopMessagesChanged();
       } else {
+        turnReplied = true;
         ctx.emitActivityState("idle", "message_complete", {
           anchor: "global",
           requestId: reqId,
@@ -1462,6 +1487,12 @@ export async function runAgentLoopImpl(
       aborted: abortController.signal.aborted,
     };
     if (isUserCancellation(err, errorCtx)) {
+      // Only label the turn when it hadn't already replied — a cancellation
+      // surfacing after the terminal SSE (deferred turn-tail bookkeeping)
+      // must not relabel a visibly-replied turn.
+      if (!turnReplied) {
+        abnormalOutcome = { outcome: "cancelled" };
+      }
       ctx.emitActivityState("idle", "generation_cancelled", {
         anchor: "global",
         requestId: reqId,
@@ -1479,6 +1510,9 @@ export async function runAgentLoopImpl(
       });
       rlog.error({ err }, "Conversation processing error");
       const classified = classifyConversationError(err, errorCtx);
+      if (!turnReplied) {
+        abnormalOutcome = { outcome: "failed", failureCode: classified.code };
+      }
       onEvent({
         type: "error",
         conversationId: ctx.conversationId,
@@ -1531,6 +1565,16 @@ export async function runAgentLoopImpl(
     // cancelled turn always unwinds before any resend can start a new one.
     // There is therefore only ever one turn alive, and clearing the shared
     // state below cannot clobber a concurrent turn.
+    // Stamp the turn's abnormal outcome (failed / cancelled) onto its
+    // user-message row BEFORE processing clears: the telemetry reporter's
+    // settled-turn barrier only releases this turn once the conversation
+    // stops processing, so ordering the stamp first guarantees the turn
+    // event ships with the outcome. A normally-replied turn stamps nothing.
+    if (abnormalOutcome) {
+      stampTurnOutcome(userMessageId, abnormalOutcome.outcome, {
+        failureCode: abnormalOutcome.failureCode,
+      });
+    }
     ctx.abortController = null;
     ctx.setProcessing(false);
     ctx.onConfirmationOutcome = undefined;

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -36,6 +36,7 @@ import {
   routeGuardianReply,
 } from "../runtime/guardian-reply-router.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
+import { stampTurnOutcome } from "../telemetry/turn-outcome.js";
 import { getLogger } from "../util/logger.js";
 import type { CleanResult, Conversation } from "./conversation.js";
 import {
@@ -1082,6 +1083,11 @@ async function drainBatch(
   // already received an error event and must not also receive the
   // assistant's streaming response for a turn that isn't theirs.
   const successfulBatch: QueuedMessage[] = [];
+  // `messages.id` of every successfully-persisted, non-deduplicated member,
+  // in persist order. All but the last are coalesced heads whose shared
+  // response lives on the final member's turn — stamped `batched` below so
+  // turn telemetry can tell them apart from failed turns.
+  const persistedMessageIds: string[] = [];
   for (let i = 0; i < batch.length; i++) {
     const qm = batch[i];
     qm.onEvent({
@@ -1183,6 +1189,7 @@ async function drainBatch(
         continue;
       }
       lastUserMessageId = batchPersistResult.id;
+      persistedMessageIds.push(batchPersistResult.id);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       log.error(
@@ -1319,6 +1326,18 @@ async function drainBatch(
     );
     conversation.preactivatedSkillIds = undefined;
     return;
+  }
+
+  // Every persisted member except the last is a coalesced-batch head: its
+  // window holds no assistant response because the shared response is
+  // attributed to the final member's turn. Stamp them `batched` (pointing at
+  // that final turn) so the turn-event scan reports them as coalesced rather
+  // than leaving them indistinguishable from failed turns. Stamping happens
+  // while the conversation is still processing, so the telemetry reporter's
+  // settled-turn barrier guarantees the stamp is visible before these turns
+  // ship.
+  for (const headId of persistedMessageIds.slice(0, -1)) {
+    stampTurnOutcome(headId, "batched", { batchedInto: lastUserMessageId });
   }
 
   // Tag turn-completion state with the last SUCCESSFUL persist so client-

--- a/assistant/src/telemetry/turn-events-store.ts
+++ b/assistant/src/telemetry/turn-events-store.ts
@@ -66,6 +66,26 @@ export interface TurnEvent {
    * wire format.
    */
   clientMetadata: string | null;
+  /**
+   * Abnormal turn outcome stamped onto `messages.metadata.turnOutcome` at
+   * turn end: `"batched"` (coalesced into a later turn's shared response),
+   * `"failed"` (loop ended in a non-cancellation error), or `"cancelled"`
+   * (user stop / barge-in). Null when the turn replied normally, when the
+   * row predates outcome stamping, or when the process died mid-turn
+   * before a stamp could land.
+   */
+  outcome: string | null;
+  /**
+   * For `"batched"` turns: `messages.id` of the batch-final turn whose
+   * window carries the shared response. Null otherwise.
+   */
+  batchedInto: string | null;
+  /**
+   * For `"failed"` turns: the stable classified error code
+   * (`classifyConversationError(...).code`). Null otherwise or when the
+   * failure had no classification.
+   */
+  failureCode: string | null;
 }
 
 /**
@@ -143,6 +163,22 @@ export function queryUnreportedTurnEvents(
       clientMetadata: sql<
         string | null
       >`json_extract(${messages.metadata}, '$.client')`.as("client_metadata"),
+      // Turn-outcome stamps written at turn end (`stampTurnOutcome`).
+      // `json_extract` returns SQL NULL when the path is absent — rows
+      // predating outcome stamping and normally-replied turns project null.
+      outcome: sql<
+        string | null
+      >`json_extract(${messages.metadata}, '$.turnOutcome')`.as("outcome"),
+      batchedInto: sql<
+        string | null
+      >`json_extract(${messages.metadata}, '$.turnBatchedInto')`.as(
+        "batched_into",
+      ),
+      failureCode: sql<
+        string | null
+      >`json_extract(${messages.metadata}, '$.turnFailureCode')`.as(
+        "failure_code",
+      ),
     })
     .from(messages)
     .innerJoin(conversations, eq(messages.conversationId, conversations.id))

--- a/assistant/src/telemetry/turn-outcome.ts
+++ b/assistant/src/telemetry/turn-outcome.ts
@@ -1,0 +1,60 @@
+import { updateMessageMetadata } from "../persistence/conversation-crud.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("turn-outcome");
+
+/**
+ * Abnormal turn outcomes stamped onto the turn's user-message row.
+ *
+ * - `"batched"` — the message was coalesced into a later turn's shared
+ *   response (`drainBatch`); the reply lives on the turn identified by
+ *   `turnBatchedInto`.
+ * - `"failed"` — the agent loop terminated in a non-cancellation error.
+ *   Includes turns whose only assistant output is the synthetic
+ *   provider-error message.
+ * - `"cancelled"` — the user cancelled the turn (stop / barge-in).
+ *
+ * A normally-replied turn carries no stamp: absence of `turnOutcome` on a
+ * settled turn means the turn replied (or, rarely, the process died
+ * mid-turn before any stamp could land).
+ */
+export type TurnOutcome = "batched" | "failed" | "cancelled";
+
+export interface TurnOutcomeExtras {
+  /**
+   * For `"batched"`: `messages.id` of the final batch member whose window
+   * carries the shared response (that turn's `daemon_event_id` on the wire).
+   */
+  batchedInto?: string;
+  /** For `"failed"`: stable classified error code (never free-form text). */
+  failureCode?: string;
+}
+
+/**
+ * Durably stamp a turn's outcome onto its user-message row
+ * (`messages.metadata.turnOutcome` / `.turnBatchedInto` / `.turnFailureCode`).
+ * The turn-event scan (`queryUnreportedTurnEvents`) projects these keys onto
+ * the `turn` telemetry event, so the stamp must land before the turn settles —
+ * callers run while the conversation is still processing.
+ *
+ * Best-effort: telemetry stamping must never break the turn path, so every
+ * error is logged and swallowed.
+ */
+export function stampTurnOutcome(
+  userMessageId: string,
+  outcome: TurnOutcome,
+  extras: TurnOutcomeExtras = {},
+): void {
+  try {
+    updateMessageMetadata(userMessageId, {
+      turnOutcome: outcome,
+      ...(extras.batchedInto ? { turnBatchedInto: extras.batchedInto } : {}),
+      ...(extras.failureCode ? { turnFailureCode: extras.failureCode } : {}),
+    });
+  } catch (err) {
+    log.warn(
+      { err, userMessageId, outcome },
+      "Failed to stamp turn outcome (non-fatal)",
+    );
+  }
+}

--- a/assistant/src/telemetry/turn-trace-store.ts
+++ b/assistant/src/telemetry/turn-trace-store.ts
@@ -291,9 +291,11 @@ function queryTurnToolCalls(
  * before producing a response) traces user-only, which is faithful: its window
  * genuinely has no response. A coalesced batch's shared response lives on the
  * batch's FINAL turn's window — exactly where the daemon already attributes it
- * (via `lastUserMessageId` / `llm_usage` / `turn_index`). There is no durable
- * batch signal in the stored messages to distinguish a real batch from a
- * failed/cancelled turn, so no batch inference is attempted.
+ * (via `lastUserMessageId` / `llm_usage` / `turn_index`). Which case an empty
+ * window is (batched vs failed vs cancelled) is recorded durably on the user
+ * message row (`messages.metadata.turnOutcome`, written by `stampTurnOutcome`)
+ * and rides the turn event's `outcome` field — the trace itself stays the
+ * plain window and attempts no inference.
  *
  * Read-only; touches only existing tables (`messages`, `tool_invocations`), so
  * no migration is involved. Caller is responsible for the consent gate and the

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -279,6 +279,38 @@ export interface TurnTelemetryEvent extends TelemetryEventBase {
    */
   client: TurnTelemetryClientInfo | null;
   /**
+   * Explicit abnormal turn outcome, stamped by the daemon at turn end:
+   *
+   * - `"batched"` — the user message was coalesced into a later turn's
+   *   shared response (`drainBatch`); its own window holds no assistant
+   *   message by design. `batched_into` identifies the turn that replied.
+   * - `"failed"` — the agent loop terminated in a non-cancellation error.
+   *   Includes turns whose only assistant output is the synthetic
+   *   provider-error message, so failure analytics don't need to
+   *   text-match error copy.
+   * - `"cancelled"` — the user cancelled the turn (stop / barge-in).
+   *
+   * Omitted when the turn replied normally, when the daemon predates
+   * outcome stamping, or when the process died mid-turn before a stamp
+   * could land — so `absent + no assistant message in trace` isolates the
+   * genuinely anomalous (crashed/unknown) turns.
+   */
+  outcome?: "batched" | "failed" | "cancelled";
+  /**
+   * For `outcome: "batched"` turns: the `daemon_event_id` of the
+   * batch-final turn whose window carries the shared response. Omitted
+   * otherwise.
+   */
+  batched_into?: string;
+  /**
+   * For `outcome: "failed"` turns: the stable classified error code
+   * (`classifyConversationError(...).code`, a `ConversationErrorCode`
+   * value like `"PROVIDER_RATE_LIMIT"` or `"MANAGED_USAGE_LIMIT"`). Never
+   * free-form error text. Omitted otherwise or when the failure had no
+   * classification.
+   */
+  failure_code?: string;
+  /**
    * Full per-turn transcript (user message + assistant responses + tool
    * calls/results). Present ONLY when trace collection is enabled — the daemon
    * composes the gate itself from the `trace-collection` feature flag (delivered

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -45,6 +45,9 @@ const mockQueryUnreportedTurnEvents = mock(
       interfaceId: string | null;
       channelId: string | null;
       clientMetadata: string | null;
+      outcome?: string | null;
+      batchedInto?: string | null;
+      failureCode?: string | null;
     }[],
 );
 
@@ -1253,7 +1256,16 @@ describe("UsageTelemetryReporter", () => {
   // Trace completeness barrier — don't emit partial traces mid-turn
   // -------------------------------------------------------------------------
 
-  function turnEvent(id: string, createdAt: number, conversationId: string) {
+  function turnEvent(
+    id: string,
+    createdAt: number,
+    conversationId: string,
+    overrides: {
+      outcome?: string | null;
+      batchedInto?: string | null;
+      failureCode?: string | null;
+    } = {},
+  ) {
     return {
       id,
       createdAt,
@@ -1263,6 +1275,7 @@ describe("UsageTelemetryReporter", () => {
       interfaceId: "macos",
       channelId: "vellum",
       clientMetadata: null,
+      ...overrides,
     };
   }
 
@@ -1415,18 +1428,17 @@ describe("UsageTelemetryReporter", () => {
     );
   });
 
-  test("with tracing disabled, an in-progress turn is NOT deferred (reporting timing unchanged)", async () => {
-    // The completeness barrier is trace-eligible-only. With trace collection
-    // off, turn telemetry / turn_raw behavior is unchanged: the turn ships
-    // immediately and `isTurnSettled` is never consulted.
+  test("with tracing disabled, an in-progress turn is still deferred (outcome stamps must ship with the event)", async () => {
+    // The completeness barrier applies to every turn event, not just
+    // trace-eligible ones: the `outcome` stamp is written while the
+    // conversation is still processing, and the watermark advances on ship,
+    // so an in-flight turn reported early would be frozen without its stamp.
     mockGetCachedShareDiagnostics.mockReturnValue(false);
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
     const checkpoints = useStatefulCheckpoints();
     mockQueryUnreportedTurnEvents.mockReturnValue([
       turnEvent("evt-inflight", 1700000050000, "conv-1"),
     ]);
-    // Even though the turn would be "in-flight", the gate is off so this is
-    // never consulted.
     mockIsTurnSettled.mockReturnValue(false);
     mockFetch.mockImplementation(() =>
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
@@ -1435,19 +1447,114 @@ describe("UsageTelemetryReporter", () => {
     const reporter = new UsageTelemetryReporter();
     await reporter.flush();
 
-    expect(mockIsTurnSettled).not.toHaveBeenCalled();
-    // The turn ships immediately, trace-free.
+    expect(mockIsTurnSettled).toHaveBeenCalled();
+    // Nothing ships and the watermark holds, so the turn is retried complete.
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(checkpoints.get("telemetry:turns:last_reported_at")).toBeUndefined();
+  });
+
+  test("with tracing disabled, a settled turn ships trace-free and advances the watermark", async () => {
+    mockGetCachedShareDiagnostics.mockReturnValue(false);
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    const checkpoints = useStatefulCheckpoints();
+    mockQueryUnreportedTurnEvents.mockReturnValue([
+      turnEvent("evt-settled", 1700000050000, "conv-1"),
+    ]);
+    mockIsTurnSettled.mockReturnValue(true);
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const body = JSON.parse(
       (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
     );
     expect(body.events.length).toBe(1);
-    expect(body.events[0].daemon_event_id).toBe("evt-inflight");
+    expect(body.events[0].daemon_event_id).toBe("evt-settled");
     expect("trace" in body.events[0]).toBe(false);
     // Watermark advances as usual.
     expect(checkpoints.get("telemetry:turns:last_reported_at")).toBe(
       String(1700000050000),
     );
+  });
+
+  test("outcome stamps ride the turn event: batched carries batched_into, failed carries failure_code", async () => {
+    mockGetCachedShareDiagnostics.mockReturnValue(false);
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    useStatefulCheckpoints();
+    mockQueryUnreportedTurnEvents.mockReturnValue([
+      turnEvent("evt-batched-head", 1700000010000, "conv-1", {
+        outcome: "batched",
+        batchedInto: "evt-batch-final",
+      }),
+      turnEvent("evt-batch-final", 1700000011000, "conv-1"),
+      turnEvent("evt-failed", 1700000012000, "conv-2", {
+        outcome: "failed",
+        failureCode: "PROVIDER_RATE_LIMIT",
+      }),
+      turnEvent("evt-cancelled", 1700000013000, "conv-3", {
+        outcome: "cancelled",
+      }),
+    ]);
+    mockIsTurnSettled.mockReturnValue(true);
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":4}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    const byId = Object.fromEntries(
+      body.events.map((e: { daemon_event_id: string }) => [
+        e.daemon_event_id,
+        e,
+      ]),
+    );
+    expect(byId["evt-batched-head"].outcome).toBe("batched");
+    expect(byId["evt-batched-head"].batched_into).toBe("evt-batch-final");
+    expect("failure_code" in byId["evt-batched-head"]).toBe(false);
+    // The batch-final turn replied normally: no outcome keys at all.
+    expect("outcome" in byId["evt-batch-final"]).toBe(false);
+    expect("batched_into" in byId["evt-batch-final"]).toBe(false);
+    expect(byId["evt-failed"].outcome).toBe("failed");
+    expect(byId["evt-failed"].failure_code).toBe("PROVIDER_RATE_LIMIT");
+    expect("batched_into" in byId["evt-failed"]).toBe(false);
+    expect(byId["evt-cancelled"].outcome).toBe("cancelled");
+    expect("failure_code" in byId["evt-cancelled"]).toBe(false);
+  });
+
+  test("an unrecognized outcome value in metadata is dropped from the wire", async () => {
+    mockGetCachedShareDiagnostics.mockReturnValue(false);
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    useStatefulCheckpoints();
+    mockQueryUnreportedTurnEvents.mockReturnValue([
+      turnEvent("evt-garbage", 1700000010000, "conv-1", {
+        outcome: "exploded",
+        batchedInto: "evt-other",
+        failureCode: "BOOM",
+      }),
+    ]);
+    mockIsTurnSettled.mockReturnValue(true);
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect("outcome" in body.events[0]).toBe(false);
+    expect("batched_into" in body.events[0]).toBe(false);
+    expect("failure_code" in body.events[0]).toBe(false);
   });
 
   test("llm_usage events carry conversation_id, conversation_type, and turn_index", async () => {

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -432,20 +432,23 @@ export class UsageTelemetryReporter {
         BATCH_SIZE,
       );
 
-      // Trace completeness barrier (trace-eligible owners only).
+      // Turn completeness barrier (every turn event).
       //
-      // When trace collection is on, a turn's trace must only be sent once that
-      // turn is COMPLETE — otherwise a flush that races an in-progress reply
-      // would capture a partial transcript and the watermark would advance past
-      // the turn, leaving it permanently partial. So we report only the leading
-      // run of complete turns and STOP at the first incomplete (in-flight) one:
-      // the turn watermark is a single monotonic `(createdAt, id)` cursor, so a
-      // later complete turn cannot be reported past an earlier deferred one
-      // without skipping it. The deferred turn (and everything after it) is
-      // picked up on a later flush once its response settles.
-      //
-      // When trace collection is OFF, no turn is deferred and reporting timing
-      // is unchanged for everyone else — `turn_raw` behavior is untouched.
+      // A turn event must only be sent once that turn is COMPLETE, for two
+      // reasons sharing the same failure mode (the watermark advances on ship,
+      // so anything captured early is frozen forever):
+      //   - the consented `trace` would capture a partial mid-reply
+      //     transcript, and
+      //   - the `outcome` stamp (`messages.metadata.turnOutcome`, written by
+      //     the agent loop / drainBatch while the conversation is still
+      //     processing) would be missed, permanently mislabeling a
+      //     failed/cancelled/batched turn as normally-replied.
+      // So we report only the leading run of complete turns and STOP at the
+      // first incomplete (in-flight) one: the turn watermark is a single
+      // monotonic `(createdAt, id)` cursor, so a later complete turn cannot be
+      // reported past an earlier deferred one without skipping it. The
+      // deferred turn (and everything after it) is picked up on a later flush
+      // once its response settles.
       //
       // Trace eligibility is composed daemon-side to mirror the platform's
       // authoritative owner-based ingest gate, so traces for ineligible owners
@@ -462,7 +465,7 @@ export class UsageTelemetryReporter {
         getCachedShareDiagnostics() &&
         isDiagnosticsConsentVersionEligible(getCachedShareDiagnosticsVersion());
       let reportableTurnEvents = turnEvents;
-      if (traceEligible && turnEvents.length > 0) {
+      if (turnEvents.length > 0) {
         let barrier = turnEvents.length;
         for (let i = 0; i < turnEvents.length; i++) {
           const t = turnEvents[i];
@@ -605,6 +608,16 @@ export class UsageTelemetryReporter {
               );
             }
           }
+          // Narrow the raw metadata projection to the wire union — only
+          // `stampTurnOutcome` writes the key, but the JSON column is
+          // uncontrolled, so an unexpected value is dropped rather than
+          // shipped.
+          const outcome =
+            e.outcome === "batched" ||
+            e.outcome === "failed" ||
+            e.outcome === "cancelled"
+              ? e.outcome
+              : null;
           return {
             type: "turn",
             daemon_event_id: e.id,
@@ -615,6 +628,15 @@ export class UsageTelemetryReporter {
             interface_id: e.interfaceId,
             channel_id: e.channelId,
             client,
+            // Outcome stamps are omit-when-absent: a normally-replied turn's
+            // wire shape is byte-identical to a pre-outcome turn event.
+            ...(outcome ? { outcome } : {}),
+            ...(outcome === "batched" && e.batchedInto
+              ? { batched_into: e.batchedInto }
+              : {}),
+            ...(outcome === "failed" && e.failureCode
+              ? { failure_code: e.failureCode }
+              : {}),
             // Only attach `trace` when consent is on AND a bounded trace was
             // assembled. Omitting the key entirely when there's no trace keeps
             // the wire shape byte-identical to pre-trace turn events for the


### PR DESCRIPTION
## Why

The 2026-07-07 "assistant never replied" investigation found that turn telemetry rows with no assistant message in the trace are ambiguous: ~90% are benign coalesced-batch heads (rapid-fire user sends and subagent completion bursts drain as one batch; the shared reply is attributed to the final turn's window) while a small residue are genuinely dead turns. `turn-trace-store.ts` documented the gap: "There is no durable batch signal in the stored messages to distinguish a real batch from a failed/cancelled turn." Separately, provider-failure turns that persist a synthetic assistant error row (credit-wall bounces) are indistinguishable from real replies — the 07-04 usage analysis had to text-match "run out of credits".

## What

New `outcome` (+ `batched_into`, `failure_code`) optional fields on the `turn` telemetry event, sourced from durable stamps on the turn's user-message row (`messages.metadata.turnOutcome` / `.turnBatchedInto` / `.turnFailureCode` — no migration, same `json_extract` pattern as the sibling attribution keys):

| `outcome` | stamped by | meaning |
|---|---|---|
| *(absent)* | — | replied normally (or legacy daemon / crashed mid-turn) |
| `batched` | `drainBatch` | coalesced into `batched_into`'s shared response |
| `failed` | agent-loop catch + provider-error terminal path | non-cancellation error; `failure_code` = classified `ConversationErrorCode`. Includes synthetic-error-reply turns |
| `cancelled` | abort fast-paths + cancellation catch | user stop / barge-in |

**Barrier semantics change:** the reporter's settled-turn completeness barrier now applies to **every** turn event, not just trace-eligible ones. Stamps are written while the conversation is still processing and the watermark advances on ship, so an in-flight turn reported early would be frozen without its outcome. Cost: an in-flight turn's event defers one 5-minute sweep.

A `turnReplied` guard ensures an error thrown after the terminal SSE (deferred turn-tail bookkeeping) can't relabel a visibly-replied turn.

## Sequencing

The platform companion PR (DRF serializer fields + BigQuery Terraform schema columns) must **deploy before this reaches users** — DRF silently drops undeclared event fields at ingest. This lands on main now and ships with the next release, which satisfies that ordering as long as the platform PR merges first.

## Testing

- `bun test src/__tests__/turn-events-store.test.ts` — stamp projection (incl. metadata shallow-merge preserving attribution keys) and never-throws.
- `bun test src/telemetry/usage-telemetry-reporter.test.ts` — wire shape (include/omit per outcome, unknown-value drop), barrier-now-unconditional (deferral with tracing disabled; settled turns ship trace-free).
- `bun test src/__tests__/conversation-queue.test.ts` — drainBatch stamps exactly the coalesced heads, pointing at the batch-final member.
- `bunx tsc --noEmit` clean; scoped eslint clean (0 errors, pre-existing warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)