### PR TITLE
feat(web): add ambient-transcript toggles to the Voice settings page

### DIFF
--- a/clients/web/src/domains/settings/pages/voice-page.test.tsx
+++ b/clients/web/src/domains/settings/pages/voice-page.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * Transcription card on the Voice settings page.
+ *
+ * Both transcript toggles default OFF on first render (the persisted
+ * voice-prefs store starts empty), and flipping each switch writes the new
+ * value straight through to `useVoicePrefsStore`.
+ *
+ * Drives the real `VoicePage` and the real `voice-prefs-store`; only
+ * `localStorage` is stubbed so the persist middleware has somewhere to write.
+ * Follows single-file `bun test` isolation.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+import { VoicePage } from "@/domains/settings/pages/voice-page";
+import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <VoicePage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  useVoicePrefsStore.setState({
+    showUserTranscript: false,
+    showAssistantTranscript: false,
+    firstRunSeen: false,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("VoicePage transcription toggles", () => {
+  test("both transcript toggles default to off on first render", () => {
+    renderPage();
+
+    const userToggle = screen.getByRole("switch", {
+      name: "Show the words you say",
+    });
+    const assistantToggle = screen.getByRole("switch", {
+      name: "Show the words the assistant says",
+    });
+
+    expect(userToggle.getAttribute("aria-checked")).toBe("false");
+    expect(assistantToggle.getAttribute("aria-checked")).toBe("false");
+  });
+
+  test("toggling the user transcript updates the store", () => {
+    renderPage();
+
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Show the words you say" }),
+    );
+
+    expect(useVoicePrefsStore.getState().showUserTranscript).toBe(true);
+    expect(useVoicePrefsStore.getState().showAssistantTranscript).toBe(false);
+  });
+
+  test("toggling the assistant transcript updates the store", () => {
+    renderPage();
+
+    fireEvent.click(
+      screen.getByRole("switch", {
+        name: "Show the words the assistant says",
+      }),
+    );
+
+    expect(useVoicePrefsStore.getState().showAssistantTranscript).toBe(true);
+    expect(useVoicePrefsStore.getState().showUserTranscript).toBe(false);
+  });
+});

--- a/clients/web/src/domains/settings/pages/voice-page.tsx
+++ b/clients/web/src/domains/settings/pages/voice-page.tsx
@@ -38,6 +38,7 @@ import {
     getPreferredInputDeviceId,
 } from "@/utils/voice-input-device";
 import { canConfigureFnPushToTalk } from "@/runtime/hotkey";
+import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 
 const LS_CONVERSATION_TIMEOUT = "vellum:voice:conversationTimeoutSeconds";
 
@@ -84,7 +85,72 @@ export function VoicePage() {
       <MicrophoneCard />
       <PushToTalkCard />
       <ConversationTimeoutCard />
+      <TranscriptionCard />
     </div>
+  );
+}
+
+function TranscriptRow({
+  label,
+  description,
+  checked,
+  onChange,
+}: {
+  label: string;
+  description?: string;
+  checked: boolean;
+  onChange: (next: boolean) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 py-1">
+      <div>
+        <div className="text-body-medium-lighter text-[var(--content-default)]">
+          {label}
+        </div>
+        {description && (
+          <div className="text-body-small-default text-[var(--content-tertiary)]">
+            {description}
+          </div>
+        )}
+      </div>
+      <Toggle checked={checked} onChange={onChange} aria-label={label} />
+    </div>
+  );
+}
+
+function TranscriptionCard() {
+  const showUserTranscript = useVoicePrefsStore.use.showUserTranscript();
+  const showAssistantTranscript =
+    useVoicePrefsStore.use.showAssistantTranscript();
+  const setShowUserTranscript =
+    useVoicePrefsStore.use.setShowUserTranscript();
+  const setShowAssistantTranscript =
+    useVoicePrefsStore.use.setShowAssistantTranscript();
+
+  return (
+    <DetailCard
+      title="Transcription"
+      subtitle="Show live text of what you and the assistant say during a voice conversation."
+    >
+      <div className="flex flex-col gap-2">
+        <TranscriptRow
+          label="Show the words you say"
+          description="Live transcription while you speak."
+          checked={showUserTranscript}
+          onChange={setShowUserTranscript}
+        />
+        <TranscriptRow
+          label="Show the words the assistant says"
+          description="Text alongside the spoken response."
+          checked={showAssistantTranscript}
+          onChange={setShowAssistantTranscript}
+        />
+        <p className={`${labelClasses} pt-1`}>
+          We recommend keeping both off to start. It feels more like a real
+          conversation.
+        </p>
+      </div>
+    </DetailCard>
   );
 }
 


### PR DESCRIPTION
## Summary
- Add a Transcription card to the Voice settings page with two toggles (show your words / show the assistant's words), both default OFF, wired to the persisted voice-prefs store.

Part of plan: voice-mode-ui-overhaul.md (PR 5 of 8)