### PR TITLE
refactor(calls): collapse the preferWav/requiresWavAudio sentinel into explicit PCM naming

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -93,7 +93,7 @@ mock.module("../config/loader.js", () => {
 // ── Credential mock (prevents real key lookups) ──────────────────────
 
 // Provider API keys resolve by default so telephony playability checks
-// (WAV-transport tests) can select providers; tests can narrow the
+// (PCM-transport tests) can select providers; tests can narrow the
 // resolvable set. Reset to null (all resolve) in beforeEach.
 let mockResolvableProviderKeys: ((service: string) => string | null) | null =
   null;
@@ -408,8 +408,8 @@ function setupController(
   opts?: {
     assistantId?: string;
     trustContext?: import("../daemon/trust-context-types.js").TrustContext;
-    /** Simulate the media-stream transport's WAV requirement. */
-    requiresWavAudio?: boolean;
+    /** Simulate the media-stream transport's PCM requirement. */
+    requiresPcmAudio?: boolean;
   },
 ) {
   ensureConversation("conv-ctrl-test");
@@ -422,8 +422,8 @@ function setupController(
   });
   updateCallSession(session.id, { status: "in_progress" });
   const transport = createMockTransport();
-  if (opts?.requiresWavAudio) {
-    Object.assign(transport, { requiresWavAudio: true });
+  if (opts?.requiresPcmAudio) {
+    Object.assign(transport, { requiresPcmAudio: true });
   }
   const controller = new CallController(session.id, transport, task ?? null, {
     assistantId: opts?.assistantId,
@@ -3493,16 +3493,16 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
-  // ── Per-segment fallback on WAV-requiring transports ────────────────
+  // ── Per-segment fallback on PCM-requiring transports ────────────────
 
   /**
    * Register a failing fish-audio primary and a recording elevenlabs
    * fallback, with fish-audio configured as the active provider. Used by
-   * the WAV-transport segment-fallback tests. With
+   * the PCM-transport segment-fallback tests. With
    * `fishEmitsChunkBeforeFailing`, the primary emits one audio chunk (so
    * the play URL reaches the transport) before failing mid-stream.
    */
-  function registerWavFallbackProviders(opts?: {
+  function registerPcmFallbackProviders(opts?: {
     fishEmitsChunkBeforeFailing?: boolean;
   }): {
     fishTexts: string[];
@@ -3557,13 +3557,13 @@ describe("call-controller", () => {
     return { fishTexts, fallbackTexts };
   }
 
-  test("WAV transport: a failed segment and the rest of the turn synthesize via a playable fallback provider", async () => {
-    const { fishTexts, fallbackTexts } = registerWavFallbackProviders();
+  test("PCM transport: a failed segment and the rest of the turn synthesize via a playable fallback provider", async () => {
+    const { fishTexts, fallbackTexts } = registerPcmFallbackProviders();
     mockStartVoiceTurn.mockImplementation(
       createMockVoiceTurn(["First part is done. ", "Second part is done."]),
     );
     const { relay, controller } = setupController(undefined, {
-      requiresWavAudio: true,
+      requiresPcmAudio: true,
     });
 
     await controller.handleCallerUtterance("Hi");
@@ -3577,7 +3577,7 @@ describe("call-controller", () => {
       "Second part is done.",
     ]);
     expect(relay.sentPlayUrls.length).toBe(2);
-    // No text routes through native tokens on a WAV transport.
+    // No text routes through native tokens on a PCM transport.
     expect(relay.sentTokens.filter((t) => t.token.length > 0)).toEqual([]);
     const lastToken = relay.sentTokens[relay.sentTokens.length - 1];
     expect(lastToken).toEqual({ token: "", last: true });
@@ -3585,15 +3585,15 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
-  test("WAV transport: a mid-stream failure after audio reached the caller is not re-spoken, but later segments use the fallback", async () => {
-    const { fishTexts, fallbackTexts } = registerWavFallbackProviders({
+  test("PCM transport: a mid-stream failure after audio reached the caller is not re-spoken, but later segments use the fallback", async () => {
+    const { fishTexts, fallbackTexts } = registerPcmFallbackProviders({
       fishEmitsChunkBeforeFailing: true,
     });
     mockStartVoiceTurn.mockImplementation(
       createMockVoiceTurn(["First part is done. ", "Second part is done."]),
     );
     const { relay, controller } = setupController(undefined, {
-      requiresWavAudio: true,
+      requiresPcmAudio: true,
     });
 
     await controller.handleCallerUtterance("Hi");
@@ -3612,16 +3612,16 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
-  test("WAV transport: when no playable fallback exists, failed segments are skipped and end-of-turn still fires", async () => {
+  test("PCM transport: when no playable fallback exists, failed segments are skipped and end-of-turn still fires", async () => {
     // Only fish-audio's key resolves, so the fallback scan finds nothing.
     mockResolvableProviderKeys = (service) =>
       service === "fish-audio" ? "test-key" : null;
-    const { fishTexts, fallbackTexts } = registerWavFallbackProviders();
+    const { fishTexts, fallbackTexts } = registerPcmFallbackProviders();
     mockStartVoiceTurn.mockImplementation(
       createMockVoiceTurn(["First part is done. ", "Second part is done."]),
     );
     const { relay, controller } = setupController(undefined, {
-      requiresWavAudio: true,
+      requiresPcmAudio: true,
     });
 
     await controller.handleCallerUtterance("Hi");
@@ -3629,7 +3629,7 @@ describe("call-controller", () => {
     expect(fishTexts).toEqual(["First part is done."]);
     expect(fallbackTexts).toEqual([]);
     expect(relay.sentPlayUrls.length).toBe(0);
-    // Native tokens are never used on a WAV transport, and the turn
+    // Native tokens are never used on a PCM transport, and the turn
     // still closes with the end-of-turn signal.
     expect(relay.sentTokens.filter((t) => t.token.length > 0)).toEqual([]);
     const lastToken = relay.sentTokens[relay.sentTokens.length - 1];

--- a/assistant/src/__tests__/call-setup-flow.test.ts
+++ b/assistant/src/__tests__/call-setup-flow.test.ts
@@ -58,7 +58,7 @@ function createFakeTransport() {
     endSession: (reason) => {
       endReasons.push(reason);
     },
-    requiresWavAudio: true,
+    requiresPcmAudio: true,
   };
   return { transport, spokenTokens, endReasons };
 }

--- a/assistant/src/__tests__/media-stream-output.test.ts
+++ b/assistant/src/__tests__/media-stream-output.test.ts
@@ -25,7 +25,7 @@ mock.module("../calls/resolve-call-tts-provider.js", () => ({
   resolveCallTtsProvider: jest.fn(() => ({
     provider: mockProvider,
     useSynthesizedPath: false,
-    audioFormat: "wav" as const,
+    audioFormat: "pcm" as const,
   })),
 }));
 
@@ -196,7 +196,7 @@ function useProvider(provider: unknown): void {
   mockResolveCallTtsProvider.mockImplementation(() => ({
     provider,
     useSynthesizedPath: false,
-    audioFormat: "wav" as const,
+    audioFormat: "pcm" as const,
   }));
 }
 
@@ -230,7 +230,7 @@ afterEach(() => {
   mockResolveCallTtsProvider.mockImplementation(() => ({
     provider: mockProvider,
     useSynthesizedPath: false,
-    audioFormat: "wav" as const,
+    audioFormat: "pcm" as const,
   }));
 });
 

--- a/assistant/src/__tests__/telephony-tts-guard.test.ts
+++ b/assistant/src/__tests__/telephony-tts-guard.test.ts
@@ -4,10 +4,10 @@
  * Covers three layers:
  * 1. `resolveTelephonyTtsCapability` — catalog `mediaStreamPlayback` format
  *    plus credential availability produce the playable / not-playable verdict.
- * 2. `resolveCallTtsProvider({ preferWav: true })` — a not-playable configured
- *    provider is swapped for a playable credentialed fallback instead of
- *    resolving into guaranteed media-stream silence.
- * 3. `speakSystemPrompt` on a WAV-requiring transport — synthesis failure
+ * 2. `resolveCallTtsProvider({ requiresPcmAudio: true })` — a not-playable
+ *    configured provider is swapped for a playable credentialed fallback
+ *    instead of resolving into guaranteed media-stream silence.
+ * 3. `speakSystemPrompt` on a PCM-requiring transport — synthesis failure
  *    retries once via the fallback provider before degrading to an
  *    end-of-turn-only signal; a mid-stream failure after the play URL went
  *    out skips all fallback (the truncated prompt stands); aborted
@@ -64,7 +64,7 @@ interface FakeCatalogEntry {
   callMode: "native-twilio" | "synthesized-play";
   allowNativeFallback: boolean;
   capabilities: { supportsStreaming: boolean; supportedFormats: string[] };
-  mediaStreamPlayback: { outputFormat: "pcm" | "wav" | "none" };
+  mediaStreamPlayback: { outputFormat: "pcm" | "none" };
   secretRequirements: Array<{
     credentialStoreKey: string;
     displayName: string;
@@ -75,7 +75,7 @@ interface FakeCatalogEntry {
 function makeEntry(
   id: string,
   callMode: "native-twilio" | "synthesized-play",
-  outputFormat: "pcm" | "wav" | "none",
+  outputFormat: "pcm" | "none",
   allowNativeFallback: boolean,
 ): FakeCatalogEntry {
   return {
@@ -97,7 +97,7 @@ function makeEntry(
 
 const fakeCatalog: FakeCatalogEntry[] = [
   makeEntry("elevenlabs", "native-twilio", "pcm", true),
-  makeEntry("fish-audio", "synthesized-play", "wav", true),
+  makeEntry("fish-audio", "synthesized-play", "pcm", true),
   makeEntry("deepgram", "synthesized-play", "pcm", false),
   makeEntry("compressed-only", "synthesized-play", "none", false),
 ];
@@ -257,11 +257,11 @@ function registerStreamingStubProvider(
   return provider;
 }
 
-function createRelay(requiresWavAudio: boolean) {
+function createRelay(requiresPcmAudio: boolean) {
   const sentTokens: Array<{ token: string; last: boolean }> = [];
   const sentPlayUrls: string[] = [];
   const relay: CallTransport = {
-    requiresWavAudio,
+    requiresPcmAudio,
     sendTextToken: (token, last) => {
       sentTokens.push({ token, last });
     },
@@ -302,7 +302,7 @@ describe("resolveTelephonyTtsCapability", () => {
     expect(capability).toEqual({ status: "playable", providerId: "deepgram" });
   });
 
-  test("wav provider with a resolvable key and referenceId is playable", async () => {
+  test("fish-audio with a resolvable key and referenceId is playable", async () => {
     testConfig.services.tts.provider = "fish-audio";
     testConfig.services.tts.providers["fish-audio"].referenceId = "ref-123";
     storedKeys["fish-audio"] = "fa-key";
@@ -398,7 +398,7 @@ describe("findPlayableTelephonyTtsFallback", () => {
 // Call TTS resolver — media-stream playability guard
 // ---------------------------------------------------------------------------
 
-describe("resolveCallTtsProvider with preferWav", () => {
+describe("resolveCallTtsProvider with requiresPcmAudio", () => {
   test("keeps the configured provider when it is playable and credentialed", async () => {
     testConfig.services.tts.provider = "deepgram";
     storedKeys["deepgram"] = "dg-key";
@@ -406,10 +406,10 @@ describe("resolveCallTtsProvider with preferWav", () => {
       return { audio: Buffer.from("x"), contentType: "audio/pcm" };
     });
 
-    const result = await resolveCallTtsProvider({ preferWav: true });
+    const result = await resolveCallTtsProvider({ requiresPcmAudio: true });
     expect(result.provider?.id).toBe("deepgram");
     expect(result.useSynthesizedPath).toBe(true);
-    expect(result.audioFormat).toBe("wav");
+    expect(result.audioFormat).toBe("pcm");
   });
 
   test("falls back to a playable credentialed provider when the configured provider has an unsupported format", async () => {
@@ -423,9 +423,9 @@ describe("resolveCallTtsProvider with preferWav", () => {
       return { audio: Buffer.from("x"), contentType: "audio/pcm" };
     });
 
-    const result = await resolveCallTtsProvider({ preferWav: true });
+    const result = await resolveCallTtsProvider({ requiresPcmAudio: true });
     expect(result.provider?.id).toBe("elevenlabs");
-    expect(result.audioFormat).toBe("wav");
+    expect(result.audioFormat).toBe("pcm");
   });
 
   test("falls back when configured fish-audio has a key but no referenceId", async () => {
@@ -439,9 +439,9 @@ describe("resolveCallTtsProvider with preferWav", () => {
       return { audio: Buffer.from("x"), contentType: "audio/pcm" };
     });
 
-    const result = await resolveCallTtsProvider({ preferWav: true });
+    const result = await resolveCallTtsProvider({ requiresPcmAudio: true });
     expect(result.provider?.id).toBe("elevenlabs");
-    expect(result.audioFormat).toBe("wav");
+    expect(result.audioFormat).toBe("pcm");
   });
 
   test("falls back when the configured provider is missing credentials", async () => {
@@ -454,11 +454,11 @@ describe("resolveCallTtsProvider with preferWav", () => {
       return { audio: Buffer.from("x"), contentType: "audio/pcm" };
     });
 
-    const result = await resolveCallTtsProvider({ preferWav: true });
+    const result = await resolveCallTtsProvider({ requiresPcmAudio: true });
     expect(result.provider?.id).toBe("elevenlabs");
   });
 
-  test("without preferWav the configured provider is not swapped", async () => {
+  test("without requiresPcmAudio the configured provider is not swapped", async () => {
     testConfig.services.tts.provider = "deepgram";
     // No credentials at all — the CR transport path does not consult the
     // media-stream playability capability.
@@ -477,7 +477,7 @@ describe("resolveCallTtsProvider with preferWav", () => {
 // speakSystemPrompt — media-stream synthesis failure retries the fallback
 // ---------------------------------------------------------------------------
 
-describe("speakSystemPrompt on a WAV-requiring transport", () => {
+describe("speakSystemPrompt on a PCM-requiring transport", () => {
   test("retries with the fallback provider instead of emitting only end-of-turn", async () => {
     testConfig.services.tts.provider = "deepgram";
     storedKeys["deepgram"] = "dg-key";
@@ -563,7 +563,7 @@ describe("speakSystemPrompt mid-stream failure after audio started", () => {
     };
   }
 
-  test("WAV transport: skips the fallback retry — the truncated prompt stands", async () => {
+  test("PCM transport: skips the fallback retry — the truncated prompt stands", async () => {
     testConfig.services.tts.provider = "deepgram";
     storedKeys["deepgram"] = "dg-key";
     storedKeys["elevenlabs"] = "el-key";
@@ -584,7 +584,7 @@ describe("speakSystemPrompt mid-stream failure after audio started", () => {
     expect(sentTokens).toEqual([{ token: "", last: true }]);
   });
 
-  test("non-WAV transport: skips the native text fallback — no full-prompt re-speak", async () => {
+  test("non-PCM transport: skips the native text fallback — no full-prompt re-speak", async () => {
     testConfig.services.tts.provider = "fish-audio";
     testConfig.services.tts.providers["fish-audio"].referenceId = "ref-123";
 
@@ -628,7 +628,7 @@ describe("speakSystemPrompt mid-stream failure after audio started", () => {
 // ---------------------------------------------------------------------------
 
 describe("speakSystemPrompt aborted synthesis", () => {
-  test("WAV transport: abort mid-flight skips the fallback retry and end-of-turn", async () => {
+  test("PCM transport: abort mid-flight skips the fallback retry and end-of-turn", async () => {
     testConfig.services.tts.provider = "deepgram";
     storedKeys["deepgram"] = "dg-key";
     storedKeys["elevenlabs"] = "el-key";
@@ -657,7 +657,7 @@ describe("speakSystemPrompt aborted synthesis", () => {
     expect(sentTokens).toEqual([]);
   });
 
-  test("non-WAV transport with native-fallback provider: abort skips the text fallback and end-of-turn", async () => {
+  test("non-PCM transport with native-fallback provider: abort skips the text fallback and end-of-turn", async () => {
     testConfig.services.tts.provider = "fish-audio";
     testConfig.services.tts.providers["fish-audio"].referenceId = "ref-123";
 
@@ -712,7 +712,7 @@ describe("speakSystemPrompt aborted synthesis", () => {
     expect(sentTokens).toEqual([]);
   });
 
-  test("provider AbortError without our signal aborted is a failure — WAV fallback retry still runs", async () => {
+  test("provider AbortError without our signal aborted is a failure — PCM fallback retry still runs", async () => {
     testConfig.services.tts.provider = "deepgram";
     storedKeys["deepgram"] = "dg-key";
     storedKeys["elevenlabs"] = "el-key";
@@ -742,7 +742,7 @@ describe("speakSystemPrompt aborted synthesis", () => {
     expect(sentTokens).toEqual([{ token: "", last: true }]);
   });
 
-  test("provider AbortError without any signal is a failure — non-WAV native fallback still runs", async () => {
+  test("provider AbortError without any signal is a failure — non-PCM native fallback still runs", async () => {
     testConfig.services.tts.provider = "fish-audio";
     testConfig.services.tts.providers["fish-audio"].referenceId = "ref-123";
 

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -658,12 +658,12 @@ export class CallController {
     // Native-twilio providers stream text tokens through the transport,
     // which re-synthesizes them via daemon TTS on media-stream.
     //
-    // When the transport requires WAV (media-stream), request WAV so
+    // When the transport requires PCM (media-stream), request PCM so
     // the audio store entry and any downstream fetch/transcode receives
-    // PCM that audioBufferToFrames can convert to mu-law.
+    // raw PCM that audioBufferToFrames can convert to mu-law.
     const { provider, useSynthesizedPath, audioFormat } =
       await resolveCallTtsProvider({
-        preferWav: this.transport.requiresWavAudio,
+        requiresPcmAudio: this.transport.requiresPcmAudio,
       });
 
     // Buffer incoming tokens so we can strip control markers ([ASK_GUARDIAN:...], [END_CALL])
@@ -680,14 +680,14 @@ export class CallController {
     let pendingSynthText = "";
     let synthesisChain: Promise<void> = Promise.resolve();
     // After a segment fails, the rest of the turn stays off the primary
-    // provider so text is never spoken out of order: non-WAV transports
-    // send native tokens; WAV-requiring transports (media-stream) retry
+    // provider so text is never spoken out of order: non-PCM transports
+    // send native tokens; PCM-requiring transports (media-stream) retry
     // through a playable fallback provider.
     let synthesisFellBack = false;
-    // Fallback provider for WAV-requiring transports, resolved once per
+    // Fallback provider for PCM-requiring transports, resolved once per
     // turn. `undefined` = not yet resolved; `null` = none available (or
     // the fallback failed too) — affected segments are skipped.
-    let wavFallbackProvider: TtsProvider | null | undefined;
+    let pcmFallbackProvider: TtsProvider | null | undefined;
     // Non-recoverable failure (allowNativeFallback: false providers):
     // remaining segments are skipped and the error rethrows after the
     // chain drains so the outer handler speaks the generic recovery copy.
@@ -696,21 +696,21 @@ export class CallController {
     // chain links check it to keep stale speech off the recovery prompt.
     let synthesisCancelled = false;
 
-    // WAV-requiring transports re-synthesize native tokens through the
+    // PCM-requiring transports re-synthesize native tokens through the
     // same failing provider path, so a failed segment (and the rest of
     // the turn) is spoken through a playable fallback provider instead.
-    const speakSegmentViaWavFallback = async (
+    const speakSegmentViaPcmFallback = async (
       failedProviderId: string,
       segment: string,
     ): Promise<void> => {
-      if (wavFallbackProvider === undefined) {
-        wavFallbackProvider =
+      if (pcmFallbackProvider === undefined) {
+        pcmFallbackProvider =
           await findPlayableTelephonyTtsFallbackProvider(failedProviderId);
-        if (wavFallbackProvider) {
+        if (pcmFallbackProvider) {
           log.warn(
             {
               provider: failedProviderId,
-              fallbackProvider: wavFallbackProvider.id,
+              fallbackProvider: pcmFallbackProvider.id,
             },
             "Speaking remaining TTS segments via fallback provider",
           );
@@ -722,21 +722,21 @@ export class CallController {
         }
       }
       if (
-        !wavFallbackProvider ||
+        !pcmFallbackProvider ||
         synthesisCancelled ||
         !this.isCurrentRun(runVersion)
       ) {
         return;
       }
       const fallbackStatus = await this.synthesizeAndStreamAudio(
-        wavFallbackProvider,
+        pcmFallbackProvider,
         segment,
         runVersion,
         audioFormat,
       );
       if (fallbackStatus !== "ok") {
         // The fallback provider is failing too — stop retrying.
-        wavFallbackProvider = null;
+        pcmFallbackProvider = null;
       }
     };
 
@@ -771,7 +771,7 @@ export class CallController {
                 return;
               }
               synthesisFellBack = true;
-              if (!this.transport.requiresWavAudio) {
+              if (!this.transport.requiresPcmAudio) {
                 // synthesizeAndStreamAudio already handled the failed
                 // segment: its text went out as native tokens, or its
                 // partially-played audio stands.
@@ -784,14 +784,14 @@ export class CallController {
                 // segments still route through the fallback provider.
                 return;
               }
-            } else if (!this.transport.requiresWavAudio) {
+            } else if (!this.transport.requiresPcmAudio) {
               // Native route. Segments are trimmed, so restore the
               // inter-segment separator.
               this.beginSpeakingOnAudioStart(runVersion);
               this.transport.sendTextToken(`${segment} `, false);
               return;
             }
-            await speakSegmentViaWavFallback(ttsProvider.id, segment);
+            await speakSegmentViaPcmFallback(ttsProvider.id, segment);
           } catch (err) {
             synthesisFailure = { err };
           }
@@ -990,7 +990,7 @@ export class CallController {
    * @returns `"ok"` on success or abort. On a handled provider failure,
    *   `"failed-before-audio"` when the segment's play URL never went out:
    *   on transports that accept text tokens the failed text has already
-   *   been sent natively; on WAV-requiring transports nothing was sent —
+   *   been sent natively; on PCM-requiring transports nothing was sent —
    *   the caller owns the fallback-provider retry. `"failed-after-audio"`
    *   when the provider failed mid-stream after the play URL was
    *   delivered: the caller hears the truncated audio and nothing more is
@@ -1003,17 +1003,19 @@ export class CallController {
     provider: TtsProvider,
     text: string,
     runVersion: number,
-    format: "mp3" | "wav" | "opus" = "mp3",
+    format: "mp3" | "wav" | "opus" | "pcm" = "mp3",
   ): Promise<SegmentSynthesisStatus> {
     let sink: AudioStoreSink | null = null;
     let playUrlSent = false;
     const abortController = new AbortController();
     try {
-      // When format is WAV (media-stream transport), request raw PCM from
-      // the provider so the audio bytes match the store's content-type.
-      // Without this, providers like Fish Audio still return mp3 and the
-      // downstream mu-law transcoder fails on the format mismatch.
-      const outputFormat = format === "wav" ? ("pcm" as const) : undefined;
+      // Transport-forced PCM and user-configured WAV both request raw PCM
+      // from the provider so the audio bytes match the store's
+      // content-type. Without this, providers like Fish Audio still return
+      // mp3 and the downstream mu-law transcoder fails on the format
+      // mismatch.
+      const outputFormat =
+        format === "pcm" || format === "wav" ? ("pcm" as const) : undefined;
 
       // Use "pcm" as the store format when requesting PCM output so the
       // audio store entry's content-type (audio/pcm) matches the raw PCM
@@ -1083,7 +1085,7 @@ export class CallController {
           { err, provider: provider.id, errName, errCode },
           "TTS synthesis failed — falling back to native token TTS",
         );
-        // If synthesis fails before any audio has started on a non-WAV
+        // If synthesis fails before any audio has started on a non-PCM
         // transport, degrade to token-based speech so the caller still
         // hears a response instead of silence. This fallback is only
         // used for providers whose catalog entry allows native fallback.
@@ -1091,7 +1093,7 @@ export class CallController {
         // leak into the next caller turn.
         if (
           !playUrlSent &&
-          !this.transport.requiresWavAudio &&
+          !this.transport.requiresPcmAudio &&
           this.isCurrentRun(runVersion)
         ) {
           this.beginSpeakingOnAudioStart(runVersion);

--- a/assistant/src/calls/call-setup-flow-types.ts
+++ b/assistant/src/calls/call-setup-flow-types.ts
@@ -19,7 +19,7 @@ import type { TrustContext } from "../daemon/trust-context-types.js";
 export interface SetupFlowTransport {
   sendTextToken(token: string, last: boolean): void;
   endSession(reason?: string): void;
-  readonly requiresWavAudio?: boolean;
+  readonly requiresPcmAudio?: boolean;
 }
 
 // ── Flow state ───────────────────────────────────────────────────────

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -56,13 +56,13 @@ export async function speakSystemPrompt(
   text: string,
   signal?: AbortSignal,
 ): Promise<void> {
-  // When the transport requires WAV (media-stream), request WAV so
-  // the audio store entry contains PCM that audioBufferToFrames can
+  // When the transport requires PCM (media-stream), request PCM so
+  // the audio store entry contains raw PCM that audioBufferToFrames can
   // transcode to mu-law. Without this, compressed formats (mp3, opus)
   // are fetched by processFetchUrlItem and produce garbled audio.
   const { provider, useSynthesizedPath, audioFormat } =
     await resolveCallTtsProvider({
-      preferWav: relay.requiresWavAudio,
+      requiresPcmAudio: relay.requiresPcmAudio,
     });
 
   if (!useSynthesizedPath || !provider) {
@@ -90,13 +90,13 @@ export async function speakSystemPrompt(
  *
  * On synthesis failure before any audio the behavior depends on the
  * transport:
- * - WAV-requiring transports (media-stream) retry once with a playable
+ * - PCM-requiring transports (media-stream) retry once with a playable
  *   fallback provider — native token TTS cannot rescue the prompt there
  *   because text tokens are themselves synthesized via the same provider
  *   path. When no fallback exists (or the retry also fails), only an
  *   empty end-of-turn signal is sent so the transport transitions back
  *   to listening state.
- * - On non-WAV transports, providers with a native Twilio TTS fallback
+ * - On non-PCM transports, providers with a native Twilio TTS fallback
  *   (e.g. Fish Audio) fall back to `sendTextToken(text)` so the caller
  *   still hears the message; providers without one (e.g. Deepgram) log
  *   the error and send only the end-of-turn signal.
@@ -110,18 +110,19 @@ async function synthesizeAndPlay(
   relay: CallTransport,
   provider: TtsProvider,
   text: string,
-  format: "mp3" | "wav" | "opus",
+  format: "mp3" | "wav" | "opus" | "pcm",
   signal?: AbortSignal,
   isFallbackRetry = false,
 ): Promise<void> {
   let sink: AudioStoreSink | null = null;
   let playUrlSent = false;
   try {
-    // When format is WAV (media-stream transport), request raw PCM from
-    // the provider so the audio bytes match the store's content-type.
+    // Transport-forced PCM and user-configured WAV both request raw PCM
+    // from the provider so the audio bytes match the store's content-type.
     // Without this, providers like Fish Audio still return mp3 and the
     // downstream mu-law transcoder fails on the format mismatch.
-    const outputFormat = format === "wav" ? ("pcm" as const) : undefined;
+    const outputFormat =
+      format === "pcm" || format === "wav" ? ("pcm" as const) : undefined;
 
     // Use "pcm" as the store format when requesting PCM output so the
     // audio store entry's content-type (audio/pcm) matches the raw PCM
@@ -198,8 +199,8 @@ async function synthesizeAndPlay(
       return;
     }
 
-    if (relay.requiresWavAudio) {
-      // WAV-requiring transport (media-stream): native token TTS routes
+    if (relay.requiresPcmAudio) {
+      // PCM-requiring transport (media-stream): native token TTS routes
       // back through the same synthesis path, so retry once with a
       // playable fallback provider before degrading to end-of-turn only.
       if (!isFallbackRetry) {
@@ -231,7 +232,7 @@ async function synthesizeAndPlay(
       }
       log.error(
         { err, provider: provider.id, errName, errCode },
-        "System prompt TTS synthesis failed on WAV-requiring transport — sending end-of-turn only",
+        "System prompt TTS synthesis failed on PCM-requiring transport — sending end-of-turn only",
       );
       // Send the end-of-turn signal so the transport transitions from
       // "assistant speaking" to "caller speaking" state.

--- a/assistant/src/calls/call-transport.ts
+++ b/assistant/src/calls/call-transport.ts
@@ -31,14 +31,15 @@ export interface CallTransport {
   endSession(reason?: string): void;
 
   /**
-   * When true, the transport requires WAV (PCM) audio for playback.
+   * When true, the transport synthesizes speech itself and requires raw
+   * PCM audio for playback.
    *
    * The media-stream transport sets this because its mu-law transcoder
-   * can only decode WAV (raw PCM) — compressed formats (mp3, opus)
-   * produce garbled audio. The call controller uses this to request
-   * WAV from TTS providers and the audio store.
+   * needs raw PCM — compressed formats (mp3, opus) produce garbled
+   * audio. The call controller uses this to request PCM from TTS
+   * providers and the audio store.
    */
-  readonly requiresWavAudio?: boolean;
+  readonly requiresPcmAudio?: boolean;
 
   /**
    * Arm a one-shot callback invoked when the transport sends the first

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -139,10 +139,10 @@ export class MediaStreamOutput implements CallTransport {
   private audioStartCallback: (() => void) | null = null;
 
   /**
-   * The media-stream transport requires WAV (PCM) audio because its
+   * The media-stream transport requires raw PCM audio because its
    * mu-law transcoder cannot decode compressed formats (mp3, opus).
    */
-  readonly requiresWavAudio = true;
+  readonly requiresPcmAudio = true;
 
   constructor(ws: ServerWebSocket<unknown>, streamSid: string) {
     this.ws = ws;
@@ -503,11 +503,11 @@ export class MediaStreamOutput implements CallTransport {
     this.activePlaybackAbort = abortController;
 
     try {
-      // Request WAV so audioBufferToFrames gets PCM it can transcode
+      // Request PCM so audioBufferToFrames gets raw PCM it can transcode
       // to mu-law. Compressed formats (mp3, opus) would be sent as raw
       // bytes and produce garbled audio.
       const { provider, audioFormat } = await resolveCallTtsProvider({
-        preferWav: true,
+        requiresPcmAudio: true,
       });
       if (!provider) {
         log.warn(
@@ -621,8 +621,10 @@ export class MediaStreamOutput implements CallTransport {
 
       // Derive the format from the provider's actual content type rather
       // than the declared audioFormat. The declared format may not match
-      // reality (e.g. preferWav requests WAV but the provider returns mp3).
-      // audioBufferToFrames also sniffs magic bytes as a safety net.
+      // reality (e.g. requiresPcmAudio requests PCM but the provider
+      // returns mp3). For unknown content types, fall back to the declared
+      // format (PCM on this path — the bytes were requested as raw PCM,
+      // and audioBufferToFrames sniffs magic bytes as a safety net).
       const actualFormat: "mp3" | "wav" | "opus" | "pcm" =
         result.contentType.includes("wav") ||
         result.contentType.includes("x-wav")

--- a/assistant/src/calls/resolve-call-tts-provider.ts
+++ b/assistant/src/calls/resolve-call-tts-provider.ts
@@ -43,7 +43,7 @@ export interface ResolvedCallTts {
   useSynthesizedPath: boolean;
 
   /** Audio format to use for synthesized audio. */
-  audioFormat: "mp3" | "wav" | "opus";
+  audioFormat: "mp3" | "wav" | "opus" | "pcm";
 }
 
 // ---------------------------------------------------------------------------
@@ -52,18 +52,17 @@ export interface ResolvedCallTts {
 
 export interface ResolveCallTtsOptions {
   /**
-   * When true, force `audioFormat` to `"wav"` regardless of the
+   * When true, resolve `audioFormat` to `"pcm"` regardless of the
    * provider's configured format. The media-stream transport sets this
-   * because its {@link audioBufferToFrames} can only correctly
-   * transcode WAV (PCM) to mu-law -- compressed formats (mp3, opus)
-   * are sent as raw bytes and produce garbled audio.
+   * because it transcodes raw PCM to mu-law -- compressed formats
+   * (mp3, opus) are sent as raw bytes and produce garbled audio.
    *
    * Also gates the media-stream playability guard: a configured provider
-   * that cannot produce playable PCM/WAV audio (or lacks credentials) is
+   * that cannot produce playable PCM audio (or lacks credentials) is
    * swapped for a playable fallback provider instead of resolving into a
    * provider whose only possible media-stream outcome is silence.
    */
-  preferWav?: boolean;
+  requiresPcmAudio?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -80,8 +79,8 @@ export interface ResolveCallTtsOptions {
  * `callMode: "native-twilio"` send text via `sendTextToken`, which the
  * media-stream transport re-synthesizes through daemon TTS.
  *
- * For WAV-requiring transports (`preferWav`, i.e. media-stream), the
- * resolved provider is validated against the media-stream playability
+ * For PCM-requiring transports (`requiresPcmAudio`, i.e. media-stream),
+ * the resolved provider is validated against the media-stream playability
  * capability (format + credentials); a not-playable provider is replaced
  * by {@link findPlayableTelephonyTtsFallback}.
  *
@@ -108,9 +107,9 @@ export async function resolveCallTtsProvider(
     const fishAudioUnusable =
       providerId === "fish-audio" && !fishAudioReferenceIdConfigured();
 
-    if (options?.preferWav) {
+    if (options?.requiresPcmAudio) {
       // Media-stream transport: every spoken turn is synthesized, so the
-      // provider must produce playable PCM/WAV with resolvable credentials
+      // provider must produce playable PCM with resolvable credentials
       // and satisfied config invariants (the capability check covers the
       // fish-audio referenceId rule). Swap in a playable fallback rather
       // than resolving into a provider that can only be silent.
@@ -134,7 +133,7 @@ export async function resolveCallTtsProvider(
         }
       }
     } else if (useSynthesizedPath && fishAudioUnusable) {
-      // Non-WAV transport: degrade to the native token path rather than
+      // Non-PCM transport: degrade to the native token path rather than
       // letting the call stay silent.
       log.warn(
         { provider: providerId },
@@ -149,21 +148,23 @@ export async function resolveCallTtsProvider(
     // config so the streaming store entry's content-type matches the
     // actual audio bytes the provider produces.
     //
-    // When preferWav is set (media-stream transport), force WAV so
-    // audioBufferToFrames receives PCM it can transcode to mu-law.
-    const audioFormat: "mp3" | "wav" | "opus" = options?.preferWav
-      ? "wav"
-      : (() => {
-          const configuredFormat = (
-            resolved.providerConfig as { format?: string }
-          ).format;
-          return (
-            configuredFormat &&
-            ["mp3", "wav", "opus"].includes(configuredFormat)
-              ? configuredFormat
-              : "mp3"
-          ) as "mp3" | "wav" | "opus";
-        })();
+    // When requiresPcmAudio is set (media-stream transport), resolve to
+    // PCM so audioBufferToFrames receives raw PCM it can transcode to
+    // mu-law.
+    const audioFormat: "mp3" | "wav" | "opus" | "pcm" =
+      options?.requiresPcmAudio
+        ? "pcm"
+        : (() => {
+            const configuredFormat = (
+              resolved.providerConfig as { format?: string }
+            ).format;
+            return (
+              configuredFormat &&
+              ["mp3", "wav", "opus"].includes(configuredFormat)
+                ? configuredFormat
+                : "mp3"
+            ) as "mp3" | "wav" | "opus";
+          })();
 
     return { provider, useSynthesizedPath, audioFormat };
   } catch {

--- a/assistant/src/calls/telephony-tts-capability.ts
+++ b/assistant/src/calls/telephony-tts-capability.ts
@@ -4,9 +4,9 @@
  * Validates whether a TTS provider can produce audio that is actually
  * playable over the media-stream call transport. Playability requires:
  *
- * 1. The catalog entry's `mediaStreamPlayback.outputFormat` is `"pcm"` or
- *    `"wav"` — the media-stream mu-law transcoder cannot decode compressed
- *    formats (mp3, opus).
+ * 1. The catalog entry's `mediaStreamPlayback.outputFormat` is `"pcm"` —
+ *    the media-stream mu-law transcoder cannot decode compressed formats
+ *    (mp3, opus).
  * 2. Every secret the catalog entry requires resolves to a value.
  * 3. Provider-specific config invariants hold — Fish Audio requires a
  *    configured `referenceId` (no per-request voiceId is supplied on the
@@ -65,7 +65,7 @@ export type TelephonyTtsCapability =
  * the media-stream call transport.
  *
  * Callers can branch on the discriminated `status` field:
- * - `"playable"` — the provider produces PCM/WAV and credentials resolve.
+ * - `"playable"` — the provider produces PCM and credentials resolve.
  * - `"not-playable"` — see `reason` (`"unsupported-format"` when the
  *   provider is unknown or only produces compressed audio,
  *   `"missing-credentials"` when a required secret does not resolve,

--- a/assistant/src/tts/__tests__/provider-catalog.test.ts
+++ b/assistant/src/tts/__tests__/provider-catalog.test.ts
@@ -54,7 +54,7 @@ describe("TTS provider catalog", () => {
   });
 
   test("every entry declares a valid mediaStreamPlayback output format", () => {
-    const validFormats = new Set(["pcm", "wav", "none"]);
+    const validFormats = new Set(["pcm", "none"]);
     for (const entry of entries) {
       expect(validFormats.has(entry.mediaStreamPlayback.outputFormat)).toBe(
         true,

--- a/assistant/src/tts/provider-definition.ts
+++ b/assistant/src/tts/provider-definition.ts
@@ -66,14 +66,13 @@ export interface TtsProviderCatalogCapabilities {
  * Output format the provider's adapter produces when a caller requests
  * PCM output (`outputFormat: "pcm"`) for media-stream playback.
  *
- * The media-stream transport can only transcode raw PCM or WAV
- * (PCM-in-container) to mu-law — compressed formats (mp3, opus) produce
- * garbled audio. Providers whose adapter honours the PCM hint declare
- * `"pcm"`; providers that substitute WAV declare `"wav"`; providers that
- * can only produce compressed audio declare `"none"` and are not playable
- * over media-stream transports.
+ * The media-stream transport can only transcode raw PCM to mu-law —
+ * compressed formats (mp3, opus) produce garbled audio. Providers whose
+ * adapter honours the PCM hint declare `"pcm"`; providers that can only
+ * produce compressed audio declare `"none"` and are not playable over
+ * media-stream transports.
  */
-export type TtsMediaStreamOutputFormat = "pcm" | "wav" | "none";
+export type TtsMediaStreamOutputFormat = "pcm" | "none";
 
 /**
  * How the provider's synthesized audio plays over media-stream transports.

--- a/docs/proposals/live-voice-channel.md
+++ b/docs/proposals/live-voice-channel.md
@@ -40,7 +40,7 @@ export interface CallTransport {
   sendPlayUrl(url: string): Promise<void>;
   endSession(reason?: string): Promise<void>;
   getConnectionState(): ConnectionState;
-  readonly requiresWavAudio?: boolean;
+  readonly requiresPcmAudio?: boolean;
 }
 ```
 


### PR DESCRIPTION
## Summary
- Rename requiresWavAudio/preferWav to requiresPcmAudio and resolve the PCM-transport audioFormat to "pcm" instead of the "wav" sentinel
- Drop the dead "wav" member from TtsMediaStreamOutputFormat (all catalog entries declare pcm)
- User-configured format: "wav" behavior preserved; only delta is media-stream's unknown-content-type sniff fallback now declares pcm

Part of plan: tts-deferred-cleanups.md (PR 3 of 4)