### PR TITLE
fix(web): fetch real content for video attachments with thumbnail previewUrl [LUM-2752]

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.test.tsx
@@ -112,4 +112,38 @@ describe("AttachmentPreviewModal content loading", () => {
     expect(screen.queryByAltText("photo.png")).toBeNull();
     expect(screen.getByText("Download")).toBeDefined();
   });
+
+  test("fetches real content for video attachments with a thumbnail previewUrl", async () => {
+    // Video attachments receive a JPEG thumbnail as previewUrl (not the actual
+    // video). The modal must fetch the real bytes from the daemon rather than
+    // feeding the thumbnail to a <video> element. See LUM-2752.
+    renderModal({
+      ...ATTACHMENT,
+      filename: "clip.mp4",
+      mimeType: "video/mp4",
+      previewUrl: "data:image/jpeg;base64,THUMBNAIL",
+    });
+
+    const video = await screen.findByTestId("preview-video");
+    // The <video> src should be the blob URL from the daemon fetch, not the
+    // JPEG thumbnail data URI.
+    expect(video.getAttribute("src")).toBe("blob:preview-mock");
+    expect(video.getAttribute("src")).not.toBe("data:image/jpeg;base64,THUMBNAIL");
+    expect(attachmentsByIdContentGet).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not fetch when an image attachment has a real inline previewUrl", () => {
+    // Image attachments with inline data are the one case where previewUrl
+    // IS the actual content — the modal should render it directly without
+    // hitting the daemon.
+    renderModal({
+      ...ATTACHMENT,
+      previewUrl: "data:image/png;base64,AAAA",
+    });
+
+    expect(screen.getByAltText("photo.png").getAttribute("src")).toBe(
+      "data:image/png;base64,AAAA",
+    );
+    expect(attachmentsByIdContentGet).not.toHaveBeenCalled();
+  });
 });

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
@@ -92,11 +92,24 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
   const isRehydrated =
     !attachment.previewUrl && attachment.id.startsWith("rehydrated:");
 
-  // Fetch content from the daemon only when there's no inline previewUrl and we
-  // have a real, resolvable id to fetch with.
+  // Detect when previewUrl is a thumbnail (data:image/jpeg) rather than the
+  // actual file content. The backend sends thumbnailData as a JPEG for video
+  // and other non-image attachments when inline data is too large — but the
+  // preview modal needs the real bytes to render a playable <video>. Without
+  // this check, shouldFetch is false (previewUrl is truthy) and the modal
+  // feeds a JPEG data URI to a <video> element, which renders controls but
+  // can't play. See LUM-2752.
+  const isThumbnailPreview =
+    !!attachment.previewUrl &&
+    attachment.previewUrl.startsWith("data:image/") &&
+    !attachment.mimeType.toLowerCase().startsWith("image/");
+
+  // Fetch content from the daemon when there's no inline previewUrl OR when
+  // the previewUrl is a thumbnail for a non-image attachment (video, etc.).
+  // In both cases we need the real bytes from the daemon's content endpoint.
   const shouldFetch =
     open &&
-    !attachment.previewUrl &&
+    (!attachment.previewUrl || isThumbnailPreview) &&
     !!assistantId &&
     !!attachment.id &&
     !isRehydrated;
@@ -133,7 +146,9 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
     };
   }, [blob]);
 
-  const effectiveUrl = attachment.previewUrl ?? objectUrl;
+  // When the previewUrl is a thumbnail for a non-image attachment (video),
+  // prefer the fetched blob URL — the thumbnail is a JPEG and can't be played.
+  const effectiveUrl = isThumbnailPreview ? objectUrl : attachment.previewUrl ?? objectUrl;
 
   // A full-size image whose bytes the browser can't decode (e.g. HEIC on
   // Chromium, even after fetching the stored original) falls through to the
