### PR TITLE
fix(web): reconnect live voice through a retryable velay tunnel drop (JARVIS-1255)

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
@@ -82,7 +82,7 @@ class FakeWebSocket {
   onopen: (() => void) | null = null;
   onmessage: ((event: { data: unknown }) => void) | null = null;
   onerror: (() => void) | null = null;
-  onclose: (() => void) | null = null;
+  onclose: ((event: { code: number; reason: string }) => void) | null = null;
 
   constructor(url: string) {
     this.url = url;
@@ -116,8 +116,8 @@ class FakeWebSocket {
   emitError(): void {
     this.onerror?.();
   }
-  emitClose(): void {
-    this.onclose?.();
+  emitClose(code = 1000, reason = ""): void {
+    this.onclose?.({ code, reason });
   }
 
   get sentText(): string[] {
@@ -728,5 +728,36 @@ describe("teardown", () => {
 
     expect(errors).toHaveLength(1);
     expect(errors[0]!.reason).toBe("connection-failed");
+  });
+
+  test("forwards the far-side close code on the closed event", async () => {
+    const client = makeClient();
+    const ws = await connectAndGetSocket(client);
+    ws.open();
+    ws.receive({ type: "ready", seq: 1, sessionId: "s", conversationId: "c" });
+
+    const closes: { code: number | null; reason: string }[] = [];
+    client.on("closed", (info) => closes.push(info));
+
+    // velay drops its tunnel to the assistant → retryable 1013 close.
+    ws.emitClose(1013, "assistant tunnel disconnected");
+
+    expect(closes).toEqual([
+      { code: 1013, reason: "assistant tunnel disconnected" },
+    ]);
+  });
+
+  test("a locally-initiated close reports a null code", async () => {
+    const client = makeClient();
+    const ws = await connectAndGetSocket(client);
+    ws.open();
+    ws.receive({ type: "ready", seq: 1, sessionId: "s", conversationId: "c" });
+
+    const closes: { code: number | null; reason: string }[] = [];
+    client.on("closed", (info) => closes.push(info));
+
+    client.close();
+
+    expect(closes).toEqual([{ code: null, reason: "client closed" }]);
   });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
@@ -730,6 +730,27 @@ describe("teardown", () => {
     expect(errors[0]!.reason).toBe("connection-failed");
   });
 
+  test("a retryable close before ready forwards the code instead of failing", async () => {
+    const client = makeClient();
+    const ws = await connectAndGetSocket(client);
+    ws.open();
+
+    const errors: unknown[] = [];
+    const closes: { code: number | null; reason: string }[] = [];
+    client.on("error", (e) => errors.push(e));
+    client.on("closed", (info) => closes.push(info));
+
+    // velay closes a reconnect's socket before `ready` because its tunnel is
+    // still re-registering — retryable, so the controller must see the code
+    // (and keep its reconnect budget), not a connection-failed error.
+    ws.emitClose(1013, "assistant tunnel disconnected");
+
+    expect(errors).toHaveLength(0);
+    expect(closes).toEqual([
+      { code: 1013, reason: "assistant tunnel disconnected" },
+    ]);
+  });
+
   test("forwards the far-side close code on the closed event", async () => {
     const client = makeClient();
     const ws = await connectAndGetSocket(client);

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
@@ -45,6 +45,20 @@ import {
 /** Fail the session if no `ready` frame arrives within this window. */
 const CONNECT_TIMEOUT_MS = 10_000;
 
+/**
+ * WebSocket close codes that are transient and retryable rather than terminal.
+ * `1013` ("Try Again Later") is what velay sends when its tunnel to the
+ * assistant drops ("assistant tunnel disconnected"); `1012` ("Service Restart")
+ * is treated the same. The controller reconnects a hands-free session through
+ * these; the transport also uses them to distinguish a retryable close that
+ * lands *before* `ready` (which must reach the controller with its code) from a
+ * genuine pre-ready connection failure. A locally-initiated close (`code: null`)
+ * is never retryable.
+ */
+export const RETRYABLE_LIVE_VOICE_CLOSE_CODES: ReadonlySet<number> = new Set([
+  1012, 1013,
+]);
+
 /** Reason a live-voice session failed, surfaced via the `error` event. */
 export type LiveVoiceClientErrorReason =
   | "connection-failed"
@@ -388,15 +402,22 @@ export class LiveVoiceChannelClient {
 
   private handleClose(event: CloseEvent): void {
     if (this.state === "closed") return;
-    // An unexpected transport close before `ready` is a connection failure;
-    // otherwise it's a clean teardown.
-    if (this.state === "connecting") {
+    // An unexpected close before `ready` is normally a connection failure — but
+    // a *retryable* close (velay's 1012/1013) can land pre-`ready` when a
+    // reconnect races the tunnel's re-registration. Forward those as a normal
+    // close carrying the code so the controller can spend its remaining
+    // reconnect budget instead of failing the session on the first blip;
+    // genuine pre-ready closes still fail.
+    if (
+      this.state === "connecting" &&
+      !RETRYABLE_LIVE_VOICE_CLOSE_CODES.has(event.code)
+    ) {
       this.fail("connection-failed", "Live-voice WebSocket closed before ready");
       return;
     }
     this.teardown();
-    // Remotely initiated: forward the far-side close code so the controller
-    // can reconnect through a retryable tunnel drop (velay 1013).
+    // Forward the far-side close code so the controller can reconnect through a
+    // retryable tunnel drop (velay 1013).
     this.emit("closed", { code: event.code, reason: event.reason });
   }
 

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
@@ -64,6 +64,22 @@ export interface LiveVoiceClientError {
 }
 
 /**
+ * Payload of the `closed` event. `code` is the WebSocket close code from the
+ * far side (velay/gateway/runtime) when the socket was closed remotely, or
+ * `null` when this client initiated the close (`close()`/`end()`/`fail()`).
+ *
+ * The distinction matters for reconnect: velay closes a proxied session with
+ * code 1013 ("Try Again Later") when its tunnel to the assistant drops — a
+ * transient, retryable condition the session controller should reconnect
+ * through rather than tear down. A local `null` close is deliberate and never
+ * reconnects.
+ */
+export interface LiveVoiceClientClosed {
+  readonly code: number | null;
+  readonly reason: string;
+}
+
+/**
  * Typed event payloads. Names map 1:1 to the server frame types (camelCased),
  * plus `closed` for transport teardown. Frame `seq` is preserved so consumers
  * can order or dedupe.
@@ -89,7 +105,7 @@ export interface LiveVoiceClientEventMap {
   busy: LiveVoiceBusyServerFrame;
   error: LiveVoiceClientError;
   /** Fired exactly once when the transport closes (clean or otherwise). */
-  closed: void;
+  closed: LiveVoiceClientClosed;
 }
 
 export type LiveVoiceClientEventName = keyof LiveVoiceClientEventMap;
@@ -227,7 +243,7 @@ export class LiveVoiceChannelClient {
     ws.onmessage = (event) => this.handleMessage(event);
     ws.onerror = () =>
       this.fail("connection-failed", "Live-voice WebSocket error");
-    ws.onclose = () => this.handleClose();
+    ws.onclose = (event) => this.handleClose(event);
 
     this.connectTimeout = setTimeout(() => {
       if (this.state === "connecting") {
@@ -270,7 +286,9 @@ export class LiveVoiceChannelClient {
   close(): void {
     if (this.state === "closed") return;
     this.teardown();
-    this.emit("closed", undefined);
+    // Locally initiated: `code: null` tells the controller this was a
+    // deliberate close (never a reconnect trigger).
+    this.emit("closed", { code: null, reason: "client closed" });
   }
 
   private handleOpen(): void {
@@ -368,7 +386,7 @@ export class LiveVoiceChannelClient {
     }
   }
 
-  private handleClose(): void {
+  private handleClose(event: CloseEvent): void {
     if (this.state === "closed") return;
     // An unexpected transport close before `ready` is a connection failure;
     // otherwise it's a clean teardown.
@@ -377,7 +395,9 @@ export class LiveVoiceChannelClient {
       return;
     }
     this.teardown();
-    this.emit("closed", undefined);
+    // Remotely initiated: forward the far-side close code so the controller
+    // can reconnect through a retryable tunnel drop (velay 1013).
+    this.emit("closed", { code: event.code, reason: event.reason });
   }
 
   private sendControlFrame(type: "ptt_release" | "interrupt"): void {
@@ -406,7 +426,8 @@ export class LiveVoiceChannelClient {
     if (this.state === "closed") return;
     this.teardown();
     this.emit("error", { reason, message, ...(code ? { code } : {}) });
-    this.emit("closed", undefined);
+    // Locally initiated after surfacing the failure; never a reconnect trigger.
+    this.emit("closed", { code: null, reason: message });
   }
 
   private teardown(): void {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -1477,4 +1477,68 @@ describe("hands-free reconnect (retryable tunnel close)", () => {
     expect(h.view.result.current.state).toBe("idle");
     expect(h.client.connectArgs).toBe(connectArgsBeforeStop);
   });
+
+  test("unmounting during the reconnect gap resets the store to idle", async () => {
+    const h = renderController({ reconnectBackoffMs: FAST_BACKOFF });
+    await startListening(h, { handsFree: true });
+    await act(async () => {
+      h.client.emit("closed", { code: 1013, reason: "tunnel disconnected" });
+    });
+    expect(useLiveVoiceStore.getState().state).toBe("connecting");
+
+    // Unmount mid-gap (sessionRef is null, store still shows an active session
+    // with live controls) — e.g. navigating away from the chat layout. The
+    // controller's unmount cleanup must reset the store, not strand it.
+    const connectArgsAtUnmount = h.client.connectArgs;
+    await act(async () => {
+      h.view.unmount();
+    });
+    expect(useLiveVoiceStore.getState().state).toBe("idle");
+    expect(useLiveVoiceStore.getState().controls).toBeNull();
+
+    // The pending reconnect was cancelled — nothing reconnects after the gap.
+    await act(async () => {
+      await sleep(80);
+    });
+    expect(h.client.connectArgs).toBe(connectArgsAtUnmount);
+  });
+
+  test("spends the next backoff attempt when a reconnect also closes retryably", async () => {
+    const h = renderController({ reconnectBackoffMs: FAST_BACKOFF });
+    await startListening(h, { handsFree: true });
+
+    // First tunnel drop → first reconnect scheduled.
+    await act(async () => {
+      h.client.emit("closed", { code: 1013, reason: "drop 1" });
+    });
+    expect(h.view.result.current.state).toBe("connecting");
+    await act(async () => {
+      await sleep(40); // backoff[0]=20 → the reconnect connect runs
+    });
+
+    // The reconnect's socket closes retryably again (tunnel still down). The
+    // controller must spend the next attempt rather than fail — this is the
+    // budget the transport now preserves for pre-`ready` retryable closes.
+    await act(async () => {
+      h.client.emit("closed", { code: 1013, reason: "drop 2" });
+    });
+    expect(h.view.result.current.state).toBe("connecting");
+    expect(h.view.result.current.error).toBeNull();
+    await act(async () => {
+      await sleep(60); // backoff[1]=40 → the second reconnect connect runs
+    });
+
+    // The next connect readies → the session resumes instead of failing.
+    await act(async () => {
+      h.client.emit("ready", {
+        type: "ready",
+        seq: 1,
+        sessionId: "s3",
+        conversationId: "conv-1",
+        turnDetection: "server_vad",
+      });
+      await Promise.resolve();
+    });
+    expect(h.view.result.current.state).toBe("listening");
+  });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -48,7 +48,12 @@ const { useLiveVoiceStore } = await import(
 // Harness
 // ---------------------------------------------------------------------------
 
-function renderController(extraOptions: { observeAudioState?: boolean } = {}) {
+function renderController(
+  extraOptions: {
+    observeAudioState?: boolean;
+    reconnectBackoffMs?: number[];
+  } = {},
+) {
   const client = new FakeClient();
   const player = new FakePlayer();
   let capture!: FakeCapture;
@@ -1365,5 +1370,111 @@ describe("stop/start races", () => {
       await Promise.resolve();
     });
     expect(useLiveVoiceStore.getState().state).toBe("listening");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hands-free reconnect on a retryable tunnel close (JARVIS-1255)
+// ---------------------------------------------------------------------------
+
+describe("hands-free reconnect (retryable tunnel close)", () => {
+  // The reconnect backoff uses real timers; inject a tiny schedule so specs
+  // don't wait real seconds, and sleep just past the first delay (20ms).
+  const FAST_BACKOFF = [20, 40, 60];
+  const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  test("reconnects to the same conversation on a retryable close (1013) instead of ending", async () => {
+    const h = renderController({ reconnectBackoffMs: FAST_BACKOFF });
+    await startListening(h, { handsFree: true });
+    expect(h.view.result.current.state).toBe("listening");
+
+    // velay drops its tunnel to the assistant mid-session → retryable 1013.
+    await act(async () => {
+      h.client.emit("closed", {
+        code: 1013,
+        reason: "assistant tunnel disconnected",
+      });
+    });
+    // Not idle: the surface shows a reconnect, and a stop control stays live so
+    // the user can still bail during the gap.
+    expect(h.view.result.current.state).toBe("connecting");
+    expect(useLiveVoiceStore.getState().controls).not.toBeNull();
+
+    // Backoff elapses → a fresh connect to the SAME conversation.
+    await act(async () => {
+      await sleep(80);
+    });
+    expect(h.client.connectArgs).toEqual({
+      assistantId: "assistant-1",
+      conversationId: "conv-1",
+      turnDetection: "server_vad",
+    });
+
+    // The reconnected session's `ready` resumes listening (a torn-down session
+    // would be idle with no handlers, so `ready` would be a no-op).
+    await act(async () => {
+      h.client.emit("ready", {
+        type: "ready",
+        seq: 1,
+        sessionId: "s2",
+        conversationId: "conv-1",
+        turnDetection: "server_vad",
+      });
+      await Promise.resolve();
+    });
+    expect(h.view.result.current.state).toBe("listening");
+  });
+
+  test("does not reconnect on a non-retryable far-side close", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+    await act(async () => {
+      h.client.emit("closed", { code: 1000, reason: "normal closure" });
+    });
+    expect(h.view.result.current.state).toBe("idle");
+  });
+
+  test("does not reconnect a locally-initiated close (code null)", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+    await act(async () => {
+      h.client.emit("closed", { code: null, reason: "client closed" });
+    });
+    expect(h.view.result.current.state).toBe("idle");
+  });
+
+  test("does not reconnect a manual (non-server_vad) session even on 1013", async () => {
+    const h = renderController();
+    await startListening(h); // manual — `ready` echoes turnDetection "manual"
+    await act(async () => {
+      h.client.emit("closed", {
+        code: 1013,
+        reason: "assistant tunnel disconnected",
+      });
+    });
+    expect(h.view.result.current.state).toBe("idle");
+  });
+
+  test("stop() during the reconnect gap cancels the pending reconnect", async () => {
+    const h = renderController({ reconnectBackoffMs: FAST_BACKOFF });
+    await startListening(h, { handsFree: true });
+    await act(async () => {
+      h.client.emit("closed", { code: 1013, reason: "tunnel disconnected" });
+    });
+    expect(h.view.result.current.state).toBe("connecting");
+    const connectArgsBeforeStop = h.client.connectArgs;
+
+    await act(async () => {
+      await h.view.result.current.stop();
+    });
+    expect(h.view.result.current.state).toBe("idle");
+
+    // The backoff would have elapsed by now — but the timer was cancelled, so
+    // no reconnect connect fires.
+    await act(async () => {
+      await sleep(80);
+    });
+    expect(h.view.result.current.state).toBe("idle");
+    expect(h.client.connectArgs).toBe(connectArgsBeforeStop);
   });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -75,6 +75,7 @@ import { useCallback, useEffect, useRef } from "react";
 
 import {
   LiveVoiceChannelClient,
+  RETRYABLE_LIVE_VOICE_CLOSE_CODES,
   type LiveVoiceClientError,
 } from "@/domains/chat/voice/live-voice/live-voice-client";
 import {
@@ -111,16 +112,9 @@ const MINIMUM_SPEECH_DURATION_BEFORE_RELEASE_MS = 120;
 // Reconnect (hands-free only)
 // ---------------------------------------------------------------------------
 
-/**
- * WebSocket close codes that are transient and retryable: the far side asked us
- * to try again rather than reporting a terminal failure. `1013` ("Try Again
- * Later") is what velay sends when its tunnel to the assistant drops mid-session
- * ("assistant tunnel disconnected") — the runtime session is gone, but the
- * conversation persists, so a fresh session re-attached to the same
- * conversation resumes seamlessly. `1012` ("Service Restart") is treated the
- * same. A locally-initiated close (`code: null`) is never retryable.
- */
-const RETRYABLE_CLOSE_CODES = new Set([1012, 1013]);
+// Retryable close codes (velay 1012/1013) are defined by the transport
+// (RETRYABLE_LIVE_VOICE_CLOSE_CODES) and shared here so the transport's
+// pre-`ready` handling and this controller's reconnect gate stay in lockstep.
 
 /**
  * Backoff before each hands-free reconnect attempt. The first delay clears the
@@ -348,7 +342,18 @@ export function useLiveVoice(
     clearReconnectTimer();
     reconnectAttemptRef.current = 0;
     const session = sessionRef.current;
-    if (!session) return;
+    if (!session) {
+      // During the reconnect backoff gap `sessionRef` is null while the store
+      // still shows an active (`connecting`) session with live controls. An
+      // unmount here (its cleanup calls teardown) must still reset the store,
+      // or it strands non-idle with stale controls — dictation stays disabled
+      // and a phantom session lingers after navigation. Guard on non-idle so a
+      // teardown with nothing to do doesn't churn the store.
+      if (useLiveVoiceStore.getState().state !== "idle") {
+        useLiveVoiceStore.getState().reset();
+      }
+      return;
+    }
     sessionRef.current = null;
     disposeSessionPrimitives(session);
     useLiveVoiceStore.getState().reset();
@@ -631,7 +636,7 @@ export function useLiveVoice(
           if (
             session.handsFree &&
             info.code !== null &&
-            RETRYABLE_CLOSE_CODES.has(info.code) &&
+            RETRYABLE_LIVE_VOICE_CLOSE_CODES.has(info.code) &&
             reconnectAttemptRef.current < backoff.length
           ) {
             const attempt = reconnectAttemptRef.current;

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -108,6 +108,30 @@ const SILENCE_DURATION_BEFORE_RELEASE_MS = 1000;
 const MINIMUM_SPEECH_DURATION_BEFORE_RELEASE_MS = 120;
 
 // ---------------------------------------------------------------------------
+// Reconnect (hands-free only)
+// ---------------------------------------------------------------------------
+
+/**
+ * WebSocket close codes that are transient and retryable: the far side asked us
+ * to try again rather than reporting a terminal failure. `1013` ("Try Again
+ * Later") is what velay sends when its tunnel to the assistant drops mid-session
+ * ("assistant tunnel disconnected") — the runtime session is gone, but the
+ * conversation persists, so a fresh session re-attached to the same
+ * conversation resumes seamlessly. `1012` ("Service Restart") is treated the
+ * same. A locally-initiated close (`code: null`) is never retryable.
+ */
+const RETRYABLE_CLOSE_CODES = new Set([1012, 1013]);
+
+/**
+ * Backoff before each hands-free reconnect attempt. The first delay clears the
+ * gateway's velay-tunnel re-registration window (~0.8s observed) so the retry
+ * doesn't race ahead of the tunnel and fail pre-`ready`; later attempts back
+ * off to ride out a longer outage. The array length caps the number of
+ * attempts — after the last one the session fails.
+ */
+const RECONNECT_BACKOFF_MS = [1200, 3000, 6000];
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -167,6 +191,12 @@ export interface UseLiveVoiceOptions {
    * Defaults to `true` (subscribe to everything, the original behavior).
    */
   observeAudioState?: boolean;
+  /**
+   * Override the hands-free reconnect backoff schedule (ms per attempt; length
+   * caps the attempt count). Primarily a test seam so specs don't wait real
+   * seconds; production uses {@link RECONNECT_BACKOFF_MS}.
+   */
+  reconnectBackoffMs?: number[];
 }
 
 /**
@@ -174,6 +204,8 @@ export interface UseLiveVoiceOptions {
  * ref alongside the active primitives; replaced wholesale on each `start()`.
  */
 interface SessionContext {
+  /** Assistant the session is bound to; reused verbatim on reconnect. */
+  assistantId: string;
   client: LiveVoiceChannelClient;
   capture: LiveVoiceAudioCapture;
   player: LiveVoiceAudioPlayer;
@@ -276,6 +308,30 @@ export function useLiveVoice(
     optionsRef.current = options;
   });
 
+  // Hands-free reconnect bookkeeping. `reconnectAttemptRef` counts consecutive
+  // retryable-close reconnects (reset to 0 on a fresh `start()` and on every
+  // `ready`); `reconnectTimerRef` holds the pending backoff timer so stop()/
+  // teardown()/unmount can cancel an in-flight reconnect. `connectSessionRef`
+  // lets the transport `closed` handler re-enter the connect flow without a
+  // useCallback self-reference cycle.
+  const reconnectAttemptRef = useRef(0);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const connectSessionRef = useRef<
+    | ((
+        assistantId: string,
+        conversationId: string | undefined,
+        startOptions: LiveVoiceStartOptions,
+      ) => Promise<void>)
+    | null
+  >(null);
+
+  const clearReconnectTimer = useCallback(() => {
+    if (reconnectTimerRef.current !== null) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+  }, []);
+
   /**
    * Tear down the active session's primitives, clear the ref, and reset the
    * store to idle.
@@ -287,22 +343,22 @@ export function useLiveVoice(
    * set it *after* calling `teardown()`, so the reset can't clobber it.
    */
   const teardown = useCallback(() => {
+    // Cancel any pending hands-free reconnect first — teardown is terminal, so
+    // a queued reconnect must not resurrect the session behind idle UI.
+    clearReconnectTimer();
+    reconnectAttemptRef.current = 0;
     const session = sessionRef.current;
     if (!session) return;
     sessionRef.current = null;
-    // Bump the generation so any in-flight async callbacks become stale no-ops.
-    session.generation += 1;
-    for (const unsubscribe of session.unsubscribes) unsubscribe();
-    session.unsubscribes = [];
-    session.client.close();
-    // dispose() stops playback *and* releases the AudioContext; a bare stop()
-    // would leak the context across repeated sessions until page unload.
-    void session.player.dispose();
-    void session.capture.shutdown();
+    disposeSessionPrimitives(session);
     useLiveVoiceStore.getState().reset();
-  }, []);
+  }, [clearReconnectTimer]);
 
   const stop = useCallback(async () => {
+    // A user-initiated stop ends the session outright — drop any pending
+    // reconnect and its attempt budget.
+    clearReconnectTimer();
+    reconnectAttemptRef.current = 0;
     const session = sessionRef.current;
     if (!session) {
       useLiveVoiceStore.getState().reset();
@@ -323,7 +379,7 @@ export function useLiveVoice(
     // here would leave that session's mic hot behind idle UI.
     if (startGenerationRef.current !== startGeneration) return;
     useLiveVoiceStore.getState().reset();
-  }, []);
+  }, [clearReconnectTimer]);
 
   /**
    * Manual push-to-talk release — same internal path as the automatic silence
@@ -354,18 +410,17 @@ export function useLiveVoice(
     interruptIfSpeaking(session, teardown);
   }, [teardown]);
 
-  const start = useCallback(
+  // The connect flow, shared by the user-facing `start()` and the hands-free
+  // reconnect path. `start()` owns the "already active" guard and resets the
+  // reconnect budget; `connectSession` assumes it may run. On reconnect it is
+  // invoked with the authoritative conversation id so the fresh session
+  // re-attaches to the same conversation.
+  const connectSession = useCallback(
     async (
       assistantId: string,
-      conversationId?: string,
-      startOptions?: LiveVoiceStartOptions,
+      conversationId: string | undefined,
+      startOptions: LiveVoiceStartOptions,
     ) => {
-      // A live session (anything but idle/failed) blocks a new start. Keyed
-      // on the store phase alone — NOT on `sessionRef` — because during
-      // `ending` stop() has already nulled the ref while its async teardown
-      // is still in flight; a start() admitted in that window would be wiped
-      // by stop()'s trailing reset (hot mic behind idle UI).
-      if (isLiveVoiceSessionActive(useLiveVoiceStore.getState().state)) return;
       if (sessionRef.current) teardown();
       startGenerationRef.current += 1;
 
@@ -388,12 +443,13 @@ export function useLiveVoice(
       player.prewarm();
 
       const session: SessionContext = {
+        assistantId,
         client,
         capture: undefined as unknown as LiveVoiceAudioCapture,
         player,
         unsubscribes: [],
         generation: 0,
-        handsFree: startOptions?.handsFree === true,
+        handsFree: startOptions.handsFree === true,
         captureRunning: false,
         forwardingAudio: false,
         responseAudioStarted: false,
@@ -425,6 +481,9 @@ export function useLiveVoice(
           if (session.handsFree && frame.turnDetection !== "server_vad") {
             session.handsFree = false;
           }
+          // A `ready` means the (re)connection succeeded — clear the reconnect
+          // budget so a later, unrelated tunnel drop gets its full retry set.
+          reconnectAttemptRef.current = 0;
           // When started from a new/empty conversation, `conversationId` was
           // undefined at start() and the store published `null`. The server
           // assigns (or confirms) the attached conversation on `ready`, so
@@ -555,11 +614,57 @@ export function useLiveVoice(
           }
           finishWithError(session, teardown, err.message);
         }),
-        client.on("closed", () => {
+        client.on("closed", (info) => {
           // A transport close after a clean end()/teardown is expected; only an
-          // unexpected close while still attached needs cleanup. teardown()
-          // resets the store to idle.
+          // unexpected close while still attached needs cleanup.
           if (!live()) return;
+          // Hands-free resilience: velay tears down a proxied session with a
+          // retryable close code (1013 "assistant tunnel disconnected") when
+          // its tunnel to the assistant drops mid-conversation (deploy, key
+          // rotation, network blip). The runtime session is gone, but the
+          // conversation persists — so reconnect a fresh session to the same
+          // conversation instead of silently ending (which reads to the user
+          // as an unexplained cancel). Bounded by the backoff table; a manual
+          // (non-server_vad) session and a locally-initiated close never retry.
+          const backoff =
+            optionsRef.current.reconnectBackoffMs ?? RECONNECT_BACKOFF_MS;
+          if (
+            session.handsFree &&
+            info.code !== null &&
+            RETRYABLE_CLOSE_CODES.has(info.code) &&
+            reconnectAttemptRef.current < backoff.length
+          ) {
+            const attempt = reconnectAttemptRef.current;
+            reconnectAttemptRef.current = attempt + 1;
+            const delayMs = backoff[attempt] ?? 0;
+            // The server-assigned conversation id (republished on `ready`) so
+            // the fresh session resumes the same conversation.
+            const store = useLiveVoiceStore.getState();
+            const conversationId =
+              store.conversationId ?? store.startedConversationId ?? undefined;
+            const assistantId = session.assistantId;
+            // Drop the dead primitives but hold the UI in `connecting` (not
+            // idle) with a live stop control, so the surface shows a
+            // reconnect rather than a vanished session and the user can still
+            // bail during the gap.
+            sessionRef.current = null;
+            disposeSessionPrimitives(session);
+            const s = useLiveVoiceStore.getState();
+            s.setState("connecting");
+            s.setControls({ stop: () => void stop(), release, interrupt });
+            console.warn(
+              `live-voice: transport closed (code ${info.code}); reconnecting ` +
+                `(attempt ${attempt + 1}/${backoff.length})`,
+            );
+            reconnectTimerRef.current = setTimeout(() => {
+              reconnectTimerRef.current = null;
+              void connectSessionRef.current?.(assistantId, conversationId, {
+                handsFree: true,
+              });
+            }, delayMs);
+            return;
+          }
+          // Non-retryable (or budget exhausted): tear down to idle.
           teardown();
         }),
       );
@@ -573,9 +678,40 @@ export function useLiveVoice(
     [teardown, stop, release, interrupt],
   );
 
+  // Let the transport `closed` handler re-enter the connect flow for a
+  // reconnect without a useCallback self-reference cycle. Updated in an effect
+  // (not during render) per the react-compiler "no refs during render" rule;
+  // the handler only reads it after a backoff timer, well after this commits.
+  useEffect(() => {
+    connectSessionRef.current = connectSession;
+  }, [connectSession]);
+
+  const start = useCallback(
+    async (
+      assistantId: string,
+      conversationId?: string,
+      startOptions?: LiveVoiceStartOptions,
+    ) => {
+      // A live session (anything but idle/failed) blocks a new start. Keyed
+      // on the store phase alone — NOT on `sessionRef` — because during
+      // `ending` stop() has already nulled the ref while its async teardown
+      // is still in flight; a start() admitted in that window would be wiped
+      // by stop()'s trailing reset (hot mic behind idle UI). `connecting`
+      // also covers an in-flight reconnect, so a mic click during the backoff
+      // gap doesn't spawn a second session.
+      if (isLiveVoiceSessionActive(useLiveVoiceStore.getState().state)) return;
+      // Fresh user-initiated session: drop any stale reconnect budget/timer.
+      clearReconnectTimer();
+      reconnectAttemptRef.current = 0;
+      await connectSession(assistantId, conversationId, startOptions ?? {});
+    },
+    [connectSession, clearReconnectTimer],
+  );
+
   // Release everything if the consumer unmounts mid-session. teardown() also
   // resets the store to idle so a mid-session unmount doesn't strand it in a
-  // non-idle phase (which would keep dictation disabled via the composer).
+  // non-idle phase (which would keep dictation disabled via the composer) and
+  // cancels any pending reconnect so it can't fire after unmount.
   useEffect(() => () => teardown(), [teardown]);
 
   return {
@@ -593,6 +729,23 @@ export function useLiveVoice(
 // ---------------------------------------------------------------------------
 // Session helpers (operate on the session context; never re-render directly)
 // ---------------------------------------------------------------------------
+
+/**
+ * Release a session's primitives (event subscriptions, socket, playback
+ * AudioContext, mic capture) and bump its generation so any in-flight async
+ * callbacks become stale no-ops. Does NOT touch the store — callers set the
+ * next store phase themselves (`teardown()` → idle; the reconnect path →
+ * `connecting`). `dispose()` (not a bare `stop()`) releases the AudioContext,
+ * which a bare stop would leak across sessions until page unload.
+ */
+function disposeSessionPrimitives(session: SessionContext): void {
+  session.generation += 1;
+  for (const unsubscribe of session.unsubscribes) unsubscribe();
+  session.unsubscribes = [];
+  session.client.close();
+  void session.player.dispose();
+  void session.capture.shutdown();
+}
 
 /** Open the mic and begin streaming PCM. Failure transitions to `failed`. */
 async function startCapture(


### PR DESCRIPTION
## Problem

A hands-free in-app live-voice session died mid-conversation with no error — the UI reset to idle, "like I cancelled but didn't." Reported as JARVIS-1255 ("turn 1 plays, turn 2 gets no audio and the session closes").

## Root cause (traced end-to-end from pod `assistant-666122d0` logs)

Not a bug in the web teardown code — that reacted correctly to a real disconnect. The chain:

1. The gateway↔velay **tunnel drops** mid-session. In prod: deploy / key rotation / network blip. Locally (minikube): the Docker VM pauses (Mac sleep/throttle) → velay heartbeat **read-timeout** → tunnel reconnect. On reconnect the gateway's `VelayTunnelClient` runs `webSocketBridge.closeAll()`.
2. velay tears down the proxied browser WebSocket with **close code `1013` "assistant tunnel disconnected"** (1013 = "Try Again Later" — explicitly *retryable*). Confirmed from the browser: `{ code: 1013, reason: "assistant tunnel disconnected", wasClean: true }`, and velay's registration tunnel ended the same instant the live-voice WS did.
3. The runtime `LiveVoiceSession` is destroyed; the web transport fires `closed`; `useLiveVoice` tore the session down to `idle` — no error banner, so it read as a silent cancel.

The teardown is correct for a *terminal* close, but 1013 is retryable and the **conversation persists** across the destroyed runtime session.

## Fix — reconnect instead of ending

- **Transport** (`live-voice-client.ts`): the `closed` event now carries the WebSocket close `code` (`null` for a locally-initiated `close()`/`end()`/`fail()`), so the controller can distinguish a retryable far-side drop from a deliberate end.
- **Controller** (`use-live-voice.ts`): on a retryable code (`1012`/`1013`) in hands-free mode, hold the UI in `connecting` with a live stop control, dispose the dead primitives, and reconnect a fresh session **re-attached to the authoritative conversation id** after a bounded backoff (`[1200, 3000, 6000]` ms). The first delay clears the gateway's observed ~0.8s tunnel re-registration window so the retry doesn't race ahead and fail pre-`ready`. The budget resets on every `ready`; exhausting it (or a manual session, or a local close) tears down as before. `stop()`/`teardown()`/unmount cancel a pending reconnect.

User experiences a ~1–2s "connecting" gap on a tunnel blip instead of a dead session; the conversation continues.

## Scope notes
- Local minikube tunnel *churn* (the reason it flaps so often locally) is environmental (VM pause → heartbeat timeout) and intentionally left as-is — this fix rides through it.
- A velay-side "hold the proxied WS during a brief reconnect" was considered and rejected: it can't preserve the already-destroyed runtime session and is cross-repo.

## Tests
- `use-live-voice.test.ts` (+5): retryable 1013 → reconnect to same conversation & resume `listening`; non-retryable / `null`-code / manual-session closes → idle (no reconnect); `stop()` during the gap cancels the pending reconnect. Backoff is injectable so specs stay fast.
- `live-voice-client.test.ts` (+2): far-side close forwards the code; local close reports `code: null`.
- Full touched-suite green (48 / 29 / 7 / 25), typecheck + lint clean.

## Verification
Unit-tested the exact reconnect state machine. End-to-end confirmation is easiest live: the local velay tunnel drops on its own every ~60–75s, so reproducing mid-session now shows a reconnect (`live-voice: transport closed (code 1013); reconnecting (attempt 1/3)`) and the conversation resuming, instead of the session dying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)