### PR TITLE
feat(web): add the state-driven VoiceAvatar component

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar-state.test.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar-state.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+
+import type { LiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live-voice-store";
+
+import { toVoiceAvatarVisual, type VoiceAvatarVisual } from "./voice-avatar-state";
+
+// Every session phase paired with both `reconnecting` values (8 × 2 = 16).
+const CASES: ReadonlyArray<{
+  state: LiveVoiceSessionState;
+  reconnecting: boolean;
+  expected: VoiceAvatarVisual;
+}> = [
+  { state: "idle", reconnecting: false, expected: "idle" },
+  { state: "idle", reconnecting: true, expected: "idle" },
+  { state: "connecting", reconnecting: false, expected: "idle" },
+  { state: "connecting", reconnecting: true, expected: "reconnecting" },
+  { state: "listening", reconnecting: false, expected: "listening" },
+  { state: "listening", reconnecting: true, expected: "listening" },
+  { state: "transcribing", reconnecting: false, expected: "thinking" },
+  { state: "transcribing", reconnecting: true, expected: "thinking" },
+  { state: "thinking", reconnecting: false, expected: "thinking" },
+  { state: "thinking", reconnecting: true, expected: "thinking" },
+  { state: "speaking", reconnecting: false, expected: "responding" },
+  { state: "speaking", reconnecting: true, expected: "responding" },
+  { state: "ending", reconnecting: false, expected: "idle" },
+  { state: "ending", reconnecting: true, expected: "idle" },
+  { state: "failed", reconnecting: false, expected: "idle" },
+  { state: "failed", reconnecting: true, expected: "idle" },
+];
+
+describe("toVoiceAvatarVisual", () => {
+  for (const { state, reconnecting, expected } of CASES) {
+    it(`maps ${state} (reconnecting=${reconnecting}) → ${expected}`, () => {
+      expect(toVoiceAvatarVisual(state, reconnecting)).toBe(expected);
+    });
+  }
+
+  it("only maps connecting to reconnecting when reconnecting is set", () => {
+    expect(toVoiceAvatarVisual("connecting", true)).toBe("reconnecting");
+    expect(toVoiceAvatarVisual("connecting", false)).toBe("idle");
+    // reconnecting must be ignored for every non-connecting phase.
+    expect(toVoiceAvatarVisual("listening", true)).toBe("listening");
+    expect(toVoiceAvatarVisual("speaking", true)).toBe("responding");
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar-state.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar-state.ts
@@ -1,0 +1,47 @@
+import type { LiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live-voice-store";
+
+/**
+ * Visual mode the {@link VoiceAvatar} renders, distilled from the richer
+ * live-voice session phase. Several session phases collapse to one visual
+ * (e.g. `transcribing` and `thinking` both read as `"thinking"`), and the
+ * orthogonal `reconnecting` signal promotes `connecting` to `"reconnecting"`.
+ */
+export type VoiceAvatarVisual =
+  | "idle"
+  | "listening"
+  | "thinking"
+  | "responding"
+  | "reconnecting";
+
+/**
+ * Pure mapping from a live-voice session phase (plus the orthogonal
+ * `reconnecting` retry signal) to the avatar's visual mode.
+ *
+ * - `connecting` while `reconnecting` → `"reconnecting"` (a dropped connection
+ *   is being retried; visually distinct from the initial connect).
+ * - `connecting` / `idle` / `ending` / `failed` → `"idle"` (no live activity to
+ *   express — hosts typically unmount the room in the terminal states).
+ * - `listening` → `"listening"`.
+ * - `transcribing` / `thinking` → `"thinking"`.
+ * - `speaking` → `"responding"`.
+ */
+export function toVoiceAvatarVisual(
+  state: LiveVoiceSessionState,
+  reconnecting: boolean,
+): VoiceAvatarVisual {
+  switch (state) {
+    case "connecting":
+      return reconnecting ? "reconnecting" : "idle";
+    case "idle":
+    case "ending":
+    case "failed":
+      return "idle";
+    case "listening":
+      return "listening";
+    case "transcribing":
+    case "thinking":
+      return "thinking";
+    case "speaking":
+      return "responding";
+  }
+}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar.tsx
@@ -1,0 +1,137 @@
+import { motion, useReducedMotion } from "motion/react";
+import { useEffect, useLayoutEffect, useRef } from "react";
+
+import { ChatAvatar } from "@/components/avatar/chat-avatar";
+import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
+
+import type { VoiceAvatarVisual } from "./voice-avatar-state";
+
+/**
+ * Enter/scale spring played when the visual changes. Mirrors the app's
+ * overshoot convention (constellation `NODE_SPRING`); `responding` gets a
+ * bouncier pop to read as a burst of energy.
+ */
+const ENTER_SPRING = { type: "spring" as const, stiffness: 180, damping: 20 };
+const RESPOND_SPRING = {
+  type: "spring" as const,
+  visualDuration: 0.3,
+  bounce: 0.5,
+};
+
+const DEFAULT_SIZE = 160;
+
+export interface VoiceAvatarProps {
+  /** Assistant whose avatar to render; `null` renders the "V" fallback. */
+  assistantId: string | null;
+  /** Current visual mode, derived from the live-voice session phase. */
+  visual: VoiceAvatarVisual;
+  /**
+   * Amplitude source (0–1), polled inside a rAF loop for the audio-reactive
+   * visuals so amplitude never flows through React state/props.
+   */
+  getAmplitude: () => number;
+  /** Rendered avatar diameter in px. */
+  size?: number;
+}
+
+/** Visuals whose scale rides live amplitude via the rAF loop. */
+function isAudioReactive(visual: VoiceAvatarVisual): boolean {
+  return visual === "responding" || visual === "listening";
+}
+
+/**
+ * The large, state-driven assistant avatar at the center of the live-voice
+ * room. Resolves the real assistant avatar (character / custom image / "V"
+ * fallback) via {@link useAssistantAvatar} and expresses the session phase
+ * through a continuous per-visual CSS loop (see `.voice-avatar-*` in
+ * index.css) plus a motion spring on each discrete visual change.
+ *
+ * For the audio-reactive visuals a requestAnimationFrame loop polls
+ * `getAmplitude()` and writes the `--voice-amp` custom property on the avatar
+ * wrapper — never through React state, so per-sample updates cause no
+ * re-render. Reduced-motion users get the static avatar (CSS loops and the
+ * amplitude scale are both disabled).
+ */
+export function VoiceAvatar({
+  assistantId,
+  visual,
+  getAmplitude,
+  size = DEFAULT_SIZE,
+}: VoiceAvatarProps) {
+  const reduce = useReducedMotion();
+  const { components, traits, customImageUrl } = useAssistantAvatar(assistantId);
+
+  const ampRef = useRef<HTMLDivElement | null>(null);
+  // Keep the latest amplitude source without re-initializing the rAF loop.
+  const getAmplitudeRef = useRef(getAmplitude);
+  useLayoutEffect(() => {
+    getAmplitudeRef.current = getAmplitude;
+  }, [getAmplitude]);
+
+  const audioReactive = isAudioReactive(visual);
+
+  useEffect(() => {
+    const node = ampRef.current;
+    if (!node) {
+      return;
+    }
+    // Non-reactive visuals (or reduced motion) sit at rest.
+    if (reduce || !audioReactive) {
+      node.style.setProperty("--voice-amp", "0");
+      return;
+    }
+
+    let rafId = 0;
+    let lastWritten = "";
+    const tick = () => {
+      const amp = Math.min(1, Math.max(0, getAmplitudeRef.current()));
+      const next = amp.toFixed(3);
+      // Skip the style write (and its recalc) when the rounded value is
+      // unchanged — amplitude often holds flat between frames.
+      if (next !== lastWritten) {
+        lastWritten = next;
+        node.style.setProperty("--voice-amp", next);
+      }
+      rafId = requestAnimationFrame(tick);
+    };
+    rafId = requestAnimationFrame(tick);
+    return () => {
+      cancelAnimationFrame(rafId);
+      node.style.setProperty("--voice-amp", "0");
+    };
+    // `visual` rebinds the loop to the freshly-keyed wrapper node on any
+    // visual change, not just when the audio-reactive boundary is crossed.
+  }, [visual, audioReactive, reduce]);
+
+  const enterTransition = reduce
+    ? { duration: 0 }
+    : visual === "responding"
+      ? RESPOND_SPRING
+      : ENTER_SPRING;
+
+  return (
+    <motion.div
+      // Re-key on visual so each change replays the enter spring and restarts
+      // the continuous CSS loop from a clean frame.
+      key={visual}
+      initial={reduce ? false : { scale: 0.9, opacity: 0.6 }}
+      animate={{ scale: 1, opacity: 1 }}
+      transition={enterTransition}
+      style={{ width: size, height: size, transformOrigin: "center" }}
+    >
+      <div
+        className={`voice-avatar voice-avatar--${visual}`}
+        style={{ width: size, height: size }}
+      >
+        <div ref={ampRef} className="voice-avatar__amp">
+          <ChatAvatar
+            components={components}
+            traits={traits}
+            customImageUrl={customImageUrl}
+            size={size}
+          />
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -327,3 +327,138 @@ body {
     animation: none;
   }
 }
+
+/* ─── Live-voice room avatar ─────────────────────────────────────────────────
+ * State-driven animation for the enlarged assistant avatar in the voice room.
+ * Each live-voice visual (idle / listening / thinking / responding /
+ * reconnecting) gets one continuous CSS loop here; the discrete enter/scale
+ * transition when the visual changes is a motion spring at the call site. The
+ * `responding` (and `listening`) visual additionally rides live mic/TTS
+ * amplitude, fed imperatively through the `--voice-amp` custom property by a
+ * requestAnimationFrame loop — never React state. See voice-avatar.tsx.
+ *
+ * The sonar ripple's cyan→indigo gradient is a deliberate decorative accent
+ * that stays constant across all themes (like a data-viz series or annotation
+ * overlay), so it is expressed as fixed rgba rather than a theme token. */
+.voice-avatar {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transform-origin: center;
+}
+
+/* Amplitude-reactive inner layer. `--voice-amp` (0–1) is written imperatively
+ * per frame; the small coefficient keeps the pulse subtle. Defaults to 0 so
+ * non-audio-reactive visuals sit at rest. */
+.voice-avatar__amp {
+  --voice-amp: 0;
+  display: inline-flex;
+  transform: scale(calc(1 + var(--voice-amp) * 0.12));
+  transform-origin: center;
+  will-change: transform;
+}
+
+/* Decorative ring/ripple layer shared by idle (invitation pulse) and listening
+ * (sonar). Inert until a visual class animates it. */
+.voice-avatar::after {
+  content: "";
+  position: absolute;
+  inset: -6%;
+  border-radius: 50%;
+  pointer-events: none;
+  opacity: 0;
+}
+
+/* Idle — gentle 4.5s breathing scale, mirroring macOS startBreathing(). */
+@keyframes voice-avatar-idle-breathe {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.03); }
+}
+
+/* Idle — faint invitation ring that swells and fades, inviting the user to
+ * speak without the urgency of the listening sonar. */
+@keyframes voice-avatar-invite-ring {
+  0% { opacity: 0; transform: scale(0.96); }
+  50% { opacity: 0.35; }
+  100% { opacity: 0; transform: scale(1.12); }
+}
+
+.voice-avatar--idle {
+  animation: voice-avatar-idle-breathe 4.5s ease-in-out infinite;
+}
+
+.voice-avatar--idle::after {
+  border: 1px solid var(--border-active);
+  animation: voice-avatar-invite-ring 4.5s ease-in-out infinite;
+}
+
+/* Listening — sonar ripple expanding from the avatar surface: cyan at the
+ * center fading to indigo at the outer edge. */
+@keyframes voice-avatar-listen-ripple {
+  0% { opacity: 0.55; transform: scale(0.9); }
+  100% { opacity: 0; transform: scale(1.6); }
+}
+
+.voice-avatar--listening::after {
+  background: radial-gradient(
+    circle,
+    rgba(34, 211, 238, 0.45) 0%,
+    rgba(99, 102, 241, 0.28) 60%,
+    rgba(99, 102, 241, 0) 72%
+  );
+  animation: voice-avatar-listen-ripple 1.8s ease-out infinite;
+}
+
+/* Thinking — "stillness with intent": a slow brightness/saturation cycle on
+ * the avatar itself. Deliberately NOT a spinner. */
+@keyframes voice-avatar-think-glow {
+  0%, 100% { filter: brightness(1) saturate(1); }
+  50% { filter: brightness(1.12) saturate(1.35); }
+}
+
+.voice-avatar--thinking {
+  animation: voice-avatar-think-glow 2.6s ease-in-out infinite;
+}
+
+/* Responding — subtle baseline energy bounce; the live amplitude scale rides
+ * on top via .voice-avatar__amp. */
+@keyframes voice-avatar-respond-bounce {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.04); }
+}
+
+.voice-avatar--responding {
+  animation: voice-avatar-respond-bounce 1.1s ease-in-out infinite;
+}
+
+/* Reconnecting — dimmed, slow pulse, distinct from idle-breathe (full opacity)
+ * and think-glow (brightens rather than dims). */
+@keyframes voice-avatar-reconnect-pulse {
+  0%, 100% { opacity: 0.45; transform: scale(0.98); }
+  50% { opacity: 0.7; transform: scale(1.01); }
+}
+
+.voice-avatar--reconnecting {
+  animation: voice-avatar-reconnect-pulse 2s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .voice-avatar--idle,
+  .voice-avatar--thinking,
+  .voice-avatar--responding,
+  .voice-avatar--reconnecting {
+    animation: none;
+  }
+  .voice-avatar--idle::after,
+  .voice-avatar--listening::after {
+    animation: none;
+    opacity: 0;
+  }
+  .voice-avatar--reconnecting {
+    opacity: 0.6;
+  }
+  .voice-avatar__amp {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- New VoiceAvatar: enlarges the real assistant avatar and expresses live-voice states (idle/listening/thinking/responding/reconnecting) via CSS keyframes + motion springs.
- Audio-reactive amplitude driven through a RAF loop + CSS var (no per-sample re-render). Pure state->visual mapping is unit-tested.

Part of plan: voice-mode-ui-overhaul.md (PR 4 of 8)