### PR TITLE
refactor(tts): ElevenLabs adopts the shared nearest-rate PCM clamp

### DIFF
--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -389,7 +389,7 @@ describe("ElevenLabs TTS provider adapter", () => {
     expect(capturedUrl).toContain("output_format=pcm_16000");
   });
 
-  test("pcm output with unmatched sampleRateHz falls back to pcm_16000", async () => {
+  test("pcm output clamps an unsupported sampleRateHz hint to the nearest supported rate", async () => {
     const audioPayload = new Uint8Array([0x00, 0x01]);
     let capturedUrl = "";
 
@@ -402,8 +402,12 @@ describe("ElevenLabs TTS provider adapter", () => {
     await provider.synthesize(
       makeRequest({ outputFormat: "pcm", sampleRateHz: 8000 }),
     );
-
     expect(capturedUrl).toContain("output_format=pcm_16000");
+
+    await provider.synthesize(
+      makeRequest({ outputFormat: "pcm", sampleRateHz: 48000 }),
+    );
+    expect(capturedUrl).toContain("output_format=pcm_44100");
   });
 
   test("resolveOutputSampleRateHz reports the actual PCM rate without synthesis", () => {
@@ -418,7 +422,7 @@ describe("ElevenLabs TTS provider adapter", () => {
       provider.resolveOutputSampleRateHz!(
         makeRequest({ outputFormat: "pcm", sampleRateHz: 48000 }),
       ),
-    ).toBe(16000);
+    ).toBe(44100);
     expect(provider.resolveOutputSampleRateHz!(makeRequest())).toBeUndefined();
   });
 

--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -404,9 +404,27 @@ describe("ElevenLabs TTS provider adapter", () => {
     );
     expect(capturedUrl).toContain("output_format=pcm_16000");
 
+    // 48 kHz clamps to 24 kHz, not the Pro-tier-gated pcm_44100.
     await provider.synthesize(
       makeRequest({ outputFormat: "pcm", sampleRateHz: 48000 }),
     );
+    expect(capturedUrl).toContain("output_format=pcm_24000");
+  });
+
+  test("pcm output uses Pro-tier pcm_44100 only on an exact 44100 hint", async () => {
+    const audioPayload = new Uint8Array([0x00, 0x01]);
+    let capturedUrl = "";
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      capturedUrl = typeof input === "string" ? input : input.toString();
+      return new Response(audioPayload, { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider();
+    await provider.synthesize(
+      makeRequest({ outputFormat: "pcm", sampleRateHz: 44100 }),
+    );
+
     expect(capturedUrl).toContain("output_format=pcm_44100");
   });
 
@@ -421,6 +439,11 @@ describe("ElevenLabs TTS provider adapter", () => {
     expect(
       provider.resolveOutputSampleRateHz!(
         makeRequest({ outputFormat: "pcm", sampleRateHz: 48000 }),
+      ),
+    ).toBe(24000);
+    expect(
+      provider.resolveOutputSampleRateHz!(
+        makeRequest({ outputFormat: "pcm", sampleRateHz: 44100 }),
       ),
     ).toBe(44100);
     expect(provider.resolveOutputSampleRateHz!(makeRequest())).toBeUndefined();

--- a/assistant/src/tts/providers/elevenlabs-provider.ts
+++ b/assistant/src/tts/providers/elevenlabs-provider.ts
@@ -165,15 +165,30 @@ function resolveVoiceId(
   return voiceId;
 }
 
-/**
- * Sample rates of the ElevenLabs `pcm_*` output formats this provider
- * requests (`pcm_16000`…`pcm_44100`).
- */
-const SUPPORTED_PCM_SAMPLE_RATES_HZ = [16_000, 22_050, 24_000, 44_100] as const;
+/** ElevenLabs `pcm_*` rates available on every subscription tier. */
+const UNRESTRICTED_PCM_SAMPLE_RATES_HZ = [16_000, 22_050, 24_000] as const;
 
-/** PCM rate resolver bound to the ElevenLabs-supported rate list (e.g. 48 kHz → 44.1 kHz). */
-const resolveElevenLabsPcmSampleRateHz = (request: TtsSynthesisRequest) =>
-  resolvePcmOutputSampleRateHz(request, SUPPORTED_PCM_SAMPLE_RATES_HZ);
+/** `pcm_44100` requires Pro tier or above upstream. */
+const PRO_TIER_PCM_SAMPLE_RATE_HZ = 44_100;
+
+/**
+ * PCM rate resolver for ElevenLabs. pcm_44100 is Pro-tier-gated upstream, so
+ * it is only used on an exact 44.1 kHz hint (explicit opt-in), never as a
+ * clamp target; all other hints clamp to the tier-unrestricted rates
+ * (e.g. 48 kHz → 24 kHz).
+ */
+const resolveElevenLabsPcmSampleRateHz = (request: TtsSynthesisRequest) => {
+  if (
+    request.outputFormat === "pcm" &&
+    request.sampleRateHz === PRO_TIER_PCM_SAMPLE_RATE_HZ
+  ) {
+    return PRO_TIER_PCM_SAMPLE_RATE_HZ;
+  }
+  return resolvePcmOutputSampleRateHz(
+    request,
+    UNRESTRICTED_PCM_SAMPLE_RATES_HZ,
+  );
+};
 
 /**
  * Choose the ElevenLabs output format based on the use case and optional
@@ -181,10 +196,9 @@ const resolveElevenLabsPcmSampleRateHz = (request: TtsSynthesisRequest) =>
  *
  * When the caller requests `outputFormat: "pcm"` (e.g. the media-stream
  * transport which needs raw PCM for mu-law transcoding), we request the
- * `pcm_*` format — 16-bit signed little-endian — at the `sampleRateHz` hint
- * clamped to the nearest supported rate (ties prefer higher), defaulting to
- * 16 kHz when no hint is given (the shared no-hint convention across TTS
- * providers).
+ * `pcm_*` format — 16-bit signed little-endian — at the rate chosen by
+ * {@link resolveElevenLabsPcmSampleRateHz}, defaulting to 16 kHz when no
+ * hint is given (the shared no-hint convention across TTS providers).
  *
  * Otherwise:
  * - Phone calls benefit from lower-latency, smaller payloads (mp3 at 22050/32).

--- a/assistant/src/tts/providers/elevenlabs-provider.ts
+++ b/assistant/src/tts/providers/elevenlabs-provider.ts
@@ -13,6 +13,7 @@ import type { TtsElevenLabsProviderConfig } from "../../config/schemas/tts.js";
 import { credentialKey } from "../../security/credential-key.js";
 import { getSecureKeyAsync } from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
+import { resolvePcmOutputSampleRateHz } from "../pcm-sample-rates.js";
 import type { TtsProviderDefinition } from "../provider-definition.js";
 import {
   consumeSynthesisResponse,
@@ -164,43 +165,37 @@ function resolveVoiceId(
   return voiceId;
 }
 
-/** ElevenLabs PCM output formats by exact sample rate. */
-const PCM_FORMAT_BY_SAMPLE_RATE: Record<number, string> = {
-  16000: "pcm_16000",
-  22050: "pcm_22050",
-  24000: "pcm_24000",
-  44100: "pcm_44100",
-};
+/**
+ * Sample rates of the ElevenLabs `pcm_*` output formats this provider
+ * requests (`pcm_16000`…`pcm_44100`).
+ */
+const SUPPORTED_PCM_SAMPLE_RATES_HZ = [16_000, 22_050, 24_000, 44_100] as const;
+
+/** PCM rate resolver bound to the ElevenLabs-supported rate list (e.g. 48 kHz → 44.1 kHz). */
+const resolveElevenLabsPcmSampleRateHz = (request: TtsSynthesisRequest) =>
+  resolvePcmOutputSampleRateHz(request, SUPPORTED_PCM_SAMPLE_RATES_HZ);
 
 /**
  * Choose the ElevenLabs output format based on the use case and optional
  * format hint.
  *
  * When the caller requests `outputFormat: "pcm"` (e.g. the media-stream
- * transport which needs raw PCM for mu-law transcoding), we map the optional
- * `sampleRateHz` hint to an exact ElevenLabs PCM format — 16-bit signed
- * little-endian. An absent or unmatched hint defaults to `pcm_16000`, which
- * preserves the media-stream transport's behavior (its `audioBufferToFrames`
- * handles the 16 kHz -> 8 kHz downsample).
+ * transport which needs raw PCM for mu-law transcoding), we request the
+ * `pcm_*` format — 16-bit signed little-endian — at the `sampleRateHz` hint
+ * clamped to the nearest supported rate (ties prefer higher), defaulting to
+ * 16 kHz when no hint is given (the shared no-hint convention across TTS
+ * providers).
  *
  * Otherwise:
  * - Phone calls benefit from lower-latency, smaller payloads (mp3 at 22050/32).
  * - Message playback uses higher quality (mp3 at 44100/128).
  */
 function resolveOutputFormat(request: TtsSynthesisRequest): string {
-  if (request.outputFormat === "pcm") {
-    return (
-      PCM_FORMAT_BY_SAMPLE_RATE[request.sampleRateHz ?? 16000] ?? "pcm_16000"
-    );
+  const pcmSampleRateHz = resolveElevenLabsPcmSampleRateHz(request);
+  if (pcmSampleRateHz != null) {
+    return `pcm_${pcmSampleRateHz}`;
   }
   return request.useCase === "phone-call" ? "mp3_22050_32" : "mp3_44100_128";
-}
-
-/** Sample rate of a `pcm_*` output format in Hz; undefined for non-PCM formats. */
-function pcmFormatSampleRateHz(outputFormat: string): number | undefined {
-  return outputFormat.startsWith("pcm_")
-    ? Number(outputFormat.slice("pcm_".length))
-    : undefined;
 }
 
 /**
@@ -346,8 +341,7 @@ export function createElevenLabsProvider(
   return {
     id: "elevenlabs",
     capabilities,
-    resolveOutputSampleRateHz: (request) =>
-      pcmFormatSampleRateHz(resolveOutputFormat(request)),
+    resolveOutputSampleRateHz: resolveElevenLabsPcmSampleRateHz,
     synthesize: (request) => performSynthesis(request, { stream: false }),
     synthesizeStream: (request, onChunk) =>
       performSynthesis(request, { stream: true, onChunk, ...streamTimeouts }),


### PR DESCRIPTION
## Summary
- Replace ElevenLabs exact-match-or-16k PCM rate resolution with the shared nearest-rate clamp from tts/pcm-sample-rates.ts (48 kHz hint now yields pcm_44100 instead of pcm_16000)
- Probe and output_format derive from the same clamped rate; drop the format-string round-trip helper

Part of plan: tts-deferred-cleanups.md (PR 1 of 4)