### PR TITLE
feat(live-voice): measure and report the turn round-trip latency server-side

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-metrics.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-metrics.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  getLiveVoiceMetricsAggregateFields,
   LiveVoiceMetricsCollector,
   type LiveVoiceMetricsFrame,
 } from "../live-voice-metrics.js";
@@ -64,6 +65,9 @@ describe("LiveVoiceMetricsCollector", () => {
         pttReleaseToFinalTranscriptMs: 90,
         finalTranscriptToFirstAssistantDeltaMs: 45,
         firstAssistantDeltaToFirstTtsAudioMs: 60,
+        // Manual mode: no utterance_end mark, so the round trip falls back
+        // to ptt_release → first TTS audio.
+        roundTripMs: 195,
         totalTurnDurationMs: 595,
       },
     });
@@ -92,6 +96,68 @@ describe("LiveVoiceMetricsCollector", () => {
     });
   });
 
+  test("derives roundTripMs from utterance_end to first TTS audio and aggregates it", () => {
+    const clock = makeClock(0);
+    const collector = new LiveVoiceMetricsCollector({
+      sessionId: "session-round-trip",
+      clock: clock.now,
+    });
+
+    collector.startTurn("turn-vad");
+    clock.advance(10);
+    collector.markUtteranceEnd();
+    clock.advance(40);
+    // utterance_end takes precedence over a later ptt_release mark.
+    collector.markPushToTalkRelease();
+    clock.advance(50);
+    collector.markFinalTranscript();
+    clock.advance(25);
+    collector.markFirstAssistantDelta();
+    clock.advance(75);
+    collector.markFirstTtsAudio();
+    const turn = collector.completeTurn();
+
+    expect(turn.durations.roundTripMs).toBe(190);
+
+    const snapshot = collector.getSnapshot();
+    expect(getLiveVoiceMetricsAggregateFields(snapshot, "turn-vad")).toEqual({
+      sttMs: 50,
+      llmFirstDeltaMs: 25,
+      ttsFirstAudioMs: 75,
+      roundTripMs: 190,
+      totalMs: 200,
+    });
+    expect(snapshot.summary.durations.roundTripMs).toEqual({
+      count: 1,
+      p50Ms: 190,
+      p95Ms: 190,
+    });
+  });
+
+  test("roundTripMs is null when the end-of-speech or first TTS mark is missing", () => {
+    const clock = makeClock(0);
+    const collector = new LiveVoiceMetricsCollector({
+      sessionId: "session-round-trip-null",
+      clock: clock.now,
+    });
+
+    // First TTS audio without an end-of-speech mark.
+    collector.startTurn("turn-no-speech-end");
+    clock.advance(30);
+    collector.markFirstTtsAudio();
+    expect(collector.completeTurn().durations.roundTripMs).toBeNull();
+
+    // End-of-speech mark without first TTS audio.
+    collector.startTurn("turn-no-tts");
+    clock.advance(20);
+    collector.markUtteranceEnd();
+    expect(collector.completeTurn().durations.roundTripMs).toBeNull();
+
+    expect(
+      getLiveVoiceMetricsAggregateFields(collector.getSnapshot()).roundTripMs,
+    ).toBeNull();
+  });
+
   test("keeps missing phases nullable when a turn is cancelled", () => {
     const clock = makeClock(5_000);
     const frames: LiveVoiceMetricsFrame[] = [];
@@ -116,6 +182,7 @@ describe("LiveVoiceMetricsCollector", () => {
         pttReleaseToFinalTranscriptMs: null,
         finalTranscriptToFirstAssistantDeltaMs: null,
         firstAssistantDeltaToFirstTtsAudioMs: null,
+        roundTripMs: null,
         totalTurnDurationMs: 50,
       },
     });

--- a/assistant/src/live-voice/__tests__/protocol.test.ts
+++ b/assistant/src/live-voice/__tests__/protocol.test.ts
@@ -506,6 +506,7 @@ describe("LiveVoiceServerFrameSequencer", () => {
       sttMs: 25,
       llmFirstDeltaMs: null,
       ttsFirstAudioMs: null,
+      roundTripMs: null,
       totalMs: 100,
     });
 
@@ -515,6 +516,7 @@ describe("LiveVoiceServerFrameSequencer", () => {
       sttMs: 25,
       llmFirstDeltaMs: null,
       ttsFirstAudioMs: null,
+      roundTripMs: null,
       totalMs: 100,
       seq: 42,
     });

--- a/assistant/src/live-voice/live-voice-metrics.ts
+++ b/assistant/src/live-voice/live-voice-metrics.ts
@@ -1,3 +1,7 @@
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("live-voice-metrics");
+
 export type LiveVoiceMetricsClock = () => number;
 
 export type LiveVoiceMetricsEvent =
@@ -74,6 +78,9 @@ interface LiveVoiceTurnDurations {
   utteranceEndToFinalTranscriptMs: number | null;
   finalTranscriptToFirstAssistantDeltaMs: number | null;
   firstAssistantDeltaToFirstTtsAudioMs: number | null;
+  // End-of-speech (utterance_end, or ptt_release in manual mode) to first
+  // TTS audio: the server-side turn round trip.
+  roundTripMs: number | null;
   totalTurnDurationMs: number | null;
 }
 
@@ -101,6 +108,7 @@ interface LiveVoiceMetricsSummary {
     utteranceEndToFinalTranscriptMs: LiveVoiceDurationSummary;
     finalTranscriptToFirstAssistantDeltaMs: LiveVoiceDurationSummary;
     firstAssistantDeltaToFirstTtsAudioMs: LiveVoiceDurationSummary;
+    roundTripMs: LiveVoiceDurationSummary;
     totalTurnDurationMs: LiveVoiceDurationSummary;
   };
 }
