### PR TITLE
Revert "feat(web): show active model profile and access level in composer"

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -671,12 +671,12 @@ export function ChatComposer({
                 onSend={releaseLiveVoiceTurn}
               />
             ) : (
-              <div className="flex items-center justify-between gap-1 px-2 pb-2">
-                <div className="flex min-w-0 items-center gap-1">
-                  {contextWindowIndicatorSlot}
+              <div className="flex items-center justify-between px-2 pb-2">
+                <div className="flex items-center gap-1">
                   {thresholdPickerSlot}
+                  {contextWindowIndicatorSlot}
                 </div>
-                <div className="flex shrink-0 items-center gap-1">
+                <div className="flex items-center gap-1">
                   {canStopGenerating ? (
                     <>
                       {/* Desktop: always show stop. Mobile: show stop only when there is no sendable content. */}

--- a/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -365,11 +365,7 @@ describe("Profile selection after conversation change (LUM-2279)", () => {
       );
 
     const { rerender } = render(tree("conv-1"));
-    // "Smart" now renders both on the composer trigger and in the menu row, so
-    // wait for at least one occurrence rather than asserting a single match.
-    await waitFor(() =>
-      expect(screen.getAllByText("Smart").length).toBeGreaterThan(0),
-    );
+    await waitFor(() => expect(screen.getByText("Smart")).toBeTruthy());
 
     // Hang subsequent config fetches so the re-fetch from the conversationId
     // change never completes — holds the race window open.
@@ -423,11 +419,7 @@ describe("Profile selection with no active conversation (new draft chat)", () =>
       ),
     );
 
-    // "Smart" now renders both on the composer trigger and in the menu row, so
-    // wait for at least one occurrence rather than asserting a single match.
-    await waitFor(() =>
-      expect(screen.getAllByText("Smart").length).toBeGreaterThan(0),
-    );
+    await waitFor(() => expect(screen.getByText("Smart")).toBeTruthy());
 
     const smart = screen
       .getAllByTestId("menu-item")

--- a/clients/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -410,19 +410,6 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
     [orderedProfileEntries, profileActiveKey],
   );
 
-  // Label for the currently-active profile, shown inline on the composer
-  // trigger so a power user can see which profile a conversation runs on
-  // without opening the menu.
-  const activeProfileLabel = useMemo(() => {
-    if (!profileActiveKey) {
-      return null;
-    }
-    const entry = orderedProfileEntries.find(
-      (e) => e.name === profileActiveKey,
-    );
-    return entry ? profilePickerLabel(entry) : null;
-  }, [orderedProfileEntries, profileActiveKey]);
-
   // Quick-add is owned by the top-level ProfileQuickAddProvider (chat must not
   // import settings directly — see local/no-cross-domain-imports). The provider
   // renders the ProfileEditorModal in create mode, persists the new profile,
@@ -477,48 +464,13 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
   // Render
   // ---------------------------------------------------------------------------
 
-  // Access-level segment: gate on a settled fetch (or an active override) so the
-  // trigger never flashes the `THRESHOLD_PRESETS[1]` fallback before the real
-  // value loads.
-  const AccessIcon = activePreset.icon;
-  const showAccess = globalThresholdsQuery.isSuccess || serverIsOverride;
-  const hasTriggerContent = !!activeProfileLabel || showAccess;
-
-  // Each segment highlights independently on hover to signal it opens the menu;
-  // the whole button is the trigger.
-  const segmentClass =
-    "flex items-center gap-1.5 rounded-md px-1.5 py-1 transition-colors hover:bg-[var(--surface-active)] hover:text-[var(--content-default)]";
-
   const trigger = (
-    <button
-      type="button"
+    <Button
+      variant="ghost"
+      iconOnly={<SlidersHorizontal className="h-[18px] w-[18px]" />}
       aria-label="Conversation settings"
-      className="flex h-7 min-w-0 items-center gap-0.5 rounded-md text-body-small-default text-[var(--content-secondary)] data-[state=open]:text-[var(--content-default)]"
-    >
-      {hasTriggerContent ? (
-        <>
-          {activeProfileLabel ? (
-            // min-w-0 lets the label truncate instead of pushing the composer's
-            // action buttons off-screen on narrow viewports; the cap is tighter
-            // on mobile where the bottom bar has the least room.
-            <span className={`${segmentClass} min-w-0`}>
-              <Sparkles className="h-3.5 w-3.5 shrink-0" />
-              <span className="max-w-[7rem] truncate sm:max-w-[10rem]">
-                {activeProfileLabel}
-              </span>
-            </span>
-          ) : null}
-          {showAccess ? (
-            <span className={`${segmentClass} shrink-0`}>
-              <AccessIcon className="h-3.5 w-3.5 shrink-0" />
-              {activePreset.label}
-            </span>
-          ) : null}
-        </>
-      ) : (
-        <SlidersHorizontal className="mx-1 h-[18px] w-[18px]" />
-      )}
-    </button>
+      className="[--vbtn-fg:var(--content-secondary)] data-[state=open]:[--vbtn-fg:var(--content-default)]"
+    />
   );
 
   if (isMobile) {


### PR DESCRIPTION
meant to merge a different tab whoops

Reverts vellum-ai/vellum-assistant#37449
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->