### PR TITLE
feat(assistant): stamp `reason` on Anthropic provider errors and preserve it across gateway re-tag

### DIFF
--- a/assistant/src/__tests__/anthropic-error-formatting.test.ts
+++ b/assistant/src/__tests__/anthropic-error-formatting.test.ts
@@ -235,6 +235,18 @@ describe("AnthropicProvider — semantic reason stamping", () => {
     expect(err.apiErrorType).toBe("rate_limit_error");
   });
 
+  test("surfaces the inner human message, not JSON, when the SDK stringifies the body", async () => {
+    const inner = "You do not have access to this model on your current plan.";
+    // Real SDK behaviour: no top-level message, so error.message is the raw JSON body.
+    const body = anthropicBody("permission_error", inner);
+    const err = await reasonFor(
+      new FakeAPIError(403, JSON.stringify(body), body),
+    );
+    expect(err.reason).toBe("model_restricted");
+    expect(err.message).toContain(inner);
+    expect(err.message).not.toContain("{");
+  });
+
   test("context overflow → ContextOverflowError with reason context_overflow", async () => {
     nextThrown = new FakeAPIError(
       400,

--- a/assistant/src/__tests__/anthropic-error-formatting.test.ts
+++ b/assistant/src/__tests__/anthropic-error-formatting.test.ts
@@ -10,11 +10,18 @@ import type { Message } from "../providers/types.js";
 class FakeAPIError extends Error {
   status: number | undefined;
   headers: Map<string, string> = new Map();
-  constructor(status: number | undefined, message: string) {
+  error: unknown;
+  constructor(status: number | undefined, message: string, body?: unknown) {
     super(message);
     this.status = status;
+    this.error = body;
     this.name = "APIError";
   }
+}
+
+/** Anthropic error body shape: `{ type: "error", error: { type, message } }`. */
+function anthropicBody(type: string, message?: string): unknown {
+  return { type: "error", error: { type, message: message ?? "" } };
 }
 
 let nextThrown: FakeAPIError | null = null;
@@ -48,7 +55,9 @@ mock.module("@anthropic-ai/sdk", () => ({
 }));
 
 import { AnthropicProvider } from "../providers/anthropic/client.js";
-import { ProviderError } from "../util/errors.js";
+import { ContextOverflowError } from "../providers/types.js";
+import { createAbortReason } from "../util/abort-reasons.js";
+import { ProviderError, type ProviderErrorReason } from "../util/errors.js";
 
 function userMsg(text: string): Message {
   return { role: "user", content: [{ type: "text", text }] };
@@ -93,6 +102,162 @@ describe("AnthropicProvider — error message formatting (JARVIS-390)", () => {
       const message = (err as Error).message;
       expect(message).toContain("Anthropic API error (402):");
       expect((err as ProviderError).statusCode).toBe(402);
+    }
+  });
+});
+
+describe("AnthropicProvider — semantic reason stamping", () => {
+  beforeEach(() => {
+    nextThrown = null;
+  });
+
+  async function reasonFor(error: FakeAPIError): Promise<ProviderError> {
+    nextThrown = error;
+    const provider = new AnthropicProvider("sk-ant-test", "claude-sonnet-4-6");
+    try {
+      await provider.sendMessage([userMsg("hi")]);
+      throw new Error("expected sendMessage to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ProviderError);
+      return err as ProviderError;
+    }
+  }
+
+  const cases: Array<{
+    name: string;
+    error: FakeAPIError;
+    reason: ProviderErrorReason;
+  }> = [
+    {
+      name: "authentication_error → invalid_credentials",
+      error: new FakeAPIError(
+        401,
+        "invalid x-api-key",
+        anthropicBody("authentication_error"),
+      ),
+      reason: "invalid_credentials",
+    },
+    {
+      name: "generic 403 permission → invalid_credentials",
+      error: new FakeAPIError(
+        403,
+        "Forbidden",
+        anthropicBody("permission_error"),
+      ),
+      reason: "invalid_credentials",
+    },
+    {
+      name: "403 model/plan restriction → model_restricted",
+      error: new FakeAPIError(
+        403,
+        "Your plan does not have access to this model",
+        anthropicBody("permission_error"),
+      ),
+      reason: "model_restricted",
+    },
+    {
+      name: "not_found_error → model_not_found",
+      error: new FakeAPIError(
+        404,
+        "model: claude-nope not found",
+        anthropicBody("not_found_error"),
+      ),
+      reason: "model_not_found",
+    },
+    {
+      name: "rate_limit_error → rate_limited",
+      error: new FakeAPIError(
+        429,
+        "rate limited",
+        anthropicBody("rate_limit_error"),
+      ),
+      reason: "rate_limited",
+    },
+    {
+      name: "overloaded_error (529) → overloaded",
+      error: new FakeAPIError(
+        529,
+        "Overloaded",
+        anthropicBody("overloaded_error"),
+      ),
+      reason: "overloaded",
+    },
+    {
+      name: "billing/credits → insufficient_credits",
+      error: new FakeAPIError(
+        400,
+        "Your credit balance is too low to access the API.",
+        anthropicBody("invalid_request_error"),
+      ),
+      reason: "insufficient_credits",
+    },
+    {
+      name: "5xx → server_error",
+      error: new FakeAPIError(503, "internal", anthropicBody("api_error")),
+      reason: "server_error",
+    },
+    {
+      name: "other 4xx → bad_request",
+      error: new FakeAPIError(
+        400,
+        "messages: malformed request",
+        anthropicBody("invalid_request_error"),
+      ),
+      reason: "bad_request",
+    },
+  ];
+
+  for (const c of cases) {
+    test(c.name, async () => {
+      const err = await reasonFor(c.error);
+      expect(err.reason).toBe(c.reason);
+    });
+  }
+
+  test("stamps apiErrorType from the inner error body", async () => {
+    const err = await reasonFor(
+      new FakeAPIError(429, "rate limited", anthropicBody("rate_limit_error")),
+    );
+    expect(err.apiErrorType).toBe("rate_limit_error");
+  });
+
+  test("context overflow → ContextOverflowError with reason context_overflow", async () => {
+    nextThrown = new FakeAPIError(
+      400,
+      "prompt is too long: 250000 tokens > 200000 maximum",
+      anthropicBody(
+        "invalid_request_error",
+        "prompt is too long: 250000 tokens > 200000 maximum",
+      ),
+    );
+    const provider = new AnthropicProvider("sk-ant-test", "claude-sonnet-4-6");
+    try {
+      await provider.sendMessage([userMsg("hi")]);
+      throw new Error("expected sendMessage to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContextOverflowError);
+      const overflow = err as ContextOverflowError;
+      expect(overflow.reason).toBe("context_overflow");
+      expect(overflow.actualTokens).toBe(250000);
+      expect(overflow.maxTokens).toBe(200000);
+    }
+  });
+
+  test("does not stamp a reason on caller-aborted requests", async () => {
+    const abortReason = createAbortReason("user_cancel", "test");
+    const controller = new AbortController();
+    controller.abort(abortReason);
+    nextThrown = new FakeAPIError(undefined, "Request was aborted.");
+    const provider = new AnthropicProvider("sk-ant-test", "claude-sonnet-4-6");
+    try {
+      await provider.sendMessage([userMsg("hi")], {
+        signal: controller.signal,
+      });
+      throw new Error("expected sendMessage to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ProviderError);
+      expect((err as ProviderError).reason).toBeUndefined();
+      expect((err as ProviderError).abortReason).toBe(abortReason);
     }
   });
 });

--- a/assistant/src/__tests__/anthropic-error-formatting.test.ts
+++ b/assistant/src/__tests__/anthropic-error-formatting.test.ts
@@ -156,6 +156,15 @@ describe("AnthropicProvider — semantic reason stamping", () => {
       reason: "model_restricted",
     },
     {
+      name: "generic 403 'not allowed' without model context → invalid_credentials",
+      error: new FakeAPIError(
+        403,
+        "Request not allowed: access denied",
+        anthropicBody("permission_error"),
+      ),
+      reason: "invalid_credentials",
+    },
+    {
       name: "not_found_error → model_not_found",
       error: new FakeAPIError(
         404,
@@ -163,6 +172,11 @@ describe("AnthropicProvider — semantic reason stamping", () => {
         anthropicBody("not_found_error"),
       ),
       reason: "model_not_found",
+    },
+    {
+      name: "non-model 404 (missing gateway resource) → bad_request (defers to legacy fallback)",
+      error: new FakeAPIError(404, "Not Found: /v1/messages", undefined),
+      reason: "bad_request",
     },
     {
       name: "rate_limit_error → rate_limited",

--- a/assistant/src/__tests__/anthropic-gateway-shared.test.ts
+++ b/assistant/src/__tests__/anthropic-gateway-shared.test.ts
@@ -79,6 +79,32 @@ describe("retagDelegateError", () => {
     expect(err.cause).toBe(inner);
   });
 
+  test("carries reason + structured fields across the re-tag", () => {
+    const inner = new ProviderError("model restricted", "anthropic", 403, {
+      reason: "model_restricted",
+      apiErrorType: "permission_error",
+      apiErrorCode: "restricted",
+      apiErrorParam: "model",
+      rawBody: '{"type":"error"}',
+    });
+
+    let caught: unknown;
+    try {
+      retagDelegateError(inner, providerName);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(ProviderError);
+    const err = caught as ProviderError;
+    expect(err.provider).toBe(providerName);
+    expect(err.reason).toBe("model_restricted");
+    expect(err.apiErrorType).toBe("permission_error");
+    expect(err.apiErrorCode).toBe("restricted");
+    expect(err.apiErrorParam).toBe("model");
+    expect(err.rawBody).toBe('{"type":"error"}');
+  });
+
   test("re-tags a delegate ContextOverflowError, preserving token counts", () => {
     const inner = new ContextOverflowError("context overflow", "anthropic", {
       actualTokens: 250_000,

--- a/assistant/src/providers/anthropic-gateway-shared.ts
+++ b/assistant/src/providers/anthropic-gateway-shared.ts
@@ -52,6 +52,11 @@ export function retagDelegateError(
       cause: error.cause ?? error,
       retryAfterMs: error.retryAfterMs,
       abortReason: error.abortReason,
+      reason: error.reason,
+      apiErrorType: error.apiErrorType,
+      apiErrorCode: error.apiErrorCode,
+      apiErrorParam: error.apiErrorParam,
+      rawBody: error.rawBody,
     });
   }
   throw error;

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -88,6 +88,19 @@ function readAnthropicErrorCode(
 }
 
 /**
+ * The SDK JSON-stringifies the nested body into `error.message` when there is
+ * no top-level message, so read the inner human message for display.
+ */
+function readAnthropicMessage(
+  error: InstanceType<typeof Anthropic.APIError>,
+): string | undefined {
+  const body = error.error as
+    { message?: string; error?: { message?: string } } | undefined;
+  const inner = body?.error?.message ?? body?.message;
+  return typeof inner === "string" && inner.length > 0 ? inner : undefined;
+}
+
+/**
  * Map an Anthropic `APIError` to a semantic {@link ProviderErrorReason} from
  * its error type and/or status. Order matters: billing precedes credentials,
  * and the 403 branch disambiguates a model/plan restriction from generic auth.
@@ -1618,7 +1631,7 @@ export class AnthropicProvider implements Provider {
         const rewrittenMessage =
           isAbortMessage && innerTimeoutFired
             ? `Anthropic stream timed out after ${Math.round(elapsedMs / 1000)}s (inner streamTimeoutMs)`
-            : error.message;
+            : (readAnthropicMessage(error) ?? error.message);
         // Only include the `(status)` parenthetical when the SDK surfaced a
         // real HTTP status. Abort paths and mid-stream protocol errors have
         // `error.status === undefined`, and string-interpolating that produces

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -111,14 +111,21 @@ export function deriveAnthropicReason(
   if (apiType === "authentication_error" || status === 401) {
     return "invalid_credentials";
   }
+  // A plan/tier model restriction requires an explicit model signal; a generic
+  // authorization/scope 403 or a missing gateway resource on 404 stays on the
+  // credential path / defers to the legacy fallback so the real detail survives.
+  const mentionsModel = /\bmodel\b/i.test(haystack);
   if (apiType === "permission_error" || status === 403) {
-    return /model|plan|not\s+(?:allowed|permitted|enabled)|access/i.test(
-      haystack,
-    )
+    return mentionsModel &&
+      /\b(?:plan|tier|upgrade|restricted|not\s+available|access|entitle)/i.test(
+        haystack,
+      )
       ? "model_restricted"
       : "invalid_credentials";
   }
-  if (apiType === "not_found_error" || status === 404) return "model_not_found";
+  if (apiType === "not_found_error" || status === 404) {
+    return mentionsModel ? "model_not_found" : "bad_request";
+  }
   if (apiType === "rate_limit_error" || status === 429) return "rate_limited";
   if (apiType === "overloaded_error" || status === 529) return "overloaded";
   if (status !== undefined && status >= 500) return "server_error";

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -2,7 +2,7 @@ import Anthropic from "@anthropic-ai/sdk";
 
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../prompts/cache-boundary.js";
 import { isAbortReason } from "../../util/abort-reasons.js";
-import { ProviderError } from "../../util/errors.js";
+import { ProviderError, type ProviderErrorReason } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import { extractRetryAfterMs } from "../../util/retry.js";
 import { stripOrphanedSurrogatesDeep } from "../../util/unicode.js";
@@ -64,6 +64,71 @@ export function detectAnthropicContextOverflow(
   if (!/prompt.?is.?too.?long|prompt_too_long/i.test(combined)) return null;
   // Prefer the clean inner message over the JSON-stringified top-level string.
   return extractOverflowTokensFromMessage(innerMessage || topLevelMessage);
+}
+
+/**
+ * Read Anthropic's inner error type from an `APIError`. The body is shaped
+ * `{ type: "error", error: { type: <real>, message } }`, so the real type
+ * lives nested under `error.error.type`; some proxies flatten it to the top.
+ */
+function readAnthropicErrorType(
+  error: InstanceType<typeof Anthropic.APIError>,
+): string | undefined {
+  const body = error.error as
+    { type?: string; error?: { type?: string; code?: string } } | undefined;
+  return body?.error?.type ?? body?.type;
+}
+
+function readAnthropicErrorCode(
+  error: InstanceType<typeof Anthropic.APIError>,
+): string | undefined {
+  const body = error.error as { error?: { code?: string } } | undefined;
+  const code = body?.error?.code;
+  return typeof code === "string" && code.length > 0 ? code : undefined;
+}
+
+/**
+ * Map an Anthropic `APIError` to a semantic {@link ProviderErrorReason} from
+ * its error type and/or status. Order matters: billing precedes credentials,
+ * and the 403 branch disambiguates a model/plan restriction from generic auth.
+ * Context-overflow is handled separately (see {@link detectAnthropicContextOverflow}).
+ */
+export function deriveAnthropicReason(
+  error: InstanceType<typeof Anthropic.APIError>,
+): ProviderErrorReason {
+  const apiType = readAnthropicErrorType(error);
+  const status = error.status;
+  const haystack = `${apiType ?? ""} ${error.message ?? ""}`;
+
+  if (
+    status === 402 ||
+    /credit balance is too low/i.test(haystack) ||
+    /insufficient.*credits?/i.test(haystack) ||
+    /\bbilling\b/i.test(haystack)
+  ) {
+    return "insufficient_credits";
+  }
+  if (apiType === "authentication_error" || status === 401) {
+    return "invalid_credentials";
+  }
+  if (apiType === "permission_error" || status === 403) {
+    return /model|plan|not\s+(?:allowed|permitted|enabled)|access/i.test(
+      haystack,
+    )
+      ? "model_restricted"
+      : "invalid_credentials";
+  }
+  if (apiType === "not_found_error" || status === 404) return "model_not_found";
+  if (apiType === "rate_limit_error" || status === 429) return "rate_limited";
+  if (apiType === "overloaded_error" || status === 529) return "overloaded";
+  if (status !== undefined && status >= 500) return "server_error";
+  if (
+    apiType === "invalid_request_error" ||
+    (status !== undefined && status >= 400)
+  ) {
+    return "bad_request";
+  }
+  return "unknown";
 }
 
 /** Rate-limit the orphaned-surrogate warning so a single bad stream can't flood logs. */
@@ -800,8 +865,7 @@ export class AnthropicProvider implements Provider {
     const { tools, systemPrompt, config, onEvent, signal } = options ?? {};
     const cacheTtl: "5m" | "1h" =
       ((config as Record<string, unknown> | undefined)?.cacheTtl as
-        | "5m"
-        | "1h") ?? "1h";
+        "5m" | "1h") ?? "1h";
     // Opt-out for callers (e.g. the memory router) that send a single
     // user message per call with content that changes every time. The
     // turn-start cache breakpoint below is only useful when the same
@@ -1510,6 +1574,7 @@ export class AnthropicProvider implements Provider {
               actualTokens: overflow.actualTokens,
               maxTokens: overflow.maxTokens,
               statusCode: error.status,
+              reason: "context_overflow",
               cause: error,
             },
           );
@@ -1519,10 +1584,23 @@ export class AnthropicProvider implements Provider {
           retryAfterMs?: number;
           abortReason?: unknown;
           cause?: unknown;
+          reason?: ProviderErrorReason;
+          apiErrorType?: string;
+          apiErrorCode?: string;
         } = {};
         if (retryAfterMs !== undefined)
           errorOptions.retryAfterMs = retryAfterMs;
         if (abortReason) errorOptions.abortReason = abortReason;
+        // Stamp the semantic reason + structured type/code so downstream
+        // classification/retry can switch on intent. Skip on caller-abort:
+        // abortReason already short-circuits and carries the intent.
+        if (!abortReason) {
+          errorOptions.reason = deriveAnthropicReason(error);
+          const apiErrorType = readAnthropicErrorType(error);
+          if (apiErrorType) errorOptions.apiErrorType = apiErrorType;
+          const apiErrorCode = readAnthropicErrorCode(error);
+          if (apiErrorCode) errorOptions.apiErrorCode = apiErrorCode;
+        }
         // Only preserve the original error as `cause` for transport aborts
         // without a daemon-tagged reason — it's the diagnostic signal the
         // retry layer and log reader rely on. Don't leak it through the


### PR DESCRIPTION
## Summary
- Anthropic adapter now maps its error type/status to a ProviderErrorReason and stamps it (plus apiErrorType/apiErrorCode) on the thrown ProviderError.
- retagDelegateError carries reason + structured fields so OpenRouter/Vercel Anthropic-delegate paths keep their signal.
- Removes the Anthropic-anchored retry regex where the reason short-circuit fully covers it.

Part of plan: provider-error-reason.md (PR 2 of 4)