@@ -116,6 +124,7 @@ interface LiveVoiceMetricsAggregateFields {
   sttMs: number | null;
   llmFirstDeltaMs: number | null;
   ttsFirstAudioMs: number | null;
+  roundTripMs: number | null;
   totalMs: number | null;
 }
 
@@ -365,6 +374,26 @@ export class LiveVoiceMetricsCollector {
     while (this.recentTurns.length > this.recentTurnLimit) {
       this.recentTurns.shift();
     }
+    this.logFinishedTurn(turn);
+  }
+
+  // One structured line per finished turn so latency is greppable from
+  // daemon logs without a connected client.
+  private logFinishedTurn(turn: MutableTurn): void {
+    const finishReason =
+      turn.status === "completed"
+        ? "completed"
+        : (turn.cancellationReason ?? "cancelled");
+    log.info(
+      {
+        sessionId: this.sessionId,
+        conversationId: this.conversationId,
+        turnId: turn.turnId,
+        finishReason,
+        ...aggregateFieldsForTurn(snapshotTurn(turn)),
+      },
+      "Live voice turn latency",
+    );
   }
 
   private timestamp(): number {
@@ -413,10 +442,17 @@ export function getLiveVoiceMetricsAggregateFields(
       sttMs: null,
       llmFirstDeltaMs: null,
       ttsFirstAudioMs: null,
+      roundTripMs: null,
       totalMs: null,
     };
   }
 
+  return aggregateFieldsForTurn(turn);
+}
+
+function aggregateFieldsForTurn(
+  turn: LiveVoiceTurnMetrics,
+): LiveVoiceMetricsAggregateFields {
   return {
     // Manual mode stamps ptt_release; server-VAD sessions stamp utterance_end
     // instead, so the VAD boundary plays the sttMs role there.
@@ -425,6 +461,7 @@ export function getLiveVoiceMetricsAggregateFields(
       turn.durations.utteranceEndToFinalTranscriptMs,
     llmFirstDeltaMs: turn.durations.finalTranscriptToFirstAssistantDeltaMs,
     ttsFirstAudioMs: turn.durations.firstAssistantDeltaToFirstTtsAudioMs,
+    roundTripMs: turn.durations.roundTripMs,
     totalMs: turn.durations.totalTurnDurationMs,
   };
 }
@@ -491,6 +528,10 @@ function snapshotTurn(turn: MutableTurn): LiveVoiceTurnMetrics {
         timestamps.firstAssistantDeltaAtMs,
         timestamps.firstTtsAudioAtMs,
       ),
+      roundTripMs: duration(
+        timestamps.utteranceEndAtMs ?? timestamps.pttReleaseAtMs,
+        timestamps.firstTtsAudioAtMs,
+      ),
       totalTurnDurationMs: duration(
         timestamps.startedAtMs,
         timestamps.completedAtMs ?? timestamps.cancelledAtMs,
@@ -524,6 +565,9 @@ function summarizeTurns(turns: MutableTurn[]): LiveVoiceMetricsSummary {
       ),
       firstAssistantDeltaToFirstTtsAudioMs: summarizeDuration(
         durations.map((value) => value.firstAssistantDeltaToFirstTtsAudioMs),
+      ),
+      roundTripMs: summarizeDuration(
+        durations.map((value) => value.roundTripMs),
       ),
       totalTurnDurationMs: summarizeDuration(
         durations.map((value) => value.totalTurnDurationMs),

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -209,6 +209,8 @@ export interface LiveVoiceMetricsServerFrame extends LiveVoiceServerFrameBase {
   readonly sttMs: number | null;
   readonly llmFirstDeltaMs: number | null;
   readonly ttsFirstAudioMs: number | null;
+  /** End-of-speech (utterance_end, or ptt_release in manual mode) to first TTS audio. */
+  readonly roundTripMs: number | null;
   readonly totalMs: number | null;
 }
 


### PR DESCRIPTION
## Summary
- Adds a derived roundTripMs (end-of-speech → first TTS audio) to live-voice turn metrics, wire frame, and p50/p95 aggregates
- Emits one structured per-turn log line with the full latency breakdown

Part of plan: voice-mode-latency.md (PR 1 of 13)