### PR TITLE
TTS deferred cleanups: ElevenLabs rate clamp, shared stream reader, PCM sentinel collapse, chunk-aligner consolidation

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -93,7 +93,7 @@ mock.module("../config/loader.js", () => {
 // ── Credential mock (prevents real key lookups) ──────────────────────
 
 // Provider API keys resolve by default so telephony playability checks
-// (WAV-transport tests) can select providers; tests can narrow the
+// (PCM-transport tests) can select providers; tests can narrow the
 // resolvable set. Reset to null (all resolve) in beforeEach.
 let mockResolvableProviderKeys: ((service: string) => string | null) | null =
   null;
@@ -408,8 +408,8 @@ function setupController(
   opts?: {
     assistantId?: string;
     trustContext?: import("../daemon/trust-context-types.js").TrustContext;
-    /** Simulate the media-stream transport's WAV requirement. */
-    requiresWavAudio?: boolean;
+    /** Simulate the media-stream transport's PCM requirement. */
+    requiresPcmAudio?: boolean;
   },
 ) {
   ensureConversation("conv-ctrl-test");
@@ -422,8 +422,8 @@ function setupController(
   });
   updateCallSession(session.id, { status: "in_progress" });
   const transport = createMockTransport();
-  if (opts?.requiresWavAudio) {
-    Object.assign(transport, { requiresWavAudio: true });
+  if (opts?.requiresPcmAudio) {
+    Object.assign(transport, { requiresPcmAudio: true });
   }
   const controller = new CallController(session.id, transport, task ?? null, {
     assistantId: opts?.assistantId,
@@ -3493,16 +3493,16 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
-  // ── Per-segment fallback on WAV-requiring transports ────────────────
+  // ── Per-segment fallback on PCM-requiring transports ────────────────
 
   /**
    * Register a failing fish-audio primary and a recording elevenlabs
    * fallback, with fish-audio configured as the active provider. Used by
-   * the WAV-transport segment-fallback tests. With
+   * the PCM-transport segment-fallback tests. With
    * `fishEmitsChunkBeforeFailing`, the primary emits one audio chunk (so
    * the play URL reaches the transport) before failing mid-stream.
    */
-  function registerWavFallbackProviders(opts?: {
+  function registerPcmFallbackProviders(opts?: {
     fishEmitsChunkBeforeFailing?: boolean;
   }): {
     fishTexts: string[];
@@ -3557,13 +3557,13 @@ describe("call-controller", () => {
     return { fishTexts, fallbackTexts };
   }
 
-  test("WAV transport: a failed segment and the rest of the turn synthesize via a playable fallback provider", async () => {
-    const { fishTexts, fallbackTexts } = registerWavFallbackProviders();
+  test("PCM transport: a failed segment and the rest of the turn synthesize via a playable fallback provider", async () => {
+    const { fishTexts, fallbackTexts } = registerPcmFallbackProviders();
     mockStartVoiceTurn.mockImplementation(
       createMockVoiceTurn(["First part is done. ", "Second part is done."]),
     );
     const { relay, controller } = setupController(undefined, {
-      requiresWavAudio: true,
+      requiresPcmAudio: true,
     });
 
     await controller.handleCallerUtterance("Hi");
@@ -3577,7 +3577,7 @@ describe("call-controller", () => {
       "Second part is done.",
     ]);
     expect(relay.sentPlayUrls.length).toBe(2);
-    // No text routes through native tokens on a WAV transport.
+    // No text routes through native tokens on a PCM transport.
     expect(relay.sentTokens.filter((t) => t.token.length > 0)).toEqual([]);
     const lastToken = relay.sentTokens[relay.sentTokens.length - 1];
     expect(lastToken).toEqual({ token: "", last: true });
@@ -3585,15 +3585,15 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
-  test("WAV transport: a mid-stream failure after audio reached the caller is not re-spoken, but later segments use the fallback", async () => {
-    const { fishTexts, fallbackTexts } = registerWavFallbackProviders({
+  test("PCM transport: a mid-stream failure after audio reached the caller is not re-spoken, but later segments use the fallback", async () => {
+    const { fishTexts, fallbackTexts } = registerPcmFallbackProviders({
       fishEmitsChunkBeforeFailing: true,
     });
     mockStartVoiceTurn.mockImplementation(
       createMockVoiceTurn(["First part is done. ", "Second part is done."]),
     );
     const { relay, controller } = setupController(undefined, {
-      requiresWavAudio: true,
+      requiresPcmAudio: true,
     });
 
     await controller.handleCallerUtterance("Hi");
@@ -3612,16 +3612,16 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
-  test("WAV transport: when no playable fallback exists, failed segments are skipped and end-of-turn still fires", async () => {
+  test("PCM transport: when no playable fallback exists, failed segments are skipped and end-of-turn still fires", async () => {
     // Only fish-audio's key resolves, so the fallback scan finds nothing.
     mockResolvableProviderKeys = (service) =>
       service === "fish-audio" ? "test-key" : null;
-    const { fishTexts, fallbackTexts } = registerWavFallbackProviders();
+    const { fishTexts, fallbackTexts } = registerPcmFallbackProviders();
     mockStartVoiceTurn.mockImplementation(
       createMockVoiceTurn(["First part is done. ", "Second part is done."]),
     );
     const { relay, controller } = setupController(undefined, {
-      requiresWavAudio: true,
+      requiresPcmAudio: true,
     });
 
     await controller.handleCallerUtterance("Hi");
@@ -3629,7 +3629,7 @@ describe("call-controller", () => {
     expect(fishTexts).toEqual(["First part is done."]);
     expect(fallbackTexts).toEqual([]);
     expect(relay.sentPlayUrls.length).toBe(0);
-    // Native tokens are never used on a WAV transport, and the turn
+    // Native tokens are never used on a PCM transport, and the turn
     // still closes with the end-of-turn signal.
     expect(relay.sentTokens.filter((t) => t.token.length > 0)).toEqual([]);
     const lastToken = relay.sentTokens[relay.sentTokens.length - 1];

--- a/assistant/src/__tests__/call-setup-flow.test.ts
+++ b/assistant/src/__tests__/call-setup-flow.test.ts
@@ -58,7 +58,7 @@ function createFakeTransport() {
     endSession: (reason) => {
       endReasons.push(reason);
     },
-    requiresWavAudio: true,
+    requiresPcmAudio: true,
   };
   return { transport, spokenTokens, endReasons };
 }

--- a/assistant/src/__tests__/media-stream-output.test.ts
+++ b/assistant/src/__tests__/media-stream-output.test.ts
@@ -25,7 +25,7 @@ mock.module("../calls/resolve-call-tts-provider.js", () => ({
   resolveCallTtsProvider: jest.fn(() => ({
     provider: mockProvider,
     useSynthesizedPath: false,
-    audioFormat: "wav" as const,
+    audioFormat: "pcm" as const,
   })),
 }));
 
@@ -196,7 +196,7 @@ function useProvider(provider: unknown): void {
   mockResolveCallTtsProvider.mockImplementation(() => ({
     provider,
     useSynthesizedPath: false,
-    audioFormat: "wav" as const,
+    audioFormat: "pcm" as const,
   }));
 }
 
@@ -230,7 +230,7 @@ afterEach(() => {
   mockResolveCallTtsProvider.mockImplementation(() => ({
     provider: mockProvider,
     useSynthesizedPath: false,
-    audioFormat: "wav" as const,
+    audioFormat: "pcm" as const,
   }));
 });
 

--- a/assistant/src/__tests__/telephony-tts-guard.test.ts
+++ b/assistant/src/__tests__/telephony-tts-guard.test.ts
@@ -4,10 +4,10 @@
  * Covers three layers:
  * 1. `resolveTelephonyTtsCapability` — catalog `mediaStreamPlayback` format
  *    plus credential availability produce the playable / not-playable verdict.
- * 2. `resolveCallTtsProvider({ preferWav: true })` — a not-playable configured
- *    provider is swapped for a playable credentialed fallback instead of
- *    resolving into guaranteed media-stream silence.
- * 3. `speakSystemPrompt` on a WAV-requiring transport — synthesis failure
+ * 2. `resolveCallTtsProvider({ requiresPcmAudio: true })` — a not-playable
+ *    configured provider is swapped for a playable credentialed fallback
+ *    instead of resolving into guaranteed media-stream silence.
+ * 3. `speakSystemPrompt` on a PCM-requiring transport — synthesis failure
  *    retries once via the fallback provider before degrading to an
  *    end-of-turn-only signal; a mid-stream failure after the play URL went
  *    out skips all fallback (the truncated prompt stands); aborted
@@ -64,7 +64,7 @@ interface FakeCatalogEntry {
   callMode: "native-twilio" | "synthesized-play";
   allowNativeFallback: boolean;
   capabilities: { supportsStreaming: boolean; supportedFormats: string[] };
-  mediaStreamPlayback: { outputFormat: "pcm" | "wav" | "none" };
+  mediaStreamPlayback: { outputFormat: "pcm" | "none" };
   secretRequirements: Array<{
     credentialStoreKey: string;
     displayName: string;
@@ -75,7 +75,7 @@ interface FakeCatalogEntry {
 function makeEntry(
   id: string,
   callMode: "native-twilio" | "synthesized-play",
-  outputFormat: "pcm" | "wav" | "none",
+  outputFormat: "pcm" | "none",
   allowNativeFallback: boolean,
 ): FakeCatalogEntry {
   return {
@@ -97,7 +97,7 @@ function makeEntry(
 
 const fakeCatalog: FakeCatalogEntry[] = [
   makeEntry("elevenlabs", "native-twilio", "pcm", true),
-  makeEntry("fish-audio", "synthesized-play", "wav", true),
+  makeEntry("fish-audio", "synthesized-play", "pcm", true),
   makeEntry("deepgram", "synthesized-play", "pcm", false),
   makeEntry("compressed-only", "synthesized-play", "none", false),
 ];
@@ -257,11 +257,11 @@ function registerStreamingStubProvider(
   return provider;
 }
 
-function createRelay(requiresWavAudio: boolean) {
+function createRelay(requiresPcmAudio: boolean) {
   const sentTokens: Array<{ token: string; last: boolean }> = [];
   const sentPlayUrls: string[] = [];
   const relay: CallTransport = {
-    requiresWavAudio,
+    requiresPcmAudio,
     sendTextToken: (token, last) => {
       sentTokens.push({ token, last });
     },
@@ -302,7 +302,7 @@ describe("resolveTelephonyTtsCapability", () => {
     expect(capability).toEqual({ status: "playable", providerId: "deepgram" });
   });
 
-  test("wav provider with a resolvable key and referenceId is playable", async () => {
+  test("fish-audio with a resolvable key and referenceId is playable", async () => {
     testConfig.services.tts.provider = "fish-audio";
     testConfig.services.tts.providers["fish-audio"].referenceId = "ref-123";
     storedKeys["fish-audio"] = "fa-key";
@@ -398,7 +398,7 @@ describe("findPlayableTelephonyTtsFallback", () => {
 // Call TTS resolver — media-stream playability guard
 // ---------------------------------------------------------------------------
 
-describe("resolveCallTtsProvider with preferWav", () => {
+describe("resolveCallTtsProvider with requiresPcmAudio", () => {
   test("keeps the configured provider when it is playable and credentialed", async () => {
     testConfig.services.tts.provider = "deepgram";
     storedKeys["deepgram"] = "dg-key";
@@ -406,10 +406,10 @@ describe("resolveCallTtsProvider with preferWav", () => {
       return { audio: Buffer.from("x"), contentType: "audio/pcm" };
     });
 
-    const result = await resolveCallTtsProvider({ preferWav: true });
+    const result = await resolveCallTtsProvider({ requiresPcmAudio: true });
     expect(result.provider?.id).toBe("deepgram");
     expect(result.useSynthesizedPath).toBe(true);
-    expect(result.audioFormat).toBe("wav");
+    expect(result.audioFormat).toBe("pcm");
   });
 
   test("falls back to a playable credentialed provider when the configured provider has an unsupported format", async () => {
@@ -423,9 +423,9 @@ describe("resolveCallTtsProvider with preferWav", () => {
       return { audio: Buffer.from("x"), contentType: "audio/pcm" };
     });
 
-    const result = await resolveCallTtsProvider({ preferWav: true });
+    const result = await resolveCallTtsProvider({ requiresPcmAudio: true });
     expect(result.provider?.id).toBe("elevenlabs");
-    expect(result.audioFormat).toBe("wav");
+    expect(result.audioFormat).toBe("pcm");
   });
 
   test("falls back when configured fish-audio has a key but no referenceId", async () => {
@@ -439,9 +439,9 @@ describe("resolveCallTtsProvider with preferWav", () => {
       return { audio: Buffer.from("x"), contentType: "audio/pcm" };
     });
 
-    const result = await resolveCallTtsProvider({ preferWav: true });
+    const result = await resolveCallTtsProvider({ requiresPcmAudio: true });
     expect(result.provider?.id).toBe("elevenlabs");
-    expect(result.audioFormat).toBe("wav");
+    expect(result.audioFormat).toBe("pcm");
   });
 
   test("falls back when the configured provider is missing credentials", async () => {
@@ -454,11 +454,11 @@ describe("resolveCallTtsProvider with preferWav", () => {
       return { audio: Buffer.from("x"), contentType: "audio/pcm" };
     });
 
-    const result = await resolveCallTtsProvider({ preferWav: true });
+    const result = await resolveCallTtsProvider({ requiresPcmAudio: true });
     expect(result.provider?.id).toBe("elevenlabs");
   });
 
-  test("without preferWav the configured provider is not swapped", async () => {
+  test("without requiresPcmAudio the configured provider is not swapped", async () => {
     testConfig.services.tts.provider = "deepgram";
     // No credentials at all — the CR transport path does not consult the
     // media-stream playability capability.
@@ -477,7 +477,7 @@ describe("resolveCallTtsProvider with preferWav", () => {
 // speakSystemPrompt — media-stream synthesis failure retries the fallback
 // ---------------------------------------------------------------------------
 
-describe("speakSystemPrompt on a WAV-requiring transport", () => {
+describe("speakSystemPrompt on a PCM-requiring transport", () => {
   test("retries with the fallback provider instead of emitting only end-of-turn", async () => {
     testConfig.services.tts.provider = "deepgram";
     storedKeys["deepgram"] = "dg-key";
@@ -563,7 +563,7 @@ describe("speakSystemPrompt mid-stream failure after audio started", () => {
     };
   }
 
-  test("WAV transport: skips the fallback retry — the truncated prompt stands", async () => {
+  test("PCM transport: skips the fallback retry — the truncated prompt stands", async () => {
     testConfig.services.tts.provider = "deepgram";
     storedKeys["deepgram"] = "dg-key";
     storedKeys["elevenlabs"] = "el-key";
@@ -584,7 +584,7 @@ describe("speakSystemPrompt mid-stream failure after audio started", () => {
     expect(sentTokens).toEqual([{ token: "", last: true }]);
   });
 
-  test("non-WAV transport: skips the native text fallback — no full-prompt re-speak", async () => {
+  test("non-PCM transport: skips the native text fallback — no full-prompt re-speak", async () => {
     testConfig.services.tts.provider = "fish-audio";
     testConfig.services.tts.providers["fish-audio"].referenceId = "ref-123";
 
@@ -628,7 +628,7 @@ describe("speakSystemPrompt mid-stream failure after audio started", () => {
 // ---------------------------------------------------------------------------
 
 describe("speakSystemPrompt aborted synthesis", () => {
-  test("WAV transport: abort mid-flight skips the fallback retry and end-of-turn", async () => {
+  test("PCM transport: abort mid-flight skips the fallback retry and end-of-turn", async () => {
     testConfig.services.tts.provider = "deepgram";
     storedKeys["deepgram"] = "dg-key";
     storedKeys["elevenlabs"] = "el-key";
@@ -657,7 +657,7 @@ describe("speakSystemPrompt aborted synthesis", () => {
     expect(sentTokens).toEqual([]);
   });
 
-  test("non-WAV transport with native-fallback provider: abort skips the text fallback and end-of-turn", async () => {
+  test("non-PCM transport with native-fallback provider: abort skips the text fallback and end-of-turn", async () => {
     testConfig.services.tts.provider = "fish-audio";
     testConfig.services.tts.providers["fish-audio"].referenceId = "ref-123";
 
@@ -712,7 +712,7 @@ describe("speakSystemPrompt aborted synthesis", () => {
     expect(sentTokens).toEqual([]);
   });
 
-  test("provider AbortError without our signal aborted is a failure — WAV fallback retry still runs", async () => {
+  test("provider AbortError without our signal aborted is a failure — PCM fallback retry still runs", async () => {
     testConfig.services.tts.provider = "deepgram";
     storedKeys["deepgram"] = "dg-key";
     storedKeys["elevenlabs"] = "el-key";
@@ -742,7 +742,7 @@ describe("speakSystemPrompt aborted synthesis", () => {
     expect(sentTokens).toEqual([{ token: "", last: true }]);
   });
 
-  test("provider AbortError without any signal is a failure — non-WAV native fallback still runs", async () => {
+  test("provider AbortError without any signal is a failure — non-PCM native fallback still runs", async () => {
     testConfig.services.tts.provider = "fish-audio";
     testConfig.services.tts.providers["fish-audio"].referenceId = "ref-123";
 

--- a/assistant/src/calls/__tests__/fish-audio-client.test.ts
+++ b/assistant/src/calls/__tests__/fish-audio-client.test.ts
@@ -83,3 +83,20 @@ describe("synthesizeWithFishAudio request body", () => {
     expect(body.sample_rate).toBe(24000);
   });
 });
+
+describe("synthesizeWithFishAudio response consumption", () => {
+  test("rejects when the response body closes after zero bytes", async () => {
+    globalThis.fetch = mock(async () => {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.close();
+        },
+      });
+      return new Response(body, { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    await expect(synthesizeWithFishAudio("hello", config)).rejects.toThrow(
+      "Fish Audio API returned empty audio",
+    );
+  });
+});

--- a/assistant/src/calls/audio-store.ts
+++ b/assistant/src/calls/audio-store.ts
@@ -1,5 +1,8 @@
 import { randomUUID } from "node:crypto";
 
+/** Audio formats that flow through call synthesis and the audio store. */
+export type CallAudioFormat = "mp3" | "wav" | "opus" | "pcm";
+
 interface AudioEntry {
   buffer: Buffer;
   contentType: string;
@@ -22,10 +25,7 @@ const TTL_MS = 60_000; // 60 seconds
 
 let currentBytes = 0;
 
-export function storeAudio(
-  buffer: Buffer,
-  format: "mp3" | "wav" | "opus" | "pcm",
-): string {
+export function storeAudio(buffer: Buffer, format: CallAudioFormat): string {
   evictExpired();
   // Evict oldest if over capacity
   while (currentBytes + buffer.length > MAX_STORE_BYTES && store.size > 0) {
@@ -50,7 +50,7 @@ export interface StreamingAudioHandle {
 }
 
 export function createStreamingEntry(
-  format: "mp3" | "wav" | "opus" | "pcm",
+  format: CallAudioFormat,
 ): StreamingAudioHandle {
   evictExpired();
   const id = randomUUID();
@@ -162,7 +162,7 @@ export function getAudio(id: string): AudioResult | null {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-function contentTypeForFormat(format: "mp3" | "wav" | "opus" | "pcm"): string {
+function contentTypeForFormat(format: CallAudioFormat): string {
   return format === "mp3"
     ? "audio/mpeg"
     : format === "wav"

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -658,12 +658,12 @@ export class CallController {
     // Native-twilio providers stream text tokens through the transport,
     // which re-synthesizes them via daemon TTS on media-stream.
     //
-    // When the transport requires WAV (media-stream), request WAV so
+    // When the transport requires PCM (media-stream), request PCM so
     // the audio store entry and any downstream fetch/transcode receives
-    // PCM that audioBufferToFrames can convert to mu-law.
+    // raw PCM that audioBufferToFrames can convert to mu-law.
     const { provider, useSynthesizedPath, audioFormat } =
       await resolveCallTtsProvider({
-        preferWav: this.transport.requiresWavAudio,
+        requiresPcmAudio: this.transport.requiresPcmAudio,
       });
 
     // Buffer incoming tokens so we can strip control markers ([ASK_GUARDIAN:...], [END_CALL])
@@ -680,14 +680,14 @@ export class CallController {
     let pendingSynthText = "";
     let synthesisChain: Promise<void> = Promise.resolve();
     // After a segment fails, the rest of the turn stays off the primary
-    // provider so text is never spoken out of order: non-WAV transports
-    // send native tokens; WAV-requiring transports (media-stream) retry
+    // provider so text is never spoken out of order: non-PCM transports
+    // send native tokens; PCM-requiring transports (media-stream) retry
     // through a playable fallback provider.
     let synthesisFellBack = false;
-    // Fallback provider for WAV-requiring transports, resolved once per
+    // Fallback provider for PCM-requiring transports, resolved once per
     // turn. `undefined` = not yet resolved; `null` = none available (or
     // the fallback failed too) — affected segments are skipped.
-    let wavFallbackProvider: TtsProvider | null | undefined;
+    let pcmFallbackProvider: TtsProvider | null | undefined;
     // Non-recoverable failure (allowNativeFallback: false providers):
     // remaining segments are skipped and the error rethrows after the
     // chain drains so the outer handler speaks the generic recovery copy.
@@ -696,21 +696,21 @@ export class CallController {
     // chain links check it to keep stale speech off the recovery prompt.
     let synthesisCancelled = false;
 
-    // WAV-requiring transports re-synthesize native tokens through the
+    // PCM-requiring transports re-synthesize native tokens through the
     // same failing provider path, so a failed segment (and the rest of
     // the turn) is spoken through a playable fallback provider instead.
-    const speakSegmentViaWavFallback = async (
+    const speakSegmentViaPcmFallback = async (
       failedProviderId: string,
       segment: string,
     ): Promise<void> => {
-      if (wavFallbackProvider === undefined) {
-        wavFallbackProvider =
+      if (pcmFallbackProvider === undefined) {
+        pcmFallbackProvider =
           await findPlayableTelephonyTtsFallbackProvider(failedProviderId);
-        if (wavFallbackProvider) {
+        if (pcmFallbackProvider) {
           log.warn(
             {
               provider: failedProviderId,
-              fallbackProvider: wavFallbackProvider.id,
+              fallbackProvider: pcmFallbackProvider.id,
             },
             "Speaking remaining TTS segments via fallback provider",
           );
@@ -722,21 +722,21 @@ export class CallController {
         }
       }
       if (
-        !wavFallbackProvider ||
+        !pcmFallbackProvider ||
         synthesisCancelled ||
         !this.isCurrentRun(runVersion)
       ) {
         return;
       }
       const fallbackStatus = await this.synthesizeAndStreamAudio(
-        wavFallbackProvider,
+        pcmFallbackProvider,
         segment,
         runVersion,
         audioFormat,
       );
       if (fallbackStatus !== "ok") {
         // The fallback provider is failing too — stop retrying.
-        wavFallbackProvider = null;
+        pcmFallbackProvider = null;
       }
     };
 
@@ -771,7 +771,7 @@ export class CallController {
                 return;
               }
               synthesisFellBack = true;
-              if (!this.transport.requiresWavAudio) {
+              if (!this.transport.requiresPcmAudio) {
                 // synthesizeAndStreamAudio already handled the failed
                 // segment: its text went out as native tokens, or its
                 // partially-played audio stands.
@@ -784,14 +784,14 @@ export class CallController {
                 // segments still route through the fallback provider.
                 return;
               }
-            } else if (!this.transport.requiresWavAudio) {
+            } else if (!this.transport.requiresPcmAudio) {
               // Native route. Segments are trimmed, so restore the
               // inter-segment separator.
               this.beginSpeakingOnAudioStart(runVersion);
               this.transport.sendTextToken(`${segment} `, false);
               return;
             }
-            await speakSegmentViaWavFallback(ttsProvider.id, segment);
+            await speakSegmentViaPcmFallback(ttsProvider.id, segment);
           } catch (err) {
             synthesisFailure = { err };
           }
@@ -990,7 +990,7 @@ export class CallController {
    * @returns `"ok"` on success or abort. On a handled provider failure,
    *   `"failed-before-audio"` when the segment's play URL never went out:
    *   on transports that accept text tokens the failed text has already
-   *   been sent natively; on WAV-requiring transports nothing was sent —
+   *   been sent natively; on PCM-requiring transports nothing was sent —
    *   the caller owns the fallback-provider retry. `"failed-after-audio"`
    *   when the provider failed mid-stream after the play URL was
    *   delivered: the caller hears the truncated audio and nothing more is
@@ -1003,17 +1003,19 @@ export class CallController {
     provider: TtsProvider,
     text: string,
     runVersion: number,
-    format: "mp3" | "wav" | "opus" = "mp3",
+    format: "mp3" | "wav" | "opus" | "pcm" = "mp3",
   ): Promise<SegmentSynthesisStatus> {
     let sink: AudioStoreSink | null = null;
     let playUrlSent = false;
     const abortController = new AbortController();
     try {
-      // When format is WAV (media-stream transport), request raw PCM from
-      // the provider so the audio bytes match the store's content-type.
-      // Without this, providers like Fish Audio still return mp3 and the
-      // downstream mu-law transcoder fails on the format mismatch.
-      const outputFormat = format === "wav" ? ("pcm" as const) : undefined;
+      // Transport-forced PCM and user-configured WAV both request raw PCM
+      // from the provider so the audio bytes match the store's
+      // content-type. Without this, providers like Fish Audio still return
+      // mp3 and the downstream mu-law transcoder fails on the format
+      // mismatch.
+      const outputFormat =
+        format === "pcm" || format === "wav" ? ("pcm" as const) : undefined;
 
       // Use "pcm" as the store format when requesting PCM output so the
       // audio store entry's content-type (audio/pcm) matches the raw PCM
@@ -1083,7 +1085,7 @@ export class CallController {
           { err, provider: provider.id, errName, errCode },
           "TTS synthesis failed — falling back to native token TTS",
         );
-        // If synthesis fails before any audio has started on a non-WAV
+        // If synthesis fails before any audio has started on a non-PCM
         // transport, degrade to token-based speech so the caller still
         // hears a response instead of silence. This fallback is only
         // used for providers whose catalog entry allows native fallback.
@@ -1091,7 +1093,7 @@ export class CallController {
         // leak into the next caller turn.
         if (
           !playUrlSent &&
-          !this.transport.requiresWavAudio &&
+          !this.transport.requiresPcmAudio &&
           this.isCurrentRun(runVersion)
         ) {
           this.beginSpeakingOnAudioStart(runVersion);

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -28,6 +28,7 @@ import {
 } from "../tts/synthesis-stream.js";
 import type { TtsProvider, TtsProviderId } from "../tts/types.js";
 import { getLogger } from "../util/logger.js";
+import type { CallAudioFormat } from "./audio-store.js";
 import {
   getEndCallListenWindowMs,
   getMaxCallDurationMs,
@@ -1004,7 +1005,7 @@ export class CallController {
     provider: TtsProvider,
     text: string,
     runVersion: number,
-    format: "mp3" | "wav" | "opus" | "pcm" = "mp3",
+    format: CallAudioFormat = "mp3",
   ): Promise<SegmentSynthesisStatus> {
     let sink: AudioStoreSink | null = null;
     let playUrlSent = false;

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -59,6 +59,7 @@ import { dispatchGuardianQuestion } from "./guardian-dispatch.js";
 import {
   findPlayableTelephonyTtsFallbackProvider,
   resolveCallTtsProvider,
+  resolveSynthesisFormats,
 } from "./resolve-call-tts-provider.js";
 import type { PromptSpeakerContext } from "./speaker-identification.js";
 import { sanitizeForTts } from "./tts-text-sanitizer.js";
@@ -1009,21 +1010,9 @@ export class CallController {
     let playUrlSent = false;
     const abortController = new AbortController();
     try {
-      // Transport-forced PCM and user-configured WAV both request raw PCM
-      // from the provider so the audio bytes match the store's
-      // content-type. Without this, providers like Fish Audio still return
-      // mp3 and the downstream mu-law transcoder fails on the format
-      // mismatch.
-      const outputFormat =
-        format === "pcm" || format === "wav" ? ("pcm" as const) : undefined;
-
-      // Use "pcm" as the store format when requesting PCM output so the
-      // audio store entry's content-type (audio/pcm) matches the raw PCM
-      // bytes providers return. Without this, the store says "audio/wav"
-      // but the bytes have no RIFF header, causing audioBufferToFrames to
-      // fall through to the wrong decode path.
+      const { outputFormat, storeFormat } = resolveSynthesisFormats(format);
       sink = createAudioStoreSink({
-        format: outputFormat ? "pcm" : format,
+        format: storeFormat,
         onPlayUrl: (url) => {
           // Audio is now reaching the caller (or, on transports with an
           // audio-start signal, will be the moment the first fetched frame

--- a/assistant/src/calls/call-setup-flow-types.ts
+++ b/assistant/src/calls/call-setup-flow-types.ts
@@ -19,7 +19,7 @@ import type { TrustContext } from "../daemon/trust-context-types.js";
 export interface SetupFlowTransport {
   sendTextToken(token: string, last: boolean): void;
   endSession(reason?: string): void;
-  readonly requiresWavAudio?: boolean;
+  readonly requiresPcmAudio?: boolean;
 }
 
 // ── Flow state ───────────────────────────────────────────────────────

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -56,13 +56,13 @@ export async function speakSystemPrompt(
   text: string,
   signal?: AbortSignal,
 ): Promise<void> {
-  // When the transport requires WAV (media-stream), request WAV so
-  // the audio store entry contains PCM that audioBufferToFrames can
+  // When the transport requires PCM (media-stream), request PCM so
+  // the audio store entry contains raw PCM that audioBufferToFrames can
   // transcode to mu-law. Without this, compressed formats (mp3, opus)
   // are fetched by processFetchUrlItem and produce garbled audio.
   const { provider, useSynthesizedPath, audioFormat } =
     await resolveCallTtsProvider({
-      preferWav: relay.requiresWavAudio,
+      requiresPcmAudio: relay.requiresPcmAudio,
     });
 
   if (!useSynthesizedPath || !provider) {
@@ -90,13 +90,13 @@ export async function speakSystemPrompt(
  *
  * On synthesis failure before any audio the behavior depends on the
  * transport:
- * - WAV-requiring transports (media-stream) retry once with a playable
+ * - PCM-requiring transports (media-stream) retry once with a playable
  *   fallback provider — native token TTS cannot rescue the prompt there
  *   because text tokens are themselves synthesized via the same provider
  *   path. When no fallback exists (or the retry also fails), only an
  *   empty end-of-turn signal is sent so the transport transitions back
  *   to listening state.
- * - On non-WAV transports, providers with a native Twilio TTS fallback
+ * - On non-PCM transports, providers with a native Twilio TTS fallback
  *   (e.g. Fish Audio) fall back to `sendTextToken(text)` so the caller
  *   still hears the message; providers without one (e.g. Deepgram) log
  *   the error and send only the end-of-turn signal.
@@ -110,18 +110,19 @@ async function synthesizeAndPlay(
   relay: CallTransport,
   provider: TtsProvider,
   text: string,
-  format: "mp3" | "wav" | "opus",
+  format: "mp3" | "wav" | "opus" | "pcm",
   signal?: AbortSignal,
   isFallbackRetry = false,
 ): Promise<void> {
   let sink: AudioStoreSink | null = null;
   let playUrlSent = false;
   try {
-    // When format is WAV (media-stream transport), request raw PCM from
-    // the provider so the audio bytes match the store's content-type.
+    // Transport-forced PCM and user-configured WAV both request raw PCM
+    // from the provider so the audio bytes match the store's content-type.
     // Without this, providers like Fish Audio still return mp3 and the
     // downstream mu-law transcoder fails on the format mismatch.
-    const outputFormat = format === "wav" ? ("pcm" as const) : undefined;
+    const outputFormat =
+      format === "pcm" || format === "wav" ? ("pcm" as const) : undefined;
 
     // Use "pcm" as the store format when requesting PCM output so the
     // audio store entry's content-type (audio/pcm) matches the raw PCM
@@ -198,8 +199,8 @@ async function synthesizeAndPlay(
       return;
     }
 
-    if (relay.requiresWavAudio) {
-      // WAV-requiring transport (media-stream): native token TTS routes
+    if (relay.requiresPcmAudio) {
+      // PCM-requiring transport (media-stream): native token TTS routes
       // back through the same synthesis path, so retry once with a
       // playable fallback provider before degrading to end-of-turn only.
       if (!isFallbackRetry) {
@@ -231,7 +232,7 @@ async function synthesizeAndPlay(
       }
       log.error(
         { err, provider: provider.id, errName, errCode },
-        "System prompt TTS synthesis failed on WAV-requiring transport — sending end-of-turn only",
+        "System prompt TTS synthesis failed on PCM-requiring transport — sending end-of-turn only",
       );
       // Send the end-of-turn signal so the transport transitions from
       // "assistant speaking" to "caller speaking" state.

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -23,6 +23,7 @@ import {
 } from "../tts/synthesis-stream.js";
 import type { TtsProvider, TtsProviderId } from "../tts/types.js";
 import { getLogger } from "../util/logger.js";
+import type { CallAudioFormat } from "./audio-store.js";
 import type { CallTransport } from "./call-transport.js";
 import {
   findPlayableTelephonyTtsFallbackProvider,
@@ -111,7 +112,7 @@ async function synthesizeAndPlay(
   relay: CallTransport,
   provider: TtsProvider,
   text: string,
-  format: "mp3" | "wav" | "opus" | "pcm",
+  format: CallAudioFormat,
   signal?: AbortSignal,
   isFallbackRetry = false,
 ): Promise<void> {

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -27,6 +27,7 @@ import type { CallTransport } from "./call-transport.js";
 import {
   findPlayableTelephonyTtsFallbackProvider,
   resolveCallTtsProvider,
+  resolveSynthesisFormats,
 } from "./resolve-call-tts-provider.js";
 
 const log = getLogger("call-speech-output");
@@ -117,19 +118,7 @@ async function synthesizeAndPlay(
   let sink: AudioStoreSink | null = null;
   let playUrlSent = false;
   try {
-    // Transport-forced PCM and user-configured WAV both request raw PCM
-    // from the provider so the audio bytes match the store's content-type.
-    // Without this, providers like Fish Audio still return mp3 and the
-    // downstream mu-law transcoder fails on the format mismatch.
-    const outputFormat =
-      format === "pcm" || format === "wav" ? ("pcm" as const) : undefined;
-
-    // Use "pcm" as the store format when requesting PCM output so the
-    // audio store entry's content-type (audio/pcm) matches the raw PCM
-    // bytes providers return. Without this, the store says "audio/wav"
-    // but the bytes have no RIFF header, causing audioBufferToFrames to
-    // fall through to the wrong decode path.
-    const storeFormat = outputFormat ? "pcm" : format;
+    const { outputFormat, storeFormat } = resolveSynthesisFormats(format);
     sink = createAudioStoreSink({
       format: storeFormat,
       onPlayUrl: (url) => {

--- a/assistant/src/calls/call-transport.ts
+++ b/assistant/src/calls/call-transport.ts
@@ -31,14 +31,15 @@ export interface CallTransport {
   endSession(reason?: string): void;
 
   /**
-   * When true, the transport requires WAV (PCM) audio for playback.
+   * When true, the transport synthesizes speech itself and requires raw
+   * PCM audio for playback.
    *
    * The media-stream transport sets this because its mu-law transcoder
-   * can only decode WAV (raw PCM) — compressed formats (mp3, opus)
-   * produce garbled audio. The call controller uses this to request
-   * WAV from TTS providers and the audio store.
+   * needs raw PCM — compressed formats (mp3, opus) produce garbled
+   * audio. The call controller uses this to request PCM from TTS
+   * providers and the audio store.
    */
-  readonly requiresWavAudio?: boolean;
+  readonly requiresPcmAudio?: boolean;
 
   /**
    * Arm a one-shot callback invoked when the transport sends the first

--- a/assistant/src/calls/fish-audio-client.ts
+++ b/assistant/src/calls/fish-audio-client.ts
@@ -1,7 +1,7 @@
 import type { FishAudioConfig } from "../config/schemas/fish-audio.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
-import { readChunkedBody } from "../tts/stream-read.js";
+import { consumeSynthesisResponse } from "../tts/stream-read.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("fish-audio-client");
@@ -86,14 +86,17 @@ export async function synthesizeWithFishAudio(
     throw new Error(`Fish Audio API error (${response.status}): ${errorText}`);
   }
 
-  if (!response.body) {
-    throw new Error("Fish Audio API returned no body");
-  }
-
-  const audio = await readChunkedBody(response.body, {
+  const audio = await consumeSynthesisResponse(response, {
+    stream: true,
     onChunk: options?.onChunk,
     makeTimeoutError: (timeoutMs) =>
       new Error(`Fish Audio read timed out after ${timeoutMs}ms`),
+    makeEmptyError: (kind) =>
+      new Error(
+        kind === "no-body"
+          ? "Fish Audio API returned no body"
+          : "Fish Audio API returned empty audio",
+      ),
   });
 
   log.debug({ bytes: audio.byteLength }, "Fish Audio synthesis complete");

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -39,6 +39,7 @@ import { createPcmChunkAligner } from "../tts/pcm-chunk-aligner.js";
 import { extractSpeakableSegments } from "../tts/speakable-segments.js";
 import { synthesizeAndEmit } from "../tts/synthesis-stream.js";
 import { getLogger } from "../util/logger.js";
+import type { CallAudioFormat } from "./audio-store.js";
 import type { CallTransport } from "./call-transport.js";
 import {
   chunkMulawToBase64Frames,
@@ -637,7 +638,7 @@ export class MediaStreamOutput implements CallTransport {
       // returns mp3). For unknown content types, fall back to the declared
       // format (PCM on this path — the bytes were requested as raw PCM,
       // and audioBufferToFrames sniffs magic bytes as a safety net).
-      const actualFormat: "mp3" | "wav" | "opus" | "pcm" =
+      const actualFormat: CallAudioFormat =
         result.contentType.includes("wav") ||
         result.contentType.includes("x-wav")
           ? "wav"
@@ -709,7 +710,7 @@ export class MediaStreamOutput implements CallTransport {
       }
 
       const contentType = response.headers.get("content-type") ?? "audio/mpeg";
-      const format: "mp3" | "wav" | "opus" | "pcm" = contentType.includes("wav")
+      const format: CallAudioFormat = contentType.includes("wav")
         ? "wav"
         : contentType.includes("opus")
           ? "opus"
@@ -763,7 +764,7 @@ export class MediaStreamOutput implements CallTransport {
    */
   private audioBufferToFrames(
     audio: Buffer,
-    format: "mp3" | "wav" | "opus" | "pcm",
+    format: CallAudioFormat,
   ): string[] {
     // Sniff the actual bytes rather than trusting the declared format.
     // WAV files always start with the ASCII magic "RIFF" (0x52494646).
@@ -805,8 +806,9 @@ export class MediaStreamOutput implements CallTransport {
 
     // When the declared format is "wav" but the RIFF check failed, the
     // bytes might be either:
-    // (a) Raw PCM stored under audio/wav content-type (when
-    //     outputFormat: "pcm" is used with createStreamingEntry("wav"))
+    // (a) Raw PCM served under a wav content-type (declared "wav" only
+    //     arrives via content-type sniffing; some providers label raw
+    //     PCM streams audio/wav)
     // (b) Compressed audio (mp3/opus) from a provider that ignores
     //     outputFormat (e.g. Fish Audio defaults to mp3)
     //

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -140,10 +140,10 @@ export class MediaStreamOutput implements CallTransport {
   private audioStartCallback: (() => void) | null = null;
 
   /**
-   * The media-stream transport requires WAV (PCM) audio because its
+   * The media-stream transport requires raw PCM audio because its
    * mu-law transcoder cannot decode compressed formats (mp3, opus).
    */
-  readonly requiresWavAudio = true;
+  readonly requiresPcmAudio = true;
 
   constructor(ws: ServerWebSocket<unknown>, streamSid: string) {
     this.ws = ws;
@@ -522,11 +522,11 @@ export class MediaStreamOutput implements CallTransport {
     this.activePlaybackAbort = abortController;
 
     try {
-      // Request WAV so audioBufferToFrames gets PCM it can transcode
+      // Request PCM so audioBufferToFrames gets raw PCM it can transcode
       // to mu-law. Compressed formats (mp3, opus) would be sent as raw
       // bytes and produce garbled audio.
       const { provider, audioFormat } = await resolveCallTtsProvider({
-        preferWav: true,
+        requiresPcmAudio: true,
       });
       if (!provider) {
         log.warn(
@@ -633,8 +633,10 @@ export class MediaStreamOutput implements CallTransport {
 
       // Derive the format from the provider's actual content type rather
       // than the declared audioFormat. The declared format may not match
-      // reality (e.g. preferWav requests WAV but the provider returns mp3).
-      // audioBufferToFrames also sniffs magic bytes as a safety net.
+      // reality (e.g. requiresPcmAudio requests PCM but the provider
+      // returns mp3). For unknown content types, fall back to the declared
+      // format (PCM on this path — the bytes were requested as raw PCM,
+      // and audioBufferToFrames sniffs magic bytes as a safety net).
       const actualFormat: "mp3" | "wav" | "opus" | "pcm" =
         result.contentType.includes("wav") ||
         result.contentType.includes("x-wav")

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -747,9 +747,9 @@ export class MediaStreamOutput implements CallTransport {
    * base64-encoded mu-law frames.
    *
    * Rather than trusting the declared `format` parameter (which may not
-   * match the actual bytes — e.g. when a provider is asked for WAV but
-   * returns mp3), this method **sniffs the magic bytes** to detect the
-   * real format:
+   * match the actual bytes — e.g. the declared format may be pcm while
+   * the provider returned mp3), this method **sniffs the magic bytes**
+   * to detect the real format:
    *
    * - **WAV** (`RIFF` header, bytes `0x52 0x49 0x46 0x46`): extracts
    *   raw PCM data from the WAV container, converts it to 8 kHz using the

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -35,6 +35,7 @@
 
 import type { ServerWebSocket } from "bun";
 
+import { createPcmChunkAligner } from "../tts/pcm-chunk-aligner.js";
 import { extractSpeakableSegments } from "../tts/speakable-segments.js";
 import { synthesizeAndEmit } from "../tts/synthesis-stream.js";
 import { getLogger } from "../util/logger.js";
@@ -193,7 +194,9 @@ export class MediaStreamOutput implements CallTransport {
    * PCM, and re-encode as mu-law frames for Twilio.
    */
   sendPlayUrl(url: string): void {
-    if (this.state === "closed") return;
+    if (this.state === "closed") {
+      return;
+    }
     this.enqueuePlayback({ type: "fetch-url", url });
   }
 
@@ -231,7 +234,9 @@ export class MediaStreamOutput implements CallTransport {
    * closes.
    */
   endSession(reason?: string): void {
-    if (this.state === "closed") return;
+    if (this.state === "closed") {
+      return;
+    }
     this.state = "closed";
 
     // Cancel any in-flight playback
@@ -258,7 +263,9 @@ export class MediaStreamOutput implements CallTransport {
    * Send a base64-encoded audio frame to Twilio for playback.
    */
   sendAudioPayload(base64Payload: string): void {
-    if (this.state === "closed") return;
+    if (this.state === "closed") {
+      return;
+    }
 
     const command: MediaStreamSendMediaCommand = {
       event: "media",
@@ -283,7 +290,9 @@ export class MediaStreamOutput implements CallTransport {
    * back a `mark` event when the caller reaches this point in playback.
    */
   sendMark(name: string): void {
-    if (this.state === "closed") return;
+    if (this.state === "closed") {
+      return;
+    }
 
     const command: MediaStreamSendMarkCommand = {
       event: "mark",
@@ -317,7 +326,9 @@ export class MediaStreamOutput implements CallTransport {
    * when it actually aborts the turn.
    */
   clearAudio(): void {
-    if (this.state === "closed") return;
+    if (this.state === "closed") {
+      return;
+    }
 
     // Flush our internal playback queue and abort in-flight work.
     this.flushPlaybackQueue();
@@ -337,7 +348,9 @@ export class MediaStreamOutput implements CallTransport {
    * (initial greeting, setup handoff prompt) survives to play after.
    */
   clearBufferedAudio(): void {
-    if (this.state === "closed") return;
+    if (this.state === "closed") {
+      return;
+    }
     this.sendClearCommand();
   }
 
@@ -431,7 +444,9 @@ export class MediaStreamOutput implements CallTransport {
    * before sending.
    */
   private async drainPlaybackQueue(): Promise<void> {
-    if (this.draining) return;
+    if (this.draining) {
+      return;
+    }
     this.draining = true;
 
     try {
@@ -459,7 +474,9 @@ export class MediaStreamOutput implements CallTransport {
 
         // If the playback version changed (clearAudio was called), stop
         // processing stale items.
-        if (version !== this.playbackVersion) break;
+        if (version !== this.playbackVersion) {
+          break;
+        }
       }
     } finally {
       this.draining = false;
@@ -477,7 +494,9 @@ export class MediaStreamOutput implements CallTransport {
    * the one-shot audio-start signal before the first frame goes out.
    */
   private sendFrames(frames: string[]): void {
-    if (frames.length === 0) return;
+    if (frames.length === 0) {
+      return;
+    }
     const audioStartCallback = this.audioStartCallback;
     if (audioStartCallback) {
       this.audioStartCallback = null;
@@ -534,7 +553,8 @@ export class MediaStreamOutput implements CallTransport {
       // Chunk boundaries can split a 16-bit sample or a decimation pair;
       // the unprocessable tail (< 4 bytes) carries into the next chunk so
       // sample alignment and decimation phase stay stable across chunks.
-      let pcmCarry: Buffer | undefined;
+      // 4 bytes = two 16 kHz samples = one 8 kHz output sample.
+      const pcmAligner = createPcmChunkAligner(4);
       // Mu-law bytes short of a whole 20 ms frame, carried likewise.
       let mulawCarry: Buffer = Buffer.alloc(0);
 
@@ -575,20 +595,12 @@ export class MediaStreamOutput implements CallTransport {
           if (!isCurrent()) {
             return;
           }
-          const combined = pcmCarry
-            ? Buffer.concat([pcmCarry, chunk.audio])
-            : chunk.audio;
-          // 4 bytes = two 16 kHz samples = one 8 kHz output sample.
-          const usableBytes = combined.length & ~3;
-          pcmCarry =
-            usableBytes < combined.length
-              ? combined.subarray(usableBytes)
-              : undefined;
-          if (usableBytes === 0) {
+          const aligned = pcmAligner.align(chunk.audio);
+          if (aligned.byteLength === 0) {
             return;
           }
           const pcm8k = this.pcm16ToTelephonyRate(
-            combined.subarray(0, usableBytes),
+            aligned,
             STREAMING_PCM_SAMPLE_RATE_HZ,
           );
           sendMulaw(pcm16ToMulaw(pcm8k), false);
@@ -600,11 +612,11 @@ export class MediaStreamOutput implements CallTransport {
       }
 
       if (streamsPcm) {
-        if (pcmCarry) {
+        if (pcmAligner.carryLength() > 0) {
           // A sub-sample tail is malformed provider output; decimation
           // would drop it anyway.
           log.debug(
-            { streamSid: this.streamSid, carryBytes: pcmCarry.length },
+            { streamSid: this.streamSid, carryBytes: pcmAligner.carryLength() },
             "Dropping sub-sample tail from PCM16 TTS stream",
           );
         }
@@ -685,10 +697,14 @@ export class MediaStreamOutput implements CallTransport {
         return;
       }
 
-      if (version !== this.playbackVersion || this.isClosed()) return;
+      if (version !== this.playbackVersion || this.isClosed()) {
+        return;
+      }
 
       const buffer = Buffer.from(await response.arrayBuffer());
-      if (version !== this.playbackVersion || this.isClosed()) return;
+      if (version !== this.playbackVersion || this.isClosed()) {
+        return;
+      }
 
       const contentType = response.headers.get("content-type") ?? "audio/mpeg";
       const format: "mp3" | "wav" | "opus" | "pcm" = contentType.includes("wav")
@@ -700,7 +716,9 @@ export class MediaStreamOutput implements CallTransport {
             : "mp3";
 
       const frames = this.audioBufferToFrames(buffer, format);
-      if (version !== this.playbackVersion || this.isClosed()) return;
+      if (version !== this.playbackVersion || this.isClosed()) {
+        return;
+      }
 
       this.sendFrames(frames);
     } catch (err) {
@@ -762,7 +780,9 @@ export class MediaStreamOutput implements CallTransport {
       const sampleRate = audio.readUInt32LE(24);
       const bitsPerSample = audio.readUInt16LE(34);
       let pcmData: Buffer = audio.subarray(44);
-      if (pcmData.length < 2) return [];
+      if (pcmData.length < 2) {
+        return [];
+      }
 
       if (bitsPerSample !== 16 || channels > 2 || channels === 0) {
         // Limitation: only 16-bit mono/stereo PCM is decoded here.
@@ -827,7 +847,9 @@ export class MediaStreamOutput implements CallTransport {
     // ElevenLabs pcm_16000 produces 16-bit signed LE at 16 kHz. Twilio
     // needs 8 kHz mu-law, so we downsample by taking every other sample.
     if (format === "pcm" || format === "wav") {
-      if (audio.length < 2) return [];
+      if (audio.length < 2) {
+        return [];
+      }
       // Headerless PCM carries no declared rate; assume the 16 kHz that
       // ElevenLabs pcm_16000 produces and downsample to 8 kHz.
       const downsampled = decimatePcm16(audio, 2);
@@ -876,7 +898,9 @@ export class MediaStreamOutput implements CallTransport {
    * assumption with a warning.
    */
   private pcm16ToTelephonyRate(pcm: Buffer, sampleRate: number): Buffer {
-    if (sampleRate === TELEPHONY_SAMPLE_RATE_HZ) return pcm;
+    if (sampleRate === TELEPHONY_SAMPLE_RATE_HZ) {
+      return pcm;
+    }
     if (!Number.isFinite(sampleRate) || sampleRate <= 0) {
       log.warn(
         { streamSid: this.streamSid, sampleRate },

--- a/assistant/src/calls/resolve-call-tts-provider.ts
+++ b/assistant/src/calls/resolve-call-tts-provider.ts
@@ -176,6 +176,30 @@ export async function resolveCallTtsProvider(
 }
 
 /**
+ * Decode a resolved call audio format into the provider request format
+ * and the audio-store format.
+ *
+ * Transport-forced PCM and user-configured WAV both request raw PCM from
+ * the provider so the audio bytes match the store's content-type —
+ * without this, providers like Fish Audio still return mp3 and the
+ * downstream mu-law transcoder fails on the format mismatch. The store
+ * format follows the request: when raw PCM is requested the entry's
+ * content-type must be audio/pcm, otherwise the store would say
+ * "audio/wav" while the bytes have no RIFF header and
+ * audioBufferToFrames falls through to the wrong decode path.
+ */
+export function resolveSynthesisFormats(
+  format: "mp3" | "wav" | "opus" | "pcm",
+): {
+  outputFormat: "pcm" | undefined;
+  storeFormat: "mp3" | "wav" | "opus" | "pcm";
+} {
+  const outputFormat =
+    format === "pcm" || format === "wav" ? ("pcm" as const) : undefined;
+  return { outputFormat, storeFormat: outputFormat ?? format };
+}
+
+/**
  * Find a catalog provider that can produce playable media-stream audio
  * with resolvable credentials.
  *

--- a/assistant/src/calls/resolve-call-tts-provider.ts
+++ b/assistant/src/calls/resolve-call-tts-provider.ts
@@ -163,7 +163,7 @@ export async function resolveCallTtsProvider(
             ["mp3", "wav", "opus"].includes(configuredFormat)
               ? configuredFormat
               : "mp3"
-          ) as "mp3" | "wav" | "opus";
+          ) as Exclude<CallAudioFormat, "pcm">;
         })();
 
     return { provider, useSynthesizedPath, audioFormat };

--- a/assistant/src/calls/resolve-call-tts-provider.ts
+++ b/assistant/src/calls/resolve-call-tts-provider.ts
@@ -43,7 +43,7 @@ export interface ResolvedCallTts {
   useSynthesizedPath: boolean;
 
   /** Audio format to use for synthesized audio. */
-  audioFormat: "mp3" | "wav" | "opus";
+  audioFormat: "mp3" | "wav" | "opus" | "pcm";
 }
 
 // ---------------------------------------------------------------------------
@@ -52,18 +52,17 @@ export interface ResolvedCallTts {
 
 export interface ResolveCallTtsOptions {
   /**
-   * When true, force `audioFormat` to `"wav"` regardless of the
+   * When true, resolve `audioFormat` to `"pcm"` regardless of the
    * provider's configured format. The media-stream transport sets this
-   * because its {@link audioBufferToFrames} can only correctly
-   * transcode WAV (PCM) to mu-law -- compressed formats (mp3, opus)
-   * are sent as raw bytes and produce garbled audio.
+   * because it transcodes raw PCM to mu-law -- compressed formats
+   * (mp3, opus) are sent as raw bytes and produce garbled audio.
    *
    * Also gates the media-stream playability guard: a configured provider
-   * that cannot produce playable PCM/WAV audio (or lacks credentials) is
+   * that cannot produce playable PCM audio (or lacks credentials) is
    * swapped for a playable fallback provider instead of resolving into a
    * provider whose only possible media-stream outcome is silence.
    */
-  preferWav?: boolean;
+  requiresPcmAudio?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -80,8 +79,8 @@ export interface ResolveCallTtsOptions {
  * `callMode: "native-twilio"` send text via `sendTextToken`, which the
  * media-stream transport re-synthesizes through daemon TTS.
  *
- * For WAV-requiring transports (`preferWav`, i.e. media-stream), the
- * resolved provider is validated against the media-stream playability
+ * For PCM-requiring transports (`requiresPcmAudio`, i.e. media-stream),
+ * the resolved provider is validated against the media-stream playability
  * capability (format + credentials); a not-playable provider is replaced
  * by {@link findPlayableTelephonyTtsFallback}.
  *
@@ -108,9 +107,9 @@ export async function resolveCallTtsProvider(
     const fishAudioUnusable =
       providerId === "fish-audio" && !fishAudioReferenceIdConfigured();
 
-    if (options?.preferWav) {
+    if (options?.requiresPcmAudio) {
       // Media-stream transport: every spoken turn is synthesized, so the
-      // provider must produce playable PCM/WAV with resolvable credentials
+      // provider must produce playable PCM with resolvable credentials
       // and satisfied config invariants (the capability check covers the
       // fish-audio referenceId rule). Swap in a playable fallback rather
       // than resolving into a provider that can only be silent.
@@ -134,7 +133,7 @@ export async function resolveCallTtsProvider(
         }
       }
     } else if (useSynthesizedPath && fishAudioUnusable) {
-      // Non-WAV transport: degrade to the native token path rather than
+      // Non-PCM transport: degrade to the native token path rather than
       // letting the call stay silent.
       log.warn(
         { provider: providerId },
@@ -149,21 +148,23 @@ export async function resolveCallTtsProvider(
     // config so the streaming store entry's content-type matches the
     // actual audio bytes the provider produces.
     //
-    // When preferWav is set (media-stream transport), force WAV so
-    // audioBufferToFrames receives PCM it can transcode to mu-law.
-    const audioFormat: "mp3" | "wav" | "opus" = options?.preferWav
-      ? "wav"
-      : (() => {
-          const configuredFormat = (
-            resolved.providerConfig as { format?: string }
-          ).format;
-          return (
-            configuredFormat &&
-            ["mp3", "wav", "opus"].includes(configuredFormat)
-              ? configuredFormat
-              : "mp3"
-          ) as "mp3" | "wav" | "opus";
-        })();
+    // When requiresPcmAudio is set (media-stream transport), resolve to
+    // PCM so audioBufferToFrames receives raw PCM it can transcode to
+    // mu-law.
+    const audioFormat: "mp3" | "wav" | "opus" | "pcm" =
+      options?.requiresPcmAudio
+        ? "pcm"
+        : (() => {
+            const configuredFormat = (
+              resolved.providerConfig as { format?: string }
+            ).format;
+            return (
+              configuredFormat &&
+              ["mp3", "wav", "opus"].includes(configuredFormat)
+                ? configuredFormat
+                : "mp3"
+            ) as "mp3" | "wav" | "opus";
+          })();
 
     return { provider, useSynthesizedPath, audioFormat };
   } catch {

--- a/assistant/src/calls/resolve-call-tts-provider.ts
+++ b/assistant/src/calls/resolve-call-tts-provider.ts
@@ -16,6 +16,7 @@ import {
 import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
 import type { TtsProvider, TtsProviderId } from "../tts/types.js";
 import { getLogger } from "../util/logger.js";
+import type { CallAudioFormat } from "./audio-store.js";
 import {
   evaluateTelephonyTtsPlayability,
   fishAudioReferenceIdConfigured,
@@ -43,7 +44,7 @@ export interface ResolvedCallTts {
   useSynthesizedPath: boolean;
 
   /** Audio format to use for synthesized audio. */
-  audioFormat: "mp3" | "wav" | "opus" | "pcm";
+  audioFormat: CallAudioFormat;
 }
 
 // ---------------------------------------------------------------------------
@@ -151,20 +152,19 @@ export async function resolveCallTtsProvider(
     // When requiresPcmAudio is set (media-stream transport), resolve to
     // PCM so audioBufferToFrames receives raw PCM it can transcode to
     // mu-law.
-    const audioFormat: "mp3" | "wav" | "opus" | "pcm" =
-      options?.requiresPcmAudio
-        ? "pcm"
-        : (() => {
-            const configuredFormat = (
-              resolved.providerConfig as { format?: string }
-            ).format;
-            return (
-              configuredFormat &&
-              ["mp3", "wav", "opus"].includes(configuredFormat)
-                ? configuredFormat
-                : "mp3"
-            ) as "mp3" | "wav" | "opus";
-          })();
+    const audioFormat: CallAudioFormat = options?.requiresPcmAudio
+      ? "pcm"
+      : (() => {
+          const configuredFormat = (
+            resolved.providerConfig as { format?: string }
+          ).format;
+          return (
+            configuredFormat &&
+            ["mp3", "wav", "opus"].includes(configuredFormat)
+              ? configuredFormat
+              : "mp3"
+          ) as "mp3" | "wav" | "opus";
+        })();
 
     return { provider, useSynthesizedPath, audioFormat };
   } catch {
@@ -188,11 +188,9 @@ export async function resolveCallTtsProvider(
  * "audio/wav" while the bytes have no RIFF header and
  * audioBufferToFrames falls through to the wrong decode path.
  */
-export function resolveSynthesisFormats(
-  format: "mp3" | "wav" | "opus" | "pcm",
-): {
+export function resolveSynthesisFormats(format: CallAudioFormat): {
   outputFormat: "pcm" | undefined;
-  storeFormat: "mp3" | "wav" | "opus" | "pcm";
+  storeFormat: CallAudioFormat;
 } {
   const outputFormat =
     format === "pcm" || format === "wav" ? ("pcm" as const) : undefined;

--- a/assistant/src/calls/telephony-tts-capability.ts
+++ b/assistant/src/calls/telephony-tts-capability.ts
@@ -4,9 +4,9 @@
  * Validates whether a TTS provider can produce audio that is actually
  * playable over the media-stream call transport. Playability requires:
  *
- * 1. The catalog entry's `mediaStreamPlayback.outputFormat` is `"pcm"` or
- *    `"wav"` — the media-stream mu-law transcoder cannot decode compressed
- *    formats (mp3, opus).
+ * 1. The catalog entry's `mediaStreamPlayback.outputFormat` is `"pcm"` —
+ *    the media-stream mu-law transcoder cannot decode compressed formats
+ *    (mp3, opus).
  * 2. Every secret the catalog entry requires resolves to a value.
  * 3. Provider-specific config invariants hold — Fish Audio requires a
  *    configured `referenceId` (no per-request voiceId is supplied on the
@@ -65,7 +65,7 @@ export type TelephonyTtsCapability =
  * the media-stream call transport.
  *
  * Callers can branch on the discriminated `status` field:
- * - `"playable"` — the provider produces PCM/WAV and credentials resolve.
+ * - `"playable"` — the provider produces PCM and credentials resolve.
  * - `"not-playable"` — see `reason` (`"unsupported-format"` when the
  *   provider is unknown or only produces compressed audio,
  *   `"missing-credentials"` when a required secret does not resolve,

--- a/assistant/src/calls/telephony-tts-capability.ts
+++ b/assistant/src/calls/telephony-tts-capability.ts
@@ -129,7 +129,7 @@ export async function evaluateTelephonyTtsPlayability(
  * Single source of truth for the fish-audio usability invariant: the
  * telephony path supplies no per-request voiceId, so synthesis requires a
  * configured reference ID. Shared by {@link evaluateTelephonyTtsPlayability}
- * and the call TTS resolver's non-WAV degrade path.
+ * and the call TTS resolver's non-PCM (native token) degrade path.
  *
  * When fish-audio is the active `services.tts.provider`, its config is
  * read through the {@link resolveTtsConfig} provider-options layer — the

--- a/assistant/src/live-voice/live-voice-tts.ts
+++ b/assistant/src/live-voice/live-voice-tts.ts
@@ -1,3 +1,4 @@
+import { createPcmChunkAligner } from "../tts/pcm-chunk-aligner.js";
 import { getTtsProvider } from "../tts/provider-catalog.js";
 import { synthesizeAndEmit } from "../tts/synthesis-stream.js";
 import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
@@ -130,16 +131,7 @@ export async function streamLiveVoiceTtsAudio(
 
   // Provider chunks can split a 16-bit PCM sample across chunk boundaries;
   // a trailing odd byte is carried into the next chunk to keep frames aligned.
-  let pcm16Carry: Buffer | undefined;
-  const alignPcm16 = (audio: Buffer): Buffer => {
-    const combined = pcm16Carry ? Buffer.concat([pcm16Carry, audio]) : audio;
-    const alignedLength = combined.byteLength & ~1;
-    pcm16Carry =
-      alignedLength < combined.byteLength
-        ? combined.subarray(alignedLength)
-        : undefined;
-    return combined.subarray(0, alignedLength);
-  };
+  const pcmAligner = createPcmChunkAligner(2);
 
   try {
     const result = await synthesizeAndEmit({
@@ -154,7 +146,7 @@ export async function streamLiveVoiceTtsAudio(
         if (canStreamChunks) {
           emitAudioFrame(
             chunk.contentType || chunkContentType,
-            alignPcm16(chunk.audio),
+            pcmAligner.align(chunk.audio),
           );
         } else {
           bufferedAudio.push(chunk.audio);
@@ -164,7 +156,7 @@ export async function streamLiveVoiceTtsAudio(
 
     // A dangling final byte is malformed provider output — drop it rather
     // than emit a torn sample.
-    if (pcm16Carry) {
+    if (pcmAligner.carryLength() > 0) {
       log.debug(
         { provider: providerId },
         "Dropping trailing odd byte from PCM16 TTS stream",
@@ -230,7 +222,9 @@ function normalizeProviderError(
   err: unknown,
   providerId: TtsProviderId,
 ): LiveVoiceTtsError {
-  if (err instanceof LiveVoiceTtsError) return err;
+  if (err instanceof LiveVoiceTtsError) {
+    return err;
+  }
 
   const message = err instanceof Error ? err.message : String(err);
   if (isProviderConfigurationError(err)) {

--- a/assistant/src/tts/__tests__/pcm-chunk-aligner.test.ts
+++ b/assistant/src/tts/__tests__/pcm-chunk-aligner.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+
+import { createPcmChunkAligner } from "../pcm-chunk-aligner.js";
+
+describe("createPcmChunkAligner", () => {
+  test("passes whole-block chunks through unchanged", () => {
+    const aligner = createPcmChunkAligner(2);
+    const chunk = Buffer.from([1, 2, 3, 4]);
+    expect(aligner.align(chunk)).toEqual(chunk);
+    expect(aligner.carryLength()).toBe(0);
+  });
+
+  test("re-joins a sample split across two chunks", () => {
+    const aligner = createPcmChunkAligner(2);
+    expect(aligner.align(Buffer.from([1, 2, 3]))).toEqual(Buffer.from([1, 2]));
+    expect(aligner.carryLength()).toBe(1);
+    expect(aligner.align(Buffer.from([4, 5, 6]))).toEqual(
+      Buffer.from([3, 4, 5, 6]),
+    );
+    expect(aligner.carryLength()).toBe(0);
+  });
+
+  test("returns empty and carries a sub-block first chunk", () => {
+    const aligner = createPcmChunkAligner(2);
+    expect(aligner.align(Buffer.from([7])).byteLength).toBe(0);
+    expect(aligner.carryLength()).toBe(1);
+    expect(aligner.align(Buffer.from([8]))).toEqual(Buffer.from([7, 8]));
+    expect(aligner.carryLength()).toBe(0);
+  });
+
+  test("aligns 4-byte decimation pairs", () => {
+    const aligner = createPcmChunkAligner(4);
+    expect(aligner.align(Buffer.from([1, 2, 3, 4, 5]))).toEqual(
+      Buffer.from([1, 2, 3, 4]),
+    );
+    expect(aligner.carryLength()).toBe(1);
+    expect(aligner.align(Buffer.from([6, 7, 8, 9, 10]))).toEqual(
+      Buffer.from([5, 6, 7, 8]),
+    );
+    expect(aligner.carryLength()).toBe(2);
+  });
+
+  test("keeps a dangling final byte in carry", () => {
+    const aligner = createPcmChunkAligner(2);
+    aligner.align(Buffer.from([1, 2, 3, 4, 5]));
+    expect(aligner.carryLength()).toBe(1);
+  });
+});

--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -389,7 +389,7 @@ describe("ElevenLabs TTS provider adapter", () => {
     expect(capturedUrl).toContain("output_format=pcm_16000");
   });
 
-  test("pcm output with unmatched sampleRateHz falls back to pcm_16000", async () => {
+  test("pcm output clamps an unsupported sampleRateHz hint to the nearest supported rate", async () => {
     const audioPayload = new Uint8Array([0x00, 0x01]);
     let capturedUrl = "";
 
@@ -402,8 +402,30 @@ describe("ElevenLabs TTS provider adapter", () => {
     await provider.synthesize(
       makeRequest({ outputFormat: "pcm", sampleRateHz: 8000 }),
     );
-
     expect(capturedUrl).toContain("output_format=pcm_16000");
+
+    // 48 kHz clamps to 24 kHz, not the Pro-tier-gated pcm_44100.
+    await provider.synthesize(
+      makeRequest({ outputFormat: "pcm", sampleRateHz: 48000 }),
+    );
+    expect(capturedUrl).toContain("output_format=pcm_24000");
+  });
+
+  test("pcm output uses Pro-tier pcm_44100 only on an exact 44100 hint", async () => {
+    const audioPayload = new Uint8Array([0x00, 0x01]);
+    let capturedUrl = "";
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      capturedUrl = typeof input === "string" ? input : input.toString();
+      return new Response(audioPayload, { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const provider = createElevenLabsProvider();
+    await provider.synthesize(
+      makeRequest({ outputFormat: "pcm", sampleRateHz: 44100 }),
+    );
+
+    expect(capturedUrl).toContain("output_format=pcm_44100");
   });
 
   test("resolveOutputSampleRateHz reports the actual PCM rate without synthesis", () => {
@@ -418,7 +440,12 @@ describe("ElevenLabs TTS provider adapter", () => {
       provider.resolveOutputSampleRateHz!(
         makeRequest({ outputFormat: "pcm", sampleRateHz: 48000 }),
       ),
-    ).toBe(16000);
+    ).toBe(24000);
+    expect(
+      provider.resolveOutputSampleRateHz!(
+        makeRequest({ outputFormat: "pcm", sampleRateHz: 44100 }),
+      ),
+    ).toBe(44100);
     expect(provider.resolveOutputSampleRateHz!(makeRequest())).toBeUndefined();
   });
 

--- a/assistant/src/tts/__tests__/provider-catalog.test.ts
+++ b/assistant/src/tts/__tests__/provider-catalog.test.ts
@@ -54,7 +54,7 @@ describe("TTS provider catalog", () => {
   });
 
   test("every entry declares a valid mediaStreamPlayback output format", () => {
-    const validFormats = new Set(["pcm", "wav", "none"]);
+    const validFormats = new Set(["pcm", "none"]);
     for (const entry of entries) {
       expect(validFormats.has(entry.mediaStreamPlayback.outputFormat)).toBe(
         true,

--- a/assistant/src/tts/pcm-chunk-aligner.ts
+++ b/assistant/src/tts/pcm-chunk-aligner.ts
@@ -1,0 +1,29 @@
+/**
+ * Block-aligning carry buffer for streamed PCM chunks. Chunk boundaries can
+ * split a sample (or a decimation pair) across chunks; `align` returns the
+ * largest prefix of carry+chunk that is a whole number of blocks and retains
+ * the remainder for the next call.
+ */
+export interface PcmChunkAligner {
+  /** Aligned prefix of carry+chunk; empty when too few bytes have arrived. */
+  align(chunk: Buffer): Buffer;
+  /** Bytes held as carry (non-zero at end-of-stream means a torn tail). */
+  carryLength(): number;
+}
+
+export function createPcmChunkAligner(blockBytes: number): PcmChunkAligner {
+  let carry: Buffer | undefined;
+  return {
+    align(chunk) {
+      const combined = carry ? Buffer.concat([carry, chunk]) : chunk;
+      const alignedLength =
+        combined.byteLength - (combined.byteLength % blockBytes);
+      carry =
+        alignedLength < combined.byteLength
+          ? combined.subarray(alignedLength)
+          : undefined;
+      return combined.subarray(0, alignedLength);
+    },
+    carryLength: () => carry?.byteLength ?? 0,
+  };
+}

--- a/assistant/src/tts/pcm-chunk-aligner.ts
+++ b/assistant/src/tts/pcm-chunk-aligner.ts
@@ -4,7 +4,7 @@
  * largest prefix of carry+chunk that is a whole number of blocks and retains
  * the remainder for the next call.
  */
-export interface PcmChunkAligner {
+interface PcmChunkAligner {
   /** Aligned prefix of carry+chunk; empty when too few bytes have arrived. */
   align(chunk: Buffer): Buffer;
   /** Bytes held as carry (non-zero at end-of-stream means a torn tail). */

--- a/assistant/src/tts/provider-definition.ts
+++ b/assistant/src/tts/provider-definition.ts
@@ -66,14 +66,13 @@ export interface TtsProviderCatalogCapabilities {
  * Output format the provider's adapter produces when a caller requests
  * PCM output (`outputFormat: "pcm"`) for media-stream playback.
  *
- * The media-stream transport can only transcode raw PCM or WAV
- * (PCM-in-container) to mu-law — compressed formats (mp3, opus) produce
- * garbled audio. Providers whose adapter honours the PCM hint declare
- * `"pcm"`; providers that substitute WAV declare `"wav"`; providers that
- * can only produce compressed audio declare `"none"` and are not playable
- * over media-stream transports.
+ * The media-stream transport can only transcode raw PCM to mu-law —
+ * compressed formats (mp3, opus) produce garbled audio. Providers whose
+ * adapter honours the PCM hint declare `"pcm"`; providers that can only
+ * produce compressed audio declare `"none"` and are not playable over
+ * media-stream transports.
  */
-export type TtsMediaStreamOutputFormat = "pcm" | "wav" | "none";
+export type TtsMediaStreamOutputFormat = "pcm" | "none";
 
 /**
  * How the provider's synthesized audio plays over media-stream transports.

--- a/assistant/src/tts/providers/elevenlabs-provider.ts
+++ b/assistant/src/tts/providers/elevenlabs-provider.ts
@@ -13,6 +13,7 @@ import type { TtsElevenLabsProviderConfig } from "../../config/schemas/tts.js";
 import { credentialKey } from "../../security/credential-key.js";
 import { getSecureKeyAsync } from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
+import { resolvePcmOutputSampleRateHz } from "../pcm-sample-rates.js";
 import type { TtsProviderDefinition } from "../provider-definition.js";
 import {
   consumeSynthesisResponse,
@@ -164,12 +165,29 @@ function resolveVoiceId(
   return voiceId;
 }
 
-/** ElevenLabs PCM output formats by exact sample rate. */
-const PCM_FORMAT_BY_SAMPLE_RATE: Record<number, string> = {
-  16000: "pcm_16000",
-  22050: "pcm_22050",
-  24000: "pcm_24000",
-  44100: "pcm_44100",
+/** ElevenLabs `pcm_*` rates available on every subscription tier. */
+const UNRESTRICTED_PCM_SAMPLE_RATES_HZ = [16_000, 22_050, 24_000] as const;
+
+/** `pcm_44100` requires Pro tier or above upstream. */
+const PRO_TIER_PCM_SAMPLE_RATE_HZ = 44_100;
+
+/**
+ * PCM rate resolver for ElevenLabs. pcm_44100 is Pro-tier-gated upstream, so
+ * it is only used on an exact 44.1 kHz hint (explicit opt-in), never as a
+ * clamp target; all other hints clamp to the tier-unrestricted rates
+ * (e.g. 48 kHz → 24 kHz).
+ */
+const resolveElevenLabsPcmSampleRateHz = (request: TtsSynthesisRequest) => {
+  if (
+    request.outputFormat === "pcm" &&
+    request.sampleRateHz === PRO_TIER_PCM_SAMPLE_RATE_HZ
+  ) {
+    return PRO_TIER_PCM_SAMPLE_RATE_HZ;
+  }
+  return resolvePcmOutputSampleRateHz(
+    request,
+    UNRESTRICTED_PCM_SAMPLE_RATES_HZ,
+  );
 };
 
 /**
@@ -177,30 +195,21 @@ const PCM_FORMAT_BY_SAMPLE_RATE: Record<number, string> = {
  * format hint.
  *
  * When the caller requests `outputFormat: "pcm"` (e.g. the media-stream
- * transport which needs raw PCM for mu-law transcoding), we map the optional
- * `sampleRateHz` hint to an exact ElevenLabs PCM format — 16-bit signed
- * little-endian. An absent or unmatched hint defaults to `pcm_16000`, which
- * preserves the media-stream transport's behavior (its `audioBufferToFrames`
- * handles the 16 kHz -> 8 kHz downsample).
+ * transport which needs raw PCM for mu-law transcoding), we request the
+ * `pcm_*` format — 16-bit signed little-endian — at the rate chosen by
+ * {@link resolveElevenLabsPcmSampleRateHz}, defaulting to 16 kHz when no
+ * hint is given (the shared no-hint convention across TTS providers).
  *
  * Otherwise:
  * - Phone calls benefit from lower-latency, smaller payloads (mp3 at 22050/32).
  * - Message playback uses higher quality (mp3 at 44100/128).
  */
 function resolveOutputFormat(request: TtsSynthesisRequest): string {
-  if (request.outputFormat === "pcm") {
-    return (
-      PCM_FORMAT_BY_SAMPLE_RATE[request.sampleRateHz ?? 16000] ?? "pcm_16000"
-    );
+  const pcmSampleRateHz = resolveElevenLabsPcmSampleRateHz(request);
+  if (pcmSampleRateHz != null) {
+    return `pcm_${pcmSampleRateHz}`;
   }
   return request.useCase === "phone-call" ? "mp3_22050_32" : "mp3_44100_128";
-}
-
-/** Sample rate of a `pcm_*` output format in Hz; undefined for non-PCM formats. */
-function pcmFormatSampleRateHz(outputFormat: string): number | undefined {
-  return outputFormat.startsWith("pcm_")
-    ? Number(outputFormat.slice("pcm_".length))
-    : undefined;
 }
 
 /**
@@ -346,8 +355,7 @@ export function createElevenLabsProvider(
   return {
     id: "elevenlabs",
     capabilities,
-    resolveOutputSampleRateHz: (request) =>
-      pcmFormatSampleRateHz(resolveOutputFormat(request)),
+    resolveOutputSampleRateHz: resolveElevenLabsPcmSampleRateHz,
     synthesize: (request) => performSynthesis(request, { stream: false }),
     synthesizeStream: (request, onChunk) =>
       performSynthesis(request, { stream: true, onChunk, ...streamTimeouts }),

--- a/assistant/src/tts/stream-read.ts
+++ b/assistant/src/tts/stream-read.ts
@@ -1,12 +1,13 @@
 /**
  * Shared response-consumption helpers for streaming TTS HTTP responses.
  *
- * `readChunkedBody` reads a fetch response body to completion, forwarding each
- * non-empty chunk to an optional callback, and guards against stalled upstream
- * streams with a first-chunk timeout and an idle (between-chunks) timeout. On
- * timeout the reader is cancelled and the caller-supplied error is thrown.
- * `consumeSynthesisResponse` wraps it with the provider-common empty-response
- * guards and the buffered (non-streaming) read path.
+ * `consumeSynthesisResponse` is the public API: it consumes an OK TTS response
+ * into complete audio, with provider-common empty-response guards and a
+ * buffered (non-streaming) read path. Its streaming path reads the body to
+ * completion, forwarding each non-empty chunk to an optional callback, and
+ * guards against stalled upstreams with a first-chunk timeout and an idle
+ * (between-chunks) timeout; on timeout the reader is cancelled and the
+ * caller-supplied error is thrown.
  */
 
 /** Default timeout waiting for the first chunk of a TTS stream (ms). */
@@ -24,7 +25,7 @@ export interface StreamReadTimeouts {
   idleTimeoutMs?: number;
 }
 
-export interface ReadChunkedBodyOptions extends StreamReadTimeouts {
+interface ReadChunkedBodyOptions extends StreamReadTimeouts {
   /** Invoked with each non-empty chunk as it arrives. */
   onChunk?: (chunk: Uint8Array) => void;
 
@@ -38,7 +39,7 @@ export interface ReadChunkedBodyOptions extends StreamReadTimeouts {
  * and switches from the first-chunk timeout to the idle timeout; only
  * non-empty chunks are collected and forwarded to `onChunk`.
  */
-export async function readChunkedBody(
+async function readChunkedBody(
   body: ReadableStream<Uint8Array>,
   options: ReadChunkedBodyOptions,
 ): Promise<Buffer> {

--- a/assistant/src/tts/synthesis-stream.ts
+++ b/assistant/src/tts/synthesis-stream.ts
@@ -8,7 +8,10 @@
  * for transports that play audio via the audio store's `/v1/audio/:id` URLs.
  */
 
-import { createStreamingEntry } from "../calls/audio-store.js";
+import {
+  type CallAudioFormat,
+  createStreamingEntry,
+} from "../calls/audio-store.js";
 import { loadConfig } from "../config/loader.js";
 import { getPublicBaseUrl } from "../inbound/public-ingress-urls.js";
 import type {
@@ -200,12 +203,9 @@ export async function synthesizeAndEmit(
 // Audio-store sink
 // ---------------------------------------------------------------------------
 
-/** Audio formats accepted by the audio store. */
-export type AudioStoreFormat = Parameters<typeof createStreamingEntry>[0];
-
 export interface AudioStoreSinkOptions {
   /** Store format — determines the entry's served content type. */
-  format: AudioStoreFormat;
+  format: CallAudioFormat;
 
   /**
    * Invoked exactly once, when the first audio chunk arrives, with the

--- a/docs/proposals/live-voice-channel.md
+++ b/docs/proposals/live-voice-channel.md
@@ -40,7 +40,7 @@ export interface CallTransport {
   sendPlayUrl(url: string): Promise<void>;
   endSession(reason?: string): Promise<void>;
   getConnectionState(): ConnectionState;
-  readonly requiresWavAudio?: boolean;
+  readonly requiresPcmAudio?: boolean;
 }
 ```
 


### PR DESCRIPTION
## Summary
Closes out the four deferred cleanups documented across the TTS streaming arc (#37369, #37444, #37467), now that all four catalog providers stream PCM:
- **ElevenLabs** adopts the shared nearest-rate PCM clamp (`tts/pcm-sample-rates.ts`); `pcm_44100` is Pro-tier-gated upstream, so it is honored only on an exact 44.1 kHz hint — other hints clamp over 16/22.05/24 kHz (48 kHz → 24 kHz, previously 16 kHz).
- **calls/fish-audio-client.ts** adopts the shared `consumeSynthesisResponse` (zero-byte streams now throw; no-body/timeout messages unchanged).
- **preferWav/requiresWavAudio sentinel collapsed** into `requiresPcmAudio` + `audioFormat: "pcm"` end-to-end; dead `"wav"` member dropped from `TtsMediaStreamOutputFormat`; user-configured `format: "wav"` behavior preserved exactly.
- **Shared `createPcmChunkAligner`** replaces the duplicated live-voice (2-byte) and media-stream (4-byte) PCM carry closures — pure refactor with unit tests.

## Self-review result
GAPS FOUND → fixed. 3 review rounds (external-feedback, faithfulness, integration, slop passes): round 1 found 3 actionable gaps (fixed in #37525, #37526), round 2 found 2 minor residuals (fixed in #37538), round 3 found 1 cosmetic cast (fixed via direct push 0ae722b392). Codex's P1 on #37515 (Pro-tier pcm_44100 clamping) was addressed in-cycle (f7335db3b4).

## PRs merged into feature branch
- #37515: refactor(tts): ElevenLabs adopts the shared nearest-rate PCM clamp
- #37512: refactor(calls): fish-audio-client adopts shared consumeSynthesisResponse
- #37516: refactor(calls): collapse the preferWav/requiresWavAudio sentinel into explicit PCM naming
- #37514: refactor(tts): shared PCM chunk-carry aligner for live-voice and media-stream

### Fix PRs
- #37525: demote orphaned stream-read and pcm-chunk-aligner exports to module-private
- #37526: extract shared synthesis-format decode helper; refresh stale WAV comments
- #37538: name the call audio-format union (CallAudioFormat); refresh stale wav-store comment

Part of plan: tts-deferred-cleanups.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)