### PR TITLE
feat(config): completeCustomProfile — standalone materialization of partial custom profiles (M6 PR1)

### DIFF
--- a/assistant/src/config/__tests__/profile-materialization.test.ts
+++ b/assistant/src/config/__tests__/profile-materialization.test.ts
@@ -37,7 +37,7 @@ describe("completeCustomProfile", () => {
     expect(completed.verbosity).toBe("medium");
   });
 
-  test("never inherits temperature, topP, or logitBias", () => {
+  test("inherits non-null default sampling; never inherits logitBias or null sampling", () => {
     const dflt = LLMConfigBase.parse({
       ...fullDefault,
       temperature: 0.7,
@@ -45,13 +45,24 @@ describe("completeCustomProfile", () => {
       logitBias: "suppress-cjk",
     });
     const completed = completeCustomProfile(dflt, { model: "claude-fable-5" });
-    expect(completed.temperature).toBeUndefined();
-    expect(completed.topP).toBeUndefined();
+    // The resolver leaves llm.default's base sampling standing when no
+    // profile opts in, so non-null defaults must be baked in.
+    expect(completed.temperature).toBe(0.7);
+    expect(completed.topP).toBe(0.9);
+    // logitBias is deleted post-merge unless the winning profile set it.
     expect(completed.logitBias).toBeUndefined();
-    // The profile's own sampling values are preserved untouched.
+    // The profile's own sampling wins over the default's.
     const own = completeCustomProfile(dflt, { temperature: 0.2 });
     expect(own.temperature).toBe(0.2);
-    expect(own.topP).toBeUndefined();
+    expect(own.topP).toBe(0.9);
+    // A null schema-default is skipped, not baked in as an explicit null.
+    const nullDefaults = completeCustomProfile(fullDefault, {});
+    expect(nullDefaults.temperature).toBeUndefined();
+    expect(nullDefaults.topP).toBeUndefined();
+    // A profile's explicit null is preserved (it clears the default's value
+    // in the resolver, and must keep doing so standalone).
+    const explicitNull = completeCustomProfile(dflt, { temperature: null });
+    expect(explicitNull.temperature).toBeNull();
   });
 
   test("merges partial nested thinking leaf-by-leaf", () => {
@@ -219,6 +230,7 @@ describe("completeCustomProfile — resolver equivalence", () => {
     "model only, served by default provider": { model: "claude-fable-5" },
     "model only, implies another provider": { model: "gpt-5.5" },
     "sampling only": { temperature: 0.3 },
+    "explicit null sampling": { temperature: null },
     "nested thinking fragment": { thinking: { enabled: false } },
     "tokens and effort": { maxTokens: 1234, effort: "low" },
     "explicit cross-provider without connection": {
@@ -242,9 +254,22 @@ describe("completeCustomProfile — resolver equivalence", () => {
     },
   };
 
-  const resolveWith = (profile: ProfileEntry) => {
+  // Run the whole matrix against two defaults: the schema-typical null
+  // sampling, and a default with non-null temperature/topP — the latter is
+  // what catches sampling-inheritance regressions (null defaults make those
+  // cases pass vacuously).
+  const DEFAULTS: Record<string, LLMConfigBase> = {
+    "null sampling": fullDefault,
+    "non-null sampling": LLMConfigBase.parse({
+      ...fullDefault,
+      temperature: 0.7,
+      topP: 0.9,
+    }),
+  };
+
+  const resolveWith = (dflt: LLMConfigBase, profile: ProfileEntry) => {
     const llm = LLMSchema.parse({
-      default: fullDefault,
+      default: dflt,
       profiles: { "custom-x": { source: "user", ...profile } },
     });
     return resolveCallSiteConfig("vision", llm, {
@@ -252,13 +277,17 @@ describe("completeCustomProfile — resolver equivalence", () => {
     });
   };
 
-  for (const [name, partial] of Object.entries(PARTIALS)) {
-    test(`partial and completed resolve identically: ${name}`, () => {
-      const completed = completeCustomProfile(fullDefault, {
-        source: "user",
-        ...partial,
+  for (const [defaultName, dflt] of Object.entries(DEFAULTS)) {
+    for (const [name, partial] of Object.entries(PARTIALS)) {
+      test(`partial and completed resolve identically (${defaultName} default): ${name}`, () => {
+        const completed = completeCustomProfile(dflt, {
+          source: "user",
+          ...partial,
+        });
+        expect(resolveWith(dflt, completed)).toEqual(
+          resolveWith(dflt, partial),
+        );
       });
-      expect(resolveWith(completed)).toEqual(resolveWith(partial));
-    });
+    }
   }
 });

--- a/assistant/src/config/__tests__/profile-materialization.test.ts
+++ b/assistant/src/config/__tests__/profile-materialization.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { VELLUM_MANAGED_CONNECTION_NAME } from "../../providers/vellum-model-routing.js";
 import { resolveCallSiteConfig } from "../llm-resolver.js";
 import { completeCustomProfile } from "../profile-materialization.js";
 import { LLMConfigBase, LLMSchema, ProfileEntry } from "../schemas/llm.js";
@@ -105,6 +106,25 @@ describe("completeCustomProfile", () => {
     });
     expect(completed.provider).toBe("openai");
     expect(completed.provider_connection).toBeUndefined();
+  });
+
+  test("always inherits the provider-agnostic vellum managed connection, even across an implied provider change", () => {
+    const managedDefault = LLMConfigBase.parse({
+      ...fullDefault,
+      provider_connection: VELLUM_MANAGED_CONNECTION_NAME,
+    });
+    // Model implication flips the provider, but the vellum connection routes
+    // any managed provider via `expectedProvider` — dropping it would cut the
+    // profile off from platform-proxy routing.
+    const implied = completeCustomProfile(managedDefault, { model: "gpt-5.5" });
+    expect(implied.provider).toBe("openai");
+    expect(implied.provider_connection).toBe(VELLUM_MANAGED_CONNECTION_NAME);
+
+    const explicit = completeCustomProfile(managedDefault, {
+      provider: "openai",
+      model: "gpt-5.4",
+    });
+    expect(explicit.provider_connection).toBe(VELLUM_MANAGED_CONNECTION_NAME);
   });
 
   test("keeps the inherited provider for a model unknown to the catalog", () => {

--- a/assistant/src/config/__tests__/profile-materialization.test.ts
+++ b/assistant/src/config/__tests__/profile-materialization.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveCallSiteConfig } from "../llm-resolver.js";
+import { completeCustomProfile } from "../profile-materialization.js";
+import { LLMConfigBase, LLMSchema, ProfileEntry } from "../schemas/llm.js";
+
+const fullDefault = LLMConfigBase.parse({
+  provider: "anthropic",
+  provider_connection: "anthropic-personal",
+  model: "claude-opus-4-8",
+  maxTokens: 64000,
+  effort: "max",
+  speed: "standard",
+  verbosity: "medium",
+  temperature: null,
+  topP: null,
+  thinking: { enabled: true, streamThinking: true },
+  contextWindow: {
+    enabled: true,
+    maxInputTokens: 200000,
+    overflowRecovery: { enabled: true, maxAttempts: 3 },
+  },
+});
+
+describe("completeCustomProfile", () => {
+  test("inherits omitted scalar fields from the default", () => {
+    const completed = completeCustomProfile(fullDefault, {
+      model: "claude-fable-5",
+    });
+    expect(completed.model).toBe("claude-fable-5");
+    expect(completed.provider).toBe("anthropic");
+    expect(completed.provider_connection).toBe("anthropic-personal");
+    expect(completed.maxTokens).toBe(64000);
+    expect(completed.effort).toBe("max");
+    expect(completed.speed).toBe("standard");
+    expect(completed.verbosity).toBe("medium");
+  });
+
+  test("never inherits temperature, topP, or logitBias", () => {
+    const dflt = LLMConfigBase.parse({
+      ...fullDefault,
+      temperature: 0.7,
+      topP: 0.9,
+      logitBias: "suppress-cjk",
+    });
+    const completed = completeCustomProfile(dflt, { model: "claude-fable-5" });
+    expect(completed.temperature).toBeUndefined();
+    expect(completed.topP).toBeUndefined();
+    expect(completed.logitBias).toBeUndefined();
+    // The profile's own sampling values are preserved untouched.
+    const own = completeCustomProfile(dflt, { temperature: 0.2 });
+    expect(own.temperature).toBe(0.2);
+    expect(own.topP).toBeUndefined();
+  });
+
+  test("merges partial nested thinking leaf-by-leaf", () => {
+    const completed = completeCustomProfile(fullDefault, {
+      thinking: { enabled: false },
+    });
+    expect(completed.thinking).toEqual({
+      enabled: false,
+      streamThinking: true,
+    });
+  });
+
+  test("merges nested contextWindow leaves including overflowRecovery", () => {
+    const completed = completeCustomProfile(fullDefault, {
+      contextWindow: { overflowRecovery: { maxAttempts: 5 } },
+    });
+    expect(completed.contextWindow?.maxInputTokens).toBe(200000);
+    expect(completed.contextWindow?.overflowRecovery?.maxAttempts).toBe(5);
+    expect(completed.contextWindow?.overflowRecovery?.enabled).toBe(true);
+  });
+
+  test("keeps the inherited provider when it serves the profile's model", () => {
+    const completed = completeCustomProfile(fullDefault, {
+      model: "claude-fable-5",
+    });
+    expect(completed.provider).toBe("anthropic");
+    expect(completed.provider_connection).toBe("anthropic-personal");
+  });
+
+  test("stamps the catalog owner for a model the default provider does not serve, and drops the default's connection", () => {
+    const completed = completeCustomProfile(fullDefault, { model: "gpt-5.5" });
+    expect(completed.provider).toBe("openai");
+    // anthropic-personal belongs to the replaced provider; dispatch
+    // auto-resolves an absent connection by provider, same as the partial
+    // profile resolves today.
+    expect(completed.provider_connection).toBeUndefined();
+  });
+
+  test("keeps an explicit provider_connection even when the provider is implied", () => {
+    const completed = completeCustomProfile(fullDefault, {
+      model: "gpt-5.5",
+      provider_connection: "my-openai",
+    });
+    expect(completed.provider).toBe("openai");
+    expect(completed.provider_connection).toBe("my-openai");
+  });
+
+  test("does not inherit the default's connection onto an explicit different provider", () => {
+    const completed = completeCustomProfile(fullDefault, {
+      provider: "openai",
+      model: "gpt-5.4",
+    });
+    expect(completed.provider).toBe("openai");
+    expect(completed.provider_connection).toBeUndefined();
+  });
+
+  test("keeps the inherited provider for a model unknown to the catalog", () => {
+    const completed = completeCustomProfile(fullDefault, {
+      model: "totally-custom-model",
+    });
+    expect(completed.provider).toBe("anthropic");
+    expect(completed.provider_connection).toBe("anthropic-personal");
+  });
+
+  test("passes mix profiles through untouched", () => {
+    const mix: ProfileEntry = {
+      label: "A/B",
+      mix: [
+        { profile: "a", weight: 1 },
+        { profile: "b", weight: 1 },
+      ],
+    };
+    expect(completeCustomProfile(fullDefault, mix)).toBe(mix);
+  });
+
+  test("passes managed profiles through untouched", () => {
+    const managed: ProfileEntry = { source: "managed", topP: 0.9 };
+    expect(completeCustomProfile(fullDefault, managed)).toBe(managed);
+  });
+
+  test("preserves metadata fields", () => {
+    const completed = completeCustomProfile(fullDefault, {
+      source: "user",
+      label: "Fast drafts",
+      description: "cheap and quick",
+      status: "disabled",
+      model: "claude-haiku-4-5-20251001",
+    });
+    expect(completed.source).toBe("user");
+    expect(completed.label).toBe("Fast drafts");
+    expect(completed.description).toBe("cheap and quick");
+    expect(completed.status).toBe("disabled");
+  });
+
+  test("is idempotent", () => {
+    const partials: ProfileEntry[] = [
+      {},
+      { model: "gpt-5.5" },
+      { temperature: 0.3 },
+      { thinking: { enabled: false }, maxTokens: 1234 },
+    ];
+    for (const partial of partials) {
+      const once = completeCustomProfile(fullDefault, partial);
+      const twice = completeCustomProfile(fullDefault, once);
+      expect(twice).toEqual(once);
+    }
+  });
+
+  test("completed entries still parse as ProfileEntry", () => {
+    const partials: ProfileEntry[] = [
+      {},
+      { model: "gpt-5.5" },
+      { temperature: 0.3, label: "t" },
+      { thinking: { enabled: false } },
+    ];
+    for (const partial of partials) {
+      const completed = completeCustomProfile(fullDefault, partial);
+      expect(() => ProfileEntry.parse(completed)).not.toThrow();
+    }
+  });
+
+  test("does not alias the default's nested objects", () => {
+    const completed = completeCustomProfile(fullDefault, {});
+    expect(completed.thinking).toEqual(fullDefault.thinking);
+    expect(completed.thinking).not.toBe(fullDefault.thinking);
+    expect(completed.contextWindow).not.toBe(fullDefault.contextWindow);
+  });
+});
+
+// Equivalence with the live deep-merge resolver: on a profile-less call site
+// with no activeProfile, the custom profile is the only profile layer above
+// `llm.default`, which is exactly the standalone meaning materialization
+// bakes in. Partial and completed forms must resolve identically — this is
+// the contract that lets migration 128 rewrite profiles without changing
+// behavior under the current resolver, and lets the M6 resolver treat the
+// completed form as the profile's full meaning.
+//
+// (Deliberately NOT covered: a partial profile layered above other profiles
+// — e.g. mainAgent activeProfile above the balanced call-site layer — where
+// omitted fields inherit from the mid layer today. That context-dependent
+// meaning is unrepresentable as a single complete profile; the standalone
+// reading is the one that ships. See the M6 plan, Behavior changes #4.)
+describe("completeCustomProfile — resolver equivalence", () => {
+  const PARTIALS: Record<string, ProfileEntry> = {
+    empty: {},
+    "model only, served by default provider": { model: "claude-fable-5" },
+    "model only, implies another provider": { model: "gpt-5.5" },
+    "sampling only": { temperature: 0.3 },
+    "nested thinking fragment": { thinking: { enabled: false } },
+    "tokens and effort": { maxTokens: 1234, effort: "low" },
+    "explicit cross-provider without connection": {
+      provider: "openai",
+      model: "gpt-5.4",
+    },
+    "complete profile": {
+      provider: "openai",
+      model: "gpt-5.4",
+      provider_connection: "openai-personal",
+      maxTokens: 9000,
+      effort: "high",
+      temperature: 0.1,
+      topP: 0.5,
+    },
+    "metadata alongside config": {
+      model: "gpt-5.5",
+      label: "My GPT",
+      description: "d",
+      status: "active",
+    },
+  };
+
+  const resolveWith = (profile: ProfileEntry) => {
+    const llm = LLMSchema.parse({
+      default: fullDefault,
+      profiles: { "custom-x": { source: "user", ...profile } },
+    });
+    return resolveCallSiteConfig("vision", llm, {
+      overrideProfile: "custom-x",
+    });
+  };
+
+  for (const [name, partial] of Object.entries(PARTIALS)) {
+    test(`partial and completed resolve identically: ${name}`, () => {
+      const completed = completeCustomProfile(fullDefault, {
+        source: "user",
+        ...partial,
+      });
+      expect(resolveWith(completed)).toEqual(resolveWith(partial));
+    });
+  }
+});

--- a/assistant/src/config/profile-materialization.ts
+++ b/assistant/src/config/profile-materialization.ts
@@ -2,6 +2,7 @@ import {
   getCatalogProviderForModel,
   isModelInCatalog,
 } from "../providers/model-catalog.js";
+import { VELLUM_MANAGED_CONNECTION_NAME } from "../providers/vellum-model-routing.js";
 import type { LLMConfigBase, ProfileEntry } from "./schemas/llm.js";
 
 /**
@@ -27,10 +28,14 @@ import type { LLMConfigBase, ProfileEntry } from "./schemas/llm.js";
  * - A model-only profile gets the provider `withImpliedProviders` would
  *   stamp: the inherited default provider when it serves the model, else the
  *   model's catalog owner.
- * - The default's `provider_connection` is inherited only when the completed
- *   provider is still the default's provider; a profile that resolves to a
- *   different provider (explicitly or via model implication) gets no baked
- *   connection, and dispatch auto-resolves by provider as it does today.
+ * - The default's `provider_connection` is inherited when the completed
+ *   provider is still the default's provider, and always when it is the
+ *   provider-agnostic Vellum managed connection (which routes any managed
+ *   provider via `expectedProvider`). A provider-SPECIFIC connection is not
+ *   baked onto a profile that resolved to a different provider (explicitly
+ *   or via model implication) — that would pin a mismatch; dispatch
+ *   auto-resolves an absent connection by provider, exactly as it does for
+ *   the partial profile today.
  *
  * Mix profiles (no config fields, schema-enforced) and managed profiles
  * (bodies owned by the code catalog) pass through untouched.
@@ -43,16 +48,30 @@ export function completeCustomProfile(
   dflt: LLMConfigBase,
   profile: ProfileEntry,
 ): ProfileEntry {
-  if (profile.mix != null || profile.source === "managed") return profile;
+  if (profile.mix != null || profile.source === "managed") {
+    return profile;
+  }
 
   const completed: ProfileEntry = { ...profile };
 
-  if (profile.provider === undefined) completed.provider = dflt.provider;
-  if (profile.model === undefined) completed.model = dflt.model;
-  if (profile.maxTokens === undefined) completed.maxTokens = dflt.maxTokens;
-  if (profile.effort === undefined) completed.effort = dflt.effort;
-  if (profile.speed === undefined) completed.speed = dflt.speed;
-  if (profile.verbosity === undefined) completed.verbosity = dflt.verbosity;
+  if (profile.provider === undefined) {
+    completed.provider = dflt.provider;
+  }
+  if (profile.model === undefined) {
+    completed.model = dflt.model;
+  }
+  if (profile.maxTokens === undefined) {
+    completed.maxTokens = dflt.maxTokens;
+  }
+  if (profile.effort === undefined) {
+    completed.effort = dflt.effort;
+  }
+  if (profile.speed === undefined) {
+    completed.speed = dflt.speed;
+  }
+  if (profile.verbosity === undefined) {
+    completed.verbosity = dflt.verbosity;
+  }
   if (profile.disableCache === undefined && dflt.disableCache !== undefined) {
     completed.disableCache = dflt.disableCache;
   }
@@ -78,16 +97,20 @@ export function completeCustomProfile(
     }
   }
 
-  // The default's connection is inherited only when the completed provider
-  // is still the default's provider — a connection row belongs to one
-  // provider, and stamping it onto a profile that resolved to a different
-  // provider (explicitly or via model implication) would bake in a mismatch.
+  // A provider-specific connection row belongs to one provider: inheriting
+  // it onto a profile that resolved to a different provider (explicitly or
+  // via model implication) would bake in a mismatch, so it is inherited only
+  // when the completed provider is still the default's. The Vellum managed
+  // connection is the exception — it is provider-agnostic (dispatch routes
+  // it with `expectedProvider` set to the profile's provider), so dropping
+  // it would cut managed installs off from platform-proxy routing.
   // Dispatch auto-resolves an absent connection by provider, exactly as it
   // does for the partial profile today.
   if (
     profile.provider_connection === undefined &&
     dflt.provider_connection !== undefined &&
-    completed.provider === dflt.provider
+    (completed.provider === dflt.provider ||
+      dflt.provider_connection === VELLUM_MANAGED_CONNECTION_NAME)
   ) {
     completed.provider_connection = dflt.provider_connection;
   }
@@ -118,11 +141,17 @@ function isPlainObject(value: unknown): value is PlainObject {
  * rationale.)
  */
 function mergeNestedFragment<T>(base: T, fragment: unknown): T {
-  if (fragment === undefined) return base;
-  if (!isPlainObject(base) || !isPlainObject(fragment)) return fragment as T;
+  if (fragment === undefined) {
+    return base;
+  }
+  if (!isPlainObject(base) || !isPlainObject(fragment)) {
+    return fragment as T;
+  }
   const out: PlainObject = { ...base };
   for (const [key, value] of Object.entries(fragment)) {
-    if (value === undefined) continue;
+    if (value === undefined) {
+      continue;
+    }
     const existing = out[key];
     out[key] =
       isPlainObject(value) && isPlainObject(existing)

--- a/assistant/src/config/profile-materialization.ts
+++ b/assistant/src/config/profile-materialization.ts
@@ -1,0 +1,133 @@
+import {
+  getCatalogProviderForModel,
+  isModelInCatalog,
+} from "../providers/model-catalog.js";
+import type { LLMConfigBase, ProfileEntry } from "./schemas/llm.js";
+
+/**
+ * Materializes a partial custom profile into a complete, standalone override
+ * by baking in the fields it currently inherits from `llm.default` under the
+ * deep-merge resolver.
+ *
+ * The completed entry pins the profile's *standalone* meaning: what
+ * `resolveCallSiteConfig` produces today when this profile is the only
+ * profile layer above `llm.default` (e.g. an override on a profile-less call
+ * site). This is the baseline the M6 override-or-default resolver assumes —
+ * once resolution stops merging, a profile must carry everything it means.
+ *
+ * Deliberate parity quirks with the current resolver:
+ *
+ * - `temperature`, `topP`, and `logitBias` are NEVER inherited. They are
+ *   winning-profile-scoped in `resolveCallSiteConfig` (a profile that omits
+ *   them resolves without them regardless of `llm.default`), so baking them
+ *   in would change behavior.
+ * - Nested `thinking`/`contextWindow`/`openrouter` fragments merge
+ *   leaf-by-leaf into the default's full object, mirroring the resolver's
+ *   `deepMerge`.
+ * - A model-only profile gets the provider `withImpliedProviders` would
+ *   stamp: the inherited default provider when it serves the model, else the
+ *   model's catalog owner.
+ * - The default's `provider_connection` is inherited only when the completed
+ *   provider is still the default's provider; a profile that resolves to a
+ *   different provider (explicitly or via model implication) gets no baked
+ *   connection, and dispatch auto-resolves by provider as it does today.
+ *
+ * Mix profiles (no config fields, schema-enforced) and managed profiles
+ * (bodies owned by the code catalog) pass through untouched.
+ *
+ * Idempotent: completing an already-complete profile is the identity.
+ * Pure and synchronous; the returned entry never aliases `dflt`'s nested
+ * objects.
+ */
+export function completeCustomProfile(
+  dflt: LLMConfigBase,
+  profile: ProfileEntry,
+): ProfileEntry {
+  if (profile.mix != null || profile.source === "managed") return profile;
+
+  const completed: ProfileEntry = { ...profile };
+
+  if (profile.provider === undefined) completed.provider = dflt.provider;
+  if (profile.model === undefined) completed.model = dflt.model;
+  if (profile.maxTokens === undefined) completed.maxTokens = dflt.maxTokens;
+  if (profile.effort === undefined) completed.effort = dflt.effort;
+  if (profile.speed === undefined) completed.speed = dflt.speed;
+  if (profile.verbosity === undefined) completed.verbosity = dflt.verbosity;
+  if (profile.disableCache === undefined && dflt.disableCache !== undefined) {
+    completed.disableCache = dflt.disableCache;
+  }
+
+  completed.thinking = mergeNestedFragment(dflt.thinking, profile.thinking);
+  completed.contextWindow = mergeNestedFragment(
+    dflt.contextWindow,
+    profile.contextWindow,
+  );
+  completed.openrouter = mergeNestedFragment(
+    dflt.openrouter,
+    profile.openrouter,
+  );
+
+  if (
+    profile.model !== undefined &&
+    profile.provider === undefined &&
+    !isModelInCatalog(dflt.provider, profile.model)
+  ) {
+    const implied = getCatalogProviderForModel(profile.model);
+    if (implied !== undefined) {
+      completed.provider = implied as ProfileEntry["provider"];
+    }
+  }
+
+  // The default's connection is inherited only when the completed provider
+  // is still the default's provider — a connection row belongs to one
+  // provider, and stamping it onto a profile that resolved to a different
+  // provider (explicitly or via model implication) would bake in a mismatch.
+  // Dispatch auto-resolves an absent connection by provider, exactly as it
+  // does for the partial profile today.
+  if (
+    profile.provider_connection === undefined &&
+    dflt.provider_connection !== undefined &&
+    completed.provider === dflt.provider
+  ) {
+    completed.provider_connection = dflt.provider_connection;
+  }
+
+  return structuredClone(completed);
+}
+
+type PlainObject = Record<string, unknown>;
+
+function isPlainObject(value: unknown): value is PlainObject {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}
+
+/**
+ * Merge a partial nested fragment into the default's full object with the
+ * same semantics as the resolver's `deepMerge`: `undefined` fragment values
+ * are "no opinion", plain objects recurse, everything else replaces.
+ *
+ * Intentionally re-declared rather than shared with `llm-resolver.ts`:
+ * materialization is a semantic snapshot of the merge behavior profiles were
+ * created under, and its output must not drift when the resolver's own merge
+ * evolves. (Mirrors the resolver's self-contained `seededUnitFloat`
+ * rationale.)
+ */
+function mergeNestedFragment<T>(base: T, fragment: unknown): T {
+  if (fragment === undefined) return base;
+  if (!isPlainObject(base) || !isPlainObject(fragment)) return fragment as T;
+  const out: PlainObject = { ...base };
+  for (const [key, value] of Object.entries(fragment)) {
+    if (value === undefined) continue;
+    const existing = out[key];
+    out[key] =
+      isPlainObject(value) && isPlainObject(existing)
+        ? mergeNestedFragment(existing, value)
+        : value;
+  }
+  return out as T;
+}

--- a/assistant/src/config/profile-materialization.ts
+++ b/assistant/src/config/profile-materialization.ts
@@ -18,10 +18,14 @@ import type { LLMConfigBase, ProfileEntry } from "./schemas/llm.js";
  *
  * Deliberate parity quirks with the current resolver:
  *
- * - `temperature`, `topP`, and `logitBias` are NEVER inherited. They are
- *   winning-profile-scoped in `resolveCallSiteConfig` (a profile that omits
- *   them resolves without them regardless of `llm.default`), so baking them
- *   in would change behavior.
+ * - Non-null `temperature`/`topP` on the default ARE inherited: the
+ *   resolver's winning-profile scoping only blocks one PROFILE's sampling
+ *   from leaking under another, while `llm.default`'s base sampling stands
+ *   whenever no profile opts in. A null default (the schema default) is
+ *   skipped — baking an explicit `null` would be noise with the same
+ *   resolved result. `logitBias` is NEVER inherited: the resolver deletes
+ *   any non-profile value post-merge, so only a profile that opted in
+ *   carries it.
  * - Nested `thinking`/`contextWindow`/`openrouter` fragments merge
  *   leaf-by-leaf into the default's full object, mirroring the resolver's
  *   `deepMerge`.
@@ -74,6 +78,12 @@ export function completeCustomProfile(
   }
   if (profile.disableCache === undefined && dflt.disableCache !== undefined) {
     completed.disableCache = dflt.disableCache;
+  }
+  if (profile.temperature === undefined && dflt.temperature != null) {
+    completed.temperature = dflt.temperature;
+  }
+  if (profile.topP === undefined && dflt.topP != null) {
+    completed.topP = dflt.topP;
   }
 
   completed.thinking = mergeNestedFragment(dflt.thinking, profile.thinking);


### PR DESCRIPTION
## Summary
- Adds `completeCustomProfile(dflt, profile)` in `assistant/src/config/profile-materialization.ts`: materializes a partial custom profile into a complete, standalone override by baking in what it inherits from `llm.default` under the current deep-merge resolver — including the resolver's parity quirks (winning-profile-scoped `temperature`/`topP`/`logitBias` are never inherited; nested `thinking`/`contextWindow`/`openrouter` merge leaf-by-leaf; model-only profiles get the `withImpliedProviders` provider; `provider_connection` is inherited only when the effective provider matches the default's).
- Inert: no production consumers yet. This is PR 1 of the M6 plan — the write-path normalization (PR 2) and workspace migration 128 (PR 3) build on it.
- Tests include a resolver-equivalence suite pinning that partial and completed profiles resolve identically when the profile is the only profile layer above `llm.default` (profile-less call site) — the contract that lets migration 128 rewrite profiles without behavior change, plus idempotency, nested-merge, implication, and passthrough coverage.

## Original prompt
Milestone 6 of the Inference Management Refactor replaces deep-merge profile resolution with override-or-default semantics (custom profile = complete override; default intents resolve through `llm.defaultProvider` via the code catalog; new resolver ships behind the `override-or-default-resolution` kill-switch flag). Existing custom profiles are partial (omitted fields inherit via merge), so they must be materialized into complete profiles before the resolver flip. This PR is the shared completion helper that the write-path normalization and migration will use. Full plan attached below as the durable papertrail.

<details>
<summary>M6 plan: Override-or-Default Profile Resolution (papertrail)</summary>

# M6: Override-or-Default Profile Resolution

## Overview

Replace the deep-merge cascade in `assistant/src/config/llm-resolver.ts` with override-or-default semantics: resolution picks exactly one complete profile (explicit override, or the call site's default intent resolved through `llm.defaultProvider` via the code catalog), plus at most the call site's own tweak fragment. Prerequisite state (M4 code catalog, M5 `llm.defaultProvider`) is fully merged. The plan front-loads the compatibility work (materializing partial custom profiles, write-path normalization, defaultProvider-aware catalog lookup, error groundwork) so the resolver flip itself is one reviewable PR that must not change behavior for materialized workspaces.

Notion: vellum-ai/Inference-Management-Refactor-38e9035c57bd804d9f92c11f27391856 (Milestone 6). Everything is inside `assistant/` — the resolver has no consumers in gateway/cli/clients/packages, and route contracts do not change (that's M7). No cross-repo work.

## Design decisions (resolved during planning)

- **Materialization baseline**: a custom profile is completed against the layers *below* it — `llm.default` plus the profile itself ("what the profile means standalone"). Call-site layers above it stay call-site concerns. Replicates current merge quirks exactly: `temperature`/`topP`/`logitBias` are winning-profile-scoped today and are **not** inherited from `llm.default`; nested `thinking`/`contextWindow` deep-merge leaf-by-leaf; provider is copied from `llm.default` and the (retained) single-profile model→provider implication corrects it when the model isn't served.
- **Mix profiles survive unchanged**: a mix carries no config fields (schema-enforced), it's a weighted pointer. Expansion at dereference stays; the chosen arm (a complete profile post-materialization) is the winner. Mixes are not materialized.
- **Model→provider implication is retained** as a live, code-owned resolution step applied to the single winning profile (`withImpliedProviders` semantics collapse to one check). This keeps the materialization migration free of a frozen model-catalog snapshot.
- **`forceOverrideProfile` collapses**: under override-always-wins there is no "float above" distinction. The resolver option becomes a documented no-op alias; the three drivers (scheduler opportunity-wake, memory-retrospective fork, subagent advisor) and agent-wake's string-form convention keep working untouched. Removal is M9 scope.
- **`activeProfile` becomes mainAgent-only**: it is the mainAgent call site's selection, second in that site's chain. It no longer folds into other call sites (today it back-fills profileless sites). `advisorProfile` is unaffected (enters as `overrideProfile` via subagent spawn).
- **Profileless call sites (`vision`, `workflowLeaf`) re-anchor to the default provider**: they resolve balanced-intent through `llm.defaultProvider` plus their fragment tweaks, instead of `llm.default` + activeProfile-backfill. This is a deliberate behavior change (see Behavior changes). `llm.default` drops out of live resolution; the completeness base becomes `LLMConfigBase` code defaults. `llm.default` itself stays on disk (delete-guard and legacy readers reference it) — retirement is M9.
- **`LLMSchema.superRefine` stays strict**: config-file profile references are still validated at load (dangling refs are pruned by config recovery). The resolver's deleted-profile fallback covers the refs schema can't see — DB-backed pins (conversation `inferenceProfile`, `cron_jobs.inferenceProfile`) arriving as `overrideProfile`, plus delete races.
- **Auto-recovery connection scans stay in M6** (`connection-resolution.ts:152-176`, `:241-262`): they handle stale-but-recoverable references (compat aliases), which is different from *missing* — missing gets explainable errors. Removing auto-recovery is M9 scope.
- **The small internal `deepMerge` helper survives** for composing exactly three known layers (code-default base → winning profile → call-site tweak fragment) so a tweak like `{thinking: {enabled: false}}` doesn't wipe sibling nested fields. What M6 removes is the multi-profile fragment *cascade* and its provenance machinery (`samplingRef`/`biasRef`, per-layer implied providers, mainAgent's flipped precedence).
- **Release sequencing**: all seven PRs ship in the same release (decided 2026-07-08 — no soak cycle). Ordering is safe: workspace migrations run at boot before traffic, so every install materializes profiles before the new resolver runs. Since there's no field-soak of the migration under the old resolver, the plan compensates with (a) an adversarial fixture matrix in PR 3 covering drifted/hand-edited configs, (b) a structured log from the migration recording exactly which fields it baked into which profiles (so a field report of "wrong model" is immediately attributable to data vs. resolver), and (c) PR 6's before/after resolution-parity fixtures.
- **Kill-switch feature flag** (decided 2026-07-08): the new resolver semantics ship behind assistant flag `override-or-default-resolution`, `defaultEnabled: true`. It gates pure read-time logic only (PR 6's resolver branch + PR 7's preflight); PRs 1–5 ship unconditional because migration/write-normalization/catalog/error-groundwork are valid under both semantics by construction (PR 1's equivalence test). Flag-off instantly restores the merge cascade with no reconcile lifecycle — this is what M5's "no flag" decision deferred to M6. Remote flag sync = fleet-wide kill without a release (fully offline self-hosted installs only get the registry default). The old cascade is therefore NOT deleted in PR 6; deletion of the cascade machinery + this flag is M9 scope (Notion M9 already lists "old deep-merge helper paths"). `usage/attribution.ts` must follow the same flag so attribution never disagrees with the active resolver. Requires a small companion Terraform PR in vellum-assistant-platform to create the flag on the platform (per meta/feature-flags/AGENTS.md).

## Behavior changes to call out in PR descriptions

1. Profileless sites (`vision`, `workflowLeaf`) and BYOK installs whose call site resolved no profile no longer inherit `activeProfile`; they resolve balanced-intent through the default provider. (`vision` continues passing its own self-resolved vision-capable `overrideProfile`, so its dispatch path is unchanged in practice.)
2. Custom profiles stop inheriting: after materialization, editing `llm.default` no longer changes what an existing custom profile resolves to. Web UI "inherit" editing snapshots values at save time until M7 reworks the editor (flag for M7).
3. A shadowed profile can no longer leak *any* field into a resolution (today's samplingRef/biasRef machinery exists to prevent most of this; single-winner semantics prevent all of it).
4. Materialization defines a partial custom profile's meaning as `llm.default`-standalone. Today a partial profile used as mainAgent `activeProfile` (or as a forced override above a call-site pin) inherits its omitted fields from the profile layer *beneath* it (e.g. `balanced`'s maxTokens/thinking), not from `llm.default`. A profile's effective content is context-dependent today, so no single materialization preserves every context; the standalone reading matches the profile editor's "inherit from default config" mental model and is what ships. Affected: partial (web-editor-created) custom profiles selected as activeProfile — their inherited fields may shift from the balanced layer's values to `llm.default`'s at migration time.

## PR 1: Standalone profile-completion helper

### Depends on
None

### Branch
m6-override-default/pr-1-completion-helper

### Title
feat(config): add completeCustomProfile — standalone materialization of partial custom profiles

### Files
- assistant/src/config/profile-materialization.ts (new)
- assistant/src/config/__tests__/profile-materialization.test.ts (new)

### Implementation steps
1. Create `profile-materialization.ts` exporting `completeCustomProfile(dflt: z.infer<typeof LLMConfigBase>, profile: ProfileEntry): ProfileEntry`, pure and synchronous.
2. Return the entry unchanged when `profile.mix != null` (mixes carry no config fields — schema-enforced) or `profile.source === "managed"` (catalog-owned).
3. Otherwise build the completed entry:
   - Inheritable fields copied from `dflt` when the profile omits them: `provider`, `model`, `maxTokens`, `effort`, `speed`, `verbosity`, `contextWindow`, `openrouter`, `disableCache`, `provider_connection`.
   - `thinking` and `contextWindow` (and `contextWindow.overflowRecovery`) merge leaf-by-leaf when the profile sets a partial nested object (mirror `deepMerge` semantics from `llm-resolver.ts:585`).
   - **Never** inherit `temperature`, `topP`, `logitBias` — these are winning-profile-scoped in the current resolver (`llm-resolver.ts:63-70`); keep only the profile's own values.
   - Provider implication parity: when the profile sets `model` but not `provider`, keep the inherited `dflt.provider` if `isModelInCatalog(dflt.provider, model)`, else stamp `getCatalogProviderForModel(model)` (mirrors `withImpliedProviders`, `llm-resolver.ts:416`). When implication changes the provider away from `dflt.provider`, do **not** inherit `dflt.provider_connection` (it belongs to the other provider); leave `provider_connection` as the profile had it.
   - Preserve metadata untouched: `source`, `label`, `description`, `status`.
4. The function must be idempotent: `completeCustomProfile(d, completeCustomProfile(d, p))` deep-equals the single application.
5. Tests: field inheritance, sampling non-inheritance, nested `thinking` partial merge, model-only profile provider implication (both the "default provider serves it" and "implied elsewhere" branches, including the provider_connection non-inheritance rule), mix/managed passthrough, idempotency.
6. Equivalence test against the live resolver: for a matrix of partial profiles, assert `resolveCallSiteConfig("vision", llm, { overrideProfile: "custom-x" })` (a profileless call site, no activeProfile set — so the custom profile is the only profile layer above `llm.default`) produces identical output whether `llm.profiles["custom-x"]` is the partial original or the completed version. This pins the standalone semantics the materialization preserves. Note the deliberate limit: where a partial profile rides ABOVE other profile layers today (mainAgent activeProfile above the balanced call-site layer, forced overrides above call-site pins), it currently inherits from those mid layers, and no single materialization can preserve every layered context — see Behavior changes #4.

### Acceptance criteria
- `bun test assistant/src/config/__tests__/profile-materialization.test.ts` passes.
- Equivalence test proves partial vs completed profiles resolve identically under the current resolver.
- No production call sites yet (helper is inert); `bun run typecheck` clean.

## PR 2: Normalize custom-profile writes to complete entries

### Depends on
PR 1

### Branch
m6-override-default/pr-2-write-normalization

### Title
feat(config): complete partial custom profiles at write time

### Files
- assistant/src/runtime/routes/conversation-query-routes.ts
- assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts

### Implementation steps
1. In `handleReplaceInferenceProfile` (the `PUT /v1/config/llm/profiles/:name` handler, ~line 1427 where mix validation lives), after existing validation and before persisting: when the incoming entry is user-source and non-mix, replace it with `completeCustomProfile(config.llm.default, entry)`.
2. In the generic config write paths (`PATCH /v1/config` ~line 925 and `POST /v1/config/set` ~line 964), apply the same completion to any `llm.profiles.*` entry being created or replaced that is user-source and non-mix. Follow the existing managed-profile guard placement so managed-entry restrictions are untouched.
3. Do not touch delete/reorder/status-only paths; completion applies only when profile config fields are being written.
4. Tests: partial PUT is stored complete (assert stored provider/maxTokens inherited from `llm.default`, temperature NOT inherited); generic PATCH creating a partial profile is stored complete; mix writes unchanged; managed thin-stub writes unchanged; a complete profile round-trips byte-identical (idempotency at the route layer).

### Acceptance criteria
- After this PR, no route can persist a new partial user profile.
- Existing tests for managed-profile write protection still pass unchanged.
- Note in the PR description: web profile editor still sends partial entries; server-side completion snapshots inherited values at save time (M7 reworks the editor UX).

## PR 3: Workspace migration 128 — materialize existing custom profiles

### Depends on
PR 1

### Branch
m6-override-default/pr-3-materialize-migration

### Title
feat(workspace): migration 128 materializes partial custom profiles into complete overrides

### Files
- assistant/src/workspace/migrations/128-materialize-custom-profiles.ts (new)
- assistant/src/workspace/migrations/registry.ts
- assistant/src/__tests__/workspace-migration-128-materialize-custom-profiles.test.ts (new)

### Implementation steps
1. Read `assistant/src/workspace/migrations/AGENTS.md` first. Migrations are frozen self-contained snapshots — no imports from `config/` (126/127 precedent: hand-copied constants).
2. Create `materializeCustomProfilesMigration` with id `128-materialize-custom-profiles`: read `config.json`; for every `llm.profiles` entry with `source !== "managed"` and no `mix`, complete it against `llm.default` using a **frozen copy** of PR 1's completion logic. The frozen copy needs no model-catalog snapshot: copy `provider` from `llm.default` when absent, and skip copying `provider_connection` when the profile pins a `model` and no `provider` (the live resolver's retained implication step corrects provider at resolution time — document this in the migration header).
3. Skip entries that are already complete (idempotent). Forward-only `down` (mirror 126/127). Log one structured line per modified profile listing exactly which fields were baked and their values (`{ profile, bakedFields }`) — with migration and flip shipping in the same release, this log is the primary tool for attributing a field report to bad baked data vs. resolver semantics.
4. Register by appending to `WORKSPACE_MIGRATIONS` in `registry.ts` (import at top, append at end — never reorder).
5. No boot ensure-pass sibling: the hatch overlay no longer injects profile bodies (CLI writes only `llm.default.provider`; platform has no producer), and `seedInferenceProfiles` creates custom-* entries via `materializeProfile`, which are already complete. State this reasoning in the migration header.
6. Tests, following `workspace-migration-127-*.test.ts` conventions (temp workspaceDir, write config.json, run, re-read): partial profile completed; sampling not inherited; complete profile untouched; managed stubs untouched; mix untouched; idempotent second run; **equivalence test importing PR 1's helper** (test-only import is allowed) asserting the frozen copy and the live helper produce identical output for the fixture matrix.
7. Since there is no soak release, the fixture matrix must include adversarial/drifted shapes, not just happy paths: hand-edited entries with unknown extra keys, entries missing `source`, entries whose `model` implies a different provider than `llm.default`, entries with explicit `null` values, an `llm.default` missing optional fields, and a config with no custom profiles at all. Each must either materialize correctly or be left untouched — never corrupted.

### Acceptance criteria
- Migration is registered as 128 and passes its test file.
- Running twice produces identical config.json (idempotent).
- Equivalence with PR 1's helper is pinned by test, so drift between frozen copy and live helper fails CI.

## PR 4: defaultProvider-aware default-intent resolution in the catalog

### Depends on
None

### Branch
m6-override-default/pr-4-provider-aware-catalog

### Title
feat(config): resolve default-profile intents through llm.defaultProvider

### Files
- assistant/src/config/default-profile-catalog.ts
- assistant/src/config/__tests__/default-profile-catalog.test.ts

### Implementation steps
1. Add export `resolveDefaultProfileForProvider(name: string, defaultProvider: DefaultProviderConfig | null, workspaceProfiles: Record<string, ProfileEntry> | undefined): ProfileEntry | undefined` to `default-profile-catalog.ts`.
2. Behavior:
   - A user-source workspace entry for `name` wins outright (complete override) — same rule as `getEffectiveProfile` (line 336).
   - For a default profile key: pick the `PROFILE_IMPLS[name][defaultProvider.provider]` column and materialize via the existing `materializeProfile` (line 244) with `connectionName = resolveDefaultConnectionName(defaultProvider)` (from `config/default-provider.ts:23`) — an explicit `defaultProvider.connectionName` wins, vellum maps to the managed connection, BYOK maps to `${provider}-personal`.
   - Overlay workspace-owned fields (`label`/`status`/`topP`) from a managed-source workspace entry, by key-presence — extract the existing overlay logic in `getEffectiveProfile` into a shared private helper rather than duplicating it.
   - `defaultProvider == null` (defensive only — M5 guarantees the field post-boot): fall back to the existing `CODE_DEFAULT_PROFILE_ENTRIES` vellum body, matching today's behavior.
   - `os-beta` keeps its existing special-casing (flag-gated, together-only template); it is not part of the intent × provider matrix.
3. No production consumers in this PR — the function is inert until PR 6. Do not change `getEffectiveProfile`/`getEffectiveProfiles` call sites.
4. Tests: column pick for each of the six `DEFAULT_PROFILE_PROVIDERS`; connection stamping (vellum → `VELLUM_MANAGED_CONNECTION_NAME`, anthropic → `anthropic-personal`, explicit connectionName wins); user shadow wins; managed overlay fields apply; null defaultProvider falls back to vellum bodies; intent→model resolution per column (`resolveModelIntent` path) and pinned-model columns.

### Acceptance criteria
- New export fully unit-tested; existing `default-profile-catalog.test.ts` suites pass unchanged.
- No behavior change anywhere (no consumers yet).

## PR 5: Explainable dispatch-error groundwork

### Depends on
None

### Branch
m6-override-default/pr-5-error-groundwork

### Title
feat(providers): reason-specific user messages for connection resolution failures

### Files
- assistant/src/providers/connection-resolution.ts
- assistant/src/daemon/conversation-error.ts
- assistant/src/daemon/conversation-agent-loop.ts
- assistant/src/daemon/__tests__/conversation-error.test.ts (or nearest existing classifier test file)

### Implementation steps
1. Rebase `ConnectionResolutionError` (connection-resolution.ts:55) onto the `VellumError`/`ConfigError` hierarchy from `util/errors.ts` per `assistant/docs/error-handling.md` (it currently extends bare `Error`). Preserve the five `reason` codes and `connectionName`; add optional `profileName` and `model` fields, populated at existing throw sites where available.
2. In `classifyConversationError` (conversation-error.ts:261-274), stop collapsing the five reasons into one generic banner: produce a reason-specific `userMessage` that names the broken thing and the fix —
   - `not_found` / `lookup_failed`: "Connection \"X\" (used by profile \"Y\") no longer exists — pick a provider in Settings → Models & Services."
   - `missing_connection`: "No connection is configured for provider Z — add an API key or log in."
   - `provider_mismatch` / `model_incompatible`: name the connection, provider, and model.
   Keep `code: PROVIDER_NOT_CONFIGURED` (client compat); emit the reason via `errorCategory`/`debugDetails` so M8 telemetry can consume it.
3. Plumb attribution: the main-loop catch (conversation-agent-loop.ts:1482-1485) builds `errorCtx` with only `{phase, aborted}` — populate the existing-but-unused `ErrorContext.connectionName`/`profileName` fields (conversation-error.ts:164-183) from the turn's resolved profile when available.
4. Tests: one classifier test per reason asserting the userMessage names the connection/profile/model; `ProviderNotConfiguredError` paths unchanged.

### Acceptance criteria
- Each `ConnectionResolutionError.reason` yields a distinct, named, actionable `userMessage` on the `conversation_error` event.
- `ConnectionResolutionError instanceof VellumError` (structured error codes reach logging/monitoring per repo convention).
- No change to which paths throw vs degrade (that's PR 7).

## PR 6: The resolver flip — override-or-default

### Depends on
PR 2, PR 3, PR 4

### Branch
m6-override-default/pr-6-resolver-flip

### Title
feat(config): override-or-default profile resolution behind a kill-switch flag

### Files
- assistant/src/config/llm-resolver.ts
- assistant/src/usage/attribution.ts
- meta/feature-flags/feature-flag-registry.json (+ bundled copies via sync script)
- assistant/src/__tests__/llm-resolver.test.ts
- assistant/src/__tests__/usage-attribution.test.ts
- assistant/src/__tests__/agent-loop-callsite-precedence.test.ts
- assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
- (test updates as needed: workflowLeaf/vision expectations in workflow/embedding/home suites, workspace-migration 051/054/066 seeding assertions)

### Implementation steps
0. Register assistant flag `override-or-default-resolution` (`defaultEnabled: true`) in `meta/feature-flags/feature-flag-registry.json`, run `bun run meta/feature-flags/sync-bundled-copies.ts`, and add a gate predicate per meta/feature-flags/AGENTS.md (`isAssistantFeatureFlagEnabled` delegate). The resolver is pure and receives only `llm`, so thread the decision in from callers' config — add `opts.legacyMergeResolution?: boolean` (or a resolver-module entry point that takes `AssistantConfig`) rather than reading global state inside the pure function; pick whichever matches how `sync-gated-profiles` consumers thread flag state today. File the companion Terraform PR in vellum-assistant-platform to create the flag (note it in the PR description; it is not part of this repo's diff).
1. Implement the new semantics as a new code path selected by the flag (flag on → override-or-default; flag off → the existing cascade, byte-for-byte untouched). Do NOT delete the cascade machinery (`samplingRef`/`biasRef`, `appendProfileLayer`, `appendCallSiteLayers`, `effectiveDefault`, multi-layer `deepMerge` use) — deletion is M9 scope. New path: rewrite `resolveCallSiteConfig` around single-winner selection. Winner = first entry in the chain that resolves to an existing, non-disabled profile (mix entries expand to their arm via the retained `resolveProfileFragment`); an invalid entry reports a fallback (step 6) and the chain continues:
   - `opts.overrideProfile` (per-turn/conversation/schedule pin) — always first, every call site.
   - mainAgent only: `llm.activeProfile`.
   - `llm.callSites[callSite].profile` (workspace call-site override).
   - `CALL_SITE_DEFAULTS[callSite].profile` resolved via `resolveDefaultProfileForProvider(intent, getDefaultProvider(config), llm.profiles)` — preserving the existing `custom-${intent}` fallback when the intent's effective entry is missing/disabled (BYOK legacy, `llm-resolver.ts:391-397` behavior).
   - No profile anywhere (profileless sites `vision`/`workflowLeaf`, or every rung invalid): balanced intent through the default provider — the M5 fallback anchor.
2. Compose the result as exactly three layers: `LLMConfigBase` code defaults (schema `.parse({})`, replacing `llm.default` as the completeness base) → the winning profile (complete) → the call-site tweak fragment (`llm.callSites[callSite]` minus `profile` if present, else `CALL_SITE_DEFAULTS[callSite]` minus `profile`). Use the internal `deepMerge` for these three layers only, so nested tweaks (`thinking.enabled`) don't wipe siblings. Sampling: winner's own `temperature`/`topP`/`logitBias` apply; a call-site tweak's explicit values override. The new path never touches `samplingRef`/`biasRef`/`appendProfileLayer`/`appendCallSiteLayers`/`effectiveDefault` — those remain solely on the flag-off cascade path until M9 deletes them.
3. Reduce `withImpliedProviders` to a single-winner check: if the winner (or tweak) pins `model` without `provider` and the current provider doesn't serve it (`isModelInCatalog`), stamp `getCatalogProviderForModel(model)` and clear an inherited `provider_connection` that belongs to the replaced provider.
4. `forceOverrideProfile` becomes a documented no-op **on the new path** (override already always wins); it keeps its current meaning on the flag-off cascade path. Keep it in `ResolveCallSiteOpts` with a doc-comment noting both. Callers (scheduler `:551`, agent-wake `:715`, memory-retrospective, advisor spawn) need no changes.
5. Rewrite `resolveDefaultProfileKey` to mirror the new chain minus `opts.overrideProfile` (mainAgent: activeProfile → callSites profile → catalog default; others: callSites profile → catalog default; keep the `custom-*` fallback). `resolveProfilelessModelKey` unchanged in shape. The call-site catalog route (`llm-call-sites-routes.ts:38`) picks the new values up automatically — verify its test expectations.
6. Fallback observability (M5 decision: silent to the call, visible in logs): add `opts.onResolutionFallback?: (info: { callSite, requested: string, reason: "missing" | "disabled", fellBackTo: string }) => void`; invoke on every skipped chain rung that had an explicit name. Wire `conversation-agent-loop.ts` (both resolution sites, :413/:434) to log it at `warn` with structured fields. M8 extends this into telemetry.
7. Update `usage/attribution.ts` (:103, :124, :184-243) in the same PR — it independently mirrors resolver precedence and is the known silent-drift risk. It must follow the flag: flag on → applied-profile derivation is "the winner the resolver picked" (export the winner-selection helper and reuse it — do not hand-roll a second precedence copy); flag off → the existing mirror, untouched.
8. Tests run as two matrices while the flag exists: the existing `llm-resolver.test.ts` suite keeps passing verbatim with the flag off (cascade untouched), and a new suite covers the flag-on semantics: single-winner selection per chain rung, mainAgent-as-normal-call-site, deleted/disabled fallback with `onResolutionFallback` assertions, mix expansion, sampling from winner only, three-layer tweak composition, profileless-site anchor, defaultProvider column selection. Integration suites listed in Files run with the flag ON (the shipped default) and get updated expectations, plus any workflowLeaf/vision assertions that encoded activeProfile backfill.

### Acceptance criteria
- For a workspace with materialized profiles and `defaultProvider` set, flag-on mainAgent/summarization/subagent resolutions match flag-off output (an explicit parity fixture test asserting this for the common configurations: vellum default, anthropic BYOK, custom activeProfile, conversation pin).
- Deleted-profile pin (DB row referencing a removed custom profile) resolves to the call-site default and fires `onResolutionFallback`; nothing throws (flag on).
- With the flag off, the existing `llm-resolver.test.ts` suite and `usage-attribution.test.ts` pass without modification — the cascade path is untouched.
- Flag registered `defaultEnabled: true`; bundled copies synced; companion platform Terraform PR linked in the description.
- `usage-attribution` flag-on path asserts against the shared winner-selection logic (no duplicated precedence).
- Full assistant test suite green. (Cascade deletion + flag removal are M9 — note in PR description.)

## PR 7: Resolution preflight — explainable static failures at dispatch

### Depends on
PR 5, PR 6

### Branch
m6-override-default/pr-7-resolution-preflight

### Title
feat(providers): explainable errors for missing connection/credential/model at dispatch

### Files
- assistant/src/providers/connection-resolution.ts
- assistant/src/daemon/conversation-store.ts
- assistant/src/subagent/manager.ts
- assistant/src/daemon/approval-generators.ts
- assistant/src/providers/__tests__/connection-resolution.test.ts (or nearest existing)

### Implementation steps
1. Add async `preflightResolvedConfig(resolved, { profileName, callSite })` to `connection-resolution.ts` performing the statically-detectable checks, each throwing a reason-carrying `ConnectionResolutionError` (PR 5 shape) naming profile + connection + fix:
   - connection row exists (`getConnection`, sync);
   - model↔connection compatibility (`isConnectionCompatibleWithModel` / `describeSubscriptionModelIncompatibility`), naming the model;
   - credential existence for `api_key`-auth connections via `getSecureKeyResultAsync` (`security/secure-keys.ts:456`) — **distinguish** `value: undefined, unreachable: false` (credential genuinely missing → hard explainable error "connection X needs an API key") from `unreachable: true` (CES down → transient; do NOT convert to a config error, preserve today's soft/retryable handling). Platform-auth connections check managed-proxy prereqs (`resolveManagedProxyContext` path) analogously.
2. Wire preflight into the paths that already throw for users: `conversation-store.ts:124-134` (main agent), `subagent/manager.ts:372-378`, `approval-generators.ts:149-155` — replacing generic `ProviderNotConfiguredError` throws with the preflight's named errors (keep `ProviderNotConfiguredError` as the final fallback). Pass `profileName` from the resolved winner (PR 6's resolver makes it available). Gate the preflight wiring behind the same `override-or-default-resolution` flag: flag off → today's throw behavior exactly, so the kill switch reverts M6 as one unit.
3. Satellite soft-null paths (memory plugins, home greeting, title/summarization, reply suggestions) keep degrading gracefully — but upgrade their silent `null` handling to one structured `log.warn` with `{ callSite, reason, connectionName, profileName }` at the `provider-send-message.ts` null-return sites (:126, :168-174, :183-188), so every degradation is observable. This is the M8 telemetry spine; no telemetry events in this PR.
4. Keep the auto-recovery scans as-is (stale-reference compat; removal is M9).
5. Tests: preflight unit tests per failure class (missing connection, missing credential vs CES-unreachable, incompatible model); conversation-store main-agent path surfaces the named message end-to-end (classifier test from PR 5 asserts wording); a memory-plugin path still degrades silently but logs the structured warn.

### Acceptance criteria
- A BYOK default provider with a deleted API key produces a conversation error naming the connection and the fix, not a generic "provider not configured".
- CES-unreachable is never misreported as a missing credential (distinct handling asserted by test).
- No satellite call site loses its graceful degradation; each degradation now logs a structured reason.

## Release plan

- All seven PRs ship in the next release (single-release decision, 2026-07-08). Boot ordering guarantees migration-before-resolution on every install.
- Kill switch: assistant flag `override-or-default-resolution` ships `defaultEnabled: true` and gates PR 6 + PR 7 as one unit. Remote flag sync allows fleet-wide revert to merge semantics without a release; requires the companion Terraform PR in vellum-assistant-platform before release cut.
- Rollback story: reverting to the previous release restores merge semantics; materialized profiles are valid inputs to the old resolver (pinned by PR 1's equivalence test), and migration 128 is idempotent on re-upgrade. Bad baked *data* cannot be fixed by rollback — that needs a repair migration — which is why PR 3's per-profile baked-fields log and adversarial fixture matrix are required, not optional.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->