### PR TITLE
fix(ces): credential writes bypass the reconnect cooldown

### DIFF
--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -485,5 +485,35 @@ describe("secure-keys", () => {
       expect(counter.runs).toBe(1);
       expect(result.unreachable).toBe(true);
     });
+
+    test("set during the cooldown upgrades from the encrypted-store fallback to CES", async () => {
+      // No CES client installed — the resolver lands on the encrypted store,
+      // the fallback used when CES fails at startup.
+      await getSecureKeyAsync("prime-key");
+
+      const fresh = makeMockCesClient(true);
+      const counter = { runs: 0 };
+      setCesReconnect(async () => {
+        counter.runs++;
+        // First attempt fails; later attempts hand back a live CES client.
+        return counter.runs === 1 ? undefined : fresh;
+      });
+
+      // A read attempts the CES upgrade (and fails), stamping the cooldown.
+      await getSecureKeyAsync("prime-key");
+      expect(counter.runs).toBe(1);
+
+      const ok = await setSecureKeyAsync("credential/vellum/api_key", "sk-2");
+
+      expect(ok).toBe(true);
+      expect(counter.runs).toBe(2);
+      expect(fresh.sets).toEqual([
+        { account: "credential/vellum/api_key", value: "sk-2" },
+      ]);
+      // The write went to CES, not the local fallback store.
+      expect(
+        encryptedStore.getKey("credential/vellum/api_key"),
+      ).toBeUndefined();
+    });
   });
 });

--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -296,6 +296,40 @@ describe("secure-keys", () => {
   });
 
   // -----------------------------------------------------------------------
+  // Mock CES client — shared by the reconnection test suites below
+  // -----------------------------------------------------------------------
+
+  interface MockCesClient extends CesClient {
+    setReady: (ready: boolean) => void;
+    /** Credential writes received via `call`, in order. */
+    sets: Array<{ account: string; value: string }>;
+  }
+
+  function makeMockCesClient(initialReady = true): MockCesClient {
+    let ready = initialReady;
+    const sets: Array<{ account: string; value: string }> = [];
+    return {
+      handshake: async () => ({ accepted: true }),
+      call: async (_method: unknown, params: unknown) => {
+        const p = params as { account?: string; value?: string };
+        if (typeof p?.account === "string" && typeof p?.value === "string") {
+          sets.push({ account: p.account, value: p.value });
+        }
+        return { ok: true, found: false, value: undefined } as never;
+      },
+      isReady: () => ready,
+      close: () => {
+        ready = false;
+      },
+      updateAssistantApiKey: async () => ({ updated: true }),
+      setReady: (r: boolean) => {
+        ready = r;
+      },
+      sets,
+    } as MockCesClient;
+  }
+
+  // -----------------------------------------------------------------------
   // CES reconnection reentrancy
   // -----------------------------------------------------------------------
   //
