### PR TITLE
docs(plugins): codify plugin self-containment + guard test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,10 @@ Each LLM call site has a stable identifier (`LLMCallSite` from `assistant/src/co
 
 The `assistant/` module must not import from `skills/` via relative paths (e.g. `../skills/<name>/...`), and `skills/` must not import from `assistant/`. Both directions are enforced by `assistant/src/__tests__/skill-boundary-guard.test.ts`.
 
+## Plugin Self-Containment
+
+A plugin owns its state end-to-end: durable data lives in the plugin's storage dir (`InitContext.pluginStorageDir`), schema is created idempotently by the plugin's `init` hook, handles close in `shutdown`, and per-conversation rows are purged in `conversation-deleted`. Plugin state never goes in the main database or the global migration chain (`assistant/src/persistence/migrations/` / `steps.ts`). Full rules, the canonical `image-fallback` example, and the guard test: `assistant/src/plugins/AGENTS.md`. When creating or scaffolding a plugin, follow the `plugin-builder` skill (`skills/plugin-builder/`).
+
 ## Tooling Direction
 
 New non-skill tool registrations are strongly discouraged — see `assistant/src/tools/AGENTS.md`.

--- a/assistant/AGENTS.md
+++ b/assistant/AGENTS.md
@@ -2,7 +2,7 @@
 
 For error handling conventions (throw vs result objects vs null), see [docs/error-handling.md](docs/error-handling.md).
 
-Subdirectory-scoped rules live in local AGENTS.md files: `src/cli/`, `src/runtime/`, `src/approvals/`, `src/notifications/`, `src/workspace/migrations/`.
+Subdirectory-scoped rules live in local AGENTS.md files: `src/cli/`, `src/runtime/`, `src/approvals/`, `src/notifications/`, `src/plugins/`, `src/workspace/migrations/`.
 
 ## Adding new environment variables
 

--- a/assistant/src/plugins/AGENTS.md
+++ b/assistant/src/plugins/AGENTS.md
@@ -1,0 +1,19 @@
+# Plugins — Agent Instructions
+
+Rules for code under `assistant/src/plugins/`, including the first-party default plugins in `defaults/`. For authoring or scaffolding a plugin (default or external), follow the `plugin-builder` skill (`skills/plugin-builder/`) — it documents the directory layout, hook contracts, and the `@vellumai/plugin-api` surface.
+
+## Plugin Self-Containment
+
+A plugin owns its state end-to-end. Everything a plugin persists lives in its own storage directory and is created, maintained, and cleaned up through the plugin's lifecycle hooks — never through the assistant's global persistence layer.
+
+- **Storage location**: all durable plugin state lives under `InitContext.pluginStorageDir` (`<pluginDir>/data/` for installed plugins; `<workspaceDir>/plugins-data/<name>/` for defaults and standalone workspace hooks). Do not write plugin state anywhere else in the workspace.
+- **Schema in `init`**: open plugin-owned storage (e.g. a SQLite file) and apply the plugin's own schema/migrations in the `init` hook, idempotently — it re-runs on every boot. Never add plugin tables to the main database schema and never register plugin migrations in `assistant/src/persistence/migrations/` / `steps.ts`.
+- **Close in `shutdown`**: release storage handles so daemon shutdown and in-place plugin redeploys never leak them.
+- **Purge in `conversation-deleted`**: remove per-conversation rows so derived data (captions, caches, logs) does not outlive the conversation that produced it.
+- **Fail open**: a plugin whose storage cannot be opened should degrade (e.g. to in-memory behavior), not block boot or the turn.
+
+Canonical example: `defaults/image-fallback` — `hooks/init.ts` opens `caption-cache.sqlite` in the storage dir and ensures its schema, `hooks/shutdown.ts` closes it, `hooks/conversation-deleted.ts` purges the conversation's rows (`src/caption-cache.ts`).
+
+**Grandfathered exception**: `defaults/memory` predates this rule and uses main-database tables via `persistence/schema` / `db-connection`. Do not extend that pattern to other plugins or grow memory's main-DB surface. Enforced by `__tests__/plugin-state-boundary-guard.test.ts`.
+
+Calling the assistant's service APIs from a default plugin (e.g. `persistence/conversation-crud.ts` reads) is fine — the boundary is about _owning state_: plugin tables, plugin migrations, and plugin files belong to the plugin.

--- a/assistant/src/plugins/__tests__/plugin-state-boundary-guard.test.ts
+++ b/assistant/src/plugins/__tests__/plugin-state-boundary-guard.test.ts
@@ -14,10 +14,11 @@ import { Glob } from "bun";
  * into the assistant's global persistence layer to own state:
  *
  * - `persistence/migrations/` and `persistence/steps` (the global
- *   migration chain), `persistence/schema` (main-DB tables), and
- *   `persistence/db-connection` (the raw DB handle) are frozen to the
- *   grandfathered `memory` plugin, whose main-DB tables predate the rule.
- *   New plugins keep their state in plugin-owned storage.
+ *   migration chain), `persistence/schema` (main-DB tables),
+ *   `persistence/db-connection` (the raw DB handle), and
+ *   `persistence/raw-query` (raw SQL against the main DB) are frozen to
+ *   the grandfathered `memory` plugin, whose main-DB tables predate the
+ *   rule. New plugins keep their state in plugin-owned storage.
  *
  * Service-API imports (e.g. `persistence/conversation-crud`) are allowed —
  * the boundary is about owning state, not reading through APIs.
@@ -30,7 +31,7 @@ const MAIN_DB_GRANDFATHERED_PLUGINS = new Set(["memory"]);
 
 /** Import specifiers that mean a plugin is owning main-DB state. */
 const MAIN_DB_STATE_PATTERN =
-  /\b(?:from\s*|import\s*\(\s*)["'][^"']*persistence\/(?:schema(?:\/[^"']*)?|db-connection|migrations\/[^"']*|steps)(?:\.js)?["']/;
+  /\b(?:from\s*|import\s*\(\s*)["'][^"']*persistence\/(?:schema(?:\/[^"']*)?|db-connection|raw-query|migrations\/[^"']*|steps)(?:\.js)?["']/;
 
 function scanDefaultPlugins(
   pattern: RegExp,

--- a/assistant/src/plugins/__tests__/plugin-state-boundary-guard.test.ts
+++ b/assistant/src/plugins/__tests__/plugin-state-boundary-guard.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import { Glob } from "bun";
+
+/**
+ * Guard tests for plugin state self-containment. See `../AGENTS.md`
+ * "Plugin Self-Containment".
+ *
+ * Plugins own their state: durable data lives in the plugin's storage dir,
+ * schema is applied by the plugin's `init` hook, and cleanup happens in
+ * `shutdown` / `conversation-deleted`. Plugins therefore must not reach
+ * into the assistant's global persistence layer to own state:
+ *
+ * - `persistence/migrations/` and `persistence/steps` (the global
+ *   migration chain), `persistence/schema` (main-DB tables), and
+ *   `persistence/db-connection` (the raw DB handle) are frozen to the
+ *   grandfathered `memory` plugin, whose main-DB tables predate the rule.
+ *   New plugins keep their state in plugin-owned storage.
+ *
+ * Service-API imports (e.g. `persistence/conversation-crud`) are allowed —
+ * the boundary is about owning state, not reading through APIs.
+ */
+
+const DEFAULTS_DIR = join(process.cwd(), "src/plugins/defaults");
+
+/** Plugins allowed to import main-DB state modules. Frozen — do not add. */
+const MAIN_DB_GRANDFATHERED_PLUGINS = new Set(["memory"]);
+
+/** Import specifiers that mean a plugin is owning main-DB state. */
+const MAIN_DB_STATE_PATTERN =
+  /\b(?:from\s*|import\s*\(\s*)["'][^"']*persistence\/(?:schema(?:\/[^"']*)?|db-connection|migrations\/[^"']*|steps)(?:\.js)?["']/;
+
+function scanDefaultPlugins(
+  pattern: RegExp,
+): Array<{ plugin: string; file: string }> {
+  const hits: Array<{ plugin: string; file: string }> = [];
+  for (const relPath of new Glob("**/*.ts").scanSync({ cwd: DEFAULTS_DIR })) {
+    const content = readFileSync(join(DEFAULTS_DIR, relPath), "utf-8");
+    if (pattern.test(content)) {
+      hits.push({ plugin: relPath.split("/")[0]!, file: relPath });
+    }
+  }
+  return hits.sort((a, b) => a.file.localeCompare(b.file));
+}
+
+describe("plugin state boundary guard", () => {
+  test("main-DB state imports are frozen to grandfathered plugins", () => {
+    const violations = scanDefaultPlugins(MAIN_DB_STATE_PATTERN).filter(
+      ({ plugin }) => !MAIN_DB_GRANDFATHERED_PLUGINS.has(plugin),
+    );
+    expect(violations).toEqual([]);
+  });
+
+  test("the grandfathered set still needs its exemption", () => {
+    const importers = new Set(
+      scanDefaultPlugins(MAIN_DB_STATE_PATTERN).map(({ plugin }) => plugin),
+    );
+    for (const plugin of MAIN_DB_GRANDFATHERED_PLUGINS) {
+      expect(importers.has(plugin)).toBe(true);
+    }
+  });
+});

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -653,7 +653,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-08T11:48:21.000Z"
+      "updatedAt": "2026-07-08T19:30:57.000Z"
     },
     {
       "id": "public-ingress",

--- a/skills/plugin-builder/SKILL.md
+++ b/skills/plugin-builder/SKILL.md
@@ -58,13 +58,14 @@ Vellum's plugin model was designed to line up with the agent harnesses you may a
 
 ## Before you write a single file
 
-Ask before building. Five questions, in this order. Stop if the user is unclear on any of them.
+Ask before building. Six questions, in this order. Stop if the user is unclear on any of them.
 
 1. **What job does the plugin do?** One sentence, plain language. If you cannot write this, the plugin should not be built yet.
 2. **Which surfaces does it ship?** Tools (model calls), hooks (lifecycle transforms), and skills (on-demand instructions) are the three. Most plugins ship one or two, not all three. See `references/plugins.md` for the directory layout and manifest, and the surface-specific references for each surface's contract.
 3. **Does it need credentials?** An API key, OAuth token, or webhook secret is not a value that belongs in a `.ts` file. For LLM inference credentials, use `getConfiguredProvider()` from `@vellumai/plugin-api` to route through the workspace's stored credentials without handling plaintext. For other credential types (OAuth tokens, webhook secrets), store them via the credential vault and resolve at runtime through the assistant's credential system.
-4. **Where will the source live?** A GitHub repo, ideally under the user's own namespace. The marketplace entry pins to a full commit SHA.
-5. **Is the user writing TypeScript or compiling ahead?** In-repo Bun/Node compile on assistant start is the default. If they want a different build, ask now.
+4. **Does it keep state?** A plugin is fully self-contained: durable state lives in its `data/` directory (`InitContext.pluginStorageDir`), with schema created idempotently by the `init` hook, handles closed in `shutdown`, and per-conversation rows purged in `conversation-deleted`. A plugin never persists state in the assistant's database or elsewhere in the workspace. See "State is plugin-owned" in `references/plugins.md`.
+5. **Where will the source live?** A GitHub repo, ideally under the user's own namespace. The marketplace entry pins to a full commit SHA.
+6. **Is the user writing TypeScript or compiling ahead?** In-repo Bun/Node compile on assistant start is the default. If they want a different build, ask now.
 
 You have an alignment problem if the user cannot answer questions 1 and 2. Push back and clarify before scaffolding. The most expensive waste of plugin-authoring time is building a plugin whose job is fuzzy.
 
@@ -110,6 +111,7 @@ Once merged, users install by name: `assistant plugins install my-plugin`. The n
 - Job and surfaces locked in the alignment pass (questions 1 and 2 answered).
 - Directory matches the loader convention (`hooks/`, `tools/`, `skills/`, optional `src/`).
 - `package.json` declares `name`, `version`, and a real `peerDependencies["@vellumai/plugin-api"]` range.
+- Any durable state lives in `data/`, created by `init` and cleaned up by `shutdown` / `conversation-deleted`.
 - Each surface has been exercised locally with a working example.
 - A `marketplace.json` entry exists with a full SHA in `source.ref`, and the Vellum team's review is in flight.
 

--- a/skills/plugin-builder/references/hooks.md
+++ b/skills/plugin-builder/references/hooks.md
@@ -32,7 +32,8 @@ These are the lifecycle hooks. The full set of wired hook names lives in the [`H
 
 **Context:** `InitContext`
 **When:** Once, when the plugin is first registered (on boot or install).
-**Use it to:** Validate config and open resources. Throwing aborts the plugin's load.
+**Use it to:** Validate config and open resources. This is where plugin-owned storage is set up: create data files under `pluginStorageDir` and apply the plugin's own schema, idempotently — `init` runs on every boot. Throwing aborts the plugin's load.
+**Example:** [image-fallback](https://github.com/vellum-ai/vellum-assistant/blob/main/assistant/src/plugins/defaults/image-fallback/hooks/init.ts)
 
 | Field              | Type           | Access    | Description                                                                                            |
 | ------------------ | -------------- | --------- | ------------------------------------------------------------------------------------------------------ |
@@ -165,7 +166,8 @@ These are the lifecycle hooks. The full set of wired hook names lives in the [`H
 
 **Context:** `ShutdownContext`
 **When:** Once, when the Assistant tears down the plugin (process exit, unload).
-**Use it to:** Best-effort cleanup. Do not rely on it for critical writes; persist durably during normal operation instead.
+**Use it to:** Best-effort cleanup: close storage handles opened in `init` and release other resources. Do not rely on it for critical writes; persist durably during normal operation instead.
+**Example:** [image-fallback](https://github.com/vellum-ai/vellum-assistant/blob/main/assistant/src/plugins/defaults/image-fallback/hooks/shutdown.ts)
 
 | Field              | Type     | Access    | Description                                        |
 | ------------------ | -------- | --------- | -------------------------------------------------- |

--- a/skills/plugin-builder/references/plugins.md
+++ b/skills/plugin-builder/references/plugins.md
@@ -44,6 +44,16 @@ Three entries at the plugin root are runtime-owned state, not part of the plugin
 
 Uninstalling a plugin (`assistant plugins uninstall`) removes the entire plugin directory, so `config.json`, `data/`, and `.disabled` go with it. No orphaned state is left behind.
 
+### State is plugin-owned
+
+A plugin must be fully self-contained: every byte of durable state it keeps lives in `data/`, and its lifecycle hooks own that state end-to-end.
+
+- **Create in `init`.** Open storage files (e.g. a SQLite database under `pluginStorageDir`) and apply the plugin's own schema in the `init` hook. Make it idempotent — `init` runs on every assistant boot, so `CREATE TABLE IF NOT EXISTS` plus in-place schema checks, not one-shot migrations.
+- **Close in `shutdown`.** Release storage handles so shutdown and in-place plugin redeploys never leak them.
+- **Purge in `conversation-deleted`.** Key per-conversation rows by conversation id and delete them when the hook fires, so data derived from a conversation does not outlive it.
+
+The assistant's own database is internal — `@vellumai/plugin-api` exposes no handle to it, and a plugin must not persist state elsewhere in the workspace. Keeping everything in `data/` is also what makes uninstall clean: removing the plugin directory removes all of its state.
+
 Each surface can also be dropped straight into the workspace at `/workspace/<surface>/<name>/` without wrapping it in a plugin. A plugin is what lets you ship several surfaces together as one installable unit.
 
 ## The manifest


### PR DESCRIPTION
## Why

PR #37418 (image-fallback durable caption cache) was originally headed toward main-DB tables created via global migrations for plugin state, and needed review feedback to land as a self-contained plugin (sqlite in the plugin storage dir, opened in `init`, closed in `shutdown`, purged in `conversation-deleted`). This PR turns that feedback into durable guidance + enforcement so the next plugin gets it right by default.

## What

- **New `assistant/src/plugins/AGENTS.md`** — the self-containment rules: state in `pluginStorageDir`, schema applied idempotently in `init`, close in `shutdown`, purge in `conversation-deleted`, never main-DB tables or entries in `persistence/migrations/` / `steps.ts`. Points at `defaults/image-fallback` as the canonical example and documents the grandfathered `memory` exception.
- **New guard test** `assistant/src/plugins/__tests__/plugin-state-boundary-guard.test.ts` — freezes imports of `persistence/{schema,db-connection,migrations,steps}` in `defaults/` to the grandfathered `memory` plugin, so a new plugin reaching for main-DB state fails CI instead of relying on review to catch it.
- **Root `AGENTS.md`** — new "Plugin Self-Containment" section (next to Skill Isolation) summarizing the rule and directing plugin creation through the `plugin-builder` skill.
- **`plugin-builder` skill** — new "State is plugin-owned" section in `references/plugins.md`, a "Does it keep state?" question in the SKILL.md alignment pass + a ship-checklist bullet, and storage guidance/examples on the `init` and `shutdown` hook docs in `references/hooks.md`.

## Follow-up

The public docs at vellum.ai/docs/extensibility (hooks + plugins pages) mirror the skill references and live in `vellum-assistant-platform` — companion PR to sync the same guidance there is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->