### PR TITLE
[DRAFT REFERENCE] attachment references — superseded by split PRs

### DIFF
--- a/assistant/src/__tests__/attachment-reference-persistence.test.ts
+++ b/assistant/src/__tests__/attachment-reference-persistence.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Regression tests for ATL-991: uploaded attachments are persisted into
+ * `messages.content` as workspace *references* (attachment id + size/dimension
+ * hints), never inline base64. The bytes live in the attachment store and are
+ * resolved back at the provider boundary (and for any stored-content byte
+ * reader) on demand.
+ *
+ * Uses the real SQLite DB wired up via `test-preload.ts` (per-file temp
+ * workspace).
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { persistUserMessageRow } from "../daemon/conversation-messaging.js";
+import {
+  createConversation,
+  getMessages,
+} from "../persistence/conversation-crud.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { extractMediaBlocks } from "../persistence/message-content.js";
+import { resolveMediaReferences } from "../providers/media-resolve.js";
+import type { ContentBlock } from "../providers/types.js";
+
+await initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.run("DELETE FROM message_attachments");
+  db.run("DELETE FROM attachments");
+  db.run("DELETE FROM memory_segments");
+  db.run("DELETE FROM memory_embeddings");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+/** Minimal PNG whose IHDR declares the given pixel dimensions. */
+function makePngBase64(width: number, height: number): string {
+  return Buffer.from(
+    Uint8Array.from([
+      0x89,
+      0x50,
+      0x4e,
+      0x47,
+      0x0d,
+      0x0a,
+      0x1a,
+      0x0a, // signature
+      0x00,
+      0x00,
+      0x00,
+      0x0d, // IHDR length
+      0x49,
+      0x48,
+      0x44,
+      0x52, // "IHDR"
+      (width >>> 24) & 0xff,
+      (width >>> 16) & 0xff,
+      (width >>> 8) & 0xff,
+      width & 0xff,
+      (height >>> 24) & 0xff,
+      (height >>> 16) & 0xff,
+      (height >>> 8) & 0xff,
+      height & 0xff,
+      0x08,
+      0x06,
+      0x00,
+      0x00,
+      0x00,
+    ]),
+  ).toString("base64");
+}
+
+function storedBlocks(conversationId: string): {
+  raw: string;
+  blocks: ContentBlock[];
+} {
+  const [row] = getMessages(conversationId);
+  return {
+    raw: row!.content,
+    blocks: JSON.parse(row!.content) as ContentBlock[],
+  };
+}
+
+describe("attachment reference persistence", () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test("persists an uploaded image as a reference, not inline base64", async () => {
+    const conv = createConversation();
+    const pngBase64 = makePngBase64(120, 80);
+
+    await persistUserMessageRow({
+      conversationId: conv.id,
+      content: "look at this diagram",
+      attachmentInputs: [
+        { filename: "diagram.png", mimeType: "image/png", data: pngBase64 },
+      ],
+    });
+
+    const { raw, blocks } = storedBlocks(conv.id);
+
+    // The base64 payload must not appear anywhere in the stored row.
+    expect(raw).not.toContain(pngBase64);
+
+    const imageBlock = blocks.find((b) => b.type === "image");
+    expect(imageBlock).toBeDefined();
+    const source = (imageBlock as Extract<ContentBlock, { type: "image" }>)
+      .source;
+    expect(source.type).toBe("attachment_ref");
+    if (source.type === "attachment_ref") {
+      expect(source.media_type).toBe("image/png");
+      expect(source.attachmentId).toBeTruthy();
+      expect(source.sizeBytes).toBeGreaterThan(0);
+      // Dimension hints let the token estimator cost the image without a disk read.
+      expect(source.width).toBe(120);
+      expect(source.height).toBe(80);
+      expect((source as unknown as { data?: string }).data).toBeUndefined();
+    }
+  });
+
+  test("resolveMediaReferences rehydrates the reference to inline base64", async () => {
+    const conv = createConversation();
+    const pngBase64 = makePngBase64(64, 64);
+
+    await persistUserMessageRow({
+      conversationId: conv.id,
+      content: "resolve me",
+      attachmentInputs: [
+        { filename: "shot.png", mimeType: "image/png", data: pngBase64 },
+      ],
+    });
+
+    const { blocks } = storedBlocks(conv.id);
+    const [resolved] = resolveMediaReferences([
+      { role: "user", content: blocks },
+    ]);
+    const resolvedImage = resolved!.content.find((b) => b.type === "image");
+    const resolvedSource = (
+      resolvedImage as Extract<ContentBlock, { type: "image" }>
+    ).source;
+
+    expect(resolvedSource.type).toBe("base64");
+    if (resolvedSource.type === "base64") {
+      // The fake PNG cannot be downscaled off macOS, so the resolved bytes are
+      // the stored bytes verbatim.
+      expect(resolvedSource.data).toBe(pngBase64);
+      expect(resolvedSource.media_type).toBe("image/png");
+    }
+  });
+
+  test("extractMediaBlocks resolves reference bytes from the attachment store", async () => {
+    const conv = createConversation();
+    const pngBase64 = makePngBase64(32, 48);
+
+    await persistUserMessageRow({
+      conversationId: conv.id,
+      content: "index me",
+      attachmentInputs: [
+        { filename: "thumb.png", mimeType: "image/png", data: pngBase64 },
+      ],
+    });
+
+    const { raw } = storedBlocks(conv.id);
+    const media = extractMediaBlocks(raw);
+    expect(media).toHaveLength(1);
+    expect(media[0]!.mimeType).toBe("image/png");
+    expect(media[0]!.data.toString("base64")).toBe(pngBase64);
+  });
+});

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -1282,9 +1282,14 @@ describe("Batched drain", () => {
     await waitForPendingRun(2);
 
     // Two persisted user rows in the DB (one per batched message), each with
-    // its own imageSourcePaths metadata keyed by the right filename.
+    // its own imageSourcePaths metadata keyed by the right filename. Attachment
+    // media is written as a workspace reference via a follow-up
+    // updateMessageContent (not the initial addMessage), so identify the rows by
+    // their imageSourcePaths metadata rather than inline image content.
     const userRows = capturedAddMessages.filter(
-      (m) => m.role === "user" && m.content.includes('"image"'),
+      (m) =>
+        m.role === "user" &&
+        (m.metadata as Record<string, unknown> | undefined)?.imageSourcePaths,
     );
     expect(userRows).toHaveLength(2);
     const pathsA = (userRows[0].metadata as Record<string, unknown>)

--- a/assistant/src/__tests__/persist-unsendable-image-downscale.test.ts
+++ b/assistant/src/__tests__/persist-unsendable-image-downscale.test.ts
@@ -139,9 +139,12 @@ describe("persistUnsendableImageDowngrades (downscalable host)", () => {
     };
     const nested = toolResult.contentBlocks?.[0];
     expect(nested?.type).toBe("image");
-    expect(
-      (nested as Extract<ContentBlock, { type: "image" }>).source.data,
-    ).toBe(SHRUNK_DATA);
+    const nestedSource = (nested as Extract<ContentBlock, { type: "image" }>)
+      .source;
+    expect(nestedSource.type).toBe("base64");
+    expect(nestedSource.type === "base64" ? nestedSource.data : undefined).toBe(
+      SHRUNK_DATA,
+    );
   });
 
   /** Re-running is a no-op: the downscaled payload is within limits. */

--- a/assistant/src/__tests__/process-message-display-content.test.ts
+++ b/assistant/src/__tests__/process-message-display-content.test.ts
@@ -7,6 +7,8 @@ const addMessageCalls: Array<{
   metadata?: Record<string, unknown>;
 }> = [];
 
+const updateContentCalls: Array<{ messageId: string; content: string }> = [];
+
 let activeConversation: unknown;
 
 type TestSlashResolution =
@@ -30,8 +32,25 @@ mock.module("../persistence/attachments-store.js", () => ({
   getAttachmentsByIds: () => [],
   getSourcePathsForAttachments: () => new Map<string, string>(),
   attachmentExists: () => false,
-  linkAttachmentToMessage: () => {},
-  attachInlineAttachmentToMessage: () => {},
+  linkAttachmentToMessage: () => "att-1",
+  attachInlineAttachmentToMessage: (
+    _messageId: string,
+    _position: number,
+    filename: string,
+    mimeType: string,
+    data: string,
+  ) => ({
+    id: "att-1",
+    originalFilename: filename,
+    mimeType,
+    sizeBytes: Math.floor((data.length * 3) / 4),
+    kind: "document",
+    thumbnailBase64: null,
+    createdAt: 0,
+    filePath: `/tmp/${filename}`,
+  }),
+  getAttachmentById: () => null,
+  getFilePathForAttachment: () => "/tmp/attachment.pdf",
   validateAttachmentUpload: () => ({ ok: true }),
   AttachmentUploadError: class extends Error {},
 }));
@@ -58,6 +77,12 @@ mock.module("../persistence/conversation-crud.js", () => ({
   setConversationOriginChannelIfUnset: () => {},
   setConversationOriginInterfaceIfUnset: () => {},
   reserveMessage: mock(async () => ({ id: "msg-reserve" })),
+  updateMessageContent: (messageId: string, content: string) => {
+    updateContentCalls.push({ messageId, content });
+  },
+  updateMessageMetadata: () => {},
+  extractImageSourcePaths: () => undefined,
+  extractAttachmentStoredPaths: () => undefined,
 }));
 
 mock.module("../persistence/conversation-disk-view.js", () => ({
@@ -260,6 +285,7 @@ async function expectOmittedDisplayContentPersistsModelContent(
 describe("processMessage displayContent", () => {
   beforeEach(() => {
     addMessageCalls.length = 0;
+    updateContentCalls.length = 0;
     activeConversation = undefined;
     resolveSlashForTest = (content) => ({ kind: "passthrough", content });
   });
@@ -346,21 +372,30 @@ describe("processMessage displayContent", () => {
       displayContent: "",
     });
 
+    // The row is inserted with text-only content (empty here since
+    // displayContent is ""), then rewritten to carry the attachment as a
+    // workspace reference — no inline base64 in messages.content.
     expect(addMessageCalls).toHaveLength(1);
-    const persistedBlocks = JSON.parse(addMessageCalls[0]!.content);
+    expect(JSON.parse(addMessageCalls[0]!.content)).toEqual([]);
+    expect(updateContentCalls).toHaveLength(1);
+    const persistedBlocks = JSON.parse(updateContentCalls[0]!.content);
     expect(persistedBlocks).toEqual([
       {
         type: "file",
         _attachmentId: "att-1",
         source: {
-          type: "base64",
+          type: "attachment_ref",
           media_type: "application/pdf",
-          data: Buffer.from("pdf bytes").toString("base64"),
+          attachmentId: "att-1",
           filename: "attachment.pdf",
+          sizeBytes: Buffer.from("pdf bytes").length,
         },
       },
     ]);
-    expect(addMessageCalls[0]!.content).not.toContain("<external_content");
+    expect(updateContentCalls[0]!.content).not.toContain("<external_content");
+    expect(updateContentCalls[0]!.content).not.toContain(
+      Buffer.from("pdf bytes").toString("base64"),
+    );
     const inMemoryMessage = conversation.getMessages()[0]!;
     expect(inMemoryMessage.role).toBe("user");
     expect(inMemoryMessage.content[0]).toEqual({

--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -109,6 +109,7 @@ import {
   readSlackMetadata,
   writeSlackMetadata,
 } from "../messaging/providers/slack/message-metadata.js";
+import { getAttachmentContent } from "../persistence/attachments-store.js";
 import type { MessageRow } from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
@@ -1010,7 +1011,15 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
     expect(textBlock?.text).toBe("uploaded the diagram");
     expect(textBlock?.text).not.toContain("<external_content");
     expect(imageBlock?.source.media_type).toBe("image/png");
-    expect(imageBlock?.source.data).toBe(imageBase64);
+    // The image is persisted as a workspace reference (no inline base64); it
+    // resolves back to the uploaded bytes from the attachment store.
+    expect(imageBlock?.source.type).toBe("attachment_ref");
+    const imageSource = imageBlock?.source;
+    if (imageSource?.type === "attachment_ref") {
+      expect(
+        getAttachmentContent(imageSource.attachmentId)?.toString("base64"),
+      ).toBe(imageBase64);
+    }
 
     const context = loadSlackChronologicalContext(conv.id, SLACK_CHANNEL_CAPS, {
       loader: readMessageRowsByConversation,

--- a/assistant/src/agent/attachments.ts
+++ b/assistant/src/agent/attachments.ts
@@ -1,3 +1,4 @@
+import { parseImageDimensions } from "../context/image-dimensions.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 import { optimizeImageForTransport } from "./image-optimize.js";
 
@@ -15,6 +16,69 @@ export interface MessageAttachmentInput {
    * from `filePath`, which is where the upload originally came from.
    */
   storedPath?: string;
+}
+
+/**
+ * A user attachment that has been linked to a message and is ready to be
+ * PERSISTED as a reference block (see {@link attachmentsToReferenceBlocks}).
+ * Unlike {@link MessageAttachmentInput}, `attachmentId` is the final linked
+ * attachment-row id, and `data` is present only so image pixel dimensions can
+ * be derived at persist time — it is never stored.
+ */
+export interface AttachmentReferenceInput {
+  attachmentId: string;
+  filename: string;
+  mimeType: string;
+  sizeBytes: number;
+  /** Base64 payload, used only to derive image dimensions; not persisted. */
+  data?: string;
+  extractedText?: string;
+}
+
+/**
+ * Build the PERSISTED content blocks for a user message's attachments as
+ * workspace references — no inline base64. Mirrors the block shape of
+ * {@link attachmentsToContentBlocks} (image vs file) but the `source` is an
+ * `attachment_ref` addressing the workspace attachment store, carrying
+ * size/dimension hints so size-only consumers (the token estimator) need not
+ * read the file. The bytes are resolved back at the provider boundary via
+ * `resolveMediaReferences`.
+ */
+export function attachmentsToReferenceBlocks(
+  attachments: AttachmentReferenceInput[],
+): ContentBlock[] {
+  return attachments.map((attachment) => {
+    if (attachment.mimeType.toLowerCase().startsWith("image/")) {
+      const dims = attachment.data
+        ? parseImageDimensions(attachment.data, attachment.mimeType)
+        : null;
+      return {
+        type: "image",
+        source: {
+          type: "attachment_ref",
+          media_type: attachment.mimeType,
+          attachmentId: attachment.attachmentId,
+          sizeBytes: attachment.sizeBytes,
+          ...(dims ? { width: dims.width, height: dims.height } : {}),
+        },
+      } as ContentBlock;
+    }
+
+    return {
+      type: "file",
+      source: {
+        type: "attachment_ref",
+        media_type: attachment.mimeType,
+        attachmentId: attachment.attachmentId,
+        filename: attachment.filename,
+        sizeBytes: attachment.sizeBytes,
+      },
+      ...(attachment.extractedText
+        ? { extracted_text: attachment.extractedText }
+        : {}),
+      _attachmentId: attachment.attachmentId,
+    } as ContentBlock;
+  });
 }
 
 export function attachmentsToContentBlocks(

--- a/assistant/src/context/token-estimator.ts
+++ b/assistant/src/context/token-estimator.ts
@@ -1,9 +1,11 @@
 import {
-  estimateGeminiAudioTokens,
+  base64ByteLength,
+  estimateGeminiAudioTokensFromBytes,
   normalizeGeminiAudioMime,
 } from "../providers/gemini/inline-media.js";
 import type {
   ContentBlock,
+  MediaSource,
   Message,
   Provider,
   ToolDefinition,
@@ -98,12 +100,22 @@ export function estimateTextTokens(text: string | undefined): number {
   return Math.ceil(text.length / CHARS_PER_TOKEN);
 }
 
-function estimateAnthropicPdfTokens(base64Data: string): number {
-  const rawBytes = Math.ceil((base64Data.length * 3) / 4);
+function estimateAnthropicPdfTokens(rawBytes: number): number {
   return Math.max(
     ANTHROPIC_PDF_MIN_TOKENS,
     Math.ceil(rawBytes * ANTHROPIC_PDF_TOKENS_PER_BYTE),
   );
+}
+
+/**
+ * Raw byte length behind a media source, whether it carries inline base64 or a
+ * workspace reference (whose `sizeBytes` hint is captured at persist time). Lets
+ * the estimator cost referenced attachments without reading them off disk.
+ */
+function mediaSourceByteLength(source: MediaSource): number {
+  return source.type === "base64"
+    ? base64ByteLength(source.data)
+    : source.sizeBytes;
 }
 
 function estimateFileDataTokens(
@@ -112,12 +124,11 @@ function estimateFileDataTokens(
 ): number {
   const providerName = options?.providerName;
 
+  const mediaType = block.source.media_type;
+
   // Anthropic sends PDFs as native document blocks and renders each page as an image
-  if (
-    providerName === "anthropic" &&
-    block.source.media_type === "application/pdf"
-  ) {
-    return estimateAnthropicPdfTokens(block.source.data);
+  if (providerName === "anthropic" && mediaType === "application/pdf") {
+    return estimateAnthropicPdfTokens(mediaSourceByteLength(block.source));
   }
 
   // Gemini hears audio natively (inline base64) but bills it at ~32 tokens/sec.
@@ -125,17 +136,22 @@ function estimateFileDataTokens(
   // would trigger spurious compaction.
   if (
     providerName === "gemini" &&
-    normalizeGeminiAudioMime(block.source.media_type) !== null
+    normalizeGeminiAudioMime(mediaType) !== null
   ) {
-    return estimateGeminiAudioTokens(block.source.data);
+    return estimateGeminiAudioTokensFromBytes(
+      mediaSourceByteLength(block.source),
+    );
   }
 
-  // Gemini sends certain file types inline as base64
+  // Gemini sends certain file types inline as base64; approximate the token
+  // cost from the (base64-inflated) payload length.
   if (
     providerName === "gemini" &&
-    GEMINI_INLINE_FILE_MIME_TYPES.has(block.source.media_type)
+    GEMINI_INLINE_FILE_MIME_TYPES.has(mediaType)
   ) {
-    return estimateTextTokens(block.source.data);
+    return Math.ceil(
+      (mediaSourceByteLength(block.source) * 4) / 3 / CHARS_PER_TOKEN,
+    );
   }
 
   return 0;
@@ -185,7 +201,14 @@ function estimateImageTokens(
   block: Extract<ContentBlock, { type: "image" }>,
   options?: TokenEstimatorOptions,
 ): number {
-  const dims = parseImageDimensions(block.source.data, block.source.media_type);
+  // A reference source carries decoded dimensions as a hint; an inline source
+  // is parsed from its base64 header.
+  const dims =
+    block.source.type === "base64"
+      ? parseImageDimensions(block.source.data, block.source.media_type)
+      : block.source.width != null && block.source.height != null
+        ? { width: block.source.width, height: block.source.height }
+        : null;
   if (dims) {
     if (options?.providerName === "gemini") {
       return estimateGeminiImageTokens(dims.width, dims.height);

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -1402,8 +1402,12 @@ export async function handleToolResult(
   const imageBlocks = event.contentBlocks?.filter(
     (b): b is ImageContent => b.type === "image",
   );
+  // Live tool-result images carry inline base64; a reference source (no inline
+  // bytes) is skipped.
   const imageDataList = imageBlocks?.length
-    ? imageBlocks.map((b) => b.source.data)
+    ? imageBlocks
+        .map((b) => (b.source.type === "base64" ? b.source.data : undefined))
+        .filter((d): d is string => d != null)
     : undefined;
 
   // Perform state mutations before deps.onEvent() so that if onEvent throws

--- a/assistant/src/daemon/conversation-media-retry.ts
+++ b/assistant/src/daemon/conversation-media-retry.ts
@@ -203,10 +203,18 @@ export function estimateUnconditionalStubTokens(
   return stubTokens;
 }
 
+function mediaSourceSizeBytes(
+  source: Extract<ContentBlock, { type: "image" | "file" }>["source"],
+): number {
+  return source.type === "base64"
+    ? Math.ceil(source.data.length / 4) * 3
+    : source.sizeBytes;
+}
+
 function imageBlockToStub(
   block: Extract<ContentBlock, { type: "image" }>,
 ): Extract<ContentBlock, { type: "text" }> {
-  const sizeBytes = Math.ceil(block.source.data.length / 4) * 3;
+  const sizeBytes = mediaSourceSizeBytes(block.source);
   return {
     type: "text",
     text: `[Image omitted from retry context: ${block.source.media_type}, ${sizeBytes} bytes]`,
@@ -216,7 +224,7 @@ function imageBlockToStub(
 function fileBlockToStub(
   block: Extract<ContentBlock, { type: "file" }>,
 ): Extract<ContentBlock, { type: "text" }> {
-  const sizeBytes = Math.ceil(block.source.data.length / 4) * 3;
+  const sizeBytes = mediaSourceSizeBytes(block.source);
   const extracted = (block.extracted_text ?? "").trim();
   const preview =
     extracted.length > MAX_MEDIA_STUB_TEXT

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -8,6 +8,8 @@
 import { v4 as uuid } from "uuid";
 
 import {
+  type AttachmentReferenceInput,
+  attachmentsToReferenceBlocks,
   enrichMessageWithSourcePaths,
   type MessageAttachmentInput,
 } from "../agent/attachments.js";
@@ -31,6 +33,7 @@ import {
   attachInlineAttachmentToMessage,
   attachmentExists,
   AttachmentUploadError,
+  getAttachmentById,
   getFilePathForAttachment,
   linkAttachmentToMessage,
   validateAttachmentUpload,
@@ -43,6 +46,7 @@ import {
   provenanceFromTrustContext,
   setConversationOriginChannelIfUnset,
   setConversationOriginInterfaceIfUnset,
+  updateMessageContent,
   updateMessageMetadata,
 } from "../persistence/conversation-crud.js";
 import {
@@ -216,17 +220,153 @@ export interface MessagingConversationContext {
   getTurnInterfaceContext(): TurnInterfaceContext | null;
 }
 
-export function serializePersistedUserMessageContent(
-  content: string,
-  attachments: MessageAttachmentInput[],
-  displayContent: string | undefined,
-): string {
-  return JSON.stringify(
-    createUserMessage(
-      displayContent !== undefined ? displayContent : content,
-      attachments,
-    ).content,
+/** Byte length of a base64 payload (padding-aware). */
+function base64ByteLength(base64: string): number {
+  if (!base64) return 0;
+  const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
+  return Math.max(0, Math.floor((base64.length * 3) / 4) - padding);
+}
+
+/**
+ * Serialize the text-only portion of a user message for the initial row insert.
+ * Attachment media is added afterwards as reference blocks by
+ * {@link linkUserAttachmentsAndWriteReferences}, once the attachments are
+ * linked and their final ids are known.
+ */
+function serializePersistedUserTextContent(text: string): string {
+  return JSON.stringify(createUserMessage(text, []).content);
+}
+
+/**
+ * Link a user message's attachments to the message row, then rewrite the row's
+ * `content` so each attachment is a workspace reference block
+ * ({@link attachmentsToReferenceBlocks}) instead of inline base64. Keeping
+ * base64 out of `messages.content` keeps the DB row (and the lexical index)
+ * small; the bytes are resolved back at the provider boundary.
+ *
+ * Mutates `attachmentInputs[i].storedPath` with each attachment's resolved
+ * on-disk path (used by the caller for path annotations + the
+ * `attachmentStoredPaths` metadata). When no attachment links successfully the
+ * row keeps its text-only content untouched.
+ */
+export function linkUserAttachmentsAndWriteReferences(
+  messageId: string,
+  textContent: string,
+  attachmentInputs: MessageAttachmentInput[],
+): void {
+  const refs: AttachmentReferenceInput[] = [];
+  for (let i = 0; i < attachmentInputs.length; i++) {
+    const a = attachmentInputs[i];
+    try {
+      let finalId: string | undefined;
+      // Pre-uploaded (already in the store, e.g. file-backed) attachment: link
+      // the existing row directly without re-uploading.
+      if (a.id && attachmentExists(a.id)) {
+        finalId = linkAttachmentToMessage(messageId, a.id, i);
+        a.storedPath = getFilePathForAttachment(finalId) ?? undefined;
+      } else if (a.data) {
+        const validation = validateAttachmentUpload(a.filename, a.mimeType);
+        if (!validation.ok) {
+          log.warn(
+            { filename: a.filename, error: validation.error },
+            "Skipping user attachment indexing: validation failed",
+          );
+          continue;
+        }
+        const stored = attachInlineAttachmentToMessage(
+          messageId,
+          i,
+          a.filename,
+          a.mimeType,
+          a.data,
+          { sourcePath: a.filePath, normalizeImage: true },
+        );
+        finalId = stored.id;
+        a.storedPath = stored.filePath;
+      } else {
+        continue;
+      }
+
+      if (!finalId) continue;
+      // The linked row is the source of truth for the stored mime/size/filename
+      // (upload-time normalization may have rewritten e.g. HEIC → JPEG). Read
+      // metadata only — no file hydration.
+      const row = getAttachmentById(finalId);
+      refs.push({
+        attachmentId: finalId,
+        filename: row?.originalFilename ?? a.filename,
+        mimeType: row?.mimeType ?? a.mimeType,
+        sizeBytes: row?.sizeBytes ?? base64ByteLength(a.data),
+        data: a.data || undefined,
+        extractedText: a.extractedText,
+      });
+    } catch (err) {
+      if (err instanceof AttachmentUploadError) {
+        log.warn(
+          { filename: a.filename, error: err.message },
+          "Skipping user attachment indexing",
+        );
+      } else {
+        log.error(
+          { filename: a.filename, err },
+          "Failed to index user attachment",
+        );
+      }
+    }
+  }
+
+  if (refs.length === 0) return;
+  const refContent = [
+    ...createUserMessage(textContent, []).content,
+    ...attachmentsToReferenceBlocks(refs),
+  ];
+  updateMessageContent(messageId, JSON.stringify(refContent));
+}
+
+/**
+ * Persist a user-message row whose attachment media is stored as workspace
+ * references rather than inline base64. Inserts the row with text-only content,
+ * then links each attachment and rewrites the row to carry `attachment_ref`
+ * blocks. The single choke point every user-message persist site funnels
+ * through, so no site writes base64 media into `messages.content`.
+ *
+ * `attachmentInputs` is mutated in place (each gets its resolved `storedPath`)
+ * so callers can build path annotations / `attachmentStoredPaths` metadata from
+ * it after this returns.
+ */
+export async function persistUserMessageRow(params: {
+  conversationId: string;
+  content: string;
+  displayContent?: string;
+  attachmentInputs: MessageAttachmentInput[];
+  metadata?: Record<string, unknown>;
+  clientMessageId?: string;
+  id?: string;
+}): Promise<Awaited<ReturnType<typeof addMessage>>> {
+  const text =
+    params.displayContent !== undefined
+      ? params.displayContent
+      : params.content;
+  const inserted = await addMessage(
+    params.conversationId,
+    "user",
+    serializePersistedUserTextContent(text),
+    {
+      ...(params.metadata ? { metadata: params.metadata } : {}),
+      ...(params.clientMessageId
+        ? { clientMessageId: params.clientMessageId }
+        : {}),
+      ...(params.id ? { id: params.id } : {}),
+    },
   );
+  if (!inserted.deduplicated && params.attachmentInputs.length > 0) {
+    linkUserAttachmentsAndWriteReferences(
+      inserted.id,
+      text,
+      params.attachmentInputs,
+    );
+  }
+  return inserted;
 }
 
 function extractTurnChannelContext(
@@ -566,18 +706,18 @@ export async function persistQueuedMessageBody(
     // When displayContent is provided (e.g. original text before recording
     // intent stripping), persist that to DB so users see the full message
     // after restart. The in-memory userMessage (sent to the LLM) still uses
-    // the stripped content.
-    const contentToPersist = serializePersistedUserMessageContent(
+    // the stripped content. Attachment media is stored as workspace references
+    // (not inline base64) and its bytes are resolved at the provider boundary
+    // — see persistUserMessageRow / resolveMediaReferences.
+    const persistedUserMessage = await persistUserMessageRow({
+      conversationId: ctx.conversationId,
       content,
+      ...(displayContent !== undefined ? { displayContent } : {}),
       attachmentInputs,
-      displayContent,
-    );
-    const persistedUserMessage = await addMessage(
-      ctx.conversationId,
-      "user",
-      contentToPersist,
-      { metadata: mergedMetadata, clientMessageId, id: requestId },
-    );
+      metadata: mergedMetadata,
+      ...(clientMessageId ? { clientMessageId } : {}),
+      id: requestId,
+    });
 
     if (persistedUserMessage.deduplicated) {
       return { id: persistedUserMessage.id, deduplicated: true };
@@ -606,63 +746,6 @@ export async function persistQueuedMessageBody(
 
     if (!persistedUserMessage.id) {
       throw new Error("Failed to persist user message");
-    }
-
-    // Index user attachments in the attachments table for later retrieval,
-    // capturing the resolved stored path of each linked attachment. Name
-    // collisions in the conversation's attachments/ dir get a -2/-3 suffix,
-    // so the stored path — not the original filename — is the only reliable
-    // on-disk handle for the file.
-    for (let i = 0; i < attachments.length; i++) {
-      const a = attachments[i];
-      try {
-        // If the attachment already exists in the store (e.g. file-backed
-        // attachments uploaded separately), link it directly without
-        // re-uploading. This handles the case where data is empty because
-        // the attachment content lives on disk.
-        if (a.id && attachmentExists(a.id)) {
-          const scopedAttachmentId = linkAttachmentToMessage(
-            persistedUserMessage.id,
-            a.id,
-            i,
-          );
-          attachmentInputs[i].storedPath =
-            getFilePathForAttachment(scopedAttachmentId) ?? undefined;
-          continue;
-        }
-
-        if (!a.data) continue;
-
-        const validation = validateAttachmentUpload(a.filename, a.mimeType);
-        if (!validation.ok) {
-          log.warn(
-            { filename: a.filename, error: validation.error },
-            "Skipping user attachment indexing: validation failed",
-          );
-          continue;
-        }
-        const stored = attachInlineAttachmentToMessage(
-          persistedUserMessage.id,
-          i,
-          a.filename,
-          a.mimeType,
-          a.data,
-          { sourcePath: a.filePath, normalizeImage: true },
-        );
-        attachmentInputs[i].storedPath = stored.filePath;
-      } catch (err) {
-        if (err instanceof AttachmentUploadError) {
-          log.warn(
-            { filename: a.filename, error: err.message },
-            "Skipping user attachment indexing",
-          );
-        } else {
-          log.error(
-            { filename: a.filename, err },
-            "Failed to index user attachment",
-          );
-        }
-      }
     }
 
     // Persist the resolved paths so history reloads can rebuild the same

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -40,7 +40,7 @@ import { getLogger } from "../util/logger.js";
 import type { CleanResult, Conversation } from "./conversation.js";
 import {
   persistQueuedMessageBody,
-  serializePersistedUserMessageContent,
+  persistUserMessageRow,
 } from "./conversation-messaging.js";
 import type {
   QueuedMessage,
@@ -564,13 +564,15 @@ async function drainSingleMessage(
       );
       // When displayContent is provided (e.g. original text before recording
       // intent stripping), persist that to DB so users see the full message.
-      // The in-memory userMessage (sent to the LLM) still uses the stripped content.
-      const contentToPersist = serializePersistedUserMessageContent(
-        next.content,
-        next.attachments,
-        next.displayContent,
-      );
-      await addMessage(conversation.conversationId, "user", contentToPersist, {
+      // The in-memory userMessage (sent to the LLM) still uses the stripped
+      // content. Attachment media is stored as workspace references.
+      await persistUserMessageRow({
+        conversationId: conversation.conversationId,
+        content: next.content,
+        ...(next.displayContent !== undefined
+          ? { displayContent: next.displayContent }
+          : {}),
+        attachmentInputs: next.attachments ?? [],
         metadata: drainChannelMeta,
       });
       conversation.messages.push(llmUserMsg);
@@ -658,16 +660,15 @@ async function drainSingleMessage(
         sentAt: next.sentAt,
       };
       const cleanUserMsg = createUserMessage(next.content, next.attachments);
-      await addMessage(
-        conversation.conversationId,
-        "user",
-        serializePersistedUserMessageContent(
-          next.content,
-          next.attachments,
-          next.displayContent,
-        ),
-        { metadata: drainChannelMeta },
-      );
+      await persistUserMessageRow({
+        conversationId: conversation.conversationId,
+        content: next.content,
+        ...(next.displayContent !== undefined
+          ? { displayContent: next.displayContent }
+          : {}),
+        attachmentInputs: next.attachments ?? [],
+        metadata: drainChannelMeta,
+      });
       persistedCompactMessage = true;
       conversation.messages.push(cleanUserMsg);
 
@@ -744,16 +745,15 @@ async function drainSingleMessage(
         sentAt: next.sentAt,
       };
       const cleanUserMsg = createUserMessage(next.content, next.attachments);
-      await addMessage(
-        conversation.conversationId,
-        "user",
-        serializePersistedUserMessageContent(
-          next.content,
-          next.attachments,
-          next.displayContent,
-        ),
-        { metadata: drainChannelMeta },
-      );
+      await persistUserMessageRow({
+        conversationId: conversation.conversationId,
+        content: next.content,
+        ...(next.displayContent !== undefined
+          ? { displayContent: next.displayContent }
+          : {}),
+        attachmentInputs: next.attachments ?? [],
+        metadata: drainChannelMeta,
+      });
       persistedCleanMessage = true;
       conversation.messages.push(cleanUserMsg);
 
@@ -1521,16 +1521,13 @@ export async function processMessage(
         cleanUserMsg,
         attachments,
       );
-      const persisted = await addMessage(
-        conversation.conversationId,
-        "user",
-        serializePersistedUserMessageContent(
-          content,
-          attachments,
-          displayContent,
-        ),
-        { metadata: routerChannelMeta },
-      );
+      const persisted = await persistUserMessageRow({
+        conversationId: conversation.conversationId,
+        content,
+        ...(displayContent !== undefined ? { displayContent } : {}),
+        attachmentInputs: attachments ?? [],
+        metadata: routerChannelMeta,
+      });
       conversation.messages.push(llmUserMsg);
 
       const replyText =
@@ -1613,17 +1610,13 @@ export async function processMessage(
     // When displayContent is provided (e.g. original text before recording
     // intent stripping), persist that to DB so users see the full message.
     // The in-memory userMessage (sent to the LLM) still uses the stripped content.
-    const contentToPersist = serializePersistedUserMessageContent(
+    const persisted = await persistUserMessageRow({
+      conversationId: conversation.conversationId,
       content,
-      attachments,
-      displayContent,
-    );
-    const persisted = await addMessage(
-      conversation.conversationId,
-      "user",
-      contentToPersist,
-      { metadata: pmChannelMeta },
-    );
+      ...(displayContent !== undefined ? { displayContent } : {}),
+      attachmentInputs: attachments ?? [],
+      metadata: pmChannelMeta,
+    });
     conversation.messages.push(llmUserMsg);
 
     const assistantMsg = createAssistantMessage(slashResult.message);
@@ -1693,16 +1686,13 @@ export async function processMessage(
           : {}),
       };
       const cleanUserMsg = createUserMessage(content, attachments);
-      const persisted = await addMessage(
-        conversation.conversationId,
-        "user",
-        serializePersistedUserMessageContent(
-          content,
-          attachments,
-          displayContent,
-        ),
-        { metadata: pmChannelMeta },
-      );
+      const persisted = await persistUserMessageRow({
+        conversationId: conversation.conversationId,
+        content,
+        ...(displayContent !== undefined ? { displayContent } : {}),
+        attachmentInputs: attachments ?? [],
+        metadata: pmChannelMeta,
+      });
       persistedCompactMessage = true;
       conversation.messages.push(cleanUserMsg);
 
@@ -1770,16 +1760,13 @@ export async function processMessage(
           : {}),
       };
       const cleanUserMsg = createUserMessage(content, attachments);
-      const persisted = await addMessage(
-        conversation.conversationId,
-        "user",
-        serializePersistedUserMessageContent(
-          content,
-          attachments,
-          displayContent,
-        ),
-        { metadata: pmChannelMeta },
-      );
+      const persisted = await persistUserMessageRow({
+        conversationId: conversation.conversationId,
+        content,
+        ...(displayContent !== undefined ? { displayContent } : {}),
+        attachmentInputs: attachments ?? [],
+        metadata: pmChannelMeta,
+      });
       persistedCleanMessage = true;
       conversation.messages.push(cleanUserMsg);
 

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -36,7 +36,7 @@ import { getLogger } from "../util/logger.js";
 import type { Conversation } from "./conversation.js";
 import {
   buildSlackMetaForPersistence,
-  serializePersistedUserMessageContent,
+  persistUserMessageRow,
 } from "./conversation-messaging.js";
 import {
   formatCleanResult,
@@ -370,16 +370,15 @@ export async function processMessage(
       : serverChannelMeta;
     const cleanMsg = createUserMessage(content, attachments);
     const llmMsg = enrichMessageWithSourcePaths(cleanMsg, attachments);
-    const persisted = await addMessage(
+    const persisted = await persistUserMessageRow({
       conversationId,
-      "user",
-      serializePersistedUserMessageContent(
-        content,
-        attachments,
-        options?.displayContent,
-      ),
-      { metadata: userMetaWithSlack },
-    );
+      content,
+      ...(options?.displayContent !== undefined
+        ? { displayContent: options.displayContent }
+        : {}),
+      attachmentInputs: attachments,
+      metadata: userMetaWithSlack,
+    });
     conversation.getMessages().push(llmMsg);
 
     if (serverTurnCtx) {
@@ -463,16 +462,15 @@ export async function processMessage(
       ? { ...compactChannelMeta, slackMeta }
       : compactChannelMeta;
     const cleanMsg = createUserMessage(content, attachments);
-    const persisted = await addMessage(
+    const persisted = await persistUserMessageRow({
       conversationId,
-      "user",
-      serializePersistedUserMessageContent(
-        content,
-        attachments,
-        options?.displayContent,
-      ),
-      { metadata: compactUserMeta },
-    );
+      content,
+      ...(options?.displayContent !== undefined
+        ? { displayContent: options.displayContent }
+        : {}),
+      attachmentInputs: attachments,
+      metadata: compactUserMeta,
+    });
     conversation.getMessages().push(cleanMsg);
 
     conversation.emitActivityState("thinking", "context_compacting");
@@ -518,16 +516,15 @@ export async function processMessage(
       ? { ...cleanChannelMeta, slackMeta }
       : cleanChannelMeta;
     const cleanMsg = createUserMessage(content, attachments);
-    const persisted = await addMessage(
+    const persisted = await persistUserMessageRow({
       conversationId,
-      "user",
-      serializePersistedUserMessageContent(
-        content,
-        attachments,
-        options?.displayContent,
-      ),
-      { metadata: cleanUserMeta },
-    );
+      content,
+      ...(options?.displayContent !== undefined
+        ? { displayContent: options.displayContent }
+        : {}),
+      attachmentInputs: attachments,
+      metadata: cleanUserMeta,
+    });
     conversation.getMessages().push(cleanMsg);
 
     const result = await conversation.forceClean();

--- a/assistant/src/daemon/wake-conversation-ops.ts
+++ b/assistant/src/daemon/wake-conversation-ops.ts
@@ -87,8 +87,14 @@ function translateAgentEventToServerMessage(
       const imageBlocks = event.contentBlocks?.filter(
         (b): b is Extract<typeof b, { type: "image" }> => b.type === "image",
       );
+      // Live tool-result images carry inline base64; a reference source (no
+      // inline bytes) is skipped from the wake payload.
       const imageDataList = imageBlocks?.length
-        ? imageBlocks.map((b) => b.source.data)
+        ? imageBlocks
+            .map((b) =>
+              b.source.type === "base64" ? b.source.data : undefined,
+            )
+            .filter((d): d is string => d != null)
         : undefined;
       return {
         type: "tool_result",

--- a/assistant/src/persistence/message-content.ts
+++ b/assistant/src/persistence/message-content.ts
@@ -1,5 +1,6 @@
 import type { ContentBlock } from "../providers/types.js";
 import { escapeXmlAttr } from "../util/xml.js";
+import { getAttachmentContent } from "./attachments-store.js";
 
 export function extractTextFromStoredMessageContent(raw: string): string {
   try {
@@ -84,9 +85,16 @@ export function extractMediaBlocks(raw: string): Array<{
     for (let i = 0; i < parsed.length; i++) {
       const block = parsed[i] as ContentBlock;
       if (block.type === "image") {
+        // Stored image blocks carry either inline base64 or a workspace
+        // reference; resolve the reference from the attachment store.
+        const data =
+          block.source.type === "base64"
+            ? Buffer.from(block.source.data, "base64")
+            : getAttachmentContent(block.source.attachmentId);
+        if (!data) continue;
         results.push({
           type: "image" as const,
-          data: Buffer.from(block.source.data, "base64"),
+          data,
           mimeType: block.source.media_type,
           index: i,
         });

--- a/assistant/src/plugins/defaults/image-fallback/src/caption-blocks.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/caption-blocks.ts
@@ -76,8 +76,12 @@ export async function captionImageBlocks(
     const image = block as ImageContent;
 
     // Persist the original to a known, content-hash-deduped location so it
-    // survives the text substitution and stays findable on disk.
-    persistImage(image.source.data, image.source.media_type);
+    // survives the text substitution and stays findable on disk. Reference
+    // sources already live durably in the attachment store, so there is
+    // nothing to persist for them.
+    if (image.source.type === "base64") {
+      persistImage(image.source.data, image.source.media_type);
+    }
 
     if (visionProfileKey != null) {
       const caption = await captionImage(image, visionProfileKey, logger);

--- a/assistant/src/plugins/defaults/image-fallback/src/vision-caption.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/vision-caption.ts
@@ -64,7 +64,12 @@ export async function captionImage(
   profileKey: string,
   logger: PluginLogger,
 ): Promise<string | null> {
-  const hash = imageHash(image.source.data);
+  // Reference-source images have no inline bytes here; their attachment id is a
+  // stable cache key. The provider resolves the bytes when the block is sent.
+  const hash =
+    image.source.type === "base64"
+      ? imageHash(image.source.data)
+      : image.source.attachmentId;
   const cached = getCachedCaption(hash);
   if (cached !== undefined) {
     return cached;

--- a/assistant/src/plugins/defaults/image-recovery/recover.ts
+++ b/assistant/src/plugins/defaults/image-recovery/recover.ts
@@ -63,6 +63,10 @@ export const UNSENDABLE_IMAGE_NOTE =
 export function oversizedImageReplacement(
   block: Extract<ContentBlock, { type: "image" }>,
 ): ContentBlock | null {
+  // Reference-source images keep no bytes in the content row (they are resolved
+  // — and transport-optimized — at the provider boundary), so there is nothing
+  // to downgrade here.
+  if (block.source.type !== "base64") return null;
   const payloadBytes = block.source.data.length;
   const dims = parseImageDimensions(block.source.data, block.source.media_type);
   const exceedsDimensionCap =

--- a/assistant/src/plugins/defaults/memory/graph/retriever.ts
+++ b/assistant/src/plugins/defaults/memory/graph/retriever.ts
@@ -10,6 +10,7 @@ import type { ContentBlock, ImageContent } from "@vellumai/plugin-api";
 import { getConfiguredProvider } from "@vellumai/plugin-api";
 
 import type { AssistantConfig } from "../../../../config/types.js";
+import { getAttachmentContent } from "../../../../persistence/attachments-store.js";
 import { embedWithRetry } from "../../../../persistence/embeddings/embed.js";
 import { generateSparseEmbedding } from "../../../../persistence/embeddings/embedding-backend.js";
 import type { QdrantSparseVector } from "../../../../persistence/embeddings/qdrant-client.js";
@@ -980,9 +981,16 @@ export async function retrieveForTurn(
           i++
         ) {
           const img = imageBlocks[i];
+          // Resolve the image bytes: inline base64, or a workspace reference
+          // loaded from the attachment store.
+          const imageData =
+            img.source.type === "base64"
+              ? Buffer.from(img.source.data, "base64")
+              : getAttachmentContent(img.source.attachmentId);
+          if (!imageData) continue;
           const imageInput = {
             type: "image" as const,
-            data: Buffer.from(img.source.data, "base64"),
+            data: imageData,
             mimeType: img.source.media_type,
           };
           const imgResult = await embedWithRetry(opts.config, [imageInput], {

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -6,6 +6,7 @@ import { ProviderError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import { extractRetryAfterMs } from "../../util/retry.js";
 import { stripOrphanedSurrogatesDeep } from "../../util/unicode.js";
+import { base64Source, resolveMediaReferences } from "../media-resolve.js";
 import {
   couldBePlaceholderSentinelPrefix,
   isPlaceholderSentinelText,
@@ -1612,7 +1613,9 @@ export class AnthropicProvider implements Provider {
    * only thing layered on top in `sendMessage`.
    */
   private buildSentMessages(messages: Message[]): Anthropic.MessageParam[] {
-    const formatted = messages
+    // Resolve persisted attachment references to inline base64 before walking
+    // the content blocks; live turns already carry base64 and pass through.
+    const formatted = resolveMediaReferences(messages)
       .map((m) => {
         // Track whether an unknown block was dropped during filtering
         let droppedUnknownBlock = false;
@@ -1820,27 +1823,29 @@ export class AnthropicProvider implements Provider {
         };
       case "redacted_thinking":
         return { type: "redacted_thinking", data: block.data };
-      case "image":
-        if (!ANTHROPIC_SUPPORTED_IMAGE_TYPES.has(block.source.media_type)) {
+      case "image": {
+        const imageSource = base64Source(block.source);
+        if (!ANTHROPIC_SUPPORTED_IMAGE_TYPES.has(imageSource.media_type)) {
           log.warn(
-            `Unsupported image MIME type for Anthropic: ${block.source.media_type}; replacing with text placeholder`,
+            `Unsupported image MIME type for Anthropic: ${imageSource.media_type}; replacing with text placeholder`,
           );
           return {
             type: "text",
-            text: `[Image: ${block.source.media_type} — format not supported by this provider]`,
+            text: `[Image: ${imageSource.media_type} — format not supported by this provider]`,
           };
         }
         return {
           type: "image",
           source: {
             type: "base64",
-            media_type: block.source
-              .media_type as Anthropic.Base64ImageSource["media_type"],
-            data: block.source.data,
+            media_type:
+              imageSource.media_type as Anthropic.Base64ImageSource["media_type"],
+            data: imageSource.data,
           },
         };
+      }
       case "file": {
-        const { media_type, data, filename } = block.source;
+        const { media_type, data, filename } = base64Source(block.source);
         if (media_type === "application/pdf") {
           // Only valid base64 document source for Anthropic
           return {
@@ -1892,13 +1897,14 @@ export class AnthropicProvider implements Provider {
           ];
           for (const cb of usableBlocks) {
             if (cb.type === "image") {
+              const cbSource = base64Source(cb.source);
               parts.push({
                 type: "image" as const,
                 source: {
                   type: "base64" as const,
-                  media_type: cb.source
-                    .media_type as Anthropic.Base64ImageSource["media_type"],
-                  data: cb.source.data,
+                  media_type:
+                    cbSource.media_type as Anthropic.Base64ImageSource["media_type"],
+                  data: cbSource.data,
                 },
               });
             } else if (cb.type === "text") {

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -9,6 +9,7 @@ import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../prompts/cache-boundary.js";
 import { isAbortReason } from "../../util/abort-reasons.js";
 import { ProviderError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
+import { base64Source, resolveMediaReferences } from "../media-resolve.js";
 import { PROVIDER_CATALOG } from "../model-catalog.js";
 import { createStreamTimeout } from "../stream-timeout.js";
 import type {
@@ -566,6 +567,9 @@ export class GeminiProvider implements Provider {
     messages: Message[],
     model: string,
   ): genai.Content[] {
+    // Resolve persisted attachment references to inline base64 before walking
+    // the content blocks; live turns already carry base64 and pass through.
+    messages = resolveMediaReferences(messages);
     const result: genai.Content[] = [];
 
     // Build a map from tool_use id → function name so tool_result blocks
@@ -616,39 +620,42 @@ export class GeminiProvider implements Provider {
         case "text":
           parts.push({ text: block.text });
           break;
-        case "image":
+        case "image": {
+          const imageSource = base64Source(block.source);
           parts.push({
             inlineData: {
-              mimeType: block.source.media_type,
-              data: block.source.data,
+              mimeType: imageSource.media_type,
+              data: imageSource.data,
             },
           });
           break;
+        }
         case "file": {
-          if (this.supportsGeminiInlineFile(block.source.media_type)) {
+          const fileSource = base64Source(block.source);
+          if (this.supportsGeminiInlineFile(fileSource.media_type)) {
             // Normalize audio MIME onto Gemini's spelling (e.g. audio/mpeg →
             // audio/mp3); PDFs pass through unchanged. Guard the 20 MB inline
             // request limit for audio so an oversize clip degrades to a text
             // note rather than 400ing the whole request.
-            const audioMime = normalizeGeminiAudioMime(block.source.media_type);
-            const rawBytes = base64ByteLength(block.source.data);
+            const audioMime = normalizeGeminiAudioMime(fileSource.media_type);
+            const rawBytes = base64ByteLength(fileSource.data);
             if (audioMime && rawBytes > GEMINI_MAX_INLINE_AUDIO_BYTES) {
               const approxMb = Math.round(rawBytes / (1024 * 1024));
               parts.push({
-                text: `[Audio file too large to send inline: ${block.source.filename} (${block.source.media_type}, ~${approxMb}MB). Gemini's inline request limit is 20MB; this file was omitted. Ask the user for a shorter clip.]`,
+                text: `[Audio file too large to send inline: ${fileSource.filename} (${fileSource.media_type}, ~${approxMb}MB). Gemini's inline request limit is 20MB; this file was omitted. Ask the user for a shorter clip.]`,
               });
             } else {
               parts.push({
                 inlineData: {
-                  mimeType: audioMime ?? block.source.media_type,
-                  data: block.source.data,
+                  mimeType: audioMime ?? fileSource.media_type,
+                  data: fileSource.data,
                 },
               });
             }
           } else {
             const fallback = block.extracted_text?.trim()
-              ? `[Attached file: ${block.source.filename} (${block.source.media_type})]\n${block.extracted_text}`
-              : `[Attached file: ${block.source.filename} (${block.source.media_type})]\nNo extracted text available.`;
+              ? `[Attached file: ${fileSource.filename} (${fileSource.media_type})]\n${block.extracted_text}`
+              : `[Attached file: ${fileSource.filename} (${fileSource.media_type})]\nNo extracted text available.`;
             parts.push({ text: fallback });
           }
           break;
@@ -685,23 +692,23 @@ export class GeminiProvider implements Provider {
             // mixing inlineData with functionResponse in the same Content entry.
             for (const cb of block.contentBlocks) {
               if (cb.type === "image") {
+                const cbSource = base64Source(cb.source);
                 toolResultMediaParts.push({
                   inlineData: {
-                    mimeType: cb.source.media_type,
-                    data: cb.source.data,
+                    mimeType: cbSource.media_type,
+                    data: cbSource.data,
                   },
                 });
               } else if (cb.type === "file") {
-                const audioMime = normalizeGeminiAudioMime(
-                  cb.source.media_type,
-                );
+                const cbSource = base64Source(cb.source);
+                const audioMime = normalizeGeminiAudioMime(cbSource.media_type);
                 if (
                   audioMime &&
-                  base64ByteLength(cb.source.data) <=
+                  base64ByteLength(cbSource.data) <=
                     GEMINI_MAX_INLINE_AUDIO_BYTES
                 ) {
                   toolResultMediaParts.push({
-                    inlineData: { mimeType: audioMime, data: cb.source.data },
+                    inlineData: { mimeType: audioMime, data: cbSource.data },
                   });
                 } else if (audioMime) {
                   // Oversize audio: note it in the functionResponse output
@@ -710,7 +717,7 @@ export class GeminiProvider implements Provider {
                   // Gemini's request-size limit).
                   outputText =
                     outputText +
-                    `\n[Audio too large to send inline: ${cb.source.filename}. Ask for a shorter clip.]`;
+                    `\n[Audio too large to send inline: ${cbSource.filename}. Ask for a shorter clip.]`;
                 }
                 // Non-inline-able file sub-blocks (m4a/opus/pdf) are skipped
                 // here; the tool's text output already conveys the file.

--- a/assistant/src/providers/gemini/inline-media.ts
+++ b/assistant/src/providers/gemini/inline-media.ts
@@ -67,8 +67,11 @@ export const GEMINI_MAX_INLINE_AUDIO_BYTES = 12 * 1024 * 1024;
 const GEMINI_AUDIO_TOKENS_PER_SECOND = 32;
 const APPROX_AUDIO_BYTES_PER_SECOND = 16_000;
 
-export function estimateGeminiAudioTokens(base64Data: string): number {
-  const approxSeconds =
-    base64ByteLength(base64Data) / APPROX_AUDIO_BYTES_PER_SECOND;
+export function estimateGeminiAudioTokensFromBytes(rawBytes: number): number {
+  const approxSeconds = rawBytes / APPROX_AUDIO_BYTES_PER_SECOND;
   return Math.ceil(approxSeconds * GEMINI_AUDIO_TOKENS_PER_SECOND);
+}
+
+export function estimateGeminiAudioTokens(base64Data: string): number {
+  return estimateGeminiAudioTokensFromBytes(base64ByteLength(base64Data));
 }

--- a/assistant/src/providers/media-resolve.ts
+++ b/assistant/src/providers/media-resolve.ts
@@ -1,0 +1,185 @@
+/**
+ * Resolve persisted media references into inline base64 at the provider send
+ * boundary.
+ *
+ * User-uploaded image/file blocks are PERSISTED into `messages.content` as
+ * {@link AttachmentRefMediaSource} references (attachment id + size/dimension
+ * hints) rather than inline base64, keeping large blobs out of the DB row and
+ * the lexical index. The reference bytes live in the workspace attachment
+ * store. Just before a provider serializes a turn, {@link resolveMediaReferences}
+ * walks the message content and swaps every reference source for a
+ * {@link Base64MediaSource} loaded from disk, so each provider transform can
+ * keep reading `block.source.data` exactly as before.
+ *
+ * Blocks that already carry base64 (a live, in-flight turn) pass through
+ * untouched — no disk read — so only reloaded history pays the resolution cost,
+ * and only on its first send after reload.
+ *
+ * The walk is pure: it returns fresh block/message objects and never mutates
+ * the caller's in-memory history, so `Conversation.messages` keeps holding
+ * references (and their smaller memory footprint) across turns.
+ */
+
+import { optimizeImageForTransport } from "../agent/image-optimize.js";
+import { getAttachmentContent } from "../persistence/attachments-store.js";
+import { getLogger } from "../util/logger.js";
+import type {
+  ContentBlock,
+  FileContent,
+  ImageContent,
+  MediaSource,
+  Message,
+} from "./types.js";
+
+const log = getLogger("media-resolve");
+
+/**
+ * Narrow a media source to its base64 arm. After {@link resolveMediaReferences}
+ * runs, provider transforms only ever see base64 sources; this asserts that
+ * invariant and gives call sites the concrete `data`/`media_type` fields
+ * without an inline type guard. Throwing here (rather than silently emitting an
+ * empty payload) surfaces a missed resolution as a loud failure.
+ */
+export function base64Source<T extends MediaSource>(
+  source: T,
+): Extract<T, { type: "base64" }> {
+  if (source.type !== "base64") {
+    throw new Error(
+      `Unresolved attachment_ref media source reached the provider transform (attachmentId=${source.attachmentId}). ` +
+        `resolveMediaReferences must run before serializing messages.`,
+    );
+  }
+  return source as Extract<T, { type: "base64" }>;
+}
+
+/**
+ * Resolve a single media source to inline base64, loading a reference source
+ * from the attachment store. Returns `null` when a referenced attachment can no
+ * longer be read. For consumers that hold an individual in-memory block (image
+ * captioning, media retry) and need its bytes outside the provider transform.
+ */
+export function resolveMediaSourceData(
+  source: MediaSource,
+): { data: string; media_type: string } | null {
+  if (source.type === "base64") {
+    return { data: source.data, media_type: source.media_type };
+  }
+  const bytes = getAttachmentContent(source.attachmentId);
+  if (!bytes) {
+    return null;
+  }
+  return { data: bytes.toString("base64"), media_type: source.media_type };
+}
+
+function resolveImageBlock(block: ImageContent): ContentBlock {
+  if (block.source.type === "base64") {
+    return block;
+  }
+  const bytes = getAttachmentContent(block.source.attachmentId);
+  if (!bytes) {
+    log.warn(
+      { attachmentId: block.source.attachmentId },
+      "Image attachment reference could not be resolved; substituting a text note",
+    );
+    return {
+      type: "text",
+      text: "[Attachment unavailable: image could not be loaded]",
+    };
+  }
+  // Apply the same transport optimization the inline-base64 path used, so a
+  // reloaded (reference) turn sends the model the same bytes a live turn would.
+  const { data, mediaType } = optimizeImageForTransport(
+    bytes.toString("base64"),
+    block.source.media_type,
+  );
+  return {
+    type: "image",
+    source: {
+      type: "base64",
+      media_type: mediaType,
+      data,
+    },
+  };
+}
+
+function resolveFileBlock(block: FileContent): ContentBlock {
+  if (block.source.type === "base64") {
+    return block;
+  }
+  const { attachmentId, media_type, filename } = block.source;
+  const bytes = getAttachmentContent(attachmentId);
+  if (!bytes) {
+    log.warn(
+      { attachmentId, filename },
+      "File attachment reference could not be resolved; falling back to extracted text",
+    );
+    // Providers render non-inline files as their extracted text anyway; when the
+    // bytes are gone that text is the best remaining representation. With no
+    // extracted text there is nothing to send but a note.
+    return {
+      type: "text",
+      text: block.extracted_text ?? `[Attachment unavailable: ${filename}]`,
+    };
+  }
+  return {
+    type: "file",
+    source: {
+      type: "base64",
+      media_type,
+      filename,
+      data: bytes.toString("base64"),
+    },
+    ...(block.extracted_text !== undefined
+      ? { extracted_text: block.extracted_text }
+      : {}),
+    ...(block._attachmentId !== undefined
+      ? { _attachmentId: block._attachmentId }
+      : {}),
+  };
+}
+
+function resolveBlock(block: ContentBlock): ContentBlock {
+  switch (block.type) {
+    case "image":
+      return resolveImageBlock(block);
+    case "file":
+      return resolveFileBlock(block);
+    case "tool_result": {
+      // Nested media (e.g. a browser screenshot) may also carry references.
+      if (!block.contentBlocks?.length) {
+        return block;
+      }
+      const resolved = block.contentBlocks.map(resolveBlock);
+      return { ...block, contentBlocks: resolved };
+    }
+    default:
+      return block;
+  }
+}
+
+function contentHasReference(content: ContentBlock[]): boolean {
+  return content.some((block) => {
+    if (block.type === "image" || block.type === "file") {
+      return block.source.type === "attachment_ref";
+    }
+    if (block.type === "tool_result" && block.contentBlocks?.length) {
+      return contentHasReference(block.contentBlocks);
+    }
+    return false;
+  });
+}
+
+/**
+ * Return a copy of `messages` with every {@link AttachmentRefMediaSource}
+ * resolved to inline base64. Messages with no references are returned
+ * unchanged (same object reference) so the common all-base64 live turn does no
+ * allocation or disk I/O.
+ */
+export function resolveMediaReferences(messages: Message[]): Message[] {
+  return messages.map((message) => {
+    if (!contentHasReference(message.content)) {
+      return message;
+    }
+    return { ...message, content: message.content.map(resolveBlock) };
+  });
+}

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -5,6 +5,7 @@ import { isAbortReason } from "../../util/abort-reasons.js";
 import { ProviderError } from "../../util/errors.js";
 import { extractRetryAfterMs } from "../../util/retry.js";
 import { escapeXmlAttr } from "../../util/xml.js";
+import { base64Source, resolveMediaReferences } from "../media-resolve.js";
 import { PLACEHOLDER_EMPTY_TURN } from "../placeholder-sentinels.js";
 import { createStreamTimeout } from "../stream-timeout.js";
 import { createToolProgressEmitter } from "../tool-progress-events.js";
@@ -806,6 +807,9 @@ export class OpenAIChatCompletionsProvider implements Provider {
     messages: Message[],
     systemPrompt?: string,
   ): OpenAI.Chat.Completions.ChatCompletionMessageParam[] {
+    // Resolve persisted attachment references to inline base64 before walking
+    // the content blocks; live turns already carry base64 and pass through.
+    messages = resolveMediaReferences(messages);
     const result: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
 
     if (systemPrompt) {
@@ -959,21 +963,23 @@ export class OpenAIChatCompletionsProvider implements Provider {
         case "text":
           parts.push({ type: "text", text: block.text });
           break;
-        case "image":
-          if (!OPENAI_SUPPORTED_IMAGE_TYPES.has(block.source.media_type)) {
+        case "image": {
+          const imageSource = base64Source(block.source);
+          if (!OPENAI_SUPPORTED_IMAGE_TYPES.has(imageSource.media_type)) {
             parts.push({
               type: "text",
-              text: `[Image: ${block.source.media_type} — format not supported by this provider]`,
+              text: `[Image: ${imageSource.media_type} — format not supported by this provider]`,
             });
           } else {
             parts.push({
               type: "image_url",
               image_url: {
-                url: `data:${block.source.media_type};base64,${block.source.data}`,
+                url: `data:${imageSource.media_type};base64,${imageSource.data}`,
               },
             });
           }
           break;
+        }
         case "file":
           parts.push({
             type: "text",

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -6,6 +6,7 @@ import { ProviderError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import { extractRetryAfterMs } from "../../util/retry.js";
 import { escapeXmlAttr } from "../../util/xml.js";
+import { base64Source, resolveMediaReferences } from "../media-resolve.js";
 import { createStreamTimeout } from "../stream-timeout.js";
 import { createToolProgressEmitter } from "../tool-progress-events.js";
 import type {
@@ -651,6 +652,9 @@ export class OpenAIResponsesProvider implements Provider {
 
   /** Convert a user message's content blocks to Responses input items. */
   private appendUserItems(result: unknown[], msg: Message): void {
+    // Resolve persisted attachment references to inline base64 before walking
+    // the content blocks; live turns already carry base64 and pass through.
+    msg = resolveMediaReferences([msg])[0] ?? msg;
     // Separate tool results from other blocks
     const toolResults = msg.content.filter(
       (b): b is Extract<ContentBlock, { type: "tool_result" }> =>
@@ -712,19 +716,21 @@ export class OpenAIResponsesProvider implements Provider {
         case "text":
           parts.push({ type: "input_text", text: block.text });
           break;
-        case "image":
-          if (!OPENAI_SUPPORTED_IMAGE_TYPES.has(block.source.media_type)) {
+        case "image": {
+          const imageSource = base64Source(block.source);
+          if (!OPENAI_SUPPORTED_IMAGE_TYPES.has(imageSource.media_type)) {
             parts.push({
               type: "input_text",
-              text: `[Image: ${block.source.media_type} — format not supported by this provider]`,
+              text: `[Image: ${imageSource.media_type} — format not supported by this provider]`,
             });
           } else {
             parts.push({
               type: "input_image",
-              image_url: `data:${block.source.media_type};base64,${block.source.data}`,
+              image_url: `data:${imageSource.media_type};base64,${imageSource.data}`,
             });
           }
           break;
+        }
         case "file":
           parts.push({
             type: "input_text",

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -9,23 +9,55 @@ export interface TextContent {
   text: string;
 }
 
+/**
+ * Base64-inline media source: the bytes travel with the block. This is the
+ * runtime shape the provider transforms consume, and the shape produced for a
+ * live (in-flight) turn.
+ */
+export interface Base64MediaSource {
+  type: "base64";
+  media_type: string;
+  data: string;
+}
+
+/**
+ * Reference media source: the bytes live in the workspace attachment store,
+ * addressed by `attachmentId`. This is the shape PERSISTED into
+ * `messages.content` — it keeps base64 blobs out of the DB row (and out of the
+ * lexical index). It is resolved back into a {@link Base64MediaSource} at the
+ * provider send boundary (see `providers/media-resolve.ts`) so the model always
+ * receives inline bytes; consumers that need raw bytes out of stored content
+ * (e.g. `extractMediaBlocks`) resolve it via `getAttachmentContent`.
+ *
+ * `sizeBytes` (and, for images, `width`/`height`) are captured at persist time
+ * so size-only consumers — chiefly the per-turn token estimator — can cost the
+ * block without reading the file back off disk.
+ */
+export interface AttachmentRefMediaSource {
+  type: "attachment_ref";
+  media_type: string;
+  /** Attachment row id; resolve to bytes via `getAttachmentContent`. */
+  attachmentId: string;
+  /** Byte length of the referenced file. */
+  sizeBytes: number;
+  /** Decoded pixel width, when the reference is an image. */
+  width?: number;
+  /** Decoded pixel height, when the reference is an image. */
+  height?: number;
+}
+
+export type MediaSource = Base64MediaSource | AttachmentRefMediaSource;
+
 export interface ImageContent {
   type: "image";
-  source: {
-    type: "base64";
-    media_type: string;
-    data: string;
-  };
+  source: MediaSource;
 }
 
 export interface FileContent {
   type: "file";
-  source: {
-    type: "base64";
-    media_type: string;
-    data: string;
-    filename: string;
-  };
+  source:
+    | (Base64MediaSource & { filename: string })
+    | (AttachmentRefMediaSource & { filename: string });
   extracted_text?: string;
   /**
    * Internal id linking this block to a row in the attachments table.

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -13,8 +13,8 @@ import {
 } from "@vellumai/gateway-client";
 
 import {
-  attachmentsToContentBlocks,
-  type MessageAttachmentInput,
+  type AttachmentReferenceInput,
+  attachmentsToReferenceBlocks,
 } from "../../agent/attachments.js";
 import {
   CHANNEL_IDS,
@@ -1677,7 +1677,7 @@ async function persistBackfilledSlackMessage(params: {
   const hydratedAttachments = await withSlackBotToken(
     params.account,
     async (token) => {
-      const attachments: MessageAttachmentInput[] = [];
+      const attachments: AttachmentReferenceInput[] = [];
 
       for (let i = 0; i < imageFiles.length; i++) {
         const file = imageFiles[i];
@@ -1700,7 +1700,7 @@ async function persistBackfilledSlackMessage(params: {
             );
             continue;
           }
-          attachInlineAttachmentToMessage(
+          const stored = attachInlineAttachmentToMessage(
             persisted.id,
             i,
             downloaded.filename,
@@ -1709,8 +1709,10 @@ async function persistBackfilledSlackMessage(params: {
             { normalizeImage: true },
           );
           attachments.push({
-            filename: downloaded.filename,
-            mimeType: downloaded.mimeType,
+            attachmentId: stored.id,
+            filename: stored.originalFilename,
+            mimeType: stored.mimeType,
+            sizeBytes: stored.sizeBytes,
             data: downloaded.data,
           });
         } catch (err) {
@@ -1755,13 +1757,13 @@ async function persistBackfilledSlackMessage(params: {
 
 function buildBackfilledSlackContentBlocks(
   text: string,
-  attachments: MessageAttachmentInput[],
+  attachments: AttachmentReferenceInput[],
 ): ContentBlock[] {
   const blocks: ContentBlock[] = [];
   if (text.trim().length > 0) {
     blocks.push({ type: "text", text });
   }
-  blocks.push(...attachmentsToContentBlocks(attachments));
+  blocks.push(...attachmentsToReferenceBlocks(attachments));
   return blocks;
 }
 


### PR DESCRIPTION
## Prompt / plan

[ATL-991](https://linear.app/vellum/issue/ATL-991/uploaded-files-serialized-as-inline-base64-into-messagescontent-fts) — uploaded files were being serialized as inline base64 into the `messages.content` column (and thus into the message lexical/search index).

**Confirmed the bug:** every user-uploaded image/file was hydrated back to base64 from disk on each turn (`process-message.ts` → `getAttachmentsByIds({ hydrateFileData: true })`) and written verbatim into `messages.content` via `attachmentsToContentBlocks` (`source.data`). So each row (and the lexical index built from it) carried a full copy of bytes that already live on disk in the attachment store — migration 180 fixed this for the `attachments` table but the message-content copy was never addressed, and the code actively re-inflated it.

**Approach (design agreed with the requester):** persist a *reference* to the workspace attachment instead of the bytes, and have the send path resolve it back to base64 for the model.

- Add an `attachment_ref` variant to image/file `source` (`{ attachmentId, media_type, sizeBytes, width?, height? }`). `messages.content` and the lexical index no longer contain base64.
- All user-message persist sites funnel through a new `persistUserMessageRow`: insert the row with text-only content, link each attachment, then rewrite the row to carry `attachment_ref` blocks. This also links slash-command attachments that previously went unlinked entirely.
- Resolve references → inline base64 at the four provider transforms (`resolveMediaReferences`, narrowed via `base64Source`). A live turn still carries base64 in memory and passes through untouched; only reloaded history pays the (first-send) resolve, and references stay in RAM so daemon memory shrinks on reload.
- The token estimator costs referenced media from the persisted size/dimension hints — no disk read on the per-turn compaction check.
- Stored-content byte readers (`extractMediaBlocks` behind the memory image graph, image-fallback captioning, image-recovery, media-retry) resolve references from the attachment store on demand.

**Scope:** user-uploaded attachments only (web/CLI, channel inbound, slash-command turns, Slack backfill). Assistant/tool-generated media (e.g. browser-screenshot `tool_result` images) still embed base64 and are a tracked follow-up (second PR this session). Forward-only — no backfill of existing rows (message rows are immutable and age out via retention).

## Test plan

- New `attachment-reference-persistence.test.ts`: an uploaded image persists as an `attachment_ref` (no base64 in the row), `resolveMediaReferences` rehydrates it to inline base64, and `extractMediaBlocks` resolves the bytes from the store.
- Updated existing contracts to the reference shape: `process-message-display-content` (persist path), `thread-backfill` (Slack backfill now stores a ref that round-trips to the uploaded bytes), `persist-unsendable-image-downscale`.
- Ran the affected suites individually (providers, persistence, media, token estimator, agent loop, slack persistence) — all green. `bunx tsc --noEmit` clean; eslint clean (0 errors); no new circular deps.

## CLI verb checklist

No new IPC routes added — n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013KcQ6J4ggzKmNUP8BnqqvB)_