### PR TITLE
fix(assistant): persist cleanup cadence across restarts

### DIFF
--- a/assistant/src/__tests__/memory-jobs-worker-backoff.test.ts
+++ b/assistant/src/__tests__/memory-jobs-worker-backoff.test.ts
@@ -37,6 +37,14 @@ mock.module("../persistence/jobs-store.js", () => ({
   enqueuePruneOldConversationsJob: () => null,
 }));
 
+// Mock checkpoints (accesses DB) — worker startup seeds the cleanup throttle
+// from persisted checkpoints.
+mock.module("../persistence/checkpoints.js", () => ({
+  getMemoryCheckpoint: () => null,
+  setMemoryCheckpoint: () => {},
+  deleteMemoryCheckpoint: () => {},
+}));
+
 import {
   POLL_INTERVAL_MAX_MS,
   POLL_INTERVAL_MIN_MS,

--- a/assistant/src/__tests__/memory-jobs-worker-cleanup-cadence.test.ts
+++ b/assistant/src/__tests__/memory-jobs-worker-cleanup-cadence.test.ts
@@ -8,8 +8,10 @@
  * (`tool_invocations`) pruning follows `auditLog.retentionDays`.
  *
  * The real cleanup-schedule-state module (pure, in-memory, no DB) provides the
- * per-job throttle; only jobs-store's enqueue functions and the logger are
- * mocked so we can observe which jobs were enqueued on each tick.
+ * per-job throttle; jobs-store's enqueue functions, the checkpoint store (which
+ * persists each enqueue so the cadence survives restarts), and the logger are
+ * mocked so we can observe which jobs were enqueued on each tick and what was
+ * persisted.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -49,13 +51,33 @@ mock.module("../persistence/jobs-store.js", () => ({
   },
 }));
 
+// In-memory stand-in for the persisted checkpoint store.
+const checkpointStore = new Map<string, string>();
+
+mock.module("../persistence/checkpoints.js", () => ({
+  getMemoryCheckpoint: (key: string) => checkpointStore.get(key) ?? null,
+  setMemoryCheckpoint: (key: string, value: string) => {
+    checkpointStore.set(key, value);
+  },
+  deleteMemoryCheckpoint: (key: string) => {
+    checkpointStore.delete(key);
+  },
+}));
+
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({ memory: { enabled: false } }),
   loadConfig: () => ({ memory: { enabled: false } }),
 }));
 
 import { resetCleanupScheduleThrottle } from "../persistence/cleanup-schedule-state.js";
-import { maybeEnqueueScheduledCleanupJobs } from "../plugins/defaults/memory/jobs-worker.js";
+import {
+  maybeEnqueueScheduledCleanupJobs,
+  seedCleanupScheduleFromCheckpoints,
+} from "../plugins/defaults/memory/jobs-worker.js";
+
+const CONV_CHECKPOINT_KEY = "cleanup:last_enqueue:conversations";
+const LLM_CHECKPOINT_KEY = "cleanup:last_enqueue:llm_request_logs";
+const TOOL_CHECKPOINT_KEY = "cleanup:last_enqueue:tool_invocations";
 
 const HOUR = 60 * 60 * 1000;
 
@@ -92,6 +114,7 @@ describe("maybeEnqueueScheduledCleanupJobs retention-derived cadence", () => {
     convCalls = [];
     llmCalls = [];
     toolCalls = [];
+    checkpointStore.clear();
     resetCleanupScheduleThrottle();
   });
 
