### PR TITLE
feat(plugins): add cofounder to the marketplace catalog

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -102,6 +102,18 @@
       "license": "MIT"
     },
     {
+      "name": "cofounder",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/cofounder",
+        "ref": "9c7d8febcd3bd2c04d7e063724383046ae88ce78"
+      },
+      "description": "AI co-founder that remembers your company context, challenges your thinking, and tracks your decisions.",
+      "category": "productivity",
+      "homepage": "https://github.com/vellum-ai/cofounder",
+      "license": "MIT"
+    },
+    {
       "name": "git-workflow",
       "source": {
         "source": "github",


### PR DESCRIPTION
## What

Adds a SHA-pinned marketplace entry for the **cofounder** plugin.

- Repo: [vellum-ai/cofounder](https://github.com/vellum-ai/cofounder)
- Pinned ref: `9c7d8febcd3bd2c04d7e063724383046ae88ce78`
- Category: `productivity`
- Surfaces: 5 tools, 4 hooks, 3 skills

An AI co-founder that remembers your company context, challenges your thinking, and tracks your decisions. All tools are `RiskLevel.Low` — they only read/write the plugin's own data directory (no credentials, no external calls, no inbox/calendar mutations).

## Verification

- `plugin-marketplace.test.ts` passes (12/12) — entry is schema-valid.
- `marketplace.json` parses; catalog now lists 18 plugins.
- Faithful loader discovery can't be exercised locally (resolving `@vellumai/plugin-api` to the raw workspace source triggers a circular init on `RiskLevel`; the known-good `admin-copilot` fails the same local harness identically). Discovery was verified in the plugin's dev workspace: 5 tools / 4 hooks / 3 skills, status `installed`.

## Note

Per the admin-copilot precedent, the platform catalog serves a pinned commit of this repo rather than `main` HEAD — a catalog pin bump may be needed before cofounder appears in the live marketplace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)