### PR TITLE
feat(config): complete partial custom profiles at write time (M6 PR2)

### DIFF
--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -1202,11 +1202,14 @@ describe("code-owned default profiles — leaf SET source stamping", () => {
       body: { path: "llm.profiles.balanced.model", value: "gpt-5.4" },
     });
     expect(result).toEqual({ ok: true });
-    expect(savedProfile("balanced")).toEqual({
+    // Write normalization completes the changed user entry; the guard's
+    // concern is only that `source` stays user-owned.
+    expect(savedProfile("balanced")).toMatchObject({
       source: "user",
       provider: "openai",
       model: "gpt-5.4",
     });
+    expect(savedProfile("balanced").source).toBe("user");
   });
 
   test("a leaf SET writing content to an absent default is rejected", async () => {

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -1235,6 +1235,24 @@ describe("custom profile write normalization (complete overrides)", () => {
     });
   });
 
+  test("nested unknown keys survive completion of a touched entry", async () => {
+    (
+      rawConfigFixture.llm as { profiles: Record<string, unknown> }
+    ).profiles.partial = {
+      source: "user",
+      model: "claude-haiku-4-5-20251001",
+      contextWindow: { futureField: "keep-me", maxInputTokens: 111 },
+    };
+    await configSetRoute.handler({
+      body: { path: "llm.profiles.partial.maxTokens", value: 999 },
+    });
+    const saved = savedProfiles().partial;
+    const contextWindow = saved.contextWindow as Record<string, unknown>;
+    expect(contextWindow.futureField).toBe("keep-me");
+    expect(contextWindow.maxInputTokens).toBe(111);
+    expect(saved.provider).toBe("anthropic");
+  });
+
   test("unknown profile keys survive completion of a touched entry", async () => {
     (
       rawConfigFixture.llm as { profiles: Record<string, unknown> }

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -1252,6 +1252,17 @@ describe("custom profile write normalization (complete overrides)", () => {
     expect(saved.provider).toBe("anthropic");
   });
 
+  test("a bogus managed source on a non-catalog name is normalized and completed", async () => {
+    await replaceProfileRoute.handler({
+      pathParams: { name: "mine" },
+      body: { source: "managed", model: "claude-haiku-4-5-20251001" },
+    });
+    const saved = savedProfiles().mine;
+    expect(saved.source).toBe("user");
+    expect(saved.provider).toBe("anthropic");
+    expect(saved.maxTokens).toBe(12345);
+  });
+
   test("a managed status re-enable stays a thin stub", async () => {
     (
       rawConfigFixture.llm as { profiles: Record<string, unknown> }

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -56,6 +56,7 @@ mock.module("../../../persistence/embeddings/embedding-backend.js", () => ({
   },
 }));
 
+import { LLMConfigBase } from "../../../config/schemas/llm.js";
 import type { ConversationCreateType } from "../../../persistence/conversation-types.js";
 import { getDb, getLogsDb } from "../../../persistence/db-connection.js";
 import { initializeDb } from "../../../persistence/db-init.js";
@@ -760,11 +761,17 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
 
     expect(savedProfile.provider).toBe("openai");
     expect(savedProfile.model).toBe("gpt-5.5");
-    expect(savedProfile.maxTokens).toBeUndefined();
+    // Write normalization completes the entry against llm.default (schema
+    // defaults here — the fixture has none), so UI-cleared fields land as
+    // explicit values instead of inherit-by-absence.
+    const schemaDefault = LLMConfigBase.parse({});
+    expect(savedProfile.maxTokens).toBe(schemaDefault.maxTokens);
     expect(savedProfile.contextWindow).toEqual({
+      ...schemaDefault.contextWindow,
       targetBudgetRatio: 0.3,
       summaryBudgetRatio: 0.08,
       overflowRecovery: {
+        ...schemaDefault.contextWindow.overflowRecovery,
         enabled: true,
         maxAttempts: 4,
       },
@@ -792,11 +799,14 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
       }
     ).profiles.custom;
 
+    const schemaDefault = LLMConfigBase.parse({});
     expect(savedProfile.contextWindow).toEqual({
+      ...schemaDefault.contextWindow,
       maxInputTokens: 150000,
       targetBudgetRatio: 0.3,
       summaryBudgetRatio: 0.08,
       overflowRecovery: {
+        ...schemaDefault.contextWindow.overflowRecovery,
         enabled: true,
         maxAttempts: 4,
       },
@@ -1134,6 +1144,141 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
       expect(invalidateConfigCacheCalls).toBe(1);
       expect(clearEmbeddingBackendCacheCalls).toBe(1);
     });
+  });
+});
+
+describe("custom profile write normalization (complete overrides)", () => {
+  const configPatchRoute = ROUTES.find(
+    (r) => r.operationId === "config_patch",
+  )!;
+  const configSetRoute = ROUTES.find((r) => r.operationId === "config_set")!;
+
+  const distinctiveDefault = {
+    provider: "anthropic",
+    model: "claude-opus-4-8",
+    maxTokens: 12345,
+    temperature: 0.7,
+    logitBias: "suppress-cjk",
+  };
+
+  beforeEach(() => {
+    savedRawConfig = null;
+    rawConfigFixture = {
+      llm: {
+        default: structuredClone(distinctiveDefault),
+        profiles: {
+          partial: { source: "user", model: "claude-haiku-4-5-20251001" },
+        },
+      },
+    };
+  });
+
+  const savedProfiles = () =>
+    (
+      savedRawConfig?.llm as {
+        profiles: Record<string, Record<string, unknown>>;
+      }
+    ).profiles;
+
+  test("PUT of a partial body stores a complete profile", async () => {
+    await replaceProfileRoute.handler({
+      pathParams: { name: "mine" },
+      body: { model: "claude-haiku-4-5-20251001" },
+    });
+    const saved = savedProfiles().mine;
+    expect(saved.model).toBe("claude-haiku-4-5-20251001");
+    expect(saved.provider).toBe("anthropic");
+    expect(saved.maxTokens).toBe(12345);
+    // Non-null default sampling is baked in; logitBias never is.
+    expect(saved.temperature).toBe(0.7);
+    expect(saved.logitBias).toBeUndefined();
+    expect(saved.thinking).toBeDefined();
+    expect(saved.contextWindow).toBeDefined();
+  });
+
+  test("PATCH creating a partial profile stores it complete", async () => {
+    await configPatchRoute.handler({
+      body: {
+        llm: {
+          default: structuredClone(distinctiveDefault),
+          profiles: {
+            mine: { source: "user", model: "claude-haiku-4-5-20251001" },
+          },
+        },
+      },
+    });
+    const saved = savedProfiles().mine;
+    expect(saved.provider).toBe("anthropic");
+    expect(saved.maxTokens).toBe(12345);
+    expect(saved.temperature).toBe(0.7);
+    expect(saved.logitBias).toBeUndefined();
+  });
+
+  test("SET on a profile leaf completes the whole entry", async () => {
+    await configSetRoute.handler({
+      body: { path: "llm.profiles.partial.maxTokens", value: 999 },
+    });
+    const saved = savedProfiles().partial;
+    expect(saved.maxTokens).toBe(999);
+    expect(saved.provider).toBe("anthropic");
+    expect(saved.temperature).toBe(0.7);
+    expect(saved.model).toBe("claude-haiku-4-5-20251001");
+  });
+
+  test("an unrelated write leaves untouched partial profiles byte-identical", async () => {
+    await configSetRoute.handler({
+      body: { path: "heartbeat.activeHoursStart", value: 9 },
+    });
+    expect(savedProfiles().partial).toEqual({
+      source: "user",
+      model: "claude-haiku-4-5-20251001",
+    });
+  });
+
+  test("a managed status re-enable stays a thin stub", async () => {
+    (
+      rawConfigFixture.llm as { profiles: Record<string, unknown> }
+    ).profiles.balanced = { source: "managed", status: "disabled" };
+    await replaceProfileRoute.handler({
+      pathParams: { name: "balanced" },
+      body: { status: null },
+    });
+    expect(savedProfiles().balanced).toEqual({ source: "managed" });
+  });
+
+  test("a mix profile write is not completed", async () => {
+    await replaceProfileRoute.handler({
+      pathParams: { name: "ab" },
+      body: {
+        label: "A/B",
+        mix: [
+          { profile: "balanced", weight: 1 },
+          { profile: "cost-optimized", weight: 1 },
+        ],
+      },
+    });
+    const saved = savedProfiles().ab;
+    expect(saved.mix).toBeDefined();
+    expect(saved.provider).toBeUndefined();
+    expect(saved.model).toBeUndefined();
+    expect(saved.maxTokens).toBeUndefined();
+  });
+
+  test("re-writing a completed profile is idempotent", async () => {
+    // Deterministic connection state: the PUT handler derives a connection
+    // for provider-carrying bodies, so both writes must see the same rows.
+    getDb().delete(providerConnections).run();
+    await replaceProfileRoute.handler({
+      pathParams: { name: "mine" },
+      body: { provider: "anthropic", model: "claude-haiku-4-5-20251001" },
+    });
+    const first = structuredClone(savedProfiles().mine);
+    rawConfigFixture = structuredClone(savedRawConfig!);
+    await replaceProfileRoute.handler({
+      pathParams: { name: "mine" },
+      body: first as Record<string, unknown>,
+    });
+    expect(savedProfiles().mine).toEqual(first);
   });
 });
 

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -1235,6 +1235,23 @@ describe("custom profile write normalization (complete overrides)", () => {
     });
   });
 
