### PR TITLE
feat(web): skill detail right-hand sidepanel in chat (viewer-store + panel)

### DIFF
--- a/clients/web/src/domains/chat/components/chat-content-layout.tsx
+++ b/clients/web/src/domains/chat/components/chat-content-layout.tsx
@@ -49,6 +49,8 @@ const importBackgroundTaskDetailPanel = () =>
   import(
     "@/domains/chat/components/background-task-detail-panel/background-task-detail-panel"
   );
+const importSkillDetailPanel = () =>
+  import("@/domains/chat/components/skill-detail-panel");
 
 const SubagentDetailPanel = lazy(() =>
   importSubagentDetailPanel().then((m) => ({ default: m.SubagentDetailPanel })),
@@ -66,6 +68,9 @@ const BackgroundTaskDetailPanel = lazy(() =>
   importBackgroundTaskDetailPanel().then((m) => ({
     default: m.BackgroundTaskDetailPanel,
   })),
+);
+const SkillDetailPanel = lazy(() =>
+  importSkillDetailPanel().then((m) => ({ default: m.SkillDetailPanel })),
 );
 
 // ---------------------------------------------------------------------------
@@ -98,6 +103,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
   const activeBackgroundTaskEntry = useBackgroundTaskStore((s) =>
     activeBackgroundTaskId ? s.byId[activeBackgroundTaskId] : undefined,
   );
+  const activeSkillDetailId = useViewerStore.use.activeSkillDetailId();
   const activeChannelSetup = useViewerStore.use.activeChannelSetup();
 
   const isSharing = useDeployStore.use.isSharing();
@@ -187,6 +193,10 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
     useViewerStore.getState().closeBackgroundTaskDetail();
   }, []);
 
+  const onCloseSkillDetail = useCallback(() => {
+    useViewerStore.getState().closeSkillDetail();
+  }, []);
+
   const onCloseChannelSetup = useCallback(() => {
     useViewerStore.getState().closeChannelSetup();
   }, []);
@@ -215,7 +225,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
   // -------------------------------------------------------------------------
   // Escape closes whichever right-hand side panel is open (tool detail /
   // thought process, subagent detail, workflow detail, acp run detail,
-  // document viewer). Surfaces stacked
+  // skill detail, document viewer). Surfaces stacked
   // above the panel that own Escape — Radix layers (dialogs, popovers,
   // dropdowns), the command palette, voice recording, the attachment
   // preview — all run before this bubble-phase window listener (document
@@ -251,6 +261,9 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
         case "background-task-detail":
           viewer.closeBackgroundTaskDetail();
           break;
+        case "skill-detail":
+          viewer.closeSkillDetail();
+          break;
         case "channel-setup":
           viewer.closeChannelSetup();
           break;
@@ -278,6 +291,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
       importAcpRunDetailPanel().catch(() => {});
       importWorkflowDetailPanel().catch(() => {});
       importBackgroundTaskDetailPanel().catch(() => {});
