### PR TITLE
feat(credential-requests): serve the entry page from the gateway and allowlist it for Velay

### DIFF
--- a/gateway/src/__tests__/credential-entry-page.test.ts
+++ b/gateway/src/__tests__/credential-entry-page.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+
+import { handleCredentialEntryPage } from "../http/routes/credential-entry-page.js";
+
+describe("credential entry page", () => {
+  test("serves a self-contained HTML page with no-store and no-referrer", async () => {
+    const res = handleCredentialEntryPage(
+      new Request("http://gateway.local/assistant/credentials/enter"),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/html");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Referrer-Policy")).toBe("no-referrer");
+
+    const html = await res.text();
+    // The page reads the token from the fragment and calls the public
+    // credential-request routes with a path prefix derived from its own URL
+    // (Velay-style /<assistantId>/... prefixes included).
+    expect(html).toContain("location.hash");
+    expect(html).toContain("/v1/credential-requests/peek");
+    expect(html).toContain("/v1/credential-requests/submit");
+    expect(html).toContain("history.replaceState");
+    // Fully static template: no external asset references.
+    expect(html).not.toContain('src="http');
+    expect(html).not.toContain('href="http');
+  });
+
+  test("rejects non-GET methods", () => {
+    const res = handleCredentialEntryPage(
+      new Request("http://gateway.local/assistant/credentials/enter", {
+        method: "POST",
+      }),
+    );
+    expect(res.status).toBe(405);
+  });
+});

