### PR TITLE
fix(web): skills list state preservation + stale-list not-found guard (review gaps)

### DIFF
--- a/clients/web/src/domains/intelligence/components/skills/skills-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skills-tab.tsx
@@ -12,8 +12,8 @@ import {
     X,
     Zap,
 } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
-import { useNavigate } from "react-router";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useLocation, useNavigate, useSearchParams } from "react-router";
 
 import { CategorySidebar } from "@/domains/intelligence/components/skills/category-sidebar";
 import { FilterBar } from "@/domains/intelligence/components/skills/skill-filters";
@@ -22,6 +22,11 @@ import { SkillRow } from "@/domains/intelligence/components/skills/skill-row";
 import { SkillsErrorState } from "@/domains/intelligence/components/skills/skills-error-state";
 import { SkillsLoadingState } from "@/domains/intelligence/components/skills/skills-loading-state";
 import { SkillsStateCard } from "@/domains/intelligence/components/skills/skills-state-card";
+import {
+  type SkillsSearchParamsUpdate,
+  buildSkillsSearchParams,
+  readSkillsUrlState,
+} from "@/domains/intelligence/skills/skills-url-state";
 import {
     type SkillFilter,
     type SkillInfo,
@@ -44,11 +49,46 @@ const TIP_STORAGE_KEY = "vellum:skills:tipDismissed";
 
 export function SkillsTab({ assistantId }: SkillsTabProps) {
   const navigate = useNavigate();
+  const location = useLocation();
 
-  const [searchValue, setSearchValue] = useState("");
+  // Search/filter/category live in the URL (`?q=&filter=&category=`) so the
+  // filtered view survives navigating to a skill detail page and back.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { q, filter, category } = useMemo(
+    () => readSkillsUrlState(searchParams),
+    [searchParams],
+  );
+
+  const updateUrlState = useCallback(
+    (update: SkillsSearchParamsUpdate) => {
+      // Replace rather than push so filter tweaks and typing don't pile up
+      // history entries (same pattern as the usage tab's URL state).
+      setSearchParams((prev) => buildSkillsSearchParams(prev, update), {
+        replace: true,
+      });
+    },
+    [setSearchParams],
+  );
+
+  // The search input stays in local state for responsive typing; the settled
+  // (debounced) value is reflected into `?q=` below and drives the query.
+  const [searchValue, setSearchValue] = useState(q);
   const debouncedSearch = useDebouncedValue(searchValue.trim(), SEARCH_DEBOUNCE_MS);
-  const [filter, setFilter] = useState<SkillFilter>("all");
-  const [category, setCategory] = useState<string | null>(null);
+  useEffect(() => {
+    if (debouncedSearch !== q) {
+      updateUrlState({ q: debouncedSearch });
+    }
+  }, [debouncedSearch, q, updateUrlState]);
+
+  const handleFilterChange = useCallback(
+    (next: SkillFilter) => updateUrlState({ filter: next }),
+    [updateUrlState],
+  );
+  const handleCategoryChange = useCallback(
+    (next: string | null) => updateUrlState({ category: next }),
+    [updateUrlState],
+  );
+
   const [tipDismissed, setTipDismissed] = useState(() =>
     getLocalBool(TIP_STORAGE_KEY, false),
   );
@@ -133,11 +173,11 @@ export function SkillsTab({ assistantId }: SkillsTabProps) {
         search={searchValue}
         onSearchChange={setSearchValue}
         filter={filter}
-        onFilterChange={setFilter}
+        onFilterChange={handleFilterChange}
         isSearching={isSearching}
         categories={categories}
         category={category}
-        onCategoryChange={setCategory}
+        onCategoryChange={handleCategoryChange}
         counts={counts}
         totalCount={totalCount}
         showCounts={!isSearching}
@@ -147,7 +187,7 @@ export function SkillsTab({ assistantId }: SkillsTabProps) {
         <aside className="hidden w-56 shrink-0 overflow-y-auto sm:block">
           <CategorySidebar
             selected={category}
-            onSelect={setCategory}
+            onSelect={handleCategoryChange}
             counts={counts}
             totalCount={totalCount}
             showCounts={!isSearching}
@@ -168,7 +208,13 @@ export function SkillsTab({ assistantId }: SkillsTabProps) {
                 <li key={skill.id}>
                   <SkillRow
                     skill={skill}
-                    onSelect={() => navigate(routes.skills.detail(skill.id))}
+                    onSelect={() =>
+                      // Pass the current query string so the detail page's
+                      // back button can restore this filtered view.
+                      navigate(routes.skills.detail(skill.id), {
+                        state: { listSearch: location.search },
+                      })
+                    }
                     onInstall={() => handleInstall(skill)}
                     onRemove={() => handleRemove(skill)}
                     isInstalling={isInstallingSkill(skill)}

--- a/clients/web/src/domains/intelligence/skill-detail-page.test.tsx
+++ b/clients/web/src/domains/intelligence/skill-detail-page.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * Tests for the skill detail route (`/assistant/skills/:skillId`) — the
+ * page-level branching, not the detail rendering:
+ *
+ * - the not-found guard waits for an in-flight list refetch before declaring
+ *   a skill missing (a fresh skill can be absent from a stale cached list),
+ * - the back button restores the Skills list's query string passed as
+ *   router state (search/filter/category survive detail navigation).
+ *
+ * The generated SDK's `skillsGet` is mocked with a per-test deferred so a
+ * case can hold the list refetch pending; the heavy `SkillDetail` /
+ * `SkillDetailMobile` views are stubbed with light stand-ins exposing the
+ * `onBack` wiring. Mounted via `@testing-library/react` (happy-dom — see
+ * `clients/web/test-setup.ts`).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+
+import type { SkillInfo } from "@/domains/intelligence/skills/types";
+import type { SkillsGetResponse } from "@/generated/daemon/types.gen";
+
+const ASSISTANT_ID = "asst-1";
+const okResponse = { response: new Response(), error: undefined };
+
+// Per-test holder: each `skillsGet` call resolves with the current payload,
+// gated on `listGate` when set (lets a case hold a refetch in flight).
+let listSkills: SkillInfo[];
+let listGate: Promise<unknown> | null = null;
+
+mock.module("@/assistant/use-active-assistant-id", () => ({
+  useActiveAssistantId: () => ASSISTANT_ID,
+}));
+
+const sdkActual = await import("@/generated/daemon/sdk.gen");
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...sdkActual,
+  skillsGet: mock(async () => {
+    if (listGate) {
+      await listGate;
+    }
+    return {
+      data: { skills: listSkills } as SkillsGetResponse,
+      ...okResponse,
+    };
+  }),
+}));
+
+// Stub the heavy detail views — this suite targets the page's branching, not
+// the file browser. The stand-ins expose the `onBack` wiring under test.
+mock.module("@/domains/intelligence/components/skills/skill-detail", () => ({
+  SkillDetail: ({
+    skill,
+    onBack,
+  }: {
+    skill: SkillInfo;
+    onBack: () => void;
+  }) => (
+    <div>
+      <span>Detail: {skill.name}</span>
+      <button type="button" onClick={onBack}>
+        Back to skills
+      </button>
+    </div>
+  ),
+}));
+mock.module(
+  "@/domains/intelligence/components/skills/skill-detail-mobile",
+  () => ({
+    SkillDetailMobile: () => <div>Mobile detail</div>,
+  }),
+);
+
+const { SkillDetailPage } = await import(
+  "@/domains/intelligence/skill-detail-page"
+);
+const { skillsGetOptions } = await import(
+  "@/generated/daemon/@tanstack/react-query.gen"
+);
+
+function makeSkill(overrides: Partial<SkillInfo> = {}): SkillInfo {
+  return {
+    id: "skill-1",
+    name: "Fresh Skill",
+    description: "A skill used in detail page tests",
+    kind: "installed",
+    status: "enabled",
+    origin: "custom",
+    category: "general",
+    ...overrides,
+  };
+}
+
+/** The exact list query key the page (and the Skills tab) resolves from. */
+function listQueryKey() {
+  return skillsGetOptions({
+    path: { assistant_id: ASSISTANT_ID },
+    query: { include: "catalog" },
+  }).queryKey;
+}
+
+// Sentinel at the list route so tests can prove which query string the back
+// navigation landed on.
+function SkillsListLanding() {
+  const location = useLocation();
+  return <div>Skills list at: [{location.search}]</div>;
+}
+
+function renderDetail({
+  skillId,
+  listSearch,
+  client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  }),
+}: {
+  skillId: string;
+  listSearch?: string;
+  client?: QueryClient;
+}): void {
+  const entry = {
+    pathname: `/assistant/skills/${skillId}`,
+    state: listSearch === undefined ? null : { listSearch },
+  };
+  render(
+    <MemoryRouter initialEntries={[entry]}>
+      <QueryClientProvider client={client}>
+        <Routes>
+          <Route
+            path="/assistant/skills/:skillId"
+            element={<SkillDetailPage />}
+          />
+          <Route path="/assistant/skills" element={<SkillsListLanding />} />
+        </Routes>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  listSkills = [makeSkill()];
+  listGate = null;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SkillDetailPage stale-list guard", () => {
+  test("shows loading (not 'Skill not found') while a stale cached list refetches", async () => {
+    // Seed a stale cached list that predates the requested skill; hold the
+    // mount-triggered background refetch in flight.
+    let releaseGate!: (value?: unknown) => void;
+    listGate = new Promise((resolve) => {
+      releaseGate = resolve;
+    });
+    listSkills = [makeSkill()];
+
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    client.setQueryData(listQueryKey(), {
+      skills: [makeSkill({ id: "older-skill", name: "Older Skill" })],
+    } as SkillsGetResponse);
+
+    renderDetail({ skillId: "skill-1", client });
+
+    // Stale data without the skill + refetch in flight: loading, no verdict.
+    expect(screen.queryByText("Skill not found")).toBeNull();
+    expect(document.querySelector(".animate-spin")).not.toBeNull();
+
+    releaseGate();
+
+    // The refetch lands with the fresh skill and the detail renders.
+    await waitFor(() => {
+      expect(screen.getByText("Detail: Fresh Skill")).toBeTruthy();
+    });
+    expect(screen.queryByText("Skill not found")).toBeNull();
+  });
+
+  test("declares not-found once the list has settled without the skill", async () => {
+    listSkills = [];
+
+    renderDetail({ skillId: "missing-skill" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Skill not found")).toBeTruthy();
+    });
+  });
+});
+
+describe("SkillDetailPage back navigation", () => {
+  test("back restores the list query string passed as router state", async () => {
+    renderDetail({
+      skillId: "skill-1",
+      listSearch: "?filter=installed&category=email",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Detail: Fresh Skill")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText("Back to skills"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Skills list at: [?filter=installed&category=email]"),
+      ).toBeTruthy();
+    });
+  });
+
+  test("back falls back to the plain list without router state", async () => {
+    renderDetail({ skillId: "skill-1" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Detail: Fresh Skill")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText("Back to skills"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Skills list at: []")).toBeTruthy();
+    });
+  });
+});

