### PR TITLE
feat(assistant): stamp `reason` on Gemini provider errors and fix 429-as-overflow hack

### DIFF
--- a/assistant/src/__tests__/gemini-provider.test.ts
+++ b/assistant/src/__tests__/gemini-provider.test.ts
@@ -6,8 +6,9 @@ import type {
   ProviderEvent,
   ToolDefinition,
 } from "../providers/types.js";
+import { ContextOverflowError } from "../providers/types.js";
 import { createAbortReason } from "../util/abort-reasons.js";
-import { ProviderError } from "../util/errors.js";
+import { ProviderError, type ProviderErrorReason } from "../util/errors.js";
 
 // ---------------------------------------------------------------------------
 // Mock @google/genai module — must be before importing the provider
@@ -1386,6 +1387,123 @@ describe("GeminiProvider", () => {
     } catch (error) {
       expect(error).toBeInstanceOf(ProviderError);
       expect((error as ProviderError).abortReason).toBeUndefined();
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Error reason mapping
+  // -----------------------------------------------------------------------
+  async function reasonForApiError(
+    status: number,
+    message: string,
+  ): Promise<ProviderErrorReason | undefined> {
+    shouldThrow = new FakeApiError(status, message);
+    try {
+      await provider.sendMessage([
+        { role: "user", content: [{ type: "text", text: "Hi" }] },
+      ]);
+      throw new Error("expected sendMessage to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProviderError);
+      return (error as ProviderError).reason;
+    }
+  }
+
+  test("maps 401 / UNAUTHENTICATED to invalid_credentials", async () => {
+    expect(await reasonForApiError(401, "API key not valid")).toBe(
+      "invalid_credentials",
+    );
+    expect(await reasonForApiError(0, "UNAUTHENTICATED: bad key")).toBe(
+      "invalid_credentials",
+    );
+  });
+
+  test("maps a plan/model-restricted 403 to model_restricted", async () => {
+    expect(
+      await reasonForApiError(
+        403,
+        "PERMISSION_DENIED: Gemini API model gemini-3-pro is not available on your billing plan",
+      ),
+    ).toBe("model_restricted");
+  });
+
+  test("maps a generic 403 with no model signal to invalid_credentials", async () => {
+    expect(
+      await reasonForApiError(
+        403,
+        "PERMISSION_DENIED: The caller does not have permission",
+      ),
+    ).toBe("invalid_credentials");
+  });
+
+  test("maps 404 / NOT_FOUND to model_not_found", async () => {
+    expect(
+      await reasonForApiError(404, "NOT_FOUND: model does not exist"),
+    ).toBe("model_not_found");
+  });
+
+  test("maps a plain 429 (no token signal) to rate_limited, not context overflow", async () => {
+    shouldThrow = new FakeApiError(
+      429,
+      "RESOURCE_EXHAUSTED: Quota exceeded for requests per minute",
+    );
+    try {
+      await provider.sendMessage([
+        { role: "user", content: [{ type: "text", text: "Hi" }] },
+      ]);
+      throw new Error("expected sendMessage to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProviderError);
+      expect(error).not.toBeInstanceOf(ContextOverflowError);
+      expect((error as ProviderError).reason).toBe("rate_limited");
+    }
+  });
+
+  test("maps 5xx to server_error, or overloaded when the body says so", async () => {
+    expect(await reasonForApiError(500, "Internal error")).toBe("server_error");
+    expect(
+      await reasonForApiError(
+        503,
+        "UNAVAILABLE: The model is overloaded. Please try again later.",
+      ),
+    ).toBe("overloaded");
+  });
+
+  test("maps other 4xx to bad_request", async () => {
+    expect(await reasonForApiError(400, "INVALID_ARGUMENT: bad field")).toBe(
+      "bad_request",
+    );
+  });
+
+  test("a genuine token-limit 429 still yields ContextOverflowError / context_overflow", async () => {
+    shouldThrow = new FakeApiError(
+      429,
+      "RESOURCE_EXHAUSTED: The input token count (2000000) exceeds the maximum number of tokens allowed (1048576).",
+    );
+    try {
+      await provider.sendMessage([
+        { role: "user", content: [{ type: "text", text: "Hi" }] },
+      ]);
+      throw new Error("expected sendMessage to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ContextOverflowError);
+      expect((error as ProviderError).reason).toBe("context_overflow");
+    }
+  });
+
+  test("a token-limit 400 still yields ContextOverflowError / context_overflow", async () => {
+    shouldThrow = new FakeApiError(
+      400,
+      "INVALID_ARGUMENT: The prompt is too long; token count exceeds the model's context length.",
+    );
+    try {
+      await provider.sendMessage([
+        { role: "user", content: [{ type: "text", text: "Hi" }] },
+      ]);
+      throw new Error("expected sendMessage to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ContextOverflowError);
+      expect((error as ProviderError).reason).toBe("context_overflow");
     }
   });
 

--- a/assistant/src/__tests__/gemini-provider.test.ts
+++ b/assistant/src/__tests__/gemini-provider.test.ts
@@ -1436,6 +1436,15 @@ describe("GeminiProvider", () => {
     ).toBe("invalid_credentials");
   });
 
+  test("maps an IAM 403 on a models/* resource to invalid_credentials, not model_restricted", async () => {
+    expect(
+      await reasonForApiError(
+        403,
+        "PERMISSION_DENIED: Permission 'generativelanguage.models.generateContent' denied on resource //generativelanguage.googleapis.com/models/gemini-2.5-pro",
+      ),
+    ).toBe("invalid_credentials");
+  });
+
   test("maps 404 / NOT_FOUND to model_not_found", async () => {
     expect(
       await reasonForApiError(404, "NOT_FOUND: model does not exist"),

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -214,9 +214,13 @@ export function detectGeminiContextOverflow(
   return extractOverflowTokensFromMessage(message);
 }
 
-/** 403/PERMISSION_DENIED bodies that signal a model/plan restriction, not a bad key. */
+/**
+ * 403/PERMISSION_DENIED bodies that signal a model/plan restriction, not a bad
+ * key. Requires explicit restriction prose — a bare "model" mention would also
+ * match IAM permission failures on a `.../models/...` resource.
+ */
 const GEMINI_MODEL_RESTRICTED_PATTERNS =
-  /\bmodel\b|not (?:supported|available|enabled|accessible|allowed)|does not have access|billing|not enabled|\bplan\b|\btier\b/i;
+  /not (?:supported|available|enabled|accessible|allowed)|does not have access|billing|not enabled|\bplan\b|\btier\b/i;
 
 /** 5xx/UNAVAILABLE bodies that indicate transient overload rather than a generic server error. */
 const GEMINI_OVERLOAD_PATTERNS = /overload/i;

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -7,7 +7,7 @@ import {
 } from "../../config/schemas/llm.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../prompts/cache-boundary.js";
 import { isAbortReason } from "../../util/abort-reasons.js";
-import { ProviderError } from "../../util/errors.js";
+import { ProviderError, type ProviderErrorReason } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import { base64Source, resolveMediaReferences } from "../media-resolve.js";
 import { PROVIDER_CATALOG } from "../model-catalog.js";
@@ -212,6 +212,44 @@ export function detectGeminiContextOverflow(
     GEMINI_CONTEXT_OVERFLOW_TOKEN_PATTERNS.test(message);
   if (!matches) return null;
   return extractOverflowTokensFromMessage(message);
+}
+
+/** 403/PERMISSION_DENIED bodies that signal a model/plan restriction, not a bad key. */
+const GEMINI_MODEL_RESTRICTED_PATTERNS =
+  /\bmodel\b|not (?:supported|available|enabled|accessible|allowed)|does not have access|billing|not enabled|\bplan\b|\btier\b/i;
+
+/** 5xx/UNAVAILABLE bodies that indicate transient overload rather than a generic server error. */
+const GEMINI_OVERLOAD_PATTERNS = /overload/i;
+
+/**
+ * Map a Gemini `ApiError`'s HTTP status / status-name to a semantic
+ * {@link ProviderErrorReason}. The SDK's `ApiError` exposes only `status` and
+ * `message`, and the canonical status-name (e.g. `PERMISSION_DENIED`) rides the
+ * message body, so we match on both. Context-overflow is handled separately by
+ * {@link detectGeminiContextOverflow}; a plain 429 here is a rate limit.
+ */
+export function deriveGeminiReason(error: ApiError): ProviderErrorReason {
+  const status = error.status;
+  const message = error.message ?? "";
+  const upper = message.toUpperCase();
+  const hasName = (name: string) => upper.includes(name);
+
+  if (status === 401 || hasName("UNAUTHENTICATED"))
+    return "invalid_credentials";
+  if (status === 403 || hasName("PERMISSION_DENIED")) {
+    return GEMINI_MODEL_RESTRICTED_PATTERNS.test(message)
+      ? "model_restricted"
+      : "invalid_credentials";
+  }
+  if (status === 404 || hasName("NOT_FOUND")) return "model_not_found";
+  if (status === 429 || hasName("RESOURCE_EXHAUSTED")) return "rate_limited";
+  if (status >= 500 || hasName("UNAVAILABLE")) {
+    return GEMINI_OVERLOAD_PATTERNS.test(message)
+      ? "overloaded"
+      : "server_error";
+  }
+  if (status >= 400) return "bad_request";
+  return "unknown";
 }
 
 const log = getLogger("gemini-client");
@@ -506,7 +544,10 @@ export class GeminiProvider implements Provider {
           `Gemini API error (${error.status}): ${error.message}`,
           "gemini",
           error.status,
-          abortReason ? { abortReason } : undefined,
+          {
+            reason: deriveGeminiReason(error),
+            ...(abortReason ? { abortReason } : {}),
+          },
         );
       }
       throw new ProviderError(

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -234,21 +234,28 @@ export function deriveGeminiReason(error: ApiError): ProviderErrorReason {
   const upper = message.toUpperCase();
   const hasName = (name: string) => upper.includes(name);
 
-  if (status === 401 || hasName("UNAUTHENTICATED"))
+  if (status === 401 || hasName("UNAUTHENTICATED")) {
     return "invalid_credentials";
+  }
   if (status === 403 || hasName("PERMISSION_DENIED")) {
     return GEMINI_MODEL_RESTRICTED_PATTERNS.test(message)
       ? "model_restricted"
       : "invalid_credentials";
   }
-  if (status === 404 || hasName("NOT_FOUND")) return "model_not_found";
-  if (status === 429 || hasName("RESOURCE_EXHAUSTED")) return "rate_limited";
+  if (status === 404 || hasName("NOT_FOUND")) {
+    return "model_not_found";
+  }
+  if (status === 429 || hasName("RESOURCE_EXHAUSTED")) {
+    return "rate_limited";
+  }
   if (status >= 500 || hasName("UNAVAILABLE")) {
     return GEMINI_OVERLOAD_PATTERNS.test(message)
       ? "overloaded"
       : "server_error";
   }
-  if (status >= 400) return "bad_request";
+  if (status >= 400) {
+    return "bad_request";
+  }
   return "unknown";
 }
 


### PR DESCRIPTION
## Summary
- Gemini adapter now maps its status/status-name to a ProviderErrorReason and stamps it on the thrown ProviderError.
- A plain Gemini 429 is now classified as rate_limited instead of being misdetected as context overflow; genuine token-limit overflow still yields ContextOverflowError.

Part of plan: provider-error-reason.md (PR 3 of 4)