### PR TITLE
feat(schedule): surface a run's conversations in the schedule detail panel

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -24826,6 +24826,29 @@ paths:
                           anyOf:
                             - type: number
                             - type: "null"
+                        conversations:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                              title:
+                                anyOf:
+                                  - type: string
+                                  - type: "null"
+                              exists:
+                                type: boolean
+                              archivedAt:
+                                anyOf:
+                                  - type: number
+                                  - type: "null"
+                            required:
+                              - id
+                              - title
+                              - exists
+                              - archivedAt
+                            additionalProperties: false
                         estimatedCostUsd:
                           type: number
                         createdAt:
@@ -24842,6 +24865,7 @@ paths:
                         - conversationId
                         - conversationExists
                         - conversationArchivedAt
+                        - conversations
                         - estimatedCostUsd
                         - createdAt
                       additionalProperties: false

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -11,7 +11,10 @@ import { getOrCreateConversation } from "../../daemon/conversation-store.js";
 import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../../daemon/trust-context.js";
 import { bootstrapConversation } from "../../persistence/conversation-bootstrap.js";
 import { getConversation } from "../../persistence/conversation-crud.js";
-import { getUsageCostForRun } from "../../persistence/llm-usage-store.js";
+import {
+  getUsageCostForRun,
+  listRunConversationIds,
+} from "../../persistence/llm-usage-store.js";
 import { validateScheduleInferenceProfile } from "../../schedule/inference-profile.js";
 import {
   describeRRuleExpression,
@@ -109,6 +112,20 @@ const scheduleRunSchema = z.object({
   conversationId: z.string().nullable(),
   conversationExists: z.boolean(),
   conversationArchivedAt: z.number().nullable(),
+  // Every real conversation this firing touched. Script runs store a
+  // synthetic "script:<jobId>" sentinel in the legacy `conversationId` field,
+  // so their real conversations are recovered from the usage ledger via
+  // `cron_run_id`. Execute and wake runs contribute their legacy pointer as
+  // well. A pruned conversation keeps its entry with `exists` set to false so
+  // the UI can label it as unavailable.
+  conversations: z.array(
+    z.object({
+      id: z.string(),
+      title: z.string().nullable(),
+      exists: z.boolean(),
+      archivedAt: z.number().nullable(),
+    }),
+  ),
   estimatedCostUsd: z.number(),
   createdAt: z.number(),
 });
@@ -584,6 +601,25 @@ function handleListScheduleRuns(
       const conversation = r.conversationId
         ? getConversation(r.conversationId)
         : null;
+      // The usage ledger supplies every conversation stamped with this run's
+      // cron_run_id. The legacy single pointer is added on top, which covers
+      // runs whose usage predates cron_run_id stamping. The synthetic
+      // "script:<jobId>" sentinel never resolves to a conversation, so it
+      // drops out here on its own.
+      const runConversationIds = new Set(listRunConversationIds(r.id));
+      if (r.conversationId && conversation) {
+        runConversationIds.add(r.conversationId);
+      }
+      const conversations = [...runConversationIds].map((cid) => {
+        const c =
+          cid === r.conversationId ? conversation : getConversation(cid);
+        return {
+          id: cid,
+          title: c?.title ?? null,
+          exists: c != null,
+          archivedAt: c?.archivedAt ?? null,
+        };
+      });
       return {
         id: r.id,
         jobId: r.jobId,
@@ -596,6 +632,7 @@ function handleListScheduleRuns(
         conversationId: r.conversationId,
         conversationExists: conversation != null,
         conversationArchivedAt: conversation?.archivedAt ?? null,
+        conversations,
         estimatedCostUsd: getUsageCostForRun({
           cronRunId: r.id,
           conversationId: r.conversationId ?? undefined,

--- a/clients/web/src/domains/home/components/schedule-detail-panel.tsx
+++ b/clients/web/src/domains/home/components/schedule-detail-panel.tsx
@@ -119,27 +119,53 @@ function StatCards({ usage }: { usage: ScheduleRowUsage }) {
   );
 }
 
+type RunConversation = NonNullable<ScheduleRun["conversations"]>[number];
+
+// A pruned or archived conversation is listed but not navigable. This mirrors
+// the legacy `canOpenScheduleRunConversation` rule.
+function canOpenRunConversation(c: RunConversation): boolean {
+  return c.exists && c.archivedAt == null;
+}
+
 function RunRow({
   run,
   index,
   isExpanded,
+  disableDirectOpen,
   onOpenConversation,
   onToggleDetails,
 }: {
   run: ScheduleRun;
   index: number;
   isExpanded: boolean;
+  disableDirectOpen: boolean;
   onOpenConversation: (conversationId: string) => void;
   onToggleDetails: (runId: string) => void;
 }) {
-  const conversationId = getOpenableScheduleRunConversationId(run);
-  // Script runs have no conversation to open; instead their captured
-  // stdout/stderr is shown inline by expanding the row.
+  // Older daemons do not send `conversations`, so the scalar pointer is
+  // wrapped in the same shape here. Newer daemons fold that pointer into the
+  // array themselves.
+  const legacyOpenId = getOpenableScheduleRunConversationId(run);
+  const conversations =
+    run.conversations ??
+    (legacyOpenId
+      ? [{ id: legacyOpenId, title: null, exists: true, archivedAt: null }]
+      : []);
   const hasOutput = hasRunText(run.output);
   const hasError = hasRunText(run.error);
-  const hasLocalDetails = !conversationId && (hasOutput || hasError);
+  // Clicking a run with exactly one openable conversation goes straight to
+  // it. Script mode disables that shortcut so the row expands instead,
+  // keeping stdout and stderr reachable.
+  const directOpenId =
+    !disableDirectOpen &&
+    conversations.length === 1 &&
+    canOpenRunConversation(conversations[0])
+      ? conversations[0].id
+      : null;
+  const hasExpand =
+    !directOpenId && (conversations.length > 0 || hasOutput || hasError);
   const detailsId = `schedule-run-details-${index}`;
-  const isInteractive = !!conversationId || hasLocalDetails;
+  const isInteractive = !!directOpenId || hasExpand;
 
   const body = (
     <>
@@ -163,7 +189,7 @@ function RunRow({
         <ChevronRight
           className={cn(
             "h-4 w-4 shrink-0 text-[var(--content-tertiary)] transition-transform",
-            hasLocalDetails && isExpanded ? "rotate-90" : "",
+            hasExpand && isExpanded ? "rotate-90" : "",
           )}
         />
       ) : null}
@@ -171,9 +197,38 @@ function RunRow({
   );
 
   const details =
-    hasLocalDetails && isExpanded ? (
+    hasExpand && isExpanded ? (
       <div id={detailsId} className="px-2 pb-3">
         <div className="space-y-3 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-sunken)] p-3">
+          {conversations.length > 0 ? (
+            <div>
+              <div className="mb-1 text-body-small-default text-[var(--content-secondary)]">
+                Conversations
+              </div>
+              <div className="space-y-1">
+                {conversations.map((c) =>
+                  canOpenRunConversation(c) ? (
+                    <button
+                      key={c.id}
+                      type="button"
+                      onClick={() => onOpenConversation(c.id)}
+                      className="block w-full truncate text-left text-body-small-default text-[var(--content-default)] hover:underline"
+                    >
+                      {hasRunText(c.title) ? c.title : "Conversation"}
+                    </button>
+                  ) : (
+                    <span
+                      key={c.id}
+                      className="block truncate text-body-small-default text-[var(--content-tertiary)] italic"
+                    >
+                      {hasRunText(c.title) ? c.title : "Conversation"}{" "}
+                      {c.exists ? "(archived)" : "(unavailable)"}
+                    </span>
+                  ),
+                )}
+              </div>
+            </div>
+          ) : null}
           {hasOutput ? (
             <div>
               <div className="mb-1 text-body-small-default text-[var(--content-secondary)]">
@@ -198,12 +253,12 @@ function RunRow({
       </div>
     ) : null;
 
-  if (conversationId) {
+  if (directOpenId) {
     return (
       <div>
         <button
           type="button"
-          onClick={() => onOpenConversation(conversationId)}
+          onClick={() => onOpenConversation(directOpenId)}
           aria-label={`Open conversation for run at ${formatTimestamp(run.startedAt)}`}
           className="flex w-full cursor-pointer items-center gap-3 px-2 py-3 text-left shadow-none transition-colors hover:bg-[var(--surface-hover)] focus:outline-none"
         >
@@ -213,13 +268,13 @@ function RunRow({
     );
   }
 
-  if (hasLocalDetails) {
+  if (hasExpand) {
     return (
       <div>
         <button
           type="button"
           onClick={() => onToggleDetails(run.id)}
-          aria-label={`Toggle output for run at ${formatTimestamp(run.startedAt)}`}
+          aria-label={`Toggle details for run at ${formatTimestamp(run.startedAt)}`}
           aria-expanded={isExpanded}
           aria-controls={detailsId}
           className="flex w-full cursor-pointer items-center gap-3 px-2 py-3 text-left shadow-none transition-colors hover:bg-[var(--surface-hover)] focus:outline-none"
@@ -237,10 +292,12 @@ function RunRow({
 function RecentRuns({
   runs,
   isLoading,
+  disableDirectOpen,
   onOpenConversation,
 }: {
   runs: ScheduleRun[] | undefined;
   isLoading: boolean;
+  disableDirectOpen: boolean;
   onOpenConversation: (conversationId: string) => void;
 }) {
   const [expandedRunId, setExpandedRunId] = useState<string | null>(null);
@@ -267,6 +324,7 @@ function RecentRuns({
           run={run}
           index={index}
           isExpanded={expandedRunId === run.id}
+          disableDirectOpen={disableDirectOpen}
           onOpenConversation={onOpenConversation}
           onToggleDetails={(runId) =>
             setExpandedRunId((current) => (current === runId ? null : runId))
@@ -300,7 +358,9 @@ export function ScheduleDetailPanel({
 }: ScheduleDetailPanelProps) {
   const navigate = useNavigate();
   const { data: runs, isLoading } = useQuery({
-    queryKey: schedulesByIdRunsGetQueryKey({ path: { assistant_id: assistantId, id: schedule.id } }),
+    queryKey: schedulesByIdRunsGetQueryKey({
+      path: { assistant_id: assistantId, id: schedule.id },
+    }),
     queryFn: () => fetchScheduleRuns(assistantId, schedule.id),
     staleTime: 10_000,
   });
@@ -406,6 +466,7 @@ export function ScheduleDetailPanel({
           <RecentRuns
             runs={runs?.runs}
             isLoading={isLoading}
+            disableDirectOpen={schedule.mode === "script"}
             onOpenConversation={(conversationId) =>
               navigate(routes.conversation(conversationId))
             }

--- a/clients/web/src/domains/settings/types/schedules.ts
+++ b/clients/web/src/domains/settings/types/schedules.ts
@@ -12,10 +12,25 @@ export type Schedule = SchedulesGetResponse["schedules"][number] & {
   createdFromConversationArchivedAt?: number | null;
 };
 
-export type ScheduleRun = SchedulesByIdRunsGetResponse["runs"][number] & {
+export type ScheduleRun = Omit<
+  SchedulesByIdRunsGetResponse["runs"][number],
+  "conversations"
+> & {
   conversationExists?: boolean;
   conversationArchivedAt?: number | null;
   estimatedCostUsd?: number;
+  /**
+   * Real conversations this firing touched, derived from the usage ledger.
+   * The schedule-runs endpoint always sends this, but the field is optional
+   * here because runs also arrive from sources that lack it. Those are the
+   * system-task run endpoints and daemons that predate the field.
+   */
+  conversations?: Array<{
+    id: string;
+    title: string | null;
+    exists: boolean;
+    archivedAt: number | null;
+  }>;
   /**
    * Conversation title shown as the run's primary label when present.
    * Set for memory retrospective runs, where the title ("<source title>

--- a/clients/web/src/domains/settings/utils/schedule-formatters.ts
+++ b/clients/web/src/domains/settings/utils/schedule-formatters.ts
@@ -93,6 +93,7 @@ export function canOpenScheduleSourceConversation(schedule: Schedule): boolean {
   );
 }
 
+/** Legacy single-conversation rule. See {@link getOpenableScheduleRunConversationId}. */
 export function canOpenScheduleRunConversation(run: ScheduleRun): boolean {
   return (
     !!run.conversationId &&
@@ -109,6 +110,18 @@ export function getOpenableScheduleSourceConversationId(
     : null;
 }
 
+/**
+ * @deprecated Prefer `ScheduleRun.conversations`. A schedule run can touch
+ * multiple conversations, and script runs usually do. The schedule-runs
+ * endpoint now derives the full list from the usage ledger and returns it as
+ * `conversations`, where each entry carries its own title, exists flag, and
+ * archive timestamp. This helper reads the legacy scalar fields and can only
+ * ever name one conversation.
+ *
+ * It remains in use where the new list is never sent. That covers daemons
+ * that predate `conversations`, and the system-task run endpoints for
+ * heartbeat, consolidation, and retrospective runs.
+ */
 export function getOpenableScheduleRunConversationId(
   run: ScheduleRun,
 ): string | null {


### PR DESCRIPTION
A script-mode schedule run can spawn multiple conversations, but run rows in Activity > Schedules only knew the single legacy conversation pointer, which for script runs is a synthetic sentinel. Those runs showed no way to reach their conversations.

- The schedule-runs endpoint now returns every conversation a firing touched, derived from the usage ledger's `cron_run_id` stamp. Each entry carries its own title, exists flag, and archive timestamp, and the legacy pointer is folded in so runs predating the stamping still resolve.
- The schedule detail panel lists these conversations in the expanded run row. Pruned conversations show as unavailable and archived ones as archived, neither navigable. A run with exactly one openable conversation still opens it directly on click, except in script mode where the row expands instead so stdout/stderr stay reachable.
- `getOpenableScheduleRunConversationId` is deprecated in favor of the new array. It remains for older daemons and for the system-task run endpoints, which only send the single pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)