### PR TITLE
marketplace: add google-drive-search plugin

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -208,6 +208,18 @@
       "category": "lifestyle",
       "homepage": "https://github.com/AnitaKirkovska/amex-perk-reminder",
       "license": "MIT"
+    },
+    {
+      "name": "google-drive-search",
+      "source": {
+        "source": "github",
+        "repo": "ZeebBoyBlue/google-drive-search",
+        "ref": "ddd5013477cc1ec8d1fb174db6b599dbfe1cca21"
+      },
+      "description": "Local full-text search across your Google Drive. Indexes file metadata and document content into SQLite FTS5 for instant, private search.",
+      "category": "productivity",
+      "homepage": "https://github.com/ZeebBoyBlue/google-drive-search",
+      "license": "Apache-2.0"
     }
   ]
 }


### PR DESCRIPTION
Adds **google-drive-search** to the plugin marketplace.

**Repo:** https://github.com/ZeebBoyBlue/google-drive-search
**Pinned commit:** `ddd5013477cc1ec8d1fb174db6b599dbfe1cca21`

Local full-text search across Google Drive for the Vellum assistant:
- Three tools: `drive_search`, `drive_status`, `drive_index`
- SQLite FTS5 index built and stored locally — document content never leaves the machine
- Auth via the daemon's managed Google OAuth connection (no raw tokens handled)
- Manifest: unscoped kebab-case name, `@vellumai/plugin-api` peerDep `^0.8.0`

Verified locally: `assistant plugins list` shows status `ok`, all three tools exercised end-to-end (768 files indexed, search returns names/paths/snippets/links).