### PR TITLE
refactor(assistant): unify image/file media into a single MediaSource type

### DIFF
--- a/assistant/src/__tests__/conversation-history-web-search.test.ts
+++ b/assistant/src/__tests__/conversation-history-web-search.test.ts
@@ -675,6 +675,12 @@ describe("web_search_tool_result structural guard", () => {
     // there is nothing there to sweep.
     "plugins/defaults/image-fallback/src/caption-blocks.ts",
 
+    // Walks a tool_result's rich `contentBlocks` to detect nested media that
+    // needs resolving from a workspace reference. web_search_tool_result blocks
+    // carry no contentBlocks, so only tool_result is relevant here. Same
+    // reasoning as caption-blocks.ts above.
+    "providers/media-resolve.ts",
+
     // Detects turn boundaries by checking whether a user message carries any
     // tool_result block (internal continuation) vs. none (genuine user prompt).
     // A web_search_tool_result-only message is also internal, but treating one

--- a/assistant/src/__tests__/gemini-inline-media.test.ts
+++ b/assistant/src/__tests__/gemini-inline-media.test.ts
@@ -58,14 +58,14 @@ describe("estimateGeminiAudioTokens", () => {
   test("scales with payload size and stays far below the base64-as-text count", () => {
     // ~3 MB of base64 ≈ ~2.25 MB raw ≈ ~140s at 16 KB/s ≈ ~4.5k tokens.
     const data = "A".repeat(3 * 1024 * 1024);
-    const tokens = estimateGeminiAudioTokens(data);
+    const tokens = estimateGeminiAudioTokens(base64ByteLength(data));
     expect(tokens).toBeGreaterThan(1_000);
     // Must be a small fraction of the naive base64-length/4 estimate (~786k).
     expect(tokens).toBeLessThan(data.length / 40);
   });
 
   test("returns zero for empty data", () => {
-    expect(estimateGeminiAudioTokens("")).toBe(0);
+    expect(estimateGeminiAudioTokens(0)).toBe(0);
   });
 });
 

--- a/assistant/src/__tests__/persist-unsendable-image-downscale.test.ts
+++ b/assistant/src/__tests__/persist-unsendable-image-downscale.test.ts
@@ -38,6 +38,7 @@ import {
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { persistUnsendableImageDowngrades } from "../plugins/defaults/image-recovery/recover.js";
+import { base64Source } from "../providers/media-resolve.js";
 import type { ContentBlock } from "../providers/types.js";
 
 await initializeDb();
@@ -140,7 +141,8 @@ describe("persistUnsendableImageDowngrades (downscalable host)", () => {
     const nested = toolResult.contentBlocks?.[0];
     expect(nested?.type).toBe("image");
     expect(
-      (nested as Extract<ContentBlock, { type: "image" }>).source.data,
+      base64Source((nested as Extract<ContentBlock, { type: "image" }>).source)
+        .data,
     ).toBe(SHRUNK_DATA);
   });
 

--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -113,6 +113,7 @@ import type { MessageRow } from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { recordInbound } from "../persistence/delivery-crud.js";
+import { base64Source } from "../providers/media-resolve.js";
 import type { Message } from "../providers/types.js";
 import {
   _backfillTriggerCache,
@@ -1010,7 +1011,7 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
     expect(textBlock?.text).toBe("uploaded the diagram");
     expect(textBlock?.text).not.toContain("<external_content");
     expect(imageBlock?.source.media_type).toBe("image/png");
-    expect(imageBlock?.source.data).toBe(imageBase64);
+    expect(base64Source(imageBlock!.source).data).toBe(imageBase64);
 
     const context = loadSlackChronologicalContext(conv.id, SLACK_CHANNEL_CAPS, {
       loader: readMessageRowsByConversation,

--- a/assistant/src/context/image-dimensions.ts
+++ b/assistant/src/context/image-dimensions.ts
@@ -4,7 +4,7 @@ import type { MediaSource } from "../providers/types.js";
  * Parse image pixel dimensions, either from a base64 payload (reading binary
  * headers — PNG, JPEG, GIF, WebP) or from an image block's media `source`.
  *
- * For an `attachment_ref` source the dimensions come from the hints captured at
+ * For a `workspace_ref` source the dimensions come from the hints captured at
  * persist time (no disk read); for an inline `base64` source they are parsed
  * from the header. Returns null when parsing fails or the reference carries no
  * dimension hints.
@@ -21,7 +21,7 @@ export function parseImageDimensions(
   mediaType?: string,
 ): { width: number; height: number } | null {
   if (typeof arg !== "string") {
-    if (arg.type === "attachment_ref") {
+    if (arg.type === "workspace_ref") {
       return arg.width != null && arg.height != null
         ? { width: arg.width, height: arg.height }
         : null;

--- a/assistant/src/context/image-dimensions.ts
+++ b/assistant/src/context/image-dimensions.ts
@@ -1,12 +1,34 @@
+import type { MediaSource } from "../providers/types.js";
+
 /**
- * Parses image dimensions from base64-encoded image data by reading binary headers.
- * Supports PNG, JPEG, GIF, and WebP formats.
- * Returns null if parsing fails for any reason (corrupt, truncated, unrecognized).
+ * Parse image pixel dimensions, either from a base64 payload (reading binary
+ * headers — PNG, JPEG, GIF, WebP) or from an image block's media `source`.
+ *
+ * For an `attachment_ref` source the dimensions come from the hints captured at
+ * persist time (no disk read); for an inline `base64` source they are parsed
+ * from the header. Returns null when parsing fails or the reference carries no
+ * dimension hints.
  */
 export function parseImageDimensions(
   base64Data: string,
   mediaType: string,
+): { width: number; height: number } | null;
+export function parseImageDimensions(
+  source: MediaSource,
+): { width: number; height: number } | null;
+export function parseImageDimensions(
+  arg: string | MediaSource,
+  mediaType?: string,
 ): { width: number; height: number } | null {
+  if (typeof arg !== "string") {
+    if (arg.type === "attachment_ref") {
+      return arg.width != null && arg.height != null
+        ? { width: arg.width, height: arg.height }
+        : null;
+    }
+    return parseImageDimensions(arg.data, arg.media_type);
+  }
+  const base64Data = arg;
   try {
     switch (mediaType) {
       case "image/png":

--- a/assistant/src/context/token-estimator.ts
+++ b/assistant/src/context/token-estimator.ts
@@ -2,6 +2,7 @@ import {
   estimateGeminiAudioTokens,
   normalizeGeminiAudioMime,
 } from "../providers/gemini/inline-media.js";
+import { mediaSourceByteLength } from "../providers/media-resolve.js";
 import type {
   ContentBlock,
   Message,
@@ -98,8 +99,7 @@ export function estimateTextTokens(text: string | undefined): number {
   return Math.ceil(text.length / CHARS_PER_TOKEN);
 }
 
-function estimateAnthropicPdfTokens(base64Data: string): number {
-  const rawBytes = Math.ceil((base64Data.length * 3) / 4);
+function estimateAnthropicPdfTokens(rawBytes: number): number {
   return Math.max(
     ANTHROPIC_PDF_MIN_TOKENS,
     Math.ceil(rawBytes * ANTHROPIC_PDF_TOKENS_PER_BYTE),
@@ -111,13 +111,16 @@ function estimateFileDataTokens(
   options?: TokenEstimatorOptions,
 ): number {
   const providerName = options?.providerName;
+  // Size the payload from the source hint, resolving neither base64 nor a
+  // reference back to bytes — this runs on the per-turn hot path.
+  const byteLength = mediaSourceByteLength(block.source);
 
   // Anthropic sends PDFs as native document blocks and renders each page as an image
   if (
     providerName === "anthropic" &&
     block.source.media_type === "application/pdf"
   ) {
-    return estimateAnthropicPdfTokens(block.source.data);
+    return estimateAnthropicPdfTokens(byteLength);
   }
 
   // Gemini hears audio natively (inline base64) but bills it at ~32 tokens/sec.
@@ -127,15 +130,16 @@ function estimateFileDataTokens(
     providerName === "gemini" &&
     normalizeGeminiAudioMime(block.source.media_type) !== null
   ) {
-    return estimateGeminiAudioTokens(block.source.data);
+    return estimateGeminiAudioTokens(byteLength);
   }
 
-  // Gemini sends certain file types inline as base64
+  // Gemini sends certain file types inline as base64; cost the encoded payload
+  // (~4 base64 chars per 3 bytes) as text.
   if (
     providerName === "gemini" &&
     GEMINI_INLINE_FILE_MIME_TYPES.has(block.source.media_type)
   ) {
-    return estimateTextTokens(block.source.data);
+    return Math.ceil((Math.ceil(byteLength / 3) * 4) / CHARS_PER_TOKEN);
   }
 
   return 0;
@@ -185,7 +189,7 @@ function estimateImageTokens(
   block: Extract<ContentBlock, { type: "image" }>,
   options?: TokenEstimatorOptions,
 ): number {
-  const dims = parseImageDimensions(block.source.data, block.source.media_type);
+  const dims = parseImageDimensions(block.source);
   if (dims) {
     if (options?.providerName === "gemini") {
       return estimateGeminiImageTokens(dims.width, dims.height);

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -54,6 +54,7 @@ import { indexMessageNow } from "../plugins/defaults/memory/indexer.js";
 import { backfillMemoryRecallLogMessageId } from "../plugins/defaults/memory/memory-recall-log-store.js";
 import { backfillMemoryV2ActivationMessageId } from "../plugins/defaults/memory/memory-v2-activation-log-store.js";
 import { backfillMemoryV3SelectionMessageId } from "../plugins/defaults/memory/v3/shadow-plugin.js";
+import { resolveMediaSourceData } from "../providers/media-resolve.js";
 import type {
   ContentBlock,
   ImageContent,
@@ -1403,7 +1404,9 @@ export async function handleToolResult(
     (b): b is ImageContent => b.type === "image",
   );
   const imageDataList = imageBlocks?.length
-    ? imageBlocks.map((b) => b.source.data)
+    ? imageBlocks
+        .map((b) => resolveMediaSourceData(b.source)?.data)
+        .filter((d): d is string => d != null)
     : undefined;
 
   // Perform state mutations before deps.onEvent() so that if onEvent throws

--- a/assistant/src/daemon/conversation-media-retry.ts
+++ b/assistant/src/daemon/conversation-media-retry.ts
@@ -8,6 +8,7 @@
 
 import { estimateContentBlockTokens } from "../context/token-estimator.js";
 import { getSummaryFromContextMessage } from "../plugins/defaults/compaction/window-manager.js";
+import { mediaSourceByteLength } from "../providers/media-resolve.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 
 export interface StripMediaOptions {
@@ -206,7 +207,7 @@ export function estimateUnconditionalStubTokens(
 function imageBlockToStub(
   block: Extract<ContentBlock, { type: "image" }>,
 ): Extract<ContentBlock, { type: "text" }> {
-  const sizeBytes = Math.ceil(block.source.data.length / 4) * 3;
+  const sizeBytes = mediaSourceByteLength(block.source);
   return {
     type: "text",
     text: `[Image omitted from retry context: ${block.source.media_type}, ${sizeBytes} bytes]`,
@@ -216,7 +217,7 @@ function imageBlockToStub(
 function fileBlockToStub(
   block: Extract<ContentBlock, { type: "file" }>,
 ): Extract<ContentBlock, { type: "text" }> {
-  const sizeBytes = Math.ceil(block.source.data.length / 4) * 3;
+  const sizeBytes = mediaSourceByteLength(block.source);
   const extracted = (block.extracted_text ?? "").trim();
   const preview =
     extracted.length > MAX_MEDIA_STUB_TEXT

--- a/assistant/src/daemon/wake-conversation-ops.ts
+++ b/assistant/src/daemon/wake-conversation-ops.ts
@@ -20,6 +20,7 @@ import {
 } from "../persistence/conversation-crud.js";
 import { syncMessageToDisk } from "../persistence/conversation-disk-view.js";
 import { backfillMessageIdOnLogs } from "../persistence/llm-request-log-store.js";
+import { resolveMediaSourceData } from "../providers/media-resolve.js";
 import type { Message } from "../providers/types.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
@@ -88,7 +89,9 @@ function translateAgentEventToServerMessage(
         (b): b is Extract<typeof b, { type: "image" }> => b.type === "image",
       );
       const imageDataList = imageBlocks?.length
-        ? imageBlocks.map((b) => b.source.data)
+        ? imageBlocks
+            .map((b) => resolveMediaSourceData(b.source)?.data)
+            .filter((d): d is string => d != null)
         : undefined;
       return {
         type: "tool_result",

--- a/assistant/src/persistence/attachments-store.ts
+++ b/assistant/src/persistence/attachments-store.ts
@@ -20,6 +20,7 @@ import { basename, dirname, extname, join } from "node:path";
 import { eq } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import type { MediaSource } from "../providers/types.js";
 import {
   jpegFilenameFor,
   normalizeImageBase64,
@@ -687,13 +688,24 @@ export function getFilePathBySourcePath(
 }
 
 /**
- * Return the raw binary content for an attachment by reading from its
- * on-disk file path.
+ * Return the raw binary content for a stored attachment, or for a media source
+ * (image/file block `source`). This is the single place the base64-vs-reference
+ * distinction is resolved: an inline `base64` source decodes in place, an
+ * `attachment_ref` source (or a bare attachment id) reads the referenced file
+ * from disk.
  *
  * Returns null if the attachment does not exist or the file is missing.
  */
-export function getAttachmentContent(attachmentId: string): Buffer | null {
-  const row = getAttachmentRow(attachmentId);
+export function getAttachmentContent(attachmentId: string): Buffer | null;
+export function getAttachmentContent(source: MediaSource): Buffer | null;
+export function getAttachmentContent(arg: string | MediaSource): Buffer | null {
+  if (typeof arg !== "string") {
+    if (arg.type === "base64") {
+      return Buffer.from(arg.data, "base64");
+    }
+    return getAttachmentContent(arg.attachmentId);
+  }
+  const row = getAttachmentRow(arg);
   if (!row) return null;
 
   try {

--- a/assistant/src/persistence/attachments-store.ts
+++ b/assistant/src/persistence/attachments-store.ts
@@ -20,7 +20,6 @@ import { basename, dirname, extname, join } from "node:path";
 import { eq } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import type { MediaSource } from "../providers/types.js";
 import {
   jpegFilenameFor,
   normalizeImageBase64,
@@ -688,24 +687,16 @@ export function getFilePathBySourcePath(
 }
 
 /**
- * Return the raw binary content for a stored attachment, or for a media source
- * (image/file block `source`). This is the single place the base64-vs-reference
- * distinction is resolved: an inline `base64` source decodes in place, an
- * `attachment_ref` source (or a bare attachment id) reads the referenced file
- * from disk.
+ * Return the raw binary content for a stored attachment by reading from its
+ * on-disk file path (or its inline base64, for legacy rows).
  *
- * Returns null if the attachment does not exist or the file is missing.
+ * Returns null if the attachment does not exist or the file is missing. To
+ * resolve an image/file block's `source` (base64 or workspace reference) to
+ * bytes, use `mediaSourceBytes` / `resolveMediaSourceData` in
+ * `providers/media-resolve.ts`, which delegates here for the attachment route.
  */
-export function getAttachmentContent(attachmentId: string): Buffer | null;
-export function getAttachmentContent(source: MediaSource): Buffer | null;
-export function getAttachmentContent(arg: string | MediaSource): Buffer | null {
-  if (typeof arg !== "string") {
-    if (arg.type === "base64") {
-      return Buffer.from(arg.data, "base64");
-    }
-    return getAttachmentContent(arg.attachmentId);
-  }
-  const row = getAttachmentRow(arg);
+export function getAttachmentContent(attachmentId: string): Buffer | null {
+  const row = getAttachmentRow(attachmentId);
   if (!row) return null;
 
   try {

--- a/assistant/src/persistence/message-content.ts
+++ b/assistant/src/persistence/message-content.ts
@@ -1,6 +1,6 @@
+import { mediaSourceBytes } from "../providers/media-resolve.js";
 import type { ContentBlock } from "../providers/types.js";
 import { escapeXmlAttr } from "../util/xml.js";
-import { getAttachmentContent } from "./attachments-store.js";
 
 export function extractTextFromStoredMessageContent(raw: string): string {
   try {
@@ -85,9 +85,9 @@ export function extractMediaBlocks(raw: string): Array<{
     for (let i = 0; i < parsed.length; i++) {
       const block = parsed[i] as ContentBlock;
       if (block.type === "image") {
-        // The source may be inline base64 or a workspace attachment reference;
-        // getAttachmentContent resolves both to raw bytes.
-        const bytes = getAttachmentContent(block.source);
+        // The source may be inline base64 or a workspace reference;
+        // mediaSourceBytes resolves both to raw bytes.
+        const bytes = mediaSourceBytes(block.source);
         if (!bytes) continue;
         results.push({
           type: "image" as const,

--- a/assistant/src/persistence/message-content.ts
+++ b/assistant/src/persistence/message-content.ts
@@ -1,5 +1,6 @@
 import type { ContentBlock } from "../providers/types.js";
 import { escapeXmlAttr } from "../util/xml.js";
+import { getAttachmentContent } from "./attachments-store.js";
 
 export function extractTextFromStoredMessageContent(raw: string): string {
   try {
@@ -32,19 +33,19 @@ export function extractTextFromStoredMessageContent(raw: string): string {
             `<image type="${escapeXmlAttr(block.source.media_type)}" />`,
           );
           break;
-        case "file":
+        case "file": {
+          const filename = block.source.filename ?? "";
           if (block.extracted_text) {
-            lines.push(
-              `File (${block.source.filename}): ${block.extracted_text}`,
-            );
+            lines.push(`File (${filename}): ${block.extracted_text}`);
           } else {
             lines.push(
               `<file name="${escapeXmlAttr(
-                block.source.filename,
+                filename,
               )}" type="${escapeXmlAttr(block.source.media_type)}" />`,
             );
           }
           break;
+        }
         case "server_tool_use": {
           const query =
             typeof block.input?.query === "string"
@@ -84,9 +85,13 @@ export function extractMediaBlocks(raw: string): Array<{
     for (let i = 0; i < parsed.length; i++) {
       const block = parsed[i] as ContentBlock;
       if (block.type === "image") {
+        // The source may be inline base64 or a workspace attachment reference;
+        // getAttachmentContent resolves both to raw bytes.
+        const bytes = getAttachmentContent(block.source);
+        if (!bytes) continue;
         results.push({
           type: "image" as const,
-          data: Buffer.from(block.source.data, "base64"),
+          data: bytes,
           mimeType: block.source.media_type,
           index: i,
         });

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -160,6 +160,13 @@ export { doesSupportVision } from "./vision-support.js";
 // float the chosen profile above the call-site layers when the plugin must
 // run on a specific profile regardless of workspace tuning.
 export { getConfiguredProvider } from "../providers/provider-send-message.js";
+// Resolve an image/file block's media `source` to its bytes as inline base64,
+// whether the source is inline base64 or a persisted workspace reference
+// (attachment-store row or a file on disk). Returns null when a reference can no
+// longer be read. Plugins that need the raw bytes of a media block — captioning
+// an image, embedding it, re-encoding it — use this instead of reaching into
+// the host attachment store, so they stay agnostic to how media is persisted.
+export { resolveMediaSourceData } from "../providers/media-resolve.js";
 // Classify a provider stop reason: whether the turn was truncated at the
 // output token cap (vs. a natural stop or a tool call). A `post-model-call`
 // hook reads it off `PostModelCallContext.stopReason` to decide whether to

--- a/assistant/src/plugins/defaults/image-fallback/__tests__/image-fallback.test.ts
+++ b/assistant/src/plugins/defaults/image-fallback/__tests__/image-fallback.test.ts
@@ -35,6 +35,14 @@ const fakeProvider = {
   },
 };
 
+// The plugin resolves an image block's bytes via `resolveMediaSourceData`.
+// Media in these tests is inline base64, so mirror the real helper's base64
+// branch; a workspace reference would return null (not exercised here).
+const mockResolveMediaSourceData = (source: ImageContent["source"]) =>
+  source.type === "base64"
+    ? { data: source.data, media_type: source.media_type }
+    : null;
+
 // Mock @vellumai/plugin-api — only the runtime handles the plugin imports.
 // `extractAllText` stays real (imported from the relative path, not plugin-api).
 mock.module("@vellumai/plugin-api", () => ({
@@ -43,6 +51,7 @@ mock.module("@vellumai/plugin-api", () => ({
       ? visionModels.has(arg)
       : visionProfiles.has(arg.key),
   getModelProfiles: () => mockProfiles,
+  resolveMediaSourceData: mockResolveMediaSourceData,
   getConfiguredProvider: async () => (providerResolves ? fakeProvider : null),
 }));
 
@@ -324,6 +333,7 @@ describe("image-fallback user-prompt-submit hook", () => {
           ? visionModels.has(arg)
           : visionProfiles.has(arg.key),
       getModelProfiles: () => mockProfiles,
+      resolveMediaSourceData: mockResolveMediaSourceData,
       getConfiguredProvider: async () => trackingProvider,
     }));
 
@@ -345,6 +355,7 @@ describe("image-fallback user-prompt-submit hook", () => {
           ? visionModels.has(arg)
           : visionProfiles.has(arg.key),
       getModelProfiles: () => mockProfiles,
+      resolveMediaSourceData: mockResolveMediaSourceData,
       getConfiguredProvider: async () =>
         providerResolves ? fakeProvider : null,
     }));
@@ -566,6 +577,7 @@ describe("image-fallback post-compact hook", () => {
           ? visionModels.has(arg)
           : visionProfiles.has(arg.key),
       getModelProfiles: () => mockProfiles,
+      resolveMediaSourceData: mockResolveMediaSourceData,
       getConfiguredProvider: async () => trackingProvider,
     }));
 
@@ -588,6 +600,7 @@ describe("image-fallback post-compact hook", () => {
           ? visionModels.has(arg)
           : visionProfiles.has(arg.key),
       getModelProfiles: () => mockProfiles,
+      resolveMediaSourceData: mockResolveMediaSourceData,
       getConfiguredProvider: async () =>
         providerResolves ? fakeProvider : null,
     }));
@@ -627,6 +640,7 @@ describe("image-fallback conversation-deleted hook", () => {
           ? visionModels.has(arg)
           : visionProfiles.has(arg.key),
       getModelProfiles: () => mockProfiles,
+      resolveMediaSourceData: mockResolveMediaSourceData,
       getConfiguredProvider: async () => trackingProvider,
     }));
 
@@ -656,6 +670,7 @@ describe("image-fallback conversation-deleted hook", () => {
           ? visionModels.has(arg)
           : visionProfiles.has(arg.key),
       getModelProfiles: () => mockProfiles,
+      resolveMediaSourceData: mockResolveMediaSourceData,
       getConfiguredProvider: async () =>
         providerResolves ? fakeProvider : null,
     }));
@@ -676,6 +691,7 @@ describe("image-fallback conversation-deleted hook", () => {
           ? visionModels.has(arg)
           : visionProfiles.has(arg.key),
       getModelProfiles: () => mockProfiles,
+      resolveMediaSourceData: mockResolveMediaSourceData,
       getConfiguredProvider: async () => trackingProvider,
     }));
 
@@ -710,6 +726,7 @@ describe("image-fallback conversation-deleted hook", () => {
           ? visionModels.has(arg)
           : visionProfiles.has(arg.key),
       getModelProfiles: () => mockProfiles,
+      resolveMediaSourceData: mockResolveMediaSourceData,
       getConfiguredProvider: async () =>
         providerResolves ? fakeProvider : null,
     }));

--- a/assistant/src/plugins/defaults/image-fallback/src/caption-blocks.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/caption-blocks.ts
@@ -36,9 +36,9 @@ import {
   type ImageContent,
   type Message,
   type PluginLogger,
+  resolveMediaSourceData,
 } from "@vellumai/plugin-api";
 
-import { resolveMediaSourceData } from "../../../../providers/media-resolve.js";
 import { persistImage } from "./image-persist.js";
 import { captionImage } from "./vision-caption.js";
 

--- a/assistant/src/plugins/defaults/image-fallback/src/caption-blocks.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/caption-blocks.ts
@@ -38,6 +38,7 @@ import {
   type PluginLogger,
 } from "@vellumai/plugin-api";
 
+import { resolveMediaSourceData } from "../../../../providers/media-resolve.js";
 import { persistImage } from "./image-persist.js";
 import { captionImage } from "./vision-caption.js";
 
@@ -86,8 +87,12 @@ export async function captionImageBlocks(
     const image = block as ImageContent;
 
     // Persist the original to a known, content-hash-deduped location so it
-    // survives the text substitution and stays findable on disk.
-    persistImage(image.source.data, image.source.media_type);
+    // survives the text substitution and stays findable on disk. Resolve a
+    // reference source to its bytes first (a no-op for inline base64).
+    const resolvedForPersist = resolveMediaSourceData(image.source);
+    if (resolvedForPersist) {
+      persistImage(resolvedForPersist.data, resolvedForPersist.media_type);
+    }
 
     if (visionProfileKey != null) {
       const caption = await captionImage(

--- a/assistant/src/plugins/defaults/image-fallback/src/vision-caption.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/vision-caption.ts
@@ -16,6 +16,7 @@ import {
   type PluginLogger,
 } from "@vellumai/plugin-api";
 
+import { resolveMediaSourceData } from "../../../../providers/media-resolve.js";
 import {
   getCachedCaption,
   imageHash,
@@ -67,7 +68,11 @@ export async function captionImage(
   profileKey: string,
   logger: PluginLogger,
 ): Promise<string | null> {
-  const hash = imageHash(image.source.data);
+  // Hash the image's content (resolving a reference source to its bytes, a
+  // no-op for inline base64) so the caption cache keys on the image itself.
+  const resolved = resolveMediaSourceData(image.source);
+  if (!resolved) return null;
+  const hash = imageHash(resolved.data);
   const cached = getCachedCaption(hash, conversationId);
   if (cached !== undefined) {
     return cached;

--- a/assistant/src/plugins/defaults/image-fallback/src/vision-caption.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/vision-caption.ts
@@ -14,9 +14,9 @@ import {
   getModelProfiles,
   type ImageContent,
   type PluginLogger,
+  resolveMediaSourceData,
 } from "@vellumai/plugin-api";
 
-import { resolveMediaSourceData } from "../../../../providers/media-resolve.js";
 import {
   getCachedCaption,
   imageHash,

--- a/assistant/src/plugins/defaults/image-recovery/recover.ts
+++ b/assistant/src/plugins/defaults/image-recovery/recover.ts
@@ -21,6 +21,7 @@ import {
   getMessages,
   updateMessageContent,
 } from "../../../persistence/conversation-crud.js";
+import { resolveMediaSourceData } from "../../../providers/media-resolve.js";
 import { getLogger } from "../../../util/logger.js";
 
 const log = getLogger("image-recovery");
@@ -63,8 +64,13 @@ export const UNSENDABLE_IMAGE_NOTE =
 export function oversizedImageReplacement(
   block: Extract<ContentBlock, { type: "image" }>,
 ): ContentBlock | null {
-  const payloadBytes = block.source.data.length;
-  const dims = parseImageDimensions(block.source.data, block.source.media_type);
+  // Resolve reference sources to their bytes so a reloaded (referenced) image
+  // is gated on the same payload/dimension caps as an inline one. When the
+  // attachment can no longer be read, leave the block untouched.
+  const resolved = resolveMediaSourceData(block.source);
+  if (!resolved) return null;
+  const payloadBytes = resolved.data.length;
+  const dims = parseImageDimensions(block.source);
   const exceedsDimensionCap =
     dims != null &&
     (dims.width > PROVIDER_MAX_IMAGE_DIMENSION ||
@@ -73,10 +79,10 @@ export function oversizedImageReplacement(
   if (!exceedsDimensionCap && !exceedsPayloadCap) return null;
 
   const optimized = optimizeImageForTransport(
-    block.source.data,
-    block.source.media_type,
+    resolved.data,
+    resolved.media_type,
   );
-  if (optimized.data !== block.source.data) {
+  if (optimized.data !== resolved.data) {
     return {
       type: "image",
       source: {

--- a/assistant/src/plugins/defaults/image-recovery/recover.ts
+++ b/assistant/src/plugins/defaults/image-recovery/recover.ts
@@ -13,7 +13,11 @@
  * so a rejected image cannot resurface and re-reject on every later turn.
  */
 
-import type { ContentBlock, Message } from "@vellumai/plugin-api";
+import {
+  type ContentBlock,
+  type Message,
+  resolveMediaSourceData,
+} from "@vellumai/plugin-api";
 
 import { optimizeImageForTransport } from "../../../agent/image-optimize.js";
 import { parseImageDimensions } from "../../../context/image-dimensions.js";
@@ -21,7 +25,6 @@ import {
   getMessages,
   updateMessageContent,
 } from "../../../persistence/conversation-crud.js";
-import { resolveMediaSourceData } from "../../../providers/media-resolve.js";
 import { getLogger } from "../../../util/logger.js";
 
 const log = getLogger("image-recovery");

--- a/assistant/src/plugins/defaults/memory/graph/retriever.ts
+++ b/assistant/src/plugins/defaults/memory/graph/retriever.ts
@@ -7,10 +7,12 @@
 // ---------------------------------------------------------------------------
 
 import type { ContentBlock, ImageContent } from "@vellumai/plugin-api";
-import { getConfiguredProvider } from "@vellumai/plugin-api";
+import {
+  getConfiguredProvider,
+  resolveMediaSourceData,
+} from "@vellumai/plugin-api";
 
 import type { AssistantConfig } from "../../../../config/types.js";
-import { getAttachmentContent } from "../../../../persistence/attachments-store.js";
 import { embedWithRetry } from "../../../../persistence/embeddings/embed.js";
 import { generateSparseEmbedding } from "../../../../persistence/embeddings/embedding-backend.js";
 import type { QdrantSparseVector } from "../../../../persistence/embeddings/qdrant-client.js";
@@ -982,12 +984,12 @@ export async function retrieveForTurn(
         ) {
           const img = imageBlocks[i];
           // Resolve the image bytes whether stored inline or as a workspace
-          // attachment reference; skip when the attachment can't be read.
-          const imgBytes = getAttachmentContent(img.source);
-          if (!imgBytes) continue;
+          // reference; skip when the bytes can't be read.
+          const resolved = resolveMediaSourceData(img.source);
+          if (!resolved) continue;
           const imageInput = {
             type: "image" as const,
-            data: imgBytes,
+            data: Buffer.from(resolved.data, "base64"),
             mimeType: img.source.media_type,
           };
           const imgResult = await embedWithRetry(opts.config, [imageInput], {

--- a/assistant/src/plugins/defaults/memory/graph/retriever.ts
+++ b/assistant/src/plugins/defaults/memory/graph/retriever.ts
@@ -10,6 +10,7 @@ import type { ContentBlock, ImageContent } from "@vellumai/plugin-api";
 import { getConfiguredProvider } from "@vellumai/plugin-api";
 
 import type { AssistantConfig } from "../../../../config/types.js";
+import { getAttachmentContent } from "../../../../persistence/attachments-store.js";
 import { embedWithRetry } from "../../../../persistence/embeddings/embed.js";
 import { generateSparseEmbedding } from "../../../../persistence/embeddings/embedding-backend.js";
 import type { QdrantSparseVector } from "../../../../persistence/embeddings/qdrant-client.js";
@@ -980,9 +981,13 @@ export async function retrieveForTurn(
           i++
         ) {
           const img = imageBlocks[i];
+          // Resolve the image bytes whether stored inline or as a workspace
+          // attachment reference; skip when the attachment can't be read.
+          const imgBytes = getAttachmentContent(img.source);
+          if (!imgBytes) continue;
           const imageInput = {
             type: "image" as const,
-            data: Buffer.from(img.source.data, "base64"),
+            data: imgBytes,
             mimeType: img.source.media_type,
           };
           const imgResult = await embedWithRetry(opts.config, [imageInput], {

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -6,6 +6,7 @@ import { ProviderError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import { extractRetryAfterMs } from "../../util/retry.js";
 import { stripOrphanedSurrogatesDeep } from "../../util/unicode.js";
+import { base64Source, resolveMediaReferences } from "../media-resolve.js";
 import {
   couldBePlaceholderSentinelPrefix,
   isPlaceholderSentinelText,
@@ -1612,6 +1613,9 @@ export class AnthropicProvider implements Provider {
    * only thing layered on top in `sendMessage`.
    */
   private buildSentMessages(messages: Message[]): Anthropic.MessageParam[] {
+    // Swap any persisted attachment references back to inline base64 before
+    // serializing, so the block transforms below can read `source.data`.
+    messages = resolveMediaReferences(messages);
     const formatted = messages
       .map((m) => {
         // Track whether an unknown block was dropped during filtering
@@ -1836,11 +1840,11 @@ export class AnthropicProvider implements Provider {
             type: "base64",
             media_type: block.source
               .media_type as Anthropic.Base64ImageSource["media_type"],
-            data: block.source.data,
+            data: base64Source(block.source).data,
           },
         };
       case "file": {
-        const { media_type, data, filename } = block.source;
+        const { media_type, data, filename } = base64Source(block.source);
         if (media_type === "application/pdf") {
           // Only valid base64 document source for Anthropic
           return {
@@ -1898,7 +1902,7 @@ export class AnthropicProvider implements Provider {
                   type: "base64" as const,
                   media_type: cb.source
                     .media_type as Anthropic.Base64ImageSource["media_type"],
-                  data: cb.source.data,
+                  data: base64Source(cb.source).data,
                 },
               });
             } else if (cb.type === "text") {

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -9,6 +9,7 @@ import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../prompts/cache-boundary.js";
 import { isAbortReason } from "../../util/abort-reasons.js";
 import { ProviderError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
+import { base64Source, resolveMediaReferences } from "../media-resolve.js";
 import { PROVIDER_CATALOG } from "../model-catalog.js";
 import { createStreamTimeout } from "../stream-timeout.js";
 import type {
@@ -566,6 +567,9 @@ export class GeminiProvider implements Provider {
     messages: Message[],
     model: string,
   ): genai.Content[] {
+    // Swap any persisted attachment references back to inline base64 before
+    // building parts, so the transforms below can read `source.data`.
+    messages = resolveMediaReferences(messages);
     const result: genai.Content[] = [];
 
     // Build a map from tool_use id → function name so tool_result blocks
@@ -616,39 +620,42 @@ export class GeminiProvider implements Provider {
         case "text":
           parts.push({ text: block.text });
           break;
-        case "image":
+        case "image": {
+          const imageSrc = base64Source(block.source);
           parts.push({
             inlineData: {
-              mimeType: block.source.media_type,
-              data: block.source.data,
+              mimeType: imageSrc.media_type,
+              data: imageSrc.data,
             },
           });
           break;
+        }
         case "file": {
-          if (this.supportsGeminiInlineFile(block.source.media_type)) {
+          const fileSrc = base64Source(block.source);
+          if (this.supportsGeminiInlineFile(fileSrc.media_type)) {
             // Normalize audio MIME onto Gemini's spelling (e.g. audio/mpeg →
             // audio/mp3); PDFs pass through unchanged. Guard the 20 MB inline
             // request limit for audio so an oversize clip degrades to a text
             // note rather than 400ing the whole request.
-            const audioMime = normalizeGeminiAudioMime(block.source.media_type);
-            const rawBytes = base64ByteLength(block.source.data);
+            const audioMime = normalizeGeminiAudioMime(fileSrc.media_type);
+            const rawBytes = base64ByteLength(fileSrc.data);
             if (audioMime && rawBytes > GEMINI_MAX_INLINE_AUDIO_BYTES) {
               const approxMb = Math.round(rawBytes / (1024 * 1024));
               parts.push({
-                text: `[Audio file too large to send inline: ${block.source.filename} (${block.source.media_type}, ~${approxMb}MB). Gemini's inline request limit is 20MB; this file was omitted. Ask the user for a shorter clip.]`,
+                text: `[Audio file too large to send inline: ${fileSrc.filename} (${fileSrc.media_type}, ~${approxMb}MB). Gemini's inline request limit is 20MB; this file was omitted. Ask the user for a shorter clip.]`,
               });
             } else {
               parts.push({
                 inlineData: {
-                  mimeType: audioMime ?? block.source.media_type,
-                  data: block.source.data,
+                  mimeType: audioMime ?? fileSrc.media_type,
+                  data: fileSrc.data,
                 },
               });
             }
           } else {
             const fallback = block.extracted_text?.trim()
-              ? `[Attached file: ${block.source.filename} (${block.source.media_type})]\n${block.extracted_text}`
-              : `[Attached file: ${block.source.filename} (${block.source.media_type})]\nNo extracted text available.`;
+              ? `[Attached file: ${fileSrc.filename} (${fileSrc.media_type})]\n${block.extracted_text}`
+              : `[Attached file: ${fileSrc.filename} (${fileSrc.media_type})]\nNo extracted text available.`;
             parts.push({ text: fallback });
           }
           break;
@@ -685,23 +692,22 @@ export class GeminiProvider implements Provider {
             // mixing inlineData with functionResponse in the same Content entry.
             for (const cb of block.contentBlocks) {
               if (cb.type === "image") {
+                const cbSrc = base64Source(cb.source);
                 toolResultMediaParts.push({
                   inlineData: {
-                    mimeType: cb.source.media_type,
-                    data: cb.source.data,
+                    mimeType: cbSrc.media_type,
+                    data: cbSrc.data,
                   },
                 });
               } else if (cb.type === "file") {
-                const audioMime = normalizeGeminiAudioMime(
-                  cb.source.media_type,
-                );
+                const cbSrc = base64Source(cb.source);
+                const audioMime = normalizeGeminiAudioMime(cbSrc.media_type);
                 if (
                   audioMime &&
-                  base64ByteLength(cb.source.data) <=
-                    GEMINI_MAX_INLINE_AUDIO_BYTES
+                  base64ByteLength(cbSrc.data) <= GEMINI_MAX_INLINE_AUDIO_BYTES
                 ) {
                   toolResultMediaParts.push({
-                    inlineData: { mimeType: audioMime, data: cb.source.data },
+                    inlineData: { mimeType: audioMime, data: cbSrc.data },
                   });
                 } else if (audioMime) {
                   // Oversize audio: note it in the functionResponse output
@@ -710,7 +716,7 @@ export class GeminiProvider implements Provider {
                   // Gemini's request-size limit).
                   outputText =
                     outputText +
-                    `\n[Audio too large to send inline: ${cb.source.filename}. Ask for a shorter clip.]`;
+                    `\n[Audio too large to send inline: ${cbSrc.filename}. Ask for a shorter clip.]`;
                 }
                 // Non-inline-able file sub-blocks (m4a/opus/pdf) are skipped
                 // here; the tool's text output already conveys the file.

--- a/assistant/src/providers/gemini/inline-media.ts
+++ b/assistant/src/providers/gemini/inline-media.ts
@@ -67,8 +67,7 @@ export const GEMINI_MAX_INLINE_AUDIO_BYTES = 12 * 1024 * 1024;
 const GEMINI_AUDIO_TOKENS_PER_SECOND = 32;
 const APPROX_AUDIO_BYTES_PER_SECOND = 16_000;
 
-export function estimateGeminiAudioTokens(base64Data: string): number {
-  const approxSeconds =
-    base64ByteLength(base64Data) / APPROX_AUDIO_BYTES_PER_SECOND;
+export function estimateGeminiAudioTokens(byteLength: number): number {
+  const approxSeconds = byteLength / APPROX_AUDIO_BYTES_PER_SECOND;
   return Math.ceil(approxSeconds * GEMINI_AUDIO_TOKENS_PER_SECOND);
 }

--- a/assistant/src/providers/media-resolve.ts
+++ b/assistant/src/providers/media-resolve.ts
@@ -3,23 +3,19 @@
  * boundary.
  *
  * Image/file blocks are PERSISTED into `messages.content` as
- * {@link WorkspaceRefMediaSource} references (a workspace location + size/
- * dimension hints) rather than inline base64, keeping large blobs out of the DB
- * row and the lexical index. The reference bytes live in the workspace (an
- * attachment-store row or a file on disk). Just before a provider serializes a
- * turn, {@link resolveMediaReferences}
+ * {@link WorkspaceRefMediaSource} references (an attachment id + size/dimension
+ * hints) rather than inline base64, keeping large blobs out of the DB row and
+ * the lexical index. The reference bytes live in the workspace attachment
+ * store. Just before a provider serializes a turn, {@link resolveMediaReferences}
  * walks the message content and swaps every reference source for a
- * {@link Base64MediaSource} loaded from disk, so each provider transform can
- * keep reading `block.source.data` exactly as before.
+ * {@link Base64MediaSource} loaded from the store, so each provider transform
+ * can keep reading `block.source.data` exactly as before.
  *
  * Blocks that already carry base64 (a live, in-flight turn) pass through
  * untouched — no disk read — so only reloaded history pays the resolution cost,
  * and only on its first send after reload. The walk is pure: it returns fresh
  * block/message objects and never mutates the caller's in-memory history.
  */
-
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 
 import { optimizeImageForTransport } from "../agent/image-optimize.js";
 import { getAttachmentContent } from "../persistence/attachments-store.js";
@@ -31,40 +27,18 @@ import type {
   ImageContent,
   MediaSource,
   Message,
-  WorkspaceRefMediaSource,
 } from "./types.js";
 
 const log = getLogger("media-resolve");
 
 /**
- * Read the raw bytes a workspace reference points at, trying each location
- * route in turn: an attachment-store row, then an absolute file path, then a
- * workspace directory joined with the file's name. Returns `null` when no
- * route resolves or the file can no longer be read.
- */
-function workspaceRefBytes(source: WorkspaceRefMediaSource): Buffer | null {
-  if (source.attachmentId) return getAttachmentContent(source.attachmentId);
-  const path =
-    source.filePath ??
-    (source.dir && source.filename
-      ? join(source.dir, source.filename)
-      : undefined);
-  if (!path) return null;
-  try {
-    return readFileSync(path);
-  } catch {
-    return null;
-  }
-}
-
-/**
  * Raw bytes for any media source: an inline base64 payload decoded in place, or
- * a workspace reference read back from its stored location. Returns `null` when
- * a reference can no longer be resolved.
+ * a workspace reference read back from the attachment store. Returns `null`
+ * when a reference can no longer be resolved.
  */
 export function mediaSourceBytes(source: MediaSource): Buffer | null {
   if (source.type === "base64") return Buffer.from(source.data, "base64");
-  return workspaceRefBytes(source);
+  return getAttachmentContent(source.attachmentId);
 }
 
 /**
@@ -80,7 +54,7 @@ export function base64Source<T extends MediaSource>(
   if (source.type !== "base64") {
     throw new Error(
       `Unresolved workspace_ref media source reached the provider transform ` +
-        `(attachmentId=${source.attachmentId ?? "none"}, filePath=${source.filePath ?? "none"}). ` +
+        `(attachmentId=${source.attachmentId}). ` +
         `resolveMediaReferences must run before serializing messages.`,
     );
   }
@@ -111,20 +85,17 @@ export function resolveMediaSourceData(
   if (source.type === "base64") {
     return { data: source.data, media_type: source.media_type };
   }
-  const bytes = workspaceRefBytes(source);
+  const bytes = getAttachmentContent(source.attachmentId);
   if (!bytes) return null;
   return { data: bytes.toString("base64"), media_type: source.media_type };
 }
 
 function resolveImageBlock(block: ImageContent): ContentBlock {
   if (block.source.type === "base64") return block;
-  const bytes = workspaceRefBytes(block.source);
+  const bytes = getAttachmentContent(block.source.attachmentId);
   if (!bytes) {
     log.warn(
-      {
-        attachmentId: block.source.attachmentId,
-        filePath: block.source.filePath,
-      },
+      { attachmentId: block.source.attachmentId },
       "Image workspace reference could not be resolved; substituting a text note",
     );
     return {
@@ -147,7 +118,7 @@ function resolveImageBlock(block: ImageContent): ContentBlock {
 function resolveFileBlock(block: FileContent): ContentBlock {
   if (block.source.type === "base64") return block;
   const { attachmentId, media_type, filename } = block.source;
-  const bytes = workspaceRefBytes(block.source);
+  const bytes = getAttachmentContent(attachmentId);
   if (!bytes) {
     log.warn(
       { attachmentId, filename },
@@ -159,7 +130,7 @@ function resolveFileBlock(block: FileContent): ContentBlock {
       type: "text",
       text:
         block.extracted_text ??
-        `[Attachment unavailable: ${filename ?? attachmentId ?? "file"}]`,
+        `[Attachment unavailable: ${filename ?? attachmentId}]`,
     };
   }
   const source: Base64MediaSource = {

--- a/assistant/src/providers/media-resolve.ts
+++ b/assistant/src/providers/media-resolve.ts
@@ -1,0 +1,182 @@
+/**
+ * Resolve persisted media references into inline base64 at the provider send
+ * boundary.
+ *
+ * Image/file blocks are PERSISTED into `messages.content` as
+ * {@link AttachmentRefMediaSource} references (attachment id + size/dimension
+ * hints) rather than inline base64, keeping large blobs out of the DB row and
+ * the lexical index. The reference bytes live in the workspace attachment
+ * store. Just before a provider serializes a turn, {@link resolveMediaReferences}
+ * walks the message content and swaps every reference source for a
+ * {@link Base64MediaSource} loaded from disk, so each provider transform can
+ * keep reading `block.source.data` exactly as before.
+ *
+ * Blocks that already carry base64 (a live, in-flight turn) pass through
+ * untouched — no disk read — so only reloaded history pays the resolution cost,
+ * and only on its first send after reload. The walk is pure: it returns fresh
+ * block/message objects and never mutates the caller's in-memory history.
+ */
+
+import { optimizeImageForTransport } from "../agent/image-optimize.js";
+import { getAttachmentContent } from "../persistence/attachments-store.js";
+import { getLogger } from "../util/logger.js";
+import type {
+  Base64MediaSource,
+  ContentBlock,
+  FileContent,
+  ImageContent,
+  MediaSource,
+  Message,
+} from "./types.js";
+
+const log = getLogger("media-resolve");
+
+/**
+ * Narrow a media source to its base64 arm. After {@link resolveMediaReferences}
+ * runs, provider transforms only ever see base64 sources; this asserts that
+ * invariant and gives call sites the concrete `data`/`media_type` fields
+ * without an inline guard. Throwing (rather than emitting an empty payload)
+ * surfaces a missed resolution as a loud failure.
+ */
+export function base64Source<T extends MediaSource>(
+  source: T,
+): Extract<T, { type: "base64" }> {
+  if (source.type !== "base64") {
+    throw new Error(
+      `Unresolved attachment_ref media source reached the provider transform (attachmentId=${source.attachmentId}). ` +
+        `resolveMediaReferences must run before serializing messages.`,
+    );
+  }
+  return source as Extract<T, { type: "base64" }>;
+}
+
+/**
+ * Raw byte length of a media source's payload, without reading the file back.
+ * For a base64 source it is derived from the string length (4 chars → 3 bytes);
+ * for a reference it is the `sizeBytes` hint captured at persist time. Lets
+ * size-only consumers (the per-turn token estimator especially) cost a block
+ * without decoding or a disk read.
+ */
+export function mediaSourceByteLength(source: MediaSource): number {
+  if (source.type === "attachment_ref") return source.sizeBytes;
+  return Math.floor((source.data.length * 3) / 4);
+}
+
+/**
+ * Resolve a media source to inline base64, loading a reference source from the
+ * attachment store. Returns `null` when a referenced attachment can no longer
+ * be read. For consumers that hold an individual in-memory block (image
+ * captioning, media retry) and need its bytes outside the provider transform.
+ */
+export function resolveMediaSourceData(
+  source: MediaSource,
+): { data: string; media_type: string } | null {
+  if (source.type === "base64") {
+    return { data: source.data, media_type: source.media_type };
+  }
+  const bytes = getAttachmentContent(source);
+  if (!bytes) return null;
+  return { data: bytes.toString("base64"), media_type: source.media_type };
+}
+
+function resolveImageBlock(block: ImageContent): ContentBlock {
+  if (block.source.type === "base64") return block;
+  const bytes = getAttachmentContent(block.source);
+  if (!bytes) {
+    log.warn(
+      { attachmentId: block.source.attachmentId },
+      "Image attachment reference could not be resolved; substituting a text note",
+    );
+    return {
+      type: "text",
+      text: "[Attachment unavailable: image could not be loaded]",
+    };
+  }
+  // Apply the same transport optimization the inline-base64 path used, so a
+  // reloaded (reference) turn sends the model the same bytes a live turn would.
+  const { data, mediaType } = optimizeImageForTransport(
+    bytes.toString("base64"),
+    block.source.media_type,
+  );
+  return {
+    type: "image",
+    source: { type: "base64", media_type: mediaType, data },
+  };
+}
+
+function resolveFileBlock(block: FileContent): ContentBlock {
+  if (block.source.type === "base64") return block;
+  const { attachmentId, media_type, filename } = block.source;
+  const bytes = getAttachmentContent(block.source);
+  if (!bytes) {
+    log.warn(
+      { attachmentId, filename },
+      "File attachment reference could not be resolved; falling back to extracted text",
+    );
+    // Providers render non-inline files as their extracted text anyway; when the
+    // bytes are gone that text is the best remaining representation.
+    return {
+      type: "text",
+      text:
+        block.extracted_text ??
+        `[Attachment unavailable: ${filename ?? attachmentId}]`,
+    };
+  }
+  const source: Base64MediaSource = {
+    type: "base64",
+    media_type,
+    data: bytes.toString("base64"),
+    ...(filename !== undefined ? { filename } : {}),
+  };
+  return {
+    type: "file",
+    source,
+    ...(block.extracted_text !== undefined
+      ? { extracted_text: block.extracted_text }
+      : {}),
+    ...(block._attachmentId !== undefined
+      ? { _attachmentId: block._attachmentId }
+      : {}),
+  };
+}
+
+function resolveBlock(block: ContentBlock): ContentBlock {
+  switch (block.type) {
+    case "image":
+      return resolveImageBlock(block);
+    case "file":
+      return resolveFileBlock(block);
+    case "tool_result": {
+      // Nested media (e.g. a browser screenshot) may also carry references.
+      if (!block.contentBlocks?.length) return block;
+      return { ...block, contentBlocks: block.contentBlocks.map(resolveBlock) };
+    }
+    default:
+      return block;
+  }
+}
+
+function contentHasReference(content: ContentBlock[]): boolean {
+  return content.some((block) => {
+    if (block.type === "image" || block.type === "file") {
+      return block.source.type === "attachment_ref";
+    }
+    if (block.type === "tool_result" && block.contentBlocks?.length) {
+      return contentHasReference(block.contentBlocks);
+    }
+    return false;
+  });
+}
+
+/**
+ * Return a copy of `messages` with every {@link AttachmentRefMediaSource}
+ * resolved to inline base64. Messages with no references are returned unchanged
+ * (same object reference) so the common all-base64 live turn does no allocation
+ * or disk I/O.
+ */
+export function resolveMediaReferences(messages: Message[]): Message[] {
+  return messages.map((message) => {
+    if (!contentHasReference(message.content)) return message;
+    return { ...message, content: message.content.map(resolveBlock) };
+  });
+}

--- a/assistant/src/providers/media-resolve.ts
+++ b/assistant/src/providers/media-resolve.ts
@@ -3,10 +3,11 @@
  * boundary.
  *
  * Image/file blocks are PERSISTED into `messages.content` as
- * {@link AttachmentRefMediaSource} references (attachment id + size/dimension
- * hints) rather than inline base64, keeping large blobs out of the DB row and
- * the lexical index. The reference bytes live in the workspace attachment
- * store. Just before a provider serializes a turn, {@link resolveMediaReferences}
+ * {@link WorkspaceRefMediaSource} references (a workspace location + size/
+ * dimension hints) rather than inline base64, keeping large blobs out of the DB
+ * row and the lexical index. The reference bytes live in the workspace (an
+ * attachment-store row or a file on disk). Just before a provider serializes a
+ * turn, {@link resolveMediaReferences}
  * walks the message content and swaps every reference source for a
  * {@link Base64MediaSource} loaded from disk, so each provider transform can
  * keep reading `block.source.data` exactly as before.
@@ -16,6 +17,9 @@
  * and only on its first send after reload. The walk is pure: it returns fresh
  * block/message objects and never mutates the caller's in-memory history.
  */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
 import { optimizeImageForTransport } from "../agent/image-optimize.js";
 import { getAttachmentContent } from "../persistence/attachments-store.js";
@@ -27,9 +31,41 @@ import type {
   ImageContent,
   MediaSource,
   Message,
+  WorkspaceRefMediaSource,
 } from "./types.js";
 
 const log = getLogger("media-resolve");
+
+/**
+ * Read the raw bytes a workspace reference points at, trying each location
+ * route in turn: an attachment-store row, then an absolute file path, then a
+ * workspace directory joined with the file's name. Returns `null` when no
+ * route resolves or the file can no longer be read.
+ */
+function workspaceRefBytes(source: WorkspaceRefMediaSource): Buffer | null {
+  if (source.attachmentId) return getAttachmentContent(source.attachmentId);
+  const path =
+    source.filePath ??
+    (source.dir && source.filename
+      ? join(source.dir, source.filename)
+      : undefined);
+  if (!path) return null;
+  try {
+    return readFileSync(path);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Raw bytes for any media source: an inline base64 payload decoded in place, or
+ * a workspace reference read back from its stored location. Returns `null` when
+ * a reference can no longer be resolved.
+ */
+export function mediaSourceBytes(source: MediaSource): Buffer | null {
+  if (source.type === "base64") return Buffer.from(source.data, "base64");
+  return workspaceRefBytes(source);
+}
 
 /**
  * Narrow a media source to its base64 arm. After {@link resolveMediaReferences}
@@ -43,7 +79,8 @@ export function base64Source<T extends MediaSource>(
 ): Extract<T, { type: "base64" }> {
   if (source.type !== "base64") {
     throw new Error(
-      `Unresolved attachment_ref media source reached the provider transform (attachmentId=${source.attachmentId}). ` +
+      `Unresolved workspace_ref media source reached the provider transform ` +
+        `(attachmentId=${source.attachmentId ?? "none"}, filePath=${source.filePath ?? "none"}). ` +
         `resolveMediaReferences must run before serializing messages.`,
     );
   }
@@ -58,14 +95,14 @@ export function base64Source<T extends MediaSource>(
  * without decoding or a disk read.
  */
 export function mediaSourceByteLength(source: MediaSource): number {
-  if (source.type === "attachment_ref") return source.sizeBytes;
+  if (source.type === "workspace_ref") return source.sizeBytes;
   return Math.floor((source.data.length * 3) / 4);
 }
 
 /**
- * Resolve a media source to inline base64, loading a reference source from the
- * attachment store. Returns `null` when a referenced attachment can no longer
- * be read. For consumers that hold an individual in-memory block (image
+ * Resolve a media source to inline base64, reading a reference source back from
+ * its workspace location. Returns `null` when a reference can no longer be
+ * read. For consumers that hold an individual in-memory block (image
  * captioning, media retry) and need its bytes outside the provider transform.
  */
 export function resolveMediaSourceData(
@@ -74,18 +111,21 @@ export function resolveMediaSourceData(
   if (source.type === "base64") {
     return { data: source.data, media_type: source.media_type };
   }
-  const bytes = getAttachmentContent(source);
+  const bytes = workspaceRefBytes(source);
   if (!bytes) return null;
   return { data: bytes.toString("base64"), media_type: source.media_type };
 }
 
 function resolveImageBlock(block: ImageContent): ContentBlock {
   if (block.source.type === "base64") return block;
-  const bytes = getAttachmentContent(block.source);
+  const bytes = workspaceRefBytes(block.source);
   if (!bytes) {
     log.warn(
-      { attachmentId: block.source.attachmentId },
-      "Image attachment reference could not be resolved; substituting a text note",
+      {
+        attachmentId: block.source.attachmentId,
+        filePath: block.source.filePath,
+      },
+      "Image workspace reference could not be resolved; substituting a text note",
     );
     return {
       type: "text",
@@ -107,11 +147,11 @@ function resolveImageBlock(block: ImageContent): ContentBlock {
 function resolveFileBlock(block: FileContent): ContentBlock {
   if (block.source.type === "base64") return block;
   const { attachmentId, media_type, filename } = block.source;
-  const bytes = getAttachmentContent(block.source);
+  const bytes = workspaceRefBytes(block.source);
   if (!bytes) {
     log.warn(
       { attachmentId, filename },
-      "File attachment reference could not be resolved; falling back to extracted text",
+      "File workspace reference could not be resolved; falling back to extracted text",
     );
     // Providers render non-inline files as their extracted text anyway; when the
     // bytes are gone that text is the best remaining representation.
@@ -119,7 +159,7 @@ function resolveFileBlock(block: FileContent): ContentBlock {
       type: "text",
       text:
         block.extracted_text ??
-        `[Attachment unavailable: ${filename ?? attachmentId}]`,
+        `[Attachment unavailable: ${filename ?? attachmentId ?? "file"}]`,
     };
   }
   const source: Base64MediaSource = {
@@ -159,7 +199,7 @@ function resolveBlock(block: ContentBlock): ContentBlock {
 function contentHasReference(content: ContentBlock[]): boolean {
   return content.some((block) => {
     if (block.type === "image" || block.type === "file") {
-      return block.source.type === "attachment_ref";
+      return block.source.type === "workspace_ref";
     }
     if (block.type === "tool_result" && block.contentBlocks?.length) {
       return contentHasReference(block.contentBlocks);
@@ -169,7 +209,7 @@ function contentHasReference(content: ContentBlock[]): boolean {
 }
 
 /**
- * Return a copy of `messages` with every {@link AttachmentRefMediaSource}
+ * Return a copy of `messages` with every {@link WorkspaceRefMediaSource}
  * resolved to inline base64. Messages with no references are returned unchanged
  * (same object reference) so the common all-base64 live turn does no allocation
  * or disk I/O.

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -5,6 +5,7 @@ import { isAbortReason } from "../../util/abort-reasons.js";
 import { ProviderError } from "../../util/errors.js";
 import { extractRetryAfterMs } from "../../util/retry.js";
 import { escapeXmlAttr } from "../../util/xml.js";
+import { base64Source, resolveMediaReferences } from "../media-resolve.js";
 import { PLACEHOLDER_EMPTY_TURN } from "../placeholder-sentinels.js";
 import { createStreamTimeout } from "../stream-timeout.js";
 import { createToolProgressEmitter } from "../tool-progress-events.js";
@@ -806,6 +807,9 @@ export class OpenAIChatCompletionsProvider implements Provider {
     messages: Message[],
     systemPrompt?: string,
   ): OpenAI.Chat.Completions.ChatCompletionMessageParam[] {
+    // Swap any persisted attachment references back to inline base64 before
+    // serializing, so the block transforms below can read `source.data`.
+    messages = resolveMediaReferences(messages);
     const result: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
 
     if (systemPrompt) {
@@ -966,10 +970,11 @@ export class OpenAIChatCompletionsProvider implements Provider {
               text: `[Image: ${block.source.media_type} — format not supported by this provider]`,
             });
           } else {
+            const imageSrc = base64Source(block.source);
             parts.push({
               type: "image_url",
               image_url: {
-                url: `data:${block.source.media_type};base64,${block.source.data}`,
+                url: `data:${imageSrc.media_type};base64,${imageSrc.data}`,
               },
             });
           }
@@ -999,7 +1004,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
     block: Extract<ContentBlock, { type: "file" }>,
   ): string {
     const header = `<attached_file name="${escapeXmlAttr(
-      block.source.filename,
+      block.source.filename ?? "",
     )}" type="${escapeXmlAttr(block.source.media_type)}" />`;
     if (block.extracted_text && block.extracted_text.trim().length > 0) {
       return `${header}\n${block.extracted_text}`;

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -6,6 +6,7 @@ import { ProviderError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import { extractRetryAfterMs } from "../../util/retry.js";
 import { escapeXmlAttr } from "../../util/xml.js";
+import { base64Source, resolveMediaReferences } from "../media-resolve.js";
 import { createStreamTimeout } from "../stream-timeout.js";
 import { createToolProgressEmitter } from "../tool-progress-events.js";
 import type {
@@ -591,6 +592,9 @@ export class OpenAIResponsesProvider implements Provider {
    * System prompt is NOT included here — it goes into the `instructions` param.
    */
   private toResponsesInput(messages: Message[]): unknown[] {
+    // Swap any persisted attachment references back to inline base64 before
+    // serializing, so the block transforms below can read `source.data`.
+    messages = resolveMediaReferences(messages);
     const result: unknown[] = [];
 
     for (const msg of messages) {
@@ -719,9 +723,10 @@ export class OpenAIResponsesProvider implements Provider {
               text: `[Image: ${block.source.media_type} — format not supported by this provider]`,
             });
           } else {
+            const imageSrc = base64Source(block.source);
             parts.push({
               type: "input_image",
-              image_url: `data:${block.source.media_type};base64,${block.source.data}`,
+              image_url: `data:${imageSrc.media_type};base64,${imageSrc.data}`,
             });
           }
           break;
@@ -754,7 +759,7 @@ export class OpenAIResponsesProvider implements Provider {
     block: Extract<ContentBlock, { type: "file" }>,
   ): string {
     const header = `<attached_file name="${escapeXmlAttr(
-      block.source.filename,
+      block.source.filename ?? "",
     )}" type="${escapeXmlAttr(block.source.media_type)}" />`;
     if (block.extracted_text && block.extracted_text.trim().length > 0) {
       return `${header}\n${block.extracted_text}`;

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -37,46 +37,29 @@ export interface Base64MediaSource {
 }
 
 /**
- * Fields common to every workspace reference, independent of how the bytes are
- * located. `sizeBytes` (and, for images, `width`/`height`) are the persist-time
- * hints that let size-only consumers cost the block without a disk read.
+ * A reference to bytes stored in the workspace rather than inlined. The bytes
+ * live in the workspace attachment store, addressed by `attachmentId`, and are
+ * read back at the provider send boundary. User uploads are attachment rows
+ * already; tool-result media is materialized into attachment rows before it is
+ * referenced, so a single `attachmentId` resolves every case and needs no
+ * fallback locator.
+ *
+ * `sizeBytes` (and, for images, `width`/`height`) are the persist-time hints
+ * that let size-only consumers cost the block without a disk read.
  */
-interface WorkspaceRefBase {
+export interface WorkspaceRefMediaSource {
   type: "workspace_ref";
   media_type: string;
-  filename?: string;
+  /** Attachment row id; resolves to bytes via the attachment store. */
+  attachmentId: string;
   /** Byte length of the referenced file. */
   sizeBytes: number;
+  filename?: string;
   /** Decoded pixel width, when the reference is an image. */
   width?: number;
   /** Decoded pixel height, when the reference is an image. */
   height?: number;
 }
-
-/**
- * A reference to bytes stored in the workspace rather than inlined. We start
- * with attachment-store rows (user uploads) and will extend the same shape to
- * tool-result media (files on disk) in later PRs — hence the location is one of
- * three mutually exclusive routes, at least one of which is always present:
- *
- * - `attachmentId` — an attachment-store row; resolves via the store.
- * - `filePath` — an absolute workspace file path.
- * - `dir` + `filename` — a workspace directory joined with the file's name.
- *
- * The union enforces at construction that a reference is always resolvable;
- * `providers/media-resolve.ts` reads the routes in the order above.
- */
-export type WorkspaceRefMediaSource = WorkspaceRefBase &
-  (
-    | { attachmentId: string; filePath?: string; dir?: string }
-    | { attachmentId?: undefined; filePath: string; dir?: string }
-    | {
-        attachmentId?: undefined;
-        filePath?: undefined;
-        dir: string;
-        filename: string;
-      }
-  );
 
 export type MediaSource = Base64MediaSource | WorkspaceRefMediaSource;
 

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -16,12 +16,12 @@ export interface TextContent {
  * - `base64` — the bytes travel inline with the block. This is the runtime
  *   shape the provider transforms consume and the shape produced for a live
  *   (in-flight) turn.
- * - `attachment_ref` — the bytes live in the workspace attachment store,
- *   addressed by `attachmentId`. This is the shape PERSISTED into
- *   `messages.content`, keeping large blobs out of the DB row and the lexical
- *   index. It is resolved back to inline bytes at the provider send boundary
- *   (`providers/media-resolve.ts`); any consumer that needs the raw bytes from
- *   stored content resolves it with `getAttachmentContent(source)`.
+ * - `workspace_ref` — the bytes live somewhere in the workspace, not inline.
+ *   This is the shape PERSISTED into `messages.content`, keeping large blobs
+ *   out of the DB row and the lexical index. It is resolved back to inline
+ *   bytes at the provider send boundary (`providers/media-resolve.ts`); any
+ *   consumer that needs the raw bytes from stored content resolves it with
+ *   `resolveMediaSourceData(source)`.
  *
  * `filename` is optional on both arms (present for file blocks and for
  * generated-media references). For references, `sizeBytes` (and, for images,
@@ -36,21 +36,49 @@ export interface Base64MediaSource {
   filename?: string;
 }
 
-export interface AttachmentRefMediaSource {
-  type: "attachment_ref";
+/**
+ * Fields common to every workspace reference, independent of how the bytes are
+ * located. `sizeBytes` (and, for images, `width`/`height`) are the persist-time
+ * hints that let size-only consumers cost the block without a disk read.
+ */
+interface WorkspaceRefBase {
+  type: "workspace_ref";
   media_type: string;
-  /** Attachment row id; resolve to bytes via `getAttachmentContent`. */
-  attachmentId: string;
+  filename?: string;
   /** Byte length of the referenced file. */
   sizeBytes: number;
-  filename?: string;
   /** Decoded pixel width, when the reference is an image. */
   width?: number;
   /** Decoded pixel height, when the reference is an image. */
   height?: number;
 }
 
-export type MediaSource = Base64MediaSource | AttachmentRefMediaSource;
+/**
+ * A reference to bytes stored in the workspace rather than inlined. We start
+ * with attachment-store rows (user uploads) and will extend the same shape to
+ * tool-result media (files on disk) in later PRs — hence the location is one of
+ * three mutually exclusive routes, at least one of which is always present:
+ *
+ * - `attachmentId` — an attachment-store row; resolves via the store.
+ * - `filePath` — an absolute workspace file path.
+ * - `dir` + `filename` — a workspace directory joined with the file's name.
+ *
+ * The union enforces at construction that a reference is always resolvable;
+ * `providers/media-resolve.ts` reads the routes in the order above.
+ */
+export type WorkspaceRefMediaSource = WorkspaceRefBase &
+  (
+    | { attachmentId: string; filePath?: string; dir?: string }
+    | { attachmentId?: undefined; filePath: string; dir?: string }
+    | {
+        attachmentId?: undefined;
+        filePath?: undefined;
+        dir: string;
+        filename: string;
+      }
+  );
+
+export type MediaSource = Base64MediaSource | WorkspaceRefMediaSource;
 
 export interface ImageContent {
   type: "image";

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -9,31 +9,65 @@ export interface TextContent {
   text: string;
 }
 
+/**
+ * Media payload for an image or file content block. One unified type covers
+ * both blocks and both storage forms:
+ *
+ * - `base64` — the bytes travel inline with the block. This is the runtime
+ *   shape the provider transforms consume and the shape produced for a live
+ *   (in-flight) turn.
+ * - `attachment_ref` — the bytes live in the workspace attachment store,
+ *   addressed by `attachmentId`. This is the shape PERSISTED into
+ *   `messages.content`, keeping large blobs out of the DB row and the lexical
+ *   index. It is resolved back to inline bytes at the provider send boundary
+ *   (`providers/media-resolve.ts`); any consumer that needs the raw bytes from
+ *   stored content resolves it with `getAttachmentContent(source)`.
+ *
+ * `filename` is optional on both arms (present for file blocks and for
+ * generated-media references). For references, `sizeBytes` (and, for images,
+ * `width`/`height`) are captured at persist time so size-only consumers — the
+ * per-turn token estimator especially — can cost the block without reading the
+ * file back off disk.
+ */
+export interface Base64MediaSource {
+  type: "base64";
+  media_type: string;
+  data: string;
+  filename?: string;
+}
+
+export interface AttachmentRefMediaSource {
+  type: "attachment_ref";
+  media_type: string;
+  /** Attachment row id; resolve to bytes via `getAttachmentContent`. */
+  attachmentId: string;
+  /** Byte length of the referenced file. */
+  sizeBytes: number;
+  filename?: string;
+  /** Decoded pixel width, when the reference is an image. */
+  width?: number;
+  /** Decoded pixel height, when the reference is an image. */
+  height?: number;
+}
+
+export type MediaSource = Base64MediaSource | AttachmentRefMediaSource;
+
 export interface ImageContent {
   type: "image";
-  source: {
-    type: "base64";
-    media_type: string;
-    data: string;
-  };
+  source: MediaSource;
 }
 
 export interface FileContent {
   type: "file";
-  source: {
-    type: "base64";
-    media_type: string;
-    data: string;
-    filename: string;
-  };
+  source: MediaSource;
   extracted_text?: string;
   /**
-   * Internal id linking this block to a row in the attachments table.
-   * Set when the file block originates from a persisted user-message
-   * attachment so downstream consumers (DB joins, inline-chip
-   * positioning) can correlate the block back to its attachment id.
-   * Stripped by `daemon/handlers/shared.ts` before sending to the
-   * model.
+   * Internal id linking a base64 file block to a row in the attachments table
+   * so consumers (DB joins, inline-chip positioning) can correlate the block
+   * back to its attachment. Redundant once the block is a reference (use
+   * `source.attachmentId`); retained only while file media is still persisted
+   * inline as base64, and removed when file uploads move to references.
+   * Stripped by `daemon/handlers/shared.ts` before sending to the model.
    */
   _attachmentId?: string;
 }


### PR DESCRIPTION
## Prompt / plan

Groundwork for ATL-991 (attachments serialized as inline base64 into `messages.content`). The fix is being split into three stacked-but-independent PRs off `main`, per review feedback to "get the new data models in and merged first":

- **PR A (this one)** — land the unified data model + centralized helpers, behavior-neutral.
- **PR B** — persist user uploads as references (single-write).
- **PR C** — persist tool/assistant-generated media as references.

The two earlier exploratory PRs (#37451, #37453) are kept as **draft references** only; this PR supersedes their type/helper layer.

### What this changes

Introduces one `MediaSource` union — `Base64MediaSource | AttachmentRefMediaSource` — as the `source` of both `image` and `file` content blocks, replacing the ad-hoc base64-only shapes and unifying the two block types on a single media type.

- `base64` arm — bytes inline; unchanged, and still the runtime shape every provider transform consumes.
- `attachment_ref` arm — bytes live in the workspace attachment store, addressed by `attachmentId` with `sizeBytes` / `width` / `height` hints captured at persist time, keeping large blobs out of the DB row and lexical index.

Centralized helpers (`providers/media-resolve.ts`), each with a real caller:

- `resolveMediaReferences(messages)` — run at each provider send boundary (anthropic, openai chat + responses, gemini) to swap references back to inline base64 so the transforms keep reading `source.data`. No-op (same object, no disk I/O) on all-base64 content.
- `base64Source(source)` — narrow to the base64 arm at transform read sites, throwing loudly if an unresolved reference slips through.
- `resolveMediaSourceData(source)` / `getAttachmentContent(source)` overload — resolve a single block's bytes for consumers outside the transform (image captioning, recovery, memory image embedding, tool-result display).
- `mediaSourceByteLength(source)` / `parseImageDimensions(source)` overload — size/dimension a block from the reference hints with no disk read, for the per-turn token-estimator hot path.

`filename` is now optional on both arms; readers handle its absence.

**This PR is behavior-neutral:** nothing constructs an `attachment_ref` yet (the reference *producer* lands in PR B), so persistence is unchanged and every reader continues to see base64 at runtime. The point is to get the type and the resolution seam merged first.

## Test plan

- `bunx tsc --noEmit` — clean across the whole project.
- Affected suites pass in isolation: `anthropic-provider`, `gemini-provider`, `openai-provider`, `openai-responses-provider`, `gemini-inline-media`, `context-token-estimator`, `openrouter-token-estimation`, `image-recovery-hook`, `image-fallback`, `conversation-media-retry`, `compactor-media-strip`, `context-overflow-reducer`, `thread-backfill`, `persist-unsendable-image[-downscale]`, `process-message-display-content`, `conversation-queue`, `server-history-render`, `attachments`, `assistant-attachments`.
- prettier + eslint (import-sort) clean; pre-commit hook green (0 lint errors, typecheck OK).
- One pre-existing cross-file test-ordering flake in the image-attachment store (content-hash collision) reproduces identically on a clean `main` checkout — not introduced here.


---
_Generated by [Claude Code](https://claude.ai/code/session_013KcQ6J4ggzKmNUP8BnqqvB)_