### PR TITLE
[DRAFT REFERENCE] tool/assistant media references — superseded by split PRs

### DIFF
--- a/assistant/src/__tests__/persist-media-references.test.ts
+++ b/assistant/src/__tests__/persist-media-references.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Regression tests for ATL-991 (part 2): assistant/tool-generated media
+ * (screenshots, generated images) is materialized into the attachment store and
+ * persisted as workspace references, not inline base64 in `messages.content`.
+ *
+ * Uses the real SQLite DB wired up via `test-preload.ts` (per-file temp
+ * workspace).
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { referenceMediaBlocksForPersist } from "../daemon/persist-media-references.js";
+import {
+  addMessage,
+  createConversation,
+} from "../persistence/conversation-crud.js";
+import { getDb, getSqliteFrom } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { resolveMediaReferences } from "../providers/media-resolve.js";
+import type { ContentBlock } from "../providers/types.js";
+
+await initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.run("DELETE FROM message_attachments");
+  db.run("DELETE FROM attachments");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+/** Minimal PNG whose IHDR declares the given pixel dimensions. */
+function makePngBase64(width: number, height: number): string {
+  return Buffer.from(
+    Uint8Array.from([
+      0x89,
+      0x50,
+      0x4e,
+      0x47,
+      0x0d,
+      0x0a,
+      0x1a,
+      0x0a,
+      0x00,
+      0x00,
+      0x00,
+      0x0d,
+      0x49,
+      0x48,
+      0x44,
+      0x52,
+      (width >>> 24) & 0xff,
+      (width >>> 16) & 0xff,
+      (width >>> 8) & 0xff,
+      width & 0xff,
+      (height >>> 24) & 0xff,
+      (height >>> 16) & 0xff,
+      (height >>> 8) & 0xff,
+      height & 0xff,
+      0x08,
+      0x06,
+      0x00,
+      0x00,
+      0x00,
+    ]),
+  ).toString("base64");
+}
+
+async function newRow(): Promise<{
+  conversationId: string;
+  messageId: string;
+}> {
+  const conv = createConversation();
+  const msg = await addMessage(conv.id, "user", "[]", { skipIndexing: true });
+  return { conversationId: conv.id, messageId: msg.id };
+}
+
+describe("referenceMediaBlocksForPersist", () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test("references a base64 image nested in a tool_result", async () => {
+    const { messageId } = await newRow();
+    const png = makePngBase64(100, 60);
+    const blocks: ContentBlock[] = [
+      {
+        type: "tool_result",
+        tool_use_id: "toolu_1",
+        content: "Screenshot captured",
+        contentBlocks: [
+          {
+            type: "image",
+            source: { type: "base64", media_type: "image/png", data: png },
+          },
+        ],
+      },
+    ];
+
+    const [referenced] = referenceMediaBlocksForPersist(messageId, blocks);
+    const nested = (
+      referenced as Extract<ContentBlock, { type: "tool_result" }>
+    ).contentBlocks![0] as Extract<ContentBlock, { type: "image" }>;
+
+    expect(nested.source.type).toBe("attachment_ref");
+    if (nested.source.type === "attachment_ref") {
+      expect(nested.source.media_type).toBe("image/png");
+      expect(nested.source.attachmentId).toBeTruthy();
+      expect(nested.source.width).toBe(100);
+      expect(nested.source.height).toBe(60);
+      expect(
+        (nested.source as unknown as { data?: string }).data,
+      ).toBeUndefined();
+    }
+
+    // No base64 survives in the serialized row.
+    expect(JSON.stringify(referenced)).not.toContain(png);
+
+    // A linked attachment row was created for the screenshot.
+    const links = getSqliteFrom(getDb())
+      .query(
+        "SELECT COUNT(*) AS c FROM message_attachments WHERE message_id = ?",
+      )
+      .get(messageId) as { c: number };
+    expect(links.c).toBe(1);
+  });
+
+  test("the referenced tool_result resolves back to the original bytes", async () => {
+    const { messageId } = await newRow();
+    const png = makePngBase64(48, 48);
+    const blocks: ContentBlock[] = [
+      {
+        type: "tool_result",
+        tool_use_id: "toolu_2",
+        content: "shot",
+        contentBlocks: [
+          {
+            type: "image",
+            source: { type: "base64", media_type: "image/png", data: png },
+          },
+        ],
+      },
+    ];
+
+    const referenced = referenceMediaBlocksForPersist(messageId, blocks);
+    const [resolved] = resolveMediaReferences([
+      { role: "user", content: referenced },
+    ]);
+    const nested = (
+      resolved!.content[0] as Extract<ContentBlock, { type: "tool_result" }>
+    ).contentBlocks![0] as Extract<ContentBlock, { type: "image" }>;
+
+    expect(nested.source.type).toBe("base64");
+    if (nested.source.type === "base64") {
+      // The fake PNG cannot be downscaled off macOS, so bytes round-trip verbatim.
+      expect(nested.source.data).toBe(png);
+    }
+  });
+
+  test("references a model-emitted top-level image", async () => {
+    const { messageId } = await newRow();
+    const png = makePngBase64(20, 20);
+    const blocks: ContentBlock[] = [
+      { type: "text", text: "here is your image" },
+      {
+        type: "image",
+        source: { type: "base64", media_type: "image/png", data: png },
+      },
+    ];
+
+    const referenced = referenceMediaBlocksForPersist(messageId, blocks);
+    const image = referenced[1] as Extract<ContentBlock, { type: "image" }>;
+    expect(image.source.type).toBe("attachment_ref");
+    expect(JSON.stringify(referenced)).not.toContain(png);
+  });
+
+  test("leaves an already-referenced block untouched (idempotent shape)", async () => {
+    const { messageId } = await newRow();
+    const blocks: ContentBlock[] = [
+      {
+        type: "image",
+        source: {
+          type: "attachment_ref",
+          media_type: "image/png",
+          attachmentId: "att-existing",
+          sizeBytes: 123,
+        },
+      },
+    ];
+    const referenced = referenceMediaBlocksForPersist(messageId, blocks);
+    expect(referenced[0]).toEqual(blocks[0]);
+    const links = getSqliteFrom(getDb())
+      .query(
+        "SELECT COUNT(*) AS c FROM message_attachments WHERE message_id = ?",
+      )
+      .get(messageId) as { c: number };
+    expect(links.c).toBe(0);
+  });
+});

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -100,6 +100,7 @@ import type {
   WebSearchMetadata,
   WebSearchResultItem,
 } from "./message-types/web-activity.js";
