### PR TITLE
fix(web): skill card + panel interaction gaps (review gaps)

### DIFF
--- a/clients/web/src/domains/chat/components/chat-content-layout.tsx
+++ b/clients/web/src/domains/chat/components/chat-content-layout.tsx
@@ -222,6 +222,20 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
     navigate(`${routes.channels}?setup=${channel}`);
   }, [isMobile, mainView, activeChannelSetup, navigate]);
 
+  // Same hand-off for the skill detail panel: narrowing the viewport with the
+  // panel open (resize/rotation) would otherwise strand the viewer store in
+  // "skill-detail" with nothing rendered — the right panel is desktop-only,
+  // MobileChatOverlays has no skill-detail entry, and mobile Escape is
+  // disabled. Redirect to the dedicated skill detail page instead (the same
+  // destination the in-chat card uses on mobile). Unlike channel setup, no
+  // hand-off notification is needed — the detail page is self-contained.
+  useEffect(() => {
+    if (!isMobile) return;
+    if (mainView !== "skill-detail" || !activeSkillDetailId) return;
+    useViewerStore.getState().closeSkillDetail();
+    navigate(routes.skills.detail(activeSkillDetailId));
+  }, [isMobile, mainView, activeSkillDetailId, navigate]);
+
   // -------------------------------------------------------------------------
   // Escape closes whichever right-hand side panel is open (tool detail /
   // thought process, subagent detail, workflow detail, acp run detail,

--- a/clients/web/src/domains/chat/components/surfaces/skill-created-card.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/skill-created-card.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { MemoryRouter, useLocation } from "react-router";
 
