### PR TITLE
feat(config): resolve default-profile intents through llm.defaultProvider (M6 PR4)

### DIFF
--- a/assistant/src/config/__tests__/default-profile-catalog.test.ts
+++ b/assistant/src/config/__tests__/default-profile-catalog.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, test } from "bun:test";
 
+import { resolveModelIntent } from "../../providers/model-intents.js";
 import { CALL_SITE_DEFAULTS } from "../call-site-defaults.js";
 import {
   CODE_DEFAULT_PROFILE_ENTRIES,
   getEffectiveProfile,
   getEffectiveProfiles,
+  resolveDefaultProfileForProvider,
 } from "../default-profile-catalog.js";
 import {
   DEFAULT_PROFILE_KEYS,
+  DEFAULT_PROFILE_PROVIDERS,
   OS_BETA_PROFILE_KEY,
 } from "../default-profile-names.js";
 import {
@@ -143,7 +146,9 @@ describe("resolver integration", () => {
   test("an empty workspace resolves every call-site default from the catalog", () => {
     const llm = LLMSchema.parse({ activeProfile: "balanced" });
     for (const [callSite, dflt] of Object.entries(CALL_SITE_DEFAULTS)) {
-      if (dflt.profile == null) continue;
+      if (dflt.profile == null) {
+        continue;
+      }
       const expected = CODE_DEFAULT_PROFILE_ENTRIES[dflt.profile];
       const resolved = resolveCallSiteConfig(callSite as LLMCallSite, llm);
       expect(resolved.model).toBe(expected.model as string);
@@ -213,5 +218,157 @@ describe("schema validation", () => {
     expect(() =>
       LLMSchema.parse({ callSites: { mainAgent: { profile: "no-such" } } }),
     ).toThrow();
+  });
+});
+
+describe("resolveDefaultProfileForProvider", () => {
+  const dp = (
+    provider: (typeof DEFAULT_PROFILE_PROVIDERS)[number],
+    connectionName?: string,
+  ) => ({ provider, ...(connectionName ? { connectionName } : {}) });
+
+  test("every matrix column materializes every default profile key", () => {
+    for (const provider of DEFAULT_PROFILE_PROVIDERS) {
+      for (const key of DEFAULT_PROFILE_KEYS) {
+        const entry = resolveDefaultProfileForProvider(
+          undefined,
+          key,
+          dp(provider),
+        );
+        expect(entry).toBeDefined();
+        expect(typeof entry?.model).toBe("string");
+        expect(entry?.provider).toBeDefined();
+        expect(entry?.provider_connection).toBeDefined();
+        expect(entry?.source).toBe("managed");
+      }
+    }
+  });
+
+  test("BYOK columns resolve the intent to a provider-specific model and personal connection", () => {
+    const entry = resolveDefaultProfileForProvider(
+      undefined,
+      "balanced",
+      dp("anthropic"),
+    );
+    expect(entry?.provider).toBe("anthropic");
+    expect(entry?.provider_connection).toBe("anthropic-personal");
+    expect(entry?.model).toBe(resolveModelIntent("anthropic", "balanced"));
+  });
+
+  test("the vellum column keeps its underlying dispatch provider and managed connection", () => {
+    const entry = resolveDefaultProfileForProvider(
+      undefined,
+      "balanced",
+      dp("vellum"),
+    );
+    // `vellum` is a routing identity: balanced dispatches through fireworks.
+    expect(entry?.provider).toBe(
+      CODE_DEFAULT_PROFILE_ENTRIES.balanced.provider,
+    );
+    expect(entry?.provider_connection).toBe(
+      CODE_DEFAULT_PROFILE_ENTRIES.balanced.provider_connection,
+    );
+    expect(entry?.model).toBe(
+      CODE_DEFAULT_PROFILE_ENTRIES.balanced.model as string,
+    );
+  });
+
+  test("an explicit connectionName wins over the convention", () => {
+    const entry = resolveDefaultProfileForProvider(
+      undefined,
+      "balanced",
+      dp("openai", "work-openai"),
+    );
+    expect(entry?.provider).toBe("openai");
+    expect(entry?.provider_connection).toBe("work-openai");
+  });
+
+  test("a user-source workspace entry shadows the provider-resolved default", () => {
+    const workspace: Record<string, ProfileEntry> = {
+      balanced: { source: "user", provider: "openai", model: "gpt-5.5" },
+    };
+    const entry = resolveDefaultProfileForProvider(
+      workspace,
+      "balanced",
+      dp("anthropic"),
+    );
+    expect(entry).toBe(workspace.balanced);
+  });
+
+  test("a managed-source stub contributes only label/status/topP over the provider-resolved body", () => {
+    const workspace: Record<string, ProfileEntry> = {
+      balanced: {
+        source: "managed",
+        label: "Balanced (BYOK)",
+        status: "disabled",
+        topP: 0.7,
+        model: "stale-model-should-be-ignored",
+      },
+    };
+    const entry = resolveDefaultProfileForProvider(
+      workspace,
+      "balanced",
+      dp("gemini"),
+    );
+    expect(entry?.label).toBe("Balanced (BYOK)");
+    expect(entry?.status).toBe("disabled");
+    expect(entry?.topP).toBe(0.7);
+    expect(entry?.provider).toBe("gemini");
+    expect(entry?.model).toBe(resolveModelIntent("gemini", "balanced"));
+    expect(entry?.provider_connection).toBe("gemini-personal");
+  });
+
+  test("a null defaultProvider falls back to the vellum code bodies", () => {
+    for (const key of DEFAULT_PROFILE_KEYS) {
+      expect(resolveDefaultProfileForProvider(undefined, key, null)).toEqual(
+        getEffectiveProfile(undefined, key) as ProfileEntry,
+      );
+    }
+  });
+
+  test("non-matrix names pass through like getEffectiveProfile", () => {
+    const workspace: Record<string, ProfileEntry> = {
+      "custom-mine": { source: "user", provider: "openai", model: "gpt-5.4" },
+    };
+    expect(
+      resolveDefaultProfileForProvider(
+        workspace,
+        "custom-mine",
+        dp("anthropic"),
+      ),
+    ).toBe(workspace["custom-mine"]);
+    expect(
+      resolveDefaultProfileForProvider(workspace, "no-such", dp("anthropic")),
+    ).toBeUndefined();
+  });
+
+  test("os-beta stays flag-gated and provider-independent", () => {
+    expect(
+      resolveDefaultProfileForProvider(
+        undefined,
+        OS_BETA_PROFILE_KEY,
+        dp("anthropic"),
+      ),
+    ).toBeUndefined();
+    const workspace: Record<string, ProfileEntry> = {
+      [OS_BETA_PROFILE_KEY]: { source: "managed" },
+    };
+    const entry = resolveDefaultProfileForProvider(
+      workspace,
+      OS_BETA_PROFILE_KEY,
+      dp("anthropic"),
+    );
+    // The os-beta body never varies with the default provider.
+    expect(entry?.provider).toBe(
+      CODE_DEFAULT_PROFILE_ENTRIES[OS_BETA_PROFILE_KEY].provider,
+    );
+  });
+
+  test("agrees with getEffectiveProfile for the vellum default provider", () => {
+    for (const key of DEFAULT_PROFILE_KEYS) {
+      expect(
+        resolveDefaultProfileForProvider(undefined, key, dp("vellum")),
+      ).toEqual(getEffectiveProfile(undefined, key) as ProfileEntry);
+    }
   });
 });

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -9,8 +9,10 @@ import {
   type DefaultProfileProvider,
   OS_BETA_PROFILE_KEY,
 } from "./default-profile-names.js";
+import { resolveDefaultConnectionName } from "./default-provider-resolution.js";
 import {
   DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
+  type DefaultProviderConfig,
   type ProfileEntry,
 } from "./schemas/llm.js";
 
@@ -340,8 +342,23 @@ export function getEffectiveProfile(
     Record<string, ProfileEntry>
   > = CODE_DEFAULT_PROFILE_ENTRIES,
 ): ProfileEntry | undefined {
-  const workspace = workspaceProfiles?.[name];
-  const body = catalogEntries[name];
+  return resolveAgainstBody(
+    workspaceProfiles?.[name],
+    name,
+    catalogEntries[name],
+  );
+}
+
+/**
+ * The shared workspace-overlay step of effective-profile resolution: given
+ * the workspace entry for a name and the code-owned body that name resolves
+ * to, apply the precedence documented on `getEffectiveProfile`.
+ */
+function resolveAgainstBody(
+  workspace: ProfileEntry | undefined,
+  name: string,
+  body: ProfileEntry | undefined,
+): ProfileEntry | undefined {
   if (body == null) {
     return workspace;
   }
@@ -358,6 +375,68 @@ export function getEffectiveProfile(
     }
   }
   return merged;
+}
+
+/**
+ * Resolve a default-profile intent through the workspace's default provider:
+ * like `getEffectiveProfile`, but the code-owned body for a default profile
+ * key comes from that provider's column of the intent × provider matrix
+ * instead of always the `vellum` column.
+ *
+ * - The body's connection is `resolveDefaultConnectionName(defaultProvider)`
+ *   (an explicit `connectionName` wins; `vellum` maps to the managed
+ *   connection; BYOK maps to `${provider}-personal`). For the `vellum`
+ *   column the stamped provider stays the column's underlying provider
+ *   (e.g. `fireworks` for `balanced`) — `vellum` is a routing identity, not
+ *   a dispatch provider.
+ * - The resolved body carries `source: "managed"` regardless of column:
+ *   default profile content is code-owned whichever provider implements it.
+ *   (The BYOK templates' `source: "user"` is hatch-time state for
+ *   materialized `custom-*` copies, not an ownership claim on the catalog
+ *   body.)
+ * - Workspace precedence is identical to `getEffectiveProfile`: a
+ *   user-source workspace entry shadows the default outright; a
+ *   managed-source stub contributes only `label`/`status`/`topP`.
+ * - A `null` defaultProvider (defensive: M5 guarantees the field post-boot)
+ *   and every non-matrix name (custom profiles, `os-beta`) fall back to
+ *   `CODE_DEFAULT_PROFILE_ENTRIES` — exactly `getEffectiveProfile`'s
+ *   behavior.
+ *
+ * No runtime consumers yet: the M6 override-or-default resolver adopts this
+ * as the call-site default-intent lookup.
+ */
+export function resolveDefaultProfileForProvider(
+  workspaceProfiles: Record<string, ProfileEntry> | undefined,
+  name: string,
+  defaultProvider: DefaultProviderConfig | null,
+): ProfileEntry | undefined {
+  return resolveAgainstBody(
+    workspaceProfiles?.[name],
+    name,
+    defaultProfileBodyForProvider(name, defaultProvider),
+  );
+}
+
+function isDefaultProfileKey(name: string): name is DefaultProfileKey {
+  return (DEFAULT_PROFILE_KEYS as readonly string[]).includes(name);
+}
+
+function defaultProfileBodyForProvider(
+  name: string,
+  defaultProvider: DefaultProviderConfig | null,
+): ProfileEntry | undefined {
+  if (defaultProvider == null || !isDefaultProfileKey(name)) {
+    return CODE_DEFAULT_PROFILE_ENTRIES[name];
+  }
+  const impl = PROFILE_IMPLS[name][defaultProvider.provider];
+  return {
+    ...materializeProfile(
+      impl,
+      impl.provider,
+      resolveDefaultConnectionName(defaultProvider),
+    ),
+    source: "managed",
+  };
 }
 
 /**

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -378,29 +378,20 @@ function resolveAgainstBody(
 }
 
 /**
- * Resolve a default-profile intent through the workspace's default provider:
- * like `getEffectiveProfile`, but the code-owned body for a default profile
- * key comes from that provider's column of the intent × provider matrix
- * instead of always the `vellum` column.
+ * Like `getEffectiveProfile`, but a default profile key's code-owned body
+ * comes from the default provider's column of the intent × provider matrix
+ * instead of always the `vellum` column. A `null` defaultProvider and every
+ * non-matrix name fall back to `getEffectiveProfile`'s behavior.
  *
- * - The body's connection is `resolveDefaultConnectionName(defaultProvider)`
- *   (an explicit `connectionName` wins; `vellum` maps to the managed
- *   connection; BYOK maps to `${provider}-personal`). For the `vellum`
- *   column the stamped provider stays the column's underlying provider
- *   (e.g. `fireworks` for `balanced`) — `vellum` is a routing identity, not
- *   a dispatch provider.
+ * Non-obvious rules:
+ *
+ * - For the `vellum` column the stamped provider stays the column's
+ *   underlying provider (e.g. `fireworks` for `balanced`) — `vellum` is a
+ *   routing identity, not a dispatch provider.
  * - The resolved body carries `source: "managed"` regardless of column:
  *   default profile content is code-owned whichever provider implements it.
- *   (The BYOK templates' `source: "user"` is hatch-time state for
- *   materialized `custom-*` copies, not an ownership claim on the catalog
- *   body.)
- * - Workspace precedence is identical to `getEffectiveProfile`: a
- *   user-source workspace entry shadows the default outright; a
- *   managed-source stub contributes only `label`/`status`/`topP`.
- * - A `null` defaultProvider (defensive: the field is always written at
- *   hatch/backfill) and every non-matrix name (custom profiles, `os-beta`)
- *   fall back to `CODE_DEFAULT_PROFILE_ENTRIES` — exactly
- *   `getEffectiveProfile`'s behavior.
+ *   The BYOK templates' `source: "user"` is hatch-time state for
+ *   materialized `custom-*` copies, not an ownership claim on the body.
  */
 export function resolveDefaultProfileForProvider(
   workspaceProfiles: Record<string, ProfileEntry> | undefined,

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -397,13 +397,10 @@ function resolveAgainstBody(
  * - Workspace precedence is identical to `getEffectiveProfile`: a
  *   user-source workspace entry shadows the default outright; a
  *   managed-source stub contributes only `label`/`status`/`topP`.
- * - A `null` defaultProvider (defensive: M5 guarantees the field post-boot)
- *   and every non-matrix name (custom profiles, `os-beta`) fall back to
- *   `CODE_DEFAULT_PROFILE_ENTRIES` — exactly `getEffectiveProfile`'s
- *   behavior.
- *
- * No runtime consumers yet: the M6 override-or-default resolver adopts this
- * as the call-site default-intent lookup.
+ * - A `null` defaultProvider (defensive: the field is always written at
+ *   hatch/backfill) and every non-matrix name (custom profiles, `os-beta`)
+ *   fall back to `CODE_DEFAULT_PROFILE_ENTRIES` — exactly
+ *   `getEffectiveProfile`'s behavior.
  */
 export function resolveDefaultProfileForProvider(
   workspaceProfiles: Record<string, ProfileEntry> | undefined,


### PR DESCRIPTION
## Summary
- Adds `resolveDefaultProfileForProvider(workspaceProfiles, name, defaultProvider)` to `default-profile-catalog.ts`: resolves a default-profile intent through the workspace's `llm.defaultProvider` by picking that provider's column of the intent × provider matrix (`PROFILE_IMPLS`) and stamping the connection via `resolveDefaultConnectionName` (explicit `connectionName` wins; vellum → managed connection with the column's underlying dispatch provider; BYOK → `${provider}-personal`).
- Workspace precedence is identical to `getEffectiveProfile` (user-source entries shadow outright; managed-source stubs contribute only `label`/`status`/`topP`) — the shared overlay step is extracted into a private `resolveAgainstBody` used by both.
- Provider-resolved default bodies carry `source: "managed"` regardless of column: default profile content is code-owned whichever provider implements it. `null` defaultProvider and non-matrix names (custom profiles, flag-gated `os-beta`) fall back to today's `CODE_DEFAULT_PROFILE_ENTRIES` behavior.
- Inert: no runtime consumers yet. This is PR 4 of the M6 plan — the override-or-default resolver (PR 6) adopts it as the call-site default-intent lookup.

## Original prompt
Milestone 6 of the Inference Management Refactor replaces deep-merge profile resolution with override-or-default semantics: a call site's default profile intent (`balanced`/`quality-optimized`/`cost-optimized`) must resolve through `llm.defaultProvider` (M5) via the code-defined catalog (M4) instead of always the vellum column. This PR ships that lookup as an inert, fully-tested export so the resolver flip lands as a smaller change. Full M6 plan is attached to PR #37518 (M6 PR 1) as the papertrail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37519" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->