### PR TITLE
fix(web): voice-room correctness (sidebar persist, pop-out) + shared predicates/constants

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -299,27 +299,17 @@ export function ChatLayout() {
     consumeSidebarCollapse();
   }, [sidebarCollapseRequested, consumeSidebarCollapse]);
 
-  // The full-screen voice room takes over the viewport, so collapse the sidebar
-  // and blur the chat body while it is visible — then restore the user's prior
-  // collapsed state exactly on exit. Mirrors the research-onboarding
-  // sidebar-collapse pattern above, but fully reversible: the pre-room value is
-  // captured in a ref before forcing (the sentinel `null` means "room not
-  // currently forcing"), so any external session end restores it.
+  // The full-screen voice room takes over the viewport, so the sidebar reads as
+  // collapsed and the chat body blurs while it is visible. This override is
+  // EPHEMERAL — it is OR'd into the rendered collapsed value (`sideMenuCollapsed`
+  // below) rather than routed through `setCollapsed`, so it never touches the
+  // persistence effect above. That matters: forcing the persisted `collapsed`
+  // true (the old approach) let a reload / tab-close mid-session write the
+  // forced value to `localStorage` and leave the sidebar collapsed forever. On
+  // exit the room override simply drops and the sidebar returns to exactly the
+  // user's persisted value — no restore dance needed.
   const voiceRoomVisible = useIsVoiceRoomVisible();
-  const collapsedBeforeRoomRef = useRef<boolean | null>(null);
-  useEffect(() => {
-    if (voiceRoomVisible) {
-      if (collapsedBeforeRoomRef.current === null) {
-        collapsedBeforeRoomRef.current = collapsed;
-        setCollapsed(true);
-      }
-      return;
-    }
-    if (collapsedBeforeRoomRef.current !== null) {
-      setCollapsed(collapsedBeforeRoomRef.current);
-      collapsedBeforeRoomRef.current = null;
-    }
-  }, [voiceRoomVisible, collapsed]);
+  const sideMenuCollapsed = collapsed || voiceRoomVisible;
 
   const drawerVisible = isMobile && drawerOpen;
 
