### PR TITLE
refactor(tts): extract shared PCM sample-rate clamp helper

### DIFF
--- a/assistant/src/tts/__tests__/pcm-sample-rates.test.ts
+++ b/assistant/src/tts/__tests__/pcm-sample-rates.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_PCM_SAMPLE_RATE_HZ,
+  nearestSupportedPcmSampleRateHz,
+  resolvePcmOutputSampleRateHz,
+} from "../pcm-sample-rates.js";
+import type { TtsSynthesisRequest } from "../types.js";
+
+const RATES = [8_000, 16_000, 24_000, 32_000, 44_100] as const;
+
+function makeRequest(
+  overrides?: Partial<TtsSynthesisRequest>,
+): TtsSynthesisRequest {
+  return {
+    text: "Hello world",
+    useCase: "message-playback",
+    ...overrides,
+  };
+}
+
+describe("nearestSupportedPcmSampleRateHz", () => {
+  test("returns an exact match unchanged", () => {
+    expect(nearestSupportedPcmSampleRateHz(24_000, RATES)).toBe(24_000);
+  });
+
+  test("clamps to the nearest rate below", () => {
+    expect(nearestSupportedPcmSampleRateHz(48_000, RATES)).toBe(44_100);
+  });
+
+  test("clamps to the nearest rate above", () => {
+    expect(nearestSupportedPcmSampleRateHz(7_000, RATES)).toBe(8_000);
+  });
+
+  test("ties prefer the higher rate", () => {
+    expect(nearestSupportedPcmSampleRateHz(12_000, RATES)).toBe(16_000);
+  });
+});
+
+describe("resolvePcmOutputSampleRateHz", () => {
+  test("returns undefined for non-PCM requests", () => {
+    expect(
+      resolvePcmOutputSampleRateHz(makeRequest({ sampleRateHz: 24_000 }), RATES),
+    ).toBeUndefined();
+  });
+
+  test("defaults hint-less PCM requests to 16 kHz", () => {
+    expect(
+      resolvePcmOutputSampleRateHz(makeRequest({ outputFormat: "pcm" }), RATES),
+    ).toBe(DEFAULT_PCM_SAMPLE_RATE_HZ);
+  });
+
+  test("clamps a PCM hint to the nearest supported rate", () => {
+    expect(
+      resolvePcmOutputSampleRateHz(
+        makeRequest({ outputFormat: "pcm", sampleRateHz: 48_000 }),
+        RATES,
+      ),
+    ).toBe(44_100);
+  });
+});

--- a/assistant/src/tts/pcm-sample-rates.ts
+++ b/assistant/src/tts/pcm-sample-rates.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared PCM sample-rate clamp logic for TTS providers. Each provider keeps
+ * its own list of API-supported rates and passes it in.
+ */
+
+import type { TtsSynthesisRequest } from "./types.js";
+
+/**
+ * Sample rate for PCM requests that carry no `sampleRateHz` hint. The
+ * media-stream transcoder assumes headerless PCM is 16 kHz (the shared
+ * no-hint default across TTS providers) and downsamples to 8 kHz telephony.
+ */
+export const DEFAULT_PCM_SAMPLE_RATE_HZ = 16_000;
+
+/** Nearest supported PCM sample rate to `hintHz`; ties prefer the higher rate. */
+export function nearestSupportedPcmSampleRateHz(
+  hintHz: number,
+  supportedRatesHz: readonly number[],
+): number {
+  return supportedRatesHz.reduce((best, rate) => {
+    const bestDelta = Math.abs(best - hintHz);
+    const delta = Math.abs(rate - hintHz);
+    if (delta < bestDelta || (delta === bestDelta && rate > best)) {
+      return rate;
+    }
+    return best;
+  });
+}
+
+/**
+ * Actual PCM output sample rate for a request. A PCM request's hint is clamped
+ * to the nearest supported rate so the same value is both sent to the API and
+ * reported to callers; non-PCM formats carry their rate in the container and
+ * report undefined.
+ */
+export function resolvePcmOutputSampleRateHz(
+  request: TtsSynthesisRequest,
+  supportedRatesHz: readonly number[],
+): number | undefined {
+  if (request.outputFormat !== "pcm") {
+    return undefined;
+  }
+  return nearestSupportedPcmSampleRateHz(
+    request.sampleRateHz ?? DEFAULT_PCM_SAMPLE_RATE_HZ,
+    supportedRatesHz,
+  );
+}

