### PR TITLE
feat(tts): xAI chunk-streaming synthesis via WebSocket (true streaming PCM provider)

### DIFF
--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -1519,12 +1519,17 @@ describe("xAI TTS provider adapter", () => {
     expect(provider.id).toBe("xai");
   });
 
-  test("advertises mp3 and wav format support without streaming", () => {
+  test("advertises mp3, wav, and pcm format support with streaming", () => {
     const provider = createXaiProvider();
     expect(provider.capabilities).toEqual({
-      supportsStreaming: false,
-      supportedFormats: ["mp3", "wav"],
+      supportsStreaming: true,
+      supportedFormats: ["mp3", "wav", "pcm"],
     });
+  });
+
+  test("implements synthesizeStream", () => {
+    const provider = createXaiProvider();
+    expect(typeof provider.synthesizeStream).toBe("function");
   });
 
   // -- Request mapping -----------------------------------------------------
@@ -1774,6 +1779,246 @@ describe("xAI TTS provider adapter", () => {
       expect(err).toBeInstanceOf(XaiTtsError);
       expect((err as XaiTtsError).code).toBe("XAI_TTS_EMPTY_RESPONSE");
     }
+  });
+
+  // -- Streaming (WebSocket) -------------------------------------------------
+
+  describe("synthesizeStream", () => {
+    type WsEventType = "open" | "close" | "error" | "message";
+    type WsListener = (...args: unknown[]) => void;
+
+    /** Minimal mock WebSocket simulating the xAI TTS streaming endpoint. */
+    class MockWebSocket {
+      readyState = 0; // CONNECTING
+      closeCalled = false;
+      private listeners = new Map<WsEventType, WsListener[]>();
+
+      addEventListener(type: WsEventType, listener: WsListener): void {
+        const list = this.listeners.get(type) ?? [];
+        list.push(listener);
+        this.listeners.set(type, list);
+      }
+
+      send(): void {
+        if (this.readyState !== 1) {
+          throw new Error("WebSocket is not open");
+        }
+      }
+
+      close(): void {
+        this.closeCalled = true;
+        this.readyState = 3; // CLOSED
+      }
+
+      simulateOpen(): void {
+        this.readyState = 1; // OPEN
+        for (const l of this.listeners.get("open") ?? []) l();
+      }
+
+      simulateMessage(data: unknown): void {
+        for (const l of this.listeners.get("message") ?? []) l({ data });
+      }
+    }
+
+    let mockWs: MockWebSocket;
+    let constructorCalls: {
+      url: string;
+      options?: { headers?: Record<string, string> };
+    }[];
+    let originalWebSocket: unknown;
+
+    beforeEach(() => {
+      mockWs = new MockWebSocket();
+      constructorCalls = [];
+      originalWebSocket = (globalThis as Record<string, unknown>).WebSocket;
+
+      const ws = mockWs;
+      (globalThis as Record<string, unknown>).WebSocket = class {
+        constructor(
+          url: string,
+          options?: { headers?: Record<string, string> },
+        ) {
+          constructorCalls.push({ url, options });
+          return ws;
+        }
+      };
+    });
+
+    afterEach(() => {
+      (globalThis as Record<string, unknown>).WebSocket = originalWebSocket;
+    });
+
+    /** Wait for the async key/config resolution to construct the socket. */
+    async function untilSocketConstructed(): Promise<void> {
+      for (let i = 0; i < 50 && constructorCalls.length === 0; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      expect(constructorCalls).toHaveLength(1);
+    }
+
+    function audioDeltaFrame(bytes: string): string {
+      return JSON.stringify({
+        type: "audio.delta",
+        delta: Buffer.from(bytes).toString("base64"),
+      });
+    }
+
+    const AUDIO_DONE_FRAME = JSON.stringify({ type: "audio.done" });
+
+    test("connects with the REST-mirrored pcm output format and Bearer auth", async () => {
+      const provider = createXaiProvider();
+      const promise = provider.synthesizeStream!(
+        makeRequest({ outputFormat: "pcm" }),
+        () => {},
+      );
+      await untilSocketConstructed();
+
+      const { url, options } = constructorCalls[0]!;
+      expect(url).toContain("wss://api.x.ai/v1/tts");
+      expect(url).toContain("language=auto");
+      expect(url).toContain("voice=eve");
+      expect(url).toContain("codec=pcm");
+      expect(url).toContain("sample_rate=16000");
+      expect(url).not.toContain("bit_rate=");
+      expect(options?.headers?.Authorization).toBe("Bearer test-xai-api-key");
+
+      mockWs.simulateOpen();
+      mockWs.simulateMessage(audioDeltaFrame("pcm"));
+      mockWs.simulateMessage(AUDIO_DONE_FRAME);
+      await promise;
+    });
+
+    test("pcm sampleRateHz hint is carried in the stream URL", async () => {
+      const provider = createXaiProvider();
+      const promise = provider.synthesizeStream!(
+        makeRequest({ outputFormat: "pcm", sampleRateHz: 22_050 }),
+        () => {},
+      );
+      await untilSocketConstructed();
+
+      expect(constructorCalls[0]!.url).toContain("sample_rate=22050");
+
+      mockWs.simulateOpen();
+      mockWs.simulateMessage(audioDeltaFrame("pcm"));
+      mockWs.simulateMessage(AUDIO_DONE_FRAME);
+      await promise;
+    });
+
+    test("mp3 requests carry codec=mp3 and bit_rate and resolve audio/mpeg", async () => {
+      const provider = createXaiProvider();
+      const promise = provider.synthesizeStream!(makeRequest(), () => {});
+      await untilSocketConstructed();
+
+      const { url } = constructorCalls[0]!;
+      expect(url).toContain("codec=mp3");
+      expect(url).toContain("sample_rate=24000");
+      expect(url).toContain("bit_rate=128000");
+
+      mockWs.simulateOpen();
+      mockWs.simulateMessage(audioDeltaFrame("mp3"));
+      mockWs.simulateMessage(AUDIO_DONE_FRAME);
+
+      const result = await promise;
+      expect(result.contentType).toBe("audio/mpeg");
+    });
+
+    test("forwards decoded chunks in order and resolves with the concatenation", async () => {
+      const received: Buffer[] = [];
+      const provider = createXaiProvider();
+      const promise = provider.synthesizeStream!(
+        makeRequest({ outputFormat: "pcm" }),
+        (chunk) => received.push(Buffer.from(chunk)),
+      );
+      await untilSocketConstructed();
+
+      mockWs.simulateOpen();
+      mockWs.simulateMessage(audioDeltaFrame("chunk-1"));
+      mockWs.simulateMessage(audioDeltaFrame("chunk-2"));
+      mockWs.simulateMessage(AUDIO_DONE_FRAME);
+
+      const result = await promise;
+      expect(received.map((c) => c.toString())).toEqual([
+        "chunk-1",
+        "chunk-2",
+      ]);
+      expect(result.audio.toString()).toBe("chunk-1chunk-2");
+      expect(result.contentType).toBe("audio/pcm");
+    });
+
+    test("throws XAI_TTS_NO_API_KEY without constructing a socket", async () => {
+      mockXaiApiKey = null;
+
+      const provider = createXaiProvider();
+
+      try {
+        await provider.synthesizeStream!(makeRequest(), () => {});
+        throw new Error("Expected synthesizeStream to throw");
+      } catch (err) {
+        expect(err).toBeInstanceOf(XaiTtsError);
+        expect((err as XaiTtsError).code).toBe("XAI_TTS_NO_API_KEY");
+      }
+      expect(constructorCalls).toHaveLength(0);
+    });
+
+    test("throws XAI_TTS_STREAM_TIMEOUT when the stream stalls", async () => {
+      const provider = createXaiProvider({
+        connectTimeoutMs: 20,
+        firstChunkTimeoutMs: 20,
+        idleTimeoutMs: 20,
+      });
+      const promise = provider.synthesizeStream!(
+        makeRequest({ outputFormat: "pcm" }),
+        () => {},
+      );
+      await untilSocketConstructed();
+      mockWs.simulateOpen();
+
+      try {
+        await promise;
+        throw new Error("Expected synthesizeStream to throw");
+      } catch (err) {
+        expect(err).toBeInstanceOf(XaiTtsError);
+        expect((err as XaiTtsError).code).toBe("XAI_TTS_STREAM_TIMEOUT");
+        expect((err as XaiTtsError).message).toContain("20ms");
+      }
+    });
+
+    test("throws XAI_TTS_STREAM_FAILED on an error frame", async () => {
+      const provider = createXaiProvider();
+      const promise = provider.synthesizeStream!(
+        makeRequest({ outputFormat: "pcm" }),
+        () => {},
+      );
+      await untilSocketConstructed();
+      mockWs.simulateOpen();
+      mockWs.simulateMessage(
+        JSON.stringify({ type: "error", message: "voice not found" }),
+      );
+
+      try {
+        await promise;
+        throw new Error("Expected synthesizeStream to throw");
+      } catch (err) {
+        expect(err).toBeInstanceOf(XaiTtsError);
+        expect((err as XaiTtsError).code).toBe("XAI_TTS_STREAM_FAILED");
+        expect((err as XaiTtsError).message).toContain("voice not found");
+      }
+    });
+
+    test("abort rejects with AbortError", async () => {
+      const controller = new AbortController();
+      const provider = createXaiProvider();
+      const promise = provider.synthesizeStream!(
+        makeRequest({ outputFormat: "pcm", signal: controller.signal }),
+        () => {},
+      );
+      await untilSocketConstructed();
+      mockWs.simulateOpen();
+      controller.abort();
+
+      await expect(promise).rejects.toMatchObject({ name: "AbortError" });
+      expect(mockWs.closeCalled).toBe(true);
+    });
   });
 });
 