@@ -308,26 +342,6 @@ describe("secure-keys", () => {
   // reentrant case so nested reads resolve immediately (as "unreachable")
   // and the outer reconnect makes progress.
   describe("reconnect callback reentrancy", () => {
-    interface ControllableClient extends CesClient {
-      setReady: (ready: boolean) => void;
-    }
-
-    function makeControllableClient(initialReady = true): ControllableClient {
-      let ready = initialReady;
-      return {
-        handshake: async () => ({ accepted: true }),
-        call: async () => ({ found: false, value: undefined }) as never,
-        isReady: () => ready,
-        close: () => {
-          ready = false;
-        },
-        updateAssistantApiKey: async () => ({ updated: true }),
-        setReady: (r: boolean) => {
-          ready = r;
-        },
-      } as ControllableClient;
-    }
-
     test("nested credential read inside reconnect callback does not deadlock", async () => {
       // Seed the encrypted store with a value so nested reads have something
       // to target if they were to accidentally succeed via fallback paths.
@@ -336,7 +350,7 @@ describe("secure-keys", () => {
       // Install a CES client that starts ready so the first read resolves
       // the backend to CES RPC, then flip it to unready so the NEXT read
       // triggers the reconnect path.
-      const client = makeControllableClient(true);
+      const client = makeMockCesClient(true);
       setCesClient(client);
 
       // Prime the resolver so `_resolvedBackend` points at CES RPC.
@@ -358,7 +372,7 @@ describe("secure-keys", () => {
         await Promise.resolve();
         await getSecureKeyAsync("test-key");
         nestedReadResolved = true;
-        return makeControllableClient(true);
+        return makeMockCesClient(true);
       });
 
       const start = Date.now();
@@ -373,7 +387,7 @@ describe("secure-keys", () => {
     });
 
     test("reconnect callback that throws still releases the reentrancy flag", async () => {
-      const client = makeControllableClient(true);
+      const client = makeMockCesClient(true);
       setCesClient(client);
       await getSecureKeyAsync("any-key"); // prime the resolver
       client.setReady(false);
@@ -390,12 +404,86 @@ describe("secure-keys", () => {
       let secondCallbackRan = 0;
       setCesReconnect(async () => {
         secondCallbackRan++;
-        return makeControllableClient(true);
+        return makeMockCesClient(true);
       });
       await new Promise((resolve) => setTimeout(resolve, 3_100));
 
       await getSecureKeyAsync("any-key");
       expect(secondCallbackRan).toBe(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Write ops bypass the reconnect cooldown
+  // -----------------------------------------------------------------------
+  //
+  // Credential writes are rare and have no fallback: a set that fails
+  // because a reconnect completed moments earlier is silently dropped by
+  // callers (e.g. the post-login platform credential push stores the
+  // assistant API key exactly once). Writes therefore force a reconnection
+  // attempt even inside the cooldown window, while reads keep respecting
+  // the cooldown to avoid restart stampedes.
+  describe("write ops bypass the reconnect cooldown", () => {
+    /**
+     * Resolve the backend to a CES client, kill it, and burn one
+     * reconnection attempt (which fails) so the cooldown window is active.
+     * Returns the number of reconnect callback runs via a counter ref.
+     */
+    async function enterCooldownWithDeadBackend(): Promise<{
+      counter: { runs: number };
+      setReconnectResult: (client: CesClient | undefined) => void;
+    }> {
+      const client = makeMockCesClient(true);
+      setCesClient(client);
+      await getSecureKeyAsync("prime-key");
+      client.setReady(false);
+
+      const counter = { runs: 0 };
+      let reconnectResult: CesClient | undefined;
+      setCesReconnect(async () => {
+        counter.runs++;
+        return reconnectResult;
+      });
+
+      // Trigger one failed reconnection attempt to stamp the cooldown.
+      await getSecureKeyAsync("prime-key");
+
+      return {
+        counter,
+        setReconnectResult: (c) => {
+          reconnectResult = c;
+        },
+      };
+    }
+
+    test("set during the cooldown reconnects and stores on the fresh client", async () => {
+      const { counter, setReconnectResult } =
+        await enterCooldownWithDeadBackend();
+      expect(counter.runs).toBe(1);
+
+      const fresh = makeMockCesClient(true);
+      setReconnectResult(fresh);
+
+      const ok = await setSecureKeyAsync("credential/vellum/api_key", "sk-1");
+
+      expect(ok).toBe(true);
+      expect(counter.runs).toBe(2);
+      expect(fresh.sets).toEqual([
+        { account: "credential/vellum/api_key", value: "sk-1" },
+      ]);
+    });
+
+    test("read during the cooldown does not trigger another reconnect", async () => {
+      const { counter, setReconnectResult } =
+        await enterCooldownWithDeadBackend();
+      expect(counter.runs).toBe(1);
+
+      setReconnectResult(makeMockCesClient(true));
+
+      const result = await getSecureKeyResultAsync("prime-key");
+
+      expect(counter.runs).toBe(1);
+      expect(result.unreachable).toBe(true);
     });
   });
 });

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -225,7 +225,11 @@ async function resolveBackendAsync(
       // - We're on ces-http but an operation returned unreachable (HTTP
       //   endpoint is actually down even though isAvailable() returned true,
       //   since it only checks env vars, not actual connectivity).
-      const reconnected = await attemptCesReconnection();
+      // Mutating ops bypass the cooldown here too, so a write during the
+      // window lands on CES rather than on a fallback CES never sees.
+      const reconnected = await attemptCesReconnection({
+        ignoreCooldown: options.forceReconnect,
+      });
       if (reconnected) {
         // setCesClient() cleared the cache — fall through to re-resolve.
       } else {

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -147,7 +147,9 @@ export function setCesReconnect(
 }
 
 function getEncryptedStoreBackend(): CredentialBackend {
-  if (!_encryptedStore) {_encryptedStore = createEncryptedStoreBackend();}
+  if (!_encryptedStore) {
+    _encryptedStore = createEncryptedStoreBackend();
+  }
   return _encryptedStore;
 }
 
@@ -184,7 +186,9 @@ function getEncryptedStoreBackend(): CredentialBackend {
  *
  * Call `_resetBackend()` in tests to clear the cached resolution.
  */
-async function resolveBackendAsync(): Promise<CredentialBackend> {
+async function resolveBackendAsync(
+  options: { forceReconnect?: boolean } = {},
+): Promise<CredentialBackend> {
   if (_resolvedBackend) {
     if (!_resolvedBackend.isAvailable()) {
       const cesHttpFallback = tryFailoverToCesHttpBackend(_resolvedBackend);
@@ -192,8 +196,14 @@ async function resolveBackendAsync(): Promise<CredentialBackend> {
         return cesHttpFallback;
       }
 
-      // Backend is no longer reachable — attempt CES reconnection.
-      const reconnected = await attemptCesReconnection();
+      // Backend is no longer reachable — attempt CES reconnection. Mutating
+      // ops pass `forceReconnect` to bypass the cooldown: writes are rare,
+      // and refusing the reconnect turns a transient transport blip into a
+      // silently dropped credential (reads degrade gracefully via env-var
+      // and dead-backend fallbacks; writes have no fallback).
+      const reconnected = await attemptCesReconnection({
+        ignoreCooldown: options.forceReconnect,
+      });
       if (reconnected) {
         // setCesClient() cleared the cache — fall through to re-resolve
         // with the fresh client.
@@ -235,13 +245,17 @@ async function resolveBackendAsync(): Promise<CredentialBackend> {
 function tryFailoverToCesHttpBackend(
   backend: CredentialBackend,
 ): CredentialBackend | undefined {
-  if (backend.name !== "ces-rpc") {return undefined;}
+  if (backend.name !== "ces-rpc") {
+    return undefined;
+  }
   if (!getIsContainerized() || !process.env.CES_CREDENTIAL_URL) {
     return undefined;
   }
 
   const cesHttp = createCesCredentialBackend();
-  if (!cesHttp.isAvailable()) {return undefined;}
+  if (!cesHttp.isAvailable()) {
+    return undefined;
+  }
 
   _resolvedBackend = cesHttp;
   _resolvePromise = undefined;
@@ -258,14 +272,20 @@ function tryFailoverToCesHttpBackend(
  *
  * Concurrent callers share the same in-flight reconnection attempt to avoid
  * racing on the same process manager. A timestamp cooldown prevents rapid
- * back-to-back attempts after completion.
+ * back-to-back attempts after completion; `ignoreCooldown` bypasses it for
+ * callers (credential writes) where a refused attempt loses data. The
+ * in-flight dedup and reentrancy guard still apply either way.
  *
  * Exported so the proactive reconnect loop in ces-runtime.ts can trigger
  * reconnection immediately on transport close, reusing the same dedup +
  * cooldown machinery as the lazy (credential-op-triggered) path.
  */
-export async function attemptCesReconnection(): Promise<boolean> {
-  if (!_cesReconnect) {return false;}
+export async function attemptCesReconnection(
+  options: { ignoreCooldown?: boolean } = {},
+): Promise<boolean> {
+  if (!_cesReconnect) {
+    return false;
+  }
 
   // Reentrancy guard. A nested credential read from inside the reconnect
   // callback must not `await` our own in-flight promise — that would
@@ -274,13 +294,22 @@ export async function attemptCesReconnection(): Promise<boolean> {
   // dead-backend response) without blocking. Concurrent callers on other
   // async chains don't see the ALS store, so they still share the
   // in-flight promise normally.
-  if (_reconnectContext.getStore()) {return false;}
+  if (_reconnectContext.getStore()) {
+    return false;
+  }
 
   // If a reconnection is already in flight, share it.
-  if (_reconnectInFlight) {return _reconnectInFlight;}
+  if (_reconnectInFlight) {
+    return _reconnectInFlight;
+  }
 
   // Cooldown — don't retry immediately after a completed attempt.
-  if (Date.now() - _lastReconnectAttempt < RECONNECT_COOLDOWN_MS) {return false;}
+  if (
+    !options.ignoreCooldown &&
+    Date.now() - _lastReconnectAttempt < RECONNECT_COOLDOWN_MS
+  ) {
+    return false;
+  }
 
   _lastReconnectAttempt = Date.now();
   log.warn("Credential backend unavailable — attempting CES reconnection");
@@ -450,14 +479,16 @@ export async function getSecureKeyAsync(
 
 /**
  * Store a secret in secure storage. Writes to exactly one backend —
- * no dual-writing.
+ * no dual-writing. Forces a CES reconnection when the backend is dead —
+ * callers (e.g. the post-login platform credential push) do not retry a
+ * failed write.
  */
 export async function setSecureKeyAsync(
   account: string,
   value: string,
 ): Promise<boolean> {
   return withCredentialTimeout(async () => {
-    const backend = await resolveBackendAsync();
+    const backend = await resolveBackendAsync({ forceReconnect: true });
     const ok = await backend.set(account, value);
     if (!ok) {
       log.warn(
@@ -481,7 +512,7 @@ export async function deleteSecureKeyAsync(
   account: string,
 ): Promise<DeleteResult> {
   return withCredentialTimeout(async () => {
-    const backend = await resolveBackendAsync();
+    const backend = await resolveBackendAsync({ forceReconnect: true });
     const result = await backend.delete(account);
     if (result === "deleted") {
       log.info({ account, backend: backend.name }, "Credential deleted");
@@ -502,7 +533,7 @@ export async function bulkSetSecureKeysAsync(
 ): Promise<Array<{ account: string; ok: boolean }>> {
   return withCredentialTimeout(
     async () => {
-      const backend = await resolveBackendAsync();
+      const backend = await resolveBackendAsync({ forceReconnect: true });
       let results: Array<{ account: string; ok: boolean }>;
       if (backend.bulkSet) {
         results = await backend.bulkSet(credentials);
@@ -514,7 +545,9 @@ export async function bulkSetSecureKeysAsync(
         let anyFailed = false;
         for (const { account, value } of credentials) {
           const ok = await backend.set(account, value);
-          if (!ok) {anyFailed = true;}
+          if (!ok) {
+            anyFailed = true;
+          }
           results.push({ account, ok });
         }
         updateCesHttpReachability(backend, anyFailed);
@@ -558,7 +591,9 @@ export async function getProviderKeyAsync(
   const stored =
     (await getSecureKeyAsync(credentialKey(provider, "api_key"))) ??
     (await getSecureKeyAsync(provider));
-  if (stored) {return stored;}
+  if (stored) {
+    return stored;
+  }
   const envVar = getAnyProviderEnvVar(provider);
   return envVar ? process.env[envVar] : undefined;
 }
@@ -576,7 +611,9 @@ export async function getMaskedProviderKey(
   provider: string,
 ): Promise<string | null> {
   const key = await getProviderKeyAsync(provider);
-  if (!key || key.length === 0) {return null;}
+  if (!key || key.length === 0) {
+    return null;
+  }
   const minHidden = 3;
   const maxVisible = Math.max(1, key.length - minHidden);
   const prefixLen = Math.min(10, maxVisible);
@@ -621,31 +658,34 @@ export type BackendInfo =
  * visible.
  */
 export function getActiveBackendInfoAsync(): Promise<BackendInfo> {
-  return withCredentialTimeout(async () => {
-    const backend = await resolveBackendAsync();
-    if (backend.name === "encrypted-store") {
-      const protectedDir = getProtectedDir();
-      const storePath = join(protectedDir, "keys.enc");
-      const storeKeyPath = join(protectedDir, "store.key");
-      return {
-        backend: "encrypted-store" as const,
-        storePath,
-        storeKeyPath,
-        storeExists: existsSync(storePath),
-        storeKeyExists: existsSync(storeKeyPath),
-      };
-    }
-    if (backend.name === "ces-rpc") {
-      return { backend: "ces-rpc" as const, ready: backend.isAvailable() };
-    }
-    if (backend.name === "ces-http") {
-      return {
-        backend: "ces-http" as const,
-        url: process.env.CES_CREDENTIAL_URL ?? "",
-      };
-    }
-    return { backend: "none" as const };
-  }, { backend: "none" as const });
+  return withCredentialTimeout(
+    async () => {
+      const backend = await resolveBackendAsync();
+      if (backend.name === "encrypted-store") {
+        const protectedDir = getProtectedDir();
+        const storePath = join(protectedDir, "keys.enc");
+        const storeKeyPath = join(protectedDir, "store.key");
+        return {
+          backend: "encrypted-store" as const,
+          storePath,
+          storeKeyPath,
+          storeExists: existsSync(storePath),
+          storeKeyExists: existsSync(storeKeyPath),
+        };
+      }
+      if (backend.name === "ces-rpc") {
+        return { backend: "ces-rpc" as const, ready: backend.isAvailable() };
+      }
+      if (backend.name === "ces-http") {
+        return {
+          backend: "ces-http" as const,
+          url: process.env.CES_CREDENTIAL_URL ?? "",
+        };
+      }
+      return { backend: "none" as const };
+    },
+    { backend: "none" as const },
+  );
 }
 
 /** @internal Test-only: reset the cached backends so they're re-created. */


### PR DESCRIPTION
## Summary
- Credential mutations (`setSecureKeyAsync`, `deleteSecureKeyAsync`, `bulkSetSecureKeysAsync`) now pass `forceReconnect` to the backend resolver, which bypasses the 3s CES reconnect cooldown when the resolved backend is dead. Reads keep respecting the cooldown, and the in-flight dedup + reentrancy guards still apply.
- Fixes the incident where the post-login platform credential push (assistant API key, base URL, assistant/org IDs, webhook secret) landed ~600ms after a CES transport death, was refused a reconnect by the cooldown, failed with 500s, and was never retried — leaving managed profiles permanently without platform auth (`Platform auth unavailable for connection 'vellum'`).
- Adds regression tests: a write during the cooldown reconnects and stores on the fresh client; a read during the cooldown still does not trigger another reconnect.

## Original prompt
Debugging a staging assistant where managed profiles stayed broken after login: logs showed the CES stdio transport spuriously dying, and the login's five `POST /v1/secrets` writes failing instantly because the reconnect cooldown refused to bring the backend back. Of the options discussed (client-side backoff retries, replay queue, file-store fallback), we chose the daemon-side fix: let credential writes force a reconnection attempt — they are rare, have no fallback, and their callers do not retry — turning this failure mode into a ~100ms delay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->