### PR TITLE
feat(assistant): persist user uploads as workspace references (ATL-991)

### DIFF
--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -23,6 +23,7 @@ mock.module("../config/loader.js", () => ({
 import {
   attachInlineAttachmentToMessage,
   AttachmentUploadError,
+  createInlineAttachment,
   deleteAttachment,
   deleteOrphanAttachments,
   getAttachmentById,
@@ -44,6 +45,7 @@ import { getConversationDirPath } from "../persistence/conversation-disk-view.js
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { rawGet, rawRun } from "../persistence/raw-query.js";
+import { mediaSourceBytes } from "../providers/media-resolve.js";
 import { getConversationsDir } from "../util/platform.js";
 
 await initializeDb();
@@ -393,6 +395,44 @@ describe("getAttachmentById", () => {
 // ---------------------------------------------------------------------------
 // attachInlineAttachmentToMessage — filename collisions
 // ---------------------------------------------------------------------------
+
+describe("createInlineAttachment (workspace_ref persistence)", () => {
+  beforeEach(resetTables);
+
+  test("creates an unlinked row whose bytes resolve back via a workspace_ref", async () => {
+    const conv = createConversation();
+    const msg = await addMessage(conv.id, "user", "hi");
+
+    // "aGVsbG8=" = "hello"
+    const stored = createInlineAttachment(
+      conv.id,
+      conv.createdAt,
+      "note.txt",
+      "text/plain",
+      "aGVsbG8=",
+    );
+
+    // The row exists but is NOT yet linked to the message (the persist path
+    // writes the link after addMessage, once the message id exists).
+    expect(getAttachmentsForMessage(msg.id)).toHaveLength(0);
+    expect(readFileSync(stored.filePath).toString()).toBe("hello");
+
+    // A workspace_ref pointing at the row resolves to the original bytes.
+    const resolved = mediaSourceBytes({
+      type: "workspace_ref",
+      media_type: "text/plain",
+      attachmentId: stored.id,
+      sizeBytes: stored.sizeBytes,
+    });
+    expect(resolved?.toString()).toBe("hello");
+
+    // Linking writes the GC anchor so the row is retrievable by message.
+    linkAttachmentToMessage(msg.id, stored.id, 0);
+    expect(getAttachmentsForMessage(msg.id).map((a) => a.id)).toEqual([
+      stored.id,
+    ]);
+  });
+});
 
 describe("attachInlineAttachmentToMessage filename collisions", () => {
   beforeEach(resetTables);

--- a/assistant/src/__tests__/attachments.test.ts
+++ b/assistant/src/__tests__/attachments.test.ts
@@ -2,9 +2,86 @@ import { describe, expect, test } from "bun:test";
 
 import {
   attachmentsToContentBlocks,
+  attachmentsToReferenceBlocks,
   enrichMessageWithSourcePaths,
 } from "../agent/attachments.js";
 import { createUserMessage } from "../agent/message-types.js";
+
+// ---------------------------------------------------------------------------
+// attachmentsToReferenceBlocks
+// ---------------------------------------------------------------------------
+
+describe("attachmentsToReferenceBlocks", () => {
+  test("builds an image workspace_ref with dimension hints, no base64", () => {
+    const blocks = attachmentsToReferenceBlocks([
+      {
+        attachmentId: "att-1",
+        filename: "photo.png",
+        mimeType: "image/png",
+        sizeBytes: 1234,
+        width: 800,
+        height: 600,
+      },
+    ]);
+
+    expect(blocks).toEqual([
+      {
+        type: "image",
+        source: {
+          type: "workspace_ref",
+          media_type: "image/png",
+          attachmentId: "att-1",
+          sizeBytes: 1234,
+          width: 800,
+          height: 600,
+        },
+      },
+    ]);
+    // The large blob never appears in the persisted block.
+    expect(JSON.stringify(blocks)).not.toContain("data");
+  });
+
+  test("builds a file workspace_ref with filename and extracted text", () => {
+    const blocks = attachmentsToReferenceBlocks([
+      {
+        attachmentId: "att-2",
+        filename: "report.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 42,
+        extractedText: "hello",
+      },
+    ]);
+
+    expect(blocks).toEqual([
+      {
+        type: "file",
+        source: {
+          type: "workspace_ref",
+          media_type: "application/pdf",
+          attachmentId: "att-2",
+          sizeBytes: 42,
+          filename: "report.pdf",
+        },
+        extracted_text: "hello",
+      },
+    ]);
+  });
+
+  test("omits image dimension hints when unknown", () => {
+    const [block] = attachmentsToReferenceBlocks([
+      {
+        attachmentId: "att-3",
+        filename: "photo.png",
+        mimeType: "image/png",
+        sizeBytes: 10,
+      },
+    ]);
+    const source = (block as unknown as { source: Record<string, unknown> })
+      .source;
+    expect("width" in source).toBe(false);
+    expect("height" in source).toBe(false);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // attachmentsToContentBlocks

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -225,10 +225,40 @@ let mockAttachmentIdCounter = 0;
 mock.module("../persistence/attachments-store.js", () => ({
   AttachmentUploadError: class AttachmentUploadError extends Error {},
   uploadAttachment: () => ({ id: `att-${Date.now()}` }),
+  attachmentExists: () => false,
+  validateAttachmentUpload: () => ({ ok: true }),
+  scopeAttachmentToMessageConversation: () => null,
+  getAttachmentContent: () => null,
   linkAttachmentToMessage: () => {
     if (linkAttachmentShouldThrow) {
       throw new Error("Simulated linkAttachmentToMessage failure");
     }
+  },
+  createInlineAttachment: (
+    _conversationId: string,
+    _conversationCreatedAt: number,
+    filename: string,
+    mimeType: string,
+    dataBase64: string,
+  ) => {
+    if (linkAttachmentShouldThrow) {
+      throw new Error("Simulated createInlineAttachment failure");
+    }
+
+    return {
+      id: `att-inline-${++mockAttachmentIdCounter}`,
+      originalFilename: filename,
+      mimeType,
+      sizeBytes: Buffer.from(dataBase64, "base64").byteLength,
+      kind: mimeType.startsWith("image/")
+        ? "image"
+        : mimeType.startsWith("video/")
+          ? "video"
+          : "file",
+      thumbnailBase64: null,
+      createdAt: Date.now(),
+      filePath: `/tmp/${filename}`,
+    };
   },
   attachInlineAttachmentToMessage: (
     _messageId: string,

--- a/assistant/src/__tests__/process-message-display-content.test.ts
+++ b/assistant/src/__tests__/process-message-display-content.test.ts
@@ -30,8 +30,25 @@ mock.module("../persistence/attachments-store.js", () => ({
   getAttachmentsByIds: () => [],
   getSourcePathsForAttachments: () => new Map<string, string>(),
   attachmentExists: () => false,
-  linkAttachmentToMessage: () => {},
-  attachInlineAttachmentToMessage: () => {},
+  linkAttachmentToMessage: () => "att-stored",
+  scopeAttachmentToMessageConversation: () => null,
+  createInlineAttachment: (
+    _conversationId: string,
+    _conversationCreatedAt: number,
+    filename: string,
+    mimeType: string,
+  ) => ({
+    id: "att-stored",
+    originalFilename: filename,
+    mimeType,
+    sizeBytes: 9,
+    kind: "file",
+    thumbnailBase64: null,
+    createdAt: 0,
+    filePath: "/tmp/att-stored.pdf",
+  }),
+  getAttachmentContent: () => null,
+  getFilePathForAttachment: () => "/tmp/att-stored.pdf",
   validateAttachmentUpload: () => ({ ok: true }),
   AttachmentUploadError: class extends Error {},
 }));
@@ -57,6 +74,9 @@ mock.module("../persistence/conversation-crud.js", () => ({
   provenanceFromTrustContext: () => ({}),
   setConversationOriginChannelIfUnset: () => {},
   setConversationOriginInterfaceIfUnset: () => {},
+  extractImageSourcePaths: () => undefined,
+  extractAttachmentStoredPaths: () => undefined,
+  updateMessageMetadata: () => {},
   reserveMessage: mock(async () => ({ id: "msg-reserve" })),
 }));
 
@@ -348,14 +368,16 @@ describe("processMessage displayContent", () => {
 
     expect(addMessageCalls).toHaveLength(1);
     const persistedBlocks = JSON.parse(addMessageCalls[0]!.content);
+    // Persisted as a workspace reference (attachment id + size), not inline
+    // base64, so the blob stays out of the messages.content row.
     expect(persistedBlocks).toEqual([
       {
         type: "file",
-        _attachmentId: "att-1",
         source: {
-          type: "base64",
+          type: "workspace_ref",
           media_type: "application/pdf",
-          data: Buffer.from("pdf bytes").toString("base64"),
+          attachmentId: "att-stored",
+          sizeBytes: 9,
           filename: "attachment.pdf",
         },
       },

--- a/assistant/src/agent/attachments.ts
+++ b/assistant/src/agent/attachments.ts
@@ -17,6 +17,63 @@ export interface MessageAttachmentInput {
   storedPath?: string;
 }
 
+/**
+ * A user attachment that has already been materialized into an attachment-store
+ * row, described by the fields needed to build a persisted `workspace_ref`
+ * content block: the row id, the stored (post-normalization) MIME type and byte
+ * size, and — for images — the pixel dimensions the model will receive. The raw
+ * bytes are NOT carried here; they live in the attachment store and are read
+ * back only at the provider send boundary.
+ */
+export interface AttachmentReferenceInput {
+  attachmentId: string;
+  filename: string;
+  mimeType: string;
+  sizeBytes: number;
+  width?: number;
+  height?: number;
+  extractedText?: string;
+}
+
+/**
+ * Build the persisted content blocks for user attachments as workspace
+ * references (`workspace_ref`) rather than inline base64, so the large blob
+ * stays in the attachment store instead of the `messages.content` row and the
+ * lexical index. The bytes are resolved back to base64 at the provider send
+ * boundary (`resolveMediaReferences`) and fetched by clients on render.
+ */
+export function attachmentsToReferenceBlocks(
+  refs: AttachmentReferenceInput[],
+): ContentBlock[] {
+  return refs.map((ref) => {
+    if (ref.mimeType.toLowerCase().startsWith("image/")) {
+      return {
+        type: "image",
+        source: {
+          type: "workspace_ref",
+          media_type: ref.mimeType,
+          attachmentId: ref.attachmentId,
+          sizeBytes: ref.sizeBytes,
+          ...(ref.width != null ? { width: ref.width } : {}),
+          ...(ref.height != null ? { height: ref.height } : {}),
+        },
+      } as ContentBlock;
+    }
+
+    return {
+      type: "file",
+      source: {
+        type: "workspace_ref",
+        media_type: ref.mimeType,
+        attachmentId: ref.attachmentId,
+        sizeBytes: ref.sizeBytes,
+        filename: ref.filename,
+      },
+      extracted_text: ref.extractedText,
+    } as ContentBlock;
+  });
+}
+
 export function attachmentsToContentBlocks(
   attachments: MessageAttachmentInput[],
 ): ContentBlock[] {

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -8,9 +8,12 @@
 import { v4 as uuid } from "uuid";
 
 import {
+  type AttachmentReferenceInput,
+  attachmentsToReferenceBlocks,
   enrichMessageWithSourcePaths,
   type MessageAttachmentInput,
 } from "../agent/attachments.js";
+import { optimizeImageForTransport } from "../agent/image-optimize.js";
 import { createUserMessage } from "../agent/message-types.js";
 import type {
   TurnChannelContext,
@@ -21,6 +24,7 @@ import {
   parseClientOs,
   parseInterfaceId,
 } from "../channels/types.js";
+import { parseImageDimensions } from "../context/image-dimensions.js";
 import {
   buildSlackTimezoneMetadata,
   type SlackMessageMetadata,
@@ -28,11 +32,13 @@ import {
 } from "../messaging/providers/slack/message-metadata.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
 import {
-  attachInlineAttachmentToMessage,
   attachmentExists,
   AttachmentUploadError,
+  createInlineAttachment,
+  getAttachmentContent,
   getFilePathForAttachment,
   linkAttachmentToMessage,
+  scopeAttachmentToMessageConversation,
   validateAttachmentUpload,
 } from "../persistence/attachments-store.js";
 import {
@@ -49,7 +55,7 @@ import {
   syncMessageToDisk,
   updateMetaFile,
 } from "../persistence/conversation-disk-view.js";
-import type { Message } from "../providers/types.js";
+import type { ContentBlock, Message } from "../providers/types.js";
 import type { AuthContext } from "../runtime/auth/types.js";
 import { getLogger } from "../util/logger.js";
 import type { MessageQueue } from "./conversation-queue-manager.js";
@@ -216,17 +222,137 @@ export interface MessagingConversationContext {
   getTurnInterfaceContext(): TurnInterfaceContext | null;
 }
 
+/**
+ * Serialize the user message as it is PERSISTED into `messages.content`.
+ *
+ * When `attachmentRefs` is supplied (the regular upload path), attachments are
+ * written as `workspace_ref` blocks so their bytes stay in the attachment store
+ * instead of the DB row and lexical index. Callers without materialized
+ * attachments (slash-command branches) omit it and fall back to the base64
+ * blocks the in-memory message carries.
+ */
 export function serializePersistedUserMessageContent(
   content: string,
   attachments: MessageAttachmentInput[],
   displayContent: string | undefined,
+  attachmentRefs?: AttachmentReferenceInput[],
 ): string {
-  return JSON.stringify(
-    createUserMessage(
-      displayContent !== undefined ? displayContent : content,
-      attachments,
-    ).content,
+  const text = displayContent !== undefined ? displayContent : content;
+  if (attachmentRefs === undefined) {
+    return JSON.stringify(createUserMessage(text, attachments).content);
+  }
+  const blocks: ContentBlock[] = [];
+  if (text.trim().length > 0) {
+    blocks.push({ type: "text", text });
+  }
+  blocks.push(...attachmentsToReferenceBlocks(attachmentRefs));
+  return JSON.stringify(blocks);
+}
+
+/**
+ * Pixel dimensions to record on an image reference. The model receives the
+ * transport-optimized image (`resolveMediaReferences` applies the same
+ * optimization at send time), so we hint the optimized dimensions rather than
+ * the stored original — keeping the per-turn token estimate accurate without a
+ * disk read on the hot path.
+ */
+function computeReferenceImageDimensions(
+  attachmentId: string,
+  mediaType: string,
+): { width: number; height: number } | null {
+  const bytes = getAttachmentContent(attachmentId);
+  if (!bytes) return null;
+  const optimized = optimizeImageForTransport(
+    bytes.toString("base64"),
+    mediaType,
   );
+  return parseImageDimensions(optimized.data, optimized.mediaType);
+}
+
+interface PreparedUserAttachment {
+  position: number;
+  attachmentId: string;
+  ref: AttachmentReferenceInput;
+}
+
+/**
+ * Materialize each user attachment into an attachment-store row BEFORE the
+ * message content is serialized, so the content can reference it by id instead
+ * of inlining base64. Pre-uploaded attachments are scoped into the
+ * conversation; inline uploads create a new row now (rather than after
+ * `addMessage`). Returns the per-attachment reference inputs plus the row id
+ * and position needed to write the `message_attachments` link once the message
+ * exists. Attachments that fail validation are skipped (logged), matching the
+ * prior best-effort indexing behavior.
+ */
+function prepareUserAttachmentReferences(
+  conversationId: string,
+  conversationCreatedAt: number,
+  attachments: MessageAttachmentInput[],
+): PreparedUserAttachment[] {
+  const prepared: PreparedUserAttachment[] = [];
+  for (let i = 0; i < attachments.length; i++) {
+    const a = attachments[i];
+    let stored: { id: string; mimeType: string; sizeBytes: number } | null =
+      null;
+    try {
+      if (a.id && attachmentExists(a.id)) {
+        stored = scopeAttachmentToMessageConversation(
+          conversationId,
+          conversationCreatedAt,
+          a.id,
+        );
+      } else if (a.data) {
+        const validation = validateAttachmentUpload(a.filename, a.mimeType);
+        if (!validation.ok) {
+          log.warn(
+            { filename: a.filename, error: validation.error },
+            "Skipping user attachment: validation failed",
+          );
+          continue;
+        }
+        stored = createInlineAttachment(
+          conversationId,
+          conversationCreatedAt,
+          a.filename,
+          a.mimeType,
+          a.data,
+          { sourcePath: a.filePath, normalizeImage: true },
+        );
+      }
+    } catch (err) {
+      if (err instanceof AttachmentUploadError) {
+        log.warn(
+          { filename: a.filename, error: err.message },
+          "Skipping user attachment",
+        );
+      } else {
+        log.error(
+          { filename: a.filename, err },
+          "Failed to materialize user attachment",
+        );
+      }
+      continue;
+    }
+    if (!stored) continue;
+
+    const ref: AttachmentReferenceInput = {
+      attachmentId: stored.id,
+      filename: a.filename,
+      mimeType: stored.mimeType,
+      sizeBytes: stored.sizeBytes,
+      extractedText: a.extractedText,
+    };
+    if (stored.mimeType.toLowerCase().startsWith("image/")) {
+      const dims = computeReferenceImageDimensions(stored.id, stored.mimeType);
+      if (dims) {
+        ref.width = dims.width;
+        ref.height = dims.height;
+      }
+    }
+    prepared.push({ position: i, attachmentId: stored.id, ref });
+  }
+  return prepared;
 }
 
 function extractTurnChannelContext(
@@ -563,6 +689,18 @@ export async function persistQueuedMessageBody(
       ...(slackMeta ? { slackMeta } : {}),
     };
 
+    // Materialize each attachment into an attachment-store row up front so the
+    // persisted content can reference it by id instead of inlining base64. The
+    // message link (message_attachments) is written after addMessage below,
+    // once the message id exists.
+    const conversationCreatedAt =
+      getConversation(ctx.conversationId)?.createdAt ?? Date.now();
+    const preparedAttachments = prepareUserAttachmentReferences(
+      ctx.conversationId,
+      conversationCreatedAt,
+      attachmentInputs,
+    );
+
     // When displayContent is provided (e.g. original text before recording
     // intent stripping), persist that to DB so users see the full message
     // after restart. The in-memory userMessage (sent to the LLM) still uses
@@ -571,6 +709,7 @@ export async function persistQueuedMessageBody(
       content,
       attachmentInputs,
       displayContent,
+      preparedAttachments.map((p) => p.ref),
     );
     const persistedUserMessage = await addMessage(
       ctx.conversationId,
@@ -608,60 +747,25 @@ export async function persistQueuedMessageBody(
       throw new Error("Failed to persist user message");
     }
 
-    // Index user attachments in the attachments table for later retrieval,
-    // capturing the resolved stored path of each linked attachment. Name
-    // collisions in the conversation's attachments/ dir get a -2/-3 suffix,
-    // so the stored path — not the original filename — is the only reliable
-    // on-disk handle for the file.
-    for (let i = 0; i < attachments.length; i++) {
-      const a = attachments[i];
+    // Link each materialized attachment to the persisted message. The link row
+    // is the GC anchor (an attachment with no link is collectible), and it
+    // resolves the canonical stored path — name collisions in the conversation's
+    // attachments/ dir get a -2/-3 suffix, so the stored path (not the original
+    // filename) is the only reliable on-disk handle for the file.
+    for (const p of preparedAttachments) {
       try {
-        // If the attachment already exists in the store (e.g. file-backed
-        // attachments uploaded separately), link it directly without
-        // re-uploading. This handles the case where data is empty because
-        // the attachment content lives on disk.
-        if (a.id && attachmentExists(a.id)) {
-          const scopedAttachmentId = linkAttachmentToMessage(
-            persistedUserMessage.id,
-            a.id,
-            i,
-          );
-          attachmentInputs[i].storedPath =
-            getFilePathForAttachment(scopedAttachmentId) ?? undefined;
-          continue;
-        }
-
-        if (!a.data) continue;
-
-        const validation = validateAttachmentUpload(a.filename, a.mimeType);
-        if (!validation.ok) {
-          log.warn(
-            { filename: a.filename, error: validation.error },
-            "Skipping user attachment indexing: validation failed",
-          );
-          continue;
-        }
-        const stored = attachInlineAttachmentToMessage(
+        const scopedAttachmentId = linkAttachmentToMessage(
           persistedUserMessage.id,
-          i,
-          a.filename,
-          a.mimeType,
-          a.data,
-          { sourcePath: a.filePath, normalizeImage: true },
+          p.attachmentId,
+          p.position,
         );
-        attachmentInputs[i].storedPath = stored.filePath;
+        attachmentInputs[p.position].storedPath =
+          getFilePathForAttachment(scopedAttachmentId) ?? undefined;
       } catch (err) {
-        if (err instanceof AttachmentUploadError) {
-          log.warn(
-            { filename: a.filename, error: err.message },
-            "Skipping user attachment indexing",
-          );
-        } else {
-          log.error(
-            { filename: a.filename, err },
-            "Failed to index user attachment",
-          );
-        }
+        log.error(
+          { attachmentId: p.attachmentId, err },
+          "Failed to link user attachment to message",
+        );
       }
     }
 

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -212,17 +212,22 @@ function extractFileBlockMetadata(
       source && typeof source.filename === "string"
         ? source.filename
         : "attachment",
+    // A workspace_ref source carries `sizeBytes` directly; a legacy base64
+    // source carries the payload, whose byte length we estimate.
     sizeBytes:
-      source && typeof source.data === "string"
-        ? estimateBase64Bytes(source.data)
-        : 0,
+      source && typeof source.sizeBytes === "number"
+        ? source.sizeBytes
+        : source && typeof source.data === "string"
+          ? estimateBase64Bytes(source.data)
+          : 0,
   };
 }
 
 /**
  * Build the positional attachment reference for a `file` content block:
- * filename/mime/size from the block's source plus the persisted
- * `_attachmentId` when present (user-uploaded files).
+ * filename/mime/size from the block's source plus its attachment id. Reference
+ * blocks carry the id on `source.attachmentId`; legacy base64 blocks carry it
+ * on the top-level `_attachmentId`.
  */
 function fileBlockToAttachmentRef(
   block: Record<string, unknown>,
@@ -233,8 +238,15 @@ function fileBlockToAttachmentRef(
     mimeType: meta.mediaType,
     sizeBytes: meta.sizeBytes,
   };
-  if (typeof block._attachmentId === "string" && block._attachmentId) {
-    ref.attachmentId = block._attachmentId;
+  const source = isRecord(block.source) ? block.source : null;
+  const attachmentId =
+    source && typeof source.attachmentId === "string" && source.attachmentId
+      ? source.attachmentId
+      : typeof block._attachmentId === "string" && block._attachmentId
+        ? block._attachmentId
+        : null;
+  if (attachmentId) {
+    ref.attachmentId = attachmentId;
   }
   return ref;
 }

--- a/assistant/src/persistence/attachments-store.ts
+++ b/assistant/src/persistence/attachments-store.ts
@@ -340,6 +340,38 @@ function scopeAttachmentToConversation(
   return row.id;
 }
 
+/**
+ * Scope a pre-uploaded attachment into a conversation WITHOUT linking it to a
+ * message, returning the scoped row's metadata. Mirrors {@link createInlineAttachment}
+ * for the already-uploaded case: it gives the persist path the final attachment
+ * id and stored MIME/size before it serializes the message content into a
+ * workspace reference. The message link is written separately once the message
+ * id exists. Returns null when the attachment row cannot be read after scoping.
+ */
+export function scopeAttachmentToMessageConversation(
+  conversationId: string,
+  conversationCreatedAt: number,
+  attachmentId: string,
+): (StoredAttachment & { filePath: string | null }) | null {
+  const scopedId = scopeAttachmentToConversation(
+    attachmentId,
+    conversationId,
+    conversationCreatedAt,
+  );
+  const row = getAttachmentRow(scopedId);
+  if (!row) return null;
+  return {
+    id: row.id,
+    originalFilename: row.originalFilename,
+    mimeType: row.mimeType,
+    sizeBytes: row.sizeBytes,
+    kind: row.kind,
+    thumbnailBase64: null,
+    createdAt: row.createdAt,
+    filePath: row.filePath ?? null,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Size and encoding limits
 // ---------------------------------------------------------------------------
@@ -813,23 +845,33 @@ export function uploadAttachment(
   };
 }
 
-export function attachInlineAttachmentToMessage(
-  messageId: string,
-  position: number,
+export interface CreateInlineAttachmentOptions {
+  sourcePath?: string;
+  skipSizeLimit?: boolean;
+  /**
+   * Store HEIF/HEIC content as a JPEG master (with the filename extension
+   * rewritten) so every client surface can render it. User-sourced ingress
+   * opts in; assistant-produced attachments are stored verbatim — if the
+   * assistant deliberately emits a HEIC, rewriting it would be wrong.
+   */
+  normalizeImage?: boolean;
+}
+
+/**
+ * Create an attachment row from inline base64, materialized into the
+ * conversation's attachments/ directory, WITHOUT linking it to a message. The
+ * caller links it separately (`insertMessageAttachmentLink`) once the message
+ * id exists — which lets the persist path create the row (and learn its id,
+ * normalized MIME type, and byte size) before it serializes the message
+ * content into a workspace reference.
+ */
+export function createInlineAttachment(
+  conversationId: string,
+  conversationCreatedAt: number,
   filename: string,
   mimeType: string,
   dataBase64: string,
-  options?: {
-    sourcePath?: string;
-    skipSizeLimit?: boolean;
-    /**
-     * Store HEIF/HEIC content as a JPEG master (with the filename extension
-     * rewritten) so every client surface can render it. User-sourced ingress
-     * opts in; assistant-produced attachments are stored verbatim — if the
-     * assistant deliberately emits a HEIC, rewriting it would be wrong.
-     */
-    normalizeImage?: boolean;
-  },
+  options?: CreateInlineAttachmentOptions,
 ): StoredAttachment & { filePath: string } {
   if (options?.normalizeImage) {
     ({ filename, mimeType, dataBase64 } = normalizeUploadedImageBase64(
@@ -842,14 +884,10 @@ export function attachInlineAttachmentToMessage(
   const sizeBytes = validateAttachmentPayload(dataBase64, {
     skipSizeLimit: options?.skipSizeLimit,
   });
-  const ctx = getMessageConversationContext(messageId);
-  if (!ctx) {
-    throw new Error(`Message not found: ${messageId}`);
-  }
 
   const attachDir = getConversationAttachmentsDirPath(
-    ctx.conversationId,
-    ctx.conversationCreatedAt,
+    conversationId,
+    conversationCreatedAt,
   );
   mkdirSync(attachDir, { recursive: true });
   const resolvedName = resolveUniqueFilename(attachDir, filename);
@@ -877,14 +915,12 @@ export function attachInlineAttachmentToMessage(
 
   if (options?.sourcePath) {
     rawRun(
-      "attachments:attachInline:sourcePath",
+      "attachments:createInline:sourcePath",
       `UPDATE attachments SET source_path = ? WHERE id = ?`,
       options.sourcePath,
       id,
     );
   }
-
-  insertMessageAttachmentLink(messageId, id, position);
 
   return {
     id,
@@ -896,6 +932,31 @@ export function attachInlineAttachmentToMessage(
     createdAt: now,
     filePath: targetPath,
   };
+}
+
+export function attachInlineAttachmentToMessage(
+  messageId: string,
+  position: number,
+  filename: string,
+  mimeType: string,
+  dataBase64: string,
+  options?: CreateInlineAttachmentOptions,
+): StoredAttachment & { filePath: string } {
+  const ctx = getMessageConversationContext(messageId);
+  if (!ctx) {
+    throw new Error(`Message not found: ${messageId}`);
+  }
+
+  const stored = createInlineAttachment(
+    ctx.conversationId,
+    ctx.conversationCreatedAt,
+    filename,
+    mimeType,
+    dataBase64,
+    options,
+  );
+  insertMessageAttachmentLink(messageId, stored.id, position);
+  return stored;
 }
 
 export function attachFileBackedAttachmentToMessage(

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -207,11 +207,12 @@ interface AlignedAttachments {
 
 /**
  * Align DB-hydrated attachment rows with the file-block refs `renderHistoryContent`
- * captured. When a file block was persisted with `_attachmentId` (user-message
- * uploads) we join on that id to position the chip inline; DB rows without a
- * matching ref go to the tail as orphan chips, and unmatched refs drop their
- * `attachment:N` entry. Assistant-authored file blocks carry no `_attachmentId`,
- * so when no ids match we fall back to positional alignment if the ref and row
+ * captured. When a file block carries an attachment id (user-message uploads —
+ * on `source.attachmentId` for reference blocks, or the legacy top-level
+ * `_attachmentId`) we join on that id to position the chip inline; DB rows
+ * without a matching ref go to the tail as orphan chips, and unmatched refs drop
+ * their `attachment:N` entry. Assistant-authored file blocks carry no id, so
+ * when no ids match we fall back to positional alignment if the ref and row
  * counts agree; otherwise we strip the markers and let chips fall to the tail.
  */
 function alignAttachments(


### PR DESCRIPTION
## Prompt / plan

PR B of the ATL-991 split. PR A (#37469, merged) landed the `MediaSource` / `workspace_ref` data model + resolvers; this PR flips the **user-upload persist path** from inline base64 to workspace references. PR C will do the same for tool/assistant-generated media.

Direction followed: **references live in the DB (and, in a follow-up, on the UI wire); bytes are resolved only at the two edges — the provider send boundary and UI render.**

## What changes

User-uploaded images/files were serialized as inline base64 into the `messages.content` column (and the lexical index). Now they persist as `workspace_ref` blocks — the bytes stay in the attachment store, addressed by `attachmentId`, and are resolved back to base64 only at the provider send boundary (`resolveMediaReferences`) or fetched by clients on render.

**Single-write persist.** `persistQueuedMessageBody` now materializes each attachment into an attachment-store row *before* serializing the message:
- inline uploads → `createInlineAttachment` (new store fn: creates the row without a message link),
- pre-uploaded → `scopeAttachmentToMessageConversation` (new store fn: scopes into the conversation, returns the final id/metadata),

so `serializePersistedUserMessageContent` emits `workspace_ref` blocks — carrying `sizeBytes` and, for images, the transport-optimized `width`/`height` hints (kept accurate for the token estimator) — in **one** `addMessage`. The `message_attachments` GC link is written afterward, once the message id exists. No text-only-then-update step, so no reindex gap, and no base64 in the row or the index.

**Render is unaffected.** Image bytes already reach clients from the attachment *row* via the link table, not from `content`; the live `user_message_echo` carries only text. The readers that keyed off the now-redundant `_attachmentId` (`shared.ts` `fileBlockToAttachmentRef`, `conversation-routes` `alignAttachments`) read `source.attachmentId` for reference blocks while still honoring `_attachmentId` on **legacy** base64 rows — messages are immutable, so no backfill and old rows keep rendering.

The in-memory message sent to the model *this* turn keeps its base64 blocks (no extra disk round-trip); only the persisted row changes. Slash-command persist branches carry no attachments and are untouched.

### Scope boundary (next step, not in this PR)
Making the **UI wire itself carry refs** for user-upload images — clients fetch `GET /attachments/:id/content` on render instead of the server hydrating base64 into the `messages_get` response — needs coordinated `clients/web` + macOS changes, so it's a follow-up. The serving endpoint already exists.

## Test plan

- `bunx tsc --noEmit` clean; prettier + eslint (import-sort) clean; pre-commit hook green.
- New coverage: `attachmentsToReferenceBlocks` unit tests (attachments.test.ts) and a real-store round-trip — `createInlineAttachment` → `mediaSourceBytes` resolves the original bytes, link writes the GC anchor (attachments-store.test.ts).
- Updated to the reference contract: `process-message-display-content` (persisted block is now a `workspace_ref`), `conversation-queue` batched-drain (store mock gains the new fns).
- Regression: `attachments`, `attachments-store`, `server-history-render`, `list-messages-attachments`, `http-user-message-parity`, `thread-backfill`, `image-source-path-reinject`, `conversation-attachments` — all pass. Legacy `_attachmentId` render path verified intact.


---
_Generated by [Claude Code](https://claude.ai/code/session_013KcQ6J4ggzKmNUP8BnqqvB)_