### PR TITLE
feat(web): first-run voice-mode preferences card

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -39,6 +39,16 @@ mock.module("@/runtime/is-electron", () => ({
   isElectron: () => mockIsElectron,
 }));
 
+// Capacitor-iOS detection. The composer skips the first-run prefs card on the
+// native iOS shell (a dismissible pre-prompt before the `getUserMedia`
+// permission alert violates `docs/CAPACITOR.md` § OS permission requests) and
+// starts the session directly. Defaults to non-iOS (web) so the existing
+// first-run tests exercise the card path unchanged.
+let mockIsNativeIOS = false;
+mock.module("@/runtime/platform-detection", () => ({
+  isNativeIOS: () => mockIsNativeIOS,
+}));
+
 // Live-voice integration. The session controller (`useLiveVoice`) lives in
 // the layout-mounted `useLiveVoiceSessionController`, NOT in the composer —
 // the composer only reads the real `useLiveVoiceStore` (self-contained
@@ -138,6 +148,7 @@ mock.module("@/domains/chat/voice/voice-recording-store", () => ({
 
 function resetLiveVoiceMocks() {
   mockIsElectron = false;
+  mockIsNativeIOS = false;
   mockVoiceMode = false;
   mockVoicePhase = "idle";
   setAudioLevelSpy.mockClear();
@@ -876,6 +887,44 @@ describe("ChatComposer — live-voice integration", () => {
     expect(queryByTestId("first-run-card")).toBeNull();
     expect(liveStarterSpy).not.toHaveBeenCalled();
     expect(useVoicePrefsStore.getState().firstRunSeen).toBe(false);
+  });
+
+  test("Capacitor iOS: first-ever entry skips the card and starts directly (permission alert reached)", () => {
+    // GIVEN the native iOS shell, the flag on, no session, and a first-ever
+    // entry — a dismissible pre-prompt here would violate CAPACITOR.md
+    // § OS permission requests, so the card must be skipped.
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockIsNativeIOS = true;
+    useVoicePrefsStore.setState({ firstRunSeen: false });
+
+    // WHEN the user clicks the entry-point mic
+    const { getByLabelText, queryByTestId } = renderVoiceComposer();
+    fireEvent.click(getByLabelText("Start voice mode"));
+
+    // THEN no card renders and the session starts straight away so the OS
+    // getUserMedia alert is the next thing the user sees. The first-run flag
+    // is left untouched (the card, not the mic, owns marking it seen).
+    expect(queryByTestId("first-run-card")).toBeNull();
+    expect(liveStarterSpy).toHaveBeenCalledTimes(1);
+    expect(liveStarterSpy).toHaveBeenCalledWith("asst_test", "conv_test");
+  });
+
+  test("Capacitor iOS: returning-user entry still starts directly (unchanged)", () => {
+    // GIVEN the native iOS shell with the first run already consumed
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockIsNativeIOS = true;
+    // resetLiveVoiceMocks already sets firstRunSeen: true
+
+    // WHEN the user clicks the entry-point mic
+    const { getByLabelText, queryByTestId } = renderVoiceComposer();
+    fireEvent.click(getByLabelText("Start voice mode"));
+
+    // THEN it behaves exactly like the returning-user path on any platform
+    expect(queryByTestId("first-run-card")).toBeNull();
+    expect(liveStarterSpy).toHaveBeenCalledTimes(1);
+    expect(liveStarterSpy).toHaveBeenCalledWith("asst_test", "conv_test");
   });
 
   test("owned active session swaps the action row for the voice bar (mutual exclusion by absence)", () => {

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -16,6 +16,7 @@ import { cleanup, fireEvent, render } from "@testing-library/react";
 import { type ChatAttachment, useComposerStore } from "@/domains/chat/composer-store";
 import type { VoiceInputButtonHandle } from "@/domains/chat/components/voice-input-button";
 import { INITIAL_TURN_STATE, useTurnStore } from "@/domains/chat/turn-store";
+import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 
 // Pure helpers live in `chat-composer-utils` (no mocks needed), so import them
 // statically. `ChatComposer` itself is imported dynamically *after* the mocks
@@ -101,6 +102,23 @@ mock.module("@/domains/chat/components/voice-input-button", () => ({
   ),
 }));
 
+// First-run prefs card. Stubbed to a lightweight probe that exposes the two
+// wired callbacks — the real card pulls in `useAssistantAvatar` (React Query),
+// irrelevant to the composer's interception wiring, which is all these tests
+// assert. Full card behavior lives in `voice-first-run-card.test.tsx`.
+mock.module("@/domains/chat/voice/voice-room/voice-first-run-card", () => ({
+  VoiceFirstRunCard: (props: { onStart: () => void; onDismiss?: () => void }) => (
+    <div data-testid="first-run-card">
+      <button type="button" onClick={props.onStart}>
+        first-run-start
+      </button>
+      <button type="button" onClick={() => props.onDismiss?.()}>
+        first-run-dismiss
+      </button>
+    </div>
+  ),
+}));
+
 // Dictation recording phase. The composer reads `useVoiceRecordingStore`
 // (cross-domain `voice` store) to derive its `isVoiceActive` signal. Mock it
 // via `mock.module` (rather than importing the store) so the `chat` test stays
@@ -129,6 +147,15 @@ function resetLiveVoiceMocks() {
   liveControls.interrupt.mockClear();
   useLiveVoiceStore.getState().reset();
   useLiveVoiceStore.getState().setStarter(liveStarterSpy);
+  // Default to the returning-user path so the entry-point mic starts a session
+  // directly. First-run interception (the prefs card) is covered by
+  // `voice-first-run-card.test.tsx`; a test that wants it opts in by setting
+  // `firstRunSeen: false`.
+  useVoicePrefsStore.setState({
+    showUserTranscript: false,
+    showAssistantTranscript: false,
+    firstRunSeen: true,
+  });
 }
 
 // Imported after the mocks so the component (and its transitive flag-store /
@@ -799,6 +826,56 @@ describe("ChatComposer — live-voice integration", () => {
     // context (the composer holds no controller of its own)
     expect(liveStarterSpy).toHaveBeenCalledTimes(1);
     expect(liveStarterSpy).toHaveBeenCalledWith("asst_test", "conv_test");
+  });
+
+  test("first-ever entry opens the prefs card instead of starting the session", () => {
+    // GIVEN the flag is on, no session, and the user has never entered voice
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    useVoicePrefsStore.setState({ firstRunSeen: false });
+
+    // WHEN the user clicks the entry-point mic
+    const { getByLabelText, getByTestId } = renderVoiceComposer();
+    fireEvent.click(getByLabelText("Start voice mode"));
+
+    // THEN the prefs card appears and the session has NOT started yet
+    expect(getByTestId("first-run-card")).toBeTruthy();
+    expect(liveStarterSpy).not.toHaveBeenCalled();
+  });
+
+  test("first-run card Start persists the flag then starts the session", () => {
+    // GIVEN the first-run card is open
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    useVoicePrefsStore.setState({ firstRunSeen: false });
+    const { getByLabelText, getByText, queryByTestId } = renderVoiceComposer();
+    fireEvent.click(getByLabelText("Start voice mode"));
+
+    // WHEN the user commits via Start
+    fireEvent.click(getByText("first-run-start"));
+
+    // THEN the first run is consumed, the card closes, and the session starts
+    expect(useVoicePrefsStore.getState().firstRunSeen).toBe(true);
+    expect(queryByTestId("first-run-card")).toBeNull();
+    expect(liveStarterSpy).toHaveBeenCalledTimes(1);
+    expect(liveStarterSpy).toHaveBeenCalledWith("asst_test", "conv_test");
+  });
+
+  test("dismissing the first-run card cancels without consuming the first run", () => {
+    // GIVEN the first-run card is open
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    useVoicePrefsStore.setState({ firstRunSeen: false });
+    const { getByLabelText, getByText, queryByTestId } = renderVoiceComposer();
+    fireEvent.click(getByLabelText("Start voice mode"));
+
+    // WHEN the user dismisses it
+    fireEvent.click(getByText("first-run-dismiss"));
+
+    // THEN nothing started and the first run is still available for next time
+    expect(queryByTestId("first-run-card")).toBeNull();
+    expect(liveStarterSpy).not.toHaveBeenCalled();
+    expect(useVoicePrefsStore.getState().firstRunSeen).toBe(false);
   });
 
   test("owned active session swaps the action row for the voice bar (mutual exclusion by absence)", () => {

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -1207,9 +1207,11 @@ describe("ChatComposer — live-voice integration", () => {
 
 describe("ChatComposer — live-voice transcript area", () => {
   test("streaming speech hides the textarea and renders the transcript in its place", () => {
-    // GIVEN a listening owned session with an in-flight partial transcript
+    // GIVEN a listening owned session with an in-flight partial transcript,
+    // and the user opted in to seeing their own words
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
+    useVoicePrefsStore.setState({ showUserTranscript: true });
     seedLiveVoiceSession("listening");
     useLiveVoiceStore
       .getState()
@@ -1228,6 +1230,31 @@ describe("ChatComposer — live-voice transcript area", () => {
     expect(region.querySelector('[data-testid="voice-transcript-caret"]')).toBeTruthy();
     const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
     expect(textarea.className).toContain("hidden");
+    expect(textarea.disabled).toBe(true);
+  });
+
+  test("streaming speech does NOT render the transcript when the show-your-words pref is off (default)", () => {
+    // GIVEN a listening owned session streaming speech, but the user has kept
+    // "Show the words you say" OFF (the default) — the composer must not
+    // surface their spoken words
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    // `showUserTranscript` defaults to false in the per-test reset; make the
+    // intent explicit here.
+    useVoicePrefsStore.setState({ showUserTranscript: false });
+    seedLiveVoiceSession("listening");
+    useLiveVoiceStore
+      .getState()
+      .setPartialTranscript("this is a text that I am just speaking");
+
+    // WHEN the composer renders
+    const { container, queryByLabelText } = renderVoiceComposer();
+
+    // THEN no transcript region mounts and the (still-uneditable) textarea
+    // stays visible so its placeholder shows through instead
+    expect(queryByLabelText("Voice transcript")).toBeNull();
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea.className).not.toContain("hidden");
     expect(textarea.disabled).toBe(true);
   });
 

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -49,6 +49,7 @@ import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { isElectron } from "@/runtime/is-electron";
 import { useIsNativePlatform } from "@/runtime/native-auth";
+import { isNativeIOS } from "@/runtime/platform-detection";
 import { isPointerCoarse } from "@/utils/pointer";
 import { Button, Notice, Popover } from "@vellumai/design-library";
 
@@ -299,7 +300,15 @@ export function ChatComposer({
     if (!assistantId) {
       return;
     }
-    if (!useVoicePrefsStore.getState().firstRunSeen) {
+    // First-run preferences card — shown on every platform EXCEPT Capacitor
+    // iOS. On the iOS shell a dismissible pre-prompt before the live-voice
+    // `getUserMedia` permission alert violates `docs/CAPACITOR.md` § OS
+    // permission requests (Apple HIG / App Store Review 5.1.1(iv)) and the
+    // `voice/live-voice/pcm-capture.ts` caller contract, which require any
+    // pre-permission UI to lead directly to the system alert. On iOS we
+    // therefore start directly (same as the returning-user path) so the OS
+    // alert is reached without an intervening dismissible modal.
+    if (!useVoicePrefsStore.getState().firstRunSeen && !isNativeIOS()) {
       setFirstRunCardOpen(true);
       return;
     }

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -271,11 +271,19 @@ export function ChatComposer({
   const hasLiveVoiceTranscript = useLiveVoiceStore(
     (s) => Boolean(s.partialTranscript || s.finalTranscript),
   );
+  // The in-composer transcript shows the *user's* own speech, so it must
+  // honor the "Show the words you say" voice preference (default OFF). When
+  // the pref is off we never swap in the transcript — the disabled textarea
+  // and its placeholder stay visible instead. This gate is scoped to the
+  // transcript rendering only; `isLiveVoiceActive` still drives the voice-bar
+  // row swap, ghost-suffix suppression, and textarea disabled state.
+  const showUserTranscriptPref = useVoicePrefsStore.use.showUserTranscript();
   // While speech is streaming, the disabled textarea is visually hidden and
   // the display-only transcript renders in its grid cell (Light 55). With no
-  // transcript yet, the textarea stays visible so its placeholder shows
-  // through (Light 53 baseline).
-  const showLiveVoiceTranscript = isLiveVoiceActive && hasLiveVoiceTranscript;
+  // transcript yet (or the pref off) the textarea stays visible so its
+  // placeholder shows through (Light 53 baseline).
+  const showLiveVoiceTranscript =
+    isLiveVoiceActive && hasLiveVoiceTranscript && showUserTranscriptPref;
   // Session verbs go through the store seams registered by the layout-owned
   // controller: `starter` (registered for the controller's whole mount) to
   // start, per-session `controls` to stop/release — the latter via the shared
@@ -661,12 +669,14 @@ export function ChatComposer({
                 }`}
                 style={{ maxHeight: `${textareaMaxHeightPx}px` }}
               />
-              {isLiveVoiceActive && (
+              {showLiveVoiceTranscript && (
                 // Live speech streams display-only into the textarea's grid
-                // cell (Light 55); renders nothing until there is text, so
-                // the placeholder above stays visible. The shared cell keeps
-                // the grid's auto-grow/max-height behavior identical to the
-                // textarea it visually replaces.
+                // cell (Light 55); gated on `showLiveVoiceTranscript` so it
+                // only mounts once there is text *and* the user opted in via
+                // the "Show the words you say" pref — otherwise the disabled
+                // textarea and its placeholder stay visible. The shared cell
+                // keeps the grid's auto-grow/max-height behavior identical to
+                // the textarea it visually replaces.
                 <VoiceLiveTranscript
                   className="col-start-1 row-start-1"
                   maxHeightPx={textareaMaxHeightPx}

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -43,7 +43,9 @@ import {
     useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 import { useAudioAmplitude } from "@/domains/chat/voice/use-audio-amplitude";
+import { VoiceFirstRunCard } from "@/domains/chat/voice/voice-room/voice-first-run-card";
 import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
+import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { isElectron } from "@/runtime/is-electron";
 import { useIsNativePlatform } from "@/runtime/native-auth";
@@ -279,12 +281,35 @@ export function ChatComposer({
   // module-level `endLiveVoiceSession`/`releaseLiveVoiceTurn` helpers, which
   // read the store with `getState()` per STATE_MANAGEMENT.md (no subscription
   // needed for callback-only reads).
-  const handleLiveVoiceStart = useCallback(() => {
+  // First-run interception: the very first voice-mode entry opens a
+  // preferences card (see `VoiceFirstRunCard`) instead of starting the
+  // session, so the user chooses their transcript prefs before listening
+  // begins. Every subsequent entry (`firstRunSeen === true`) starts directly
+  // — the card and the engine stay decoupled. Purely additive: with the
+  // `voice-mode` flag off this path is unreachable and the app-editing variant
+  // (no voice entry point) never renders the card.
+  const [firstRunCardOpen, setFirstRunCardOpen] = useState(false);
+  const startLiveVoiceSession = useCallback(() => {
     if (!assistantId) {
       return;
     }
     useLiveVoiceStore.getState().starter?.(assistantId, conversationId ?? null);
   }, [assistantId, conversationId]);
+  const handleLiveVoiceStart = useCallback(() => {
+    if (!assistantId) {
+      return;
+    }
+    if (!useVoicePrefsStore.getState().firstRunSeen) {
+      setFirstRunCardOpen(true);
+      return;
+    }
+    startLiveVoiceSession();
+  }, [assistantId, startLiveVoiceSession]);
+  const handleFirstRunStart = useCallback(() => {
+    useVoicePrefsStore.getState().markFirstRunSeen();
+    setFirstRunCardOpen(false);
+    startLiveVoiceSession();
+  }, [startLiveVoiceSession]);
 
   const pointerCoarse = useMemo(() => isPointerCoarse(), []);
   const isMobile = useIsMobile();
@@ -391,6 +416,16 @@ export function ChatComposer({
 
   return (
     <>
+      {firstRunCardOpen && (
+        // First voice-mode entry only — the card commits prefs + starts via
+        // `handleFirstRunStart`; a plain dismiss cancels without consuming the
+        // first run, so it returns on the next entry.
+        <VoiceFirstRunCard
+          assistantId={assistantId}
+          onStart={handleFirstRunStart}
+          onDismiss={() => setFirstRunCardOpen(false)}
+        />
+      )}
       {/* Composer-owned draft/attachment notices (self-sourced), above the
           orchestration banner stack. */}
       <ComposerDraftNotices />

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Tests for `VoiceFirstRunCard`.
+ *
+ * The card is exercised in isolation: `onStart` is a spy, and the real
+ * persisted `voice-prefs` store backs the toggles (reset between tests). The
+ * assistant-avatar hook is stubbed so the card renders without the React Query
+ * graph — the avatar is chrome, not behavior.
+ *
+ * Load-bearing behavior:
+ *   - the card renders on first run and does NOT start on its own,
+ *   - the toggles mutate the shared voice-prefs store (both default OFF),
+ *   - "Start" invokes the caller's `onStart`; wiring that `onStart` to
+ *     `markFirstRunSeen` (as the composer does) consumes the first run so a
+ *     second entry would skip the card.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+// Stub the avatar hook so the card renders without the assistant-avatar React
+// Query graph — irrelevant to the card's preference behavior.
+mock.module("@/hooks/use-assistant-avatar", () => ({
+  useAssistantAvatar: () => ({
+    components: null,
+    traits: null,
+    customImageUrl: null,
+    isLoading: false,
+    invalidate: () => {},
+  }),
+}));
+
+import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
+
+// Imported after the mock so the card resolves against the stubbed hook.
+const { VoiceFirstRunCard } = await import(
+  "@/domains/chat/voice/voice-room/voice-first-run-card"
+);
+
+afterEach(cleanup);
+beforeEach(() => {
+  // Fresh first run, both transcripts off — the real first-entry state.
+  useVoicePrefsStore.setState({
+    showUserTranscript: false,
+    showAssistantTranscript: false,
+    firstRunSeen: false,
+  });
+});
+
+describe("VoiceFirstRunCard", () => {
+  test("renders the card and does not start on its own", () => {
+    const onStart = mock(() => {});
+    const { getByText, getByLabelText } = render(
+      <VoiceFirstRunCard assistantId="asst_test" onStart={onStart} />,
+    );
+
+    // Title + both toggles are present, and nothing has started yet.
+    expect(getByText("Voice mode")).toBeTruthy();
+    expect(getByLabelText("Show the words you say")).toBeTruthy();
+    expect(getByLabelText("Show the words the assistant says")).toBeTruthy();
+    expect(getByText("Start")).toBeTruthy();
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  test("toggles are OFF by default and flip the shared voice-prefs store", () => {
+    const { getByLabelText } = render(
+      <VoiceFirstRunCard assistantId="asst_test" onStart={() => {}} />,
+    );
+
+    // Defaults OFF.
+    expect(useVoicePrefsStore.getState().showUserTranscript).toBe(false);
+    expect(useVoicePrefsStore.getState().showAssistantTranscript).toBe(false);
+
+    // Flipping each toggle writes through to the same store the settings
+    // page reads.
+    fireEvent.click(getByLabelText("Show the words you say"));
+    expect(useVoicePrefsStore.getState().showUserTranscript).toBe(true);
+
+    fireEvent.click(getByLabelText("Show the words the assistant says"));
+    expect(useVoicePrefsStore.getState().showAssistantTranscript).toBe(true);
+  });
+
+  test("Start invokes onStart", () => {
+    const onStart = mock(() => {});
+    const { getByText } = render(
+      <VoiceFirstRunCard assistantId="asst_test" onStart={onStart} />,
+    );
+
+    fireEvent.click(getByText("Start"));
+    expect(onStart).toHaveBeenCalledTimes(1);
+  });
+
+  test("Start wired to markFirstRunSeen (as the composer does) consumes the first run", () => {
+    // Mirror the composer's onStart handler: committing marks the first run
+    // seen so a second entry would skip the card entirely.
+    const onStart = mock(() => useVoicePrefsStore.getState().markFirstRunSeen());
+    const { getByText } = render(
+      <VoiceFirstRunCard assistantId="asst_test" onStart={onStart} />,
+    );
+
+    expect(useVoicePrefsStore.getState().firstRunSeen).toBe(false);
+    fireEvent.click(getByText("Start"));
+    expect(useVoicePrefsStore.getState().firstRunSeen).toBe(true);
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
@@ -1,0 +1,139 @@
+import { Button } from "@vellumai/design-library/components/button";
+import { Modal } from "@vellumai/design-library/components/modal";
+import { Toggle } from "@vellumai/design-library/components/toggle";
+
+import { ChatAvatar } from "@/components/avatar/chat-avatar";
+import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
+import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
+
+/**
+ * One-time preferences card shown the first time a user enters voice mode,
+ * before the live session starts.
+ *
+ * The two transcript toggles are bound to the SAME persisted `voice-prefs`
+ * store as the Voice settings page (`settings/pages/voice-page.tsx`), so a
+ * choice made here is the choice the settings screen shows — the card is just
+ * an earlier, in-context surface for the same preferences. Both default OFF;
+ * the "Recommended off" badge and the closing note nudge users to try the
+ * hands-free, transcript-free experience first, matching the settings copy.
+ *
+ * The card does NOT persist `firstRunSeen` itself: dismissing it (Escape /
+ * backdrop / ✕) is a plain cancel and must leave the first run un-consumed so
+ * the card returns on the next entry. Only committing via "Start" advances the
+ * first-run flag, and that lives in the caller's `onStart` handler (the
+ * composer) alongside actually starting the session.
+ */
+
+/** Mini idle avatar diameter — a quiet, in-context echo of the room avatar. */
+const AVATAR_SIZE = 44;
+
+export interface VoiceFirstRunCardProps {
+  /** Assistant whose avatar anchors the card; `null` renders the "V" fallback. */
+  assistantId: string | null;
+  /** Commit: enter voice mode. The caller persists `firstRunSeen` here. */
+  onStart: () => void;
+  /** Cancel: dismissed without starting (does not consume the first run). */
+  onDismiss?: () => void;
+}
+
+function RecommendedOffBadge() {
+  return (
+    <span className="shrink-0 rounded-full bg-[var(--surface-active)] px-2 py-0.5 text-body-small-default text-[var(--content-tertiary)]">
+      Recommended off
+    </span>
+  );
+}
+
+function TranscriptToggleRow({
+  label,
+  checked,
+  onChange,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (next: boolean) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 py-1">
+      <div className="flex min-w-0 items-center gap-2">
+        <span className="truncate text-body-medium-lighter text-[var(--content-default)]">
+          {label}
+        </span>
+        <RecommendedOffBadge />
+      </div>
+      <Toggle checked={checked} onChange={onChange} aria-label={label} />
+    </div>
+  );
+}
+
+export function VoiceFirstRunCard({
+  assistantId,
+  onStart,
+  onDismiss,
+}: VoiceFirstRunCardProps) {
+  const { components, traits, customImageUrl } =
+    useAssistantAvatar(assistantId);
+
+  const showUserTranscript = useVoicePrefsStore.use.showUserTranscript();
+  const showAssistantTranscript =
+    useVoicePrefsStore.use.showAssistantTranscript();
+  const setShowUserTranscript = useVoicePrefsStore.use.setShowUserTranscript();
+  const setShowAssistantTranscript =
+    useVoicePrefsStore.use.setShowAssistantTranscript();
+
+  return (
+    <Modal.Root
+      open
+      onOpenChange={(next) => {
+        // Escape / backdrop / ✕ all route through here; treat any close as a
+        // cancel so the first run stays un-consumed.
+        if (!next) {
+          onDismiss?.();
+        }
+      }}
+    >
+      <Modal.Content size="sm">
+        <Modal.Header>
+          <div className="flex items-center gap-3">
+            <span className="shrink-0">
+              <ChatAvatar
+                components={components}
+                traits={traits}
+                customImageUrl={customImageUrl}
+                size={AVATAR_SIZE}
+              />
+            </span>
+            <Modal.Title>Voice mode</Modal.Title>
+          </div>
+          <Modal.Description>
+            A hands-free, spoken conversation. Speak naturally and your
+            assistant listens, then replies out loud.
+          </Modal.Description>
+        </Modal.Header>
+        <Modal.Body>
+          <div className="flex flex-col gap-1">
+            <TranscriptToggleRow
+              label="Show the words you say"
+              checked={showUserTranscript}
+              onChange={setShowUserTranscript}
+            />
+            <TranscriptToggleRow
+              label="Show the words the assistant says"
+              checked={showAssistantTranscript}
+              onChange={setShowAssistantTranscript}
+            />
+            <p className="pt-2 text-body-small-default text-[var(--content-tertiary)]">
+              You can change these anytime in settings. We recommend keeping
+              both off to start. It feels more like a real conversation.
+            </p>
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="primary" onClick={onStart}>
+            Start
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal.Root>
+  );
+}

--- a/clients/web/src/runtime/platform-detection.ts
+++ b/clients/web/src/runtime/platform-detection.ts
@@ -149,6 +149,25 @@ export function detectClientOs(): ClientOs {
 }
 
 /**
+ * True only on the native Capacitor iOS runtime (the WKWebView shell) —
+ * `Capacitor.isNativePlatform()` AND `Capacitor.getPlatform() === "ios"`.
+ *
+ * Distinct from `isIOSBrowser()` (iOS mobile Safari/Chrome, NOT the shell) and
+ * from `isNativePlatform()` (true for the iOS AND Android shells). Use this to
+ * gate iOS-shell-only behavior — most notably any pre-permission UI before an
+ * OS permission alert (`getUserMedia`, `Notification.requestPermission`, etc.),
+ * which per `docs/CAPACITOR.md` § OS permission requests must be skipped (or
+ * carry zero exit affordances) so it leads directly to the system alert per
+ * Apple HIG / App Store Review 5.1.1(iv). Android is excluded because no native
+ * Capacitor Android shell ships today (mirrors `isRemotePushSupported`);
+ * revisit if one does. Safe server-side — falls through to `false` before
+ * hydration.
+ */
+export function isNativeIOS(): boolean {
+  return isNativePlatform() && Capacitor.getPlatform() === "ios";
+}
+
+/**
  * Browser attribution for turn telemetry (`metadata.client.browser_family` /
  * `.browser_version`). Family is engine-level: Chromium derivatives without
  * their own brand entry (Opera, Brave, Arc) report as `"chrome"`.


### PR DESCRIPTION
## Summary
- On first voice-mode entry, show a preferences card (two ambient-transcript toggles, both default OFF) before the session starts; Start persists prefs and enters voice mode. Subsequent entries skip it.
- Shares the persisted voice-prefs store with the Voice settings toggles.

Part of plan: voice-mode-ui-overhaul.md (PR 7 of 8)