### PR TITLE
fix(web): make in-app live voice audible — hands-free + audio-context resume

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
@@ -140,9 +140,13 @@ export class FakePlayer {
   enqueued: unknown[] = [];
   stopCount = 0;
   disposeCount = 0;
+  prewarmCount = 0;
   isPlaying = false;
   private drainResolvers: Array<() => void> = [];
 
+  prewarm(): void {
+    this.prewarmCount++;
+  }
   enqueue(chunk: unknown): void {
     this.enqueued.push(chunk);
     this.isPlaying = true;

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
@@ -27,7 +27,14 @@ interface MockSource {
 class MockAudioContext {
   currentTime = 0;
   closed = false;
+  state: AudioContextState = "suspended";
+  resumeCount = 0;
   readonly sources: MockSource[] = [];
+
+  async resume(): Promise<void> {
+    this.resumeCount++;
+    this.state = "running";
+  }
 
   /** ArrayBuffers passed to decodeAudioData, in call order. */
   readonly decodedInputs: ArrayBuffer[] = [];
@@ -189,6 +196,23 @@ describe("LiveVoiceAudioPlayer", () => {
 
   beforeEach(() => {
     ({ player, ctx } = makePlayer());
+  });
+
+  test("prewarm resumes a suspended context up front", () => {
+    // A fresh context starts suspended (browser autoplay policy); if it's only
+    // created lazily on the first frame it never plays, dropping the first turn.
+    expect(ctx.state).toBe("suspended");
+
+    player.prewarm();
+
+    expect(ctx.resumeCount).toBe(1);
+    expect(ctx.state).toBe("running");
+  });
+
+  test("prewarm is idempotent once the context is running", () => {
+    player.prewarm();
+    player.prewarm();
+    expect(ctx.resumeCount).toBe(1);
   });
 
   test("schedules chunks in order, gaplessly, at the frame sample rate", () => {

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
@@ -89,6 +89,14 @@ export interface AudioContextLike {
   readonly currentTime: number;
   readonly sampleRate: number;
   readonly destination: AudioNode;
+  /**
+   * Playback state. A context created outside a user gesture starts
+   * `"suspended"` under the browser autoplay policy and outputs nothing until
+   * resumed — see {@link LiveVoiceAudioPlayer.prewarm}.
+   */
+  readonly state: AudioContextState;
+  /** Resume a suspended context. Must first be called from a user gesture. */
+  resume(): Promise<void>;
   createBuffer(
     numberOfChannels: number,
     length: number,
@@ -372,6 +380,20 @@ export class LiveVoiceAudioPlayer {
     const context = this.context;
     this.context = null;
     if (context) await context.close();
+  }
+
+  /**
+   * Eagerly create and resume the `AudioContext` from within the user gesture
+   * that starts a session (the mic-button click). Otherwise the context is
+   * created lazily on the first `tts_audio` frame — which arrives seconds later,
+   * outside any gesture — so the browser autoplay policy starts it `"suspended"`
+   * and it never plays; audio only comes through once the context happens to
+   * flip to `"running"`, which is why the first turn(s) drop and later ones
+   * work. Safe to call repeatedly; `resume()` is a no-op once running.
+   */
+  prewarm(): void {
+    const context = this.ensureContext();
+    if (context.state !== "running") void context.resume();
   }
 
   private ensureContext(): AudioContextLike {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
@@ -96,6 +96,10 @@ async function startListeningViaStarter(
       seq: 1,
       sessionId: "s1",
       conversationId: conversationId ?? "conv-server-assigned",
+      // Echo server_vad so the session stays hands-free (the controller starts
+      // every session hands-free); without the echo the client falls back to
+      // manual single-turn.
+      turnDetection: "server_vad",
     });
     await Promise.resolve();
   });
@@ -134,6 +138,7 @@ describe("starter registration", () => {
     expect(h.lastClient().connectArgs).toEqual({
       assistantId: "assistant-1",
       conversationId: "conv-1",
+      turnDetection: "server_vad",
     });
     expect(useLiveVoiceStore.getState().state).toBe("listening");
     expect(useLiveVoiceStore.getState().conversationId).toBe("conv-1");
@@ -150,6 +155,7 @@ describe("starter registration", () => {
     expect(h.lastClient().connectArgs).toEqual({
       assistantId: "assistant-1",
       conversationId: undefined,
+      turnDetection: "server_vad",
     });
     expect(useLiveVoiceStore.getState().startedConversationId).toBeNull();
   });

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
@@ -50,7 +50,14 @@ export function useLiveVoiceSessionController(
     useLiveVoiceStore
       .getState()
       .setStarter((assistantId, conversationId) =>
-        void start(assistantId, conversationId ?? undefined),
+        // Hands-free (server-side turn detection) is the only mode the voice
+        // button starts — it keeps one socket open across turns so the
+        // assistant's TTS drains instead of the session tearing down each
+        // turn. Manual single-turn survives only as the version-skew fallback
+        // when the daemon's `ready` doesn't echo `server_vad`.
+        void start(assistantId, conversationId ?? undefined, {
+          handsFree: true,
+        }),
       );
     return () => {
       useLiveVoiceStore.getState().setStarter(null);

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -665,6 +665,26 @@ describe("hands-free mode", () => {
     expect(h.player.isPlaying).toBe(true);
     expect(h.view.result.current.state).toBe("speaking");
   });
+
+  test("controls.release is a no-op in hands-free (mic forwarding stays on)", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    // The "send now" ↑ is manual-only. In hands-free the server VAD owns
+    // utterance boundaries, so release must not fire ptt_release or drop
+    // forwarding — otherwise the session strands (looks live, drops chunks).
+    act(() => {
+      useLiveVoiceStore.getState().controls?.release();
+    });
+    expect(h.client.pttReleaseCount).toBe(0);
+    expect(h.view.result.current.state).toBe("listening");
+
+    // Forwarding is untouched: the next mic chunk still streams to the server.
+    act(() => {
+      h.getCapture().pushChunk(pcmChunk(20));
+    });
+    expect(h.client.sentAudio).toHaveLength(1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -333,6 +333,13 @@ export function useLiveVoice(
   const release = useCallback(() => {
     const session = sessionRef.current;
     if (!session) return;
+    // Hands-free sessions have no manual push-to-talk to release: the server
+    // VAD owns utterance boundaries and mic forwarding stays on for the whole
+    // session. A release here would flip `forwardingAudio` off — which the
+    // hands-free `tts_done`/listening return never re-enables — so every later
+    // mic chunk is dropped and the session strands (looks live, accepts no
+    // turns). No-op instead; the "send now" affordance is manual-mode only.
+    if (session.handsFree) return;
     if (useLiveVoiceStore.getState().state !== "listening") return;
     releasePushToTalk(session);
   }, []);

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -381,6 +381,11 @@ export function useLiveVoice(
       const opts = optionsRef.current;
       const client = (opts.createClient ?? (() => new LiveVoiceChannelClient()))();
       const player = (opts.createPlayer ?? (() => new LiveVoiceAudioPlayer()))();
+      // Resume the playback AudioContext now, while we're still in the
+      // mic-button click's gesture. Deferring to the first `tts_audio` frame
+      // (its lazy creation point) lands outside any gesture, so the browser
+      // starts it suspended and the first turn's audio is silently dropped.
+      player.prewarm();
 
       const session: SessionContext = {
         client,


### PR DESCRIPTION
Three fixes that together make in-app live voice actually work end-to-end. All found while driving the real flow on the local stack after JARVIS-1251 unblocked the velay origin.

## 1. Start sessions hands-free (JARVIS-1253)
When #37292 made `LiveVoiceButton` presentational and moved `start()` into the controller's store-registered `starter`, the `{ handsFree: true }` the old button passed was dropped. Every session connected **manual single-turn** (no `turnDetection`), so the daemon ran one turn and the session tore down each turn — cutting TTS off mid-stream. Now the starter passes `{ handsFree: true }` → `turnDetection: "server_vad"`, one socket across turns.

## 2. `release` is a no-op in hands-free (Codex P2)
With sessions now always hands-free, the "send now" (↑) control still ran `releasePushToTalk()`, flipping `forwardingAudio` off — which the hands-free listening return never re-enables — stranding the session (looks live, drops every later mic chunk). `release` now no-ops when `handsFree`; manual (version-skew fallback) keeps send-now.

## 3. Resume the playback AudioContext up front (JARVIS-1254)
Assistant TTS was silent on the first turn(s) and "warmed up" over 2–3 turns. The player created its `AudioContext` lazily on the first `tts_audio` frame — seconds after the click, outside any gesture — so the browser autoplay policy started it `suspended` and never resumed it; early buffers were dropped. Added `LiveVoiceAudioPlayer.prewarm()` (create + `resume()`), called synchronously from `start()` inside the mic-button gesture. Mirrors what dictation already does (`use-push-to-talk.ts`).

## Verification
Driven end-to-end on the local stack: multi-turn hands-free, first turn audible, no per-turn cutout. `tsc` clean; voice tests green (use-live-voice 43, tts-playback 24, controller 7, live-voice-button 4, chat-composer 68, pill-host 27, store 25).

Resolves JARVIS-1253 and JARVIS-1254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)