### PR TITLE
refactor(web): share voice transcript-toggle row + copy

### DIFF
--- a/clients/web/src/components/voice-transcript-toggles.test.tsx
+++ b/clients/web/src/components/voice-transcript-toggles.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * Tests for the shared `VoiceTranscriptToggles`.
+ *
+ * This is the single component both the Voice settings page and the voice
+ * first-run card render, so its contract is load-bearing for both surfaces:
+ * two toggles bound to the shared `voice-prefs` store, both default OFF, each
+ * writing straight through to the store. The `showDescription` /
+ * `showRecommendedBadge` props select the per-surface affordance.
+ *
+ * Follows single-file `bun test` isolation.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { VoiceTranscriptToggles } from "@/components/voice-transcript-toggles";
+import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
+
+beforeEach(() => {
+  localStorage.clear();
+  useVoicePrefsStore.setState({
+    showUserTranscript: false,
+    showAssistantTranscript: false,
+    firstRunSeen: false,
+  });
+});
+
+afterEach(cleanup);
+
+describe("VoiceTranscriptToggles", () => {
+  test("renders both toggles, off by default, and writes through to the store", () => {
+    render(<VoiceTranscriptToggles />);
+
+    const userToggle = screen.getByRole("switch", {
+      name: "Show the words you say",
+    });
+    const assistantToggle = screen.getByRole("switch", {
+      name: "Show the words the assistant says",
+    });
+
+    expect(userToggle.getAttribute("aria-checked")).toBe("false");
+    expect(assistantToggle.getAttribute("aria-checked")).toBe("false");
+
+    fireEvent.click(userToggle);
+    expect(useVoicePrefsStore.getState().showUserTranscript).toBe(true);
+    expect(useVoicePrefsStore.getState().showAssistantTranscript).toBe(false);
+
+    fireEvent.click(assistantToggle);
+    expect(useVoicePrefsStore.getState().showAssistantTranscript).toBe(true);
+  });
+
+  test("showDescription renders the per-toggle description lines", () => {
+    render(<VoiceTranscriptToggles showDescription />);
+    expect(screen.getByText("Live transcription while you speak.")).toBeTruthy();
+    expect(
+      screen.getByText("Text alongside the spoken response."),
+    ).toBeTruthy();
+  });
+
+  test("showRecommendedBadge renders a 'Recommended off' pill per toggle", () => {
+    render(<VoiceTranscriptToggles showRecommendedBadge />);
+    expect(screen.getAllByText("Recommended off")).toHaveLength(2);
+  });
+});

