### PR TITLE
fix(web): auto-scroll staged quote-reply strip to the newest entry

### DIFF
--- a/clients/web/src/domains/chat/components/staged-quotes-strip.tsx
+++ b/clients/web/src/domains/chat/components/staged-quotes-strip.tsx
@@ -8,6 +8,7 @@
  */
 
 import { MessageSquareQuote, X } from "lucide-react";
+import { useEffect, useRef } from "react";
 import {
   Button,
   Card,
@@ -80,13 +81,26 @@ function StagedQuoteChip({ quote }: { quote: StagedQuote }) {
 
 export function StagedQuotesStrip() {
   const stagedQuotes = useQuoteReplyStore.use.stagedQuotes();
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const prevCountRef = useRef(stagedQuotes.length);
+
+  // When a quote is appended, bring the newest chip into view — otherwise a
+  // new reply lands below the 120px cap and the strip silently stays scrolled
+  // to the top. Only scroll on growth so removing a chip doesn't yank the view.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el && stagedQuotes.length > prevCountRef.current) {
+      el.scrollTop = el.scrollHeight;
+    }
+    prevCountRef.current = stagedQuotes.length;
+  }, [stagedQuotes.length]);
 
   if (stagedQuotes.length === 0) {
     return null;
   }
 
   return (
-    <div className="mb-2 max-h-[120px] overflow-y-auto">
+    <div ref={scrollRef} className="mb-2 max-h-[120px] overflow-y-auto">
       <div className="flex flex-col gap-1.5">
         {stagedQuotes.map((quote) => (
           <StagedQuoteChip key={quote.id} quote={quote} />


### PR DESCRIPTION
## Problem

When a user adds a quote-reply via **Add to Chat**, the staged-quotes strip above the composer (capped at `max-h-[120px]`) kept its current scroll position. Once a few quotes were staged, a newly added entry landed *below the 120px fold and out of view* — the strip quietly grew downward instead of showing the reply that was just added.

## Fix

`staged-quotes-strip.tsx`: add a ref to the scroll container and a `useEffect` keyed on the staged-quotes count that scrolls to the bottom whenever the list **grows**, bringing the just-added chip into view. Guarded on growth (`length > prev`) so removing a chip doesn't yank the scroll position.

Both append paths (the button and the Enter-key shortcut) funnel through `addStagedQuote`, so the effect covers both automatically.

## Verification

Rendered `StagedQuotesStrip` in an interactive Storybook harness and added several quotes past the 120px cap: each addition scrolls the strip so the newest chip is visible at the bottom, directly above the composer — never added out of view. `tsc` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->