### PR TITLE
refactor(runtime): eject assistant-event-hub from the daemon-core cycle

### DIFF
--- a/assistant/src/permissions/confirmation-canonical-request.ts
+++ b/assistant/src/permissions/confirmation-canonical-request.ts
@@ -1,0 +1,118 @@
+/**
+ * Promote a `confirmation_request` (tool approval) into a canonical guardian
+ * request and bridge it to the guardian's channels.
+ *
+ * Called fire-and-forget by the paths that emit a `confirmation_request`:
+ * the `PermissionPrompter` (interactive tool approvals) and the ACP route
+ * approval gate. Keeping the promotion at the emitter — rather than inside the
+ * generic event hub — lets the hub stay a pure pub/sub primitive with no
+ * dependency on the conversation registry or guardian bridge.
+ *
+ * Channel guardian decisions (reactions, buttons, text) all route through the
+ * canonical pipeline, so without this record none of them can resolve the
+ * confirmation.
+ *
+ * The heavy dependencies (conversation registry, canonical guardian store,
+ * guardian bridge) are loaded lazily so importing this module — and therefore
+ * the emitters — stays cheap and free of import-time database access.
+ */
+
+import type { ServerMessage } from "../daemon/message-protocol.js";
+import { IntegrityError } from "../util/errors.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("confirmation-canonical-request");
+
+function resolveCanonicalRequestSourceType(
+  sourceChannel: string,
+): "desktop" | "channel" | "voice" {
+  if (sourceChannel === "phone") return "voice";
+  if (sourceChannel === "vellum") return "desktop";
+  return "channel";
+}
+
+/**
+ * Create a canonical guardian request + bridge for a `confirmation_request`
+ * message. Safe to call fire-and-forget; failures are logged, never thrown.
+ */
+export async function createCanonicalRequestForConfirmation(
+  msg: ServerMessage & { type: "confirmation_request" },
+  conversationId: string,
+): Promise<void> {
+  try {
+    const [
+      { findConversation },
+      { createCanonicalGuardianRequest, generateCanonicalRequestCode },
+      { redactSecrets },
+      { summarizeToolInput },
+      { DAEMON_INTERNAL_ASSISTANT_ID },
+      { bridgeConfirmationRequestToGuardian },
+    ] = await Promise.all([
+      import("../daemon/conversation-registry.js"),
+      import("../contacts/canonical-guardian-store.js"),
+      import("../security/secret-scanner.js"),
+      import("../tools/tool-input-summary.js"),
+      import("../runtime/assistant-scope.js"),
+      import("../runtime/confirmation-request-guardian-bridge.js"),
+    ]);
+
+    const conversation = findConversation(conversationId);
+    const trustContext = conversation?.trustContext;
+    const sourceChannel = trustContext?.sourceChannel ?? "vellum";
+    const inputRecord = msg.input as Record<string, unknown>;
+    const activityRaw =
+      (typeof inputRecord.activity === "string"
+        ? inputRecord.activity
+        : undefined) ??
+      (typeof inputRecord.reason === "string" ? inputRecord.reason : undefined);
+    const canonicalRequest = createCanonicalGuardianRequest({
+      id: msg.requestId,
+      kind: "tool_approval",
+      sourceType: resolveCanonicalRequestSourceType(sourceChannel),
+      sourceChannel,
+      conversationId,
+      requesterExternalUserId: trustContext?.requesterExternalUserId,
+      requesterChatId: trustContext?.requesterChatId,
+      guardianExternalUserId: trustContext?.guardianExternalUserId,
+      guardianPrincipalId: trustContext?.guardianPrincipalId ?? undefined,
+      toolName: msg.toolName,
+      commandPreview:
+        redactSecrets(summarizeToolInput(msg.toolName, inputRecord)) ||
+        undefined,
+      riskLevel: msg.riskLevel,
+      activityText: activityRaw ? redactSecrets(activityRaw) : undefined,
+      executionTarget: msg.executionTarget,
+      status: "pending",
+      requestCode: generateCanonicalRequestCode(),
+      expiresAt: Date.now() + 5 * 60 * 1000,
+    });
+
+    if (trustContext && conversation) {
+      await bridgeConfirmationRequestToGuardian({
+        canonicalRequest,
+        trustContext,
+        conversationId,
+        toolName: msg.toolName,
+        assistantId: conversation.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
+      });
+    }
+  } catch (err) {
+    if (err instanceof IntegrityError) {
+      // The confirmation could not be promoted to a canonical guardian request
+      // (e.g. its trust context resolved no guardianPrincipalId). Channel
+      // guardian decisions — reactions, buttons, and text — all route through
+      // the canonical pipeline, so without this record none of them can resolve
+      // the confirmation. Surface it rather than swallowing: for a guardian's
+      // own confirmation a bound principal should always be present.
+      log.warn(
+        { err, conversationId, requestId: msg.requestId },
+        "Could not create canonical guardian request for confirmation; channel guardian decisions will not work for it",
+      );
+    } else {
+      log.debug(
+        { err, conversationId },
+        "Failed to create canonical request from broadcast",
+      );
+    }
+  }
+}

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -7,6 +7,7 @@ import { redactSensitiveFields } from "../security/redaction.js";
 import type { ExecutionTarget } from "../tools/tool-types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