@@ -262,6 +277,7 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
     if (isVideo && effectiveUrl) {
       return (
         <video
+          data-testid="preview-video"
           src={effectiveUrl}
           controls
           className="max-h-[80vh] max-w-[90vw] rounded"


### PR DESCRIPTION
## What

Video attachments (`.mp4`, etc.) cannot be played in the attachment preview modal. The `<video>` element renders with controls visible but won't play — it's receiving a JPEG thumbnail as its `src` instead of the actual video bytes.

## Root Cause

Video attachments are too large for inline base64, so the backend sends `thumbnailData` (a JPEG) instead of `data`. Both `display-attachments.ts` and `attachment-mapping.ts` construct `previewUrl = "data:image/jpeg;base64,${thumbnailData}"` — a JPEG data URI.

The preview modal's `shouldFetch` logic was:
```ts
const shouldFetch = open && !attachment.previewUrl && ...
```

Since `previewUrl` is truthy (it's the thumbnail), `shouldFetch` evaluated to `false`. The modal never fetched the real video bytes from the daemon's `/v1/attachments/:id/content` endpoint. `effectiveUrl` fell through to `attachment.previewUrl` — the JPEG thumbnail — which was fed to `<video src={...}>`. A `<video>` element with a JPEG src renders controls but can't play.

**Why download works:** `downloadAttachment()` always tries `fetchAttachmentContentBlob()` first, regardless of `previewUrl`. It correctly ignores the thumbnail and fetches the real bytes.

## Fix

Two changes in `attachment-preview-modal.tsx`:

1. **Detect thumbnail-only previewUrls:** Added `isThumbnailPreview` — true when `previewUrl` starts with `data:image/` but the attachment MIME type is NOT `image/*`. This identifies cases where `previewUrl` is a thumbnail, not the actual content.

2. **Fetch real content for thumbnails:** Updated `shouldFetch` to also trigger when `isThumbnailPreview` is true. Updated `effectiveUrl` to prefer the fetched blob URL over the thumbnail when `isThumbnailPreview` is true.

## Root Cause Analysis

**How did the code get into this state?** The `shouldFetch` logic was written when the modal only handled images. For images, `previewUrl` IS the content (inline base64 or a thumbnail that renders fine as an `<img>`). Video support was added later (commit `ab407228a9` — the React Query refactor), but the `shouldFetch` condition was never updated to account for the thumbnail-vs-content distinction for non-image types.

**What mistakes led to it?** The `display-attachments.ts` and `attachment-mapping.ts` functions set `previewUrl` to a thumbnail for any attachment with `thumbnailData`, regardless of MIME type. This was correct for images (a thumbnail is a valid `<img>` src) but incorrect for videos (a JPEG is not a valid `<video>` src). The preview modal trusted that `previewUrl` was always the actual content.

**Were there warning signs missed?** The `downloadAttachment()` function already had a comment noting that `previewUrl` may be a JPEG thumbnail rather than the actual file for video attachments. This knowledge wasn't propagated to the preview modal.

**Prevention:** When adding support for a new media type to a component that consumes `previewUrl`, verify that `previewUrl` actually contains content suitable for that media type's renderer — not just a thumbnail.

## Safety

- No behavioral change for image attachments — `isThumbnailPreview` is `false` when MIME is `image/*`, so the existing path is untouched
- No behavioral change for attachments with no `previewUrl` — the existing fetch-on-null path still fires
- Download path was already correct (it always fetches from the daemon first)
- 2 new tests added, all 7 tests pass
- No type errors in changed files

## Alternatives Considered

1. **Check MIME type in `display-attachments.ts` instead** — Don't set `previewUrl` for non-image types when only `thumbnailData` is available. Rejected: would break the attachment chip rendering (which shows the thumbnail as the file icon for videos) and changes the contract of `DisplayAttachment` more broadly.
2. **Add `thumbnailUrl` as a separate field** — More correct but larger surface area change. Rejected for this fix: the thumbnail is still useful for the chip, and separating it would require changes across the attachment type, both mapping functions, and all consumers.
3. **CSP fix (Vex's theory)** — The CSP already allows `blob:` in `media-src`. The issue was never CSP — the video bytes were never fetched.

## Linear

[LUM-2752](https://linear.app/vellum/issue/LUM-2752)