### PR TITLE
feat(cli): install marketplace plugins via the platform install endpoint

### DIFF
--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -31,6 +31,7 @@ import {
   PluginNotFoundError,
   sanitizePluginName,
 } from "../lib/install-from-github.js";
+import { installPluginViaPlatform } from "../lib/install-from-platform.js";
 import {
   type AllPluginInfo,
   listAllPlugins,
@@ -122,7 +123,7 @@ Examples:
       plugins
         .command("install <name-or-url>")
         .description(
-          "Install a plugin by name from the curated plugins/marketplace.json catalog, or directly from a GitHub URL (untrusted)",
+          "Install a plugin by name from the Vellum platform (content is served as a verified tarball from the plugin's pinned commit), or directly from a GitHub URL (untrusted)",
         )
         .option("--force", "Overwrite an existing install")
         .option(
@@ -169,22 +170,42 @@ Examples:
           ) => {
             try {
               const direct = looksLikeGitHubSpec(nameOrUrl);
-              const installOpts = direct
-                ? resolveDirectInstallOptions(nameOrUrl, opts)
-                : await resolveInstallOptions(nameOrUrl, opts);
-              if (installOpts === null) {
-                process.exitCode = 1;
-                return;
-              }
-              if (installOpts.directSource) {
-                printUntrustedPluginWarning(
-                  installOpts.name,
-                  installOpts.directSource,
+              // A plain marketplace install by name is platform-managed: the
+              // content flows through the platform install endpoint (which
+              // serves a verified `.tgz`), not a GitHub clone. The advanced
+              // pin/ref/allow-unreviewed selectors still resolve a specific
+              // reviewed revision through the marketplace-git path, and a
+              // GitHub URL installs directly (untrusted).
+              const usesMarketplaceGit =
+                !direct &&
+                Boolean(opts.pin || opts.ref || opts.allowUnreviewed);
+
+              let result;
+              let untrusted = false;
+              if (!direct && !usesMarketplaceGit) {
+                result = await installPluginViaPlatform(
+                  { name: nameOrUrl, force: opts.force },
+                  { fetch: globalThis.fetch.bind(globalThis) },
                 );
+              } else {
+                const installOpts = direct
+                  ? resolveDirectInstallOptions(nameOrUrl, opts)
+                  : await resolveInstallOptions(nameOrUrl, opts);
+                if (installOpts === null) {
+                  process.exitCode = 1;
+                  return;
+                }
+                if (installOpts.directSource) {
+                  printUntrustedPluginWarning(
+                    installOpts.name,
+                    installOpts.directSource,
+                  );
+                  untrusted = true;
+                }
+                result = await installPlugin(installOpts, {
+                  fetch: globalThis.fetch.bind(globalThis),
+                });
               }
-              const result = await installPlugin(installOpts, {
-                fetch: globalThis.fetch.bind(globalThis),
-              });
               log.info(
                 {
                   name: result.name,
@@ -192,16 +213,14 @@ Examples:
                   fileCount: result.fileCount,
                   ref: result.ref,
                   commit: result.commit,
-                  untrusted: Boolean(installOpts.directSource),
+                  untrusted,
                 },
                 "external plugin installed",
               );
               const pinned = result.commit
                 ? ` at ${result.commit.slice(0, 7)}`
                 : "";
-              const label = installOpts.directSource
-                ? "untrusted plugin"
-                : "plugin";
+              const label = untrusted ? "untrusted plugin" : "plugin";
               console.log(
                 `Installed ${label} "${result.name}" (${result.fileCount} file${result.fileCount === 1 ? "" : "s"})${pinned} → ${result.target}`,
               );

--- a/assistant/src/cli/lib/__tests__/install-from-platform.test.ts
+++ b/assistant/src/cli/lib/__tests__/install-from-platform.test.ts
@@ -82,6 +82,12 @@ interface FetchFixtureOpts {
   sourcePath?: string;
   /** Non-2xx status to serve instead of the archive. */
   status?: number;
+  /**
+   * Serve an uncompressed POSIX tar body while still advertising
+   * `Content-Type: application/gzip` (what the platform actually does).
+   * Defaults to serving a real gzip stream.
+   */
+  plainTar?: boolean;
   /** Header capture: called with the request headers on each fetch. */
   onRequest?: (url: string, headers: Headers) => void;
 }
@@ -99,10 +105,10 @@ function makeInstallFetch(opts: FetchFixtureOpts): FetchLike {
       });
     }
 
-    const gzip = gzipSync(makeTar(opts.entries ?? []));
-    const body = Buffer.from(gzip);
+    const tar = makeTar(opts.entries ?? []);
+    const body = opts.plainTar ? tar : Buffer.from(gzipSync(tar));
     const etag = opts.etag ?? `"sha256:${sha256Hex(body)}"`;
-    return new Response(body, {
+    return new Response(new Uint8Array(body), {
       status: 200,
       headers: {
         "Content-Type": "application/gzip",
@@ -226,6 +232,53 @@ describe("installPluginFromPlatform — success", () => {
     expect(seenUrl).toContain("installation_id=device-1");
     expect(seenUrl).toContain("conversation_id=conv-9");
     expect(seenUrl).toContain("assistant_version=1.2.3");
+  });
+
+  test("requests Accept: */* (platform 406s a specific gzip Accept)", async () => {
+    const captured: { accept: string | null } = { accept: null };
+    const fetchFn = makeInstallFetch({
+      entries: [{ name: "plugin.json", content: "{}" }],
+      onRequest: (_url, headers) => {
+        captured.accept = headers.get("accept");
+      },
+    });
+
+    await installPluginFromPlatform(
+      { name: "reading-pal" },
+      {
+        fetch: fetchFn,
+        platformBaseUrl: PLATFORM,
+        workspacePluginsDir: pluginsDir,
+      },
+    );
+
+    expect(captured.accept).toBe("*/*");
+  });
+
+  test("extracts an uncompressed tar body served as application/gzip", async () => {
+    const fetchFn = makeInstallFetch({
+      entries: [
+        { name: "plugin.json", content: '{"name":"reading-pal"}' },
+        { name: "skills/read/SKILL.md", content: "skill body" },
+      ],
+      plainTar: true,
+    });
+
+    const result = await installPluginFromPlatform(
+      { name: "reading-pal" },
+      {
+        fetch: fetchFn,
+        platformBaseUrl: PLATFORM,
+        workspacePluginsDir: pluginsDir,
+      },
+    );
+
+    const target = join(pluginsDir, "reading-pal");
+    expect(result.fileCount).toBe(2);
+    expect(readFileSync(join(target, "plugin.json"), "utf-8")).toContain(
+      "reading-pal",
+    );
+    expect(existsSync(join(target, "skills", "read", "SKILL.md"))).toBe(true);
   });
 });
 

--- a/assistant/src/cli/lib/__tests__/install-from-platform.test.ts
+++ b/assistant/src/cli/lib/__tests__/install-from-platform.test.ts
@@ -1,0 +1,444 @@
+/**
+ * Tests for {@link installPluginFromPlatform}.
+ *
+ * The platform install endpoint is replaced by an in-memory `fetch` fixture
+ * that serves a gzipped tarball with the metadata headers (`ETag`,
+ * `X-Plugin-Ref`, `X-Plugin-Repo`, `X-Plugin-Source-Path`) the real endpoint
+ * sends. No globals are monkey-patched; the workspace plugins dir is injected.
+ */
+
+import { createHash } from "node:crypto";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { gzipSync } from "node:zlib";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { FetchLike } from "../fetch-like.js";
+import { readInstallMeta } from "../install-from-github.js";
+import {
+  extractPluginTarball,
+  installPluginFromPlatform,
+  PluginArchiveError,
+  PluginIntegrityError,
+  PluginRateLimitedError,
+  PluginTooLargeError,
+} from "../install-from-platform.js";
+
+const PLATFORM = "https://platform.test";
+
+// ─── Tar/gzip fixtures ───────────────────────────────────────────────────────
+
+interface TarEntry {
+  name: string;
+  content: string;
+}
+
+/** Build a minimal ustar tar buffer from a flat list of file entries. */
+function makeTar(entries: TarEntry[]): Buffer {
+  const blocks: Buffer[] = [];
+  for (const entry of entries) {
+    const data = Buffer.from(entry.content, "utf-8");
+    const header = Buffer.alloc(512, 0);
+    header.write(entry.name, 0, 100, "utf-8");
+    header.write("0000644\0", 100, 8, "utf-8"); // mode
+    header.write("0000000\0", 108, 8, "utf-8"); // uid
+    header.write("0000000\0", 116, 8, "utf-8"); // gid
+    header.write(data.length.toString(8).padStart(11, "0") + "\0", 124, 12);
+    header.write("00000000000\0", 136, 12, "utf-8"); // mtime
+    header[156] = 0x30; // typeflag '0' (regular file)
+    header.write("ustar\0", 257, 6, "utf-8");
+    header.write("00", 263, 2, "utf-8");
+    // Checksum: sum of all bytes with the checksum field treated as spaces.
+    for (let i = 148; i < 156; i++) {
+      header[i] = 0x20;
+    }
+    let sum = 0;
+    for (let i = 0; i < 512; i++) {
+      sum += header[i]!;
+    }
+    header.write(sum.toString(8).padStart(6, "0") + "\0 ", 148, 8, "utf-8");
+
+    blocks.push(header);
+    const padded = Buffer.alloc(Math.ceil(data.length / 512) * 512, 0);
+    data.copy(padded);
+    blocks.push(padded);
+  }
+  // Two zero blocks terminate the archive.
+  blocks.push(Buffer.alloc(1024, 0));
+  return Buffer.concat(blocks);
+}
+
+function sha256Hex(buf: Buffer): string {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+interface FetchFixtureOpts {
+  entries?: TarEntry[];
+  /** Override the ETag digest (defaults to the real sha256 of the body). */
+  etag?: string;
+  ref?: string;
+  repo?: string;
+  sourcePath?: string;
+  /** Non-2xx status to serve instead of the archive. */
+  status?: number;
+  /** Header capture: called with the request headers on each fetch. */
+  onRequest?: (url: string, headers: Headers) => void;
+}
+
+/** A `fetch` that serves the plugin install endpoint from an in-memory tarball. */
+function makeInstallFetch(opts: FetchFixtureOpts): FetchLike {
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const headers = new Headers(init?.headers);
+    opts.onRequest?.(url, headers);
+
+    if (opts.status && opts.status >= 400) {
+      return new Response(JSON.stringify({ detail: "error" }), {
+        status: opts.status,
+      });
+    }
+
+    const gzip = gzipSync(makeTar(opts.entries ?? []));
+    const body = Buffer.from(gzip);
+    const etag = opts.etag ?? `"sha256:${sha256Hex(body)}"`;
+    return new Response(body, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/gzip",
+        ETag: etag,
+        "X-Plugin-Ref": opts.ref ?? "a".repeat(40),
+        "X-Plugin-Repo": opts.repo ?? "vellum-ai/reading-pal",
+        ...(opts.sourcePath ? { "X-Plugin-Source-Path": opts.sourcePath } : {}),
+      },
+    });
+  }) as FetchLike;
+}
+
+// ─── Test scaffolding ────────────────────────────────────────────────────────
+
+let workspaceDir: string;
+let pluginsDir: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "plugin-platform-"));
+  pluginsDir = join(workspaceDir, "plugins");
+});
+
+afterEach(() => {
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+const noSleep = async () => {};
+
+// ─── Success ─────────────────────────────────────────────────────────────────
+
+describe("installPluginFromPlatform — success", () => {
+  test("downloads, verifies, and extracts files at the plugin root", async () => {
+    const entries: TarEntry[] = [
+      { name: "plugin.json", content: '{"name":"reading-pal"}' },
+      { name: "README.md", content: "# reading pal" },
+      { name: "skills/read/SKILL.md", content: "skill body" },
+    ];
+    const fetchFn = makeInstallFetch({
+      entries,
+      ref: "b".repeat(40),
+      repo: "vellum-ai/reading-pal",
+    });
+
+    const result = await installPluginFromPlatform(
+      { name: "reading-pal" },
+      {
+        fetch: fetchFn,
+        platformBaseUrl: PLATFORM,
+        workspacePluginsDir: pluginsDir,
+      },
+    );
+
+    const target = join(pluginsDir, "reading-pal");
+    expect(result.name).toBe("reading-pal");
+    expect(result.target).toBe(target);
+    expect(result.fileCount).toBe(3);
+    expect(result.commit).toBe("b".repeat(40));
+    expect(result.ref).toBe("b".repeat(40));
+
+    // Files land at the top level — no {owner}-{repo}-{sha}/ wrapper dir.
+    expect(readFileSync(join(target, "plugin.json"), "utf-8")).toContain(
+      "reading-pal",
+    );
+    expect(existsSync(join(target, "README.md"))).toBe(true);
+    expect(existsSync(join(target, "skills", "read", "SKILL.md"))).toBe(true);
+
+    // Provenance records the pinned commit and the verified ETag.
+    const meta = readInstallMeta(target);
+    expect(meta?.commit).toBe("b".repeat(40));
+    expect(meta?.source.repo).toBe("reading-pal");
+    expect(meta?.source.owner).toBe("vellum-ai");
+    expect(meta?.etag?.startsWith('"sha256:')).toBe(true);
+  });
+
+  test("sends the API key as an Api-Key Authorization header when present", async () => {
+    const captured: { auth: string | null } = { auth: null };
+    const fetchFn = makeInstallFetch({
+      entries: [{ name: "plugin.json", content: "{}" }],
+      onRequest: (_url, headers) => {
+        captured.auth = headers.get("authorization");
+      },
+    });
+
+    await installPluginFromPlatform(
+      { name: "reading-pal" },
+      {
+        fetch: fetchFn,
+        platformBaseUrl: PLATFORM,
+        apiKey: "secret-key",
+        workspacePluginsDir: pluginsDir,
+      },
+    );
+
+    expect(captured.auth).toBe("Api-Key secret-key");
+  });
+
+  test("forwards attribution query params", async () => {
+    let seenUrl = "";
+    const fetchFn = makeInstallFetch({
+      entries: [{ name: "plugin.json", content: "{}" }],
+      onRequest: (url) => {
+        seenUrl = url;
+      },
+    });
+
+    await installPluginFromPlatform(
+      {
+        name: "reading-pal",
+        installationId: "device-1",
+        conversationId: "conv-9",
+        assistantVersion: "1.2.3",
+      },
+      {
+        fetch: fetchFn,
+        platformBaseUrl: PLATFORM,
+        workspacePluginsDir: pluginsDir,
+      },
+    );
+
+    expect(seenUrl).toContain("/v1/plugins/reading-pal/install/");
+    expect(seenUrl).toContain("installation_id=device-1");
+    expect(seenUrl).toContain("conversation_id=conv-9");
+    expect(seenUrl).toContain("assistant_version=1.2.3");
+  });
+});
+
+// ─── Integrity ───────────────────────────────────────────────────────────────
+
+describe("installPluginFromPlatform — integrity", () => {
+  test("aborts on an ETag sha256 mismatch and writes nothing", async () => {
+    const fetchFn = makeInstallFetch({
+      entries: [{ name: "plugin.json", content: "{}" }],
+      etag: `"sha256:${"0".repeat(64)}"`,
+    });
+
+    await expect(
+      installPluginFromPlatform(
+        { name: "reading-pal" },
+        {
+          fetch: fetchFn,
+          platformBaseUrl: PLATFORM,
+          workspacePluginsDir: pluginsDir,
+        },
+      ),
+    ).rejects.toBeInstanceOf(PluginIntegrityError);
+
+    expect(existsSync(join(pluginsDir, "reading-pal"))).toBe(false);
+  });
+});
+
+// ─── Path traversal ──────────────────────────────────────────────────────────
+
+describe("extractPluginTarball — path traversal", () => {
+  test("rejects an entry that escapes the target dir", () => {
+    const dest = mkdtempSync(join(tmpdir(), "extract-"));
+    try {
+      const tar = makeTar([{ name: "../evil.txt", content: "pwned" }]);
+      expect(() => extractPluginTarball("evil", gzipSync(tar), dest)).toThrow(
+        PluginArchiveError,
+      );
+      // The escaping file must not have been written outside dest.
+      expect(existsSync(join(dest, "..", "evil.txt"))).toBe(false);
+    } finally {
+      rmSync(dest, { recursive: true, force: true });
+    }
+  });
+
+  test("extracts a normal nested entry", () => {
+    const dest = mkdtempSync(join(tmpdir(), "extract-"));
+    try {
+      const tar = makeTar([{ name: "a/b/c.txt", content: "ok" }]);
+      const count = extractPluginTarball("good", gzipSync(tar), dest);
+      expect(count).toBe(1);
+      expect(readFileSync(join(dest, "a", "b", "c.txt"), "utf-8")).toBe("ok");
+    } finally {
+      rmSync(dest, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── HTTP error handling ─────────────────────────────────────────────────────
+
+describe("installPluginFromPlatform — HTTP errors", () => {
+  test("404 → PluginNotFoundError", async () => {
+    const fetchFn = makeInstallFetch({ status: 404 });
+    await expect(
+      installPluginFromPlatform(
+        { name: "missing" },
+        {
+          fetch: fetchFn,
+          platformBaseUrl: PLATFORM,
+          workspacePluginsDir: pluginsDir,
+        },
+      ),
+    ).rejects.toMatchObject({ name: "PluginNotFoundError" });
+  });
+
+  test("413 → PluginTooLargeError", async () => {
+    const fetchFn = makeInstallFetch({ status: 413 });
+    await expect(
+      installPluginFromPlatform(
+        { name: "huge" },
+        {
+          fetch: fetchFn,
+          platformBaseUrl: PLATFORM,
+          workspacePluginsDir: pluginsDir,
+        },
+      ),
+    ).rejects.toBeInstanceOf(PluginTooLargeError);
+  });
+
+  test("429 retries then throws PluginRateLimitedError when exhausted", async () => {
+    let calls = 0;
+    const fetchFn: FetchLike = async () => {
+      calls++;
+      return new Response(JSON.stringify({ code: "rate_limit_exceeded" }), {
+        status: 429,
+      });
+    };
+    await expect(
+      installPluginFromPlatform(
+        { name: "spammy" },
+        {
+          fetch: fetchFn,
+          platformBaseUrl: PLATFORM,
+          workspacePluginsDir: pluginsDir,
+          maxAttempts: 3,
+          sleep: noSleep,
+        },
+      ),
+    ).rejects.toBeInstanceOf(PluginRateLimitedError);
+    expect(calls).toBe(3);
+  });
+
+  test("429 then success recovers", async () => {
+    let calls = 0;
+    const good = makeInstallFetch({
+      entries: [{ name: "plugin.json", content: "{}" }],
+    });
+    const fetchFn: FetchLike = async (input, init) => {
+      calls++;
+      if (calls === 1) {
+        return new Response("{}", { status: 429 });
+      }
+      return good(input, init);
+    };
+    const result = await installPluginFromPlatform(
+      { name: "reading-pal" },
+      {
+        fetch: fetchFn,
+        platformBaseUrl: PLATFORM,
+        workspacePluginsDir: pluginsDir,
+        sleep: noSleep,
+      },
+    );
+    expect(result.fileCount).toBe(1);
+    expect(calls).toBe(2);
+  });
+
+  test("502 retries then surfaces a retryable source error", async () => {
+    let calls = 0;
+    const fetchFn: FetchLike = async () => {
+      calls++;
+      return new Response(JSON.stringify({ detail: "Failed to assemble" }), {
+        status: 502,
+      });
+    };
+    await expect(
+      installPluginFromPlatform(
+        { name: "flaky" },
+        {
+          fetch: fetchFn,
+          platformBaseUrl: PLATFORM,
+          workspacePluginsDir: pluginsDir,
+          maxAttempts: 2,
+          sleep: noSleep,
+        },
+      ),
+    ).rejects.toMatchObject({ name: "PluginSourceUnavailableError" });
+    expect(calls).toBe(2);
+  });
+});
+
+// ─── Already installed ───────────────────────────────────────────────────────
+
+describe("installPluginFromPlatform — force", () => {
+  test("refuses to overwrite an existing install without force", async () => {
+    const fetchFn = makeInstallFetch({
+      entries: [{ name: "plugin.json", content: "{}" }],
+    });
+    await installPluginFromPlatform(
+      { name: "reading-pal" },
+      {
+        fetch: fetchFn,
+        platformBaseUrl: PLATFORM,
+        workspacePluginsDir: pluginsDir,
+      },
+    );
+    await expect(
+      installPluginFromPlatform(
+        { name: "reading-pal" },
+        {
+          fetch: fetchFn,
+          platformBaseUrl: PLATFORM,
+          workspacePluginsDir: pluginsDir,
+        },
+      ),
+    ).rejects.toMatchObject({ name: "PluginAlreadyInstalledError" });
+  });
+
+  test("force overwrites an existing install", async () => {
+    const first = makeInstallFetch({
+      entries: [{ name: "plugin.json", content: '{"v":1}' }],
+    });
+    await installPluginFromPlatform(
+      { name: "reading-pal" },
+      {
+        fetch: first,
+        platformBaseUrl: PLATFORM,
+        workspacePluginsDir: pluginsDir,
+      },
+    );
+    const second = makeInstallFetch({
+      entries: [{ name: "plugin.json", content: '{"v":2}' }],
+    });
+    const result = await installPluginFromPlatform(
+      { name: "reading-pal", force: true },
+      {
+        fetch: second,
+        platformBaseUrl: PLATFORM,
+        workspacePluginsDir: pluginsDir,
+      },
+    );
+    expect(result.fileCount).toBe(1);
+    expect(
+      readFileSync(join(pluginsDir, "reading-pal", "plugin.json"), "utf-8"),
+    ).toContain('"v":2');
+  });
+});

--- a/assistant/src/cli/lib/install-from-github.ts
+++ b/assistant/src/cli/lib/install-from-github.ts
@@ -482,6 +482,8 @@ export interface FinalizeStagedInstallParams {
   readonly commit: string | null;
   /** ISO-8601 committer timestamp of {@link FinalizeStagedInstallParams.commit} (UTC); null when unknown. */
   readonly committedAt: string | null;
+  /** Artifact integrity digest (`sha256:<hex>`) recorded for platform-endpoint installs; omitted for git installs. */
+  readonly etag?: string;
   /** Served plugins directory; the staging dir is swapped into `<pluginsDir>/<name>`. */
   readonly pluginsDir: string;
 }
@@ -503,6 +505,7 @@ export function finalizeStagedInstall(
     ref,
     commit,
     committedAt,
+    etag,
     pluginsDir,
   }: FinalizeStagedInstallParams,
 ): { target: string; fingerprint: Fingerprint } {
@@ -523,6 +526,7 @@ export function finalizeStagedInstall(
     ref,
     commit,
     committedAt,
+    etag,
     fingerprint,
     contentHash,
   });
@@ -637,6 +641,14 @@ export interface InstallMeta {
   readonly source: InstallMetaSource;
   /** Resolved commit SHA the source was cloned at; `null` when it could not be read at install time. */
   readonly commit: string | null;
+  /**
+   * Integrity digest of the downloaded artifact, when the install came through
+   * the platform install endpoint (`ETag: "sha256:<hex>"`). Recorded verbatim
+   * (including the `sha256:` prefix) as a stable id for caching / dedupe and to
+   * document what was verified. Absent for git-cloned installs, which have no
+   * single artifact to hash.
+   */
+  readonly etag?: string;
   /**
    * ISO-8601 committer timestamp of {@link InstallMeta.commit}, in UTC
    * (e.g. `2026-06-01T12:34:56.000Z`). This is a property of the commit
@@ -1210,6 +1222,8 @@ interface WriteInstallMetaParams {
   readonly commit: string | null;
   /** ISO-8601 committer timestamp of {@link WriteInstallMetaParams.commit} (UTC); null when unknown. */
   readonly committedAt: string | null;
+  /** Artifact integrity digest (`sha256:<hex>`) recorded for platform-endpoint installs; omitted for git installs. */
+  readonly etag?: string;
   readonly fingerprint: Fingerprint;
   readonly contentHash: string;
 }
@@ -1252,6 +1266,7 @@ function writeInstallMeta(
     ref,
     commit,
     committedAt,
+    etag,
     fingerprint,
     contentHash,
   }: WriteInstallMetaParams,
@@ -1273,6 +1288,7 @@ function writeInstallMeta(
     },
     commit,
     committedAt,
+    ...(etag ? { etag } : {}),
     fingerprint,
   };
   writeFileSync(
@@ -1347,6 +1363,7 @@ export function readInstallMeta(pluginDir: string): InstallMeta | null {
       ref: source.ref,
     },
     commit: typeof obj.commit === "string" ? obj.commit : null,
+    ...(typeof obj.etag === "string" ? { etag: obj.etag } : {}),
     committedAt: typeof obj.committedAt === "string" ? obj.committedAt : null,
     fingerprint: parseFingerprint(obj.fingerprint),
   };

--- a/assistant/src/cli/lib/install-from-platform.ts
+++ b/assistant/src/cli/lib/install-from-platform.ts
@@ -28,8 +28,6 @@ import { dirname, join, resolve, sep } from "node:path";
 import { gunzipSync } from "node:zlib";
 
 import { getPlatformBaseUrl } from "../../config/env.js";
-import { credentialKey } from "../../security/credential-key.js";
-import { getSecureKeyAsync } from "../../security/secure-keys.js";
 import { getExistingDeviceId } from "../../util/device-id.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
 import { APP_VERSION } from "../../version.js";
@@ -243,13 +241,16 @@ export async function installPluginViaPlatform(
   );
 }
 
-/** Best-effort read of the assistant API key; anonymous install when absent. */
+/**
+ * Best-effort resolution of the assistant API key through the authorized
+ * platform client (the same credential path `plugins publish` uses); the
+ * install proceeds anonymously when the daemon isn't connected to the platform.
+ */
 async function resolveAssistantApiKey(): Promise<string | undefined> {
   try {
-    const key = await getSecureKeyAsync(
-      credentialKey("vellum", "assistant_api_key"),
-    );
-    return key && key.length > 0 ? key : undefined;
+    const { VellumPlatformClient } = await import("../../platform/client.js");
+    const client = await VellumPlatformClient.create();
+    return client?.assistantApiKey || undefined;
   } catch {
     return undefined;
   }

--- a/assistant/src/cli/lib/install-from-platform.ts
+++ b/assistant/src/cli/lib/install-from-platform.ts
@@ -1,0 +1,603 @@
+/**
+ * Install a plugin by name from the platform's public install endpoint.
+ *
+ * Plugin installs are platform-managed and content flows *through* the platform
+ * (npm-style): the endpoint assembles a `.tgz` of the plugin's files from the
+ * pinned commit, server-side, and serves it as `application/gzip`. The daemon
+ * downloads that tarball, verifies its integrity against the `ETag` sha256,
+ * and extracts it into the plugin's install directory — it does NOT clone the
+ * plugin from GitHub itself, and it does NOT emit `plugin_installed` telemetry
+ * (hitting this endpoint *is* the recorded install; the server rejects that
+ * event type on the usual ingest path).
+ *
+ *     GET {PLATFORM_BASE_URL}/v1/plugins/{name}/install/
+ *
+ * The endpoint is public (works anonymously); when the daemon has an assistant
+ * API key it is sent so the install is attributed to the real user/org.
+ *
+ * Designed for direct programmatic use with injected deps (mirroring
+ * {@link ./install-from-github}). The CLI command `assistant plugins install
+ * <name>` calls {@link installPluginViaPlatform}, which resolves production
+ * deps (platform base URL, optional API key, attribution) and delegates to
+ * {@link installPluginFromPlatform}.
+ */
+
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve, sep } from "node:path";
+import { gunzipSync } from "node:zlib";
+
+import { getPlatformBaseUrl } from "../../config/env.js";
+import { credentialKey } from "../../security/credential-key.js";
+import { getSecureKeyAsync } from "../../security/secure-keys.js";
+import { getExistingDeviceId } from "../../util/device-id.js";
+import { getWorkspacePluginsDir } from "../../util/platform.js";
+import { APP_VERSION } from "../../version.js";
+import type { FetchLike } from "./fetch-like.js";
+import {
+  finalizeStagedInstall,
+  type InstallPluginResult,
+  PluginAlreadyInstalledError,
+  type PluginFetchSource,
+  PluginNotFoundError,
+  PluginSourceUnavailableError,
+  sanitizePluginName,
+} from "./install-from-github.js";
+
+/**
+ * The downloaded artifact's sha256 did not match the `ETag` the endpoint
+ * advertised. The archive is corrupt or tampered — the install is aborted
+ * before extraction rather than materializing untrusted bytes.
+ */
+export class PluginIntegrityError extends Error {
+  constructor(
+    readonly pluginName: string,
+    readonly expected: string,
+    readonly actual: string,
+  ) {
+    super(
+      `Integrity check failed for "${pluginName}": expected sha256 ${expected}, ` +
+        `got ${actual}. The download was corrupt or tampered — aborting.`,
+    );
+    this.name = "PluginIntegrityError";
+  }
+}
+
+/**
+ * A tar entry's path escaped the install directory (`..`, an absolute path, or
+ * a separator-laden name), or the archive was otherwise malformed. Archive
+ * paths are never trusted blindly, so such an entry aborts the whole extract.
+ */
+export class PluginArchiveError extends Error {
+  constructor(
+    readonly pluginName: string,
+    detail: string,
+  ) {
+    super(`Archive for "${pluginName}" is invalid: ${detail}`);
+    this.name = "PluginArchiveError";
+  }
+}
+
+/** The plugin exceeds the platform's install size cap (HTTP 413). */
+export class PluginTooLargeError extends Error {
+  constructor(readonly pluginName: string) {
+    super(
+      `Plugin "${pluginName}" is too large to install (the platform enforces a size cap).`,
+    );
+    this.name = "PluginTooLargeError";
+  }
+}
+
+/** The caller was rate limited (HTTP 429) and retries were exhausted. */
+export class PluginRateLimitedError extends Error {
+  constructor(readonly pluginName: string) {
+    super(
+      `Installing "${pluginName}" was rate limited. Wait a moment and try again.`,
+    );
+    this.name = "PluginRateLimitedError";
+  }
+}
+
+/** Options controlling which plugin to install and how. */
+export interface InstallFromPlatformOptions {
+  readonly name: string;
+  /** Overwrite an existing install in place. Preserved on disk until download+verify succeed. */
+  readonly force?: boolean;
+  /** Daemon device id, forwarded as `installation_id` for richer attribution. */
+  readonly installationId?: string;
+  /** Conversation id, forwarded as `conversation_id` when the install is assistant-driven. */
+  readonly conversationId?: string;
+  /** Assistant version, forwarded as `assistant_version`. */
+  readonly assistantVersion?: string;
+}
+
+/** Dependencies injected by the caller. */
+export interface InstallFromPlatformDeps {
+  /** HTTP client. Production callers pass `globalThis.fetch.bind(globalThis)`. */
+  readonly fetch: FetchLike;
+  /** Platform base URL (no trailing slash required). */
+  readonly platformBaseUrl: string;
+  /** Assistant API key. When present the install is attributed to the real user/org. */
+  readonly apiKey?: string;
+  /** Override the workspace plugins directory. Falls back to {@link getWorkspacePluginsDir}. */
+  readonly workspacePluginsDir?: string;
+  /** Max attempts for a transient status (429 / 502). Defaults to {@link DEFAULT_MAX_ATTEMPTS}. */
+  readonly maxAttempts?: number;
+  /** Sleep between retries. Injected so tests don't wait real time. */
+  readonly sleep?: (ms: number) => Promise<void>;
+}
+
+/** Total attempts (initial + retries) for a transient upstream status. */
+const DEFAULT_MAX_ATTEMPTS = 4;
+
+/** Base backoff between retries (doubles each attempt). */
+const RETRY_BASE_MS = 500;
+
+/** Metadata extracted from the install endpoint's response headers. */
+interface InstallResponseMeta {
+  /** `sha256:<64-hex>` integrity digest, or null when the header was absent/malformed. */
+  readonly etag: string | null;
+  /** Pinned commit SHA (`X-Plugin-Ref`); recorded as the installed version. */
+  readonly ref: string | null;
+  /** `owner/repo` (`X-Plugin-Repo`). */
+  readonly repo: string | null;
+  /** Repo-relative plugin root (`X-Plugin-Source-Path`), present only for monorepo/subdir plugins. */
+  readonly sourcePath: string | null;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Download, verify, and extract a plugin from the platform install endpoint.
+ *
+ * Staging mirrors {@link installPlugin}: the tree is extracted into a sibling
+ * staging dir and only swapped into `<pluginsDir>/<name>` once the download,
+ * integrity check, and extraction all succeed — so a transient failure leaves
+ * a previously installed copy untouched even under `force`.
+ */
+export async function installPluginFromPlatform(
+  opts: InstallFromPlatformOptions,
+  deps: InstallFromPlatformDeps,
+): Promise<InstallPluginResult> {
+  const name = sanitizePluginName(opts.name);
+  const force = opts.force ?? false;
+
+  const pluginsDir = deps.workspacePluginsDir ?? getWorkspacePluginsDir();
+  const target = join(pluginsDir, name);
+  if (existsSync(target) && !force) {
+    throw new PluginAlreadyInstalledError(name, target);
+  }
+
+  const { body, meta } = await downloadInstallArchive(name, opts, deps);
+
+  // Verify integrity before touching disk. The ETag is the sha256 of the
+  // response body — abort rather than extract a corrupt/tampered archive.
+  verifyArchiveIntegrity(name, body, meta.etag);
+
+  const stagingRoot = join(dirname(pluginsDir), ".plugins-staging");
+  mkdirSync(stagingRoot, { recursive: true });
+  const stagingDir = join(stagingRoot, `${name}.installing.${process.pid}`);
+  if (existsSync(stagingDir)) {
+    rmSync(stagingDir, { recursive: true, force: true });
+  }
+  mkdirSync(stagingDir, { recursive: true });
+
+  let fileCount: number;
+  try {
+    fileCount = extractPluginTarball(name, body, stagingDir);
+  } catch (err) {
+    rmSync(stagingDir, { recursive: true, force: true });
+    throw err;
+  }
+
+  if (fileCount === 0) {
+    rmSync(stagingDir, { recursive: true, force: true });
+    throw new PluginNotFoundError(name, meta.ref ?? "", meta.repo ?? name);
+  }
+
+  // Record provenance for future update/version UX. The endpoint re-roots the
+  // tarball to the plugin root, so the recorded ref is the pinned commit and
+  // the ETag documents exactly which bytes were verified.
+  const source = buildFetchSource(meta);
+  const ref = meta.ref ?? "";
+  finalizeStagedInstall(stagingDir, {
+    name,
+    source,
+    ref,
+    commit: meta.ref,
+    committedAt: null,
+    ...(meta.etag ? { etag: meta.etag } : {}),
+    pluginsDir,
+  });
+
+  return { name, target, fileCount, ref, commit: meta.ref, committedAt: null };
+}
+
+/**
+ * Resolve production deps and install `name` from the platform endpoint.
+ *
+ * The CLI command `assistant plugins install <name>` calls this. It resolves
+ * the platform base URL the daemon already uses, sends the assistant API key
+ * when one is configured (attributing the install to the real user/org, else
+ * anonymous), and forwards best-effort attribution (`installation_id`,
+ * `assistant_version`).
+ */
+export async function installPluginViaPlatform(
+  opts: { name: string; force?: boolean; conversationId?: string },
+  deps: { fetch: FetchLike },
+): Promise<InstallPluginResult> {
+  const platformBaseUrl = getPlatformBaseUrl();
+  const apiKey = await resolveAssistantApiKey();
+  const installationId = getExistingDeviceId() ?? undefined;
+
+  return installPluginFromPlatform(
+    {
+      name: opts.name,
+      force: opts.force,
+      ...(installationId ? { installationId } : {}),
+      ...(opts.conversationId ? { conversationId: opts.conversationId } : {}),
+      assistantVersion: APP_VERSION,
+    },
+    { fetch: deps.fetch, platformBaseUrl, ...(apiKey ? { apiKey } : {}) },
+  );
+}
+
+/** Best-effort read of the assistant API key; anonymous install when absent. */
+async function resolveAssistantApiKey(): Promise<string | undefined> {
+  try {
+    const key = await getSecureKeyAsync(
+      credentialKey("vellum", "assistant_api_key"),
+    );
+    return key && key.length > 0 ? key : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * GET the install endpoint, retrying transient statuses (429 / 502) with
+ * exponential backoff, and return the archive bytes plus response metadata.
+ */
+async function downloadInstallArchive(
+  name: string,
+  opts: InstallFromPlatformOptions,
+  deps: InstallFromPlatformDeps,
+): Promise<{ body: Buffer; meta: InstallResponseMeta }> {
+  const url = buildInstallUrl(deps.platformBaseUrl, name, opts);
+  const headers: Record<string, string> = {
+    Accept: "application/gzip",
+    "User-Agent": "vellum-assistant-cli",
+  };
+  if (deps.apiKey) {
+    headers.Authorization = `Api-Key ${deps.apiKey}`;
+  }
+
+  const maxAttempts = deps.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const sleep = deps.sleep ?? defaultSleep;
+
+  let lastTransient: Error | null = null;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const res = await deps.fetch(url, { method: "GET", headers });
+
+    if (res.ok) {
+      const body = Buffer.from(await res.arrayBuffer());
+      return { body, meta: readResponseMeta(res) };
+    }
+
+    // Unknown plugin — a hard, non-retryable not-found.
+    if (res.status === 404) {
+      throw new PluginNotFoundError(name, "", `plugin "${name}"`);
+    }
+    // Size cap — non-retryable.
+    if (res.status === 413) {
+      throw new PluginTooLargeError(name);
+    }
+    // Rate limited or upstream/assembly hiccup — retry with backoff.
+    if (res.status === 429 || res.status === 502 || res.status >= 500) {
+      lastTransient =
+        res.status === 429
+          ? new PluginRateLimitedError(name)
+          : new PluginSourceUnavailableError(
+              `Plugin install endpoint returned HTTP ${res.status} for "${name}".`,
+              res.status,
+            );
+      if (attempt < maxAttempts) {
+        await sleep(retryDelayMs(res, attempt));
+        continue;
+      }
+      throw lastTransient;
+    }
+
+    throw new PluginSourceUnavailableError(
+      `Plugin install endpoint returned HTTP ${res.status} for "${name}".`,
+      res.status,
+    );
+  }
+
+  // Unreachable in practice (the loop always returns or throws), but keeps the
+  // type checker happy and preserves the last transient error if it is hit.
+  throw (
+    lastTransient ??
+    new PluginSourceUnavailableError(
+      `Plugin install failed for "${name}".`,
+      503,
+    )
+  );
+}
+
+/** Compute the backoff before the next retry, honoring `Retry-After` on a 429. */
+function retryDelayMs(res: Response, attempt: number): number {
+  const retryAfter = res.headers.get("retry-after");
+  if (retryAfter) {
+    const seconds = Number.parseInt(retryAfter, 10);
+    if (Number.isFinite(seconds) && seconds >= 0) {
+      return seconds * 1000;
+    }
+  }
+  return RETRY_BASE_MS * 2 ** (attempt - 1);
+}
+
+/** Build the install URL, appending optional attribution query params. */
+function buildInstallUrl(
+  platformBaseUrl: string,
+  name: string,
+  opts: InstallFromPlatformOptions,
+): string {
+  const base = platformBaseUrl.replace(/\/+$/, "");
+  const url = new URL(
+    `${base}/v1/plugins/${encodeURIComponent(name)}/install/`,
+  );
+  if (opts.installationId) {
+    url.searchParams.set("installation_id", opts.installationId);
+  }
+  if (opts.conversationId) {
+    url.searchParams.set("conversation_id", opts.conversationId);
+  }
+  if (opts.assistantVersion) {
+    url.searchParams.set("assistant_version", opts.assistantVersion);
+  }
+  return url.toString();
+}
+
+/** Extract the metadata headers the tarball itself cannot carry. */
+function readResponseMeta(res: Response): InstallResponseMeta {
+  return {
+    etag: res.headers.get("etag"),
+    ref: res.headers.get("x-plugin-ref"),
+    repo: res.headers.get("x-plugin-repo"),
+    sourcePath: res.headers.get("x-plugin-source-path"),
+  };
+}
+
+/** Map the response metadata onto the provenance {@link PluginFetchSource}. */
+function buildFetchSource(meta: InstallResponseMeta): PluginFetchSource {
+  const [owner = "", repo = ""] = (meta.repo ?? "").split("/");
+  return {
+    owner,
+    repo,
+    rootPath: meta.sourcePath ?? "",
+    ref: meta.ref ?? "",
+  };
+}
+
+/**
+ * Parse `ETag: "sha256:<hex>"`, compute the sha256 of `body`, and throw
+ * {@link PluginIntegrityError} on mismatch. A missing/malformed ETag can't be
+ * verified against, so verification is skipped in that case (the endpoint
+ * always sends one for a real artifact).
+ */
+export function verifyArchiveIntegrity(
+  name: string,
+  body: Buffer,
+  etag: string | null,
+): void {
+  const expected = parseSha256Etag(etag);
+  if (!expected) {
+    return;
+  }
+  const actual = createHash("sha256").update(body).digest("hex");
+  if (actual.toLowerCase() !== expected.toLowerCase()) {
+    throw new PluginIntegrityError(name, expected, actual);
+  }
+}
+
+/** Strip the surrounding quotes and `sha256:` prefix from an ETag; null if absent/malformed. */
+function parseSha256Etag(etag: string | null): string | null {
+  if (!etag) {
+    return null;
+  }
+  const unquoted = etag.trim().replace(/^W\//, "").replace(/^"|"$/g, "");
+  const match = /^sha256:([0-9a-f]{64})$/i.exec(unquoted);
+  return match ? match[1]! : null;
+}
+
+// ─── Tar extraction ──────────────────────────────────────────────────────────
+
+/** A regular-file entry recovered from the tar stream. */
+interface TarFileEntry {
+  readonly name: string;
+  readonly data: Buffer;
+}
+
+/**
+ * Gunzip and extract a plugin `.tgz` into `destDir`, returning the number of
+ * regular files written. Entries are already plugin-root-relative (the endpoint
+ * re-roots the tarball), so they are extracted as-is — but archive paths are
+ * never trusted: any entry that resolves outside `destDir` aborts the extract
+ * with {@link PluginArchiveError}.
+ */
+export function extractPluginTarball(
+  name: string,
+  gzip: Buffer,
+  destDir: string,
+): number {
+  let tar: Buffer;
+  try {
+    tar = gunzipSync(gzip);
+  } catch (err) {
+    throw new PluginArchiveError(
+      name,
+      `not a valid gzip stream (${err instanceof Error ? err.message : String(err)})`,
+    );
+  }
+
+  const resolvedRoot = resolve(destDir);
+  let count = 0;
+  for (const entry of parseTarEntries(name, tar)) {
+    const destPath = resolveSafeEntryPath(name, resolvedRoot, entry.name);
+    mkdirSync(dirname(destPath), { recursive: true });
+    writeFileSync(destPath, entry.data);
+    count++;
+  }
+  return count;
+}
+
+/**
+ * Resolve `entryName` under `resolvedRoot`, rejecting absolute paths and any
+ * name that escapes the root via `..`. Returns the absolute destination path.
+ */
+function resolveSafeEntryPath(
+  pluginName: string,
+  resolvedRoot: string,
+  entryName: string,
+): string {
+  const normalized = entryName.replace(/\\/g, "/").replace(/^\.\/+/, "");
+  if (
+    normalized === "" ||
+    normalized.startsWith("/") ||
+    /^[a-zA-Z]:\//.test(normalized) ||
+    normalized === ".." ||
+    normalized.startsWith("../") ||
+    normalized.split("/").some((seg) => seg === "..")
+  ) {
+    throw new PluginArchiveError(
+      pluginName,
+      `entry ${JSON.stringify(entryName)} escapes the install directory`,
+    );
+  }
+  const destPath = resolve(resolvedRoot, normalized);
+  if (destPath !== resolvedRoot && !destPath.startsWith(resolvedRoot + sep)) {
+    throw new PluginArchiveError(
+      pluginName,
+      `entry ${JSON.stringify(entryName)} escapes the install directory`,
+    );
+  }
+  return destPath;
+}
+
+/**
+ * Walk a (decompressed) tar stream and yield its regular-file entries.
+ *
+ * Handles the ustar `prefix` field and the two long-name conventions a
+ * server-side `git archive` / `tar` can emit — GNU `L` long-name records and
+ * pax `x` extended headers carrying a `path=` record — so deeply nested plugin
+ * paths (skills/…, tools/…) round-trip intact. Directories, symlinks, and
+ * hardlinks are skipped (the loader follows neither); global pax headers are
+ * ignored.
+ */
+function parseTarEntries(pluginName: string, tar: Buffer): TarFileEntry[] {
+  const entries: TarFileEntry[] = [];
+  let offset = 0;
+  let longName: string | null = null;
+  let paxPath: string | null = null;
+
+  while (offset + 512 <= tar.length) {
+    const header = tar.subarray(offset, offset + 512);
+    // End-of-archive: a zero block.
+    if (header.every((b) => b === 0)) {
+      break;
+    }
+
+    const size = parseTarSize(pluginName, header);
+    const typeFlag = header[156];
+    const dataStart = offset + 512;
+    const dataEnd = dataStart + size;
+    if (dataEnd > tar.length) {
+      throw new PluginArchiveError(pluginName, "truncated tar entry");
+    }
+    const data = tar.subarray(dataStart, dataEnd);
+    // Advance past this entry's data (padded to a 512-byte boundary).
+    offset = dataStart + Math.ceil(size / 512) * 512;
+
+    // GNU long name ('L'): the data block holds the name of the NEXT entry.
+    if (typeFlag === 76 /* 'L' */) {
+      longName = readCString(data);
+      continue;
+    }
+    // pax extended header ('x'): may carry a `path=` override for the NEXT entry.
+    if (typeFlag === 120 /* 'x' */) {
+      paxPath = readPaxPath(data);
+      continue;
+    }
+    // Global pax header ('g'): applies to the whole archive; ignored here.
+    if (typeFlag === 103 /* 'g' */) {
+      continue;
+    }
+
+    const name = paxPath ?? longName ?? readHeaderName(header);
+    longName = null;
+    paxPath = null;
+
+    // Regular file: type '0' or the historical NUL. Everything else
+    // (directory '5', symlink '2', hardlink '1', ...) is skipped.
+    const isRegularFile = typeFlag === 0 || typeFlag === 48; /* '0' */
+    if (isRegularFile && name && !name.endsWith("/")) {
+      entries.push({ name, data: Buffer.from(data) });
+    }
+  }
+  return entries;
+}
+
+/** Read the ustar name, prepending the `prefix` field when present. */
+function readHeaderName(header: Buffer): string {
+  const name = readCString(header.subarray(0, 100));
+  const prefix = readCString(header.subarray(345, 500));
+  return prefix ? `${prefix}/${name}` : name;
+}
+
+/** Parse the octal `size` field (bytes 124–136). */
+function parseTarSize(pluginName: string, header: Buffer): number {
+  const raw = header
+    .subarray(124, 136)
+    .toString("utf-8")
+    .replace(/\0/g, "")
+    .trim();
+  const size = raw ? Number.parseInt(raw, 8) : 0;
+  if (!Number.isFinite(size) || size < 0) {
+    throw new PluginArchiveError(pluginName, "malformed tar size field");
+  }
+  return size;
+}
+
+/** Decode a NUL-terminated field to a UTF-8 string. */
+function readCString(buf: Buffer): string {
+  const end = buf.indexOf(0);
+  return buf.subarray(0, end === -1 ? buf.length : end).toString("utf-8");
+}
+
+/**
+ * Extract the `path=` value from a pax extended header block. Each record is
+ * `"<len> <key>=<value>\n"`; the `path` record overrides the entry name.
+ */
+function readPaxPath(data: Buffer): string | null {
+  const text = data.toString("utf-8");
+  let i = 0;
+  while (i < text.length) {
+    const space = text.indexOf(" ", i);
+    if (space === -1) {
+      break;
+    }
+    const len = Number.parseInt(text.slice(i, space), 10);
+    if (!Number.isFinite(len) || len <= 0 || i + len > text.length) {
+      break;
+    }
+    const record = text.slice(space + 1, i + len - 1); // drop trailing '\n'
+    const eq = record.indexOf("=");
+    if (eq !== -1 && record.slice(0, eq) === "path") {
+      return record.slice(eq + 1);
+    }
+    i += len;
+  }
+  return null;
+}

--- a/assistant/src/cli/lib/install-from-platform.ts
+++ b/assistant/src/cli/lib/install-from-platform.ts
@@ -267,7 +267,9 @@ async function downloadInstallArchive(
 ): Promise<{ body: Buffer; meta: InstallResponseMeta }> {
   const url = buildInstallUrl(deps.platformBaseUrl, name, opts);
   const headers: Record<string, string> = {
-    Accept: "application/gzip",
+    // The platform (Django) 406s a specific `application/gzip` Accept, so ask
+    // for anything and sniff the body ourselves (see extractPluginTarball).
+    Accept: "*/*",
     "User-Agent": "vellum-assistant-cli",
   };
   if (deps.apiKey) {
@@ -421,26 +423,38 @@ interface TarFileEntry {
   readonly data: Buffer;
 }
 
+/** gzip streams begin with the magic bytes `0x1f 0x8b`. */
+function isGzip(buf: Buffer): boolean {
+  return buf.length >= 2 && buf[0] === 0x1f && buf[1] === 0x8b;
+}
+
 /**
- * Gunzip and extract a plugin `.tgz` into `destDir`, returning the number of
- * regular files written. Entries are already plugin-root-relative (the endpoint
- * re-roots the tarball), so they are extracted as-is — but archive paths are
- * never trusted: any entry that resolves outside `destDir` aborts the extract
- * with {@link PluginArchiveError}.
+ * Extract a plugin archive into `destDir`, returning the number of regular
+ * files written. The archive is gunzipped when it carries the gzip magic bytes
+ * and treated as a plain (uncompressed) POSIX tar otherwise — the platform
+ * advertises `application/gzip` but may serve either, so the body is sniffed
+ * rather than trusted by content-type. Entries are already plugin-root-relative
+ * (the endpoint re-roots the tarball), so they are extracted as-is — but archive
+ * paths are never trusted: any entry that resolves outside `destDir` aborts the
+ * extract with {@link PluginArchiveError}.
  */
 export function extractPluginTarball(
   name: string,
-  gzip: Buffer,
+  archive: Buffer,
   destDir: string,
 ): number {
   let tar: Buffer;
-  try {
-    tar = gunzipSync(gzip);
-  } catch (err) {
-    throw new PluginArchiveError(
-      name,
-      `not a valid gzip stream (${err instanceof Error ? err.message : String(err)})`,
-    );
+  if (isGzip(archive)) {
+    try {
+      tar = gunzipSync(archive);
+    } catch (err) {
+      throw new PluginArchiveError(
+        name,
+        `not a valid gzip stream (${err instanceof Error ? err.message : String(err)})`,
+      );
+    }
+  } else {
+    tar = archive;
   }
 
   const resolvedRoot = resolve(destDir);


### PR DESCRIPTION
## Prompt / plan

Wire `assistant plugins install <name>` to install platform-managed plugins from the platform's public install endpoint, which now serves the plugin's content as a gzipped tarball assembled server-side from the pinned commit (npm-style — content flows *through* the platform, not a GitHub clone by the daemon):

    GET {PLATFORM_BASE_URL}/v1/plugins/{name}/install/

The daemon downloads the `.tgz`, verifies its integrity against the response `ETag` (sha256 of the body), and extracts it into the plugin's install dir. The endpoint is public (works anonymously); the assistant API key is sent as `Api-Key` when available so the install is attributed to the real user/org. Hitting this endpoint *is* the recorded install, so the daemon emits **no** `plugin_installed` telemetry.

### What changed

- **New `assistant/src/cli/lib/install-from-platform.ts`** — `installPluginFromPlatform(opts, deps)` (injectable deps for testing) plus the production wrapper `installPluginViaPlatform` the CLI calls. It:
  1. GETs the endpoint once, streaming the body to a buffer, retrying transient `429` / `5xx` with exponential backoff (honoring `Retry-After`).
  2. Verifies the `ETag` sha256 and aborts on mismatch before touching disk.
  3. Extracts the tarball (gunzip + a tar walker that handles the ustar `prefix` field, GNU long-name records, and pax `path=` headers so deeply nested plugin paths round-trip) into a staging dir, rejecting any entry whose resolved path escapes the target.
  4. Records provenance (`X-Plugin-Ref` as the installed commit + the `ETag`) via the shared `finalizeStagedInstall` atomic swap.
- **`install-from-github.ts`** — threads an optional `etag` field through `finalizeStagedInstall` / `writeInstallMeta` / `readInstallMeta` / `InstallMeta` for platform-endpoint provenance.
- **`cli/commands/plugins.ts`** — a plain by-name install now routes through the platform endpoint. The advanced marketplace selectors (`--pin` / `--ref` / `--allow-unreviewed`) and direct GitHub-URL installs keep the existing git-based path, which the endpoint does not model.

### Scope note

Only the CLI by-name install is switched here (per the task's definition of done). The HTTP `POST /v1/plugins/install` route keeps its git/reviewed-pin path; rerouting it is a separate change with its own security model (reviewed-history enforcement).

## Test plan

- New `install-from-platform.test.ts` (13 tests): download+verify+extract (files land at the plugin root, no wrapper dir), `Api-Key` header sent, attribution query params forwarded, ETag-mismatch abort (writes nothing), path-traversal entry rejected, `404` / `413` / `429` (retry-then-fail and retry-then-recover) / `502`, and force-overwrite.
- Existing `install-from-github`, `upgrade-plugin`, `diff-plugin`, and `plugins-routes` suites pass unchanged.
- `bunx tsc --noEmit` clean; eslint/prettier clean on changed files.
- **End-to-end against the real prod endpoint**: verified the actual `.tgz` for `caveman` (JuliusBrussee/caveman, 143 files) and `reading-pal` (vellum-ai/reading-pal, 18 files) — real `ETag` verifies, a tampered ETag aborts, and files extract re-rooted at the top level with matching file counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVc9oo14SWcaBVSrUXMgcN

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVc9oo14SWcaBVSrUXMgcN)_