### PR TITLE
feat(plugins): add coffee-aficionado to the marketplace

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -232,6 +232,18 @@
       "category": "productivity",
       "homepage": "https://github.com/ZeebBoyBlue/google-drive-search",
       "license": "Apache-2.0"
+    },
+    {
+      "name": "coffee-aficionado",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/coffee-aficionado",
+        "ref": "b37a0b5adc2bda5559d3b21abe38e436093c1ff3"
+      },
+      "description": "Find great coffee beans and machines matched to your taste profile, budget, and kitchen. Persistent memory learns your preferences over time.",
+      "category": "lifestyle",
+      "homepage": "https://github.com/vellum-ai/coffee-aficionado",
+      "license": "MIT"
     }
   ]
 }


### PR DESCRIPTION
Whitelists the **coffee-aficionado** plugin in `plugins/marketplace.json`, pinned to its initial-release commit `b37a0b5`.

- **Repo:** https://github.com/vellum-ai/coffee-aficionado (public, MIT)
- **Category:** lifestyle
- **Credential-free:** curated origin/equipment knowledge is baked in; live pricing comes from the built-in web search.

## What the plugin does

| Surface | Kind | Purpose |
|---|---|---|
| `coffee_profile` | tool | Persistent taste profile (roasts, flavors, brew methods, budget, kitchen constraints, owned gear) + bean log with auto-learning (4–5★ → preferred origin, 1–2★ → avoided) |
| `coffee_find_beans` | tool | Scores 15 curated origins against the profile and emits optimized `web_search` queries for current, buyable bags |
| `coffee_find_machine` | tool | Ranks 18 curated machines/grinders/brewers across entry→commercial tiers by budget + experience |
| `bean-discovery` | skill | Bean recommendation workflow + coffee education reference |
| `equipment-guide` | skill | Equipment selection workflow + gear education reference |

## Verification

- `bunx tsc` clean against the `@vellumai/plugin-api` surface.
- Runtime smoke test exercised the full loop: profile CRUD, ranked bean/machine recommendations, and rating-driven auto-learn of preferred/avoided origins.
- marketplace.json validated as JSON; `ref` is a full 40-char commit SHA (immutable pin, per marketplace rules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)