@@ -199,5 +222,82 @@ describe("maybeEnqueueScheduledCleanupJobs retention-derived cadence", () => {
     expect(convCalls.length).toBe(2);
     expect(llmCalls.length).toBe(2);
     expect(toolCalls.length).toBe(2);
+  });
+});
+
+describe("cleanup schedule persistence across restarts", () => {
+  beforeEach(() => {
+    convCalls = [];
+    llmCalls = [];
+    toolCalls = [];
+    checkpointStore.clear();
+    resetCleanupScheduleThrottle();
+  });
+
+  test("each enqueue persists its timestamp to a per-job checkpoint", () => {
+    const config = makeConfig({
+      conversationRetentionDays: 1,
+      llmRequestLogRetentionMs: HOUR,
+      auditLogRetentionDays: 1,
+    });
+
+    maybeEnqueueScheduledCleanupJobs(config, BASE);
+
+    expect(checkpointStore.get(CONV_CHECKPOINT_KEY)).toBe(String(BASE));
+    expect(checkpointStore.get(LLM_CHECKPOINT_KEY)).toBe(String(BASE));
+    expect(checkpointStore.get(TOOL_CHECKPOINT_KEY)).toBe(String(BASE));
+  });
+
+  test("seeding from checkpoints resumes the cadence instead of re-firing", () => {
+    // Simulate a prior run at BASE that persisted its checkpoint, then a
+    // restart: reset the in-memory throttle (as a fresh process would start)
+    // and seed from the persisted checkpoint.
+    checkpointStore.set(LLM_CHECKPOINT_KEY, String(BASE));
+    resetCleanupScheduleThrottle();
+    seedCleanupScheduleFromCheckpoints();
+
+    const config = makeConfig({ llmRequestLogRetentionMs: HOUR });
+
+    // 30 min after the persisted enqueue: still within the window, so a boot
+    // tick does NOT re-fire (the pre-persistence behavior would have fired
+    // because the throttle started at 0).
+    expect(
+      maybeEnqueueScheduledCleanupJobs(config, BASE + 30 * 60 * 1000),
+    ).toBe(false);
+    expect(llmCalls).toEqual([]);
+
+    // Past the window: due again.
+    expect(maybeEnqueueScheduledCleanupJobs(config, BASE + HOUR + 1)).toBe(
+      true,
+    );
+    expect(llmCalls).toEqual([HOUR]);
+  });
+
+  test("a job with no checkpoint fires on the first tick (never run yet)", () => {
+    // No checkpoints present — seeding is a no-op and the throttle stays 0.
+    seedCleanupScheduleFromCheckpoints();
+
+    const config = makeConfig({ conversationRetentionDays: 30 });
+
+    expect(maybeEnqueueScheduledCleanupJobs(config, BASE)).toBe(true);
+    expect(convCalls).toEqual([30]);
+    expect(checkpointStore.get(CONV_CHECKPOINT_KEY)).toBe(String(BASE));
+  });
+
+  test("seeding ignores malformed or non-positive checkpoint values", () => {
+    checkpointStore.set(LLM_CHECKPOINT_KEY, "not-a-number");
+    checkpointStore.set(CONV_CHECKPOINT_KEY, "0");
+    resetCleanupScheduleThrottle();
+    seedCleanupScheduleFromCheckpoints();
+
+    const config = makeConfig({
+      conversationRetentionDays: 30,
+      llmRequestLogRetentionMs: HOUR,
+    });
+
+    // Both seeds were rejected, so the throttle is still 0 and both fire.
+    expect(maybeEnqueueScheduledCleanupJobs(config, BASE)).toBe(true);
+    expect(convCalls).toEqual([30]);
+    expect(llmCalls).toEqual([HOUR]);
   });
 });

--- a/assistant/src/persistence/cleanup-schedule-state.ts
+++ b/assistant/src/persistence/cleanup-schedule-state.ts
@@ -9,10 +9,15 @@
  * `auditLog.retentionDays` respectively.
  *
  * `maybeEnqueueScheduledCleanupJobs` in jobs-worker.ts owns that decision;
