### PR TITLE
feat(stt): add utterance finalize to the streaming transcriber contract and Deepgram

### DIFF
--- a/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
@@ -89,6 +89,7 @@ function resultsFrame(
   options: {
     is_final?: boolean;
     speech_final?: boolean;
+    from_finalize?: boolean;
     words?: { word: string; speaker?: number }[];
   } = {},
 ): string {
@@ -99,6 +100,9 @@ function resultsFrame(
     start: 0,
     is_final: options.is_final ?? false,
     speech_final: options.speech_final ?? false,
+    ...(options.from_finalize !== undefined
+      ? { from_finalize: options.from_finalize }
+      : {}),
     channel: {
       alternatives: [
         {
@@ -595,7 +599,9 @@ describe("DeepgramRealtimeTranscriber", () => {
     test("UtteranceEnd flushes withheld segments as a single final", async () => {
       const { events } = await startSession({ utteranceBoundaryFinals: true });
 
-      mockWs.simulateMessage(resultsFrame("trailing words", { is_final: true }));
+      mockWs.simulateMessage(
+        resultsFrame("trailing words", { is_final: true }),
+      );
       mockWs.simulateMessage(utteranceEndFrame());
 
       const finals = events.filter((e) => e.type === "final");
@@ -652,6 +658,150 @@ describe("DeepgramRealtimeTranscriber", () => {
         "first part done",
         "second utterance",
       ]);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // finalizeUtterance (mid-stream flush)
+  // ─────────────────────────────────────────────────────────────────
+
+  describe("finalizeUtterance", () => {
+    test("sends the Finalize control frame on an open socket", async () => {
+      const { transcriber, events } = await startSession();
+
+      transcriber.finalizeUtterance();
+
+      const textMessages = mockWs.sentData.filter((d) => typeof d === "string");
+      expect(textMessages).toHaveLength(1);
+      expect(JSON.parse(textMessages[0] as string)).toEqual({
+        type: "Finalize",
+      });
+      // No finalized event until the provider's from_finalize flush arrives.
+      expect(events).toHaveLength(0);
+    });
+
+    test("from_finalize results message emits final then finalized", async () => {
+      const { transcriber, events } = await startSession();
+
+      transcriber.finalizeUtterance();
+      mockWs.simulateMessage(
+        resultsFrame("buffered tail", { is_final: true, from_finalize: true }),
+      );
+
+      expect(events).toEqual([
+        { type: "final", text: "buffered tail", confidence: 0.95 },
+        { type: "finalized" },
+      ]);
+    });
+
+    test("empty-transcript flush emits only finalized", async () => {
+      const { transcriber, events } = await startSession();
+
+      transcriber.finalizeUtterance();
+      mockWs.simulateMessage(
+        resultsFrame("", { is_final: true, from_finalize: true }),
+      );
+
+      expect(events).toEqual([{ type: "finalized" }]);
+    });
+
+    test("stream stays usable after finalized (audio still transcribes)", async () => {
+      const { transcriber, events } = await startSession();
+
+      transcriber.finalizeUtterance();
+      mockWs.simulateMessage(
+        resultsFrame("first utterance", {
+          is_final: true,
+          from_finalize: true,
+        }),
+      );
+      expect(events.at(-1)).toEqual({ type: "finalized" });
+
+      // The socket stays open — audio still flows and transcribes.
+      transcriber.sendAudio(Buffer.from("more-pcm"), "audio/pcm");
+      const binaryFrames = mockWs.sentData.filter(
+        (d) => d instanceof Uint8Array,
+      );
+      expect(binaryFrames).toHaveLength(1);
+      expect(mockWs.closeCalled).toBe(false);
+
+      mockWs.simulateMessage(
+        resultsFrame("second utterance", { is_final: true }),
+      );
+      expect(events.at(-1)).toEqual({
+        type: "final",
+        text: "second utterance",
+        confidence: 0.95,
+      });
+    });
+
+    test("emits finalized synchronously when the socket is not open", async () => {
+      const { transcriber, events } = await startSession();
+
+      // Socket dropped underneath us; the close event has not yet fired.
+      mockWs.readyState = 3; // CLOSED
+
+      transcriber.finalizeUtterance();
+
+      expect(events).toEqual([{ type: "finalized" }]);
+      // Nothing was sent on the dead socket.
+      expect(mockWs.sentData).toHaveLength(0);
+    });
+
+    test("emits finalized at most once per finalize request", async () => {
+      const { transcriber, events } = await startSession();
+
+      transcriber.finalizeUtterance();
+      mockWs.simulateMessage(
+        resultsFrame("flush one", { is_final: true, from_finalize: true }),
+      );
+      // A stray second from_finalize frame must not emit another finalized.
+      mockWs.simulateMessage(
+        resultsFrame("flush two", { is_final: true, from_finalize: true }),
+      );
+
+      const finalized = events.filter((e) => e.type === "finalized");
+      expect(finalized).toHaveLength(1);
+      expect(events.at(-1)).toEqual({
+        type: "final",
+        text: "flush two",
+        confidence: 0.95,
+      });
+    });
+
+    test("flushes withheld segments before finalized in utteranceBoundaryFinals mode", async () => {
+      const { transcriber, events } = await startSession({
+        utteranceBoundaryFinals: true,
+      });
+
+      mockWs.simulateMessage(resultsFrame("first part", { is_final: true }));
+      transcriber.finalizeUtterance();
+      mockWs.simulateMessage(
+        resultsFrame("tail", { is_final: true, from_finalize: true }),
+      );
+
+      expect(events).toEqual([
+        { type: "final", text: "first part tail" },
+        { type: "finalized" },
+      ]);
+    });
+
+    test("stop() teardown path is unchanged after a finalize cycle", async () => {
+      const { transcriber, events } = await startSession();
+
+      transcriber.finalizeUtterance();
+      mockWs.simulateMessage(
+        resultsFrame("", { is_final: true, from_finalize: true }),
+      );
+
+      transcriber.stop();
+      const textMessages = mockWs.sentData.filter((d) => typeof d === "string");
+      expect(JSON.parse(textMessages.at(-1) as string)).toEqual({
+        type: "CloseStream",
+      });
+      mockWs.simulateClose(1000, "normal");
+
+      expect(events.filter((e) => e.type === "closed")).toHaveLength(1);
     });
   });
 

--- a/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
@@ -705,6 +705,41 @@ describe("DeepgramRealtimeTranscriber", () => {
       expect(events).toEqual([{ type: "finalized" }]);
     });
 
+    test("emits finalized via fallback when no from_finalize flush arrives", async () => {
+      const { transcriber, events } = await startSession({
+        finalizeFallbackMs: 20,
+      });
+
+      // Deepgram omits the flush entirely when nothing significant is
+      // buffered — the fallback timer must complete the contract.
+      transcriber.finalizeUtterance();
+      expect(events).toHaveLength(0);
+      await new Promise((resolve) => setTimeout(resolve, 40));
+
+      expect(events).toEqual([{ type: "finalized" }]);
+
+      // A flush arriving after the fallback must not double-emit.
+      mockWs.simulateMessage(
+        resultsFrame("", { is_final: true, from_finalize: true }),
+      );
+      expect(events).toEqual([{ type: "finalized" }]);
+    });
+
+    test("a pending finalize completes as finalized before closed on teardown", async () => {
+      const { transcriber, events } = await startSession({
+        finalizeFallbackMs: 60_000,
+      });
+
+      transcriber.finalizeUtterance();
+      transcriber.stop();
+      mockWs.simulateClose(1000, "normal");
+
+      const finalizedIndex = events.findIndex((e) => e.type === "finalized");
+      const closedIndex = events.findIndex((e) => e.type === "closed");
+      expect(finalizedIndex).toBeGreaterThanOrEqual(0);
+      expect(closedIndex).toBeGreaterThan(finalizedIndex);
+    });
+
     test("stream stays usable after finalized (audio still transcribes)", async () => {
       const { transcriber, events } = await startSession();
 

--- a/assistant/src/providers/speech-to-text/deepgram-realtime.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.ts
@@ -12,10 +12,13 @@
  *    established.
  * 2. {@link sendAudio} forwards audio chunks over the open socket with
  *    backpressure-safe bufferedAmount checks.
- * 3. {@link stop} sends the Deepgram `CloseStream` message and waits for
+ * 3. {@link finalizeUtterance} sends the Deepgram `Finalize` message to
+ *    flush provider-buffered audio into finals without closing the
+ *    stream; the flush completion is signalled with a `finalized` event.
+ * 4. {@link stop} sends the Deepgram `CloseStream` message and waits for
  *    the provider to flush any remaining finals before closing.
- * 4. The `onEvent` callback receives `partial`, `final`, `error`, and
- *    `closed` events throughout the session lifetime.
+ * 5. The `onEvent` callback receives `partial`, `final`, `finalized`,
+ *    `error`, and `closed` events throughout the session lifetime.
  *
  * Error handling:
  * - Provider WebSocket errors and unexpected closes are mapped to
@@ -198,6 +201,12 @@ interface DeepgramStreamResponse {
   type?: string;
   is_final?: boolean;
   speech_final?: boolean;
+  /**
+   * True when this Results frame is the flush produced by a `Finalize`
+   * control message (see {@link DeepgramRealtimeTranscriber.finalizeUtterance}).
+   * The flushed transcript may be empty when nothing was buffered.
+   */
+  from_finalize?: boolean;
   channel?: DeepgramStreamChannel;
   channel_index?: number[];
   /** Duration of the audio segment in seconds. */
@@ -287,6 +296,14 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
 
   /** Whether the session has been fully closed. */
   private closed = false;
+
+  /**
+   * Whether a `Finalize` control frame is in flight — armed when
+   * {@link finalizeUtterance} sends the frame, cleared when the
+   * resulting `from_finalize` flush emits the `finalized` event. Keeps
+   * `finalized` emitted at most once per finalize request.
+   */
+  private finalizePending = false;
 
   /** Whether stop() has been called. */
   private stopping = false;
@@ -411,6 +428,36 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
 
     // Deepgram's live endpoint accepts raw audio bytes on the WebSocket.
     ws.send(new Uint8Array(audio));
+  }
+
+  /**
+   * Flush all provider-buffered audio into final transcript(s) without
+   * closing the stream.
+   *
+   * Sends the Deepgram `Finalize` control message; Deepgram responds by
+   * flushing buffered audio as a Results frame with `from_finalize: true`
+   * (possibly with an empty transcript). The adapter emits the resulting
+   * `final` (when non-empty) followed by one `finalized` event, and the
+   * stream stays open for more audio. When the socket is not open there
+   * is nothing buffered provider-side, so `finalized` is emitted
+   * immediately. {@link stop} remains the session-teardown path.
+   */
+  finalizeUtterance(): void {
+    const ws = this.ws;
+    if (this.closed || this.stopping || !ws || ws.readyState !== WS_OPEN) {
+      // Nothing buffered provider-side — the flush is trivially complete.
+      this.emitEvent({ type: "finalized" });
+      return;
+    }
+
+    try {
+      ws.send(JSON.stringify({ type: "Finalize" }));
+    } catch (err) {
+      log.warn({ err }, "Deepgram Finalize send failed");
+      this.emitEvent({ type: "finalized" });
+      return;
+    }
+    this.finalizePending = true;
   }
 
   stop(): void {
@@ -558,10 +605,14 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
    * We emit:
    * - `partial` for `is_final: false` frames (if interim results enabled).
    * - `final` for `is_final: true` frames.
+   * - `finalized` after the `final` of a `from_finalize: true` flush frame
+   *   (the response to {@link finalizeUtterance}). An empty flush emits
+   *   only `finalized` — silence flushes carry no transcript to commit.
    */
   private handleTranscriptFrame(frame: DeepgramStreamResponse): void {
     const alternative = frame.channel?.alternatives?.[0];
     const transcript = alternative?.transcript;
+    const fromFinalize = frame.from_finalize === true;
 
     // Extract text, defaulting to empty string for silence segments.
     const text = typeof transcript === "string" ? transcript.trim() : "";
@@ -576,22 +627,24 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
 
     if (frame.is_final) {
       if (this.utteranceBoundaryFinals) {
-        // Withhold committed segments until an utterance boundary.
+        // Withhold committed segments until an utterance boundary. A
+        // Finalize flush is a forced boundary — flush what is pending.
         if (text.length > 0) {
           this.pendingFinalSegments.push(text);
         }
-        if (frame.speech_final) {
+        if (frame.speech_final || fromFinalize) {
           this.flushPendingUtterance();
         }
-        return;
+      } else if (text.length > 0 || !fromFinalize) {
+        // Committed transcript — emit as final. Empty Finalize flushes
+        // are suppressed (nothing was buffered provider-side).
+        this.emitEvent({
+          type: "final",
+          text,
+          ...(speakerLabel !== undefined ? { speakerLabel } : {}),
+          ...(confidence !== undefined ? { confidence } : {}),
+        });
       }
-      // Committed transcript — emit as final.
-      this.emitEvent({
-        type: "final",
-        text,
-        ...(speakerLabel !== undefined ? { speakerLabel } : {}),
-        ...(confidence !== undefined ? { confidence } : {}),
-      });
     } else if (this.interimResults) {
       // Interim transcript — emit as partial.
       this.emitEvent({
@@ -600,6 +653,10 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
         ...(speakerLabel !== undefined ? { speakerLabel } : {}),
         ...(confidence !== undefined ? { confidence } : {}),
       });
+    }
+
+    if (fromFinalize) {
+      this.emitFinalizedIfPending();
     }
   }
 
@@ -684,6 +741,17 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
     const text = this.pendingFinalSegments.join(" ");
     this.pendingFinalSegments = [];
     this.emitEvent({ type: "final", text });
+  }
+
+  /**
+   * Emit the `finalized` event for an in-flight {@link finalizeUtterance}
+   * request. No-op unless a Finalize frame is pending, so `finalized` is
+   * emitted at most once per request.
+   */
+  private emitFinalizedIfPending(): void {
+    if (!this.finalizePending) return;
+    this.finalizePending = false;
+    this.emitEvent({ type: "finalized" });
   }
 
   /**

--- a/assistant/src/providers/speech-to-text/deepgram-realtime.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.ts
@@ -80,6 +80,14 @@ const MAX_BUFFERED_AMOUNT = 1024 * 1024; // 1 MiB
  */
 const CLOSE_GRACE_MS = 5_000;
 
+/**
+ * Grace period (ms) after sending Finalize before the adapter emits
+ * `finalized` on its own. Deepgram sends no `from_finalize` Results frame
+ * when it has no significant audio buffered, so a caller waiting on the
+ * completion signal would otherwise stall indefinitely.
+ */
+const FINALIZE_FALLBACK_MS = 2_000;
+
 // ---------------------------------------------------------------------------
 // Options
 // ---------------------------------------------------------------------------
@@ -108,6 +116,11 @@ export interface DeepgramRealtimeOptions {
    * silence).
    */
   keepaliveIntervalMs?: number;
+  /**
+   * Grace (ms) after a Finalize before `finalized` is emitted without a
+   * `from_finalize` flush from Deepgram. Default: 2_000.
+   */
+  finalizeFallbackMs?: number;
   /** Audio sample rate in Hz (default: 16000). Passed through from the client WebSocket connection. */
   sampleRate?: number;
   /**
@@ -267,6 +280,7 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
   private readonly connectTimeoutMs: number;
   private readonly inactivityTimeoutMs: number;
   private readonly keepaliveIntervalMs: number;
+  private readonly finalizeFallbackMs: number;
   private readonly sampleRate: number;
   /**
    * Whether speaker diarization is requested. Forwarded to the Deepgram
@@ -305,6 +319,14 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
    */
   private finalizePending = false;
 
+  /**
+   * Fallback timer for an in-flight Finalize. Deepgram omits the
+   * `from_finalize` flush when nothing significant is buffered, so this
+   * timer emits `finalized` after {@link FINALIZE_FALLBACK_MS} to keep the
+   * completion contract. Cleared when the flush arrives or on cleanup.
+   */
+  private finalizeFallbackTimer: ReturnType<typeof setTimeout> | null = null;
+
   /** Whether stop() has been called. */
   private stopping = false;
 
@@ -335,6 +357,8 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
       options.inactivityTimeoutMs ?? DEFAULT_INACTIVITY_TIMEOUT_MS;
     this.keepaliveIntervalMs =
       options.keepaliveIntervalMs ?? DEFAULT_KEEPALIVE_INTERVAL_MS;
+    this.finalizeFallbackMs =
+      options.finalizeFallbackMs ?? FINALIZE_FALLBACK_MS;
     this.sampleRate = options.sampleRate ?? 16_000;
     this.diarize = options.diarize ?? false;
     this.utteranceBoundaryFinals = options.utteranceBoundaryFinals ?? false;
@@ -458,6 +482,15 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
       return;
     }
     this.finalizePending = true;
+    if (this.finalizeFallbackTimer !== null) {
+      clearTimeout(this.finalizeFallbackTimer);
+    }
+    this.finalizeFallbackTimer = setTimeout(() => {
+      log.debug(
+        "Deepgram sent no from_finalize flush — emitting finalized fallback",
+      );
+      this.emitFinalizedIfPending();
+    }, this.finalizeFallbackMs);
   }
 
   stop(): void {
@@ -749,6 +782,10 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
    * emitted at most once per request.
    */
   private emitFinalizedIfPending(): void {
+    if (this.finalizeFallbackTimer !== null) {
+      clearTimeout(this.finalizeFallbackTimer);
+      this.finalizeFallbackTimer = null;
+    }
     if (!this.finalizePending) return;
     this.finalizePending = false;
     this.emitEvent({ type: "finalized" });
@@ -768,6 +805,9 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
     this.forceClose();
 
     this.flushPendingUtterance();
+    // A Finalize with no flush response must still complete before the
+    // stream reports closed, so waiters see finalized → closed in order.
+    this.emitFinalizedIfPending();
     this.emitEvent({ type: "closed" });
     this.onEvent = null;
   }
@@ -803,6 +843,10 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
     if (this.keepaliveTimer !== null) {
       clearInterval(this.keepaliveTimer);
       this.keepaliveTimer = null;
+    }
+    if (this.finalizeFallbackTimer !== null) {
+      clearTimeout(this.finalizeFallbackTimer);
+      this.finalizeFallbackTimer = null;
     }
   }
 

--- a/assistant/src/stt/types.ts
+++ b/assistant/src/stt/types.ts
@@ -229,6 +229,7 @@ export interface SttStreamClientStopEvent {
 export type SttStreamServerEvent =
   | SttStreamServerPartialEvent
   | SttStreamServerFinalEvent
+  | SttStreamServerFinalizedEvent
   | SttStreamServerErrorEvent
   | SttStreamServerClosedEvent;
 
@@ -265,6 +266,16 @@ export interface SttStreamServerFinalEvent {
   readonly confidence?: number;
 }
 
+/**
+ * All provider-buffered audio has been flushed into `final` event(s) in
+ * response to {@link StreamingTranscriber.finalizeUtterance}. Emitted
+ * exactly once per finalize request, after the flushed `final` event(s).
+ * The stream stays open and continues to accept audio.
+ */
+export interface SttStreamServerFinalizedEvent {
+  readonly type: "finalized";
+}
+
 /** An error occurred during streaming transcription. */
 export interface SttStreamServerErrorEvent {
   readonly type: "error";
@@ -294,8 +305,10 @@ export interface SttStreamServerClosedEvent {
  * Lifecycle:
  * 1. Call {@link start} to open the provider session.
  * 2. Feed audio chunks via {@link sendAudio}.
- * 3. Call {@link stop} when the client finishes recording.
- * 4. The `onEvent` callback receives server events until `closed`.
+ * 3. Optionally call {@link finalizeUtterance} between utterances to
+ *    flush buffered audio into finals while keeping the stream open.
+ * 4. Call {@link stop} when the client finishes recording.
+ * 5. The `onEvent` callback receives server events until `closed`.
  */
 export interface StreamingTranscriber {
   /** Which provider backs this transcriber. */
@@ -318,6 +331,17 @@ export interface StreamingTranscriber {
    * {@link stop} has been called.
    */
   sendAudio(audio: Buffer, mimeType: string): void;
+
+  /**
+   * Flush all buffered audio into final transcript(s) without closing
+   * the stream.
+   *
+   * Emits `final` event(s) for pending audio followed by one `finalized`
+   * event; the stream stays open for more audio. Optional — callers must
+   * feature-detect this method and fall back to {@link stop} (full
+   * teardown) when the provider does not support it.
+   */
+  finalizeUtterance?(): void;
 
   /**
    * Signal that the client has finished sending audio.


### PR DESCRIPTION
## Summary
- Adds optional finalizeUtterance() to the StreamingTranscriber contract plus a 'finalized' stream event
- Deepgram implementation sends {type: Finalize} and maps from_finalize results to final + finalized without closing the socket

Part of plan: voice-mode-latency.md (PR 4 of 13)