### PR TITLE
refactor(persistence): eject notifications/signal from the daemon-core cycle

### DIFF
--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -17,7 +17,7 @@ import {
   getGuardianDelivery,
   guardianForChannel,
 } from "../contacts/guardian-delivery-reader.js";
-import type { ConversationCreateType } from "../persistence/conversation-crud.js";
+import type { ConversationCreateType } from "../persistence/conversation-types.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getLogger } from "../util/logger.js";
 import { VellumAdapter } from "./adapters/macos.js";

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -9,7 +9,7 @@
 
 import { z } from "zod";
 
-import type { ConversationCreateType } from "../persistence/conversation-crud.js";
+import type { ConversationCreateType } from "../persistence/conversation-types.js";
 import type { GuardianQuestionPayload } from "./guardian-question-mode.js";
 import { UrgencySchema } from "./urgency.js";
 

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -67,6 +67,7 @@ import {
 import { ensureDisplayOrderMigration } from "./conversation-display-order-migration.js";
 import { ensureGroupMigration } from "./conversation-group-migration.js";
 import { deleteConversationRowsInBatches } from "./conversation-row-batch-delete.js";
+import type { ConversationCreateType } from "./conversation-types.js";
 import { runAsyncSqlite } from "./db-async-query.js";
 import {
   type DrizzleDb,
@@ -458,8 +459,6 @@ const parseMessage = createRowMapper<typeof messages.$inferSelect, MessageRow>({
   metadata: "metadata",
   clientMessageId: "clientMessageId",
 });
-
-export type ConversationCreateType = "standard" | "background" | "scheduled";
 
 /**
  * Monotonic timestamp source for message ordering. Two messages saved within

--- a/assistant/src/persistence/conversation-types.ts
+++ b/assistant/src/persistence/conversation-types.ts
@@ -1,10 +1,14 @@
-// Re-exports the canonical conversation-type union (defined alongside the
-// create path in `conversation-crud.ts`) under a read-side name and provides
+// The canonical conversation-type union — how a conversation was created / what
+// execution mode it runs in. Defined here (a leaf) so the create path in
+// `conversation-crud.ts`, the notification pipeline, and read-side filters
+// share one declaration without importing the heavy CRUD module. Also provides
 // the shared "is this a non-interactive / background conversation?" predicate
 // used by notification-feed and memory filters.
 
-import type { ConversationCreateType } from "./conversation-crud.js";
+/** How a conversation was created / its execution mode. */
+export type ConversationCreateType = "standard" | "background" | "scheduled";
 
+/** Read-side alias of {@link ConversationCreateType}. */
 export type ConversationType = ConversationCreateType;
 
 // Tolerant of null/undefined/unknown strings so it can be called directly on

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -56,7 +56,7 @@ mock.module("../../../persistence/embeddings/embedding-backend.js", () => ({
   },
 }));
 
-import type { ConversationCreateType } from "../../../persistence/conversation-crud.js";
+import type { ConversationCreateType } from "../../../persistence/conversation-types.js";
 import { getDb, getLogsDb } from "../../../persistence/db-connection.js";
 import { initializeDb } from "../../../persistence/db-init.js";
 import {

--- a/assistant/src/runtime/routes/conversation-cli-routes.ts
+++ b/assistant/src/runtime/routes/conversation-cli-routes.ts
@@ -13,7 +13,6 @@ import { clearAllConversations as clearAllActive } from "../../daemon/handlers/c
 import { formatJson, formatMarkdown } from "../../export/formatter.js";
 import { ipcCall as ipcCallGateway } from "../../ipc/gateway-client.js";
 import { sendSlackReply } from "../../messaging/providers/slack/send.js";
-import type { ConversationCreateType } from "../../persistence/conversation-crud.js";
 import { isConversationProcessing } from "../../persistence/conversation-crud.js";
 import {
   addMessage,
@@ -23,6 +22,7 @@ import {
 } from "../../persistence/conversation-crud.js";
 import { setConversationKey } from "../../persistence/conversation-key-store.js";
 import { listConversations } from "../../persistence/conversation-queries.js";
+import type { ConversationCreateType } from "../../persistence/conversation-types.js";
 import { getBindingByConversation } from "../../persistence/external-conversation-store.js";
 import { getLogger } from "../../util/logger.js";
 import { withSqliteRetry } from "../../util/sqlite-retry.js";


### PR DESCRIPTION
## Prompt / plan

Part of the ongoing campaign to dismantle the daemon-core import cycle in `/assistant`. This installment targets `notifications/signal.ts` — a high-fan-in module (in-degree 15) that was trapped in the daemon-core SCC by a **single type-only edge**.

`signal.ts` imported `ConversationCreateType` from `persistence/conversation-crud.ts` — a large, heavily-connected CRUD module — purely to type the optional `conversationType` field on `NotificationSignal.conversationMetadata`. That one type import roped `signal.ts` (and everything downstream of it) into the core cycle.

`ConversationCreateType` is a trivial union: `"standard" | "background" | "scheduled"`. The fix moves its definition into the existing leaf `persistence/conversation-types.ts` (aliased there as `ConversationType`) and repoints `conversation-crud.ts` plus the four consumers at the leaf. No re-export shim — consumers import directly from the new home.

**Core SCC: 336 → 327 files (−9).** Both `notifications/signal.ts` and `persistence/conversation-types.ts` are now out of every cycle.

## Test plan

- `bunx tsc --noEmit` — clean (0 errors)
- `bun test` on affected suites: `decision-engine.test.ts` (11/11), `conversation-query-routes.test.ts` (38/38)
- Full-graph Tarjan SCC recomputed to confirm the −9 core reduction and the ejection of both files
- Pre-commit + pre-push hooks (prettier, eslint, tsc) green

## CLI verb checklist

No new routes — pure type relocation. Section N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWL4FYZVRGkJkMwL46PY3m)_