--- a/gateway/src/http/routes/credential-entry-page.ts
+++ b/gateway/src/http/routes/credential-entry-page.ts
@@ -1,0 +1,184 @@
+/**
+ * Gateway-served one-time credential entry page.
+ *
+ * Velay-tunneled deployments have no SPA server behind the tunnel (Velay only
+ * proxies allowlisted paths to the gateway, and the gateway serves no web
+ * bundle), so the React entry page in `clients/web` is unreachable there.
+ * This route serves a SELF-CONTAINED static page instead — inline CSS/JS, no
+ * external assets — following the `oauth-callback.ts` static-page pattern.
+ * nginx-fronted deployments never hit this route: nginx serves the SPA for
+ * `/assistant/*` paths, so the React page wins there.
+ *
+ * SECURITY:
+ * - The single-use token rides the URL FRAGMENT (`#token=`), which browsers
+ *   never send over HTTP — this handler never sees it. The inline script
+ *   reads it, strips it from history, and sends it only in POST bodies to
+ *   the peek/submit routes (which validate it server-side).
+ * - The page template is fully static: no request data is interpolated, and
+ *   all dynamic content is rendered client-side via `textContent`.
+ */
+
+const PAGE_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex, nofollow">
+<title>Provide a credential</title>
+<style>
+  :root { color-scheme: light dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; min-height: 100vh; display: flex; align-items: center;
+    justify-content: center; padding: 24px;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    background: #f5f5f7; color: #1a1f27;
+  }
+  @media (prefers-color-scheme: dark) {
+    body { background: #111318; color: #e8eaed; }
+    .card { background: #1c1f26; border-color: #2c313a; }
+    input[type="password"] { background: #111318; border-color: #3a404b; color: #e8eaed; }
+    .muted { color: #9aa0aa; }
+  }
+  .card {
+    width: 100%; max-width: 420px; background: #fff; border: 1px solid #e2e5ea;
+    border-radius: 12px; padding: 28px; box-shadow: 0 1px 4px rgba(0,0,0,0.06);
+  }
+  h1 { font-size: 18px; margin: 0 0 6px; }
+  p { font-size: 14px; line-height: 1.5; margin: 8px 0; }
+  .muted { color: #5f6672; font-size: 13px; }
+  .mono { font-family: Menlo, Consolas, monospace; font-size: 13px; }
+  input[type="password"] {
+    width: 100%; padding: 10px 12px; font-size: 14px; border: 1px solid #c9cedb;
+    border-radius: 8px; margin: 10px 0 14px; background: #fff; color: inherit;
+  }
+  button {
+    width: 100%; padding: 10px 12px; font-size: 14px; font-weight: 600;
+    border: none; border-radius: 8px; background: #4453f2; color: #fff; cursor: pointer;
+  }
+  button:disabled { opacity: 0.5; cursor: default; }
+  .error { color: #d64545; }
+  .ok { color: #2e9e5b; }
+  .hidden { display: none; }
+</style>
+</head>
+<body>
+<main class="card">
+  <div id="loading"><h1>One-time credential link</h1><p class="muted">Checking this link…</p></div>
+
+  <form id="form" class="hidden">
+    <h1>Provide a credential</h1>
+    <p>This one-time link securely collects <strong><span id="label"></span></strong> <span class="muted mono" id="slot"></span> for the assistant. The value goes straight into its encrypted vault — it is never shown in chat.</p>
+    <p class="muted" id="expiry"></p>
+    <input id="value" type="password" autocomplete="off" placeholder="Paste the value" required>
+    <button id="submit" type="submit">Save credential</button>
+    <p id="formError" class="error hidden"></p>
+  </form>
+
+  <div id="done" class="hidden"><h1 class="ok">Credential saved</h1><p>The value is stored in the assistant's encrypted vault. This link has now been used and can't be opened again — you can close this tab.</p></div>
+  <div id="invalid" class="hidden"><h1 class="error">Invalid link</h1><p>This credential link isn't valid. Ask for a new one if a value still needs to be provided.</p></div>
+  <div id="expired" class="hidden"><h1 class="error">Link expired</h1><p>This credential link has expired. Ask for a new one and use it within its validity window.</p></div>
+  <div id="used" class="hidden"><h1 class="error">Link already used</h1><p>Each link works exactly once. Ask for a new one if the value still needs to be provided.</p></div>
+  <div id="failed" class="hidden"><h1 class="error">Link no longer valid</h1><p>The assistant could not store the credential, and for safety this one-time link cannot be reused. Ask for a new link and try again there.</p></div>
+</main>
+<script>
+(function () {
+  "use strict";
+  var MARKER = "/assistant/credentials/enter";
+  var prefix = location.pathname.slice(0, location.pathname.indexOf(MARKER));
+
+  var hashParams = new URLSearchParams(location.hash.replace(/^#/, ""));
+  var token = (hashParams.get("token") || "").trim();
+  if (!token) {
+    token = (new URLSearchParams(location.search).get("token") || "").trim();
+  }
+  // Strip the token from the address bar and this history entry immediately.
+  history.replaceState(history.state, "", location.pathname);
+
+  function show(id) {
+    ["loading", "form", "done", "invalid", "expired", "used", "failed"].forEach(function (s) {
+      document.getElementById(s).classList.toggle("hidden", s !== id);
+    });
+  }
+
+  function outcomeFor(res, body) {
+    if (res.status === 404 && body && body.error) {
+      var code = body.error.code;
+      if (code === "EXPIRED") return "expired";
+      if (code === "USED") return "used";
+      return "invalid";
+    }
+    if (res.status === 502) return "failed";
+    return "invalid";
+  }
+
+  function post(path, payload) {
+    return fetch(prefix + path, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      credentials: "omit",
+    }).then(function (res) {
+      return res.json().catch(function () { return null; }).then(function (body) {
+        return { res: res, body: body };
+      });
+    });
+  }
+
+  if (!token) { show("invalid"); return; }
+
+  post("/v1/credential-requests/peek", { token: token }).then(function (r) {
+    if (!r.res.ok) { show(outcomeFor(r.res, r.body)); return; }
+    var label = r.body.label || (r.body.service + ":" + r.body.field);
+    document.getElementById("label").textContent = label;
+    document.getElementById("slot").textContent = "(" + r.body.service + ":" + r.body.field + ")";
+    if (r.body.expiresAt) {
+      var mins = Math.max(1, Math.round((r.body.expiresAt - Date.now()) / 60000));
+      document.getElementById("expiry").textContent =
+        "Single-use \\u00b7 expires in about " + mins + " minute" + (mins === 1 ? "" : "s") + ".";
+    }
+    show("form");
+  }).catch(function () { show("invalid"); });
+
+  document.getElementById("form").addEventListener("submit", function (e) {
+    e.preventDefault();
+    var value = document.getElementById("value").value;
+    if (!value.trim()) return;
+    var btn = document.getElementById("submit");
+    var err = document.getElementById("formError");
+    btn.disabled = true;
+    err.classList.add("hidden");
+    // The value is submitted verbatim — trimming only gates empty input.
+    post("/v1/credential-requests/submit", { token: token, value: value }).then(function (r) {
+      if (r.res.ok) { document.getElementById("value").value = ""; show("done"); return; }
+      var outcome = outcomeFor(r.res, r.body);
+      if (outcome === "failed") { show("failed"); return; }
+      show(outcome);
+    }).catch(function () {
+      btn.disabled = false;
+      err.textContent = "Something went wrong while submitting. Check your connection and try again.";
+      err.classList.remove("hidden");
+    });
+  });
+})();
+</script>
+</body>
+</html>
+`;
+
+export function handleCredentialEntryPage(req: Request): Response {
+  if (req.method !== "GET") {
+    return new Response("method not allowed", {
+      status: 405,
+      headers: { Allow: "GET" },
+    });
+  }
+  return new Response(PAGE_HTML, {
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "no-store",
+      "Referrer-Policy": "no-referrer",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -85,6 +85,7 @@ import {
   handleRevokeDevice,
 } from "./http/routes/devices.js";
 import { handlePair } from "./http/routes/pair.js";
+import { handleCredentialEntryPage } from "./http/routes/credential-entry-page.js";
 import {
   handleCredentialRequestPeek,
   handleCredentialRequestSubmit,
@@ -923,6 +924,15 @@ async function main() {
     // ── Credential requests (one-time credential-collection links) ──
     // Unauthenticated by design: the single-use token in the request BODY is
     // the credential to act. Invalid tokens count as auth failures.
+    // The entry page is a static self-contained HTML shell (no token
+    // server-side — it rides the URL fragment); Velay-tunneled deployments
+    // have no SPA server behind the tunnel, so the gateway serves it.
+    {
+      path: "/assistant/credentials/enter",
+      method: "GET",
+      auth: "none",
+      handler: (req) => handleCredentialEntryPage(req),
+    },
     {
       path: "/v1/credential-requests/peek",
       method: "POST",

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -2473,6 +2473,18 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/assistant/credentials/enter": {
+        get: {
+          summary: "One-time credential entry page",
+          description:
+            "Self-contained static HTML page for redeeming a one-time credential link. The single-use token rides the URL fragment (never sent over HTTP); the page calls the credential-requests peek/submit routes with the token in POST bodies.",
+          operationId: "credentialEntryPage",
+          responses: {
+            "200": { description: "HTML entry page" },
+            "405": { description: "Method not allowed" },
+          },
+        },
+      },
       "/v1/credential-requests/peek": {
         post: {
           summary: "Validate a credential-request token without consuming it",

--- a/gateway/src/velay/allowed-paths.test.ts
+++ b/gateway/src/velay/allowed-paths.test.ts
@@ -33,7 +33,7 @@ describe("VELAY_ALLOWED_PATHS", () => {
     }
   });
 
-  it("matches the four gateway public-surface route shapes", () => {
+  it("matches the gateway public-surface route shapes", () => {
     // Allowlist coverage check — if you add a public route in
     // `gateway/src/index.ts` that needs to be reachable through the Velay
     // tunnel, add a matching regex to VELAY_ALLOWED_PATHS and a sample here.
@@ -50,7 +50,14 @@ describe("VELAY_ALLOWED_PATHS", () => {
       "/v1/audio/some-uuid.mp3": true,
       "/v1/live-voice": true,
       "/v1/stt/stream": true,
+      "/assistant/credentials/enter": true,
+      "/v1/credential-requests/peek": true,
+      "/v1/credential-requests/submit": true,
       // Negative samples — paths that must NOT be tunnel-public.
+      "/v1/credential-requests": false,
+      "/v1/credential-requests/other": false,
+      "/assistant/credentials": false,
+      "/assistant/settings/credentials": false,
       "/v1/contacts/abc": false,
       "/v1/health": false,
       "/v1/pair": false,

--- a/gateway/src/velay/allowed-paths.ts
+++ b/gateway/src/velay/allowed-paths.ts
@@ -22,6 +22,12 @@
  *   - `^/v1/live-voice` — exact match for the browser live-voice WebSocket
  *     (the Twilio media-stream WebSocket rides `^/webhooks/`).
  *   - `^/v1/stt/stream` — exact match for the public STT streaming WebSocket.
+ *   - `^/assistant/credentials/enter$` — the gateway-served one-time
+ *     credential entry page (self-contained HTML; the single-use token rides
+ *     the URL fragment, which never reaches Velay or the gateway logs).
+ *   - `^/v1/credential-requests/(peek|submit)$` — the entry page's
+ *     unauthenticated API calls; the single-use token travels in the POST
+ *     body and is validated by the gateway handlers.
  *
  * If you add a new public route to `gateway/src/index.ts` that must be
  * reachable through the Velay tunnel (i.e. anything an external provider
@@ -34,6 +40,8 @@ export const VELAY_ALLOWED_PATHS: readonly string[] = Object.freeze([
   "^/v1/audio/",
   "^/v1/live-voice$",
   "^/v1/stt/stream$",
+  "^/assistant/credentials/enter$",
+  "^/v1/credential-requests/(peek|submit)$",
 ]);
 
 /**
@@ -48,6 +56,5 @@ export const VELAY_ALLOWED_PATHS_HEADER = "X-Vellum-Velay-Allowed-Paths";
  * module load — the allowlist is static for the lifetime of the gateway
  * process.
  */
-export const VELAY_ALLOWED_PATHS_HEADER_VALUE = JSON.stringify(
-  VELAY_ALLOWED_PATHS,
-);
+export const VELAY_ALLOWED_PATHS_HEADER_VALUE =
+  JSON.stringify(VELAY_ALLOWED_PATHS);

--- a/gateway/src/velay/bridge-utils.ts
+++ b/gateway/src/velay/bridge-utils.ts
@@ -10,6 +10,14 @@ const VELAY_ALLOWED_HTTP_PATH_PREFIXES = [
   "/webhooks/twilio/",
   "/v1/audio/",
 ] as const;
+// Exact-match HTTP paths (no trailing segments). Keep in sync with the
+// registration allowlist in allowed-paths.ts — Velay enforces that list
+// platform-side, and this bridge check is the local second layer.
+const VELAY_ALLOWED_HTTP_EXACT_PATHS = [
+  "/assistant/credentials/enter",
+  "/v1/credential-requests/peek",
+  "/v1/credential-requests/submit",
+] as const;
 const VELAY_ALLOWED_WEBSOCKET_EXACT_PATHS = [
   "/v1/live-voice",
   "/v1/stt/stream",
@@ -26,8 +34,13 @@ const VELAY_ALLOWED_WEBSOCKET_EXACT_PATHS = [
 export const VELAY_FORWARDED_HEADER = "x-velay-forwarded" as const;
 
 export function isAllowedVelayHttpPath(path: string): boolean {
-  return VELAY_ALLOWED_HTTP_PATH_PREFIXES.some((prefix) =>
-    path.startsWith(prefix),
+  return (
+    VELAY_ALLOWED_HTTP_PATH_PREFIXES.some((prefix) =>
+      path.startsWith(prefix),
+    ) ||
+    VELAY_ALLOWED_HTTP_EXACT_PATHS.includes(
+      path as (typeof VELAY_ALLOWED_HTTP_EXACT_PATHS)[number],
+    )
   );
 }
 

--- a/gateway/src/velay/http-bridge.test.ts
+++ b/gateway/src/velay/http-bridge.test.ts
@@ -179,13 +179,49 @@ describe("Velay HTTP bridge", () => {
     fetchMock = mock(async () => new Response("audio-bytes", { status: 200 }));
 
     const response = await bridgeVelayHttpRequest(
-      makeFrame({ path: "/v1/audio/550e8400-e29b-41d4-a716-446655440000", method: "GET" }),
+      makeFrame({
+        path: "/v1/audio/550e8400-e29b-41d4-a716-446655440000",
+        method: "GET",
+      }),
       "http://127.0.0.1:7830",
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(response.status_code).toBe(200);
     expect(decodeBase64(response.body_base64)).toBe("audio-bytes");
+  });
+
+  test("forwards the credential entry page and its API paths to the loopback listener", async () => {
+    for (const path of [
+      "/assistant/credentials/enter",
+      "/v1/credential-requests/peek",
+      "/v1/credential-requests/submit",
+    ]) {
+      fetchMock = mock(async () => new Response("ok", { status: 200 }));
+      const response = await bridgeVelayHttpRequest(
+        makeFrame({ path, method: path.endsWith("enter") ? "GET" : "POST" }),
+        "http://127.0.0.1:7830",
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(response.status_code).toBe(200);
+    }
+  });
+
+  test("rejects near-miss credential paths without contacting the loopback listener", async () => {
+    for (const path of [
+      "/assistant/credentials/enterX",
+      "/v1/credential-requests",
+      "/v1/credential-requests/other",
+    ]) {
+      fetchMock = mock(async () => {
+        throw new Error("should not fetch");
+      });
+      const response = await bridgeVelayHttpRequest(
+        makeFrame({ path }),
+        "http://127.0.0.1:7830",
+      );
+      expect(response.status_code).toBe(502);
+    }
   });
 
   test("rejects unsafe absolute paths without contacting the loopback listener", async () => {


### PR DESCRIPTION
## Problem

One-time credential links minted on **Velay-tunneled deployments** (dev-assistant, managed self-hosted) were dead on arrival — clicking the link returned Velay's `{"detail":"not found"}`. Two independent gaps:

1. Velay enforces the path allowlist the gateway declares at tunnel registration (`VELAY_ALLOWED_PATHS`), which only covered webhook/voice paths — the entry page and `/v1/credential-requests/*` were rejected before reaching the gateway.
2. Even if allowlisted, nothing behind the tunnel serves the SPA: the React entry page is served by the **nginx front** on domain-based self-hosted setups; Velay itself serves nothing, and the gateway had no web surface.

This was the Codex finding on #37493 that was scoped out as a follow-up — live testing on dev-assistant showed Velay is the *default* managed ingress (the Slack flow minted a perfectly good link that nobody could open), so it's due now.

## Fix

- **Gateway-served static entry page** at `GET /assistant/credentials/enter` — the `oauth-callback.ts` self-contained-page pattern: inline CSS/JS, zero external assets, light/dark aware. It reads the single-use token from the URL fragment (never sent over HTTP), strips it from history, derives the Velay `/<assistantId>` path prefix from its own URL, and calls peek/submit with the token in POST bodies. The template interpolates nothing from the request; all dynamic content renders via `textContent`. Same states as the React page, including the terminal "link no longer valid" on store failure.
- **`VELAY_ALLOWED_PATHS`** gains `^/assistant/credentials/enter$` and `^/v1/credential-requests/(peek|submit)$` (RE2-safe; declared at registration, enforced platform-side — no platform change needed, a gateway restart re-registers with the new list).
- **nginx-fronted deployments unchanged** — nginx serves the React SPA for `/assistant/*` first, so this page is only ever reached through the tunnel.

## Testing

- `credential-entry-page.test.ts` — headers (no-store, no-referrer), fragment/token/prefix markers, no external assets, 405 on non-GET
- `allowed-paths.test.ts` — new positive samples + negatives (`/v1/credential-requests` bare, settings paths)
- `route-schema-guard` + `remote-web-ingress-denylist` guards pass; gateway tsc clean; eslint clean

## To verify on dev-assistant (after this deploys + gateway restart re-registers the tunnel)

Re-run the Slack flow from today's test: the minted `velay-dev.vellum.ai/<id>/assistant/credentials/enter#token=…` link should now render the entry form, and submitting should store the value (confirm via `assistant credentials inspect`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)