### PR TITLE
feat(calls): flush the first TTS segment eagerly on telephony turns

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -3493,6 +3493,115 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
+  // ── Eager first segment (synthesized-play path) ─────────────────────
+
+  test("synthesized provider: the turn's first segment flushes eagerly at a clause boundary before any sentence ends", async () => {
+    const { synthesizedTexts } = registerFishAudioSegmentRecorder();
+    const { relay, controller } = setupController();
+
+    let segmentsBeforeSentenceEnd = -1;
+    mockStartVoiceTurn.mockImplementation(
+      async (opts: {
+        onTextDelta: (t: string) => void;
+        onComplete: () => void;
+      }) => {
+        opts.onTextDelta("Let me take a look at that, ");
+        // The clause-bounded prefix must reach synthesis while no sentence
+        // has ended yet — full-sentence rules would still be buffering.
+        await pollUntil(() => synthesizedTexts.length > 0);
+        segmentsBeforeSentenceEnd = synthesizedTexts.length;
+        opts.onTextDelta("and get right back to you.");
+        opts.onComplete();
+        return { turnId: "run-eager", abort: () => {} };
+      },
+    );
+
+    await controller.handleCallerUtterance("Hi");
+
+    expect(segmentsBeforeSentenceEnd).toBe(1);
+    expect(synthesizedTexts).toEqual([
+      "Let me take a look at that,",
+      "and get right back to you.",
+    ]);
+    expect(relay.sentPlayUrls.length).toBe(2);
+
+    controller.destroy();
+  });
+
+  test("synthesized provider: eager mode applies only to the first segment — later clauses wait for sentence ends", async () => {
+    const { synthesizedTexts } = registerFishAudioSegmentRecorder();
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn([
+        "Let me take a look at that, and then, after checking, I will confirm.",
+      ]),
+    );
+    const { controller } = setupController();
+
+    await controller.handleCallerUtterance("Hi");
+
+    expect(synthesizedTexts).toEqual([
+      "Let me take a look at that,",
+      "and then, after checking, I will confirm.",
+    ]);
+
+    controller.destroy();
+  });
+
+  test("synthesized provider: a long unpunctuated opening flushes at the eager 60-char cap; the force-flushed tail is unaffected", async () => {
+    const { synthesizedTexts } = registerFishAudioSegmentRecorder();
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn([
+        "The quick brown fox jumps over the lazy dog near the quiet river bank",
+      ]),
+    );
+    const { controller } = setupController();
+
+    await controller.handleCallerUtterance("Hi");
+
+    // First segment splits at the last whitespace under the 60-char eager
+    // cap (the default cap is 180); the short remainder never reaches a
+    // boundary and force-flushes at turn completion.
+    expect(synthesizedTexts).toEqual([
+      "The quick brown fox jumps over the lazy dog near the quiet",
+      "river bank",
+    ]);
+
+    controller.destroy();
+  });
+
+  test("synthesized provider: a short reply below every eager threshold only force-flushes at turn completion", async () => {
+    const { synthesizedTexts } = registerFishAudioSegmentRecorder();
+    mockStartVoiceTurn.mockImplementation(createMockVoiceTurn(["Quick note"]));
+    const { relay, controller } = setupController();
+
+    await controller.handleCallerUtterance("Hi");
+
+    expect(synthesizedTexts).toEqual(["Quick note"]);
+    expect(relay.sentPlayUrls.length).toBe(1);
+
+    controller.destroy();
+  });
+
+  test("synthesized provider: each turn's first segment is eager again", async () => {
+    const { synthesizedTexts } = registerFishAudioSegmentRecorder();
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Let me take a look at that, one moment."]),
+    );
+    const { controller } = setupController();
+
+    await controller.handleCallerUtterance("Hi");
+    await controller.handleCallerUtterance("Thanks");
+
+    expect(synthesizedTexts).toEqual([
+      "Let me take a look at that,",
+      "one moment.",
+      "Let me take a look at that,",
+      "one moment.",
+    ]);
+
+    controller.destroy();
+  });
+
   // ── Per-segment fallback on WAV-requiring transports ────────────────
 
   /**

--- a/assistant/src/__tests__/media-stream-output.test.ts
+++ b/assistant/src/__tests__/media-stream-output.test.ts
@@ -1055,6 +1055,124 @@ describe("MediaStreamOutput", () => {
     });
   });
 
+  describe("eager first segment", () => {
+    function usePlayableWav(): void {
+      mockSynthesize.mockResolvedValue({
+        audio: makeWavBuffer([1000, 2000, 3000, 4000]),
+        contentType: "audio/wav",
+      });
+    }
+
+    test("the turn's first segment synthesizes at a clause boundary before any sentence ends", async () => {
+      usePlayableWav();
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+
+      // No sentence has ended yet — full-sentence rules would still be
+      // buffering, but the clause-bounded prefix synthesizes immediately.
+      output.sendTextToken("Let me take a look at that, ", false);
+      await drain(() => mockSynthesize.mock.calls.length > 0);
+
+      expect(mockSynthesize).toHaveBeenCalledTimes(1);
+      expect(mockSynthesize.mock.calls[0][0].text).toBe(
+        "Let me take a look at that,",
+      );
+
+      output.sendTextToken("and get right back to you.", true);
+      await drain(() => countEvents(sent, "mark") > 0);
+
+      expect(mockSynthesize).toHaveBeenCalledTimes(2);
+      expect(mockSynthesize.mock.calls[1][0].text).toBe(
+        "and get right back to you.",
+      );
+    });
+
+    test("eager mode applies only to the first segment — later clauses wait for sentence ends", async () => {
+      usePlayableWav();
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+
+      output.sendTextToken(
+        "Let me take a look at that, and then, after checking, I will confirm.",
+        false,
+      );
+      output.sendTextToken("", true);
+      await drain(() => countEvents(sent, "mark") > 0);
+
+      expect(mockSynthesize.mock.calls.map((c) => c[0].text)).toEqual([
+        "Let me take a look at that,",
+        "and then, after checking, I will confirm.",
+      ]);
+    });
+
+    test("a long unpunctuated opening flushes at the eager 60-char cap", async () => {
+      usePlayableWav();
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+
+      // 69 chars, no punctuation: below the default 180-char cap but past
+      // the eager 60-char cap, so the opening splits at the last whitespace
+      // under 60 chars.
+      output.sendTextToken(
+        "The quick brown fox jumps over the lazy dog near the quiet river bank",
+        false,
+      );
+      await drain(() => mockSynthesize.mock.calls.length > 0);
+
+      expect(mockSynthesize).toHaveBeenCalledTimes(1);
+      expect(mockSynthesize.mock.calls[0][0].text).toBe(
+        "The quick brown fox jumps over the lazy dog near the quiet",
+      );
+
+      output.sendTextToken("", true);
+      await drain(() => countEvents(sent, "mark") > 0);
+
+      // The short remainder never reaches a boundary and force-flushes on
+      // last: true.
+      expect(mockSynthesize).toHaveBeenCalledTimes(2);
+      expect(mockSynthesize.mock.calls[1][0].text).toBe("river bank");
+    });
+
+    test("the next turn's first segment is eager again", async () => {
+      usePlayableWav();
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+
+      output.sendTextToken("Let me take a look at that, one moment.", true);
+      await drain(() => countEvents(sent, "mark") >= 1);
+
+      output.sendTextToken("Here is the second answer, coming right up.", true);
+      await drain(() => countEvents(sent, "mark") >= 2);
+
+      expect(mockSynthesize.mock.calls.map((c) => c[0].text)).toEqual([
+        "Let me take a look at that,",
+        "one moment.",
+        "Here is the second answer,",
+        "coming right up.",
+      ]);
+    });
+
+    test("discardPendingText re-arms eager segmentation for the next turn", async () => {
+      usePlayableWav();
+      const { ws } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+
+      output.sendTextToken("Let me take a look at that, plus extra", false);
+      await drain(() => mockSynthesize.mock.calls.length > 0);
+
+      // Turn aborted: the unsegmented remainder is dropped and the next
+      // turn's first segment is eager again.
+      output.discardPendingText();
+      output.sendTextToken("Here is the second answer, plus more", false);
+      await drain(() => mockSynthesize.mock.calls.length > 1);
+
+      expect(mockSynthesize.mock.calls.map((c) => c[0].text)).toEqual([
+        "Let me take a look at that,",
+        "Here is the second answer,",
+      ]);
+    });
+  });
+
   // ---------------------------------------------------------------------------
   // Streaming PCM synthesis (incremental transcode)
   // ---------------------------------------------------------------------------

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -678,6 +678,10 @@ export class CallController {
     // (transport FIFO gives gapless playback).
     const synthProvider = useSynthesizedPath ? provider : null;
     let pendingSynthText = "";
+    // Eager segmentation applies until the turn's first segment is
+    // enqueued: the opening clause flushes early so speech onset does not
+    // wait for a full sentence.
+    let firstSynthSegmentEnqueued = false;
     let synthesisChain: Promise<void> = Promise.resolve();
     // After a segment fails, the rest of the turn stays off the primary
     // provider so text is never spoken out of order: non-WAV transports
@@ -751,6 +755,7 @@ export class CallController {
         if (segment.length === 0) {
           continue;
         }
+        firstSynthSegmentEnqueued = true;
         synthesisChain = synthesisChain.then(async () => {
           if (
             !this.isCurrentRun(runVersion) ||
@@ -808,6 +813,7 @@ export class CallController {
         const { segments, remainder } = extractSpeakableSegments(
           pendingSynthText,
           false,
+          { eager: !firstSynthSegmentEnqueued },
         );
         pendingSynthText = remainder;
         enqueueSynthesisSegments(synthProvider, segments);

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -117,6 +117,15 @@ export class MediaStreamOutput implements CallTransport {
    */
   private textBuffer = "";
 
