### PR TITLE
feat(providers): reason-specific user messages for connection resolution failures (M6 PR5)

### DIFF
--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -19,7 +19,12 @@ import {
   type AbortReasonKind,
   createAbortReason,
 } from "../util/abort-reasons.js";
-import { ProviderError, ProviderNotConfiguredError } from "../util/errors.js";
+import {
+  ConfigError,
+  ProviderError,
+  ProviderNotConfiguredError,
+  VellumError,
+} from "../util/errors.js";
 
 describe("isUserCancellation", () => {
   it("returns false for non-AbortError even when abort flag is set", () => {
@@ -1027,20 +1032,96 @@ describe("ConnectionResolutionError classification", () => {
     );
     const result = classifyConversationError(err, errCtx);
     expect(result.code).toBe("PROVIDER_NOT_CONFIGURED");
-    expect(result.userMessage).toContain("No compatible provider connection");
+    expect(result.userMessage).toContain('"anthropic-managed"');
+    expect(result.userMessage).toContain("different provider");
     expect(result.userMessage).toContain("Settings");
     expect(result.userMessage).not.toContain("provider_connection");
     expect(result.connectionName).toBe("anthropic-managed");
+    expect(result.debugDetails).toContain(
+      "connection_resolution:provider_mismatch",
+    );
   });
 
-  it("classifies not_found as PROVIDER_NOT_CONFIGURED", () => {
+  it("classifies not_found as PROVIDER_NOT_CONFIGURED naming the connection and profile", () => {
     const err = new ConnectionResolutionError(
       "deleted-connection",
       "not_found",
       'provider_connection "deleted-connection" not found in DB',
+      { profileName: "custom-fast" },
     );
     const result = classifyConversationError(err, errCtx);
     expect(result.code).toBe("PROVIDER_NOT_CONFIGURED");
+    expect(result.userMessage).toContain('"deleted-connection"');
+    expect(result.userMessage).toContain('profile "custom-fast"');
+    expect(result.userMessage).toContain("no longer exists");
     expect(result.userMessage).not.toContain("not found in DB");
+    expect(result.profileName).toBe("custom-fast");
+  });
+
+  it("classifies missing_connection with an add-a-key fix and no sentinel name", () => {
+    const err = new ConnectionResolutionError(
+      "<llm.default>",
+      "missing_connection",
+      "llm.default.provider_connection is unset",
+    );
+    const result = classifyConversationError(err, errCtx);
+    expect(result.userMessage).toContain(
+      "No provider connection is configured",
+    );
+    expect(result.userMessage).toContain("Add an API key or log in");
+    expect(result.userMessage).not.toContain("<llm.default>");
+    expect(result.connectionName).toBeUndefined();
+  });
+
+  it("classifies model_incompatible naming the model", () => {
+    const err = new ConnectionResolutionError(
+      "chatgpt-codex",
+      "model_incompatible",
+      "subscription connection only serves codex models",
+      { model: "claude-fable-5" },
+    );
+    const result = classifyConversationError(err, errCtx);
+    expect(result.userMessage).toContain('Model "claude-fable-5"');
+    expect(result.userMessage).toContain('"chatgpt-codex"');
+  });
+
+  it("classifies lookup_failed with a restart hint and preserves the cause", () => {
+    const cause = new Error("db locked");
+    const err = new ConnectionResolutionError(
+      "anthropic-personal",
+      "lookup_failed",
+      "lookup failed",
+      { cause },
+    );
+    expect(err.cause).toBe(cause);
+    const result = classifyConversationError(err, errCtx);
+    expect(result.userMessage).toContain("Restart the assistant");
+  });
+
+  it("is a structured VellumError (ConfigError) for logging/monitoring", () => {
+    const err = new ConnectionResolutionError("x", "not_found", "m");
+    expect(err).toBeInstanceOf(VellumError);
+    expect(err).toBeInstanceOf(ConfigError);
+    expect(err.name).toBe("ConnectionResolutionError");
+  });
+
+  it("prefers the error's own profileName over context attribution", () => {
+    const err = new ConnectionResolutionError("c", "not_found", "m", {
+      profileName: "from-error",
+    });
+    const result = classifyConversationError(err, {
+      ...errCtx,
+      profileName: "from-context",
+    });
+    expect(result.profileName).toBe("from-error");
+  });
+
+  it("falls back to context attribution when the error carries no profile", () => {
+    const err = new ConnectionResolutionError("c", "not_found", "m");
+    const result = classifyConversationError(err, {
+      ...errCtx,
+      profileName: "from-context",
+    });
+    expect(result.profileName).toBe("from-context");
   });
 });

--- a/assistant/src/__tests__/llm-resolver.test.ts
+++ b/assistant/src/__tests__/llm-resolver.test.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import {
   resolveCallSiteConfig,
   resolveDefaultProfileKey,
+  resolveEffectiveProfileKey,
 } from "../config/llm-resolver.js";
 import { type LLMCallSite, LLMSchema } from "../config/schemas/llm.js";
 
@@ -1451,6 +1452,73 @@ describe("resolveDefaultProfileKey", () => {
       activeProfile: "ab",
     });
     expect(resolveDefaultProfileKey("mainAgent", llm)).toBe("balanced");
+  });
+});
+
+describe("resolveEffectiveProfileKey", () => {
+  const llm = LLMSchema.parse({
+    default: fullDefault,
+    profiles: {
+      balanced: { provider: "anthropic", model: "claude-sonnet-4-7" },
+      "cost-optimized": { provider: "openai", model: "gpt-5-mini" },
+      pinned: { provider: "gemini", model: "gemini-2.5-pro" },
+    },
+    activeProfile: "balanced",
+  });
+
+  test("mainAgent: override wins over active", () => {
+    expect(
+      resolveEffectiveProfileKey("mainAgent", llm, {
+        overrideProfile: "pinned",
+      }),
+    ).toBe("pinned");
+  });
+
+  test("mainAgent: active wins when no override", () => {
+    expect(resolveEffectiveProfileKey("mainAgent", llm)).toBe("balanced");
+  });
+
+  // Codex P2: a pinned override on a bare non-mainAgent site must attribute to
+  // the override — `effectiveDefault` strips the catalog default when an
+  // override is present, so the override is the profile that supplies the config.
+  test("non-mainAgent: pinned override wins over stripped catalog default", () => {
+    expect(
+      resolveEffectiveProfileKey("filingAgent", llm, {
+        overrideProfile: "pinned",
+      }),
+    ).toBe("pinned");
+  });
+
+  test("non-mainAgent: catalog default when no override", () => {
+    // filingAgent's CALL_SITE_DEFAULTS profile is `cost-optimized`.
+    expect(resolveEffectiveProfileKey("filingAgent", llm)).toBe(
+      "cost-optimized",
+    );
+  });
+
+  test("non-mainAgent: explicit call-site profile is authoritative over override", () => {
+    const withSite = LLMSchema.parse({
+      ...llm,
+      callSites: { filingAgent: { profile: "cost-optimized" } },
+    });
+    expect(
+      resolveEffectiveProfileKey("filingAgent", withSite, {
+        overrideProfile: "pinned",
+      }),
+    ).toBe("cost-optimized");
+  });
+
+  test("non-mainAgent: forced override floats above the call-site profile", () => {
+    const withSite = LLMSchema.parse({
+      ...llm,
+      callSites: { filingAgent: { profile: "cost-optimized" } },
+    });
+    expect(
+      resolveEffectiveProfileKey("filingAgent", withSite, {
+        overrideProfile: "pinned",
+        forceOverrideProfile: true,
+      }),
+    ).toBe("pinned");
   });
 });
 

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -357,6 +357,38 @@ export function resolveDefaultProfileKey(
 }
 
 /**
+ * Returns the profile key that `resolveCallSiteConfig` would actually treat as
+ * the winning (highest-precedence) profile for a turn — the profile whose
+ * fragment supplies the resolved provider/model. Unlike `resolveDefaultProfileKey`
+ * this accounts for the per-turn `overrideProfile`/`forceOverrideProfile` and
+ * for `effectiveDefault` stripping the catalog default when an override is
+ * present, so error attribution names the slot the resolver really used:
+ * - `mainAgent`: override → active → catalog default.
+ * - forced override: the override.
+ * - other sites: the call-site's own profile (explicit or catalog default) when
+ *   one survives; otherwise override → active. A pinned override on a bare call
+ *   site therefore attributes to the override, not the stripped catalog default.
+ */
+export function resolveEffectiveProfileKey(
+  callSite: LLMCallSite,
+  llm: z.infer<typeof LLMSchema>,
+  opts: ResolveCallSiteOpts = {},
+): string | undefined {
+  const override = opts.overrideProfile ?? undefined;
+  if (callSite === "mainAgent") {
+    return override ?? resolveDefaultProfileKey(callSite, llm);
+  }
+  if (opts.forceOverrideProfile === true && override != null) {
+    return override;
+  }
+  const site =
+    llm.callSites?.[callSite] ??
+    effectiveDefault(callSite, llm, override != null);
+  if (site?.profile != null) return site.profile;
+  return override ?? llm.activeProfile ?? undefined;
+}
+
+/**
  * Stable non-null identity for profileless configs. Callers should prefer real
  * profile keys first; when no named profile applies, the resolved model id is
  * the only model-selection identifier available.

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -29,6 +29,7 @@ import {
 import {
   resolveCallSiteConfig,
   resolveDefaultProfileKey,
+  resolveEffectiveProfileKey,
   resolveProfilelessModelKey,
 } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
@@ -414,22 +415,21 @@ export async function runAgentLoopImpl(
   } => {
     try {
       const overrideProfile = readCurrentOverrideProfile();
-      const resolved = resolveCallSiteConfig(turnCallSite, config.llm, {
+      const resolveOpts = {
         overrideProfile,
         forceOverrideProfile,
         selectionSeed: ctx.conversationId,
-      });
-      // Mirror the resolver's precedence: for mainAgent (and a forced
-      // override) the override/active selection wins; for other call sites
-      // the call-site's own profile is authoritative and the override/active
-      // profile only stands when the site resolves no profile of its own.
-      const siteProfileKey =
-        config.llm.callSites?.[turnCallSite]?.profile ??
-        resolveDefaultProfileKey(turnCallSite, config.llm);
-      const profileName =
-        turnCallSite === "mainAgent" || forceOverrideProfile
-          ? (overrideProfile ?? siteProfileKey ?? config.llm.activeProfile)
-          : (siteProfileKey ?? overrideProfile ?? config.llm.activeProfile);
+      };
+      const resolved = resolveCallSiteConfig(
+        turnCallSite,
+        config.llm,
+        resolveOpts,
+      );
+      const profileName = resolveEffectiveProfileKey(
+        turnCallSite,
+        config.llm,
+        resolveOpts,
+      );
       return {
         ...(resolved.provider_connection
           ? { connectionName: resolved.provider_connection }

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -419,10 +419,17 @@ export async function runAgentLoopImpl(
         forceOverrideProfile,
         selectionSeed: ctx.conversationId,
       });
-      const profileName =
-        overrideProfile ??
-        config.llm.activeProfile ??
+      // Mirror the resolver's precedence: for mainAgent (and a forced
+      // override) the override/active selection wins; for other call sites
+      // the call-site's own profile is authoritative and the override/active
+      // profile only stands when the site resolves no profile of its own.
+      const siteProfileKey =
+        config.llm.callSites?.[turnCallSite]?.profile ??
         resolveDefaultProfileKey(turnCallSite, config.llm);
+      const profileName =
+        turnCallSite === "mainAgent" || forceOverrideProfile
+          ? (overrideProfile ?? siteProfileKey ?? config.llm.activeProfile)
+          : (siteProfileKey ?? overrideProfile ?? config.llm.activeProfile);
       return {
         ...(resolved.provider_connection
           ? { connectionName: resolved.provider_connection }

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -404,6 +404,36 @@ export async function runAgentLoopImpl(
   const readCurrentOverrideProfile = (): string | undefined =>
     options?.overrideProfile ?? resolveOverrideProfile(ctx);
 
+  // Best-effort attribution for error classification: names the resolved
+  // connection and profile so credential/connection errors point at the
+  // exact slot to fix instead of a generic banner. Resolution can itself
+  // throw on a broken config — attribution must never mask the real error.
+  const turnErrorAttribution = (): {
+    connectionName?: string;
+    profileName?: string;
+  } => {
+    try {
+      const overrideProfile = readCurrentOverrideProfile();
+      const resolved = resolveCallSiteConfig(turnCallSite, config.llm, {
+        overrideProfile,
+        forceOverrideProfile,
+        selectionSeed: ctx.conversationId,
+      });
+      const profileName =
+        overrideProfile ??
+        config.llm.activeProfile ??
+        resolveDefaultProfileKey(turnCallSite, config.llm);
+      return {
+        ...(resolved.provider_connection
+          ? { connectionName: resolved.provider_connection }
+          : {}),
+        ...(profileName ? { profileName } : {}),
+      };
+    } catch {
+      return {};
+    }
+  };
+
   const effectiveContextWindow = resolveEffectiveContextWindow({
     llm: config.llm,
     callSite: turnCallSite,
@@ -1510,7 +1540,10 @@ export async function runAgentLoopImpl(
         requestId: reqId,
       });
       rlog.error({ err }, "Conversation processing error");
-      const classified = classifyConversationError(err, errorCtx);
+      const classified = classifyConversationError(err, {
+        ...errorCtx,
+        ...turnErrorAttribution(),
+      });
       if (!turnReplied) {
         abnormalOutcome = { outcome: "failed", failureCode: classified.code };
       }

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -259,17 +259,22 @@ export function classifyConversationError(
   }
 
   if (error instanceof ConnectionResolutionError) {
+    const profileName = error.profileName ?? attribution.profileName;
+    const connectionName = displayableConnectionName(error.connectionName);
     return {
       code: "PROVIDER_NOT_CONFIGURED",
-      userMessage:
-        "No compatible provider connection found for this profile. Check your provider connections in Settings → Models & Services.",
+      userMessage: connectionResolutionUserMessage(
+        error,
+        connectionName,
+        profileName,
+      ),
       retryable: true,
-      debugDetails,
+      // The reason discriminant rides in debugDetails so telemetry can
+      // distinguish the five failure classes without a new wire field.
+      debugDetails: `connection_resolution:${error.reason} — ${debugDetails}`,
       errorCategory: "provider_not_configured",
-      ...(error.connectionName ? { connectionName: error.connectionName } : {}),
-      ...(attribution.profileName
-        ? { profileName: attribution.profileName }
-        : {}),
+      ...(connectionName ? { connectionName } : {}),
+      ...(profileName ? { profileName } : {}),
     };
   }
 
@@ -279,6 +284,39 @@ export function classifyConversationError(
     ...classified,
     debugDetails,
   };
+}
+
+/**
+ * Internal throw sites use sentinel pseudo-names (`<llm.default>`,
+ * `<resolved-callsite>`) when no real connection row is involved; those must
+ * not render as literal connection names.
+ */
+function displayableConnectionName(name: string): string | undefined {
+  return name && !name.startsWith("<") ? name : undefined;
+}
+
+function connectionResolutionUserMessage(
+  error: ConnectionResolutionError,
+  connectionName: string | undefined,
+  profileName: string | undefined,
+): string {
+  const connection = connectionName
+    ? `Provider connection "${connectionName}"`
+    : "The provider connection";
+  const usedBy = profileName ? ` (used by profile "${profileName}")` : "";
+  const fixPath = "Settings → Models & Services";
+  switch (error.reason) {
+    case "lookup_failed":
+      return `${connection}${usedBy} couldn't be read from the connections database. Restart the assistant, then check ${fixPath}.`;
+    case "not_found":
+      return `${connection}${usedBy} no longer exists. Pick a provider in ${fixPath}.`;
+    case "provider_mismatch":
+      return `${connection}${usedBy} is bound to a different provider than the profile declares. Update the profile's connection in ${fixPath}.`;
+    case "missing_connection":
+      return `No provider connection is configured${usedBy}. Add an API key or log in via ${fixPath}.`;
+    case "model_incompatible":
+      return `${error.model ? `Model "${error.model}"` : "The requested model"} isn't available on ${connectionName ? `connection "${connectionName}"` : "the configured connection"}${usedBy}. Pick a different model or connection in ${fixPath}.`;
+  }
 }
 
 /**

--- a/assistant/src/providers/call-site-routing.ts
+++ b/assistant/src/providers/call-site-routing.ts
@@ -257,6 +257,7 @@ export class CallSiteRoutingProvider implements Provider {
           "<resolved-callsite>",
           "model_incompatible",
           incompatMsg,
+          { model: resolved.model },
         );
       }
     }

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -29,6 +29,7 @@
 
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { getDb } from "../persistence/db-connection.js";
+import { ConfigError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import {
   describeSubscriptionModelIncompatibility,
@@ -52,7 +53,10 @@ const log = getLogger("providers/connection-resolution");
  * declared provider). These are deterministic configuration bugs that
  * should fail loudly rather than silently rerouting.
  */
