### PR TITLE
fix(memory): skill-card message hardening (review gaps)

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -1846,11 +1846,12 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     expect(sent[2].role).toBe("user");
   });
 
-  test("assistant message carrying only a skill_card ui_surface block is stripped without breaking role alternation", async () => {
-    // Contract-shaped block persisted by the memory retrospective's
-    // skill-card insertion (memory-retrospective-skill-card.ts): the message
-    // content is ONLY the ui_surface block, so the provider must drop the
-    // block and keep the assistant turn alive via a placeholder.
+  test("assistant skill_card message: ui_surface is stripped and the _surfaceFallback text reaches the wire", async () => {
+    // Contract-shaped block pair persisted by the memory retrospective's
+    // skill-card insertion (memory-retrospective-skill-card.ts): the
+    // ui_surface card plus a `_surfaceFallback` text sibling. The provider
+    // must drop the ui_surface block and send the fallback text as the
+    // assistant turn's real content — no placeholder needed.
     const skillCardBlock = {
       type: "ui_surface",
       surfaceId: "skill-card-run-conv-1",
@@ -1868,9 +1869,14 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
         ],
       },
     } as unknown as ContentBlock;
+    const fallbackBlock = {
+      type: "text",
+      text: "New skill learned: Example skill",
+      _surfaceFallback: true,
+    } as unknown as ContentBlock;
     const messages: Message[] = [
       userMsg("Start"),
-      { role: "assistant", content: [skillCardBlock] },
+      { role: "assistant", content: [skillCardBlock, fallbackBlock] },
       userMsg("Continue"),
     ];
     await provider.sendMessage(messages);
@@ -1881,15 +1887,17 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     }>;
 
     // No ui_surface block (or any of its payload) reaches the wire; the
-    // assistant turn survives as a placeholder so alternation holds.
+    // assistant turn carries the fallback text (stripped of the internal
+    // `_surfaceFallback` marker), so alternation holds without a placeholder.
     expect(sent).toHaveLength(3);
     expect(
       sent.flatMap((m) => m.content).every((b) => b.type !== "ui_surface"),
     ).toBe(true);
     expect(JSON.stringify(sent)).not.toContain("skill_card");
+    expect(JSON.stringify(sent)).not.toContain("_surfaceFallback");
     expect(sent[1].role).toBe("assistant");
     expect(sent[1].content).toEqual([
-      { type: "text", text: PLACEHOLDER_BLOCKS_OMITTED },
+      { type: "text", text: "New skill learned: Example skill" },
     ]);
     for (let i = 1; i < sent.length; i++) {
       expect(sent[i].role).not.toBe(sent[i - 1].role);

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-skill-card.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-skill-card.test.ts
@@ -20,6 +20,8 @@ let addMessageCalls: Array<{
   options: Record<string, unknown> | undefined;
 }> = [];
 let addMessageThrowsFor: string | null = null;
+let addMessageDeduplicatesFor: string | null = null;
+let processingConversationIds: string[] = [];
 
 let syncedToDisk: Array<{
   conversationId: string;
@@ -61,7 +63,8 @@ mock.module("../../../../persistence/conversation-crud.js", () => ({
       createdAt: 1111,
     };
   },
-  isConversationProcessing: (_id: string) => false,
+  isConversationProcessing: (id: string) =>
+    processingConversationIds.includes(id),
   forkConversationForRetrospective: async (_params: unknown) => ({
     id: "fork-conv-1",
   }),
@@ -81,7 +84,7 @@ mock.module("../../../../persistence/conversation-crud.js", () => ({
       role,
       content,
       createdAt: 42,
-      deduplicated: false,
+      deduplicated: addMessageDeduplicatesFor === conversationId,
     };
   },
   deleteConversation: (_id: string) => {},
@@ -287,6 +290,8 @@ describe("memory-retrospective skill card", () => {
     ];
     addMessageCalls = [];
     addMessageThrowsFor = null;
+    addMessageDeduplicatesFor = null;
+    processingConversationIds = [];
     syncedToDisk = [];
     publishedConversationIds = [];
     conversationOverrides = {};
@@ -300,6 +305,10 @@ describe("memory-retrospective skill card", () => {
   // -------------------------------------------------------------------------
 
   test("extractor returns only successful, non-overwrite scaffolds", () => {
+    conversationOverrides["retro-1"] = {
+      source: "memory-retrospective",
+      forkParentMessageId: null,
+    };
     messagesByConversationId["retro-1"] = [
       // Successful create — included.
       scaffoldMsg("tu-1", skillInput("skill-a", { emoji: "🧭" }), {
@@ -333,10 +342,7 @@ describe("memory-retrospective skill card", () => {
       toolResultMsg("tu-5", { createdAt: 2008 }),
     ];
 
-    const skills = extractRetrospectiveRunSkillScaffolds(
-      "retro-1",
-      "memory-retrospective",
-    );
+    const skills = extractRetrospectiveRunSkillScaffolds("retro-1");
 
     expect(skills).toEqual([
       {
@@ -348,7 +354,9 @@ describe("memory-retrospective skill card", () => {
     ]);
   });
 
-  test("extractor scopes fork-kind runs to the post-fork tail", () => {
+  test("extractor resolves the run's source itself and scopes fork-kind runs to the post-fork tail", () => {
+    // The fork-kind source comes from the conversation row (getConversation),
+    // not a caller-supplied parameter — tail scoping proves it was read.
     conversationOverrides["retro-fork-1"] = {
       source: "memory-retrospective-fork",
       forkParentMessageId: null,
@@ -369,24 +377,22 @@ describe("memory-retrospective skill card", () => {
       toolResultMsg("tu-tail", { createdAt: 2100 }),
     ];
 
-    const skills = extractRetrospectiveRunSkillScaffolds(
-      "retro-fork-1",
-      "memory-retrospective-fork",
-    );
+    const skills = extractRetrospectiveRunSkillScaffolds("retro-fork-1");
 
     expect(skills.map((s) => s.skillId)).toEqual(["tail-skill"]);
   });
 
   test("extractor degrades to empty for a fork-kind run with no detectable boundary", () => {
+    conversationOverrides["retro-fork-2"] = {
+      source: "memory-retrospective-fork",
+      forkParentMessageId: null,
+    };
     messagesByConversationId["retro-fork-2"] = [
       scaffoldMsg("tu-1", skillInput("skill-a"), { createdAt: 1000 }),
       toolResultMsg("tu-1", { createdAt: 1100 }),
     ];
 
-    const skills = extractRetrospectiveRunSkillScaffolds(
-      "retro-fork-2",
-      "memory-retrospective-fork",
-    );
+    const skills = extractRetrospectiveRunSkillScaffolds("retro-fork-2");
 
     expect(skills).toEqual([]);
   });
@@ -434,6 +440,13 @@ describe("memory-retrospective skill card", () => {
           ],
         },
       },
+      // Plain-text fallback: fed to the model and flat-text consumers;
+      // surface-capable clients skip it via the `_surfaceFallback` flag.
+      {
+        type: "text",
+        text: "New skill learned: Skill A, Skill B",
+        _surfaceFallback: true,
+      },
     ]);
     expect(call.options).toEqual({
       metadata: { kind: "skill-authored-card", automated: true },
@@ -460,6 +473,32 @@ describe("memory-retrospective skill card", () => {
     ]);
 
     expect(addMessageCalls).toHaveLength(0);
+    expect(syncedToDisk).toHaveLength(0);
+    expect(publishedConversationIds).toHaveLength(0);
+  });
+
+  test("insert is a no-op when the source conversation is mid-turn", async () => {
+    processingConversationIds = ["src-conv-9"];
+
+    await insertSkillCardMessage("src-conv-9", "run-conv-1", [
+      { skillId: "skill-a", name: "Skill A", description: "Does A" },
+    ]);
+
+    expect(addMessageCalls).toHaveLength(0);
+    expect(syncedToDisk).toHaveLength(0);
+    expect(publishedConversationIds).toHaveLength(0);
+  });
+
+  test("deduplicated insert (retried finalize) skips disk sync and publish", async () => {
+    addMessageDeduplicatesFor = "src-conv-9";
+
+    await insertSkillCardMessage("src-conv-9", "run-conv-1", [
+      { skillId: "skill-a", name: "Skill A", description: "Does A" },
+    ]);
+
+    // The idempotent addMessage call still happens (it detects the dup)...
+    expect(addMessageCalls).toHaveLength(1);
+    // ...but the disk-view append and client broadcast do not repeat.
     expect(syncedToDisk).toHaveLength(0);
     expect(publishedConversationIds).toHaveLength(0);
   });
@@ -495,15 +534,24 @@ describe("memory-retrospective skill card", () => {
     const cards = cardMessagesFor("src-conv-1");
     expect(cards).toHaveLength(1);
     const blocks = JSON.parse(cards[0]!.content) as Array<{
-      surfaceId: string;
-      data: { skills: Array<{ skillId: string }> };
+      type: string;
+      surfaceId?: string;
+      data?: { skills: Array<{ skillId: string }> };
+      text?: string;
+      _surfaceFallback?: boolean;
     }>;
-    expect(blocks).toHaveLength(1);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]!.type).toBe("ui_surface");
     expect(blocks[0]!.surfaceId).toBe("skill-card-fork-conv-1");
-    expect(blocks[0]!.data.skills.map((s) => s.skillId)).toEqual([
+    expect(blocks[0]!.data!.skills.map((s) => s.skillId)).toEqual([
       "skill-a",
       "skill-b",
     ]);
+    expect(blocks[1]).toEqual({
+      type: "text",
+      text: "New skill learned: Skill skill-a, Skill skill-b",
+      _surfaceFallback: true,
+    });
     expect(publishedConversationIds).toEqual(["src-conv-1"]);
   });
 

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -644,7 +644,6 @@ async function finalizeSuccessfulRetrospective(args: {
   ) {
     const authoredSkills = extractRetrospectiveRunSkillScaffolds(
       retrospectiveConversationId,
-      getConversation(retrospectiveConversationId)?.source ?? null,
     );
     if (authoredSkills.length > 0) {
       await insertSkillCardMessage(

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-skill-card.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-skill-card.ts
@@ -5,10 +5,11 @@
 // When a retrospective run authors NEW managed skills (successful
 // `scaffold_managed_skill` calls without `overwrite: true`), the finalize
 // path surfaces them to the user as a single `skill_card` ui_surface message
-// appended to the SOURCE conversation. The block is rendered by the web
-// client's surface router; the Anthropic provider strips `ui_surface` blocks
-// during request assembly, so the card never reaches the model as renderable
-// content.
+// appended to the SOURCE conversation. The ui_surface block is rendered by
+// the web client's surface router and is paired with a `_surfaceFallback`
+// text block (the approval-card pattern) so providers that drop `ui_surface`
+// blocks still send a non-empty assistant turn and flat-text consumers (CLI,
+// search, channel replies) see readable content.
 //
 // Everything here is best-effort: a card failure must never fail the
 // retrospective job.
@@ -16,6 +17,7 @@
 import {
   addMessage,
   getConversation,
+  isConversationProcessing,
 } from "../../../persistence/conversation-crud.js";
 import { syncMessageToDisk } from "../../../persistence/conversation-disk-view.js";
 import { publishConversationMessagesChanged } from "../../../runtime/sync/resource-sync-events.js";
@@ -42,7 +44,8 @@ export interface AuthoredSkill {
 
 /**
  * Pull the newly created skills out of a retrospective run's own work.
- * Mirrors `extractRetrospectiveRunRemembers`: `loadRetrospectiveRunMessages`
+ * Mirrors `extractRetrospectiveRunRemembers`: the run conversation's
+ * `source` kind is resolved internally, and `loadRetrospectiveRunMessages`
  * scopes fork-kind rows to the post-fork tail (the copied prefix contains
  * the source conversation's own inline tool calls) and returns `null` on
  * load failure or an undetectable fork boundary — treated here as "the run
@@ -56,11 +59,10 @@ export interface AuthoredSkill {
  */
 export function extractRetrospectiveRunSkillScaffolds(
   retrospectiveConversationId: string,
-  source: string | null | undefined,
 ): AuthoredSkill[] {
   const runMessages = loadRetrospectiveRunMessages(
     retrospectiveConversationId,
-    source,
+    getConversation(retrospectiveConversationId)?.source ?? null,
   );
   if (runMessages == null) {
     return [];
@@ -169,12 +171,15 @@ function readScaffoldInput(input: unknown): AuthoredSkill | null {
 }
 
 /**
- * Append the `skill_card` ui_surface message to the source conversation and
- * notify connected clients. The `surfaceId` (doubling as the insert's
- * idempotency nonce via `clientMessageId`) is derived from the run
- * conversation id, so a retried finalize cannot produce two cards for one
- * run. Skips when the source conversation no longer exists (deleted
- * mid-run). Best-effort — failures are logged and never thrown.
+ * Append the `skill_card` ui_surface message (plus its `_surfaceFallback`
+ * text sibling) to the source conversation and notify connected clients. The
+ * `surfaceId` (doubling as the insert's idempotency nonce via
+ * `clientMessageId`) is derived from the run conversation id, so a retried
+ * finalize cannot produce two cards for one run — a deduplicated insert also
+ * skips the disk-view sync and client broadcast. Skips when the source
+ * conversation no longer exists (deleted mid-run) or is mid-turn (inserting
+ * would splice the card into an in-flight display turn; the admission check
+ * ran minutes earlier). Best-effort — failures are logged and never thrown.
  */
 export async function insertSkillCardMessage(
   sourceConversationId: string,
@@ -190,8 +195,15 @@ export async function insertSkillCardMessage(
       );
       return;
     }
+    if (isConversationProcessing(sourceConversationId)) {
+      log.debug(
+        { sourceConversationId, runConversationId },
+        "skill card: source conversation is mid-turn; skipping",
+      );
+      return;
+    }
     const surfaceId = `skill-card-${runConversationId}`;
-    const block = {
+    const surfaceBlock = {
       type: "ui_surface",
       surfaceId,
       surfaceType: "skill_card",
@@ -206,16 +218,32 @@ export async function insertSkillCardMessage(
         })),
       },
     };
+    // Plain-text fallback (approval-card pattern): feeds the model, search,
+    // CLI display, and channel replies. Surface-capable clients skip it —
+    // `renderHistoryContent` keeps `_surfaceFallback` text out of the
+    // rendered content blocks so the card is never double-rendered.
+    const fallbackBlock = {
+      type: "text",
+      text: `New skill learned: ${skills.map((s) => s.name).join(", ")}`,
+      _surfaceFallback: true,
+    };
     const persisted = await addMessage(
       sourceConversationId,
       "assistant",
-      JSON.stringify([block]),
+      JSON.stringify([surfaceBlock, fallbackBlock]),
       {
         metadata: { kind: SKILL_CARD_MESSAGE_KIND, automated: true },
         skipIndexing: true,
         clientMessageId: surfaceId,
       },
     );
+    if (persisted.deduplicated) {
+      log.debug(
+        { sourceConversationId, runConversationId },
+        "skill card: message already exists (deduplicated); skipping sync and publish",
+      );
+      return;
+    }
     // Mirror `persistWakeTriggerMessage`: keep the conversation's disk view
     // in sync (its own failure is non-fatal so the client broadcast below
     // still fires), then tell connected clients the message list changed.


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for skill-surfacing-v1.md:
- _surfaceFallback text block alongside the ui_surface card (strict OpenAI-compatible providers + flat-text consumers)
- dedup-aware disk-sync/publish on retried finalize
- isConversationProcessing re-check before insert
- extractor resolves conversation source internally (drops duplicate DB read)

🤖 Generated with [Claude Code](https://claude.com/claude-code)