### PR TITLE
fix(persistence): retry the processing-flag write on the message-send path

### DIFF
--- a/assistant/src/__tests__/persist-user-message-set-processing-failure.test.ts
+++ b/assistant/src/__tests__/persist-user-message-set-processing-failure.test.ts
@@ -53,6 +53,47 @@ describe("persistUserMessage setProcessing failure", () => {
     expect(ctx.isProcessing()).toBe(false);
   });
 
+  test("retries a transient SQLITE_BUSY from setProcessing(true)", async () => {
+    // A coded SQLITE_BUSY is transient WAL contention: `persistUserMessage`
+    // wraps the acquiring `setProcessing(true)` in `withSqliteRetry`, so it is
+    // re-attempted rather than failing the send immediately.
+    let trueCalls = 0;
+    const ctx = makeContext((value) => {
+      if (value) {
+        trueCalls += 1;
+        throw Object.assign(new Error("database is locked"), {
+          code: "SQLITE_BUSY",
+        });
+      }
+    });
+
+    await expect(
+      persistUserMessage(ctx, { content: "hello", requestId: "req-busy" }),
+    ).rejects.toThrow("database is locked");
+
+    // Initial attempt + 3 retries before withSqliteRetry gives up.
+    expect(trueCalls).toBe(4);
+    expect(ctx.currentRequestId).toBeUndefined();
+    expect(ctx.abortController).toBeNull();
+  });
+
+  test("does not retry a non-transient setProcessing(true) failure", async () => {
+    // No SQLite code / a non-BUSY code → not contention → fail fast, no retry.
+    let trueCalls = 0;
+    const ctx = makeContext((value) => {
+      if (value) {
+        trueCalls += 1;
+        throw new Error("boom");
+      }
+    });
+
+    await expect(
+      persistUserMessage(ctx, { content: "hello", requestId: "req-boom" }),
+    ).rejects.toThrow("boom");
+
+    expect(trueCalls).toBe(1);
+  });
+
   test("a failing clear does not mask the original persist error", async () => {
     // setProcessing throws on both the set and the clear; the original error
     // must still propagate and the bookkeeping must still be reset.

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -58,6 +58,7 @@ import {
 import type { ContentBlock, Message } from "../providers/types.js";
 import type { AuthContext } from "../runtime/auth/types.js";
 import { getLogger } from "../util/logger.js";
+import { withSqliteRetry } from "../util/sqlite-retry.js";
 import type { MessageQueue } from "./conversation-queue-manager.js";
 import type { SlackInboundMessageMetadata } from "./handlers/shared.js";
 import type {
@@ -559,7 +560,16 @@ export async function persistUserMessage(
     // `setProcessing(true)` persists the flag and can throw (e.g.
     // SQLITE_BUSY). Keeping it inside the try ensures a failure here unwinds
     // the request-id/abort bookkeeping below rather than stranding it.
-    ctx.setProcessing(true);
+    //
+    // This is the first DB write on the message-send path — it precedes the
+    // (already retried) message insert — so under transient WAL contention it
+    // must retry too, or the turn dies here before the insert is ever reached.
+    // `setProcessing` reverts its in-memory flag when its persist throws, so
+    // each attempt is safe to re-run.
+    await withSqliteRetry(() => ctx.setProcessing(true), {
+      op: "conversation:setProcessing",
+      context: { conversationId: ctx.conversationId },
+    });
     const result = await persistQueuedMessageBody(ctx, {
       ...options,
       attachments,


### PR DESCRIPTION
## Prompt / plan

Investigating a report that sending a message failed immediately with a `database is locked` (SQLITE_BUSY) error, despite the expectation that a retry was in place.

The retry (`withSqliteRetry`) does wrap the message-row insert (`insertMessageCore`), but that is not the *first* DB write on the send path. `persistUserMessage` calls `Conversation.setProcessing(true)` **before** the insert, which persists the processing flag via `setConversationProcessingStartedAt` → a bare `rawRun` with no retry. Under transient WAL write contention this `UPDATE` throws `SQLITE_BUSY` and aborts the turn before the retried insert is ever reached — so the failure surfaces as if no retry existed.

### Fix

Wrap the acquiring `setProcessing(true)` call in `persistUserMessage` — the chokepoint every send / batched-drain / subagent / voice / ACP path funnels through — in the existing async `withSqliteRetry`:

- No new retry primitive: reuses the existing async helper (`setProcessing` stays synchronous, so its many synchronous teardown/`finally` callsites are untouched).
- `setProcessing` reverts its in-memory flag when its persist throws, so each retry attempt is safe to re-run.
- Retries on the same `SQLITE_BUSY*` / `SQLITE_IOERR*` families as the message insert.

Net diff is confined to `conversation-messaging.ts` plus tests.

## Test plan

- Extended `assistant/src/__tests__/persist-user-message-set-processing-failure.test.ts`:
  - retries a coded transient `SQLITE_BUSY` from `setProcessing(true)` (asserts 4 attempts: initial + 3 retries) then unwinds request-id/abort bookkeeping;
  - does **not** retry a non-transient failure (fails fast, single attempt).
- Existing regression suites still pass (each run in its own process per `scripts/test.sh` isolation): `persist-user-message-set-processing-failure`, `processing-flag-persist-failure`, `conversation-queue`, `conversation-loop-db-lock-resilience`.
- `prettier --check`, `eslint`, and `tsc --noEmit` clean on the changed files (enforced by the pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrSoZ2emJ8SKhS4eaCQk8K