### PR TITLE
fix(assistant): persist the conversation row before the first live-voice turn (JARVIS-1259)

### DIFF
--- a/assistant/src/__tests__/ensure-conversation-exists.test.ts
+++ b/assistant/src/__tests__/ensure-conversation-exists.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+  }),
+}));
+
+import {
+  addMessage,
+  createConversation,
+  ensureConversationExists,
+  getConversation,
+} from "../persistence/conversation-crud.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+
+await initializeDb();
+
+describe("ensureConversationExists", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM messages");
+    db.run("DELETE FROM conversations");
+  });
+
+  test("adopts the given id so a first message persists without an FK error", async () => {
+    // Regression (JARVIS-1259): the live-voice first turn of a new chat adopts
+    // an unpersisted client conversation id. Persisting the user message before
+    // the row exists tripped `FOREIGN KEY constraint failed`.
+    const conversationId = "brand-new-live-voice-conversation";
+
+    ensureConversationExists(conversationId);
+
+    const row = getConversation(conversationId);
+    expect(row?.id).toBe(conversationId);
+
+    // The FK target now exists, so the user-message insert succeeds.
+    const message = await addMessage(
+      conversationId,
+      "user",
+      "hello from voice",
+      {
+        skipIndexing: true,
+      },
+    );
+    expect(message.conversationId).toBe(conversationId);
+  });
+
+  test("is idempotent and never clobbers an existing conversation", () => {
+    const created = createConversation({ title: "already here" });
+
+    // Two extra ensures must be no-ops — no throw, no title/row change.
+    ensureConversationExists(created.id);
+    ensureConversationExists(created.id);
+
+    const row = getConversation(created.id);
+    expect(row?.id).toBe(created.id);
+    expect(row?.title).toBe("already here");
+  });
+});

