### PR TITLE
fix(web): animate entry of the first staged quote-reply chip

### DIFF
--- a/clients/web/src/domains/chat/components/staged-quotes-strip.stories.tsx
+++ b/clients/web/src/domains/chat/components/staged-quotes-strip.stories.tsx
@@ -70,3 +70,8 @@ export const Overflowing: Story = {
 export const Single: Story = {
   render: () => <StripHarness initialCount={1} />,
 };
+
+/** Starts empty; click "Stage another" to confirm the very first chip animates in. */
+export const Empty: Story = {
+  render: () => <StripHarness initialCount={0} />,
+};

--- a/clients/web/src/domains/chat/components/staged-quotes-strip.tsx
+++ b/clients/web/src/domains/chat/components/staged-quotes-strip.tsx
@@ -137,7 +137,13 @@ export function StagedQuotesStrip() {
       className="mb-2 max-h-[140px]"
     >
       <div className="flex flex-col gap-1.5">
-        <AnimatePresence initial={false}>
+        {/*
+         * `initial` is left at its default (true) so the first chip animates in
+         * too: this subtree unmounts whenever the strip is empty and remounts
+         * on the 0→1 transition, so that first chip is present at mount and
+         * would otherwise be skipped by `initial={false}`.
+         */}
+        <AnimatePresence>
           {stagedQuotes.map((quote) => (
             <motion.div
               key={quote.id}


### PR DESCRIPTION
Follow-up to #37532. The quote-reply context cards animate in/out with `motion`, but the **very first** card added to an empty strip did not animate — only the second and later cards did.

## Root cause
`StagedQuotesStrip` returns `null` when there are no staged quotes, so its `AnimatePresence` subtree unmounts and remounts on the 0→1 transition. `AnimatePresence initial={false}` suppresses the entrance animation of children that are present when it *first* mounts — which is exactly the first chip every time the strip reappears. Subsequent chips animate because `AnimatePresence` is already mounted by then.

## Fix
Drop `initial={false}`. That prop exists to *skip* the mount animation, but this subtree genuinely mounts fresh each time a first quote appears, so the mount animation is what we want. The first chip now runs the same height/opacity/scale entrance transition (and `prefers-reduced-motion` fallback) as every later chip.

Also adds an `Empty` Storybook story (`Chat/StagedQuotesStrip`) that starts with zero quotes, so the 0→first-chip transition — the previously-broken path — is directly exercisable.

## Verification
- `clients/web` typecheck, lint, and the 8 quote-reply component tests pass.
- Drove the new `Empty` story in a browser: clicking "Stage another quote" mounts the first chip at `opacity: 0, height: 0` (the entrance `initial` state) and grows it to `opacity: 1, height: auto` — before this change the first chip rendered straight at its final state with no animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->