### PR TITLE
feat(web): full-screen voice room overlay with robust exit

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -68,6 +68,8 @@ import { OnboardingCheckinOverlay } from "@/components/onboarding-checkin-overla
 import { OnboardingAvatarApplier } from "@/components/onboarding-avatar-applier";
 import { VoiceSessionPillHost } from "@/domains/chat/components/voice-session-pill-host";
 import { useLiveVoiceSessionController } from "@/domains/chat/voice/live-voice/use-live-voice-session-controller";
+import { VoiceRoom } from "@/domains/chat/voice/voice-room/voice-room";
+import { useIsVoiceRoomVisible } from "@/domains/chat/voice/voice-room/use-is-voice-room-visible";
 import { ChatConversationHeader } from "./chat-conversation-header";
 import { ChatLayoutHeader } from "./chat-layout-header";
 import { RenameDialogFromStore } from "./rename-dialog-from-store";
@@ -296,6 +298,28 @@ export function ChatLayout() {
     setDrawerOpen(false);
     consumeSidebarCollapse();
   }, [sidebarCollapseRequested, consumeSidebarCollapse]);
+
+  // The full-screen voice room takes over the viewport, so collapse the sidebar
+  // and blur the chat body while it is visible — then restore the user's prior
+  // collapsed state exactly on exit. Mirrors the research-onboarding
+  // sidebar-collapse pattern above, but fully reversible: the pre-room value is
+  // captured in a ref before forcing (the sentinel `null` means "room not
+  // currently forcing"), so any external session end restores it.
+  const voiceRoomVisible = useIsVoiceRoomVisible();
+  const collapsedBeforeRoomRef = useRef<boolean | null>(null);
+  useEffect(() => {
+    if (voiceRoomVisible) {
+      if (collapsedBeforeRoomRef.current === null) {
+        collapsedBeforeRoomRef.current = collapsed;
+        setCollapsed(true);
+      }
+      return;
+    }
+    if (collapsedBeforeRoomRef.current !== null) {
+      setCollapsed(collapsedBeforeRoomRef.current);
+      collapsedBeforeRoomRef.current = null;
+    }
+  }, [voiceRoomVisible, collapsed]);
 
   const drawerVisible = isMobile && drawerOpen;
 
@@ -646,6 +670,13 @@ export function ChatLayout() {
     />
   );
 
