### PR TITLE
feat(web): make mid-turn tool-result images openable and downloadable

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/tool-result-images.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/tool-result-images.tsx
@@ -10,8 +10,8 @@ import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { DisplayAttachment } from "@/types/attachment-types";
 
-function inferImageMimeType(imageData: string): string {
-  const normalized = imageData.replace(/\s/g, "");
+function inferImageMimeType(base64: string): string {
+  const normalized = base64.replace(/\s/g, "");
   if (normalized.startsWith("iVBORw0KGgo")) {
     return "image/png";
   }
@@ -30,12 +30,34 @@ function inferImageMimeType(imageData: string): string {
   return "image/png";
 }
 
-function toolResultImageSrc(imageData: string, mimeType: string): string {
+const DATA_URI_RE = /^data:(image\/[a-z0-9.+-]+);base64,/i;
+
+/**
+ * Normalize a tool-result image payload — either raw base64 or a full
+ * `data:image/...;base64,` URI — into its MIME type, bare base64 payload, and
+ * a `data:` URL `src`. Data URIs carry their MIME type in the prefix; raw
+ * payloads fall back to magic-byte sniffing.
+ */
+function normalizeToolResultImage(imageData: string): {
+  mimeType: string;
+  base64: string;
+  src: string;
+} {
   const trimmed = imageData.trim();
-  if (/^data:image\/[a-z0-9.+-]+;base64,/i.test(trimmed)) {
-    return trimmed;
+  const dataUriMatch = trimmed.match(DATA_URI_RE);
+  if (dataUriMatch) {
+    return {
+      mimeType: dataUriMatch[1]!.toLowerCase(),
+      base64: trimmed.slice(dataUriMatch[0].length),
+      src: trimmed,
+    };
   }
-  return `data:${mimeType};base64,${trimmed}`;
+  const mimeType = inferImageMimeType(trimmed);
+  return {
+    mimeType,
+    base64: trimmed,
+    src: `data:${mimeType};base64,${trimmed}`,
+  };
 }
 
 /**
@@ -58,9 +80,10 @@ function toolNameToFilePrefix(toolName?: string): string {
  * Project a message's tool-result images into synthetic {@link DisplayAttachment}
  * objects. The base64 payload is embedded directly as a data-URL `previewUrl`,
  * so the preview modal renders it without a daemon fetch and downloads save the
- * bytes straight from the URL. Filenames mirror the server's eventual naming
- * (`<tool-prefix>.png`); a tool that emits more than one image gets an index
- * suffix so the names stay distinct.
+ * bytes straight from the URL. Filenames use the server's `<tool-prefix>.<ext>`
+ * naming; a tool that emits more than one image additionally gets an index
+ * suffix so the names stay distinct (the server keeps same-named attachments
+ * apart by id instead).
  */
 function buildToolResultAttachments(
   toolCalls: ChatMessageToolCall[],
@@ -76,7 +99,7 @@ function buildToolResultAttachments(
     const prefix = toolNameToFilePrefix(tc.name);
     images.forEach((imageData, i) => {
       globalIndex += 1;
-      const mimeType = inferImageMimeType(imageData);
+      const { mimeType, base64, src } = normalizeToolResultImage(imageData);
       const ext = mimeType.split("/")[1] ?? "png";
       const base = tc.name ? prefix : `image-${globalIndex}`;
       const suffix = images.length > 1 ? `-${i + 1}` : "";
@@ -84,8 +107,8 @@ function buildToolResultAttachments(
         id: `tool-image:${tc.id}:${i}`,
         filename: `${base}${suffix}.${ext}`,
         mimeType,
-        sizeBytes: estimateBase64Bytes(imageData),
-        previewUrl: toolResultImageSrc(imageData, mimeType),
+        sizeBytes: estimateBase64Bytes(base64),
+        previewUrl: src,
       });
     });
   }

--- a/clients/web/src/domains/chat/components/chat-attachments/tool-result-images.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/tool-result-images.tsx
@@ -1,0 +1,182 @@
+import { Download } from "lucide-react";
+import type { FC } from "react";
+import { useCallback, useMemo } from "react";
+
+import { Tooltip } from "@vellumai/design-library";
+
+import { downloadAttachment } from "@/domains/chat/components/chat-attachments/download-attachment";
+import { estimateBase64Bytes } from "@/domains/chat/components/chat-attachments/utils";
+import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments/use-attachment-preview";
+import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
+import type { DisplayAttachment } from "@/types/attachment-types";
+
+function inferImageMimeType(imageData: string): string {
+  const normalized = imageData.replace(/\s/g, "");
+  if (normalized.startsWith("iVBORw0KGgo")) {
+    return "image/png";
+  }
+  if (normalized.startsWith("/9j/")) {
+    return "image/jpeg";
+  }
+  if (normalized.startsWith("UklGR")) {
+    return "image/webp";
+  }
+  if (normalized.startsWith("R0lGOD")) {
+    return "image/gif";
+  }
+  if (normalized.startsWith("Qk")) {
+    return "image/bmp";
+  }
+  return "image/png";
+}
+
+function toolResultImageSrc(imageData: string, mimeType: string): string {
+  const trimmed = imageData.trim();
+  if (/^data:image\/[a-z0-9.+-]+;base64,/i.test(trimmed)) {
+    return trimmed;
+  }
+  return `data:${mimeType};base64,${trimmed}`;
+}
+
+/**
+ * Derive a human-friendly filename prefix from the tool name that produced the
+ * image. Mirrors the daemon's `toolNameToFilePrefix` in
+ * `assistant/src/daemon/assistant-attachments.ts` so a mid-turn image carries
+ * the same name the server assigns once the turn completes.
+ */
+function toolNameToFilePrefix(toolName?: string): string {
+  if (!toolName) {
+    return "tool-output";
+  }
+  return toolName
+    .replace(/([a-z])([A-Z])/g, "$1-$2")
+    .replace(/_/g, "-")
+    .toLowerCase();
+}
+
+/**
+ * Project a message's tool-result images into synthetic {@link DisplayAttachment}
+ * objects. The base64 payload is embedded directly as a data-URL `previewUrl`,
+ * so the preview modal renders it without a daemon fetch and downloads save the
+ * bytes straight from the URL. Filenames mirror the server's eventual naming
+ * (`<tool-prefix>.png`); a tool that emits more than one image gets an index
+ * suffix so the names stay distinct.
+ */
+function buildToolResultAttachments(
+  toolCalls: ChatMessageToolCall[],
+): DisplayAttachment[] {
+  const attachments: DisplayAttachment[] = [];
+  let globalIndex = 0;
+  for (const tc of toolCalls) {
+    const images = tc.imageDataList?.length
+      ? tc.imageDataList
+      : tc.imageData
+        ? [tc.imageData]
+        : [];
+    const prefix = toolNameToFilePrefix(tc.name);
+    images.forEach((imageData, i) => {
+      globalIndex += 1;
+      const mimeType = inferImageMimeType(imageData);
+      const ext = mimeType.split("/")[1] ?? "png";
+      const base = tc.name ? prefix : `image-${globalIndex}`;
+      const suffix = images.length > 1 ? `-${i + 1}` : "";
+      attachments.push({
+        id: `tool-image:${tc.id}:${i}`,
+        filename: `${base}${suffix}.${ext}`,
+        mimeType,
+        sizeBytes: estimateBase64Bytes(imageData),
+        previewUrl: toolResultImageSrc(imageData, mimeType),
+      });
+    });
+  }
+  return attachments;
+}
+
+interface ToolResultImagesProps {
+  toolCalls: ChatMessageToolCall[];
+  /** When true, end-of-turn `message.attachments` have arrived and render the
+   *  interactive chips, so the mid-turn strip suppresses itself. */
+  hasAttachments: boolean;
+  assistantId?: string | null;
+}
+
+/**
+ * Inline strip of images returned by tool results during an assistant turn
+ * (e.g. `file_read` on an image, generated images). Each image opens the shared
+ * full-screen {@link AttachmentPreviewModal} on click and exposes a hover
+ * download affordance — the same interactivity end-of-turn attachments get via
+ * {@link MessageAttachmentSquare} — while the base64 payloads are not yet
+ * persisted attachments with daemon ids.
+ */
+export const ToolResultImages: FC<ToolResultImagesProps> = ({
+  toolCalls,
+  hasAttachments,
+  assistantId,
+}) => {
+  const attachments = useMemo(
+    () => (hasAttachments ? [] : buildToolResultAttachments(toolCalls)),
+    [toolCalls, hasAttachments],
+  );
+  const { openPreview, previewModal } = useAttachmentPreview(
+    assistantId,
+    attachments,
+  );
+
+  const handleDownload = useCallback((att: DisplayAttachment) => {
+    // No daemon id backs these data-URL images, so download saves the
+    // `previewUrl` bytes directly (assistantId omitted skips the fetch path).
+    void downloadAttachment(att, undefined);
+  }, []);
+
+  if (attachments.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className="flex w-full flex-wrap gap-2">
+        {attachments.map((att) => (
+          <div
+            key={att.id}
+            role="button"
+            aria-label={att.filename}
+            title={att.filename}
+            tabIndex={0}
+            onClick={() => openPreview(att)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                openPreview(att);
+              }
+            }}
+            className="group/toolimg relative w-fit cursor-pointer"
+          >
+            <img
+              data-testid="tool-result-image"
+              src={att.previewUrl!}
+              alt={att.filename}
+              className="max-h-72 max-w-full rounded-md border border-[var(--border-base)] bg-[var(--surface-base)] object-contain sm:max-w-[28rem]"
+            />
+            <div className="pointer-events-none absolute inset-0 rounded-md bg-black/50 opacity-0 transition-opacity group-hover/toolimg:pointer-events-auto group-hover/toolimg:opacity-100 group-focus-within/toolimg:pointer-events-auto group-focus-within/toolimg:opacity-100">
+              <Tooltip content="Download">
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleDownload(att);
+                  }}
+                  onKeyDown={(e) => e.stopPropagation()}
+                  aria-label={`Download ${att.filename}`}
+                  className="absolute bottom-1 right-1 flex h-6 w-6 items-center justify-center rounded-md text-white/80 transition-colors hover:bg-white/20 hover:text-white"
+                >
+                  <Download className="h-3.5 w-3.5" />
+                </button>
+              </Tooltip>
+            </div>
+          </div>
+        ))}
+      </div>
+      {previewModal}
+    </>
+  );
+};