--- a/clients/web/src/domains/intelligence/skill-detail-page.tsx
+++ b/clients/web/src/domains/intelligence/skill-detail-page.tsx
@@ -33,9 +33,17 @@ export function SkillDetailPage() {
   const assistantId = useActiveAssistantId();
   const { skillId } = useParams<{ skillId: string }>();
   const navigate = useNavigate();
-  const { pathname } = useLocation();
+  const location = useLocation();
+  const { pathname } = location;
   const isMobile = useIsMobile();
   const swipeContainerRef = useRef<HTMLDivElement>(null);
+
+  // The Skills list passes its current query string (search/filter/category)
+  // as router state so the back button restores the same filtered view.
+  // Direct deep-links carry no state and fall back to the plain list.
+  const routerState = location.state as { listSearch?: unknown } | null;
+  const listSearch =
+    typeof routerState?.listSearch === "string" ? routerState.listSearch : "";
 
   const skillsQuery = useQuery({
     ...skillsGetOptions({
@@ -49,8 +57,8 @@ export function SkillDetailPage() {
     // Replace (rather than push) so browser Back doesn't bounce the user
     // back to the detail entry — which may be a not-found page after the
     // skill was removed via `onRemoved`.
-    navigate(routes.skills.root, { replace: true });
-  }, [navigate]);
+    navigate(`${routes.skills.root}${listSearch}`, { replace: true });
+  }, [navigate, listSearch]);
 
   // Register as the mobile back-swipe owner so a left-edge swipe navigates
   // back to the skills list instead of opening the nav drawer (`ChatLayout`
@@ -107,6 +115,13 @@ export function SkillDetailPage() {
 
   if (skillsQuery.isError) {
     return <SkillsErrorState />;
+  }
+
+  // A skill can be missing from a stale cached list while a refetch is in
+  // flight — e.g. a freshly-authored skill opened from the in-chat card or a
+  // cross-device link. Wait for the refetch before declaring it not found.
+  if (!skill && skillsQuery.isFetching) {
+    return <SkillsLoadingState />;
   }
 
   if (!skill) {

--- a/clients/web/src/domains/intelligence/skills/skills-url-state.test.ts
+++ b/clients/web/src/domains/intelligence/skills/skills-url-state.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildSkillsSearchParams,
+  readSkillsUrlState,
+} from "@/domains/intelligence/skills/skills-url-state";
+
+describe("readSkillsUrlState", () => {
+  test("empty params resolve to the defaults", () => {
+    expect(readSkillsUrlState(new URLSearchParams())).toEqual({
+      q: "",
+      filter: "all",
+      category: null,
+    });
+  });
+
+  test("reads q, filter, and category from the params", () => {
+    const params = new URLSearchParams(
+      "?q=git&filter=installed&category=email",
+    );
+    expect(readSkillsUrlState(params)).toEqual({
+      q: "git",
+      filter: "installed",
+      category: "email",
+    });
+  });
+
+  test("an unknown filter value falls back to 'all'", () => {
+    const params = new URLSearchParams("?filter=bogus");
+    expect(readSkillsUrlState(params).filter).toBe("all");
+  });
+
+  test("an empty category param reads as null", () => {
+    const params = new URLSearchParams("?category=");
+    expect(readSkillsUrlState(params).category).toBeNull();
+  });
+});
+
+describe("buildSkillsSearchParams", () => {
+  test("omits defaults so the plain URL stays clean", () => {
+    const next = buildSkillsSearchParams(new URLSearchParams(), {
+      q: "",
+      filter: "all",
+      category: null,
+    });
+    expect(next.toString()).toBe("");
+  });
+
+  test("sets non-default values", () => {
+    const next = buildSkillsSearchParams(new URLSearchParams(), {
+      q: "git",
+      filter: "clawhub",
+      category: "email",
+    });
+    expect(next.get("q")).toBe("git");
+    expect(next.get("filter")).toBe("clawhub");
+    expect(next.get("category")).toBe("email");
+  });
+
+  test("resetting a value back to its default removes the param", () => {
+    const params = new URLSearchParams("?q=git&filter=installed&category=email");
+    const next = buildSkillsSearchParams(params, {
+      q: "",
+      filter: "all",
+      category: null,
+    });
+    expect(next.toString()).toBe("");
+  });
+
+  test("leaves keys absent from the update untouched", () => {
+    const params = new URLSearchParams("?q=git&filter=installed");
+    const next = buildSkillsSearchParams(params, { category: "email" });
+    expect(next.get("q")).toBe("git");
+    expect(next.get("filter")).toBe("installed");
+    expect(next.get("category")).toBe("email");
+  });
+
+  test("preserves unrelated params", () => {
+    const params = new URLSearchParams("?other=1");
+    const next = buildSkillsSearchParams(params, { q: "git" });
+    expect(next.get("other")).toBe("1");
+    expect(next.get("q")).toBe("git");
+  });
+
+  test("whitespace-only search is treated as empty", () => {
+    const params = new URLSearchParams("?q=git");
+    const next = buildSkillsSearchParams(params, { q: "   " });
+    expect(next.has("q")).toBe(false);
+  });
+
+  test("round-trips through readSkillsUrlState", () => {
+    const next = buildSkillsSearchParams(new URLSearchParams(), {
+      q: "memory",
+      filter: "assistant-memory",
+      category: "productivity",
+    });
+    expect(readSkillsUrlState(next)).toEqual({
+      q: "memory",
+      filter: "assistant-memory",
+      category: "productivity",
+    });
+  });
+});

--- a/clients/web/src/domains/intelligence/skills/skills-url-state.ts
+++ b/clients/web/src/domains/intelligence/skills/skills-url-state.ts
@@ -1,0 +1,95 @@
+import { type SkillFilter } from "./types";
+
+/**
+ * URL search-param state for the Skills list (`/assistant/skills`).
+ *
+ * The list reflects its search text, status filter, and category into
+ * `?q=` / `?filter=` / `?category=` so the filtered view survives route
+ * navigation (detail page and back, browser history, shared links).
+ * Defaults are omitted so the plain `/assistant/skills` URL stays clean.
+ *
+ * Mirrors the usage tab's URL-state pattern (`domains/logs/usage-tab-state.ts`).
+ */
+
+export const DEFAULT_SKILL_FILTER: SkillFilter = "all";
+
+const SKILL_FILTERS = new Set<SkillFilter>([
+  "all",
+  "installed",
+  "available",
+  "vellum",
+  "clawhub",
+  "skillssh",
+  "custom",
+  "assistant-memory",
+]);
+
+export interface SkillsUrlState {
+  /** Search text (`?q=`); empty string when absent. */
+  q: string;
+  /** Status/origin filter (`?filter=`); `"all"` when absent or invalid. */
+  filter: SkillFilter;
+  /** Category slug (`?category=`); `null` when absent. */
+  category: string | null;
+}
+
+export interface SkillsSearchParamsUpdate {
+  q?: string;
+  filter?: SkillFilter;
+  /** `null` clears the category (the "All" row). */
+  category?: string | null;
+}
+
+export function readSkillsUrlState(
+  searchParams: URLSearchParams,
+): SkillsUrlState {
+  const rawFilter = searchParams.get("filter");
+  const category = searchParams.get("category");
+  return {
+    q: searchParams.get("q") ?? "",
+    filter: isSkillFilter(rawFilter) ? rawFilter : DEFAULT_SKILL_FILTER,
+    category: category || null,
+  };
+}
+
+/**
+ * Build the next search params from `searchParams` with `update` applied.
+ * Default values (empty search, `"all"` filter, no category) are removed
+ * rather than serialized; unrelated params are preserved.
+ */
+export function buildSkillsSearchParams(
+  searchParams: URLSearchParams,
+  update: SkillsSearchParamsUpdate,
+): URLSearchParams {
+  const next = new URLSearchParams(searchParams);
+  if (update.q !== undefined) {
+    setOrDelete(next, "q", update.q.trim() || null);
+  }
+  if (update.filter !== undefined) {
+    setOrDelete(
+      next,
+      "filter",
+      update.filter === DEFAULT_SKILL_FILTER ? null : update.filter,
+    );
+  }
+  if (update.category !== undefined) {
+    setOrDelete(next, "category", update.category);
+  }
+  return next;
+}
+
+function setOrDelete(
+  params: URLSearchParams,
+  key: string,
+  value: string | null,
+): void {
+  if (value === null) {
+    params.delete(key);
+  } else {
+    params.set(key, value);
+  }
+}
+
+function isSkillFilter(value: string | null): value is SkillFilter {
+  return value !== null && SKILL_FILTERS.has(value as SkillFilter);
+}


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for skill-surfacing-v1.md:
- search/filter/category reflected in URL params; detail back-navigation restores them
- not-found state waits for an in-flight list refetch before declaring a skill missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)