### PR TITLE
feat(web): drive the reconnecting signal from the live-voice controller

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -1542,3 +1542,95 @@ describe("hands-free reconnect (retryable tunnel close)", () => {
     expect(h.view.result.current.state).toBe("listening");
   });
 });
+
+// ---------------------------------------------------------------------------
+// `reconnecting` signal (JARVIS-1255): true only during a genuine retry
+// ---------------------------------------------------------------------------
+
+describe("reconnecting signal", () => {
+  const FAST_BACKOFF = [20, 40, 60];
+  const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  test("a retryable close flips reconnecting true while connecting; ready clears it", async () => {
+    const h = renderController({ reconnectBackoffMs: FAST_BACKOFF });
+    await startListening(h, { handsFree: true });
+    // A live, first-connect session never carries the reconnect label.
+    expect(useLiveVoiceStore.getState().reconnecting).toBe(false);
+
+    // velay drops its tunnel → retryable 1013 → reconnect scheduled.
+    await act(async () => {
+      h.client.emit("closed", { code: 1013, reason: "tunnel disconnected" });
+    });
+    expect(h.view.result.current.state).toBe("connecting");
+    expect(useLiveVoiceStore.getState().reconnecting).toBe(true);
+
+    // Stays true across the backoff gap and the fresh connect (still no ready).
+    await act(async () => {
+      await sleep(40);
+    });
+    expect(h.view.result.current.state).toBe("connecting");
+    expect(useLiveVoiceStore.getState().reconnecting).toBe(true);
+
+    // The reconnected session readies → the reconnect label clears.
+    await act(async () => {
+      h.client.emit("ready", {
+        type: "ready",
+        seq: 1,
+        sessionId: "s2",
+        conversationId: "conv-1",
+        turnDetection: "server_vad",
+      });
+      await Promise.resolve();
+    });
+    expect(h.view.result.current.state).toBe("listening");
+    expect(useLiveVoiceStore.getState().reconnecting).toBe(false);
+  });
+
+  test("a first connect never sets reconnecting true", async () => {
+    const h = renderController();
+    expect(useLiveVoiceStore.getState().reconnecting).toBe(false);
+
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-1");
+    });
+    // Initial connect: connecting, but NOT a reconnect.
+    expect(h.view.result.current.state).toBe("connecting");
+    expect(useLiveVoiceStore.getState().reconnecting).toBe(false);
+
+    await act(async () => {
+      h.client.emit("ready", {
+        type: "ready",
+        seq: 1,
+        sessionId: "s1",
+        conversationId: "conv-1",
+      });
+      await Promise.resolve();
+    });
+    expect(h.view.result.current.state).toBe("listening");
+    expect(useLiveVoiceStore.getState().reconnecting).toBe(false);
+  });
+
+  test("the fail path clears reconnecting", async () => {
+    const h = renderController({ reconnectBackoffMs: FAST_BACKOFF });
+    await startListening(h, { handsFree: true });
+
+    // Drop the tunnel and let the reconnect connect fire so a fresh (pre-ready)
+    // session is attached while the reconnect label is still up.
+    await act(async () => {
+      h.client.emit("closed", { code: 1013, reason: "tunnel disconnected" });
+    });
+    await act(async () => {
+      await sleep(40);
+    });
+    expect(useLiveVoiceStore.getState().reconnecting).toBe(true);
+
+    // A fatal error on the reconnected session fails it (teardown → reset),
+    // which must also drop the reconnect label.
+    act(() => {
+      h.client.emit("error", { reason: "protocol-error", message: "kaboom" });
+    });
+    expect(h.view.result.current.state).toBe("failed");
+    expect(h.view.result.current.error).toBe("kaboom");
+    expect(useLiveVoiceStore.getState().reconnecting).toBe(false);
+  });
+});

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -432,6 +432,12 @@ export function useLiveVoice(
       const store = useLiveVoiceStore.getState();
       store.reset();
       store.setState("connecting");
+      // A retry re-enters here via the backoff timer with `reconnectAttemptRef`
+      // already bumped (> 0) by the transport `closed` handler, so relabel the
+      // connect as a reconnect; a fresh `start()` (attempt 0) clears it. The
+      // `store.reset()` above already cleared `reconnecting`, so this only needs
+      // to (re)assert true on the reconnect path.
+      store.setReconnecting(reconnectAttemptRef.current > 0);
       store.setSessionContext(assistantId, conversationId ?? null);
       // Registered here (not on `ready`) so a globally mounted surface can
       // drive the session from the moment it exists; cleared by the store
@@ -487,8 +493,10 @@ export function useLiveVoice(
             session.handsFree = false;
           }
           // A `ready` means the (re)connection succeeded — clear the reconnect
-          // budget so a later, unrelated tunnel drop gets its full retry set.
+          // budget so a later, unrelated tunnel drop gets its full retry set,
+          // and drop the reconnect label so the surface stops showing a retry.
           reconnectAttemptRef.current = 0;
+          useLiveVoiceStore.getState().setReconnecting(false);
           // When started from a new/empty conversation, `conversationId` was
           // undefined at start() and the store published `null`. The server
           // assigns (or confirms) the attached conversation on `ready`, so
@@ -656,6 +664,10 @@ export function useLiveVoice(
             disposeSessionPrimitives(session);
             const s = useLiveVoiceStore.getState();
             s.setState("connecting");
+            // Hold the reconnect label through the backoff gap (before the
+            // timer re-enters `connectSession`) so the surface shows a
+            // reconnect, not a fresh connect. Cleared on `ready`/teardown.
+            s.setReconnecting(true);
             s.setControls({ stop: () => void stop(), release, interrupt });
             console.warn(
               `live-voice: transport closed (code ${info.code}); reconnecting ` +


### PR DESCRIPTION
## Summary
- Controller now sets store.reconnecting true during a genuine reconnect (attempt > 0) and clears it on ready/fail/teardown.
- Purely additive; no state-machine or backoff change.

Part of plan: voice-mode-ui-overhaul.md (PR 3 of 8)