+import { createCanonicalRequestForConfirmation } from "./confirmation-canonical-request.js";
 import type { AllowlistOption, ScopeOption, UserDecision } from "./types.js";
 
 const log = getLogger("permission-prompter");
@@ -142,7 +143,9 @@ export class PermissionPrompter {
         signal.addEventListener("abort", onAbort, { once: true });
       }
 
-      this.sendToClient({
+      const confirmationMsg: ServerMessage & {
+        type: "confirmation_request";
+      } = {
         type: "confirmation_request",
         requestId,
         toolName,
@@ -170,7 +173,17 @@ export class PermissionPrompter {
         executionTarget,
         persistentDecisionsAllowed: persistentDecisionsAllowed ?? true,
         toolUseId,
-      });
+      };
+      this.sendToClient(confirmationMsg);
+
+      // Promote the confirmation to a canonical guardian request so channel
+      // guardian decisions (reactions, buttons, text) can resolve it.
+      if (conversationId) {
+        void createCanonicalRequestForConfirmation(
+          confirmationMsg,
+          conversationId,
+        );
+      }
 
       this.onStateChanged?.(requestId, "pending", "system", toolUseId);
     });

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -40,7 +40,6 @@ export function capabilityForMessageType(
   return HOST_PREFIX_TO_CAPABILITY[stem];
 }
 import { appendEventToStream } from "../signals/event-stream.js";