@@ -14,13 +14,21 @@ mock.module("@/hooks/use-is-mobile", () => ({
 import { SkillCreatedCard } from "@/domains/chat/components/surfaces/skill-created-card";
 import { SurfaceRouter } from "@/domains/chat/components/surfaces/surface-router";
 import type { Surface } from "@/domains/chat/types/types";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useViewerStore } from "@/stores/viewer-store";
+
+// `skill-creation-card` defaults off; every rendering test below exercises
+// the flag-on path. The dedicated kill-switch test flips it back off.
+beforeEach(() => {
+  useClientFeatureFlagStore.setState({ skillCreationCard: true });
+});
 
 afterEach(() => {
   cleanup();
   isMobileRef.value = false;
   // Clicks mutate the real viewer store; restore it for the next test.
   useViewerStore.getState().reset();
+  useClientFeatureFlagStore.setState({ skillCreationCard: false });
 });
 
 function makeSurface(overrides: Partial<Surface> = {}): Surface {
@@ -142,6 +150,35 @@ describe("SkillCreatedCard", () => {
     // The panel path is not taken on mobile.
     expect(useViewerStore.getState().mainView).toBe("chat");
     expect(useViewerStore.getState().activeSkillDetailId).toBeNull();
+  });
+
+  test("clicking the row body (skill name) opens the skill detail — the whole row is the control, not just the View chip", () => {
+    const { getByText } = renderCard(
+      makeSurface({
+        data: {
+          skills: [
+            { skillId: "skill-1", name: "Skill one" },
+            { skillId: "skill-2", name: "Skill two" },
+          ],
+        },
+      }),
+    );
+
+    fireEvent.click(getByText("Skill two"));
+
+    expect(useViewerStore.getState().mainView).toBe("skill-detail");
+    expect(useViewerStore.getState().activeSkillDetailId).toBe("skill-2");
+  });
+
+  test("skill-creation-card flag gates rendering (kill-switch for already-persisted cards)", () => {
+    useClientFeatureFlagStore.setState({ skillCreationCard: false });
+    const flagOff = renderCard(makeSurface());
+    expect(flagOff.queryByText("New skill learned")).toBeNull();
+    flagOff.unmount();
+
+    useClientFeatureFlagStore.setState({ skillCreationCard: true });
+    const flagOn = renderCard(makeSurface());
+    expect(flagOn.getByText("New skill learned")).toBeTruthy();
   });
 
   test("falls back to the Brain icon when a skill has no emoji", () => {

--- a/clients/web/src/domains/chat/components/surfaces/skill-created-card.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/skill-created-card.tsx
@@ -1,7 +1,6 @@
 import { Brain } from "lucide-react";
 import { useNavigate } from "react-router";
 
-import { Button } from "@vellumai/design-library";
 import type { Surface } from "@/domains/chat/types/types";
 
 import { SurfaceContainer } from "@/domains/chat/components/surfaces/surface-container";
@@ -10,6 +9,7 @@ import {
   str,
 } from "@/domains/chat/components/surfaces/surface-parse-helpers";
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useViewerStore } from "@/stores/viewer-store";
 import { routes } from "@/utils/routes";
 
@@ -68,6 +68,11 @@ function parseSkills(skills: unknown): SkillCardEntry[] {
 export function SkillCreatedCard({ surface, onAction }: SkillCreatedCardProps) {
   const navigate = useNavigate();
   const isMobile = useIsMobile();
+  // Client-side half of the `skill-creation-card` flag (scope "both"): the
+  // assistant side gates card *insertion*, this gates *rendering*, so
+  // flipping the flag off also hides cards already persisted in transcripts
+  // (a true kill-switch).
+  const skillCardEnabled = useClientFeatureFlagStore.use.skillCreationCard();
   const skills = parseSkills(surface.data.skills);
 
   // Desktop: open the skill detail sidepanel in place, keeping the
@@ -82,7 +87,7 @@ export function SkillCreatedCard({ surface, onAction }: SkillCreatedCardProps) {
     useViewerStore.getState().openSkillDetail(skillId);
   };
 
-  if (skills.length === 0) {
+  if (!skillCardEnabled || skills.length === 0) {
     return null;
   }
 
@@ -96,10 +101,18 @@ export function SkillCreatedCard({ surface, onAction }: SkillCreatedCardProps) {
       </p>
 
       <div className="mt-3 divide-y divide-[var(--border-base)]">
+        {/* The whole row is one native button (name, description, and the
+            "View" chip all open the skill) — matching the clickable-row
+            pattern in home-schedule-row.tsx. The chip is purely visual, so
+            no nested interactive elements and no stopPropagation dance;
+            `aria-label` keeps the accessible name unique per skill. */}
         {skills.map((skill) => (
-          <div
+          <button
             key={skill.skillId}
-            className="flex items-center gap-3 py-2.5 first:pt-0 last:pb-0"
+            type="button"
+            aria-label={`View ${skill.name}`}
+            onClick={() => handleView(skill.skillId)}
+            className="flex w-full cursor-pointer items-center gap-3 rounded-md py-2.5 text-left transition-colors first:pt-0 last:pb-0 hover:bg-[var(--surface-hover)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
           >
             <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-[var(--tag-bg-neutral)] text-body-large-default">
               {skill.emoji ?? (
@@ -116,15 +129,13 @@ export function SkillCreatedCard({ surface, onAction }: SkillCreatedCardProps) {
                 </p>
               )}
             </div>
-            <Button
-              variant="outlined"
-              size="compact"
-              aria-label={`View ${skill.name}`}
-              onClick={() => handleView(skill.skillId)}
+            <span
+              aria-hidden="true"
+              className="flex h-6 shrink-0 items-center rounded-md border border-[var(--border-element)] px-2 text-label-medium-default text-[var(--primary-base)]"
             >
               View
-            </Button>
-          </div>
+            </span>
+          </button>
         ))}
       </div>
     </SurfaceContainer>


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for skill-surfacing-v1.md:
- card rows are now clickable with proper button semantics (same handler as View)
- skill_card rendering gated on the client-side skill-creation-card flag (true kill-switch)
- narrowing the viewport with the skill panel open now hands off to the detail route instead of stranding the view