### PR TITLE
feat(skills): surface source-conversation lineage on skill detail (API + web)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -26390,6 +26390,11 @@ paths:
                           origin:
                             type: string
                             const: assistant-memory
+                          sourceConversationId:
+                            description:
+                              Conversation whose trace the retrospective distilled this skill from. Present only when recorded in
+                              install-meta.
+                            type: string
                         required:
                           - id
                           - name

--- a/assistant/src/__tests__/get-skill-detail-audit.test.ts
+++ b/assistant/src/__tests__/get-skill-detail-audit.test.ts
@@ -30,9 +30,11 @@ const mockReadInstallMeta = mock(
     _dir: string,
   ): {
     origin: string;
-    slug: string;
+    slug?: string;
     sourceRepo?: string;
     installedAt?: string;
+    author?: "assistant" | "user";
+    sourceConversationId?: string;
   } | null => null,
 );
 
@@ -354,5 +356,91 @@ describe("getSkill — skillssh audit enrichment", () => {
     if (detail.origin === "vellum") {
       expect(detail.owner).toEqual({ kind: "plugin", id: "caveman" });
     }
+  });
+});
+
+describe("getSkill — assistant-memory conversation lineage", () => {
+  beforeEach(() => {
+    mockResolveSkillStates.mockReset();
+    mockReadInstallMeta.mockReset();
+    mockFetchSkillAudits.mockReset();
+
+    mockResolveSkillStates.mockReturnValue([
+      {
+        summary: {
+          id: "triage-inbox",
+          displayName: "Triage Inbox",
+          description: "Distilled inbox triage procedure",
+          source: "managed" as const,
+          directoryPath: "/tmp/test-skills/triage-inbox",
+        },
+        state: "enabled" as const,
+      },
+    ]);
+    mockFetchSkillAudits.mockResolvedValue({});
+  });
+
+  test("includes sourceConversationId when install-meta records it", async () => {
+    // GIVEN a retrospective-authored skill whose install-meta carries lineage
+    mockReadInstallMeta.mockReturnValue({
+      origin: "custom",
+      author: "assistant",
+      sourceConversationId: "conv-123",
+      installedAt: "2026-01-01T00:00:00Z",
+    });
+
+    const result = await getSkill("triage-inbox");
+
+    expect("skill" in result).toBe(true);
+    if (!("skill" in result)) {
+      throw new Error("Expected skill response");
+    }
+
+    const detail = result.skill;
+    expect(detail.origin).toBe("assistant-memory");
+    if (detail.origin === "assistant-memory") {
+      expect(detail.sourceConversationId).toBe("conv-123");
+    }
+  });
+
+  test("omits sourceConversationId when install-meta has none", async () => {
+    // GIVEN a retrospective-authored skill without recorded lineage
+    mockReadInstallMeta.mockReturnValue({
+      origin: "custom",
+      author: "assistant",
+      installedAt: "2026-01-01T00:00:00Z",
+    });
+
+    const result = await getSkill("triage-inbox");
+
+    expect("skill" in result).toBe(true);
+    if (!("skill" in result)) {
+      throw new Error("Expected skill response");
+    }
+
+    const detail = result.skill;
+    expect(detail.origin).toBe("assistant-memory");
+    expect("sourceConversationId" in detail).toBe(false);
+  });
+
+  test("never exposes lineage on non-assistant-memory origins", async () => {
+    // GIVEN a user-installed custom skill that (unexpectedly) carries a
+    // sourceConversationId in install-meta
+    mockReadInstallMeta.mockReturnValue({
+      origin: "custom",
+      sourceConversationId: "conv-123",
+      installedAt: "2026-01-01T00:00:00Z",
+    });
+
+    const result = await getSkill("triage-inbox");
+
+    expect("skill" in result).toBe(true);
+    if (!("skill" in result)) {
+      throw new Error("Expected skill response");
+    }
+
+    const detail = result.skill;
+    expect(detail.origin).toBe("custom");
+    expect("sourceConversationId" in detail).toBe(false);
   });
 });

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -731,6 +731,14 @@ export async function getSkill(
     category: slim.category,
     owner: slim.owner,
   };