--- a/assistant/src/tts/__tests__/provider-catalog.test.ts
+++ b/assistant/src/tts/__tests__/provider-catalog.test.ts
@@ -205,3 +205,33 @@ describe("Deepgram catalog entry", () => {
     expect(apiKeySecret!.setCommand).toContain("assistant keys set deepgram");
   });
 });
+
+describe("xAI catalog entry", () => {
+  const entry = getCatalogProvider("xai");
+
+  test("uses synthesized-play call mode", () => {
+    expect(entry.callMode).toBe("synthesized-play");
+  });
+
+  test("supports streaming", () => {
+    expect(entry.capabilities.supportsStreaming).toBe(true);
+  });
+
+  test("supports mp3, wav, and pcm formats", () => {
+    expect(entry.capabilities.supportedFormats).toContain("mp3");
+    expect(entry.capabilities.supportedFormats).toContain("wav");
+    expect(entry.capabilities.supportedFormats).toContain("pcm");
+  });
+
+  test("plays over media-stream via PCM output", () => {
+    expect(entry.mediaStreamPlayback.outputFormat).toBe("pcm");
+  });
+
+  test("requires an API key stored under 'credential/xai/api_key'", () => {
+    const apiKeySecret = entry.secretRequirements.find(
+      (s) => s.credentialStoreKey === "credential/xai/api_key",
+    );
+    expect(apiKeySecret).toBeDefined();
+    expect(apiKeySecret!.displayName).toContain("xAI");
+  });
+});

