### PR TITLE
fix(web): skills q-sync direction + detail staleTime revalidation (review gaps r2)

### DIFF
--- a/clients/web/src/domains/intelligence/components/skills/skills-tab.test.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skills-tab.test.tsx
@@ -1,0 +1,217 @@
+/**
+ * Tests for the Skills tab's search ↔ URL (`?q=`) synchronization — the
+ * two-way sync direction, not the list rendering:
+ *
+ * - typing debounces into `?q=` exactly once per settled value,
+ * - an external `?q=` change WITHOUT a remount (re-clicking the Skills nav
+ *   link to clear the query, back/forward, in-app filtered links) wins over
+ *   the local input instead of being debounce-bounced back to the stale
+ *   local value.
+ *
+ * The generated SDK is mocked with empty payloads (the queries only need to
+ * settle); the tab is mounted with sibling probe/controls components on the
+ * same route so URL changes never remount it. Mounted via
+ * `@testing-library/react` (happy-dom — see `clients/web/test-setup.ts`).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { useEffect } from "react";
+import {
+  MemoryRouter,
+  Route,
+  Routes,
+  useLocation,
+  useSearchParams,
+} from "react-router";
+
+import type {
+  SkillsCategoriesGetResponse,
+  SkillsGetResponse,
+} from "@/generated/daemon/types.gen";
+
+const ASSISTANT_ID = "asst-1";
+const okResponse = { response: new Response(), error: undefined };
+
+/** Mirrors `SEARCH_DEBOUNCE_MS` in `skills-tab.tsx` (not exported). */
+const SEARCH_DEBOUNCE_MS = 300;
+
+const sdkActual = await import("@/generated/daemon/sdk.gen");
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...sdkActual,
+  skillsGet: mock(async () => ({
+    data: { skills: [] } as SkillsGetResponse,
+    ...okResponse,
+  })),
+  skillsCategoriesGet: mock(async () => ({
+    data: { categories: [] } as SkillsCategoriesGetResponse,
+    ...okResponse,
+  })),
+}));
+
+const { SkillsTab } =
+  await import("@/domains/intelligence/components/skills/skills-tab");
+
+/** Every distinct `location.search` the router passed through, in order. */
+const searchLog: string[] = [];
+
+function UrlProbe() {
+  const location = useLocation();
+  useEffect(() => {
+    searchLog.push(location.search);
+  }, [location.search]);
+  return <div data-testid="url">{location.search}</div>;
+}
+
+/**
+ * Simulates `?q=` changing from OUTSIDE the tab while it stays mounted —
+ * the same route transition a nav-link re-click or an in-app filtered link
+ * produces.
+ */
+function ExternalControls() {
+  const [, setSearchParams] = useSearchParams();
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() =>
+          setSearchParams(new URLSearchParams(), { replace: true })
+        }
+      >
+        external-clear
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          setSearchParams(new URLSearchParams([["q", "zeta"]]), {
+            replace: true,
+          })
+        }
+      >
+        external-set
+      </button>
+    </>
+  );
+}
+
+async function renderTab(initialSearch = ""): Promise<HTMLInputElement> {
+  // Async act so the mocked queries' immediate resolutions flush in-act.
+  await act(async () => {
+    render(
+      <MemoryRouter initialEntries={[`/assistant/skills${initialSearch}`]}>
+        <QueryClientProvider
+          client={
+            new QueryClient({
+              defaultOptions: { queries: { retry: false, gcTime: 0 } },
+            })
+          }
+        >
+          <Routes>
+            <Route
+              path="/assistant/skills"
+              element={
+                <>
+                  <SkillsTab assistantId={ASSISTANT_ID} />
+                  <UrlProbe />
+                  <ExternalControls />
+                </>
+              }
+            />
+          </Routes>
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+  });
+  return screen.getByLabelText("Search skills") as HTMLInputElement;
+}
+
+/** Lets a full debounce window elapse so a wrong-direction write would land. */
+async function settleDebounce() {
+  await act(async () => {
+    await new Promise((resolve) =>
+      setTimeout(resolve, SEARCH_DEBOUNCE_MS + 150),
+    );
+  });
+  // A debounced URL write re-keys the skills query as the act above exits;
+  // the new fetch's resolution notifies subscribers through react-query's
+  // `setTimeout(0)` — absorb that macrotask inside act as well.
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  });
+}
+
+/** `fireEvent` here is raw DOM dispatch — act-wrap so updates flush in-act. */
+function typeSearch(input: HTMLInputElement, value: string) {
+  act(() => {
+    fireEvent.change(input, { target: { value } });
+  });
+}
+
+function clickButton(label: string) {
+  act(() => {
+    fireEvent.click(screen.getByText(label));
+  });
+}
+
+beforeEach(() => {
+  searchLog.length = 0;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SkillsTab search ↔ ?q= sync", () => {
+  test("typing debounces into the URL exactly once", async () => {
+    const input = await renderTab();
+
+    typeSearch(input, "focus");
+
+    // Local state updates immediately; the URL only after the debounce.
+    expect(input.value).toBe("focus");
+    expect(screen.getByTestId("url").textContent).toBe("");
+
+    await settleDebounce();
+
+    expect(screen.getByTestId("url").textContent).toBe("?q=focus");
+    expect(searchLog.filter((s) => s.includes("q="))).toEqual(["?q=focus"]);
+  });
+
+  test("externally clearing ?q= resets the input instead of bouncing the URL", async () => {
+    const input = await renderTab();
+
+    typeSearch(input, "focus");
+    await settleDebounce();
+    expect(screen.getByTestId("url").textContent).toBe("?q=focus");
+
+    // Nav-link re-click: same route, query string dropped, no remount. The
+    // adoption effect runs within the click's act flush.
+    clickButton("external-clear");
+    expect(input.value).toBe("");
+
+    // The stale debounced value must not resurrect `?q=focus`.
+    await settleDebounce();
+    expect(screen.getByTestId("url").textContent).toBe("");
+    expect(input.value).toBe("");
+  });
+
+  test("an external ?q= value replaces the current input", async () => {
+    const input = await renderTab("?q=alpha");
+    expect(input.value).toBe("alpha");
+
+    clickButton("external-set");
+    expect(input.value).toBe("zeta");
+
+    // The adopted value must stick — no bounce back to "alpha".
+    await settleDebounce();
+    expect(screen.getByTestId("url").textContent).toBe("?q=zeta");
+    expect(input.value).toBe("zeta");
+  });
+});

