### PR TITLE
feat(web): add /assistant/skills/:skillId route and navigate to it from the Skills list

### DIFF
--- a/clients/web/src/domains/intelligence/components/skills/skill-detail-mobile.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-detail-mobile.tsx
@@ -9,7 +9,7 @@ import {
     Loader2,
     Trash2,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useState, type RefObject } from "react";
 import { createPortal } from "react-dom";
 
 import { isMarkdown } from "@/components/file-markdown";
@@ -33,6 +33,12 @@ interface SkillDetailMobileProps {
   onRemove?: () => void;
   isInstalling?: boolean;
   isRemoving?: boolean;
+  /**
+   * Attached to the overlay root so the route-level `useEdgeSwipeBack` drag
+   * transform tracks this surface. The overlay portals out of the page's DOM
+   * subtree, so the owning page can't wrap it in its own ref'd container.
+   */
+  swipeContainerRef?: RefObject<HTMLDivElement | null>;
 }
 
 /**
@@ -62,6 +68,7 @@ export function SkillDetailMobile({
   onRemove,
   isInstalling = false,
   isRemoving = false,
+  swipeContainerRef,
 }: SkillDetailMobileProps) {
   const available = isAvailableSkill(skill);
   const removable = isRemovableSkill(skill);
@@ -99,6 +106,7 @@ export function SkillDetailMobile({
 
   const overlay = (
     <div
+      ref={swipeContainerRef}
       className="fixed inset-0 z-40 flex flex-col overflow-hidden bg-[var(--surface-overlay)]"
       style={{
         paddingTop:

--- a/clients/web/src/domains/intelligence/components/skills/skill-removal-dialog.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-removal-dialog.tsx
@@ -1,0 +1,32 @@
+import { type SkillInfo } from "@/domains/intelligence/skills/types";
+import { ConfirmDialog } from "@vellumai/design-library";
+
+interface SkillRemovalDialogProps {
+  /** Skill awaiting removal confirmation; `null` keeps the dialog closed. */
+  skill: SkillInfo | null;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * Confirm-gated removal dialog for a skill, shared by the Skills list and
+ * the skill detail page. Pair with `useSkillActions`, which owns the
+ * pending-removal state and the confirm/cancel handlers.
+ */
+export function SkillRemovalDialog({
+  skill,
+  onConfirm,
+  onCancel,
+}: SkillRemovalDialogProps) {
+  return (
+    <ConfirmDialog
+      open={skill !== null}
+      title="Remove skill"
+      message={skill ? `Remove "${skill.name}" from this assistant?` : ""}
+      confirmLabel="Remove"
+      destructive
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+    />
+  );
+}

--- a/clients/web/src/domains/intelligence/components/skills/skills-error-state.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skills-error-state.tsx
@@ -1,0 +1,15 @@
+import { TriangleAlert } from "lucide-react";
+
+import { SkillsStateCard } from "./skills-state-card";
+
+/** Error card shown when the skills list query fails. */
+export function SkillsErrorState() {
+  return (
+    <SkillsStateCard
+      icon={TriangleAlert}
+      iconColor="var(--system-danger)"
+      title="Failed to load skills"
+      subtitle="Something went wrong. Try refreshing the page."
+    />
+  );
+}

--- a/clients/web/src/domains/intelligence/components/skills/skills-loading-state.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skills-loading-state.tsx
@@ -1,0 +1,13 @@
+import { Loader2 } from "lucide-react";
+
+/** Centered spinner shown while a Skills surface query is in flight. */
+export function SkillsLoadingState() {
+  return (
+    <div className="flex items-center justify-center py-16">
+      <Loader2
+        className="h-6 w-6 animate-spin"
+        style={{ color: "var(--content-tertiary)" }}
+      />
+    </div>
+  );
+}