@@ -683,7 +673,7 @@ export function ChatLayout() {
         <ChatLayoutHeader
           isMobile={isMobile}
           drawerOpen={drawerOpen}
-          collapsed={collapsed}
+          collapsed={sideMenuCollapsed}
           sidebarWidth={sidebarWidth}
           toggleSidebar={toggleSidebar}
           topBarCenter={topBarCenter}
@@ -784,7 +774,7 @@ export function ChatLayout() {
             className="shrink-0"
             aria-label="Navigation"
           >
-            {renderSideMenu({ collapsed, variant: "rail", width: sidebarWidth, onWidthChange: handleSidebarWidthChange })}
+            {renderSideMenu({ collapsed: sideMenuCollapsed, variant: "rail", width: sidebarWidth, onWidthChange: handleSidebarWidthChange })}
           </aside>
           <main
             className={`flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden ${mainRoomClass}`}

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.test.tsx
@@ -40,9 +40,13 @@ const OTHER_CONVERSATION_ID = "conv-other";
 const ASSISTANT_ID = "assistant-1";
 
 let mockPathname = routes.conversation(OTHER_CONVERSATION_ID);
+// The pill's visibility is popout-independent by design (it keys off the
+// room's popout-free owning-surface core), so `search` never changes what the
+// pill sees — it exists here only to exercise that invariant explicitly.
+let mockSearch = "";
 const navigateFn = mock(() => {});
 mock.module("react-router", () => ({
-  useLocation: () => ({ pathname: mockPathname }),
+  useLocation: () => ({ pathname: mockPathname, search: mockSearch }),
   useNavigate: () => navigateFn,
 }));
 
@@ -98,6 +102,7 @@ function startSession(
 
 beforeEach(() => {
   mockPathname = routes.conversation(OTHER_CONVERSATION_ID);
+  mockSearch = "";
   mockMainView = "chat";
   mockIsMobile = false;
   mockOwningConversation = {
@@ -311,6 +316,31 @@ describe("VoiceSessionPillHost — standalone variant (headerless pop-outs)", ()
     mockPathname = routes.conversation(OWNING_CONVERSATION_ID);
     const { container } = render(<VoiceSessionPillHost variant="standalone" />);
     expect(container.firstChild).toBeNull();
+  });
+
+  test("in a pop-out, still hides while the composer owns the session (no double control with its voice bar)", () => {
+    // The room is gated off in pop-outs, but the composer's voice bar still
+    // renders there and owns the session — so the standalone pill must keep
+    // deferring to it. The pill's owning-surface complement is popout-free, so
+    // `?popout=1` does not resurrect it.
+    startSession("listening");
+    useConversationStore
+      .getState()
+      .setActiveConversationId(OWNING_CONVERSATION_ID);
+    mockPathname = routes.conversation(OWNING_CONVERSATION_ID);
+    mockSearch = "?popout=1";
+    const { container } = render(<VoiceSessionPillHost variant="standalone" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("in a pop-out, floats the pill once another conversation is viewed", () => {
+    // Complement of the room's pop-out exclusion: with the room gone, the
+    // standalone pill is the pop-out's only session surface when the on-screen
+    // composer does not own the session.
+    startSession("listening");
+    mockSearch = "?popout=1";
+    render(<VoiceSessionPillHost variant="standalone" />);
+    expect(pill()).not.toBeNull();
   });
 
   test("floats the error chip for a failure on a composer-less route", () => {

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
@@ -11,12 +11,16 @@
  * carried to another conversation via in-window switching (Cmd+Up/Down) must
  * still have a visible control.
  *
- * Visibility is the exact complement of the full-screen voice room — the
- * owning-composer surface — so that for any active session exactly one of the
- * two renders. Both derive from the shared {@link useIsVoiceRoomVisible}
- * predicate (session active AND the on-screen composer owns it): the room shows
- * when it is `true`, the pill when a session is active and it is `false`.
- * Concretely, the pill shows when:
+ * Visibility is the exact complement of the owning-composer voice surface — the
+ * one the full-screen voice room also renders against — so that in the main
+ * window, for any active session, exactly one of {room, pill} renders. Both
+ * derive from the shared {@link useOwningComposerSurfaceVisible} predicate
+ * (session active AND the on-screen composer owns it): the pill shows when a
+ * session is active and it is `false`, the room when it is `true` and this is
+ * the main window. Because the pill keys off that popout-free primitive (not
+ * the room's own `!isPopout` gate), a headerless pop-out's standalone pill
+ * still hides while the composer's voice bar owns the session — no double
+ * control. Concretely, the pill shows when:
  *
  * - the user is viewing a different conversation than the session's,
  * - the user is off the chat routes entirely (Home, Library, …) or on a
@@ -54,18 +58,17 @@
  */
 
 import { useCallback } from "react";
-import { useLocation, useNavigate } from "react-router";
+import { useNavigate } from "react-router";
 import type { ReactNode } from "react";
 
-import { useIsMobile } from "@/hooks/use-is-mobile";
 import { navigateToConversation } from "@/utils/conversation-navigation";
-import { isConversationChatPath } from "@/utils/routes";
 
 import {
   VoiceSessionErrorChip,
   VoiceSessionPill,
 } from "@/domains/chat/components/voice-session-pill";
 import { useActiveConversation } from "@/domains/chat/hooks/use-active-conversation";
+import { useComposerOnScreen } from "@/domains/chat/hooks/use-composer-on-screen";
 import {
   LIVE_VOICE_STATE_LABELS,
   dismissLiveVoiceFailure,
@@ -75,8 +78,7 @@ import {
   releaseLiveVoiceTurn,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
-import { useIsVoiceRoomVisible } from "@/domains/chat/voice/voice-room/use-is-voice-room-visible";
-import { useViewerStore } from "@/stores/viewer-store";
+import { useOwningComposerSurfaceVisible } from "@/domains/chat/voice/voice-room/use-is-voice-room-visible";
 
 export interface VoiceSessionPillHostProps {
   /**
@@ -97,27 +99,24 @@ export function VoiceSessionPillHost({
   const sessionAssistantId = useLiveVoiceStore.use.assistantId();
   const sessionConversationId = useLiveVoiceStore.use.conversationId();
 
-  const mainView = useViewerStore.use.mainView();
-  const isMobile = useIsMobile();
-  const location = useLocation();
   const navigate = useNavigate();
 
   const sessionActive = isLiveVoiceSessionActive(state);
-  // Mirror of `chat-content-layout.tsx`: the desktop `app` view replaces
-  // `ChatMainPanel` (composer included); every other view — and mobile's
-  // portal-overlay `app` view — keeps the composer mounted. The strict chat
-  // predicate matters: conversation subroutes like the inspector
-  // (`/assistant/conversations/:id/inspect`) render no composer, so the pill
-  // must stay up there even for the owning conversation. Retained here only for
-  // the failure surface below — the pill's own visibility keys off the room.
-  const composerOnScreen =
-    isConversationChatPath(location.pathname) &&
-    !(mainView === "app" && !isMobile);
-  // Exact complement of the full-screen voice room (the owning-composer
-  // surface): the pill shows for an active session precisely when the room does
-  // not. Both read the one shared predicate so they can never drift.
-  const voiceRoomVisible = useIsVoiceRoomVisible();
-  const visible = sessionActive && !voiceRoomVisible;
+  // Shared with the voice room (see `use-composer-on-screen.ts`): a conversation
+  // chat route is mounted and not covered by the desktop fullscreen app viewer.
+  // The strict chat predicate matters — conversation subroutes like the
+  // inspector (`/assistant/conversations/:id/inspect`) render no composer, so
+  // the pill must stay up there even for the owning conversation. Retained here
+  // only for the failure surface below — the pill's own visibility keys off the
+  // owning-composer surface primitive.
+  const composerOnScreen = useComposerOnScreen();
+  // Exact complement of the owning-composer voice surface: the pill shows for an
+  // active session precisely when that surface is NOT on screen. Both derive
+  // from the one shared predicate so they can never drift. This is the room's
+  // popout-free core — so in a pop-out the pill still hides while the composer's
+  // voice bar owns the session (the room itself never renders there).
+  const owningSurfaceVisible = useOwningComposerSurfaceVisible();
+  const visible = sessionActive && !owningSurfaceVisible;
   // Failure surface: exact complement of the composer's failure Notice, which
   // any on-screen voice-enabled composer renders regardless of ownership.
   const showFailure = state === "failed" && error !== null && !composerOnScreen;

--- a/clients/web/src/domains/chat/hooks/use-composer-on-screen.ts
+++ b/clients/web/src/domains/chat/hooks/use-composer-on-screen.ts
@@ -1,0 +1,35 @@
+/**
+ * Whether the conversation composer (its voice bar included) is currently the
+ * on-screen surface.
+ *
+ * True when a conversation chat route is mounted AND it is not covered by the
+ * desktop fullscreen app viewer. Mirrors the render decision in
+ * `chat-content-layout.tsx`: the desktop `app` view replaces `ChatMainPanel`
+ * (composer included), while every other view — and mobile's portal-overlay
+ * `app` view — keeps the composer mounted. The strict chat predicate
+ * (`isConversationChatPath`) matters because conversation subroutes like the
+ * inspector (`/assistant/conversations/:id/inspect`) render no composer.
+ *
+ * Extracted so the two live-voice surfaces that gate on it — the full-screen
+ * voice room ({@link useIsVoiceRoomVisible}) and the title-bar session pill
+ * ({@link VoiceSessionPillHost}) — derive the predicate from one place and can
+ * never drift.
+ */
+
+import { useLocation } from "react-router";
+
+import { useIsMobile } from "@/hooks/use-is-mobile";
+import { isConversationChatPath } from "@/utils/routes";
+
+import { useViewerStore } from "@/stores/viewer-store";
+
+export function useComposerOnScreen(): boolean {
+  const mainView = useViewerStore.use.mainView();
+  const isMobile = useIsMobile();
+  const location = useLocation();
+
+  return (
+    isConversationChatPath(location.pathname) &&
+    !(mainView === "app" && !isMobile)
+  );
+}

--- a/clients/web/src/domains/chat/voice/voice-room/use-is-voice-room-visible.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-is-voice-room-visible.ts
@@ -3,50 +3,57 @@
  * visible.
  *
  * The room is the owning-composer's voice surface: it shows exactly when a
- * session is active AND the composer currently on screen owns it. That is the
- * precise complement of the title-bar session pill, whose host consumes this
- * hook's negation (`sessionActive && !voiceRoomVisible`) so the two surfaces
- * can never both render — or both hide — for an active owned session.
+ * session is active AND the composer currently on screen owns it AND this is
+ * the main window (never a pop-out — see below). Its popout-free core,
+ * {@link useOwningComposerSurfaceVisible}, is the precise complement of the
+ * title-bar session pill, whose host consumes that primitive's negation
+ * (`sessionActive && !owningSurfaceVisible`) so the two surfaces can never both
+ * render — or both hide — for an active owned session.
  *
  * The inputs mirror {@link VoiceSessionPillHost} one-for-one:
- * - `composerOnScreen` — a conversation chat route is mounted and not covered
- *   by the desktop fullscreen app viewer (mobile's app view keeps the composer
- *   mounted under a portal). Matches `chat-content-layout.tsx`.
+ * - `composerOnScreen` — shared via {@link useComposerOnScreen}: a conversation
+ *   chat route is mounted and not covered by the desktop fullscreen app viewer
+ *   (mobile's app view keeps the composer mounted under a portal).
  * - `activeComposerOwnsSession` — the on-screen composer's conversation owns
  *   the session (`isLiveVoiceSessionOwnedBy`), covering the draft case too.
+ *
+ * Pop-outs: the room is a `fixed inset-0` overlay, so in an Electron pop-out
+ * thread window it would cover the `variant="standalone"` pill that headerless
+ * pop-outs rely on. Pop-outs therefore never show the room — the standalone
+ * pill is their only session surface — so the room predicate ANDs in
+ * `!isPopout`. The pill keeps its own popout-free complement
+ * ({@link useOwningComposerSurfaceVisible}), so in a pop-out it still hides
+ * while the composer's voice bar owns the session (no double control).
  *
  * Deliberately does NOT re-check the `voice-mode` flag: entry already gated the
  * session, and a live session keeps its UI even if the flag later flips (the
  * mid-session-eligibility-drop invariant).
  */
 
+import { useState } from "react";
 import { useLocation } from "react-router";
 
-import { useIsMobile } from "@/hooks/use-is-mobile";
-import { isConversationChatPath } from "@/utils/routes";
+import { isPopoutWindow } from "@/runtime/popout-window";
 
+import { useComposerOnScreen } from "@/domains/chat/hooks/use-composer-on-screen";
 import {
   isLiveVoiceSessionActive,
   useIsLiveVoiceSessionOwnedBy,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 import { useConversationStore } from "@/stores/conversation-store";
-import { useViewerStore } from "@/stores/viewer-store";
 
 /**
- * Whether the full-screen voice room should render. See the module docstring
- * for the exact-complement contract with the title-bar session pill.
+ * Whether the owning composer's voice surface is currently on screen for the
+ * active session — session active AND the on-screen composer owns it. The
+ * popout-free primitive shared by the room and the pill: the room adds the
+ * main-window gate ({@link useIsVoiceRoomVisible}); the pill shows for an active
+ * session precisely when this is `false`.
  */
-export function useIsVoiceRoomVisible(): boolean {
+export function useOwningComposerSurfaceVisible(): boolean {
   const state = useLiveVoiceStore.use.state();
   const activeConversationId = useConversationStore.use.activeConversationId();
-  const mainView = useViewerStore.use.mainView();
-  const isMobile = useIsMobile();
-  const location = useLocation();
-
-  const composerOnScreen =
-    isConversationChatPath(location.pathname) &&
-    !(mainView === "app" && !isMobile);
+  const composerOnScreen = useComposerOnScreen();
   const activeComposerOwnsSession =
     useIsLiveVoiceSessionOwnedBy(activeConversationId);
 
@@ -55,4 +62,21 @@ export function useIsVoiceRoomVisible(): boolean {
     composerOnScreen &&
     activeComposerOwnsSession
   );
+}
+
+/**
+ * Whether the full-screen voice room should render. See the module docstring
+ * for the exact-complement contract with the title-bar session pill and the
+ * pop-out exclusion.
+ */
+export function useIsVoiceRoomVisible(): boolean {
+  const owningSurfaceVisible = useOwningComposerSurfaceVisible();
+  const location = useLocation();
+  // Capture pop-out mode once at mount: pop-out URLs carry `?popout=1` only on
+  // the window's initial load (in-window navigation drops the query), and this
+  // hook is consumed at persistent layout scope, so the mount-time value is the
+  // window's lifetime value — mirroring `ChatLayout`'s own capture.
+  const [isPopout] = useState(() => isPopoutWindow(location.search));
+
+  return owningSurfaceVisible && !isPopout;
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar.tsx
@@ -4,14 +4,13 @@ import { useEffect, useLayoutEffect, useRef } from "react";
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 
+import { AVATAR_VISUAL_SPRING } from "./voice-motion";
 import type { VoiceAvatarVisual } from "./voice-avatar-state";
 
 /**
- * Enter/scale spring played when the visual changes. Mirrors the app's
- * overshoot convention (constellation `NODE_SPRING`); `responding` gets a
- * bouncier pop to read as a burst of energy.
+ * Bouncier pop for the `responding` visual — reads as a burst of energy. The
+ * default per-visual spring is the shared `AVATAR_VISUAL_SPRING`.
  */
-const ENTER_SPRING = { type: "spring" as const, stiffness: 180, damping: 20 };
 const RESPOND_SPRING = {
   type: "spring" as const,
   visualDuration: 0.3,
@@ -107,7 +106,7 @@ export function VoiceAvatar({
     ? { duration: 0 }
     : visual === "responding"
       ? RESPOND_SPRING
-      : ENTER_SPRING;
+      : AVATAR_VISUAL_SPRING;
 
   return (
     <motion.div

--- a/clients/web/src/domains/chat/voice/voice-room/voice-motion.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-motion.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared motion-spring constants for the live-voice room surfaces.
+ *
+ * Kept here — inside the voice domain — so `voice-avatar.tsx` and
+ * `voice-room.tsx` declare each spring once instead of hand-copying it, without
+ * reaching into the constellation domain for its `NODE_SPRING`. The two springs
+ * are intentionally different tunings, so both live here as named exports.
+ */
+
+/**
+ * Avatar enter/scale spring replayed on each discrete visual change (see
+ * `voice-avatar.tsx`). Value-identical to the app's constellation `NODE_SPRING`
+ * overshoot convention.
+ */
+export const AVATAR_VISUAL_SPRING = {
+  type: "spring" as const,
+  stiffness: 180,
+  damping: 20,
+};
+
+/**
+ * Room entry spring (see `voice-room.tsx`): the avatar rises from a smaller,
+ * lower offset to center with a slightly stiffer overshoot than the per-visual
+ * spring.
+ */
+export const AVATAR_ENTER_SPRING = {
+  type: "spring" as const,
+  stiffness: 200,
+  damping: 18,
+};

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -36,8 +36,11 @@ const OTHER_CONVERSATION_ID = "conv-other";
 const ASSISTANT_ID = "assistant-1";
 
 let mockPathname = routes.conversation(OWNING_CONVERSATION_ID);
+// `search` feeds the room's pop-out gate (`isPopoutWindow`): "" is the main
+// window, "?popout=1" is an Electron pop-out thread window.
+let mockSearch = "";
 mock.module("react-router", () => ({
-  useLocation: () => ({ pathname: mockPathname }),
+  useLocation: () => ({ pathname: mockPathname, search: mockSearch }),
 }));
 
 let mockMainView: MainView = "chat";
@@ -80,6 +83,7 @@ function startOwnedSession(state: LiveVoiceSessionState = "listening") {
 
 beforeEach(() => {
   mockPathname = routes.conversation(OWNING_CONVERSATION_ID);
+  mockSearch = "";
   mockMainView = "chat";
   mockIsMobile = false;
   controls.stop.mockClear();
@@ -129,6 +133,16 @@ describe("VoiceRoom — visibility", () => {
   test("renders nothing over the desktop fullscreen app viewer (composer replaced)", () => {
     startOwnedSession("listening");
     mockMainView = "app";
+    render(<VoiceRoom />);
+    expect(roomDialog()).toBeNull();
+  });
+
+  test("renders nothing in an Electron pop-out even when the composer owns the session", () => {
+    // The `fixed inset-0` room would cover the pop-out's standalone pill, so
+    // pop-outs never show it — the standalone pill is their only session
+    // surface. The owning composer's voice bar still renders underneath.
+    startOwnedSession("listening");
+    mockSearch = "?popout=1";
     render(<VoiceRoom />);
     expect(roomDialog()).toBeNull();
   });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -36,19 +36,9 @@ import {
 import { toVoiceAvatarVisual } from "./voice-avatar-state";
 import { VoiceAmbientTranscript } from "./voice-ambient-transcript";
 import { VoiceAvatar } from "./voice-avatar";
+import { AVATAR_ENTER_SPRING } from "./voice-motion";
 import { VoiceRoomAmbientBackground } from "./voice-room-ambient-background";
 import { useIsVoiceRoomVisible } from "./use-is-voice-room-visible";
-
-/**
- * Avatar entry spring: rises from a smaller, lower offset to center with a
- * slight overshoot. Mirrors the app's `NODE_SPRING` overshoot convention
- * (defined locally to avoid a cross-domain import, as `voice-avatar.tsx` does).
- */
-const AVATAR_ENTER_SPRING = {
-  type: "spring" as const,
-  stiffness: 200,
-  damping: 18,
-};
 
 const AVATAR_SIZE = 220;
 /** The one-time "how to speak" hint auto-dismisses after this long. */


### PR DESCRIPTION
## Summary
- Fix: room no longer persists a forced sidebar collapse (ephemeral override), so a reload mid-session can't leave the sidebar collapsed.
- Fix: room is gated off in pop-out windows (they keep the standalone pill); no cross-window localStorage side effect.
- Cleanup: shared useComposerOnScreen() hook (room + pill) and a shared voice motion-constants module.

Part of plan: voice-mode-ui-overhaul.md (self-review remediation)