### PR TITLE
fix(web): surface the live-voice turn on a new/empty chat (JARVIS-1265)

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -68,6 +68,7 @@ import { OnboardingCheckinOverlay } from "@/components/onboarding-checkin-overla
 import { OnboardingAvatarApplier } from "@/components/onboarding-avatar-applier";
 import { VoiceSessionPillHost } from "@/domains/chat/components/voice-session-pill-host";
 import { useLiveVoiceSessionController } from "@/domains/chat/voice/live-voice/use-live-voice-session-controller";
+import { useSeedLiveVoiceSnapshot } from "@/domains/chat/voice/live-voice/use-seed-live-voice-snapshot";
 import { VoiceRoom } from "@/domains/chat/voice/voice-room/voice-room";
 import { useIsVoiceRoomVisible } from "@/domains/chat/voice/voice-room/use-is-voice-room-visible";
 import { ChatConversationHeader } from "./chat-conversation-header";
@@ -153,6 +154,9 @@ export function ChatLayout() {
   // pill as its control surface. The composer starts/stops sessions
   // through the seams this registers in `useLiveVoiceStore`.
   useLiveVoiceSessionController();
+  // Fold a live-voice turn into the transcript on a fresh/empty chat, where the
+  // unseeded draft snapshot would otherwise drop the turn's echo (JARVIS-1265).
+  useSeedLiveVoiceSnapshot();
 
   // Subscribe to the sidebar conversation list at the layout level so every
   // chat-layout child route (home, library, contacts, identity, chat)

--- a/clients/web/src/domains/chat/voice/live-voice/use-seed-live-voice-snapshot.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-seed-live-voice-snapshot.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Tests for {@link useSeedLiveVoiceSnapshot} (JARVIS-1265).
+ *
+ * The hook seeds an empty chat snapshot when a live-voice session attaches to
+ * the currently-viewed (draft) conversation with no snapshot yet, so the
+ * daemon's `user_message_echo` folds in instead of being dropped by
+ * `applyEnvelopeToSnapshot`'s null-snapshot no-op. These tests drive the real
+ * live-voice, conversation, and chat-session stores.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { cleanup, render } from "@testing-library/react";
+
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import { useConversationStore } from "@/stores/conversation-store";
+
+import { seedLiveVoiceSession } from "./live-voice-fakes.test-helper";
+import { useLiveVoiceStore } from "./live-voice-store";
+import { useSeedLiveVoiceSnapshot } from "./use-seed-live-voice-snapshot";
+
+const DRAFT_CONVERSATION_ID = "conv-draft";
+const ASSISTANT_ID = "assistant-1";
+
+function Harness() {
+  useSeedLiveVoiceSnapshot();
+  return null;
+}
+
+beforeEach(() => {
+  useLiveVoiceStore.getState().reset();
+  useConversationStore.getState().reset();
+  useChatSessionStore.setState({ snapshot: null });
+  useConversationStore.getState().setActiveConversationId(DRAFT_CONVERSATION_ID);
+});
+
+afterEach(() => {
+  cleanup();
+  useLiveVoiceStore.getState().reset();
+  useConversationStore.getState().reset();
+  useChatSessionStore.setState({ snapshot: null });
+});
+
+describe("useSeedLiveVoiceSnapshot", () => {
+  test("seeds an empty snapshot when the viewed conversation owns a session and none is seeded", () => {
+    seedLiveVoiceSession("listening", {
+      assistantId: ASSISTANT_ID,
+      conversationId: DRAFT_CONVERSATION_ID,
+    });
+    render(<Harness />);
+
+    const snapshot = useChatSessionStore.getState().snapshot;
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.messages).toEqual([]);
+    expect(snapshot?.seq).toBeNull();
+  });
+
+  test("leaves an already-seeded snapshot untouched (no clobber of existing history)", () => {
+    useChatSessionStore.getState().seedSnapshot(DRAFT_CONVERSATION_ID, {
+      messages: [],
+      seq: 1,
+      hasMore: false,
+      oldestTimestamp: null,
+      oldestMessageId: null,
+      processing: undefined,
+    });
+    const before = useChatSessionStore.getState().snapshot;
+
+    seedLiveVoiceSession("listening", {
+      assistantId: ASSISTANT_ID,
+      conversationId: DRAFT_CONVERSATION_ID,
+    });
+    render(<Harness />);
+
+    // Same object identity — the hook did not re-seed over existing history.
+    expect(useChatSessionStore.getState().snapshot).toBe(before);
+  });
+
+  test("does not seed when the viewed conversation does not own the session", () => {
+    seedLiveVoiceSession("listening", {
+      assistantId: ASSISTANT_ID,
+      conversationId: "conv-other-thread",
+    });
+    // Viewing the draft while the session belongs to another conversation.
+    useConversationStore
+      .getState()
+      .setActiveConversationId(DRAFT_CONVERSATION_ID);
+    render(<Harness />);
+
+    expect(useChatSessionStore.getState().snapshot).toBeNull();
+  });
+
+  test("does not seed when there is no active live-voice session", () => {
+    render(<Harness />);
+    expect(useChatSessionStore.getState().snapshot).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/voice/live-voice/use-seed-live-voice-snapshot.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-seed-live-voice-snapshot.ts
@@ -1,0 +1,53 @@
+import { useEffect } from "react";
+
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import { useConversationStore } from "@/stores/conversation-store";
+
+import { useIsLiveVoiceSessionOwnedBy } from "./live-voice-store";
+
+/**
+ * Surfaces a live-voice turn into the chat transcript on a brand-new / empty
+ * conversation.
+ *
+ * On the empty-state landing the viewed conversation is a client-minted draft
+ * id with no seeded history snapshot. When a voice session attaches to it, the
+ * daemon persists and broadcasts the user turn (`user_message_echo`) under that
+ * same draft id — but {@link useChatSessionStore}'s `applyEnvelopeToSnapshot`
+ * is a no-op while the snapshot is null, so the turn is dropped and the empty
+ * state never flips. The text-send path avoids this by adding an optimistic row
+ * and seeding a snapshot on send; voice does neither.
+ *
+ * This hook is the voice analogue: when the active (viewed) conversation owns
+ * the live-voice session and its snapshot is still unseeded, seed an empty one
+ * so the incoming echo/stream folds in and the transcript renders in place (the
+ * daemon adopts the draft id, so no navigation is needed). Seeding only when
+ * the snapshot is null leaves existing conversations — whose history seeds
+ * itself — untouched.
+ *
+ * Mounted once at layout scope (see `chat-layout.tsx`) alongside the session
+ * controller so it spans every chat route.
+ */
+export function useSeedLiveVoiceSnapshot(): void {
+  const activeConversationId = useConversationStore.use.activeConversationId();
+  const ownsActiveConversation =
+    useIsLiveVoiceSessionOwnedBy(activeConversationId);
+
+  useEffect(() => {
+    if (!ownsActiveConversation || activeConversationId == null) {
+      return;
+    }
+    // Read (don't subscribe) the snapshot: seed only a genuinely unseeded
+    // draft, so an existing conversation's own history seed is never clobbered.
+    if (useChatSessionStore.getState().snapshot !== null) {
+      return;
+    }
+    useChatSessionStore.getState().seedSnapshot(activeConversationId, {
+      messages: [],
+      seq: null,
+      hasMore: false,
+      oldestTimestamp: null,
+      oldestMessageId: null,
+      processing: undefined,
+    });
+  }, [ownsActiveConversation, activeConversationId]);
+}


### PR DESCRIPTION
## Summary
Starting voice mode from a brand-new/empty chat, speaking, and exiting left you on the landing with no turn in the transcript. The daemon was already persisting and broadcasting the voice user turn under the draft conversation id the client is viewing — but the chat store's `applyEnvelopeToSnapshot` no-ops while the snapshot is null (an unseeded draft), so the turn was dropped and the empty state never flipped. The text-send path avoids this by adding an optimistic row and seeding a snapshot on send; voice did neither.

Adds a layout-scoped `useSeedLiveVoiceSnapshot` hook: when the viewed conversation owns the live-voice session and its snapshot is still unseeded, it seeds an empty snapshot so the incoming `user_message_echo`/stream folds in and the transcript renders in place (the daemon adopts the draft id, so no navigation is needed). Only seeds when the snapshot is null, leaving existing conversations untouched.

**Client-only** — no daemon change (the runtime side already broadcasts correctly). Third fix in the "live-voice bypasses the text-send path" class (after JARVIS-1258 user-echo, JARVIS-1259 conversation-row persistence).

## Tests
`use-seed-live-voice-snapshot.test.tsx` (4): seeds on an unseeded owned draft; leaves an already-seeded snapshot untouched; does not seed for a non-owning conversation or with no active session. Verified manually end-to-end (new chat → speak → turn appears).

Closes JARVIS-1265