### PR TITLE
feat(runtime): GET/PUT /v1/config/llm/default-provider with availability status

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -32597,6 +32597,7 @@ components:
                 - missing_default
                 - missing_connection
                 - missing_credential
+                - provider_mismatch
                 - unsupported_auth
                 - vellum_unauthenticated
                 - unknown

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4506,6 +4506,60 @@ paths:
                   - domains
                   - callSites
                 additionalProperties: false
+  /v1/config/llm/default-provider:
+    get:
+      operationId: config_llm_defaultprovider_get
+      summary: Get the default provider and its availability
+      description:
+        Returns `llm.defaultProvider`, the connection name it resolves to, and whether that connection is currently
+        usable (connection exists, credential stored, Vellum authenticated). Availability is informational — a broken
+        default is a valid persisted state that surfaces explainable errors at resolution time.
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DefaultProviderStatus"
+    put:
+      operationId: config_llm_defaultprovider_put
+      summary: Set the default provider
+      description:
+        Replaces `llm.defaultProvider`. Strict-validates the body (unlike the generic config write paths, which
+        silently drop invalid values). Does not require the referenced connection to exist — a dangling name is allowed
+        by design and reported via the availability status.
+      tags:
+        - config
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                provider:
+                  type: string
+                  enum:
+                    - anthropic
+                    - openai
+                    - gemini
+                    - fireworks
+                    - openrouter
+                    - vellum
+                connectionName:
+                  type: string
+                  minLength: 1
+              required:
+                - provider
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DefaultProviderStatus"
   /v1/config/llm/profiles:
     get:
       operationId: config_llm_profiles_get
@@ -32141,6 +32195,24 @@ components:
                 provider_connection:
                   type: string
               additionalProperties: false
+            defaultProvider:
+              type: object
+              properties:
+                provider:
+                  type: string
+                  enum:
+                    - anthropic
+                    - openai
+                    - gemini
+                    - fireworks
+                    - openrouter
+                    - vellum
+                connectionName:
+                  type: string
+                  minLength: 1
+              required:
+                - provider
+              additionalProperties: false
             profiles:
               type: object
               propertyNames:
@@ -32495,6 +32567,48 @@ components:
         invariant:
           type: boolean
       additionalProperties: {}
+    DefaultProviderStatus:
+      type: object
+      properties:
+        provider:
+          anyOf:
+            - type: string
+              enum:
+                - anthropic
+                - openai
+                - gemini
+                - fireworks
+                - openrouter
+                - vellum
+            - type: "null"
+        connectionName:
+          type: string
+        resolvedConnectionName:
+          anyOf:
+            - type: string
+            - type: "null"
+        availability:
+          type: object
+          properties:
+            status:
+              type: string
+              enum:
+                - ok
+                - missing_default
+                - missing_connection
+                - missing_credential
+                - vellum_unauthenticated
+                - unknown
+            message:
+              type: string
+          required:
+            - status
+          additionalProperties: false
+      required:
+        - provider
+        - resolvedConnectionName
+        - availability
+      additionalProperties: false
     ProviderConnection:
       type: object
       properties:

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -32597,6 +32597,7 @@ components:
                 - missing_default
                 - missing_connection
                 - missing_credential
+                - unsupported_auth
                 - vellum_unauthenticated
                 - unknown
             message:

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -237,6 +237,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "tools/executor.ts", // CES approval bridge resolves the CES RPC client via getCesClient
       "tools/network/web-fetch.ts", // Firecrawl /scrape BYOK fetch provider API key lookup (firecrawl provider key)
       "workspace/default-provider-ensure.ts", // legacy anthropic echo disambiguation (vault key presence check)
+      "runtime/routes/default-provider-routes.ts", // default-provider availability status (credential presence check only; value never leaves the handler)
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));

