### PR TITLE
refactor(tts): consolidate stream-consumption helper and timeout types

### DIFF
--- a/assistant/src/tts/providers/deepgram-provider.ts
+++ b/assistant/src/tts/providers/deepgram-provider.ts
@@ -15,7 +15,10 @@ import type { TtsDeepgramProviderConfig } from "../../config/schemas/tts.js";
 import { getProviderKeyAsync } from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
 import type { TtsProviderDefinition } from "../provider-definition.js";
-import { readChunkedBody } from "../stream-read.js";
+import {
+  consumeSynthesisResponse,
+  type StreamReadTimeouts,
+} from "../stream-read.js";
 import type {
   TtsProvider,
   TtsProviderCapabilities,
@@ -249,12 +252,6 @@ async function performTtsRequest(
   return { response, contentType };
 }
 
-/** Stream-stall timeouts, injectable for tests. */
-export interface DeepgramStreamTimeouts {
-  firstChunkTimeoutMs?: number;
-  idleTimeoutMs?: number;
-}
-
 /**
  * Issue the TTS request and consume the response into a complete result.
  * The streaming path forwards chunks via `onChunk` as they arrive, guarded
@@ -265,38 +262,25 @@ async function performSynthesis(
   options: {
     stream: boolean;
     onChunk?: (chunk: Uint8Array) => void;
-  } & DeepgramStreamTimeouts,
+  } & StreamReadTimeouts,
 ): Promise<TtsSynthesisResult> {
   const { response, contentType } = await performTtsRequest(request);
 
-  let audio: Buffer;
-  if (options.stream) {
-    if (!response.body) {
-      throw new DeepgramTtsError(
+  const audio = await consumeSynthesisResponse(response, {
+    ...options,
+    makeTimeoutError: (timeoutMs) =>
+      new DeepgramTtsError(
+        "DEEPGRAM_TTS_STREAM_TIMEOUT",
+        `Deepgram streaming TTS read timed out after ${timeoutMs}ms`,
+      ),
+    makeEmptyError: (kind) =>
+      new DeepgramTtsError(
         "DEEPGRAM_TTS_EMPTY_RESPONSE",
-        "Deepgram streaming TTS returned no response body",
-      );
-    }
-    audio = await readChunkedBody(response.body, {
-      onChunk: options.onChunk,
-      firstChunkTimeoutMs: options.firstChunkTimeoutMs,
-      idleTimeoutMs: options.idleTimeoutMs,
-      makeTimeoutError: (timeoutMs) =>
-        new DeepgramTtsError(
-          "DEEPGRAM_TTS_STREAM_TIMEOUT",
-          `Deepgram streaming TTS read timed out after ${timeoutMs}ms`,
-        ),
-    });
-  } else {
-    audio = Buffer.from(await response.arrayBuffer());
-  }
-
-  if (audio.byteLength === 0) {
-    throw new DeepgramTtsError(
-      "DEEPGRAM_TTS_EMPTY_RESPONSE",
-      "Deepgram TTS returned an empty audio response",
-    );
-  }
+        kind === "no-body"
+          ? "Deepgram streaming TTS returned no response body"
+          : "Deepgram TTS returned an empty audio response",
+      ),
+  });
 
   log.debug(
     { bytes: audio.byteLength, stream: options.stream },
@@ -307,7 +291,7 @@ async function performSynthesis(
 }
 
 export function createDeepgramProvider(
-  streamTimeouts: DeepgramStreamTimeouts = {},
+  streamTimeouts: StreamReadTimeouts = {},
 ): TtsProvider {
   const capabilities: TtsProviderCapabilities = {
     supportsStreaming: true,

--- a/assistant/src/tts/providers/elevenlabs-provider.ts
+++ b/assistant/src/tts/providers/elevenlabs-provider.ts
@@ -14,7 +14,10 @@ import { credentialKey } from "../../security/credential-key.js";
 import { getSecureKeyAsync } from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
 import type { TtsProviderDefinition } from "../provider-definition.js";
-import { readChunkedBody } from "../stream-read.js";
+import {
+  consumeSynthesisResponse,
+  type StreamReadTimeouts,
+} from "../stream-read.js";
 import type {
   TtsProvider,
   TtsProviderCapabilities,
@@ -292,12 +295,6 @@ async function performTtsRequest(
   return { response, contentType };
 }
 
-/** Stream-stall timeouts, injectable for tests. */
-export interface ElevenLabsStreamTimeouts {
-  firstChunkTimeoutMs?: number;
-  idleTimeoutMs?: number;
-}
-
 /**
  * Issue the TTS request and consume the response into a complete result.
  * The streaming path forwards chunks via `onChunk` as they arrive, guarded
@@ -308,40 +305,27 @@ async function performSynthesis(
   options: {
     stream: boolean;
     onChunk?: (chunk: Uint8Array) => void;
-  } & ElevenLabsStreamTimeouts,
+  } & StreamReadTimeouts,
 ): Promise<TtsSynthesisResult> {
   const { response, contentType } = await performTtsRequest(request, {
     stream: options.stream,
   });
 
-  let audio: Buffer;
-  if (options.stream) {
-    if (!response.body) {
-      throw new ElevenLabsTtsError(
+  const audio = await consumeSynthesisResponse(response, {
+    ...options,
+    makeTimeoutError: (timeoutMs) =>
+      new ElevenLabsTtsError(
+        "ELEVENLABS_TTS_STREAM_TIMEOUT",
+        `ElevenLabs streaming TTS read timed out after ${timeoutMs}ms`,
+      ),
+    makeEmptyError: (kind) =>
+      new ElevenLabsTtsError(
         "ELEVENLABS_TTS_EMPTY_RESPONSE",
-        "ElevenLabs streaming TTS returned no response body",
-      );
-    }
-    audio = await readChunkedBody(response.body, {
-      onChunk: options.onChunk,
-      firstChunkTimeoutMs: options.firstChunkTimeoutMs,
-      idleTimeoutMs: options.idleTimeoutMs,
-      makeTimeoutError: (timeoutMs) =>
-        new ElevenLabsTtsError(
-          "ELEVENLABS_TTS_STREAM_TIMEOUT",
-          `ElevenLabs streaming TTS read timed out after ${timeoutMs}ms`,
-        ),
-    });
-  } else {
-    audio = Buffer.from(await response.arrayBuffer());
-  }
-
-  if (audio.byteLength === 0) {
-    throw new ElevenLabsTtsError(
-      "ELEVENLABS_TTS_EMPTY_RESPONSE",
-      "ElevenLabs TTS returned an empty audio response",
-    );
-  }
+        kind === "no-body"
+          ? "ElevenLabs streaming TTS returned no response body"
+          : "ElevenLabs TTS returned an empty audio response",
+      ),
+  });
 
   log.debug(
     { bytes: audio.byteLength, stream: options.stream },
@@ -352,7 +336,7 @@ async function performSynthesis(
 }
 
 export function createElevenLabsProvider(
-  streamTimeouts: ElevenLabsStreamTimeouts = {},
+  streamTimeouts: StreamReadTimeouts = {},
 ): TtsProvider {
   const capabilities: TtsProviderCapabilities = {
     supportsStreaming: true,

--- a/assistant/src/tts/stream-read.ts
+++ b/assistant/src/tts/stream-read.ts
@@ -1,10 +1,12 @@
 /**
- * Shared chunked-body reader for streaming TTS HTTP responses.
+ * Shared response-consumption helpers for streaming TTS HTTP responses.
  *
- * Reads a fetch response body to completion, forwarding each non-empty chunk
- * to an optional callback, and guards against stalled upstream streams with a
- * first-chunk timeout and an idle (between-chunks) timeout. On timeout the
- * reader is cancelled and the caller-supplied error is thrown.
+ * `readChunkedBody` reads a fetch response body to completion, forwarding each
+ * non-empty chunk to an optional callback, and guards against stalled upstream
+ * streams with a first-chunk timeout and an idle (between-chunks) timeout. On
+ * timeout the reader is cancelled and the caller-supplied error is thrown.
+ * `consumeSynthesisResponse` wraps it with the provider-common empty-response
+ * guards and the buffered (non-streaming) read path.
  */
 
 /** Default timeout waiting for the first chunk of a TTS stream (ms). */
@@ -13,15 +15,18 @@ const DEFAULT_FIRST_CHUNK_TIMEOUT_MS = 10_000;
 /** Default timeout waiting between consecutive chunks (ms). */
 const DEFAULT_IDLE_TIMEOUT_MS = 5_000;
 
-export interface ReadChunkedBodyOptions {
-  /** Invoked with each non-empty chunk as it arrives. */
-  onChunk?: (chunk: Uint8Array) => void;
-
+/** Stream-stall timeouts, injectable for tests. */
+export interface StreamReadTimeouts {
   /** Timeout waiting for the first chunk (ms). */
   firstChunkTimeoutMs?: number;
 
   /** Timeout waiting between consecutive chunks (ms). */
   idleTimeoutMs?: number;
+}
+
+export interface ReadChunkedBodyOptions extends StreamReadTimeouts {
+  /** Invoked with each non-empty chunk as it arrives. */
+  onChunk?: (chunk: Uint8Array) => void;
 
   /** Builds the error thrown when a read times out. */
   makeTimeoutError: (timeoutMs: number) => Error;
@@ -83,4 +88,48 @@ export async function readChunkedBody(
   }
 
   return Buffer.concat(chunks);
+}
+
+/** Discriminates the two empty-response failure modes for `makeEmptyError`. */
+export type EmptyResponseKind = "no-body" | "empty-audio";
+
+export interface ConsumeSynthesisResponseOptions extends StreamReadTimeouts {
+  /** When true, stream the body forwarding chunks; otherwise buffer it whole. */
+  stream: boolean;
+
+  /** Invoked with each non-empty chunk as it arrives (streaming only). */
+  onChunk?: (chunk: Uint8Array) => void;
+
+  /** Builds the error thrown when a streamed read times out. */
+  makeTimeoutError: (timeoutMs: number) => Error;
+
+  /** Builds the error thrown for a missing body or zero-byte audio. */
+  makeEmptyError: (kind: EmptyResponseKind) => Error;
+}
+
+/**
+ * Consume an OK TTS response into complete audio. The streaming path forwards
+ * chunks via `onChunk` guarded by stall timeouts; the buffer path reads the
+ * whole body. Throws via `makeEmptyError` when the response has no body
+ * (streaming) or yields zero audio bytes.
+ */
+export async function consumeSynthesisResponse(
+  response: Response,
+  options: ConsumeSynthesisResponseOptions,
+): Promise<Buffer> {
+  let audio: Buffer;
+  if (options.stream) {
+    if (!response.body) {
+      throw options.makeEmptyError("no-body");
+    }
+    audio = await readChunkedBody(response.body, options);
+  } else {
+    audio = Buffer.from(await response.arrayBuffer());
+  }
+
+  if (audio.byteLength === 0) {
+    throw options.makeEmptyError("empty-audio");
+  }
+
+  return audio;
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for deepgram-streaming-pcm.md.

**Gap:** performSynthesis and the StreamTimeouts interface were verbatim copies across the ElevenLabs and Deepgram providers (timeout fields declared a third time in ReadChunkedBodyOptions).
**Fix:** shared consumption helper + StreamReadTimeouts type in stream-read.ts; both providers rewired with zero behavior change.