### PR TITLE
feat(tts): xAI TTS WebSocket streaming session module

### DIFF
--- a/assistant/src/tts/providers/__tests__/xai-tts-socket.test.ts
+++ b/assistant/src/tts/providers/__tests__/xai-tts-socket.test.ts
@@ -1,0 +1,348 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { XaiTtsSocketOptions } from "../xai-tts-socket.js";
+import { synthesizeOverXaiTtsSocket } from "../xai-tts-socket.js";
+
+const TEST_API_KEY = "xai-test-key-for-tts";
+const TEST_URL =
+  "wss://api.x.ai/v1/tts?language=auto&voice=eve&codec=pcm&sample_rate=16000";
+
+// ---------------------------------------------------------------------------
+// Mock WebSocket
+// ---------------------------------------------------------------------------
+
+type WsEventType = "open" | "close" | "error" | "message";
+type WsListener = (...args: unknown[]) => void;
+
+/**
+ * Minimal mock WebSocket simulating the xAI TTS endpoint. Tests drive
+ * behavior via helper methods (`simulateOpen`, `simulateMessage`, …).
+ */
+class MockWebSocket {
+  readyState = 0; // CONNECTING
+
+  /** All data sent via `.send()`. */
+  sentData: (string | Uint8Array)[] = [];
+
+  /** Whether `.close()` was called. */
+  closeCalled = false;
+
+  private listeners = new Map<WsEventType, WsListener[]>();
+
+  addEventListener(type: WsEventType, listener: WsListener): void {
+    const list = this.listeners.get(type) ?? [];
+    list.push(listener);
+    this.listeners.set(type, list);
+  }
+
+  send(data: string | Uint8Array): void {
+    if (this.readyState !== 1) {
+      throw new Error("WebSocket is not open");
+    }
+    this.sentData.push(data);
+  }
+
+  close(): void {
+    this.closeCalled = true;
+    this.readyState = 3; // CLOSED
+  }
+
+  // ── Test helpers ──────────────────────────────────────────────────
+
+  simulateOpen(): void {
+    this.readyState = 1; // OPEN
+    for (const l of this.listeners.get("open") ?? []) l();
+  }
+
+  simulateMessage(data: unknown): void {
+    for (const l of this.listeners.get("message") ?? []) l({ data });
+  }
+
+  simulateClose(code = 1000, reason = ""): void {
+    this.readyState = 3;
+    for (const l of this.listeners.get("close") ?? []) l({ code, reason });
+  }
+
+  simulateError(err: unknown = new Error("boom")): void {
+    for (const l of this.listeners.get("error") ?? []) l(err);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Frame helpers
+// ---------------------------------------------------------------------------
+
+function audioDeltaFrame(bytes: string): string {
+  return JSON.stringify({
+    type: "audio.delta",
+    delta: Buffer.from(bytes).toString("base64"),
+  });
+}
+
+const AUDIO_DONE_FRAME = JSON.stringify({
+  type: "audio.done",
+  trace_id: "trace-1",
+});
+
+function errorFrame(message: string): string {
+  return JSON.stringify({ type: "error", message });
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe("synthesizeOverXaiTtsSocket", () => {
+  let mockWs: MockWebSocket;
+  let constructorCalls: {
+    url: string;
+    options?: { headers?: Record<string, string> };
+  }[];
+  let originalWebSocket: unknown;
+
+  beforeEach(() => {
+    mockWs = new MockWebSocket();
+    constructorCalls = [];
+    originalWebSocket = (globalThis as Record<string, unknown>).WebSocket;
+
+    const ws = mockWs;
+    (globalThis as Record<string, unknown>).WebSocket = class {
+      constructor(
+        url: string,
+        options?: { headers?: Record<string, string> },
+      ) {
+        constructorCalls.push({ url, options });
+        return ws;
+      }
+    };
+  });
+
+  afterEach(() => {
+    (globalThis as Record<string, unknown>).WebSocket = originalWebSocket;
+  });
+
+  function makeOptions(
+    overrides: Partial<XaiTtsSocketOptions> = {},
+  ): XaiTtsSocketOptions {
+    return {
+      url: TEST_URL,
+      apiKey: TEST_API_KEY,
+      text: "Hello world",
+      connectTimeoutMs: 1_000,
+      firstChunkTimeoutMs: 1_000,
+      idleTimeoutMs: 1_000,
+      makeTimeoutError: (timeoutMs) => new Error(`timed out after ${timeoutMs}ms`),
+      makeStreamError: (detail) => new Error(`stream failed: ${detail}`),
+      makeEmptyError: () => new Error("empty audio"),
+      ...overrides,
+    };
+  }
+
+  /** Frames sent by the session, parsed as JSON. */
+  function sentFrames(): { type?: string; delta?: string }[] {
+    return mockWs.sentData.map((d) => JSON.parse(d as string));
+  }
+
+  // ── Connect + text framing ─────────────────────────────────────────
+
+  test("passes the exact URL and Authorization header to the constructor", async () => {
+    const promise = synthesizeOverXaiTtsSocket(makeOptions());
+    mockWs.simulateOpen();
+    mockWs.simulateMessage(audioDeltaFrame("pcm"));
+    mockWs.simulateMessage(AUDIO_DONE_FRAME);
+    await promise;
+
+    expect(constructorCalls).toHaveLength(1);
+    expect(constructorCalls[0]!.url).toBe(TEST_URL);
+    expect(constructorCalls[0]!.options?.headers?.Authorization).toBe(
+      `Bearer ${TEST_API_KEY}`,
+    );
+  });
+
+  test("sends text.delta then text.done after open", async () => {
+    const promise = synthesizeOverXaiTtsSocket(makeOptions({ text: "Hi there" }));
+    mockWs.simulateOpen();
+
+    expect(sentFrames()).toEqual([
+      { type: "text.delta", delta: "Hi there" },
+      { type: "text.done" },
+    ]);
+
+    mockWs.simulateMessage(audioDeltaFrame("pcm"));
+    mockWs.simulateMessage(AUDIO_DONE_FRAME);
+    await promise;
+  });
+
+  test("splits >15,000-char text into multiple text.delta frames before one text.done", async () => {
+    const text = "a".repeat(15_000) + "b".repeat(500);
+    const promise = synthesizeOverXaiTtsSocket(makeOptions({ text }));
+    mockWs.simulateOpen();
+
+    const frames = sentFrames();
+    expect(frames).toHaveLength(3);
+    expect(frames[0]).toEqual({ type: "text.delta", delta: "a".repeat(15_000) });
+    expect(frames[1]).toEqual({ type: "text.delta", delta: "b".repeat(500) });
+    expect(frames[2]).toEqual({ type: "text.done" });
+
+    mockWs.simulateMessage(audioDeltaFrame("pcm"));
+    mockWs.simulateMessage(AUDIO_DONE_FRAME);
+    await promise;
+  });
+
+  // ── Audio streaming ────────────────────────────────────────────────
+
+  test("decodes audio.delta frames in order and resolves with the concatenation", async () => {
+    const received: Buffer[] = [];
+    const promise = synthesizeOverXaiTtsSocket(
+      makeOptions({ onChunk: (chunk) => received.push(Buffer.from(chunk)) }),
+    );
+    mockWs.simulateOpen();
+    mockWs.simulateMessage(audioDeltaFrame("chunk-1"));
+    mockWs.simulateMessage(audioDeltaFrame("chunk-2"));
+    mockWs.simulateMessage(AUDIO_DONE_FRAME);
+
+    const audio = await promise;
+    expect(received.map((c) => c.toString())).toEqual(["chunk-1", "chunk-2"]);
+    expect(audio.toString()).toBe("chunk-1chunk-2");
+    expect(mockWs.closeCalled).toBe(true);
+  });
+
+  test("skips zero-length audio deltas without invoking onChunk", async () => {
+    const received: Buffer[] = [];
+    const promise = synthesizeOverXaiTtsSocket(
+      makeOptions({ onChunk: (chunk) => received.push(Buffer.from(chunk)) }),
+    );
+    mockWs.simulateOpen();
+    mockWs.simulateMessage(JSON.stringify({ type: "audio.delta", delta: "" }));
+    mockWs.simulateMessage(audioDeltaFrame("real"));
+    mockWs.simulateMessage(AUDIO_DONE_FRAME);
+
+    const audio = await promise;
+    expect(received.map((c) => c.toString())).toEqual(["real"]);
+    expect(audio.toString()).toBe("real");
+  });
+
+  test("ignores unparseable frames and unknown frame types", async () => {
+    const promise = synthesizeOverXaiTtsSocket(makeOptions());
+    mockWs.simulateOpen();
+    mockWs.simulateMessage("not-json{");
+    mockWs.simulateMessage(JSON.stringify({ type: "something.else" }));
+    mockWs.simulateMessage(audioDeltaFrame("pcm"));
+    mockWs.simulateMessage(AUDIO_DONE_FRAME);
+
+    const audio = await promise;
+    expect(audio.toString()).toBe("pcm");
+  });
+
+  // ── Timeouts ───────────────────────────────────────────────────────
+
+  test("rejects via makeTimeoutError when the socket never opens", async () => {
+    const promise = synthesizeOverXaiTtsSocket(
+      makeOptions({ connectTimeoutMs: 20 }),
+    );
+    await expect(promise).rejects.toThrow("timed out after 20ms");
+    expect(mockWs.closeCalled).toBe(true);
+  });
+
+  test("rejects via makeTimeoutError when no server frame arrives after text.done", async () => {
+    const promise = synthesizeOverXaiTtsSocket(
+      makeOptions({ firstChunkTimeoutMs: 20 }),
+    );
+    mockWs.simulateOpen();
+    await expect(promise).rejects.toThrow("timed out after 20ms");
+    expect(mockWs.closeCalled).toBe(true);
+  });
+
+  test("rejects via makeTimeoutError when the stream goes idle mid-utterance", async () => {
+    const received: Buffer[] = [];
+    const promise = synthesizeOverXaiTtsSocket(
+      makeOptions({
+        idleTimeoutMs: 20,
+        onChunk: (chunk) => received.push(Buffer.from(chunk)),
+      }),
+    );
+    mockWs.simulateOpen();
+    mockWs.simulateMessage(audioDeltaFrame("only-chunk"));
+
+    await expect(promise).rejects.toThrow("timed out after 20ms");
+    expect(received.map((c) => c.toString())).toEqual(["only-chunk"]);
+    expect(mockWs.closeCalled).toBe(true);
+  });
+
+  // ── Protocol + transport errors ────────────────────────────────────
+
+  test("rejects via makeStreamError on an error frame", async () => {
+    const promise = synthesizeOverXaiTtsSocket(makeOptions());
+    mockWs.simulateOpen();
+    mockWs.simulateMessage(errorFrame("voice not found"));
+
+    await expect(promise).rejects.toThrow("stream failed: voice not found");
+    expect(mockWs.closeCalled).toBe(true);
+  });
+
+  test("rejects via makeStreamError on unexpected close before audio.done", async () => {
+    const promise = synthesizeOverXaiTtsSocket(makeOptions());
+    mockWs.simulateOpen();
+    mockWs.simulateClose(1006, "abnormal closure");
+
+    await expect(promise).rejects.toThrow(/1006/);
+  });
+
+  test("rejects via makeStreamError on a socket error event", async () => {
+    const promise = synthesizeOverXaiTtsSocket(makeOptions());
+    mockWs.simulateOpen();
+    mockWs.simulateError(new Error("connection reset"));
+
+    await expect(promise).rejects.toThrow("stream failed: connection reset");
+    expect(mockWs.closeCalled).toBe(true);
+  });
+
+  test("rejects via makeEmptyError when audio.done arrives with no audio bytes", async () => {
+    const promise = synthesizeOverXaiTtsSocket(makeOptions());
+    mockWs.simulateOpen();
+    mockWs.simulateMessage(AUDIO_DONE_FRAME);
+
+    await expect(promise).rejects.toThrow("empty audio");
+    expect(mockWs.closeCalled).toBe(true);
+  });
+
+  // ── Abort ──────────────────────────────────────────────────────────
+
+  test("abort mid-stream rejects with AbortError and closes the socket", async () => {
+    const controller = new AbortController();
+    const promise = synthesizeOverXaiTtsSocket(
+      makeOptions({ signal: controller.signal }),
+    );
+    mockWs.simulateOpen();
+    mockWs.simulateMessage(audioDeltaFrame("partial"));
+    controller.abort();
+
+    await expect(promise).rejects.toMatchObject({ name: "AbortError" });
+    expect(mockWs.closeCalled).toBe(true);
+  });
+
+  test("pre-aborted signal rejects immediately without constructing a socket", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const promise = synthesizeOverXaiTtsSocket(
+      makeOptions({ signal: controller.signal }),
+    );
+
+    await expect(promise).rejects.toMatchObject({ name: "AbortError" });
+    expect(constructorCalls).toHaveLength(0);
+  });
+
+  // ── Settle guard ───────────────────────────────────────────────────
+
+  test("error frame after audio.done does not double-settle", async () => {
+    const promise = synthesizeOverXaiTtsSocket(makeOptions());
+    mockWs.simulateOpen();
+    mockWs.simulateMessage(audioDeltaFrame("pcm"));
+    mockWs.simulateMessage(AUDIO_DONE_FRAME);
+    mockWs.simulateMessage(errorFrame("late error"));
+    mockWs.simulateClose(1000, "");
+
+    const audio = await promise;
+    expect(audio.toString()).toBe("pcm");
+  });
+});

--- a/assistant/src/tts/providers/xai-tts-socket.ts
+++ b/assistant/src/tts/providers/xai-tts-socket.ts
@@ -12,8 +12,8 @@
  * pattern), keeping this module free of provider imports.
  */
 
-import type { StreamReadTimeouts } from "../stream-read.js";
 import { getLogger } from "../../util/logger.js";
+import type { StreamReadTimeouts } from "../stream-read.js";
 
 const log = getLogger("xai-tts-socket");
 
@@ -153,7 +153,7 @@ export function synthesizeOverXaiTtsSocket(
     };
 
     const settle = (fn: () => void) => {
-      if (settled) return;
+      if (settled) {return;}
       settled = true;
       clearTimers();
       signal?.removeEventListener("abort", onAbort);
@@ -177,7 +177,7 @@ export function synthesizeOverXaiTtsSocket(
      * counts as activity (mirrors `readChunkedBody`).
      */
     const armStallTimer = () => {
-      if (stallTimer !== null) clearTimeout(stallTimer);
+      if (stallTimer !== null) {clearTimeout(stallTimer);}
       const timeoutMs = receivedAnyFrame ? idleTimeoutMs : firstChunkTimeoutMs;
       stallTimer = setTimeout(() => {
         fail(makeTimeoutError(timeoutMs));
@@ -191,7 +191,7 @@ export function synthesizeOverXaiTtsSocket(
     signal?.addEventListener("abort", onAbort, { once: true });
 
     ws.addEventListener("open", () => {
-      if (settled) return;
+      if (settled) {return;}
       if (connectTimer !== null) {
         clearTimeout(connectTimer);
         connectTimer = null;
@@ -219,12 +219,12 @@ export function synthesizeOverXaiTtsSocket(
     });
 
     ws.addEventListener("message", (ev) => {
-      if (settled) return;
+      if (settled) {return;}
 
       receivedAnyFrame = true;
       armStallTimer();
 
-      if (typeof ev.data !== "string") return;
+      if (typeof ev.data !== "string") {return;}
 
       let frame: XaiTtsFrame;
       try {
@@ -233,13 +233,13 @@ export function synthesizeOverXaiTtsSocket(
         log.debug("Dropped non-JSON xAI TTS frame");
         return;
       }
-      if (!frame || typeof frame !== "object") return;
+      if (!frame || typeof frame !== "object") {return;}
 
       switch (frame.type) {
         case "audio.delta": {
-          if (typeof frame.delta !== "string") return;
+          if (typeof frame.delta !== "string") {return;}
           const chunk = Buffer.from(frame.delta, "base64");
-          if (chunk.byteLength === 0) return;
+          if (chunk.byteLength === 0) {return;}
           chunks.push(chunk);
           onChunk?.(chunk);
           return;

--- a/assistant/src/tts/providers/xai-tts-socket.ts
+++ b/assistant/src/tts/providers/xai-tts-socket.ts
@@ -1,0 +1,295 @@
+/**
+ * xAI TTS WebSocket streaming session.
+ *
+ * Runs a single-utterance synthesis session against xAI's streaming TTS
+ * endpoint (`wss://api.x.ai/v1/tts`): sends the utterance as `text.delta`
+ * frames followed by `text.done`, forwards decoded base64 `audio.delta`
+ * chunks as they arrive, and resolves with the concatenated audio on
+ * `audio.done`. The protocol keeps the socket open for multi-turn use;
+ * this session closes it after the one utterance.
+ *
+ * Error codes/wording are caller-owned via error factories (stream-read
+ * pattern), keeping this module free of provider imports.
+ */
+
+import type { StreamReadTimeouts } from "../stream-read.js";
+import { getLogger } from "../../util/logger.js";
+
+const log = getLogger("xai-tts-socket");
+
+/** Default timeout (ms) for the WebSocket connection handshake. */
+const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
+
+/** Stall-timeout defaults (ms), matching `stream-read.ts`. */
+const DEFAULT_FIRST_CHUNK_TIMEOUT_MS = 10_000;
+const DEFAULT_IDLE_TIMEOUT_MS = 5_000;
+
+/** Maximum characters per `text.delta` frame, per xAI docs. */
+const MAX_TEXT_DELTA_CHARS = 15_000;
+
+/**
+ * Minimal structural WebSocket interface so tests can substitute a mock.
+ * Intentionally duplicated from the STT adapter (`xai-realtime.ts`) to
+ * keep tts/ free of a cross-subsystem dependency.
+ */
+interface WsLike {
+  readonly readyState: number;
+  send(data: string | ArrayBufferLike | ArrayBuffer | Uint8Array): void;
+  close(code?: number, reason?: string): void;
+  addEventListener(type: "open", listener: () => void): void;
+  addEventListener(
+    type: "close",
+    listener: (ev: { code: number; reason: string }) => void,
+  ): void;
+  addEventListener(type: "error", listener: (ev: unknown) => void): void;
+  addEventListener(
+    type: "message",
+    listener: (ev: { data: unknown }) => void,
+  ): void;
+}
+
+/** Server frames: `audio.delta` (base64), `audio.done`, `error`. */
+interface XaiTtsFrame {
+  type?: string;
+  delta?: string;
+  message?: string;
+}
+
+/**
+ * Create a WebSocket authenticated via the `Authorization: Bearer` header.
+ * Bun's WebSocket constructor supports a second `options` argument with
+ * custom headers, unlike the browser WebSocket API.
+ */
+function createWebSocket(url: string, apiKey: string): WsLike {
+  const WebSocketCtor = (
+    globalThis as unknown as {
+      WebSocket: new (
+        url: string,
+        options?: { headers?: Record<string, string> },
+      ) => WsLike;
+    }
+  ).WebSocket;
+  if (typeof WebSocketCtor !== "function") {
+    throw new Error("global WebSocket is not available in this runtime");
+  }
+  return new WebSocketCtor(url, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  });
+}
+
+export interface XaiTtsSocketOptions extends StreamReadTimeouts {
+  /** Full wss:// URL including query params (language, voice, codec, sample_rate…). */
+  url: string;
+  apiKey: string;
+  /** Full utterance text; split into ≤15,000-char text.delta frames. */
+  text: string;
+  onChunk?: (chunk: Uint8Array) => void;
+  signal?: AbortSignal;
+  connectTimeoutMs?: number;
+  /** Error factories keep provider-owned codes/wording (stream-read pattern). */
+  makeTimeoutError: (timeoutMs: number) => Error;
+  makeStreamError: (detail: string) => Error;
+  makeEmptyError: () => Error;
+}
+
+/**
+ * Synthesize one utterance over an xAI TTS WebSocket, resolving with the
+ * complete audio. Chunks are forwarded to `onChunk` as they arrive.
+ */
+export function synthesizeOverXaiTtsSocket(
+  options: XaiTtsSocketOptions,
+): Promise<Buffer> {
+  return new Promise<Buffer>((resolve, reject) => {
+    const { signal, onChunk, makeTimeoutError, makeStreamError, makeEmptyError } =
+      options;
+    const connectTimeoutMs =
+      options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
+    const firstChunkTimeoutMs =
+      options.firstChunkTimeoutMs ?? DEFAULT_FIRST_CHUNK_TIMEOUT_MS;
+    const idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
+
+    const abortReason = () =>
+      signal?.reason ??
+      new DOMException("This operation was aborted", "AbortError");
+
+    if (signal?.aborted) {
+      reject(abortReason());
+      return;
+    }
+
+    let ws: WsLike;
+    try {
+      ws = createWebSocket(options.url, options.apiKey);
+    } catch (err) {
+      reject(err);
+      return;
+    }
+
+    let settled = false;
+    const chunks: Buffer[] = [];
+    let receivedAnyFrame = false;
+    let connectTimer: ReturnType<typeof setTimeout> | null = null;
+    let stallTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const clearTimers = () => {
+      if (connectTimer !== null) {
+        clearTimeout(connectTimer);
+        connectTimer = null;
+      }
+      if (stallTimer !== null) {
+        clearTimeout(stallTimer);
+        stallTimer = null;
+      }
+    };
+
+    const closeSocket = () => {
+      try {
+        ws.close();
+      } catch {
+        // Best effort — already-closed sockets may throw.
+      }
+    };
+
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimers();
+      signal?.removeEventListener("abort", onAbort);
+      fn();
+    };
+
+    const fail = (err: unknown) => {
+      settle(() => {
+        closeSocket();
+        reject(err);
+      });
+    };
+
+    const onAbort = () => {
+      fail(abortReason());
+    };
+
+    /**
+     * (Re)arm the stall timer: first-chunk budget until any server frame
+     * arrives, idle budget between frames thereafter. Any server frame
+     * counts as activity (mirrors `readChunkedBody`).
+     */
+    const armStallTimer = () => {
+      if (stallTimer !== null) clearTimeout(stallTimer);
+      const timeoutMs = receivedAnyFrame ? idleTimeoutMs : firstChunkTimeoutMs;
+      stallTimer = setTimeout(() => {
+        fail(makeTimeoutError(timeoutMs));
+      }, timeoutMs);
+    };
+
+    connectTimer = setTimeout(() => {
+      fail(makeTimeoutError(connectTimeoutMs));
+    }, connectTimeoutMs);
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+
+    ws.addEventListener("open", () => {
+      if (settled) return;
+      if (connectTimer !== null) {
+        clearTimeout(connectTimer);
+        connectTimer = null;
+      }
+      try {
+        const text = options.text;
+        for (let offset = 0; offset < text.length; offset += MAX_TEXT_DELTA_CHARS) {
+          ws.send(
+            JSON.stringify({
+              type: "text.delta",
+              delta: text.slice(offset, offset + MAX_TEXT_DELTA_CHARS),
+            }),
+          );
+        }
+        ws.send(JSON.stringify({ type: "text.done" }));
+      } catch (err) {
+        fail(
+          makeStreamError(
+            `failed to send text frames: ${err instanceof Error ? err.message : String(err)}`,
+          ),
+        );
+        return;
+      }
+      armStallTimer();
+    });
+
+    ws.addEventListener("message", (ev) => {
+      if (settled) return;
+
+      receivedAnyFrame = true;
+      armStallTimer();
+
+      if (typeof ev.data !== "string") return;
+
+      let frame: XaiTtsFrame;
+      try {
+        frame = JSON.parse(ev.data) as XaiTtsFrame;
+      } catch {
+        log.debug("Dropped non-JSON xAI TTS frame");
+        return;
+      }
+      if (!frame || typeof frame !== "object") return;
+
+      switch (frame.type) {
+        case "audio.delta": {
+          if (typeof frame.delta !== "string") return;
+          const chunk = Buffer.from(frame.delta, "base64");
+          if (chunk.byteLength === 0) return;
+          chunks.push(chunk);
+          onChunk?.(chunk);
+          return;
+        }
+
+        case "audio.done":
+          settle(() => {
+            closeSocket();
+            if (chunks.length === 0) {
+              reject(makeEmptyError());
+              return;
+            }
+            resolve(Buffer.concat(chunks));
+          });
+          return;
+
+        case "error":
+          // One-shot session: fatal even though the protocol leaves the
+          // socket open after an error frame.
+          fail(
+            makeStreamError(
+              typeof frame.message === "string"
+                ? frame.message
+                : "xAI error frame",
+            ),
+          );
+          return;
+
+        default:
+          // Unknown frame types are informational — ignored.
+          return;
+      }
+    });
+
+    ws.addEventListener("close", (ev) => {
+      fail(
+        makeStreamError(
+          `socket closed before audio.done (code=${ev.code}, reason=${ev.reason})`,
+        ),
+      );
+    });
+
+    ws.addEventListener("error", (ev) => {
+      const message =
+        ev instanceof Error
+          ? ev.message
+          : typeof ev === "object" && ev !== null && "message" in ev
+            ? String((ev as { message: unknown }).message)
+            : "WebSocket error";
+      fail(makeStreamError(message));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- New self-contained one-utterance WS session for xAI TTS (wss://api.x.ai/v1/tts): text.delta/text.done out, base64 audio.delta in, audio.done resolve
- Connect + first-chunk + idle stall timeouts, abort→close, error factories (stream-read pattern, no provider import cycle)
- MockWebSocket test harness mirrors the existing xai-realtime STT client tests

Part of plan: xai-ws-streaming-tts.md (PR 3 of 4)