### PR TITLE
feat(assistant): persist tool-result media as workspace references (ATL-991)

### DIFF
--- a/assistant/src/__tests__/conversation-history-web-search.test.ts
+++ b/assistant/src/__tests__/conversation-history-web-search.test.ts
@@ -681,6 +681,12 @@ describe("web_search_tool_result structural guard", () => {
     // reasoning as caption-blocks.ts above.
     "providers/media-resolve.ts",
 
+    // Walks a tool_result's rich `contentBlocks` to materialize nested base64
+    // media into workspace references at persist time. web_search_tool_result
+    // blocks carry no contentBlocks, so only tool_result is relevant. Same
+    // reasoning as media-resolve.ts above.
+    "daemon/persist-media-references.ts",
+
     // Detects turn boundaries by checking whether a user message carries any
     // tool_result block (internal continuation) vs. none (genuine user prompt).
     // A web_search_tool_result-only message is also internal, but treating one

--- a/assistant/src/__tests__/persist-media-references.test.ts
+++ b/assistant/src/__tests__/persist-media-references.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+import { referenceMediaBlocksForPersist } from "../daemon/persist-media-references.js";
+import { getAttachmentsForMessage } from "../persistence/attachments-store.js";
+import {
+  addMessage,
+  createConversation,
+} from "../persistence/conversation-crud.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { mediaSourceBytes } from "../providers/media-resolve.js";
+import type { ContentBlock } from "../providers/types.js";
+
+await initializeDb();
+
+function resetTables() {
+  const db = getDb();
+  db.run("DELETE FROM message_attachments");
+  db.run("DELETE FROM attachments");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+// "aGVsbG8=" = "hello"
+const IMAGE_B64 = Buffer.from("hello").toString("base64");
+
+describe("referenceMediaBlocksForPersist", () => {
+  beforeEach(resetTables);
+
+  test("materializes tool_result base64 media into a linked workspace_ref", async () => {
+    const conv = createConversation();
+    const msg = await addMessage(conv.id, "user", "tool results");
+
+    const blocks: ContentBlock[] = [
+      {
+        type: "tool_result",
+        tool_use_id: "tool-1",
+        content: "screenshot captured",
+        contentBlocks: [
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: IMAGE_B64,
+            },
+          },
+        ],
+      },
+    ];
+
+    const referenced = referenceMediaBlocksForPersist(
+      conv.id,
+      conv.createdAt,
+      msg.id,
+      blocks,
+    );
+
+    // The nested image is now a workspace_ref, not inline base64.
+    const toolResult = referenced[0] as Extract<
+      ContentBlock,
+      { type: "tool_result" }
+    >;
+    const nested = toolResult.contentBlocks![0] as Extract<
+      ContentBlock,
+      { type: "image" }
+    >;
+    expect(nested.source.type).toBe("workspace_ref");
+    expect(JSON.stringify(referenced)).not.toContain(IMAGE_B64);
+
+    // The attachment row is linked to the message (GC anchor) and its bytes
+    // resolve back to the original image.
+    if (nested.source.type !== "workspace_ref") throw new Error("expected ref");
+    const linked = getAttachmentsForMessage(msg.id);
+    expect(linked.map((a) => a.id)).toEqual([nested.source.attachmentId]);
+    expect(mediaSourceBytes(nested.source)?.toString()).toBe("hello");
+  });
+
+  test("leaves an already-referenced block untouched and creates no row", async () => {
+    const conv = createConversation();
+    const msg = await addMessage(conv.id, "user", "tool results");
+
+    const blocks: ContentBlock[] = [
+      {
+        type: "tool_result",
+        tool_use_id: "tool-1",
+        content: "ok",
+        contentBlocks: [
+          {
+            type: "image",
+            source: {
+              type: "workspace_ref",
+              media_type: "image/png",
+              attachmentId: "att-existing",
+              sizeBytes: 5,
+            },
+          },
+        ],
+      },
+    ];
+
+    const referenced = referenceMediaBlocksForPersist(
+      conv.id,
+      conv.createdAt,
+      msg.id,
+      blocks,
+    );
+
+    expect(referenced).toEqual(blocks);
+    expect(getAttachmentsForMessage(msg.id)).toHaveLength(0);
+  });
+});

--- a/assistant/src/__tests__/server-history-render.test.ts
+++ b/assistant/src/__tests__/server-history-render.test.ts
@@ -257,6 +257,36 @@ describe("renderHistoryContent", () => {
     ]);
   });
 
