### PR TITLE
fix: extract shared synthesis-format decode helper; refresh stale WAV comments

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -59,6 +59,7 @@ import { dispatchGuardianQuestion } from "./guardian-dispatch.js";
 import {
   findPlayableTelephonyTtsFallbackProvider,
   resolveCallTtsProvider,
+  resolveSynthesisFormats,
 } from "./resolve-call-tts-provider.js";
 import type { PromptSpeakerContext } from "./speaker-identification.js";
 import { sanitizeForTts } from "./tts-text-sanitizer.js";
@@ -1009,21 +1010,9 @@ export class CallController {
     let playUrlSent = false;
     const abortController = new AbortController();
     try {
-      // Transport-forced PCM and user-configured WAV both request raw PCM
-      // from the provider so the audio bytes match the store's
-      // content-type. Without this, providers like Fish Audio still return
-      // mp3 and the downstream mu-law transcoder fails on the format
-      // mismatch.
-      const outputFormat =
-        format === "pcm" || format === "wav" ? ("pcm" as const) : undefined;
-
-      // Use "pcm" as the store format when requesting PCM output so the
-      // audio store entry's content-type (audio/pcm) matches the raw PCM
-      // bytes providers return. Without this, the store says "audio/wav"
-      // but the bytes have no RIFF header, causing audioBufferToFrames to
-      // fall through to the wrong decode path.
+      const { outputFormat, storeFormat } = resolveSynthesisFormats(format);
       sink = createAudioStoreSink({
-        format: outputFormat ? "pcm" : format,
+        format: storeFormat,
         onPlayUrl: (url) => {
           // Audio is now reaching the caller (or, on transports with an
           // audio-start signal, will be the moment the first fetched frame

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -27,6 +27,7 @@ import type { CallTransport } from "./call-transport.js";
 import {
   findPlayableTelephonyTtsFallbackProvider,
   resolveCallTtsProvider,
+  resolveSynthesisFormats,
 } from "./resolve-call-tts-provider.js";
 
 const log = getLogger("call-speech-output");
@@ -117,19 +118,7 @@ async function synthesizeAndPlay(
   let sink: AudioStoreSink | null = null;
   let playUrlSent = false;
   try {
-    // Transport-forced PCM and user-configured WAV both request raw PCM
-    // from the provider so the audio bytes match the store's content-type.
-    // Without this, providers like Fish Audio still return mp3 and the
-    // downstream mu-law transcoder fails on the format mismatch.
-    const outputFormat =
-      format === "pcm" || format === "wav" ? ("pcm" as const) : undefined;
-
-    // Use "pcm" as the store format when requesting PCM output so the
-    // audio store entry's content-type (audio/pcm) matches the raw PCM
-    // bytes providers return. Without this, the store says "audio/wav"
-    // but the bytes have no RIFF header, causing audioBufferToFrames to
-    // fall through to the wrong decode path.
-    const storeFormat = outputFormat ? "pcm" : format;
+    const { outputFormat, storeFormat } = resolveSynthesisFormats(format);
     sink = createAudioStoreSink({
       format: storeFormat,
       onPlayUrl: (url) => {

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -747,9 +747,9 @@ export class MediaStreamOutput implements CallTransport {
    * base64-encoded mu-law frames.
    *
    * Rather than trusting the declared `format` parameter (which may not
-   * match the actual bytes — e.g. when a provider is asked for WAV but
-   * returns mp3), this method **sniffs the magic bytes** to detect the
-   * real format:
+   * match the actual bytes — e.g. the declared format may be pcm while
+   * the provider returned mp3), this method **sniffs the magic bytes**
+   * to detect the real format:
    *
    * - **WAV** (`RIFF` header, bytes `0x52 0x49 0x46 0x46`): extracts
    *   raw PCM data from the WAV container, converts it to 8 kHz using the

--- a/assistant/src/calls/resolve-call-tts-provider.ts
+++ b/assistant/src/calls/resolve-call-tts-provider.ts
@@ -176,6 +176,30 @@ export async function resolveCallTtsProvider(
 }
 
 /**
+ * Decode a resolved call audio format into the provider request format
+ * and the audio-store format.
+ *
+ * Transport-forced PCM and user-configured WAV both request raw PCM from
+ * the provider so the audio bytes match the store's content-type —
+ * without this, providers like Fish Audio still return mp3 and the
+ * downstream mu-law transcoder fails on the format mismatch. The store
+ * format follows the request: when raw PCM is requested the entry's
+ * content-type must be audio/pcm, otherwise the store would say
+ * "audio/wav" while the bytes have no RIFF header and
+ * audioBufferToFrames falls through to the wrong decode path.
+ */
+export function resolveSynthesisFormats(
+  format: "mp3" | "wav" | "opus" | "pcm",
+): {
+  outputFormat: "pcm" | undefined;
+  storeFormat: "mp3" | "wav" | "opus" | "pcm";
+} {
+  const outputFormat =
+    format === "pcm" || format === "wav" ? ("pcm" as const) : undefined;
+  return { outputFormat, storeFormat: outputFormat ?? format };
+}
+
+/**
  * Find a catalog provider that can produce playable media-stream audio
  * with resolvable credentials.
  *

--- a/assistant/src/calls/telephony-tts-capability.ts
+++ b/assistant/src/calls/telephony-tts-capability.ts
@@ -129,7 +129,7 @@ export async function evaluateTelephonyTtsPlayability(
  * Single source of truth for the fish-audio usability invariant: the
  * telephony path supplies no per-request voiceId, so synthesis requires a
  * configured reference ID. Shared by {@link evaluateTelephonyTtsPlayability}
- * and the call TTS resolver's non-WAV degrade path.
+ * and the call TTS resolver's non-PCM (native token) degrade path.
  *
  * When fish-audio is the active `services.tts.provider`, its config is
  * read through the {@link resolveTtsConfig} provider-options layer — the


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for tts-deferred-cleanups.md.

**Gap:** duplicated outputFormat/storeFormat decode block in call-speech-output and call-controller; two stale WAV-era comments.
**Fix:** one shared resolveSynthesisFormats helper next to ResolvedCallTts; comments updated to the PCM-era reality.