--- a/clients/web/src/domains/chat/components/chat-attachments/tool-result-images.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/tool-result-images.tsx
@@ -63,8 +63,9 @@ function normalizeToolResultImage(imageData: string): {
 /**
  * Derive a human-friendly filename prefix from the tool name that produced the
  * image. Mirrors the daemon's `toolNameToFilePrefix` in
- * `assistant/src/daemon/assistant-attachments.ts` so a mid-turn image carries
- * the same name the server assigns once the turn completes.
+ * `assistant/src/daemon/assistant-attachments.ts` so mid-turn names share the
+ * server's `<tool-prefix>` base (see {@link buildToolResultAttachments} for
+ * where the client intentionally adds a multi-image index suffix).
  */
 function toolNameToFilePrefix(toolName?: string): string {
   if (!toolName) {

--- a/clients/web/src/domains/chat/components/chat-attachments/utils.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/utils.ts
@@ -115,6 +115,18 @@ export function classifyAttachment(mimeType: string, filename: string): Attachme
 }
 
 /**
+ * Estimate the decoded byte length of a base64-encoded string, accounting for
+ * trailing `=` padding. Mirrors the daemon's `estimateBase64Bytes` so
+ * client-derived sizes for inline tool-result images agree with the sizes the
+ * server later assigns to the persisted attachments.
+ */
+export function estimateBase64Bytes(base64: string): number {
+  const trimmed = base64.replace(/\s/g, "");
+  const padding = trimmed.endsWith("==") ? 2 : trimmed.endsWith("=") ? 1 : 0;
+  return Math.max(0, Math.floor((trimmed.length * 3) / 4) - padding);
+}
+
+/**
  * Decode a base64 data URI into a Uint8Array. Returns null if the URI does
  * not contain a recognizable `;base64,` segment.
  */

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -7,7 +7,7 @@ import {
   test,
 } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 
 // The transcript transitively pulls in the viewer store → the generated daemon
 // SDK (not built in CI/worktree checkouts). Stub the two endpoints it references
@@ -178,6 +178,15 @@ mock.module(
   }),
 );
 