--- a/assistant/src/tts/providers/xai-provider.ts
+++ b/assistant/src/tts/providers/xai-provider.ts
@@ -1,9 +1,11 @@
 /**
  * xAI TTS provider adapter.
  *
- * Wraps the xAI REST text-to-speech API (`/v1/tts`) behind the uniform
- * {@link TtsProvider} interface. Reads the API key from the secure credential
- * store under `credential/xai/api_key` and the model configuration from the
+ * Wraps the xAI text-to-speech API behind the uniform {@link TtsProvider}
+ * interface: the REST endpoint (`/v1/tts`) for batch synthesis and the
+ * WebSocket endpoint (`wss://api.x.ai/v1/tts`) for chunk streaming. Reads
+ * the API key from the secure credential store under
+ * `credential/xai/api_key` and the model configuration from the
  * `services.tts.providers.xai` config section.
  */
 
@@ -14,12 +16,14 @@ import { getSecureKeyAsync } from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
 import { resolvePcmOutputSampleRateHz } from "../pcm-sample-rates.js";
 import type { TtsProviderDefinition } from "../provider-definition.js";
+import type { StreamReadTimeouts } from "../stream-read.js";
 import type {
   TtsProvider,
   TtsProviderCapabilities,
   TtsSynthesisRequest,
   TtsSynthesisResult,
 } from "../types.js";
