### PR TITLE
feat(daemon): replace the voice turn's processing-lock poll with an idle waiter

### DIFF
--- a/assistant/src/__tests__/conversation-wait-for-idle.test.ts
+++ b/assistant/src/__tests__/conversation-wait-for-idle.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Tests for `Conversation.waitForIdle` — the event-driven replacement for the
+ * voice bridge's 50 ms processing-lock poll.
+ *
+ * Contract: resolves `true` as soon as `processing` is false (synchronous
+ * fast path included), `false` on timeout, rejects on signal abort, and is
+ * notified from the committed `setProcessing(false)` transition — a clear
+ * whose persisted write throws (and therefore reverts) must NOT release
+ * waiters.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+import { CompactionCircuit } from "../agent/compaction-circuit.js";
+import type { AgentEvent } from "../agent/loop.js";
+import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { Message, ProviderResponse } from "../providers/types.js";
+
+// ---------------------------------------------------------------------------
+// Mocks — must precede Conversation import
+// ---------------------------------------------------------------------------
+
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of [
+    "info",
+    "warn",
+    "error",
+    "debug",
+    "trace",
+    "fatal",
+    "silent",
+    "child",
+  ]) {
+    stub[m] = m === "child" ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeLoggerStub(),
+}));
+
+mock.module("../providers/registry.js", () => ({
+  getProvider: () => ({ name: "mock-provider" }),
+  initializeProviders: async () => {},
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    llm: {
+      default: {
+        provider: "mock-provider",
+        model: "mock-model",
+        maxTokens: 4096,
+        effort: "high" as const,
+        speed: "standard" as const,
+        temperature: null,
+        thinking: { enabled: false, streamThinking: true },
+        contextWindow: {
+          enabled: true,
+          maxInputTokens: 100000,
+          targetBudgetRatio: 0.3,
+          compactThreshold: 0.8,
+          summaryBudgetRatio: 0.05,
+          overflowRecovery: {
+            enabled: true,
+            safetyMarginRatio: 0.05,
+            maxAttempts: 3,
+            interactiveLatestTurnCompression: "summarize",
+            nonInteractiveLatestTurnCompression: "truncate",
+          },
+        },
+      },
+      profiles: {},
+      callSites: {},
+      pricingOverrides: [],
+    },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    timeouts: { permissionTimeoutSec: 1 },
+    skills: { entries: {}, allowBundled: true },
+    permissions: { mode: "workspace" },
+  }),
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: () => true,
+}));
+
+mock.module("../prompts/system-prompt.js", () => ({
+  buildSystemPrompt: () => "system prompt",
+}));
+
+mock.module("../config/skills.js", () => ({
+  loadSkillCatalog: () => [],
+  loadSkillBySelector: () => ({ skill: null }),
+  ensureSkillIcon: async () => null,
+}));
+
+mock.module("../config/skill-state.js", () => ({
+  resolveSkillStates: () => [],
+}));
+
+mock.module("../permissions/trust-store.js", () => ({
+  addRule: () => {},
+  findHighestPriorityRule: () => null,
+  clearCache: () => {},
+}));
+
+mock.module("../security/secret-allowlist.js", () => ({
+  resetAllowlist: () => {},
+}));
+
+// Controllable persisted-write behavior: `setProcessing` reverts its
+// in-memory flag when this throws, and waiters must not observe that
+// aborted clear as a release.
+let failNextProcessingWrite = false;
+
+mock.module("../persistence/conversation-crud.js", () => ({
+  setConversationProcessingStartedAt: () => {
+    if (failNextProcessingWrite) {
+      failNextProcessingWrite = false;
+      throw new Error("database is locked (SQLITE_BUSY)");
+    }
+  },
+  isConversationProcessing: () => false,
+  setConversationOriginChannelIfUnset: () => {},
+  updateConversationContextWindow: () => {},
+  deleteMessageById: () => {},
+  provenanceFromTrustContext: () => ({
+    source: "user",
+    trustContext: undefined,
+  }),
+  getConversationOriginInterface: () => null,
+  getConversationOriginChannel: () => null,
+  getMessages: () => [],
+  getConversation: () => ({
+    id: "conv-1",
+    contextSummary: null,
+    contextCompactedMessageCount: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalEstimatedCost: 0,
+  }),
+  createConversation: () => ({ id: "conv-1" }),
+  addMessage: () => ({ id: `msg-${Date.now()}` }),
+  updateConversationUsage: () => {},
+  updateConversationTitle: () => {},
+  reserveMessage: mock(async () => ({ id: "msg-reserve" })),
+}));
+
+mock.module("../persistence/conversation-queries.js", () => ({
+  listConversations: () => [],
+}));
+
+mock.module("../persistence/attachments-store.js", () => ({
+  uploadAttachment: () => ({ id: `att-${Date.now()}` }),
+  linkAttachmentToMessage: () => {},
+}));
+
+mock.module("../memory/retriever.js", () => ({
+  buildMemoryRecall: async () => ({
+    enabled: false,
+    degraded: false,
+    injectedText: "",
+    semanticHits: 0,
+    injectedTokens: 0,
+    latencyMs: 0,
+  }),
+  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
+}));
+
+mock.module("../plugins/defaults/compaction/window-manager.js", () => ({
+  ContextWindowManager: class {
+    estimateInputTokens() {
+      return 0;
+    }
+    get tokenCountInputs() {
+      return { systemPrompt: "", tools: undefined };
+    }
+    constructor() {}
+    updateConfig() {}
+    shouldCompact() {
+      return { needed: false, estimatedTokens: 0 };
+    }
+    async maybeCompact() {
+      return { compacted: false };
+    }
+    resetOverflowRecovery() {}
+  },
+  createContextSummaryMessage: () => ({
+    role: "user",
+    content: [{ type: "text", text: "summary" }],
+  }),
+  getSummaryFromContextMessage: () => null,
+}));
+
+mock.module("../persistence/llm-usage-store.js", () => ({
+  recordUsageEvent: () => ({ id: "mock-id", createdAt: Date.now() }),
+  listUsageEvents: () => [],
+}));
+
+mock.module("../agent/loop.js", () => ({
+  AgentLoop: class {
+    compactionCircuit = new CompactionCircuit("test-conv");
+    constructor() {}
+    getToolTokenBudget() {
+      return 0;
+    }
+    getResolvedTools() {
+      return [];
+    }
+    getActiveModel() {
+      return undefined;
+    }
+    async run(_options: {
+      messages: Message[];
+      onEvent: (event: AgentEvent) => void;
+    }): Promise<Message[]> {
+      return [];
+    }
+  },
+}));
+
+mock.module("../contacts/canonical-guardian-store.js", () => ({
+  listPendingCanonicalGuardianRequestsByDestinationConversation: () => [],
+  listCanonicalGuardianRequests: () => [],
+  listPendingRequestsByConversationScope: () => [],
+  createCanonicalGuardianRequest: () => ({
+    id: "mock-cg-id",
+    code: "MOCK",
+    status: "pending",
+  }),
+  getCanonicalGuardianRequest: () => null,
+  getCanonicalGuardianRequestByCode: () => null,
+  updateCanonicalGuardianRequest: () => {},
+  resolveCanonicalGuardianRequest: () => {},
+  createCanonicalGuardianDelivery: () => ({ id: "mock-cgd-id" }),
+  listCanonicalGuardianDeliveries: () => [],
+  listPendingCanonicalGuardianRequestsByDestinationChat: () => [],
+  updateCanonicalGuardianDelivery: () => {},
+  generateCanonicalRequestCode: () => "MOCK-CODE",
+}));
+
+// ---------------------------------------------------------------------------
+// Import Conversation AFTER mocks
+// ---------------------------------------------------------------------------
+
+import { Conversation } from "../daemon/conversation.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProvider() {
+  return {
+    name: "mock",
+    async sendMessage(): Promise<ProviderResponse> {
+      return {
+        content: [],
+        model: "mock",
+        usage: { inputTokens: 0, outputTokens: 0 },
+        stopReason: "end_turn",
+      };
+    },
+  };
+}
+
+let conversationSeq = 0;
+
+function makeConversation(): Conversation {
+  conversationSeq += 1;
+  return new Conversation(
+    `conv-wait-for-idle-${conversationSeq}`,
+    makeProvider(),
+    "system prompt",
+    (_msg: ServerMessage) => {},
+    "/tmp",
+    { maxTokens: 4096 },
+  );
+}
+
+/** Track a promise's settlement without awaiting it. */
+function observe<T>(promise: Promise<T>) {
+  const state = { settled: false, value: undefined as T | undefined };
+  void promise.then((value) => {
+    state.settled = true;
+    state.value = value;
+  });
+  return state;
+}
+
+const flushMicrotasks = async () => {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve();
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Conversation.waitForIdle", () => {
+  test("resolves true synchronously-fast when the conversation is already idle", async () => {
+    const conversation = makeConversation();
+    // Long timeout: if the fast path were missing, resolution would require
+    // a lock release that never comes and the test would time out.
+    await expect(conversation.waitForIdle({ timeoutMs: 60_000 })).resolves.toBe(
+      true,
+    );
+  });
+
+  test("resolves true when setProcessing(false) fires, with no timer advance", async () => {
+    const conversation = makeConversation();
+    conversation.setProcessing(true);
+
+    const waiter = observe(conversation.waitForIdle({ timeoutMs: 60_000 }));
+    await flushMicrotasks();
+    expect(waiter.settled).toBe(false);
+
+    conversation.setProcessing(false);
+    await flushMicrotasks();
+    // Only microtasks were flushed — resolution came from the release
+    // notification, not from any timer.
+    expect(waiter.settled).toBe(true);
+    expect(waiter.value).toBe(true);
+  });
+
+  test("resolves false on timeout while the lock is held", async () => {
+    const conversation = makeConversation();
+    conversation.setProcessing(true);
+
+    await expect(conversation.waitForIdle({ timeoutMs: 10 })).resolves.toBe(
+      false,
+    );
+
+    // A release after the timeout must not throw against the expired waiter.
+    conversation.setProcessing(false);
+  });
+
+  test("rejects when the signal aborts mid-wait", async () => {
+    const conversation = makeConversation();
+    conversation.setProcessing(true);
+    const controller = new AbortController();
+
+    const wait = conversation.waitForIdle({
+      timeoutMs: 60_000,
+      signal: controller.signal,
+    });
+    controller.abort();
+    await expect(wait).rejects.toBeDefined();
+
+    conversation.setProcessing(false);
+  });
+
+  test("rejects immediately for an already-aborted signal", async () => {
+    const conversation = makeConversation();
+    conversation.setProcessing(true);
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      conversation.waitForIdle({
+        timeoutMs: 60_000,
+        signal: controller.signal,
+      }),
+    ).rejects.toBeDefined();
+
+    conversation.setProcessing(false);
+  });
+
+  test("two concurrent waiters both resolve on a single release", async () => {
+    const conversation = makeConversation();
+    conversation.setProcessing(true);
+
+    const first = observe(conversation.waitForIdle({ timeoutMs: 60_000 }));
+    const second = observe(conversation.waitForIdle({ timeoutMs: 60_000 }));
+    await flushMicrotasks();
+    expect(first.settled).toBe(false);
+    expect(second.settled).toBe(false);
+
+    conversation.setProcessing(false);
+    await flushMicrotasks();
+    expect(first.value).toBe(true);
+    expect(second.value).toBe(true);
+  });
+
+  test("a clear whose persisted write throws does not release waiters", async () => {
+    const conversation = makeConversation();
+    conversation.setProcessing(true);
+
+    const waiter = observe(conversation.waitForIdle({ timeoutMs: 60_000 }));
+
+    failNextProcessingWrite = true;
+    expect(() => conversation.setProcessing(false)).toThrow(
+      "database is locked",
+    );
+    await flushMicrotasks();
+    // The write failed, so the flag reverted to processing — the waiter must
+    // still be pending.
+    expect(conversation.isProcessing()).toBe(true);
+    expect(waiter.settled).toBe(false);
+
+    // The retried clear commits and releases the waiter.
+    conversation.setProcessing(false);
+    await flushMicrotasks();
+    expect(waiter.value).toBe(true);
+  });
+});

