### PR TITLE
feat(live-voice): reject the session start frame on a failed STT/TTS credential preflight

### DIFF
--- a/assistant/src/calls/telephony-tts-capability.ts
+++ b/assistant/src/calls/telephony-tts-capability.ts
@@ -103,7 +103,7 @@ export async function evaluateTelephonyTtsPlayability(
   }
 
   for (const secret of entry.secretRequirements) {
-    if (!(await secretResolves(secret.credentialStoreKey))) {
+    if (!(await ttsSecretResolves(secret.credentialStoreKey))) {
       return {
         status: "not-playable",
         providerId: entry.id,
@@ -159,18 +159,18 @@ export function fishAudioReferenceIdConfigured(): boolean {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
 /**
- * Check whether a catalog `credentialStoreKey` resolves to a value.
+ * Check whether a TTS catalog `credentialStoreKey` resolves to a value.
  *
  * API keys (`credential/{service}/api_key` or a bare service name) go
  * through `getProviderKeyAsync` so env-var-only setups are honoured;
- * other namespaced fields are looked up verbatim.
+ * other namespaced fields are looked up verbatim. Shared by
+ * {@link evaluateTelephonyTtsPlayability} and the live-voice credential
+ * preflight.
  */
-async function secretResolves(credentialStoreKey: string): Promise<boolean> {
+export async function ttsSecretResolves(
+  credentialStoreKey: string,
+): Promise<boolean> {
   const parts = credentialStoreKey.split("/");
   if (parts.length === 1) {
     return Boolean(await getProviderKeyAsync(credentialStoreKey));

--- a/assistant/src/live-voice/__tests__/live-voice-credential-preflight.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-credential-preflight.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Tests for the live-voice credential-readiness preflight resolver.
+ *
+ * The STT streaming-transcriber resolver, secure-keys lookups, and config
+ * loader are mocked so the readiness combination logic is exercised in
+ * isolation (the real TTS provider catalog is used — provider ids like
+ * "fish-audio" and "xai" carry their real streaming capabilities).
+ * `mock.module` is process-global in Bun and leaks into sibling files that
+ * run later in the same `bun test` invocation, so each stub delegates to
+ * the real implementation unless this file's tests are active
+ * (`preflightMocksActive`, toggled in beforeAll/afterAll). The real exports
+ * are snapshotted into plain objects NOW, before the stubs register — a
+ * module namespace is a live view, so reading the real export after the
+ * stub installs would resolve back to the stub (infinite recursion).
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+let preflightMocksActive = false;
+
+const realSttResolveModule = {
+  ...(await import("../../providers/speech-to-text/resolve.js")),
+};
+const realSecureKeysModule = {
+  ...(await import("../../security/secure-keys.js")),
+};
+const realConfigLoaderModule = {
+  ...(await import("../../config/loader.js")),
+};
+
+// -- Mutable stub state --------------------------------------------------------
+
+import type { StreamingTranscriber } from "../../stt/types.js";
+
+let streamingTranscriber: StreamingTranscriber | null;
+let providerKeys: Record<string, string>;
+let sttProvider: string;
+let ttsProvider: string;
+let ttsProviders: Record<string, unknown>;
+
+mock.module("../../providers/speech-to-text/resolve.js", () => ({
+  ...realSttResolveModule,
+  resolveStreamingTranscriber: async () =>
+    preflightMocksActive
+      ? streamingTranscriber
+      : realSttResolveModule.resolveStreamingTranscriber(),
+}));
+
+mock.module("../../security/secure-keys.js", () => ({
+  ...realSecureKeysModule,
+  getProviderKeyAsync: async (provider: string) =>
+    preflightMocksActive
+      ? providerKeys[provider]
+      : realSecureKeysModule.getProviderKeyAsync(provider),
+  getSecureKeyAsync: async (account: string) =>
+    preflightMocksActive
+      ? undefined
+      : realSecureKeysModule.getSecureKeyAsync(account),
+}));
+
+mock.module("../../config/loader.js", () => ({
+  ...realConfigLoaderModule,
+  getConfig: () =>
+    preflightMocksActive
+      ? ({
+          services: {
+            stt: { provider: sttProvider },
+            tts: { provider: ttsProvider, providers: ttsProviders },
+          },
+        } as unknown as ReturnType<typeof realConfigLoaderModule.getConfig>)
+      : realConfigLoaderModule.getConfig(),
+}));
+
+import { resolveLiveVoiceCredentialReadiness } from "../live-voice-credential-preflight.js";
+
+beforeAll(() => {
+  preflightMocksActive = true;
+});
+
+afterAll(() => {
+  preflightMocksActive = false;
+});
+
+beforeEach(() => {
+  // Baseline: everything ready — a streaming STT transcriber resolves and
+  // the streaming-capable fish-audio TTS provider has credentials plus a
+  // configured voice reference ID.
+  streamingTranscriber = {} as StreamingTranscriber;
+  providerKeys = { deepgram: "test-key", "fish-audio": "test-key" };
+  sttProvider = "deepgram";
+  ttsProvider = "fish-audio";
+  ttsProviders = { "fish-audio": { referenceId: "ref-123" } };
+});
+
+function expectNotReady(
+  readiness: Awaited<ReturnType<typeof resolveLiveVoiceCredentialReadiness>>,
+) {
+  expect(readiness.status).toBe("not-ready");
+  if (readiness.status !== "not-ready") {
+    throw new Error("expected not-ready");
+  }
+  return readiness;
+}
+
+describe("resolveLiveVoiceCredentialReadiness", () => {
+  test("streaming STT + streaming TTS with credentials → ready", async () => {
+    const readiness = await resolveLiveVoiceCredentialReadiness();
+    expect(readiness).toEqual({ status: "ready" });
+  });
+
+  test("STT credentials missing → not-ready with an stt entry naming the credential provider", async () => {
+    streamingTranscriber = null;
+    delete providerKeys.deepgram;
+
+    const readiness = expectNotReady(
+      await resolveLiveVoiceCredentialReadiness(),
+    );
+    expect(readiness.missing).toEqual([
+      {
+        kind: "stt",
+        providerId: "deepgram",
+        reason: 'No API key configured for credential provider "deepgram"',
+      },
+    ]);
+    expect(readiness.userMessage).toContain('"deepgram"');
+    expect(readiness.userMessage).toContain("speech-to-text");
+  });
+
+  test("unknown STT provider → not-ready with a catalog gap naming the configured id", async () => {
+    streamingTranscriber = null;
+    sttProvider = "acme-stt";
+
+    const readiness = expectNotReady(
+      await resolveLiveVoiceCredentialReadiness(),
+    );
+    expect(readiness.missing).toEqual([
+      {
+        kind: "stt",
+        providerId: "acme-stt",
+        reason: 'STT provider "acme-stt" is not in the provider catalog',
+      },
+    ]);
+    expect(readiness.userMessage).toContain('"acme-stt"');
+  });
+
+  test("keyed STT provider that resolves no streaming transcriber → not-ready with a capability gap", async () => {
+    streamingTranscriber = null;
+
+    const readiness = expectNotReady(
+      await resolveLiveVoiceCredentialReadiness(),
+    );
+    expect(readiness.missing).toEqual([
+      {
+        kind: "stt",
+        providerId: "deepgram",
+        reason:
+          'STT provider "deepgram" does not support streaming transcription',
+      },
+    ]);
+    expect(readiness.userMessage).toContain("live transcription");
+  });
+
+  test("non-streaming TTS provider → not-ready with a tts entry naming the provider", async () => {
+    ttsProvider = "xai";
+    providerKeys.xai = "test-key";
+
+    const readiness = expectNotReady(
+      await resolveLiveVoiceCredentialReadiness(),
+    );
+    expect(readiness.missing).toEqual([
+      {
+        kind: "tts",
+        providerId: "xai",
+        reason: 'TTS provider "xai" does not support streaming synthesis',
+      },
+    ]);
+    expect(readiness.userMessage).toContain('"xai"');
+    expect(readiness.userMessage).toContain("streaming synthesis");
+  });
+
+  test("streaming TTS provider missing credentials → not-ready naming the missing key", async () => {
+    delete providerKeys["fish-audio"];
+
+    const readiness = expectNotReady(
+      await resolveLiveVoiceCredentialReadiness(),
+    );
+    expect(readiness.missing).toEqual([
+      {
+        kind: "tts",
+        providerId: "fish-audio",
+        reason:
+          'TTS provider "fish-audio" is missing credentials (Fish Audio API Key)',
+      },
+    ]);
+    expect(readiness.userMessage).toContain('"fish-audio"');
+    expect(readiness.userMessage).toContain("text-to-speech");
+    expect(readiness.userMessage).toContain("Fish Audio API Key");
+  });
+
+  test("fish-audio keyed but referenceId-less → not-ready naming the reference ID", async () => {
+    ttsProviders = {};
+
+    const readiness = expectNotReady(
+      await resolveLiveVoiceCredentialReadiness(),
+    );
+    expect(readiness.missing).toEqual([
+      {
+        kind: "tts",
+        providerId: "fish-audio",
+        reason:
+          'TTS provider "fish-audio" has no Fish Audio reference ID configured (services.tts.providers.fish-audio.referenceId)',
+      },
+    ]);
+    expect(readiness.userMessage).toContain("Fish Audio voice reference ID");
+    expect(readiness.userMessage).toContain(
+      "services.tts.providers.fish-audio.referenceId",
+    );
+  });
+
+  test("unknown TTS provider → not-ready with a catalog gap naming the configured id", async () => {
+    ttsProvider = "acme-tts";
+
+    const readiness = expectNotReady(
+      await resolveLiveVoiceCredentialReadiness(),
+    );
+    expect(readiness.missing).toEqual([
+      {
+        kind: "tts",
+        providerId: "acme-tts",
+        reason: 'TTS provider "acme-tts" is not in the provider catalog',
+      },
+    ]);
+    expect(readiness.userMessage).toContain('"acme-tts"');
+  });
+
+  test("both STT and TTS missing → both entries, message names both providers", async () => {
+    streamingTranscriber = null;
+    delete providerKeys.deepgram;
+    delete providerKeys["fish-audio"];
+
+    const readiness = expectNotReady(
+      await resolveLiveVoiceCredentialReadiness(),
+    );
+    expect(readiness.missing.map((gap) => gap.kind)).toEqual(["stt", "tts"]);
+    expect(readiness.userMessage).toContain('"deepgram"');
+    expect(readiness.userMessage).toContain('"fish-audio"');
+    // Single sentence: suitable for the client `error` frame.
+    expect(readiness.userMessage).not.toContain("\n");
+    expect(readiness.userMessage.endsWith(".")).toBe(true);
+  });
+});

--- a/assistant/src/live-voice/__tests__/live-voice-integration.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-integration.test.ts
@@ -213,6 +213,8 @@ function createMultiCycleHarness(startVoiceTurn: LiveVoiceTurnStarter) {
   const { context, frames } = createContext(VAD_START_FRAME);
   let turnCount = 0;
   const session = createLiveVoiceSession(context, {
+    // Credential-free harness: every leg is injected, so skip the preflight.
+    resolveCredentialReadiness: null,
     resolveTranscriber,
     startVoiceTurn,
     streamTtsAudio,
@@ -248,6 +250,7 @@ describe("LiveVoiceSession integration smoke harness", () => {
     });
     const { context, frames } = createContext();
     const session = createLiveVoiceSession(context, {
+      resolveCredentialReadiness: null,
       resolveTranscriber: mock(async () => transcriber),
       startVoiceTurn,
       streamTtsAudio,
@@ -354,6 +357,7 @@ describe("LiveVoiceSession integration smoke harness", () => {
     );
     const { context, frames } = createContext();
     const session = createLiveVoiceSession(context, {
+      resolveCredentialReadiness: null,
       resolveTranscriber: mock(async () => transcriber),
       startVoiceTurn,
       streamTtsAudio,

--- a/assistant/src/live-voice/__tests__/live-voice-session-preflight.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-session-preflight.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Session-start gating on the live-voice credential preflight.
+ *
+ * The preflight resolver is injected as a stub — the resolver's own
+ * readiness logic is covered in live-voice-credential-preflight.test.ts.
+ * These tests pin the wiring: a not-ready verdict rejects the session at
+ * the start frame with a `credentials_unavailable` error frame carrying
+ * the preflight's user message, before any transcriber is resolved, and
+ * leaves the session manager free for a retry.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import type { StreamingTranscriber } from "../../stt/types.js";
+import type { LiveVoiceCredentialReadiness } from "../live-voice-credential-preflight.js";
+import { LiveVoiceSession } from "../live-voice-session.js";
+import {
+  type LiveVoiceSessionFactoryContext,
+  LiveVoiceSessionManager,
+  LiveVoiceSessionStartupError,
+} from "../live-voice-session-manager.js";
+import {
+  createLiveVoiceServerFrameSequencer,
+  type LiveVoiceClientStartFrame,
+  type LiveVoiceServerFrame,
+} from "../protocol.js";
+
+const START_FRAME = {
+  type: "start",
+  conversationId: "conversation-123",
+  audio: {
+    mimeType: "audio/pcm",
+    sampleRate: 24_000,
+    channels: 1,
+  },
+} as const satisfies LiveVoiceClientStartFrame;
+
+const NOT_READY: LiveVoiceCredentialReadiness = {
+  status: "not-ready",
+  missing: [
+    {
+      kind: "tts",
+      providerId: "fish-audio",
+      reason:
+        'TTS provider "fish-audio" is missing credentials (Fish Audio API Key)',
+    },
+  ],
+  userMessage:
+    'Live voice is unavailable because it requires an API key for the text-to-speech provider "fish-audio" (Fish Audio API Key).',
+};
+
+class MockStreamingTranscriber implements StreamingTranscriber {
+  readonly providerId = "deepgram" as const;
+  readonly boundaryId = "daemon-streaming" as const;
+
+  async start(): Promise<void> {}
+
+  sendAudio(): void {}
+
+  stop(): void {}
+}
+
+function createContext(): {
+  context: LiveVoiceSessionFactoryContext;
+  frames: LiveVoiceServerFrame[];
+} {
+  const sequencer = createLiveVoiceServerFrameSequencer();
+  const frames: LiveVoiceServerFrame[] = [];
+
+  return {
+    frames,
+    context: {
+      sessionId: "session-123",
+      startFrame: START_FRAME,
+      sendFrame: mock(async (payload) => {
+        const frame = sequencer.next(payload);
+        frames.push(frame);
+        return frame;
+      }),
+    },
+  };
+}
+
+describe("live-voice session credential preflight gating", () => {
+  test("not-ready preflight rejects the start frame before resolving a transcriber", async () => {
+    const { context, frames } = createContext();
+    const resolveTranscriber = mock(async () => new MockStreamingTranscriber());
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber,
+      resolveCredentialReadiness: mock(async () => NOT_READY),
+    });
+
+    await expect(session.start()).rejects.toBeInstanceOf(
+      LiveVoiceSessionStartupError,
+    );
+
+    expect(resolveTranscriber).not.toHaveBeenCalled();
+    expect(frames).toEqual([
+      {
+        type: "error",
+        seq: 1,
+        code: "credentials_unavailable",
+        message: NOT_READY.userMessage,
+      },
+    ]);
+  });
+
+  test("ready preflight proceeds to the normal ready frame", async () => {
+    const { context, frames } = createContext();
+    const resolveCredentialReadiness = mock(
+      async (): Promise<LiveVoiceCredentialReadiness> => ({ status: "ready" }),
+    );
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: mock(async () => new MockStreamingTranscriber()),
+      resolveCredentialReadiness,
+    });
+
+    await session.start();
+
+    expect(resolveCredentialReadiness).toHaveBeenCalledTimes(1);
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toMatchObject({
+      type: "ready",
+      sessionId: "session-123",
+      conversationId: "conversation-123",
+    });
+
+    await session.close("websocket_close");
+  });
+
+  test("a rejected start frees the manager slot for a retry", async () => {
+    const manager = new LiveVoiceSessionManager({
+      createSession: (context) =>
+        new LiveVoiceSession(context, {
+          resolveTranscriber: mock(async () => new MockStreamingTranscriber()),
+          resolveCredentialReadiness: mock(async () => NOT_READY),
+        }),
+    });
+    const frames: LiveVoiceServerFrame[] = [];
+
+    const result = await manager.startSession(START_FRAME, {
+      sendFrame: (frame) => {
+        frames.push(frame);
+      },
+    });
+
+    expect(result.status).toBe("failed");
+    expect(manager.activeSessionId).toBeNull();
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toMatchObject({
+      type: "error",
+      code: "credentials_unavailable",
+      message: NOT_READY.userMessage,
+    });
+  });
+});

--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -467,7 +467,7 @@ describe("LiveVoiceSession STT", () => {
     expect(frames).toHaveLength(1);
     expect(frames[0]).toMatchObject({
       type: "error",
-      code: "invalid_field",
+      code: "credentials_unavailable",
     });
     const [errorFrame] = frames;
     if (errorFrame?.type !== "error") {

--- a/assistant/src/live-voice/__tests__/runtime-websocket-shell.test.ts
+++ b/assistant/src/live-voice/__tests__/runtime-websocket-shell.test.ts
@@ -1,9 +1,34 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 
 import type {
   StreamingTranscriber,
   SttStreamServerEvent,
 } from "../../stt/types.js";
+
+// `mock.module` is process-global in Bun and leaks into sibling files that
+// run later in the same `bun test` invocation, so the STT/preflight stubs
+// delegate to the real implementation unless this file's tests are active
+// (`shellMocksActive`, toggled in beforeAll/afterAll). The real exports are
+// snapshotted into plain objects NOW, before the stubs register — a module
+// namespace is a live view, so reading the real export after the stub
+// installs would resolve back to the stub (infinite recursion).
+let shellMocksActive = false;
+
+const realSttResolveModule = {
+  ...(await import("../../providers/speech-to-text/resolve.js")),
+};
+const realPreflightModule = {
+  ...(await import("../live-voice-credential-preflight.js")),
+};
 
 mock.module("../../util/logger.js", () => ({
   getLogger: () =>
@@ -81,12 +106,31 @@ function createResolvedTranscriber(): MockStreamingTranscriber {
 }
 
 let resolveStreamingTranscriberImpl = async () => createResolvedTranscriber();
-const resolveStreamingTranscriberMock = mock(() =>
-  resolveStreamingTranscriberImpl(),
+const resolveStreamingTranscriberMock = mock(
+  (
+    options?: Parameters<
+      typeof realSttResolveModule.resolveStreamingTranscriber
+    >[0],
+  ) =>
+    shellMocksActive
+      ? resolveStreamingTranscriberImpl()
+      : realSttResolveModule.resolveStreamingTranscriber(options),
 );
 
 mock.module("../../providers/speech-to-text/resolve.js", () => ({
+  ...realSttResolveModule,
   resolveStreamingTranscriber: resolveStreamingTranscriberMock,
+}));
+
+// The shell tests exercise WebSocket frame routing and session locking, not
+// credential resolution — the preflight is stubbed ready so start frames
+// reach the session legs mocked above.
+mock.module("../live-voice-credential-preflight.js", () => ({
+  ...realPreflightModule,
+  resolveLiveVoiceCredentialReadiness: async () =>
+    shellMocksActive
+      ? { status: "ready" }
+      : realPreflightModule.resolveLiveVoiceCredentialReadiness(),
 }));
 
 import { CURRENT_POLICY_EPOCH } from "../../runtime/auth/policy.js";
@@ -234,6 +278,14 @@ describe("RuntimeHttpServer live voice WebSocket shell", () => {
   let baseUrl: string;
   let wsBaseUrl: string;
   let clients: WebSocket[];
+
+  beforeAll(() => {
+    shellMocksActive = true;
+  });
+
+  afterAll(() => {
+    shellMocksActive = false;
+  });
 
   beforeEach(async () => {
     delete process.env.DISABLE_HTTP_AUTH;

--- a/assistant/src/live-voice/live-voice-credential-preflight.ts
+++ b/assistant/src/live-voice/live-voice-credential-preflight.ts
@@ -1,0 +1,205 @@
+/**
+ * Live-voice credential-readiness preflight.
+ *
+ * A live voice session needs the daemon to run both audio legs: streaming
+ * speech-to-text for caller audio, and streaming text-to-speech for
+ * assistant audio. This resolver combines the two checks into a single
+ * ready / not-ready verdict with a user-facing message suitable for the
+ * client `error` frame, so a session fails at the `start` frame instead of
+ * mid-conversation. It opens no live connections and performs no session
+ * wiring — the session gates startup on the verdict. Mirrors
+ * `calls/telephony-credential-preflight.ts` for the phone-call transport.
+ */
+
+import {
+  fishAudioReferenceIdConfigured,
+  ttsSecretResolves,
+} from "../calls/telephony-tts-capability.js";
+import { getConfig } from "../config/loader.js";
+import { getProviderEntry } from "../providers/speech-to-text/provider-catalog.js";
+import {
+  resolveStreamingTranscriber,
+  sttProviderKeyResolves,
+} from "../providers/speech-to-text/resolve.js";
+import type { SttProviderId } from "../stt/types.js";
+import type { TtsProviderCatalogEntry } from "../tts/provider-catalog.js";
+import { getCatalogProvider, getTtsProvider } from "../tts/provider-catalog.js";
+import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** A single credential/capability gap blocking live-voice readiness. */
+export interface LiveVoiceCredentialGap {
+  kind: "stt" | "tts";
+  providerId: string;
+  reason: string;
+}
+
+/** Result of resolving whether live-voice STT+TTS credentials are in order. */
+export type LiveVoiceCredentialReadiness =
+  | { status: "ready" }
+  | {
+      status: "not-ready";
+      missing: LiveVoiceCredentialGap[];
+      /**
+       * A single human-readable sentence naming the offending provider(s)
+       * and missing credential(s), suitable for the client `error` frame.
+       */
+      userMessage: string;
+    };
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve whether the daemon can run both audio legs of a live voice
+ * session.
+ *
+ * Readiness requires:
+ * - STT: the configured `services.stt.provider` resolves a streaming
+ *   transcriber (the session arms one per utterance — there is no batch
+ *   fallback on the live-voice transport).
+ * - TTS: the configured `services.tts.provider` supports streaming
+ *   synthesis (`synthesizeStream`), all of its required secrets resolve,
+ *   and provider-specific config invariants hold (fish-audio requires a
+ *   configured `referenceId` — live voice supplies no per-request voiceId).
+ */
+export async function resolveLiveVoiceCredentialReadiness(): Promise<LiveVoiceCredentialReadiness> {
+  const gaps = (await Promise.all([resolveSttGap(), resolveTtsGap()])).filter(
+    (gap) => gap !== null,
+  );
+
+  if (gaps.length === 0) {
+    return { status: "ready" };
+  }
+
+  return {
+    status: "not-ready",
+    missing: gaps.map(({ gap }) => gap),
+    userMessage: `Live voice is unavailable because it requires ${gaps
+      .map(({ clause }) => clause)
+      .join(" and ")}.`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** A gap entry plus its user-message clause. */
+interface GapWithClause {
+  gap: LiveVoiceCredentialGap;
+  clause: string;
+}
+
+/**
+ * Resolve the STT leg: no gap when the configured provider yields a
+ * streaming transcriber. When none resolves, classify why so the gap
+ * names the missing piece.
+ */
+async function resolveSttGap(): Promise<GapWithClause | null> {
+  if ((await resolveStreamingTranscriber()) !== null) {
+    return null;
+  }
+
+  const providerId = getConfig().services.stt.provider;
+  const entry = getProviderEntry(providerId as SttProviderId);
+  if (!entry) {
+    return {
+      gap: {
+        kind: "stt",
+        providerId,
+        reason: `STT provider "${providerId}" is not in the provider catalog`,
+      },
+      clause: `a recognized speech-to-text provider (the configured "${providerId}" is not in the provider catalog)`,
+    };
+  }
+
+  if (!(await sttProviderKeyResolves(entry.credentialProvider))) {
+    return {
+      gap: {
+        kind: "stt",
+        providerId: entry.id,
+        reason: `No API key configured for credential provider "${entry.credentialProvider}"`,
+      },
+      clause: `an API key for the speech-to-text provider "${entry.id}"`,
+    };
+  }
+
+  return {
+    gap: {
+      kind: "stt",
+      providerId: entry.id,
+      reason: `STT provider "${entry.id}" does not support streaming transcription`,
+    },
+    clause: `a speech-to-text provider that supports live transcription (the configured "${entry.id}" does not)`,
+  };
+}
+
+/**
+ * Resolve the TTS leg: no gap when the configured provider supports
+ * streaming synthesis, every secret its catalog entry requires resolves
+ * to a value, and fish-audio (which live voice drives without a
+ * per-request voiceId) has a configured `referenceId`.
+ */
+async function resolveTtsGap(): Promise<GapWithClause | null> {
+  const { provider: providerId } = resolveTtsConfig(getConfig());
+
+  let entry: TtsProviderCatalogEntry;
+  try {
+    entry = getCatalogProvider(providerId);
+  } catch {
+    return {
+      gap: {
+        kind: "tts",
+        providerId,
+        reason: `TTS provider "${providerId}" is not in the provider catalog`,
+      },
+      clause: `a recognized text-to-speech provider (the configured "${providerId}" is not in the provider catalog)`,
+    };
+  }
+
+  const adapter = getTtsProvider(entry.id);
+  if (
+    !adapter.capabilities.supportsStreaming ||
+    typeof adapter.synthesizeStream !== "function"
+  ) {
+    return {
+      gap: {
+        kind: "tts",
+        providerId: entry.id,
+        reason: `TTS provider "${entry.id}" does not support streaming synthesis`,
+      },
+      clause: `a text-to-speech provider that supports streaming synthesis (the configured "${entry.id}" does not)`,
+    };
+  }
+
+  for (const secret of entry.secretRequirements) {
+    if (!(await ttsSecretResolves(secret.credentialStoreKey))) {
+      return {
+        gap: {
+          kind: "tts",
+          providerId: entry.id,
+          reason: `TTS provider "${entry.id}" is missing credentials (${secret.displayName})`,
+        },
+        clause: `an API key for the text-to-speech provider "${entry.id}" (${secret.displayName})`,
+      };
+    }
+  }
+
+  if (entry.id === "fish-audio" && !fishAudioReferenceIdConfigured()) {
+    return {
+      gap: {
+        kind: "tts",
+        providerId: entry.id,
+        reason: `TTS provider "${entry.id}" has no Fish Audio reference ID configured (services.tts.providers.fish-audio.referenceId)`,
+      },
+      clause: `a Fish Audio voice reference ID for the text-to-speech provider "${entry.id}" (set services.tts.providers.fish-audio.referenceId)`,
+    };
+  }
+
+  return null;
+}

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -25,6 +25,7 @@ import type {
   LiveVoiceAudioArchiveResult,
   LiveVoiceAudioArchiveRole,
 } from "./live-voice-archive.js";
+import type { LiveVoiceCredentialReadiness } from "./live-voice-credential-preflight.js";
 import {
   getLiveVoiceMetricsAggregateFields,
   type LiveVoiceMetricsClock,
@@ -67,6 +68,9 @@ export type LiveVoiceStreamingTranscriberResolver = (
   options: ResolveStreamingTranscriberOptions,
 ) => Promise<StreamingTranscriber | null>;
 
+export type LiveVoiceCredentialReadinessResolver =
+  () => Promise<LiveVoiceCredentialReadiness>;
+
 export type LiveVoiceTurnStarter = (
   options: VoiceTurnOptions,
 ) => Promise<VoiceTurnHandle>;
@@ -95,6 +99,12 @@ export type LiveVoiceSessionAudioArchiver = (
 
 export interface LiveVoiceSessionOptions {
   resolveTranscriber?: LiveVoiceStreamingTranscriberResolver;
+  /**
+   * STT/TTS credential preflight run before any session wiring; a
+   * `not-ready` verdict rejects the start frame with its `userMessage`.
+   * `null` skips the preflight.
+   */
+  resolveCredentialReadiness?: LiveVoiceCredentialReadinessResolver | null;
   startVoiceTurn?: LiveVoiceTurnStarter;
   streamTtsAudio?: LiveVoiceTtsStreamer | null;
   archiveAudio?: LiveVoiceSessionAudioArchiver | null;
@@ -176,6 +186,7 @@ interface ActiveAssistantTurn {
 export class LiveVoiceSession implements LiveVoiceSessionContract {
   private readonly context: LiveVoiceSessionFactoryContext;
   private readonly resolveTranscriber: LiveVoiceStreamingTranscriberResolver;
+  private readonly resolveCredentialReadiness: LiveVoiceCredentialReadinessResolver | null;
   private readonly startVoiceTurn: LiveVoiceTurnStarter | null;
   private readonly streamTtsAudio: LiveVoiceTtsStreamer | null;
   private readonly archiveAudio: LiveVoiceSessionAudioArchiver | null;
@@ -212,6 +223,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.context = context;
     this.resolveTranscriber =
       options.resolveTranscriber ?? defaultResolveStreamingTranscriber;
+    this.resolveCredentialReadiness =
+      options.resolveCredentialReadiness ?? null;
     this.startVoiceTurn = options.startVoiceTurn ?? null;
     this.streamTtsAudio = options.streamTtsAudio ?? null;
     this.archiveAudio = options.archiveAudio ?? null;
@@ -245,11 +258,25 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   async start(): Promise<void> {
     if (this.state !== "initializing") return;
 
+    if (this.resolveCredentialReadiness) {
+      const readiness = await this.resolveCredentialReadiness();
+      if (readiness.status === "not-ready") {
+        return await this.failStartup(
+          readiness.userMessage,
+          LiveVoiceProtocolErrorCode.CredentialsUnavailable,
+        );
+      }
+    }
+
     const result = await this.beginUtterance();
     switch (result.status) {
       case "stale":
         return;
       case "unavailable":
+        return await this.failStartup(
+          result.message,
+          LiveVoiceProtocolErrorCode.CredentialsUnavailable,
+        );
       case "error":
         return await this.failStartup(result.message);
       case "started":
@@ -1503,11 +1530,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     });
   }
 
-  private async failStartup(message: string): Promise<never> {
+  private async failStartup(
+    message: string,
+    code: LiveVoiceProtocolErrorCode = LiveVoiceProtocolErrorCode.InvalidField,
+  ): Promise<never> {
     this.state = "failed";
     await this.sendFrame({
       type: "error",
-      code: LiveVoiceProtocolErrorCode.InvalidField,
+      code,
       message,
     });
     throw new LiveVoiceSessionStartupError(message);
@@ -1557,6 +1587,10 @@ export function createLiveVoiceSession(
 ): LiveVoiceSession {
   return new LiveVoiceSession(context, {
     ...options,
+    resolveCredentialReadiness:
+      options.resolveCredentialReadiness === undefined
+        ? defaultResolveLiveVoiceCredentialReadiness
+        : options.resolveCredentialReadiness,
     startVoiceTurn: options.startVoiceTurn ?? defaultStartVoiceTurn,
     streamTtsAudio:
       options.streamTtsAudio === undefined
@@ -1576,6 +1610,12 @@ async function defaultResolveStreamingTranscriber(
   const { resolveStreamingTranscriber } =
     await import("../providers/speech-to-text/resolve.js");
   return resolveStreamingTranscriber(options);
+}
+
+async function defaultResolveLiveVoiceCredentialReadiness(): Promise<LiveVoiceCredentialReadiness> {
+  const { resolveLiveVoiceCredentialReadiness } =
+    await import("./live-voice-credential-preflight.js");
+  return resolveLiveVoiceCredentialReadiness();
 }
 
 async function defaultStartVoiceTurn(

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -35,6 +35,12 @@ export const LiveVoiceProtocolErrorCode = {
   MissingRequiredField: "missing_required_field",
   InvalidField: "invalid_field",
   InvalidAudioPayload: "invalid_audio_payload",
+  /**
+   * Session startup was rejected because the daemon cannot run both audio
+   * legs (STT/TTS providers or credentials are unresolved). The error
+   * `message` names the offending provider(s) and missing credential(s).
+   */
+  CredentialsUnavailable: "credentials_unavailable",
 } as const;
 
 export type LiveVoiceProtocolErrorCode =

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -449,3 +449,15 @@ async function createStreamingTranscriber(
     }
   }
 }
+
+/**
+ * True when an API key resolves for the given credential provider name.
+ *
+ * Centralized here (an authorized secure-keys importer) so callers that only
+ * need a key-existence check don't import secure-keys directly.
+ */
+export async function sttProviderKeyResolves(
+  credentialProviderName: string,
+): Promise<boolean> {
+  return (await getProviderKeyAsync(credentialProviderName)) !== undefined;
+}


### PR DESCRIPTION
Closes JARVIS-1246.

## What

A live-voice session whose STT/TTS providers or credentials can't be resolved previously failed **mid-conversation** — TTS credential problems only surfaced when the first assistant turn tried to synthesize. This PR gates session startup on a credential-readiness preflight so the `start` frame is rejected immediately with an actionable error, mirroring the telephony preflight (`calls/telephony-credential-preflight.ts`) Gap/Readiness shapes.

- **`live-voice/live-voice-credential-preflight.ts`** (new): `resolveLiveVoiceCredentialReadiness()` combines both audio legs into one `ready` / `not-ready` verdict with a single-sentence `userMessage` naming the offending provider(s) and missing credential(s):
  - **STT**: the configured `services.stt.provider` must resolve a streaming transcriber (the same `resolveStreamingTranscriber` the session arms per utterance, so the check can't drift). On failure, the gap is classified: unknown catalog id → missing API key → no streaming support.
  - **TTS**: the configured `services.tts.provider` must be in the catalog, support streaming synthesis, resolve all `secretRequirements`, and — for fish-audio — have a configured `referenceId` (live voice supplies no per-request voiceId, same invariant as telephony).
- **Wiring**: `LiveVoiceSession.start()` runs the preflight before any session wiring; `not-ready` → error frame with the new `credentials_unavailable` protocol code + the actionable message → `LiveVoiceSessionStartupError`, so the manager releases the slot and the client can retry after fixing credentials. The pre-existing no-streaming-transcriber startup failure now also reports `credentials_unavailable` instead of the misleading `invalid_field`.
- **Credential-security invariant**: the preflight imports no secure-keys — the STT key-existence check routes through new `sttProviderKeyResolves` in `providers/speech-to-text/resolve.ts`, and the TTS secret check through now-exported `ttsSecretResolves` in `calls/telephony-tts-capability.ts` (both allowlisted importers).
- **Injectable**: the preflight is a session option (`resolveCredentialReadiness`, `null` skips); the real resolver is defaulted only in `createLiveVoiceSession`, so unit tests constructing `LiveVoiceSession` directly are unaffected.

Adapted from the abandoned-rewrite reference commit `38c397c92b`, minus its batch-transcriber fallback (the shipped engine strictly requires streaming STT) and plus the fish-audio referenceId check. The wire change is additive: clients type the error `code` as `string` and already surface `message`.

## Tests

- `live-voice-credential-preflight.test.ts`: readiness combination logic across all gap classes (9 tests).
- `live-voice-session-preflight.test.ts`: start-frame gating — error frame shape, no transcriber resolved on rejection, manager slot freed for retry (3 tests).
- `runtime-websocket-shell.test.ts`: stubs the preflight ready (the shell tests exercise frame routing, not credentials) and converts its process-global STT mock to the snapshot-and-toggle pattern so it stops clobbering sibling test files.
- `live-voice-integration.test.ts`: the credential-free harnesses explicitly skip the preflight.
- `live-voice-stt.test.ts`: updated the unavailable-transcriber expectation to `credentials_unavailable`.

All 14 live-voice test files green (139 tests), plus `telephony-credential-preflight` and `credential-security-invariants`; full `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)