+      importSkillDetailPanel().catch(() => {});
     };
     if (typeof window.requestIdleCallback === "function") {
       const id = window.requestIdleCallback(run);
@@ -448,6 +462,15 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
             onClose={onCloseWorkflowDetail}
             onStop={onStopWorkflow}
             onRequestJournal={onRequestWorkflowJournal}
+          />
+        </LazyBoundary>
+      );
+    } else if (mainView === "skill-detail" && activeSkillDetailId) {
+      rightPanel = (
+        <LazyBoundary>
+          <SkillDetailPanel
+            skillId={activeSkillDetailId}
+            onClose={onCloseSkillDetail}
           />
         </LazyBoundary>
       );

--- a/clients/web/src/domains/chat/components/detail-shell.tsx
+++ b/clients/web/src/domains/chat/components/detail-shell.tsx
@@ -29,6 +29,8 @@ export interface DetailShellProps {
   closeVariant?: "ghost" | "outlined";
   onClose: () => void;
   children: ReactNode;
+  /** Pinned action row below the scrollable body (e.g. a primary CTA). */
+  footer?: ReactNode;
 }
 
 export function DetailShell({
@@ -41,6 +43,7 @@ export function DetailShell({
   closeVariant = "ghost",
   onClose,
   children,
+  footer,
 }: DetailShellProps) {
   return (
     <div className="flex h-full flex-col overflow-hidden rounded-xl bg-[var(--surface-lift)]">
@@ -76,6 +79,13 @@ export function DetailShell({
 
       {/* Scrollable body */}
       <div className="flex-1 overflow-y-auto px-5 py-5">{children}</div>
+
+      {/* Pinned footer */}
+      {footer && (
+        <div className="shrink-0 border-t border-[var(--border-base)] px-5 py-4">
+          {footer}
+        </div>
+      )}
     </div>
   );
 }

--- a/clients/web/src/domains/chat/components/skill-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/skill-detail-panel.tsx
@@ -1,0 +1,195 @@
+/**
+ * Right-hand side-drawer showing a skill's detail next to the chat: skill
+ * emoji + name header, description + SKILL.md body rendered as markdown, and
+ * a pinned "Go to Skill" footer that navigates to the skill's dedicated page.
+ * Removal (installed skills only) lives behind a header overflow menu with a
+ * confirmation dialog; on success the panel closes.
+ *
+ * Driven by `activeSkillDetailId` in `viewer-store` (see `openSkillDetail`).
+ * Rendered inside the shared chat `AnimatedRightDrawer` by
+ * `chat-content-layout`, matching its sibling `ToolDetailPanel`.
+ */
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Brain, Loader2, MoreHorizontal, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { useNavigate } from "react-router";
+
+import {
+  Button,
+  ConfirmDialog,
+  Menu,
+  Typography,
+} from "@vellumai/design-library";
+
+import { FileMarkdown } from "@/components/file-markdown";
+import { DetailShell } from "@/domains/chat/components/detail-shell";
+import {
+  skillsByIdFilesContentGetOptions,
+  skillsByIdFilesGetOptions,
+  skillsByIdGetOptions,
+  useSkillsByIdDeleteMutation,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import { captureError } from "@/lib/sentry/capture-error";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { routes } from "@/utils/routes";
+
+interface SkillDetailPanelProps {
+  skillId: string;
+  onClose: () => void;
+}
+
+export function SkillDetailPanel({ skillId, onClose }: SkillDetailPanelProps) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
+  const [confirmingRemoval, setConfirmingRemoval] = useState(false);
+
+  const skillQuery = useQuery({
+    ...skillsByIdGetOptions({
+      path: { assistant_id: assistantId ?? "", id: skillId },
+    }),
+    select: (data) => data.skill,
+    enabled: Boolean(assistantId),
+  });
+  const skill = skillQuery.data;
+
+  // SKILL.md is resolved the way the intelligence skill-detail views do:
+  // list the skill's files, find the SKILL.md entry by name, fetch its
+  // content. (Duplicated from `domains/intelligence` rather than imported —
+  // cross-domain imports are disallowed.)
+  const filesQuery = useQuery({
+    ...skillsByIdFilesGetOptions({
+      path: { assistant_id: assistantId ?? "", id: skillId },
+    }),
+    enabled: Boolean(assistantId),
+  });
+  const skillMdPath =
+    filesQuery.data?.files.find((f) => f.name === "SKILL.md")?.path ?? null;
+  const contentQuery = useQuery({
+    ...skillsByIdFilesContentGetOptions({
+      path: { assistant_id: assistantId ?? "", id: skillId },
+      query: { path: skillMdPath ?? "" },
+    }),
+    enabled: Boolean(assistantId && skillMdPath),
+  });
+
+  const removeMutation = useSkillsByIdDeleteMutation({
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: [{ _id: "skillsGet" }] });
+      onClose();
+    },
+    onError: (error) => {
+      captureError(error, { context: "skill-detail-panel-remove" });
+    },
+  });
+
+  const confirmRemove = () => {
+    if (!assistantId) {
+      return;
+    }
+    removeMutation.mutate({ path: { assistant_id: assistantId, id: skillId } });
+    setConfirmingRemoval(false);
+  };
+
+  // `isPending` (no data yet) rather than `isLoading` (actively fetching) so
+  // the disabled-query window while `assistantId` resolves also shows the
+  // spinner instead of a flash of empty body. The content query only counts
+  // once a SKILL.md path exists — a skill without one isn't "loading".
+  const isLoading =
+    skillQuery.isPending ||
+    filesQuery.isPending ||
+    (skillMdPath != null && contentQuery.isPending);
+  const skillMdContent = contentQuery.data?.content ?? null;
+
+  // Bundled skills ship with the assistant and can't be removed; the daemon
+  // rejects deletes for anything but installed skills.
+  const removable = skill?.kind === "installed";
+
+  return (
+    <>
+      <DetailShell
+        // `icon` wins over `Glyph` in DetailShell, so Brain is the
+        // no-emoji fallback (matching the skill-created-card rows).
+        icon={
+          skill?.emoji ? (
+            <span className="text-xl leading-none" aria-hidden>
+              {skill.emoji}
+            </span>
+          ) : undefined
+        }
+        Glyph={Brain}
+        title={skill?.name ?? "Skill"}
+        closeLabel="Close skill details"
+        onClose={onClose}
+        headerActions={
+          removable ? (
+            <Menu.Root>
+              <Menu.Trigger asChild>
+                <Button
+                  variant="ghost"
+                  iconOnly={<MoreHorizontal />}
+                  aria-label="Skill actions"
+                  className="shrink-0"
+                />
+              </Menu.Trigger>
+              <Menu.Content side="bottom" align="end">
+                <Menu.Item
+                  leftIcon={<Trash2 size={14} />}
+                  onSelect={() => setConfirmingRemoval(true)}
+                >
+                  Remove skill
+                </Menu.Item>
+              </Menu.Content>
+            </Menu.Root>
+          ) : undefined
+        }
+        footer={
+          <Button
+            fullWidth
+            onClick={() => navigate(routes.skills.detail(skillId))}
+          >
+            Go to Skill
+          </Button>
+        }
+      >
+        {skillQuery.isError ? (
+          <Typography
+            variant="body-medium-lighter"
+            as="p"
+            className="py-8 text-center text-[var(--content-tertiary)]"
+          >
+            This skill could not be loaded. It may have been removed.
+          </Typography>
+        ) : isLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-5 w-5 animate-spin text-[var(--content-tertiary)]" />
+          </div>
+        ) : (
+          <>
+            {skill?.description && (
+              <Typography
+                variant="body-medium-lighter"
+                as="p"
+                className="mb-4 text-[var(--content-secondary)]"
+              >
+                {skill.description}
+              </Typography>
+            )}
+            {skillMdContent && <FileMarkdown content={skillMdContent} />}
+          </>
+        )}
+      </DetailShell>
+
+      <ConfirmDialog
+        open={confirmingRemoval}
+        title="Remove skill"
+        message={skill ? `Remove "${skill.name}" from this assistant?` : ""}
+        confirmLabel="Remove"
+        destructive
+        onConfirm={confirmRemove}
+        onCancel={() => setConfirmingRemoval(false)}
+      />
+    </>
+  );
+}

--- a/clients/web/src/domains/chat/components/surfaces/skill-created-card.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/skill-created-card.test.tsx
@@ -86,7 +86,7 @@ describe("SkillCreatedCard", () => {
     expect(container.querySelectorAll(".rounded-lg")).toHaveLength(1);
   });
 
-  test("View navigates to the Skills tab deep-link for the clicked skill", () => {
+  test("View navigates to the skill detail page for the clicked skill", () => {
     const { getByRole, getByTestId } = renderCard(
       makeSurface({
         data: {
@@ -101,7 +101,7 @@ describe("SkillCreatedCard", () => {
     fireEvent.click(getByRole("button", { name: "View Skill two" }));
 
     expect(getByTestId("location").textContent).toBe(
-      "/assistant/skills?skill=skill-2",
+      "/assistant/skills/skill-2",
     );
   });
 

--- a/clients/web/src/domains/chat/components/surfaces/skill-created-card.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/skill-created-card.tsx
@@ -67,9 +67,9 @@ export function SkillCreatedCard({ surface, onAction }: SkillCreatedCardProps) {
   const navigate = useNavigate();
   const skills = parseSkills(surface.data.skills);
 
-  // Every row deep-links to the Skills tab with the clicked skill selected.
+  // Every row deep-links to the skill's dedicated detail page.
   const handleView = (skillId: string) => {
-    navigate(`${routes.skills}?skill=${encodeURIComponent(skillId)}`);
+    navigate(routes.skills.detail(skillId));
   };
 
   if (skills.length === 0) {

--- a/clients/web/src/stores/viewer-store.test.ts
+++ b/clients/web/src/stores/viewer-store.test.ts
@@ -343,6 +343,90 @@ describe("closeBackgroundTaskDetail", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Skill detail
+// ---------------------------------------------------------------------------
+
+describe("openSkillDetail", () => {
+  it("saves current view and switches to skill-detail", () => {
+    getState().openSkillDetail("skill-1");
+    const state = getState();
+    expect(state.mainView).toBe("skill-detail");
+    expect(state.activeSkillDetailId).toBe("skill-1");
+    expect(state.viewBeforeSkillDetail).toBe("chat");
+  });
+
+  it("preserves existing viewBeforeSkillDetail when already in skill-detail", () => {
+    useViewerStore.setState({
+      mainView: "skill-detail",
+      viewBeforeSkillDetail: "app",
+      activeSkillDetailId: "skill-1",
+    });
+    getState().openSkillDetail("skill-2");
+    const state = getState();
+    expect(state.viewBeforeSkillDetail).toBe("app");
+    expect(state.activeSkillDetailId).toBe("skill-2");
+  });
+
+  it("saves non-chat view correctly", () => {
+    useViewerStore.setState({ mainView: "app" });
+    getState().openSkillDetail("skill-1");
+    expect(getState().viewBeforeSkillDetail).toBe("app");
+  });
+
+  it("does not overwrite a real prior view with a transient one when opened over tool-detail", () => {
+    useViewerStore.setState({
+      mainView: "tool-detail",
+      viewBeforeSkillDetail: "app",
+      activeToolDetail: SAMPLE_TOOL,
+    });
+    getState().openSkillDetail("skill-1");
+    const state = getState();
+    expect(state.mainView).toBe("skill-detail");
+    expect(state.viewBeforeSkillDetail).toBe("app");
+  });
+});
+
+describe("closeSkillDetail", () => {
+  it("restores viewBeforeSkillDetail and clears activeSkillDetailId", () => {
+    useViewerStore.setState({
+      mainView: "skill-detail",
+      viewBeforeSkillDetail: "chat",
+      activeSkillDetailId: "skill-1",
+    });
+    getState().closeSkillDetail();
+    const state = getState();
+    expect(state.mainView).toBe("chat");
+    expect(state.activeSkillDetailId).toBeNull();
+  });
+
+  it("restores a non-chat view", () => {
+    useViewerStore.setState({
+      mainView: "skill-detail",
+      viewBeforeSkillDetail: "app",
+      activeSkillDetailId: "skill-1",
+    });
+    getState().closeSkillDetail();
+    const state = getState();
+    expect(state.mainView).toBe("app");
+    expect(state.activeSkillDetailId).toBeNull();
+  });
+
+  it("unwinds stacked panels one layer at a time (skill-detail over tool-detail)", () => {
+    // Mirrors the Escape flow: each panel keeps its own viewBefore*, so
+    // closing skill-detail restores its saved non-overlay view, and closing
+    // tool-detail afterwards restores the view it saved — the stack never
+    // dead-ends inside an overlay.
+    getState().openToolDetail(SAMPLE_TOOL);
+    getState().openSkillDetail("skill-1");
+    getState().closeSkillDetail();
+    expect(getState().mainView).toBe("chat");
+    expect(getState().activeSkillDetailId).toBeNull();
+    getState().closeToolDetail();
+    expect(getState().mainView).toBe("chat");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Workflow detail
 // ---------------------------------------------------------------------------
 

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -17,6 +17,7 @@
  * - `activeWorkflowRunId` — workflow detail panel
  * - `activeAcpRunId` — ACP run detail panel
  * - `activeBackgroundTaskId` — background-task detail panel
+ * - `activeSkillDetailId` — skill detail panel
  *
  * App share/deploy lifecycle lives in `domains/chat/deploy-store.ts`.
  *
@@ -42,6 +43,7 @@ type OverlayView =
   | "workflow-detail"
   | "acp-run-detail"
   | "background-task-detail"
+  | "skill-detail"
   | "channel-setup";
 
 /**
@@ -105,6 +107,7 @@ function resolveViewBefore(
     | "viewBeforeWorkflowDetail"
     | "viewBeforeAcpRunDetail"
     | "viewBeforeBackgroundTaskDetail"
+    | "viewBeforeSkillDetail"
     | "viewBeforeChannelSetup",
 ): Exclude<MainView, OverlayView> {
   const mv = state.mainView;
@@ -115,6 +118,7 @@ function resolveViewBefore(
     mv === "workflow-detail" ||
     mv === "acp-run-detail" ||
     mv === "background-task-detail" ||
+    mv === "skill-detail" ||
     mv === "channel-setup"
   ) {
     return state[field];
@@ -136,6 +140,7 @@ export type MainView =
   | "workflow-detail"
   | "acp-run-detail"
   | "background-task-detail"
+  | "skill-detail"
   | "channel-setup";
 
 export type IntelligenceTab = "identity" | "skills" | "workspace" | "contacts";
@@ -277,6 +282,8 @@ export interface ViewerState {
   viewBeforeAcpRunDetail: Exclude<MainView, OverlayView>;
   activeBackgroundTaskId: string | null;
   viewBeforeBackgroundTaskDetail: Exclude<MainView, OverlayView>;
+  activeSkillDetailId: string | null;
+  viewBeforeSkillDetail: Exclude<MainView, OverlayView>;
   activeChannelSetup: ChannelSetupPayload | null;
   viewBeforeChannelSetup: Exclude<MainView, OverlayView>;
   /**
@@ -319,6 +326,10 @@ export interface ViewerActions {
   // --- Background task detail ---
   openBackgroundTaskDetail: (id: string) => void;
   closeBackgroundTaskDetail: () => void;
+
+  // --- Skill detail ---
+  openSkillDetail: (skillId: string) => void;
+  closeSkillDetail: () => void;
 
   // --- Process-detail routing facade ---
   /**
@@ -395,6 +406,8 @@ const INITIAL_STATE: ViewerState = {
   viewBeforeAcpRunDetail: "chat",
   activeBackgroundTaskId: null,
   viewBeforeBackgroundTaskDetail: "chat",
+  activeSkillDetailId: null,
+  viewBeforeSkillDetail: "chat",
   activeChannelSetup: null,
   viewBeforeChannelSetup: "chat",
   ruleEditorRequestSeq: 0,
@@ -570,6 +583,23 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
     set({
       mainView: get().viewBeforeBackgroundTaskDetail,
       activeBackgroundTaskId: null,
+    });
+  },
+
+  // --- Skill detail ---
+
+  openSkillDetail: (skillId) => {
+    set({
+      mainView: "skill-detail",
+      activeSkillDetailId: skillId,
+      viewBeforeSkillDetail: resolveViewBefore(get(), "viewBeforeSkillDetail"),
+    });
+  },
+
+  closeSkillDetail: () => {
+    set({
+      mainView: get().viewBeforeSkillDetail,
+      activeSkillDetailId: null,
     });
   },
 


### PR DESCRIPTION
## Summary
- New skill-detail viewer-store mainView + SkillDetailPanel following the seven existing chat panel precedents (lazy chunk, idle prefetch, Escape unwind)
- Panel renders skill emoji/name/description + SKILL.md markdown; Go to Skill lands on /assistant/skills/:skillId; delete is confirm-gated behind an overflow menu
- PR 7 wires the in-chat skill card to openSkillDetail

## Notes for review
- `DetailShell` gains an optional pinned `footer` slot for the Go to Skill CTA (shared by future panels).
- The panel uses the generated `skillsByIdGet`/`skillsByIdFilesGet`/`skillsByIdFilesContentGet`/`useSkillsByIdDeleteMutation` artifacts plus the design-library `ConfirmDialog` directly instead of reusing `useSkillActions`/`skill-removal-dialog` from `domains/intelligence` — the `local/no-cross-domain-imports` ESLint rule forbids new chat-to-intelligence imports and allowlist additions, and lifting those modules (plus their `SkillInfo`/install dependencies) to shared dirs is out of scope here. The duplicated surface is the ~15-line remove-mutation wiring and the two-query SKILL.md fetch, both marked with why-comments.
- Drive-by fix: `skill-created-card.tsx` still interpolated the old string-shaped `routes.skills` after PR 5 turned it into an object, so View navigated to `/[object Object]?skill=...` and its test failed on this branch. Now navigates to `routes.skills.detail(skillId)` (PR 7 rewires desktop to the sidepanel on top of this).
- Pre-existing prettier drift in the touched files (viewer-store, chat-content-layout, detail-shell) is left untouched; only new code is formatted.

Part of plan: skill-surfacing-v1.md (PR 6 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)