--- a/clients/web/src/domains/intelligence/components/skills/skills-state-card.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skills-state-card.tsx
@@ -1,0 +1,51 @@
+import { type LucideIcon } from "lucide-react";
+import { type ReactNode } from "react";
+
+import { Card } from "@vellumai/design-library";
+
+interface SkillsStateCardProps {
+  icon: LucideIcon;
+  /** CSS color for the icon; defaults to the tertiary content tone. */
+  iconColor?: string;
+  title: string;
+  subtitle: string;
+  /** Optional action row rendered below the subtitle. */
+  children?: ReactNode;
+}
+
+/**
+ * Centered icon + title + subtitle card used for the Skills surface's
+ * empty, error, and not-found states.
+ */
+export function SkillsStateCard({
+  icon: Icon,
+  iconColor = "var(--content-tertiary)",
+  title,
+  subtitle,
+  children,
+}: SkillsStateCardProps) {
+  return (
+    <Card.Root>
+      <Card.Body className="flex flex-col items-center justify-center py-16 text-center">
+        <Icon
+          className="mb-3 h-8 w-8"
+          style={{ color: iconColor }}
+          aria-hidden
+        />
+        <h3
+          className="text-title-small"
+          style={{ color: "var(--content-default)" }}
+        >
+          {title}
+        </h3>
+        <p
+          className="mt-1 max-w-sm text-body-medium-lighter"
+          style={{ color: "var(--content-tertiary)" }}
+        >
+          {subtitle}
+        </p>
+        {children}
+      </Card.Body>
+    </Card.Root>
+  );
+}

--- a/clients/web/src/domains/intelligence/components/skills/skills-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skills-tab.tsx
@@ -1,73 +1,67 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import {
     CheckCircle,
     CloudOff,
     Globe,
     LayoutGrid,
-    Loader2,
     Package,
     Puzzle,
     Sparkles,
     Terminal,
-    TriangleAlert,
     User,
     X,
     Zap,
 } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
+import { useNavigate } from "react-router";
 
 import { CategorySidebar } from "@/domains/intelligence/components/skills/category-sidebar";
-import { SkillDetail } from "@/domains/intelligence/components/skills/skill-detail";
-import { SkillDetailMobile } from "@/domains/intelligence/components/skills/skill-detail-mobile";
 import { FilterBar } from "@/domains/intelligence/components/skills/skill-filters";
+import { SkillRemovalDialog } from "@/domains/intelligence/components/skills/skill-removal-dialog";
 import { SkillRow } from "@/domains/intelligence/components/skills/skill-row";
-import { installSkill } from "@/domains/intelligence/skills/install";
+import { SkillsErrorState } from "@/domains/intelligence/components/skills/skills-error-state";
+import { SkillsLoadingState } from "@/domains/intelligence/components/skills/skills-loading-state";
+import { SkillsStateCard } from "@/domains/intelligence/components/skills/skills-state-card";
 import {
     type SkillFilter,
     type SkillInfo,
 } from "@/domains/intelligence/skills/types";
+import { useSkillActions } from "@/domains/intelligence/skills/use-skill-actions";
 import { useSkillCategories } from "@/domains/intelligence/skills/use-skill-categories";
 import { resolveFilterParams, sortSkills } from "@/domains/intelligence/skills/utils";
