### PR TITLE
feat(calls): stream audio-store playback into frames instead of arrayBuffer draining

### DIFF
--- a/assistant/src/__tests__/media-stream-output.test.ts
+++ b/assistant/src/__tests__/media-stream-output.test.ts
@@ -1211,4 +1211,250 @@ describe("MediaStreamOutput", () => {
       expect(totalMulawBytes(sent)).toBe(400);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Streaming play-URL playback (processFetchUrlItem)
+  // ---------------------------------------------------------------------------
+
+  describe("sendPlayUrl streaming", () => {
+    const originalFetch = globalThis.fetch;
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    /** Mock global fetch to resolve with the given response for any URL. */
+    function mockFetch(response: Response): void {
+      globalThis.fetch = (async () => response) as unknown as typeof fetch;
+    }
+
+    /**
+     * A fetch response whose body is a manually driven stream, so tests
+     * control exactly when bytes arrive and when the body completes.
+     * `arrayBuffer()` throws: the streaming path must never buffer the
+     * response wholesale.
+     */
+    function fakeStreamingResponse(contentType: string): {
+      response: Response;
+      push: (bytes: Buffer) => void;
+      close: () => void;
+      cancelled: () => boolean;
+    } {
+      let controller!: ReadableStreamDefaultController<Uint8Array>;
+      let cancelled = false;
+      const stream = new ReadableStream<Uint8Array>({
+        start(c) {
+          controller = c;
+        },
+        cancel() {
+          cancelled = true;
+        },
+      });
+      const response = {
+        ok: true,
+        headers: new Headers({ "content-type": contentType }),
+        body: stream,
+        arrayBuffer: () => {
+          throw new Error(
+            "arrayBuffer must not be called on the streaming path",
+          );
+        },
+      } as unknown as Response;
+      return {
+        response,
+        push: (bytes) => {
+          try {
+            controller.enqueue(new Uint8Array(bytes));
+          } catch {
+            // Stream already cancelled/closed — stale producer push.
+          }
+        },
+        close: () => {
+          try {
+            controller.close();
+          } catch {
+            // Already cancelled.
+          }
+        },
+        cancelled: () => cancelled,
+      };
+    }
+
+    test("WAV play-URL frames go out before the response stream completes", async () => {
+      // 1280 samples at 16 kHz -> 640 at 8 kHz = four whole frames.
+      const wav = makeWavBuffer(sineSamples(1280, 440, 16000), {
+        sampleRate: 16000,
+      });
+      // Header + 320 samples: exactly one 20 ms frame after 2x decimation.
+      const firstPart = wav.subarray(0, 44 + 320 * 2);
+      const rest = wav.subarray(44 + 320 * 2);
+
+      const fake = fakeStreamingResponse("audio/wav");
+      mockFetch(fake.response);
+
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendPlayUrl("http://127.0.0.1/audio/test.wav");
+
+      fake.push(firstPart);
+      await drain(() => countEvents(sent, "media") >= 1);
+
+      // The first frame went out while the body is still open.
+      expect(countEvents(sent, "media")).toBe(1);
+
+      fake.push(rest);
+      fake.close();
+      await drain(() => countEvents(sent, "media") >= 4);
+
+      // Byte-identical to the whole-buffer transcode.
+      const expected = pcm16ToMulaw(decimateByTwo(wav.subarray(44)));
+      expect(concatMulawPayloads(sent).equals(expected)).toBe(true);
+    });
+
+    test("audio/pcm play-URL streams raw PCM incrementally", async () => {
+      const pcm = pcm16Buffer(sineSamples(1280, 440, 16000));
+      const fake = fakeStreamingResponse("audio/pcm");
+      mockFetch(fake.response);
+
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendPlayUrl("http://127.0.0.1/audio/test.pcm");
+
+      fake.push(pcm.subarray(0, 320 * 2)); // 320 samples -> one whole frame
+      await drain(() => countEvents(sent, "media") >= 1);
+      expect(countEvents(sent, "media")).toBe(1);
+
+      fake.push(pcm.subarray(320 * 2));
+      fake.close();
+      await drain(() => countEvents(sent, "media") >= 4);
+
+      const expected = pcm16ToMulaw(decimateByTwo(pcm));
+      expect(concatMulawPayloads(sent).equals(expected)).toBe(true);
+    });
+
+    test("clearAudio mid-stream cancels the body read and sends clear", async () => {
+      const wav = makeWavBuffer(sineSamples(1280, 440, 16000), {
+        sampleRate: 16000,
+      });
+      const fake = fakeStreamingResponse("audio/wav");
+      mockFetch(fake.response);
+
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendPlayUrl("http://127.0.0.1/audio/test.wav");
+
+      fake.push(wav.subarray(0, 44 + 320 * 2));
+      await drain(() => countEvents(sent, "media") >= 1);
+      const framesBefore = countEvents(sent, "media");
+      expect(framesBefore).toBeGreaterThan(0);
+
+      output.clearAudio();
+      await drain(() => fake.cancelled());
+
+      // The in-flight body read was cancelled and Twilio's buffer cleared.
+      expect(fake.cancelled()).toBe(true);
+      expect(countEvents(sent, "clear")).toBe(1);
+
+      // Bytes arriving after the abort never become frames.
+      fake.push(wav.subarray(44 + 320 * 2));
+      await drain();
+      expect(countEvents(sent, "media")).toBe(framesBefore);
+    });
+
+    test("audio/mpeg keeps the whole-buffer path (no body streaming)", async () => {
+      const mp3Bytes = Buffer.alloc(256, 0x80);
+      mp3Bytes[0] = 0xff; // MPEG sync
+      mp3Bytes[1] = 0xfb; // MPEG Layer 3
+
+      let bodyAccessed = false;
+      let arrayBufferCalled = false;
+      const response = {
+        ok: true,
+        headers: new Headers({ "content-type": "audio/mpeg" }),
+        get body(): ReadableStream<Uint8Array> {
+          bodyAccessed = true;
+          throw new Error("body must not be streamed for compressed formats");
+        },
+        arrayBuffer: async () => {
+          arrayBufferCalled = true;
+          return mp3Bytes.buffer.slice(
+            mp3Bytes.byteOffset,
+            mp3Bytes.byteOffset + mp3Bytes.byteLength,
+          );
+        },
+      } as unknown as Response;
+      mockFetch(response);
+
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendPlayUrl("http://127.0.0.1/audio/test.mp3");
+
+      await drain(() => arrayBufferCalled);
+
+      expect(arrayBufferCalled).toBe(true);
+      expect(bodyAccessed).toBe(false);
+      // mp3 cannot be transcoded in this path: silence, exactly as before.
+      expect(countEvents(sent, "media")).toBe(0);
+    });
+
+    test("non-canonical WAV (stereo) falls back to the whole-buffer path", async () => {
+      // Stereo is not streamable; the buffered path keeps the left channel.
+      const left = sineSamples(400, 440, 8000);
+      const interleaved: number[] = [];
+      for (const s of left) {
+        interleaved.push(s, -s);
+      }
+      const wav = makeWavBuffer(interleaved, { sampleRate: 8000, channels: 2 });
+
+      const fake = fakeStreamingResponse("audio/wav");
+      mockFetch(fake.response);
+
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendPlayUrl("http://127.0.0.1/audio/stereo.wav");
+
+      fake.push(wav.subarray(0, 100));
+      // No frames while the fallback drains the body.
+      await drain();
+      expect(countEvents(sent, "media")).toBe(0);
+
+      fake.push(wav.subarray(100));
+      fake.close();
+      await drain(() => countEvents(sent, "media") > 0);
+
+      // Left channel of 400 pairs at 8 kHz -> 400 mu-law bytes.
+      expect(totalMulawBytes(sent)).toBe(400);
+    });
+
+    test("malformed WAV header falls back without throwing", async () => {
+      // RIFF magic but garbage after it: not streamable, and the buffered
+      // path's fixed-offset reads produce no usable frames.
+      const junk = Buffer.alloc(64, 0x42);
+      junk.write("RIFF", 0);
+
+      const fake = fakeStreamingResponse("audio/wav");
+      mockFetch(fake.response);
+
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendPlayUrl("http://127.0.0.1/audio/junk.wav");
+
+      fake.push(junk);
+      fake.close();
+      await drain(() => output.getPlaybackQueueLength() === 0);
+      await drain();
+
+      // No crash; behavior matches the pre-existing buffered transcode.
+      expect(countEvents(sent, "media")).toBe(0);
+
+      // The output still works for a subsequent playable item.
+      const good = fakeStreamingResponse("audio/pcm");
+      mockFetch(good.response);
+      output.sendPlayUrl("http://127.0.0.1/audio/good.pcm");
+      good.push(pcm16Buffer(sineSamples(320, 440, 16000)));
+      good.close();
+      await drain(() => countEvents(sent, "media") > 0);
+      expect(countEvents(sent, "media")).toBe(1);
+    });
+  });
 });