--- a/assistant/src/tts/providers/deepgram-provider.ts
+++ b/assistant/src/tts/providers/deepgram-provider.ts
@@ -14,6 +14,7 @@ import { getConfig } from "../../config/loader.js";
 import type { TtsDeepgramProviderConfig } from "../../config/schemas/tts.js";
 import { getProviderKeyAsync } from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
+import { resolvePcmOutputSampleRateHz } from "../pcm-sample-rates.js";
 import type { TtsProviderDefinition } from "../provider-definition.js";
 import {
   consumeSynthesisResponse,
@@ -62,13 +63,6 @@ export class DeepgramTtsError extends Error {
 const DEEPGRAM_API_BASE = "https://api.deepgram.com";
 
 /**
- * Sample rate for PCM requests that carry no `sampleRateHz` hint. The
- * media-stream transcoder assumes headerless PCM is 16 kHz (the shared
- * no-hint default across TTS providers) and downsamples to 8 kHz telephony.
- */
-const DEFAULT_PCM_SAMPLE_RATE_HZ = 16_000;
-
-/**
  * Sample rates Deepgram's linear16 encoding accepts. Per
  * https://developers.deepgram.com/docs/tts-media-output-settings
  * these are 8/16/24/32/48 kHz (22.05 and 44.1 kHz are not supported).
@@ -101,34 +95,9 @@ interface DeepgramOutputParams {
   contentTypeKey: string;
 }
 
-/** Nearest Deepgram-supported PCM sample rate to `hintHz`; ties prefer the higher rate. */
-function nearestSupportedPcmSampleRateHz(hintHz: number): number {
-  return SUPPORTED_PCM_SAMPLE_RATES_HZ.reduce((best, rate) => {
-    const bestDelta = Math.abs(best - hintHz);
-    const delta = Math.abs(rate - hintHz);
-    if (delta < bestDelta || (delta === bestDelta && rate > best)) {
-      return rate;
-    }
-    return best;
-  });
-}
-
-/**
- * Actual PCM output sample rate for a request. A PCM request's hint is clamped
- * to the nearest Deepgram-supported rate (e.g. 44.1 kHz → 48 kHz) so the same
- * value is both sent to the API and reported to callers; non-PCM formats carry
- * their rate in the container and report undefined.
- */
-function resolvePcmOutputSampleRateHz(
-  request: TtsSynthesisRequest,
-): number | undefined {
-  if (request.outputFormat !== "pcm") {
-    return undefined;
-  }
-  return nearestSupportedPcmSampleRateHz(
-    request.sampleRateHz ?? DEFAULT_PCM_SAMPLE_RATE_HZ,
-  );
-}
+/** PCM rate resolver bound to the Deepgram-supported rate list (e.g. 44.1 kHz → 48 kHz). */
+const resolveDeepgramPcmSampleRateHz = (request: TtsSynthesisRequest) =>
+  resolvePcmOutputSampleRateHz(request, SUPPORTED_PCM_SAMPLE_RATES_HZ);
 
 /**
  * Resolve the Deepgram output encoding, container, and sample rate based on
@@ -157,7 +126,7 @@ function resolveOutputParams(
     return {
       encoding: "linear16",
       container: "none",
-      sample_rate: resolvePcmOutputSampleRateHz(request),
+      sample_rate: resolveDeepgramPcmSampleRateHz(request),
       contentTypeKey: "linear16",
     };
   }
@@ -301,7 +270,7 @@ export function createDeepgramProvider(
   return {
     id: "deepgram",
     capabilities,
-    resolveOutputSampleRateHz: resolvePcmOutputSampleRateHz,
+    resolveOutputSampleRateHz: resolveDeepgramPcmSampleRateHz,
     synthesize: (request) => performSynthesis(request, { stream: false }),
     synthesizeStream: (request, onChunk) =>
       performSynthesis(request, { stream: true, onChunk, ...streamTimeouts }),

--- a/assistant/src/tts/providers/fish-audio-provider.ts
+++ b/assistant/src/tts/providers/fish-audio-provider.ts
@@ -17,6 +17,7 @@ import {
 import { getConfig } from "../../config/loader.js";
 import type { TtsFishAudioProviderConfig } from "../../config/schemas/tts.js";
 import { getLogger } from "../../util/logger.js";
+import { resolvePcmOutputSampleRateHz } from "../pcm-sample-rates.js";
 import type { TtsProviderDefinition } from "../provider-definition.js";
 import type {
   TtsProvider,
@@ -26,13 +27,6 @@ import type {
 } from "../types.js";
 
 const log = getLogger("tts:fish-audio");
-
-/**
- * Sample rate for PCM requests that carry no `sampleRateHz` hint. The
- * media-stream transcoder assumes headerless PCM is 16 kHz (the
- * ElevenLabs/Deepgram/xAI convention) and downsamples to 8 kHz telephony.
- */
-const DEFAULT_PCM_SAMPLE_RATE_HZ = 16_000;
 
 /**
  * PCM/WAV sample rates the Fish Audio TTS API accepts. Per
@@ -93,34 +87,9 @@ function resolveReferenceId(
   return referenceId;
 }
 
-/** Nearest Fish-supported PCM sample rate to `hintHz`; ties prefer the higher rate. */
-function nearestSupportedPcmSampleRateHz(hintHz: number): number {
-  return SUPPORTED_PCM_SAMPLE_RATES_HZ.reduce((best, rate) => {
-    const bestDelta = Math.abs(best - hintHz);
-    const delta = Math.abs(rate - hintHz);
-    if (delta < bestDelta || (delta === bestDelta && rate > best)) {
-      return rate;
-    }
-    return best;
-  });
-}
-
-/**
- * Actual PCM output sample rate for a request. A PCM request's hint is clamped
- * to the nearest Fish-supported rate (e.g. 48 kHz → 44.1 kHz) so the same value
- * is both sent to the API and reported to callers; non-PCM formats carry their
- * rate in the container and report undefined.
- */
-function resolvePcmOutputSampleRateHz(
-  request: TtsSynthesisRequest,
-): number | undefined {
-  if (request.outputFormat !== "pcm") {
-    return undefined;
-  }
-  return nearestSupportedPcmSampleRateHz(
-    request.sampleRateHz ?? DEFAULT_PCM_SAMPLE_RATE_HZ,
-  );
-}
+/** PCM rate resolver bound to the Fish-supported rate list (e.g. 48 kHz → 44.1 kHz). */
+const resolveFishPcmSampleRateHz = (request: TtsSynthesisRequest) =>
+  resolvePcmOutputSampleRateHz(request, SUPPORTED_PCM_SAMPLE_RATES_HZ);
 
 // ---------------------------------------------------------------------------
 // Provider implementation
@@ -137,7 +106,7 @@ async function performSynthesis(
   // hinted sample rate is clamped to the nearest API-supported rate.
   const pcmRequested = request.outputFormat === "pcm";
   const effectiveFormat = pcmRequested ? "pcm" : config.format;
-  const sampleRateHz = resolvePcmOutputSampleRateHz(request);
+  const sampleRateHz = resolveFishPcmSampleRateHz(request);
 
   const effectiveConfig: FishAudioSynthesisConfig = {
     ...config,
@@ -185,7 +154,7 @@ export function createFishAudioProvider(): TtsProvider {
   return {
     id: "fish-audio",
     capabilities,
-    resolveOutputSampleRateHz: resolvePcmOutputSampleRateHz,
+    resolveOutputSampleRateHz: resolveFishPcmSampleRateHz,
     synthesize: (request) => performSynthesis(request),
     synthesizeStream: (request, onChunk) => performSynthesis(request, onChunk),
   };


### PR DESCRIPTION
## Summary
- New `tts/pcm-sample-rates.ts`: parameterized nearest-rate clamp + shared 16 kHz no-hint default + PCM rate resolver
- fish-audio and deepgram providers consume it (each keeps only its provider-specific rate list); zero behavior change
- Third consumer (xAI) lands later in this plan — this is the consolidation the fish↔deepgram duplication deferral called for

Part of plan: xai-ws-streaming-tts.md (PR 1 of 4)