-import {
-    skillsGetOptions,
-    skillsGetQueryKey,
-    useSkillsByIdDeleteMutation,
-} from "@/generated/daemon/@tanstack/react-query.gen";
-import { type Options } from "@/generated/daemon/sdk.gen";
-import type { SkillsGetData } from "@/generated/daemon/types.gen";
+import { skillsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
-import { useIsMobile } from "@/hooks/use-is-mobile";
 import { getLocalBool, setLocalBool } from "@/utils/local-settings";
-import { Button, Card, ConfirmDialog } from "@vellumai/design-library";
+import { routes } from "@/utils/routes";
+import { Button } from "@vellumai/design-library";
 
 interface SkillsTabProps {
   assistantId: string;
-  /**
-   * Optional skill id to open in the detail view on first mount. Comes from
-   * the `?skill=<id>` deep-link. Only seeds the initial state — internal
-   * navigation thereafter is local state.
-   */
-  initialSkillId?: string;
 }
 
 const SEARCH_DEBOUNCE_MS = 300;
 const TIP_STORAGE_KEY = "vellum:skills:tipDismissed";
 
-export function SkillsTab({ assistantId, initialSkillId }: SkillsTabProps) {
-  const queryClient = useQueryClient();
-  const isMobile = useIsMobile();
+export function SkillsTab({ assistantId }: SkillsTabProps) {
+  const navigate = useNavigate();
 
   const [searchValue, setSearchValue] = useState("");
   const debouncedSearch = useDebouncedValue(searchValue.trim(), SEARCH_DEBOUNCE_MS);
   const [filter, setFilter] = useState<SkillFilter>("all");
   const [category, setCategory] = useState<string | null>(null);
-  const [selectedSkillId, setSelectedSkillId] = useState<string | null>(initialSkillId ?? null);
-  const [installingSkillId, setInstallingSkillId] = useState<string | null>(null);
-  const [removingSkillId, setRemovingSkillId] = useState<string | null>(null);
-  const [skillPendingRemoval, setSkillPendingRemoval] = useState<SkillInfo | null>(null);
   const [tipDismissed, setTipDismissed] = useState(() =>
     getLocalBool(TIP_STORAGE_KEY, false),
   );
+
+  const {
+    handleInstall,
+    handleRemove,
+    isInstallingSkill,
+    isRemovingSkill,
+    skillPendingRemoval,
+    confirmRemove,
+    cancelRemove,
+  } = useSkillActions(assistantId);
 
   const { data: categories = [] } = useSkillCategories(assistantId);
 
@@ -110,52 +104,6 @@ export function SkillsTab({ assistantId, initialSkillId }: SkillsTabProps) {
     enabled: Boolean(assistantId) && category !== null,
   });
 
-  const invalidateSkills = useCallback(() => {
-    void queryClient.invalidateQueries({
-      queryKey: skillsGetQueryKey({
-        path: { assistant_id: assistantId },
-      } as Options<SkillsGetData>),
-    });
-  }, [assistantId, queryClient]);
-
-  const installMutation = useMutation({
-    mutationFn: (slug: string) => installSkill(assistantId, slug),
-    onMutate: (slug) => setInstallingSkillId(slug),
-    onSettled: () => {
-      setInstallingSkillId(null);
-      invalidateSkills();
-    },
-  });
-
-  const uninstallMutation = useSkillsByIdDeleteMutation({
-    onMutate: (variables) => setRemovingSkillId(variables.path.id),
-    onSettled: () => {
-      setRemovingSkillId(null);
-      invalidateSkills();
-    },
-  });
-
-  const handleInstall = useCallback(
-    (skill: SkillInfo) => {
-      installMutation.mutate(skill.slug ?? skill.id);
-    },
-    [installMutation],
-  );
-
-  const handleRemove = useCallback((skill: SkillInfo) => {
-    setSkillPendingRemoval(skill);
-  }, []);
-
-  const confirmRemove = useCallback(() => {
-    if (!skillPendingRemoval) {
-      return;
-    }
-    uninstallMutation.mutate({
-      path: { assistant_id: assistantId, id: skillPendingRemoval.id },
-    });
-    setSkillPendingRemoval(null);
-  }, [assistantId, skillPendingRemoval, uninstallMutation]);
-
   const handleDismissTip = useCallback(() => {
     setTipDismissed(true);
     setLocalBool(TIP_STORAGE_KEY, true);
@@ -174,50 +122,6 @@ export function SkillsTab({ assistantId, initialSkillId }: SkillsTabProps) {
   );
 
   const displayedSkills = useMemo(() => sortSkills(allSkills), [allSkills]);
-
-  const selectedSkill = useMemo(() => {
-    if (!selectedSkillId) return null;
-    return allSkills.find((s) => s.id === selectedSkillId) ?? null;
-  }, [allSkills, selectedSkillId]);
-
-  const removalDialog = (
-    <ConfirmDialog
-      open={skillPendingRemoval !== null}
-      title="Remove skill"
-      message={
-        skillPendingRemoval
-          ? `Remove "${skillPendingRemoval.name}" from this assistant?`
-          : ""
-      }
-      confirmLabel="Remove"
-      destructive
-      onConfirm={confirmRemove}
-      onCancel={() => setSkillPendingRemoval(null)}
-    />
-  );
-
-  if (selectedSkill) {
-    const detailProps = {
-      assistantId,
-      skill: selectedSkill,
-      onBack: () => setSelectedSkillId(null),
-      onInstall: () => handleInstall(selectedSkill),
-      onRemove: () => handleRemove(selectedSkill),
-      isInstalling:
-        installingSkillId === (selectedSkill.slug ?? selectedSkill.id),
-      isRemoving: removingSkillId === selectedSkill.id,
-    };
-    return (
-      <>
-        {isMobile ? (
-          <SkillDetailMobile {...detailProps} />
-        ) : (
-          <SkillDetail {...detailProps} />
-        )}
-        {removalDialog}
-      </>
-    );
-  }
 
   const isSearching = skillsQuery.isFetching && Boolean(debouncedSearch);
 
@@ -253,9 +157,9 @@ export function SkillsTab({ assistantId, initialSkillId }: SkillsTabProps) {
 
         <div className="min-w-0 flex-1 overflow-y-auto">
           {skillsQuery.isLoading ? (
-            <LoadingState />
+            <SkillsLoadingState />
           ) : skillsQuery.isError ? (
-            <ErrorState />
+            <SkillsErrorState />
           ) : displayedSkills.length === 0 ? (
             <EmptyState filter={filter} category={category} />
           ) : (
@@ -264,11 +168,11 @@ export function SkillsTab({ assistantId, initialSkillId }: SkillsTabProps) {
                 <li key={skill.id}>
                   <SkillRow
                     skill={skill}
-                    onSelect={() => setSelectedSkillId(skill.id)}
+                    onSelect={() => navigate(routes.skills.detail(skill.id))}
                     onInstall={() => handleInstall(skill)}
                     onRemove={() => handleRemove(skill)}
-                    isInstalling={installingSkillId === (skill.slug ?? skill.id)}
-                    isRemoving={removingSkillId === skill.id}
+                    isInstalling={isInstallingSkill(skill)}
+                    isRemoving={isRemovingSkill(skill)}
                   />
                 </li>
               ))}
@@ -276,7 +180,11 @@ export function SkillsTab({ assistantId, initialSkillId }: SkillsTabProps) {
           )}
         </div>
       </div>
-      {removalDialog}
+      <SkillRemovalDialog
+        skill={skillPendingRemoval}
+        onConfirm={confirmRemove}
+        onCancel={cancelRemove}
+      />
     </div>
   );
 }
@@ -335,43 +243,6 @@ function TipBanner({ onDismiss }: { onDismiss: () => void }) {
   );
 }
 
-function LoadingState() {
-  return (
-    <div className="flex items-center justify-center py-16">
-      <Loader2
-        className="h-6 w-6 animate-spin"
-        style={{ color: "var(--content-tertiary)" }}
-      />
-    </div>
-  );
-}
-
-function ErrorState() {
-  return (
-    <Card.Root>
-      <Card.Body className="flex flex-col items-center justify-center py-16 text-center">
-        <TriangleAlert
-          className="mb-3 h-8 w-8"
-          style={{ color: "var(--system-danger)" }}
-          aria-hidden
-        />
-        <h3
-          className="text-title-small"
-          style={{ color: "var(--content-default)" }}
-        >
-          Failed to load skills
-        </h3>
-        <p
-          className="mt-1 max-w-sm text-body-medium-lighter"
-          style={{ color: "var(--content-tertiary)" }}
-        >
-          Something went wrong. Try refreshing the page.
-        </p>
-      </Card.Body>
-    </Card.Root>
-  );
-}
-
 function EmptyState({
   filter,
   category,
@@ -380,29 +251,7 @@ function EmptyState({
   category: string | null;
 }) {
   const { title, subtitle, Icon } = getEmptyStateCopy(filter, category);
-  return (
-    <Card.Root>
-      <Card.Body className="flex flex-col items-center justify-center py-16 text-center">
-        <Icon
-          className="mb-3 h-8 w-8"
-          style={{ color: "var(--content-tertiary)" }}
-          aria-hidden
-        />
-        <h3
-          className="text-title-small"
-          style={{ color: "var(--content-default)" }}
-        >
-          {title}
-        </h3>
-        <p
-          className="mt-1 max-w-sm text-body-medium-lighter"
-          style={{ color: "var(--content-tertiary)" }}
-        >
-          {subtitle}
-        </p>
-      </Card.Body>
-    </Card.Root>
-  );
+  return <SkillsStateCard icon={Icon} title={title} subtitle={subtitle} />;
 }
 
 function getEmptyStateCopy(

--- a/clients/web/src/domains/intelligence/intelligence-layout.tsx
+++ b/clients/web/src/domains/intelligence/intelligence-layout.tsx
@@ -18,7 +18,7 @@ interface IntelligenceTab {
 
 const BASE_INTELLIGENCE_TABS: readonly IntelligenceTab[] = [
   { label: "Identity", to: routes.identity },
-  { label: "Skills", to: routes.skills },
+  { label: "Skills", to: routes.skills.root },
   { label: "Workspace", to: routes.workspace },
   { label: "Contacts", to: routes.contacts.root },
 ];

--- a/clients/web/src/domains/intelligence/skill-detail-page.tsx
+++ b/clients/web/src/domains/intelligence/skill-detail-page.tsx
@@ -1,0 +1,118 @@
+import { useQuery } from "@tanstack/react-query";
+import { ArrowLeft, SearchX } from "lucide-react";
+import { useCallback, useMemo } from "react";
+import { Navigate, useNavigate, useParams } from "react-router";
+
+import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
+import { SkillDetail } from "@/domains/intelligence/components/skills/skill-detail";
+import { SkillDetailMobile } from "@/domains/intelligence/components/skills/skill-detail-mobile";
+import { SkillRemovalDialog } from "@/domains/intelligence/components/skills/skill-removal-dialog";
+import { SkillsErrorState } from "@/domains/intelligence/components/skills/skills-error-state";
+import { SkillsLoadingState } from "@/domains/intelligence/components/skills/skills-loading-state";
+import { SkillsStateCard } from "@/domains/intelligence/components/skills/skills-state-card";
+import { type SkillInfo } from "@/domains/intelligence/skills/types";
+import { useSkillActions } from "@/domains/intelligence/skills/use-skill-actions";
+import { skillsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
+import { useIsMobile } from "@/hooks/use-is-mobile";
+import { routes } from "@/utils/routes";
+import { Button } from "@vellumai/design-library";
+
+/**
+ * Dedicated page for a single skill at `/assistant/skills/:skillId`.
+ *
+ * Resolves the skill from the same catalog list query the Skills tab uses
+ * (cache-shared, so navigating from the list renders instantly) and renders
+ * the existing `SkillDetail` / `SkillDetailMobile` views. Removing the skill
+ * navigates back to the list.
+ */
+export function SkillDetailPage() {
+  const assistantId = useActiveAssistantId();
+  const { skillId } = useParams<{ skillId: string }>();
+  const navigate = useNavigate();
+  const isMobile = useIsMobile();
+
+  const skillsQuery = useQuery({
+    ...skillsGetOptions({
+      path: { assistant_id: assistantId },
+      query: { include: "catalog" },
+    }),
+    select: (data): SkillInfo[] => data.skills,
+  });
+
+  const handleBack = useCallback(() => {
+    navigate(routes.skills.root);
+  }, [navigate]);
+
+  const {
+    handleInstall,
+    handleRemove,
+    isInstallingSkill,
+    isRemovingSkill,
+    skillPendingRemoval,
+    confirmRemove,
+    cancelRemove,
+  } = useSkillActions(assistantId, { onRemoved: handleBack });
+
+  const skills = skillsQuery.data;
+  const skill = useMemo(
+    () => skills?.find((s) => s.id === skillId) ?? null,
+    [skills, skillId],
+  );
+
+  if (!skillId) {
+    return <Navigate to={routes.skills.root} replace />;
+  }
+
+  if (skillsQuery.isLoading) {
+    return <SkillsLoadingState />;
+  }
+
+  if (skillsQuery.isError) {
+    return <SkillsErrorState />;
+  }
+
+  if (!skill) {
+    return (
+      <SkillsStateCard
+        icon={SearchX}
+        title="Skill not found"
+        subtitle="This skill may have been removed, or the link is out of date."
+      >
+        <Button
+          type="button"
+          variant="outlined"
+          className="mt-4"
+          leftIcon={<ArrowLeft aria-hidden />}
+          onClick={handleBack}
+        >
+          Back to skills
+        </Button>
+      </SkillsStateCard>
+    );
+  }
+
+  const detailProps = {
+    assistantId,
+    skill,
+    onBack: handleBack,
+    onInstall: () => handleInstall(skill),
+    onRemove: () => handleRemove(skill),
+    isInstalling: isInstallingSkill(skill),
+    isRemoving: isRemovingSkill(skill),
+  };
+
+  return (
+    <>
+      {isMobile ? (
+        <SkillDetailMobile {...detailProps} />
+      ) : (
+        <SkillDetail {...detailProps} />
+      )}
+      <SkillRemovalDialog
+        skill={skillPendingRemoval}
+        onConfirm={confirmRemove}
+        onCancel={cancelRemove}
+      />
+    </>
+  );
+}

--- a/clients/web/src/domains/intelligence/skill-detail-page.tsx
+++ b/clients/web/src/domains/intelligence/skill-detail-page.tsx
@@ -40,7 +40,10 @@ export function SkillDetailPage() {
   });
 
   const handleBack = useCallback(() => {
-    navigate(routes.skills.root);
+    // Replace (rather than push) so browser Back doesn't bounce the user
+    // back to the detail entry — which may be a not-found page after the
+    // skill was removed via `onRemoved`.
+    navigate(routes.skills.root, { replace: true });
   }, [navigate]);
 
   const {

--- a/clients/web/src/domains/intelligence/skill-detail-page.tsx
+++ b/clients/web/src/domains/intelligence/skill-detail-page.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft, SearchX } from "lucide-react";
-import { useCallback, useMemo } from "react";
-import { Navigate, useNavigate, useParams } from "react-router";
+import { useCallback, useMemo, useRef } from "react";
+import { Navigate, useLocation, useNavigate, useParams } from "react-router";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { SkillDetail } from "@/domains/intelligence/components/skills/skill-detail";
@@ -13,6 +13,7 @@ import { SkillsStateCard } from "@/domains/intelligence/components/skills/skills
 import { type SkillInfo } from "@/domains/intelligence/skills/types";
 import { useSkillActions } from "@/domains/intelligence/skills/use-skill-actions";
 import { skillsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
+import { useEdgeSwipeBack } from "@/hooks/use-edge-swipe-back";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library";
@@ -29,7 +30,9 @@ export function SkillDetailPage() {
   const assistantId = useActiveAssistantId();
   const { skillId } = useParams<{ skillId: string }>();
   const navigate = useNavigate();
+  const { pathname } = useLocation();
   const isMobile = useIsMobile();
+  const swipeContainerRef = useRef<HTMLDivElement>(null);
 
   const skillsQuery = useQuery({
     ...skillsGetOptions({
@@ -45,6 +48,21 @@ export function SkillDetailPage() {
     // skill was removed via `onRemoved`.
     navigate(routes.skills.root, { replace: true });
   }, [navigate]);
+
+  // Register as the mobile back-swipe owner so a left-edge swipe navigates
+  // back to the skills list instead of opening the nav drawer (`ChatLayout`
+  // only yields the edge while an owner is registered). The container ref is
+  // threaded into `SkillDetailMobile`'s portaled overlay root — a page-level
+  // wrapper wouldn't contain the overlay's DOM, so the drag transform would
+  // move nothing. On the loading/error/not-found branches the ref is
+  // unattached and a committed swipe still resolves to `handleBack` (see
+  // `useEdgeSwipeBack`'s null-container commit path).
+  useEdgeSwipeBack({
+    containerRef: swipeContainerRef,
+    onBack: handleBack,
+    enabled: isMobile,
+    navKey: pathname,
+  });
 
   const {
     handleInstall,
@@ -107,7 +125,10 @@ export function SkillDetailPage() {
   return (
     <>
       {isMobile ? (
-        <SkillDetailMobile {...detailProps} />
+        <SkillDetailMobile
+          {...detailProps}
+          swipeContainerRef={swipeContainerRef}
+        />
       ) : (
         <SkillDetail {...detailProps} />
       )}

--- a/clients/web/src/domains/intelligence/skills-page.tsx
+++ b/clients/web/src/domains/intelligence/skills-page.tsx
@@ -1,12 +1,19 @@
-import { useSearchParams } from "react-router";
+import { Navigate, useSearchParams } from "react-router";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { SkillsTab } from "@/domains/intelligence/components/skills/skills-tab";
+import { routes } from "@/utils/routes";
 
 export function SkillsPage() {
   const assistantId = useActiveAssistantId();
   const [searchParams] = useSearchParams();
-  const initialSkillId = searchParams.get("skill") ?? undefined;
 
-  return <SkillsTab assistantId={assistantId} initialSkillId={initialSkillId} />;
+  // Back-compat: `?skill=<id>` deep-links resolve to the dedicated detail
+  // route so existing bookmarks keep working.
+  const skillId = searchParams.get("skill");
+  if (skillId) {
+    return <Navigate to={routes.skills.detail(skillId)} replace />;
+  }
+
+  return <SkillsTab assistantId={assistantId} />;
 }

--- a/clients/web/src/domains/intelligence/skills/use-skill-actions.ts
+++ b/clients/web/src/domains/intelligence/skills/use-skill-actions.ts
@@ -1,0 +1,121 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useState } from "react";
+
+import {
+  skillsGetQueryKey,
+  useSkillsByIdDeleteMutation,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import { type Options } from "@/generated/daemon/sdk.gen";
+import type { SkillsGetData } from "@/generated/daemon/types.gen";
+
+import { installSkill } from "./install";
+import { type SkillInfo } from "./types";
+
+interface UseSkillActionsOptions {
+  /** Called after a removal succeeds (e.g. navigate away from a detail page). */
+  onRemoved?: () => void;
+}
+
+interface UseSkillActionsResult {
+  handleInstall: (skill: SkillInfo) => void;
+  /** Stages `skill` for removal — confirm via `confirmRemove`. */
+  handleRemove: (skill: SkillInfo) => void;
+  isInstallingSkill: (skill: SkillInfo) => boolean;
+  isRemovingSkill: (skill: SkillInfo) => boolean;
+  /** Skill awaiting removal confirmation (drives `SkillRemovalDialog`). */
+  skillPendingRemoval: SkillInfo | null;
+  confirmRemove: () => void;
+  cancelRemove: () => void;
+}
+
+/**
+ * Install / remove actions for skills, shared by the Skills list and the
+ * skill detail page. Owns the per-skill pending state, the confirm-gated
+ * removal flow, and skills-cache invalidation after either mutation settles.
+ */
+export function useSkillActions(
+  assistantId: string,
+  { onRemoved }: UseSkillActionsOptions = {},
+): UseSkillActionsResult {
+  const queryClient = useQueryClient();
+
+  const [installingSkillId, setInstallingSkillId] = useState<string | null>(
+    null,
+  );
+  const [removingSkillId, setRemovingSkillId] = useState<string | null>(null);
+  const [skillPendingRemoval, setSkillPendingRemoval] =
+    useState<SkillInfo | null>(null);
+
+  const invalidateSkills = useCallback(() => {
+    void queryClient.invalidateQueries({
+      queryKey: skillsGetQueryKey({
+        path: { assistant_id: assistantId },
+      } as Options<SkillsGetData>),
+    });
+  }, [assistantId, queryClient]);
+
+  const installMutation = useMutation({
+    mutationFn: (slug: string) => installSkill(assistantId, slug),
+    onMutate: (slug) => setInstallingSkillId(slug),
+    onSettled: () => {
+      setInstallingSkillId(null);
+      invalidateSkills();
+    },
+  });
+
+  const uninstallMutation = useSkillsByIdDeleteMutation({
+    onMutate: (variables) => setRemovingSkillId(variables.path.id),
+    onSuccess: () => {
+      onRemoved?.();
+    },
+    onSettled: () => {
+      setRemovingSkillId(null);
+      invalidateSkills();
+    },
+  });
+
+  const handleInstall = useCallback(
+    (skill: SkillInfo) => {
+      installMutation.mutate(skill.slug ?? skill.id);
+    },
+    [installMutation],
+  );
+
+  const handleRemove = useCallback((skill: SkillInfo) => {
+    setSkillPendingRemoval(skill);
+  }, []);
+
+  const confirmRemove = useCallback(() => {
+    if (!skillPendingRemoval) {
+      return;
+    }
+    uninstallMutation.mutate({
+      path: { assistant_id: assistantId, id: skillPendingRemoval.id },
+    });
+    setSkillPendingRemoval(null);
+  }, [assistantId, skillPendingRemoval, uninstallMutation]);
+
+  const cancelRemove = useCallback(() => {
+    setSkillPendingRemoval(null);
+  }, []);
+
+  const isInstallingSkill = useCallback(
+    (skill: SkillInfo) => installingSkillId === (skill.slug ?? skill.id),
+    [installingSkillId],
+  );
+
+  const isRemovingSkill = useCallback(
+    (skill: SkillInfo) => removingSkillId === skill.id,
+    [removingSkillId],
+  );
+
+  return {
+    handleInstall,
+    handleRemove,
+    isInstallingSkill,
+    isRemovingSkill,
+    skillPendingRemoval,
+    confirmRemove,
+    cancelRemove,
+  };
+}

--- a/clients/web/src/routes.test.ts
+++ b/clients/web/src/routes.test.ts
@@ -127,6 +127,28 @@ describe("schedules routes", () => {
   });
 });
 
+describe("skills routes", () => {
+  test("captures the skill id as a route param", () => {
+    const matches =
+      matchRoutes(routeTree as never, "/assistant/skills/my-skill") ?? [];
+    expect(matches.at(-1)?.params.skillId).toBe("my-skill");
+  });
+
+  // Round-trip for namespaced skills.sh catalog ids (`org/repo/skill`):
+  // `routes.skills.detail` percent-encodes the id into a single path segment
+  // so `skills/:skillId` matches, and React Router decodes the param back to
+  // the raw id — the detail page must NOT decode again.
+  test("round-trips slash-containing skill ids through detail URLs", async () => {
+    const { routes } = await import("@/utils/routes");
+    const url = routes.skills.detail("org/repo/shared-skill");
+    expect(url).toBe("/assistant/skills/org%2Frepo%2Fshared-skill");
+
+    const matches = matchRoutes(routeTree as never, url) ?? [];
+    expect(matches.length).toBeGreaterThan(0);
+    expect(matches.at(-1)?.params.skillId).toBe("org/repo/shared-skill");
+  });
+});
+
 describe("settings route compatibility", () => {
   test("legacy MCP settings URL redirects to the Integrations MCP tab", () => {
     expect(leafRouteComponentName("/assistant/settings/mcp")).toBe(

--- a/clients/web/src/routes.tsx
+++ b/clients/web/src/routes.tsx
@@ -339,6 +339,7 @@ export const routeTree = [
                     { path: "plugins", lazy: { Component: () => import("@/domains/intelligence/plugins-page").then((m) => m.PluginsPage) } },
                     { path: "plugins/:name", lazy: { Component: () => import("@/domains/intelligence/plugin-detail-page").then((m) => m.PluginDetailPage) } },
                     { path: "skills", lazy: { Component: () => import("@/domains/intelligence/skills-page").then((m) => m.SkillsPage) } },
+                    { path: "skills/:skillId", lazy: { Component: () => import("@/domains/intelligence/skill-detail-page").then((m) => m.SkillDetailPage) } },
                     { path: "workspace", lazy: { Component: () => import("@/domains/workspace/workspace-page").then((m) => m.WorkspacePage) } },
                     { path: "contacts", lazy: { Component: () => import("@/contacts-page-route").then((m) => m.ContactsPageRoute) } },
                     { path: "channels", lazy: { Component: () => import("@/channels-page-route").then((m) => m.ChannelsPageRoute) } },

--- a/clients/web/src/utils/routes.test.ts
+++ b/clients/web/src/utils/routes.test.ts
@@ -21,4 +21,17 @@ describe("routes", () => {
       "/assistant/schedules/sch_123",
     );
   });
+
+  test("builds the skills tab and per-skill detail paths", () => {
+    expect(routes.skills.root).toBe("/assistant/skills");
+    expect(routes.skills.detail("my-skill")).toBe("/assistant/skills/my-skill");
+  });
+
+  test("encodes namespaced skill ids into a single path segment", () => {
+    // skills.sh catalog ids contain slashes (org/repo/skill); the produced
+    // URL must keep the id as ONE segment so `skills/:skillId` can match it.
+    expect(routes.skills.detail("org/repo/shared-skill")).toBe(
+      "/assistant/skills/org%2Frepo%2Fshared-skill",
+    );
+  });
 });

--- a/clients/web/src/utils/routes.ts
+++ b/clients/web/src/utils/routes.ts
@@ -132,7 +132,14 @@ export const routes = {
   },
   identity: r("/assistant/identity"),
   plugins: r("/assistant/plugins"),
-  skills: r("/assistant/skills"),
+  /**
+   * Skills surface — the list plus a dedicated per-skill detail page.
+   * `detail` deep-links a single skill (`/assistant/skills/:skillId`).
+   */
+  skills: {
+    root: r("/assistant/skills"),
+    detail: (skillId: string) => dyn(r("/assistant/skills"), skillId),
+  },
   workspace: r("/assistant/workspace"),
   library: {
     root: r("/assistant/library"),
@@ -199,7 +206,7 @@ export const routes = {
 const ABOUT_ASSISTANT_PATHS: readonly string[] = [
   routes.identity,
   routes.plugins,
-  routes.skills,
+  routes.skills.root,
   routes.workspace,
   routes.contacts.root,
   routes.channels,

--- a/clients/web/src/utils/routes.ts
+++ b/clients/web/src/utils/routes.ts
@@ -135,10 +135,17 @@ export const routes = {
   /**
    * Skills surface — the list plus a dedicated per-skill detail page.
    * `detail` deep-links a single skill (`/assistant/skills/:skillId`).
+   *
+   * Callers pass raw skill ids. skills.sh catalog ids are namespaced with
+   * slashes (`org/repo/skill`), so `detail` percent-encodes the id to keep it
+   * a single path segment — otherwise it would never match the
+   * `skills/:skillId` route. React Router decodes route params, so
+   * `useParams()` in the detail page yields the original id unchanged.
    */
   skills: {
     root: r("/assistant/skills"),
-    detail: (skillId: string) => dyn(r("/assistant/skills"), skillId),
+    detail: (skillId: string) =>
+      dyn(r("/assistant/skills"), encodeURIComponent(skillId)),
   },
   workspace: r("/assistant/workspace"),
   library: {


### PR DESCRIPTION
## Summary
- Adds a dedicated /assistant/skills/:skillId route (mirrors plugins/:name) rendering the existing SkillDetail components
- Skills list click now navigates (URL-driven, browser-back friendly) instead of swapping local state
- ?skill=<id> deep-links redirect to the new route

Part of plan: skill-surfacing-v1.md (PR 5 of 8)