+  /**
+   * True once the current turn's first speakable segment has been queued
+   * for synthesis. Gates eager segmentation: each turn's opening clause
+   * flushes early so speech onset does not wait for a full sentence.
+   * Cleared when a turn completes (`last: true`) or its pending text is
+   * discarded, so the next turn's first segment is eager again.
+   */
+  private turnSegmentEnqueued = false;
+
   /** FIFO queue of playback items awaiting delivery. */
   private playbackQueue: PlaybackItem[] = [];
 
@@ -172,16 +181,19 @@ export class MediaStreamOutput implements CallTransport {
     const { segments, remainder } = extractSpeakableSegments(
       this.textBuffer,
       last,
+      { eager: !this.turnSegmentEnqueued },
     );
     this.textBuffer = remainder;
     for (const segment of segments) {
       this.enqueuePlayback({ type: "synthesize", text: segment });
+      this.turnSegmentEnqueued = true;
     }
 
     if (last) {
       // Always send an end-of-turn mark so the media-stream server
       // can detect turn boundaries.
       this.enqueuePlayback({ type: "mark", name: "end-of-turn" });
+      this.turnSegmentEnqueued = false;
     }
   }
 
@@ -213,6 +225,7 @@ export class MediaStreamOutput implements CallTransport {
    */
   discardPendingText(): void {
     this.textBuffer = "";
+    this.turnSegmentEnqueued = false;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Telephony synthesized and native TTS paths now use eager segmentation for the first segment of each turn (clause boundary ≥24 chars or 60-char cap)
- Matches the tradeoff live voice already ships: earlier first audio, first clause synthesized alone

Part of plan: voice-mode-latency.md (PR 11 of 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)