### PR TITLE
fix(web): drop the redundant Channels page subtitle

### DIFF
--- a/clients/web/src/domains/channels/channels-page.tsx
+++ b/clients/web/src/domains/channels/channels-page.tsx
@@ -1,4 +1,3 @@
-import { DetailCard } from "@/components/detail-card";
 import { assistantDisplayName } from "@/utils/assistant-display-name";
 import { AssistantChannelsList } from "@/domains/channels/components/assistant-channels-list";
 import { GenerateInviteLinkDialog } from "@/components/generate-invite-link-dialog";
@@ -17,11 +16,12 @@ export interface ChannelsPageProps {
 /**
  * Channels settings — the Slack/Telegram/Phone master-detail surface where
  * the guardian manages how and where the assistant can be reached. Rendered
- * as its own tab in the About Assistant nav (`/assistant/channels`): a
- * page-level subtitle above the adapter list + detail panel (the nav's tab
- * already reads "Channels", so the page repeats no heading). The Contacts
- * page's assistant detail (`AssistantChannelsDetail`) shows only a
- * connect/disconnect summary of the same channels; management stays here.
+ * as its own tab in the About Assistant nav (`/assistant/channels`): the
+ * adapter list beside the selected adapter's detail panel, with no page
+ * heading or subtitle (the nav's tab already reads "Channels", matching the
+ * sibling Contacts tab). The Contacts page's assistant detail
+ * (`AssistantChannelsDetail`) shows only a connect/disconnect summary of the
+ * same channels; management stays here.
  */
 export function ChannelsPage({
   assistantId,
@@ -41,11 +41,6 @@ export function ChannelsPage({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-hidden">
-      <DetailCard
-        showBorder={false}
-        subtitle={`Manage where ${displayName} can be reached.`}
-      />
-
       <AssistantChannelsList
         assistantId={assistantId}
         assistantName={displayName}

--- a/clients/web/src/domains/channels/components/assistant-channels-list.stories.tsx
+++ b/clients/web/src/domains/channels/components/assistant-channels-list.stories.tsx
@@ -2,7 +2,6 @@ import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useLayoutEffect } from "react";
 
-import { DetailCard } from "@/components/detail-card";
 import { useChannelAdapterSelectionStore } from "@/domains/channels/adapter-selection-store";
 import type { SetupChannelId } from "@/types/channel-types";
 
@@ -10,9 +9,9 @@ import { AssistantChannelsList } from "./assistant-channels-list";
 
 /**
  * The standalone Channels tab composition (`ChannelsPage` minus its data
- * wiring): a borderless page subtitle over the adapter master-detail — a left
- * rail of adapters beside the selected adapter's detail panel, matching the
- * sibling Contacts tab's Entries + detail shape.
+ * wiring): the adapter master-detail — a left rail of adapters beside the
+ * selected adapter's detail panel, matching the sibling Contacts tab's
+ * Entries + detail shape.
  */
 // The Slack panel owns its own queries (`SlackChannelSection`), so stories
 // need a QueryClient. Requests fail in Storybook (no daemon), so the Slack
@@ -69,10 +68,6 @@ const meta: Meta<typeof AssistantChannelsList> = {
           gap: 24,
         }}
       >
-        <DetailCard
-          showBorder={false}
-          subtitle="Manage where Example Assistant can be reached."
-        />
         <Story />
       </div>
     ),

--- a/clients/web/src/domains/channels/components/channel-adapter-list.tsx
+++ b/clients/web/src/domains/channels/components/channel-adapter-list.tsx
@@ -3,6 +3,7 @@ import { PanelItem } from "@vellumai/design-library/components/panel-item";
 import { Tag } from "@vellumai/design-library/components/tag";
 
 import { ChannelIcon, getChannelLabel } from "@/utils/channel-presentation";
+import { publicAsset } from "@/utils/public-asset";
 import type {
   AssistantChannelState,
   SetupChannelId,
@@ -73,10 +74,21 @@ function AdapterRow({ channel, selected, onClick }: AdapterRowProps) {
         onClick={onClick}
         className="flex h-auto w-full items-center gap-2 rounded-[6px] px-[8px] py-2 text-left"
       >
-        <ChannelIcon
-          channelId={channel.key}
-          className="h-4 w-4 shrink-0 text-[color:var(--content-secondary)]"
-        />
+        {channel.key === "slack" ? (
+          // Slack ships a real brand logo (the same asset the connection card
+          // uses); the shared ChannelIcon only has a `#` stand-in for it, so
+          // render the logo directly. Telegram/Phone use their Lucide glyphs.
+          <img
+            src={publicAsset("/images/integrations/slack.svg")}
+            alt=""
+            className="h-4 w-4 shrink-0"
+          />
+        ) : (
+          <ChannelIcon
+            channelId={channel.key}
+            className="h-4 w-4 shrink-0 text-[color:var(--content-secondary)]"
+          />
+        )}
         <span className="min-w-0 flex-1 truncate text-body-medium-default">
           {label}
         </span>

--- a/clients/web/src/domains/channels/components/channel-adapter-list.tsx
+++ b/clients/web/src/domains/channels/components/channel-adapter-list.tsx
@@ -3,7 +3,6 @@ import { PanelItem } from "@vellumai/design-library/components/panel-item";
 import { Tag } from "@vellumai/design-library/components/tag";
 
 import { ChannelIcon, getChannelLabel } from "@/utils/channel-presentation";
-import { publicAsset } from "@/utils/public-asset";
 import type {
   AssistantChannelState,
   SetupChannelId,
@@ -74,21 +73,10 @@ function AdapterRow({ channel, selected, onClick }: AdapterRowProps) {
         onClick={onClick}
         className="flex h-auto w-full items-center gap-2 rounded-[6px] px-[8px] py-2 text-left"
       >
-        {channel.key === "slack" ? (
-          // Slack ships a real brand logo (the same asset the connection card
-          // uses); the shared ChannelIcon only has a `#` stand-in for it, so
-          // render the logo directly. Telegram/Phone use their Lucide glyphs.
-          <img
-            src={publicAsset("/images/integrations/slack.svg")}
-            alt=""
-            className="h-4 w-4 shrink-0"
-          />
-        ) : (
-          <ChannelIcon
-            channelId={channel.key}
-            className="h-4 w-4 shrink-0 text-[color:var(--content-secondary)]"
-          />
-        )}
+        <ChannelIcon
+          channelId={channel.key}
+          className="h-4 w-4 shrink-0 text-[color:var(--content-secondary)]"
+        />
         <span className="min-w-0 flex-1 truncate text-body-medium-default">
           {label}
         </span>


### PR DESCRIPTION
## Prompt / plan

Follow-up polish to #37471 (LUM-2746). The Channels tab carried a page-level subtitle ("Manage where {name} can be reached.") that the sibling Contacts tab doesn't have. Remove it for consistency — the About Assistant nav tab already labels the surface "Channels", so the page needs no extra heading or subtitle. The Storybook composition is updated to match.

Note: an earlier commit on this branch swapped the Slack rail icon to the brand logo; it's reverted here — the current `ChannelIcon` glyphs are kept, so the adapter rail is unchanged from `main`. The net diff is subtitle-only (`channels-page.tsx` + its story).

## Test plan

- `bun test src/domains/channels` — 36 pass, 0 fail.
- `bunx tsc --noEmit` — clean.
- `bun run lint` (changed files) — clean.

## CLI verb checklist

No new routes — web-client-only copy/layout tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lg8AATXnbLE6qJLcXA96N7