### PR TITLE
Tighten workspace gitignore: runtime installs, caches, media, and large binary blobs

### DIFF
--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -787,6 +787,41 @@ describe("WorkspaceGitService", () => {
       expect(headFiles).toContain("notes.md");
     });
 
+    test("appending rules keeps negations last even when already present mid-file", async () => {
+      execFileSync("git", ["init", "-b", "main"], { cwd: testDir });
+      execFileSync("git", ["config", "user.name", "Test"], { cwd: testDir });
+      execFileSync("git", ["config", "user.email", "user@example.com"], {
+        cwd: testDir,
+      });
+      // Negation already present BEFORE the extension rules get appended —
+      // if it stayed there, a later *.png would win and re-ignore the avatar.
+      writeFileSync(
+        join(testDir, ".gitignore"),
+        "!data/avatar/**\nnode_modules/\n",
+      );
+      mkdirSync(join(testDir, "data", "avatar"), { recursive: true });
+      writeFileSync(join(testDir, "data", "avatar", "avatar-image.png"), "img");
+      mkdirSync(join(testDir, "pkb"), { recursive: true });
+      writeFileSync(join(testDir, "pkb", "photo.png"), "junk");
+      execFileSync("git", ["add", "-A", "-f"], { cwd: testDir });
+      execFileSync("git", ["commit", "-m", "init"], { cwd: testDir });
+
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const content = readFileSync(join(testDir, ".gitignore"), "utf-8");
+      expect(content.lastIndexOf("!data/avatar/**")).toBeGreaterThan(
+        content.indexOf("*.png"),
+      );
+
+      const tracked = execFileSync("git", ["ls-files"], {
+        cwd: testDir,
+        encoding: "utf-8",
+      });
+      expect(tracked).toContain("data/avatar/avatar-image.png");
+      expect(tracked).not.toContain("pkb/photo.png");
+    });
+
     test("untracking is limited to Vellum rules and keeps avatar/sounds state", async () => {
       execFileSync("git", ["init", "-b", "main"], { cwd: testDir });
       execFileSync("git", ["config", "user.name", "Test"], { cwd: testDir });

--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -69,7 +69,9 @@ describe("WorkspaceGitService", () => {
       expect(content).toContain("*.sock");
       expect(content).toContain("*.pid");
       expect(content).toContain("session-token");
-      expect(content).toContain("plugins/*/node_modules/");
+      expect(content).toContain("node_modules/");
+      expect(content).toContain("/embedding-models/");
+      expect(content).toContain(".DS_Store");
     });
 
     test("sets git identity correctly", async () => {
@@ -830,7 +832,7 @@ describe("WorkspaceGitService", () => {
         cwd: testDir,
       });
       const gitignoreContent =
-        "# Runtime state - excluded from git tracking\ndata/db/\ndata/qdrant/\ndata/monitoring/\ndata/apps/*/records/\ndata/apps/*/dist/\ndata/apps/*.preview\nplugins/*/node_modules/\nlogs/\n*.log\n*.sock\n*.pid\n*.sqlite\n*.sqlite-journal\n*.sqlite-wal\n*.sqlite-shm\n*.db\n*.db-journal\n*.db-wal\n*.db-shm\nvellum.pid\nsession-token\n";
+        "# Runtime state - excluded from git tracking\ndata/db/\ndata/qdrant/\ndata/monitoring/\ndata/apps/*/records/\ndata/apps/*/dist/\ndata/apps/*.preview\n/embedding-models/\n/external/\n/bin/\n/plugins-data/\nnode_modules/\n__pycache__/\n.venv/\nlogs/\n*.log\n*.sock\n*.pid\ndaemon-startup.lock\nsession-token\n*.sqlite*\n*.db\n*.db-*\n.DS_Store\n*.zip\n*.tar\n*.gz\n*.tgz\n*.dmg\n*.iso\n";
       writeFileSync(join(testDir, ".gitignore"), gitignoreContent);
       writeFileSync(join(testDir, "file.txt"), "content");
       execFileSync("git", ["add", "-A"], { cwd: testDir });

--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -778,6 +778,14 @@ describe("WorkspaceGitService", () => {
       writeFileSync(join(testDir, "data", "avatar", "avatar-image.png"), "img");
       mkdirSync(join(testDir, "data", "sounds"), { recursive: true });
       writeFileSync(join(testDir, "data", "sounds", "ding.mp3"), "snd");
+      mkdirSync(join(testDir, "data", "apps", "my-app", "dist"), {
+        recursive: true,
+      });
+      writeFileSync(join(testDir, "data", "apps", "my-app", "icon.png"), "ic");
+      writeFileSync(
+        join(testDir, "data", "apps", "my-app", "dist", "bundle.png"),
+        "junk",
+      );
       // Media junk elsewhere that should be untracked
       mkdirSync(join(testDir, "pkb"), { recursive: true });
       writeFileSync(join(testDir, "pkb", "photo.png"), "junk");
@@ -800,8 +808,11 @@ describe("WorkspaceGitService", () => {
       });
       expect(tracked).toContain("data/avatar/avatar-image.png");
       expect(tracked).toContain("data/sounds/ding.mp3");
+      expect(tracked).toContain("data/apps/my-app/icon.png");
       expect(tracked).toContain("fixture-keep.md");
       expect(tracked).not.toContain("pkb/photo.png");
+      // The icon negation must not drag dist/ back in
+      expect(tracked).not.toContain("data/apps/my-app/dist/bundle.png");
     });
 
     test("existing repo with old data/ rule gets it replaced with selective rules", async () => {
@@ -911,7 +922,7 @@ describe("WorkspaceGitService", () => {
         cwd: testDir,
       });
       const gitignoreContent =
-        "# Runtime state - excluded from git tracking\ndata/db/\ndata/qdrant/\ndata/monitoring/\ndata/apps/*/records/\ndata/apps/*/dist/\ndata/apps/*.preview\n/embedding-models/\n/external/\n/bin/\n/plugins-data/\nnode_modules/\n__pycache__/\n.venv/\nlogs/\n*.log\n*.sock\n*.pid\ndaemon-startup.lock\nsession-token\n*.sqlite*\n*.db\n*.db-*\n.DS_Store\n*.zip\n*.tar\n*.gz\n*.tgz\n*.bz2\n*.xz\n*.7z\n*.rar\n*.dmg\n*.iso\n*.png\n*.jpg\n*.jpeg\n*.gif\n*.webp\n*.heic\n*.bmp\n*.tiff\n*.mp3\n*.wav\n*.m4a\n*.flac\n*.ogg\n*.mp4\n*.mov\n*.avi\n*.mkv\n*.webm\n*.pdf\n*.gguf\n*.onnx\n*.safetensors\n*.pt\n*.pth\n!data/avatar/**\n!data/sounds/**\n";
+        "# Runtime state - excluded from git tracking\ndata/db/\ndata/qdrant/\ndata/monitoring/\ndata/apps/*/records/\ndata/apps/*/dist/\ndata/apps/*.preview\n/embedding-models/\n/external/\n/bin/\n/plugins-data/\nnode_modules/\n__pycache__/\n.venv/\nlogs/\n*.log\n*.sock\n*.pid\ndaemon-startup.lock\nsession-token\n*.sqlite*\n*.db\n*.db-*\n.DS_Store\n*.zip\n*.tar\n*.gz\n*.tgz\n*.bz2\n*.xz\n*.7z\n*.rar\n*.dmg\n*.iso\n*.png\n*.jpg\n*.jpeg\n*.gif\n*.webp\n*.heic\n*.bmp\n*.tiff\n*.mp3\n*.wav\n*.m4a\n*.flac\n*.ogg\n*.mp4\n*.mov\n*.avi\n*.mkv\n*.webm\n*.pdf\n*.gguf\n*.onnx\n*.safetensors\n*.pt\n*.pth\n!data/avatar/**\n!data/sounds/**\n!data/apps/*/icon.png\n";
       writeFileSync(join(testDir, ".gitignore"), gitignoreContent);
       writeFileSync(join(testDir, "file.txt"), "content");
       execFileSync("git", ["add", "-A"], { cwd: testDir });

--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -725,6 +725,47 @@ describe("WorkspaceGitService", () => {
       expect(contentAfter).toContain("session-token");
     });
 
+    test("existing repo with committed runtime state gets it untracked on init", async () => {
+      // Repo that committed runtime state before the ignore rule existed
+      execFileSync("git", ["init", "-b", "main"], { cwd: testDir });
+      execFileSync("git", ["config", "user.name", "Test"], { cwd: testDir });
+      execFileSync("git", ["config", "user.email", "user@example.com"], {
+        cwd: testDir,
+      });
+      mkdirSync(join(testDir, "embedding-models"), { recursive: true });
+      writeFileSync(join(testDir, "embedding-models", "model.bin"), "weights");
+      writeFileSync(join(testDir, "notes.md"), "keep me");
+      execFileSync("git", ["add", "-A"], { cwd: testDir });
+      execFileSync("git", ["commit", "-m", "init"], { cwd: testDir });
+
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      // Now-ignored path is dropped from the index; tracked files survive.
+      const tracked = execFileSync("git", ["ls-files"], {
+        cwd: testDir,
+        encoding: "utf-8",
+      });
+      expect(tracked).not.toContain("embedding-models/model.bin");
+      expect(tracked).toContain("notes.md");
+
+      // Working tree is untouched — only the index entry is removed.
+      expect(existsSync(join(testDir, "embedding-models", "model.bin"))).toBe(
+        true,
+      );
+
+      // The staged deletion rides along with the next commit and the file
+      // is not re-added despite `git add -A`.
+      await service.commitChanges("next turn");
+      const headFiles = execFileSync(
+        "git",
+        ["ls-tree", "-r", "--name-only", "HEAD"],
+        { cwd: testDir, encoding: "utf-8" },
+      );
+      expect(headFiles).not.toContain("embedding-models/model.bin");
+      expect(headFiles).toContain("notes.md");
+    });
+
     test("existing repo with old data/ rule gets it replaced with selective rules", async () => {
       // Set up a pre-existing git repo with the OLD broad data/ rule
       execFileSync("git", ["init", "-b", "main"], { cwd: testDir });

--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -767,6 +767,43 @@ describe("WorkspaceGitService", () => {
       expect(headFiles).toContain("notes.md");
     });
 
+    test("untracking keeps avatar/sounds state and ignores user exclude files", async () => {
+      execFileSync("git", ["init", "-b", "main"], { cwd: testDir });
+      execFileSync("git", ["config", "user.name", "Test"], { cwd: testDir });
+      execFileSync("git", ["config", "user.email", "user@example.com"], {
+        cwd: testDir,
+      });
+      // Canonical user state that matches the media extension rules
+      mkdirSync(join(testDir, "data", "avatar"), { recursive: true });
+      writeFileSync(join(testDir, "data", "avatar", "avatar-image.png"), "img");
+      mkdirSync(join(testDir, "data", "sounds"), { recursive: true });
+      writeFileSync(join(testDir, "data", "sounds", "ding.mp3"), "snd");
+      // Media junk elsewhere that should be untracked
+      mkdirSync(join(testDir, "pkb"), { recursive: true });
+      writeFileSync(join(testDir, "pkb", "photo.png"), "junk");
+      // Tracked file matching only the user's repo-local exclude file — the
+      // untrack step must not consult it.
+      writeFileSync(join(testDir, "fixture-keep.md"), "keep");
+      writeFileSync(
+        join(testDir, ".git", "info", "exclude"),
+        "fixture-keep.md\n",
+      );
+      execFileSync("git", ["add", "-A", "-f"], { cwd: testDir });
+      execFileSync("git", ["commit", "-m", "init"], { cwd: testDir });
+
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const tracked = execFileSync("git", ["ls-files"], {
+        cwd: testDir,
+        encoding: "utf-8",
+      });
+      expect(tracked).toContain("data/avatar/avatar-image.png");
+      expect(tracked).toContain("data/sounds/ding.mp3");
+      expect(tracked).toContain("fixture-keep.md");
+      expect(tracked).not.toContain("pkb/photo.png");
+    });
+
     test("existing repo with old data/ rule gets it replaced with selective rules", async () => {
       // Set up a pre-existing git repo with the OLD broad data/ rule
       execFileSync("git", ["init", "-b", "main"], { cwd: testDir });
@@ -874,7 +911,7 @@ describe("WorkspaceGitService", () => {
         cwd: testDir,
       });
       const gitignoreContent =
-        "# Runtime state - excluded from git tracking\ndata/db/\ndata/qdrant/\ndata/monitoring/\ndata/apps/*/records/\ndata/apps/*/dist/\ndata/apps/*.preview\n/embedding-models/\n/external/\n/bin/\n/plugins-data/\nnode_modules/\n__pycache__/\n.venv/\nlogs/\n*.log\n*.sock\n*.pid\ndaemon-startup.lock\nsession-token\n*.sqlite*\n*.db\n*.db-*\n.DS_Store\n*.zip\n*.tar\n*.gz\n*.tgz\n*.bz2\n*.xz\n*.7z\n*.rar\n*.dmg\n*.iso\n*.png\n*.jpg\n*.jpeg\n*.gif\n*.webp\n*.heic\n*.bmp\n*.tiff\n*.mp3\n*.wav\n*.m4a\n*.flac\n*.ogg\n*.mp4\n*.mov\n*.avi\n*.mkv\n*.webm\n*.pdf\n*.gguf\n*.onnx\n*.safetensors\n*.pt\n*.pth\n";
+        "# Runtime state - excluded from git tracking\ndata/db/\ndata/qdrant/\ndata/monitoring/\ndata/apps/*/records/\ndata/apps/*/dist/\ndata/apps/*.preview\n/embedding-models/\n/external/\n/bin/\n/plugins-data/\nnode_modules/\n__pycache__/\n.venv/\nlogs/\n*.log\n*.sock\n*.pid\ndaemon-startup.lock\nsession-token\n*.sqlite*\n*.db\n*.db-*\n.DS_Store\n*.zip\n*.tar\n*.gz\n*.tgz\n*.bz2\n*.xz\n*.7z\n*.rar\n*.dmg\n*.iso\n*.png\n*.jpg\n*.jpeg\n*.gif\n*.webp\n*.heic\n*.bmp\n*.tiff\n*.mp3\n*.wav\n*.m4a\n*.flac\n*.ogg\n*.mp4\n*.mov\n*.avi\n*.mkv\n*.webm\n*.pdf\n*.gguf\n*.onnx\n*.safetensors\n*.pt\n*.pth\n!data/avatar/**\n!data/sounds/**\n";
       writeFileSync(join(testDir, ".gitignore"), gitignoreContent);
       writeFileSync(join(testDir, "file.txt"), "content");
       execFileSync("git", ["add", "-A"], { cwd: testDir });

--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -72,6 +72,7 @@ describe("WorkspaceGitService", () => {
       expect(content).toContain("node_modules/");
       expect(content).toContain("/embedding-models/");
       expect(content).toContain(".DS_Store");
+      expect(content).toContain("*.png");
     });
 
     test("sets git identity correctly", async () => {
@@ -873,7 +874,7 @@ describe("WorkspaceGitService", () => {
         cwd: testDir,
       });
       const gitignoreContent =
-        "# Runtime state - excluded from git tracking\ndata/db/\ndata/qdrant/\ndata/monitoring/\ndata/apps/*/records/\ndata/apps/*/dist/\ndata/apps/*.preview\n/embedding-models/\n/external/\n/bin/\n/plugins-data/\nnode_modules/\n__pycache__/\n.venv/\nlogs/\n*.log\n*.sock\n*.pid\ndaemon-startup.lock\nsession-token\n*.sqlite*\n*.db\n*.db-*\n.DS_Store\n*.zip\n*.tar\n*.gz\n*.tgz\n*.dmg\n*.iso\n";
+        "# Runtime state - excluded from git tracking\ndata/db/\ndata/qdrant/\ndata/monitoring/\ndata/apps/*/records/\ndata/apps/*/dist/\ndata/apps/*.preview\n/embedding-models/\n/external/\n/bin/\n/plugins-data/\nnode_modules/\n__pycache__/\n.venv/\nlogs/\n*.log\n*.sock\n*.pid\ndaemon-startup.lock\nsession-token\n*.sqlite*\n*.db\n*.db-*\n.DS_Store\n*.zip\n*.tar\n*.gz\n*.tgz\n*.bz2\n*.xz\n*.7z\n*.rar\n*.dmg\n*.iso\n*.png\n*.jpg\n*.jpeg\n*.gif\n*.webp\n*.heic\n*.bmp\n*.tiff\n*.mp3\n*.wav\n*.m4a\n*.flac\n*.ogg\n*.mp4\n*.mov\n*.avi\n*.mkv\n*.webm\n*.pdf\n*.gguf\n*.onnx\n*.safetensors\n*.pt\n*.pth\n";
       writeFileSync(join(testDir, ".gitignore"), gitignoreContent);
       writeFileSync(join(testDir, "file.txt"), "content");
       execFileSync("git", ["add", "-A"], { cwd: testDir });

--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -767,7 +767,7 @@ describe("WorkspaceGitService", () => {
       expect(headFiles).toContain("notes.md");
     });
 
-    test("untracking keeps avatar/sounds state and ignores user exclude files", async () => {
+    test("untracking is limited to Vellum rules and keeps avatar/sounds state", async () => {
       execFileSync("git", ["init", "-b", "main"], { cwd: testDir });
       execFileSync("git", ["config", "user.name", "Test"], { cwd: testDir });
       execFileSync("git", ["config", "user.email", "user@example.com"], {
@@ -796,6 +796,10 @@ describe("WorkspaceGitService", () => {
         join(testDir, ".git", "info", "exclude"),
         "fixture-keep.md\n",
       );
+      // Force-added despite a user-authored .gitignore rule — the untrack
+      // step matches Vellum-managed rules only, so it must stay tracked.
+      writeFileSync(join(testDir, ".gitignore"), "user-secret.md\n");
+      writeFileSync(join(testDir, "user-secret.md"), "keep");
       execFileSync("git", ["add", "-A", "-f"], { cwd: testDir });
       execFileSync("git", ["commit", "-m", "init"], { cwd: testDir });
 
@@ -810,6 +814,7 @@ describe("WorkspaceGitService", () => {
       expect(tracked).toContain("data/sounds/ding.mp3");
       expect(tracked).toContain("data/apps/my-app/icon.png");
       expect(tracked).toContain("fixture-keep.md");
+      expect(tracked).toContain("user-secret.md");
       expect(tracked).not.toContain("pkb/photo.png");
       // The icon negation must not drag dist/ back in
       expect(tracked).not.toContain("data/apps/my-app/dist/bundle.png");

--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -767,6 +767,26 @@ describe("WorkspaceGitService", () => {
       expect(headFiles).toContain("notes.md");
     });
 
+    test("partial init with staged now-ignored files drops them from the initial commit", async () => {
+      // Interrupted previous init: `.git` exists with staged files, no commit
+      execFileSync("git", ["init", "-b", "main"], { cwd: testDir });
+      mkdirSync(join(testDir, "embedding-models"), { recursive: true });
+      writeFileSync(join(testDir, "embedding-models", "model.bin"), "weights");
+      writeFileSync(join(testDir, "notes.md"), "keep me");
+      execFileSync("git", ["add", "-A"], { cwd: testDir });
+
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const headFiles = execFileSync(
+        "git",
+        ["ls-tree", "-r", "--name-only", "HEAD"],
+        { cwd: testDir, encoding: "utf-8" },
+      );
+      expect(headFiles).not.toContain("embedding-models/model.bin");
+      expect(headFiles).toContain("notes.md");
+    });
+
     test("untracking is limited to Vellum rules and keeps avatar/sounds state", async () => {
       execFileSync("git", ["init", "-b", "main"], { cwd: testDir });
       execFileSync("git", ["config", "user.name", "Test"], { cwd: testDir });

--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -73,6 +73,8 @@ describe("WorkspaceGitService", () => {
       expect(content).toContain("/embedding-models/");
       expect(content).toContain(".DS_Store");
       expect(content).toContain("*.png");
+      expect(content).toContain("*.jsonl");
+      expect(content).toContain("!conversations/**");
     });
 
     test("sets git identity correctly", async () => {
@@ -726,67 +728,6 @@ describe("WorkspaceGitService", () => {
       expect(contentAfter).toContain("session-token");
     });
 
-    test("existing repo with committed runtime state gets it untracked on init", async () => {
-      // Repo that committed runtime state before the ignore rule existed
-      execFileSync("git", ["init", "-b", "main"], { cwd: testDir });
-      execFileSync("git", ["config", "user.name", "Test"], { cwd: testDir });
-      execFileSync("git", ["config", "user.email", "user@example.com"], {
-        cwd: testDir,
-      });
-      mkdirSync(join(testDir, "embedding-models"), { recursive: true });
-      writeFileSync(join(testDir, "embedding-models", "model.bin"), "weights");
-      writeFileSync(join(testDir, "notes.md"), "keep me");
-      execFileSync("git", ["add", "-A"], { cwd: testDir });
-      execFileSync("git", ["commit", "-m", "init"], { cwd: testDir });
-
-      const service = new WorkspaceGitService(testDir);
-      await service.ensureInitialized();
-
-      // Now-ignored path is dropped from the index; tracked files survive.
-      const tracked = execFileSync("git", ["ls-files"], {
-        cwd: testDir,
-        encoding: "utf-8",
-      });
-      expect(tracked).not.toContain("embedding-models/model.bin");
-      expect(tracked).toContain("notes.md");
-
-      // Working tree is untouched — only the index entry is removed.
-      expect(existsSync(join(testDir, "embedding-models", "model.bin"))).toBe(
-        true,
-      );
-
-      // The staged deletion rides along with the next commit and the file
-      // is not re-added despite `git add -A`.
-      await service.commitChanges("next turn");
-      const headFiles = execFileSync(
-        "git",
-        ["ls-tree", "-r", "--name-only", "HEAD"],
-        { cwd: testDir, encoding: "utf-8" },
-      );
-      expect(headFiles).not.toContain("embedding-models/model.bin");
-      expect(headFiles).toContain("notes.md");
-    });
-
-    test("partial init with staged now-ignored files drops them from the initial commit", async () => {
-      // Interrupted previous init: `.git` exists with staged files, no commit
-      execFileSync("git", ["init", "-b", "main"], { cwd: testDir });
-      mkdirSync(join(testDir, "embedding-models"), { recursive: true });
-      writeFileSync(join(testDir, "embedding-models", "model.bin"), "weights");
-      writeFileSync(join(testDir, "notes.md"), "keep me");
-      execFileSync("git", ["add", "-A"], { cwd: testDir });
-
-      const service = new WorkspaceGitService(testDir);
-      await service.ensureInitialized();
-
-      const headFiles = execFileSync(
-        "git",
-        ["ls-tree", "-r", "--name-only", "HEAD"],
-        { cwd: testDir, encoding: "utf-8" },
-      );
-      expect(headFiles).not.toContain("embedding-models/model.bin");
-      expect(headFiles).toContain("notes.md");
-    });
-
     test("appending rules keeps negations last even when already present mid-file", async () => {
       execFileSync("git", ["init", "-b", "main"], { cwd: testDir });
       execFileSync("git", ["config", "user.name", "Test"], { cwd: testDir });
@@ -799,11 +740,8 @@ describe("WorkspaceGitService", () => {
         join(testDir, ".gitignore"),
         "!data/avatar/**\nnode_modules/\n",
       );
-      mkdirSync(join(testDir, "data", "avatar"), { recursive: true });
-      writeFileSync(join(testDir, "data", "avatar", "avatar-image.png"), "img");
-      mkdirSync(join(testDir, "pkb"), { recursive: true });
-      writeFileSync(join(testDir, "pkb", "photo.png"), "junk");
-      execFileSync("git", ["add", "-A", "-f"], { cwd: testDir });
+      writeFileSync(join(testDir, "file.txt"), "content");
+      execFileSync("git", ["add", "-A"], { cwd: testDir });
       execFileSync("git", ["commit", "-m", "init"], { cwd: testDir });
 
       const service = new WorkspaceGitService(testDir);
@@ -814,65 +752,18 @@ describe("WorkspaceGitService", () => {
         content.indexOf("*.png"),
       );
 
-      const tracked = execFileSync("git", ["ls-files"], {
-        cwd: testDir,
-        encoding: "utf-8",
-      });
-      expect(tracked).toContain("data/avatar/avatar-image.png");
-      expect(tracked).not.toContain("pkb/photo.png");
-    });
-
-    test("untracking is limited to Vellum rules and keeps avatar/sounds state", async () => {
-      execFileSync("git", ["init", "-b", "main"], { cwd: testDir });
-      execFileSync("git", ["config", "user.name", "Test"], { cwd: testDir });
-      execFileSync("git", ["config", "user.email", "user@example.com"], {
+      // Effective behavior: the avatar path is not ignored (check-ignore
+      // exits 1 → throws), media elsewhere is (exits 0).
+      expect(() =>
+        execFileSync(
+          "git",
+          ["check-ignore", "-q", "data/avatar/avatar-image.png"],
+          { cwd: testDir },
+        ),
+      ).toThrow();
+      execFileSync("git", ["check-ignore", "-q", "pkb/photo.png"], {
         cwd: testDir,
       });
-      // Canonical user state that matches the media extension rules
-      mkdirSync(join(testDir, "data", "avatar"), { recursive: true });
-      writeFileSync(join(testDir, "data", "avatar", "avatar-image.png"), "img");
-      mkdirSync(join(testDir, "data", "sounds"), { recursive: true });
-      writeFileSync(join(testDir, "data", "sounds", "ding.mp3"), "snd");
-      mkdirSync(join(testDir, "data", "apps", "my-app", "dist"), {
-        recursive: true,
-      });
-      writeFileSync(join(testDir, "data", "apps", "my-app", "icon.png"), "ic");
-      writeFileSync(
-        join(testDir, "data", "apps", "my-app", "dist", "bundle.png"),
-        "junk",
-      );
-      // Media junk elsewhere that should be untracked
-      mkdirSync(join(testDir, "pkb"), { recursive: true });
-      writeFileSync(join(testDir, "pkb", "photo.png"), "junk");
-      // Tracked file matching only the user's repo-local exclude file — the
-      // untrack step must not consult it.
-      writeFileSync(join(testDir, "fixture-keep.md"), "keep");
-      writeFileSync(
-        join(testDir, ".git", "info", "exclude"),
-        "fixture-keep.md\n",
-      );
-      // Force-added despite a user-authored .gitignore rule — the untrack
-      // step matches Vellum-managed rules only, so it must stay tracked.
-      writeFileSync(join(testDir, ".gitignore"), "user-secret.md\n");
-      writeFileSync(join(testDir, "user-secret.md"), "keep");
-      execFileSync("git", ["add", "-A", "-f"], { cwd: testDir });
-      execFileSync("git", ["commit", "-m", "init"], { cwd: testDir });
-
-      const service = new WorkspaceGitService(testDir);
-      await service.ensureInitialized();
-
-      const tracked = execFileSync("git", ["ls-files"], {
-        cwd: testDir,
-        encoding: "utf-8",
-      });
-      expect(tracked).toContain("data/avatar/avatar-image.png");
-      expect(tracked).toContain("data/sounds/ding.mp3");
-      expect(tracked).toContain("data/apps/my-app/icon.png");
-      expect(tracked).toContain("fixture-keep.md");
-      expect(tracked).toContain("user-secret.md");
-      expect(tracked).not.toContain("pkb/photo.png");
-      // The icon negation must not drag dist/ back in
-      expect(tracked).not.toContain("data/apps/my-app/dist/bundle.png");
     });
 
     test("existing repo with old data/ rule gets it replaced with selective rules", async () => {
@@ -982,7 +873,7 @@ describe("WorkspaceGitService", () => {
         cwd: testDir,
       });
       const gitignoreContent =
-        "# Runtime state - excluded from git tracking\ndata/db/\ndata/qdrant/\ndata/monitoring/\ndata/apps/*/records/\ndata/apps/*/dist/\ndata/apps/*.preview\n/embedding-models/\n/external/\n/bin/\n/plugins-data/\nnode_modules/\n__pycache__/\n.venv/\nlogs/\n*.log\n*.sock\n*.pid\ndaemon-startup.lock\nsession-token\n*.sqlite*\n*.db\n*.db-*\n.DS_Store\n*.zip\n*.tar\n*.gz\n*.tgz\n*.bz2\n*.xz\n*.7z\n*.rar\n*.dmg\n*.iso\n*.png\n*.jpg\n*.jpeg\n*.gif\n*.webp\n*.heic\n*.bmp\n*.tiff\n*.mp3\n*.wav\n*.m4a\n*.flac\n*.ogg\n*.mp4\n*.mov\n*.avi\n*.mkv\n*.webm\n*.pdf\n*.gguf\n*.onnx\n*.safetensors\n*.pt\n*.pth\n!data/avatar/**\n!data/sounds/**\n!data/apps/*/icon.png\n";
+        "# Runtime state - excluded from git tracking\ndata/db/\ndata/qdrant/\ndata/monitoring/\ndata/apps/*/records/\ndata/apps/*/dist/\ndata/apps/*.preview\n/embedding-models/\n/external/\n/bin/\n/plugins-data/\nnode_modules/\n__pycache__/\n.venv/\nlogs/\n*.log\n*.jsonl\n*.sock\n*.pid\ndaemon-startup.lock\nsession-token\n*.sqlite*\n*.db\n*.db-*\n.DS_Store\n*.zip\n*.tar\n*.gz\n*.tgz\n*.bz2\n*.xz\n*.7z\n*.rar\n*.dmg\n*.iso\n*.png\n*.jpg\n*.jpeg\n*.gif\n*.webp\n*.heic\n*.bmp\n*.tiff\n*.mp3\n*.wav\n*.m4a\n*.flac\n*.ogg\n*.mp4\n*.mov\n*.avi\n*.mkv\n*.webm\n*.pdf\n*.gguf\n*.onnx\n*.safetensors\n*.pt\n*.pth\n!data/avatar/**\n!data/sounds/**\n!data/apps/*/icon.png\n!conversations/**\n";
       writeFileSync(join(testDir, ".gitignore"), gitignoreContent);
       writeFileSync(join(testDir, "file.txt"), "content");
       execFileSync("git", ["add", "-A"], { cwd: testDir });

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -81,6 +81,7 @@ const WORKSPACE_GITIGNORE_RULES = [
   // Logs and process state
   "logs/",
   "*.log",
+  "*.jsonl",
   "*.sock",
   "*.pid",
   "daemon-startup.lock",
@@ -129,12 +130,15 @@ const WORKSPACE_GITIGNORE_RULES = [
   "*.safetensors",
   "*.pt",
   "*.pth",
-  // Canonical user state re-included despite the media rules above.
+  // Canonical user state re-included despite the extension rules above.
   // Must stay after the extension rules: last matching pattern wins.
   // (Not a broad !data/apps/** — that would also re-include dist/.)
+  // conversations/ holds the messages.jsonl disk view that DB recovery
+  // rebuilds from, so it survives the *.jsonl rule.
   "!data/avatar/**",
   "!data/sounds/**",
   "!data/apps/*/icon.png",
+  "!conversations/**",
 ];
 
 const NULL_GIT_OID = "0000000000000000000000000000000000000000";
@@ -486,7 +490,6 @@ export class WorkspaceGitService {
                 // These calls are OUTSIDE the rev-parse try/catch so that
                 // normalization errors are not misclassified as "no commits".
                 this.ensureGitignoreRulesLocked();
-                await this.untrackIgnoredFilesLocked();
                 this.ensureBranchGuardHookLocked();
                 await this.ensureCommitIdentityLocked();
                 await this.ensureBranchGuardConfigLocked();
@@ -507,9 +510,6 @@ export class WorkspaceGitService {
           // in the corruption-recovery path we fall through here after
           // removing .git, so branch enforcement is still useful.
           this.ensureGitignoreRulesLocked();
-          // A partial init (`.git` exists, no commit) can carry staged
-          // now-ignored paths from an interrupted `git add -A`.
-          await this.untrackIgnoredFilesLocked();
           this.ensureBranchGuardHookLocked();
           await this.ensureCommitIdentityLocked();
           await this.ensureBranchGuardConfigLocked();
@@ -863,67 +863,6 @@ export class WorkspaceGitService {
         WORKSPACE_GITIGNORE_RULES.join("\n") +
         "\n";
       writeFileSync(gitignorePath, gitignore, "utf-8");
-    }
-  }
-
-  /**
-   * Drop tracked files matched by the Vellum-managed ignore rules from the
-   * index (working tree untouched). Ignore rules only affect untracked
-   * paths, so committed runtime state (e.g. embedding-models/) stays in the
-   * index — and churns every commit — until explicitly removed here. The
-   * staged deletions ride along with the next commit. Best-effort: failures
-   * are logged, never block init. Must be called with the mutex lock held.
-   *
-   * Deliberately matches against the Vellum-managed rules only — not the
-   * workspace .gitignore (which may carry user-authored rules whose matches
-   * are force-added on purpose) and not --exclude-standard (the user's
-   * global/local exclude files). The rules are passed via a temp file under
-   * .git so gitignore semantics, including negation order, are preserved.
-   */
-  private async untrackIgnoredFilesLocked(): Promise<void> {
-    const rulesPath = join(this.workspaceDir, ".git", "vellum-untrack-rules");
-    try {
-      writeFileSync(
-        rulesPath,
-        WORKSPACE_GITIGNORE_RULES.join("\n") + "\n",
-        "utf-8",
-      );
-      const { stdout } = await this.execGitStreaming([
-        "ls-files",
-        "-z",
-        "--cached",
-        "--ignored",
-        `--exclude-from=${rulesPath}`,
-      ]);
-      const files = stdout.split("\0").filter(Boolean);
-      if (files.length === 0) {
-        return;
-      }
-      // Chunked to stay under OS argv limits on bloated workspaces.
-      const chunkSize = 200;
-      for (let i = 0; i < files.length; i += chunkSize) {
-        await this.execGit([
-          "rm",
-          "--cached",
-          "-r",
-          "-q",
-          "--ignore-unmatch",
-          "--",
-          ...files.slice(i, i + chunkSize),
-        ]);
-      }
-      log.info(
-        { fileCount: files.length },
-        "Untracked newly ignored files from workspace index",
-      );
-    } catch (err) {
-      log.warn({ err }, "Failed to untrack newly ignored files");
-    } finally {
-      try {
-        unlinkSync(rulesPath);
-      } catch {
-        // Never created, or already gone.
-      }
     }
   }
 

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -507,6 +507,9 @@ export class WorkspaceGitService {
           // in the corruption-recovery path we fall through here after
           // removing .git, so branch enforcement is still useful.
           this.ensureGitignoreRulesLocked();
+          // A partial init (`.git` exists, no commit) can carry staged
+          // now-ignored paths from an interrupted `git add -A`.
+          await this.untrackIgnoredFilesLocked();
           this.ensureBranchGuardHookLocked();
           await this.ensureCommitIdentityLocked();
           await this.ensureBranchGuardConfigLocked();
@@ -849,16 +852,16 @@ export class WorkspaceGitService {
   }
 
   /**
-   * Drop tracked files that are now matched by ignore rules from the index
-   * (working tree untouched). Ignore rules only affect untracked paths, so a
-   * workspace that committed runtime state (e.g. embedding-models/) before a
-   * rule existed would otherwise keep committing it forever. The staged
-   * deletions ride along with the next commit. Best-effort: failures are
-   * logged, never block init. Must be called with the mutex lock held.
+   * Drop tracked files matched by the Vellum-managed ignore rules from the
+   * index (working tree untouched). Ignore rules only affect untracked
+   * paths, so committed runtime state (e.g. embedding-models/) stays in the
+   * index — and churns every commit — until explicitly removed here. The
+   * staged deletions ride along with the next commit. Best-effort: failures
+   * are logged, never block init. Must be called with the mutex lock held.
    *
    * Deliberately matches against the Vellum-managed rules only — not the
    * workspace .gitignore (which may carry user-authored rules whose matches
-   * were force-added on purpose) and not --exclude-standard (the user's
+   * are force-added on purpose) and not --exclude-standard (the user's
    * global/local exclude files). The rules are passed via a temp file under
    * .git so gitignore semantics, including negation order, are preserved.
    */

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -856,18 +856,26 @@ export class WorkspaceGitService {
    * deletions ride along with the next commit. Best-effort: failures are
    * logged, never block init. Must be called with the mutex lock held.
    *
-   * Deliberately reads only the workspace .gitignore (not --exclude-standard):
-   * the user's global/local exclude files must not cause deletions of files
-   * they force-added on purpose.
+   * Deliberately matches against the Vellum-managed rules only — not the
+   * workspace .gitignore (which may carry user-authored rules whose matches
+   * were force-added on purpose) and not --exclude-standard (the user's
+   * global/local exclude files). The rules are passed via a temp file under
+   * .git so gitignore semantics, including negation order, are preserved.
    */
   private async untrackIgnoredFilesLocked(): Promise<void> {
+    const rulesPath = join(this.workspaceDir, ".git", "vellum-untrack-rules");
     try {
+      writeFileSync(
+        rulesPath,
+        WORKSPACE_GITIGNORE_RULES.join("\n") + "\n",
+        "utf-8",
+      );
       const { stdout } = await this.execGitStreaming([
         "ls-files",
         "-z",
         "--cached",
         "--ignored",
-        "--exclude-from=.gitignore",
+        `--exclude-from=${rulesPath}`,
       ]);
       const files = stdout.split("\0").filter(Boolean);
       if (files.length === 0) {
@@ -892,6 +900,12 @@ export class WorkspaceGitService {
       );
     } catch (err) {
       log.warn({ err }, "Failed to untrack newly ignored files");
+    } finally {
+      try {
+        unlinkSync(rulesPath);
+      } catch {
+        // Never created, or already gone.
+      }
     }
   }
 

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -60,6 +60,7 @@ function cleanGitEnv(workspaceDir: string): Record<string, string> {
  * These are written to .gitignore on init and appended to existing .gitignore files.
  */
 const WORKSPACE_GITIGNORE_RULES = [
+  // Runtime state directories
   "data/db/",
   "data/qdrant/",
   "data/monitoring/",
@@ -69,21 +70,34 @@ const WORKSPACE_GITIGNORE_RULES = [
   "data/apps/*/records/",
   "data/apps/*/dist/",
   "data/apps/*.preview",
-  "plugins/*/node_modules/",
+  // Runtime-managed installs and caches — large and restorable
+  "/embedding-models/",
+  "/external/",
+  "/bin/",
+  "/plugins-data/",
+  "node_modules/",
+  "__pycache__/",
+  ".venv/",
+  // Logs and process state
   "logs/",
   "*.log",
   "*.sock",
   "*.pid",
-  "*.sqlite",
-  "*.sqlite-journal",
-  "*.sqlite-wal",
-  "*.sqlite-shm",
-  "*.db",
-  "*.db-journal",
-  "*.db-wal",
-  "*.db-shm",
-  "vellum.pid",
+  "daemon-startup.lock",
   "session-token",
+  // Databases (covers sidecar -journal/-wal/-shm files)
+  "*.sqlite*",
+  "*.db",
+  "*.db-*",
+  // OS junk
+  ".DS_Store",
+  // Large binary blobs
+  "*.zip",
+  "*.tar",
+  "*.gz",
+  "*.tgz",
+  "*.dmg",
+  "*.iso",
 ];
 
 const NULL_GIT_OID = "0000000000000000000000000000000000000000";
@@ -766,8 +780,13 @@ export class WorkspaceGitService {
         }
       }
 
+      // Exact line matching: a substring check would let an existing rule like
+      // "plugins/*/node_modules/" mask the broader "node_modules/" rule.
+      const existingLines = new Set(
+        content.split("\n").map((line) => line.trim()),
+      );
       const missingRules = WORKSPACE_GITIGNORE_RULES.filter(
-        (rule) => !content.includes(rule),
+        (rule) => !existingLines.has(rule),
       );
       if (hadLegacyDataRule || missingRules.length > 0) {
         let updated = content;

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -129,6 +129,10 @@ const WORKSPACE_GITIGNORE_RULES = [
   "*.safetensors",
   "*.pt",
   "*.pth",
+  // Canonical user state re-included despite the media rules above.
+  // Must stay after the extension rules: last matching pattern wins.
+  "!data/avatar/**",
+  "!data/sounds/**",
 ];
 
 const NULL_GIT_OID = "0000000000000000000000000000000000000000";
@@ -849,6 +853,10 @@ export class WorkspaceGitService {
    * rule existed would otherwise keep committing it forever. The staged
    * deletions ride along with the next commit. Best-effort: failures are
    * logged, never block init. Must be called with the mutex lock held.
+   *
+   * Deliberately reads only the workspace .gitignore (not --exclude-standard):
+   * the user's global/local exclude files must not cause deletions of files
+   * they force-added on purpose.
    */
   private async untrackIgnoredFilesLocked(): Promise<void> {
     try {
@@ -857,7 +865,7 @@ export class WorkspaceGitService {
         "-z",
         "--cached",
         "--ignored",
-        "--exclude-standard",
+        "--exclude-from=.gitignore",
       ]);
       const files = stdout.split("\0").filter(Boolean);
       if (files.length === 0) {

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -449,6 +449,7 @@ export class WorkspaceGitService {
                 // These calls are OUTSIDE the rev-parse try/catch so that
                 // normalization errors are not misclassified as "no commits".
                 this.ensureGitignoreRulesLocked();
+                await this.untrackIgnoredFilesLocked();
                 this.ensureBranchGuardHookLocked();
                 await this.ensureCommitIdentityLocked();
                 await this.ensureBranchGuardConfigLocked();
@@ -807,6 +808,49 @@ export class WorkspaceGitService {
         WORKSPACE_GITIGNORE_RULES.join("\n") +
         "\n";
       writeFileSync(gitignorePath, gitignore, "utf-8");
+    }
+  }
+
+  /**
+   * Drop tracked files that are now matched by ignore rules from the index
+   * (working tree untouched). Ignore rules only affect untracked paths, so a
+   * workspace that committed runtime state (e.g. embedding-models/) before a
+   * rule existed would otherwise keep committing it forever. The staged
+   * deletions ride along with the next commit. Best-effort: failures are
+   * logged, never block init. Must be called with the mutex lock held.
+   */
+  private async untrackIgnoredFilesLocked(): Promise<void> {
+    try {
+      const { stdout } = await this.execGitStreaming([
+        "ls-files",
+        "-z",
+        "--cached",
+        "--ignored",
+        "--exclude-standard",
+      ]);
+      const files = stdout.split("\0").filter(Boolean);
+      if (files.length === 0) {
+        return;
+      }
+      // Chunked to stay under OS argv limits on bloated workspaces.
+      const chunkSize = 200;
+      for (let i = 0; i < files.length; i += chunkSize) {
+        await this.execGit([
+          "rm",
+          "--cached",
+          "-r",
+          "-q",
+          "--ignore-unmatch",
+          "--",
+          ...files.slice(i, i + chunkSize),
+        ]);
+      }
+      log.info(
+        { fileCount: files.length },
+        "Untracked newly ignored files from workspace index",
+      );
+    } catch (err) {
+      log.warn({ err }, "Failed to untrack newly ignored files");
     }
   }
 

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -131,8 +131,10 @@ const WORKSPACE_GITIGNORE_RULES = [
   "*.pth",
   // Canonical user state re-included despite the media rules above.
   // Must stay after the extension rules: last matching pattern wins.
+  // (Not a broad !data/apps/** — that would also re-include dist/.)
   "!data/avatar/**",
   "!data/sounds/**",
+  "!data/apps/*/icon.png",
 ];
 
 const NULL_GIT_OID = "0000000000000000000000000000000000000000";

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -91,13 +91,44 @@ const WORKSPACE_GITIGNORE_RULES = [
   "*.db-*",
   // OS junk
   ".DS_Store",
-  // Large binary blobs
+  // Archives and disk images
   "*.zip",
   "*.tar",
   "*.gz",
   "*.tgz",
+  "*.bz2",
+  "*.xz",
+  "*.7z",
+  "*.rar",
   "*.dmg",
   "*.iso",
+  // Images (svg is text-based and stays tracked)
+  "*.png",
+  "*.jpg",
+  "*.jpeg",
+  "*.gif",
+  "*.webp",
+  "*.heic",
+  "*.bmp",
+  "*.tiff",
+  // Audio and video
+  "*.mp3",
+  "*.wav",
+  "*.m4a",
+  "*.flac",
+  "*.ogg",
+  "*.mp4",
+  "*.mov",
+  "*.avi",
+  "*.mkv",
+  "*.webm",
+  // Documents and model weights
+  "*.pdf",
+  "*.gguf",
+  "*.onnx",
+  "*.safetensors",
+  "*.pt",
+  "*.pth",
 ];
 
 const NULL_GIT_OID = "0000000000000000000000000000000000000000";

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -832,12 +832,27 @@ export class WorkspaceGitService {
       if (hadLegacyDataRule || missingRules.length > 0) {
         let updated = content;
         if (missingRules.length > 0) {
+          // Negation rules must trail every Vellum rule (last matching
+          // pattern wins), so pull existing ones out and re-append them
+          // after the additions instead of leaving them mid-file.
+          const negationRules = WORKSPACE_GITIGNORE_RULES.filter((rule) =>
+            rule.startsWith("!"),
+          );
+          const negationSet = new Set(negationRules);
+          updated = updated
+            .split("\n")
+            .filter((line) => !negationSet.has(line.trim()))
+            .join("\n");
           if (!updated.endsWith("\n")) {
             updated += "\n";
           }
+          const additions = [
+            ...missingRules.filter((rule) => !rule.startsWith("!")),
+            ...negationRules,
+          ];
           updated +=
             "# Vellum runtime state (auto-added)\n" +
-            missingRules.join("\n") +
+            additions.join("\n") +
             "\n";
         }
         writeFileSync(gitignorePath, updated, "utf-8");


### PR DESCRIPTION
## Summary
- Expand `WORKSPACE_GITIGNORE_RULES` (the source of the assistant workspace repo's `.gitignore`) to ignore runtime-managed installs (`/embedding-models/` — ~250MB on a live install, `/external/`, `/bin/`, `/plugins-data/`), caches (`node_modules/`, `__pycache__/`, `.venv/`), `daemon-startup.lock`, `.DS_Store`, `*.jsonl`, archives/disk images, images, audio/video, PDFs, and ML model weights
- Carve-outs keep canonical user state tracked despite the extension rules: `!data/avatar/**`, `!data/sounds/**`, `!data/apps/*/icon.png`, `!conversations/**` (the `messages.jsonl` disk view is the DB-recovery source)
- Consolidate redundant rules (sqlite/db sidecars 8→3, drop `vellum.pid`, generalize `plugins/*/node_modules/` → `node_modules/`), fix missing-rule detection to exact line matching, and always re-append negations last so last-match-wins ordering can't silently override the carve-outs

**Scope note:** ignore rules only affect untracked paths — untracking of already-committed files is split into stacked follow-up #37835.

## Original prompt
Review the .gitignore used by the assistant workspace's git backing, tighten it, and add entries to block large files and other junk (including `*.jsonl` and anything likely over ~100KB, like images). Maddie asked for the init-time untracking logic to live in a separate PR, so this one is the rule changes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)