--- a/assistant/src/__tests__/ensure-conversation-exists.test.ts
+++ b/assistant/src/__tests__/ensure-conversation-exists.test.ts
@@ -41,7 +41,9 @@ describe("ensureConversationExists", () => {
     // the row exists tripped `FOREIGN KEY constraint failed`.
     const conversationId = "brand-new-live-voice-conversation";
 
-    ensureConversationExists(conversationId);
+    // Reports that it inserted the row so callers can emit a one-time
+    // conversations-list invalidation.
+    expect(ensureConversationExists(conversationId)).toBe(true);
 
     const row = getConversation(conversationId);
     expect(row?.id).toBe(conversationId);
@@ -61,12 +63,30 @@ describe("ensureConversationExists", () => {
   test("is idempotent and never clobbers an existing conversation", () => {
     const created = createConversation({ title: "already here" });
 
-    // Two extra ensures must be no-ops — no throw, no title/row change.
-    ensureConversationExists(created.id);
-    ensureConversationExists(created.id);
+    // Two extra ensures must be no-ops — return false (did not create), no
+    // throw, no title/row change.
+    expect(ensureConversationExists(created.id)).toBe(false);
+    expect(ensureConversationExists(created.id)).toBe(false);
 
     const row = getConversation(created.id);
     expect(row?.id).toBe(created.id);
     expect(row?.title).toBe("already here");
+  });
+
+  test("rejects an unsafe adopted id instead of writing outside the conversations dir", () => {
+    // The id becomes a path component of the on-disk conversation dir, so a
+    // traversal value from an untrusted live-voice start frame must be refused
+    // before createConversation() touches disk.
+    for (const unsafe of ["../../tmp/x", "a/b", "..", "with space", ""]) {
+      expect(() => ensureConversationExists(unsafe)).toThrow(
+        /unsafe conversation id/,
+      );
+      expect(getConversation(unsafe)).toBeNull();
+    }
+
+    // A plain uuid-shaped id is still accepted.
+    expect(
+      ensureConversationExists("0f9c1e2a-3b4d-5e6f-7a8b-9c0d1e2f3a4b"),
+    ).toBe(true);
   });
 });

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -16,6 +16,7 @@ import {
   supportsBoundary,
 } from "../providers/speech-to-text/provider-catalog.js";
 import type { ResolveStreamingTranscriberOptions } from "../providers/speech-to-text/resolve.js";
+import { publishConversationListAndMetadataChanged } from "../runtime/sync/resource-sync-events.js";
 import { detectPcm16SpeechActivity } from "../stt/speech-energy.js";
 import type {
   StreamingTranscriber,
@@ -257,7 +258,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   async start(): Promise<void> {
-    if (this.state !== "initializing") return;
+    if (this.state !== "initializing") {
+      return;
+    }
 
     if (this.resolveCredentialReadiness) {
       const readiness = await this.resolveCredentialReadiness();
@@ -292,7 +295,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   async handleClientFrame(frame: LiveVoiceClientFrame): Promise<void> {
-    if (this.state === "closed" || this.state === "failed") return;
+    if (this.state === "closed" || this.state === "failed") {
+      return;
+    }
 
     switch (frame.type) {
       case "audio":
@@ -316,7 +321,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   async close(_reason: LiveVoiceSessionCloseReason): Promise<void> {
-    if (this.isClosed) return;
+    if (this.isClosed) {
+      return;
+    }
 
     const shouldEmitSessionEndMetrics = this.state !== "failed";
     this.state = "closed";
@@ -436,12 +443,16 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // server_vad capability; manual sessions keep single-utterance semantics
   // (no speculative post-turn transcriber).
   private scheduleRearmAfterTurn(): void {
-    if (!this.turnDetector) return;
+    if (!this.turnDetector) {
+      return;
+    }
     void this.rearmAfterTurn().catch(() => {});
   }
 
   private async rearmAfterTurn(): Promise<void> {
-    if (this.isClosed || this.state === "failed") return;
+    if (this.isClosed || this.state === "failed") {
+      return;
+    }
 
     const current = this.currentUtterance;
     if (current && !current.completed) {
@@ -455,7 +466,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
   private async armUtterance(): Promise<void> {
     const result = await this.beginUtterance();
-    if (result.status === "started" || result.status === "stale") return;
+    if (result.status === "started" || result.status === "stale") {
+      return;
+    }
 
     this.state = "failed";
     await this.sendFrame({
@@ -472,14 +485,18 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
 
     const utterance = this.currentUtterance;
-    if (!utterance || this.isClosed || this.state === "failed") return;
+    if (!utterance || this.isClosed || this.state === "failed") {
+      return;
+    }
 
     if (utterance.released || utterance.phase === "transcriber_closed") {
       await this.sendAudioAfterReleaseError();
       return;
     }
 
-    if (this.state === "initializing") return;
+    if (this.state === "initializing") {
+      return;
+    }
 
     this.collectUserAudio(utterance, chunk);
     if (utterance.phase === "pending") {
@@ -517,11 +534,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
 
     let utterance = this.currentUtterance;
-    if (!utterance) return;
+    if (!utterance) {
+      return;
+    }
     if (utterance.released || utterance.completed) {
       // Parked speech makes silent chunks arm-worthy too: the parked
       // utterance must flush without requiring more speech.
-      if (!hasSpeech && !this.vadPreRollHasSpeech) return;
+      if (!hasSpeech && !this.vadPreRollHasSpeech) {
+        return;
+      }
       if (!this.canArmNextUtterance(utterance)) {
         // Speech in the release→turn-start window: hold it in the pre-roll
         // ring so it flushes into the next utterance once it arms.
@@ -532,7 +553,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // while this chunk lands in the new utterance's pending buffer.
       void this.armUtterance();
       utterance = this.currentUtterance;
-      if (!utterance || utterance.released || utterance.completed) return;
+      if (!utterance || utterance.released || utterance.completed) {
+        return;
+      }
     }
 
     for (const preRollChunk of this.takeVadPreRoll()) {
@@ -574,7 +597,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     ) {
       return;
     }
-    if (hasSpeech) this.vadPreRollHasSpeech = true;
+    if (hasSpeech) {
+      this.vadPreRollHasSpeech = true;
+    }
     this.vadPreRollChunks.push(Buffer.from(chunk));
     while (this.vadPreRollChunks.length > SERVER_VAD_PRE_ROLL_MAX_CHUNKS) {
       this.vadPreRollChunks.shift();
@@ -647,7 +672,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // turn only once its first tts_audio chunk was forwarded — speech during
   // a pre-TTS "thinking" turn never kills the unspoken reply.
   private handleVadSpeechStart(): void {
-    if (this.isClosed || this.state === "failed") return;
+    if (this.isClosed || this.state === "failed") {
+      return;
+    }
 
     void this.sendFrame({ type: "speech_started" });
     this.vadSpeechStartPending = true;
@@ -680,7 +707,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // utterance_end, then run the standard release path.
   private handleVadUtteranceEnd(reason: "silence" | "max-duration"): void {
     void (async () => {
-      if (this.isClosed || this.state === "failed") return;
+      if (this.isClosed || this.state === "failed") {
+        return;
+      }
       this.vadSpeechStartPending = false;
       const utterance = this.currentUtterance;
       if (!utterance || utterance.released || utterance.completed) {
@@ -712,7 +741,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
   private async releaseUtterance(): Promise<void> {
     const utterance = this.currentUtterance;
-    if (!utterance || this.isClosed || this.state === "failed") return;
+    if (!utterance || this.isClosed || this.state === "failed") {
+      return;
+    }
 
     if (utterance.phase === "transcriber_closed") {
       utterance.released = true;
@@ -722,7 +753,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return;
     }
 
-    if (utterance.released) return;
+    if (utterance.released) {
+      return;
+    }
 
     utterance.released = true;
     this.markUtteranceReleased(utterance);
@@ -820,7 +853,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   private async interrupt(): Promise<void> {
-    if (this.isClosed || this.state === "failed") return;
+    if (this.isClosed || this.state === "failed") {
+      return;
+    }
 
     this.state = "interrupted";
     // A client interrupt also discards speech parked in the pre-roll ring.
@@ -855,11 +890,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
     // One assistant turn at a time: a server_vad utterance that closes while
     // the previous turn is still speaking waits; rearmAfterTurn retries it.
-    if (this.activeAssistantTurn) return;
+    if (this.activeAssistantTurn) {
+      return;
+    }
     if (utterance.phase !== "transcriber_closed") {
       return;
     }
-    if (!this.startVoiceTurn) return;
+    if (!this.startVoiceTurn) {
+      return;
+    }
 
     const content = utterance.finalTranscriptSegments.join(" ").trim();
     if (content.length === 0) {
@@ -900,7 +939,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     };
 
     await this.sendFrame({ type: "thinking", turnId });
-    if (!this.isActiveAssistantTurn(token)) return;
+    if (!this.isActiveAssistantTurn(token)) {
+      return;
+    }
 
     try {
       const handle = await this.startVoiceTurn({
@@ -918,7 +959,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         signal: abortController.signal,
         callbacks: {
           assistant_text_delta: (msg) => {
-            if (!this.isForwardingAssistantText(token)) return;
+            if (!this.isForwardingAssistantText(token)) {
+              return;
+            }
             this.markFirstAssistantDelta(utterance, turnId);
             void this.sendFrame({
               type: "assistant_text_delta",
@@ -951,12 +994,16 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           },
           persisted_user_message_id: (messageId) => {
             const activeTurn = this.activeAssistantTurn;
-            if (activeTurn?.token !== token) return;
+            if (activeTurn?.token !== token) {
+              return;
+            }
             activeTurn.utterance.userMessageId = messageId;
           },
           persisted_assistant_message_id: (messageId) => {
             const activeTurn = this.activeAssistantTurn;
-            if (activeTurn?.token !== token) return;
+            if (activeTurn?.token !== token) {
+              return;
+            }
             activeTurn.assistantMessageId = messageId;
           },
         },
@@ -975,7 +1022,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
               message,
             });
             const currentTurn = this.activeAssistantTurn;
-            if (currentTurn?.token !== token) return;
+            if (currentTurn?.token !== token) {
+              return;
+            }
             await this.finalizeAssistantTurn(currentTurn, "cancelled", "error");
           })();
         },
@@ -993,7 +1042,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
       activeTurn.handle = handle;
     } catch (err) {
-      if (!this.isActiveAssistantTurn(token)) return;
+      if (!this.isActiveAssistantTurn(token)) {
+        return;
+      }
 
       this.activeAssistantTurn = null;
       await this.sendFrame({
@@ -1059,10 +1110,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   private bufferAssistantTextForTts(token: symbol, text: string): void {
-    if (!this.streamTtsAudio || text.length === 0) return;
+    if (!this.streamTtsAudio || text.length === 0) {
+      return;
+    }
 
     const activeTurn = this.activeAssistantTurn;
-    if (activeTurn?.token !== token || activeTurn.assistantCompleted) return;
+    if (activeTurn?.token !== token || activeTurn.assistantCompleted) {
+      return;
+    }
 
     activeTurn.ttsBuffer += text;
     this.flushTtsBuffer(token, false);
@@ -1070,17 +1125,23 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
   private completeTtsForTurn(token: symbol): void {
     const activeTurn = this.activeAssistantTurn;
-    if (activeTurn?.token !== token) return;
+    if (activeTurn?.token !== token) {
+      return;
+    }
 
     this.flushTtsBuffer(token, true);
     activeTurn.ttsQueue = activeTurn.ttsQueue
       .catch(() => {})
       .then(async () => {
         const currentTurn = this.activeAssistantTurn;
-        if (currentTurn?.token !== token || currentTurn.ttsDone) return;
+        if (currentTurn?.token !== token || currentTurn.ttsDone) {
+          return;
+        }
         // Barge-in can abort while this continuation is queued; the turn
         // then finalizes as cancelled through cancelAssistantTurn.
-        if (currentTurn.abortController.signal.aborted) return;
+        if (currentTurn.abortController.signal.aborted) {
+          return;
+        }
 
         currentTurn.ttsDone = true;
         await this.finalizeAssistantTurn(
@@ -1117,7 +1178,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
   private flushTtsBuffer(token: symbol, force: boolean): void {
     const activeTurn = this.activeAssistantTurn;
-    if (activeTurn?.token !== token) return;
+    if (activeTurn?.token !== token) {
+      return;
+    }
 
     if (!this.streamTtsAudio) {
       activeTurn.ttsBuffer = "";
@@ -1147,7 +1210,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private enqueueTtsSegment(token: symbol, segment: string): void {
     const activeTurn = this.activeAssistantTurn;
     const streamTtsAudio = this.streamTtsAudio;
-    if (activeTurn?.token !== token || !streamTtsAudio) return;
+    if (activeTurn?.token !== token || !streamTtsAudio) {
+      return;
+    }
 
     activeTurn.ttsSegmentEnqueued = true;
     activeTurn.ttsQueue = activeTurn.ttsQueue
@@ -1169,9 +1234,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             outputFormat: "pcm",
             sampleRate: this.context.startFrame.audio.sampleRate,
             onAudioChunk: (chunk) => {
-              if (!this.isForwardingTts(token)) return;
+              if (!this.isForwardingTts(token)) {
+                return;
+              }
               const activeTurn = this.activeAssistantTurn;
-              if (activeTurn?.token !== token) return;
+              if (activeTurn?.token !== token) {
+                return;
+              }
               activeTurn.assistantAudioChunks.push(
                 Buffer.from(chunk.dataBase64, "base64"),
               );
@@ -1191,7 +1260,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
                 // actually written — a backed-up outbound queue must not
                 // let speech cancel a still-unspoken reply. Token match
                 // keeps a stale turn's late send from arming a newer turn.
-                if (!sent) return;
+                if (!sent) {
+                  return;
+                }
                 const turnAfterSend = this.activeAssistantTurn;
                 if (
                   turnAfterSend?.token !== token ||
@@ -1206,7 +1277,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           });
           await ttsAudioFrames;
         } catch (err) {
-          if (!this.isForwardingTts(token)) return;
+          if (!this.isForwardingTts(token)) {
+            return;
+          }
           // Per-segment failure: the turn (and session) continue, so the
           // error is recoverable for the client.
           await this.sendFrame(
@@ -1245,7 +1318,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return;
     }
     const turnId = this.ensureTurnId(utterance);
-    if (!this.startMetricsTurnIfNeeded(utterance, turnId)) return;
+    if (!this.startMetricsTurnIfNeeded(utterance, turnId)) {
+      return;
+    }
     this.metrics.markPushToTalkRelease(turnId);
   }
 
@@ -1275,7 +1350,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       mark(turnId);
       return;
     }
-    if (utterance.metricsTurnFinished) return;
+    if (utterance.metricsTurnFinished) {
+      return;
+    }
     if (utterance.stashedMetricsMarks[field] === null) {
       utterance.stashedMetricsMarks[field] = this.metricsClock();
     }
@@ -1285,7 +1362,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     utterance: UtteranceCycle,
     turnId: string,
   ): void {
-    if (!this.startMetricsTurnIfNeeded(utterance, turnId)) return;
+    if (!this.startMetricsTurnIfNeeded(utterance, turnId)) {
+      return;
+    }
     this.metrics.markFirstAssistantDelta(turnId);
   }
 
@@ -1301,9 +1380,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     utterance: UtteranceCycle,
     turnId: string,
   ): boolean {
-    if (utterance.metricsTurnFinished) return false;
-    if (utterance.metricsTurnStarted) return true;
-    if (this.hasBlockingMetricsTurn(utterance)) return false;
+    if (utterance.metricsTurnFinished) {
+      return false;
+    }
+    if (utterance.metricsTurnStarted) {
+      return true;
+    }
+    if (this.hasBlockingMetricsTurn(utterance)) {
+      return false;
+    }
     this.metrics.startTurn(turnId, toSeedMarks(utterance.stashedMetricsMarks));
     utterance.metricsTurnStarted = true;
     return true;
@@ -1328,7 +1413,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   ): Promise<void> {
     utterance.completed = true;
     const turnId = utterance.turnId;
-    if (!turnId) return;
+    if (!turnId) {
+      return;
+    }
 
     await this.archiveBufferedAudio({
       turnId,
@@ -1347,7 +1434,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     reason = "completed",
     options: { clearActive?: boolean; rearm?: boolean } = {},
   ): Promise<void> {
-    if (turn.finalized) return;
+    if (turn.finalized) {
+      return;
+    }
 
     turn.finalized = true;
     turn.utterance.completed = true;
@@ -1423,7 +1512,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     audio: Buffer;
   }): Promise<void> {
     const archiveAudio = this.archiveAudio;
-    if (!archiveAudio) return;
+    if (!archiveAudio) {
+      return;
+    }
 
     const durationMs = estimatePcmDurationMs({
       byteLength: input.audio.byteLength,
@@ -1492,7 +1583,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     reason: string,
     turnId: string,
   ): Promise<void> {
-    if (!utterance.metricsTurnStarted || utterance.metricsTurnFinished) return;
+    if (!utterance.metricsTurnStarted || utterance.metricsTurnFinished) {
+      return;
+    }
 
     if (status === "completed") {
       this.metrics.completeTurn(turnId);
@@ -1501,7 +1594,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
     utterance.metricsTurnFinished = true;
 
-    if (!this.emitMetrics) return;
+    if (!this.emitMetrics) {
+      return;
+    }
     await this.emitMetricsFrame(
       status === "completed" ? "turn_completed" : "turn_cancelled",
       turnId,
@@ -1509,7 +1604,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   private async emitSessionEndMetrics(): Promise<void> {
-    if (!this.emitMetrics || this.sessionEndMetricsEmitted) return;
+    if (!this.emitMetrics || this.sessionEndMetricsEmitted) {
+      return;
+    }
 
     this.sessionEndMetricsEmitted = true;
     await this.emitMetricsFrame("session_ended");
@@ -1561,7 +1658,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.outboundFrames = this.outboundFrames
       .catch(() => {})
       .then(async () => {
-        if (!shouldSend()) return;
+        if (!shouldSend()) {
+          return;
+        }
         await this.context.sendFrame(frame);
         sent = true;
       })
@@ -1629,7 +1728,17 @@ async function defaultStartVoiceTurn(
   // inside `startVoiceTurn` trips `FOREIGN KEY constraint failed`. Ensure it
   // exists (idempotent) before persisting. Lives in the production wiring, not
   // the session state machine, so session unit tests stay DB-free.
-  ensureConversationExists(options.conversationId);
+  const createdConversation = ensureConversationExists(options.conversationId);
+  if (createdConversation) {
+    // The row was created outside the normal send-message route, which is where
+    // sibling clients/sidebars learn about a new conversation. Emit the same
+    // "created" list invalidation that route does so they see the new voice
+    // conversation without waiting for a reload.
+    publishConversationListAndMetadataChanged(
+      "created",
+      options.conversationId,
+    );
+  }
   const { startVoiceTurn } = await import("../calls/voice-session-bridge.js");
   return startVoiceTurn(options);
 }
@@ -1674,7 +1783,9 @@ function toSeedMarks(stashed: StashedMetricsMarks): LiveVoiceTurnSeedMarks {
 }
 
 function takeBufferedAudio(chunks: Buffer[]): Buffer | null {
-  if (chunks.length === 0) return null;
+  if (chunks.length === 0) {
+    return null;
+  }
 
   const audio = Buffer.concat(chunks);
   chunks.length = 0;
@@ -1711,7 +1822,9 @@ function unavailableTranscriberMessage(): string {
 function stopTranscriberBestEffort(
   transcriber: StreamingTranscriber | null,
 ): void {
-  if (!transcriber) return;
+  if (!transcriber) {
+    return;
+  }
 
   try {
     transcriber.stop();

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -10,6 +10,7 @@ import type {
   VoiceTurnHandle,
   VoiceTurnOptions,
 } from "../calls/voice-session-bridge.js";
+import { ensureConversationExists } from "../persistence/conversation-crud.js";
 import {
   listProviderIds,
   supportsBoundary,
@@ -1621,6 +1622,14 @@ async function defaultResolveLiveVoiceCredentialReadiness(): Promise<LiveVoiceCr
 async function defaultStartVoiceTurn(
   options: VoiceTurnOptions,
 ): Promise<VoiceTurnHandle> {
+  // On the first turn of a brand-new chat the client's conversation id has no
+  // persisted `conversations` row yet — the live-voice session adopts the id
+  // from its start frame rather than minting one through the conversation-key
+  // store the text-send path uses. Without the row, the user-message persist
+  // inside `startVoiceTurn` trips `FOREIGN KEY constraint failed`. Ensure it
+  // exists (idempotent) before persisting. Lives in the production wiring, not
+  // the session state machine, so session unit tests stay DB-free.
+  ensureConversationExists(options.conversationId);
   const { startVoiceTurn } = await import("../calls/voice-session-bridge.js");
   return startVoiceTurn(options);
 }

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -772,8 +772,19 @@ export function createConversation(
 }
 
 /**
+ * A conversation id adopted verbatim from an untrusted source must be safe to
+ * embed as a single path component of the on-disk conversation dir
+ * (`<timestamp>_<id>/meta.json`). This pattern admits server uuids and the
+ * web client's `crypto.randomUUID()` / `draft-<ts>-<hex>` drafts while
+ * rejecting anything with path separators, `..`, or other traversal vectors.
+ */
+const ADOPTABLE_CONVERSATION_ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
+
+/**
  * Ensure a `conversations` row exists for `id`, creating one with default
- * columns only when absent. Idempotent.
+ * columns only when absent. Idempotent. Returns `true` iff this call inserted
+ * the row (so callers can emit a one-time creation side effect, e.g. a
+ * conversations-list invalidation).
  *
  * The normal text-send path persists the conversation row through the
  * conversation-key store before the first message is written, so `messages`
@@ -783,16 +794,32 @@ export function createConversation(
  * first turn of a brand-new chat the row does not exist yet, and persisting
  * the user message trips `FOREIGN KEY constraint failed`. Call this before the
  * first persist to close that gap while keeping the adopted id verbatim.
+ *
+ * Because the id is adopted verbatim and reaches the filesystem via
+ * `createConversation` → `initConversationDir`, an id from an external client
+ * is validated first — a value like `../../tmp/x` would otherwise write
+ * `meta.json` outside the conversations directory.
  */
-export function ensureConversationExists(id: string): void {
-  if (getConversation(id)) return;
+export function ensureConversationExists(id: string): boolean {
+  if (getConversation(id)) {
+    return false;
+  }
+  if (!ADOPTABLE_CONVERSATION_ID_RE.test(id)) {
+    throw new Error(
+      `Refusing to adopt unsafe conversation id: ${JSON.stringify(id)}`,
+    );
+  }
   try {
     createConversation({ id });
+    return true;
   } catch (err) {
     // A concurrent caller may have created the row between the check and the
     // insert (UNIQUE(id) violation). That's the desired end state, so only
     // rethrow if the row still isn't there.
-    if (!getConversation(id)) throw err;
+    if (!getConversation(id)) {
+      throw err;
+    }
+    return false;
   }
 }
 

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -669,6 +669,13 @@ export function createConversation(
   titleOrOpts?:
     | string
     | {
+        /**
+         * Adopt an explicit conversation id instead of minting a new uuid.
+         * Callers that already hold a client-provided id and want the row to
+         * carry it verbatim (e.g. {@link ensureConversationExists}) pass it
+         * here; everyone else omits it and gets a fresh uuid.
+         */
+        id?: string;
         title?: string;
         /**
          * Override the `is_auto_title` column (schema default 1). Pass
@@ -696,7 +703,7 @@ export function createConversation(
     requestedConversationType ?? "standard";
   const source = opts.source ?? "user";
   const groupId = opts.groupId;
-  const id = uuid();
+  const id = opts.id ?? uuid();
   const memoryScopeId = "default";
 
   // Ensure group_id column exists for deterministic schema readiness,
@@ -762,6 +769,31 @@ export function createConversation(
   initConversationDir({ ...conversation, originChannel: null });
 
   return conversation;
+}
+
+/**
+ * Ensure a `conversations` row exists for `id`, creating one with default
+ * columns only when absent. Idempotent.
+ *
+ * The normal text-send path persists the conversation row through the
+ * conversation-key store before the first message is written, so `messages`
+ * inserts always have their FK target. Entry points that adopt a
+ * client-provided conversation id directly — notably the live-voice session,
+ * which binds to the id from its start frame — have no such guarantee: on the
+ * first turn of a brand-new chat the row does not exist yet, and persisting
+ * the user message trips `FOREIGN KEY constraint failed`. Call this before the
+ * first persist to close that gap while keeping the adopted id verbatim.
+ */
+export function ensureConversationExists(id: string): void {
+  if (getConversation(id)) return;
+  try {
+    createConversation({ id });
+  } catch (err) {
+    // A concurrent caller may have created the row between the check and the
+    // insert (UNIQUE(id) violation). That's the desired end state, so only
+    // rethrow if the row still isn't there.
+    if (!getConversation(id)) throw err;
+  }
 }
 
 export function getConversation(id: string): ConversationRow | null {


### PR DESCRIPTION
## Problem
Starting voice mode on the **first turn of a brand-new chat** fails: `Live voice assistant turn could not be started: FOREIGN KEY constraint failed`.

## Root cause
The two entry paths persist the conversation differently:
- **Text send** resolves a new chat's id through `conversation-key-store.getOrCreateConversation`, which **INSERTs the `conversations` row** (+ key→id mapping) before any message is written.
- **Live-voice** (`live-voice-session.ts:233`) adopts `conversationId` from the client start frame and uses the *daemon* `conversation-store.getOrCreateConversation`, which only builds an in-memory object — the DB row is never inserted.

So on the first turn, `startVoiceTurn` → `persistUserMessage` → `insertMessageCore` inserts a `messages` row referencing a conversation that has no row → **FK failure**. First-turn-of-a-new-chat only (existing chats already have the row; after any text send the row exists).

## Fix
- Add an idempotent `ensureConversationExists(id)` to `conversation-crud.ts` (adopting the id verbatim via a new optional `id` on `createConversation`).
- Call it in the live-voice **production wiring** (`defaultStartVoiceTurn`), right before the bridge persists.

Placement rationale:
- **Not** in the session state machine → its DB-free unit tests stay untouched (an earlier attempt there broke ~40 session tests that inject a mock `startVoiceTurn`).
- **Not** at session start → opening the mic and closing without speaking leaves no empty conversation (matches the text path's create-on-first-message).
- Adopts the client id verbatim (no remap), so the client's `conversationId` stays stable and later text sends resolve via the key-store's "key is an existing conversation id" branch.

## Test
Adds `ensure-conversation-exists.test.ts`: after `ensureConversationExists`, an `addMessage` against the previously-unpersisted id succeeds (the exact FK path); and the helper is idempotent / never clobbers an existing conversation.

All 6 live-voice session suites pass (57 tests), new test passes, `bunx tsc --noEmit` clean, lint/prettier clean. (One unrelated `forkConversation` compaction test fails identically on unmodified main — pre-existing, not touched here.)

Closes JARVIS-1259

🤖 Generated with [Claude Code](https://claude.com/claude-code)