### PR TITLE
fix(web): retry the platform identity bootstrap across the daemon-restart window

### DIFF
--- a/clients/web/src/lib/local-platform-identity.test.ts
+++ b/clients/web/src/lib/local-platform-identity.test.ts
@@ -396,6 +396,21 @@ describe("bootstrapLocalAssistantPlatformIdentity", () => {
     secretsUnavailable = true;
   }
 
+  test("stores the API key sentinel only after the other credentials have landed", async () => {
+    simulateDaemonRestartWithMissingApiKey();
+    secretsUnavailable = false;
+
+    bootstrapLocalAssistantPlatformIdentity(RUNTIME_ASSISTANT_ID);
+    await flushAsyncWork();
+
+    // The status probe reports has_assistant_api_key based on the API key
+    // alone, and the bootstrap early-returns on it — so a partial write
+    // must never leave the key stored without the rest.
+    expect(storedSecrets.at(-1)).toBe("vellum:assistant_api_key");
+    expect(storedSecrets).toContain("vellum:platform_base_url");
+    expect(storedSecrets).toContain("vellum:platform_organization_id");
+  });
+
   test("retries after the daemon-unreachable window and stores the credentials", async () => {
     simulateDaemonRestartWithMissingApiKey();
     setBootstrapRetryDelaysForTesting([20]);

--- a/clients/web/src/lib/local-platform-identity.test.ts
+++ b/clients/web/src/lib/local-platform-identity.test.ts
@@ -196,7 +196,9 @@ beforeEach(() => {
           });
         }
         const name = (parseRequestBody(init) as { name?: unknown })?.name;
-        if (typeof name === "string") storedSecrets.push(name);
+        if (typeof name === "string") {
+          storedSecrets.push(name);
+        }
         return jsonResponse({ ok: true });
       }
       return new Response("not found", { status: 404 });

--- a/clients/web/src/lib/local-platform-identity.test.ts
+++ b/clients/web/src/lib/local-platform-identity.test.ts
@@ -30,6 +30,8 @@ let statusBody: unknown;
 let ensureRegistrationBody: unknown;
 let reprovisionApiKeyBody: unknown;
 let requests: RecordedRequest[] = [];
+let secretsUnavailable = false;
+let storedSecrets: string[] = [];
 
 const buildVellumMutatingHeadersMock = mock(
   async (
@@ -92,6 +94,7 @@ mock.module("@/stores/organization-store", () => ({
 const {
   bootstrapLocalAssistantPlatformIdentity,
   resetLocalPlatformIdentityCacheForTesting,
+  setBootstrapRetryDelaysForTesting,
   resolveLocalAssistantPlatformIdentity,
 } = await import("@/lib/local-platform-identity");
 
@@ -147,11 +150,15 @@ beforeEach(() => {
     provisioning: { assistant_api_key: "reprovisioned-key" },
   };
   requests = [];
+  secretsUnavailable = false;
+  storedSecrets = [];
   buildVellumMutatingHeadersMock.mockClear();
   primeLocalGatewayConnectionWithRepairMock.mockClear();
   fetchOrganizationsMock.mockClear();
   updateLockfileAssistantMock.mockClear();
   resetLocalPlatformIdentityCacheForTesting();
+  // Single attempt by default — retry tests opt into a schedule.
+  setBootstrapRetryDelaysForTesting([]);
 
   globalThis.fetch = mock(
     async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -183,6 +190,13 @@ beforeEach(() => {
         return jsonResponse(reprovisionApiKeyBody);
       }
       if (url.pathname.endsWith("/v1/secrets")) {
+        if (secretsUnavailable) {
+          return new Response("Failed to reach assistant runtime", {
+            status: 502,
+          });
+        }
+        const name = (parseRequestBody(init) as { name?: unknown })?.name;
+        if (typeof name === "string") storedSecrets.push(name);
         return jsonResponse({ ok: true });
       }
       return new Response("not found", { status: 404 });
@@ -193,6 +207,7 @@ beforeEach(() => {
 afterEach(() => {
   globalThis.fetch = originalFetch;
   resetLocalPlatformIdentityCacheForTesting();
+  setBootstrapRetryDelaysForTesting(null);
 });
 
 describe("resolveLocalAssistantPlatformIdentity", () => {
@@ -366,5 +381,73 @@ describe("bootstrapLocalAssistantPlatformIdentity", () => {
 
     expect(primeLocalGatewayConnectionWithRepairMock).not.toHaveBeenCalled();
     expect(requestNames()).toEqual([]);
+  });
+
+  // The assistant has no stored API key (so the bootstrap must register and
+  // inject credentials rather than early-returning on the status probe) and
+  // the daemon is mid-restart (the gateway 502s /v1/secrets).
+  function simulateDaemonRestartWithMissingApiKey(): void {
+    statusBody = {
+      ...(statusBody as Record<string, unknown>),
+      has_assistant_api_key: false,
+    };
+    secretsUnavailable = true;
+  }
+
+  test("retries after the daemon-unreachable window and stores the credentials", async () => {
+    simulateDaemonRestartWithMissingApiKey();
+    setBootstrapRetryDelaysForTesting([20]);
+    const onError = mock((_error: unknown) => {});
+
+    bootstrapLocalAssistantPlatformIdentity(RUNTIME_ASSISTANT_ID, { onError });
+    await flushAsyncWork();
+    expect(
+      requests.filter((r) => r.pathname.endsWith("/v1/secrets")).length,
+    ).toBeGreaterThan(0);
+
+    // Daemon comes back before the retry fires.
+    secretsUnavailable = false;
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(requestNames().filter((name) => name === "status")).toHaveLength(2);
+    expect(storedSecrets).toContain("vellum:assistant_api_key");
+  });
+
+  test("invokes onError only after the retry schedule is exhausted", async () => {
+    simulateDaemonRestartWithMissingApiKey();
+    setBootstrapRetryDelaysForTesting([1, 1]);
+    const onError = mock((_error: unknown) => {});
+
+    bootstrapLocalAssistantPlatformIdentity(RUNTIME_ASSISTANT_ID, { onError });
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    // Initial attempt + two retries, each re-running the full flow.
+    expect(requestNames().filter((name) => name === "status")).toHaveLength(3);
+  });
+
+  test("a second trigger while a retry loop is active does not start a parallel flow", async () => {
+    simulateDaemonRestartWithMissingApiKey();
+    setBootstrapRetryDelaysForTesting([30]);
+
+    bootstrapLocalAssistantPlatformIdentity(RUNTIME_ASSISTANT_ID);
+    await flushAsyncWork();
+    const statusProbes = requestNames().filter(
+      (name) => name === "status",
+    ).length;
+
+    // Re-trigger while the loop is waiting out the backoff delay.
+    bootstrapLocalAssistantPlatformIdentity(RUNTIME_ASSISTANT_ID);
+    await flushAsyncWork();
+
+    expect(requestNames().filter((name) => name === "status")).toHaveLength(
+      statusProbes,
+    );
+
+    // Let the pending retry drain before afterEach restores the real fetch,
+    // so the loop's last attempt doesn't hit the network.
+    secretsUnavailable = false;
+    await new Promise((resolve) => setTimeout(resolve, 60));
   });
 });

--- a/clients/web/src/lib/local-platform-identity.ts
+++ b/clients/web/src/lib/local-platform-identity.ts
@@ -494,7 +494,6 @@ async function injectPlatformCredentials(
   },
 ): Promise<void> {
   const entries: Array<[string, string | null]> = [
-    ["vellum:assistant_api_key", params.assistantApiKey],
     ["vellum:platform_assistant_id", params.platformAssistantId],
     ["vellum:platform_base_url", params.platformBaseUrl],
     ["vellum:platform_organization_id", params.organizationId],
@@ -506,6 +505,19 @@ async function injectPlatformCredentials(
       .filter((entry): entry is [string, string] => Boolean(entry[1]))
       .map(([name, value]) => injectCredential(gateway, name, value)),
   );
+
+  // The API key is the sentinel the status probe reports as
+  // has_assistant_api_key, and the bootstrap early-returns when it is
+  // present. Store it only after every other credential has landed, so a
+  // partial write can never look "healthy" to a later retry and suppress
+  // the re-injection of the missing credentials.
+  if (params.assistantApiKey) {
+    await injectCredential(
+      gateway,
+      "vellum:assistant_api_key",
+      params.assistantApiKey,
+    );
+  }
 }
 
 async function injectCredential(

--- a/clients/web/src/lib/local-platform-identity.ts
+++ b/clients/web/src/lib/local-platform-identity.ts
@@ -150,7 +150,9 @@ export function bootstrapLocalAssistantPlatformIdentity(
   // One retrying bootstrap per assistant — a second trigger while a loop is
   // waiting out a backoff delay would race the same registration and
   // secret-injection flow.
-  if (activeBootstraps.has(targetAssistantId)) return;
+  if (activeBootstraps.has(targetAssistantId)) {
+    return;
+  }
   activeBootstraps.add(targetAssistantId);
   const target = targetAssistantId;
 

--- a/clients/web/src/lib/local-platform-identity.ts
+++ b/clients/web/src/lib/local-platform-identity.ts
@@ -77,8 +77,28 @@ type ResolveLocalAssistantPlatformIdentityOptions = {
 
 const platformAssistantIdCache = new Map<string, Promise<string>>();
 
+/**
+ * Backoff schedule for the best-effort bootstrap. After a daemon restart the
+ * gateway 502s every proxied /v1/* request (including the secret injection
+ * that stores the platform credentials) until the daemon is listening again —
+ * a window observed to last ~90s — so the schedule must outlast it.
+ */
+const BOOTSTRAP_RETRY_DELAYS_MS = [2_000, 5_000, 15_000, 30_000, 60_000];
+
+let bootstrapRetryDelaysMs: readonly number[] = BOOTSTRAP_RETRY_DELAYS_MS;
+
+/** Assistants with a bootstrap retry loop currently running. */
+const activeBootstraps = new Set<string>();
+
 export function resetLocalPlatformIdentityCacheForTesting(): void {
   platformAssistantIdCache.clear();
+  activeBootstraps.clear();
+}
+
+export function setBootstrapRetryDelaysForTesting(
+  delays: readonly number[] | null,
+): void {
+  bootstrapRetryDelaysMs = delays ?? BOOTSTRAP_RETRY_DELAYS_MS;
 }
 
 export async function resolveLocalAssistantPlatformIdentity(
@@ -127,14 +147,43 @@ export function bootstrapLocalAssistantPlatformIdentity(
     targetAssistantId = assistant.assistantId;
   }
 
-  void resolveLocalAssistantPlatformIdentity(targetAssistantId, {
-    allowGatewayRepair: options.allowGatewayRepair ?? false,
-  }).catch(
-    options.onError ??
-      ((error: unknown) => {
-        console.warn("local assistant platform bootstrap failed", error);
-      }),
-  );
+  // One retrying bootstrap per assistant — a second trigger while a loop is
+  // waiting out a backoff delay would race the same registration and
+  // secret-injection flow.
+  if (activeBootstraps.has(targetAssistantId)) return;
+  activeBootstraps.add(targetAssistantId);
+  const target = targetAssistantId;
+
+  void (async () => {
+    try {
+      for (let attempt = 0; ; attempt++) {
+        try {
+          await resolveLocalAssistantPlatformIdentity(target, {
+            allowGatewayRepair: options.allowGatewayRepair ?? false,
+          });
+          return;
+        } catch (error) {
+          const delayMs = bootstrapRetryDelaysMs[attempt];
+          if (delayMs === undefined) {
+            (
+              options.onError ??
+              ((e: unknown) => {
+                console.warn("local assistant platform bootstrap failed", e);
+              })
+            )(error);
+            return;
+          }
+          console.warn(
+            `local assistant platform bootstrap attempt ${attempt + 1} failed, retrying in ${delayMs}ms`,
+            error,
+          );
+          await new Promise((resolve) => setTimeout(resolve, delayMs));
+        }
+      }
+    } finally {
+      activeBootstraps.delete(target);
+    }
+  })();
 }
 
 function resolveLocalAssistant(assistantId: string): LockfileAssistant | null {


### PR DESCRIPTION
## Summary
- `bootstrapLocalAssistantPlatformIdentity` now retries the identity resolution with a backoff schedule (2s/5s/15s/30s/60s ≈ 112s of coverage) instead of swallowing the first failure with a `console.warn`. `onError` fires only after the schedule is exhausted, and a per-assistant guard prevents a second trigger from racing an active retry loop.
- Fixes the silently-unstored platform credentials after a daemon restart: the renderer bootstrap fires on gateway-connected, but the gateway 502s every proxied `/v1/*` request (including the `/v1/secrets` credential injection) until the daemon socket is listening again — a window observed at ~90s, stretched further by port-release races and slow boots. The single fire-and-forget attempt landed inside that window and was never retried, leaving the admin panel showing "Local Assistant" and managed/platform integrations without credentials.
- Adds tests: retry succeeds once the daemon comes back (credentials stored, no onError), onError fires only after exhaustion, and a concurrent trigger doesn't start a parallel registration flow.

## Original prompt
Follow-up to the ticket where platform credentials (`vellum:assistant_api_key` and peers) are silently unstored after a daemon restart: the bootstrap chain probes status and registers with the platform successfully, then the secret POSTs 502 because the daemon is mid-restart, and the failure is permanently swallowed by the fire-and-forget catch. The daemon-side companion fix (#37481) covers CES-transport blips inside a running daemon; this PR covers the gateway-502 window where the request never reaches the daemon, by retrying the bootstrap with backoff that outlasts the observed ~90s window.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->