### PR TITLE
feat(web): Channels tab — replace adapter sub-tabs with master-detail layout (LUM-2746)

### DIFF
--- a/clients/web/src/domains/channels/adapter-selection-store.ts
+++ b/clients/web/src/domains/channels/adapter-selection-store.ts
@@ -1,0 +1,37 @@
+/**
+ * Which adapter's detail is shown in the Channels tab's master-detail layout.
+ *
+ * Kept in a module-level store rather than component state so the choice
+ * survives the tab's route remounting (navigating away to another About
+ * Assistant section and back) — the selection persists for the browser
+ * session and resets to Slack on a full reload. Slack is the default so the
+ * tab opens on the primary adapter.
+ *
+ * Reference: {@link https://zustand.docs.pmnd.rs/}
+ */
+
+import { create } from "zustand";
+
+import { createSelectors } from "@/utils/create-selectors";
+import type { SetupChannelId } from "@/types/channel-types";
+
+export interface ChannelAdapterSelectionState {
+  selectedAdapter: SetupChannelId;
+}
+
+export interface ChannelAdapterSelectionActions {
+  selectAdapter: (adapter: SetupChannelId) => void;
+}
+
+export type ChannelAdapterSelectionStore = ChannelAdapterSelectionState &
+  ChannelAdapterSelectionActions;
+
+const useChannelAdapterSelectionStoreBase =
+  create<ChannelAdapterSelectionStore>()((set) => ({
+    selectedAdapter: "slack",
+    selectAdapter: (adapter) => set({ selectedAdapter: adapter }),
+  }));
+
+export const useChannelAdapterSelectionStore = createSelectors(
+  useChannelAdapterSelectionStoreBase,
+);