+  test("unknown profile keys survive completion of a touched entry", async () => {
+    (
+      rawConfigFixture.llm as { profiles: Record<string, unknown> }
+    ).profiles.partial = {
+      source: "user",
+      model: "claude-haiku-4-5-20251001",
+      futureField: "keep-me",
+    };
+    await configSetRoute.handler({
+      body: { path: "llm.profiles.partial.maxTokens", value: 999 },
+    });
+    const saved = savedProfiles().partial;
+    expect(saved.futureField).toBe("keep-me");
+    expect(saved.maxTokens).toBe(999);
+    expect(saved.provider).toBe("anthropic");
+  });
+
   test("a managed status re-enable stays a thin stub", async () => {
     (
       rawConfigFixture.llm as { profiles: Record<string, unknown> }

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1211,6 +1211,30 @@ function assertInvariantProfilesPreserved(
 }
 
 /**
+ * `{...raw, ...completed}` recursively: completed (schema-known) values win,
+ * raw keys the schema stripped survive at every depth.
+ */
+function mergePreservingUnknownKeys(
+  raw: Record<string, unknown>,
+  completed: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...raw, ...completed };
+  for (const [key, value] of Object.entries(completed)) {
+    const rawValue = raw[key];
+    if (
+      readPlainObject(value) !== undefined &&
+      readPlainObject(rawValue) !== undefined
+    ) {
+      out[key] = mergePreservingUnknownKeys(
+        rawValue as Record<string, unknown>,
+        value as Record<string, unknown>,
+      );
+    }
+  }
+  return out;
+}
+
+/**
  * Custom profiles persist as complete overrides: any user-source, non-mix
  * profile entry this write creates or changes is completed against
  * `llm.default` (`completeCustomProfile`) before it lands on disk, so no
@@ -1249,14 +1273,17 @@ function completeChangedCustomProfiles(
       parsedEntry.data.source === "managed" && !MANAGED_PROFILE_NAMES.has(name)
         ? { ...parsedEntry.data, source: "user" as const }
         : parsedEntry.data;
-    // Spread the completed known fields over the original raw entry:
-    // `safeParse` strips keys the schema doesn't know, and dropping them
-    // here would delete forward-compatible fields whenever an unrelated
-    // leaf of the entry is edited.
-    profiles[name] = {
-      ...(readPlainObject(entry) ?? {}),
-      ...completeCustomProfile(parsedDefault.data, entryData),
-    };
+    // Merge the completed known fields over the original raw entry at every
+    // depth: `safeParse` strips keys the schema doesn't know (top-level and
+    // inside nested objects like `contextWindow`), and dropping them here
+    // would delete forward-compatible fields whenever the entry is edited.
+    profiles[name] = mergePreservingUnknownKeys(
+      readPlainObject(entry) ?? {},
+      completeCustomProfile(parsedDefault.data, entryData) as Record<
+        string,
+        unknown
+      >,
+    );
   }
 }
 

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1242,13 +1242,20 @@ function completeChangedCustomProfiles(
     if (!parsedEntry.success) {
       continue;
     }
+    // `source: "managed"` is only meaningful on catalog-owned names. On any
+    // other name it would skip completion (and read as a locked entry), so a
+    // body claiming it is normalized to user-owned before completing.
+    const entryData =
+      parsedEntry.data.source === "managed" && !MANAGED_PROFILE_NAMES.has(name)
+        ? { ...parsedEntry.data, source: "user" as const }
+        : parsedEntry.data;
     // Spread the completed known fields over the original raw entry:
     // `safeParse` strips keys the schema doesn't know, and dropping them
     // here would delete forward-compatible fields whenever an unrelated
     // leaf of the entry is edited.
     profiles[name] = {
       ...(readPlainObject(entry) ?? {}),
-      ...completeCustomProfile(parsedDefault.data, parsedEntry.data),
+      ...completeCustomProfile(parsedDefault.data, entryData),
     };
   }
 }

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -41,9 +41,14 @@ import {
   withSuppressedConfigDiskWrites,
   withSuppressedConfigDiskWritesSync,
 } from "../../config/loader.js";
+import { completeCustomProfile } from "../../config/profile-materialization.js";
 import { AssistantConfigSchema } from "../../config/schema.js";
 import { getSchemaAtPath } from "../../config/schema-utils.js";
-import { LLMConfigFragment, ProfileEntry } from "../../config/schemas/llm.js";
+import {
+  LLMConfigBase,
+  LLMConfigFragment,
+  ProfileEntry,
+} from "../../config/schemas/llm.js";
 import { VALID_MEMORY_EMBEDDING_PROVIDERS } from "../../config/schemas/memory-storage.js";
 import { ServiceModeSchema } from "../../config/schemas/services.js";
 import { getConfigWatcher } from "../../daemon/config-watcher.js";
@@ -196,11 +201,15 @@ function replaceInferenceProfileConfig(
 ): void {
   const existingLlm = asMutablePlainObject(raw.llm);
   const llm = existingLlm ?? {};
-  if (!existingLlm) raw.llm = llm;
+  if (!existingLlm) {
+    raw.llm = llm;
+  }
 
   const existingProfiles = asMutablePlainObject(llm.profiles);
   const profiles = existingProfiles ?? {};
-  if (!existingProfiles) llm.profiles = profiles;
+  if (!existingProfiles) {
+    llm.profiles = profiles;
+  }
 
   const existingProfile = asMutablePlainObject(profiles[name]) ?? {};
   const nextProfile: Record<string, unknown> = { ...existingProfile };
@@ -275,8 +284,12 @@ function applyStoredProviderToLlmContextResult(
 type LlmContextView = "full" | "summary";
 
 function resolveLlmContextView(view: string | undefined): LlmContextView {
-  if (view === undefined || view === "full") return "full";
-  if (view === "summary") return "summary";
+  if (view === undefined || view === "full") {
+    return "full";
+  }
+  if (view === "summary") {
+    return "summary";
+  }
   throw new BadRequestError(
     `Invalid view parameter: ${view}. Expected "full" or "summary".`,
   );
@@ -288,7 +301,9 @@ function resolveLlmContextView(view: string | undefined): LlmContextView {
  * for malformed/legacy rows — a bad blob must never break the inspector.
  */
 function parseLatencyBreakdown(raw: string | null): LatencyBreakdown | null {
-  if (!raw) return null;
+  if (!raw) {
+    return null;
+  }
   try {
     const parsed = LatencyBreakdownSchema.safeParse(JSON.parse(raw));
     return parsed.success ? parsed.data : null;
@@ -497,7 +512,9 @@ function synthesizeLegacyInferenceModeForPlatform(
   root: Record<string, unknown>,
 ): void {
   const services = readPlainObject(root.services);
-  if (!services) return;
+  if (!services) {
+    return;
+  }
   let inference = readPlainObject(services.inference);
   if (!inference) {
     inference = {};
@@ -524,9 +541,13 @@ function stripTransportHeadersRecursively(value: unknown): void {
   }
 
   const object = readPlainObject(value);
-  if (!object) return;
+  if (!object) {
+    return;
+  }
   const transport = readPlainObject(object.transport);
-  if (transport) delete transport.headers;
+  if (transport) {
+    delete transport.headers;
+  }
   for (const child of Object.values(object)) {
     stripTransportHeadersRecursively(child);
   }
@@ -538,9 +559,13 @@ function containsTransportHeadersRecursively(value: unknown): boolean {
   }
 
   const object = readPlainObject(value);
-  if (!object) return false;
+  if (!object) {
+    return false;
+  }
   const transport = readPlainObject(object.transport);
-  if (transport && Object.hasOwn(transport, "headers")) return true;
+  if (transport && Object.hasOwn(transport, "headers")) {
+    return true;
+  }
   return Object.values(object).some((child) =>
     containsTransportHeadersRecursively(child),
   );
@@ -548,15 +573,21 @@ function containsTransportHeadersRecursively(value: unknown): boolean {
 
 function sanitizeMcpTransportHeadersForSettingsRead(config: unknown): void {
   const root = readPlainObject(config);
-  if (!root) return;
+  if (!root) {
+    return;
+  }
   const mcp = readPlainObject(root.mcp);
-  if (!mcp || !Object.hasOwn(mcp, "servers")) return;
+  if (!mcp || !Object.hasOwn(mcp, "servers")) {
+    return;
+  }
   if (Array.isArray(mcp.servers)) {
     stripTransportHeadersRecursively(mcp.servers);
     return;
   }
   const servers = readPlainObject(mcp.servers);
-  if (!servers) return;
+  if (!servers) {
+    return;
+  }
   for (const server of Object.values(servers)) {
     stripTransportHeadersRecursively(server);
   }
@@ -565,19 +596,25 @@ function sanitizeMcpTransportHeadersForSettingsRead(config: unknown): void {
 function patchContainsMcpTransportHeaders(patch: unknown): boolean {
   const root = readPlainObject(patch);
   const mcp = readPlainObject(root?.mcp);
-  if (!mcp || !Object.hasOwn(mcp, "servers")) return false;
+  if (!mcp || !Object.hasOwn(mcp, "servers")) {
+    return false;
+  }
   if (Array.isArray(mcp.servers)) {
     return containsTransportHeadersRecursively(mcp.servers);
   }
   const servers = readPlainObject(mcp.servers);
-  if (!servers) return false;
+  if (!servers) {
+    return false;
+  }
   return Object.values(servers).some((server) =>
     containsTransportHeadersRecursively(server),
   );
 }
 
 function rejectMcpTransportHeaderWrite(patch: unknown): void {
-  if (!patchContainsMcpTransportHeaders(patch)) return;
+  if (!patchContainsMcpTransportHeaders(patch)) {
+    return;
+  }
   throw new BadRequestError(
     "MCP authentication headers must be managed through MCP server add/update APIs, not generic config writes.",
   );
@@ -808,7 +845,9 @@ function handleGetConfig() {
  */
 function overlayEffectiveProfilesForWire(config: unknown): void {
   const root = readPlainObject(config);
-  if (!root) return;
+  if (!root) {
+    return;
+  }
   const existingLlm = readPlainObject(root.llm);
   const llm = existingLlm ?? {};
   if (!existingLlm) {
@@ -886,9 +925,13 @@ function normalizeManagedProfileWrites(patch: unknown): void {
   ) as Record<string, ProfileEntry> | undefined;
 
   for (const name of Object.keys(profiles)) {
-    if (!MANAGED_PROFILE_NAMES.has(name)) continue;
+    if (!MANAGED_PROFILE_NAMES.has(name)) {
+      continue;
+    }
     const entry = readPlainObject(profiles[name]);
-    if (!entry) continue;
+    if (!entry) {
+      continue;
+    }
 
     const current = readPlainObject(currentProfiles?.[name]);
     if (current && current.source !== "managed") {
@@ -900,7 +943,9 @@ function normalizeManagedProfileWrites(patch: unknown): void {
       getEffectiveProfile(currentProfiles, name),
     );
     for (const key of Object.keys(entry)) {
-      if (key === "source" || key === "status") continue;
+      if (key === "source" || key === "status") {
+        continue;
+      }
       const matchesEffective =
         effective != null &&
         key in effective &&
@@ -975,21 +1020,31 @@ function normalizeManagedProfileWrites(patch: unknown): void {
  */
 function enrichProfilesForWire(config: unknown): void {
   const root = readPlainObject(config);
-  if (!root) return;
+  if (!root) {
+    return;
+  }
   const llm = readPlainObject(root.llm);
-  if (!llm) return;
+  if (!llm) {
+    return;
+  }
   const profiles = readPlainObject(llm.profiles);
-  if (!profiles) return;
+  if (!profiles) {
+    return;
+  }
 
   for (const [name, profile] of Object.entries(profiles)) {
     const entry = readPlainObject(profile);
-    if (!entry) continue;
+    if (!entry) {
+      continue;
+    }
     if (INVARIANT_PROFILE_NAMES.has(name) && entry.source === "managed") {
       entry.invariant = true;
     }
     const provider = entry.provider;
     const model = entry.model;
-    if (typeof provider !== "string" || typeof model !== "string") continue;
+    if (typeof provider !== "string" || typeof model !== "string") {
+      continue;
+    }
 
     const catalogProvider = PROVIDER_CATALOG.find((p) => p.id === provider);
     const catalogModel = catalogProvider?.models.find((m) => m.id === model);
@@ -1031,17 +1086,23 @@ function handleGetConfigSchema({ queryParams = {} }: RouteHandlerArgs) {
 
 function rejectManagedProfileDeletion(body: Record<string, unknown>): void {
   const llm = asMutablePlainObject(body.llm);
-  if (!llm) return;
+  if (!llm) {
+    return;
+  }
   if ("profiles" in llm && llm.profiles === null) {
     throw new BadRequestError(
       "Cannot null llm.profiles — managed profiles would be deleted.",
     );
   }
   const profiles = asMutablePlainObject(llm.profiles);
-  if (!profiles) return;
+  if (!profiles) {
+    return;
+  }
   const existingProfiles = asMutablePlainObject(getConfig().llm.profiles) ?? {};
   for (const name of Object.keys(profiles)) {
-    if (profiles[name] !== null || !MANAGED_PROFILE_NAMES.has(name)) continue;
+    if (profiles[name] !== null || !MANAGED_PROFILE_NAMES.has(name)) {
+      continue;
+    }
     // Only block deletion when the on-disk entry is Vellum-managed. A
     // user-owned profile sharing a managed name carries a non-managed `source`
     // and is freely deletable.
@@ -1150,6 +1211,45 @@ function assertInvariantProfilesPreserved(
 }
 
 /**
+ * Custom profiles persist as complete overrides: any user-source, non-mix
+ * profile entry this write creates or changes is completed against
+ * `llm.default` (`completeCustomProfile`) before it lands on disk, so no
+ * write path can persist a new partial profile. Entries the write did not
+ * touch are left byte-identical — an unrelated config write must not rewrite
+ * profile entries. Entries that do not parse as a `ProfileEntry` are also
+ * left untouched; full-config parsing owns their rejection/recovery.
+ */
+function completeChangedCustomProfiles(
+  preWrite: Record<string, unknown>,
+  raw: Record<string, unknown>,
+): void {
+  const profiles = asMutablePlainObject(readPlainObject(raw.llm)?.profiles);
+  if (!profiles) {
+    return;
+  }
+  const parsedDefault = LLMConfigBase.safeParse(
+    readPlainObject(raw.llm)?.default ?? {},
+  );
+  if (!parsedDefault.success) {
+    return;
+  }
+  const prior = readPlainObject(readPlainObject(preWrite.llm)?.profiles) ?? {};
+  for (const [name, entry] of Object.entries(profiles)) {
+    if (isDeepStrictEqual(entry, prior[name])) {
+      continue;
+    }
+    const parsedEntry = ProfileEntry.safeParse(entry);
+    if (!parsedEntry.success) {
+      continue;
+    }
+    profiles[name] = completeCustomProfile(
+      parsedDefault.data,
+      parsedEntry.data,
+    );
+  }
+}
+
+/**
  * Persist a mutated raw config object to disk and synchronize the running
  * daemon (file-watcher, embedding cache, provider registry).
  *
@@ -1164,7 +1264,9 @@ async function commitConfigWrite(
   // so it is the pre-write state; raw-to-raw comparison avoids parsed-vs-raw
   // false diffs. Runs before the watcher-suppress/save sequence so a
   // rejection needs no suppress-flag or cache cleanup.
-  assertInvariantProfilesPreserved(loadRawConfig(), raw);
+  const preWrite = loadRawConfig();
+  completeChangedCustomProfiles(preWrite, raw);
+  assertInvariantProfilesPreserved(preWrite, raw);
 
   // Suppress the file-watcher callback for the duration of the debounce
   // window. Without this, the ConfigWatcher detects the config.json write
@@ -1339,7 +1441,9 @@ async function handleSetConfig({ body }: RouteHandlerArgs) {
 function handleValidateAllowlist() {
   try {
     const errors = validateAllowlistFile();
-    if (errors == null) return { exists: false } as const;
+    if (errors == null) {
+      return { exists: false } as const;
+    }
     return { exists: true, errors } as const;
   } catch (err) {
     // `validateAllowlistFile` does a raw `JSON.parse` on
@@ -1619,8 +1723,12 @@ function resolveConversationKind(
   if (source === MEMORY_V2_CONSOLIDATION_SOURCE) {
     return "background_memory_consolidation";
   }
-  if (conversationType === "background") return "background";
-  if (conversationType === "scheduled") return "scheduled";
+  if (conversationType === "background") {
+    return "background";
+  }
+  if (conversationType === "scheduled") {
+    return "scheduled";
+  }
   return "user";
 }
 

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1242,10 +1242,14 @@ function completeChangedCustomProfiles(
     if (!parsedEntry.success) {
       continue;
     }
-    profiles[name] = completeCustomProfile(
-      parsedDefault.data,
-      parsedEntry.data,
-    );
+    // Spread the completed known fields over the original raw entry:
+    // `safeParse` strips keys the schema doesn't know, and dropping them
+    // here would delete forward-compatible fields whenever an unrelated
+    // leaf of the entry is edited.
+    profiles[name] = {
+      ...(readPlainObject(entry) ?? {}),
+      ...completeCustomProfile(parsedDefault.data, parsedEntry.data),
+    };
   }
 }
 


### PR DESCRIPTION
## Summary
- Custom profiles now persist as complete overrides: `commitConfigWrite` — the choke point all three config write paths share (profile PUT, generic PATCH, SET including leaf-level) — completes any user-source, non-mix profile entry the write creates or changes against `llm.default` via `completeCustomProfile` before it lands on disk. No write path can persist a new partial profile.
- Scoped to touched entries only: an unrelated config write leaves untouched partial profiles byte-identical (materializing pre-existing partials is the workspace migration's job, in a separate PR). Managed thin stubs and mix profiles pass through unchanged; entries that don't parse as `ProfileEntry` are left for full-config parsing to reject/recover.
- Semantic note: the web profile editor still sends partial bodies, so omitted "inherit" fields are snapshotted at save time from the current `llm.default` — the editor UX rework is a later milestone (M7).

## Original prompt
Milestone 6 of the Inference Management Refactor makes custom profiles complete overrides (no deep-merge inheritance). PR 1 (#37518) shipped the `completeCustomProfile` helper; this PR (M6 PR 2) applies it at write time so migrated cleanliness can't regress — it must land before/with the materialization migration. Full M6 plan is attached to #37518 as the papertrail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->