+import { referenceMediaBlocksForPersist } from "./persist-media-references.js";
 import type { TurnLatencyTracker } from "./turn-latency-tracker.js";
 
 const log = getLogger("agent-loop-handlers");
@@ -1278,8 +1279,17 @@ export async function finalizePendingToolResultRow(
     conversationId,
     metadata,
   );
+  // Materialize nested tool-result media (screenshots, generated images) into
+  // the attachment store as references so the finalized row — and the memory /
+  // lexical indexes built from it below — carry no inline base64. The
+  // on-arrival write above keeps base64 for mid-tool durability; this final
+  // write overwrites it with references. Single-writer here (turn boundary), so
+  // attachments are created exactly once.
   const contentJson = JSON.stringify(
-    buildToolResultBlocks(state.pendingToolResults),
+    referenceMediaBlocksForPersist(
+      rowId,
+      buildToolResultBlocks(state.pendingToolResults) as ContentBlock[],
+    ),
   );
   await persistLoopMessageContent(
     rowId,
@@ -2053,7 +2063,12 @@ export async function handleMessageComplete(
       "handleMessageComplete fired without a prior llm_call_started reserving an assistant row",
     );
   }
-  const contentJson = JSON.stringify(contentForPersistence);
+  // Reference any model-emitted top-level image (image-generation models) into
+  // the attachment store so the persisted row and its indexes carry no inline
+  // base64. No-op for the common text/thinking/tool_use assistant turn.
+  const contentJson = JSON.stringify(
+    referenceMediaBlocksForPersist(assistantMessageId, contentForPersistence),
+  );
   const persisted = await persistLoopMessageContent(
     assistantMessageId,
     contentJson,

--- a/assistant/src/daemon/persist-media-references.ts
+++ b/assistant/src/daemon/persist-media-references.ts
@@ -1,0 +1,157 @@
+/**
+ * Persist-time conversion of assistant/tool-generated media into workspace
+ * references.
+ *
+ * Tool results (browser/computer-use screenshots, `image_read`, generated
+ * images) and the occasional model-emitted top-level image arrive as inline
+ * base64 `ContentBlock`s. Writing them verbatim into `messages.content` bloats
+ * the row and the lexical index with bytes that belong on disk — the same
+ * problem solved for user uploads (ATL-991).
+ *
+ * {@link referenceMediaBlocksForPersist} runs just before a tool-result or
+ * assistant row is finalized: it materializes each base64 image/file into the
+ * conversation's attachment store (linked to that row) and swaps the block's
+ * `source` for an `attachment_ref`. The bytes are resolved back at the provider
+ * send boundary (`resolveMediaReferences`) and by any stored-content reader
+ * (`extractMediaBlocks`), both of which already understand references.
+ *
+ * On failure to materialize a block (e.g. invalid base64) the original inline
+ * block is kept, so media is never silently dropped.
+ */
+
+import { parseImageDimensions } from "../context/image-dimensions.js";
+import { attachInlineAttachmentToMessage } from "../persistence/attachments-store.js";
+import type { ContentBlock } from "../providers/types.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("persist-media-references");
+
+const IMAGE_EXTENSIONS: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "image/svg+xml": "svg",
+};
+
+function extensionFor(mediaType: string): string {
+  return IMAGE_EXTENSIONS[mediaType] ?? mediaType.split("/")[1] ?? "bin";
+}
+
+/** Materialize a base64 image block into an attachment and return a reference block. */
+function referenceImageBlock(
+  messageId: string,
+  position: number,
+  source: { media_type: string; data: string },
+): ContentBlock | null {
+  try {
+    const filename = `image-${position}.${extensionFor(source.media_type)}`;
+    const stored = attachInlineAttachmentToMessage(
+      messageId,
+      position,
+      filename,
+      source.media_type,
+      source.data,
+      { skipSizeLimit: true },
+    );
+    const dims = parseImageDimensions(source.data, source.media_type);
+    return {
+      type: "image",
+      source: {
+        type: "attachment_ref",
+        media_type: source.media_type,
+        attachmentId: stored.id,
+        sizeBytes: stored.sizeBytes,
+        ...(dims ? { width: dims.width, height: dims.height } : {}),
+      },
+    };
+  } catch (err) {
+    log.warn(
+      { err, messageId, mediaType: source.media_type },
+      "Failed to reference generated image; keeping inline base64",
+    );
+    return null;
+  }
+}
+
+/** Materialize a base64 file block into an attachment and return a reference block. */
+function referenceFileBlock(
+  messageId: string,
+  position: number,
+  block: Extract<ContentBlock, { type: "file" }>,
+): ContentBlock | null {
+  if (block.source.type !== "base64") return null;
+  const { media_type, data, filename } = block.source;
+  try {
+    const stored = attachInlineAttachmentToMessage(
+      messageId,
+      position,
+      filename,
+      media_type,
+      data,
+      { skipSizeLimit: true },
+    );
+    return {
+      type: "file",
+      source: {
+        type: "attachment_ref",
+        media_type,
+        attachmentId: stored.id,
+        filename,
+        sizeBytes: stored.sizeBytes,
+      },
+      ...(block.extracted_text !== undefined
+        ? { extracted_text: block.extracted_text }
+        : {}),
+      ...(block._attachmentId !== undefined
+        ? { _attachmentId: block._attachmentId }
+        : {}),
+    };
+  } catch (err) {
+    log.warn(
+      { err, messageId, filename },
+      "Failed to reference generated file; keeping inline base64",
+    );
+    return null;
+  }
+}
+
+/**
+ * Return a copy of `blocks` with every inline base64 image/file (top-level or
+ * nested in a `tool_result`) materialized into the attachment store — linked to
+ * `messageId` — and replaced by an `attachment_ref` source. Blocks that already
+ * carry references, or that fail to materialize, are left untouched.
+ *
+ * Must run at a single-writer persist point (a tool-result/assistant row
+ * finalize) so attachment rows are not created twice for the same media.
+ */
+export function referenceMediaBlocksForPersist(
+  messageId: string,
+  blocks: ContentBlock[],
+): ContentBlock[] {
+  let position = 0;
+  const convert = (input: ContentBlock[]): ContentBlock[] =>
+    input.map((block) => {
+      if (block.type === "image" && block.source.type === "base64") {
+        const ref = referenceImageBlock(messageId, position, block.source);
+        if (ref) {
+          position++;
+          return ref;
+        }
+        return block;
+      }
+      if (block.type === "file" && block.source.type === "base64") {
+        const ref = referenceFileBlock(messageId, position, block);
+        if (ref) {
+          position++;
+          return ref;
+        }
+        return block;
+      }
+      if (block.type === "tool_result" && block.contentBlocks?.length) {
+        return { ...block, contentBlocks: convert(block.contentBlocks) };
+      }
+      return block;
+    });
+  return convert(blocks);
+}


