### PR TITLE
feat(design-library): ScrollShadow + animated quote-reply context cards

### DIFF
--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -107,6 +107,9 @@ mock.module("@vellumai/design-library", () => ({
     }) => <div {...props}>{children}</div>,
   },
   ResizablePanel: () => <div data-testid="resizable-panel" />,
+  ScrollShadow: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
   Typography: ({ children }: { children?: ReactNode }) => (
     <span>{children}</span>
   ),

--- a/clients/web/src/domains/chat/components/staged-quotes-strip.tsx
+++ b/clients/web/src/domains/chat/components/staged-quotes-strip.tsx
@@ -114,13 +114,18 @@ export function StagedQuotesStrip() {
       const el = scrollRef.current;
       if (el) {
         let frames = 0;
+        let rafId = 0;
         const pin = () => {
           el.scrollTop = el.scrollHeight;
           if (frames++ < 20) {
-            requestAnimationFrame(pin);
+            rafId = requestAnimationFrame(pin);
           }
         };
-        requestAnimationFrame(pin);
+        rafId = requestAnimationFrame(pin);
+        prevCountRef.current = stagedQuotes.length;
+        // Cancel on unmount / re-trigger so the chain never writes to a
+        // detached element or overlaps a second run for rapid additions.
+        return () => cancelAnimationFrame(rafId);
       }
     }
     prevCountRef.current = stagedQuotes.length;