- * this module owns the per-job "last enqueue" timestamps so that code paths
- * outside jobs-worker — notably ConfigWatcher.refreshConfigFromSources — can
- * reset the throttle without pulling in jobs-worker's large transitive import
- * graph.
+ * this module owns the in-memory per-job "last enqueue" timestamps so that code
+ * paths outside jobs-worker — notably ConfigWatcher.refreshConfigFromSources —
+ * can reset the throttle without pulling in jobs-worker's large transitive
+ * import graph.
+ *
+ * These timestamps are the hot-path source of truth but are not themselves
+ * durable: jobs-worker persists each enqueue to a checkpoint and seeds this map
+ * from those checkpoints at startup, so an unchanged job's cadence survives a
+ * restart instead of re-firing on every boot.
  *
  * The ConfigWatcher uses resetCleanupScheduleThrottle() to ensure that
  * retention changes made via the UI (which flow through config.json →
@@ -47,10 +52,13 @@ export function markScheduledCleanupEnqueued(
 }
 
 /**
- * Clear every job's throttle so the next `maybeEnqueueScheduledCleanupJobs`
- * call re-enqueues immediately regardless of each job's retention window. Used
- * by ConfigWatcher when retention settings change, and by tests that need
- * deterministic scheduling.
+ * Clear every job's in-memory throttle so the next
+ * `maybeEnqueueScheduledCleanupJobs` call re-enqueues immediately regardless of
+ * each job's retention window. Used by ConfigWatcher when retention settings
+ * change, and by tests that need deterministic scheduling.
+ *
+ * This clears only the in-memory timestamps; the persisted checkpoints are
+ * rewritten by the next enqueue, so they self-heal on the following tick.
  */
 export function resetCleanupScheduleThrottle(): void {
   lastScheduledCleanupEnqueueMs.conversations = 0;

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -241,6 +241,21 @@ export function startInProcessMemoryJobsWorker(
     log.info({ recovered }, "Recovered stale running memory jobs");
   }
 
+  // Restore each cleanup job's cadence from its persisted checkpoint so a
+  // restart resumes counting from the last enqueue instead of re-firing every
+  // job on boot. Runs after resetRunningJobsToPending (which has already
+  // touched the DB), so migrations are settled. Best-effort: on failure the
+  // throttle stays at 0 and jobs fire on the first tick (the pre-persistence
+  // behavior), which is a safe degradation.
+  try {
+    seedCleanupScheduleFromCheckpoints();
+  } catch (err) {
+    log.warn(
+      { err },
+      "Failed to seed cleanup schedule from checkpoints; jobs will fire on the first tick",
+    );
+  }
+
   // After running-job recovery (so legitimate in-flight retries aren't
   // swept), clean up orphan memory-retrospective background conversations
   // left behind by daemon crashes mid-job. Best-effort — never block worker
@@ -660,13 +675,66 @@ async function processJob(
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
+const CLEANUP_JOB_KINDS: readonly CleanupJobKind[] = [
+  "conversations",
+  "llm_request_logs",
+  "tool_invocations",
+];
+
+const CLEANUP_ENQUEUE_CHECKPOINT_KEYS: Record<CleanupJobKind, string> = {
+  conversations: "cleanup:last_enqueue:conversations",
+  llm_request_logs: "cleanup:last_enqueue:llm_request_logs",
+  tool_invocations: "cleanup:last_enqueue:tool_invocations",
+};
+
+/**
+ * Seed the in-memory cleanup throttle from persisted checkpoints so each job's
+ * cadence survives a daemon restart. Without this the throttle would start at 0
+ * on every boot, re-firing every cleanup job immediately regardless of when it
+ * last ran — which for a long retention window (e.g. 30-day conversation
+ * pruning) turns a frequent restart cycle into a prune on every boot.
+ *
+ * A job with no checkpoint (never enqueued on this instance) keeps its default
+ * 0, so it fires once on the first tick and then persists its timestamp. On a
+ * fresh instance that first prune is a harmless no-op (nothing is old enough to
+ * delete yet); on an upgrade it clears whatever has already aged out.
+ *
+ * Must run after DB migrations settle — the worker startup path already
+ * satisfies this (it touches the DB before calling here).
+ */
+export function seedCleanupScheduleFromCheckpoints(): void {
+  for (const kind of CLEANUP_JOB_KINDS) {
+    const raw = getMemoryCheckpoint(CLEANUP_ENQUEUE_CHECKPOINT_KEYS[kind]);
+    if (raw === null) {
+      continue;
+    }
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      markScheduledCleanupEnqueued(kind, parsed);
+    }
+  }
+}
+
+/**
+ * Record that a cleanup job for `kind` was just enqueued: advance the in-memory
+ * throttle and persist the timestamp so the cadence survives a restart. A
+ * config-driven throttle reset (ConfigWatcher) only clears the in-memory value;
+ * the next enqueue re-persists here, so the checkpoint self-heals on the tick
+ * after a retention change.
+ */
+function recordCleanupEnqueued(kind: CleanupJobKind, nowMs: number): void {
+  markScheduledCleanupEnqueued(kind, nowMs);
+  setMemoryCheckpoint(CLEANUP_ENQUEUE_CHECKPOINT_KEYS[kind], String(nowMs));
+}
+
 /**
  * Enqueue periodic cleanup jobs, each on a cadence equal to its own retention
  * window. A job that keeps data for N is re-enqueued at most once per N:
  * pruning that retains LLM logs for 1h runs hourly, pruning that retains
  * conversations for 30d runs every 30d. Each job's throttle is tracked
- * independently in cleanup-schedule-state, and enqueue is deduped in
- * jobs-store, so repeated calls remain safe.
+ * independently in cleanup-schedule-state (and persisted via checkpoints so the
+ * cadence survives restarts), and enqueue is deduped in jobs-store, so repeated
+ * calls remain safe.
  *
  * Exported for tests; the worker calls it on every idle/drain tick.
  *
@@ -682,9 +750,10 @@ export function maybeEnqueueScheduledCleanupJobs(
   }
 
   // A job is due when at least its full retention window has elapsed since the
-  // last enqueue for that job. The throttle resets to 0 on daemon restart and
-  // whenever ConfigWatcher observes a retention change, so a due job also fires
-  // promptly after either of those.
+  // last enqueue for that job. The throttle is seeded from a persisted
+  // checkpoint at startup and reset to 0 when ConfigWatcher observes a
+  // retention change, so a due job also fires promptly after a config change
+  // while an unchanged one resumes its cadence across restarts.
   const isDue = (kind: CleanupJobKind, intervalMs: number): boolean =>
     nowMs - getLastScheduledCleanupEnqueueMs(kind) >= intervalMs;
 
@@ -697,7 +766,7 @@ export function maybeEnqueueScheduledCleanupJobs(
     const jobId = enqueuePruneOldConversationsJob(
       cleanup.conversationRetentionDays,
     );
-    markScheduledCleanupEnqueued("conversations", nowMs);
+    recordCleanupEnqueued("conversations", nowMs);
     enqueuedAny = true;
     log.debug(
       { jobId, retentionDays: cleanup.conversationRetentionDays },
@@ -712,7 +781,7 @@ export function maybeEnqueueScheduledCleanupJobs(
     const jobId = enqueuePruneOldLlmRequestLogsJob(
       cleanup.llmRequestLogRetentionMs,
     );
-    markScheduledCleanupEnqueued("llm_request_logs", nowMs);
+    recordCleanupEnqueued("llm_request_logs", nowMs);
     enqueuedAny = true;
     log.debug(
       { jobId, retentionMs: cleanup.llmRequestLogRetentionMs },
@@ -729,7 +798,7 @@ export function maybeEnqueueScheduledCleanupJobs(
     const jobId = enqueuePruneOldToolInvocationsJob(
       config.auditLog.retentionDays,
     );
-    markScheduledCleanupEnqueued("tool_invocations", nowMs);
+    recordCleanupEnqueued("tool_invocations", nowMs);
     enqueuedAny = true;
     log.debug(
       { jobId, retentionDays: config.auditLog.retentionDays },


### PR DESCRIPTION
## Prompt / plan

Follow-up to #37484. That PR tied each cleanup job's cadence to its own retention window, but the throttle tracking each job's last enqueue lived only in memory and reset to 0 on every daemon restart. As I noted in that PR, that meant a long-retention job (e.g. 30-day conversation pruning) re-fired on **every boot** on a frequently-restarting instance, instead of once per window.

The ask: seed the throttle from the last time the job actually ran, and fall back sensibly when it has never run.

## Why persistence (and not hatch time)

The restart re-fire only happened because the throttle reset to 0 on every boot. Persisting the last-enqueue time fixes that directly — a restart seeds from the real last run, so the cadence resumes instead of re-firing. That leaves only the never-run baseline, where a persisted `absent → 0` is the right default:
- **fresh instance**: the one first-tick prune deletes nothing (harmless no-op), then persistence takes over;
- **upgrade**: the first prune clears whatever has already aged out (desirable).

A hatch-time baseline would only suppress that single harmless no-op on a brand-new instance, at the cost of plumbing the lockfile `hatchedAt` into the daemon — so it isn't worth it here.

## What changed

- **`jobs-worker.ts`**: each enqueue now persists its timestamp to a per-job checkpoint (`cleanup:last_enqueue:{conversations,llm_request_logs,tool_invocations}`) via `recordCleanupEnqueued`. New `seedCleanupScheduleFromCheckpoints()` restores the in-memory throttle from those checkpoints at worker startup (right after `resetRunningJobsToPending`, so DB migrations are settled). Seeding is wrapped best-effort: a read failure is logged and startup falls back to the pre-persistence behavior (fire on first tick).
- **`cleanup-schedule-state.ts`**: docs updated — the in-memory timestamps remain the hot-path source of truth but are now durable via the checkpoint layer. The config-change reset still clears only the in-memory value; the next enqueue re-persists, so the checkpoint self-heals on the following tick.

### Behavior notes

- Malformed / non-positive checkpoint values are ignored (throttle stays 0 → fires).
- The daemon supervisor and the standalone worker process both seed from the same shared checkpoints; only the active drainer enqueues, and jobs-store dedupes, so there's no double-fire.

## Test plan

- Extended `memory-jobs-worker-cleanup-cadence.test.ts` with a mocked checkpoint store covering: persistence on enqueue, seeding resuming the cadence instead of re-firing after a simulated restart, never-run jobs firing on the first tick, and malformed/zero checkpoints being ignored.
- Updated `memory-jobs-worker-backoff.test.ts` to mock the checkpoint store (worker startup now reads it).
- `bunx tsc --noEmit` clean; eslint 0 errors; cadence/backoff/throttle/config-schema/disk-pressure/prune suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LdJTtR6wAt1UXGj2zQ49Be)_