--- a/assistant/src/runtime/routes/__tests__/default-provider-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/default-provider-routes.test.ts
@@ -101,6 +101,14 @@ function seedConnection(opts: {
     .run();
 }
 
+function seedCanonicalVellumConnection(): void {
+  seedConnection({
+    name: "vellum",
+    provider: "vellum",
+    auth: { type: "platform" },
+  });
+}
+
 // ── Setup ─────────────────────────────────────────────────────────────────────
 
 beforeEach(() => {
@@ -124,6 +132,7 @@ describe("GET config/llm/default-provider", () => {
   });
 
   test("vellum + authenticated → ok", async () => {
+    seedCanonicalVellumConnection();
     fakeConfig = { llm: { defaultProvider: { provider: "vellum" } } };
     managedProxyEnabled = true;
     const result = await get();
@@ -132,6 +141,7 @@ describe("GET config/llm/default-provider", () => {
   });
 
   test("vellum + unauthenticated → vellum_unauthenticated naming the fix", async () => {
+    seedCanonicalVellumConnection();
     fakeConfig = { llm: { defaultProvider: { provider: "vellum" } } };
     const result = await get();
     expect(availability(result).status).toBe("vellum_unauthenticated");
@@ -139,11 +149,53 @@ describe("GET config/llm/default-provider", () => {
   });
 
   test("vellum + no platform URL → vellum_unauthenticated naming the URL", async () => {
+    seedCanonicalVellumConnection();
     fakeConfig = { llm: { defaultProvider: { provider: "vellum" } } };
     managedProxyBaseUrl = "";
     const result = await get();
     expect(availability(result).status).toBe("vellum_unauthenticated");
     expect(availability(result).message).toContain("platform URL");
+  });
+
+  test("vellum default with no canonical row → missing_connection", async () => {
+    managedProxyEnabled = true;
+    fakeConfig = { llm: { defaultProvider: { provider: "vellum" } } };
+    const result = await get();
+    expect(availability(result).status).toBe("missing_connection");
+  });
+
+  test("user-owned connection claiming the vellum name → provider_mismatch, not ok", async () => {
+    // seedCanonicalConnections skips reseeding when a user row claims the
+    // name; dispatch then uses the user row, so signed-in Vellum must not
+    // read as ok.
+    seedConnection({
+      name: "vellum",
+      provider: "anthropic",
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
+    });
+    secureKeyResults["credential/anthropic/api_key"] = {
+      value: "sk-ant",
+      unreachable: false,
+    };
+    managedProxyEnabled = true;
+    fakeConfig = { llm: { defaultProvider: { provider: "vellum" } } };
+
+    const result = await get();
+    expect(availability(result).status).toBe("provider_mismatch");
+  });
+
+  test("platform-auth connection for a non-managed provider → unsupported_auth even when signed in", async () => {
+    seedConnection({
+      name: "openrouter-personal",
+      provider: "openrouter",
+      auth: { type: "platform" },
+    });
+    managedProxyEnabled = true;
+    fakeConfig = { llm: { defaultProvider: { provider: "openrouter" } } };
+
+    const result = await get();
+    expect(availability(result).status).toBe("unsupported_auth");
+    expect(availability(result).message).toContain("platform auth");
   });
 
   test("BYOK with stored key → ok, convention-resolved connection", async () => {
@@ -226,6 +278,7 @@ describe("GET config/llm/default-provider", () => {
   });
 
   test("vellum + credential store unreachable → unknown, not logged-out", async () => {
+    seedCanonicalVellumConnection();
     fakeConfig = { llm: { defaultProvider: { provider: "vellum" } } };
     secureKeyResults["credential/vellum/assistant_api_key"] = {
       value: undefined,

--- a/assistant/src/runtime/routes/__tests__/default-provider-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/default-provider-routes.test.ts
@@ -168,8 +168,12 @@ describe("GET config/llm/default-provider", () => {
     seedConnection({
       name: "work-openai",
       provider: "openai",
-      auth: { type: "none" },
+      auth: { type: "api_key", credential: "credential/openai/api_key" },
     });
+    secureKeyResults["credential/openai/api_key"] = {
+      value: "sk-oai",
+      unreachable: false,
+    };
     fakeConfig = {
       llm: {
         defaultProvider: { provider: "openai", connectionName: "work-openai" },
@@ -219,6 +223,62 @@ describe("GET config/llm/default-provider", () => {
     const result = await get();
     expect(availability(result).status).toBe("unknown");
     expect(availability(result).message).toContain("unreachable");
+  });
+
+  test("vellum + credential store unreachable → unknown, not logged-out", async () => {
+    fakeConfig = { llm: { defaultProvider: { provider: "vellum" } } };
+    secureKeyResults["credential/vellum/assistant_api_key"] = {
+      value: undefined,
+      unreachable: true,
+    };
+    const result = await get();
+    expect(availability(result).status).toBe("unknown");
+    expect(availability(result).message).toContain("unreachable");
+  });
+
+  test("vellum with a dangling explicit connectionName → missing_connection", async () => {
+    fakeConfig = {
+      llm: {
+        defaultProvider: { provider: "vellum", connectionName: "ghost" },
+      },
+    };
+    const result = await get();
+    expect(availability(result).status).toBe("missing_connection");
+  });
+
+  test("vellum pinned to another provider's connection → provider_mismatch", async () => {
+    seedConnection({
+      name: "anthropic-personal",
+      provider: "anthropic",
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
+    });
+    secureKeyResults["credential/anthropic/api_key"] = {
+      value: "sk-ant",
+      unreachable: false,
+    };
+    fakeConfig = {
+      llm: {
+        defaultProvider: {
+          provider: "vellum",
+          connectionName: "anthropic-personal",
+        },
+      },
+    };
+    const result = await get();
+    expect(availability(result).status).toBe("provider_mismatch");
+  });
+
+  test("none-auth connection on a keyed provider → unsupported_auth", async () => {
+    seedConnection({
+      name: "openai-personal",
+      provider: "openai",
+      auth: { type: "none" },
+    });
+    fakeConfig = { llm: { defaultProvider: { provider: "openai" } } };
+
+    const result = await get();
+    expect(availability(result).status).toBe("unsupported_auth");
+    expect(availability(result).message).toContain("API key");
   });
 
   test("explicit connectionName for a different provider → provider_mismatch even with credentials", async () => {
@@ -319,8 +379,12 @@ describe("PUT config/llm/default-provider", () => {
     seedConnection({
       name: "openai-personal",
       provider: "openai",
-      auth: { type: "none" },
+      auth: { type: "api_key", credential: "credential/openai/api_key" },
     });
+    secureKeyResults["credential/openai/api_key"] = {
+      value: "sk-oai",
+      unreachable: false,
+    };
 
     const result = (await put({ provider: "openai" })) as Record<
       string,

--- a/assistant/src/runtime/routes/__tests__/default-provider-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/default-provider-routes.test.ts
@@ -221,6 +221,66 @@ describe("GET config/llm/default-provider", () => {
     expect(availability(result).message).toContain("unreachable");
   });
 
+  test("explicit connectionName for a different provider → provider_mismatch even with credentials", async () => {
+    seedConnection({
+      name: "anthropic-personal",
+      provider: "anthropic",
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
+    });
+    secureKeyResults["credential/anthropic/api_key"] = {
+      value: "sk-ant",
+      unreachable: false,
+    };
+    fakeConfig = {
+      llm: {
+        defaultProvider: {
+          provider: "openai",
+          connectionName: "anthropic-personal",
+        },
+      },
+    };
+
+    const result = await get();
+    expect(availability(result).status).toBe("provider_mismatch");
+    expect(availability(result).message).toContain('"anthropic"');
+    expect(availability(result).message).toContain('"openai"');
+  });
+
+  test("vellum-managed connection pinned for a managed-routable provider follows platform auth", async () => {
+    seedConnection({
+      name: "vellum",
+      provider: "vellum",
+      auth: { type: "platform" },
+    });
+    fakeConfig = {
+      llm: {
+        defaultProvider: { provider: "anthropic", connectionName: "vellum" },
+      },
+    };
+
+    expect(availability(await get()).status).toBe("vellum_unauthenticated");
+    managedProxyEnabled = true;
+    expect(availability(await get()).status).toBe("ok");
+  });
+
+  test("vellum-managed connection pinned for a non-managed provider → provider_mismatch", async () => {
+    seedConnection({
+      name: "vellum",
+      provider: "vellum",
+      auth: { type: "platform" },
+    });
+    managedProxyEnabled = true;
+    fakeConfig = {
+      llm: {
+        defaultProvider: { provider: "openrouter", connectionName: "vellum" },
+      },
+    };
+
+    const result = await get();
+    expect(availability(result).status).toBe("provider_mismatch");
+    expect(availability(result).message).toContain("Vellum-managed");
+  });
+
   test("service_account connection → unsupported_auth even with a stored credential", async () => {
     seedConnection({
       name: "gemini-personal",

--- a/assistant/src/runtime/routes/__tests__/default-provider-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/default-provider-routes.test.ts
@@ -221,6 +221,23 @@ describe("GET config/llm/default-provider", () => {
     expect(availability(result).message).toContain("unreachable");
   });
 
+  test("service_account connection → unsupported_auth even with a stored credential", async () => {
+    seedConnection({
+      name: "gemini-personal",
+      provider: "gemini",
+      auth: { type: "service_account", credential: "credential/gemini/sa" },
+    });
+    secureKeyResults["credential/gemini/sa"] = {
+      value: "{}",
+      unreachable: false,
+    };
+    fakeConfig = { llm: { defaultProvider: { provider: "gemini" } } };
+
+    const result = await get();
+    expect(availability(result).status).toBe("unsupported_auth");
+    expect(availability(result).message).toContain("service-account");
+  });
+
   test("platform-auth connection follows managed-proxy state", async () => {
     seedConnection({
       name: "anthropic-personal",

--- a/assistant/src/runtime/routes/__tests__/default-provider-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/default-provider-routes.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Tests for the default-provider route handlers.
+ *
+ * Covers:
+ *   GET /v1/config/llm/default-provider — availability per provider kind,
+ *     connection/credential states, CES-unreachable vs missing-credential
+ *   PUT /v1/config/llm/default-provider — strict validation, persistence
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Module mocks (must come before imports) ──────────────────────────────────
+
+let fakeConfig: Record<string, unknown> = {};
+let savedRawConfig: Record<string, unknown> | null = null;
+mock.module("../../../config/loader.js", () => ({
+  getConfigReadOnly: () => fakeConfig,
+  getConfig: () => fakeConfig,
+  loadRawConfig: () => fakeConfig,
+  saveRawConfig: (config: Record<string, unknown>) => {
+    savedRawConfig = config;
+  },
+  invalidateConfigCache: () => {},
+}));
+
+let managedProxyEnabled = false;
+let managedProxyBaseUrl = "https://platform.example";
+mock.module("../../../providers/platform-proxy/context.js", () => ({
+  resolveManagedProxyContext: async () => ({
+    enabled: managedProxyEnabled,
+    platformBaseUrl: managedProxyBaseUrl,
+    assistantApiKey: managedProxyEnabled ? "key" : "",
+  }),
+}));
+
+let secureKeyResults: Record<
+  string,
+  { value: string | undefined; unreachable: boolean }
+> = {};
+mock.module("../../../security/secure-keys.js", () => ({
+  getSecureKeyResultAsync: async (account: string) =>
+    secureKeyResults[account] ?? { value: undefined, unreachable: false },
+}));
+
+// ── Real imports (after mocks) ────────────────────────────────────────────────
+
+import { getDb } from "../../../persistence/db-connection.js";
+import { initializeDb } from "../../../persistence/db-init.js";
+import { providerConnections } from "../../../persistence/schema/inference.js";
+import { ROUTES } from "../default-provider-routes.js";
+import { BadRequestError } from "../errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "../types.js";
+
+// ── DB bootstrap ──────────────────────────────────────────────────────────────
+
+await initializeDb();
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function findRoute(operationId: string): RouteDefinition {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) {
+    throw new Error(`Route ${operationId} not found`);
+  }
+  return route;
+}
+
+async function get(): Promise<Record<string, unknown>> {
+  return (await findRoute("llm_default_provider_get").handler({})) as Record<
+    string,
+    unknown
+  >;
+}
+
+async function put(body: RouteHandlerArgs["body"]): Promise<unknown> {
+  return await findRoute("llm_default_provider_put").handler({ body });
+}
+
+function availability(result: Record<string, unknown>): {
+  status: string;
+  message?: string;
+} {
+  return result.availability as { status: string; message?: string };
+}
+
+function seedConnection(opts: {
+  name: string;
+  provider: string;
+  auth: object;
+}): void {
+  const now = Date.now();
+  getDb()
+    .insert(providerConnections)
+    .values({
+      name: opts.name,
+      provider: opts.provider,
+      auth: JSON.stringify(opts.auth),
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  getDb().delete(providerConnections).run();
+  fakeConfig = { llm: {} };
+  savedRawConfig = null;
+  managedProxyEnabled = false;
+  managedProxyBaseUrl = "https://platform.example";
+  secureKeyResults = {};
+});
+
+// ── GET ───────────────────────────────────────────────────────────────────────
+
+describe("GET config/llm/default-provider", () => {
+  test("no default configured → missing_default", async () => {
+    const result = await get();
+    expect(result.provider).toBeNull();
+    expect(result.resolvedConnectionName).toBeNull();
+    expect(availability(result).status).toBe("missing_default");
+    expect(availability(result).message).toContain("default provider");
+  });
+
+  test("vellum + authenticated → ok", async () => {
+    fakeConfig = { llm: { defaultProvider: { provider: "vellum" } } };
+    managedProxyEnabled = true;
+    const result = await get();
+    expect(result.provider).toBe("vellum");
+    expect(availability(result)).toEqual({ status: "ok" });
+  });
+
+  test("vellum + unauthenticated → vellum_unauthenticated naming the fix", async () => {
+    fakeConfig = { llm: { defaultProvider: { provider: "vellum" } } };
+    const result = await get();
+    expect(availability(result).status).toBe("vellum_unauthenticated");
+    expect(availability(result).message).toContain("Log in");
+  });
+
+  test("vellum + no platform URL → vellum_unauthenticated naming the URL", async () => {
+    fakeConfig = { llm: { defaultProvider: { provider: "vellum" } } };
+    managedProxyBaseUrl = "";
+    const result = await get();
+    expect(availability(result).status).toBe("vellum_unauthenticated");
+    expect(availability(result).message).toContain("platform URL");
+  });
+
+  test("BYOK with stored key → ok, convention-resolved connection", async () => {
+    seedConnection({
+      name: "anthropic-personal",
+      provider: "anthropic",
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
+    });
+    secureKeyResults["credential/anthropic/api_key"] = {
+      value: "sk-ant",
+      unreachable: false,
+    };
+    fakeConfig = { llm: { defaultProvider: { provider: "anthropic" } } };
+
+    const result = await get();
+    expect(result.resolvedConnectionName).toBe("anthropic-personal");
+    expect(result.connectionName).toBeUndefined();
+    expect(availability(result)).toEqual({ status: "ok" });
+  });
+
+  test("explicit connectionName wins over convention", async () => {
+    seedConnection({
+      name: "work-openai",
+      provider: "openai",
+      auth: { type: "none" },
+    });
+    fakeConfig = {
+      llm: {
+        defaultProvider: { provider: "openai", connectionName: "work-openai" },
+      },
+    };
+
+    const result = await get();
+    expect(result.connectionName).toBe("work-openai");
+    expect(result.resolvedConnectionName).toBe("work-openai");
+    expect(availability(result)).toEqual({ status: "ok" });
+  });
+
+  test("no connection row → missing_connection naming connection and provider", async () => {
+    fakeConfig = { llm: { defaultProvider: { provider: "openai" } } };
+    const result = await get();
+    expect(availability(result).status).toBe("missing_connection");
+    expect(availability(result).message).toContain('"openai-personal"');
+    expect(availability(result).message).toContain('"openai"');
+  });
+
+  test("api_key connection with no stored key → missing_credential", async () => {
+    seedConnection({
+      name: "anthropic-personal",
+      provider: "anthropic",
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
+    });
+    fakeConfig = { llm: { defaultProvider: { provider: "anthropic" } } };
+
+    const result = await get();
+    expect(availability(result).status).toBe("missing_credential");
+    expect(availability(result).message).toContain("API key");
+    expect(availability(result).message).toContain('"anthropic-personal"');
+  });
+
+  test("credential store unreachable → unknown, never missing_credential", async () => {
+    seedConnection({
+      name: "anthropic-personal",
+      provider: "anthropic",
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
+    });
+    secureKeyResults["credential/anthropic/api_key"] = {
+      value: undefined,
+      unreachable: true,
+    };
+    fakeConfig = { llm: { defaultProvider: { provider: "anthropic" } } };
+
+    const result = await get();
+    expect(availability(result).status).toBe("unknown");
+    expect(availability(result).message).toContain("unreachable");
+  });
+
+  test("platform-auth connection follows managed-proxy state", async () => {
+    seedConnection({
+      name: "anthropic-personal",
+      provider: "anthropic",
+      auth: { type: "platform" },
+    });
+    fakeConfig = { llm: { defaultProvider: { provider: "anthropic" } } };
+
+    expect(availability(await get()).status).toBe("vellum_unauthenticated");
+    managedProxyEnabled = true;
+    expect(availability(await get()).status).toBe("ok");
+  });
+});
+
+// ── PUT ───────────────────────────────────────────────────────────────────────
+
+describe("PUT config/llm/default-provider", () => {
+  test("valid body persists and returns fresh status", async () => {
+    seedConnection({
+      name: "openai-personal",
+      provider: "openai",
+      auth: { type: "none" },
+    });
+
+    const result = (await put({ provider: "openai" })) as Record<
+      string,
+      unknown
+    >;
+
+    expect(
+      (savedRawConfig?.llm as Record<string, unknown>).defaultProvider,
+    ).toEqual({ provider: "openai" });
+    expect(result.provider).toBe("openai");
+    expect(availability(result)).toEqual({ status: "ok" });
+  });
+
+  test("persists an explicit connectionName", async () => {
+    await put({ provider: "openai", connectionName: "work-openai" });
+    expect(
+      (savedRawConfig?.llm as Record<string, unknown>).defaultProvider,
+    ).toEqual({ provider: "openai", connectionName: "work-openai" });
+  });
+
+  test("dangling connection is accepted and reported via availability", async () => {
+    const result = (await put({ provider: "gemini" })) as Record<
+      string,
+      unknown
+    >;
+    expect(savedRawConfig).not.toBeNull();
+    expect(availability(result).status).toBe("missing_connection");
+  });
+
+  test("invalid provider → 400 naming the allowed providers", async () => {
+    const err = await put({ provider: "not-a-provider" }).catch(
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(BadRequestError);
+    expect((err as BadRequestError).message).toContain("anthropic");
+    expect((err as BadRequestError).message).toContain("vellum");
+    expect(savedRawConfig).toBeNull();
+  });
+
+  test("unknown keys are stripped from the persisted value", async () => {
+    await put({ provider: "anthropic", extra: "nope" });
+    expect(
+      (savedRawConfig?.llm as Record<string, unknown>).defaultProvider,
+    ).toEqual({ provider: "anthropic" });
+  });
+});
+
+// ── Route policy ──────────────────────────────────────────────────────────────
+
+describe("route policy", () => {
+  test("GET requires settings.read; PUT requires settings.write", () => {
+    expect(
+      findRoute("llm_default_provider_get").policy?.requiredScopes,
+    ).toEqual(["settings.read"]);
+    expect(
+      findRoute("llm_default_provider_put").policy?.requiredScopes,
+    ).toEqual(["settings.write"]);
+  });
+});

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -45,6 +45,7 @@ import { completeCustomProfile } from "../../config/profile-materialization.js";
 import { AssistantConfigSchema } from "../../config/schema.js";
 import { getSchemaAtPath } from "../../config/schema-utils.js";
 import {
+  DefaultProviderSchema,
   LLMConfigBase,
   LLMConfigFragment,
   ProfileEntry,
@@ -657,6 +658,7 @@ const ConfigGetResponseSchema = z
         default: LLMConfigFragment.extend({
           provider_connection: z.string().optional(),
         }).optional(),
+        defaultProvider: DefaultProviderSchema.optional(),
         profiles: z.record(z.string(), WireProfileEntry).optional(),
         profileOrder: z.array(z.string()).optional(),
         activeProfile: z.string().optional(),

--- a/assistant/src/runtime/routes/default-provider-routes.ts
+++ b/assistant/src/runtime/routes/default-provider-routes.ts
@@ -27,6 +27,10 @@ import { DefaultProviderSchema } from "../../config/schemas/llm.js";
 import { getDb } from "../../persistence/db-connection.js";
 import { getConnection } from "../../providers/inference/connections.js";
 import { resolveManagedProxyContext } from "../../providers/platform-proxy/context.js";
+import {
+  isVellumManagedConnection,
+  MANAGED_ROUTABLE_PROVIDERS,
+} from "../../providers/vellum-model-routing.js";
 import { getSecureKeyResultAsync } from "../../security/secure-keys.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError } from "./errors.js";
@@ -38,6 +42,7 @@ const availabilitySchema = z.object({
     "missing_default",
     "missing_connection",
     "missing_credential",
+    "provider_mismatch",
     "unsupported_auth",
     "vellum_unauthenticated",
     "unknown",
@@ -96,6 +101,26 @@ async function computeAvailability(
     return {
       status: "missing_connection",
       message: `No connection named "${resolvedConnectionName}" exists for provider "${dp.provider}". Add one ${SETTINGS_HINT}.`,
+    };
+  }
+
+  // Mirror the dispatch-time provider check (`tryResolveProviderForConnectionName`):
+  // the provider-agnostic Vellum-managed connection routes managed-routable
+  // providers via platform auth; any other provider mismatch fails there, so
+  // usable credentials must not read as ok.
+  if (isVellumManagedConnection(connection)) {
+    if (MANAGED_ROUTABLE_PROVIDERS.has(dp.provider)) {
+      return vellumAvailability();
+    }
+    return {
+      status: "provider_mismatch",
+      message: `Connection "${resolvedConnectionName}" is the Vellum-managed connection, which cannot serve provider "${dp.provider}". Pick a connection for "${dp.provider}" ${SETTINGS_HINT}.`,
+    };
+  }
+  if (connection.provider !== dp.provider) {
+    return {
+      status: "provider_mismatch",
+      message: `Connection "${resolvedConnectionName}" is for provider "${connection.provider}", but the default provider is "${dp.provider}". Pick a connection for "${dp.provider}" or update the default ${SETTINGS_HINT}.`,
     };
   }
 

--- a/assistant/src/runtime/routes/default-provider-routes.ts
+++ b/assistant/src/runtime/routes/default-provider-routes.ts
@@ -1,0 +1,200 @@
+/**
+ * Route handlers for the workspace default provider (`llm.defaultProvider`).
+ *
+ * GET /v1/config/llm/default-provider — current value + availability status
+ * PUT /v1/config/llm/default-provider — replace the value (strict-validated)
+ *
+ * The dedicated PUT exists because the generic config write paths parse
+ * `llm.defaultProvider` through `.catch(undefined)` — an invalid value is
+ * silently dropped on the next reparse instead of rejected. This route
+ * strict-parses and fails loudly.
+ *
+ * Availability is reported, never enforced: a dangling connection name is a
+ * valid persisted state by design (see `DefaultProviderSchema`), and the GET
+ * names what is broken and how to fix it.
+ */
+import { z } from "zod";
+
+import { DEFAULT_PROFILE_PROVIDERS } from "../../config/default-profile-names.js";
+import { setDefaultProvider } from "../../config/default-provider.js";
+import {
+  getDefaultProviderFromConfig,
+  resolveDefaultConnectionName,
+} from "../../config/default-provider-resolution.js";
+import { getConfigReadOnly } from "../../config/loader.js";
+import type { DefaultProviderConfig } from "../../config/schemas/llm.js";
+import { DefaultProviderSchema } from "../../config/schemas/llm.js";
+import { getDb } from "../../persistence/db-connection.js";
+import { getConnection } from "../../providers/inference/connections.js";
+import { resolveManagedProxyContext } from "../../providers/platform-proxy/context.js";
+import { getSecureKeyResultAsync } from "../../security/secure-keys.js";
+import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { BadRequestError } from "./errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+const availabilitySchema = z.object({
+  status: z.enum([
+    "ok",
+    "missing_default",
+    "missing_connection",
+    "missing_credential",
+    "vellum_unauthenticated",
+    "unknown",
+  ]),
+  /** Present on every non-`ok` status: names the broken thing and the fix. */
+  message: z.string().optional(),
+});
+
+const defaultProviderStatusSchema = z
+  .object({
+    provider: z.enum(DEFAULT_PROFILE_PROVIDERS).nullable(),
+    /** Explicit connection pin, when the persisted value carries one. */
+    connectionName: z.string().optional(),
+    /** The connection the default resolves to (explicit pin or convention). */
+    resolvedConnectionName: z.string().nullable(),
+    availability: availabilitySchema,
+  })
+  .meta({ id: "DefaultProviderStatus" });
+
+type DefaultProviderStatus = z.infer<typeof defaultProviderStatusSchema>;
+type Availability = z.infer<typeof availabilitySchema>;
+
+const SETTINGS_HINT = "in Settings → Models & Services";
+
+async function vellumAvailability(): Promise<Availability> {
+  const ctx = await resolveManagedProxyContext();
+  if (ctx.enabled) {
+    return { status: "ok" };
+  }
+  return {
+    status: "vellum_unauthenticated",
+    message: ctx.platformBaseUrl
+      ? "Not signed in to Vellum — no assistant API key is stored. Log in to use Vellum-managed inference."
+      : "Not signed in to Vellum — the platform URL is not configured.",
+  };
+}
+
+async function computeAvailability(
+  dp: DefaultProviderConfig,
+  resolvedConnectionName: string,
+): Promise<Availability> {
+  if (dp.provider === "vellum") {
+    return vellumAvailability();
+  }
+
+  let connection;
+  try {
+    connection = getConnection(getDb(), resolvedConnectionName);
+  } catch {
+    return {
+      status: "unknown",
+      message: `Connection "${resolvedConnectionName}" could not be looked up. Try again shortly.`,
+    };
+  }
+  if (!connection) {
+    return {
+      status: "missing_connection",
+      message: `No connection named "${resolvedConnectionName}" exists for provider "${dp.provider}". Add one ${SETTINGS_HINT}.`,
+    };
+  }
+
+  switch (connection.auth.type) {
+    case "api_key":
+    case "oauth_subscription":
+    case "service_account": {
+      const result = await getSecureKeyResultAsync(connection.auth.credential);
+      if (result.value != null) {
+        return { status: "ok" };
+      }
+      if (result.unreachable) {
+        // Credential store down ≠ credential missing. Reporting
+        // `missing_credential` here would send the user re-entering a key
+        // that is probably still stored.
+        return {
+          status: "unknown",
+          message: `The credential store is unreachable, so the credential for connection "${resolvedConnectionName}" could not be verified. Try again shortly.`,
+        };
+      }
+      const noun =
+        connection.auth.type === "api_key" ? "API key" : "credential";
+      return {
+        status: "missing_credential",
+        message: `Connection "${resolvedConnectionName}" has no ${noun} stored. Add one ${SETTINGS_HINT}.`,
+      };
+    }
+    case "platform":
+      return vellumAvailability();
+    case "none":
+      return { status: "ok" };
+  }
+}
+
+async function handleGetDefaultProvider(): Promise<DefaultProviderStatus> {
+  const dp = getDefaultProviderFromConfig(getConfigReadOnly());
+  if (!dp) {
+    return {
+      provider: null,
+      resolvedConnectionName: null,
+      availability: {
+        status: "missing_default",
+        message: `No default provider is configured. Pick one ${SETTINGS_HINT}.`,
+      },
+    };
+  }
+  const resolvedConnectionName = resolveDefaultConnectionName(dp);
+  return {
+    provider: dp.provider,
+    ...(dp.connectionName ? { connectionName: dp.connectionName } : {}),
+    resolvedConnectionName,
+    availability: await computeAvailability(dp, resolvedConnectionName),
+  };
+}
+
+async function handlePutDefaultProvider({
+  body = {},
+}: RouteHandlerArgs): Promise<DefaultProviderStatus> {
+  const result = DefaultProviderSchema.safeParse(body);
+  if (!result.success) {
+    throw new BadRequestError(
+      `Invalid default provider. "provider" must be one of: ${DEFAULT_PROFILE_PROVIDERS.join(
+        ", ",
+      )}; "connectionName" is optional and must be a non-empty string.`,
+    );
+  }
+  setDefaultProvider(result.data);
+  return handleGetDefaultProvider();
+}
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "llm_default_provider_get",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    endpoint: "config/llm/default-provider",
+    handler: handleGetDefaultProvider,
+    summary: "Get the default provider and its availability",
+    description:
+      "Returns `llm.defaultProvider`, the connection name it resolves to, and whether that connection is currently usable (connection exists, credential stored, Vellum authenticated). Availability is informational — a broken default is a valid persisted state that surfaces explainable errors at resolution time.",
+    tags: ["config"],
+    responseBody: defaultProviderStatusSchema,
+  },
+  {
+    operationId: "llm_default_provider_put",
+    method: "PUT",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    endpoint: "config/llm/default-provider",
+    handler: handlePutDefaultProvider,
+    summary: "Set the default provider",
+    description:
+      "Replaces `llm.defaultProvider`. Strict-validates the body (unlike the generic config write paths, which silently drop invalid values). Does not require the referenced connection to exist — a dangling name is allowed by design and reported via the availability status.",
+    tags: ["config"],
+    requestBody: DefaultProviderSchema,
+    responseBody: defaultProviderStatusSchema,
+  },
+];

--- a/assistant/src/runtime/routes/default-provider-routes.ts
+++ b/assistant/src/runtime/routes/default-provider-routes.ts
@@ -30,7 +30,9 @@ import { resolveManagedProxyContext } from "../../providers/platform-proxy/conte
 import {
   isVellumManagedConnection,
   MANAGED_ROUTABLE_PROVIDERS,
+  VELLUM_MANAGED_CONNECTION_NAME,
 } from "../../providers/vellum-model-routing.js";
+import { credentialKey } from "../../security/credential-key.js";
 import { getSecureKeyResultAsync } from "../../security/secure-keys.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError } from "./errors.js";
@@ -72,11 +74,41 @@ async function vellumAvailability(): Promise<Availability> {
   if (ctx.enabled) {
     return { status: "ok" };
   }
+  if (!ctx.platformBaseUrl) {
+    return {
+      status: "vellum_unauthenticated",
+      message: "Not signed in to Vellum — the platform URL is not configured.",
+    };
+  }
+  // The context collapses an unreachable credential read into "no key";
+  // re-read reachability-aware so a CES outage isn't reported as logged out.
+  const key = await getSecureKeyResultAsync(
+    credentialKey("vellum", "assistant_api_key"),
+  );
+  if (key.value != null) {
+    return { status: "ok" };
+  }
+  if (key.unreachable) {
+    return {
+      status: "unknown",
+      message:
+        "The credential store is unreachable, so Vellum sign-in could not be verified. Try again shortly.",
+    };
+  }
   return {
     status: "vellum_unauthenticated",
-    message: ctx.platformBaseUrl
-      ? "Not signed in to Vellum — no assistant API key is stored. Log in to use Vellum-managed inference."
-      : "Not signed in to Vellum — the platform URL is not configured.",
+    message:
+      "Not signed in to Vellum — no assistant API key is stored. Log in to use Vellum-managed inference.",
+  };
+}
+
+function vellumManagedMismatch(
+  resolvedConnectionName: string,
+  provider: string,
+): Availability {
+  return {
+    status: "provider_mismatch",
+    message: `Connection "${resolvedConnectionName}" is the Vellum-managed connection, which cannot serve provider "${provider}". Pick a connection for "${provider}" ${SETTINGS_HINT}.`,
   };
 }
 
@@ -84,8 +116,18 @@ async function computeAvailability(
   dp: DefaultProviderConfig,
   resolvedConnectionName: string,
 ): Promise<Availability> {
-  if (dp.provider === "vellum") {
-    return vellumAvailability();
+  // Canonical managed connection (vellum convention, or an explicit pin on
+  // it): boot-seeded platform-auth row, so only platform auth needs checking.
+  // An explicit non-canonical pin — even with provider "vellum" — goes
+  // through the full row checks below instead.
+  if (resolvedConnectionName === VELLUM_MANAGED_CONNECTION_NAME) {
+    if (
+      dp.provider === "vellum" ||
+      MANAGED_ROUTABLE_PROVIDERS.has(dp.provider)
+    ) {
+      return vellumAvailability();
+    }
+    return vellumManagedMismatch(resolvedConnectionName, dp.provider);
   }
 
   let connection;
@@ -109,13 +151,13 @@ async function computeAvailability(
   // providers via platform auth; any other provider mismatch fails there, so
   // usable credentials must not read as ok.
   if (isVellumManagedConnection(connection)) {
-    if (MANAGED_ROUTABLE_PROVIDERS.has(dp.provider)) {
+    if (
+      dp.provider === "vellum" ||
+      MANAGED_ROUTABLE_PROVIDERS.has(dp.provider)
+    ) {
       return vellumAvailability();
     }
-    return {
-      status: "provider_mismatch",
-      message: `Connection "${resolvedConnectionName}" is the Vellum-managed connection, which cannot serve provider "${dp.provider}". Pick a connection for "${dp.provider}" ${SETTINGS_HINT}.`,
-    };
+    return vellumManagedMismatch(resolvedConnectionName, dp.provider);
   }
   if (connection.provider !== dp.provider) {
     return {
@@ -158,7 +200,13 @@ async function computeAvailability(
     case "platform":
       return vellumAvailability();
     case "none":
-      return { status: "ok" };
+      // Every default-provider candidate except vellum is an API-key
+      // provider; dispatch (`createAdapterFromConnection`) yields no adapter
+      // for keyless auth on them.
+      return {
+        status: "unsupported_auth",
+        message: `Connection "${resolvedConnectionName}" has no authentication configured, but provider "${dp.provider}" requires an API key. Add a key ${SETTINGS_HINT}.`,
+      };
   }
 }
 

--- a/assistant/src/runtime/routes/default-provider-routes.ts
+++ b/assistant/src/runtime/routes/default-provider-routes.ts
@@ -30,7 +30,6 @@ import { resolveManagedProxyContext } from "../../providers/platform-proxy/conte
 import {
   isVellumManagedConnection,
   MANAGED_ROUTABLE_PROVIDERS,
-  VELLUM_MANAGED_CONNECTION_NAME,
 } from "../../providers/vellum-model-routing.js";
 import { credentialKey } from "../../security/credential-key.js";
 import { getSecureKeyResultAsync } from "../../security/secure-keys.js";
@@ -116,20 +115,10 @@ async function computeAvailability(
   dp: DefaultProviderConfig,
   resolvedConnectionName: string,
 ): Promise<Availability> {
-  // Canonical managed connection (vellum convention, or an explicit pin on
-  // it): boot-seeded platform-auth row, so only platform auth needs checking.
-  // An explicit non-canonical pin — even with provider "vellum" — goes
-  // through the full row checks below instead.
-  if (resolvedConnectionName === VELLUM_MANAGED_CONNECTION_NAME) {
-    if (
-      dp.provider === "vellum" ||
-      MANAGED_ROUTABLE_PROVIDERS.has(dp.provider)
-    ) {
-      return vellumAvailability();
-    }
-    return vellumManagedMismatch(resolvedConnectionName, dp.provider);
-  }
-
+  // Every path loads the row — even the canonical `vellum` name. Boot seeding
+  // (`seedCanonicalConnections`) deliberately leaves a user-owned connection
+  // that claims that name in place, and dispatch reads whatever row is
+  // stored, so availability must judge the actual row, not the name.
   let connection;
   try {
     connection = getConnection(getDb(), resolvedConnectionName);
@@ -198,7 +187,16 @@ async function computeAvailability(
       };
     }
     case "platform":
-      return vellumAvailability();
+      // The managed proxy only serves managed-routable upstreams
+      // (`resolveAuth` → `buildManagedBaseUrl` has no proxy path for the
+      // rest), so platform auth on e.g. openrouter can never dispatch.
+      if (MANAGED_ROUTABLE_PROVIDERS.has(dp.provider)) {
+        return vellumAvailability();
+      }
+      return {
+        status: "unsupported_auth",
+        message: `Connection "${resolvedConnectionName}" uses Vellum platform auth, which cannot serve provider "${dp.provider}". Add an API-key connection for "${dp.provider}" ${SETTINGS_HINT}.`,
+      };
     case "none":
       // Every default-provider candidate except vellum is an API-key
       // provider; dispatch (`createAdapterFromConnection`) yields no adapter

--- a/assistant/src/runtime/routes/default-provider-routes.ts
+++ b/assistant/src/runtime/routes/default-provider-routes.ts
@@ -38,6 +38,7 @@ const availabilitySchema = z.object({
     "missing_default",
     "missing_connection",
     "missing_credential",
+    "unsupported_auth",
     "vellum_unauthenticated",
     "unknown",
   ]),
@@ -99,9 +100,16 @@ async function computeAvailability(
   }
 
   switch (connection.auth.type) {
+    // Schema-accepted but not dispatchable: `resolveAuth` returns
+    // not_implemented for service_account, so a stored credential still
+    // cannot serve inference.
+    case "service_account":
+      return {
+        status: "unsupported_auth",
+        message: `Connection "${resolvedConnectionName}" uses service-account auth, which inference does not support yet. Pick a connection with a different auth type.`,
+      };
     case "api_key":
-    case "oauth_subscription":
-    case "service_account": {
+    case "oauth_subscription": {
       const result = await getSecureKeyResultAsync(connection.auth.credential);
       if (result.value != null) {
         return { status: "ok" };

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -57,6 +57,7 @@ import { ROUTES as CREDENTIAL_REQUEST_ROUTES } from "./credential-request-routes
 import { ROUTES as CREDENTIAL_ROUTES } from "./credential-routes.js";
 import { ROUTES as DEBUG_BASH_ROUTES } from "./debug-bash-routes.js";
 import { ROUTES as DEBUG_ROUTES } from "./debug-routes.js";
+import { ROUTES as DEFAULT_PROVIDER_ROUTES } from "./default-provider-routes.js";
 import { ROUTES as DEFER_ROUTES } from "./defer-routes.js";
 import { ROUTES as DIAGNOSTICS_ROUTES } from "./diagnostics-routes.js";
 import { ROUTES as DISK_PRESSURE_ROUTES } from "./disk-pressure-routes.js";
@@ -198,6 +199,7 @@ export const ROUTES: RouteDefinition[] = [
   ...CONVERSATION_STARTER_ROUTES,
   ...DEBUG_BASH_ROUTES,
   ...DEBUG_ROUTES,
+  ...DEFAULT_PROVIDER_ROUTES,
   ...DIAGNOSTICS_ROUTES,
   ...DISK_PRESSURE_ROUTES,
   ...DOMAIN_ROUTES,


### PR DESCRIPTION
## Summary

- Adds `GET /v1/config/llm/default-provider` returning the persisted `llm.defaultProvider`, the connection name it resolves to, and an availability status (`ok | missing_default | missing_connection | missing_credential | vellum_unauthenticated | unknown`) with a fix-naming message on every non-ok state. CES-unreachable reports `unknown`, never `missing_credential`.
- Adds `PUT /v1/config/llm/default-provider`, the first loud write path for the field: strict `DefaultProviderSchema` validation with a 400 naming the allowed providers (the generic config writes silently drop invalid values via `.catch(undefined)`). Dangling connection names remain accepted by design and are reported via availability, not rejected.
- Types `llm.defaultProvider` on `ConfigGetResponseSchema` so generated clients see the field (it previously rode through `.passthrough()` untyped), and regenerates `openapi.yaml`.

This is PR 1 of the M7 plan (Inference Management Refactor milestone 7); the web "use as default" marker, availability notice, and delete-guard surfacing build on these routes in follow-up PRs.

## Original prompt

Milestone 7 of the Inference Management Refactor covers settings UI/API for the M5 `llm.defaultProvider` field. We planned it as 5 PRs in `.private/plans/m7-settings-ui-default-provider.md`; this implements PR 1: a dedicated, strictly-validated read/write route pair with an availability signal that the web settings UI (Providers-modal default marker + Language Model card warning) will consume. Decided during planning: availability is informational only, the UI control lives in the Providers modal rather than a second "Default ___" dropdown, and credential-store-unreachable must never masquerade as a missing key.

<details>
<summary>M7 plan (papertrail)</summary>

# M7: Settings UI/API for Default Provider and Read-Only Defaults

## Overview

Milestone 7 of the Inference Management Refactor (Notion: vellum-ai/Inference-Management-Refactor-38e9035c57bd804d9f92c11f27391856): give `llm.defaultProvider` (M5) a first-class settings surface — a typed read/write route with an availability signal, a "use as default" marker on connections in the Providers modal, user-facing "default provider unavailable" warnings, and server-message-driven delete-guard errors — while keeping the default-profile UI read-only and the custom-profile flow working under M6's complete-override semantics.

**What is already done and NOT in this plan** (verified on main @ `edc12f5765`+):
- Default profiles are fully read-only server-side: `PUT /v1/config/llm/profiles/:name` accepts only status re-enable for managed entries (`conversation-query-routes.ts:1407-1421`); generic PATCH/SET block delete/rename/disable/mutation via `rejectManagedProfileDeletion` (`:1032`) and `assertInvariantProfilesPreserved` (`:1091`). The web UI already renders managed profiles view-only (`manage-profiles-list-item.tsx:100-196`, `profile-editor-modal.tsx:202-207`).
- The connection delete guard already protects `llm.defaultProvider`: `handleDeleteConnection` 409s on the resolved connection name AND on the last connection for the default provider (`inference-provider-connection-routes.ts:359-388`, tests `:471-490`), with `ConflictError` messages that name the fix and `{ referencedBy }` details. The wire envelope is `{ error: { code, message, details } }` (`http-errors.ts:65-75`). M7's guard work is therefore web-side surfacing only.

**Design decisions:**
- **Dedicated GET/PUT route for defaultProvider** instead of generic `PATCH /v1/config`: the schema field is `.optional().catch(undefined)` (`schemas/llm.ts:506`), so a bad generic write is silently dropped on reparse with no client-visible error. A dedicated PUT strict-parses and 400s loudly; `setDefaultProvider` (`config/default-provider.ts:35`) already exists unwired. The GET also carries the availability status that powers the "unavailable default provider" UI — there is no provider-health surface today (closest is `/v1/auth/info`).
- **PUT does not require the connection to exist.** Dangling connection names are allowed by design (M5 decision, documented at `schemas/llm.ts:480-489`); availability is *reported*, never enforced at write time.
- **CES-unreachable is never reported as a missing credential** — availability returns `unknown` (mirrors M6 PR 7's `getSecureKeyResultAsync` distinction).
- **The default-provider control lives in the Providers modal, not the settings card** (decided 2026-07-08 with Emmie): a "use as default" marker per connection, like a default payment method. A second "Default ___" dropdown next to "Default Profile" (`activeProfile`) would present two competing "default" concepts; the marker reads as provider management instead. The Language Model card gets only the availability warning, no selector.
- **The marker always writes `{ provider, connectionName: <connection.name> }` explicitly.** Convention resolution (`${provider}-personal`) dangles for web-onboarded users whose connections are named bare `anthropic`/`openai` (the known BYOK naming skew); pinning the clicked connection's name is one rule with no branches, and the delete guard already protects whatever name is pinned. Only connections whose provider is in `DEFAULT_PROFILE_PROVIDERS` can be marked (others — together, ollama, openai-compatible — get a disabled action with an explanatory tooltip: the intent matrix has no column for them).
- **No feature-flag gate on the selector.** The field is durable state regardless of M6's `override-or-default-resolution` kill switch; M5 deliberately shipped it dark. If the kill switch fires, the selector still edits real state that takes effect on flag restore. (Revisit only if M7 ships releases ahead of M6.)
- **Profile editor keeps `config.llm.default` as its "default value" display source.** Until M9 retires it, `llm.default` is exactly what M6 PR 2's `completeCustomProfile` snapshots blanks against — so it is the correct answer to "what will a blank field be saved as".
- **No assistant-CLI default-provider command** — not in milestone scope; the store functions are route-local so the CLI parity test is untouched (YAGNI, revisit on demand).

**External dependency:** PR 5's copy changes describe M6 PR 2's write-time snapshot semantics and should merge in the same release as M6 (per the 2026-07-08 single-release decision). PRs 1–4 have no code dependency on M6.

**Generated-type flow** (applies to every route-touching PR): edit zod in `assistant/src/runtime/routes/` → `cd assistant && bun run generate:openapi` (CI checks staleness with `-- --check`) → web regenerates `src/generated/daemon/*` automatically via `openapi-ts` in `predev`/`pretypecheck` (generated dir is gitignored; only `assistant/openapi.yaml` is committed). `packages/gateway-client` / `packages/service-contracts` are out of scope — they don't cover these routes.

## PR 1: Default-provider routes with availability status

### Depends on
None

### Branch
m7-settings-defaults/pr-1-default-provider-routes

### Title
feat(runtime): GET/PUT /v1/config/llm/default-provider with availability status

### Files
- assistant/src/runtime/routes/default-provider-routes.ts (new)
- assistant/src/runtime/routes/index.ts
- assistant/src/runtime/routes/conversation-query-routes.ts
- assistant/src/runtime/routes/__tests__/default-provider-routes.test.ts (new)
- assistant/openapi.yaml (regenerated)

### Implementation steps
1. Create `default-provider-routes.ts` exporting `ROUTES: RouteDefinition[]` (pattern: `llm-call-sites-routes.ts`). Handlers are transport-agnostic per `assistant/src/runtime/CLAUDE.md`; use `policyKey`/scopes matching the config routes (`settings.read` for GET, `settings.write` for PUT — copy from `inference-provider-connection-routes.ts:387-511`).
2. `GET /v1/config/llm/default-provider` (op `llm_default_provider_get`), side-effect-free. Response schema (zod, `.meta({ id: "DefaultProviderStatus" })`):
   - `provider` (enum of `DEFAULT_PROFILE_PROVIDERS`) and `connectionName?` — from `getDefaultProviderFromConfig(config)` (`config/default-provider-resolution.ts`). Post-M5 the field is always set; if null (hand-edited config), return `configured: false` with availability `missing_default` and a message pointing at Settings.
   - `resolvedConnectionName` — `resolveDefaultConnectionName(dp)`.
   - `availability: { status, message? }` with `status` ∈ `ok | missing_connection | missing_credential | vellum_unauthenticated | unknown`:
     - `provider === "vellum"`: `resolveManagedProxyContext().enabled` (`providers/platform-proxy/context.ts:46`) → `ok`, else `vellum_unauthenticated` with the cause message (same texts as `auth-routes.ts:45-49` — "Platform URL not configured…" / "Assistant API key not found…").
     - otherwise: `getConnection(resolvedConnectionName)` missing → `missing_connection` ("No connection named X exists — add one under Providers"). Connection with `auth.type === "api_key"` → `getSecureKeyResultAsync` (`security/secure-keys.ts:456`): `value: undefined, unreachable: false` → `missing_credential` ("Connection X has no API key stored"); `unreachable: true` → `unknown` (credential store unreachable — do NOT claim the key is missing). Platform-auth connections → check `hasManagedProxyPrereqs()` analogously.
   - Every non-`ok` status carries a `message` naming the broken thing and the fix (core invariant: explainable errors).
3. `PUT /v1/config/llm/default-provider` (op `llm_default_provider_put`), body `{ provider, connectionName? }` validated with `DefaultProviderSchema` (`schemas/llm.ts:490`). On zod failure throw `BadRequestError` listing the allowed providers. On success call `setDefaultProvider` (`config/default-provider.ts:35`) and return the same `DefaultProviderStatus` payload (fresh availability) so the client updates in one round trip. Do not check connection existence (dangling allowed by design).
4. Register the module in `routes/index.ts`.
5. Type the field on the config read path: add `defaultProvider: DefaultProviderSchema.optional()` to `ConfigGetResponseSchema.llm` (`conversation-query-routes.ts:616-645`) so the generated web types expose `config.llm.defaultProvider` (today it rides through `.passthrough()` untyped). Leave `ConfigPatchRequestSchema` alone — the PUT is the write path.
6. Regenerate: `cd assistant && bun run generate:openapi`; commit `openapi.yaml`.
7. Tests (route-handler level, pattern: `__tests__/inference-provider-connection-routes.test.ts` with mocked config/connections/secure-keys): GET ok per provider kind (vellum authenticated, BYOK with key); missing connection; missing credential vs CES-unreachable (asserted as distinct statuses); vellum unauthenticated; explicit connectionName wins over convention; PUT happy path persists via setDefaultProvider; PUT invalid provider → 400 naming allowed values; PUT ignores/rejects unknown keys per DefaultProviderSchema parse.

### Acceptance criteria
- `cd assistant && bun test src/runtime/routes/__tests__/default-provider-routes.test.ts` passes; `bunx tsc --noEmit` clean.
- `bun run generate:openapi -- --check` passes (spec committed, includes both new operations and `llm.defaultProvider` on ConfigGetResponse).
- GET is read-only (no writes, no jobs) per runtime GET-idempotency convention.
- CES-unreachable yields `unknown`, never `missing_credential` (test-asserted).

## PR 2: Web — "use as default" marker in the Providers modal

### Depends on
PR 1

### Branch
m7-settings-defaults/pr-2-default-provider-marker

### Title
feat(web): mark a provider connection as the default provider

### Files
- clients/web/src/domains/settings/ai/manage-providers-modal.tsx
- clients/web/src/domains/settings/ai/manage-providers-modal.test.tsx (new)

### Implementation steps
1. In `ManageProvidersModalInner` (`manage-providers-modal.tsx:167-349`), read the current default from the PR 1 generated query (`llmDefaultProviderGetOptions`). On the connection row whose `name === resolvedConnectionName`, render a "Default" `Tag` (alongside the existing "Platform" tag pattern, `:276-283`) and disable its Delete button with tooltip "This connection serves your default provider. Set another connection as default first." (mirroring the managed-connection disable at `:311-316`).
2. Add a per-row "Set as default" action for every other connection whose `provider` is in `DEFAULT_PROFILE_PROVIDERS` (source the list from the generated enum on the PR 1 route types — do not hand-copy). It calls the generated PUT mutation with `{ provider: connection.provider, connectionName: connection.name }` (always explicit — see Overview decision), then invalidates the default-provider and config queries. Failures render in the existing per-row inline error slot (`:323-331`).
3. Connections for providers outside the matrix (together, ollama, openai-compatible) show the action disabled with tooltip "Built-in profiles can't run on this provider."
4. Follow web conventions: TanStack cache is the single owner of server state, `captureError` on unexpected failures, colocated bun test mocking at the generated-client boundary.
5. Tests: "Default" tag renders on the resolved connection; its delete is disabled with tooltip; "Set as default" issues PUT with explicit `{ provider, connectionName }` and refreshes the query; non-matrix provider rows show the disabled action; PUT failure renders the inline row error.

### Acceptance criteria
- `cd clients/web && bun test src/domains/settings/ai/manage-providers-modal.test.tsx` passes; `bunx tsc --noEmit` clean (regenerates the daemon client from PR 1's spec first).
- Marker round-trips against a daemon running PR 1: set a different connection as default, reload, the tag moves and `GET /v1/config/llm/default-provider` reflects the pinned name.
- A web-onboarded connection named bare `anthropic` becomes the default without dangling (explicit connectionName pinned).

## PR 3: Web — default-provider availability warning

### Depends on
PR 1

### Branch
m7-settings-defaults/pr-3-availability-notice

### Title
feat(web): warn in settings when the default provider is unavailable

### Files
- clients/web/src/domains/settings/ai/language-model-card.tsx
- clients/web/src/domains/settings/ai/language-model-card.test.tsx

### Implementation steps
1. In `language-model-card.tsx`, when the PR 1 GET reports `availability.status !== "ok"`, render a design-library `Notice` inside the card: `tone="warning"` for `unknown` (transient — credential store unreachable), `tone="error"` for `missing_connection` / `missing_credential` / `vellum_unauthenticated` / `missing_default`. Body text is the server's `availability.message` verbatim (server owns the explainable wording — do not re-derive client-side).
2. Refetch the availability query when the Providers modal closes and after a default-provider save, so fixing the problem (adding a key/connection, logging in) clears the notice without a page reload.
3. Tests: notice hidden when `ok`; shown with server message per non-ok status; tone mapping (`unknown` → warning, others → error); clears after refetch returns `ok`.

### Acceptance criteria
- A BYOK default provider with no stored key shows the server's "needs an API key" message in Settings → AI; logging-out Vellum shows the unauthenticated message.
- CES-unreachable renders as a soft warning, not "missing API key".
- `bun test src/domains/settings/ai/language-model-card.test.tsx` passes.

## PR 4: Web — surface the server's connection-delete guard errors

### Depends on
PR 2

### Branch
m7-settings-defaults/pr-4-delete-guard-surfacing

### Title
feat(web): show the daemon's delete-guard reason when a connection can't be deleted

### Files
- clients/web/src/domains/settings/ai/manage-providers-modal.tsx
- clients/web/src/domains/settings/ai/manage-providers-modal.test.tsx

### Implementation steps
1. In `handleDelete` (`manage-providers-modal.tsx:180-218`), on 409 parse the response body and render `body.error.message` (envelope `{ error: { code, message, details } }` per `http-errors.ts:65-75`) in the existing inline per-row error slot (`:323-331`), falling back to the current generic string only when the body has no message. This makes the daemon's `llm.defaultProvider` guard messages ("Update llm.defaultProvider before deleting…", `inference-provider-connection-routes.ts:373`/`:385`) and profile-reference messages appear verbatim. (The proactive disable on the default connection ships in PR 2; this path covers stale-cache races and the profile-reference guards.)
2. Keep 404-as-already-gone handling (`:191-193`) unchanged.
3. Tests: 409 with server message renders that message; 409 without a parseable body falls back to the generic string; non-guarded connections still delete cleanly.

### Acceptance criteria
- Profile-reference 409s now show which profiles reference the connection (server's `referencedBy` message) instead of the generic string.
- The `llm.defaultProvider` guard message renders verbatim when a delete slips past the PR 2 disable (stale cache).
- `bun test src/domains/settings/ai/manage-providers-modal.test.tsx` passes.

## PR 5: Web — complete-override copy in the profile editor + read-only regression tests

### Depends on
None (external: M6 PR 2 write-time completion — ship in the same release)

### Branch
m7-settings-defaults/pr-5-profile-editor-snapshot-copy

### Title
fix(web): profile editor reflects snapshot-at-save semantics; lock in read-only default-profile UI

### Files
- clients/web/src/domains/settings/ai/profile-editor-modal.tsx
- clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
- clients/web/src/domains/settings/ai/manage-profiles-modal.test.tsx

### Implementation steps
1. In `profile-editor-modal.tsx`, update the blank-field/advanced-param helper copy from "inherit" phrasing to snapshot phrasing: a blank field is "saved as the current default (<value>)" — under M6, blanks are completed server-side at write time and no longer track later default changes. Keep reading the displayed default values from `config.llm.default` (`:324-326`) — that is exactly what the server completes against until M9.
2. Do not change save payloads or the create/edit/replace flows (`manage-profiles-modal.tsx:100-182` delete-then-recreate stays; the server re-completes omitted fields). This PR is copy + tests only.
3. Regression tests locking the milestone's "stays stable/read-only" requirement:
   - `profile-editor-modal.test.tsx`: managed/invariant profile opens in view mode with all fields disabled and only the enable flip active (`:207`, `:288`); "Save As New" still clones into create mode.
   - `manage-profiles-modal.test.tsx`: managed profiles are not draggable/deletable (`manage-profiles-list-item.tsx:111`, `:183-196`); custom profile create → edit round-trip preserves explicit values (post-M6, stored entries are complete — assert the editor shows stored values rather than blanks).
4. Verify `use-sticky-profiles.ts` needs no change (managed profiles remain in every `GET /v1/config` via the effective-catalog overlay, `conversation-query-routes.ts:809`) — note in the PR description.

### Acceptance criteria
- No wire-payload change (assert PUT/PATCH bodies unchanged in tests).
- Copy no longer promises live inheritance anywhere in the editor.
- Managed-profile read-only behavior is pinned by tests that fail if an affordance is accidentally re-enabled.
- `cd clients/web && bun test src/domains/settings/ai/profile-editor-modal.test.tsx src/domains/settings/ai/manage-profiles-modal.test.tsx` passes.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->