### PR TITLE
feat(web): add persisted voice-preferences store

### DIFF
--- a/clients/web/src/stores/voice-prefs-store.test.ts
+++ b/clients/web/src/stores/voice-prefs-store.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
+
+const VOICE_PREFS_STORE_KEY = "vellum:voice-prefs";
+
+beforeEach(() => {
+  localStorage.removeItem(VOICE_PREFS_STORE_KEY);
+  useVoicePrefsStore.setState({
+    showUserTranscript: false,
+    showAssistantTranscript: false,
+    firstRunSeen: false,
+  });
+});
+
+describe("useVoicePrefsStore — voice-mode preferences", () => {
+  test("defaults are all off", () => {
+    expect(useVoicePrefsStore.getState().showUserTranscript).toBe(false);
+    expect(useVoicePrefsStore.getState().showAssistantTranscript).toBe(false);
+    expect(useVoicePrefsStore.getState().firstRunSeen).toBe(false);
+  });
+
+  test("setShowUserTranscript flips only the user-transcript field", () => {
+    useVoicePrefsStore.getState().setShowUserTranscript(true);
+
+    expect(useVoicePrefsStore.getState().showUserTranscript).toBe(true);
+    expect(useVoicePrefsStore.getState().showAssistantTranscript).toBe(false);
+    expect(useVoicePrefsStore.getState().firstRunSeen).toBe(false);
+
+    useVoicePrefsStore.getState().setShowUserTranscript(false);
+    expect(useVoicePrefsStore.getState().showUserTranscript).toBe(false);
+  });
+
+  test("setShowAssistantTranscript flips only the assistant-transcript field", () => {
+    useVoicePrefsStore.getState().setShowAssistantTranscript(true);
+
+    expect(useVoicePrefsStore.getState().showAssistantTranscript).toBe(true);
+    expect(useVoicePrefsStore.getState().showUserTranscript).toBe(false);
+    expect(useVoicePrefsStore.getState().firstRunSeen).toBe(false);
+
+    useVoicePrefsStore.getState().setShowAssistantTranscript(false);
+    expect(useVoicePrefsStore.getState().showAssistantTranscript).toBe(false);
+  });
+
+  test("markFirstRunSeen sets the flag", () => {
+    useVoicePrefsStore.getState().markFirstRunSeen();
+    expect(useVoicePrefsStore.getState().firstRunSeen).toBe(true);
+  });
+
+  test("markFirstRunSeen is idempotent and does not clobber later writes", () => {
+    useVoicePrefsStore.getState().markFirstRunSeen();
+    expect(useVoicePrefsStore.getState().firstRunSeen).toBe(true);
+
+    // A subsequent unrelated write should survive a second markFirstRunSeen().
+    useVoicePrefsStore.getState().setShowUserTranscript(true);
+    useVoicePrefsStore.getState().markFirstRunSeen();
+
+    expect(useVoicePrefsStore.getState().firstRunSeen).toBe(true);
+    expect(useVoicePrefsStore.getState().showUserTranscript).toBe(true);
+  });
+
+  test("persists to the vellum:voice-prefs localStorage key", () => {
+    useVoicePrefsStore.getState().setShowUserTranscript(true);
+    useVoicePrefsStore.getState().setShowAssistantTranscript(true);
+    useVoicePrefsStore.getState().markFirstRunSeen();
+
+    const raw = localStorage.getItem(VOICE_PREFS_STORE_KEY);
+    expect(raw).not.toBeNull();
+
+    const persisted = JSON.parse(raw as string).state;
+    expect(persisted.showUserTranscript).toBe(true);
+    expect(persisted.showAssistantTranscript).toBe(true);
+    expect(persisted.firstRunSeen).toBe(true);
+  });
+});

--- a/clients/web/src/stores/voice-prefs-store.ts
+++ b/clients/web/src/stores/voice-prefs-store.ts
@@ -1,0 +1,104 @@
+/**
+ * Zustand store for live-voice mode preferences.
+ *
+ * Owns whether the user- and assistant-side transcripts are shown in
+ * the voice UI, plus a one-time flag recording that the user has seen
+ * the first-run voice experience. Voice-mode components read these via
+ * the generated selector hooks (`useVoicePrefsStore.use.*`).
+ *
+ * **Storage model:**
+ *
+ * - The persist middleware serialises the whole voice-prefs slice into
+ *   a single localStorage key, `vellum:voice-prefs`.
+ * - Cross-tab updates: the persist middleware doesn't sync across tabs
+ *   on its own. We listen for `storage` events on `vellum:voice-prefs`
+ *   and call `persist.rehydrate()` to pull in the other tab's write.
+ *
+ * Reference:
+ * - {@link https://zustand.docs.pmnd.rs/}
+ * - {@link https://zustand.docs.pmnd.rs/integrations/persisting-store-data}
+ */
+
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+import { createSelectors } from "@/utils/create-selectors";
+
+// ---------------------------------------------------------------------------
+// State + Actions
+// ---------------------------------------------------------------------------
+
+export interface VoicePrefsState {
+  /** Whether the user-side transcript is shown in the voice UI. */
+  showUserTranscript: boolean;
+  /** Whether the assistant-side transcript is shown in the voice UI. */
+  showAssistantTranscript: boolean;
+  /** True once the user has seen the first-run voice experience. */
+  firstRunSeen: boolean;
+}
+
+export interface VoicePrefsActions {
+  setShowUserTranscript: (next: boolean) => void;
+  setShowAssistantTranscript: (next: boolean) => void;
+  /** Flip `firstRunSeen` to true on first observation. No-op afterwards. */
+  markFirstRunSeen: () => void;
+}
+
+export type VoicePrefsStore = VoicePrefsState & VoicePrefsActions;
+
+// ---------------------------------------------------------------------------
+// Initial state
+// ---------------------------------------------------------------------------
+
+const INITIAL_STATE: VoicePrefsState = {
+  showUserTranscript: false,
+  showAssistantTranscript: false,
+  firstRunSeen: false,
+};
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+const VOICE_PREFS_STORE_KEY = "vellum:voice-prefs";
+
+const useVoicePrefsStoreBase = create<VoicePrefsStore>()(
+  persist(
+    (set, get) => ({
+      ...INITIAL_STATE,
+
+      setShowUserTranscript: (next: boolean) =>
+        set({ showUserTranscript: next }),
+      setShowAssistantTranscript: (next: boolean) =>
+        set({ showAssistantTranscript: next }),
+      markFirstRunSeen: () => {
+        if (!get().firstRunSeen) {
+          set({ firstRunSeen: true });
+        }
+      },
+    }),
+    {
+      name: VOICE_PREFS_STORE_KEY,
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({
+        showUserTranscript: state.showUserTranscript,
+        showAssistantTranscript: state.showAssistantTranscript,
+        firstRunSeen: state.firstRunSeen,
+      }),
+    },
+  ),
+);
+
+export const useVoicePrefsStore = createSelectors(useVoicePrefsStoreBase);
+
+// ---------------------------------------------------------------------------
+// Cross-tab sync
+// ---------------------------------------------------------------------------
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (event) => {
+    if (event.key === VOICE_PREFS_STORE_KEY) {
+      void useVoicePrefsStoreBase.persist.rehydrate();
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- New persisted zustand store for voice-mode preferences (show-user-transcript, show-assistant-transcript, first-run-seen), all default OFF.
- Cloned from nudge-store persistence pattern; localStorage key vellum:voice-prefs.

Part of plan: voice-mode-ui-overhaul.md (PR 1 of 8)