### PR TITLE
feat(web): pref-gated ambient transcript in the voice room

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Tests for `VoiceAmbientTranscript`.
+ *
+ * Both source stores are self-contained zustand, so tests drive the real
+ * stores (as `voice-live-transcript.test.tsx` does) rather than mocking
+ * selectors: transcript fields via the live-voice store, the two visibility
+ * toggles via the voice-prefs store. The load-bearing contract is the
+ * pref-gating — both prefs default OFF, so the room stays text-free — plus the
+ * user-above / assistant-below ordering.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { act, cleanup, render, screen } from "@testing-library/react";
+
+import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
+
+import { VoiceAmbientTranscript } from "@/domains/chat/voice/voice-room/voice-ambient-transcript";
+
+function seedUser(partial: string, final = "") {
+  act(() => {
+    useLiveVoiceStore.getState().setPartialTranscript(partial);
+    useLiveVoiceStore.getState().setFinalTranscript(final);
+  });
+}
+
+function seedAssistant(text: string) {
+  act(() => {
+    useLiveVoiceStore.getState().clearAssistantTranscript();
+    useLiveVoiceStore.getState().appendAssistantTranscript(text);
+  });
+}
+
+function setPrefs({ user, assistant }: { user: boolean; assistant: boolean }) {
+  act(() => {
+    useVoicePrefsStore.getState().setShowUserTranscript(user);
+    useVoicePrefsStore.getState().setShowAssistantTranscript(assistant);
+  });
+}
+
+const userText = () => screen.queryByTestId("voice-ambient-user");
+const assistantText = () => screen.queryByTestId("voice-ambient-assistant");
+
+beforeEach(() => {
+  useLiveVoiceStore.getState().reset();
+  // Prefs default OFF; force the known default in case a prior file leaked.
+  setPrefs({ user: false, assistant: false });
+});
+
+afterEach(() => {
+  cleanup();
+  useLiveVoiceStore.getState().reset();
+  setPrefs({ user: false, assistant: false });
+});
+
+describe("VoiceAmbientTranscript — pref gating", () => {
+  test("renders nothing when both prefs are OFF (the default)", () => {
+    seedUser("hello there");
+    seedAssistant("hi, how can I help");
+    const { container } = render(<VoiceAmbientTranscript />);
+    expect(container.innerHTML).toBe("");
+    expect(userText()).toBeNull();
+    expect(assistantText()).toBeNull();
+  });
+
+  test("shows the user text (above) only when showUserTranscript is ON", () => {
+    seedUser("hello there");
+    seedAssistant("hi, how can I help");
+    setPrefs({ user: true, assistant: false });
+    render(<VoiceAmbientTranscript />);
+    expect(userText()?.textContent).toContain("hello there");
+    expect(assistantText()).toBeNull();
+  });
+
+  test("shows the assistant text (below) only when showAssistantTranscript is ON", () => {
+    seedUser("hello there");
+    seedAssistant("hi, how can I help");
+    setPrefs({ user: false, assistant: true });
+    render(<VoiceAmbientTranscript />);
+    expect(assistantText()?.textContent).toContain("hi, how can I help");
+    expect(userText()).toBeNull();
+  });
+
+  test("renders nothing while a pref is ON but its transcript is empty", () => {
+    setPrefs({ user: true, assistant: true });
+    const { container } = render(<VoiceAmbientTranscript />);
+    expect(container.innerHTML).toBe("");
+  });
+});
+
+describe("VoiceAmbientTranscript — sourcing and ordering", () => {
+  test("user half prefers the in-flight partial over the last final", () => {
+    seedUser("still speaking", "previous final");
+    setPrefs({ user: true, assistant: false });
+    render(<VoiceAmbientTranscript />);
+    expect(userText()?.textContent).toContain("still speaking");
+    expect(userText()?.textContent).not.toContain("previous final");
+  });
+
+  test("user half falls back to the final transcript when no partial is in flight", () => {
+    seedUser("", "what I said");
+    setPrefs({ user: true, assistant: false });
+    render(<VoiceAmbientTranscript />);
+    expect(userText()?.textContent).toContain("what I said");
+  });
+
+  test("renders user ABOVE assistant (DOM order) when both are ON", () => {
+    seedUser("my question");
+    seedAssistant("my answer");
+    setPrefs({ user: true, assistant: true });
+    render(<VoiceAmbientTranscript />);
+    const user = userText();
+    const assistant = assistantText();
+    expect(user).not.toBeNull();
+    expect(assistant).not.toBeNull();
+    // User node precedes the assistant node in document order.
+    expect(
+      user!.compareDocumentPosition(assistant!) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  test("streams assistant deltas without remounting", () => {
+    seedAssistant("Hel");
+    setPrefs({ user: false, assistant: true });
+    render(<VoiceAmbientTranscript />);
+    act(() => {
+      useLiveVoiceStore.getState().appendAssistantTranscript("lo world");
+    });
+    expect(assistantText()?.textContent).toContain("Hello world");
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
@@ -1,0 +1,87 @@
+/**
+ * Ambient floating transcript for the voice room — muted, secondary text that
+ * hovers near the centered avatar without ever becoming a chat bubble or
+ * displacing the avatar. Two independently pref-gated halves:
+ *
+ * - USER speech ABOVE the avatar — `partialTranscript || finalTranscript` from
+ *   the live-voice store, shown only when `showUserTranscript` is on.
+ * - ASSISTANT speech BELOW the avatar — `assistantTranscript`, shown only when
+ *   `showAssistantTranscript` is on.
+ *
+ * Both prefs default OFF, so by default this renders nothing and the room stays
+ * text-free. The avatar (centered by the room) is the primary anchor; each half
+ * is absolutely positioned relative to the room overlay so text appearing or
+ * clearing never shifts the avatar.
+ *
+ * Subscriptions are deliberately narrow — only the three transcript fields and
+ * the two prefs — so the high-frequency `inputAmplitude` (and `state`) churn on
+ * the live-voice store never re-renders this component. The full transcript
+ * still lands in the chat thread on exit via the engine path; this is a live,
+ * ambient echo only.
+ */
+
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+
+import { cn } from "@vellumai/design-library";
+
+import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
+
+/** Shared muted, constrained-width, centered treatment for both halves. */
+const AMBIENT_TEXT_CLASS =
+  "pointer-events-none absolute left-1/2 z-0 max-w-[32rem] -translate-x-1/2 px-6 text-center text-sm text-balance whitespace-pre-wrap break-words text-[var(--content-tertiary)]";
+
+export function VoiceAmbientTranscript() {
+  const showUser = useVoicePrefsStore.use.showUserTranscript();
+  const showAssistant = useVoicePrefsStore.use.showAssistantTranscript();
+
+  const partialTranscript = useLiveVoiceStore.use.partialTranscript();
+  const finalTranscript = useLiveVoiceStore.use.finalTranscript();
+  const assistantTranscript = useLiveVoiceStore.use.assistantTranscript();
+  const reduce = useReducedMotion();
+
+  // In-flight partial wins over the last finalized transcript — same precedence
+  // as the underneath composer transcript (`VoiceLiveTranscript`).
+  const userText = partialTranscript || finalTranscript;
+
+  const showUserHalf = showUser && userText.length > 0;
+  const showAssistantHalf = showAssistant && assistantTranscript.length > 0;
+
+  const fade = {
+    initial: reduce ? false : { opacity: 0 },
+    animate: { opacity: 1 },
+    exit: { opacity: 0 },
+    transition: { duration: reduce ? 0 : 0.3 },
+  } as const;
+
+  return (
+    <AnimatePresence>
+      {showUserHalf ? (
+        <motion.p
+          key="user"
+          data-testid="voice-ambient-user"
+          aria-live="polite"
+          // Above the centered avatar; bottom-anchored so it grows upward and
+          // never creeps toward the orb.
+          className={cn(AMBIENT_TEXT_CLASS, "bottom-[calc(50%+8.5rem)]")}
+          {...fade}
+        >
+          {userText}
+        </motion.p>
+      ) : null}
+
+      {showAssistantHalf ? (
+        <motion.p
+          key="assistant"
+          data-testid="voice-ambient-assistant"
+          aria-live="polite"
+          // Below the centered avatar; top-anchored so it grows downward.
+          className={cn(AMBIENT_TEXT_CLASS, "top-[calc(50%+8.5rem)]")}
+          {...fade}
+        >
+          {assistantTranscript}
+        </motion.p>
+      ) : null}
+    </AnimatePresence>
+  );
+}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 
 import { toVoiceAvatarVisual } from "./voice-avatar-state";
+import { VoiceAmbientTranscript } from "./voice-ambient-transcript";
 import { VoiceAvatar } from "./voice-avatar";
 import { VoiceRoomAmbientBackground } from "./voice-room-ambient-background";
 import { useIsVoiceRoomVisible } from "./use-is-voice-room-visible";
@@ -179,6 +180,11 @@ function VoiceRoomOverlay() {
       transition={{ duration: reduce ? 0 : 0.4 }}
     >
       <VoiceRoomAmbientBackground />
+
+      {/* Optional muted echo of the live transcript, floating above (user) and
+          below (assistant) the centered avatar. Pref-gated and absolutely
+          positioned, so it never shifts the avatar and stays absent by default. */}
+      <VoiceAmbientTranscript />
 
       {/* Persistent exit control — rendered above all room chrome and never
           gated behind avatar readiness, so exit works even mid-load / on


### PR DESCRIPTION
## Summary
- Optional ambient transcript in the voice room: user speech above the avatar, assistant speech below, each gated on its voice-prefs toggle (both default OFF, so the room stays text-free by default).
- Muted/secondary styling, narrow store subscriptions; full transcript still lands in the thread on exit.

Part of plan: voice-mode-ui-overhaul.md (PR 8 of 8)