--- a/clients/web/src/domains/channels/channels-page.tsx
+++ b/clients/web/src/domains/channels/channels-page.tsx
@@ -15,13 +15,13 @@ export interface ChannelsPageProps {
 }
 
 /**
- * Channels settings — the Slack/Telegram/Phone sub-tabs where the guardian
- * manages how and where the assistant can be reached. Rendered as its own tab
- * in the About Assistant nav (`/assistant/channels`): a page-level subtitle
- * above the tabbed content (the nav's tab already reads "Channels", so the
- * page repeats no heading). The Contacts page's assistant detail
- * (`AssistantChannelsDetail`) shows only a connect/disconnect summary of the
- * same channels; management stays here.
+ * Channels settings — the Slack/Telegram/Phone master-detail surface where
+ * the guardian manages how and where the assistant can be reached. Rendered
+ * as its own tab in the About Assistant nav (`/assistant/channels`): a
+ * page-level subtitle above the adapter list + detail panel (the nav's tab
+ * already reads "Channels", so the page repeats no heading). The Contacts
+ * page's assistant detail (`AssistantChannelsDetail`) shows only a
+ * connect/disconnect summary of the same channels; management stays here.
  */
 export function ChannelsPage({
   assistantId,
@@ -46,14 +46,12 @@ export function ChannelsPage({
         subtitle={`Manage where ${displayName} can be reached.`}
       />
 
-      <DetailCard>
-        <AssistantChannelsList
-          assistantId={assistantId}
-          assistantName={displayName}
-          initialChannel={setupChannel}
-          {...channelsController}
-        />
-      </DetailCard>
+      <AssistantChannelsList
+        assistantId={assistantId}
+        assistantName={displayName}
+        initialChannel={setupChannel}
+        {...channelsController}
+      />
 
       {a2aChannel ? (
         <ShareConnectionLinkButton onClick={inviteDialog.open} />

--- a/clients/web/src/domains/channels/channels-page.tsx
+++ b/clients/web/src/domains/channels/channels-page.tsx
@@ -40,7 +40,7 @@ export function ChannelsPage({
   });
 
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-hidden">
       <DetailCard
         showBorder={false}
         subtitle={`Manage where ${displayName} can be reached.`}

--- a/clients/web/src/domains/channels/components/assistant-channels-list.stories.tsx
+++ b/clients/web/src/domains/channels/components/assistant-channels-list.stories.tsx
@@ -1,21 +1,22 @@
 import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useLayoutEffect } from "react";
 
 import { DetailCard } from "@/components/detail-card";
+import { useChannelAdapterSelectionStore } from "@/domains/channels/adapter-selection-store";
+import type { SetupChannelId } from "@/types/channel-types";
 
 import { AssistantChannelsList } from "./assistant-channels-list";
 
 /**
  * The standalone Channels tab composition (`ChannelsPage` minus its data
- * wiring): a borderless page subtitle, then the channel sub-tabs in a card —
- * matching the sibling About Assistant tabs rather than the boxed
- * "Channels" card used inside the Contacts detail view. (The Channels tab
- * itself is gated on the `channel-trust-floors` flag in the About
- * Assistant nav.)
+ * wiring): a borderless page subtitle over the adapter master-detail — a left
+ * rail of adapters beside the selected adapter's detail panel, matching the
+ * sibling Contacts tab's Entries + detail shape.
  */
 // The Slack panel owns its own queries (`SlackChannelSection`), so stories
 // need a QueryClient. Requests fail in Storybook (no daemon), so the Slack
-// tab's channel list renders its error state; the list's full visuals live
+// panel's channel list renders its error state; the list's full visuals live
 // in the SlackChannelList stories, which mock data via props.
 const withQueryClient: Decorator = (Story) => (
   <QueryClientProvider
@@ -24,6 +25,20 @@ const withQueryClient: Decorator = (Story) => (
     <Story />
   </QueryClientProvider>
 );
+
+/**
+ * Pin the master-detail selection for a story. The active adapter lives in a
+ * module-level store that persists across story navigation, so each story
+ * seeds it explicitly rather than inheriting the previously-viewed adapter.
+ */
+function withSelectedAdapter(adapter: SetupChannelId): Decorator {
+  return function SelectAdapter(Story) {
+    useLayoutEffect(() => {
+      useChannelAdapterSelectionStore.setState({ selectedAdapter: adapter });
+    }, []);
+    return <Story />;
+  };
+}
 
 const meta: Meta<typeof AssistantChannelsList> = {
   title: "Channels/AssistantChannelsList",
@@ -58,9 +73,7 @@ const meta: Meta<typeof AssistantChannelsList> = {
           showBorder={false}
           subtitle="Manage where Example Assistant can be reached."
         />
-        <DetailCard>
-          <Story />
-        </DetailCard>
+        <Story />
       </div>
     ),
   ],
@@ -70,18 +83,20 @@ export default meta;
 
 type Story = StoryObj<typeof AssistantChannelsList>;
 
-export const ChannelsTab: Story = {};
+/** Default: Slack selected, its consolidated connection card in the detail panel. */
+export const ChannelsTab: Story = {
+  decorators: [withSelectedAdapter("slack")],
+};
 
 /**
- * Connected Slack tab: the consolidated connection card (logo, @handle,
- * Connected chip, low-weight Disconnect) with Thread Behavior in the body,
- * over the channel presence list. Slack shows no trust-floor dropdown even
- * with a policy handler wired — its floors are managed per conversation
- * type.
+ * Connected Slack: the consolidated connection card (logo, @handle, Connected
+ * chip, low-weight Disconnect) with Thread Behavior in the body, over the
+ * channel presence list. Slack shows no trust-floor dropdown even with a
+ * policy handler wired — its floors are managed per conversation type.
  */
 export const ChannelsTabSlackConnected: Story = {
+  decorators: [withSelectedAdapter("slack")],
   args: {
-    initialChannel: "slack",
     slackThreadMode: "mention_then_thread",
     onSlackThreadModeChange: () => {},
     channelPolicies: { slack: "trusted_contacts" },
@@ -89,8 +104,9 @@ export const ChannelsTabSlackConnected: Story = {
   },
 };
 
-/** Disconnected Slack tab: the setup wizard in the "Slack setup" card. */
+/** Disconnected Slack: the setup wizard in the "Slack setup" card. */
 export const ChannelsTabSlackDisconnected: Story = {
+  decorators: [withSelectedAdapter("slack")],
   args: {
     channels: [
       { key: "slack", status: "not_configured" },
@@ -100,33 +116,20 @@ export const ChannelsTabSlackDisconnected: Story = {
   },
 };
 
-/**
- * Disconnected Telegram tab: empty state with guided setup + manual escape
- * hatch. Telegram is listed first so it's the default tab — `initialChannel`
- * is reserved for setup deep links, which skip straight to the manual form.
- */
+/** Disconnected Telegram: empty state with guided setup + manual escape hatch. */
 export const ChannelsTabTelegramDisconnected: Story = {
-  args: {
-    channels: [
-      { key: "telegram", status: "not_configured" },
-      { key: "slack", status: "ready", address: "@example-assistant" },
-      { key: "phone", status: "not_configured" },
-    ],
-  },
+  decorators: [withSelectedAdapter("telegram")],
 };
 
-/** Disconnected Phone tab: empty state with guided setup + manual escape hatch. */
+/** Disconnected Phone: empty state with guided setup + manual escape hatch. */
 export const ChannelsTabPhoneDisconnected: Story = {
-  args: {
-    channels: [
-      { key: "phone", status: "not_configured" },
-      { key: "slack", status: "ready", address: "@example-assistant" },
-      { key: "telegram", status: "not_configured" },
-    ],
-  },
+  decorators: [withSelectedAdapter("phone")],
 };
 
-/** A `?setup=telegram` deep link (mobile chat handoff) lands on the manual form. */
+/**
+ * A `?setup=telegram` deep link (mobile chat handoff) selects Telegram and
+ * lands on its manual credential form rather than the empty state.
+ */
 export const ChannelsTabTelegramSetupHandoff: Story = {
   args: {
     initialChannel: "telegram",

--- a/clients/web/src/domains/channels/components/assistant-channels-list.test.tsx
+++ b/clients/web/src/domains/channels/components/assistant-channels-list.test.tsx
@@ -1,9 +1,10 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 
+import { useChannelAdapterSelectionStore } from "@/domains/channels/adapter-selection-store";
 import {
   AssistantChannelsList,
   type AssistantChannelsListProps,
@@ -38,6 +39,23 @@ function renderList(extraProps: Partial<AssistantChannelsListProps> = {}) {
   );
 }
 
+/** The left-rail adapter row whose label matches — the master-detail selector. */
+function adapterRow(label: string): HTMLElement {
+  const row = Array.from(
+    document.querySelectorAll<HTMLElement>('[data-slot="panel-item"]'),
+  ).find((el) => el.textContent?.includes(label));
+  if (!row) {
+    throw new Error(`No adapter row for "${label}"`);
+  }
+  return row;
+}
+
+beforeEach(() => {
+  // Selection lives in a module-level store; reset it so every test starts on
+  // the default Slack adapter.
+  useChannelAdapterSelectionStore.setState({ selectedAdapter: "slack" });
+});
+
 afterEach(() => {
   cleanup();
 });
@@ -50,17 +68,23 @@ describe("assistant channels list", () => {
     expect(document.body.textContent).toContain("Telegram");
   });
 
-  test("renders the adapter sub-tabs", () => {
+  test("renders the adapter list beside the detail panel, with no sub-tab strip", () => {
     renderList();
-    expect(document.querySelector('[data-slot="tabs"]')).not.toBeNull();
+    // Master-detail, not tabs: the left rail is a row of PanelItems and no
+    // Radix tab chrome is rendered.
+    expect(document.querySelector('[data-slot="tabs"]')).toBeNull();
+    expect(document.querySelectorAll('[data-slot="panel-item"]').length).toBe(
+      3,
+    );
     expect(document.body.textContent).toContain("Phone");
     expect(document.body.textContent).not.toContain("Phone Calling");
-    // Slack (connected) is the default tab: Tag chip + disconnect affordance.
+    // Slack (connected) is selected by default: its detail shows the Tag chip
+    // + disconnect affordance.
     expect(document.body.textContent).toContain("Connected");
     expect(document.body.textContent).toContain("Disconnect");
   });
 
-  test("the Slack sub-tab consolidates connection state into a single card", () => {
+  test("the Slack panel consolidates connection state into a single card", () => {
     renderList({
       onDisconnect: () => {},
       channelPolicies: { slack: "trusted_contacts" },
@@ -104,29 +128,27 @@ describe("assistant channels list", () => {
     expect(disconnected).toEqual(["slack"]);
   });
 
-  test("connected Telegram keeps the trust-floor dropdown", () => {
+  test("selecting connected Telegram reveals its trust-floor dropdown", () => {
     renderList({
       channels: [
-        { key: "telegram", status: "ready", address: "@vex_bot" },
         { key: "slack", status: "ready", address: "@vex" },
+        { key: "telegram", status: "ready", address: "@vex_bot" },
         { key: "phone", status: "not_configured" },
       ],
       channelPolicies: { telegram: "trusted_contacts" },
       onChannelPolicyChange: () => {},
     });
+    // Slack is selected by default and has no channel-wide floor control.
+    expect(document.body.textContent).not.toContain("Who can message Vex");
+
+    fireEvent.click(adapterRow("Telegram"));
     expect(document.body.textContent).toContain("Who can message Vex");
   });
 
-  test("disconnected tab swaps the empty state for the manual form on request", () => {
+  test("selecting a disconnected adapter swaps the empty state for the manual form on request", () => {
     renderList();
 
-    const telegramTab = Array.from(
-      document.querySelectorAll('[data-slot="tabs-trigger"]'),
-    ).find((t) => t.textContent === "Telegram");
-    expect(telegramTab).toBeDefined();
-    // Radix tab triggers select on mousedown (automatic activation), not click.
-    fireEvent.mouseDown(telegramTab!, { button: 0 });
-
+    fireEvent.click(adapterRow("Telegram"));
     expect(document.body.textContent).toContain("Telegram isn't connected");
     expect(document.body.textContent).not.toContain("Bot Token");
 
@@ -140,7 +162,7 @@ describe("assistant channels list", () => {
     expect(document.body.textContent).not.toContain("Telegram isn't connected");
   });
 
-  test("a setup deep link opens the manual form directly", () => {
+  test("a setup deep link selects that adapter and opens the manual form directly", () => {
     // The mobile chat-drawer handoff navigates to `?setup=<channel>` to
     // continue credential entry here — it must land on the form, not the
     // empty state whose Set up button would start another conversation.

--- a/clients/web/src/domains/channels/components/assistant-channels-list.tsx
+++ b/clients/web/src/domains/channels/components/assistant-channels-list.tsx
@@ -1,17 +1,23 @@
 import { CheckCircle } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Button } from "@vellumai/design-library/components/button";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { Dropdown } from "@vellumai/design-library/components/dropdown";
 import { Input } from "@vellumai/design-library/components/input";
 import { Notice } from "@vellumai/design-library/components/notice";
-import { Tabs } from "@vellumai/design-library/components/tabs";
 import { Tag } from "@vellumai/design-library/components/tag";
 import { Typography } from "@vellumai/design-library/components/typography";
 
+import { DetailCard } from "@/components/detail-card";
 import { EmptyState } from "@/components/empty-state";
+import {
+  MobileSidebarDrawer,
+  MobileSidebarTrigger,
+} from "@/components/mobile-sidebar-drawer";
 import { assistantDisplayName as toAssistantDisplayName } from "@/utils/assistant-display-name";
+import { useChannelAdapterSelectionStore } from "@/domains/channels/adapter-selection-store";
+import { ChannelAdapterList } from "@/domains/channels/components/channel-adapter-list";
 import { SlackChannelCard } from "@/domains/channels/components/slack-channel-card";
 import { SlackChannelSection } from "@/domains/channels/components/slack-channel-section";
 import { SlackConnectionCard } from "@/domains/channels/components/slack-connection-card";
@@ -158,12 +164,13 @@ const CHANNEL_META: Record<
 };
 
 /**
- * The Slack/Telegram/Phone adapter sub-tabs plus their disconnect and
- * trust-floor confirmation dialogs, rendered by the Channels tab
- * (`ChannelsPage`). Owns which sub-tab is active and which confirmations
- * are pending; the queries and mutations behind the props live in
- * `useAssistantChannels`. The `channel-trust-floors` flag gates the
- * Channels tab itself (in `IntelligenceLayout`), not anything in here.
+ * The Channels tab's master-detail surface: a left rail listing the
+ * Slack/Telegram/Phone adapters (`ChannelAdapterList`) beside the selected
+ * adapter's detail panel, plus the disconnect and trust-floor confirmation
+ * dialogs. Rendered by the Channels tab (`ChannelsPage`). The active adapter
+ * persists in `adapter-selection-store`; the queries and mutations behind the
+ * props live in `useAssistantChannels`. The `channel-trust-floors` flag gates
+ * the Channels tab itself (in `IntelligenceLayout`), not anything in here.
  */
 export function AssistantChannelsList({
   assistantId,
@@ -187,11 +194,11 @@ export function AssistantChannelsList({
   onSaveTwilioCredentials,
   initialChannel = null,
 }: AssistantChannelsListProps) {
+  const selectedAdapter = useChannelAdapterSelectionStore.use.selectedAdapter();
+  const selectAdapter = useChannelAdapterSelectionStore.use.selectAdapter();
+
   const [pendingDisconnect, setPendingDisconnect] = useState<ChannelKey | null>(
     null,
-  );
-  const [activeChannel, setActiveChannel] = useState<ChannelKey>(
-    () => initialChannel ?? channels[0]?.key ?? "slack",
   );
   // Floor confirmation: non-null while a floor in POLICY_CONFIRMATIONS awaits
   // the user's go-ahead before persisting.
@@ -199,6 +206,15 @@ export function AssistantChannelsList({
     channelKey: ChannelKey;
     policy: AdmissionPolicy;
   } | null>(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  // A `?setup=<channel>` deep link selects that adapter on arrival; its panel
+  // then opens the manual credential form (see `initialManualEntry`).
+  useEffect(() => {
+    if (initialChannel) {
+      selectAdapter(initialChannel);
+    }
+  }, [initialChannel, selectAdapter]);
 
   const displayName = toAssistantDisplayName(assistantName);
   const disconnectMeta = pendingDisconnect
@@ -221,55 +237,89 @@ export function AssistantChannelsList({
     onChannelPolicyChange?.(channelKey, next);
   };
 
+  const handleSelect = (channelKey: ChannelKey) => {
+    selectAdapter(channelKey);
+    setDrawerOpen(false);
+  };
+
+  // The persisted selection falls back to the first adapter if it names one
+  // that isn't present (the adapter set is fixed, so this is defensive).
+  const selected =
+    channels.find((channel) => channel.key === selectedAdapter) ?? channels[0];
+
+  if (!selected) {
+    return null;
+  }
+
+  // Keyed on the adapter so switching selection remounts the panel: its
+  // credential-form state (`initialManualEntry`) is seeded once at mount,
+  // and each adapter should start fresh.
+  const detail = (
+    <ChannelPanel
+      key={selected.key}
+      channel={selected}
+      assistantId={assistantId}
+      assistantName={assistantName}
+      assistantDisplayName={displayName}
+      pending={pendingChannelKey === selected.key}
+      initialManualEntry={initialChannel === selected.key}
+      onSetup={onSetup ? () => onSetup(selected.key) : undefined}
+      onDisconnect={
+        onDisconnect ? () => setPendingDisconnect(selected.key) : undefined
+      }
+      onSaveTelegramToken={onSaveTelegramToken}
+      onSaveSlackConfig={onSaveSlackConfig}
+      slackSaveStatus={slackSaveStatus}
+      slackSaveError={slackSaveError}
+      slackThreadMode={slackThreadMode}
+      slackThreadModePending={slackThreadModePending}
+      onSlackThreadModeChange={onSlackThreadModeChange}
+      onSaveTwilioCredentials={onSaveTwilioCredentials}
+      policy={channelPolicies?.[selected.key]}
+      policySaving={policySavingKey === selected.key}
+      policyLoading={policiesLoading}
+      policyError={policiesError}
+      onPolicyChange={
+        onChannelPolicyChange
+          ? (next) => handlePolicyChange(selected.key, next)
+          : undefined
+      }
+    />
+  );
+
   return (
-    <div className="flex flex-col">
-      <Tabs.Root
-        value={activeChannel}
-        onValueChange={(value) => setActiveChannel(value as ChannelKey)}
-      >
-        <Tabs.List>
-          {channels.map((channel) => (
-            <Tabs.Trigger key={channel.key} value={channel.key}>
-              {getChannelLabel(channel.key)}
-            </Tabs.Trigger>
-          ))}
-        </Tabs.List>
-        {channels.map((channel) => (
-          <Tabs.Panel key={channel.key} value={channel.key} className="pt-4">
-            <ChannelPanel
-              channel={channel}
-              assistantId={assistantId}
-              assistantName={assistantName}
-              assistantDisplayName={displayName}
-              pending={pendingChannelKey === channel.key}
-              initialManualEntry={initialChannel === channel.key}
-              onSetup={onSetup ? () => onSetup(channel.key) : undefined}
-              onDisconnect={
-                onDisconnect
-                  ? () => setPendingDisconnect(channel.key)
-                  : undefined
-              }
-              onSaveTelegramToken={onSaveTelegramToken}
-              onSaveSlackConfig={onSaveSlackConfig}
-              slackSaveStatus={slackSaveStatus}
-              slackSaveError={slackSaveError}
-              slackThreadMode={slackThreadMode}
-              slackThreadModePending={slackThreadModePending}
-              onSlackThreadModeChange={onSlackThreadModeChange}
-              onSaveTwilioCredentials={onSaveTwilioCredentials}
-              policy={channelPolicies?.[channel.key]}
-              policySaving={policySavingKey === channel.key}
-              policyLoading={policiesLoading}
-              policyError={policiesError}
-              onPolicyChange={
-                onChannelPolicyChange
-                  ? (next) => handlePolicyChange(channel.key, next)
-                  : undefined
-              }
-            />
-          </Tabs.Panel>
-        ))}
-      </Tabs.Root>
+    <>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:gap-6">
+        <div className="flex items-center sm:hidden">
+          <MobileSidebarTrigger onClick={() => setDrawerOpen(true)} />
+        </div>
+
+        <MobileSidebarDrawer
+          open={drawerOpen}
+          onClose={() => setDrawerOpen(false)}
+          title="Channels"
+        >
+          <ChannelAdapterList
+            channels={channels}
+            selectedKey={selected.key}
+            onSelect={handleSelect}
+          />
+        </MobileSidebarDrawer>
+
+        <aside className="hidden w-[320px] shrink-0 self-start sm:sticky sm:top-0 sm:block">
+          <ChannelAdapterList
+            channels={channels}
+            selectedKey={selected.key}
+            onSelect={handleSelect}
+          />
+        </aside>
+
+        {/* Slack brings its own cards (connection card + channel list); the
+            other adapters render bare content, so wrap them in a card to match. */}
+        <section className="min-w-0 flex-1">
+          {selected.key === "slack" ? detail : <DetailCard>{detail}</DetailCard>}
+        </section>
+      </div>
 
       <ConfirmDialog
         open={pendingDisconnect !== null}
@@ -304,7 +354,7 @@ export function AssistantChannelsList({
         }}
         onCancel={() => setPendingPolicy(null)}
       />
-    </div>
+    </>
   );
 }
 

--- a/clients/web/src/domains/channels/components/assistant-channels-list.tsx
+++ b/clients/web/src/domains/channels/components/assistant-channels-list.tsx
@@ -207,14 +207,19 @@ export function AssistantChannelsList({
     policy: AdmissionPolicy;
   } | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
+  // Capture the `?setup=<channel>` deep link once at mount. `useSetupChannelParam`
+  // consumes (clears) the param right after the first render, so reading the
+  // prop later races against this component's own store update; the frozen
+  // value reliably drives both the initial selection and the manual-entry seed.
+  const [setupChannel] = useState(initialChannel);
 
-  // A `?setup=<channel>` deep link selects that adapter on arrival; its panel
-  // then opens the manual credential form (see `initialManualEntry`).
+  // Select the deep-linked adapter on arrival; its panel then opens the manual
+  // credential form (see `initialManualEntry`).
   useEffect(() => {
-    if (initialChannel) {
-      selectAdapter(initialChannel);
+    if (setupChannel) {
+      selectAdapter(setupChannel);
     }
-  }, [initialChannel, selectAdapter]);
+  }, [setupChannel, selectAdapter]);
 
   const displayName = toAssistantDisplayName(assistantName);
   const disconnectMeta = pendingDisconnect
@@ -262,7 +267,7 @@ export function AssistantChannelsList({
       assistantName={assistantName}
       assistantDisplayName={displayName}
       pending={pendingChannelKey === selected.key}
-      initialManualEntry={initialChannel === selected.key}
+      initialManualEntry={setupChannel === selected.key}
       onSetup={onSetup ? () => onSetup(selected.key) : undefined}
       onDisconnect={
         onDisconnect ? () => setPendingDisconnect(selected.key) : undefined
@@ -289,7 +294,7 @@ export function AssistantChannelsList({
 
   return (
     <>
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:gap-6">
+      <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden sm:flex-row sm:gap-6">
         <div className="flex items-center sm:hidden">
           <MobileSidebarTrigger onClick={() => setDrawerOpen(true)} />
         </div>
@@ -306,7 +311,7 @@ export function AssistantChannelsList({
           />
         </MobileSidebarDrawer>
 
-        <aside className="hidden w-[320px] shrink-0 self-start sm:sticky sm:top-0 sm:block">
+        <aside className="hidden min-h-0 w-[320px] shrink-0 overflow-y-auto self-stretch sm:block">
           <ChannelAdapterList
             channels={channels}
             selectedKey={selected.key}
@@ -316,7 +321,7 @@ export function AssistantChannelsList({
 
         {/* Slack brings its own cards (connection card + channel list); the
             other adapters render bare content, so wrap them in a card to match. */}
-        <section className="min-w-0 flex-1">
+        <section className="min-h-0 min-w-0 flex-1 overflow-y-auto">
           {selected.key === "slack" ? detail : <DetailCard>{detail}</DetailCard>}
         </section>
       </div>

--- a/clients/web/src/domains/channels/components/channel-adapter-list.test.tsx
+++ b/clients/web/src/domains/channels/components/channel-adapter-list.test.tsx
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { ChannelAdapterList } from "@/domains/channels/components/channel-adapter-list";
+import type { AssistantChannelState } from "@/types/channel-types";
+
+const CHANNELS: AssistantChannelState[] = [
+  { key: "slack", status: "ready", address: "@vex" },
+  { key: "telegram", status: "not_configured" },
+  { key: "phone", status: "not_configured" },
+];
+
+afterEach(() => {
+  cleanup();
+});
+
+/** The adapter row whose label matches, keyed off the `PanelItem` slot. */
+function rowFor(label: string): HTMLElement {
+  const row = Array.from(
+    document.querySelectorAll<HTMLElement>('[data-slot="panel-item"]'),
+  ).find((el) => el.textContent?.includes(label));
+  if (!row) {
+    throw new Error(`No adapter row for "${label}"`);
+  }
+  return row;
+}
+
+describe("ChannelAdapterList", () => {
+  test("renders a row for every adapter", () => {
+    render(
+      <ChannelAdapterList
+        channels={CHANNELS}
+        selectedKey="slack"
+        onSelect={() => {}}
+      />,
+    );
+    expect(document.querySelectorAll('[data-slot="panel-item"]').length).toBe(
+      3,
+    );
+    expect(document.body.textContent).toContain("Slack");
+    expect(document.body.textContent).toContain("Telegram");
+    // The short "Phone" label, not the "Phone Calling" disconnect subject.
+    expect(document.body.textContent).toContain("Phone");
+    expect(document.body.textContent).not.toContain("Phone Calling");
+  });
+
+  test("badges the connected adapter and marks the rest not connected", () => {
+    render(
+      <ChannelAdapterList
+        channels={CHANNELS}
+        selectedKey="slack"
+        onSelect={() => {}}
+      />,
+    );
+    expect(rowFor("Slack").textContent).toContain("Connected");
+    expect(rowFor("Telegram").textContent).toContain("Not connected");
+    expect(rowFor("Phone").textContent).toContain("Not connected");
+  });
+
+  test("marks only the selected row as the current page", () => {
+    render(
+      <ChannelAdapterList
+        channels={CHANNELS}
+        selectedKey="telegram"
+        onSelect={() => {}}
+      />,
+    );
+    expect(rowFor("Telegram").getAttribute("aria-current")).toBe("page");
+    expect(rowFor("Slack").getAttribute("aria-current")).toBeNull();
+    expect(rowFor("Phone").getAttribute("aria-current")).toBeNull();
+  });
+
+  test("selecting a row reports that adapter's key", () => {
+    const selected: string[] = [];
+    render(
+      <ChannelAdapterList
+        channels={CHANNELS}
+        selectedKey="slack"
+        onSelect={(key) => selected.push(key)}
+      />,
+    );
+    fireEvent.click(rowFor("Telegram"));
+    fireEvent.click(rowFor("Phone"));
+    expect(selected).toEqual(["telegram", "phone"]);
+  });
+
+  test("rows are focusable native buttons, matching the Contacts EntriesList", () => {
+    render(
+      <ChannelAdapterList
+        channels={CHANNELS}
+        selectedKey="slack"
+        onSelect={() => {}}
+      />,
+    );
+    const phone = rowFor("Phone");
+    // Same affordance as the Contacts EntriesList rows: a native <button>, so
+    // it sits in the tab order and Enter/Space activate it natively — there's
+    // no custom key handler to keep in parity with.
+    expect(phone.tagName).toBe("BUTTON");
+    expect(phone.getAttribute("tabindex")).not.toBe("-1");
+    phone.focus();
+    expect(document.activeElement).toBe(phone);
+  });
+});

--- a/clients/web/src/domains/channels/components/channel-adapter-list.test.tsx
+++ b/clients/web/src/domains/channels/components/channel-adapter-list.test.tsx
@@ -58,6 +58,22 @@ describe("ChannelAdapterList", () => {
     expect(rowFor("Phone").textContent).toContain("Not connected");
   });
 
+  test("names each row with its adapter and status for screen readers", () => {
+    render(
+      <ChannelAdapterList
+        channels={CHANNELS}
+        selectedKey="slack"
+        onSelect={() => {}}
+      />,
+    );
+    // PanelItem forwards the label to the button's aria-label, so it must carry
+    // the connection status — not just the adapter name.
+    expect(rowFor("Slack").getAttribute("aria-label")).toBe("Slack, Connected");
+    expect(rowFor("Telegram").getAttribute("aria-label")).toBe(
+      "Telegram, Not connected",
+    );
+  });
+
   test("marks only the selected row as the current page", () => {
     render(
       <ChannelAdapterList

--- a/clients/web/src/domains/channels/components/channel-adapter-list.tsx
+++ b/clients/web/src/domains/channels/components/channel-adapter-list.tsx
@@ -3,7 +3,6 @@ import { PanelItem } from "@vellumai/design-library/components/panel-item";
 import { Tag } from "@vellumai/design-library/components/tag";
 
 import { ChannelIcon, getChannelLabel } from "@/utils/channel-presentation";
-import { publicAsset } from "@/utils/public-asset";
 import type {
   AssistantChannelState,
   SetupChannelId,
@@ -61,51 +60,30 @@ interface AdapterRowProps {
 
 function AdapterRow({ channel, selected, onClick }: AdapterRowProps) {
   const connected = channel.status === "ready";
+  const label = getChannelLabel(channel.key);
+  const statusLabel = connected ? "Connected" : "Not connected";
 
   return (
-    <PanelItem asChild active={selected} label={getChannelLabel(channel.key)}>
+    // `PanelItem` forwards `label` to the button's aria-label, so fold the
+    // status into it — otherwise screen readers announce only "Slack" and miss
+    // the connection state, which is the row's whole point.
+    <PanelItem asChild active={selected} label={`${label}, ${statusLabel}`}>
       <button
         type="button"
         onClick={onClick}
-        className="flex h-auto w-full items-center gap-3 rounded-[6px] px-[8px] py-2 text-left"
+        className="flex h-auto w-full items-center gap-2 rounded-[6px] px-[8px] py-2 text-left"
       >
-        <AdapterIcon channelKey={channel.key} />
-        <span className="flex min-w-0 flex-1 flex-col items-start gap-1">
-          <span className="truncate text-body-medium-default">
-            {getChannelLabel(channel.key)}
-          </span>
-          <Tag tone={connected ? "positive" : "neutral"}>
-            {connected ? "Connected" : "Not connected"}
-          </Tag>
+        <ChannelIcon
+          channelId={channel.key}
+          className="h-4 w-4 shrink-0 text-[color:var(--content-secondary)]"
+        />
+        <span className="min-w-0 flex-1 truncate text-body-medium-default">
+          {label}
+        </span>
+        <span className="flex shrink-0 items-center">
+          <Tag tone={connected ? "positive" : "neutral"}>{statusLabel}</Tag>
         </span>
       </button>
     </PanelItem>
-  );
-}
-
-/**
- * Adapter tile: the Slack brand mark for Slack (its Lucide stand-in is a
- * bare `#`), and the shared Lucide channel glyph for the rest (Telegram's
- * paper plane, Phone's handset). Rendered in a uniform rounded square so the
- * three rows line up as consistent app tiles.
- */
-function AdapterIcon({ channelKey }: { channelKey: SetupChannelId }) {
-  if (channelKey === "slack") {
-    return (
-      <img
-        src={publicAsset("/images/integrations/slack.svg")}
-        alt=""
-        className="size-6 shrink-0 rounded-[6px] bg-[var(--surface-sunken)] p-1"
-      />
-    );
-  }
-
-  return (
-    <span className="flex size-6 shrink-0 items-center justify-center rounded-[6px] bg-[var(--surface-sunken)]">
-      <ChannelIcon
-        channelId={channelKey}
-        className="size-3.5 text-[color:var(--content-secondary)]"
-      />
-    </span>
   );
 }

--- a/clients/web/src/domains/channels/components/channel-adapter-list.tsx
+++ b/clients/web/src/domains/channels/components/channel-adapter-list.tsx
@@ -1,0 +1,111 @@
+import { Card } from "@vellumai/design-library/components/card";
+import { PanelItem } from "@vellumai/design-library/components/panel-item";
+import { Tag } from "@vellumai/design-library/components/tag";
+
+import { ChannelIcon, getChannelLabel } from "@/utils/channel-presentation";
+import { publicAsset } from "@/utils/public-asset";
+import type {
+  AssistantChannelState,
+  SetupChannelId,
+} from "@/types/channel-types";
+
+export interface ChannelAdapterListProps {
+  channels: AssistantChannelState[];
+  selectedKey: SetupChannelId;
+  onSelect: (key: SetupChannelId) => void;
+}
+
+/**
+ * The Channels tab's left rail: a vertical list of the assistant's adapters
+ * (Slack, Telegram, Phone), each row showing the adapter icon, its name, and
+ * a connected / not-connected status badge. Selecting a row swaps the detail
+ * panel beside it. Mirrors the Contacts tab's `ContactsList` — same `Card`
+ * shell, same `PanelItem` selection treatment — so the two About Assistant
+ * tabs read as siblings.
+ */
+export function ChannelAdapterList({
+  channels,
+  selectedKey,
+  onSelect,
+}: ChannelAdapterListProps) {
+  return (
+    <Card.Root className="flex h-full flex-col overflow-hidden">
+      <Card.Body className="flex min-h-0 min-w-0 flex-1 flex-col gap-4">
+        <h2
+          className="text-title-medium"
+          style={{ color: "var(--content-default)" }}
+        >
+          Channels
+        </h2>
+
+        <div className="flex flex-col gap-1">
+          {channels.map((channel) => (
+            <AdapterRow
+              key={channel.key}
+              channel={channel}
+              selected={channel.key === selectedKey}
+              onClick={() => onSelect(channel.key)}
+            />
+          ))}
+        </div>
+      </Card.Body>
+    </Card.Root>
+  );
+}
+
+interface AdapterRowProps {
+  channel: AssistantChannelState;
+  selected: boolean;
+  onClick: () => void;
+}
+
+function AdapterRow({ channel, selected, onClick }: AdapterRowProps) {
+  const connected = channel.status === "ready";
+
+  return (
+    <PanelItem asChild active={selected} label={getChannelLabel(channel.key)}>
+      <button
+        type="button"
+        onClick={onClick}
+        className="flex h-auto w-full items-center gap-3 rounded-[6px] px-[8px] py-2 text-left"
+      >
+        <AdapterIcon channelKey={channel.key} />
+        <span className="flex min-w-0 flex-1 flex-col items-start gap-1">
+          <span className="truncate text-body-medium-default">
+            {getChannelLabel(channel.key)}
+          </span>
+          <Tag tone={connected ? "positive" : "neutral"}>
+            {connected ? "Connected" : "Not connected"}
+          </Tag>
+        </span>
+      </button>
+    </PanelItem>
+  );
+}
+
+/**
+ * Adapter tile: the Slack brand mark for Slack (its Lucide stand-in is a
+ * bare `#`), and the shared Lucide channel glyph for the rest (Telegram's
+ * paper plane, Phone's handset). Rendered in a uniform rounded square so the
+ * three rows line up as consistent app tiles.
+ */
+function AdapterIcon({ channelKey }: { channelKey: SetupChannelId }) {
+  if (channelKey === "slack") {
+    return (
+      <img
+        src={publicAsset("/images/integrations/slack.svg")}
+        alt=""
+        className="size-6 shrink-0 rounded-[6px] bg-[var(--surface-sunken)] p-1"
+      />
+    );
+  }
+
+  return (
+    <span className="flex size-6 shrink-0 items-center justify-center rounded-[6px] bg-[var(--surface-sunken)]">
+      <ChannelIcon
+        channelId={channelKey}
+        className="size-3.5 text-[color:var(--content-secondary)]"
+      />
+    </span>
+  );
+}


### PR DESCRIPTION
## Prompt / plan

Implements [LUM-2746](https://linear.app/vellum/issue/LUM-2746/featweb-channels-tab-replace-adapter-sub-tabs-with-master-detail). The Channels tab nested adapter sub-tabs (Slack / Telegram / Phone) inside the About Assistant top tab row — tabs-inside-tabs — and the Slack pane shared width with the sub-tab chrome, so the room list was cramped.

Pure layout restructure to a master-detail surface that mirrors the Contacts tab. Rebased on top of the now-merged #37468 (LUM-2745 `domains/channels` extract), so this diff is layout-only:

- **New `ChannelAdapterList` left rail** — a vertical list of the three adapters, each row showing the adapter icon + name + a "Connected" / "Not connected" status badge. It reuses the Contacts `ContactsList` treatment: the same `Card` shell and `PanelItem` `active` selection state, the shared `ChannelIcon` glyphs (Telegram paper plane, Phone handset), the existing Slack brand mark, and `Tag` pills — so the two About Assistant tabs read as siblings. No bespoke styling.
- **`AssistantChannelsList`** swaps its Radix `Tabs` for the master-detail layout (aside + detail `section` + `MobileSidebarDrawer`, same shape as `contacts-page`). `ChannelPanel`, the `SlackConnectionCard` (LUM-2729), the Thread Behavior radios, and the room list with search / filter chips / access-level legend / expandable rows (LUM-2727) are preserved **verbatim**. Non-Slack adapters get a `DetailCard` surface (Slack brings its own cards).
- **Selection persists per session** via a small Zustand store (`adapter-selection-store`), defaulting to Slack. A `?setup=<channel>` deep link still selects that adapter and opens its manual credential form.
- **`channels-page`** drops the outer card border so the surface sits like the Contacts page.

No copy changes (every string from LUM-2727 / 2729 / 2735 preserved) and no behavior changes to the room list, capabilities picker, or Thread Behavior controls. No adapters added or removed. The About Assistant top tab row is untouched.

## Test plan

- `bun test src/domains/channels src/domains/contacts` — **51 pass, 0 fail** across 9 files.
  - Rewrote `assistant-channels-list.test.tsx` to drive the master-detail (asserts no sub-tab strip; selects adapters via the left rail): Slack selected by default, low-weight Disconnect still confirms, Telegram trust-floor appears on selection, empty-state → manual-form swap, and the `?setup=` deep-link.
  - Added `channel-adapter-list.test.tsx` — renders all three adapters, connected / not-connected badges, selection (`aria-current`) state, `onSelect` key reporting, and native-`<button>` keyboard-nav parity with the Contacts EntriesList rows.
- `bunx tsc --noEmit` — clean.
- `bun run lint` (changed files) — clean; no new `local/no-cross-domain-imports` reaches, allowlist unchanged.
- Stories updated to the master-detail (deterministic per-story adapter selection).

## CLI verb checklist

No new routes — web-client-only layout change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lg8AATXnbLE6qJLcXA96N7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lg8AATXnbLE6qJLcXA96N7)_