--- a/assistant/src/__tests__/media-stream-output.test.ts
+++ b/assistant/src/__tests__/media-stream-output.test.ts
@@ -1393,7 +1393,7 @@ describe("MediaStreamOutput", () => {
 
       expect(arrayBufferCalled).toBe(true);
       expect(bodyAccessed).toBe(false);
-      // mp3 cannot be transcoded in this path: silence, exactly as before.
+      // mp3 cannot be transcoded in this path, so no media frames go out.
       expect(countEvents(sent, "media")).toBe(0);
     });
 
@@ -1444,7 +1444,8 @@ describe("MediaStreamOutput", () => {
       await drain(() => output.getPlaybackQueueLength() === 0);
       await drain();
 
-      // No crash; behavior matches the pre-existing buffered transcode.
+      // No crash; a malformed WAV yields no usable frames from the
+      // buffered transcode's fixed-offset reads.
       expect(countEvents(sent, "media")).toBe(0);
 
       // The output still works for a subsequent playable item.

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -15,7 +15,9 @@
  *   An empty token with `last: true` sends only the mark.
  *
  * - `sendPlayUrl()` — Fetches audio from the given URL, transcodes it
- *   to mu-law 8 kHz, and streams the resulting frames to Twilio.
+ *   to mu-law 8 kHz, and streams the resulting frames to Twilio. WAV
+ *   and raw-PCM bodies are transcoded incrementally as they download,
+ *   so playback starts before the response completes.
  *
  * - `endSession()` — Closes the underlying WebSocket, which triggers
  *   Twilio to tear down the media stream and (eventually) the call.
@@ -66,6 +68,28 @@ const TELEPHONY_SAMPLE_RATE_HZ = 8000;
 const STREAMING_PCM_SAMPLE_RATE_HZ = 16_000;
 
 /**
+ * Size of the canonical WAV header: RIFF descriptor + 16-byte PCM fmt
+ * chunk + data chunk header.
+ */
+const WAV_HEADER_BYTES = 44;
+
+/** WAV files always start with the ASCII magic "RIFF" (0x52494646). */
+function hasRiffMagic(audio: Buffer): boolean {
+  return (
+    audio.length >= 4 &&
+    audio[0] === 0x52 && // R
+    audio[1] === 0x49 && // I
+    audio[2] === 0x46 && // F
+    audio[3] === 0x46 // F
+  );
+}
+
+/** Wrap a Uint8Array's memory as a Buffer without copying. */
+function viewToBuffer(view: Uint8Array): Buffer {
+  return Buffer.from(view.buffer, view.byteOffset, view.byteLength);
+}
+
+/**
  * Keep every `factor`-th 16-bit LE sample. Cheap decimation (no anti-alias
  * filter) for rates that are integer multiples of the telephony rate; also
  * extracts the left channel from interleaved stereo when factor is 2.
@@ -79,6 +103,169 @@ function decimatePcm16(pcm: Buffer, factor: number): Buffer {
     out[i * 2 + 1] = pcm[i * factor * 2 + 1];
   }
   return out;
+}
+
+// ---------------------------------------------------------------------------
+// Incremental PCM16 → mu-law frame encoding
+// ---------------------------------------------------------------------------
+
+/**
+ * Incrementally converts 16-bit LE PCM chunks — at an integer multiple of
+ * the telephony rate — into base64 mu-law frames, emitting each frame as
+ * soon as it fills.
+ *
+ * Chunk boundaries can split a 16-bit sample or a decimation group; the
+ * unprocessable tail (less than one output sample's worth of bytes)
+ * carries into the next chunk so sample alignment and decimation phase
+ * stay stable across chunks. Mu-law bytes short of a whole 20 ms frame
+ * are carried likewise.
+ */
+class IncrementalMulawFrameEncoder {
+  /** PCM tail below one output sample, awaiting the next chunk. */
+  private pcmCarry: Buffer | undefined;
+
+  /** Mu-law bytes short of a whole frame, awaiting the next chunk. */
+  private mulawCarry: Buffer = Buffer.alloc(0);
+
+  /** Bytes per output sample: 2 input bytes per sample × decimation factor. */
+  private readonly pcmAlignBytes: number;
+
+  constructor(
+    private readonly decimationFactor: number,
+    private readonly emitFrames: (frames: string[]) => void,
+  ) {
+    this.pcmAlignBytes = 2 * decimationFactor;
+  }
+
+  /** Bytes currently held back waiting for sample alignment. */
+  get pcmCarryBytes(): number {
+    return this.pcmCarry?.length ?? 0;
+  }
+
+  /** Transcode a PCM16 LE chunk, emitting every frame that fills. */
+  push(chunk: Buffer): void {
+    const combined = this.pcmCarry
+      ? Buffer.concat([this.pcmCarry, chunk])
+      : chunk;
+    const usableBytes =
+      combined.length - (combined.length % this.pcmAlignBytes);
+    this.pcmCarry =
+      usableBytes < combined.length
+        ? combined.subarray(usableBytes)
+        : undefined;
+    if (usableBytes === 0) {
+      return;
+    }
+    const pcm8k = decimatePcm16(
+      combined.subarray(0, usableBytes),
+      this.decimationFactor,
+    );
+    this.sendMulaw(pcm16ToMulaw(pcm8k), false);
+  }
+
+  /**
+   * Emit the final partial frame — the whole-buffer path sends a short
+   * trailing frame the same way.
+   */
+  flush(): void {
+    this.sendMulaw(Buffer.alloc(0), true);
+  }
+
+  private sendMulaw(mulaw: Buffer, flushPartialFrame: boolean): void {
+    this.mulawCarry =
+      this.mulawCarry.length > 0
+        ? Buffer.concat([this.mulawCarry, mulaw])
+        : mulaw;
+    const sendableBytes = flushPartialFrame
+      ? this.mulawCarry.length
+      : this.mulawCarry.length - (this.mulawCarry.length % MULAW_FRAME_SIZE);
+    if (sendableBytes === 0) {
+      return;
+    }
+    const frames = chunkMulawToBase64Frames(
+      this.mulawCarry.subarray(0, sendableBytes),
+    );
+    this.mulawCarry = this.mulawCarry.subarray(sendableBytes);
+    this.emitFrames(frames);
+  }
+}
+
+/** Outcome of an incremental body transcode attempt. */
+type BodyStreamResult =
+  | { outcome: "streamed" }
+  | { outcome: "aborted" }
+  | { outcome: "fallback"; buffered: Buffer };
+
+type HeaderSniffDecision =
+  | { kind: "need-more-bytes" }
+  | { kind: "fallback" }
+  | { kind: "stream"; decimationFactor: number; payloadOffset: number };
+
+/**
+ * Decide from a body's leading bytes whether it can be transcoded
+ * incrementally — and with which decimation factor — or must fall back
+ * to the whole-buffer path.
+ *
+ * Sniffs the actual bytes rather than trusting the declared format,
+ * mirroring `audioBufferToFrames`: a RIFF header wins over the declared
+ * content type. Only inputs the incremental encoder transcodes exactly
+ * like the whole-buffer path are streamed: canonical-header PCM16 mono
+ * WAV at an integer multiple of the telephony rate, or headerless raw
+ * PCM (assumed 16 kHz). Anything else — RIFF layouts with extra chunks,
+ * stereo, non-16-bit samples, fractional rates (44.1 kHz needs an
+ * interpolating resample), compressed bytes under a WAV content type —
+ * falls back.
+ */
+function sniffStreamableHeader(
+  pending: Buffer,
+  format: "wav" | "pcm",
+): HeaderSniffDecision {
+  if (pending.length < 4) {
+    return { kind: "need-more-bytes" };
+  }
+
+  if (!hasRiffMagic(pending)) {
+    // Headerless raw PCM streams at the assumed 16 kHz (matching the
+    // whole-buffer path). WAV-declared bytes without a RIFF header need
+    // the whole-buffer path's compressed-format sniffing.
+    return format === "pcm"
+      ? {
+          kind: "stream",
+          decimationFactor:
+            STREAMING_PCM_SAMPLE_RATE_HZ / TELEPHONY_SAMPLE_RATE_HZ,
+          payloadOffset: 0,
+        }
+      : { kind: "fallback" };
+  }
+
+  if (pending.length < WAV_HEADER_BYTES) {
+    return { kind: "need-more-bytes" };
+  }
+
+  // Only the canonical 44-byte layout is streamed: fmt chunk at fixed
+  // offsets, PCM16 mono, "data" chunk immediately after.
+  const isCanonicalPcm16Mono =
+    pending.toString("ascii", 8, 16) === "WAVEfmt " &&
+    pending.readUInt32LE(16) === 16 && // fmt chunk size (plain PCM)
+    pending.readUInt16LE(20) === 1 && // format tag: PCM
+    pending.readUInt16LE(22) === 1 && // mono
+    pending.readUInt16LE(34) === 16 && // 16 bits per sample
+    pending.toString("ascii", 36, 40) === "data";
+  const sampleRate = pending.readUInt32LE(24);
+
+  if (
+    !isCanonicalPcm16Mono ||
+    sampleRate <= 0 ||
+    sampleRate % TELEPHONY_SAMPLE_RATE_HZ !== 0
+  ) {
+    return { kind: "fallback" };
+  }
+
+  return {
+    kind: "stream",
+    decimationFactor: sampleRate / TELEPHONY_SAMPLE_RATE_HZ,
+    payloadOffset: WAV_HEADER_BYTES,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -531,28 +718,12 @@ export class MediaStreamOutput implements CallTransport {
       const streamsPcm = provider.capabilities.supportedFormats.includes("pcm");
       const bufferedChunks: Buffer[] = [];
 
-      // Chunk boundaries can split a 16-bit sample or a decimation pair;
-      // the unprocessable tail (< 4 bytes) carries into the next chunk so
-      // sample alignment and decimation phase stay stable across chunks.
-      let pcmCarry: Buffer | undefined;
-      // Mu-law bytes short of a whole 20 ms frame, carried likewise.
-      let mulawCarry: Buffer = Buffer.alloc(0);
-
-      const sendMulaw = (mulaw: Buffer, flushPartialFrame: boolean): void => {
-        mulawCarry =
-          mulawCarry.length > 0 ? Buffer.concat([mulawCarry, mulaw]) : mulaw;
-        const sendableBytes = flushPartialFrame
-          ? mulawCarry.length
-          : mulawCarry.length - (mulawCarry.length % MULAW_FRAME_SIZE);
-        if (sendableBytes === 0) {
-          return;
-        }
-        const frames = chunkMulawToBase64Frames(
-          mulawCarry.subarray(0, sendableBytes),
-        );
-        mulawCarry = mulawCarry.subarray(sendableBytes);
-        this.sendFrames(frames);
-      };
+      const encoder = streamsPcm
+        ? new IncrementalMulawFrameEncoder(
+            STREAMING_PCM_SAMPLE_RATE_HZ / TELEPHONY_SAMPLE_RATE_HZ,
+            (frames) => this.sendFrames(frames),
+          )
+        : null;
 
       // Synthesize the text. Request PCM output so the media-stream
       // transport receives raw samples it can transcode to mu-law.
@@ -568,30 +739,14 @@ export class MediaStreamOutput implements CallTransport {
         signal: abortController.signal,
         isCurrent,
         onChunk: (chunk) => {
-          if (!streamsPcm) {
+          if (!encoder) {
             bufferedChunks.push(chunk.audio);
             return;
           }
           if (!isCurrent()) {
             return;
           }
-          const combined = pcmCarry
-            ? Buffer.concat([pcmCarry, chunk.audio])
-            : chunk.audio;
-          // 4 bytes = two 16 kHz samples = one 8 kHz output sample.
-          const usableBytes = combined.length & ~3;
-          pcmCarry =
-            usableBytes < combined.length
-              ? combined.subarray(usableBytes)
-              : undefined;
-          if (usableBytes === 0) {
-            return;
-          }
-          const pcm8k = this.pcm16ToTelephonyRate(
-            combined.subarray(0, usableBytes),
-            STREAMING_PCM_SAMPLE_RATE_HZ,
-          );
-          sendMulaw(pcm16ToMulaw(pcm8k), false);
+          encoder.push(chunk.audio);
         },
       });
 
@@ -599,18 +754,18 @@ export class MediaStreamOutput implements CallTransport {
         return;
       }
 
-      if (streamsPcm) {
-        if (pcmCarry) {
+      if (encoder) {
+        if (encoder.pcmCarryBytes > 0) {
           // A sub-sample tail is malformed provider output; decimation
           // would drop it anyway.
           log.debug(
-            { streamSid: this.streamSid, carryBytes: pcmCarry.length },
+            { streamSid: this.streamSid, carryBytes: encoder.pcmCarryBytes },
             "Dropping sub-sample tail from PCM16 TTS stream",
           );
         }
         // Flush the final partial frame — the whole-buffer path sends a
         // short trailing frame the same way.
-        sendMulaw(Buffer.alloc(0), true);
+        encoder.flush();
         return;
       }
 
@@ -667,6 +822,13 @@ export class MediaStreamOutput implements CallTransport {
   /**
    * Fetch audio from a URL (typically the audio store), transcode to
    * mu-law frames, and send to Twilio.
+   *
+   * WAV and raw-PCM bodies are transcoded incrementally — the first frame
+   * goes out as soon as enough bytes arrive, which matters for
+   * synthesized-play segments whose store entry fills only as fast as the
+   * provider synthesizes. Compressed and unknown formats (and bodies the
+   * incremental encoder cannot transcode exactly) buffer the whole
+   * response as before.
    */
   private async processFetchUrlItem(
     url: string,
@@ -687,9 +849,6 @@ export class MediaStreamOutput implements CallTransport {
 
       if (version !== this.playbackVersion || this.isClosed()) return;
 
-      const buffer = Buffer.from(await response.arrayBuffer());
-      if (version !== this.playbackVersion || this.isClosed()) return;
-
       const contentType = response.headers.get("content-type") ?? "audio/mpeg";
       const format: "mp3" | "wav" | "opus" | "pcm" = contentType.includes("wav")
         ? "wav"
@@ -698,6 +857,23 @@ export class MediaStreamOutput implements CallTransport {
           : contentType.includes("pcm") || contentType.includes("x-raw")
             ? "pcm"
             : "mp3";
+
+      let buffer: Buffer;
+      if ((format === "wav" || format === "pcm") && response.body) {
+        const result = await this.streamBodyToFrames(
+          response.body,
+          format,
+          version,
+          abortController.signal,
+        );
+        if (result.outcome !== "fallback") return;
+        // The body could not be transcoded incrementally and was drained
+        // instead; transcode it through the whole-buffer path.
+        buffer = result.buffered;
+      } else {
+        buffer = Buffer.from(await response.arrayBuffer());
+      }
+      if (version !== this.playbackVersion || this.isClosed()) return;
 
       const frames = this.audioBufferToFrames(buffer, format);
       if (version !== this.playbackVersion || this.isClosed()) return;
@@ -719,6 +895,82 @@ export class MediaStreamOutput implements CallTransport {
       if (this.activePlaybackAbort === abortController) {
         this.activePlaybackAbort = null;
       }
+    }
+  }
+
+  /**
+   * Incrementally read a WAV or raw-PCM response body, sending mu-law
+   * frames as they fill so playback starts before the body completes.
+   *
+   * Streams only what {@link sniffStreamableHeader} accepts; on any other
+   * input the remaining body is drained and returned so the caller can
+   * run the whole-buffer path, keeping output byte-identical to the
+   * buffered transcode in every case.
+   *
+   * Aborting `signal` (clearAudio / cancelPendingSpeech) cancels the
+   * reader, which settles an in-flight read so the loop exits promptly.
+   */
+  private async streamBodyToFrames(
+    body: ReadableStream<Uint8Array>,
+    format: "wav" | "pcm",
+    version: number,
+    signal: AbortSignal,
+  ): Promise<BodyStreamResult> {
+    const reader = body.getReader();
+    const onAbort = (): void => {
+      reader.cancel().catch(() => {});
+    };
+    signal.addEventListener("abort", onAbort);
+    const isCurrent = (): boolean =>
+      version === this.playbackVersion && !this.isClosed() && !signal.aborted;
+
+    try {
+      let encoder: IncrementalMulawFrameEncoder | null = null;
+      // Bytes accumulated while sniffing the header, before streaming starts.
+      let pending: Buffer = Buffer.alloc(0);
+
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (!isCurrent()) return { outcome: "aborted" };
+        if (done || !value) break;
+        let chunk = viewToBuffer(value);
+
+        if (!encoder) {
+          pending =
+            pending.length > 0 ? Buffer.concat([pending, chunk]) : chunk;
+          const decision = sniffStreamableHeader(pending, format);
+          if (decision.kind === "need-more-bytes") continue;
+          if (decision.kind === "fallback") {
+            const rest: Buffer[] = [pending];
+            for (;;) {
+              const next = await reader.read();
+              if (!isCurrent()) return { outcome: "aborted" };
+              if (next.done || !next.value) break;
+              rest.push(viewToBuffer(next.value));
+            }
+            return { outcome: "fallback", buffered: Buffer.concat(rest) };
+          }
+          encoder = new IncrementalMulawFrameEncoder(
+            decision.decimationFactor,
+            (frames) => this.sendFrames(frames),
+          );
+          chunk = pending.subarray(decision.payloadOffset);
+          if (chunk.length === 0) continue;
+        }
+
+        encoder.push(chunk);
+      }
+
+      if (!encoder) {
+        // The body ended before the header could be sniffed; the
+        // whole-buffer path handles undersized buffers.
+        return { outcome: "fallback", buffered: pending };
+      }
+      encoder.flush();
+      return { outcome: "streamed" };
+    } finally {
+      signal.removeEventListener("abort", onAbort);
+      reader.releaseLock();
     }
   }
 
@@ -746,13 +998,7 @@ export class MediaStreamOutput implements CallTransport {
     format: "mp3" | "wav" | "opus" | "pcm",
   ): string[] {
     // Sniff the actual bytes rather than trusting the declared format.
-    // WAV files always start with the ASCII magic "RIFF" (0x52494646).
-    const isWav =
-      audio.length >= 44 &&
-      audio[0] === 0x52 && // R
-      audio[1] === 0x49 && // I
-      audio[2] === 0x46 && // F
-      audio[3] === 0x46; // F
+    const isWav = audio.length >= WAV_HEADER_BYTES && hasRiffMagic(audio);
 
     if (isWav) {
       // Extract raw PCM from the WAV container, honoring the fmt-chunk
@@ -761,7 +1007,7 @@ export class MediaStreamOutput implements CallTransport {
       const channels = audio.readUInt16LE(22);
       const sampleRate = audio.readUInt32LE(24);
       const bitsPerSample = audio.readUInt16LE(34);
-      let pcmData: Buffer = audio.subarray(44);
+      let pcmData: Buffer = audio.subarray(WAV_HEADER_BYTES);
       if (pcmData.length < 2) return [];
 
       if (bitsPerSample !== 16 || channels > 2 || channels === 0) {

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -828,7 +828,7 @@ export class MediaStreamOutput implements CallTransport {
    * synthesized-play segments whose store entry fills only as fast as the
    * provider synthesizes. Compressed and unknown formats (and bodies the
    * incremental encoder cannot transcode exactly) buffer the whole
-   * response as before.
+   * response and use the buffered conversion path.
    */
   private async processFetchUrlItem(
     url: string,


### PR DESCRIPTION
## Summary
- processFetchUrlItem now streams audio/wav and audio/pcm bodies into mu-law frames incrementally instead of draining the whole response first
- Compressed/unknown formats keep the buffered path; barge-in aborts the in-flight read

Part of plan: voice-mode-latency.md (PR 12 of 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)