### PR TITLE
feat(web): polish the quote-and-reply flow

### DIFF
--- a/clients/web/src/domains/chat/components/quote-reply-bubble.stories.tsx
+++ b/clients/web/src/domains/chat/components/quote-reply-bubble.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useEffect } from "react";
+
+import { QuoteReplyBubble } from "./quote-reply-bubble";
+import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
+
+/**
+ * The reply-entry modal that opens when the user starts a reply from a text
+ * selection: the quoted passage, a reply field, and Cancel / Add to Chat
+ * (Rok's "Quote & Reply" polish — node 6485-155641).
+ */
+
+/** Seeds the reply bubble into the shared store, then renders it. */
+function WithReplyBubble({ quotedText }: { quotedText: string }) {
+  useEffect(() => {
+    useQuoteReplyStore.setState({
+      replyBubble: {
+        quotedText,
+        sourceMessageId: "msg-1",
+        anchorRect: { top: 220, left: 360, width: 0, height: 0 },
+      },
+    });
+    return () => useQuoteReplyStore.setState({ replyBubble: null });
+  }, [quotedText]);
+  return <QuoteReplyBubble />;
+}
+
+const meta: Meta<typeof QuoteReplyBubble> = {
+  title: "Chat/QuoteReplyBubble",
+  parameters: {
+    layout: "fullscreen",
+    controls: { disable: true },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof QuoteReplyBubble>;
+
+export const Default: Story = {
+  render: () => <WithReplyBubble quotedText="This is a text that's being quoted" />,
+};
+
+export const LongQuote: Story = {
+  render: () => (
+    <WithReplyBubble quotedText="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation." />
+  ),
+};

--- a/clients/web/src/domains/chat/components/quote-reply-bubble.tsx
+++ b/clients/web/src/domains/chat/components/quote-reply-bubble.tsx
@@ -1,13 +1,13 @@
 /**
  * Overlay bubble that appears after the user starts a reply from a text
  * selection. Displays the quoted passage and a text input for the user's
- * reply, with one action:
+ * reply, with two actions:
  *
+ * - **Cancel** — dismisses the bubble without staging anything.
  * - **Add to Chat** — stages the quote+reply for inclusion in the next
  *   message the user sends from the composer.
  */
 
-import { MessageSquareQuote, X } from "lucide-react";
 import {
   type KeyboardEvent as ReactKeyboardEvent,
   useCallback,
@@ -118,26 +118,6 @@ export function QuoteReplyBubble({ onAddToChat }: QuoteReplyBubbleProps) {
           className="bg-[var(--surface-base)] shadow-lg"
         >
           <Card.Body padding="sm" className="flex flex-col gap-3">
-            <div className="flex items-center justify-between gap-2">
-              <Typography
-                as="div"
-                variant="body-small-default"
-                className="flex min-w-0 items-center gap-1.5 text-[var(--content-tertiary)]"
-              >
-                <MessageSquareQuote className="h-3.5 w-3.5 shrink-0" />
-                <span>Quote &amp; Reply</span>
-              </Typography>
-              <Popover.Close asChild>
-                <Button
-                  variant="ghost"
-                  size="compact"
-                  iconOnly={<X />}
-                  expandOnMobile={false}
-                  aria-label="Close reply"
-                />
-              </Popover.Close>
-            </div>
-
             <Typography
               as="div"
               variant="body-small-default"
@@ -147,7 +127,7 @@ export function QuoteReplyBubble({ onAddToChat }: QuoteReplyBubbleProps) {
                 aria-hidden="true"
                 className={quoteBlockquoteAccentClassName}
               />
-              <span className={quoteBlockquoteContentClassName}>
+              <span className={`${quoteBlockquoteContentClassName} italic`}>
                 {truncatedQuote}
               </span>
             </Typography>
@@ -163,9 +143,16 @@ export function QuoteReplyBubble({ onAddToChat }: QuoteReplyBubbleProps) {
               className="min-h-[64px] resize-none text-body-small-default"
             />
 
-            <div className="flex items-center justify-end gap-2">
+            <div className="flex items-center justify-between gap-2">
               <Button
                 variant="outlined"
+                size="compact"
+                onClick={closeReplyBubble}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
                 size="compact"
                 onClick={handleAddToChat}
                 disabled={!replyText.trim()}

--- a/clients/web/src/domains/chat/components/quote-reply-components.test.tsx
+++ b/clients/web/src/domains/chat/components/quote-reply-components.test.tsx
@@ -242,7 +242,7 @@ describe("TextSelectionPopover", () => {
 });
 
 describe("QuoteReplyBubble", () => {
-  test("renders the reply editor with only Add to Chat", async () => {
+  test("renders the reply editor with Cancel and Add to Chat", async () => {
     useQuoteReplyStore.setState({
       replyBubble: {
         quotedText:
@@ -270,12 +270,30 @@ describe("QuoteReplyBubble", () => {
     expect(quoteBlock.previousElementSibling?.className).toContain("h-5");
     expect(quoteBlock.previousElementSibling?.className).toContain("w-0.5");
     expect(
-      screen.getByRole("button", { name: "Close reply" }).getAttribute("data-slot"),
+      screen.getByRole("button", { name: "Cancel" }).getAttribute("data-slot"),
     ).toBe("button");
     expect(
       screen.getByRole("button", { name: "Add to Chat" }).getAttribute("data-slot"),
     ).toBe("button");
+    expect(screen.queryByRole("button", { name: "Close reply" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Send Now" })).toBeNull();
+  });
+
+  test("Cancel dismisses the bubble without staging", async () => {
+    useQuoteReplyStore.setState({
+      replyBubble: {
+        quotedText: "quoted context",
+        sourceMessageId: "msg-1",
+        anchorRect: { top: 120, left: 180, width: 0, height: 0 },
+      },
+    });
+
+    render(<QuoteReplyBubble />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Cancel" }));
+
+    expect(useQuoteReplyStore.getState().replyBubble).toBeNull();
+    expect(useQuoteReplyStore.getState().stagedQuotes).toHaveLength(0);
   });
 
   test("Enter stages the reply, closes the bubble, and focuses the composer", async () => {
@@ -336,5 +354,28 @@ describe("StagedQuotesStrip", () => {
     expect(
       screen.getByRole("button", { name: "Remove quote" }).getAttribute("data-slot"),
     ).toBe("button");
+  });
+
+  test("editing a staged reply updates the store", () => {
+    useQuoteReplyStore.setState({
+      stagedQuotes: [
+        {
+          id: "quote-1",
+          quotedText: "competitive research",
+          replyText: "old reply",
+          sourceMessageId: "msg-1",
+        },
+      ],
+    });
+
+    render(<StagedQuotesStrip />);
+
+    const replyField = screen.getByLabelText("Edit reply");
+    expect((replyField as HTMLTextAreaElement).value).toBe("old reply");
+    fireEvent.change(replyField, { target: { value: "a revised reply" } });
+
+    expect(useQuoteReplyStore.getState().stagedQuotes[0]?.replyText).toBe(
+      "a revised reply",
+    );
   });
 });

--- a/clients/web/src/domains/chat/components/staged-quotes-strip.stories.tsx
+++ b/clients/web/src/domains/chat/components/staged-quotes-strip.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useEffect } from "react";
+import { Button } from "@vellumai/design-library";
+
+import { StagedQuotesStrip } from "./staged-quotes-strip";
+import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
+
+/**
+ * The staged-quotes strip: the quotes the user has pulled from assistant
+ * messages, each with an editable reply, rendered above the composer. When a
+ * quote is added the strip scrolls to reveal the newest chip.
+ */
+
+const SAMPLE_QUOTES = [
+  { quotedText: "the river model of memory", replyText: "Expand on this a lot more, please." },
+  { quotedText: "finding the path of least resistance", replyText: "What does this mean concretely?" },
+  { quotedText: "an eddy that thinks it's the river", replyText: "Is this a metaphor for identity?" },
+  { quotedText: "your memories are a record or just a current", replyText: "Which one do you believe?" },
+];
+
+/** Renders the strip plus a button that stages another quote (to test scroll). */
+function StripHarness({ initialCount }: { initialCount: number }) {
+  useEffect(() => {
+    useQuoteReplyStore.setState({ stagedQuotes: [] });
+    for (const q of SAMPLE_QUOTES.slice(0, initialCount)) {
+      useQuoteReplyStore.getState().addStagedQuote({ ...q, sourceMessageId: "msg-1" });
+    }
+    return () => useQuoteReplyStore.setState({ stagedQuotes: [] });
+  }, [initialCount]);
+
+  const stageAnother = () => {
+    const n = useQuoteReplyStore.getState().stagedQuotes.length;
+    const q = SAMPLE_QUOTES[n % SAMPLE_QUOTES.length]!;
+    useQuoteReplyStore
+      .getState()
+      .addStagedQuote({ ...q, sourceMessageId: `msg-${n}` });
+  };
+
+  return (
+    <div className="mx-auto max-w-[720px]">
+      <div className="rounded-[10px] bg-[var(--surface-base)] p-2">
+        <StagedQuotesStrip />
+        <div className="px-4 pt-3 pb-2 text-chat text-[var(--content-disabled)]">
+          What would you like to do?
+        </div>
+      </div>
+      <div className="mt-3">
+        <Button variant="outlined" size="compact" onClick={stageAnother}>
+          Stage another quote
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+const meta: Meta<typeof StagedQuotesStrip> = {
+  title: "Chat/StagedQuotesStrip",
+  parameters: { layout: "padded", controls: { disable: true } },
+};
+
+export default meta;
+type Story = StoryObj<typeof StagedQuotesStrip>;
+
+/** A few staged quotes; click "Stage another" to confirm it scrolls to the newest. */
+export const Overflowing: Story = {
+  render: () => <StripHarness initialCount={3} />,
+};
+
+/** Single staged quote with an editable reply. */
+export const Single: Story = {
+  render: () => <StripHarness initialCount={1} />,
+};

--- a/clients/web/src/domains/chat/components/staged-quotes-strip.tsx
+++ b/clients/web/src/domains/chat/components/staged-quotes-strip.tsx
@@ -1,6 +1,7 @@
 /**
  * Renders the list of staged quote-replies above the composer. Each chip
- * shows a truncated preview of the quoted text and the user's annotation,
+ * shows a truncated preview of the quoted text and an editable reply field
+ * (kept in sync with the store so replies can be revised after staging),
  * with an X button to remove it.
  *
  * The strip is scrollable when multiple quotes are staged, capped at
@@ -8,6 +9,7 @@
  */
 
 import { MessageSquareQuote, X } from "lucide-react";
+import { useEffect, useRef } from "react";
 import {
   Button,
   Card,
@@ -33,6 +35,18 @@ function truncate(text: string, maxLen: number): string {
 
 function StagedQuoteChip({ quote }: { quote: StagedQuote }) {
   const removeStagedQuote = useQuoteReplyStore.use.removeStagedQuote();
+  const updateStagedQuoteReply = useQuoteReplyStore.use.updateStagedQuoteReply();
+  const replyRef = useRef<HTMLTextAreaElement | null>(null);
+
+  // Auto-grow the reply field to fit its content.
+  useEffect(() => {
+    const el = replyRef.current;
+    if (!el) {
+      return;
+    }
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [quote.replyText]);
 
   return (
     <Card.Root
@@ -40,7 +54,7 @@ function StagedQuoteChip({ quote }: { quote: StagedQuote }) {
       bordered
       className="group/quote bg-[var(--surface-lift)]"
     >
-      <Card.Body padding="sm" className="flex items-start gap-2">
+      <Card.Body padding="md" className="flex items-start gap-2.5">
         <MessageSquareQuote className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--content-tertiary)]" />
         <div className="min-w-0 flex-1">
           <Typography
@@ -56,13 +70,17 @@ function StagedQuoteChip({ quote }: { quote: StagedQuote }) {
               {truncate(quote.quotedText, 80)}
             </span>
           </Typography>
-          <Typography
-            as="div"
-            variant="body-small-default"
-            className="mt-0.5 text-[var(--content-default)]"
-          >
-            {truncate(quote.replyText, 120)}
-          </Typography>
+          <textarea
+            ref={replyRef}
+            value={quote.replyText}
+            onChange={(e) =>
+              updateStagedQuoteReply(quote.id, e.target.value)
+            }
+            rows={1}
+            placeholder="Type your reply…"
+            aria-label="Edit reply"
+            className="mt-1.5 w-full resize-none overflow-hidden border-none bg-transparent p-0 text-body-small-default text-[var(--content-default)] placeholder:text-[var(--content-tertiary)] focus:outline-none"
+          />
         </div>
         <Button
           variant="ghost"
@@ -70,7 +88,7 @@ function StagedQuoteChip({ quote }: { quote: StagedQuote }) {
           iconOnly={<X />}
           expandOnMobile={false}
           onClick={() => removeStagedQuote(quote.id)}
-          className="shrink-0 opacity-0 transition-opacity group-hover/quote:opacity-100 focus-visible:opacity-100"
+          className="shrink-0 self-center opacity-0 transition-opacity group-hover/quote:opacity-100 focus-visible:opacity-100"
           aria-label="Remove quote"
         />
       </Card.Body>
@@ -80,13 +98,30 @@ function StagedQuoteChip({ quote }: { quote: StagedQuote }) {
 
 export function StagedQuotesStrip() {
   const stagedQuotes = useQuoteReplyStore.use.stagedQuotes();
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const prevCountRef = useRef(stagedQuotes.length);
+
+  // When a quote is added, scroll the strip to the newest chip so it never
+  // lands silently below the fold. Deferred a frame so the freshly mounted
+  // chip (and its auto-grown reply field) is measured before we scroll.
+  useEffect(() => {
+    if (stagedQuotes.length > prevCountRef.current) {
+      const el = scrollRef.current;
+      if (el) {
+        requestAnimationFrame(() => {
+          el.scrollTop = el.scrollHeight;
+        });
+      }
+    }
+    prevCountRef.current = stagedQuotes.length;
+  }, [stagedQuotes.length]);
 
   if (stagedQuotes.length === 0) {
     return null;
   }
 
   return (
-    <div className="mb-2 max-h-[120px] overflow-y-auto">
+    <div ref={scrollRef} className="mb-2 max-h-[180px] overflow-y-auto">
       <div className="flex flex-col gap-1.5">
         {stagedQuotes.map((quote) => (
           <StagedQuoteChip key={quote.id} quote={quote} />

--- a/clients/web/src/domains/chat/quote-reply-store.ts
+++ b/clients/web/src/domains/chat/quote-reply-store.ts
@@ -43,6 +43,7 @@ interface QuoteReplyActions {
   }) => void;
   closeReplyBubble: () => void;
   addStagedQuote: (quote: Omit<StagedQuote, "id">) => void;
+  updateStagedQuoteReply: (id: string, replyText: string) => void;
   removeStagedQuote: (id: string) => void;
   clearStagedQuotes: () => void;
 }
@@ -71,6 +72,13 @@ const useQuoteReplyStoreBase = create<QuoteReplyStore>()((set) => ({
         { ...quote, id: createQuoteId() },
       ],
       replyBubble: null,
+    })),
+
+  updateStagedQuoteReply: (id, replyText) =>
+    set((s) => ({
+      stagedQuotes: s.stagedQuotes.map((q) =>
+        q.id === id ? { ...q, replyText } : q,
+      ),
     })),
 
   removeStagedQuote: (id) =>


### PR DESCRIPTION
Polishes the text-quoting "reply to a passage" flow in the web chat.

## Reply-entry modal
- Removes the "Quote & Reply" header and ✕ close chrome.
- Renders the quoted passage italic inside a rounded box.
- Pairs a **Cancel** button with a filled **Add to Chat**.

## Staged-quote chips (above the composer)
- More internal padding and breathing room between the quote and the reply.
- Remove (✕) button is vertically centered on the chip.
- The reply is now an **editable, auto-growing field** — replies can be revised after staging (new `updateStagedQuoteReply` store action).
- The strip **auto-scrolls to the newest chip** when a quote is added, so it never lands silently below the fold; slightly taller max-height.

Behavior of the underlying flow (per-quote reply, staging, send assembly) is unchanged.

## Tests / stories
- Updated `quote-reply-components.test.tsx` (Cancel, reply editing) and added Storybook stories for the modal and the staged strip.

## Where to focus review
- `staged-quotes-strip.tsx`: the editable reply field + auto-scroll effect.
- `quote-reply-store.ts`: the new `updateStagedQuoteReply` action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->