--- a/clients/web/src/domains/intelligence/components/skills/skills-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skills-tab.tsx
@@ -12,7 +12,7 @@ import {
     X,
     Zap,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router";
 
 import { SkillRemovalDialog } from "@/components/skill-removal-dialog";
@@ -74,11 +74,28 @@ export function SkillsTab({ assistantId }: SkillsTabProps) {
   // (debounced) value is reflected into `?q=` below and drives the query.
   const [searchValue, setSearchValue] = useState(q);
   const debouncedSearch = useDebouncedValue(searchValue.trim(), SEARCH_DEBOUNCE_MS);
+  // Last `q` this component reconciled with the URL — distinguishes our own
+  // writes (echoed back through `useSearchParams`) from external changes
+  // (re-clicking the Skills nav link, back/forward, in-app filtered links).
+  const lastSyncedQ = useRef(q);
   useEffect(() => {
-    if (debouncedSearch !== q) {
+    if (q !== lastSyncedQ.current) {
+      // `?q=` changed externally without a remount — adopt it instead of
+      // debounce-writing the stale local value back over it.
+      lastSyncedQ.current = q;
+      if (q !== searchValue.trim()) {
+        setSearchValue(q);
+        return;
+      }
+    }
+    // Only write once the debounce has settled to the current input; while it
+    // lags (mid-typing or right after adopting an external change) a write
+    // would resurrect an outdated value.
+    if (debouncedSearch !== q && debouncedSearch === searchValue.trim()) {
+      lastSyncedQ.current = debouncedSearch;
       updateUrlState({ q: debouncedSearch });
     }
-  }, [debouncedSearch, q, updateUrlState]);
+  }, [debouncedSearch, q, searchValue, updateUrlState]);
 
   const handleFilterChange = useCallback(
     (next: SkillFilter) => updateUrlState({ filter: next }),

--- a/clients/web/src/domains/intelligence/skill-detail-page.test.tsx
+++ b/clients/web/src/domains/intelligence/skill-detail-page.test.tsx
@@ -3,7 +3,10 @@
  * page-level branching, not the detail rendering:
  *
  * - the not-found guard waits for an in-flight list refetch before declaring
- *   a skill missing (a fresh skill can be absent from a stale cached list),
+ *   a skill missing (a fresh skill can be absent from a cached list),
+ * - the page forces that refetch itself even when the cached list is still
+ *   fresh under the app QueryClient's `staleTime` (the test client mirrors
+ *   the production value so this can't silently regress),
  * - the back button restores the Skills list's query string passed as
  *   router state (search/filter/category survive detail navigation).
  *
@@ -30,6 +33,23 @@ import type { SkillsGetResponse } from "@/generated/daemon/types.gen";
 
 const ASSISTANT_ID = "asst-1";
 const okResponse = { response: new Response(), error: undefined };
+
+/**
+ * Mirrors the app QueryClient's `staleTime` (`components/providers.tsx`) so
+ * the suite exercises production mount-refetch semantics: a <10s-old cached
+ * list is fresh and would NOT refetch on mount by default — the page must
+ * force revalidation itself (`refetchOnMount: "always"`) for the not-found
+ * guard to ever see a refetch.
+ */
+const PRODUCTION_STALE_TIME_MS = 10_000;
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: PRODUCTION_STALE_TIME_MS },
+    },
+  });
+}
 
 // Per-test holder: each `skillsGet` call resolves with the current payload,
 // gated on `listGate` when set (lets a case hold a refetch in flight).