--- a/clients/web/src/components/voice-transcript-toggles.tsx
+++ b/clients/web/src/components/voice-transcript-toggles.tsx
@@ -1,0 +1,110 @@
+import { Toggle } from "@vellumai/design-library/components/toggle";
+
+import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
+import {
+  VOICE_TRANSCRIPT_TOGGLES,
+  type VoiceTranscriptPrefKey,
+} from "@/utils/voice-transcript-prefs";
+
+/** "Recommended off" pill shown next to a toggle label on the first-run card. */
+function RecommendedOffBadge() {
+  return (
+    <span className="shrink-0 rounded-full bg-[var(--surface-active)] px-2 py-0.5 text-body-small-default text-[var(--content-tertiary)]">
+      Recommended off
+    </span>
+  );
+}
+
+function TranscriptToggleRow({
+  label,
+  description,
+  showBadge,
+  checked,
+  onChange,
+}: {
+  label: string;
+  description?: string;
+  showBadge?: boolean;
+  checked: boolean;
+  onChange: (next: boolean) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 py-1">
+      <div className="min-w-0">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="truncate text-body-medium-lighter text-[var(--content-default)]">
+            {label}
+          </span>
+          {showBadge ? <RecommendedOffBadge /> : null}
+        </div>
+        {description ? (
+          <div className="text-body-small-default text-[var(--content-tertiary)]">
+            {description}
+          </div>
+        ) : null}
+      </div>
+      <Toggle checked={checked} onChange={onChange} aria-label={label} />
+    </div>
+  );
+}
+
+export interface VoiceTranscriptTogglesProps {
+  /** Render each toggle's one-line description beneath its label. */
+  showDescription?: boolean;
+  /** Show a "Recommended off" pill next to each toggle label. */
+  showRecommendedBadge?: boolean;
+}
+
+/**
+ * The two transcript-visibility toggles ("show the words you say" / "...the
+ * assistant says") bound to the shared `voice-prefs` store.
+ *
+ * Rendered by both the Voice settings page and the voice first-run card so the
+ * copy and store wiring live in exactly one place. Each surface supplies its
+ * own surrounding layout (settings `DetailCard`, first-run modal body) and the
+ * closing recommendation line via `VOICE_TRANSCRIPT_RECOMMENDATION`; this
+ * component owns only the repeated rows.
+ */
+export function VoiceTranscriptToggles({
+  showDescription = false,
+  showRecommendedBadge = false,
+}: VoiceTranscriptTogglesProps) {
+  const showUserTranscript = useVoicePrefsStore.use.showUserTranscript();
+  const showAssistantTranscript =
+    useVoicePrefsStore.use.showAssistantTranscript();
+  const setShowUserTranscript = useVoicePrefsStore.use.setShowUserTranscript();
+  const setShowAssistantTranscript =
+    useVoicePrefsStore.use.setShowAssistantTranscript();
+
+  const bindings: Record<
+    VoiceTranscriptPrefKey,
+    { checked: boolean; onChange: (next: boolean) => void }
+  > = {
+    showUserTranscript: {
+      checked: showUserTranscript,
+      onChange: setShowUserTranscript,
+    },
+    showAssistantTranscript: {
+      checked: showAssistantTranscript,
+      onChange: setShowAssistantTranscript,
+    },
+  };
+
+  return (
+    <>
+      {VOICE_TRANSCRIPT_TOGGLES.map((def) => {
+        const binding = bindings[def.prefKey];
+        return (
+          <TranscriptToggleRow
+            key={def.prefKey}
+            label={def.label}
+            description={showDescription ? def.description : undefined}
+            showBadge={showRecommendedBadge}
+            checked={binding.checked}
+            onChange={binding.onChange}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
@@ -1,10 +1,10 @@
 import { Button } from "@vellumai/design-library/components/button";
 import { Modal } from "@vellumai/design-library/components/modal";
-import { Toggle } from "@vellumai/design-library/components/toggle";
 
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
+import { VoiceTranscriptToggles } from "@/components/voice-transcript-toggles";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
-import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
+import { VOICE_TRANSCRIPT_RECOMMENDATION } from "@/utils/voice-transcript-prefs";
 
 /**
  * One-time preferences card shown the first time a user enters voice mode,
@@ -36,36 +36,6 @@ export interface VoiceFirstRunCardProps {
   onDismiss?: () => void;
 }
 
-function RecommendedOffBadge() {
-  return (
-    <span className="shrink-0 rounded-full bg-[var(--surface-active)] px-2 py-0.5 text-body-small-default text-[var(--content-tertiary)]">
-      Recommended off
-    </span>
-  );
-}
-
-function TranscriptToggleRow({
-  label,
-  checked,
-  onChange,
-}: {
-  label: string;
-  checked: boolean;
-  onChange: (next: boolean) => void;
-}) {
-  return (
-    <div className="flex items-center justify-between gap-3 py-1">
-      <div className="flex min-w-0 items-center gap-2">
-        <span className="truncate text-body-medium-lighter text-[var(--content-default)]">
-          {label}
-        </span>
-        <RecommendedOffBadge />
-      </div>
-      <Toggle checked={checked} onChange={onChange} aria-label={label} />
-    </div>
-  );
-}
-
 export function VoiceFirstRunCard({
   assistantId,
   onStart,
@@ -73,13 +43,6 @@ export function VoiceFirstRunCard({
 }: VoiceFirstRunCardProps) {
   const { components, traits, customImageUrl } =
     useAssistantAvatar(assistantId);
-
-  const showUserTranscript = useVoicePrefsStore.use.showUserTranscript();
-  const showAssistantTranscript =
-    useVoicePrefsStore.use.showAssistantTranscript();
-  const setShowUserTranscript = useVoicePrefsStore.use.setShowUserTranscript();
-  const setShowAssistantTranscript =
-    useVoicePrefsStore.use.setShowAssistantTranscript();
 
   return (
     <Modal.Root
@@ -112,19 +75,10 @@ export function VoiceFirstRunCard({
         </Modal.Header>
         <Modal.Body>
           <div className="flex flex-col gap-1">
-            <TranscriptToggleRow
-              label="Show the words you say"
-              checked={showUserTranscript}
-              onChange={setShowUserTranscript}
-            />
-            <TranscriptToggleRow
-              label="Show the words the assistant says"
-              checked={showAssistantTranscript}
-              onChange={setShowAssistantTranscript}
-            />
+            <VoiceTranscriptToggles showRecommendedBadge />
             <p className="pt-2 text-body-small-default text-[var(--content-tertiary)]">
-              You can change these anytime in settings. We recommend keeping
-              both off to start. It feels more like a real conversation.
+              You can change these anytime in settings.{" "}
+              {VOICE_TRANSCRIPT_RECOMMENDATION}
             </p>
           </div>
         </Modal.Body>

--- a/clients/web/src/domains/settings/pages/voice-page.tsx
+++ b/clients/web/src/domains/settings/pages/voice-page.tsx
@@ -14,6 +14,7 @@ import { Dropdown } from "@vellumai/design-library/components/dropdown";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 
 import { DetailCard } from "@/components/detail-card";
+import { VoiceTranscriptToggles } from "@/components/voice-transcript-toggles";
 import {
     getLocalSetting,
     removeLocalSetting,
@@ -38,7 +39,7 @@ import {
     getPreferredInputDeviceId,
 } from "@/utils/voice-input-device";
 import { canConfigureFnPushToTalk } from "@/runtime/hotkey";
-import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
+import { VOICE_TRANSCRIPT_RECOMMENDATION } from "@/utils/voice-transcript-prefs";
 
 const LS_CONVERSATION_TIMEOUT = "vellum:voice:conversationTimeoutSeconds";
 
@@ -90,64 +91,16 @@ export function VoicePage() {
   );
 }
 
-function TranscriptRow({
-  label,
-  description,
-  checked,
-  onChange,
-}: {
-  label: string;
-  description?: string;
-  checked: boolean;
-  onChange: (next: boolean) => void;
-}) {
-  return (
-    <div className="flex items-center justify-between gap-3 py-1">
-      <div>
-        <div className="text-body-medium-lighter text-[var(--content-default)]">
-          {label}
-        </div>
-        {description && (
-          <div className="text-body-small-default text-[var(--content-tertiary)]">
-            {description}
-          </div>
-        )}
-      </div>
-      <Toggle checked={checked} onChange={onChange} aria-label={label} />
-    </div>
-  );
-}
-
 function TranscriptionCard() {
-  const showUserTranscript = useVoicePrefsStore.use.showUserTranscript();
-  const showAssistantTranscript =
-    useVoicePrefsStore.use.showAssistantTranscript();
-  const setShowUserTranscript =
-    useVoicePrefsStore.use.setShowUserTranscript();
-  const setShowAssistantTranscript =
-    useVoicePrefsStore.use.setShowAssistantTranscript();
-
   return (
     <DetailCard
       title="Transcription"
       subtitle="Show live text of what you and the assistant say during a voice conversation."
     >
       <div className="flex flex-col gap-2">
-        <TranscriptRow
-          label="Show the words you say"
-          description="Live transcription while you speak."
-          checked={showUserTranscript}
-          onChange={setShowUserTranscript}
-        />
-        <TranscriptRow
-          label="Show the words the assistant says"
-          description="Text alongside the spoken response."
-          checked={showAssistantTranscript}
-          onChange={setShowAssistantTranscript}
-        />
+        <VoiceTranscriptToggles showDescription />
         <p className={`${labelClasses} pt-1`}>
-          We recommend keeping both off to start. It feels more like a real
-          conversation.
+          {VOICE_TRANSCRIPT_RECOMMENDATION}
         </p>
       </div>
     </DetailCard>

--- a/clients/web/src/utils/voice-transcript-prefs.ts
+++ b/clients/web/src/utils/voice-transcript-prefs.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared copy + toggle definitions for the two-toggle voice "transcription
+ * preferences" UI.
+ *
+ * Both the Voice settings page (`domains/settings/pages/voice-page.tsx`) and
+ * the voice first-run card (`domains/chat/voice/voice-room/`) render the same
+ * pair of transcript-visibility toggles bound to the same `voice-prefs` store.
+ * The user-facing strings and the store-field mapping are single-sourced here
+ * so the two surfaces can't drift.
+ */
+
+/** Fields on `useVoicePrefsStore` that the transcript toggles read/write. */
+export type VoiceTranscriptPrefKey =
+  | "showUserTranscript"
+  | "showAssistantTranscript";
+
+export interface VoiceTranscriptToggleDef {
+  /** Store field this toggle reads/writes on `useVoicePrefsStore`. */
+  prefKey: VoiceTranscriptPrefKey;
+  /** Toggle label; also the toggle's accessible name. */
+  label: string;
+  /** One-line description shown beneath the label (settings surface). */
+  description: string;
+}
+
+export const VOICE_TRANSCRIPT_TOGGLES: readonly VoiceTranscriptToggleDef[] = [
+  {
+    prefKey: "showUserTranscript",
+    label: "Show the words you say",
+    description: "Live transcription while you speak.",
+  },
+  {
+    prefKey: "showAssistantTranscript",
+    label: "Show the words the assistant says",
+    description: "Text alongside the spoken response.",
+  },
+];
+
+/** Closing nudge shown under both surfaces' toggle rows. */
+export const VOICE_TRANSCRIPT_RECOMMENDATION =
+  "We recommend keeping both off to start. It feels more like a real conversation.";


### PR DESCRIPTION
## Summary
- Extract the duplicated transcription toggle row + hardcoded label/recommendation strings into one shared component + constants, consumed by both the Voice settings page and the first-run card, so they can't drift.

Part of plan: voice-mode-ui-overhaul.md (self-review remediation)