### PR TITLE
chore(assistant): remove the dead forward-only matchedTrustRuleId plumbing

### DIFF
--- a/assistant/src/__tests__/annotate-risk-options.test.ts
+++ b/assistant/src/__tests__/annotate-risk-options.test.ts
@@ -168,7 +168,6 @@ describe("annotatePersistedAssistantMessage — risk-option arrays (Phase B)", (
       isError: false,
       riskLevel: "high",
       riskReason: "Modifies state",
-      matchedTrustRuleId: "rule_42",
       riskScopeOptions: scopeOptions,
       riskAllowlistOptions: allowlistOptions,
       riskDirectoryScopeOptions: directoryScopeOptions,
@@ -182,7 +181,6 @@ describe("annotatePersistedAssistantMessage — risk-option arrays (Phase B)", (
     // Existing scalars still flow through.
     expect(block._riskLevel).toBe("high");
     expect(block._riskReason).toBe("Modifies state");
-    expect(block._matchedTrustRuleId).toBe("rule_42");
     expect(block._approvalMode).toBe("prompted");
     expect(block._approvalReason).toBe("user_approved");
     expect(block._riskThreshold).toBe("relaxed");

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -266,7 +266,6 @@ export type AgentEvent =
       contentBlocks?: ContentBlock[];
       riskLevel?: string;
       riskReason?: string;
-      matchedTrustRuleId?: string;
       isContainerized?: boolean;
       riskScopeOptions?: Array<{ pattern: string; label: string }>;
       riskAllowlistOptions?: Array<{
@@ -709,7 +708,6 @@ export type LoopToolExecutor = (
   yieldToUser?: boolean;
   riskLevel?: string;
   riskReason?: string;
-  matchedTrustRuleId?: string;
   isContainerized?: boolean;
   riskScopeOptions?: Array<{ pattern: string; label: string }>;
   riskAllowlistOptions?: Array<{
@@ -2295,7 +2293,6 @@ export class AgentLoop {
             contentBlocks: result.contentBlocks,
             riskLevel: result.riskLevel,
             riskReason: result.riskReason,
-            matchedTrustRuleId: result.matchedTrustRuleId,
             isContainerized: result.isContainerized,
             riskScopeOptions: result.riskScopeOptions,
             riskAllowlistOptions: result.riskAllowlistOptions,

--- a/assistant/src/api/events/tool-result.ts
+++ b/assistant/src/api/events/tool-result.ts
@@ -121,7 +121,6 @@ export const ToolResultEventSchema = z.object({
   messageId: z.string().optional(),
   riskLevel: z.string().optional(),
   riskReason: z.string().optional(),
-  matchedTrustRuleId: z.string().optional(),
   isContainerized: z.boolean().optional(),
   riskScopeOptions: z.array(RiskScopeOptionSchema).optional(),
   riskAllowlistOptions: z.array(AllowlistOptionSchema).optional(),

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -247,7 +247,6 @@ export interface EventHandlerState {
       riskLevel: string;
       riskReason?: string;
       autoApproved: boolean;
-      matchedTrustRuleId?: string;
       approvalMode?: string;
       approvalReason?: string;
       riskThreshold?: string;
@@ -1445,7 +1444,6 @@ export async function handleToolResult(
       riskLevel: event.riskLevel,
       riskReason: event.riskReason,
       autoApproved: !state.toolConfirmationOutcomes.has(event.toolUseId),
-      matchedTrustRuleId: event.matchedTrustRuleId,
       approvalMode: event.approvalMode,
       approvalReason: event.approvalReason,
       riskThreshold: event.riskThreshold,
@@ -1538,7 +1536,6 @@ export async function handleToolResult(
     toolUseId: event.toolUseId,
     riskLevel: event.riskLevel,
     riskReason: event.riskReason,
-    matchedTrustRuleId: event.matchedTrustRuleId,
     isContainerized: event.isContainerized,
     riskScopeOptions: event.riskScopeOptions,
     riskAllowlistOptions: event.riskAllowlistOptions,
@@ -1744,9 +1741,6 @@ function annotatePersistedAssistantMessage(
           rec._riskReason = risk.riskReason;
         }
         rec._autoApproved = risk.autoApproved;
-        if (risk.matchedTrustRuleId) {
-          rec._matchedTrustRuleId = risk.matchedTrustRuleId;
-        }
         if (risk.approvalMode) {
           rec._approvalMode = risk.approvalMode;
         }

--- a/assistant/src/daemon/message-types/workspace.ts
+++ b/assistant/src/daemon/message-types/workspace.ts
@@ -91,8 +91,6 @@ export interface ToolPermissionSimulateResponse {
   };
   /** Resolved execution target for the tool. */
   executionTarget?: "host" | "sandbox";
-  /** ID of the trust rule that matched (if any). */
-  matchedTrustRuleId?: string;
   /** Error message when success is false. */
   error?: string;
 }

--- a/assistant/src/events/tool-audit-listener.ts
+++ b/assistant/src/events/tool-audit-listener.ts
@@ -58,7 +58,6 @@ function toInvocationRecord(
         ),
         decision: event.decision,
         riskLevel: event.riskLevel,
-        matchedTrustRuleId: event.matchedTrustRuleId,
         durationMs: event.durationMs,
         // Prefer the executor-stamped raw pre-sanitization size: by the
         // time listeners run, sensitive-output extraction has already
@@ -82,7 +81,6 @@ function toInvocationRecord(
         result,
         decision: "error",
         riskLevel: event.riskLevel,
-        matchedTrustRuleId: event.matchedTrustRuleId,
         durationMs: event.durationMs,
         // The error result string is built right here and never goes
         // through sensitive-output sanitization, so sizing it directly is
@@ -100,7 +98,6 @@ function toInvocationRecord(
         result: formatDeniedResult(event.reason),
         decision: "denied",
         riskLevel: event.riskLevel,
-        matchedTrustRuleId: event.matchedTrustRuleId,
         durationMs: event.durationMs,
       };
     case "start":

--- a/assistant/src/permissions/approval-provenance.test.ts
+++ b/assistant/src/permissions/approval-provenance.test.ts
@@ -25,12 +25,6 @@ describe("mapApprovalProvenance", () => {
     expect(r.approvalReason).toBe("sandbox_auto_approve");
   });
 
-  test("allow + trust rule → auto / trust_rule_allowed", () => {
-    const r = mapApprovalProvenance("allow", { matchedTrustRuleId: "rule-abc" });
-    expect(r.approvalMode).toBe("auto");
-    expect(r.approvalReason).toBe("trust_rule_allowed");
-  });
-
   test("allow (no trust rule, no sandbox) → auto / within_threshold", () => {
     const r = mapApprovalProvenance("allow", {});
     expect(r.approvalMode).toBe("auto");
@@ -62,14 +56,11 @@ describe("mapApprovalProvenance", () => {
   });
 
   test("wasSystemCancel takes priority over wasTimeout", () => {
-    const r = mapApprovalProvenance("deny", { wasSystemCancel: true, wasTimeout: true });
+    const r = mapApprovalProvenance("deny", {
+      wasSystemCancel: true,
+      wasTimeout: true,
+    });
     expect(r.approvalReason).toBe("system_cancelled");
-  });
-
-  test("denied + matchedTrustRuleId → blocked / trust_rule_denied", () => {
-    const r = mapApprovalProvenance("denied", { matchedTrustRuleId: "rule-abc" });
-    expect(r.approvalMode).toBe("blocked");
-    expect(r.approvalReason).toBe("trust_rule_denied");
   });
 
   test("denied (no matchedTrustRuleId) → blocked / no_interactive_client", () => {
@@ -82,14 +73,6 @@ describe("mapApprovalProvenance", () => {
     const r = mapApprovalProvenance("something_unexpected", {});
     expect(r.approvalMode).toBe("unknown");
     expect(r.approvalReason).toBe("unknown");
-  });
-
-  test("sandbox takes priority over trust rule when both present", () => {
-    const r = mapApprovalProvenance("allow", {
-      hasSandboxAutoApprove: true,
-      matchedTrustRuleId: "rule-xyz",
-    });
-    expect(r.approvalReason).toBe("sandbox_auto_approve");
   });
 
   test("wasPrompted takes priority over sandbox when both set", () => {

--- a/assistant/src/permissions/approval-provenance.ts
+++ b/assistant/src/permissions/approval-provenance.ts
@@ -16,7 +16,6 @@ export function mapApprovalProvenance(
   decision: string,
   opts: {
     hasSandboxAutoApprove?: boolean;
-    matchedTrustRuleId?: string;
     wasPrompted?: boolean;
     wasTimeout?: boolean;
     wasSystemCancel?: boolean;
@@ -38,9 +37,6 @@ export function mapApprovalProvenance(
     if (opts.hasSandboxAutoApprove) {
       return { approvalMode: "auto", approvalReason: "sandbox_auto_approve" };
     }
-    if (opts.matchedTrustRuleId) {
-      return { approvalMode: "auto", approvalReason: "trust_rule_allowed" };
-    }
     return { approvalMode: "auto", approvalReason: "within_threshold" };
   }
 
@@ -60,9 +56,6 @@ export function mapApprovalProvenance(
 
   // "denied" — system denied without user interaction
   if (decision === "denied") {
-    if (opts.matchedTrustRuleId) {
-      return { approvalMode: "blocked", approvalReason: "trust_rule_denied" };
-    }
     return { approvalMode: "blocked", approvalReason: "no_interactive_client" };
   }
 

--- a/assistant/src/telemetry/tool-usage-store.ts
+++ b/assistant/src/telemetry/tool-usage-store.ts
@@ -13,7 +13,6 @@ export interface ToolInvocationRecord {
   result: string;
   decision: string;
   riskLevel: string;
-  matchedTrustRuleId?: string;
   durationMs: number;
   /** Serialized input size in bytes, computed before any redaction. */
   argBytes?: number | null;
@@ -36,7 +35,6 @@ export function recordToolInvocation(record: ToolInvocationRecord): void {
       result: record.result,
       decision: record.decision,
       riskLevel: record.riskLevel,
-      matchedTrustRuleId: record.matchedTrustRuleId,
       durationMs: record.durationMs,
       createdAt: Date.now(),
       argBytes: record.argBytes,

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -80,7 +80,6 @@ export class ToolExecutor {
           isContainerized?: boolean;
         }
       | undefined;
-    let permMatchedTrustRuleId: string | undefined;
     let permApprovalMode: string | undefined;
     let permApprovalReason: string | undefined;
     let permRiskThreshold: string | undefined;
@@ -232,7 +231,6 @@ export class ToolExecutor {
         riskLevel = permResult.riskLevel;
         decision = permResult.decision;
         permRiskMeta = permResult.riskMeta;
-        permMatchedTrustRuleId = permResult.matchedTrustRuleId;
         permApprovalMode = permResult.approvalMode;
         permApprovalReason = permResult.approvalReason;
         permRiskThreshold = permResult.riskThreshold;
@@ -247,7 +245,6 @@ export class ToolExecutor {
             riskAllowlistOptions: permRiskMeta?.riskAllowlistOptions,
             riskDirectoryScopeOptions: permRiskMeta?.riskDirectoryScopeOptions,
             isContainerized: permRiskMeta?.isContainerized,
-            matchedTrustRuleId: permMatchedTrustRuleId,
             approvalMode: permApprovalMode,
             approvalReason: permApprovalReason,
             riskThreshold: permRiskThreshold,
@@ -294,7 +291,6 @@ export class ToolExecutor {
           conversationId: context.conversationId,
           requestId: context.requestId,
           riskLevel,
-          matchedTrustRuleId: permMatchedTrustRuleId,
           decision: "error",
           durationMs,
           errorMessage: msg,
@@ -353,7 +349,6 @@ export class ToolExecutor {
             conversationId: context.conversationId,
             requestId: context.requestId,
             riskLevel,
-            matchedTrustRuleId: permMatchedTrustRuleId,
             decision: "deny",
             reason: denialReason,
             durationMs,
@@ -372,7 +367,6 @@ export class ToolExecutor {
             conversationId: context.conversationId,
             requestId: context.requestId,
             riskLevel,
-            matchedTrustRuleId: permMatchedTrustRuleId,
             decision: "error",
             durationMs,
             errorMessage: errorMsg,
@@ -417,7 +411,6 @@ export class ToolExecutor {
         conversationId: context.conversationId,
         requestId: context.requestId,
         riskLevel,
-        matchedTrustRuleId: permMatchedTrustRuleId,
         approvalMode: permApprovalMode,
         approvalReason: permApprovalReason,
         decision,
@@ -438,12 +431,6 @@ export class ToolExecutor {
           riskAllowlistOptions: permRiskMeta.riskAllowlistOptions,
           riskDirectoryScopeOptions: permRiskMeta.riskDirectoryScopeOptions,
           isContainerized: permRiskMeta.isContainerized,
-        };
-      }
-      if (permMatchedTrustRuleId) {
-        execResult = {
-          ...execResult,
-          matchedTrustRuleId: permMatchedTrustRuleId,
         };
       }
       if (permApprovalMode) {
@@ -509,7 +496,6 @@ export class ToolExecutor {
         conversationId: context.conversationId,
         requestId: context.requestId,
         riskLevel,
-        matchedTrustRuleId: permMatchedTrustRuleId,
         decision: "error",
         durationMs,
         errorMessage: msg,

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -33,8 +33,6 @@ export type PermissionDecision =
       decision: string;
       riskLevel: string;
       wasPrompted?: boolean;
-      /** ID of the trust rule that matched this invocation (if any). Always set when a rule matched, even for non-classifier tools where riskMeta is absent. */
-      matchedTrustRuleId?: string;
       /** Risk metadata from the classifier assessment cache (when available). */
       riskMeta?: {
         riskLevel: string;
@@ -57,8 +55,6 @@ export type PermissionDecision =
       decision: string;
       riskLevel: string;
       content: string;
-      /** ID of the trust rule that matched this invocation (if any). Always set when a rule matched, even for non-classifier tools where riskMeta is absent. */
-      matchedTrustRuleId?: string;
       /** Risk metadata from the classifier assessment cache (when available). */
       riskMeta?: {
         riskLevel: string;

--- a/assistant/src/tools/run-standalone.ts
+++ b/assistant/src/tools/run-standalone.ts
@@ -46,7 +46,6 @@ export interface StandaloneToolResult {
   riskLevel?: string;
   approvalMode?: string;
   approvalReason?: string;
-  matchedTrustRuleId?: string;
 }
 
 /**
@@ -96,6 +95,5 @@ export async function runToolStandalone(
     riskLevel: result.riskLevel,
     approvalMode: result.approvalMode,
     approvalReason: result.approvalReason,
-    matchedTrustRuleId: result.matchedTrustRuleId,
   };
 }

--- a/assistant/src/tools/tool-types.ts
+++ b/assistant/src/tools/tool-types.ts
@@ -157,8 +157,6 @@ export interface ToolExecutionResult {
   riskLevel?: string;
   /** Human-readable reason for the risk classification. */
   riskReason?: string;
-  /** ID of the trust rule that matched this invocation (if any). */
-  matchedTrustRuleId?: string;
   /** Whether the daemon is running in a containerized (Docker) environment. */
   isContainerized?: boolean;
   /** Scope options ladder for the rule editor (narrowest to broadest). */
@@ -229,8 +227,6 @@ export interface ToolPermissionDeniedEvent extends ToolLifecycleEventBase {
   riskLevel: string;
   /** Classifier-provided reason explaining why the risk level was assigned (bash/host_bash only). */
   riskReason?: string;
-  /** ID of the trust rule that matched this invocation (if any). */
-  matchedTrustRuleId?: string;
   decision: "deny" | "always_deny";
   reason: string;
   durationMs: number;
@@ -239,8 +235,6 @@ export interface ToolPermissionDeniedEvent extends ToolLifecycleEventBase {
 export interface ToolExecutedEvent extends ToolLifecycleEventBase {
   type: "executed";
   riskLevel: string;
-  /** ID of the trust rule that matched this invocation (if any). */
-  matchedTrustRuleId?: string;
   decision: string;
   durationMs: number;
   result: ToolExecutionResult;
@@ -249,8 +243,6 @@ export interface ToolExecutedEvent extends ToolLifecycleEventBase {
 export interface ToolExecutionErrorEvent extends ToolLifecycleEventBase {
   type: "error";
   riskLevel: string;
-  /** ID of the trust rule that matched this invocation (if any). */
-  matchedTrustRuleId?: string;
   decision: string;
   durationMs: number;
   errorMessage: string;

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -89,8 +89,6 @@ export interface ToolExecutionResult {
   riskLevel?: string;
   /** Human-readable reason for the risk classification. */
   riskReason?: string;
-  /** ID of the trust rule that matched this invocation (if any). */
-  matchedTrustRuleId?: string;
   /** How the decision was reached: prompted, auto, blocked, or unknown (legacy). */
   approvalMode?: string;
   /** Why the decision was reached (stable enum for client display). */
@@ -183,8 +181,6 @@ export interface ToolExecutedEvent extends ExecutorTelemetryStamp {
   requestId?: string;
   executionTarget?: ExecutionTarget;
   riskLevel: string;
-  /** ID of the trust rule that matched this invocation (if any). */
-  matchedTrustRuleId?: string;
   /** How the approval decision was reached. Copied from PermissionDecision for analytics consumers. */
   approvalMode?: string;
   /** Why the approval decision was reached (stable enum). Copied from PermissionDecision for analytics consumers. */


### PR DESCRIPTION
Closing — not worth it.

CI (web typecheck) surfaced what a code-read had missed: `matchedTrustRuleId` is **always-`undefined` for new tool calls** (the write path has been dead since the v3 GA), but it is **not** cleanly removable:

- The web reads it off the tool_result event (`clients/web/.../rolling-snapshot.ts:127`), so it's on the regenerated daemon SDK type.
- Historical DB rows (pre-April) carry real values, rendered via the read-back path.
- Both wire schemas (tool_result event + conversation-message response) serialize it.

Removing it safely would mean keeping all three of those — at which point the "confusing dead field" the ticket wanted gone is still visible on the wire types and in the web, so the payoff evaporates while the cross-package/historical-data risk stays. It's a harmless optional field; leaving it as-is is the right call. LUM-2750 cancelled.