### PR TITLE
fix(design-library): escape bare currency amounts with a trailing +

### DIFF
--- a/packages/design-library/src/components/markdown-message.stories.tsx
+++ b/packages/design-library/src/components/markdown-message.stories.tsx
@@ -32,7 +32,7 @@ export const Default: Story = {
 export const CurrencyText: Story = {
   args: {
     content:
-      "Anthropic raised a $65B series H at $965B post-money. Tiers run $5, $1,000.50, $100M, and $1.5T — roughly $100 billion all-in.",
+      "Anthropic raised a $65B series H at $965B post-money. Tiers run $5, $1,000.50, $100M, and $1.5T — roughly $100 billion all-in. The $50+ tier funds the *launch* year; $10-15 is the *destination*.",
   },
 };
 

--- a/packages/design-library/src/components/markdown-message.test.tsx
+++ b/packages/design-library/src/components/markdown-message.test.tsx
@@ -285,6 +285,34 @@ describe("MarkdownMessage", () => {
     expect(html).toContain("$500K+");
   });
 
+  test("bare amounts with a trailing + are not mangled into math", () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, {
+        content:
+          'the $50+ "always-present" tier funds the *launch* year — the tier at $10-15 is the *destination*.',
+      }),
+    );
+
+    // "$50+" must not open a math span that closes on the escaped "$10-15",
+    // which would leak the escape backslash and swallow the emphasis.
+    expect(html).not.toContain("katex");
+    expect(html).toContain("$50+");
+    expect(html).toContain("$10-15");
+    expect(html).toMatch(/<em[^>]*>launch<\/em>/);
+    expect(html).toMatch(/<em[^>]*>destination<\/em>/);
+    expect(html).not.toContain("\\$");
+  });
+
+  test("bare arithmetic with a + still renders as math", () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, {
+        content: "The sum $1+1$ is math.",
+      }),
+    );
+
+    expect(html).toContain("katex");
+  });
+
   test("legitimate inline math still renders via KaTeX", () => {
     const html = renderToStaticMarkup(
       createElement(MarkdownMessage, {

--- a/packages/design-library/src/components/markdown-message.tsx
+++ b/packages/design-library/src/components/markdown-message.tsx
@@ -392,13 +392,14 @@ function buildMarkdownComponents(
  * `$` into an italic math span. `–—` are literal members of the class; the
  * plain `-` stays last so it is never read as a range operator.
  *
- * A `+` is consumed only as part of a *suffixed* amount (`$1M+`, `$500K+` —
- * the "or more" idiom) so those amounts terminate at a clean boundary. It is
- * deliberately NOT a general boundary char: a bare `$1+1$` keeps `1` followed
- * by `+` with no boundary, so real arithmetic math is preserved.
+ * A trailing `+` (the "or more" idiom) is consumed as part of any amount,
+ * bare (`$50+`) or suffixed (`$1M+`, `$500K+`), so those amounts terminate at
+ * a clean boundary. It is deliberately NOT a general boundary char: in
+ * `$1+1$` the char after the `+` is a digit rather than a boundary, so real
+ * arithmetic math is preserved.
  */
 const CURRENCY_AMOUNT =
-  /\$(\d[\d,]*(?:\.\d+)?(?:(?:bn|tn|trn|[KMBT])\+?)?)(?=$|[\s).,;:!?%"'’\]}/–—-]|&)/gi;
+  /\$(\d[\d,]*(?:\.\d+)?(?:bn|tn|trn|[KMBT])?\+?)(?=$|[\s).,;:!?%"'’\]}/–—-]|&)/gi;
 
 /**
  * remark-math treats `$…$` as inline LaTeX, so monetary text like


### PR DESCRIPTION
## Summary
- Recognize bare `$50+`-style amounts (digits + trailing `+`) in `CURRENCY_AMOUNT` so their `$` is escaped like other currency: previously remark-math opened a math span at the unescaped `$50+`, closed it on the already-escaped `$10-15`, and KaTeX rendered the prose as a red `katex-error` span with a leaked `\` before `10-15`.
- The `+` stays out of the boundary lookahead class, so bare arithmetic (`$1+1$`) still renders as math — pinned by a new regression test.
- Adds a bug-shape regression test (emphasis intact on both sides, no leaked backslash) and extends the `CurrencyText` story with the `$50+ … $10-15` shape.

## Original prompt
User reported chat text rendering incorrectly (screenshot): a message containing `the $50+ "always-present" tier … the tier at $10-15 is the *destination*` rendered everything between the two amounts as a red KaTeX parse-error span, dropped the first `$`, showed a stray `\` before `10-15`, and left `*launch*` as literal asterisks. Root cause traced to `escapeCurrencyDollars()` in the design-library `MarkdownMessage`: its currency regex accepted a trailing `+` only after a magnitude suffix (`$1M+`), so `$50+` fell through unescaped while `$10-15` was escaped — exactly the pairing single-dollar remark-math needs to form a bogus math span.