--- a/clients/web/src/domains/chat/components/staged-quotes-strip.tsx
+++ b/clients/web/src/domains/chat/components/staged-quotes-strip.tsx
@@ -136,7 +136,7 @@ export function StagedQuotesStrip() {
       orientation="vertical"
       size={20}
       hideScrollBar
-      className="mb-2 max-h-[180px]"
+      className="mb-2 max-h-[140px]"
     >
       <div className="flex flex-col gap-1.5">
         <AnimatePresence initial={false}>

--- a/clients/web/src/domains/chat/components/staged-quotes-strip.tsx
+++ b/clients/web/src/domains/chat/components/staged-quotes-strip.tsx
@@ -4,15 +4,19 @@
  * (kept in sync with the store so replies can be revised after staging),
  * with an X button to remove it.
  *
- * The strip is scrollable when multiple quotes are staged, capped at
- * 120 px so it never dominates the viewport.
+ * The strip is scrollable (capped so it never dominates the viewport) and
+ * wrapped in a {@link ScrollShadow} that fades its top/bottom edges. Chips
+ * animate in and out, and the strip stays pinned to the newest chip as it
+ * grows, so an addition never jolts the layout or lands below the fold.
  */
 
 import { MessageSquareQuote, X } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { useEffect, useRef } from "react";
 import {
   Button,
   Card,
+  ScrollShadow,
   Typography,
 } from "@vellumai/design-library";
 import {
@@ -100,17 +104,23 @@ export function StagedQuotesStrip() {
   const stagedQuotes = useQuoteReplyStore.use.stagedQuotes();
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const prevCountRef = useRef(stagedQuotes.length);
+  const reduceMotion = useReducedMotion();
 
-  // When a quote is added, scroll the strip to the newest chip so it never
-  // lands silently below the fold. Deferred a frame so the freshly mounted
-  // chip (and its auto-grown reply field) is measured before we scroll.
+  // When a quote is added, keep the strip pinned to the newest chip while its
+  // insert animation grows it — so the addition never lands silently below the
+  // fold. Pinning across a few frames tracks the growing height smoothly.
   useEffect(() => {
     if (stagedQuotes.length > prevCountRef.current) {
       const el = scrollRef.current;
       if (el) {
-        requestAnimationFrame(() => {
+        let frames = 0;
+        const pin = () => {
           el.scrollTop = el.scrollHeight;
-        });
+          if (frames++ < 20) {
+            requestAnimationFrame(pin);
+          }
+        };
+        requestAnimationFrame(pin);
       }
     }
     prevCountRef.current = stagedQuotes.length;
@@ -121,12 +131,38 @@ export function StagedQuotesStrip() {
   }
 
   return (
-    <div ref={scrollRef} className="mb-2 max-h-[180px] overflow-y-auto">
+    <ScrollShadow
+      ref={scrollRef}
+      orientation="vertical"
+      size={20}
+      hideScrollBar
+      className="mb-2 max-h-[180px]"
+    >
       <div className="flex flex-col gap-1.5">
-        {stagedQuotes.map((quote) => (
-          <StagedQuoteChip key={quote.id} quote={quote} />
-        ))}
+        <AnimatePresence initial={false}>
+          {stagedQuotes.map((quote) => (
+            <motion.div
+              key={quote.id}
+              layout
+              initial={
+                reduceMotion
+                  ? false
+                  : { opacity: 0, height: 0, scale: 0.98 }
+              }
+              animate={{ opacity: 1, height: "auto", scale: 1 }}
+              exit={
+                reduceMotion
+                  ? { opacity: 0 }
+                  : { opacity: 0, height: 0, scale: 0.98 }
+              }
+              transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
+              className="overflow-hidden"
+            >
+              <StagedQuoteChip quote={quote} />
+            </motion.div>
+          ))}
+        </AnimatePresence>
       </div>
-    </div>
+    </ScrollShadow>
   );
 }

--- a/packages/design-library/src/components/scroll-shadow.stories.tsx
+++ b/packages/design-library/src/components/scroll-shadow.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ScrollShadow } from "./scroll-shadow";
+
+const meta: Meta<typeof ScrollShadow> = {
+  title: "Components/ScrollShadow",
+  component: ScrollShadow,
+  argTypes: {
+    orientation: {
+      control: "inline-radio",
+      options: ["vertical", "horizontal"],
+    },
+    size: { control: { type: "number", min: 0, max: 80 } },
+    offset: { control: { type: "number", min: 0, max: 40 } },
+    hideScrollBar: { control: "boolean" },
+    isEnabled: { control: "boolean" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ScrollShadow>;
+
+export const Vertical: Story = {
+  args: { orientation: "vertical", size: 28, hideScrollBar: true },
+  render: (args) => (
+    <ScrollShadow
+      {...args}
+      className="h-[240px] max-w-[420px] rounded-lg bg-[var(--surface-lift)] p-4"
+    >
+      <div className="flex flex-col gap-3">
+        {Array.from({ length: 20 }).map((_, i) => (
+          <p
+            key={i}
+            className="text-body-medium-default text-[var(--content-default)]"
+          >
+            Row {i + 1} — scroll to watch the top and bottom fades appear and
+            disappear as you reach each edge.
+          </p>
+        ))}
+      </div>
+    </ScrollShadow>
+  ),
+};
+
+export const Horizontal: Story = {
+  args: { orientation: "horizontal", size: 40, hideScrollBar: true },
+  render: (args) => (
+    <ScrollShadow
+      {...args}
+      className="max-w-[420px] rounded-lg bg-[var(--surface-lift)] p-4"
+    >
+      <div className="flex w-max gap-3">
+        {Array.from({ length: 20 }).map((_, i) => (
+          <div
+            key={i}
+            className="shrink-0 rounded-md bg-[var(--surface-sunken)] px-6 py-8 text-[var(--content-default)]"
+          >
+            Card {i + 1}
+          </div>
+        ))}
+      </div>
+    </ScrollShadow>
+  ),
+};

--- a/packages/design-library/src/components/scroll-shadow.test.tsx
+++ b/packages/design-library/src/components/scroll-shadow.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ScrollShadow } from "./scroll-shadow";
+
+describe("ScrollShadow", () => {
+  test("renders a vertical scroll container wrapping its children", () => {
+    const html = renderToStaticMarkup(
+      <ScrollShadow>
+        <p>quoted content</p>
+      </ScrollShadow>,
+    );
+    expect(html).toContain('data-slot="scroll-shadow"');
+    expect(html).toContain('data-orientation="vertical"');
+    expect(html).toContain("overflow-y-auto");
+    expect(html).toContain("quoted content");
+  });
+
+  test("horizontal orientation scrolls on the x axis", () => {
+    const html = renderToStaticMarkup(
+      <ScrollShadow orientation="horizontal">x</ScrollShadow>,
+    );
+    expect(html).toContain('data-orientation="horizontal"');
+    expect(html).toContain("overflow-x-auto");
+  });
+
+  test("hideScrollBar hides the scrollbar", () => {
+    const html = renderToStaticMarkup(
+      <ScrollShadow hideScrollBar>x</ScrollShadow>,
+    );
+    expect(html).toContain("scrollbar-width:none");
+  });
+
+  test("applies a mask when enabled and omits it when disabled", () => {
+    const enabled = renderToStaticMarkup(<ScrollShadow>x</ScrollShadow>);
+    expect(enabled).toContain("mask-image");
+
+    const disabled = renderToStaticMarkup(
+      <ScrollShadow isEnabled={false}>x</ScrollShadow>,
+    );
+    expect(disabled).not.toContain("mask-image");
+  });
+});

--- a/packages/design-library/src/components/scroll-shadow.tsx
+++ b/packages/design-library/src/components/scroll-shadow.tsx
@@ -1,0 +1,140 @@
+import {
+  type ReactNode,
+  type Ref,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+
+import { cn } from "../utils/cn";
+
+export type ScrollShadowOrientation = "vertical" | "horizontal";
+
+export interface ScrollShadowProps {
+  children: ReactNode;
+  /** Scroll axis the fade applies to. */
+  orientation?: ScrollShadowOrientation;
+  /** Fade length in pixels at each active edge. */
+  size?: number;
+  /** Extra scroll distance past an edge before its fade is hidden. */
+  offset?: number;
+  /** When false, renders a plain scroll container with no fade. */
+  isEnabled?: boolean;
+  /** Visually hide the scrollbar (content still scrolls). */
+  hideScrollBar?: boolean;
+  className?: string;
+  /** Forwarded to the scroll container so callers can drive its scroll position. */
+  ref?: Ref<HTMLDivElement>;
+}
+
+interface EdgeState {
+  /** True when content is hidden before the visible start (top / left). */
+  start: boolean;
+  /** True when content is hidden past the visible end (bottom / right). */
+  end: boolean;
+}
+
+/**
+ * Wraps a scrollable region and fades its edges with a `mask-image` gradient,
+ * signalling that more content lies above/below (or left/right). Each edge's
+ * fade only shows while there is hidden content in that direction, so it
+ * disappears once you reach the corresponding end.
+ */
+export function ScrollShadow({
+  children,
+  orientation = "vertical",
+  size = 24,
+  offset = 0,
+  isEnabled = true,
+  hideScrollBar = false,
+  className,
+  ref,
+}: ScrollShadowProps) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [edges, setEdges] = useState<EdgeState>({ start: false, end: false });
+
+  const setRefs = useCallback(
+    (node: HTMLDivElement | null) => {
+      scrollRef.current = node;
+      if (typeof ref === "function") {
+        ref(node);
+      } else if (ref) {
+        (ref as { current: HTMLDivElement | null }).current = node;
+      }
+    },
+    [ref],
+  );
+
+  const recompute = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el || !isEnabled) {
+      setEdges((prev) => (!prev.start && !prev.end ? prev : { start: false, end: false }));
+      return;
+    }
+    const isVertical = orientation === "vertical";
+    const pos = isVertical ? el.scrollTop : el.scrollLeft;
+    const max = isVertical
+      ? el.scrollHeight - el.clientHeight
+      : el.scrollWidth - el.clientWidth;
+    const start = pos > offset;
+    const end = pos < max - offset;
+    setEdges((prev) =>
+      prev.start === start && prev.end === end ? prev : { start, end },
+    );
+  }, [isEnabled, orientation, offset]);
+
+  // Re-measure after every render so content changes (rows added/removed)
+  // update the fades even when the container's own box size is unchanged.
+  useLayoutEffect(() => {
+    recompute();
+  });
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) {
+      return;
+    }
+    el.addEventListener("scroll", recompute, { passive: true });
+    const observer =
+      typeof ResizeObserver !== "undefined" ? new ResizeObserver(recompute) : null;
+    observer?.observe(el);
+    return () => {
+      el.removeEventListener("scroll", recompute);
+      observer?.disconnect();
+    };
+  }, [recompute]);
+
+  const maskImage = isEnabled ? buildMask(orientation, size, edges) : undefined;
+
+  return (
+    <div
+      ref={setRefs}
+      data-slot="scroll-shadow"
+      data-orientation={orientation}
+      className={cn(
+        orientation === "vertical" ? "overflow-y-auto" : "overflow-x-auto",
+        hideScrollBar &&
+          "[scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+        className,
+      )}
+      style={
+        maskImage ? { maskImage, WebkitMaskImage: maskImage } : undefined
+      }
+    >
+      {children}
+    </div>
+  );
+}
+
+function buildMask(
+  orientation: ScrollShadowOrientation,
+  size: number,
+  edges: EdgeState,
+): string {
+  const direction = orientation === "vertical" ? "to bottom" : "to right";
+  const startColor = edges.start ? "transparent" : "#000";
+  const endColor = edges.end ? "transparent" : "#000";
+  return `linear-gradient(${direction}, ${startColor}, #000 ${size}px, #000 calc(100% - ${size}px), ${endColor})`;
+}