+import { synthesizeOverXaiTtsSocket } from "./xai-tts-socket.js";
 
 const log = getLogger("tts:xai");
 
@@ -31,7 +35,9 @@ export type XaiTtsErrorCode =
   | "XAI_TTS_NO_API_KEY"
   | "XAI_TTS_HTTP_ERROR"
   | "XAI_TTS_EMPTY_RESPONSE"
-  | "XAI_TTS_REQUEST_FAILED";
+  | "XAI_TTS_REQUEST_FAILED"
+  | "XAI_TTS_STREAM_TIMEOUT"
+  | "XAI_TTS_STREAM_FAILED";
 
 export class XaiTtsError extends Error {
   readonly code: XaiTtsErrorCode;
@@ -50,6 +56,8 @@ export class XaiTtsError extends Error {
 // ---------------------------------------------------------------------------
 
 const XAI_API_BASE = "https://api.x.ai";
+
+const XAI_WS_BASE = "wss://api.x.ai/v1/tts";
 
 /**
  * Sample rates xAI TTS accepts (both REST and WS). Per
@@ -141,10 +149,47 @@ function resolveVoiceId(
   return request.voiceId?.trim() || config.voiceId || "eve";
 }
 
-export function createXaiProvider(): TtsProvider {
+/** Resolve the xAI API key, throwing `XAI_TTS_NO_API_KEY` when unset. */
+async function requireApiKey(): Promise<string> {
+  const apiKey = await getSecureKeyAsync(credentialKey("xai", "api_key"));
+  if (!apiKey) {
+    throw new XaiTtsError(
+      "XAI_TTS_NO_API_KEY",
+      "xAI API key not configured. " +
+        "Add it via: assistant credentials set --service xai --field api_key <key>",
+    );
+  }
+  return apiKey;
+}
+
+/**
+ * Build the WebSocket synthesis URL. Mirrors the REST `output_format`
+ * payload (via {@link resolveOutputParams}) so both transports request
+ * identical audio.
+ */
+function buildStreamUrl(
+  request: TtsSynthesisRequest,
+  config: TtsXaiProviderConfig,
+  outputParams: XaiOutputParams,
+): string {
+  const params = new URLSearchParams({
+    language: config.language,
+    voice: resolveVoiceId(request, config),
+    codec: outputParams.codec,
+    sample_rate: String(outputParams.sample_rate),
+  });
+  if (outputParams.bit_rate != null) {
+    params.set("bit_rate", String(outputParams.bit_rate));
+  }
+  return `${XAI_WS_BASE}?${params.toString()}`;
+}
+
+export function createXaiProvider(
+  streamTimeouts: StreamReadTimeouts & { connectTimeoutMs?: number } = {},
+): TtsProvider {
   const capabilities: TtsProviderCapabilities = {
-    supportsStreaming: false,
-    supportedFormats: ["mp3", "wav"],
+    supportsStreaming: true,
+    supportedFormats: ["mp3", "wav", "pcm"],
   };
 
   return {
@@ -155,14 +200,7 @@ export function createXaiProvider(): TtsProvider {
     async synthesize(
       request: TtsSynthesisRequest,
     ): Promise<TtsSynthesisResult> {
-      const apiKey = await getSecureKeyAsync(credentialKey("xai", "api_key"));
-      if (!apiKey) {
-        throw new XaiTtsError(
-          "XAI_TTS_NO_API_KEY",
-          "xAI API key not configured. " +
-            "Add it via: assistant credentials set --service xai --field api_key <key>",
-        );
-      }
+      const apiKey = await requireApiKey();
 
       const config = getConfig().services.tts.providers.xai;
       const output = resolveOutputParams(request, config);
@@ -238,6 +276,60 @@ export function createXaiProvider(): TtsProvider {
         contentType,
       };
     },
+
+    async synthesizeStream(
+      request: TtsSynthesisRequest,
+      onChunk: (chunk: Uint8Array) => void,
+    ): Promise<TtsSynthesisResult> {
+      const apiKey = await requireApiKey();
+
+      const config = getConfig().services.tts.providers.xai;
+      const output = resolveOutputParams(request, config);
+      const url = buildStreamUrl(request, config, output);
+
+      log.info(
+        {
+          codec: output.codec,
+          sampleRate: output.sample_rate,
+          textLength: request.text.length,
+        },
+        "Starting xAI streaming TTS synthesis",
+      );
+
+      const audio = await synthesizeOverXaiTtsSocket({
+        url,
+        apiKey,
+        text: request.text,
+        onChunk,
+        signal: request.signal,
+        ...streamTimeouts,
+        makeTimeoutError: (timeoutMs) =>
+          new XaiTtsError(
+            "XAI_TTS_STREAM_TIMEOUT",
+            `xAI streaming TTS timed out after ${timeoutMs}ms`,
+          ),
+        makeStreamError: (detail) =>
+          new XaiTtsError(
+            "XAI_TTS_STREAM_FAILED",
+            `xAI streaming TTS failed: ${detail}`,
+          ),
+        makeEmptyError: () =>
+          new XaiTtsError(
+            "XAI_TTS_EMPTY_RESPONSE",
+            "xAI streaming TTS returned no audio",
+          ),
+      });
+
+      log.debug(
+        { bytes: audio.byteLength },
+        "xAI streaming TTS synthesis complete",
+      );
+
+      return {
+        audio,
+        contentType: FORMAT_CONTENT_TYPE[output.contentTypeKey] ?? "audio/mpeg",
+      };
+    },
   };
 }
 
@@ -265,8 +357,8 @@ export const xaiTtsProviderDefinition: TtsProviderDefinition = {
   callMode: "synthesized-play",
   allowNativeFallback: false,
   capabilities: {
-    supportsStreaming: false,
-    supportedFormats: ["mp3", "wav"],
+    supportsStreaming: true,
+    supportedFormats: ["mp3", "wav", "pcm"],
   },
   // The adapter honours the PCM hint via the `pcm` codec.
   mediaStreamPlayback: { outputFormat: "pcm" },


### PR DESCRIPTION
## Summary
- xAI `synthesizeStream` over wss://api.x.ai/v1/tts via the session module; REST stays for batch synthesis
- New `XAI_TTS_STREAM_TIMEOUT`/`XAI_TTS_STREAM_FAILED` codes; injectable connect/first-chunk/idle timeouts
- `supportsStreaming` flipped on adapter + catalog definition; `pcm` added to supportedFormats — all four TTS providers now stream

Part of plan: xai-ws-streaming-tts.md (PR 4 of 4)