### PR TITLE
fix(web): task card + attachment polish from Figma review

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/message-attachment-square.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/message-attachment-square.tsx
@@ -129,8 +129,8 @@ export const MessageAttachmentSquare: FC<MessageAttachmentSquareProps> = ({
       >
         {displayName}
       </Typography>
-      {/* iOS-only simplification (Figma review, node 6638-6731): the file
-          size adds noise on the narrow native layout. Web/electron keep it. */}
+      {/* The file size adds noise on the narrow native layout, so the native
+          shell hides it; web/electron keep it. */}
       {!isNative && (
         <Typography
           variant="label-small-default"

--- a/clients/web/src/domains/chat/components/chat-attachments/message-attachment-square.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/message-attachment-square.tsx
@@ -22,6 +22,7 @@ import {
     middleTruncate,
     type AttachmentIconKind,
 } from "@/domains/chat/components/chat-attachments/utils";
+import { useIsNativePlatform } from "@/runtime/native-auth";
 
 interface MessageAttachmentSquareProps {
   filename: string;
@@ -66,6 +67,7 @@ export const MessageAttachmentSquare: FC<MessageAttachmentSquareProps> = ({
   const isClickable = onPreview != null;
   const displayName = middleTruncate(filename, 18);
   const displaySize = formatAttachmentSize(sizeBytes);
+  const isNative = useIsNativePlatform();
 
   const handleDownloadClick = useCallback(
     (e: MouseEvent) => {
@@ -127,12 +129,16 @@ export const MessageAttachmentSquare: FC<MessageAttachmentSquareProps> = ({
       >
         {displayName}
       </Typography>
-      <Typography
-        variant="label-small-default"
-        className="text-[var(--content-disabled)]"
-      >
-        {displaySize}
-      </Typography>
+      {/* iOS-only simplification (Figma review, node 6638-6731): the file
+          size adds noise on the narrow native layout. Web/electron keep it. */}
+      {!isNative && (
+        <Typography
+          variant="label-small-default"
+          className="text-[var(--content-disabled)]"
+        >
+          {displaySize}
+        </Typography>
+      )}
     </div>
   );
 };

--- a/clients/web/src/domains/chat/components/surfaces/card-surface.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/card-surface.test.tsx
@@ -201,6 +201,32 @@ describe("CardSurface", () => {
     expect(rendered).toContain("Details");
   });
 
+  test("status glyphs carry visually hidden labels for assistive tech", () => {
+    const rendered = renderToStaticMarkup(
+      <CardSurface
+        surface={surface({
+          title: "Connect Gmail",
+          data: {
+            title: "Connect Gmail",
+            body: "",
+            template: "task_progress",
+            templateData: {
+              title: "Connect Gmail",
+              status: "completed",
+              steps: [{ label: "Finishing setup", status: "waiting" }],
+            },
+          },
+        })}
+        onAction={() => undefined}
+      />,
+    );
+
+    // The header glyph and each step glyph are icon-only; the sr-only label
+    // is the only status text exposed to assistive tech.
+    expect(rendered).toContain(">Completed</span>");
+    expect(rendered).toContain("sr-only");
+  });
+
   test("a body-less card renders its title (no loading spinner)", () => {
     const rendered = renderToStaticMarkup(
       <CardSurface

--- a/clients/web/src/domains/chat/components/surfaces/card-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/card-surface.tsx
@@ -1,4 +1,4 @@
-import { lazy } from "react";
+import { lazy, type ReactNode } from "react";
 import {
   Circle,
   CircleAlert,
@@ -95,44 +95,67 @@ function normalizedTitle(value: unknown): string {
 }
 
 /**
- * Status glyph shown left of the task title. Replaces the former text badge
- * ("Completed" / "In Progress" pill) per Figma review (node 6638-6732): a
- * green check-in-circle for completed, a red exclamation-in-circle for
- * failed, and the existing spinner while in progress. Pending/waiting render
- * no glyph — a bare title reads cleaner than a placeholder circle.
+ * Status glyph shown left of the task title: a green check-in-circle for
+ * completed, a red exclamation-in-circle for failed, and a spinner while in
+ * progress. Pending/waiting render no glyph — a bare title reads cleaner
+ * than a placeholder circle. A visually hidden label keeps the status
+ * available to assistive tech.
  */
 function TitleStatusIcon({ status }: { status: string | undefined }) {
-  const { colorClass } = getStatusConfig(status);
+  const { label, colorClass } = getStatusConfig(status);
   const iconClass = cn("h-4 w-4 shrink-0", colorClass);
 
+  let icon: ReactNode;
   switch (status) {
     case "completed":
-      return <CircleCheck className={iconClass} />;
+      icon = <CircleCheck aria-hidden className={iconClass} />;
+      break;
     case "failed":
-      return <CircleAlert className={iconClass} />;
+      icon = <CircleAlert aria-hidden className={iconClass} />;
+      break;
     case "in_progress":
-      return <Loader2 className={cn(iconClass, "animate-spin")} />;
+      icon = <Loader2 aria-hidden className={cn(iconClass, "animate-spin")} />;
+      break;
     default:
       return null;
   }
+
+  return (
+    <>
+      {icon}
+      <span className="sr-only">{label}</span>
+    </>
+  );
 }
 
 function StepIcon({ status }: { status: string | undefined }) {
-  const { colorClass } = getStatusConfig(status);
+  const { label, colorClass } = getStatusConfig(status);
   const iconClass = cn("h-4 w-4 shrink-0", colorClass);
 
+  let icon: ReactNode;
   switch (status) {
     case "completed":
-      return <CircleCheck className={iconClass} />;
+      icon = <CircleCheck aria-hidden className={iconClass} />;
+      break;
     case "in_progress":
-      return <Loader2 className={cn(iconClass, "animate-spin")} />;
+      icon = <Loader2 aria-hidden className={cn(iconClass, "animate-spin")} />;
+      break;
     case "waiting":
-      return <Clock className={iconClass} />;
+      icon = <Clock aria-hidden className={iconClass} />;
+      break;
     case "failed":
-      return <CircleX className={iconClass} />;
+      icon = <CircleX aria-hidden className={iconClass} />;
+      break;
     default:
-      return <Circle className={iconClass} />;
+      icon = <Circle aria-hidden className={iconClass} />;
   }
+
+  return (
+    <>
+      {icon}
+      <span className="sr-only">{label}</span>
+    </>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -196,10 +219,9 @@ function TaskStepList({
         const status = effectiveStepStatus(step.status, taskCompleted);
         const showDetailOnRight = status === "in_progress" && !!step.detail;
         return (
-          // Figma review (node 6638-6732): the number badge and status icon
-          // must center against the *title line*, not the label+detail block —
-          // so the detail lives outside the `items-center` row, indented past
-          // the 24px badge + 10px gap.
+          // The number badge and status icon center against the *title
+          // line*, not the label+detail block — the detail lives outside the
+          // `items-center` row, indented past the 24px badge + 10px gap.
           <div key={step.id || index} className="py-2 first:pt-0 last:pb-0">
             <div className="flex items-center gap-2.5">
               <span className="inline-flex h-6 min-w-6 shrink-0 items-center justify-center rounded-md bg-[var(--tag-bg-neutral)] px-1.5 text-label-medium-default tabular-nums text-[var(--content-tertiary)]">
@@ -207,8 +229,7 @@ function TaskStepList({
               </span>
               <div className="min-w-0 flex-1">
                 {/* `block` so the label's own 18px token line-height governs
-                  wrapped lines instead of the parent block's taller strut —
-                  Figma review: "Title line height is too large". */}
+                  wrapped lines instead of the parent block's taller strut. */}
                 <span className="block text-body-medium-default text-[var(--content-strong)]">
                   {step.label}
                 </span>
@@ -271,9 +292,9 @@ export function CardSurface({ surface, onAction }: CardSurfaceProps) {
     const steps = templateData.steps as TaskStepItem[];
 
     return (
-      // `max-md:mb-2` — Figma review (node 6638-6732): "4-8px more margin"
-      // below the task card before the next transcript block on mobile;
-      // stacks on the transcript column's `gap-2`.
+      // `max-md:mb-2` adds breathing room below the task card before the
+      // next transcript block on mobile; stacks on the transcript column's
+      // `gap-2`.
       <SurfaceContainer
         surface={surface}
         onAction={onAction}

--- a/clients/web/src/domains/chat/components/surfaces/card-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/card-surface.tsx
@@ -1,5 +1,12 @@
 import { lazy } from "react";
-import { Circle, CircleCheck, CircleX, Clock, Loader2 } from "lucide-react";
+import {
+  Circle,
+  CircleAlert,
+  CircleCheck,
+  CircleX,
+  Clock,
+  Loader2,
+} from "lucide-react";
 
 import { CardSurfaceDataSchema } from "@vellumai/assistant-api";
 import type { Surface } from "@/domains/chat/types/types";
@@ -87,21 +94,27 @@ function normalizedTitle(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
-function StatusBadge({ status }: { status: string | undefined }) {
-  const { label, colorClass } = getStatusConfig(status);
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-body-small-default",
-        colorClass,
-      )}
-      style={{
-        backgroundColor: "color-mix(in srgb, currentColor 15%, transparent)",
-      }}
-    >
-      {label}
-    </span>
-  );
+/**
+ * Status glyph shown left of the task title. Replaces the former text badge
+ * ("Completed" / "In Progress" pill) per Figma review (node 6638-6732): a
+ * green check-in-circle for completed, a red exclamation-in-circle for
+ * failed, and the existing spinner while in progress. Pending/waiting render
+ * no glyph — a bare title reads cleaner than a placeholder circle.
+ */
+function TitleStatusIcon({ status }: { status: string | undefined }) {
+  const { colorClass } = getStatusConfig(status);
+  const iconClass = cn("h-4 w-4 shrink-0", colorClass);
+
+  switch (status) {
+    case "completed":
+      return <CircleCheck className={iconClass} />;
+    case "failed":
+      return <CircleAlert className={iconClass} />;
+    case "in_progress":
+      return <Loader2 className={cn(iconClass, "animate-spin")} />;
+    default:
+      return null;
+  }
 }
 
 function StepIcon({ status }: { status: string | undefined }) {
@@ -183,36 +196,42 @@ function TaskStepList({
         const status = effectiveStepStatus(step.status, taskCompleted);
         const showDetailOnRight = status === "in_progress" && !!step.detail;
         return (
-          <div
-            key={step.id || index}
-            className="flex items-center gap-2.5 py-2 first:pt-0 last:pb-0"
-          >
-            <span className="inline-flex h-6 min-w-6 shrink-0 items-center justify-center rounded-md bg-[var(--tag-bg-neutral)] px-1.5 text-label-medium-default tabular-nums text-[var(--content-tertiary)]">
-              {index + 1}
-            </span>
-            <div className="min-w-0 flex-1">
-              <span className="text-body-medium-default text-[var(--content-strong)]">
-                {step.label}
+          // Figma review (node 6638-6732): the number badge and status icon
+          // must center against the *title line*, not the label+detail block —
+          // so the detail lives outside the `items-center` row, indented past
+          // the 24px badge + 10px gap.
+          <div key={step.id || index} className="py-2 first:pt-0 last:pb-0">
+            <div className="flex items-center gap-2.5">
+              <span className="inline-flex h-6 min-w-6 shrink-0 items-center justify-center rounded-md bg-[var(--tag-bg-neutral)] px-1.5 text-label-medium-default tabular-nums text-[var(--content-tertiary)]">
+                {index + 1}
               </span>
-              {step.detail && !showDetailOnRight && (
-                <p className="text-body-small-default text-[var(--content-tertiary)]">
-                  {step.detail}
-                </p>
-              )}
-            </div>
-            {showDetailOnRight && (
-              <div className="h-4 min-w-0 max-w-[50%] overflow-hidden">
-                <span
-                  className="block truncate text-body-small-default leading-[16px] text-[var(--content-tertiary)]"
-                  title={step.detail!}
-                >
-                  {step.detail}
+              <div className="min-w-0 flex-1">
+                {/* `block` so the label's own 18px token line-height governs
+                  wrapped lines instead of the parent block's taller strut —
+                  Figma review: "Title line height is too large". */}
+                <span className="block text-body-medium-default text-[var(--content-strong)]">
+                  {step.label}
                 </span>
               </div>
-            )}
-            <div className="shrink-0">
-              <StepIcon status={status} />
+              {showDetailOnRight && (
+                <div className="h-4 min-w-0 max-w-[50%] overflow-hidden">
+                  <span
+                    className="block truncate text-body-small-default leading-[16px] text-[var(--content-tertiary)]"
+                    title={step.detail!}
+                  >
+                    {step.detail}
+                  </span>
+                </div>
+              )}
+              <div className="shrink-0">
+                <StepIcon status={status} />
+              </div>
             </div>
+            {step.detail && !showDetailOnRight && (
+              <p className="pl-[34px] text-body-small-default text-[var(--content-tertiary)]">
+                {step.detail}
+              </p>
+            )}
           </div>
         );
       })}
@@ -252,13 +271,21 @@ export function CardSurface({ surface, onAction }: CardSurfaceProps) {
     const steps = templateData.steps as TaskStepItem[];
 
     return (
-      <SurfaceContainer surface={surface} onAction={onAction} hideTitle>
+      // `max-md:mb-2` — Figma review (node 6638-6732): "4-8px more margin"
+      // below the task card before the next transcript block on mobile;
+      // stacks on the transcript column's `gap-2`.
+      <SurfaceContainer
+        surface={surface}
+        onAction={onAction}
+        hideTitle
+        className="max-md:mb-2"
+      >
         <div>
-          <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <TitleStatusIcon status={status} />
             <span className="text-title-small text-[var(--content-strong)]">
               {title}
             </span>
-            <StatusBadge status={status} />
           </div>
           <TaskStepList steps={steps} taskCompleted={status === "completed"} />
         </div>

--- a/clients/web/src/domains/chat/components/surfaces/surface-container.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/surface-container.tsx
@@ -3,15 +3,18 @@ import { type ReactNode, useState } from "react";
 
 import { Button } from "@vellumai/design-library";
 import type { Surface } from "@/domains/chat/types/types";
+import { cn } from "@/utils/misc";
 
 interface SurfaceContainerProps {
   surface: Surface;
   onAction: (surfaceId: string, actionId: string, data?: Record<string, unknown>) => void | Promise<void>;
   hideTitle?: boolean;
+  /** Extra classes merged onto the card's root element. */
+  className?: string;
   children: ReactNode;
 }
 
-export function SurfaceContainer({ surface, onAction, hideTitle, children }: SurfaceContainerProps) {
+export function SurfaceContainer({ surface, onAction, hideTitle, className, children }: SurfaceContainerProps) {
   const [submittingAction, setSubmittingAction] = useState<string | null>(null);
 
   const handleAction = async (actionId: string) => {
@@ -25,7 +28,7 @@ export function SurfaceContainer({ surface, onAction, hideTitle, children }: Sur
   };
 
   return (
-    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-lift)] p-4">
+    <div className={cn("rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-lift)] p-4", className)}>
       {!hideTitle && surface.title && (
         <div className="mb-3 flex items-center gap-2">
           <span className="text-title-small text-[var(--content-strong)]">


### PR DESCRIPTION
## Summary

Five fixes from the Figma design review of the mobile chat screens (nodes `6638-6731` and `6638-6732`).

| # | Annotation | File | Fix |
|---|---|---|---|
| 1 | "We can probably lose the file sizes for simplicity" | `message-attachment-square.tsx` | Size line hidden **on iOS only** (`useIsNativePlatform()`, hydration-safe) — web/electron keep it, per review feedback. Composer chips untouched (not annotated). |
| 2 | "Move the tag above the title (maybe just place a check left of the title)" | `card-surface.tsx` | Went with the icon route per review feedback: the text badge is replaced by a glyph left of the title — green `CircleCheck` (completed), red `CircleAlert` (failed), existing spinner (in progress). Pending/waiting render no glyph. The "2px extra tag padding" note is moot with the badge gone. |
| 3 | "Title line height is too large" | `card-surface.tsx` | Root cause: the step label sets an 18px token line-height on an *inline* span, but line boxes take the parent block's strut (~1.5 leading), so wrapped labels rendered ~24px lines. `block` display lets the token govern. |
| 4 | "Center this with the title" | `card-surface.tsx` | Root cause: the number badge and status icon centered against the label+detail column, not the title line. The detail now lives outside the `items-center` row, indented `pl-[34px]` (24px badge + 10px gap). |
| 5 | "4-8px more margin" | `card-surface.tsx` + `surface-container.tsx` | `max-md:mb-2` (+8px) below the task card on mobile, stacking on the transcript's `gap-2`. Enabled by a new optional `className` pass-through on `SurfaceContainer`. |

## Scoping

Card-surface fixes (#2–#4) are **global** — approved in review: #3 is a CSS strut bug and #4 is a DOM-structure defect, both wrong on desktop too; #2 is a design change where splitting badge-vs-icon per platform would fork one component's design. #1 is iOS-only and #5 mobile-only per the mobile-screenshot scoping rule.

## What I chose NOT to do

- **No `leading-*` override** for #3 — the token's 18px is correct; forcing a utility would mask the real strut problem.
- **Didn't remove file sizes globally** (#1) — reviewer scoped it to iOS.
- **Didn't touch the composer `attachment-chip.tsx`** — the annotation targets message-bubble attachments only.
- **No bare-check-only header** (#2) — the card also carries failed/in-progress states, so a full status glyph set is needed; `CircleAlert` (exclamation-in-circle) matches the requested failure treatment.
- **Kept prettier noise out**: `surface-container.tsx` and `message-attachment-square.tsx` had pre-existing non-prettier formatting; edits preserve the original style so the diff stays surgical (7 and 18 lines respectively).

## Root cause analysis

The centering and line-height defects came from the step row conflating two concerns: one flex row was responsible for both vertical centering *and* stacking label+detail. Any two-line step broke centering by construction; the inline label additionally inherited the block strut. Warning sign missed: the `showDetailOnRight` branch already worked around this by pulling the detail out of the column for in-progress steps — the same treatment was needed for the resting state.

## Verification

- `bunx tsc --noEmit`: clean (pre-commit hook)
- eslint on touched files: clean
- `bun test`: card-surface + bubble-attachments suites, 19/19 pass (bubble tests assert sizes visible on web — still true, hide is iOS-only)
- Remote blob SHAs verified against local `git hash-object` after API push

Figma: nodes 6638-6731, 6638-6732 in file cCGBcpVDbn22kj3OPU58W8.