### PR TITLE
refactor(calls): fish-audio-client adopts shared consumeSynthesisResponse

### DIFF
--- a/assistant/src/calls/__tests__/fish-audio-client.test.ts
+++ b/assistant/src/calls/__tests__/fish-audio-client.test.ts
@@ -83,3 +83,20 @@ describe("synthesizeWithFishAudio request body", () => {
     expect(body.sample_rate).toBe(24000);
   });
 });
+
+describe("synthesizeWithFishAudio response consumption", () => {
+  test("rejects when the response body closes after zero bytes", async () => {
+    globalThis.fetch = mock(async () => {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.close();
+        },
+      });
+      return new Response(body, { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    await expect(synthesizeWithFishAudio("hello", config)).rejects.toThrow(
+      "Fish Audio API returned empty audio",
+    );
+  });
+});

--- a/assistant/src/calls/fish-audio-client.ts
+++ b/assistant/src/calls/fish-audio-client.ts
@@ -1,7 +1,7 @@
 import type { FishAudioConfig } from "../config/schemas/fish-audio.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
-import { readChunkedBody } from "../tts/stream-read.js";
+import { consumeSynthesisResponse } from "../tts/stream-read.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("fish-audio-client");
@@ -86,14 +86,17 @@ export async function synthesizeWithFishAudio(
     throw new Error(`Fish Audio API error (${response.status}): ${errorText}`);
   }
 
-  if (!response.body) {
-    throw new Error("Fish Audio API returned no body");
-  }
-
-  const audio = await readChunkedBody(response.body, {
+  const audio = await consumeSynthesisResponse(response, {
+    stream: true,
     onChunk: options?.onChunk,
     makeTimeoutError: (timeoutMs) =>
       new Error(`Fish Audio read timed out after ${timeoutMs}ms`),
+    makeEmptyError: (kind) =>
+      new Error(
+        kind === "no-body"
+          ? "Fish Audio API returned no body"
+          : "Fish Audio API returned empty audio",
+      ),
   });
 
   log.debug({ bytes: audio.byteLength }, "Fish Audio synthesis complete");


### PR DESCRIPTION
## Summary
- Replace the hand-rolled no-body guard + raw readChunkedBody in calls/fish-audio-client.ts with the shared consumeSynthesisResponse helper
- Zero-byte streams now throw (Fish Audio API returned empty audio); no-body and timeout messages unchanged

Part of plan: tts-deferred-cleanups.md (PR 2 of 4)