### PR TITLE
fix: name the call audio-format union; refresh stale wav-store comment

### DIFF
--- a/assistant/src/calls/audio-store.ts
+++ b/assistant/src/calls/audio-store.ts
@@ -1,5 +1,8 @@
 import { randomUUID } from "node:crypto";
 
+/** Audio formats that flow through call synthesis and the audio store. */
+export type CallAudioFormat = "mp3" | "wav" | "opus" | "pcm";
+
 interface AudioEntry {
   buffer: Buffer;
   contentType: string;
@@ -22,10 +25,7 @@ const TTL_MS = 60_000; // 60 seconds
 
 let currentBytes = 0;
 
-export function storeAudio(
-  buffer: Buffer,
-  format: "mp3" | "wav" | "opus" | "pcm",
-): string {
+export function storeAudio(buffer: Buffer, format: CallAudioFormat): string {
   evictExpired();
   // Evict oldest if over capacity
   while (currentBytes + buffer.length > MAX_STORE_BYTES && store.size > 0) {
@@ -50,7 +50,7 @@ export interface StreamingAudioHandle {
 }
 
 export function createStreamingEntry(
-  format: "mp3" | "wav" | "opus" | "pcm",
+  format: CallAudioFormat,
 ): StreamingAudioHandle {
   evictExpired();
   const id = randomUUID();
@@ -162,7 +162,7 @@ export function getAudio(id: string): AudioResult | null {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-function contentTypeForFormat(format: "mp3" | "wav" | "opus" | "pcm"): string {
+function contentTypeForFormat(format: CallAudioFormat): string {
   return format === "mp3"
     ? "audio/mpeg"
     : format === "wav"

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -28,6 +28,7 @@ import {
 } from "../tts/synthesis-stream.js";
 import type { TtsProvider, TtsProviderId } from "../tts/types.js";
 import { getLogger } from "../util/logger.js";
+import type { CallAudioFormat } from "./audio-store.js";
 import {
   getEndCallListenWindowMs,
   getMaxCallDurationMs,
@@ -1004,7 +1005,7 @@ export class CallController {
     provider: TtsProvider,
     text: string,
     runVersion: number,
-    format: "mp3" | "wav" | "opus" | "pcm" = "mp3",
+    format: CallAudioFormat = "mp3",
   ): Promise<SegmentSynthesisStatus> {
     let sink: AudioStoreSink | null = null;
     let playUrlSent = false;

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -23,6 +23,7 @@ import {
 } from "../tts/synthesis-stream.js";
 import type { TtsProvider, TtsProviderId } from "../tts/types.js";
 import { getLogger } from "../util/logger.js";
+import type { CallAudioFormat } from "./audio-store.js";
 import type { CallTransport } from "./call-transport.js";
 import {
   findPlayableTelephonyTtsFallbackProvider,
@@ -111,7 +112,7 @@ async function synthesizeAndPlay(
   relay: CallTransport,
   provider: TtsProvider,
   text: string,
-  format: "mp3" | "wav" | "opus" | "pcm",
+  format: CallAudioFormat,
   signal?: AbortSignal,
   isFallbackRetry = false,
 ): Promise<void> {

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -39,6 +39,7 @@ import { createPcmChunkAligner } from "../tts/pcm-chunk-aligner.js";
 import { extractSpeakableSegments } from "../tts/speakable-segments.js";
 import { synthesizeAndEmit } from "../tts/synthesis-stream.js";
 import { getLogger } from "../util/logger.js";
+import type { CallAudioFormat } from "./audio-store.js";
 import type { CallTransport } from "./call-transport.js";
 import {
   chunkMulawToBase64Frames,
@@ -637,7 +638,7 @@ export class MediaStreamOutput implements CallTransport {
       // returns mp3). For unknown content types, fall back to the declared
       // format (PCM on this path — the bytes were requested as raw PCM,
       // and audioBufferToFrames sniffs magic bytes as a safety net).
-      const actualFormat: "mp3" | "wav" | "opus" | "pcm" =
+      const actualFormat: CallAudioFormat =
         result.contentType.includes("wav") ||
         result.contentType.includes("x-wav")
           ? "wav"
@@ -709,7 +710,7 @@ export class MediaStreamOutput implements CallTransport {
       }
 
       const contentType = response.headers.get("content-type") ?? "audio/mpeg";
-      const format: "mp3" | "wav" | "opus" | "pcm" = contentType.includes("wav")
+      const format: CallAudioFormat = contentType.includes("wav")
         ? "wav"
         : contentType.includes("opus")
           ? "opus"
@@ -763,7 +764,7 @@ export class MediaStreamOutput implements CallTransport {
    */
   private audioBufferToFrames(
     audio: Buffer,
-    format: "mp3" | "wav" | "opus" | "pcm",
+    format: CallAudioFormat,
   ): string[] {
     // Sniff the actual bytes rather than trusting the declared format.
     // WAV files always start with the ASCII magic "RIFF" (0x52494646).
@@ -805,8 +806,9 @@ export class MediaStreamOutput implements CallTransport {
 
     // When the declared format is "wav" but the RIFF check failed, the
     // bytes might be either:
-    // (a) Raw PCM stored under audio/wav content-type (when
-    //     outputFormat: "pcm" is used with createStreamingEntry("wav"))
+    // (a) Raw PCM served under a wav content-type (declared "wav" only
+    //     arrives via content-type sniffing; some providers label raw
+    //     PCM streams audio/wav)
     // (b) Compressed audio (mp3/opus) from a provider that ignores
     //     outputFormat (e.g. Fish Audio defaults to mp3)
     //

--- a/assistant/src/calls/resolve-call-tts-provider.ts
+++ b/assistant/src/calls/resolve-call-tts-provider.ts
@@ -16,6 +16,7 @@ import {
 import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
 import type { TtsProvider, TtsProviderId } from "../tts/types.js";
 import { getLogger } from "../util/logger.js";
+import type { CallAudioFormat } from "./audio-store.js";
 import {
   evaluateTelephonyTtsPlayability,
   fishAudioReferenceIdConfigured,
@@ -43,7 +44,7 @@ export interface ResolvedCallTts {
   useSynthesizedPath: boolean;
 
   /** Audio format to use for synthesized audio. */
-  audioFormat: "mp3" | "wav" | "opus" | "pcm";
+  audioFormat: CallAudioFormat;
 }
 
 // ---------------------------------------------------------------------------
@@ -151,20 +152,19 @@ export async function resolveCallTtsProvider(
     // When requiresPcmAudio is set (media-stream transport), resolve to
     // PCM so audioBufferToFrames receives raw PCM it can transcode to
     // mu-law.
-    const audioFormat: "mp3" | "wav" | "opus" | "pcm" =
-      options?.requiresPcmAudio
-        ? "pcm"
-        : (() => {
-            const configuredFormat = (
-              resolved.providerConfig as { format?: string }
-            ).format;
-            return (
-              configuredFormat &&
-              ["mp3", "wav", "opus"].includes(configuredFormat)
-                ? configuredFormat
-                : "mp3"
-            ) as "mp3" | "wav" | "opus";
-          })();
+    const audioFormat: CallAudioFormat = options?.requiresPcmAudio
+      ? "pcm"
+      : (() => {
+          const configuredFormat = (
+            resolved.providerConfig as { format?: string }
+          ).format;
+          return (
+            configuredFormat &&
+            ["mp3", "wav", "opus"].includes(configuredFormat)
+              ? configuredFormat
+              : "mp3"
+          ) as "mp3" | "wav" | "opus";
+        })();
 
     return { provider, useSynthesizedPath, audioFormat };
   } catch {
@@ -188,11 +188,9 @@ export async function resolveCallTtsProvider(
  * "audio/wav" while the bytes have no RIFF header and
  * audioBufferToFrames falls through to the wrong decode path.
  */
-export function resolveSynthesisFormats(
-  format: "mp3" | "wav" | "opus" | "pcm",
-): {
+export function resolveSynthesisFormats(format: CallAudioFormat): {
   outputFormat: "pcm" | undefined;
-  storeFormat: "mp3" | "wav" | "opus" | "pcm";
+  storeFormat: CallAudioFormat;
 } {
   const outputFormat =
     format === "pcm" || format === "wav" ? ("pcm" as const) : undefined;

--- a/assistant/src/tts/synthesis-stream.ts
+++ b/assistant/src/tts/synthesis-stream.ts
@@ -8,7 +8,10 @@
  * for transports that play audio via the audio store's `/v1/audio/:id` URLs.
  */
 
-import { createStreamingEntry } from "../calls/audio-store.js";
+import {
+  type CallAudioFormat,
+  createStreamingEntry,
+} from "../calls/audio-store.js";
 import { loadConfig } from "../config/loader.js";
 import { getPublicBaseUrl } from "../inbound/public-ingress-urls.js";
 import type {
@@ -200,12 +203,9 @@ export async function synthesizeAndEmit(
 // Audio-store sink
 // ---------------------------------------------------------------------------
 
-/** Audio formats accepted by the audio store. */
-export type AudioStoreFormat = Parameters<typeof createStreamingEntry>[0];
-
 export interface AudioStoreSinkOptions {
   /** Store format — determines the entry's served content type. */
-  format: AudioStoreFormat;
+  format: CallAudioFormat;
 
   /**
    * Invoked exactly once, when the first audio chunk arrives, with the


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review round 2 for tts-deferred-cleanups.md.

**Gap:** 4-member audio-format union hand-spelled at ~12 sites; stale wav-store comment in audioBufferToFrames.
**Fix:** one exported CallAudioFormat alias adopted at every exact-match site (types only, zero behavior change); comment reworded to the sniff-path reality.