+// The mid-turn tool-result image strip downloads data-URL bytes through
+// `downloadAttachment`, which lazily imports the native-file bridge. Stub it so
+// clicking Download records the call without touching Capacitor / DOM anchors.
+const saveFileMock = mock(async () => {});
+mock.module("@/runtime/native-file", () => ({
+  saveFile: saveFileMock,
+}));
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ConversationContentBlock } from "@vellumai/assistant-api";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { DisplayMessage, Surface } from "@/domains/chat/types/types";
@@ -636,6 +645,117 @@ describe("TranscriptMessageBody", () => {
     expect(image?.getAttribute("src")).toBe(
       `data:image/jpeg;base64,${jpegData}`,
     );
+  });
+
+  test("mid-turn tool-result images are keyboard-operable and named from the tool", () => {
+    const toolCall: ChatMessageToolCall = {
+      id: "tc-fileread",
+      name: "file_read",
+      input: { path: "/tmp/diagram.png" },
+      result: "Read 1 image",
+      imageDataList: ["img-a"],
+      completedAt: 1,
+    };
+    const { container } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "m-fileread-image",
+          role: "assistant",
+          contentBlocks: [toolUseBlock(toolCall)],
+          toolCalls: [toolCall],
+          timestamp: 1_000,
+        }}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    const image = container.querySelector("[data-testid='tool-result-image']");
+    const clickable = image?.closest("[role='button']");
+    expect(clickable).not.toBeNull();
+    // Filename mirrors the daemon's `toolNameToFilePrefix` (`file_read` →
+    // `file-read.png`), surfaced as the accessible label and download label.
+    expect(clickable!.getAttribute("aria-label")).toBe("file-read.png");
+    expect(clickable!.getAttribute("tabindex")).toBe("0");
+    const download = container.querySelector(
+      "[aria-label='Download file-read.png']",
+    );
+    expect(download).not.toBeNull();
+  });
+
+  test("clicking a mid-turn tool-result image opens the shared preview", () => {
+    const toolCall: ChatMessageToolCall = {
+      id: "tc-open",
+      name: "media_generate_image",
+      input: { prompt: "diagram" },
+      result: "Generated 1 image",
+      imageDataList: ["img-a"],
+      completedAt: 1,
+    };
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const { container } = render(
+      <QueryClientProvider client={client}>
+        <TranscriptMessageBody
+          message={{
+            id: "m-open-preview",
+            role: "assistant",
+            contentBlocks: [toolUseBlock(toolCall)],
+            toolCalls: [toolCall],
+            timestamp: 1_000,
+          }}
+          onSurfaceAction={noop}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(document.querySelector("[role='dialog']")).toBeNull();
+    const clickable = container
+      .querySelector("[data-testid='tool-result-image']")
+      ?.closest("[role='button']");
+    fireEvent.click(clickable!);
+
+    // The reused AttachmentPreviewModal portals into document.body.
+    const dialog = document.querySelector("[role='dialog']");
+    expect(dialog).not.toBeNull();
+    expect(dialog!.getAttribute("aria-label")).toBe(
+      "Preview of media-generate-image.png",
+    );
+  });
+
+  test("downloading a mid-turn tool-result image saves the data-URL bytes", async () => {
+    saveFileMock.mockClear();
+    const toolCall: ChatMessageToolCall = {
+      id: "tc-dl",
+      name: "file_read",
+      input: { path: "/tmp/shot.png" },
+      result: "Read 1 image",
+      imageDataList: ["img-a"],
+      completedAt: 1,
+    };
+    const { container } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "m-download-image",
+          role: "assistant",
+          contentBlocks: [toolUseBlock(toolCall)],
+          toolCalls: [toolCall],
+          timestamp: 1_000,
+        }}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    const download = container.querySelector(
+      "[aria-label='Download file-read.png']",
+    );
+    fireEvent.click(download!);
+    await waitFor(() => {
+      expect(saveFileMock).toHaveBeenCalledWith(
+        "data:image/png;base64,img-a",
+        "file-read.png",
+      );
+    });
   });
 
   test("a tool + thinking run still renders the boxed activity card", () => {

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -12,6 +12,7 @@ import {
 import { BubbleAttachments } from "@/domains/chat/components/chat-attachments/bubble-attachments";
 import { downloadAttachment } from "@/domains/chat/components/chat-attachments/download-attachment";
 import { MessageAttachments } from "@/domains/chat/components/chat-attachments/message-attachments";
+import { ToolResultImages } from "@/domains/chat/components/chat-attachments/tool-result-images";
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
 import { toast } from "@vellumai/design-library";
 import { MessageHoverActions } from "@/domains/chat/components/message-hover-actions/message-hover-actions";
@@ -62,24 +63,6 @@ import {
   type TranscriptMessageBodyProps,
   workflowRunIdForCall,
 } from "@/domains/chat/transcript/transcript-message-body-shared";
-
-function inferImageMimeType(imageData: string): string {
-  const normalized = imageData.replace(/\s/g, "");
-  if (normalized.startsWith("iVBORw0KGgo")) return "image/png";
-  if (normalized.startsWith("/9j/")) return "image/jpeg";
-  if (normalized.startsWith("UklGR")) return "image/webp";
-  if (normalized.startsWith("R0lGOD")) return "image/gif";
-  if (normalized.startsWith("Qk")) return "image/bmp";
-  return "image/png";
-}
-
-function toolResultImageSrc(imageData: string): string {
-  const trimmed = imageData.trim();
-  if (/^data:image\/[a-z0-9.+-]+;base64,/i.test(trimmed)) {
-    return trimmed;
-  }
-  return `data:${inferImageMimeType(trimmed)};base64,${trimmed}`;
-}
 
 /**
  * Renders a `DisplayMessage`'s body by walking its unified `contentBlocks`
@@ -438,27 +421,13 @@ export function TranscriptMessageBody({
     );
   };
 
-  const renderToolResultImages = (toolCalls: ChatMessageToolCall[]) => {
-    if (hasAttachments) return null;
-    const images = toolCalls.flatMap((tc) => {
-      if (tc.imageDataList?.length) return tc.imageDataList;
-      return tc.imageData ? [tc.imageData] : [];
-    });
-    if (images.length === 0) return null;
-    return (
-      <div className="flex w-full flex-wrap gap-2">
-        {images.map((imageData, index) => (
-          <img
-            key={`tool-result-image-${index}`}
-            data-testid="tool-result-image"
-            src={toolResultImageSrc(imageData)}
-            alt={`Generated image ${index + 1}`}
-            className="max-h-72 max-w-full rounded-md border border-[var(--border-base)] bg-[var(--surface-base)] object-contain sm:max-w-[28rem]"
-          />
-        ))}
-      </div>
-    );
-  };
+  const renderToolResultImages = (toolCalls: ChatMessageToolCall[]) => (
+    <ToolResultImages
+      toolCalls={toolCalls}
+      hasAttachments={hasAttachments}
+      assistantId={assistantId}
+    />
+  );
 
   const renderSurfaceNode = (
     surface: ConversationMessageSurface,


### PR DESCRIPTION
Fixes JARVIS-1261

During an assistant turn, images returned by tool results (e.g. `file_read` on an image, generated images) render as inert inline `<img>`s — they only become clickable once the turn completes and `message_complete` swaps in the interactive `MessageAttachments` chips. This gives the mid-turn strip the same affordances as the end-of-turn attachments.

## What changed

- New `ToolResultImages` component extracts the mid-turn strip from `TranscriptMessageBody`. Each base64 tool-result image is projected into a synthetic `DisplayAttachment` whose `previewUrl` is the data URL, so the **existing** `useAttachmentPreview` → `AttachmentPreviewModal` stack renders it full-screen with zero daemon fetch and no forked modal.
- Click (or Enter/Space — the image is a keyboard-operable `role="button"` region) opens the shared full-screen preview; hover reveals the same bottom-right download affordance as `MessageAttachmentSquare`. Download saves the data-URL bytes via the existing `downloadAttachment` path.
- Filenames mirror the daemon's `toolNameToFilePrefix` naming (`file_read` → `file-read.png`, index-suffixed for multi-image tools) so the mid-turn name matches what the server assigns at end of turn; sizes come from a client `estimateBase64Bytes` matching the daemon estimator.
- Strip layout/classes (`max-h-72` etc.) unchanged — this adds interactivity, not a redesign.

## Test plan

- `bunx tsc --noEmit` (clients/web): clean
- `bun test transcript-message-body.test.tsx`: 35 pass, including 3 new tests (open-preview on click/keyboard, filename derivation, download)
- `attachment-preview-modal` + `bubble-attachments` suites: 15 pass, no regressions

## Note for review

The hover overlay reuses `MessageAttachmentSquare`'s full `bg-black/50` dim for consistency; on a large `max-h-72` image it reads heavier than on a 64px chip. Easy to swap for a bottom-corner scrim if it feels heavy in QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->