+  test("resolves a workspace_ref tool-result image back to base64", () => {
+    // "aGVsbG8=" = "hello" — a stand-in for screenshot bytes.
+    const stored = uploadAttachment("shot.png", "image/png", "aGVsbG8=");
+    const output = renderHistoryContent([
+      { type: "tool_use", id: "tu_1", name: "browser_screenshot", input: {} },
+      {
+        type: "tool_result",
+        tool_use_id: "tu_1",
+        content: "captured",
+        is_error: false,
+        contentBlocks: [
+          {
+            type: "image",
+            source: {
+              type: "workspace_ref",
+              media_type: "image/png",
+              attachmentId: stored.id,
+              sizeBytes: 5,
+            },
+          },
+        ],
+      },
+    ]);
+
+    // The persisted reference is resolved to base64 so the wire contract
+    // (imageDataList base64) is unchanged for the client.
+    expect(output.toolCalls[0].imageDataList).toEqual(["aGVsbG8="]);
+    expect(output.toolCalls[0].imageData).toBe("aGVsbG8=");
+  });
+
   test("marks error tool results", () => {
     const output = renderHistoryContent([
       { type: "tool_use", id: "tu_1", name: "bash", input: { command: "bad" } },

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -101,6 +101,7 @@ import type {
   WebSearchMetadata,
   WebSearchResultItem,
 } from "./message-types/web-activity.js";
+import { referenceMediaBlocksForPersist } from "./persist-media-references.js";
 import type { TurnLatencyTracker } from "./turn-latency-tracker.js";
 
 const log = getLogger("agent-loop-handlers");
@@ -1287,8 +1288,24 @@ export async function finalizePendingToolResultRow(
     conversationId,
     metadata,
   );
+  // `getConversation` returns `ConversationRow | null`, so `!= null` gates on a
+  // real row (skipping media referencing / disk sync when the conversation was
+  // not found rather than asking those helpers to resolve a missing id).
+  const conv = getConversation(conversationId);
+  // Swap any base64 media the tools produced (screenshots, generated images)
+  // for workspace references so the blob stays in the attachment store, out of
+  // this row and the lexical index. Runs once, here at finalize (on-arrival
+  // writes keep base64 for durability); the send boundary re-inflates the refs.
+  const blocks = buildToolResultBlocks(state.pendingToolResults);
   const contentJson = JSON.stringify(
-    buildToolResultBlocks(state.pendingToolResults),
+    conv != null
+      ? referenceMediaBlocksForPersist(
+          conversationId,
+          conv.createdAt,
+          rowId,
+          blocks as ContentBlock[],
+        )
+      : blocks,
   );
   await persistLoopMessageContent(
     rowId,
@@ -1297,10 +1314,6 @@ export async function finalizePendingToolResultRow(
     rlog,
   );
   // Sync the row to the JSONL disk view so it stays in lockstep with the DB.
-  // `getConversation` returns `ConversationRow | null`, so `!= null` gates on a
-  // real row (skipping the sync when the conversation was not found rather than
-  // asking the disk-view to resolve a missing id).
-  const conv = getConversation(conversationId);
   if (conv != null) {
     syncMessageToDisk(conversationId, rowId, conv.createdAt);
   }

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -11,7 +11,9 @@ import { getConfig } from "../../config/loader.js";
 import type { LLMCallSite, Speed } from "../../config/schemas/llm.js";
 import { ipcCall as gatewayIpcCall } from "../../ipc/gateway-client.js";
 import type { SecretPromptResult } from "../../permissions/secret-prompt-types.js";
+import { resolveMediaSourceData } from "../../providers/media-resolve.js";
 import { isPlaceholderSentinelText } from "../../providers/placeholder-sentinels.js";
+import type { MediaSource } from "../../providers/types.js";
 import { broadcastMessage } from "../../runtime/assistant-event-hub.js";
 import type { AuthContext } from "../../runtime/auth/types.js";
 import * as pendingInteractions from "../../runtime/pending-interactions.js";
@@ -656,19 +658,17 @@ export function renderHistoryContent(
       const resultContent =
         typeof block.content === "string" ? block.content : "";
       const isError = block.is_error === true;
-      // Extract base64 image data from persisted contentBlocks (e.g. browser_screenshot, image generation)
+      // Extract image data from persisted contentBlocks (e.g. browser_screenshot,
+      // image generation) as base64. The source may be inline base64 or a
+      // workspace reference; resolveMediaSourceData reads either back to base64.
       const imageDataList: string[] = [];
       if (Array.isArray(block.contentBlocks)) {
         for (const cb of block.contentBlocks) {
-          if (
-            isRecord(cb) &&
-            cb.type === "image" &&
-            isRecord(cb.source) &&
-            typeof (cb.source as Record<string, unknown>).data === "string"
-          ) {
-            imageDataList.push(
-              (cb.source as Record<string, unknown>).data as string,
+          if (isRecord(cb) && cb.type === "image" && isRecord(cb.source)) {
+            const resolved = resolveMediaSourceData(
+              cb.source as unknown as MediaSource,
             );
+            if (resolved) imageDataList.push(resolved.data);
           }
         }
       }

--- a/assistant/src/daemon/persist-media-references.ts
+++ b/assistant/src/daemon/persist-media-references.ts
@@ -1,0 +1,151 @@
+/**
+ * Convert inline base64 media blocks to workspace references at persist time —
+ * the inverse of `providers/media-resolve.ts` (`resolveMediaReferences`, which
+ * re-inflates references to base64 at the provider send boundary).
+ *
+ * Tool results carry generated media (browser screenshots, image generation)
+ * as base64 `image`/`file` blocks nested in a `tool_result`'s `contentBlocks`.
+ * Persisting that base64 into `messages.content` bloats the row and the lexical
+ * index. Just before the finalized tool-result row is written,
+ * {@link referenceMediaBlocksForPersist} materializes each base64 media block
+ * into an attachment-store row and swaps its `source` for a
+ * {@link WorkspaceRefMediaSource}, keeping the blob in the attachment store.
+ *
+ * A block whose materialization fails is left as inline base64 so media is
+ * never lost. The walk descends into `tool_result.contentBlocks`; every other
+ * block passes through untouched.
+ */
+
+import { optimizeImageForTransport } from "../agent/image-optimize.js";
+import { parseImageDimensions } from "../context/image-dimensions.js";
+import {
+  createInlineAttachment,
+  linkAttachmentToMessage,
+} from "../persistence/attachments-store.js";
+import type {
+  ContentBlock,
+  FileContent,
+  ImageContent,
+  WorkspaceRefMediaSource,
+} from "../providers/types.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("persist-media-references");
+
+/** A filename for an unnamed image block, derived from its MIME subtype. */
+function imageFilename(mediaType: string): string {
+  const subtype = mediaType.split("/")[1]?.replace(/[^a-z0-9]/gi, "") || "png";
+  return `image.${subtype}`;
+}
+
+/**
+ * Dimensions to hint on an image reference. The model receives the
+ * transport-optimized image (`resolveMediaReferences` applies the same
+ * optimization at send time), so hint the optimized dimensions.
+ */
+function optimizedImageDimensions(
+  dataBase64: string,
+  mediaType: string,
+): { width: number; height: number } | null {
+  const optimized = optimizeImageForTransport(dataBase64, mediaType);
+  return parseImageDimensions(optimized.data, optimized.mediaType);
+}
+
+/**
+ * Materialize one base64 media block into an attachment row linked to
+ * `messageId`, returning the block with a `workspace_ref` source — or null when
+ * the store write fails (caller keeps the inline base64 block).
+ */
+function referenceMediaBlock(
+  conversationId: string,
+  conversationCreatedAt: number,
+  messageId: string,
+  block: ImageContent | FileContent,
+  position: number,
+): ContentBlock | null {
+  if (block.source.type !== "base64") return block;
+  const { data, media_type } = block.source;
+  const filename =
+    block.source.filename ??
+    (block.type === "image" ? imageFilename(media_type) : "attachment");
+
+  let stored: { id: string; sizeBytes: number };
+  try {
+    stored = createInlineAttachment(
+      conversationId,
+      conversationCreatedAt,
+      filename,
+      media_type,
+      data,
+    );
+    linkAttachmentToMessage(messageId, stored.id, position);
+  } catch (err) {
+    log.warn(
+      { err, mediaType: media_type, messageId },
+      "Failed to store tool-result media; persisting inline",
+    );
+    return null;
+  }
+
+  const source: WorkspaceRefMediaSource = {
+    type: "workspace_ref",
+    media_type,
+    attachmentId: stored.id,
+    sizeBytes: stored.sizeBytes,
+    ...(block.source.filename !== undefined
+      ? { filename: block.source.filename }
+      : {}),
+  };
+  if (block.type === "image") {
+    const dims = optimizedImageDimensions(data, media_type);
+    if (dims) {
+      source.width = dims.width;
+      source.height = dims.height;
+    }
+    return { type: "image", source };
+  }
+  return {
+    type: "file",
+    source,
+    ...(block.extracted_text !== undefined
+      ? { extracted_text: block.extracted_text }
+      : {}),
+  };
+}
+
+/**
+ * Return a copy of `blocks` with every inline base64 `image`/`file` media block
+ * (including those nested in a `tool_result`'s `contentBlocks`) materialized
+ * into an attachment row linked to `messageId` and swapped for a
+ * `workspace_ref`. Blocks that are already references, carry no media, or fail
+ * to store are returned unchanged.
+ */
+export function referenceMediaBlocksForPersist(
+  conversationId: string,
+  conversationCreatedAt: number,
+  messageId: string,
+  blocks: ContentBlock[],
+): ContentBlock[] {
+  // A single link position counter across all attachments in the message so
+  // their `message_attachments` rows keep content order.
+  let position = 0;
+  const convert = (block: ContentBlock): ContentBlock => {
+    if (block.type === "image" || block.type === "file") {
+      if (block.source.type !== "base64") return block;
+      return (
+        referenceMediaBlock(
+          conversationId,
+          conversationCreatedAt,
+          messageId,
+          block,
+          position++,
+        ) ?? block
+      );
+    }
+    if (block.type === "tool_result" && block.contentBlocks?.length) {
+      return { ...block, contentBlocks: block.contentBlocks.map(convert) };
+    }
+    return block;
+  };
+  return blocks.map(convert);
+}


### PR DESCRIPTION
## Prompt / plan

Final piece of the ATL-991 split. PR A (#37469) landed the data model + resolvers, PR B (#37480) moved user uploads to references. This PR does the same for **tool-generated media** — the last base64 media still landing in `messages.content`.

## What changes

Tool media (browser screenshots, image generation, computer-use) arrives as base64 `image`/`file` blocks nested in a `tool_result`'s `contentBlocks` and was serialized verbatim into the grouped tool-result row — bloating `messages.content` and the lexical index. Now it persists as a `workspace_ref`.

- **New `daemon/persist-media-references.ts`** — `referenceMediaBlocksForPersist`, the symmetric inverse of `providers/media-resolve.ts`: it walks the blocks (descending into `tool_result.contentBlocks`), materializes each base64 media block into an attachment-store row linked to the message (the GC anchor), and swaps its `source` for a `workspace_ref` (with `sizeBytes` + optimized image dimension hints). A block whose store write fails is left inline so media is never lost.
- **Wired at the finalize choke point** (`finalizePendingToolResultRow`). It runs **once**, at finalize — on-arrival writes keep base64 for durability during the turn, and finalize is also reached on abort/loop-exit, so media never double-materializes. The finalized content (refs) is what gets indexed, so base64 leaves the lexical index too.

Assistant directive attachments already become attachment rows and the assistant content row carries no media, so tool-result media was the only remaining base64 in content.

### Client wire unchanged
The live `tool_result` SSE producers already resolve via `resolveMediaSourceData` and emit base64 (they run at emit, before finalize converts), and the historical render path (`shared.ts`) now resolves a `workspace_ref` back to base64 the same way — so `imageData`/`imageDataList` stay base64 and **no web-client change is needed**. This keeps the just-merged inline-preview work (#37574/#36024) working untouched.

### Follow-up (not in this PR)
Moving references onto the wire — clients fetching tool-result images by attachment id on render instead of receiving base64 — is the remaining half of the "refs on the UI wire" goal. The serving endpoint (`GET /attachments/:id/content`) and the web fetch-by-id helper already exist, so it's a self-contained client-side follow-up.

## Test plan

- `bunx tsc --noEmit` clean; prettier + eslint (import-sort) clean; pre-commit hook green.
- New coverage: `persist-media-references` real-store test (tool_result base64 → linked `workspace_ref`, bytes resolve back; already-referenced block untouched, no row created); `server-history-render` case asserting a `workspace_ref` tool-result image resolves back to base64 in `imageDataList`.
- Allowlisted the new file in the `web_search_tool_result` structural guard (its tool_result walk only touches `contentBlocks`).
- Regression: `agent-loop`, `conversation-agent-loop`, `conversation-abort-tool-results`, `conversation-disk-view`, `tool-preview-lifecycle`, `persistence-secret-redaction`, `compactor-media-strip`, `scrub-corrupted-image-attachments`, `headless-browser-read-tools`, `media-generate-image`, `tool-executor`, `list-messages-attachments` — all pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_013KcQ6J4ggzKmNUP8BnqqvB)_