### PR TITLE
feat(workspace): boot ensure pass materializes partial custom profiles (M6 PR3)

### DIFF
--- a/assistant/src/__tests__/custom-profile-ensure.test.ts
+++ b/assistant/src/__tests__/custom-profile-ensure.test.ts
@@ -127,6 +127,28 @@ describe("ensureCompleteCustomProfiles", () => {
     expect(after).toBe(before);
   });
 
+  test("preserves nested unknown keys on materialized entries", () => {
+    writeConfig({
+      llm: {
+        default: distinctiveDefault,
+        profiles: {
+          partial: {
+            source: "user",
+            model: "claude-haiku-4-5-20251001",
+            contextWindow: { futureField: "keep-me", maxInputTokens: 111 },
+          },
+        },
+      },
+    });
+    ensureCompleteCustomProfiles(workspaceDir);
+    const contextWindow = readProfiles().partial.contextWindow as Record<
+      string,
+      unknown
+    >;
+    expect(contextWindow.futureField).toBe("keep-me");
+    expect(contextWindow.maxInputTokens).toBe(111);
+  });
+
   test("preserves unknown keys on materialized entries", () => {
     writeConfig({
       llm: {

--- a/assistant/src/__tests__/custom-profile-ensure.test.ts
+++ b/assistant/src/__tests__/custom-profile-ensure.test.ts
@@ -1,0 +1,210 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { LLMConfigBase } from "../config/schemas/llm.js";
+import { ensureCompleteCustomProfiles } from "../workspace/custom-profile-ensure.js";
+
+let workspaceDir: string;
+
+const distinctiveDefault = {
+  provider: "anthropic",
+  provider_connection: "anthropic-personal",
+  model: "claude-opus-4-8",
+  maxTokens: 12345,
+  temperature: 0.7,
+  logitBias: "suppress-cjk",
+};
+
+function writeConfig(config: unknown): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(config, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function readProfiles(): Record<string, Record<string, unknown>> {
+  return (readConfig().llm as { profiles: Record<string, never> }).profiles;
+}
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "custom-profile-ensure-"));
+});
+
+afterEach(() => {
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+describe("ensureCompleteCustomProfiles", () => {
+  test("materializes a partial custom profile against llm.default", () => {
+    writeConfig({
+      llm: {
+        default: distinctiveDefault,
+        profiles: {
+          partial: { source: "user", model: "claude-haiku-4-5-20251001" },
+        },
+      },
+    });
+    ensureCompleteCustomProfiles(workspaceDir);
+    const saved = readProfiles().partial;
+    expect(saved.model).toBe("claude-haiku-4-5-20251001");
+    expect(saved.provider).toBe("anthropic");
+    expect(saved.provider_connection).toBe("anthropic-personal");
+    expect(saved.maxTokens).toBe(12345);
+    expect(saved.temperature).toBe(0.7);
+    expect(saved.logitBias).toBeUndefined();
+    expect(saved.thinking).toBeDefined();
+    expect(saved.contextWindow).toBeDefined();
+  });
+
+  test("implies the catalog provider for a model llm.default's provider does not serve", () => {
+    writeConfig({
+      llm: {
+        default: distinctiveDefault,
+        profiles: { gpt: { source: "user", model: "gpt-5.5" } },
+      },
+    });
+    ensureCompleteCustomProfiles(workspaceDir);
+    const saved = readProfiles().gpt;
+    expect(saved.provider).toBe("openai");
+    // anthropic-personal belongs to the replaced provider.
+    expect(saved.provider_connection).toBeUndefined();
+  });
+
+  test("inherits the vellum managed connection only onto managed-routable providers", () => {
+    writeConfig({
+      llm: {
+        default: { ...distinctiveDefault, provider_connection: "vellum" },
+        profiles: {
+          gpt: { source: "user", model: "gpt-5.5" },
+          router: {
+            source: "user",
+            provider: "openrouter",
+            model: "minimax/minimax-m3",
+          },
+        },
+      },
+    });
+    ensureCompleteCustomProfiles(workspaceDir);
+    expect(readProfiles().gpt.provider_connection).toBe("vellum");
+    expect(readProfiles().router.provider_connection).toBeUndefined();
+  });
+
+  test("leaves managed stubs, mixes, complete profiles, and unparseable entries untouched", () => {
+    const complete = {
+      source: "user",
+      ...LLMConfigBase.parse({ ...distinctiveDefault }),
+    };
+    // LLMConfigBase carries null sampling defaults ProfileEntry omits.
+    delete (complete as Record<string, unknown>).logitBias;
+    const config = {
+      llm: {
+        default: distinctiveDefault,
+        profiles: {
+          balanced: { source: "managed", status: "disabled" },
+          ab: {
+            source: "user",
+            mix: [
+              { profile: "a", weight: 1 },
+              { profile: "b", weight: 1 },
+            ],
+          },
+          complete,
+          broken: { maxTokens: "not-a-number" },
+          scalar: "not-an-object",
+        },
+      },
+    };
+    writeConfig(config);
+    const before = readFileSync(join(workspaceDir, "config.json"), "utf-8");
+    ensureCompleteCustomProfiles(workspaceDir);
+    const after = readFileSync(join(workspaceDir, "config.json"), "utf-8");
+    expect(after).toBe(before);
+  });
+
+  test("preserves unknown keys on materialized entries", () => {
+    writeConfig({
+      llm: {
+        default: distinctiveDefault,
+        profiles: {
+          partial: {
+            source: "user",
+            model: "claude-haiku-4-5-20251001",
+            futureField: "keep-me",
+          },
+        },
+      },
+    });
+    ensureCompleteCustomProfiles(workspaceDir);
+    expect(readProfiles().partial.futureField).toBe("keep-me");
+    expect(readProfiles().partial.provider).toBe("anthropic");
+  });
+
+  test("does not bake null default sampling; preserves explicit profile null", () => {
+    writeConfig({
+      llm: {
+        default: { ...distinctiveDefault, temperature: null, topP: null },
+        profiles: {
+          plain: { source: "user", model: "claude-haiku-4-5-20251001" },
+          cleared: {
+            source: "user",
+            model: "claude-haiku-4-5-20251001",
+            temperature: null,
+          },
+        },
+      },
+    });
+    ensureCompleteCustomProfiles(workspaceDir);
+    expect("temperature" in readProfiles().plain).toBe(false);
+    expect(readProfiles().cleared.temperature).toBeNull();
+  });
+
+  test("is idempotent — the second run rewrites nothing", () => {
+    writeConfig({
+      llm: {
+        default: distinctiveDefault,
+        profiles: {
+          partial: { source: "user", model: "claude-haiku-4-5-20251001" },
+        },
+      },
+    });
+    ensureCompleteCustomProfiles(workspaceDir);
+    const first = readFileSync(join(workspaceDir, "config.json"), "utf-8");
+    ensureCompleteCustomProfiles(workspaceDir);
+    const second = readFileSync(join(workspaceDir, "config.json"), "utf-8");
+    expect(second).toBe(first);
+  });
+
+  test("no-ops on adversarial config shapes", () => {
+    // Missing file.
+    ensureCompleteCustomProfiles(workspaceDir);
+    // Unparseable JSON.
+    writeFileSync(join(workspaceDir, "config.json"), "{nope");
+    ensureCompleteCustomProfiles(workspaceDir);
+    // Non-object root, missing llm, missing profiles, unparseable default.
+    for (const config of [
+      [1, 2],
+      {},
+      { llm: {} },
+      { llm: { default: { provider: "not-a-provider" }, profiles: {} } },
+      {
+        llm: {
+          default: { maxTokens: "NaN" },
+          profiles: { p: { source: "user", model: "gpt-5.5" } },
+        },
+      },
+    ]) {
+      writeConfig(config);
+      const before = readFileSync(join(workspaceDir, "config.json"), "utf-8");
+      ensureCompleteCustomProfiles(workspaceDir);
+      expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+        before,
+      );
+    }
+  });
+});

--- a/assistant/src/config/__tests__/profile-materialization.test.ts
+++ b/assistant/src/config/__tests__/profile-materialization.test.ts
@@ -113,7 +113,7 @@ describe("completeCustomProfile", () => {
     expect(completed.provider_connection).toBeUndefined();
   });
 
-  test("always inherits the provider-agnostic vellum managed connection, even across an implied provider change", () => {
+  test("inherits the vellum managed connection across a provider change, but only onto managed-routable providers", () => {
     const managedDefault = LLMConfigBase.parse({
       ...fullDefault,
       provider_connection: VELLUM_MANAGED_CONNECTION_NAME,
@@ -127,6 +127,14 @@ describe("completeCustomProfile", () => {
       model: "gpt-5.4",
     });
     expect(explicit.provider_connection).toBe(VELLUM_MANAGED_CONNECTION_NAME);
+
+    // The vellum connection can't route a non-managed provider; baking it in
+    // would fail dispatch's mismatch path instead of auto-resolving.
+    const nonRoutable = completeCustomProfile(managedDefault, {
+      provider: "openrouter",
+      model: "minimax/minimax-m3",
+    });
+    expect(nonRoutable.provider_connection).toBeUndefined();
   });
 
   test("keeps the inherited provider for a model unknown to the catalog", () => {

--- a/assistant/src/config/__tests__/profile-materialization.test.ts
+++ b/assistant/src/config/__tests__/profile-materialization.test.ts
@@ -45,22 +45,17 @@ describe("completeCustomProfile", () => {
       logitBias: "suppress-cjk",
     });
     const completed = completeCustomProfile(dflt, { model: "claude-fable-5" });
-    // The resolver leaves llm.default's base sampling standing when no
-    // profile opts in, so non-null defaults must be baked in.
     expect(completed.temperature).toBe(0.7);
     expect(completed.topP).toBe(0.9);
-    // logitBias is deleted post-merge unless the winning profile set it.
+    // The resolver deletes non-profile logitBias post-merge, unlike sampling.
     expect(completed.logitBias).toBeUndefined();
-    // The profile's own sampling wins over the default's.
     const own = completeCustomProfile(dflt, { temperature: 0.2 });
     expect(own.temperature).toBe(0.2);
     expect(own.topP).toBe(0.9);
-    // A null schema-default is skipped, not baked in as an explicit null.
     const nullDefaults = completeCustomProfile(fullDefault, {});
     expect(nullDefaults.temperature).toBeUndefined();
     expect(nullDefaults.topP).toBeUndefined();
-    // A profile's explicit null is preserved (it clears the default's value
-    // in the resolver, and must keep doing so standalone).
+    // Explicit null differs from undefined: it clears the default's value.
     const explicitNull = completeCustomProfile(dflt, { temperature: null });
     expect(explicitNull.temperature).toBeNull();
   });
@@ -95,9 +90,8 @@ describe("completeCustomProfile", () => {
   test("stamps the catalog owner for a model the default provider does not serve, and drops the default's connection", () => {
     const completed = completeCustomProfile(fullDefault, { model: "gpt-5.5" });
     expect(completed.provider).toBe("openai");
-    // anthropic-personal belongs to the replaced provider; dispatch
-    // auto-resolves an absent connection by provider, same as the partial
-    // profile resolves today.
+    // Provider-specific connections don't cross providers; dispatch
+    // auto-resolves an absent connection.
     expect(completed.provider_connection).toBeUndefined();
   });
 
@@ -124,9 +118,6 @@ describe("completeCustomProfile", () => {
       ...fullDefault,
       provider_connection: VELLUM_MANAGED_CONNECTION_NAME,
     });
-    // Model implication flips the provider, but the vellum connection routes
-    // any managed provider via `expectedProvider` — dropping it would cut the
-    // profile off from platform-proxy routing.
     const implied = completeCustomProfile(managedDefault, { model: "gpt-5.5" });
     expect(implied.provider).toBe("openai");
     expect(implied.provider_connection).toBe(VELLUM_MANAGED_CONNECTION_NAME);

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -571,11 +571,22 @@ function emptyDefaultWorkspaceConfigMergeResult(): DefaultWorkspaceConfigMergeRe
  * Schema defaults are no longer materialized into the file on load — the
  * in-memory `loadConfig()` cache applies them at access time instead.
  */
-export function mergeDefaultWorkspaceConfig(): DefaultWorkspaceConfigMergeResult {
+/**
+ * Whether an unconsumed onboarding overlay is waiting to be merged this boot.
+ * The overlay file is renamed away on merge, so this is true for at most the
+ * single boot that consumes it.
+ */
+export function hasPendingDefaultWorkspaceConfig(): boolean {
   const defaultConfigPath = process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
-  if (!defaultConfigPath || !existsSync(defaultConfigPath)) {
+  return Boolean(defaultConfigPath && existsSync(defaultConfigPath));
+}
+
+export function mergeDefaultWorkspaceConfig(): DefaultWorkspaceConfigMergeResult {
+  if (!hasPendingDefaultWorkspaceConfig()) {
     return emptyDefaultWorkspaceConfigMergeResult();
   }
+  const defaultConfigPath = process.env
+    .VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH as string;
 
   let defaults: unknown;
   try {

--- a/assistant/src/config/profile-materialization.ts
+++ b/assistant/src/config/profile-materialization.ts
@@ -6,47 +6,23 @@ import { VELLUM_MANAGED_CONNECTION_NAME } from "../providers/vellum-model-routin
 import type { LLMConfigBase, ProfileEntry } from "./schemas/llm.js";
 
 /**
- * Materializes a partial custom profile into a complete, standalone override
- * by baking in the fields it currently inherits from `llm.default` under the
- * deep-merge resolver.
+ * Materializes a partial custom profile into a complete, standalone
+ * override: what `resolveCallSiteConfig` produces when this profile is the
+ * only profile layer above `llm.default`. Replicates the deep-merge
+ * resolver's non-obvious rules exactly:
  *
- * The completed entry pins the profile's *standalone* meaning: what
- * `resolveCallSiteConfig` produces today when this profile is the only
- * profile layer above `llm.default` (e.g. an override on a profile-less call
- * site). This is the baseline the M6 override-or-default resolver assumes —
- * once resolution stops merging, a profile must carry everything it means.
- *
- * Deliberate parity quirks with the current resolver:
- *
- * - Non-null `temperature`/`topP` on the default ARE inherited: the
- *   resolver's winning-profile scoping only blocks one PROFILE's sampling
- *   from leaking under another, while `llm.default`'s base sampling stands
- *   whenever no profile opts in. A null default (the schema default) is
- *   skipped — baking an explicit `null` would be noise with the same
- *   resolved result. `logitBias` is NEVER inherited: the resolver deletes
- *   any non-profile value post-merge, so only a profile that opted in
- *   carries it.
- * - Nested `thinking`/`contextWindow`/`openrouter` fragments merge
- *   leaf-by-leaf into the default's full object, mirroring the resolver's
- *   `deepMerge`.
+ * - Non-null default `temperature`/`topP` ARE inherited — winning-profile
+ *   scoping only blocks one profile's sampling from leaking under another;
+ *   `llm.default`'s base sampling stands when no profile opts in. Null
+ *   defaults are skipped (same resolved result, no noise). `logitBias` is
+ *   NEVER inherited — the resolver deletes non-profile values post-merge.
  * - A model-only profile gets the provider `withImpliedProviders` would
- *   stamp: the inherited default provider when it serves the model, else the
- *   model's catalog owner.
- * - The default's `provider_connection` is inherited when the completed
- *   provider is still the default's provider, and always when it is the
- *   provider-agnostic Vellum managed connection (which routes any managed
- *   provider via `expectedProvider`). A provider-SPECIFIC connection is not
- *   baked onto a profile that resolved to a different provider (explicitly
- *   or via model implication) — that would pin a mismatch; dispatch
- *   auto-resolves an absent connection by provider, exactly as it does for
- *   the partial profile today.
+ *   stamp: the default provider when it serves the model, else the model's
+ *   catalog owner.
  *
  * Mix profiles (no config fields, schema-enforced) and managed profiles
- * (bodies owned by the code catalog) pass through untouched.
- *
- * Idempotent: completing an already-complete profile is the identity.
- * Pure and synchronous; the returned entry never aliases `dflt`'s nested
- * objects.
+ * (bodies owned by the code catalog) pass through untouched. Idempotent,
+ * pure, and the result never aliases `dflt`'s nested objects.
  */
 export function completeCustomProfile(
   dflt: LLMConfigBase,
@@ -107,15 +83,11 @@ export function completeCustomProfile(
     }
   }
 
-  // A provider-specific connection row belongs to one provider: inheriting
-  // it onto a profile that resolved to a different provider (explicitly or
-  // via model implication) would bake in a mismatch, so it is inherited only
-  // when the completed provider is still the default's. The Vellum managed
-  // connection is the exception — it is provider-agnostic (dispatch routes
-  // it with `expectedProvider` set to the profile's provider), so dropping
-  // it would cut managed installs off from platform-proxy routing.
-  // Dispatch auto-resolves an absent connection by provider, exactly as it
-  // does for the partial profile today.
+  // A provider-specific connection baked onto a different provider would pin
+  // a mismatch (dispatch auto-resolves an absent connection by provider
+  // instead). The Vellum managed connection is provider-agnostic — dispatch
+  // routes it via `expectedProvider` — so it must survive a provider change
+  // or managed installs lose platform-proxy routing.
   if (
     profile.provider_connection === undefined &&
     dflt.provider_connection !== undefined &&

--- a/assistant/src/config/profile-materialization.ts
+++ b/assistant/src/config/profile-materialization.ts
@@ -2,7 +2,10 @@ import {
   getCatalogProviderForModel,
   isModelInCatalog,
 } from "../providers/model-catalog.js";
-import { VELLUM_MANAGED_CONNECTION_NAME } from "../providers/vellum-model-routing.js";
+import {
+  MANAGED_ROUTABLE_PROVIDERS,
+  VELLUM_MANAGED_CONNECTION_NAME,
+} from "../providers/vellum-model-routing.js";
 import type { LLMConfigBase, ProfileEntry } from "./schemas/llm.js";
 
 /**
@@ -85,14 +88,18 @@ export function completeCustomProfile(
 
   // A provider-specific connection baked onto a different provider would pin
   // a mismatch (dispatch auto-resolves an absent connection by provider
-  // instead). The Vellum managed connection is provider-agnostic — dispatch
-  // routes it via `expectedProvider` — so it must survive a provider change
-  // or managed installs lose platform-proxy routing.
+  // instead). The Vellum managed connection must survive a provider change —
+  // dispatch routes it via `expectedProvider` — but only onto providers it
+  // can actually route; a non-managed-routable provider (openrouter, ollama)
+  // would hit the mismatch path instead of auto-resolution.
+  const vellumRoutable =
+    dflt.provider_connection === VELLUM_MANAGED_CONNECTION_NAME &&
+    completed.provider !== undefined &&
+    MANAGED_ROUTABLE_PROVIDERS.has(completed.provider);
   if (
     profile.provider_connection === undefined &&
     dflt.provider_connection !== undefined &&
-    (completed.provider === dflt.provider ||
-      dflt.provider_connection === VELLUM_MANAGED_CONNECTION_NAME)
+    (completed.provider === dflt.provider || vellumRoutable)
   ) {
     completed.provider_connection = dflt.provider_connection;
   }

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -148,6 +148,21 @@ export async function runDaemon(): Promise<void> {
 
   setDbMigrating();
 
+  // Materialize partial custom profiles BEFORE any transport binds: routes
+  // are gated on DB readiness, not on the config-shaping steps further down,
+  // so a fast-reconnecting client could otherwise resolve a turn against a
+  // partial profile in the window between readiness and the post-overlay
+  // ensure call below. Sync, DB-free, and idempotent — the second call after
+  // the overlay merge covers entries that boot itself writes.
+  try {
+    ensureCompleteCustomProfiles(getWorkspaceDir());
+  } catch (err) {
+    log.warn(
+      { err },
+      "Pre-transport custom profile materialization failed — continuing startup",
+    );
+  }
+
   // Start the runtime HTTP server early so /healthz answers ASAP. A bind
   // failure is non-fatal — the daemon falls back to IPC-only operation.
   await startRuntimeHttpServer();

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -4,7 +4,11 @@ import { reconcileCallsOnStartup } from "../calls/call-recovery.js";
 import { TwilioVoiceProvider } from "../calls/twilio-provider.js";
 import { initFeatureFlagOverrides } from "../config/assistant-feature-flags.js";
 import { setIngressPublicBaseUrl, validateEnv } from "../config/env.js";
-import { loadConfig, mergeDefaultWorkspaceConfig } from "../config/loader.js";
+import {
+  hasPendingDefaultWorkspaceConfig,
+  loadConfig,
+  mergeDefaultWorkspaceConfig,
+} from "../config/loader.js";
 import { seedInferenceProfiles } from "../config/seed-inference-profiles.js";
 import { reconcileFlagGatedProfiles } from "../config/sync-gated-profiles.js";
 import { expireAllPendingCanonicalRequests } from "../contacts/canonical-guardian-store.js";
@@ -152,15 +156,22 @@ export async function runDaemon(): Promise<void> {
   // are gated on DB readiness, not on the config-shaping steps further down,
   // so a fast-reconnecting client could otherwise resolve a turn against a
   // partial profile in the window between readiness and the post-overlay
-  // ensure call below. Sync, DB-free, and idempotent — the second call after
-  // the overlay merge covers entries that boot itself writes.
-  try {
-    ensureCompleteCustomProfiles(getWorkspaceDir());
-  } catch (err) {
-    log.warn(
-      { err },
-      "Pre-transport custom profile materialization failed — continuing startup",
-    );
+  // ensure call below. Sync, DB-free, and idempotent. Skipped when an
+  // unconsumed onboarding overlay is pending: the overlay can rewrite
+  // llm.default later this boot, and baking against the pre-overlay default
+  // would pin the wrong baseline — on that single boot (a fresh hatch, with
+  // no established clients to race the window) the post-overlay pass owns
+  // materialization; the overlay file is consumed on merge, so every
+  // subsequent boot takes this early pass.
+  if (!hasPendingDefaultWorkspaceConfig()) {
+    try {
+      ensureCompleteCustomProfiles(getWorkspaceDir());
+    } catch (err) {
+      log.warn(
+        { err },
+        "Pre-transport custom profile materialization failed — continuing startup",
+      );
+    }
   }
 
   // Start the runtime HTTP server early so /healthz answers ASAP. A bind

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -56,6 +56,7 @@ import {
 } from "../work-items/work-item-store.js";
 import { getWorkflowRunManager } from "../workflows/run-manager.js";
 import { repairAdaptiveThinkingOnManagedProfiles } from "../workspace/adaptive-thinking-repair.js";
+import { ensureCompleteCustomProfiles } from "../workspace/custom-profile-ensure.js";
 import { ensureDefaultProvider } from "../workspace/default-provider-ensure.js";
 import { startWorkspaceHeartbeatService } from "../workspace/heartbeat-service.js";
 import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
@@ -457,6 +458,20 @@ export async function runDaemon(): Promise<void> {
     log.warn(
       { err },
       "Default provider ensure pass failed — continuing startup",
+    );
+  }
+
+  // Runs on every boot, after the overlay merge and profile seeding and
+  // before the first loadConfig(), so no resolution ever sees a partial
+  // custom profile. See workspace/custom-profile-ensure.ts for why this is
+  // an ensure pass rather than a workspace migration.
+  try {
+    ensureCompleteCustomProfiles(getWorkspaceDir());
+    log.info("Custom profile materialization ensure pass complete");
+  } catch (err) {
+    log.warn(
+      { err },
+      "Custom profile materialization ensure pass failed — continuing startup",
     );
   }
 

--- a/assistant/src/workspace/custom-profile-ensure.ts
+++ b/assistant/src/workspace/custom-profile-ensure.ts
@@ -1,0 +1,106 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { isDeepStrictEqual } from "node:util";
+
+import { invalidateConfigCache } from "../config/loader.js";
+import { completeCustomProfile } from "../config/profile-materialization.js";
+import { LLMConfigBase, ProfileEntry } from "../config/schemas/llm.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("custom-profile-ensure");
+
+// Materializes partial custom profiles into complete overrides on every boot.
+//
+// This is a boot ensure pass rather than a workspace migration because
+// completion needs the live model catalog: a model-only profile takes the
+// provider `completeCustomProfile` implies from the catalog, and migrations
+// are frozen self-contained snapshots that may not import it (see
+// workspace/migrations/AGENTS.md). Using the live helper keeps this pass and
+// the write-path normalization in `commitConfigWrite` identical by
+// construction. Running unconditionally each boot (the
+// `ensureDefaultProvider` pattern) also covers configs restored from backups
+// and entries injected after the migration registry checkpoints — and it
+// completes before the first `loadConfig()`, so no resolution ever sees a
+// partial custom profile.
+//
+// Idempotent and write-avoidant: entries that are already complete (and mix
+// profiles, managed-source entries, and entries that do not parse as a
+// `ProfileEntry`) are left byte-identical; the file is rewritten only when
+// at least one entry changed. Unknown keys on an entry survive completion.
+// Each materialized profile logs the exact fields it baked so a later
+// resolution report can be attributed to baked data vs. resolver semantics.
+export function ensureCompleteCustomProfiles(workspaceDir: string): void {
+  const configPath = join(workspaceDir, "config.json");
+  if (!existsSync(configPath)) {
+    return;
+  }
+
+  let config: Record<string, unknown>;
+  try {
+    const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      return;
+    }
+    config = raw as Record<string, unknown>;
+  } catch {
+    return;
+  }
+
+  const llm = readObject(config.llm);
+  if (llm === null) {
+    return;
+  }
+  const profiles = readObject(llm.profiles);
+  if (profiles === null) {
+    return;
+  }
+  const parsedDefault = LLMConfigBase.safeParse(llm.default ?? {});
+  if (!parsedDefault.success) {
+    return;
+  }
+
+  let changed = false;
+  for (const [name, rawEntry] of Object.entries(profiles)) {
+    const entry = readObject(rawEntry);
+    if (entry === null) {
+      continue;
+    }
+    const parsed = ProfileEntry.safeParse(entry);
+    if (!parsed.success) {
+      continue;
+    }
+    // Spread over the original raw entry so keys the schema doesn't know
+    // survive (`safeParse` strips them).
+    const merged: Record<string, unknown> = {
+      ...entry,
+      ...completeCustomProfile(parsedDefault.data, parsed.data),
+    };
+    if (isDeepStrictEqual(merged, entry)) {
+      continue;
+    }
+    const bakedFields = Object.keys(merged).filter(
+      (key) => !(key in entry) || !isDeepStrictEqual(merged[key], entry[key]),
+    );
+    profiles[name] = merged;
+    changed = true;
+    log.info(
+      { profile: name, bakedFields },
+      "Materialized partial custom profile into a complete override",
+    );
+  }
+
+  if (!changed) {
+    return;
+  }
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  // The lifecycle call site runs before the first loadConfig() of this boot;
+  // this guards callers that read config earlier (and future reordering).
+  invalidateConfigCache();
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}

--- a/assistant/src/workspace/custom-profile-ensure.ts
+++ b/assistant/src/workspace/custom-profile-ensure.ts
@@ -69,12 +69,16 @@ export function ensureCompleteCustomProfiles(workspaceDir: string): void {
     if (!parsed.success) {
       continue;
     }
-    // Spread over the original raw entry so keys the schema doesn't know
-    // survive (`safeParse` strips them).
-    const merged: Record<string, unknown> = {
-      ...entry,
-      ...completeCustomProfile(parsedDefault.data, parsed.data),
-    };
+    // Merge over the original raw entry at every depth so keys the schema
+    // doesn't know survive (`safeParse` strips them, top-level and inside
+    // nested objects like `contextWindow`).
+    const merged: Record<string, unknown> = mergePreservingUnknownKeys(
+      entry,
+      completeCustomProfile(parsedDefault.data, parsed.data) as Record<
+        string,
+        unknown
+      >,
+    );
     if (isDeepStrictEqual(merged, entry)) {
       continue;
     }
@@ -96,6 +100,29 @@ export function ensureCompleteCustomProfiles(workspaceDir: string): void {
   // The lifecycle call site runs before the first loadConfig() of this boot;
   // this guards callers that read config earlier (and future reordering).
   invalidateConfigCache();
+}
+
+/**
+ * `{...raw, ...completed}` recursively: completed (schema-known) values win,
+ * raw keys the schema stripped survive at every depth. (Duplicated in the
+ * write-path normalization in conversation-query-routes.ts — the two land in
+ * independent PRs; consolidate when either next changes.)
+ */
+function mergePreservingUnknownKeys(
+  raw: Record<string, unknown>,
+  completed: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...raw, ...completed };
+  for (const [key, value] of Object.entries(completed)) {
+    const rawValue = raw[key];
+    if (readObject(value) !== null && readObject(rawValue) !== null) {
+      out[key] = mergePreservingUnknownKeys(
+        rawValue as Record<string, unknown>,
+        value as Record<string, unknown>,
+      );
+    }
+  }
+  return out;
 }
 
 function readObject(value: unknown): Record<string, unknown> | null {


### PR DESCRIPTION
## Summary
- Materializes existing partial custom profiles into complete overrides via a **boot ensure pass** (`workspace/custom-profile-ensure.ts`, wired in lifecycle after overlay-merge/seeding and before the first `loadConfig()`), not the originally planned workspace migration 128. Pivot rationale: migrations are frozen self-contained snapshots (migrations/AGENTS.md) that may not import the model catalog, so a frozen completion copy could not replicate `completeCustomProfile`'s provider-implication rule and would diverge exactly on model-implies-other-provider entries. The ensure pass uses the live helper — identical semantics by construction — and running every boot pre-traffic is strictly stronger than run-once for the "no resolution ever sees a partial profile" guarantee. Precedent: `ensureDefaultProvider`, `adaptive-thinking-repair`.
- Write-avoidant and idempotent: mix/managed/complete/unparseable entries are left byte-identical; the file rewrites only when an entry changed; unknown top-level keys survive; each materialized profile logs its exact `bakedFields` so post-release resolution reports are attributable to baked data vs. resolver semantics.
- **Also carries two orphaned commits from PR #37518** (cherry-picked): the managed-routable gate on vellum-connection inheritance and the comment trim. #37518 was merged before those review-fix pushes landed on the branch; the ensure pass's tests depend on the gate (an `openrouter` profile must not inherit the vellum connection).
- Known shared gap, deliberately left for triage (same as the open thread on #37563): unknown keys nested inside `thinking`/`contextWindow`/`openrouter` are not preserved on materialized entries — one follow-up should fix both call sites together.

## Original prompt
Milestone 6 of the Inference Management Refactor requires existing partial custom profiles to be materialized into complete overrides before the resolver flip ships (same release). This is M6 PR 3; PR 1 (#37518) shipped the completion helper and PR 2 (#37563) normalizes writes. Full M6 plan is attached to #37518 as the papertrail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->