-export class ConnectionResolutionError extends Error {
+export class ConnectionResolutionError extends ConfigError {
+  public readonly model?: string;
+  public readonly profileName?: string;
+
   constructor(
     public readonly connectionName: string,
     public readonly reason:
@@ -62,10 +66,12 @@ export class ConnectionResolutionError extends Error {
       | "missing_connection"
       | "model_incompatible",
     message: string,
-    public readonly cause?: unknown,
+    options?: { cause?: unknown; model?: string; profileName?: string },
   ) {
-    super(message);
+    super(message, { cause: options?.cause });
     this.name = "ConnectionResolutionError";
+    this.model = options?.model;
+    this.profileName = options?.profileName;
   }
 }
 
@@ -107,7 +113,7 @@ export async function tryResolveProviderForConnectionName(
       connectionName,
       "lookup_failed",
       `provider_connection lookup failed for "${connectionName}"`,
-      err,
+      { cause: err },
     );
   }
   if (!connection) {
@@ -183,6 +189,7 @@ export async function tryResolveProviderForConnectionName(
           connectionName,
           "model_incompatible",
           incompatMsg,
+          { model },
         );
       }
       throw new ConnectionResolutionError(
@@ -272,6 +279,7 @@ export async function resolveDefaultProvider(
           "<llm.default>",
           "model_incompatible",
           incompatMsg,
+          { model: resolved.model },
         );
       }
       throw new ConnectionResolutionError(


### PR DESCRIPTION
## Summary
- `ConnectionResolutionError` joins the structured error hierarchy (`ConfigError` → `VellumError`) per docs/error-handling.md, gaining optional `model`/`profileName` attribution populated at throw sites that know them; the one positional-`cause` call site moves to the options bag (native `Error.cause` preserved).
- The conversation-error classifier stops collapsing the five resolution-failure reasons into one generic banner: each reason gets a distinct, actionable userMessage naming the connection, profile, and model where known ("Provider connection X (used by profile Y) no longer exists — pick a provider in Settings → Models & Services"). The wire `code` stays `PROVIDER_NOT_CONFIGURED` and `errorCategory` stays `provider_not_configured` for client compat; the reason discriminant rides in `debugDetails` (`connection_resolution:<reason>`) for telemetry. Internal sentinel pseudo-names (`<llm.default>`) never render as literal connection names.
- The main agent loop's catch now populates the existing-but-unused `ErrorContext.connectionName`/`profileName` attribution via a best-effort re-resolution (guarded so attribution can never mask the real error), so classification names the exact slot to fix.
- No change to which paths throw vs degrade — that's the resolution-preflight PR. This is M6 PR 5 of the plan attached to #37518.

## Original prompt
Milestone 6 of the Inference Management Refactor requires missing provider/credential/model failures to produce explainable errors. This PR is the groundwork: structured error hierarchy, reason-specific user messages, and attribution plumbing — independent of the resolver flip, which builds on it behind the kill-switch flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->