### PR DESCRIPTION
## Prompt / plan

Part 2 of [ATL-991](https://linear.app/vellum/issue/ATL-991/uploaded-files-serialized-as-inline-base64-into-messagescontent-fts). PR1 (#37451) moved **user-uploaded** media in `messages.content` to workspace references. This PR does the same for **assistant/tool-generated** media, which PR1 explicitly left as a follow-up.

**Stacked on #37451** — base is `claude/attachment-serialization-check-2ef6i6`, so this diff is only the incremental PR2 changes. Merge #37451 first.

**The remaining base64 sinks (per a codebase trace):**
- Tool results (browser & computer-use screenshots, `image_read`, generated images) land as inline base64 in the grouped `user` row's `tool_result.contentBlocks`.
- The rare model-emitted top-level `image` (image-generation models) lands in the assistant row.

Unlike user uploads, these had **no referenceable attachment row** — the base64 in content was the only linkable copy.

**Approach:** at the single-writer finalize points — `finalizePendingToolResultRow` and `handleMessageComplete` — `referenceMediaBlocksForPersist` materializes each base64 image/file into the conversation's attachment store (linked to that row) and swaps the block's `source` for an `attachment_ref`.

- Finalize runs once per turn/batch (not concurrent), so attachment rows are created exactly once — no dedup gymnastics on the hot path.
- The on-arrival tool persist keeps base64 for mid-tool-crash durability; the finalize write overwrites it with references. Finalize is also the **only** path that indexes the tool-result row for memory + lexical (`indexMessageNow` / `enqueueLexicalIndexForMessage`), so the transient on-arrival base64 never reaches either index.
- Bytes resolve back at the provider send boundary and for stored-content readers via the reference infra from PR1 (`resolveMediaReferences` already descends into `tool_result.contentBlocks`; `extractMediaBlocks`, image-recovery, media-retry already handle nested refs). No read-path changes were needed.
- On materialize failure (e.g. invalid base64) the inline block is kept — media is never silently dropped.

The model-facing in-memory history is untouched (still base64 for the live turn); only the persisted row and its indexes become reference-based.

## Test plan

- New `persist-media-references.test.ts`: a base64 image nested in a `tool_result` is materialized into a linked attachment and swapped for an `attachment_ref` (no base64 in the row); it resolves back to the original bytes via `resolveMediaReferences`; a model-emitted top-level image is referenced; an already-referenced block is left untouched (creates no attachment).
- Ran the loop / tool-result / media suites individually — `conversation-agent-loop`, `persist-unsendable-image(-downscale)`, `conversation-media-retry`, `image-recovery-hook`, `conversation-disk-view`, `server-history-render`, `list-messages-attachments`, `list-messages-tool-merge`, `history-repair`, `conversation-queue`, provider suites — all green. `bunx tsc --noEmit` clean; eslint clean (0 errors).

## CLI verb checklist

No new IPC routes added — n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013KcQ6J4ggzKmNUP8BnqqvB)_