--- a/packages/design-library/src/components/scroll-shadow.tsx
+++ b/packages/design-library/src/components/scroll-shadow.tsx
@@ -53,6 +53,7 @@ export function ScrollShadow({
   ref,
 }: ScrollShadowProps) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
   const [edges, setEdges] = useState<EdgeState>({ start: false, end: false });
 
   const setRefs = useCallback(
@@ -99,7 +100,14 @@ export function ScrollShadow({
     el.addEventListener("scroll", recompute, { passive: true });
     const observer =
       typeof ResizeObserver !== "undefined" ? new ResizeObserver(recompute) : null;
+    // Observe the container (its box changes on viewport resize) AND the inner
+    // content (its box changes when rows are added/removed or a child grows) —
+    // a max-height-capped container never resizes when its content overflows,
+    // so watching only the container would miss content-size changes.
     observer?.observe(el);
+    if (contentRef.current) {
+      observer?.observe(contentRef.current);
+    }
     return () => {
       el.removeEventListener("scroll", recompute);
       observer?.disconnect();
@@ -123,7 +131,9 @@ export function ScrollShadow({
         maskImage ? { maskImage, WebkitMaskImage: maskImage } : undefined
       }
     >
-      {children}
+      <div ref={contentRef} className={orientation === "horizontal" ? "w-max" : undefined}>
+        {children}
+      </div>
     </div>
   );
 }

--- a/packages/design-library/src/index.ts
+++ b/packages/design-library/src/index.ts
@@ -24,6 +24,11 @@ export {
   type ResizablePanelProps,
 } from "./components/resizable-panel";
 export {
+  ScrollShadow,
+  type ScrollShadowProps,
+  type ScrollShadowOrientation,
+} from "./components/scroll-shadow";
+export {
   Tag,
   tagVariants,
   type TagProps,


### PR DESCRIPTION
Follow-up polish to the quote-and-reply flow (#37527). Two parts:

## `ScrollShadow` (new design-library component)
A reusable wrapper for scrollable regions that fades the edges with a `mask-image` gradient, signalling more content above/below (or left/right). Each edge's fade only shows while there is hidden content in that direction and disappears once you reach that end.

- Props: `orientation` (vertical/horizontal), `size`, `offset`, `isEnabled`, `hideScrollBar`, `className`, `ref`.
- Edge state is tracked via a scroll listener + `ResizeObserver` and re-measured after each render, so content changes (rows added/removed) update the fades even when the container's own box size is unchanged.
- Exported from the design-library barrel; includes a story (vertical + horizontal) and tests.

## Animated quote-reply cards
- The staged quote strip now renders inside `ScrollShadow` (top/bottom fade, hidden scrollbar).
- Reply context cards animate **in and out** with `motion` (height + opacity + subtle scale), respecting `prefers-reduced-motion`.
- The strip stays **pinned to the newest card as it grows**, so adding one no longer jolts the layout or lands below the fold.

## Verification
- Verified in Storybook (dark): edge fades appear/disappear at the correct ends; staging a new card animates it in and scrolls to reveal it.
- design-library + web typecheck clean; ScrollShadow tests (4) and quote-reply tests (8) pass.

## Where to focus review
- `packages/design-library/src/components/scroll-shadow.tsx`: the mask/edge-detection logic.
- `staged-quotes-strip.tsx`: the `AnimatePresence`/`motion` wiring + scroll-pin effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->