### PR TITLE
fix(assistant): derive each cleanup job's cadence from its own retention

### DIFF
--- a/assistant/src/__tests__/background-workers-disk-pressure.test.ts
+++ b/assistant/src/__tests__/background-workers-disk-pressure.test.ts
@@ -31,7 +31,6 @@ mock.module("../config/loader.js", () => ({
       },
       cleanup: {
         enabled: true,
-        enqueueIntervalMs: 60_000,
         conversationRetentionDays: 30,
         llmRequestLogRetentionMs: 60_000,
       },

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -420,18 +420,10 @@ describe("AssistantConfigSchema", () => {
     const result = AssistantConfigSchema.parse({});
     expect(result.memory.cleanup).toEqual({
       enabled: true,
-      enqueueIntervalMs: 6 * 60 * 60 * 1000,
       supersededItemRetentionMs: 30 * 24 * 60 * 60 * 1000,
       conversationRetentionDays: 0,
       llmRequestLogRetentionMs: 1 * 60 * 60 * 1000,
     });
-  });
-
-  test("rejects invalid memory.cleanup.enqueueIntervalMs", () => {
-    const result = AssistantConfigSchema.safeParse({
-      memory: { cleanup: { enqueueIntervalMs: 0 } },
-    });
-    expect(result.success).toBe(false);
   });
 
   test("accepts memory.cleanup.llmRequestLogRetentionMs at the 365-day boundary", () => {

--- a/assistant/src/__tests__/config-watcher-cleanup-throttle.test.ts
+++ b/assistant/src/__tests__/config-watcher-cleanup-throttle.test.ts
@@ -1,11 +1,11 @@
 /**
  * Regression test for Gap D: ConfigWatcher.refreshConfigFromSources must
  * reset the cleanup-scheduler throttle when memory.cleanup retention
- * settings change. Without this, a user flipping their retention setting
- * in the UI would have to wait up to 6 hours (the default
- * enqueueIntervalMs) before the change takes effect, because
- * maybeEnqueueScheduledCleanupJobs (in jobs-worker) early-returns while
- * the throttle is still within its window.
+ * settings change. Each cleanup job now runs on a cadence equal to its own
+ * retention window, so without this reset a user flipping their retention
+ * setting in the UI could wait out that entire window before the change
+ * takes effect, because maybeEnqueueScheduledCleanupJobs (in jobs-worker)
+ * skips a job while its throttle is still within its window.
  *
  * The shared throttle state lives in persistence/cleanup-schedule-state.ts so
  * that config-watcher can reset it without pulling jobs-worker's large
@@ -33,7 +33,6 @@ import { cleanupSettingsChanged } from "../daemon/config-watcher.js";
 describe("cleanupSettingsChanged", () => {
   const base: MemoryCleanupConfig = {
     enabled: true,
-    enqueueIntervalMs: 6 * 60 * 60 * 1000,
     supersededItemRetentionMs: 30 * 24 * 60 * 60 * 1000,
     conversationRetentionDays: 0,
     llmRequestLogRetentionMs: 1 * 24 * 60 * 60 * 1000,
@@ -74,12 +73,11 @@ describe("cleanupSettingsChanged", () => {
   });
 
   test("returns false when only non-tracked fields change", () => {
-    // enqueueIntervalMs and supersededItemRetentionMs are intentionally
-    // excluded — they are daemon tunables, not user-facing UI settings.
+    // supersededItemRetentionMs is intentionally excluded — it is a daemon
+    // tunable, not a user-facing UI setting.
     expect(
       cleanupSettingsChanged(base, {
         ...base,
-        enqueueIntervalMs: 1_000,
         supersededItemRetentionMs: 0,
       }),
     ).toBe(false);
@@ -136,7 +134,6 @@ interface TestConfig {
     enabled: boolean;
     cleanup: {
       enabled: boolean;
-      enqueueIntervalMs: number;
       supersededItemRetentionMs: number;
       conversationRetentionDays: number;
       llmRequestLogRetentionMs: number | null;
@@ -155,7 +152,6 @@ function makeConfig(
       enabled: true,
       cleanup: {
         enabled: true,
-        enqueueIntervalMs: 6 * 60 * 60 * 1000,
         supersededItemRetentionMs: 30 * 24 * 60 * 60 * 1000,
         conversationRetentionDays: 0,
         llmRequestLogRetentionMs: 1 * 24 * 60 * 60 * 1000,
@@ -276,10 +272,10 @@ describe("ConfigWatcher.refreshConfigFromSources cleanup throttle reset", () => 
     watcher.initFingerprint(diskConfig as never);
     primeConfigCache();
 
-    // enqueueIntervalMs is a daemon tunable, not a user-facing setting.
-    // The fingerprint changes but the tracked cleanup retention fields
-    // don't, so the throttle should NOT be reset.
-    diskConfig = makeConfig({ enqueueIntervalMs: 30_000 });
+    // supersededItemRetentionMs is a daemon tunable, not a user-facing
+    // setting. The fingerprint changes but the tracked cleanup retention
+    // fields don't, so the throttle should NOT be reset.
+    diskConfig = makeConfig({ supersededItemRetentionMs: 0 });
 
     const changed = await watcher.refreshConfigFromSources();
     expect(changed).toBe(true);
@@ -314,7 +310,7 @@ describe("ConfigWatcher.refreshConfigFromSources cleanup throttle reset", () => 
     // This is the user-facing regression guarantee: each time the user
     // changes retention via the UI, refreshConfigFromSources calls the
     // cleanup-schedule-state throttle reset so the next scheduler tick
-    // re-evaluates without waiting out the 6-hour window.
+    // re-evaluates without waiting out the retention-derived window.
     //
     // Because cleanup-schedule-state is mocked here, we verify the
     // CONTRACT (resetCleanupScheduleThrottle is called) rather than the

--- a/assistant/src/__tests__/memory-jobs-worker-cleanup-cadence.test.ts
+++ b/assistant/src/__tests__/memory-jobs-worker-cleanup-cadence.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Tests for the retention-derived cadence of the scheduled cleanup jobs.
+ *
+ * `maybeEnqueueScheduledCleanupJobs` enqueues each prune job on a cadence
+ * equal to that job's own retention window, and throttles each job
+ * independently: LLM-request-log pruning follows `llmRequestLogRetentionMs`,
+ * conversation pruning follows `conversationRetentionDays`, and audit-log
+ * (`tool_invocations`) pruning follows `auditLog.retentionDays`.
+ *
+ * The real cleanup-schedule-state module (pure, in-memory, no DB) provides the
+ * per-job throttle; only jobs-store's enqueue functions and the logger are
+ * mocked so we can observe which jobs were enqueued on each tick.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { AssistantConfig } from "../config/types.js";
+
+// ── Mocks (must precede imports of tested module) ──────────────────
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+let convCalls: Array<number | undefined> = [];
+let llmCalls: Array<number | undefined> = [];
+let toolCalls: Array<number | undefined> = [];
+
+mock.module("../persistence/jobs-store.js", () => ({
+  resetRunningJobsToPending: () => 0,
+  claimMemoryJobs: () => [],
+  completeMemoryJob: () => {},
+  deferMemoryJob: () => "deferred",
+  failMemoryJob: () => {},
+  failStalledJobs: () => 0,
+  enqueuePruneOldConversationsJob: (retentionDays?: number) => {
+    convCalls.push(retentionDays);
+    return "conv-job";
+  },
+  enqueuePruneOldLlmRequestLogsJob: (retentionMs?: number) => {
+    llmCalls.push(retentionMs);
+    return "llm-job";
+  },
+  enqueuePruneOldToolInvocationsJob: (retentionDays?: number) => {
+    toolCalls.push(retentionDays);
+    return "tool-job";
+  },
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({ memory: { enabled: false } }),
+  loadConfig: () => ({ memory: { enabled: false } }),
+}));
+
+import { resetCleanupScheduleThrottle } from "../persistence/cleanup-schedule-state.js";
+import { maybeEnqueueScheduledCleanupJobs } from "../plugins/defaults/memory/jobs-worker.js";
+
+const HOUR = 60 * 60 * 1000;
+
+// A realistic epoch-ms base. In production `nowMs` is `Date.now()`, which is
+// always astronomically larger than any retention window, so after a throttle
+// reset (last enqueue = 0) every due job fires on the first tick. Anchoring the
+// tests at a real timestamp mirrors that; using 0 would make `now - last` too
+// small to clear long retention windows.
+const BASE = 1_700_000_000_000;
+
+function makeConfig(opts: {
+  enabled?: boolean;
+  conversationRetentionDays?: number;
+  llmRequestLogRetentionMs?: number | null;
+  auditLogRetentionDays?: number;
+}): AssistantConfig {
+  return {
+    memory: {
+      cleanup: {
+        enabled: opts.enabled ?? true,
+        conversationRetentionDays: opts.conversationRetentionDays ?? 0,
+        llmRequestLogRetentionMs:
+          opts.llmRequestLogRetentionMs === undefined
+            ? null
+            : opts.llmRequestLogRetentionMs,
+      },
+    },
+    auditLog: { retentionDays: opts.auditLogRetentionDays ?? 0 },
+  } as unknown as AssistantConfig;
+}
+
+describe("maybeEnqueueScheduledCleanupJobs retention-derived cadence", () => {
+  beforeEach(() => {
+    convCalls = [];
+    llmCalls = [];
+    toolCalls = [];
+    resetCleanupScheduleThrottle();
+  });
+
+  test("LLM-log prune fires once per retention window", () => {
+    const config = makeConfig({ llmRequestLogRetentionMs: HOUR });
+
+    // First tick fires immediately (throttle starts at 0).
+    expect(maybeEnqueueScheduledCleanupJobs(config, BASE)).toBe(true);
+    expect(llmCalls).toEqual([HOUR]);
+
+    // Half a window later: not due, nothing enqueued.
+    expect(
+      maybeEnqueueScheduledCleanupJobs(config, BASE + 30 * 60 * 1000),
+    ).toBe(false);
+    expect(llmCalls).toEqual([HOUR]);
+
+    // Just past the full window: due again.
+    expect(maybeEnqueueScheduledCleanupJobs(config, BASE + HOUR + 1)).toBe(
+      true,
+    );
+    expect(llmCalls).toEqual([HOUR, HOUR]);
+  });
+
+  test("each prune throttles independently on its own retention", () => {
+    const config = makeConfig({
+      conversationRetentionDays: 1, // 1 day
+      llmRequestLogRetentionMs: HOUR, // 1 hour
+    });
+
+    // t=0: both due.
+    maybeEnqueueScheduledCleanupJobs(config, BASE);
+    expect(convCalls).toEqual([1]);
+    expect(llmCalls).toEqual([HOUR]);
+
+    // t=2h: LLM window (1h) elapsed, conversation window (1d) has not.
+    maybeEnqueueScheduledCleanupJobs(config, BASE + 2 * HOUR);
+    expect(convCalls).toEqual([1]);
+    expect(llmCalls).toEqual([HOUR, HOUR]);
+
+    // t=25h: conversation window now elapsed too.
+    maybeEnqueueScheduledCleanupJobs(config, BASE + 25 * HOUR);
+    expect(convCalls).toEqual([1, 1]);
+    expect(llmCalls.length).toBe(3);
+  });
+
+  test("tool_invocations prune follows auditLog.retentionDays", () => {
+    const config = makeConfig({ auditLogRetentionDays: 1 }); // 1 day
+
+    maybeEnqueueScheduledCleanupJobs(config, BASE);
+    expect(toolCalls).toEqual([1]);
+
+    // 12h later: within the 1-day window.
+    maybeEnqueueScheduledCleanupJobs(config, BASE + 12 * HOUR);
+    expect(toolCalls).toEqual([1]);
+
+    // 25h later: past the window.
+    maybeEnqueueScheduledCleanupJobs(config, BASE + 25 * HOUR);
+    expect(toolCalls).toEqual([1, 1]);
+  });
+
+  test("disabled cleanup enqueues nothing", () => {
+    const config = makeConfig({
+      enabled: false,
+      conversationRetentionDays: 1,
+      llmRequestLogRetentionMs: HOUR,
+      auditLogRetentionDays: 1,
+    });
+
+    expect(maybeEnqueueScheduledCleanupJobs(config, BASE)).toBe(false);
+    expect(convCalls).toEqual([]);
+    expect(llmCalls).toEqual([]);
+    expect(toolCalls).toEqual([]);
+  });
+
+  test("null LLM-log retention keeps logs forever (no prune enqueued)", () => {
+    const config = makeConfig({ llmRequestLogRetentionMs: null });
+
+    expect(maybeEnqueueScheduledCleanupJobs(config, BASE)).toBe(false);
+    expect(llmCalls).toEqual([]);
+  });
+
+  test("resetCleanupScheduleThrottle makes every job due on the next tick", () => {
+    const config = makeConfig({
+      conversationRetentionDays: 30,
+      llmRequestLogRetentionMs: HOUR,
+      auditLogRetentionDays: 30,
+    });
+
+    maybeEnqueueScheduledCleanupJobs(config, BASE);
+    expect(convCalls.length).toBe(1);
+    expect(llmCalls.length).toBe(1);
+    expect(toolCalls.length).toBe(1);
+
+    // Without a reset, a tick a minute later re-enqueues nothing (all windows
+    // are far from elapsed).
+    maybeEnqueueScheduledCleanupJobs(config, BASE + 60_000);
+    expect(convCalls.length).toBe(1);
+    expect(llmCalls.length).toBe(1);
+    expect(toolCalls.length).toBe(1);
+
+    // A retention-settings change resets the throttle; the very next tick
+    // re-enqueues every job regardless of its window.
+    resetCleanupScheduleThrottle();
+    maybeEnqueueScheduledCleanupJobs(config, BASE + 120_000);
+    expect(convCalls.length).toBe(2);
+    expect(llmCalls.length).toBe(2);
+    expect(toolCalls.length).toBe(2);
+  });
+});

--- a/assistant/src/config/schemas/memory-lifecycle.ts
+++ b/assistant/src/config/schemas/memory-lifecycle.ts
@@ -106,12 +106,6 @@ export const MemoryCleanupConfigSchema = z
       .boolean({ error: "memory.cleanup.enabled must be a boolean" })
       .default(true)
       .describe("Whether periodic memory cleanup is enabled"),
-    enqueueIntervalMs: z
-      .number({ error: "memory.cleanup.enqueueIntervalMs must be a number" })
-      .int("memory.cleanup.enqueueIntervalMs must be an integer")
-      .positive("memory.cleanup.enqueueIntervalMs must be a positive integer")
-      .default(6 * 60 * 60 * 1000)
-      .describe("How often cleanup jobs are enqueued in milliseconds"),
     supersededItemRetentionMs: z
       .number({
         error: "memory.cleanup.supersededItemRetentionMs must be a number",

--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -174,7 +174,8 @@ export class ConfigWatcher {
     clearEmbeddingBackendCache();
     // If cleanup retention settings changed, reset the cleanup scheduler
     // throttle so the next worker tick re-enqueues jobs with the new values
-    // instead of waiting out the remaining enqueueIntervalMs (default 6h).
+    // instead of waiting out the remaining retention-derived cadence (which
+    // can be as long as the retention window itself).
     const nextCleanup = config.memory?.cleanup;
     if (cleanupSettingsChanged(prevCleanup, nextCleanup)) {
       resetCleanupScheduleThrottle();

--- a/assistant/src/persistence/cleanup-schedule-state.ts
+++ b/assistant/src/persistence/cleanup-schedule-state.ts
@@ -1,37 +1,59 @@
 /**
- * Shared state for the cleanup-scheduler throttle.
+ * Per-job throttle state for the cleanup scheduler.
  *
- * `maybeEnqueueScheduledCleanupJobs` in jobs-worker.ts gates cleanup-job
- * enqueueing behind a 6-hour window (configurable via
- * memory.cleanup.enqueueIntervalMs). This module owns the "last enqueue"
- * timestamp so that code paths outside jobs-worker — notably
- * ConfigWatcher.refreshConfigFromSources — can reset the throttle without
- * pulling in jobs-worker's large transitive import graph.
+ * Each scheduled cleanup job is enqueued on a cadence equal to its own
+ * retention window: a job that keeps data for N is re-enqueued at most once
+ * per N. So conversation pruning, LLM-request-log pruning, and audit-log
+ * (`tool_invocations`) pruning each run on their own independent schedule
+ * derived from `conversationRetentionDays`, `llmRequestLogRetentionMs`, and
+ * `auditLog.retentionDays` respectively.
+ *
+ * `maybeEnqueueScheduledCleanupJobs` in jobs-worker.ts owns that decision;
+ * this module owns the per-job "last enqueue" timestamps so that code paths
+ * outside jobs-worker — notably ConfigWatcher.refreshConfigFromSources — can
+ * reset the throttle without pulling in jobs-worker's large transitive import
+ * graph.
  *
  * The ConfigWatcher uses resetCleanupScheduleThrottle() to ensure that
  * retention changes made via the UI (which flow through config.json →
- * invalidateConfigCache → refreshConfigFromSources) take effect on the
- * very next scheduler tick instead of waiting out the remaining window.
+ * invalidateConfigCache → refreshConfigFromSources) take effect on the very
+ * next scheduler tick instead of waiting out the remaining window.
  */
 
-let lastScheduledCleanupEnqueueMs = 0;
+export type CleanupJobKind =
+  | "conversations"
+  | "llm_request_logs"
+  | "tool_invocations";
 
-/** Read the timestamp of the most recent enqueue (0 if never/reset). */
-export function getLastScheduledCleanupEnqueueMs(): number {
-  return lastScheduledCleanupEnqueueMs;
+const lastScheduledCleanupEnqueueMs: Record<CleanupJobKind, number> = {
+  conversations: 0,
+  llm_request_logs: 0,
+  tool_invocations: 0,
+};
+
+/**
+ * Read the timestamp of the most recent enqueue for `kind` (0 if never/reset).
+ */
+export function getLastScheduledCleanupEnqueueMs(kind: CleanupJobKind): number {
+  return lastScheduledCleanupEnqueueMs[kind];
 }
 
-/** Record that an enqueue just happened at `nowMs`. */
-export function markScheduledCleanupEnqueued(nowMs: number): void {
-  lastScheduledCleanupEnqueueMs = nowMs;
+/** Record that an enqueue for `kind` just happened at `nowMs`. */
+export function markScheduledCleanupEnqueued(
+  kind: CleanupJobKind,
+  nowMs: number,
+): void {
+  lastScheduledCleanupEnqueueMs[kind] = nowMs;
 }
 
 /**
- * Clear the throttle so the next `maybeEnqueueScheduledCleanupJobs` call
- * bypasses the `enqueueIntervalMs` window. Used by ConfigWatcher when
- * retention settings change, and by tests that need deterministic
- * scheduling.
+ * Clear every job's throttle so the next `maybeEnqueueScheduledCleanupJobs`
+ * call re-enqueues immediately regardless of each job's retention window. Used
+ * by ConfigWatcher when retention settings change, and by tests that need
+ * deterministic scheduling.
  */
 export function resetCleanupScheduleThrottle(): void {
-  lastScheduledCleanupEnqueueMs = 0;
+  lastScheduledCleanupEnqueueMs.conversations = 0;
+  lastScheduledCleanupEnqueueMs.llm_request_logs = 0;
+  lastScheduledCleanupEnqueueMs.tool_invocations = 0;
 }

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -13,6 +13,7 @@ import {
   setMemoryCheckpoint,
 } from "../../../persistence/checkpoints.js";
 import {
+  type CleanupJobKind,
   getLastScheduledCleanupEnqueueMs,
   markScheduledCleanupEnqueued,
 } from "../../../persistence/cleanup-schedule-state.js";
@@ -657,11 +658,21 @@ async function processJob(
   throw new Error(`Unknown memory job type: ${rawType}`);
 }
 
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
 /**
- * Enqueue periodic cleanup jobs using config-driven retention windows.
- * Enqueue is deduped in jobs-store, so repeated calls remain safe.
+ * Enqueue periodic cleanup jobs, each on a cadence equal to its own retention
+ * window. A job that keeps data for N is re-enqueued at most once per N:
+ * pruning that retains LLM logs for 1h runs hourly, pruning that retains
+ * conversations for 30d runs every 30d. Each job's throttle is tracked
+ * independently in cleanup-schedule-state, and enqueue is deduped in
+ * jobs-store, so repeated calls remain safe.
+ *
+ * Exported for tests; the worker calls it on every idle/drain tick.
+ *
+ * Returns true if at least one job was enqueued this call.
  */
-function maybeEnqueueScheduledCleanupJobs(
+export function maybeEnqueueScheduledCleanupJobs(
   config: AssistantConfig,
   nowMs = Date.now(),
 ): boolean {
@@ -669,38 +680,64 @@ function maybeEnqueueScheduledCleanupJobs(
   if (!cleanup.enabled) {
     return false;
   }
-  if (nowMs - getLastScheduledCleanupEnqueueMs() < cleanup.enqueueIntervalMs) {
-    return false;
+
+  // A job is due when at least its full retention window has elapsed since the
+  // last enqueue for that job. The throttle resets to 0 on daemon restart and
+  // whenever ConfigWatcher observes a retention change, so a due job also fires
+  // promptly after either of those.
+  const isDue = (kind: CleanupJobKind, intervalMs: number): boolean =>
+    nowMs - getLastScheduledCleanupEnqueueMs(kind) >= intervalMs;
+
+  let enqueuedAny = false;
+
+  if (
+    cleanup.conversationRetentionDays > 0 &&
+    isDue("conversations", cleanup.conversationRetentionDays * MS_PER_DAY)
+  ) {
+    const jobId = enqueuePruneOldConversationsJob(
+      cleanup.conversationRetentionDays,
+    );
+    markScheduledCleanupEnqueued("conversations", nowMs);
+    enqueuedAny = true;
+    log.debug(
+      { jobId, retentionDays: cleanup.conversationRetentionDays },
+      "Enqueued scheduled prune_old_conversations",
+    );
   }
 
-  const pruneConversationsJobId =
-    cleanup.conversationRetentionDays > 0
-      ? enqueuePruneOldConversationsJob(cleanup.conversationRetentionDays)
-      : null;
-  const pruneLlmRequestLogsJobId =
-    cleanup.llmRequestLogRetentionMs !== null
-      ? enqueuePruneOldLlmRequestLogsJob(cleanup.llmRequestLogRetentionMs)
-      : null;
+  if (
+    cleanup.llmRequestLogRetentionMs !== null &&
+    isDue("llm_request_logs", cleanup.llmRequestLogRetentionMs)
+  ) {
+    const jobId = enqueuePruneOldLlmRequestLogsJob(
+      cleanup.llmRequestLogRetentionMs,
+    );
+    markScheduledCleanupEnqueued("llm_request_logs", nowMs);
+    enqueuedAny = true;
+    log.debug(
+      { jobId, retentionMs: cleanup.llmRequestLogRetentionMs },
+      "Enqueued scheduled prune_old_llm_request_logs",
+    );
+  }
+
   // Audit-log (tool_invocations) retention is configured separately under
-  // `auditLog.retentionDays`, but rides this same cleanup cadence for now.
-  const pruneToolInvocationsJobId =
-    config.auditLog.retentionDays > 0
-      ? enqueuePruneOldToolInvocationsJob(config.auditLog.retentionDays)
-      : null;
-  markScheduledCleanupEnqueued(nowMs);
-  log.debug(
-    {
-      pruneConversationsJobId,
-      pruneLlmRequestLogsJobId,
-      pruneToolInvocationsJobId,
-      enqueueIntervalMs: cleanup.enqueueIntervalMs,
-      conversationRetentionDays: cleanup.conversationRetentionDays,
-      llmRequestLogRetentionMs: cleanup.llmRequestLogRetentionMs,
-      auditLogRetentionDays: config.auditLog.retentionDays,
-    },
-    "Enqueued scheduled memory cleanup jobs",
-  );
-  return true;
+  // `auditLog.retentionDays`; its prune cadence follows that window.
+  if (
+    config.auditLog.retentionDays > 0 &&
+    isDue("tool_invocations", config.auditLog.retentionDays * MS_PER_DAY)
+  ) {
+    const jobId = enqueuePruneOldToolInvocationsJob(
+      config.auditLog.retentionDays,
+    );
+    markScheduledCleanupEnqueued("tool_invocations", nowMs);
+    enqueuedAny = true;
+    log.debug(
+      { jobId, retentionDays: config.auditLog.retentionDays },
+      "Enqueued scheduled prune_old_tool_invocations",
+    );
+  }
+
+  return enqueuedAny;
 }
 
 // ── Graph maintenance scheduling ──────────────────────────────────


### PR DESCRIPTION
## Prompt / plan

A user reported that the LLM-request-log cleanup job fired every 6 hours even though the retention was configured to 1 hour. Investigation showed the two values were independent knobs: `llmRequestLogRetentionMs` (1h default) was only the age cutoff for *what* gets deleted, while a single shared `memory.cleanup.enqueueIntervalMs` (6h default) governed *how often* the sweep ran — for all three cleanup jobs. The consequence was that retention acted as a floor, not a ceiling: a log could survive up to ~7 hours despite a 1-hour retention.

Requested change: each pruning should reference its own retention config for its cadence.

## What changed

- **`maybeEnqueueScheduledCleanupJobs` (jobs-worker.ts)** now enqueues each prune job on a cadence equal to that job's own retention window, throttled independently:
  - conversation pruning → `memory.cleanup.conversationRetentionDays`
  - LLM-request-log pruning → `memory.cleanup.llmRequestLogRetentionMs`
  - audit-log (`tool_invocations`) pruning → `auditLog.retentionDays`

  A job fires once its full retention window has elapsed since its last enqueue. In production `nowMs` is `Date.now()`, always ≫ any window, so after a throttle reset every due job fires on the first tick.

- **`cleanup-schedule-state.ts`** now tracks a per-job "last enqueue" timestamp (`CleanupJobKind` = `conversations | llm_request_logs | tool_invocations`) instead of a single shared timestamp. `resetCleanupScheduleThrottle()` clears all three, so retention edits (via ConfigWatcher) and daemon restarts still take effect on the next tick.

- **Removed the now-obsolete `memory.cleanup.enqueueIntervalMs`** config field. The schema strips unknown keys, so existing `config.json` files that still set it are unaffected.

### Behavior note

Because cadence now tracks retention, jobs with long retention windows prune less frequently (e.g. 30-day conversation retention → pruned roughly every 30 days, plus on every daemon restart). This is the intended tradeoff of tying cadence to retention; short-retention jobs like the 1-hour LLM logs now prune hourly instead of every 6 hours.

## Test plan

- New `memory-jobs-worker-cleanup-cadence.test.ts` covers: per-window firing, independent per-job throttling, `auditLog.retentionDays`-driven tool-invocation cadence, disabled/`null` retention short-circuits, and throttle reset re-arming every job.
- Updated `config-watcher-cleanup-throttle.test.ts`, `config-schema.test.ts`, and `background-workers-disk-pressure.test.ts` for the removed field.
- `bunx tsc --noEmit` clean; eslint 0 errors; affected suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LdJTtR6wAt1UXGj2zQ49Be)_