### PR TITLE
refactor(tts): shared PCM chunk-carry aligner for live-voice and media-stream

### DIFF
--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -35,6 +35,7 @@
 
 import type { ServerWebSocket } from "bun";
 
+import { createPcmChunkAligner } from "../tts/pcm-chunk-aligner.js";
 import { extractSpeakableSegments } from "../tts/speakable-segments.js";
 import { synthesizeAndEmit } from "../tts/synthesis-stream.js";
 import { getLogger } from "../util/logger.js";
@@ -193,7 +194,9 @@ export class MediaStreamOutput implements CallTransport {
    * PCM, and re-encode as mu-law frames for Twilio.
    */
   sendPlayUrl(url: string): void {
-    if (this.state === "closed") return;
+    if (this.state === "closed") {
+      return;
+    }
     this.enqueuePlayback({ type: "fetch-url", url });
   }
 
@@ -231,7 +234,9 @@ export class MediaStreamOutput implements CallTransport {
    * closes.
    */
   endSession(reason?: string): void {
-    if (this.state === "closed") return;
+    if (this.state === "closed") {
+      return;
+    }
     this.state = "closed";
 
     // Cancel any in-flight playback
@@ -258,7 +263,9 @@ export class MediaStreamOutput implements CallTransport {
    * Send a base64-encoded audio frame to Twilio for playback.
    */
   sendAudioPayload(base64Payload: string): void {
-    if (this.state === "closed") return;
+    if (this.state === "closed") {
+      return;
+    }
 
     const command: MediaStreamSendMediaCommand = {
       event: "media",
@@ -283,7 +290,9 @@ export class MediaStreamOutput implements CallTransport {
    * back a `mark` event when the caller reaches this point in playback.
    */
   sendMark(name: string): void {
-    if (this.state === "closed") return;
+    if (this.state === "closed") {
+      return;
+    }
 
     const command: MediaStreamSendMarkCommand = {
       event: "mark",
@@ -317,7 +326,9 @@ export class MediaStreamOutput implements CallTransport {
    * when it actually aborts the turn.
    */
   clearAudio(): void {
-    if (this.state === "closed") return;
+    if (this.state === "closed") {
+      return;
+    }
 
     // Flush our internal playback queue and abort in-flight work.
     this.flushPlaybackQueue();
@@ -337,7 +348,9 @@ export class MediaStreamOutput implements CallTransport {
    * (initial greeting, setup handoff prompt) survives to play after.
    */
   clearBufferedAudio(): void {
-    if (this.state === "closed") return;
+    if (this.state === "closed") {
+      return;
+    }
     this.sendClearCommand();
   }
 
@@ -431,7 +444,9 @@ export class MediaStreamOutput implements CallTransport {
    * before sending.
    */
   private async drainPlaybackQueue(): Promise<void> {
-    if (this.draining) return;
+    if (this.draining) {
+      return;
+    }
     this.draining = true;
 
     try {
@@ -459,7 +474,9 @@ export class MediaStreamOutput implements CallTransport {
 
         // If the playback version changed (clearAudio was called), stop
         // processing stale items.
-        if (version !== this.playbackVersion) break;
+        if (version !== this.playbackVersion) {
+          break;
+        }
       }
     } finally {
       this.draining = false;
@@ -477,7 +494,9 @@ export class MediaStreamOutput implements CallTransport {
    * the one-shot audio-start signal before the first frame goes out.
    */
   private sendFrames(frames: string[]): void {
-    if (frames.length === 0) return;
+    if (frames.length === 0) {
+      return;
+    }
     const audioStartCallback = this.audioStartCallback;
     if (audioStartCallback) {
       this.audioStartCallback = null;
@@ -534,7 +553,8 @@ export class MediaStreamOutput implements CallTransport {
       // Chunk boundaries can split a 16-bit sample or a decimation pair;
       // the unprocessable tail (< 4 bytes) carries into the next chunk so
       // sample alignment and decimation phase stay stable across chunks.
-      let pcmCarry: Buffer | undefined;
+      // 4 bytes = two 16 kHz samples = one 8 kHz output sample.
+      const pcmAligner = createPcmChunkAligner(4);
       // Mu-law bytes short of a whole 20 ms frame, carried likewise.
       let mulawCarry: Buffer = Buffer.alloc(0);
 
@@ -575,20 +595,12 @@ export class MediaStreamOutput implements CallTransport {
           if (!isCurrent()) {
             return;
           }
-          const combined = pcmCarry
-            ? Buffer.concat([pcmCarry, chunk.audio])
-            : chunk.audio;
-          // 4 bytes = two 16 kHz samples = one 8 kHz output sample.
-          const usableBytes = combined.length & ~3;
-          pcmCarry =
-            usableBytes < combined.length
-              ? combined.subarray(usableBytes)
-              : undefined;
-          if (usableBytes === 0) {
+          const aligned = pcmAligner.align(chunk.audio);
+          if (aligned.byteLength === 0) {
             return;
           }
           const pcm8k = this.pcm16ToTelephonyRate(
-            combined.subarray(0, usableBytes),
+            aligned,
             STREAMING_PCM_SAMPLE_RATE_HZ,
           );
           sendMulaw(pcm16ToMulaw(pcm8k), false);
@@ -600,11 +612,11 @@ export class MediaStreamOutput implements CallTransport {
       }
 
       if (streamsPcm) {
-        if (pcmCarry) {
+        if (pcmAligner.carryLength() > 0) {
           // A sub-sample tail is malformed provider output; decimation
           // would drop it anyway.
           log.debug(
-            { streamSid: this.streamSid, carryBytes: pcmCarry.length },
+            { streamSid: this.streamSid, carryBytes: pcmAligner.carryLength() },
             "Dropping sub-sample tail from PCM16 TTS stream",
           );
         }
@@ -685,10 +697,14 @@ export class MediaStreamOutput implements CallTransport {
         return;
       }
 
-      if (version !== this.playbackVersion || this.isClosed()) return;
+      if (version !== this.playbackVersion || this.isClosed()) {
+        return;
+      }
 
       const buffer = Buffer.from(await response.arrayBuffer());
-      if (version !== this.playbackVersion || this.isClosed()) return;
+      if (version !== this.playbackVersion || this.isClosed()) {
+        return;
+      }
 
       const contentType = response.headers.get("content-type") ?? "audio/mpeg";
       const format: "mp3" | "wav" | "opus" | "pcm" = contentType.includes("wav")
@@ -700,7 +716,9 @@ export class MediaStreamOutput implements CallTransport {
             : "mp3";
 
       const frames = this.audioBufferToFrames(buffer, format);
-      if (version !== this.playbackVersion || this.isClosed()) return;
+      if (version !== this.playbackVersion || this.isClosed()) {
+        return;
+      }
 
       this.sendFrames(frames);
     } catch (err) {
@@ -762,7 +780,9 @@ export class MediaStreamOutput implements CallTransport {
       const sampleRate = audio.readUInt32LE(24);
       const bitsPerSample = audio.readUInt16LE(34);
       let pcmData: Buffer = audio.subarray(44);
-      if (pcmData.length < 2) return [];
+      if (pcmData.length < 2) {
+        return [];
+      }
 
       if (bitsPerSample !== 16 || channels > 2 || channels === 0) {
         // Limitation: only 16-bit mono/stereo PCM is decoded here.
@@ -827,7 +847,9 @@ export class MediaStreamOutput implements CallTransport {
     // ElevenLabs pcm_16000 produces 16-bit signed LE at 16 kHz. Twilio
     // needs 8 kHz mu-law, so we downsample by taking every other sample.
     if (format === "pcm" || format === "wav") {
-      if (audio.length < 2) return [];
+      if (audio.length < 2) {
+        return [];
+      }
       // Headerless PCM carries no declared rate; assume the 16 kHz that
       // ElevenLabs pcm_16000 produces and downsample to 8 kHz.
       const downsampled = decimatePcm16(audio, 2);
@@ -876,7 +898,9 @@ export class MediaStreamOutput implements CallTransport {
    * assumption with a warning.
    */
   private pcm16ToTelephonyRate(pcm: Buffer, sampleRate: number): Buffer {
-    if (sampleRate === TELEPHONY_SAMPLE_RATE_HZ) return pcm;
+    if (sampleRate === TELEPHONY_SAMPLE_RATE_HZ) {
+      return pcm;
+    }
     if (!Number.isFinite(sampleRate) || sampleRate <= 0) {
       log.warn(
         { streamSid: this.streamSid, sampleRate },

--- a/assistant/src/live-voice/live-voice-tts.ts
+++ b/assistant/src/live-voice/live-voice-tts.ts
@@ -1,3 +1,4 @@
+import { createPcmChunkAligner } from "../tts/pcm-chunk-aligner.js";
 import { getTtsProvider } from "../tts/provider-catalog.js";
 import { synthesizeAndEmit } from "../tts/synthesis-stream.js";
 import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
@@ -130,16 +131,7 @@ export async function streamLiveVoiceTtsAudio(
 
   // Provider chunks can split a 16-bit PCM sample across chunk boundaries;
   // a trailing odd byte is carried into the next chunk to keep frames aligned.
-  let pcm16Carry: Buffer | undefined;
-  const alignPcm16 = (audio: Buffer): Buffer => {
-    const combined = pcm16Carry ? Buffer.concat([pcm16Carry, audio]) : audio;
-    const alignedLength = combined.byteLength & ~1;
-    pcm16Carry =
-      alignedLength < combined.byteLength
-        ? combined.subarray(alignedLength)
-        : undefined;
-    return combined.subarray(0, alignedLength);
-  };
+  const pcmAligner = createPcmChunkAligner(2);
 
   try {
     const result = await synthesizeAndEmit({
@@ -154,7 +146,7 @@ export async function streamLiveVoiceTtsAudio(
         if (canStreamChunks) {
           emitAudioFrame(
             chunk.contentType || chunkContentType,
-            alignPcm16(chunk.audio),
+            pcmAligner.align(chunk.audio),
           );
         } else {
           bufferedAudio.push(chunk.audio);
@@ -164,7 +156,7 @@ export async function streamLiveVoiceTtsAudio(
 
     // A dangling final byte is malformed provider output — drop it rather
     // than emit a torn sample.
-    if (pcm16Carry) {
+    if (pcmAligner.carryLength() > 0) {
       log.debug(
         { provider: providerId },
         "Dropping trailing odd byte from PCM16 TTS stream",
@@ -230,7 +222,9 @@ function normalizeProviderError(
   err: unknown,
   providerId: TtsProviderId,
 ): LiveVoiceTtsError {
-  if (err instanceof LiveVoiceTtsError) return err;
+  if (err instanceof LiveVoiceTtsError) {
+    return err;
+  }
 
   const message = err instanceof Error ? err.message : String(err);
   if (isProviderConfigurationError(err)) {

--- a/assistant/src/tts/__tests__/pcm-chunk-aligner.test.ts
+++ b/assistant/src/tts/__tests__/pcm-chunk-aligner.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+
+import { createPcmChunkAligner } from "../pcm-chunk-aligner.js";
+
+describe("createPcmChunkAligner", () => {
+  test("passes whole-block chunks through unchanged", () => {
+    const aligner = createPcmChunkAligner(2);
+    const chunk = Buffer.from([1, 2, 3, 4]);
+    expect(aligner.align(chunk)).toEqual(chunk);
+    expect(aligner.carryLength()).toBe(0);
+  });
+
+  test("re-joins a sample split across two chunks", () => {
+    const aligner = createPcmChunkAligner(2);
+    expect(aligner.align(Buffer.from([1, 2, 3]))).toEqual(Buffer.from([1, 2]));
+    expect(aligner.carryLength()).toBe(1);
+    expect(aligner.align(Buffer.from([4, 5, 6]))).toEqual(
+      Buffer.from([3, 4, 5, 6]),
+    );
+    expect(aligner.carryLength()).toBe(0);
+  });
+
+  test("returns empty and carries a sub-block first chunk", () => {
+    const aligner = createPcmChunkAligner(2);
+    expect(aligner.align(Buffer.from([7])).byteLength).toBe(0);
+    expect(aligner.carryLength()).toBe(1);
+    expect(aligner.align(Buffer.from([8]))).toEqual(Buffer.from([7, 8]));
+    expect(aligner.carryLength()).toBe(0);
+  });
+
+  test("aligns 4-byte decimation pairs", () => {
+    const aligner = createPcmChunkAligner(4);
+    expect(aligner.align(Buffer.from([1, 2, 3, 4, 5]))).toEqual(
+      Buffer.from([1, 2, 3, 4]),
+    );
+    expect(aligner.carryLength()).toBe(1);
+    expect(aligner.align(Buffer.from([6, 7, 8, 9, 10]))).toEqual(
+      Buffer.from([5, 6, 7, 8]),
+    );
+    expect(aligner.carryLength()).toBe(2);
+  });
+
+  test("keeps a dangling final byte in carry", () => {
+    const aligner = createPcmChunkAligner(2);
+    aligner.align(Buffer.from([1, 2, 3, 4, 5]));
+    expect(aligner.carryLength()).toBe(1);
+  });
+});

--- a/assistant/src/tts/pcm-chunk-aligner.ts
+++ b/assistant/src/tts/pcm-chunk-aligner.ts
@@ -1,0 +1,29 @@
+/**
+ * Block-aligning carry buffer for streamed PCM chunks. Chunk boundaries can
+ * split a sample (or a decimation pair) across chunks; `align` returns the
+ * largest prefix of carry+chunk that is a whole number of blocks and retains
+ * the remainder for the next call.
+ */
+export interface PcmChunkAligner {
+  /** Aligned prefix of carry+chunk; empty when too few bytes have arrived. */
+  align(chunk: Buffer): Buffer;
+  /** Bytes held as carry (non-zero at end-of-stream means a torn tail). */
+  carryLength(): number;
+}
+
+export function createPcmChunkAligner(blockBytes: number): PcmChunkAligner {
+  let carry: Buffer | undefined;
+  return {
+    align(chunk) {
+      const combined = carry ? Buffer.concat([carry, chunk]) : chunk;
+      const alignedLength =
+        combined.byteLength - (combined.byteLength % blockBytes);
+      carry =
+        alignedLength < combined.byteLength
+          ? combined.subarray(alignedLength)
+          : undefined;
+      return combined.subarray(0, alignedLength);
+    },
+    carryLength: () => carry?.byteLength ?? 0,
+  };
+}


### PR DESCRIPTION
## Summary
- Extract the duplicated PCM chunk-carry logic (live-voice 2-byte sample aligner, media-stream 4-byte decimation-pair aligner) into shared tts/pcm-chunk-aligner.ts
- Pure refactor: identical framing, log messages, and skip-empty semantics; unit tests for the helper

Part of plan: tts-deferred-cleanups.md (PR 4 of 4)