### PR TITLE
fix(tts): harden xAI WS session module

### DIFF
--- a/assistant/src/tts/providers/__tests__/xai-tts-socket.test.ts
+++ b/assistant/src/tts/providers/__tests__/xai-tts-socket.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import { stripOrphanedSurrogates } from "../../../util/unicode.js";
 import type { XaiTtsSocketOptions } from "../xai-tts-socket.js";
 import { synthesizeOverXaiTtsSocket } from "../xai-tts-socket.js";
 
@@ -189,6 +190,28 @@ describe("synthesizeOverXaiTtsSocket", () => {
     await promise;
   });
 
+  test("never splits a surrogate pair across text.delta frames", async () => {
+    // Emoji (2 UTF-16 code units) straddles the 15,000-char boundary.
+    const text = "a".repeat(14_999) + "😀" + "b".repeat(500);
+    const promise = synthesizeOverXaiTtsSocket(makeOptions({ text }));
+    mockWs.simulateOpen();
+
+    const deltas = sentFrames()
+      .filter((f) => f.type === "text.delta")
+      .map((f) => f.delta!);
+    for (const delta of deltas) {
+      const last = delta.charCodeAt(delta.length - 1);
+      expect(last >= 0xd800 && last <= 0xdbff).toBe(false);
+      // Well-formed: sanitizing orphaned surrogates must be a no-op.
+      expect(stripOrphanedSurrogates(delta)).toBe(delta);
+    }
+    expect(deltas.join("")).toBe(text);
+
+    mockWs.simulateMessage(audioDeltaFrame("pcm"));
+    mockWs.simulateMessage(AUDIO_DONE_FRAME);
+    await promise;
+  });
+
   // ── Audio streaming ────────────────────────────────────────────────
 
   test("decodes audio.delta frames in order and resolves with the concatenation", async () => {
@@ -214,12 +237,47 @@ describe("synthesizeOverXaiTtsSocket", () => {
     );
     mockWs.simulateOpen();
     mockWs.simulateMessage(JSON.stringify({ type: "audio.delta", delta: "" }));
+    // Whitespace-only base64 decodes to zero bytes and must also be skipped.
+    mockWs.simulateMessage(JSON.stringify({ type: "audio.delta", delta: " " }));
     mockWs.simulateMessage(audioDeltaFrame("real"));
     mockWs.simulateMessage(AUDIO_DONE_FRAME);
 
     const audio = await promise;
     expect(received.map((c) => c.toString())).toEqual(["real"]);
     expect(audio.toString()).toBe("real");
+  });
+
+  test("decodes an audio.delta frame delivered as a binary ArrayBuffer", async () => {
+    const received: Buffer[] = [];
+    const promise = synthesizeOverXaiTtsSocket(
+      makeOptions({ onChunk: (chunk) => received.push(Buffer.from(chunk)) }),
+    );
+    mockWs.simulateOpen();
+    const encoded = new TextEncoder().encode(audioDeltaFrame("binary-chunk"));
+    mockWs.simulateMessage(
+      encoded.buffer.slice(encoded.byteOffset, encoded.byteOffset + encoded.byteLength),
+    );
+    mockWs.simulateMessage(AUDIO_DONE_FRAME);
+
+    const audio = await promise;
+    expect(received.map((c) => c.toString())).toEqual(["binary-chunk"]);
+    expect(audio.toString()).toBe("binary-chunk");
+  });
+
+  test("a throwing onChunk rejects the promise with that error and closes the socket", async () => {
+    const sinkError = new Error("sink exploded");
+    const promise = synthesizeOverXaiTtsSocket(
+      makeOptions({
+        onChunk: () => {
+          throw sinkError;
+        },
+      }),
+    );
+    mockWs.simulateOpen();
+    mockWs.simulateMessage(audioDeltaFrame("pcm"));
+
+    await expect(promise).rejects.toBe(sinkError);
+    expect(mockWs.closeCalled).toBe(true);
   });
 
   test("ignores unparseable frames and unknown frame types", async () => {

--- a/assistant/src/tts/providers/xai-tts-socket.ts
+++ b/assistant/src/tts/providers/xai-tts-socket.ts
@@ -13,29 +13,29 @@
  */
 
 import { getLogger } from "../../util/logger.js";
+import { isHighSurrogate } from "../../util/unicode.js";
 import type { StreamReadTimeouts } from "../stream-read.js";
+import {
+  DEFAULT_FIRST_CHUNK_TIMEOUT_MS,
+  DEFAULT_IDLE_TIMEOUT_MS,
+} from "../stream-read.js";
 
 const log = getLogger("xai-tts-socket");
 
 /** Default timeout (ms) for the WebSocket connection handshake. */
 const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
 
-/** Stall-timeout defaults (ms), matching `stream-read.ts`. */
-const DEFAULT_FIRST_CHUNK_TIMEOUT_MS = 10_000;
-const DEFAULT_IDLE_TIMEOUT_MS = 5_000;
-
 /** Maximum characters per `text.delta` frame, per xAI docs. */
 const MAX_TEXT_DELTA_CHARS = 15_000;
 
 /**
  * Minimal structural WebSocket interface so tests can substitute a mock.
- * Intentionally duplicated from the STT adapter (`xai-realtime.ts`) to
- * keep tts/ free of a cross-subsystem dependency.
+ * Trimmed to the surface this module actually uses; kept local so tts/
+ * stays free of a cross-subsystem dependency on the STT adapter.
  */
 interface WsLike {
-  readonly readyState: number;
-  send(data: string | ArrayBufferLike | ArrayBuffer | Uint8Array): void;
-  close(code?: number, reason?: string): void;
+  send(data: string): void;
+  close(): void;
   addEventListener(type: "open", listener: () => void): void;
   addEventListener(
     type: "close",
@@ -198,13 +198,17 @@ export function synthesizeOverXaiTtsSocket(
       }
       try {
         const text = options.text;
-        for (let offset = 0; offset < text.length; offset += MAX_TEXT_DELTA_CHARS) {
+        let offset = 0;
+        while (offset < text.length) {
+          let end = Math.min(offset + MAX_TEXT_DELTA_CHARS, text.length);
+          // Never split a surrogate pair across delta frames.
+          if (end < text.length && isHighSurrogate(text.charCodeAt(end - 1))) {
+            end -= 1;
+          }
           ws.send(
-            JSON.stringify({
-              type: "text.delta",
-              delta: text.slice(offset, offset + MAX_TEXT_DELTA_CHARS),
-            }),
+            JSON.stringify({ type: "text.delta", delta: text.slice(offset, end) }),
           );
+          offset = end;
         }
         ws.send(JSON.stringify({ type: "text.done" }));
       } catch (err) {
@@ -224,11 +228,18 @@ export function synthesizeOverXaiTtsSocket(
       receivedAnyFrame = true;
       armStallTimer();
 
-      if (typeof ev.data !== "string") {return;}
+      let raw: string;
+      if (typeof ev.data === "string") {
+        raw = ev.data;
+      } else if (ev.data instanceof ArrayBuffer || ArrayBuffer.isView(ev.data)) {
+        raw = new TextDecoder().decode(ev.data);
+      } else {
+        return;
+      }
 
       let frame: XaiTtsFrame;
       try {
-        frame = JSON.parse(ev.data) as XaiTtsFrame;
+        frame = JSON.parse(raw) as XaiTtsFrame;
       } catch {
         log.debug("Dropped non-JSON xAI TTS frame");
         return;
@@ -241,7 +252,12 @@ export function synthesizeOverXaiTtsSocket(
           const chunk = Buffer.from(frame.delta, "base64");
           if (chunk.byteLength === 0) {return;}
           chunks.push(chunk);
-          onChunk?.(chunk);
+          try {
+            onChunk?.(chunk);
+          } catch (err) {
+            // Propagate sink failures like readChunkedBody: fail the session.
+            fail(err);
+          }
           return;
         }
 

--- a/assistant/src/tts/stream-read.ts
+++ b/assistant/src/tts/stream-read.ts
@@ -10,10 +10,10 @@
  */
 
 /** Default timeout waiting for the first chunk of a TTS stream (ms). */
-const DEFAULT_FIRST_CHUNK_TIMEOUT_MS = 10_000;
+export const DEFAULT_FIRST_CHUNK_TIMEOUT_MS = 10_000;
 
 /** Default timeout waiting between consecutive chunks (ms). */
-const DEFAULT_IDLE_TIMEOUT_MS = 5_000;
+export const DEFAULT_IDLE_TIMEOUT_MS = 5_000;
 
 /** Stream-stall timeouts, injectable for tests. */
 export interface StreamReadTimeouts {

--- a/assistant/src/util/unicode.ts
+++ b/assistant/src/util/unicode.ts
@@ -16,7 +16,7 @@ const LOW_SURROGATE_START = 0xdc00;
 const LOW_SURROGATE_END = 0xdfff;
 const REPLACEMENT_CHAR = "\ufffd";
 
-function isHighSurrogate(code: number): boolean {
+export function isHighSurrogate(code: number): boolean {
   return code >= HIGH_SURROGATE_START && code <= HIGH_SURROGATE_END;
 }
 


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for xai-ws-streaming-tts.md.

- onChunk exceptions now reject the synthesis promise via the fail path (Codex P2 on #37456)
- Binary-delivered JSON frames decoded via TextDecoder (mirrors the xai-realtime STT adapter)
- 15k text.delta split no longer tears surrogate pairs; whitespace-delta test coverage
- Stall-timeout defaults imported from stream-read.ts; WsLike trimmed to used surface