+  if (detail.origin === "assistant-memory") {
+    // Retrospective-authored skills carry conversation lineage in install-meta;
+    // surface the durable source-conversation id so clients can link back.
+    const meta = readInstallMeta(found.summary.directoryPath);
+    if (meta?.sourceConversationId) {
+      detail.sourceConversationId = meta.sourceConversationId;
+    }
+  }
   return { skill: detail };
 }
 

--- a/assistant/src/daemon/message-types/skills.ts
+++ b/assistant/src/daemon/message-types/skills.ts
@@ -235,6 +235,12 @@ interface AssistantMemorySkillDetail extends SkillDetailBase {
   origin: "assistant-memory";
   /** See {@link VellumSkillDetail.owner}. */
   owner?: OwnerInfo;
+  /**
+   * Conversation whose trace the retrospective distilled this skill from —
+   * the durable lineage recorded in install-meta. Present only when the
+   * scaffold recorded it; lets clients link back to the source conversation.
+   */
+  sourceConversationId?: string;
 }
 
 export type SkillDetailResponse =

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -142,6 +142,12 @@ const skillDetailSchema = z.discriminatedUnion("origin", [
   z.object({
     ...slimSkillBaseWithOwner,
     origin: z.literal("assistant-memory"),
+    sourceConversationId: z
+      .string()
+      .optional()
+      .describe(
+        "Conversation whose trace the retrospective distilled this skill from. Present only when recorded in install-meta.",
+      ),
   }),
 ]);
 

