### PR TITLE
feat(web): show active model profile and access level in composer

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -665,12 +665,12 @@ export function ChatComposer({
                 onSend={releaseLiveVoiceTurn}
               />
             ) : (
-              <div className="flex items-center justify-between px-2 pb-2">
-                <div className="flex items-center gap-1">
+              <div className="flex items-center justify-between gap-1 px-2 pb-2">
+                <div className="flex min-w-0 items-center gap-1">
                   {contextWindowIndicatorSlot}
                   {thresholdPickerSlot}
                 </div>
-                <div className="flex items-center gap-1">
+                <div className="flex shrink-0 items-center gap-1">
                   {canStopGenerating ? (
                     <>
                       {/* Desktop: always show stop. Mobile: show stop only when there is no sendable content. */}

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -597,8 +597,8 @@ export function ChatComposer({
             )}
             <div className="flex items-center justify-between px-2 pb-2">
               <div className="flex items-center gap-1">
-                {thresholdPickerSlot}
                 {contextWindowIndicatorSlot}
+                {thresholdPickerSlot}
               </div>
               <div className="flex items-center gap-1">
                 {canStopGenerating ? (

--- a/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -365,7 +365,11 @@ describe("Profile selection after conversation change (LUM-2279)", () => {
       );
 
     const { rerender } = render(tree("conv-1"));
-    await waitFor(() => expect(screen.getByText("Smart")).toBeTruthy());
+    // "Smart" now renders both on the composer trigger and in the menu row, so
+    // wait for at least one occurrence rather than asserting a single match.
+    await waitFor(() =>
+      expect(screen.getAllByText("Smart").length).toBeGreaterThan(0),
+    );
 
     // Hang subsequent config fetches so the re-fetch from the conversationId
     // change never completes — holds the race window open.
@@ -419,7 +423,11 @@ describe("Profile selection with no active conversation (new draft chat)", () =>
       ),
     );
 
-    await waitFor(() => expect(screen.getByText("Smart")).toBeTruthy());
+    // "Smart" now renders both on the composer trigger and in the menu row, so
+    // wait for at least one occurrence rather than asserting a single match.
+    await waitFor(() =>
+      expect(screen.getAllByText("Smart").length).toBeGreaterThan(0),
+    );
 
     const smart = screen
       .getAllByTestId("menu-item")

--- a/clients/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -493,20 +493,23 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
     <button
       type="button"
       aria-label="Conversation settings"
-      className="flex h-7 items-center gap-0.5 rounded-md text-body-small-default text-[var(--content-secondary)] data-[state=open]:text-[var(--content-default)]"
+      className="flex h-7 min-w-0 items-center gap-0.5 rounded-md text-body-small-default text-[var(--content-secondary)] data-[state=open]:text-[var(--content-default)]"
     >
       {hasTriggerContent ? (
         <>
           {activeProfileLabel ? (
-            <span className={segmentClass}>
+            // min-w-0 lets the label truncate instead of pushing the composer's
+            // action buttons off-screen on narrow viewports; the cap is tighter
+            // on mobile where the bottom bar has the least room.
+            <span className={`${segmentClass} min-w-0`}>
               <Sparkles className="h-3.5 w-3.5 shrink-0" />
-              <span className="max-w-[10rem] truncate">
+              <span className="max-w-[7rem] truncate sm:max-w-[10rem]">
                 {activeProfileLabel}
               </span>
             </span>
           ) : null}
           {showAccess ? (
-            <span className={segmentClass}>
+            <span className={`${segmentClass} shrink-0`}>
               <AccessIcon className="h-3.5 w-3.5 shrink-0" />
               {activePreset.label}
             </span>

--- a/clients/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -410,6 +410,19 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
     [orderedProfileEntries, profileActiveKey],
   );
 
+  // Label for the currently-active profile, shown inline on the composer
+  // trigger so a power user can see which profile a conversation runs on
+  // without opening the menu.
+  const activeProfileLabel = useMemo(() => {
+    if (!profileActiveKey) {
+      return null;
+    }
+    const entry = orderedProfileEntries.find(
+      (e) => e.name === profileActiveKey,
+    );
+    return entry ? profilePickerLabel(entry) : null;
+  }, [orderedProfileEntries, profileActiveKey]);
+
   // Quick-add is owned by the top-level ProfileQuickAddProvider (chat must not
   // import settings directly — see local/no-cross-domain-imports). The provider
   // renders the ProfileEditorModal in create mode, persists the new profile,
@@ -464,13 +477,45 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
   // Render
   // ---------------------------------------------------------------------------
 
+  // Access-level segment: gate on a settled fetch (or an active override) so the
+  // trigger never flashes the `THRESHOLD_PRESETS[1]` fallback before the real
+  // value loads.
+  const AccessIcon = activePreset.icon;
+  const showAccess = globalThresholdsQuery.isSuccess || serverIsOverride;
+  const hasTriggerContent = !!activeProfileLabel || showAccess;
+
+  // Each segment highlights independently on hover to signal it opens the menu;
+  // the whole button is the trigger.
+  const segmentClass =
+    "flex items-center gap-1.5 rounded-md px-1.5 py-1 transition-colors hover:bg-[var(--surface-active)] hover:text-[var(--content-default)]";
+
   const trigger = (
-    <Button
-      variant="ghost"
-      iconOnly={<SlidersHorizontal className="h-[18px] w-[18px]" />}
+    <button
+      type="button"
       aria-label="Conversation settings"
-      className="[--vbtn-fg:var(--content-secondary)] data-[state=open]:[--vbtn-fg:var(--content-default)]"
-    />
+      className="flex h-7 items-center gap-0.5 rounded-md text-body-small-default text-[var(--content-secondary)] data-[state=open]:text-[var(--content-default)]"
+    >
+      {hasTriggerContent ? (
+        <>
+          {activeProfileLabel ? (
+            <span className={segmentClass}>
+              <Sparkles className="h-3.5 w-3.5 shrink-0" />
+              <span className="max-w-[10rem] truncate">
+                {activeProfileLabel}
+              </span>
+            </span>
+          ) : null}
+          {showAccess ? (
+            <span className={segmentClass}>
+              <AccessIcon className="h-3.5 w-3.5 shrink-0" />
+              {activePreset.label}
+            </span>
+          ) : null}
+        </>
+      ) : (
+        <SlidersHorizontal className="mx-1 h-[18px] w-[18px]" />
+      )}
+    </button>
   );
 
   if (isMobile) {


### PR DESCRIPTION
## What

The composer's settings trigger rendered a bare sliders icon, so a power user flipping between conversations couldn't tell which **model profile** or **access level** a conversation was running on without opening the menu (the feedback that spawned this).

This surfaces both inline on the trigger:
- Active **model profile** — `✨ Smart`
- Active **access level** — `🔒 Strict`

Each segment highlights independently on hover to signal it opens the existing settings menu. The composer's bottom-left cluster is reordered to `[context-ring] Smart · Strict`. Falls back to the sliders icon until the values load.

Reuses the same derived values `ComposerSettingsMenu` already computes (`profileActiveKey`, `activePreset`) — no new data wiring.

## Design

Implements Rok's chosen mock from the [feedback thread](https://vellumai.slack.com/archives/C0B2X116W3D/p1783355353514209?thread_ts=1783351668.142649&cid=C0B2X116W3D) (the input-component variant).

Note: the mock drew a shield-with-alert glyph for "Strict"; I used the real `Strict` preset's lock icon so the trigger stays consistent with the icons inside the menu. Trivial to swap if we'd rather match the mock glyph.

## Verification

- `tsc --noEmit` clean; `eslint` clean (0 errors, no new warnings).
- Rendered the real component in an isolated Storybook harness (default state, per-segment hover highlight, click-to-open) — all match the mock; menu still shows both **Assistant Access** and **Model Profile** sections with correct active markers.

Closes LUM-2706

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Design decision: custom trigger element

The trigger is a raw `<button>` rather than the design-library `Button`. It renders two independently-hoverable segments (model profile + access level), which `Button` can't express — it supports `iconOnly` or text with left/right icons, but not multiple separately-highlighted hover targets in one control. The element is otherwise built from design tokens (`--surface-active`, `--content-secondary/default`, `text-body-small-default`) and reuses the menu's `Sparkles`/preset icons.

The profile label truncates (`max-w-[7rem]`, `sm:max-w-[10rem]`, `min-w-0` chain) and the action buttons are `shrink-0`, so a long custom profile name never pushes attach/voice/send off-screen on narrow viewports.