--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -74,6 +74,8 @@ interface FakeConversation {
 function makeFakeConversation(opts: {
   processing: boolean;
   waitForIdle?: (options: WaitForIdleCall) => Promise<boolean>;
+  runAgentLoop?: () => Promise<void>;
+  events?: string[];
 }) {
   const waitForIdleCalls: WaitForIdleCall[] = [];
   let persistCount = 0;
@@ -99,10 +101,15 @@ function makeFakeConversation(opts: {
     setVoiceCallControlPrompt: () => {},
     persistUserMessage: async () => {
       persistCount += 1;
+      opts.events?.push("persist");
       return { id: `msg-${persistCount}` };
     },
-    updateClient: () => {},
-    runAgentLoop: async () => {},
+    // The install (reset falsy) / reset (reset true) pair marks a turn
+    // taking ownership of the conversation vs a turn's cleanup releasing it.
+    updateClient: (_cb, reset) => {
+      opts.events?.push(reset ? "client:reset" : "client:install");
+    },
+    runAgentLoop: () => (opts.runAgentLoop ?? (async () => {}))(),
     abort: () => {},
   };
   return {
@@ -112,9 +119,9 @@ function makeFakeConversation(opts: {
   };
 }
 
-function makeTurnOptions(signal?: AbortSignal) {
+function makeTurnOptions(signal?: AbortSignal, conversationId?: string) {
   return {
-    conversationId: "conv-voice-bridge-test",
+    conversationId: conversationId ?? "conv-voice-bridge-test",
     // The synthetic opener marker keeps the turn off the user-echo
     // broadcast path (no event-hub / persisted-seq side effects in tests).
     content: CALL_OPENING_MARKER,
@@ -241,5 +248,74 @@ describe("startVoiceTurn conversation-lock wait", () => {
       startVoiceTurn(makeTurnOptions(controller.signal)),
     ).rejects.toThrow("Turn aborted while waiting for conversation");
     expect(fake.persistCount()).toBe(0);
+  });
+});
+
+describe("startVoiceTurn prior-turn teardown barrier", () => {
+  test("the next turn waits for the prior turn's cleanup before installing its state", async () => {
+    const events: string[] = [];
+    let releaseAgentLoop!: () => void;
+    const fake = makeFakeConversation({
+      // The processing flag is already false — modeling the window after
+      // `setProcessing(false)` fired the idle waiters but before the prior
+      // turn's agent-loop continuation ran `finally { cleanup() }`.
+      processing: false,
+      events,
+      runAgentLoop: () =>
+        new Promise<void>((resolve) => {
+          releaseAgentLoop = resolve;
+        }),
+    });
+    fakeConversation = fake.conversation;
+
+    // Turn 1 starts and suspends inside its agent loop.
+    await startVoiceTurn(makeTurnOptions(undefined, "conv-teardown-order"));
+    await flushMicrotasks();
+    expect(events).toEqual(["persist", "client:install"]);
+
+    // Turn 2 arrives during the teardown window: it must not persist or
+    // install its client callback until turn 1's cleanup has run.
+    const turn2 = startVoiceTurn(
+      makeTurnOptions(undefined, "conv-teardown-order"),
+    );
+    await flushMicrotasks();
+    expect(events).toEqual(["persist", "client:install"]);
+
+    releaseAgentLoop();
+    await flushMicrotasks();
+    await turn2;
+    // Turn 1's cleanup (client:reset) strictly precedes turn 2's persist
+    // and install — the state clobber the barrier exists to prevent.
+    expect(events).toEqual([
+      "persist",
+      "client:install",
+      "client:reset",
+      "persist",
+      "client:install",
+    ]);
+  });
+
+  test("an abort while waiting on a wedged prior teardown throws the turn-aborted error", async () => {
+    const controller = new AbortController();
+    const fake = makeFakeConversation({
+      processing: false,
+      // Wedged: the prior turn's agent loop never settles, so its
+      // teardown never runs.
+      runAgentLoop: () => new Promise<void>(() => {}),
+    });
+    fakeConversation = fake.conversation;
+
+    await startVoiceTurn(makeTurnOptions(undefined, "conv-teardown-wedged"));
+    expect(fake.persistCount()).toBe(1);
+
+    const turn2 = startVoiceTurn(
+      makeTurnOptions(controller.signal, "conv-teardown-wedged"),
+    );
+    await flushMicrotasks();
+    controller.abort();
+    await expect(turn2).rejects.toThrow(
+      "Turn aborted while waiting for conversation",
+    );
+    expect(fake.persistCount()).toBe(1);
   });
 });

--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Tests for `startVoiceTurn`'s conversation-lock wait.
+ *
+ * The bridge waits on `conversation.waitForIdle` (event-driven, resolved
+ * from `setProcessing(false)`) instead of polling `isProcessing()` every
+ * 50 ms, so a barge-in turn starts on the same tick the prior turn releases
+ * the lock. The call-controller re-prompt path matches on the exact error
+ * strings, so those are pinned here too. `waitForIdle`'s own semantics are
+ * covered by `src/__tests__/conversation-wait-for-idle.test.ts`.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before importing voice-session-bridge
+// ---------------------------------------------------------------------------
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => ({
+    workspaceGit: { turnCommitMaxWaitMs: 100 },
+    calls: {},
+  }),
+}));
+
+// Swapped per-test to hand startVoiceTurn a scripted fake conversation.
+let fakeConversation: FakeConversation;
+
+mock.module("../../daemon/conversation-store.js", () => ({
+  getOrCreateConversation: async () => fakeConversation,
+}));
+
+import { ABORT_WATCHDOG_MS } from "../../daemon/abort-watchdog.js";
+import { CALL_OPENING_MARKER } from "../voice-control-protocol.js";
+import { startVoiceTurn } from "../voice-session-bridge.js";
+
+// ---------------------------------------------------------------------------
+// Fake conversation
+// ---------------------------------------------------------------------------
+
+interface WaitForIdleCall {
+  timeoutMs: number;
+  signal?: AbortSignal;
+}
+
+interface FakeConversation {
+  conversationId: string;
+  callSessionId: string | undefined;
+  forcePromptSideEffects: boolean;
+  currentRequestId: string | undefined;
+  isProcessing: () => boolean;
+  waitForIdle: (options: WaitForIdleCall) => Promise<boolean>;
+  setAssistantId: (id: string) => void;
+  setTrustContext: (ctx: unknown) => void;
+  setCommandIntent: (intent: unknown) => void;
+  setTurnChannelContext: (ctx: unknown) => void;
+  setTurnInterfaceContext: (ctx: unknown) => void;
+  setChannelCapabilities: (caps: unknown) => void;
+  setVoiceCallControlPrompt: (prompt: string | null) => void;
+  persistUserMessage: (opts: {
+    content: string;
+    requestId: string;
+  }) => Promise<{ id: string }>;
+  updateClient: (cb: unknown, reset?: boolean) => void;
+  runAgentLoop: (...args: unknown[]) => Promise<void>;
+  abort: (reason?: unknown) => void;
+}
+
+function makeFakeConversation(opts: {
+  processing: boolean;
+  waitForIdle?: (options: WaitForIdleCall) => Promise<boolean>;
+}) {
+  const waitForIdleCalls: WaitForIdleCall[] = [];
+  let persistCount = 0;
+  const conversation: FakeConversation = {
+    conversationId: "conv-voice-bridge-test",
+    callSessionId: undefined,
+    forcePromptSideEffects: false,
+    currentRequestId: undefined,
+    isProcessing: () => opts.processing,
+    waitForIdle: (options) => {
+      waitForIdleCalls.push(options);
+      if (!opts.waitForIdle) {
+        throw new Error("waitForIdle not scripted for this test");
+      }
+      return opts.waitForIdle(options);
+    },
+    setAssistantId: () => {},
+    setTrustContext: () => {},
+    setCommandIntent: () => {},
+    setTurnChannelContext: () => {},
+    setTurnInterfaceContext: () => {},
+    setChannelCapabilities: () => {},
+    setVoiceCallControlPrompt: () => {},
+    persistUserMessage: async () => {
+      persistCount += 1;
+      return { id: `msg-${persistCount}` };
+    },
+    updateClient: () => {},
+    runAgentLoop: async () => {},
+    abort: () => {},
+  };
+  return {
+    conversation,
+    waitForIdleCalls,
+    persistCount: () => persistCount,
+  };
+}
+
+function makeTurnOptions(signal?: AbortSignal) {
+  return {
+    conversationId: "conv-voice-bridge-test",
+    // The synthetic opener marker keeps the turn off the user-echo
+    // broadcast path (no event-hub / persisted-seq side effects in tests).
+    content: CALL_OPENING_MARKER,
+    isInbound: true,
+    signal,
+  };
+}
+
+const flushMicrotasks = async () => {
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("startVoiceTurn conversation-lock wait", () => {
+  test("an idle conversation starts the turn without consulting waitForIdle", async () => {
+    const fake = makeFakeConversation({ processing: false });
+    fakeConversation = fake.conversation;
+
+    const handle = await startVoiceTurn(makeTurnOptions());
+
+    expect(handle.turnId).toBeString();
+    expect(fake.waitForIdleCalls.length).toBe(0);
+    expect(fake.persistCount()).toBe(1);
+  });
+
+  test("the turn starts on the same tick the prior turn releases the lock", async () => {
+    let release!: (idle: boolean) => void;
+    const fake = makeFakeConversation({
+      processing: true,
+      waitForIdle: () =>
+        new Promise<boolean>((resolve) => {
+          release = resolve;
+        }),
+    });
+    fakeConversation = fake.conversation;
+
+    const turnPromise = startVoiceTurn(makeTurnOptions());
+    await flushMicrotasks();
+    expect(fake.persistCount()).toBe(0);
+
+    // Release the lock, then flush ONLY microtasks — no timers. The old
+    // 50 ms poll loop could not reach persistUserMessage this way.
+    release(true);
+    await flushMicrotasks();
+    expect(fake.persistCount()).toBe(1);
+
+    await turnPromise;
+  });
+
+  test("passes the full processing-wait budget and the abort signal to waitForIdle", async () => {
+    const controller = new AbortController();
+    const fake = makeFakeConversation({
+      processing: true,
+      waitForIdle: async () => true,
+    });
+    fakeConversation = fake.conversation;
+
+    await startVoiceTurn(makeTurnOptions(controller.signal));
+
+    expect(fake.waitForIdleCalls.length).toBe(1);
+    // turnCommitMaxWaitMs (100, from the config mock) + abort watchdog +
+    // 1000 ms margin — see resolveProcessingWaitMs.
+    expect(fake.waitForIdleCalls[0]!.timeoutMs).toBe(
+      100 + ABORT_WATCHDOG_MS + 1000,
+    );
+    expect(fake.waitForIdleCalls[0]!.signal).toBe(controller.signal);
+  });
+
+  test("a timed-out wait throws the exact already-processing error", async () => {
+    const fake = makeFakeConversation({
+      processing: true,
+      waitForIdle: async () => false,
+    });
+    fakeConversation = fake.conversation;
+
+    await expect(startVoiceTurn(makeTurnOptions())).rejects.toThrow(
+      "Conversation is already processing a message",
+    );
+    expect(fake.persistCount()).toBe(0);
+  });
+
+  test("an abort mid-wait throws the exact turn-aborted error", async () => {
+    const controller = new AbortController();
+    const fake = makeFakeConversation({
+      processing: true,
+      waitForIdle: ({ signal }) =>
+        new Promise<boolean>((_resolve, reject) => {
+          signal?.addEventListener("abort", () => reject(signal.reason), {
+            once: true,
+          });
+        }),
+    });
+    fakeConversation = fake.conversation;
+
+    const turnPromise = startVoiceTurn(makeTurnOptions(controller.signal));
+    // Let the turn reach the waitForIdle suspension point, then abort.
+    await flushMicrotasks();
+    controller.abort();
+    await expect(turnPromise).rejects.toThrow(
+      "Turn aborted while waiting for conversation",
+    );
+    expect(fake.persistCount()).toBe(0);
+  });
+
+  test("a signal aborted despite the lock releasing still throws the turn-aborted error", async () => {
+    const controller = new AbortController();
+    const fake = makeFakeConversation({
+      processing: true,
+      waitForIdle: async () => {
+        // The lock released and the abort landed in the same window: the
+        // bridge must still honor the abort rather than start the turn.
+        controller.abort();
+        return true;
+      },
+    });
+    fakeConversation = fake.conversation;
+
+    await expect(
+      startVoiceTurn(makeTurnOptions(controller.signal)),
+    ).rejects.toThrow("Turn aborted while waiting for conversation");
+    expect(fake.persistCount()).toBe(0);
+  });
+});

--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -116,6 +116,9 @@ function makeFakeConversation(opts: {
     conversation,
     waitForIdleCalls,
     persistCount: () => persistCount,
+    setProcessingFlag: (value: boolean) => {
+      opts.processing = value;
+    },
   };
 }
 
@@ -293,6 +296,44 @@ describe("startVoiceTurn prior-turn teardown barrier", () => {
       "persist",
       "client:install",
     ]);
+  });
+
+  test("a queued drain that retakes the lock after teardown is also waited out", async () => {
+    let releaseAgentLoop!: () => void;
+    const fake = makeFakeConversation({
+      processing: false,
+      runAgentLoop: () =>
+        new Promise<void>((resolve) => {
+          releaseAgentLoop = resolve;
+        }),
+      // The prior turn's queued-message drain holds the lock when turn 2
+      // clears the teardown barrier; waitForIdle releases it.
+      waitForIdle: async () => {
+        fake.setProcessingFlag(false);
+        return true;
+      },
+    });
+    fakeConversation = fake.conversation;
+
+    await startVoiceTurn(makeTurnOptions(undefined, "conv-teardown-requeue"));
+    expect(fake.persistCount()).toBe(1);
+
+    const turn2 = startVoiceTurn(
+      makeTurnOptions(undefined, "conv-teardown-requeue"),
+    );
+    await flushMicrotasks();
+    expect(fake.persistCount()).toBe(1);
+
+    // The drain retakes the lock in the same window the teardown settles.
+    fake.setProcessingFlag(true);
+    releaseAgentLoop();
+    await flushMicrotasks();
+    await turn2;
+
+    // Turn 2 consulted waitForIdle for the retaken lock instead of
+    // failing inside persistUserMessage.
+    expect(fake.waitForIdleCalls.length).toBe(1);
+    expect(fake.persistCount()).toBe(2);
   });
 
   test("an abort while waiting on a wedged prior teardown throws the turn-aborted error", async () => {

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -409,51 +409,65 @@ export async function startVoiceTurn(
   );
   const waitStartedAt = Date.now();
 
-  if (conversation.isProcessing()) {
-    // Voice barge-in can race with turn teardown. Wait for the previous
-    // turn to finish aborting before giving up. The wait is event-driven —
-    // `waitForIdle` resolves from the `setProcessing(false)` transition —
-    // so the turn starts on the same tick the lock releases instead of
-    // paying up to a 50 ms poll interval after every barge-in.
-    let idle: boolean;
-    try {
-      idle = await conversation.waitForIdle({
-        timeoutMs: maxWaitMs,
-        signal: opts.signal,
-      });
-    } catch {
-      // waitForIdle rejects only when opts.signal aborted mid-wait.
-      throw new Error("Turn aborted while waiting for conversation");
-    }
+  // Two conditions must both clear before this turn may install its
+  // per-turn conversation state, and clearing one can re-raise the other:
+  //
+  // - The processing lock. `waitForIdle` resolves from the
+  //   `setProcessing(false)` transition, so the turn starts on the same
+  //   tick the lock releases instead of paying up to a 50 ms poll interval
+  //   after every barge-in.
+  // - The prior turn's teardown. Its `finally { cleanup() }` runs after
+  //   `setProcessing(false)` (see `pendingTurnTeardowns`), and a queued
+  //   message drained by the prior `runAgentLoop` can retake the lock
+  //   right after that teardown settles.
+  //
+  // Hence the re-check loop, bounded by one shared budget. In practice
+  // each leg settles within a few microtasks; the bound only guards a
+  // wedged prior turn.
+  let remainingWaitMs = maxWaitMs;
+  for (;;) {
     if (opts.signal?.aborted) {
       throw new Error("Turn aborted while waiting for conversation");
     }
-    if (!idle) {
-      // Waited the full budget (see resolveProcessingWaitMs) without the lock
-      // releasing, so the prior turn is genuinely wedged. The controller
-      // catches this terminal error and speaks a brief non-technical
-      // re-prompt rather than staying silent.
-      throw new Error("Conversation is already processing a message");
+    if (conversation.isProcessing()) {
+      let idle: boolean;
+      try {
+        idle = await conversation.waitForIdle({
+          timeoutMs: remainingWaitMs,
+          signal: opts.signal,
+        });
+      } catch {
+        // waitForIdle rejects only when opts.signal aborted mid-wait.
+        throw new Error("Turn aborted while waiting for conversation");
+      }
+      if (opts.signal?.aborted) {
+        throw new Error("Turn aborted while waiting for conversation");
+      }
+      if (!idle) {
+        // Waited the full budget (see resolveProcessingWaitMs) without the
+        // lock releasing, so the prior turn is genuinely wedged. The
+        // controller catches this terminal error and speaks a brief
+        // non-technical re-prompt rather than staying silent.
+        throw new Error("Conversation is already processing a message");
+      }
+      // A successful idle wait is trusted; fall through to the teardown
+      // leg in the same iteration.
+      remainingWaitMs = Math.max(0, maxWaitMs - (Date.now() - waitStartedAt));
     }
-  }
-
-  // The idle transition alone is not enough: the prior turn's
-  // `finally { cleanup() }` runs after `setProcessing(false)`. Wait for that
-  // teardown on the remaining budget so this turn's per-turn conversation
-  // state cannot be nulled by the prior turn's cleanup (see
-  // `pendingTurnTeardowns`). In practice this settles within a few
-  // microtasks; the bound only guards a wedged continuation.
-  const priorTeardown = pendingTurnTeardowns.get(opts.conversationId);
-  if (priorTeardown) {
-    const remainingMs = Math.max(0, maxWaitMs - (Date.now() - waitStartedAt));
-    const torndown = await waitForPriorTurnTeardown(
-      priorTeardown,
-      remainingMs,
-      opts.signal,
-    );
-    if (!torndown) {
-      throw new Error("Conversation is already processing a message");
+    const priorTeardown = pendingTurnTeardowns.get(opts.conversationId);
+    if (priorTeardown) {
+      const torndown = await waitForPriorTurnTeardown(
+        priorTeardown,
+        remainingWaitMs,
+        opts.signal,
+      );
+      if (!torndown) {
+        throw new Error("Conversation is already processing a message");
+      }
+      remainingWaitMs = Math.max(0, maxWaitMs - (Date.now() - waitStartedAt));
+      continue;
     }
+    break;
   }
 
   // Hoisted so the catch below can clear partially-applied turn state

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -351,26 +351,30 @@ export async function startVoiceTurn(
   const conversation = await getOrCreateConversation(opts.conversationId);
 
   if (conversation.isProcessing()) {
-    // Voice barge-in can race with turn teardown. Wait briefly for the
-    // previous turn to finish aborting before giving up.
+    // Voice barge-in can race with turn teardown. Wait for the previous
+    // turn to finish aborting before giving up. The wait is event-driven —
+    // `waitForIdle` resolves from the `setProcessing(false)` transition —
+    // so the turn starts on the same tick the lock releases instead of
+    // paying up to a 50 ms poll interval after every barge-in.
     const config = getConfig();
     const maxWaitMs = resolveProcessingWaitMs(
       config.workspaceGit?.turnCommitMaxWaitMs ?? 4000,
       ABORT_WATCHDOG_MS,
     );
-    const pollIntervalMs = 50;
-    let waited = 0;
-    while (conversation.isProcessing() && waited < maxWaitMs) {
-      if (opts.signal?.aborted) {
-        throw new Error("Turn aborted while waiting for conversation");
-      }
-      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
-      waited += pollIntervalMs;
+    let idle: boolean;
+    try {
+      idle = await conversation.waitForIdle({
+        timeoutMs: maxWaitMs,
+        signal: opts.signal,
+      });
+    } catch {
+      // waitForIdle rejects only when opts.signal aborted mid-wait.
+      throw new Error("Turn aborted while waiting for conversation");
     }
     if (opts.signal?.aborted) {
       throw new Error("Turn aborted while waiting for conversation");
     }
-    if (conversation.isProcessing()) {
+    if (!idle) {
       // Waited the full budget (see resolveProcessingWaitMs) without the lock
       // releasing, so the prior turn is genuinely wedged. The controller
       // catches this terminal error and speaks a brief non-technical

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -50,6 +50,58 @@ export function resolveProcessingWaitMs(
   return turnCommitMaxWaitMs + abortUnwindMs + PROCESSING_WAIT_MARGIN_MS;
 }
 
+/**
+ * Pending teardown of the most recent voice turn, per conversation id.
+ *
+ * `waitForIdle` releases on the `setProcessing(false)` transition, which the
+ * prior turn reaches BEFORE its agent-loop continuation runs
+ * `finally { cleanup() }`. A turn that starts on the idle transition alone
+ * could install its per-turn conversation state (trust context, call session
+ * id, client callback) and then have the prior turn's cleanup null that
+ * state mid-turn. The next turn awaits this promise — bounded by the same
+ * processing-wait budget — so cleanup always completes first.
+ */
+const pendingTurnTeardowns = new Map<string, Promise<void>>();
+
+/**
+ * Await a prior turn's teardown, bounded by `timeoutMs` and `signal`.
+ * Resolves `true` when the teardown settles, `false` on timeout; rejects
+ * when the signal aborts mid-wait. Timer and abort listener are removed on
+ * every exit path.
+ */
+async function waitForPriorTurnTeardown(
+  teardown: Promise<void>,
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<boolean> {
+  if (signal?.aborted) {
+    throw new Error("Turn aborted while waiting for conversation");
+  }
+  return await new Promise<boolean>((resolve, reject) => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const settleWait = () => {
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      signal?.removeEventListener("abort", onAbort);
+    };
+    const onAbort = () => {
+      settleWait();
+      reject(new Error("Turn aborted while waiting for conversation"));
+    };
+    timer = setTimeout(() => {
+      settleWait();
+      resolve(false);
+    }, timeoutMs);
+    signal?.addEventListener("abort", onAbort, { once: true });
+    void teardown.then(() => {
+      settleWait();
+      resolve(true);
+    });
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -350,17 +402,19 @@ export async function startVoiceTurn(
   // Get or create the conversation
   const conversation = await getOrCreateConversation(opts.conversationId);
 
+  const config = getConfig();
+  const maxWaitMs = resolveProcessingWaitMs(
+    config.workspaceGit?.turnCommitMaxWaitMs ?? 4000,
+    ABORT_WATCHDOG_MS,
+  );
+  const waitStartedAt = Date.now();
+
   if (conversation.isProcessing()) {
     // Voice barge-in can race with turn teardown. Wait for the previous
     // turn to finish aborting before giving up. The wait is event-driven —
     // `waitForIdle` resolves from the `setProcessing(false)` transition —
     // so the turn starts on the same tick the lock releases instead of
     // paying up to a 50 ms poll interval after every barge-in.
-    const config = getConfig();
-    const maxWaitMs = resolveProcessingWaitMs(
-      config.workspaceGit?.turnCommitMaxWaitMs ?? 4000,
-      ABORT_WATCHDOG_MS,
-    );
     let idle: boolean;
     try {
       idle = await conversation.waitForIdle({
@@ -379,6 +433,25 @@ export async function startVoiceTurn(
       // releasing, so the prior turn is genuinely wedged. The controller
       // catches this terminal error and speaks a brief non-technical
       // re-prompt rather than staying silent.
+      throw new Error("Conversation is already processing a message");
+    }
+  }
+
+  // The idle transition alone is not enough: the prior turn's
+  // `finally { cleanup() }` runs after `setProcessing(false)`. Wait for that
+  // teardown on the remaining budget so this turn's per-turn conversation
+  // state cannot be nulled by the prior turn's cleanup (see
+  // `pendingTurnTeardowns`). In practice this settles within a few
+  // microtasks; the bound only guards a wedged continuation.
+  const priorTeardown = pendingTurnTeardowns.get(opts.conversationId);
+  if (priorTeardown) {
+    const remainingMs = Math.max(0, maxWaitMs - (Date.now() - waitStartedAt));
+    const torndown = await waitForPriorTurnTeardown(
+      priorTeardown,
+      remainingMs,
+      opts.signal,
+    );
+    if (!torndown) {
       throw new Error("Conversation is already processing a message");
     }
   }
@@ -591,6 +664,21 @@ export async function startVoiceTurn(
   });
   clientCallbackInstalled = true;
 
+  // Registered before the agent loop starts so the NEXT turn on this
+  // conversation waits for this turn's `finally { cleanup() }` — not just
+  // the processing-flag release — before installing its own per-turn state.
+  let resolveTeardown!: () => void;
+  const teardownSettled = new Promise<void>((resolve) => {
+    resolveTeardown = resolve;
+  });
+  pendingTurnTeardowns.set(opts.conversationId, teardownSettled);
+  const settleTurnTeardown = () => {
+    if (pendingTurnTeardowns.get(opts.conversationId) === teardownSettled) {
+      pendingTurnTeardowns.delete(opts.conversationId);
+    }
+    resolveTeardown();
+  };
+
   // Fire-and-forget the agent loop
   void (async () => {
     try {
@@ -645,6 +733,7 @@ export async function startVoiceTurn(
       eventSink.onError(message);
     } finally {
       cleanup();
+      settleTurnTeardown();
     }
   })();
 

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -424,11 +424,11 @@ export async function startVoiceTurn(
   // Hence the re-check loop, bounded by one shared budget. In practice
   // each leg settles within a few microtasks; the bound only guards a
   // wedged prior turn.
+  // Abort is only honored inside the wait legs: a pre-aborted signal on an
+  // idle conversation still starts the turn, which the signal wiring below
+  // then aborts immediately (pinned by the pre-aborted-signal test).
   let remainingWaitMs = maxWaitMs;
   for (;;) {
-    if (opts.signal?.aborted) {
-      throw new Error("Turn aborted while waiting for conversation");
-    }
     if (conversation.isProcessing()) {
       let idle: boolean;
       try {

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -260,12 +260,31 @@ export interface ConversationConstructorOptions {
   parentConversationId?: string;
 }
 
+/**
+ * The rejection value for an aborted {@link Conversation.waitForIdle} wait:
+ * the signal's own reason when set, else a plain Error so callers always
+ * receive a throwable.
+ */
+function abortReasonOf(signal?: AbortSignal): unknown {
+  return (
+    signal?.reason ?? new Error("Aborted while waiting for conversation idle")
+  );
+}
+
 export class Conversation {
   public readonly conversationId: string;
   /** @internal */ provider: Provider;
   /** @internal */ messages: Message[] = [];
   /** @internal */ agentLoop: AgentLoop;
   private _processing = false;
+  /**
+   * Pending {@link waitForIdle} resolvers, notified from the committed
+   * `processing → false` transition inside {@link setProcessing}. Every
+   * `setProcessing(false)` call site funnels through that single method
+   * (agent-loop/messaging/lifecycle contexts receive the Conversation
+   * instance itself), so waiters cannot miss a release.
+   */
+  private idleWaiters = new Set<() => void>();
   private stale = false;
   /** @internal */ abortController: AbortController | null = null;
   /** @internal */ prompter: PermissionPrompter;
@@ -1474,11 +1493,59 @@ export class Conversation {
       this._processing = wasProcessing;
       throw err;
     }
+    if (!value && this.idleWaiters.size > 0) {
+      // Notify only after the persisted write above committed — a thrown
+      // write reverts the in-memory flag and re-throws, so waiters must not
+      // observe a release that never happened. Copy-and-clear so a waiter
+      // registered from inside a notification can't be re-entered.
+      const waiters = [...this.idleWaiters];
+      this.idleWaiters.clear();
+      for (const notify of waiters) {
+        notify();
+      }
+    }
     if (wasProcessing && !value) {
       void publishSyncInvalidation([
         conversationMetadataSyncTag(this.conversationId),
       ]);
     }
+  }
+
+  /**
+   * Wait until this conversation's processing lock releases.
+   *
+   * Resolves `true` as soon as `processing` is false (including a
+   * synchronous fast path when it already is), resolves `false` when
+   * `timeoutMs` elapses first, and rejects with the signal's abort reason
+   * if `signal` fires while waiting. Resolution is event-driven from the
+   * `setProcessing(false)` transition — no polling — so a voice barge-in
+   * turn can start on the same tick the prior turn releases the lock.
+   * Timer and abort listener are cleaned up on every exit path.
+   */
+  waitForIdle(options: {
+    timeoutMs: number;
+    signal?: AbortSignal;
+  }): Promise<boolean> {
+    const { timeoutMs, signal } = options;
+    if (!this._processing) {
+      return Promise.resolve(true);
+    }
+    if (signal?.aborted) {
+      return Promise.reject(abortReasonOf(signal));
+    }
+    return new Promise<boolean>((resolve, reject) => {
+      const settle = (fn: () => void) => {
+        clearTimeout(timer);
+        signal?.removeEventListener("abort", onAbort);
+        this.idleWaiters.delete(notify);
+        fn();
+      };
+      const notify = () => settle(() => resolve(true));
+      const onAbort = () => settle(() => reject(abortReasonOf(signal)));
+      const timer = setTimeout(() => settle(() => resolve(false)), timeoutMs);
+      this.idleWaiters.add(notify);
+      signal?.addEventListener("abort", onAbort, { once: true });
+    });
   }
 
   markStale(): void {


### PR DESCRIPTION
## Summary
- Adds Conversation.waitForIdle({timeoutMs, signal}) resolved event-driven from setProcessing(false)
- startVoiceTurn (telephony + live voice) waits on it instead of a 50 ms poll loop; error semantics preserved

Part of plan: voice-mode-latency.md (PR 8 of 13)