@@ -117,9 +137,7 @@ function SkillsListLanding() {
 function renderDetail({
   skillId,
   listSearch,
-  client = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  }),
+  client = makeQueryClient(),
 }: {
   skillId: string;
   listSearch?: string;
@@ -154,8 +172,8 @@ afterEach(() => {
 });
 
 describe("SkillDetailPage stale-list guard", () => {
-  test("shows loading (not 'Skill not found') while a stale cached list refetches", async () => {
-    // Seed a stale cached list that predates the requested skill; hold the
+  test("shows loading (not 'Skill not found') while an outdated cached list refetches", async () => {
+    // Seed a cached list that predates the requested skill; hold the
     // mount-triggered background refetch in flight.
     let releaseGate!: (value?: unknown) => void;
     listGate = new Promise((resolve) => {
@@ -163,22 +181,42 @@ describe("SkillDetailPage stale-list guard", () => {
     });
     listSkills = [makeSkill()];
 
-    const client = new QueryClient({
-      defaultOptions: { queries: { retry: false, gcTime: 0 } },
-    });
+    const client = makeQueryClient();
     client.setQueryData(listQueryKey(), {
       skills: [makeSkill({ id: "older-skill", name: "Older Skill" })],
     } as SkillsGetResponse);
 
     renderDetail({ skillId: "skill-1", client });
 
-    // Stale data without the skill + refetch in flight: loading, no verdict.
+    // Cached data without the skill + refetch in flight: loading, no verdict.
     expect(screen.queryByText("Skill not found")).toBeNull();
     expect(document.querySelector(".animate-spin")).not.toBeNull();
 
     releaseGate();
 
     // The refetch lands with the fresh skill and the detail renders.
+    await waitFor(() => {
+      expect(screen.getByText("Detail: Fresh Skill")).toBeTruthy();
+    });
+    expect(screen.queryByText("Skill not found")).toBeNull();
+  });
+
+  test("resolves a skill missing from a FRESH cached list (mount revalidation defeats staleTime)", async () => {
+    // Production repro: the Skills tab was viewed seconds ago (cache fresh
+    // under the 10s staleTime), then a freshly-authored skill's in-chat card
+    // is clicked. `setQueryData` stamps the entry as just-updated, so the
+    // default mount behavior would skip the refetch entirely and the page
+    // would render a terminal "Skill not found".
+    listSkills = [makeSkill()];
+
+    const client = makeQueryClient();
+    client.setQueryData(listQueryKey(), {
+      skills: [makeSkill({ id: "older-skill", name: "Older Skill" })],
+    } as SkillsGetResponse);
+
+    renderDetail({ skillId: "skill-1", client });
+
+    // The page forces a revalidation and the fresh skill resolves.
     await waitFor(() => {
       expect(screen.getByText("Detail: Fresh Skill")).toBeTruthy();
     });

--- a/clients/web/src/domains/intelligence/skill-detail-page.tsx
+++ b/clients/web/src/domains/intelligence/skill-detail-page.tsx
@@ -51,6 +51,13 @@ export function SkillDetailPage() {
       query: { include: "catalog" },
     }),
     select: (data): SkillInfo[] => data.skills,
+    // The app QueryClient's `staleTime` (10s) would skip the mount refetch
+    // when the list was viewed moments ago — but the not-found guard below
+    // depends on that refetch, or a freshly-authored skill absent from the
+    // cached list (e.g. its in-chat card clicked right after the Skills tab)
+    // renders a terminal "Skill not found". Always revalidate on mount; the
+    // shared cache key still renders the cached list instantly meanwhile.
+    refetchOnMount: "always",
   });
 
   const handleBack = useCallback(() => {


### PR DESCRIPTION
## Summary
- external URL q changes now win over stale local search state (last-written ref)
- skill detail page revalidates the skills list on mount so fresh skills resolve instead of flashing terminal not-found; test client aligned with production staleTime

🤖 Generated with [Claude Code](https://claude.com/claude-code)