### PR TITLE
feat(calls): make the Deepgram utterance-end window configurable for telephony

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -877,6 +877,7 @@ describe("AssistantConfigSchema", () => {
         language: "en-US",
         interruptSensitivity: "low",
         telephonyStreaming: true,
+        utteranceEndMs: 1000,
       },
       callerIdentity: {
         allowPerCallOverride: true,
@@ -1015,6 +1016,7 @@ describe("AssistantConfigSchema", () => {
     expect(result.calls.voice.language).toBe("en-US");
     expect(result.calls.voice.interruptSensitivity).toBe("low");
     expect(result.calls.voice.telephonyStreaming).toBe(true);
+    expect(result.calls.voice.utteranceEndMs).toBe(1000);
   });
 
   test("accepts valid calls.voice overrides", () => {
@@ -1023,11 +1025,35 @@ describe("AssistantConfigSchema", () => {
         voice: {
           language: "es-ES",
           telephonyStreaming: false,
+          utteranceEndMs: 2500,
         },
       },
     });
     expect(result.calls.voice.language).toBe("es-ES");
     expect(result.calls.voice.telephonyStreaming).toBe(false);
+    expect(result.calls.voice.utteranceEndMs).toBe(2500);
+  });
+
+  test("rejects calls.voice.utteranceEndMs outside the 500-5000 range", () => {
+    for (const utteranceEndMs of [400, 5001]) {
+      const result = AssistantConfigSchema.safeParse({
+        calls: { voice: { utteranceEndMs } },
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const msgs = result.error.issues.map((i) => i.message);
+        expect(msgs.some((m) => m.includes("calls.voice.utteranceEndMs"))).toBe(
+          true,
+        );
+      }
+    }
+  });
+
+  test("rejects non-integer calls.voice.utteranceEndMs", () => {
+    const result = AssistantConfigSchema.safeParse({
+      calls: { voice: { utteranceEndMs: 1000.5 } },
+    });
+    expect(result.success).toBe(false);
   });
 
   test("rejects non-boolean calls.voice.telephonyStreaming", () => {

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -1034,8 +1034,8 @@ describe("AssistantConfigSchema", () => {
     expect(result.calls.voice.utteranceEndMs).toBe(2500);
   });
 
-  test("rejects calls.voice.utteranceEndMs outside the 500-5000 range", () => {
-    for (const utteranceEndMs of [400, 5001]) {
+  test("rejects calls.voice.utteranceEndMs outside the 1000-5000 range", () => {
+    for (const utteranceEndMs of [999, 5001]) {
       const result = AssistantConfigSchema.safeParse({
         calls: { voice: { utteranceEndMs } },
       });

--- a/assistant/src/__tests__/media-stream-stt-session.test.ts
+++ b/assistant/src/__tests__/media-stream-stt-session.test.ts
@@ -28,10 +28,15 @@ mock.module("../providers/speech-to-text/resolve.js", () => ({
 
 // Mock the config loader so the session's telephony-streaming flag read
 // never touches the real filesystem config.
-const configState = { telephonyStreaming: true };
+const configState = { telephonyStreaming: true, utteranceEndMs: 1000 };
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
-    calls: { voice: { telephonyStreaming: configState.telephonyStreaming } },
+    calls: {
+      voice: {
+        telephonyStreaming: configState.telephonyStreaming,
+        utteranceEndMs: configState.utteranceEndMs,
+      },
+    },
   }),
 }));
 
@@ -198,6 +203,7 @@ describe("MediaStreamSttSession", () => {
     // session selects batch mode deterministically. Streaming-mode tests
     // set it back to true.
     configState.telephonyStreaming = false;
+    configState.utteranceEndMs = 1000;
 
     // Default: provider is supported and transcriber is available
     (resolveTelephonySttCapability as jest.Mock).mockResolvedValue({
@@ -692,7 +698,10 @@ describe("MediaStreamSttSession", () => {
     async function startStreamingSession(
       callbacks: ConstructorParameters<typeof MediaStreamSttSession>[1] = {},
       config: ConstructorParameters<typeof MediaStreamSttSession>[0] = {},
-    ): Promise<{ session: MediaStreamSttSession; fake: FakeStreamingTranscriber }> {
+    ): Promise<{
+      session: MediaStreamSttSession;
+      fake: FakeStreamingTranscriber;
+    }> {
       const fake = new FakeStreamingTranscriber();
       (resolveStreamingTranscriber as jest.Mock).mockResolvedValue(fake);
 
@@ -710,6 +719,20 @@ describe("MediaStreamSttSession", () => {
       expect(resolveStreamingTranscriber).toHaveBeenCalledWith({
         sampleRate: 16_000,
         utteranceBoundaryFinals: true,
+        utteranceEndMs: 1000,
+      });
+
+      session.dispose();
+    });
+
+    test("forwards the configured calls.voice.utteranceEndMs to the resolver", async () => {
+      configState.utteranceEndMs = 2500;
+      const { session } = await startStreamingSession();
+
+      expect(resolveStreamingTranscriber).toHaveBeenCalledWith({
+        sampleRate: 16_000,
+        utteranceBoundaryFinals: true,
+        utteranceEndMs: 2500,
       });
 
       session.dispose();

--- a/assistant/src/calls/media-stream-stt-session.ts
+++ b/assistant/src/calls/media-stream-stt-session.ts
@@ -400,6 +400,7 @@ export class MediaStreamSttSession {
       transcriber = await resolveStreamingTranscriber({
         sampleRate: STREAMING_SAMPLE_RATE,
         utteranceBoundaryFinals: true,
+        utteranceEndMs: getConfig().calls.voice.utteranceEndMs,
       });
     } catch (err) {
       log.warn(

--- a/assistant/src/config/schemas/calls.ts
+++ b/assistant/src/config/schemas/calls.ts
@@ -67,11 +67,11 @@ const CallsVoiceConfigSchema = z
     utteranceEndMs: z
       .number({ error: "calls.voice.utteranceEndMs must be a number" })
       .int("calls.voice.utteranceEndMs must be an integer")
-      .min(500, "calls.voice.utteranceEndMs must be >= 500")
+      .min(1000, "calls.voice.utteranceEndMs must be >= 1000")
       .max(5000, "calls.voice.utteranceEndMs must be at most 5000")
       .default(1000)
       .describe(
-        "Silence window (ms) the STT provider waits before finalizing a telephony utterance",
+        "Silence window (ms) the STT provider waits before finalizing a telephony utterance; Deepgram's hosted API floor for utterance_end_ms is 1000",
       ),
   })
   .describe("Voice and speech settings for phone calls");

--- a/assistant/src/config/schemas/calls.ts
+++ b/assistant/src/config/schemas/calls.ts
@@ -64,6 +64,15 @@ const CallsVoiceConfigSchema = z
       .describe(
         "Whether phone-call audio is streamed to the STT provider in real time; disable to fall back to per-turn batch transcription",
       ),
+    utteranceEndMs: z
+      .number({ error: "calls.voice.utteranceEndMs must be a number" })
+      .int("calls.voice.utteranceEndMs must be an integer")
+      .min(500, "calls.voice.utteranceEndMs must be >= 500")
+      .max(5000, "calls.voice.utteranceEndMs must be at most 5000")
+      .default(1000)
+      .describe(
+        "Silence window (ms) the STT provider waits before finalizing a telephony utterance",
+      ),
   })
   .describe("Voice and speech settings for phone calls");
 

--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -851,6 +851,37 @@ describe("resolveStreamingTranscriber diarize preference", () => {
     expect(options.utteranceEndMs).toBe(1000);
   });
 
+  test("utteranceBoundaryFinals with Deepgram forwards a caller-supplied utteranceEndMs", async () => {
+    mockProviderKeys["deepgram"] = "dg-key";
+    mockConfig = buildConfig({ provider: "deepgram" });
+
+    const transcriber = await resolveStreamingTranscriber({
+      utteranceBoundaryFinals: true,
+      utteranceEndMs: 2500,
+    });
+
+    expect(transcriber).not.toBeNull();
+    expect(deepgramCtorCalls).toHaveLength(1);
+    const options = deepgramCtorCalls[0]!.options as Record<string, unknown>;
+    expect(options.utteranceBoundaryFinals).toBe(true);
+    expect(options.utteranceEndMs).toBe(2500);
+  });
+
+  test("utteranceEndMs without utteranceBoundaryFinals does not reach the Deepgram constructor", async () => {
+    mockProviderKeys["deepgram"] = "dg-key";
+    mockConfig = buildConfig({ provider: "deepgram" });
+
+    const transcriber = await resolveStreamingTranscriber({
+      utteranceEndMs: 2500,
+    });
+
+    expect(transcriber).not.toBeNull();
+    expect(deepgramCtorCalls).toHaveLength(1);
+    const options = deepgramCtorCalls[0]!.options as Record<string, unknown>;
+    expect(options).not.toHaveProperty("utteranceEndMs");
+    expect(options).not.toHaveProperty("utteranceBoundaryFinals");
+  });
+
   test("utteranceBoundaryFinals with google-gemini returns null (catalog telephonyMode is batch-only)", async () => {
     mockProviderKeys["gemini"] = "gemini-key";
     mockConfig = buildConfig({ provider: "google-gemini" });

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -271,6 +271,12 @@ export interface ResolveStreamingTranscriberOptions {
    * Default: false.
    */
   utteranceBoundaryFinals?: boolean;
+  /**
+   * Silence window (ms) the provider waits before finalizing an utterance
+   * when `utteranceBoundaryFinals` is enabled (Deepgram `utterance_end_ms`).
+   * Ignored without `utteranceBoundaryFinals`. Default: 1000.
+   */
+  utteranceEndMs?: number;
 }
 
 /**
@@ -357,14 +363,17 @@ export async function resolveStreamingTranscriber(
     sampleRate: options.sampleRate,
     diarize: enableDiarization,
     utteranceBoundaryFinals: options.utteranceBoundaryFinals ?? false,
+    utteranceEndMs: options.utteranceEndMs,
   });
 }
 
 /**
- * Deepgram `utterance_end_ms` used when utterance-boundary finals are
- * requested. Deepgram requires >= 1000 ms; this is the pause length after
- * which an `UtteranceEnd` frame confirms the utterance is complete even
- * when `speech_final` endpointing never fired (e.g. background noise).
+ * Default Deepgram `utterance_end_ms` used when utterance-boundary finals
+ * are requested and the caller supplies no override. This is the pause
+ * length after which an `UtteranceEnd` frame confirms the utterance is
+ * complete even when `speech_final` endpointing never fired (e.g.
+ * background noise). Telephony callers override it via
+ * `calls.voice.utteranceEndMs`.
  */
 const UTTERANCE_BOUNDARY_END_MS = 1_000;
 
@@ -387,6 +396,12 @@ interface CreateStreamingTranscriberOptions {
    * `null` instead).
    */
   utteranceBoundaryFinals?: boolean;
+  /**
+   * Silence window (ms) before an utterance is finalized. Only forwarded
+   * to Deepgram (as `utterance_end_ms`) when `utteranceBoundaryFinals`
+   * is set. Defaults to {@link UTTERANCE_BOUNDARY_END_MS}.
+   */
+  utteranceEndMs?: number;
 }
 
 /**
@@ -413,7 +428,8 @@ async function createStreamingTranscriber(
         ...(options.utteranceBoundaryFinals
           ? {
               utteranceBoundaryFinals: true,
-              utteranceEndMs: UTTERANCE_BOUNDARY_END_MS,
+              utteranceEndMs:
+                options.utteranceEndMs ?? UTTERANCE_BOUNDARY_END_MS,
             }
           : {}),
       });


### PR DESCRIPTION
## Summary
- Adds calls.voice.utteranceEndMs (default 1000, min 500, max 5000) and threads it into the telephony streaming STT resolution
- Default behavior unchanged; this is the tuning knob for the dominant fixed turn-end cost on calls

Part of plan: voice-mode-latency.md (PR 13 of 13)