### PR TITLE
fix(web): suppress ghost suggestion during live voice (JARVIS-1257)

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -1154,4 +1154,29 @@ describe("ChatComposer — live-voice transcript area", () => {
     expect(textarea.className).not.toContain("hidden");
     expect(textarea.disabled).toBe(false);
   });
+
+  // The ghost-suffix mirror and the live transcript share the same grid cell,
+  // so a suggestion painted during a session would overlay the streaming
+  // speech. The composer suppresses the ghost while it owns the session.
+  test("ghost suffix renders normally with no active session (baseline)", () => {
+    // GIVEN an empty draft and a pending autocomplete suggestion, no session
+    const html = renderComposer({ input: "", suggestion: "ghost completion text" });
+
+    // THEN the ghost suffix paints into the composer's mirror cell
+    expect(html).toContain("ghost completion text");
+  });
+
+  test("owned live-voice session suppresses the ghost suffix (no overlay on the transcript)", () => {
+    // GIVEN a listening session this composer owns and a pending suggestion
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    seedLiveVoiceSession("listening");
+
+    // WHEN the composer renders with the suggestion present
+    const { container } = renderVoiceComposer({ suggestion: "ghost completion text" });
+
+    // THEN the ghost is gone — the shared grid cell is left for the streaming
+    // transcript, not the suggestion overlay
+    expect(container.textContent).not.toContain("ghost completion text");
+  });
 });

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -374,13 +374,19 @@ export function ChatComposer({
 
   const ghostSuffix = useMemo(
     () =>
-      computeGhostSuffix({
-        pointerCoarse,
-        suggestion: suggestion ?? null,
-        input,
-        hasAttachments: attachments.length > 0,
-      }),
-    [pointerCoarse, suggestion, input, attachments],
+      // Suppressed while this composer owns a live-voice session: the streaming
+      // speech (`VoiceLiveTranscript`) renders in the same grid cell as the
+      // ghost-suffix mirror, and the draft is empty during voice so the mirror
+      // would paint the full suggestion straight over the transcript.
+      isLiveVoiceActive
+        ? null
+        : computeGhostSuffix({
+            pointerCoarse,
+            suggestion: suggestion ?? null,
+            input,
+            hasAttachments: attachments.length > 0,
+          }),
+    [isLiveVoiceActive, pointerCoarse, suggestion, input, attachments],
   );
 
   return (


### PR DESCRIPTION
## Problem
During a hands-free live-voice session, the composer's ghost autocomplete **suggestion** renders on top of the streaming speech **transcript**.

Both occupy the composer's auto-grow grid cell (`col-start-1 row-start-1`). During voice the textarea is hidden, but the aria-hidden mirror `<div>` keeps painting the ghost suffix (`chat-composer.tsx:435-439`), and since the draft is empty while you speak, `computeGhostSuffix` returns the **entire** suggestion (`chat-composer-utils.ts:104`) — so it overlays `VoiceLiveTranscript`.

## Fix
Suppress the ghost suffix while this composer owns the live-voice session by folding `isLiveVoiceActive` into the `ghostSuffix` memo (returns `null` during voice). Contained; no effect on typed-text behavior.

## Test
Adds a regression test in `chat-composer.test.tsx`:
- baseline: with a suggestion + empty draft and no session, the ghost suffix renders (proves the assertion isn't vacuous in jsdom);
- with an owned `listening` session, the suggestion no longer appears — the shared grid cell is left for the transcript.

`bun test chat-composer.test.tsx` → 70 pass. `bun run typecheck` → clean.

Closes JARVIS-1257

🤖 Generated with [Claude Code](https://claude.com/claude-code)