-import { IntegrityError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import type { AssistantEvent } from "./assistant-event.js";
 import { buildAssistantEvent } from "./assistant-event.js";
@@ -596,13 +595,6 @@ export function broadcastMessage(
   const targetClientId = options?.targetClientId;
   const targetInterfaceId = options?.targetInterfaceId;
 
-  // Confirmation-request side effects: canonical guardian request creation.
-  // The home-feed `activity.failed` notification side-effect lives in the
-  // notifications pipeline now, so we no longer emit a feed event here.
-  if (msg.type === "confirmation_request" && resolvedConversationId) {
-    void createCanonicalRequestForConfirmation(msg, resolvedConversationId);
-  }
-
   // `conversation_list_invalidated` is a list-level system event — publish
   // it unscoped so every subscriber refreshes its sidebar.
   const scopedConversationId =
@@ -679,101 +671,4 @@ function extractConversationId(msg: ServerMessage): string | undefined {
     return record.conversationId as string;
   }
   return undefined;
-}
-
-// ── Canonical guardian request ────────────────────────────────────────────────
-
-function resolveCanonicalRequestSourceType(
-  sourceChannel: string,
-): "desktop" | "channel" | "voice" {
-  if (sourceChannel === "phone") return "voice";
-  if (sourceChannel === "vellum") return "desktop";
-  return "channel";
-}
-
-/**
- * Lazily load heavy dependencies and create a canonical guardian request +
- * bridge for a confirmation_request message. Called fire-and-forget from
- * broadcastMessage.
- */
-async function createCanonicalRequestForConfirmation(
-  msg: ServerMessage & { type: "confirmation_request" },
-  conversationId: string,
-): Promise<void> {
-  try {
-    const [
-      { findConversation },
-      { createCanonicalGuardianRequest, generateCanonicalRequestCode },
-      { redactSecrets },
-      { summarizeToolInput },
-      { DAEMON_INTERNAL_ASSISTANT_ID },
-      { bridgeConfirmationRequestToGuardian },
-    ] = await Promise.all([
-      import("../daemon/conversation-registry.js"),
-      import("../contacts/canonical-guardian-store.js"),
-      import("../security/secret-scanner.js"),
-      import("../tools/tool-input-summary.js"),
-      import("./assistant-scope.js"),
-      import("./confirmation-request-guardian-bridge.js"),
-    ]);
-
-    const conversation = findConversation(conversationId);
-    const trustContext = conversation?.trustContext;
-    const sourceChannel = trustContext?.sourceChannel ?? "vellum";
-    const inputRecord = msg.input as Record<string, unknown>;
-    const activityRaw =
-      (typeof inputRecord.activity === "string"
-        ? inputRecord.activity
-        : undefined) ??
-      (typeof inputRecord.reason === "string" ? inputRecord.reason : undefined);
-    const canonicalRequest = createCanonicalGuardianRequest({
-      id: msg.requestId,
-      kind: "tool_approval",
-      sourceType: resolveCanonicalRequestSourceType(sourceChannel),
-      sourceChannel,
-      conversationId,
-      requesterExternalUserId: trustContext?.requesterExternalUserId,
-      requesterChatId: trustContext?.requesterChatId,
-      guardianExternalUserId: trustContext?.guardianExternalUserId,
-      guardianPrincipalId: trustContext?.guardianPrincipalId ?? undefined,
-      toolName: msg.toolName,
-      commandPreview:
-        redactSecrets(summarizeToolInput(msg.toolName, inputRecord)) ||
-        undefined,
-      riskLevel: msg.riskLevel,
-      activityText: activityRaw ? redactSecrets(activityRaw) : undefined,
-      executionTarget: msg.executionTarget,
-      status: "pending",
-      requestCode: generateCanonicalRequestCode(),
-      expiresAt: Date.now() + 5 * 60 * 1000,
-    });
-
-    if (trustContext && conversation) {
-      await bridgeConfirmationRequestToGuardian({
-        canonicalRequest,
-        trustContext,
-        conversationId,
-        toolName: msg.toolName,
-        assistantId: conversation.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
-      });
-    }
-  } catch (err) {
-    if (err instanceof IntegrityError) {
-      // The confirmation could not be promoted to a canonical guardian request
-      // (e.g. its trust context resolved no guardianPrincipalId). Channel
-      // guardian decisions — reactions, buttons, and text — all route through
-      // the canonical pipeline, so without this record none of them can resolve
-      // the confirmation. Surface it rather than swallowing: for a guardian's
-      // own confirmation a bound principal should always be present.
-      log.warn(
-        { err, conversationId, requestId: msg.requestId },
-        "Could not create canonical guardian request for confirmation; channel guardian decisions will not work for it",
-      );
-    } else {
-      log.debug(
-        { err, conversationId },
-        "Failed to create canonical request from broadcast",
-      );
-    }
-  }
 }

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -19,6 +19,8 @@ import {
 } from "../../acp/session-manager.js";
 import type { AcpSessionState } from "../../acp/types.js";
 import { getConfig } from "../../config/loader.js";
+import type { ServerMessage } from "../../daemon/message-protocol.js";
+import { createCanonicalRequestForConfirmation } from "../../permissions/confirmation-canonical-request.js";
 import type { UserDecision } from "../../permissions/types.js";
 import { getDb } from "../../persistence/db-connection.js";
 import { rawChanges } from "../../persistence/raw-query.js";
@@ -155,21 +157,25 @@ function awaitRouteApproval(args: {
         settle(decision, decision === "allow" ? "approved" : "rejected"),
     });
 
-    broadcastMessage(
-      {
-        type: "confirmation_request",
-        requestId,
-        toolName,
-        input,
-        riskLevel: "high",
-        executionTarget: "host",
-        allowlistOptions: [],
-        scopeOptions: [],
-        conversationId,
-        persistentDecisionsAllowed: false,
-      },
+    const confirmationMsg: ServerMessage & {
+      type: "confirmation_request";
+    } = {
+      type: "confirmation_request",
+      requestId,
+      toolName,
+      input,
+      riskLevel: "high",
+      executionTarget: "host",
+      allowlistOptions: [],
+      scopeOptions: [],
       conversationId,
-    );
+      persistentDecisionsAllowed: false,
+    };
+    broadcastMessage(confirmationMsg, conversationId);
+
+    // Promote the confirmation to a canonical guardian request so channel
+    // guardian decisions (reactions, buttons, text) can resolve it.
+    void createCanonicalRequestForConfirmation(confirmationMsg, conversationId);
   });
 }
 


