### PR TITLE
fix(web): mobile app overlay + chat polish from Figma review

### DIFF
--- a/clients/web/src/components/app-nav-bar.test.tsx
+++ b/clients/web/src/components/app-nav-bar.test.tsx
@@ -180,7 +180,7 @@ describe("AppNavBar share + deploy", () => {
       />,
     );
     // One button rendered with the Share icon.
-    expect(html).toContain("lucide-arrow-up");
+    expect(html).toContain("lucide-share");
     expect(html).not.toContain("lucide-globe");
   });
 
@@ -193,7 +193,7 @@ describe("AppNavBar share + deploy", () => {
       />,
     );
     expect(html).toContain("lucide-globe");
-    expect(html).not.toContain("lucide-arrow-up");
+    expect(html).not.toContain("lucide-share");
   });
 
   test("collapses share + deploy into a single dropdown trigger when both are provided (desktop)", () => {
@@ -207,12 +207,12 @@ describe("AppNavBar share + deploy", () => {
       />,
     );
     // The dropdown trigger renders as a single Button wrapped in
-    // `data-testid="trigger"`, with the up-arrow icon. The Globe icon
+    // `data-testid="trigger"`, with the share icon. The Globe icon
     // should only appear inside the menu items (as a `menu-item` leftIcon),
     // not as a standalone button — so we check for the trigger testid,
     // not the global lucide-globe count.
     expect(html).toContain('data-testid="trigger"');
-    expect(html).toContain("lucide-arrow-up");
+    expect(html).toContain("lucide-share");
     // Menu items carry the Globe icon, so we look for it scoped to a
     // menu-item container rather than asserting its absence globally.
     const menuItemIcons = html.match(

--- a/clients/web/src/components/app-nav-bar.tsx
+++ b/clients/web/src/components/app-nav-bar.tsx
@@ -1,10 +1,10 @@
 import {
-  ArrowUp,
   ChevronUp,
   Globe,
   Loader2,
   Maximize2,
   Pencil,
+  Share,
   X,
 } from "lucide-react";
 import { useState } from "react";
@@ -106,7 +106,7 @@ export function AppNavBar({
               <Button
                 variant="outlined"
                 iconOnly={
-                  isSharing ? <Loader2 className="animate-spin" /> : <ArrowUp />
+                  isSharing ? <Loader2 className="animate-spin" /> : <Share />
                 }
                 onClick={onShare}
                 disabled={isSharing}
@@ -168,7 +168,7 @@ function ShareDeployMenuTrigger({
   const triggerIcon = isBusy ? (
     <Loader2 className="animate-spin" />
   ) : (
-    <ArrowUp />
+    <Share />
   );
   const triggerTooltip = isSharing
     ? "Sharing…"
@@ -193,7 +193,7 @@ function ShareDeployMenuTrigger({
           </BottomSheet.Header>
           <BottomSheet.Body className="pt-0">
             <PanelItem
-              icon={ArrowUp}
+              icon={Share}
               label={
                 <span className="flex flex-col gap-0.5 overflow-visible whitespace-normal">
                   <span>Share</span>
@@ -240,7 +240,7 @@ function ShareDeployMenuTrigger({
       </Menu.Trigger>
       <Menu.Content align="end" sideOffset={4}>
         <Menu.Item
-          leftIcon={<ArrowUp size={14} />}
+          leftIcon={<Share size={14} />}
           onSelect={() => onShare()}
           className="whitespace-nowrap"
         >

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -76,6 +76,15 @@ export interface ChatBodyProps {
    */
   composerSlot: ReactNode;
 
+  /**
+   * Optional CSS length reserved at the bottom of the panel (applied as
+   * `padding-bottom` on the outer container). Used on mobile while the app
+   * overlay is minimized to its strip: the strip overlays the bottom of the
+   * chat, so the composer lifts above it instead of hiding underneath —
+   * Figma review (node 6629-6730): "should also push the chat input up".
+   */
+  bottomInset?: string;
+
   /** Drag handlers attached to the outer container for attachment drag-and-drop. */
   dragHandlers: ChatBodyDragHandlers;
   /** True when an attachment drag is active; shows a drop-target overlay. */
@@ -178,6 +187,7 @@ export function ChatBody({
   variant,
   scrollAreaProps,
   composerSlot,
+  bottomInset,
   dragHandlers,
   isAttachmentDragOver,
   showScrollToLatest,
@@ -352,6 +362,7 @@ export function ChatBody({
     return (
       <div
         className={outerClass}
+        style={bottomInset ? { paddingBottom: bottomInset } : undefined}
         onDragEnter={dragHandlers.onDragEnter}
         onDragOver={dragHandlers.onDragOver}
         onDragLeave={dragHandlers.onDragLeave}
@@ -388,6 +399,7 @@ export function ChatBody({
   return (
     <div
       className={outerClass}
+      style={bottomInset ? { paddingBottom: bottomInset } : undefined}
       onDragEnter={dragHandlers.onDragEnter}
       onDragOver={dragHandlers.onDragOver}
       onDragLeave={dragHandlers.onDragLeave}

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -80,8 +80,7 @@ export interface ChatBodyProps {
    * Optional CSS length reserved at the bottom of the panel (applied as
    * `padding-bottom` on the outer container). Used on mobile while the app
    * overlay is minimized to its strip: the strip overlays the bottom of the
-   * chat, so the composer lifts above it instead of hiding underneath —
-   * Figma review (node 6629-6730): "should also push the chat input up".
+   * chat, so the composer lifts above it instead of hiding underneath.
    */
   bottomInset?: string;
 

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -1020,9 +1020,9 @@ export function ChatMainPanel({
 
   // Mobile-only: while the app overlay is minimized to its bottom strip, the
   // strip covers the bottom of the chat. Reserve its height so the composer
-  // sits above it — Figma review (node 6629-6730). The strip peeks
-  // `--app-strip-h` above the safe area, and the chat shell already pads for
-  // the safe area itself, so only the strip height needs reserving.
+  // sits above it. The strip peeks `--app-strip-h` above the safe area, and
+  // the chat shell already pads for the safe area itself, so only the strip
+  // height needs reserving.
   const appStripBottomInset =
     isMobile && isAppMinimized && openedAppState
       ? "var(--app-strip-h, 64px)"

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -290,6 +290,7 @@ export function ChatMainPanel({
   // -------------------------------------------------------------------------
   const mainView = useViewerStore.use.mainView();
   const openedAppState = useViewerStore.use.openedAppState();
+  const isAppMinimized = useViewerStore.use.isAppMinimized();
 
   // Conversation count (for nudges — TanStack Query deduped)
   const { conversations } = useConversationListQuery(assistantId, true);
@@ -1017,9 +1018,20 @@ export function ChatMainPanel({
   const isSidePanel = mainView === "app-editing" && !!openedAppState && !!editingConversationId;
   const variant = isSidePanel ? "side-panel" : "main";
 
+  // Mobile-only: while the app overlay is minimized to its bottom strip, the
+  // strip covers the bottom of the chat. Reserve its height so the composer
+  // sits above it — Figma review (node 6629-6730). The strip peeks
+  // `--app-strip-h` above the safe area, and the chat shell already pads for
+  // the safe area itself, so only the strip height needs reserving.
+  const appStripBottomInset =
+    isMobile && isAppMinimized && openedAppState
+      ? "var(--app-strip-h, 64px)"
+      : undefined;
+
   const chatBody = (
     <ChatBody
       variant={variant}
+      bottomInset={appStripBottomInset}
       scrollAreaProps={{
         ...chatBodyScrollAreaPropsBase,
         showMaintenanceRecoveryCard: isSidePanel ? false : isInMaintenanceWithNoMessages,

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -1020,11 +1020,13 @@ export function ChatMainPanel({
 
   // Mobile-only: while the app overlay is minimized to its bottom strip, the
   // strip covers the bottom of the chat. Reserve its height so the composer
-  // sits above it. The strip peeks `--app-strip-h` above the safe area, and
-  // the chat shell already pads for the safe area itself, so only the strip
-  // height needs reserving.
+  // sits above it. The guard mirrors the strip's mount condition — the strip
+  // renders only while `mainView === "app"`, and navigation can leave
+  // `isAppMinimized`/`openedAppState` set after it unmounts. The strip peeks
+  // `--app-strip-h` above the safe area, and the chat shell already pads for
+  // the safe area itself, so only the strip height needs reserving.
   const appStripBottomInset =
-    isMobile && isAppMinimized && openedAppState
+    isMobile && mainView === "app" && isAppMinimized && openedAppState
       ? "var(--app-strip-h, 64px)"
       : undefined;
 

--- a/clients/web/src/domains/chat/components/mobile-app-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/mobile-app-overlay.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * Tests for `MobileAppOverlay` — the minimized-strip geometry contract.
+ *
+ * `AppViewerContainer` and the viewport-style hook are mocked; these tests
+ * pin the strip transform to the hook's effective bottom inset
+ * (`--overlay-safe-area-bottom`) and keep the shell's transparent safe-area
+ * padding band from intercepting taps meant for the lifted composer.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+mock.module("@/components/app-viewer-container", () => ({
+  AppViewerContainer: () => null,
+}));
+mock.module("@/hooks/use-mobile-overlay-viewport-style", () => ({
+  useMobileOverlayViewportStyle: () => ({}),
+}));
+
+const { MobileAppOverlay } = await import(
+  "@/domains/chat/components/mobile-app-overlay"
+);
+
+function renderOverlay(isAppMinimized: boolean): string {
+  return renderToStaticMarkup(
+    <MobileAppOverlay
+      openedAppState={{
+        appId: "app-1",
+        dirName: "app-1",
+        name: "Demo",
+        html: "<p></p>",
+      }}
+      isAppMinimized={isAppMinimized}
+      assistantId="assistant-1"
+      onToggleMinimized={() => undefined}
+      onClose={() => undefined}
+      onShare={() => undefined}
+      isSharing={false}
+      isDeploying={false}
+    />,
+  );
+}
+
+describe("MobileAppOverlay", () => {
+  test("minimized transform subtracts the hook's effective bottom inset", () => {
+    const rendered = renderOverlay(true);
+
+    // The hook zeroes `--overlay-safe-area-bottom` while the keyboard is
+    // open; subtracting the raw physical inset instead floats the strip
+    // above the keyboard by the home-indicator height.
+    expect(rendered).toContain("--overlay-safe-area-bottom");
+    expect(rendered).not.toContain("safe-area-inset-bottom");
+  });
+
+  test("minimized shell does not hit-test; the inner sheet re-enables it", () => {
+    const rendered = renderOverlay(true);
+
+    // The shell's transparent padding band sits over the lifted composer —
+    // it must not swallow taps, while the visible strip stays interactive.
+    expect(rendered).toContain("pointer-events-none");
+    expect(rendered).toContain("pointer-events-auto");
+  });
+
+  test("expanded overlay keeps normal pointer events", () => {
+    const rendered = renderOverlay(false);
+
+    expect(rendered).not.toContain("pointer-events-none");
+  });
+});

--- a/clients/web/src/domains/chat/components/mobile-app-overlay.tsx
+++ b/clients/web/src/domains/chat/components/mobile-app-overlay.tsx
@@ -1,5 +1,6 @@
 import { AppViewerContainer } from "@/components/app-viewer-container";
 import { useMobileOverlayViewportStyle } from "@/hooks/use-mobile-overlay-viewport-style";
+import { cn } from "@/utils/misc";
 import type { OpenedAppState } from "@/stores/viewer-store";
 
 interface MobileAppOverlayProps {
@@ -59,11 +60,24 @@ export function MobileAppOverlay({
 
   return (
     <div
-      className="fixed inset-x-0 z-30 transition-transform duration-300 ease-out"
+      className={cn(
+        "fixed inset-x-0 z-30 transition-transform duration-300 ease-out",
+        // Figma review (node 6629-6730): the minimized strip overlays the
+        // chat, so it needs a top-directional shadow to read as a layer
+        // above it rather than blending in.
+        isAppMinimized && "shadow-[0_-4px_16px_rgba(0,0,0,0.15)]",
+      )}
       style={{
         ...shellStyle,
+        // Minimized: slide down until only the nav bar peeks above the bottom
+        // edge. The bar is 64px tall on mobile (`py-3` 24px + 40px
+        // `touch-mobile:` buttons), and both safe-area insets must be
+        // subtracted — the top inset because the shell's `paddingTop` shifts
+        // the content down, the bottom inset so the strip clears the iOS home
+        // indicator instead of hiding under it. Figma review (node 6629-6730):
+        // "moves it too far down, should be higher".
         transform: isAppMinimized
-          ? "translateY(calc(100% - var(--app-strip-h, 56px) - var(--safe-area-inset-top, env(safe-area-inset-top, 0px))))"
+          ? "translateY(calc(100% - var(--app-strip-h, 64px) - var(--safe-area-inset-top, env(safe-area-inset-top, 0px)) - var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))))"
           : "translateY(0)",
       }}
     >

--- a/clients/web/src/domains/chat/components/mobile-app-overlay.tsx
+++ b/clients/web/src/domains/chat/components/mobile-app-overlay.tsx
@@ -60,43 +60,48 @@ export function MobileAppOverlay({
 
   return (
     <div
-      className={cn(
-        "fixed inset-x-0 z-30 transition-transform duration-300 ease-out",
-        // The minimized strip overlays the chat, so it needs a
-        // top-directional shadow to read as a layer above it rather than
-        // blending in.
-        isAppMinimized && "shadow-[0_-4px_16px_rgba(0,0,0,0.15)]",
-      )}
+      className="fixed inset-x-0 z-30 transition-transform duration-300 ease-out"
       style={{
         ...shellStyle,
         // Minimized: slide down until only the nav bar peeks above the bottom
         // edge. The bar is 64px tall on mobile (`py-3` 24px + 40px
-        // `touch-mobile:` buttons). Both insets the shell's padding applies
-        // must be subtracted: the top inset because `paddingTop` shifts the
-        // content down, and the hook's effective bottom inset
-        // (`--overlay-safe-area-bottom`) so the strip clears the iOS home
-        // indicator while the keyboard is closed yet sits flush on the
-        // keyboard while it's open (the hook zeroes the inset then).
+        // `touch-mobile:` buttons), and both safe-area insets must be
+        // subtracted — the top inset because the shell's `paddingTop` shifts
+        // the content down, the bottom inset so the strip clears the iOS home
+        // indicator instead of hiding under it. Figma review (node 6629-6730):
+        // "moves it too far down, should be higher".
         transform: isAppMinimized
-          ? "translateY(calc(100% - var(--app-strip-h, 64px) - var(--safe-area-inset-top, env(safe-area-inset-top, 0px)) - var(--overlay-safe-area-bottom, 0px)))"
+          ? "translateY(calc(100% - var(--app-strip-h, 64px) - var(--safe-area-inset-top, env(safe-area-inset-top, 0px)) - var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))))"
           : "translateY(0)",
       }}
     >
-      <AppViewerContainer
-        appId={openedAppState.appId}
-        appName={openedAppState.name}
-        html={openedAppState.html}
-        assistantId={assistantId ?? ""}
-        onClose={onClose}
-        onEdit={onToggleMinimized}
-        onShare={onShare}
-        isSharing={isSharing}
-        onDeploy={onDeploy}
-        isDeploying={isDeploying}
-        isEditing={isAppMinimized}
-        route={route}
-        onAction={onAction}
-      />
+      {/* Figma review (node 6629-6730): the minimized strip overlays the
+          chat, so it needs a top-directional shadow to read as a layer above
+          it. The shadow lives on this inner wrapper — not the outer fixed
+          box — because the outer box's `paddingTop` (safe-area inset) would
+          paint the shadow above the sheet's visible top edge. */}
+      <div
+        className={cn(
+          "h-full",
+          isAppMinimized && "shadow-[0_-4px_16px_rgba(0,0,0,0.15)]",
+        )}
+      >
+        <AppViewerContainer
+          appId={openedAppState.appId}
+          appName={openedAppState.name}
+          html={openedAppState.html}
+          assistantId={assistantId ?? ""}
+          onClose={onClose}
+          onEdit={onToggleMinimized}
+          onShare={onShare}
+          isSharing={isSharing}
+          onDeploy={onDeploy}
+          isDeploying={isDeploying}
+          isEditing={isAppMinimized}
+          route={route}
+          onAction={onAction}
+        />
+      </div>
     </div>
   );
 }

--- a/clients/web/src/domains/chat/components/mobile-app-overlay.tsx
+++ b/clients/web/src/domains/chat/components/mobile-app-overlay.tsx
@@ -62,23 +62,21 @@ export function MobileAppOverlay({
     <div
       className={cn(
         "fixed inset-x-0 z-30 transition-transform duration-300 ease-out",
-        // Figma review (node 6629-6730): the minimized strip overlays the
-        // chat, so it needs a top-directional shadow to read as a layer
-        // above it rather than blending in.
+        // The minimized strip overlays the chat, so it needs a
+        // top-directional shadow to read as a layer above it rather than
+        // blending in.
         isAppMinimized && "shadow-[0_-4px_16px_rgba(0,0,0,0.15)]",
       )}
       style={{
         ...shellStyle,
         // Minimized: slide down until only the nav bar peeks above the bottom
         // edge. The bar is 64px tall on mobile (`py-3` 24px + 40px
-        // `touch-mobile:` buttons), and both insets the shell's padding
-        // applies must be subtracted — the top inset because `paddingTop`
-        // shifts the content down, and the hook's effective bottom inset
+        // `touch-mobile:` buttons). Both insets the shell's padding applies
+        // must be subtracted: the top inset because `paddingTop` shifts the
+        // content down, and the hook's effective bottom inset
         // (`--overlay-safe-area-bottom`) so the strip clears the iOS home
-        // indicator when the keyboard is closed but sits flush on the
-        // keyboard when it's open (the hook zeroes the inset then; the raw
-        // safe area would lift the strip over the composer). Figma review
-        // (node 6629-6730): "moves it too far down, should be higher".
+        // indicator while the keyboard is closed yet sits flush on the
+        // keyboard while it's open (the hook zeroes the inset then).
         transform: isAppMinimized
           ? "translateY(calc(100% - var(--app-strip-h, 64px) - var(--safe-area-inset-top, env(safe-area-inset-top, 0px)) - var(--overlay-safe-area-bottom, 0px)))"
           : "translateY(0)",

--- a/clients/web/src/domains/chat/components/mobile-app-overlay.tsx
+++ b/clients/web/src/domains/chat/components/mobile-app-overlay.tsx
@@ -71,13 +71,16 @@ export function MobileAppOverlay({
         ...shellStyle,
         // Minimized: slide down until only the nav bar peeks above the bottom
         // edge. The bar is 64px tall on mobile (`py-3` 24px + 40px
-        // `touch-mobile:` buttons), and both safe-area insets must be
-        // subtracted — the top inset because the shell's `paddingTop` shifts
-        // the content down, the bottom inset so the strip clears the iOS home
-        // indicator instead of hiding under it. Figma review (node 6629-6730):
-        // "moves it too far down, should be higher".
+        // `touch-mobile:` buttons), and both insets the shell's padding
+        // applies must be subtracted — the top inset because `paddingTop`
+        // shifts the content down, and the hook's effective bottom inset
+        // (`--overlay-safe-area-bottom`) so the strip clears the iOS home
+        // indicator when the keyboard is closed but sits flush on the
+        // keyboard when it's open (the hook zeroes the inset then; the raw
+        // safe area would lift the strip over the composer). Figma review
+        // (node 6629-6730): "moves it too far down, should be higher".
         transform: isAppMinimized
-          ? "translateY(calc(100% - var(--app-strip-h, 64px) - var(--safe-area-inset-top, env(safe-area-inset-top, 0px)) - var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))))"
+          ? "translateY(calc(100% - var(--app-strip-h, 64px) - var(--safe-area-inset-top, env(safe-area-inset-top, 0px)) - var(--overlay-safe-area-bottom, 0px)))"
           : "translateY(0)",
       }}
     >

--- a/clients/web/src/domains/chat/components/mobile-app-overlay.tsx
+++ b/clients/web/src/domains/chat/components/mobile-app-overlay.tsx
@@ -60,30 +60,39 @@ export function MobileAppOverlay({
 
   return (
     <div
-      className="fixed inset-x-0 z-30 transition-transform duration-300 ease-out"
+      className={cn(
+        "fixed inset-x-0 z-30 transition-transform duration-300 ease-out",
+        // While minimized, the shell's transparent safe-area padding band
+        // sits directly above the visible strip — over the lifted composer —
+        // so the shell must not hit-test; the inner sheet wrapper (which
+        // starts below the padding) re-enables pointer events for the strip.
+        isAppMinimized && "pointer-events-none",
+      )}
       style={{
         ...shellStyle,
         // Minimized: slide down until only the nav bar peeks above the bottom
         // edge. The bar is 64px tall on mobile (`py-3` 24px + 40px
-        // `touch-mobile:` buttons), and both safe-area insets must be
-        // subtracted — the top inset because the shell's `paddingTop` shifts
-        // the content down, the bottom inset so the strip clears the iOS home
-        // indicator instead of hiding under it. Figma review (node 6629-6730):
-        // "moves it too far down, should be higher".
+        // `touch-mobile:` buttons). Both insets the shell's padding applies
+        // must be subtracted: the top inset because `paddingTop` shifts the
+        // content down, and the hook's effective bottom inset
+        // (`--overlay-safe-area-bottom`) so the strip clears the iOS home
+        // indicator while the keyboard is closed yet sits flush on the
+        // keyboard while it's open (the hook zeroes the inset then).
         transform: isAppMinimized
-          ? "translateY(calc(100% - var(--app-strip-h, 64px) - var(--safe-area-inset-top, env(safe-area-inset-top, 0px)) - var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))))"
+          ? "translateY(calc(100% - var(--app-strip-h, 64px) - var(--safe-area-inset-top, env(safe-area-inset-top, 0px)) - var(--overlay-safe-area-bottom, 0px)))"
           : "translateY(0)",
       }}
     >
-      {/* Figma review (node 6629-6730): the minimized strip overlays the
-          chat, so it needs a top-directional shadow to read as a layer above
-          it. The shadow lives on this inner wrapper — not the outer fixed
-          box — because the outer box's `paddingTop` (safe-area inset) would
-          paint the shadow above the sheet's visible top edge. */}
+      {/* The minimized strip overlays the chat, so it needs a top-directional
+          shadow to read as a layer above it. The shadow lives on this inner
+          wrapper — not the outer fixed box — because the outer box's
+          `paddingTop` (safe-area inset) would paint the shadow above the
+          sheet's visible top edge. */}
       <div
         className={cn(
           "h-full",
-          isAppMinimized && "shadow-[0_-4px_16px_rgba(0,0,0,0.15)]",
+          isAppMinimized &&
+            "pointer-events-auto shadow-[0_-4px_16px_rgba(0,0,0,0.15)]",
         )}
       >
         <AppViewerContainer

--- a/clients/web/src/domains/chat/components/scroll-to-latest-button.tsx
+++ b/clients/web/src/domains/chat/components/scroll-to-latest-button.tsx
@@ -25,10 +25,9 @@ export function ScrollToLatestButton({
       onClick={onClick}
       ariaLabel="Go to newest message"
       size="regular"
-      // `max-md:shadow-lg` — Figma review (node 6629-6729): the pill needs a
-      // stronger shadow on mobile to lift off the busy chat background. The
-      // shared ChatPill chrome keeps `shadow-md` on desktop and for the other
-      // pill consumers.
+      // `max-md:shadow-lg`: the pill needs a stronger shadow on mobile to
+      // lift off the busy chat background. The shared ChatPill chrome keeps
+      // `shadow-md` on desktop and for the other pill consumers.
       className="text-[var(--content-emphasised)] max-md:shadow-lg"
     >
       {isStreaming && (

--- a/clients/web/src/domains/chat/components/scroll-to-latest-button.tsx
+++ b/clients/web/src/domains/chat/components/scroll-to-latest-button.tsx
@@ -25,7 +25,11 @@ export function ScrollToLatestButton({
       onClick={onClick}
       ariaLabel="Go to newest message"
       size="regular"
-      className="text-[var(--content-emphasised)]"
+      // `max-md:shadow-lg` — Figma review (node 6629-6729): the pill needs a
+      // stronger shadow on mobile to lift off the busy chat background. The
+      // shared ChatPill chrome keeps `shadow-md` on desktop and for the other
+      // pill consumers.
+      className="text-[var(--content-emphasised)] max-md:shadow-lg"
     >
       {isStreaming && (
         <span

--- a/clients/web/src/domains/chat/components/surfaces/dynamic-page-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/dynamic-page-surface.tsx
@@ -175,9 +175,9 @@ export function DynamicPageSurface({
           })
       : undefined;
     return (
-      // `max-md:mt-2` — Figma review (node 6629-6729): more breathing room
-      // between the activity status line and the app card on mobile. Stacks
-      // on the transcript column's `gap-2` for 16px total.
+      // `max-md:mt-2` adds breathing room between the activity status line
+      // and the app card on mobile; stacks on the transcript column's `gap-2`
+      // for 16px total.
       <div className="max-w-sm max-md:mt-2">
         <AppCard
           name={cardName}

--- a/clients/web/src/domains/chat/components/surfaces/dynamic-page-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/dynamic-page-surface.tsx
@@ -175,7 +175,10 @@ export function DynamicPageSurface({
           })
       : undefined;
     return (
-      <div className="max-w-sm">
+      // `max-md:mt-2` — Figma review (node 6629-6729): more breathing room
+      // between the activity status line and the app card on mobile. Stacks
+      // on the transcript column's `gap-2` for 16px total.
+      <div className="max-w-sm max-md:mt-2">
         <AppCard
           name={cardName}
           description={data.preview.description}

--- a/clients/web/src/domains/chat/components/tool-progress-card/header-step-carousel.tsx
+++ b/clients/web/src/domains/chat/components/tool-progress-card/header-step-carousel.tsx
@@ -218,10 +218,9 @@ export function HeaderStepCarousel({
         {hasInfo ? (
           <>
             {hasTitle ? (
-              // `max-md:text-[17px]` — Figma review (node 6629-6729): the
-              // pipe divider reads too small next to the labels on mobile.
-              // Bumping the glyph's font size grows it there; desktop and
-              // electron keep the inherited size.
+              // `max-md:text-[17px]`: the pipe divider reads too small
+              // next to the labels on mobile. Bumping the glyph's font size
+              // grows it there; desktop and electron keep the inherited size.
               <span
                 aria-hidden="true"
                 className="shrink-0 text-[var(--border-element)] max-md:text-[17px] max-md:leading-none"

--- a/clients/web/src/domains/chat/components/tool-progress-card/header-step-carousel.tsx
+++ b/clients/web/src/domains/chat/components/tool-progress-card/header-step-carousel.tsx
@@ -218,9 +218,13 @@ export function HeaderStepCarousel({
         {hasInfo ? (
           <>
             {hasTitle ? (
+              // `max-md:text-[17px]` — Figma review (node 6629-6729): the
+              // pipe divider reads too small next to the labels on mobile.
+              // Bumping the glyph's font size grows it there; desktop and
+              // electron keep the inherited size.
               <span
                 aria-hidden="true"
-                className="shrink-0 text-[var(--border-element)]"
+                className="shrink-0 text-[var(--border-element)] max-md:text-[17px] max-md:leading-none"
               >
                 |
               </span>

--- a/clients/web/src/hooks/use-mobile-overlay-viewport-style.test.tsx
+++ b/clients/web/src/hooks/use-mobile-overlay-viewport-style.test.tsx
@@ -52,12 +52,16 @@ describe("useMobileOverlayViewportStyle", () => {
     // WHEN the overlay style is computed
     const style = captureStyle();
 
-    // THEN it fills the viewport bottom-up with safe-area padding
+    // THEN it fills the viewport bottom-up with safe-area padding, and the
+    // effective bottom inset var mirrors the padding for caller transforms
     expect(style.position).toBe("fixed");
     expect(style.bottom).toBe(0);
     expect(style.top).toBe("auto");
     expect(style.height).toBe("100dvh");
     expect(style.paddingBottom).toContain("safe-area-inset-bottom");
+    expect(
+      (style as Record<string, unknown>)["--overlay-safe-area-bottom"],
+    ).toContain("safe-area-inset-bottom");
   });
 
   test("tracks the visual viewport when the keyboard is open", () => {
@@ -76,12 +80,17 @@ describe("useMobileOverlayViewportStyle", () => {
 
     // THEN it is pinned to the visible region above the keyboard, dropping the
     // bottom safe-area padding while preserving the top notch inset (offsetTop
-    // is scroll compensation, not the device notch inset)
+    // is scroll compensation, not the device notch inset); the effective
+    // bottom inset var is zeroed too so a minimized-strip transform sits
+    // flush on the keyboard instead of floating a safe-area above it
     expect(style.top).toBe("40px");
     expect(style.bottom).toBe("auto");
     expect(style.height).toBe("500px");
     expect(style.paddingBottom).toBe(0);
     expect(style.paddingTop).toContain("safe-area-inset-top");
+    expect(
+      (style as Record<string, unknown>)["--overlay-safe-area-bottom"],
+    ).toBe("0px");
   });
 
   test("ignores sub-threshold height deltas as incidental drift", () => {

--- a/clients/web/src/hooks/use-mobile-overlay-viewport-style.ts
+++ b/clients/web/src/hooks/use-mobile-overlay-viewport-style.ts
@@ -32,7 +32,9 @@ const SAFE_AREA_RIGHT =
  * visual-viewport scroll compensation, not the device notch inset, so it can
  * be `0` while the keyboard is up and would otherwise let a header render under
  * the status bar. The bottom inset is dropped while the keyboard is open —
- * the home indicator sits behind the keyboard.
+ * the home indicator sits behind the keyboard. The effective bottom inset is
+ * also exposed as `--overlay-safe-area-bottom` so caller transforms subtract
+ * the same value the padding uses (e.g. `MobileAppOverlay`'s minimized strip).
  *
  * Callers apply the returned style to a `position: fixed` element that also
  * sets `left/right` (e.g. `inset-x-0`) and stacking (`z-30`); animation
@@ -61,6 +63,7 @@ export function useMobileOverlayViewportStyle(): CSSProperties {
       paddingBottom: 0,
       paddingLeft: SAFE_AREA_LEFT,
       paddingRight: SAFE_AREA_RIGHT,
+      ...effectiveBottomInsetVar("0px"),
     };
   }
 
@@ -73,5 +76,11 @@ export function useMobileOverlayViewportStyle(): CSSProperties {
     paddingBottom: SAFE_AREA_BOTTOM,
     paddingLeft: SAFE_AREA_LEFT,
     paddingRight: SAFE_AREA_RIGHT,
+    ...effectiveBottomInsetVar(SAFE_AREA_BOTTOM),
   };
+}
+
+// CSSProperties has no index signature for custom properties, hence the cast.
+function effectiveBottomInsetVar(value: string): CSSProperties {
+  return { "--overlay-safe-area-bottom": value } as CSSProperties;
 }


### PR DESCRIPTION
## Summary

Seven mobile polish fixes from the Figma design review of the chat + Wind Tunnel app screens (nodes `6629-6729` and `6629-6730`).

| # | Annotation | File | Fix |
|---|---|---|---|
| 1 | "Go to newest needs a bigger shadow" | `scroll-to-latest-button.tsx` | `max-md:shadow-lg` on the pill (shared `ChatPill` chrome untouched) |
| 2 | "More spacing between Running app open and app card" | `dynamic-page-surface.tsx` | `max-md:mt-2` on the preview card wrapper (16px total with the transcript's `gap-2`) |
| 3 | "Larger \| line between Open and Surfacing" | `header-step-carousel.tsx` | Pipe glyph bumped to 17px **on mobile only** — desktop/electron unchanged per review feedback |
| 4 | "Minimized app moves too far down, should be higher" | `mobile-app-overlay.tsx` | Root cause: translateY calc assumed a 56px strip, but the nav bar is 64px on mobile (`py-3` 24px + 40px `touch-mobile:` buttons), and `safe-area-inset-bottom` was never subtracted so the strip sat under the iOS home indicator. Fixed both. |
| 5 | "Should also push the chat input up" | `chat-body.tsx`, `chat-route-content.tsx` | Nothing consumed `isAppMinimized` outside the overlay, so the strip just covered the composer. New optional `bottomInset` prop on the presentational `ChatBody`, wired from `chat-route-content` (which already reads the viewer store): `isMobile && isAppMinimized && openedAppState`. |
| 6 | Strip blends into the chat behind it | `mobile-app-overlay.tsx` | Top-directional shadow `shadow-[0_-4px_16px_rgba(0,0,0,0.15)]` while minimized |
| 7 | "Combination of Up Arrow and the Up Chevron is confusing" | `app-nav-bar.tsx` (+ test) | All 4 `ArrowUp` usages swapped to lucide `Share` — the actions are Share/Deploy semantically, and it no longer collides with the `ChevronUp` restore button. `Share` already has design-library precedent (bottom-sheet stories). Global on purpose: this is an icon-semantics fix, not a layout fix. |

## Root cause analysis (items 4/5)

The strip height regression is a classic magic-number drift: `--app-strip-h` defaulted to 56px in the overlay while the actual bar grew to 64px when `touch-mobile:h-10` button sizing landed — nothing ties the two together, so the calc silently under-translated and clipped the strip's bottom 8px. The missing safe-area subtraction compounded it on iOS. The composer overlap was never implemented at all: no chat component read `isAppMinimized`.

**Prevention:** the new calc documents where 64px comes from; the `bottomInset` prop is documented as the single hook for reserving overlay space at the bottom of the chat panel.

## What I chose NOT to do

- **No structural divider element** (item 3): kept the text glyph with a mobile-only font-size bump rather than swapping to a sized `<span>` — smaller diff, zero desktop risk, per review feedback to leave web/electron untouched.
- **Didn't touch shared `ChatPill` chrome** (item 1): other pill consumers keep `shadow-md`.
- **Didn't measure the strip height dynamically**: a ResizeObserver would be over-engineering for a fixed-height nav bar; the calc + documented constant is sufficient.

## Verification

- `bunx tsc --noEmit`: clean
- eslint on all touched files: clean (8 pre-existing `curly` warnings, none from this change)
- `bun test app-nav-bar.test.tsx`: 11/11 pass (assertions updated `lucide-arrow-up` → `lucide-share`)
- Remote blob SHAs verified against local git objects after API push

Spacing values (8px card gap, 17px divider) are judgment calls pending designer confirmation — flagged in review.

Figma: nodes 6629-6729, 6629-6730 in file cCGBcpVDbn22kj3OPU58W8.