### PR TITLE
fix(web): stop onboarding calendar step crashing under browser translate

### DIFF
--- a/clients/web/src/domains/onboarding/screens/lets-chat-tomorrow-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/lets-chat-tomorrow-step.tsx
@@ -143,7 +143,7 @@ export function LetsChatTomorrowStep({
               className="cursor-pointer text-body-small-default transition-opacity hover:opacity-100 disabled:opacity-60"
               style={{ color: tone.fgMuted }}
             >
-              Skip for now
+              <span>Skip for now</span>
             </button>
           )}
         </div>

--- a/clients/web/src/domains/onboarding/screens/lets-chat-tomorrow-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/lets-chat-tomorrow-step.tsx
@@ -86,18 +86,22 @@ export function LetsChatTomorrowStep({
           className="text-[2.6rem] leading-tight"
           style={{ fontFamily: "var(--font-serif)" }}
         >
-          {waitingForAssistant
-            ? "Waking up"
-            : missingCalendarScope
-              ? "Access not enabled"
-              : "Let me make this easy"}
+          <span>
+            {waitingForAssistant
+              ? "Waking up"
+              : missingCalendarScope
+                ? "Access not enabled"
+                : "Let me make this easy"}
+          </span>
         </h1>
         <p className="text-[16px]" style={{ color: tone.fgMuted }}>
-          {waitingForAssistant
-            ? "Your assistant is getting ready"
-            : missingCalendarScope
-              ? "Check the box next to the Google Calendar permission so I can book the check-in."
-              : "Connect your Google Calendar so I can find time to check in and start helping."}
+          <span>
+            {waitingForAssistant
+              ? "Your assistant is getting ready"
+              : missingCalendarScope
+                ? "Check the box next to the Google Calendar permission so I can book the check-in."
+                : "Connect your Google Calendar so I can find time to check in and start helping."}
+          </span>
         </p>
 
         <div className="mt-6 flex w-[234px] flex-col items-center gap-4">
@@ -114,17 +118,17 @@ export function LetsChatTomorrowStep({
             {waitingForAssistant ? (
               <>
                 <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
-                Starting assistant…
+                <span>Starting assistant…</span>
               </>
             ) : oauthInProgress ? (
               <>
                 <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
-                Waiting for authorization…
+                <span>Waiting for authorization…</span>
               </>
             ) : missingCalendarScope ? (
-              "Try again"
+              <span>Try again</span>
             ) : (
-              "Connect Calendar →"
+              <span>Connect Calendar →</span>
             )}
           </button>
           {/* Skip sits directly under the connect button. Hidden while the


### PR DESCRIPTION
## Problem

A user in onboarding (browser set to auto-translate the English UI → Vietnamese) clicked **Connect Calendar** and the app crashed to the generic error screen. They hit Reload and recovered; the Google OAuth flow had actually **succeeded** server-side.

Confirmed via LogRocket (session showed the sequence + the raw console error) and cross-checked against Sentry:

```
DOMException: Failed to execute 'removeChild' on 'Node'
```

**No failed network requests** — this is purely a client-side React reconciliation crash.

## Root cause

The classic React + browser-translation bug ([facebook/react#11538](https://github.com/facebook/react/issues/11538)). Chrome/Safari Translate wraps bare text nodes in its own `<font>` elements. React still holds references to the original text nodes. When a bare text node is a direct child of an element (or a sibling of an element inside a fragment) and the surrounding condition flips, React calls `removeChild`/`insertBefore` on a node Translate has re-parented → `DOMException` → the whole app unmounts.

In `lets-chat-tomorrow-step.tsx` the Connect Calendar button label swapped between fragments-with-bare-text and bare string literals; clicking the button flips `oauthInProgress`, triggering exactly that swap. The heading and subhead had the same latent string-ternary pattern.

## Fix

Wrap each conditionally-swapped text branch in a stable `<span>`, so Translate mutates *inside* a node React owns and React only ever removes/reorders the span — never a translated text node. Scoped to the crash site (the onboarding step) only.

## Notes for reviewers

- **This crash is invisible to Sentry by design.** `clients/web/src/lib/sentry/sentry-init.ts` explicitly lists both `Failed to execute 'removeChild' on 'Node'` and `'insertBefore'` in `ignoreErrors` (they're notorious extension/translate noise). So we suppress the telemetry but the crash is real and user-facing — worth keeping in mind that the true rate is unmeasured.
- **Follow-up under discussion:** whether this pattern is common enough elsewhere to warrant a lint rule vs. fixing case-by-case. A codebase spot-check is in progress; not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->