--- a/clients/web/src/components/skill-lineage-link.test.tsx
+++ b/clients/web/src/components/skill-lineage-link.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Tests for `SkillLineageLink` — the quiet "Learned from this conversation"
+ * link on skill detail surfaces. The component owns the render gate: only
+ * assistant-memory skills with a recorded source conversation get a link.
+ *
+ * Rendered inside a `MemoryRouter` (the component emits a react-router
+ * `<Link>`), via `@testing-library/react` on happy-dom.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+import { SkillLineageLink } from "./skill-lineage-link";
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderLink(
+  skill: { origin: string; sourceConversationId?: string | null },
+  onNavigate?: () => void,
+) {
+  return render(
+    <MemoryRouter>
+      <SkillLineageLink skill={skill} onNavigate={onNavigate} />
+    </MemoryRouter>,
+  );
+}
+
+describe("SkillLineageLink", () => {
+  test("links an assistant-memory skill with lineage to its source conversation", () => {
+    const { getByText } = renderLink({
+      origin: "assistant-memory",
+      sourceConversationId: "conv-123",
+    });
+
+    const link = getByText("Learned from this conversation").closest("a");
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute("href")).toBe(
+      "/assistant/conversations/conv-123",
+    );
+  });
+
+  test("renders nothing for non-assistant-memory origins, even with lineage", () => {
+    const { container } = renderLink({
+      origin: "custom",
+      sourceConversationId: "conv-123",
+    });
+
+    expect(container.querySelector("a")).toBeNull();
+  });
+
+  test("renders nothing for an assistant-memory skill without lineage", () => {
+    const { container } = renderLink({ origin: "assistant-memory" });
+
+    expect(container.querySelector("a")).toBeNull();
+  });
+
+  test("invokes onNavigate on click (so hosting panels can close)", () => {
+    const onNavigate = mock(() => {});
+    const { getByText } = renderLink(
+      { origin: "assistant-memory", sourceConversationId: "conv-123" },
+      onNavigate,
+    );
+
+    fireEvent.click(getByText("Learned from this conversation"));
+
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/web/src/components/skill-lineage-link.tsx
+++ b/clients/web/src/components/skill-lineage-link.tsx
@@ -1,0 +1,48 @@
+/**
+ * Quiet "Learned from this conversation" link shown on skill detail surfaces
+ * (skill detail page, chat skill sidepanel) for skills the assistant authored
+ * from a conversation. Renders only for `assistant-memory` skills whose
+ * install-meta recorded a source conversation — callers pass whatever skill
+ * shape they have and the gate lives here.
+ */
+
+import { ArrowRight } from "lucide-react";
+import { Link } from "react-router";
+
+import { cn } from "@/utils/misc";
+import { routes } from "@/utils/routes";
+
+interface SkillLineageLinkProps {
+  /**
+   * Origin plus the lineage id when known. The generated skill detail union
+   * and `SkillInfo` both satisfy this shape without narrowing.
+   */
+  skill: { origin: string; sourceConversationId?: string | null };
+  className?: string;
+  /** Invoked on click before navigation (e.g. to close the hosting panel). */
+  onNavigate?: () => void;
+}
+
+export function SkillLineageLink({
+  skill,
+  className,
+  onNavigate,
+}: SkillLineageLinkProps) {
+  if (skill.origin !== "assistant-memory" || !skill.sourceConversationId) {
+    return null;
+  }
+
+  return (
+    <Link
+      to={routes.conversation(skill.sourceConversationId)}
+      onClick={onNavigate}
+      className={cn(
+        "inline-flex w-fit items-center gap-1 text-body-small-default text-[var(--content-tertiary)] transition-colors hover:text-[var(--content-secondary)] hover:underline",
+        className,
+      )}
+    >
+      Learned from this conversation
+      <ArrowRight className="h-3.5 w-3.5 shrink-0" aria-hidden />
+    </Link>
+  );
+}

--- a/clients/web/src/domains/chat/components/skill-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/skill-detail-panel.tsx
@@ -23,6 +23,7 @@ import {
 } from "@vellumai/design-library";
 
 import { FileMarkdown } from "@/components/file-markdown";
+import { SkillLineageLink } from "@/components/skill-lineage-link";
 import { DetailShell } from "@/domains/chat/components/detail-shell";
 import {
   skillsByIdFilesContentGetOptions,
@@ -175,6 +176,13 @@ export function SkillDetailPanel({ skillId, onClose }: SkillDetailPanelProps) {
               >
                 {skill.description}
               </Typography>
+            )}
+            {skill && (
+              <SkillLineageLink
+                skill={skill}
+                className="mb-4"
+                onNavigate={onClose}
+              />
             )}
             {skillMdContent && <FileMarkdown content={skillMdContent} />}
           </>

--- a/clients/web/src/domains/intelligence/components/skills/skill-detail-mobile.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-detail-mobile.tsx
@@ -13,6 +13,7 @@ import { useEffect, useState, type RefObject } from "react";
 import { createPortal } from "react-dom";
 
 import { isMarkdown } from "@/components/file-markdown";
+import { SkillLineageLink } from "@/components/skill-lineage-link";
 import {
     isAvailableSkill,
     isRemovableSkill,
@@ -39,6 +40,11 @@ interface SkillDetailMobileProps {
    * subtree, so the owning page can't wrap it in its own ref'd container.
    */
   swipeContainerRef?: RefObject<HTMLDivElement | null>;
+  /**
+   * Source conversation this skill was distilled from (assistant-memory
+   * skills only) — renders a quiet lineage link when present.
+   */
+  sourceConversationId?: string;
 }
 
 /**
@@ -69,6 +75,7 @@ export function SkillDetailMobile({
   isInstalling = false,
   isRemoving = false,
   swipeContainerRef,
+  sourceConversationId,
 }: SkillDetailMobileProps) {
   const available = isAvailableSkill(skill);
   const removable = isRemovableSkill(skill);
@@ -168,6 +175,9 @@ export function SkillDetailMobile({
         >
           {skill.description}
         </p>
+        <SkillLineageLink
+          skill={{ origin: skill.origin, sourceConversationId }}
+        />
       </div>
 
       {/* Content card — 24px below the description */}

--- a/clients/web/src/domains/intelligence/components/skills/skill-detail.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-detail.tsx
@@ -18,6 +18,7 @@ import {
     SourcePre,
 } from "@/components/file-editor";
 import { FileMarkdown, isMarkdown } from "@/components/file-markdown";
+import { SkillLineageLink } from "@/components/skill-lineage-link";
 import { SkillIcon } from "@/domains/intelligence/components/skills/skill-icon";
 import { SkillOriginBadge } from "@/domains/intelligence/components/skills/skill-origin-badge";
 import {
@@ -44,6 +45,11 @@ interface SkillDetailProps {
   onRemove?: () => void;
   isInstalling?: boolean;
   isRemoving?: boolean;
+  /**
+   * Source conversation this skill was distilled from (assistant-memory
+   * skills only) — renders a quiet lineage link when present.
+   */
+  sourceConversationId?: string;
 }
 
 export function SkillDetail({
@@ -54,6 +60,7 @@ export function SkillDetail({
   onRemove,
   isInstalling = false,
   isRemoving = false,
+  sourceConversationId,
 }: SkillDetailProps) {
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
 
@@ -119,6 +126,10 @@ export function SkillDetail({
               >
                 {skill.description}
               </p>
+              <SkillLineageLink
+                skill={{ origin: skill.origin, sourceConversationId }}
+                className="mt-1"
+              />
             </div>
           </div>
           {available ? (

--- a/clients/web/src/domains/intelligence/skill-detail-page.tsx
+++ b/clients/web/src/domains/intelligence/skill-detail-page.tsx
@@ -12,7 +12,10 @@ import { SkillsLoadingState } from "@/domains/intelligence/components/skills/ski
 import { SkillsStateCard } from "@/domains/intelligence/components/skills/skills-state-card";
 import { type SkillInfo } from "@/domains/intelligence/skills/types";
 import { useSkillActions } from "@/domains/intelligence/skills/use-skill-actions";
-import { skillsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
+import {
+  skillsByIdGetOptions,
+  skillsGetOptions,
+} from "@/generated/daemon/@tanstack/react-query.gen";
 import { useEdgeSwipeBack } from "@/hooks/use-edge-swipe-back";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { routes } from "@/utils/routes";
@@ -80,6 +83,20 @@ export function SkillDetailPage() {
     [skills, skillId],
   );
 
+  // Conversation lineage lives only on the single-skill detail response, not
+  // the list the page resolves from — fetch it lazily, and only for
+  // retrospective-authored skills (the only origin that can carry it).
+  const lineageQuery = useQuery({
+    ...skillsByIdGetOptions({
+      path: { assistant_id: assistantId, id: skillId ?? "" },
+    }),
+    enabled: Boolean(skillId) && skill?.origin === "assistant-memory",
+    select: (data) =>
+      data.skill.origin === "assistant-memory"
+        ? (data.skill.sourceConversationId ?? null)
+        : null,
+  });
+
   if (!skillId) {
     return <Navigate to={routes.skills.root} replace />;
   }
@@ -120,6 +137,7 @@ export function SkillDetailPage() {
     onRemove: () => handleRemove(skill),
     isInstalling: isInstallingSkill(skill),
     isRemoving: isRemovingSkill(skill),
+    sourceConversationId: lineageQuery.data ?? undefined,
   };
 
   return (


### PR DESCRIPTION
## Summary
- getSkill detail response now carries sourceConversationId (from install-meta) for retrospective-authored skills
- Skill detail page and chat sidepanel show a quiet 'Learned from this conversation' link for assistant-memory skills
- openapi.yaml + web SDK regenerated (verified additive)

Part of plan: skill-surfacing-v1.md (PR 8 of 8)