### PR TITLE
fix(web): transcript-level skill-card kill-switch (review gap r2)

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-transcript-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-transcript-data.ts
@@ -19,6 +19,7 @@ import { buildTranscriptItems } from "@/domains/chat/transcript/build-items";
 import type { TranscriptItem } from "@/domains/chat/transcript/types";
 import { sanitizeDisplayMessages } from "@/domains/chat/utils/sanitize-display-messages";
 import type { DisplayMessage } from "@/domains/chat/types/types";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 
 // ---------------------------------------------------------------------------
 // Params & return type
@@ -57,6 +58,12 @@ export function useTranscriptData({
   const pendingSecret = useInteractionStore.use.pendingSecret();
   const pendingConfirmation = useInteractionStore.use.pendingConfirmation();
   const pendingContactRequest = useInteractionStore.use.pendingContactRequest();
+
+  // Client half of the `skill-creation-card` kill-switch: with the flag off,
+  // `skill_card` surfaces are dropped at projection time so persisted
+  // card-only messages leave no blank assistant row (the in-card `null`
+  // return alone would leave the surface wrapper + hover-action trailer).
+  const skillCardsEnabled = useClientFeatureFlagStore.use.skillCreationCard();
 
   // --- Sanitise -----------------------------------------------------------
   const sanitizedMessages = useMemo(
@@ -105,6 +112,7 @@ export function useTranscriptData({
         thinkingLabel,
         ephemeralMetaResults,
         showOnboardingChoice,
+        skillCardsEnabled,
       }),
     [
       sanitizedMessages,
@@ -116,6 +124,7 @@ export function useTranscriptData({
       thinkingLabel,
       ephemeralMetaResults,
       showOnboardingChoice,
+      skillCardsEnabled,
     ],
   );
 

--- a/clients/web/src/domains/chat/transcript/build-items.test.ts
+++ b/clients/web/src/domains/chat/transcript/build-items.test.ts
@@ -752,6 +752,205 @@ describe("buildTranscriptItems", () => {
     expect((second[1] as MessageItem).message).toBe(m2Updated);
   });
 
+  // ---------------------------------------------------------------------------
+  // skill-creation-card kill-switch (skillCardsEnabled === false)
+  //
+  // With the client flag off, skill_card surfaces are dropped at projection
+  // time. A message whose ONLY renderable content was skill cards is skipped
+  // entirely — otherwise the row's surface wrapper + hover-action trailer
+  // would render as a blank assistant row (the in-card `null` return removes
+  // only the card itself). A mixed message just loses those surfaces.
+  // ---------------------------------------------------------------------------
+
+  function makeSkillCardSurface(surfaceId = "skill-card-1"): Surface {
+    return makeSurface({
+      surfaceId,
+      surfaceType: "skill_card",
+      display: "inline",
+      data: { skills: [{ skillId: "skill-1", name: "Weekly digest" }] },
+    });
+  }
+
+  /** Daemon shape for a persisted card-only row: the `_surfaceFallback` text
+   *  is stripped for surface-capable clients, leaving just the surface. */
+  function makeCardOnlyMessage(id = "m-card"): DisplayMessage {
+    const surface = makeSkillCardSurface();
+    return makeMessage({
+      id,
+      role: "assistant",
+      surfaces: [surface],
+      textSegments: [],
+      contentOrder: [{ type: "surface", id: surface.surfaceId }],
+      contentBlocks: [{ type: "surface", surface }],
+    });
+  }
+
+  test("flag off: a message whose only renderable content is skill_card surfaces is skipped entirely", () => {
+    const user = makeMessage({ id: "m1", role: "user", ...textBody("Hi") });
+    const cardOnly = makeCardOnlyMessage();
+    const messages = [user, cardOnly];
+
+    const items = buildTranscriptItems({
+      ...emptyInput(),
+      messages,
+      skillCardsEnabled: false,
+    });
+
+    expect(items).toHaveLength(1);
+    expect((items[0] as MessageItem).message).toBe(user);
+    // Suppression is projection-only — the message stays in `messages` state.
+    expect(messages).toHaveLength(2);
+    expect(messages[1]).toBe(cardOnly);
+  });
+
+  test("flag off: a mixed message loses its skill_card surfaces but keeps the rest", () => {
+    const surface = makeSkillCardSurface();
+    const mixed = makeMessage({
+      id: "m-mixed",
+      role: "assistant",
+      surfaces: [surface],
+      textSegments: ["Here is what I learned."],
+      contentOrder: [
+        { type: "text", id: "0" },
+        { type: "surface", id: surface.surfaceId },
+      ],
+      contentBlocks: [
+        { type: "text", text: "Here is what I learned." },
+        { type: "surface", surface },
+      ],
+    });
+
+    const items = buildTranscriptItems({
+      ...emptyInput(),
+      messages: [mixed],
+      skillCardsEnabled: false,
+    });
+
+    expect(items).toHaveLength(1);
+    const projected = (items[0] as MessageItem).message;
+    // The row keeps its identity (key) but carries a stripped copy.
+    expect(items[0]!.key).toBe("m-mixed");
+    expect(projected).not.toBe(mixed);
+    expect(projected.surfaces).toEqual([]);
+    expect(projected.contentBlocks).toEqual([
+      { type: "text", text: "Here is what I learned." },
+    ]);
+    expect(projected.contentOrder).toEqual([{ type: "text", id: "0" }]);
+    // The input message is untouched (strip is copy-on-write).
+    expect(mixed.surfaces).toHaveLength(1);
+    expect(mixed.contentBlocks).toHaveLength(2);
+  });
+
+  test("flag off: a skill-card message with tool calls is kept (tool calls are renderable)", () => {
+    const surface = makeSkillCardSurface();
+    const toolCall = {
+      id: "tc-1",
+      name: "bash",
+      input: { command: "ls" },
+      completedAt: 1,
+      result: "file.txt",
+    };
+    const withTool = makeMessage({
+      id: "m-tool",
+      role: "assistant",
+      surfaces: [surface],
+      toolCalls: [toolCall],
+      contentBlocks: [
+        { type: "tool_use", toolCall },
+        { type: "surface", surface },
+      ],
+    });
+
+    const items = buildTranscriptItems({
+      ...emptyInput(),
+      messages: [withTool],
+      skillCardsEnabled: false,
+    });
+
+    expect(items).toHaveLength(1);
+    const projected = (items[0] as MessageItem).message;
+    expect(projected.surfaces).toEqual([]);
+    expect(projected.contentBlocks).toEqual([
+      { type: "tool_use", toolCall },
+    ]);
+  });
+
+  test("flag off: messages without skill_card surfaces pass through by reference", () => {
+    const other = makeMessage({
+      id: "m-other",
+      role: "assistant",
+      ...textBody("Plain"),
+      surfaces: [makeSurface({ surfaceId: "surf-1", surfaceType: "card" })],
+    });
+
+    const items = buildTranscriptItems({
+      ...emptyInput(),
+      messages: [other],
+      skillCardsEnabled: false,
+    });
+
+    expect(items).toHaveLength(1);
+    expect((items[0] as MessageItem).message).toBe(other);
+  });
+
+  test("flag off: the stripped projection is reference-stable across rebuilds", () => {
+    const cardOnly = makeCardOnlyMessage();
+    const surface = makeSkillCardSurface("skill-card-2");
+    const mixed = makeMessage({
+      id: "m-mixed",
+      role: "assistant",
+      surfaces: [surface],
+      textSegments: ["Kept text"],
+      contentOrder: [
+        { type: "text", id: "0" },
+        { type: "surface", id: surface.surfaceId },
+      ],
+      contentBlocks: [
+        { type: "text", text: "Kept text" },
+        { type: "surface", surface },
+      ],
+    });
+
+    const first = buildTranscriptItems({
+      ...emptyInput(),
+      messages: [cardOnly, mixed],
+      skillCardsEnabled: false,
+    });
+    const second = buildTranscriptItems({
+      ...emptyInput(),
+      messages: [cardOnly, mixed],
+      skillCardsEnabled: false,
+    });
+
+    expect(first).toHaveLength(1);
+    expect(second[0]).toBe(first[0]);
+  });
+
+  test("flag on: skill-card messages are unchanged (same reference, no stripping)", () => {
+    const cardOnly = makeCardOnlyMessage();
+
+    const items = buildTranscriptItems({
+      ...emptyInput(),
+      messages: [cardOnly],
+      skillCardsEnabled: true,
+    });
+
+    expect(items).toHaveLength(1);
+    expect((items[0] as MessageItem).message).toBe(cardOnly);
+  });
+
+  test("flag omitted: behaves as enabled (skill-card messages pass through)", () => {
+    const cardOnly = makeCardOnlyMessage();
+
+    const items = buildTranscriptItems({
+      ...emptyInput(),
+      messages: [cardOnly],
+    });
+
+    expect(items).toHaveLength(1);
+    expect((items[0] as MessageItem).message).toBe(cardOnly);
+  });
+
   test("uses clientMessageId as key when available, falls back to id", () => {
     const withClientId = makeMessage({
       id: "server-id-123",

--- a/clients/web/src/domains/chat/transcript/build-items.ts
+++ b/clients/web/src/domains/chat/transcript/build-items.ts
@@ -3,6 +3,8 @@
 // messages + interaction state and emits a flat item array that the
 // Transcript component renders via a virtualised list.
 
+import type { ConversationContentBlock } from "@vellumai/assistant-api";
+
 import type {
   DisplayMessage,
   EphemeralMetaResult,
@@ -12,6 +14,7 @@ import type {
   PendingContactRequestItem,
   TranscriptItem,
 } from "@/domains/chat/transcript/types";
+import { filterMessageSurfaces } from "@/domains/chat/utils/map-message-surfaces";
 
 export interface BuildTranscriptItemsInput {
   messages: DisplayMessage[];
@@ -32,6 +35,18 @@ export interface BuildTranscriptItemsInput {
    *  the transcript tail. Not persisted; cleared on the next send/switch. */
   ephemeralMetaResults?: EphemeralMetaResult[];
   showOnboardingChoice?: boolean;
+  /**
+   * Client half of the `skill-creation-card` kill-switch (the assistant half
+   * gates card *insertion*). When false, `skill_card` surfaces are stripped
+   * from every message before projection: a mixed message just loses those
+   * surface blocks, and a message left with nothing renderable is skipped
+   * entirely. Gating here — rather than only returning `null` inside
+   * `SkillCreatedCard` — matters because the message row's surface wrapper
+   * and hover-action trailer render unconditionally, so a persisted
+   * card-only message would otherwise leave a blank ~24px assistant row.
+   * Omitted/undefined behaves as enabled.
+   */
+  skillCardsEnabled?: boolean;
 }
 
 /**
@@ -62,6 +77,74 @@ function toMessageItem(message: DisplayMessage): MessageItem {
 }
 
 /**
+ * Flag-off skill-card projection cache, keyed by the original message ref
+ * (same identity discipline as `messageItemCache` — see its comment for why
+ * reference stability matters at streaming rebuild rates). `null` marks
+ * "nothing left to render: skip the row". Only consulted while the
+ * skill-card flag is off, so a runtime flag flip can never serve a stale
+ * projection — the flag-on path bypasses this cache entirely.
+ */
+const skillCardStripCache = new WeakMap<
+  DisplayMessage,
+  DisplayMessage | null
+>();
+
+/**
+ * Strip `skill_card` surfaces from a message for the flag-off kill-switch.
+ * Returns the message untouched when it carries no skill cards, a stripped
+ * copy (surfaces / contentOrder / contentBlocks filtered in lockstep) when
+ * other renderable content remains, or `null` when the skill cards were the
+ * only renderable content — the caller drops the row entirely so no blank
+ * assistant row (empty surface wrapper + hover-action trailer) is left
+ * behind for persisted card-only messages.
+ */
+function withoutSkillCardSurfaces(
+  message: DisplayMessage,
+): DisplayMessage | null {
+  const cached = skillCardStripCache.get(message);
+  if (cached !== undefined) return cached;
+  const stripped = filterMessageSurfaces(
+    message,
+    (s) => s.surfaceType !== "skill_card",
+  );
+  const result =
+    stripped === message
+      ? message
+      : hasRenderableContent(stripped)
+        ? stripped
+        : null;
+  skillCardStripCache.set(message, result);
+  return result;
+}
+
+/**
+ * Whether the transcript row for this message would still visibly render
+ * anything. Checks the canonical `contentBlocks` projection (what
+ * `TranscriptMessageBody` renders), the attachment / Slack regions, and —
+ * defensively — the legacy positional arrays. Blank text/thinking runs do
+ * not count: the daemon strips the `_surfaceFallback` text for
+ * surface-capable clients, so a card-only message has none of these.
+ */
+function hasRenderableContent(message: DisplayMessage): boolean {
+  return Boolean(
+    message.contentBlocks?.some(isRenderableBlock) ||
+      message.surfaces?.length ||
+      message.attachments?.length ||
+      message.slackMessage ||
+      message.toolCalls?.length ||
+      message.textSegments?.some((s) => s.trim().length > 0) ||
+      message.thinkingSegments?.some((s) => s.trim().length > 0),
+  );
+}
+
+function isRenderableBlock(block: ConversationContentBlock): boolean {
+  if (block.type === "text") return block.text.trim().length > 0;
+  if (block.type === "thinking") return block.thinking.trim().length > 0;
+  // tool_use / surface / attachment blocks always carry visible content.
+  return true;
+}
+
+/**
  * Project the chat state into an ordered flat list of transcript items.
  *
  * Rules:
@@ -72,6 +155,9 @@ function toMessageItem(message: DisplayMessage): MessageItem {
  *      within the message body by `TranscriptMessageBody` via `contentOrder` —
  *      they are NOT separate transcript rows. Tool calls stay inside the
  *      `MessageItem` — the Transcript component flattens them at render time.
+ *      When `skillCardsEnabled` is false, `skill_card` surfaces are stripped
+ *      before projection and a message left with nothing renderable is
+ *      skipped (see `withoutSkillCardSurfaces`).
  *
  *   2. After the last message, emit trailers in this exact order:
  *        a. `ThinkingItem` when `isThinking`.
@@ -115,7 +201,18 @@ export function buildTranscriptItems(
       continue;
     }
 
-    items.push(toMessageItem(message));
+    // skill-creation-card kill-switch (see `skillCardsEnabled`). Like the
+    // notification suppression above this is projection-only — `messages`
+    // state keeps the original row.
+    const projected =
+      input.skillCardsEnabled === false
+        ? withoutSkillCardSurfaces(message)
+        : message;
+    if (projected === null) {
+      continue;
+    }
+
+    items.push(toMessageItem(projected));
   }
 
   for (const result of input.ephemeralMetaResults ?? []) {


### PR DESCRIPTION
## Summary
Flag-off now suppresses skill_card surface groups during transcript construction, so card-only messages leave no blank assistant rows (previously the card returned null inside an already-rendered wrapper + trailer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)