### PR DESCRIPTION
## Prompt / plan

Continuing the campaign to dismantle the daemon-core import cycle in `/assistant`. This installment targets the single most-entangled node: `runtime/assistant-event-hub.ts` (in-degree 113, present in **87 of 191** circular chains).

The generic pub/sub hub embedded guardian business logic. `broadcastMessage` fire-and-forgot `createCanonicalRequestForConfirmation`, which dynamically imported `daemon/conversation-registry` and `runtime/confirmation-request-guardian-bridge`. Those two edges were the *only* thing keeping the hub — and its large downstream — in the core SCC.

Per the chosen approach, the promotion logic moves to the emitters of the `confirmation_request` event:
- `permissions/prompter.ts` (`PermissionPrompter.requestConfirmation`) — interactive tool approvals
- `runtime/routes/acp-routes.ts` — the ACP route approval gate

Both now call a new `permissions/confirmation-canonical-request.ts`. The heavy dependencies stay **lazily imported** (as they were inside the hub) so the emitters' import graph stays cheap and free of import-time DB access — this laziness matters: a static import chain pulled the DB modules into `acp-routes`' eager-import footprint and broke a test that imports the route module before `initializeDb()` runs. The hub is now a pure pub/sub primitive with no dependency on the registry or guardian bridge.

Semantics are preserved: every `confirmation_request` is born at exactly these two sites and is broadcast exactly once, so promoting at the emitter fires the same once-per-confirmation as the old central interception. The no-op-sender path (`tools/run-standalone.ts`) auto-denies before reaching the prompter, so it is unaffected.

**Core SCC: 327 → 284 files (−43).** Circular chains: 191 → 140; **none** involve the event hub anymore (was 87).

## Test plan

- `bunx tsc --noEmit` — clean (0 errors)
- Full-graph Tarjan SCC recomputed: core 327 → 284, `assistant-event-hub.ts` no longer in the core
- `bun run lint:circular` — 191 → 140 chains, 0 involving the hub
- `bun test` on affected suites, all green:
  - `assistant-event-hub.test.ts` (32), `runtime/routes/acp-routes.test.ts` (23), `runtime/routes/__tests__/acp-routes.test.ts` (24)
  - `tool-executor.test.ts` (80), `proxy-approval-callback.test.ts` (2), `require-fresh-approval.test.ts` (32)
  - `voice-scoped-grant-consumer.test.ts` (6)
  - `confirmation-request-guardian-bridge.test.ts`, `trusted-contact-inline-approval-integration.test.ts` (29), `conversation-routes-guardian-reply.test.ts` (9)
- Pre-commit + pre-push hooks (prettier, eslint, tsc) green

## CLI verb checklist

No new routes — the ACP approval gate and prompter are existing surfaces; this only relocates a side-effect. Section N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWL4FYZVRGkJkMwL46PY3m)_