### PR TITLE
fix(web): voice-room polish — calm avatar transitions, drop dead PTT, differentiate the voice-mode button

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -303,11 +303,10 @@ export function ChatLayout() {
   // collapsed and the chat body blurs while it is visible. This override is
   // EPHEMERAL — it is OR'd into the rendered collapsed value (`sideMenuCollapsed`
   // below) rather than routed through `setCollapsed`, so it never touches the
-  // persistence effect above. That matters: forcing the persisted `collapsed`
-  // true (the old approach) let a reload / tab-close mid-session write the
-  // forced value to `localStorage` and leave the sidebar collapsed forever. On
-  // exit the room override simply drops and the sidebar returns to exactly the
-  // user's persisted value — no restore dance needed.
+  // persistence effect above. Keeping it out of the persisted `collapsed` state
+  // means a reload / tab-close while the room is open cannot write the forced
+  // value to `localStorage`: on exit the override drops and the sidebar returns
+  // to exactly the user's persisted value.
   const voiceRoomVisible = useIsVoiceRoomVisible();
   const sideMenuCollapsed = collapsed || voiceRoomVisible;
 

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -804,8 +804,8 @@ describe("ChatComposer — live-voice integration", () => {
     expect(dictation?.disabled).toBe(false);
   });
 
-  test("flag ON, idle: live-voice button present, normal row, no voice bar", () => {
-    // GIVEN the flag is on with no active session
+  test("flag ON, idle + empty: voice-mode button owns the send slot, dictation available, no voice bar", () => {
+    // GIVEN the flag is on with no active session and an empty composer
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
 
@@ -813,15 +813,32 @@ describe("ChatComposer — live-voice integration", () => {
     const { getByLabelText, queryByLabelText, queryByRole } =
       renderVoiceComposer();
 
-    // THEN both mics are available, neither is forced disabled, and the
-    // action row is the normal composer row (no voice bar)
+    // THEN the voice-mode button occupies the send slot (there is nothing to
+    // send yet), dictation is available, and the row is the normal composer
+    // row (no voice bar). The send arrow is absent until the message has
+    // content (see the swap test below).
     expect(getByLabelText("Start voice mode")).toBeTruthy();
     const dictation = queryByLabelText(
       "Start voice input",
     ) as HTMLButtonElement | null;
     expect(dictation?.disabled).toBe(false);
     expect(queryByRole("group", { name: "Voice session" })).toBeNull();
+    expect(queryByLabelText("Send message")).toBeNull();
+  });
+
+  test("typing swaps the voice-mode button for the send arrow", () => {
+    // GIVEN the flag is on, no active session, and the user has typed content
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+
+    // WHEN the composer renders with a non-empty draft
+    const { getByLabelText, queryByLabelText } = renderVoiceComposer({
+      input: "hello",
+    });
+
+    // THEN the send arrow takes the slot and the voice-mode button steps aside
     expect(getByLabelText("Send message")).toBeTruthy();
+    expect(queryByLabelText("Start voice mode")).toBeNull();
   });
 
   test("clicking the live-voice button starts a session through the store-registered starter", () => {
@@ -953,12 +970,14 @@ describe("ChatComposer — live-voice integration", () => {
     seedLiveVoiceSession("listening", "conv-other-thread");
 
     // WHEN the composer renders
-    const { container, getByLabelText, queryByRole } = renderVoiceComposer();
+    const { container, getByLabelText, queryByLabelText, queryByRole } =
+      renderVoiceComposer();
 
     // THEN no voice bar, no transcript region, and the textarea stays
-    // editable — thread B behaves like a normal composer...
+    // editable — thread B behaves like a normal composer. The empty send slot
+    // holds the voice-mode button (disabled below), so the send arrow is absent.
     expect(queryByRole("group", { name: "Voice session" })).toBeNull();
-    expect(getByLabelText("Send message")).toBeTruthy();
+    expect(queryByLabelText("Send message")).toBeNull();
     const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
     expect(textarea.disabled).toBe(false);
     // ...except both mic entry points are disabled: the running session owns
@@ -1035,7 +1054,7 @@ describe("ChatComposer — live-voice integration", () => {
     expect(liveControls.stop).not.toHaveBeenCalled();
   });
 
-  test("dictation active disables the live-voice button (reverse mutual exclusion)", () => {
+  test("dictation active hides the live-voice button (reverse mutual exclusion)", () => {
     // GIVEN the flag is on, no live session, but dictation is active.
     // `processing` is one of the two phases that make the composer's
     // `isVoiceActive` true (alongside `recording`); we use it because
@@ -1047,12 +1066,12 @@ describe("ChatComposer — live-voice integration", () => {
     mockVoicePhase = "processing";
 
     // WHEN the composer renders
-    const { getByLabelText } = renderVoiceComposer();
+    const { queryByLabelText } = renderVoiceComposer();
 
-    // THEN the live-voice start affordance is disabled so it can't open a
-    // second mic/voice session alongside the dictation recorder
-    const liveVoice = getByLabelText("Start voice mode") as HTMLButtonElement;
-    expect(liveVoice.disabled).toBe(true);
+    // THEN the send slot (which holds the voice-mode entry point while idle) is
+    // hidden entirely during dictation, so no second mic/voice session can open
+    // alongside the recorder — mutual exclusion by absence.
+    expect(queryByLabelText("Start voice mode")).toBeNull();
   });
 
   test("electron dictation uses the system overlay instead of the inline composer preview", () => {
@@ -1063,13 +1082,13 @@ describe("ChatComposer — live-voice integration", () => {
     mockVoicePhase = "processing";
 
     // WHEN the composer renders
-    const { getByLabelText, queryByLabelText } = renderVoiceComposer();
+    const { queryByLabelText } = renderVoiceComposer();
 
     // THEN the shared top-center dictation overlay owns the visual treatment,
-    // so the composer-specific preview is absent while mutual exclusion stays.
+    // so the composer-specific preview is absent; and the send slot (voice-mode
+    // entry point) stays hidden during dictation — mutual exclusion by absence.
     expect(queryByLabelText("Transcribing")).toBeNull();
-    const liveVoice = getByLabelText("Start voice mode") as HTMLButtonElement;
-    expect(liveVoice.disabled).toBe(true);
+    expect(queryByLabelText("Start voice mode")).toBeNull();
   });
 
   test("failed live-voice state is inactive: normal row restored, dictation re-enabled", () => {
@@ -1082,9 +1101,10 @@ describe("ChatComposer — live-voice integration", () => {
     // WHEN the composer renders (dictation idle)
     const { getByLabelText, queryByRole } = renderVoiceComposer();
 
-    // THEN the voice bar is unmounted and the normal row is back...
+    // THEN the voice bar is unmounted and the normal row is back — with an
+    // empty draft the send slot shows the voice-mode entry point again...
     expect(queryByRole("group", { name: "Voice session" })).toBeNull();
-    expect(getByLabelText("Send message")).toBeTruthy();
+    expect(getByLabelText("Start voice mode")).toBeTruthy();
     // ...with dictation treated as available again (failed = inactive)
     const dictation = getByLabelText(
       "Start voice input",

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -28,6 +28,7 @@ import { StreamingWaveform } from "@/domains/chat/components/chat-composer/strea
 import { VoiceComposerBar } from "@/domains/chat/components/chat-composer/voice-composer-bar";
 import { VoiceLiveTranscript } from "@/domains/chat/components/chat-composer/voice-live-transcript";
 import { LiveVoiceButton } from "@/domains/chat/components/live-voice-button";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import {
     VoiceInputButton,
     type VoiceInputButtonHandle,
@@ -411,6 +412,14 @@ export function ChatComposer({
     useQuoteReplyStore.use.stagedQuotes().length > 0;
   const canSendMessageContent =
     Boolean(input.trim()) || canSendAttachments || hasStagedQuotes;
+  // Voice mode occupies the send slot while there is nothing to send: the
+  // send arrow only earns that spot once the message has content. Eligibility
+  // mirrors `LiveVoiceButton`'s own gate (voice-enabled composer + a bound
+  // assistant + the `voice-mode` flag) so the slot falls back to the disabled
+  // send arrow — byte-identical to before — whenever voice mode is unavailable.
+  const voiceMode = useAssistantFeatureFlagStore.use.voiceMode();
+  const showVoiceModeInSendSlot =
+    showVoiceInput && Boolean(assistantId) && voiceMode && !canSendMessageContent;
 
   const ghostSuffix = useMemo(
     () =>
@@ -788,52 +797,48 @@ export function ChatComposer({
                           }}
                         />
                       )}
-                      {showVoiceInput && assistantId && (
-                        // Self-gates on the `voice-mode` flag (renders null when
-                        // off — no layout shift). Purely the session entry
-                        // point: once a session starts, this row (button
-                        // included) is swapped for `VoiceComposerBar`, whose ✕
-                        // owns stopping.
-                        //
-                        // Mutual exclusion (reverse direction): while dictation
-                        // is active (`isVoiceActive`) — or a live-voice session
-                        // already runs in another thread — starting a session
-                        // here is disabled so a second mic/voice session can't
-                        // open alongside the running one.
-                        <LiveVoiceButton
-                          onStart={handleLiveVoiceStart}
-                          disabled={
-                            typingDisabled ||
-                            isVoiceActive ||
-                            isLiveVoiceSessionLive
-                          }
-                        />
-                      )}
                       {/* macOS parity: the send button is hidden during recording
                       and while transcription is being processed. Only the voice
-                      button (mic / stop / spinner) is shown. */}
-                      {!isVoiceActive && (
-                        <Button
-                          variant="primary"
-                          iconOnly={
-                            <ArrowUp className="h-4 w-4" strokeWidth={2.5} />
-                          }
-                          type="submit"
-                          disabled={
-                            sendDisabled ||
-                            attachmentsUploadingCount > 0 ||
-                            !canSendMessageContent
-                          }
-                          title={
-                            sendDisabled || !canSendMessageContent
-                              ? "Type a message to send"
-                              : attachmentsUploadingCount > 0
-                                ? "Uploading attachments…"
-                                : "Send message"
-                          }
-                          aria-label="Send message"
-                        />
-                      )}
+                      button (mic / stop / spinner) is shown. Otherwise the send
+                      slot holds voice mode until there is something to send, at
+                      which point the send arrow takes over. */}
+                      {!isVoiceActive &&
+                        (showVoiceModeInSendSlot ? (
+                          // Session entry point: once a session starts, this row
+                          // (button included) swaps for `VoiceComposerBar`, whose
+                          // ✕ owns stopping. Disabled while dictation is active or
+                          // a live-voice session already runs elsewhere, so a
+                          // second mic/voice capture can't open alongside it.
+                          <LiveVoiceButton
+                            onStart={handleLiveVoiceStart}
+                            disabled={
+                              typingDisabled ||
+                              isVoiceActive ||
+                              isLiveVoiceSessionLive
+                            }
+                          />
+                        ) : (
+                          <Button
+                            variant="primary"
+                            iconOnly={
+                              <ArrowUp className="h-4 w-4" strokeWidth={2.5} />
+                            }
+                            type="submit"
+                            disabled={
+                              sendDisabled ||
+                              attachmentsUploadingCount > 0 ||
+                              !canSendMessageContent
+                            }
+                            title={
+                              sendDisabled || !canSendMessageContent
+                                ? "Type a message to send"
+                                : attachmentsUploadingCount > 0
+                                  ? "Uploading attachments…"
+                                  : "Send message"
+                            }
+                            aria-label="Send message"
+                          />
+                        ))}
                     </>
                   )}
                 </div>

--- a/clients/web/src/domains/chat/components/live-voice-button.tsx
+++ b/clients/web/src/domains/chat/components/live-voice-button.tsx
@@ -16,7 +16,7 @@
  * but disabled, so this control never needs a stop affordance.
  */
 
-import { Mic } from "lucide-react";
+import { AudioLines } from "lucide-react";
 
 import { Button } from "@vellumai/design-library";
 
@@ -40,7 +40,7 @@ export function LiveVoiceButton({
   return (
     <Button
       variant="ghost"
-      iconOnly={<Mic strokeWidth={2} />}
+      iconOnly={<AudioLines strokeWidth={2} />}
       onClick={onStart}
       disabled={disabled}
       aria-label="Start voice mode"

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar.tsx
@@ -1,21 +1,10 @@
-import { motion, useReducedMotion } from "motion/react";
+import { useReducedMotion } from "motion/react";
 import { useEffect, useLayoutEffect, useRef } from "react";
 
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 
-import { AVATAR_VISUAL_SPRING } from "./voice-motion";
 import type { VoiceAvatarVisual } from "./voice-avatar-state";
-
-/**
- * Bouncier pop for the `responding` visual — reads as a burst of energy. The
- * default per-visual spring is the shared `AVATAR_VISUAL_SPRING`.
- */
-const RESPOND_SPRING = {
-  type: "spring" as const,
-  visualDuration: 0.3,
-  bounce: 0.5,
-};
 
 const DEFAULT_SIZE = 160;
 
@@ -43,7 +32,12 @@ function isAudioReactive(visual: VoiceAvatarVisual): boolean {
  * room. Resolves the real assistant avatar (character / custom image / "V"
  * fallback) via {@link useAssistantAvatar} and expresses the session phase
  * through a continuous per-visual CSS loop (see `.voice-avatar-*` in
- * index.css) plus a motion spring on each discrete visual change.
+ * index.css).
+ *
+ * The avatar node stays mounted for the whole session: a visual change only
+ * swaps the `voice-avatar--<visual>` class, so the CSS loop cross-fades in
+ * place rather than the whole avatar re-popping. The one-time entry spring is
+ * owned by the room wrapper (see `voice-room.tsx`), not here.
  *
  * For the audio-reactive visuals a requestAnimationFrame loop polls
  * `getAmplitude()` and writes the `--voice-amp` custom property on the avatar
@@ -98,39 +92,24 @@ export function VoiceAvatar({
       cancelAnimationFrame(rafId);
       node.style.setProperty("--voice-amp", "0");
     };
-    // `visual` rebinds the loop to the freshly-keyed wrapper node on any
-    // visual change, not just when the audio-reactive boundary is crossed.
+    // Re-runs on any visual change to start/stop the loop at the audio-reactive
+    // boundary; the avatar node itself is stable, so this only (re)attaches the
+    // rAF, it never remounts the avatar.
   }, [visual, audioReactive, reduce]);
 
-  const enterTransition = reduce
-    ? { duration: 0 }
-    : visual === "responding"
-      ? RESPOND_SPRING
-      : AVATAR_VISUAL_SPRING;
-
   return (
-    <motion.div
-      // Re-key on visual so each change replays the enter spring and restarts
-      // the continuous CSS loop from a clean frame.
-      key={visual}
-      initial={reduce ? false : { scale: 0.9, opacity: 0.6 }}
-      animate={{ scale: 1, opacity: 1 }}
-      transition={enterTransition}
-      style={{ width: size, height: size, transformOrigin: "center" }}
+    <div
+      className={`voice-avatar voice-avatar--${visual}`}
+      style={{ width: size, height: size }}
     >
-      <div
-        className={`voice-avatar voice-avatar--${visual}`}
-        style={{ width: size, height: size }}
-      >
-        <div ref={ampRef} className="voice-avatar__amp">
-          <ChatAvatar
-            components={components}
-            traits={traits}
-            customImageUrl={customImageUrl}
-            size={size}
-          />
-        </div>
+      <div ref={ampRef} className="voice-avatar__amp">
+        <ChatAvatar
+          components={components}
+          traits={traits}
+          customImageUrl={customImageUrl}
+          size={size}
+        />
       </div>
-    </motion.div>
+    </div>
   );
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-motion.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-motion.ts
@@ -1,27 +1,15 @@
 /**
  * Shared motion-spring constants for the live-voice room surfaces.
  *
- * Kept here — inside the voice domain — so `voice-avatar.tsx` and
- * `voice-room.tsx` declare each spring once instead of hand-copying it, without
- * reaching into the constellation domain for its `NODE_SPRING`. The two springs
- * are intentionally different tunings, so both live here as named exports.
+ * Kept here — inside the voice domain — so the room surface declares the spring
+ * once instead of hand-copying it, without reaching into the constellation
+ * domain for its `NODE_SPRING`.
  */
-
-/**
- * Avatar enter/scale spring replayed on each discrete visual change (see
- * `voice-avatar.tsx`). Value-identical to the app's constellation `NODE_SPRING`
- * overshoot convention.
- */
-export const AVATAR_VISUAL_SPRING = {
-  type: "spring" as const,
-  stiffness: 180,
-  damping: 20,
-};
 
 /**
  * Room entry spring (see `voice-room.tsx`): the avatar rises from a smaller,
- * lower offset to center with a slightly stiffer overshoot than the per-visual
- * spring.
+ * lower offset to center with a slight overshoot. Fires once when the room
+ * opens; per-state expression is the avatar's own CSS loop, not a spring.
  */
 export const AVATAR_ENTER_SPRING = {
   type: "spring" as const,

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -194,64 +194,27 @@ describe("VoiceRoom — exit", () => {
   });
 });
 
-describe("VoiceRoom — push-to-talk fallback", () => {
-  test("Space releases the current turn while listening", () => {
-    startOwnedSession("listening");
-    render(<VoiceRoom />);
-    window.dispatchEvent(
-      new KeyboardEvent("keydown", { key: " ", code: "Space" }),
-    );
-    expect(controls.release).toHaveBeenCalledTimes(1);
-  });
-
-  test("Space on the focused exit control is left for the button to activate (not swallowed)", () => {
+describe("VoiceRoom — no push-to-talk affordance (hands-free)", () => {
+  // Sessions are hands-free (server-VAD): the user just speaks, so the room
+  // offers no push-to-talk control. Space is not intercepted and there is no
+  // tappable "Speak" orb — only Escape / ✕ are wired (see the exit suite).
+  test("Space does not release the current turn while listening", () => {
     startOwnedSession("listening");
     render(<VoiceRoom />);
     const event = new KeyboardEvent("keydown", {
       key: " ",
       code: "Space",
-      bubbles: true,
       cancelable: true,
     });
-    exitButton()!.dispatchEvent(event);
-    // The global shortcut steps aside: no push-to-talk release, and Space's
-    // default (native button activation) is left intact.
+    window.dispatchEvent(event);
     expect(controls.release).not.toHaveBeenCalled();
+    // The room leaves Space alone entirely — no preventDefault.
     expect(event.defaultPrevented).toBe(false);
   });
 
-  test("Space in a text field is left for the field (not swallowed as push-to-talk)", () => {
+  test("there is no tappable Speak orb", () => {
     startOwnedSession("listening");
     render(<VoiceRoom />);
-    const input = document.createElement("input");
-    document.body.appendChild(input);
-    const event = new KeyboardEvent("keydown", {
-      key: " ",
-      code: "Space",
-      bubbles: true,
-      cancelable: true,
-    });
-    input.dispatchEvent(event);
-    // The editable guard applies to Space: no release, and the field's own
-    // space-to-type default is left intact.
-    expect(controls.release).not.toHaveBeenCalled();
-    expect(event.defaultPrevented).toBe(false);
-    input.remove();
-  });
-
-  test("Space is inert while the assistant is speaking", () => {
-    startOwnedSession("speaking");
-    render(<VoiceRoom />);
-    window.dispatchEvent(
-      new KeyboardEvent("keydown", { key: " ", code: "Space" }),
-    );
-    expect(controls.release).not.toHaveBeenCalled();
-  });
-
-  test("tapping the orb releases the current turn while listening", () => {
-    startOwnedSession("listening");
-    render(<VoiceRoom />);
-    fireEvent.click(screen.getByRole("button", { name: "Speak" }));
-    expect(controls.release).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("button", { name: "Speak" })).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -12,23 +12,21 @@
  * false and unmounts the room; a `failed` session surfaces through the existing
  * composer Notice / pill failure chip, never a dead room.
  *
- * Exit is first-class: a persistent ✕ control (always rendered, even while the
- * avatar/assistant data is loading or failed), plus global Escape (end) and
- * Space (push-to-talk "send now" fallback while idle/listening) key handlers
- * attached only while the room is mounted.
+ * Sessions are hands-free (server-VAD): the user just speaks, so there is no
+ * push-to-talk control. Exit is first-class — a persistent ✕ control (always
+ * rendered, even while the avatar/assistant data is loading or failed) plus a
+ * global Escape handler, both attached only while the room is mounted.
  */
 
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect } from "react";
 import { X } from "lucide-react";
 
 import {
   endLiveVoiceSession,
   getLiveVoiceInputAmplitude,
   liveVoiceStateLabel,
-  releaseLiveVoiceTurn,
   useLiveVoiceStore,
-  type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 
 import { toVoiceAvatarVisual } from "./voice-avatar-state";
@@ -39,8 +37,6 @@ import { VoiceRoomAmbientBackground } from "./voice-room-ambient-background";
 import { useIsVoiceRoomVisible } from "./use-is-voice-room-visible";
 
 const AVATAR_SIZE = 220;
-/** The one-time "how to speak" hint auto-dismisses after this long. */
-const HINT_TIMEOUT_MS = 6000;
 
 /**
  * Safe-area insets (see `docs/CAPACITOR.md`): the `var()` is set by
@@ -56,49 +52,6 @@ const SAFE_AREA_LEFT =
 const SAFE_AREA_RIGHT =
   "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))";
 
-/** Whether Space / an orb tap should release the current turn in `state`. */
-function canReleaseTurn(state: LiveVoiceSessionState): boolean {
-  return state === "idle" || state === "listening";
-}
-
-/**
- * Whether the event target is (or sits within) an interactive control that
- * owns Space as its own activation — a button, link, or other focusable
- * control. The global Space push-to-talk shortcut must not swallow Space when
- * one of these (e.g. the focused exit ✕) has focus, or keyboard users can't
- * activate it. This is narrower than {@link isEditableTarget} (text fields);
- * Escape stays global regardless of focus.
- */
-function isInteractiveTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof Element)) {
-    return false;
-  }
-  return (
-    target.closest(
-      'button, a[href], [role="button"], [role="link"], select, [tabindex]:not([tabindex="-1"])',
-    ) !== null
-  );
-}
-
-/**
- * Whether the event target is a text-editable control (input / textarea /
- * select / contentEditable) that should keep Space for typing.
- *
- * Local copy of the canonical helper (kept in sync with
- * `use-push-to-talk.ts`); the previously-shared `use-edge-swipe` export was
- * removed on main, so this is colocated here rather than imported.
- */
-function isEditableTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) {
-    return false;
-  }
-  if (target.isContentEditable) {
-    return true;
-  }
-  const tag = target.tagName;
-  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
-}
-
 export function VoiceRoom() {
   const visible = useIsVoiceRoomVisible();
 
@@ -108,9 +61,9 @@ export function VoiceRoom() {
 }
 
 /**
- * The mounted room. Split from {@link VoiceRoom} so its store subscriptions,
- * key handlers, and hint timer only exist while the room is actually visible
- * and are torn down cleanly on exit.
+ * The mounted room. Split from {@link VoiceRoom} so its store subscriptions and
+ * Escape handler only exist while the room is actually visible and are torn
+ * down cleanly on exit.
  */
 function VoiceRoomOverlay() {
   const state = useLiveVoiceStore.use.state();
@@ -121,47 +74,18 @@ function VoiceRoomOverlay() {
   const visual = toVoiceAvatarVisual(state, reconnecting);
   const stateLabel = liveVoiceStateLabel(state, reconnecting);
 
-  const [hintVisible, setHintVisible] = useState(true);
-  useEffect(() => {
-    const timer = setTimeout(() => setHintVisible(false), HINT_TIMEOUT_MS);
-    return () => clearTimeout(timer);
-  }, []);
-
-  // Global exit / push-to-talk keys, live only while the room is mounted.
+  // Global Escape exit, live only while the room is mounted. It fires even when
+  // the composer textarea (or any other focused element) still holds focus as
+  // the room opens, so it is intentionally not guarded by the event target.
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
-      // Escape is a global exit — it must fire even when the composer textarea
-      // (or any other editable/focused element) still holds focus as the room
-      // opens, so it is handled before any target guard.
       if (event.key === "Escape") {
         event.preventDefault();
         endLiveVoiceSession();
-        return;
-      }
-      if (event.key === " " || event.code === "Space") {
-        // Space is push-to-talk; never steal it from a text field or a focused
-        // interactive control (e.g. the exit ✕), which handle Space as their own
-        // input/activation. The orb is itself a button, so Space over it still
-        // releases via its onClick.
-        if (isEditableTarget(event.target) || isInteractiveTarget(event.target)) {
-          return;
-        }
-        if (canReleaseTurn(useLiveVoiceStore.getState().state)) {
-          event.preventDefault();
-          releaseLiveVoiceTurn();
-        }
       }
     }
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, []);
-
-  // Tapping the orb is the pointer equivalent of the Space push-to-talk
-  // fallback — "send now" while listening.
-  const handleOrbTap = useCallback(() => {
-    if (canReleaseTurn(useLiveVoiceStore.getState().state)) {
-      releaseLiveVoiceTurn();
-    }
   }, []);
 
   return (
@@ -172,9 +96,9 @@ function VoiceRoomOverlay() {
       aria-modal="true"
       aria-label="Voice session"
       // This `fixed inset-0` overlay covers `ChatLayoutHeader`, so it loses the
-      // header's safe-area protection — pad the centered chrome (avatar, hint)
-      // inside the notch/home-indicator per docs/CAPACITOR.md. The ambient
-      // void is `absolute inset-0` and stays full-bleed behind the padding.
+      // header's safe-area protection — pad the centered avatar inside the
+      // notch/home-indicator per docs/CAPACITOR.md. The ambient void is
+      // `absolute inset-0` and stays full-bleed behind the padding.
       style={{
         paddingTop: SAFE_AREA_TOP,
         paddingBottom: SAFE_AREA_BOTTOM,
@@ -212,30 +136,22 @@ function VoiceRoomOverlay() {
         <X className="size-5" />
       </button>
 
-      <div className="relative z-0 flex flex-col items-center gap-8">
-        <motion.button
-          type="button"
-          onClick={handleOrbTap}
-          aria-label="Speak"
-          className="rounded-full focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/50"
-          initial={reduce ? false : { scale: 0.8, y: 24, opacity: 0 }}
-          animate={{ scale: 1, y: 0, opacity: 1 }}
-          transition={reduce ? { duration: 0 } : AVATAR_ENTER_SPRING}
-        >
-          <VoiceAvatar
-            assistantId={assistantId}
-            visual={visual}
-            getAmplitude={getLiveVoiceInputAmplitude}
-            size={AVATAR_SIZE}
-          />
-        </motion.button>
-
-        {hintVisible ? (
-          <p className="text-sm text-white/45">
-            Tap the orb or press space to speak
-          </p>
-        ) : null}
-      </div>
+      {/* The avatar springs to center once on entry (the wrapper owns the
+          one-time entry spring); per-state expression is the avatar's own CSS
+          loop, which cross-fades in place without re-popping. */}
+      <motion.div
+        className="relative z-0"
+        initial={reduce ? false : { scale: 0.8, y: 24, opacity: 0 }}
+        animate={{ scale: 1, y: 0, opacity: 1 }}
+        transition={reduce ? { duration: 0 } : AVATAR_ENTER_SPRING}
+      >
+        <VoiceAvatar
+          assistantId={assistantId}
+          visual={visual}
+          getAmplitude={getLiveVoiceInputAmplitude}
+          size={AVATAR_SIZE}
+        />
+      </motion.div>
 
       {/* Screen readers get session-state changes here; the avatar is the
           visual channel, so this stays off-screen. */}


### PR DESCRIPTION
## Summary
Voice-mode UI polish (all on the shipped `voice-mode`-gated room).

- **Avatar no longer re-pops on state change.** `VoiceAvatar` stays mounted and swaps its `voice-avatar--<visual>` class, so idle/listening/thinking/responding/reconnecting cross-fade in place instead of the whole avatar scaling/fading back in each transition. The one-time entry spring stays on the room wrapper.
- **Removed the dead push-to-talk affordance.** Room sessions are hands-free (server-VAD), so `release()` was a no-op — the Space handler, the tappable orb, and the "tap the orb or press space to speak" hint all did nothing. Exit is ✕ + Escape. Removed the now-unused helpers and the `AVATAR_VISUAL_SPRING` export.
- **Differentiated the voice-mode button.** It now uses the `AudioLines` (waves) glyph, distinct from the dictation mic, and occupies the send slot while there's nothing to send (replacing the disabled up-arrow), swapping to the send arrow once the message has content. Falls back to the disabled send arrow when voice mode is ineligible, so flag-off / app-editing composers are byte-identical.
- **Comment nit:** rewrote the `chat-layout.tsx` sidebar-override comment to present-tense.

## Tests
`voice-room.test.tsx` (12) and `voice-avatar-state.test.ts` (17) updated/green; `chat-composer.test.tsx` (77) updated for the send-slot behavior (voice-mode owns the slot while empty; send arrow returns on input; hidden during dictation).

Closes JARVIS-1263
Closes JARVIS-1264