+  // Blur + freeze the chat body under the voice room. The room is an opaque
+  // overlay, so this mainly matters for the header strip peeking around it and
+  // to stop stray interaction with the covered chat.
+  const mainRoomClass = voiceRoomVisible
+    ? "pointer-events-none blur-sm opacity-40 transition-[filter,opacity]"
+    : "";
+
   return (
     <>
       {!isPopout && (
@@ -687,7 +718,9 @@ export function ChatLayout() {
       ) : null}
 
       {isMobile ? (
-        <main className="relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden">
+        <main
+          className={`relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden ${mainRoomClass}`}
+        >
           <Outlet  />
           {/* A popout narrowed below the mobile breakpoint lands in this
               branch — still headerless, so it still needs the floating
@@ -732,7 +765,9 @@ export function ChatLayout() {
           ) : null}
         </main>
       ) : isPopout ? (
-        <main className="relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden p-4">
+        <main
+          className={`relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden p-4 ${mainRoomClass}`}
+        >
           <Outlet />
           {/* Pop-outs render no header, but they DO support in-window
               conversation switching (Cmd+Up/Down) — so a live session started
@@ -751,7 +786,9 @@ export function ChatLayout() {
           >
             {renderSideMenu({ collapsed, variant: "rail", width: sidebarWidth, onWidthChange: handleSidebarWidthChange })}
           </aside>
-          <main className="flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden">
+          <main
+            className={`flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden ${mainRoomClass}`}
+          >
             <Outlet />
           </main>
         </div>
@@ -763,6 +800,12 @@ export function ChatLayout() {
           overlay; it never remounts the chat, so a suggestion click's
           navigate + `?prompt=` auto-send isn't raced by a remount. */}
       {isFocused ? <ResearchResultsOverlay /> : null}
+      {/* Full-screen live-voice room — a purely additive overlay mounted at
+          layout scope, next to the other full-viewport overlays. Self-gates on
+          `useIsVoiceRoomVisible()` (the exact complement of the title-bar
+          session pill); the composer's voice bar and transcript render
+          underneath, hidden by it. */}
+      <VoiceRoom />
       {/* First step of the focused flow: the gcal "Let's chat tomorrow" page,
           shown over the streaming research output until connect/skip. Self-gates
           on `checkinPending`; top-level so it can compose the onboarding screen. */}

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
@@ -11,11 +11,12 @@
  * carried to another conversation via in-window switching (Cmd+Up/Down) must
  * still have a visible control.
  *
- * Visibility is the exact complement of the composer's voice bar so that for
- * any active session exactly one of the two surfaces renders: the pill shows
- * whenever a session is active AND the composer currently on screen (if any)
- * does not own it (`isLiveVoiceSessionOwnedBy`). Concretely, the pill shows
- * when:
+ * Visibility is the exact complement of the full-screen voice room — the
+ * owning-composer surface — so that for any active session exactly one of the
+ * two renders. Both derive from the shared {@link useIsVoiceRoomVisible}
+ * predicate (session active AND the on-screen composer owns it): the room shows
+ * when it is `true`, the pill when a session is active and it is `false`.
+ * Concretely, the pill shows when:
  *
  * - the user is viewing a different conversation than the session's,
  * - the user is off the chat routes entirely (Home, Library, …) or on a
@@ -72,10 +73,9 @@ import {
   getLiveVoiceInputAmplitude,
   isLiveVoiceSessionActive,
   releaseLiveVoiceTurn,
-  useIsLiveVoiceSessionOwnedBy,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
-import { useConversationStore } from "@/stores/conversation-store";
+import { useIsVoiceRoomVisible } from "@/domains/chat/voice/voice-room/use-is-voice-room-visible";
 import { useViewerStore } from "@/stores/viewer-store";
 
 export interface VoiceSessionPillHostProps {
@@ -97,7 +97,6 @@ export function VoiceSessionPillHost({
   const sessionAssistantId = useLiveVoiceStore.use.assistantId();
   const sessionConversationId = useLiveVoiceStore.use.conversationId();
 
-  const activeConversationId = useConversationStore.use.activeConversationId();
   const mainView = useViewerStore.use.mainView();
   const isMobile = useIsMobile();
   const location = useLocation();
@@ -109,16 +108,16 @@ export function VoiceSessionPillHost({
   // portal-overlay `app` view — keeps the composer mounted. The strict chat
   // predicate matters: conversation subroutes like the inspector
   // (`/assistant/conversations/:id/inspect`) render no composer, so the pill
-  // must stay up there even for the owning conversation.
+  // must stay up there even for the owning conversation. Retained here only for
+  // the failure surface below — the pill's own visibility keys off the room.
   const composerOnScreen =
     isConversationChatPath(location.pathname) &&
     !(mainView === "app" && !isMobile);
-  // Same ownership predicate the composer's voice bar uses, evaluated for the
-  // composer currently on screen — keeps the two surfaces exact complements.
-  const activeComposerOwnsSession =
-    useIsLiveVoiceSessionOwnedBy(activeConversationId);
-  const visible =
-    sessionActive && !(composerOnScreen && activeComposerOwnsSession);
+  // Exact complement of the full-screen voice room (the owning-composer
+  // surface): the pill shows for an active session precisely when the room does
+  // not. Both read the one shared predicate so they can never drift.
+  const voiceRoomVisible = useIsVoiceRoomVisible();
+  const visible = sessionActive && !voiceRoomVisible;
   // Failure surface: exact complement of the composer's failure Notice, which
   // any on-screen voice-enabled composer renders regardless of ownership.
   const showFailure = state === "failed" && error !== null && !composerOnScreen;

--- a/clients/web/src/domains/chat/voice/voice-room/use-is-voice-room-visible.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-is-voice-room-visible.ts
@@ -1,0 +1,58 @@
+/**
+ * Single source of truth for whether the full-screen live-voice room is
+ * visible.
+ *
+ * The room is the owning-composer's voice surface: it shows exactly when a
+ * session is active AND the composer currently on screen owns it. That is the
+ * precise complement of the title-bar session pill, whose host consumes this
+ * hook's negation (`sessionActive && !voiceRoomVisible`) so the two surfaces
+ * can never both render — or both hide — for an active owned session.
+ *
+ * The inputs mirror {@link VoiceSessionPillHost} one-for-one:
+ * - `composerOnScreen` — a conversation chat route is mounted and not covered
+ *   by the desktop fullscreen app viewer (mobile's app view keeps the composer
+ *   mounted under a portal). Matches `chat-content-layout.tsx`.
+ * - `activeComposerOwnsSession` — the on-screen composer's conversation owns
+ *   the session (`isLiveVoiceSessionOwnedBy`), covering the draft case too.
+ *
+ * Deliberately does NOT re-check the `voice-mode` flag: entry already gated the
+ * session, and a live session keeps its UI even if the flag later flips (the
+ * mid-session-eligibility-drop invariant).
+ */
+
+import { useLocation } from "react-router";
+
+import { useIsMobile } from "@/hooks/use-is-mobile";
+import { isConversationChatPath } from "@/utils/routes";
+
+import {
+  isLiveVoiceSessionActive,
+  useIsLiveVoiceSessionOwnedBy,
+  useLiveVoiceStore,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
+import { useConversationStore } from "@/stores/conversation-store";
+import { useViewerStore } from "@/stores/viewer-store";
+
+/**
+ * Whether the full-screen voice room should render. See the module docstring
+ * for the exact-complement contract with the title-bar session pill.
+ */
+export function useIsVoiceRoomVisible(): boolean {
+  const state = useLiveVoiceStore.use.state();
+  const activeConversationId = useConversationStore.use.activeConversationId();
+  const mainView = useViewerStore.use.mainView();
+  const isMobile = useIsMobile();
+  const location = useLocation();
+
+  const composerOnScreen =
+    isConversationChatPath(location.pathname) &&
+    !(mainView === "app" && !isMobile);
+  const activeComposerOwnsSession =
+    useIsLiveVoiceSessionOwnedBy(activeConversationId);
+
+  return (
+    isLiveVoiceSessionActive(state) &&
+    composerOnScreen &&
+    activeComposerOwnsSession
+  );
+}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-ambient-background.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-ambient-background.tsx
@@ -1,0 +1,74 @@
+/**
+ * Ambient backdrop for the live-voice room: a deep-dark radial-gradient void
+ * (near-black center fading to pure black at the edges) with a scatter of
+ * slow-drifting indigo particles floating over it.
+ *
+ * Purely decorative — it sits behind the avatar and carries no interaction. The
+ * void gradient and particle glows are fixed rgba (a deliberate constant accent,
+ * like a data-viz series or annotation overlay — see STYLE_GUIDE color rules),
+ * not theme tokens: the room is always its own dark space regardless of app
+ * theme. The drift animation lives in `index.css` (`.voice-room-particle`) and
+ * is frozen under `prefers-reduced-motion`.
+ */
+
+import { useReducedMotion } from "motion/react";
+import { type CSSProperties } from "react";
+
+/**
+ * Deterministic particle layout — position (%), diameter (px), animation
+ * duration (s) and delay (s), and drift vector (px). Fixed rather than random
+ * so the field is stable across renders and reads as intentional.
+ */
+interface Particle {
+  left: number;
+  top: number;
+  size: number;
+  duration: number;
+  delay: number;
+  driftX: number;
+  driftY: number;
+  opacity: number;
+}
+
+const PARTICLES: Particle[] = [
+  { left: 12, top: 68, size: 5, duration: 15, delay: 0, driftX: 24, driftY: -60, opacity: 0.5 },
+  { left: 22, top: 28, size: 3, duration: 19, delay: 3, driftX: -18, driftY: -48, opacity: 0.4 },
+  { left: 34, top: 82, size: 6, duration: 17, delay: 1.5, driftX: 30, driftY: -70, opacity: 0.55 },
+  { left: 46, top: 18, size: 4, duration: 21, delay: 5, driftX: -12, driftY: -40, opacity: 0.35 },
+  { left: 58, top: 74, size: 5, duration: 16, delay: 2, driftX: -28, driftY: -66, opacity: 0.5 },
+  { left: 68, top: 34, size: 3, duration: 20, delay: 4, driftX: 20, driftY: -52, opacity: 0.4 },
+  { left: 78, top: 62, size: 6, duration: 18, delay: 0.8, driftX: -24, driftY: -74, opacity: 0.55 },
+  { left: 88, top: 24, size: 4, duration: 22, delay: 6, driftX: 14, driftY: -44, opacity: 0.35 },
+  { left: 8, top: 44, size: 3, duration: 23, delay: 2.6, driftX: 22, driftY: -56, opacity: 0.4 },
+  { left: 52, top: 52, size: 4, duration: 14, delay: 3.4, driftX: 16, driftY: -62, opacity: 0.45 },
+];
+
+export function VoiceRoomAmbientBackground() {
+  const reduce = useReducedMotion();
+
+  return (
+    <div className="voice-room-void" aria-hidden>
+      {PARTICLES.map((p, i) => (
+        <span
+          key={i}
+          className="voice-room-particle"
+          style={{
+            left: `${p.left}%`,
+            top: `${p.top}%`,
+            width: p.size,
+            height: p.size,
+            // Reduced motion: the CSS media query already freezes the
+            // animation; also drop it here so the inline vars never drive a
+            // transform. The static particles sit at a low opacity.
+            "--particle-opacity": p.opacity,
+            "--drift-x": `${p.driftX}px`,
+            "--drift-y": `${p.driftY}px`,
+            "--drift-duration": `${p.duration}s`,
+            animationDelay: reduce ? undefined : `${p.delay}s`,
+            opacity: reduce ? 0.25 : undefined,
+          } as CSSProperties}
+        />
+      ))}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * Tests for `VoiceRoom`.
+ *
+ * The room is a pure function of {@link useIsVoiceRoomVisible} (session active
+ * AND the on-screen composer owns it), so tests drive the real live-voice and
+ * conversation stores and mock only the modules with heavy dependency graphs:
+ * router hooks (mutable pathname), the viewer store (generated SDK imports),
+ * the `useIsMobile` media-query hook, and `VoiceAvatar` (which pulls in the
+ * assistant-avatar React Query graph — irrelevant to room chrome, and stubbed
+ * so the exit control's independence from avatar readiness is testable).
+ *
+ * Exit is the load-bearing behavior: the ✕ control and the global Escape key
+ * both end the session, the control renders even with no assistant resolved,
+ * and the key listeners are removed on unmount (no leaks).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import type { MainView } from "@/stores/viewer-store";
+import { routes } from "@/utils/routes";
+
+import {
+  makeControlsSpies,
+  seedLiveVoiceSession,
+} from "@/domains/chat/voice/live-voice/live-voice-fakes.test-helper";
+import {
+  useLiveVoiceStore,
+  type LiveVoiceSessionState,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
+import { useConversationStore } from "@/stores/conversation-store";
+
+const OWNING_CONVERSATION_ID = "conv-owning";
+const OTHER_CONVERSATION_ID = "conv-other";
+const ASSISTANT_ID = "assistant-1";
+
+let mockPathname = routes.conversation(OWNING_CONVERSATION_ID);
+mock.module("react-router", () => ({
+  useLocation: () => ({ pathname: mockPathname }),
+}));
+
+let mockMainView: MainView = "chat";
+mock.module("@/stores/viewer-store", () => ({
+  useViewerStore: {
+    use: {
+      mainView: () => mockMainView,
+    },
+  },
+}));
+
+let mockIsMobile = false;
+mock.module("@/hooks/use-is-mobile", () => ({
+  useIsMobile: () => mockIsMobile,
+  MOBILE_MEDIA_QUERY: "(max-width: 767px)",
+}));
+
+// Stub the avatar so the room's own chrome (exit control, key handlers) is
+// tested without the assistant-avatar query graph, and so "renders even with
+// null avatar data" is expressible.
+mock.module("@/domains/chat/voice/voice-room/voice-avatar", () => ({
+  VoiceAvatar: ({ assistantId }: { assistantId: string | null }) => (
+    <div data-testid="voice-avatar">{assistantId ?? "no-assistant"}</div>
+  ),
+}));
+
+// Imported after the mocks so the room picks up the mocked modules.
+const { VoiceRoom } = await import("@/domains/chat/voice/voice-room/voice-room");
+
+const controls = makeControlsSpies();
+
+/** Seed an active session owned by the on-screen composer's conversation. */
+function startOwnedSession(state: LiveVoiceSessionState = "listening") {
+  seedLiveVoiceSession(state, {
+    assistantId: ASSISTANT_ID,
+    conversationId: OWNING_CONVERSATION_ID,
+    controls,
+  });
+}
+
+beforeEach(() => {
+  mockPathname = routes.conversation(OWNING_CONVERSATION_ID);
+  mockMainView = "chat";
+  mockIsMobile = false;
+  controls.stop.mockClear();
+  controls.release.mockClear();
+  controls.interrupt.mockClear();
+  useLiveVoiceStore.getState().reset();
+  useConversationStore
+    .getState()
+    .setActiveConversationId(OWNING_CONVERSATION_ID);
+});
+
+afterEach(() => {
+  cleanup();
+  useLiveVoiceStore.getState().reset();
+  useConversationStore.getState().reset();
+});
+
+const roomDialog = () =>
+  screen.queryByRole("dialog", { name: "Voice session" });
+const exitButton = () =>
+  screen.queryByRole("button", { name: "Exit voice session" });
+
+describe("VoiceRoom — visibility", () => {
+  test("renders nothing when no session is active", () => {
+    render(<VoiceRoom />);
+    expect(roomDialog()).toBeNull();
+  });
+
+  test("renders the room when the on-screen composer owns an active session", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    expect(roomDialog()).not.toBeNull();
+    expect(exitButton()).not.toBeNull();
+    expect(screen.getByTestId("voice-avatar").textContent).toBe(ASSISTANT_ID);
+  });
+
+  test("renders nothing once navigated to another conversation (composer no longer owns)", () => {
+    startOwnedSession("listening");
+    useConversationStore
+      .getState()
+      .setActiveConversationId(OTHER_CONVERSATION_ID);
+    mockPathname = routes.conversation(OTHER_CONVERSATION_ID);
+    render(<VoiceRoom />);
+    expect(roomDialog()).toBeNull();
+  });
+
+  test("renders nothing over the desktop fullscreen app viewer (composer replaced)", () => {
+    startOwnedSession("listening");
+    mockMainView = "app";
+    render(<VoiceRoom />);
+    expect(roomDialog()).toBeNull();
+  });
+});
+
+describe("VoiceRoom — exit", () => {
+  test("✕ click ends the session via controls.stop", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    fireEvent.click(exitButton()!);
+    expect(controls.stop).toHaveBeenCalledTimes(1);
+  });
+
+  test("Escape ends the session via controls.stop", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(controls.stop).toHaveBeenCalledTimes(1);
+  });
+
+  test("the exit control renders even with no assistant resolved", () => {
+    startOwnedSession("listening");
+    useLiveVoiceStore.setState({ assistantId: null });
+    render(<VoiceRoom />);
+    expect(exitButton()).not.toBeNull();
+    expect(screen.getByTestId("voice-avatar").textContent).toBe("no-assistant");
+  });
+
+  test("key listeners are removed on unmount — no stray Escape teardown", () => {
+    startOwnedSession("listening");
+    const { unmount } = render(<VoiceRoom />);
+    unmount();
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(controls.stop).not.toHaveBeenCalled();
+  });
+});
+
+describe("VoiceRoom — push-to-talk fallback", () => {
+  test("Space releases the current turn while listening", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: " ", code: "Space" }),
+    );
+    expect(controls.release).toHaveBeenCalledTimes(1);
+  });
+
+  test("Space is inert while the assistant is speaking", () => {
+    startOwnedSession("speaking");
+    render(<VoiceRoom />);
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: " ", code: "Space" }),
+    );
+    expect(controls.release).not.toHaveBeenCalled();
+  });
+
+  test("tapping the orb releases the current turn while listening", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    fireEvent.click(screen.getByRole("button", { name: "Speak" }));
+    expect(controls.release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -149,6 +149,20 @@ describe("VoiceRoom — exit", () => {
     expect(controls.stop).toHaveBeenCalledTimes(1);
   });
 
+  test("Escape ends the session even when an editable element holds focus (global exit)", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    // The room can open while the composer textarea still owns focus; Escape is
+    // a global exit and must fire regardless of the editable target guard.
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+    expect(controls.stop).toHaveBeenCalledTimes(1);
+    input.remove();
+  });
+
   test("the exit control renders even with no assistant resolved", () => {
     startOwnedSession("listening");
     useLiveVoiceStore.setState({ assistantId: null });
@@ -190,6 +204,25 @@ describe("VoiceRoom — push-to-talk fallback", () => {
     // default (native button activation) is left intact.
     expect(controls.release).not.toHaveBeenCalled();
     expect(event.defaultPrevented).toBe(false);
+  });
+
+  test("Space in a text field is left for the field (not swallowed as push-to-talk)", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    const event = new KeyboardEvent("keydown", {
+      key: " ",
+      code: "Space",
+      bubbles: true,
+      cancelable: true,
+    });
+    input.dispatchEvent(event);
+    // The editable guard applies to Space: no release, and the field's own
+    // space-to-type default is left intact.
+    expect(controls.release).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+    input.remove();
   });
 
   test("Space is inert while the assistant is speaking", () => {

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -176,6 +176,22 @@ describe("VoiceRoom — push-to-talk fallback", () => {
     expect(controls.release).toHaveBeenCalledTimes(1);
   });
 
+  test("Space on the focused exit control is left for the button to activate (not swallowed)", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    const event = new KeyboardEvent("keydown", {
+      key: " ",
+      code: "Space",
+      bubbles: true,
+      cancelable: true,
+    });
+    exitButton()!.dispatchEvent(event);
+    // The global shortcut steps aside: no push-to-talk release, and Space's
+    // default (native button activation) is left intact.
+    expect(controls.release).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
   test("Space is inert while the assistant is speaking", () => {
     startOwnedSession("speaking");
     render(<VoiceRoom />);

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -1,0 +1,177 @@
+/**
+ * Full-screen "voice room" — the owning-composer surface for a live-voice
+ * session. A deep-dark ambient void with the assistant's state-driven avatar at
+ * its center, mounted at layout scope (see `chat-layout.tsx`) as a purely
+ * additive overlay: the composer's voice bar and display transcript still
+ * render underneath, hidden by this layer, so removing the room leaves the old
+ * UI intact.
+ *
+ * Visibility is a pure function of {@link useIsVoiceRoomVisible} — the exact
+ * complement of the title-bar session pill. Any session end (user exit, Escape,
+ * `failed`, conversation timeout, stop from elsewhere) flips that predicate
+ * false and unmounts the room; a `failed` session surfaces through the existing
+ * composer Notice / pill failure chip, never a dead room.
+ *
+ * Exit is first-class: a persistent ✕ control (always rendered, even while the
+ * avatar/assistant data is loading or failed), plus global Escape (end) and
+ * Space (push-to-talk "send now" fallback while idle/listening) key handlers
+ * attached only while the room is mounted.
+ */
+
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { useCallback, useEffect, useState } from "react";
+import { X } from "lucide-react";
+
+import { isEditableTarget } from "@/hooks/use-edge-swipe";
+
+import {
+  endLiveVoiceSession,
+  getLiveVoiceInputAmplitude,
+  liveVoiceStateLabel,
+  releaseLiveVoiceTurn,
+  useLiveVoiceStore,
+  type LiveVoiceSessionState,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
+
+import { toVoiceAvatarVisual } from "./voice-avatar-state";
+import { VoiceAvatar } from "./voice-avatar";
+import { VoiceRoomAmbientBackground } from "./voice-room-ambient-background";
+import { useIsVoiceRoomVisible } from "./use-is-voice-room-visible";
+
+/**
+ * Avatar entry spring: rises from a smaller, lower offset to center with a
+ * slight overshoot. Mirrors the app's `NODE_SPRING` overshoot convention
+ * (defined locally to avoid a cross-domain import, as `voice-avatar.tsx` does).
+ */
+const AVATAR_ENTER_SPRING = {
+  type: "spring" as const,
+  stiffness: 200,
+  damping: 18,
+};
+
+const AVATAR_SIZE = 220;
+/** The one-time "how to speak" hint auto-dismisses after this long. */
+const HINT_TIMEOUT_MS = 6000;
+
+/** Whether Space / an orb tap should release the current turn in `state`. */
+function canReleaseTurn(state: LiveVoiceSessionState): boolean {
+  return state === "idle" || state === "listening";
+}
+
+export function VoiceRoom() {
+  const visible = useIsVoiceRoomVisible();
+
+  return (
+    <AnimatePresence>{visible ? <VoiceRoomOverlay key="voice-room" /> : null}</AnimatePresence>
+  );
+}
+
+/**
+ * The mounted room. Split from {@link VoiceRoom} so its store subscriptions,
+ * key handlers, and hint timer only exist while the room is actually visible
+ * and are torn down cleanly on exit.
+ */
+function VoiceRoomOverlay() {
+  const state = useLiveVoiceStore.use.state();
+  const reconnecting = useLiveVoiceStore.use.reconnecting();
+  const assistantId = useLiveVoiceStore.use.assistantId();
+  const reduce = useReducedMotion();
+
+  const visual = toVoiceAvatarVisual(state, reconnecting);
+  const stateLabel = liveVoiceStateLabel(state, reconnecting);
+
+  const [hintVisible, setHintVisible] = useState(true);
+  useEffect(() => {
+    const timer = setTimeout(() => setHintVisible(false), HINT_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, []);
+
+  // Global exit / push-to-talk keys, live only while the room is mounted.
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (isEditableTarget(event.target)) {
+        return;
+      }
+      if (event.key === "Escape") {
+        event.preventDefault();
+        endLiveVoiceSession();
+        return;
+      }
+      if (event.key === " " || event.code === "Space") {
+        if (canReleaseTurn(useLiveVoiceStore.getState().state)) {
+          event.preventDefault();
+          releaseLiveVoiceTurn();
+        }
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  // Tapping the orb is the pointer equivalent of the Space push-to-talk
+  // fallback — "send now" while listening.
+  const handleOrbTap = useCallback(() => {
+    if (canReleaseTurn(useLiveVoiceStore.getState().state)) {
+      releaseLiveVoiceTurn();
+    }
+  }, []);
+
+  return (
+    <motion.div
+      className="fixed inset-0 z-50 flex items-center justify-center overflow-hidden"
+      data-theme="dark"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Voice session"
+      initial={reduce ? false : { opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: reduce ? 0 : 0.4 }}
+    >
+      <VoiceRoomAmbientBackground />
+
+      {/* Persistent exit control — rendered above all room chrome and never
+          gated behind avatar readiness, so exit works even mid-load / on
+          failure. */}
+      <button
+        type="button"
+        onClick={endLiveVoiceSession}
+        aria-label="Exit voice session"
+        className="absolute right-5 top-5 z-10 flex size-10 items-center justify-center rounded-full text-white/70 transition hover:bg-white/10 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60"
+      >
+        <X className="size-5" />
+      </button>
+
+      <div className="relative z-0 flex flex-col items-center gap-8">
+        <motion.button
+          type="button"
+          onClick={handleOrbTap}
+          aria-label="Speak"
+          className="rounded-full focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/50"
+          initial={reduce ? false : { scale: 0.8, y: 24, opacity: 0 }}
+          animate={{ scale: 1, y: 0, opacity: 1 }}
+          transition={reduce ? { duration: 0 } : AVATAR_ENTER_SPRING}
+        >
+          <VoiceAvatar
+            assistantId={assistantId}
+            visual={visual}
+            getAmplitude={getLiveVoiceInputAmplitude}
+            size={AVATAR_SIZE}
+          />
+        </motion.button>
+
+        {hintVisible ? (
+          <p className="text-sm text-white/45">
+            Tap the orb or press space to speak
+          </p>
+        ) : null}
+      </div>
+
+      {/* Screen readers get session-state changes here; the avatar is the
+          visual channel, so this stays off-screen. */}
+      <div aria-live="polite" className="sr-only">
+        {stateLabel}
+      </div>
+    </motion.div>
+  );
+}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -53,9 +53,42 @@ const AVATAR_SIZE = 220;
 /** The one-time "how to speak" hint auto-dismisses after this long. */
 const HINT_TIMEOUT_MS = 6000;
 
+/**
+ * Safe-area insets (see `docs/CAPACITOR.md`): the `var()` is set by
+ * `capacitor-plugin-safe-area` on Capacitor iOS, `env()` covers standard
+ * browsers with `viewport-fit=cover`, and `0px` covers desktop / non-notch
+ * devices — so these are inert everywhere except a notched iOS shell.
+ */
+const SAFE_AREA_TOP = "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))";
+const SAFE_AREA_BOTTOM =
+  "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))";
+const SAFE_AREA_LEFT =
+  "var(--safe-area-inset-left, env(safe-area-inset-left, 0px))";
+const SAFE_AREA_RIGHT =
+  "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))";
+
 /** Whether Space / an orb tap should release the current turn in `state`. */
 function canReleaseTurn(state: LiveVoiceSessionState): boolean {
   return state === "idle" || state === "listening";
+}
+
+/**
+ * Whether the event target is (or sits within) an interactive control that
+ * owns Space as its own activation — a button, link, or other focusable
+ * control. The global Space push-to-talk shortcut must not swallow Space when
+ * one of these (e.g. the focused exit ✕) has focus, or keyboard users can't
+ * activate it. This is narrower than {@link isEditableTarget} (text fields);
+ * Escape stays global regardless of focus.
+ */
+function isInteractiveTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) {
+    return false;
+  }
+  return (
+    target.closest(
+      'button, a[href], [role="button"], [role="link"], select, [tabindex]:not([tabindex="-1"])',
+    ) !== null
+  );
 }
 
 export function VoiceRoom() {
@@ -98,6 +131,12 @@ function VoiceRoomOverlay() {
         return;
       }
       if (event.key === " " || event.code === "Space") {
+        // Let a focused interactive control (e.g. the exit ✕) handle Space as
+        // its own activation instead of swallowing it as push-to-talk. The orb
+        // is itself a button, so Space over it still releases via its onClick.
+        if (isInteractiveTarget(event.target)) {
+          return;
+        }
         if (canReleaseTurn(useLiveVoiceStore.getState().state)) {
           event.preventDefault();
           releaseLiveVoiceTurn();
@@ -123,6 +162,16 @@ function VoiceRoomOverlay() {
       role="dialog"
       aria-modal="true"
       aria-label="Voice session"
+      // This `fixed inset-0` overlay covers `ChatLayoutHeader`, so it loses the
+      // header's safe-area protection — pad the centered chrome (avatar, hint)
+      // inside the notch/home-indicator per docs/CAPACITOR.md. The ambient
+      // void is `absolute inset-0` and stays full-bleed behind the padding.
+      style={{
+        paddingTop: SAFE_AREA_TOP,
+        paddingBottom: SAFE_AREA_BOTTOM,
+        paddingLeft: SAFE_AREA_LEFT,
+        paddingRight: SAFE_AREA_RIGHT,
+      }}
       initial={reduce ? false : { opacity: 0 }}
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
@@ -137,7 +186,14 @@ function VoiceRoomOverlay() {
         type="button"
         onClick={endLiveVoiceSession}
         aria-label="Exit voice session"
-        className="absolute right-5 top-5 z-10 flex size-10 items-center justify-center rounded-full text-white/70 transition hover:bg-white/10 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60"
+        // Absolute position is relative to the padding box, so the overlay's
+        // safe-area padding does not shift this — inset it from the notch /
+        // Dynamic Island directly, clamped to the desktop 1.25rem gap.
+        style={{
+          top: `max(1.25rem, ${SAFE_AREA_TOP})`,
+          right: `max(1.25rem, ${SAFE_AREA_RIGHT})`,
+        }}
+        className="absolute z-10 flex size-10 items-center justify-center rounded-full text-white/70 transition hover:bg-white/10 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60"
       >
         <X className="size-5" />
       </button>

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -122,19 +122,20 @@ function VoiceRoomOverlay() {
   // Global exit / push-to-talk keys, live only while the room is mounted.
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
-      if (isEditableTarget(event.target)) {
-        return;
-      }
+      // Escape is a global exit — it must fire even when the composer textarea
+      // (or any other editable/focused element) still holds focus as the room
+      // opens, so it is handled before any target guard.
       if (event.key === "Escape") {
         event.preventDefault();
         endLiveVoiceSession();
         return;
       }
       if (event.key === " " || event.code === "Space") {
-        // Let a focused interactive control (e.g. the exit ✕) handle Space as
-        // its own activation instead of swallowing it as push-to-talk. The orb
-        // is itself a button, so Space over it still releases via its onClick.
-        if (isInteractiveTarget(event.target)) {
+        // Space is push-to-talk; never steal it from a text field or a focused
+        // interactive control (e.g. the exit ✕), which handle Space as their own
+        // input/activation. The orb is itself a button, so Space over it still
+        // releases via its onClick.
+        if (isEditableTarget(event.target) || isInteractiveTarget(event.target)) {
           return;
         }
         if (canReleaseTurn(useLiveVoiceStore.getState().state)) {

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -462,3 +462,60 @@ body {
     transform: none;
   }
 }
+
+/* ─── Live-voice room ambient void ───────────────────────────────────────────
+ * Backdrop for the full-screen voice room: a deep-dark radial void with a
+ * scatter of slow-drifting indigo particles. The gradient and particle glow are
+ * fixed rgba — a deliberate constant accent that stays the same regardless of
+ * app theme (the room is always its own dark space), like a data-viz series or
+ * annotation overlay rather than a themed UI surface. See
+ * voice-room-ambient-background.tsx. */
+.voice-room-void {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  background: radial-gradient(
+    circle at 50% 44%,
+    rgb(12, 14, 24) 0%,
+    rgb(5, 6, 11) 46%,
+    rgb(0, 0, 0) 100%
+  );
+}
+
+@keyframes voice-room-particle-drift {
+  0% {
+    transform: translate3d(0, 0, 0);
+    opacity: 0;
+  }
+  12% {
+    opacity: var(--particle-opacity, 0.5);
+  }
+  88% {
+    opacity: var(--particle-opacity, 0.5);
+  }
+  100% {
+    transform: translate3d(var(--drift-x, 0), var(--drift-y, -60px), 0);
+    opacity: 0;
+  }
+}
+
+.voice-room-particle {
+  position: absolute;
+  border-radius: 50%;
+  pointer-events: none;
+  background: radial-gradient(
+    circle,
+    rgba(129, 140, 248, 0.6) 0%,
+    rgba(99, 102, 241, 0) 70%
+  );
+  animation: voice-room-particle-drift var(--drift-duration, 16s) ease-in-out
+    infinite;
+  will-change: transform, opacity;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .voice-room-particle {
+    animation: none;
+    opacity: 0.25;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a full-screen spatial voice room: deep-dark void + ambient particles + centered live avatar, mounted at layout scope; blurs chat and collapses the sidebar while active.
- Purely additive overlay: existing composer bar/transcript untouched underneath. Room and title-bar pill are exact complements via a shared useIsVoiceRoomVisible() predicate.
- Robust exit: persistent X, Escape, and any session end tears the room down and restores the chat.

Part of plan: voice-mode-ui-overhaul.md (PR 6 of 8)