### PR TITLE
feat(web): mark a provider connection as the default provider

### DIFF
--- a/clients/web/docs/BACKWARDS_COMPAT.md
+++ b/clients/web/docs/BACKWARDS_COMPAT.md
@@ -124,6 +124,7 @@ Each module owns one feature's old/new split. Current registry:
 | `conversation-processing-state.ts` | `0.8.8` | Client-side optimistic mirror (`processingConversationIds`), cleared manually on terminal events | Trust the server `isProcessing` flag on the conversation row |
 | `llm-context-summary-view.ts` | `0.8.12` | Inline context sections from the list response | `view=summary` light list + lazy per-log detail via `GET /v1/llm-request-logs/:id/context` |
 | `vision-attachment-gate.ts` | `0.10.0-dev.202606211252.5cf8576` | Client filters images out for non-vision models | Allow any file type; the image-fallback plugin filters/captions server-side |
+| `default-provider-settings.ts` | `0.10.8` | No default-provider marker UI in the Providers modal; status query never fires | "Default" tag + "Set as default" via `GET/PUT /v1/config/llm/default-provider` |
 
 When you delete a row here, also delete its module, its test, and the now-dead
 legacy branch at the call site.

--- a/clients/web/src/domains/settings/ai/manage-providers-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/manage-providers-modal.test.tsx
@@ -26,6 +26,7 @@ let defaultProviderState: DefaultProviderStatus = {
   resolvedConnectionName: null,
   availability: { status: "missing_default" },
 };
+let defaultProviderGetCalls = 0;
 let putBodies: Array<{ provider: string; connectionName?: string }> = [];
 let putShouldFail = false;
 let deleteCalls: string[] = [];
@@ -37,7 +38,10 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   inferenceProviderconnectionsGet: async () => ({
     data: { connections: connectionsState },
   }),
-  configLlmDefaultproviderGet: async () => ({ data: defaultProviderState }),
+  configLlmDefaultproviderGet: async () => {
+    defaultProviderGetCalls += 1;
+    return { data: defaultProviderState };
+  },
   configLlmDefaultproviderPut: async (options?: {
     body?: { provider: string; connectionName?: string };
   }) => {
@@ -69,6 +73,8 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
 
 const { ManageProvidersModal } =
   await import("@/domains/settings/ai/manage-providers-modal");
+const { useAssistantIdentityStore } =
+  await import("@/stores/assistant-identity-store");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -132,12 +138,16 @@ beforeEach(() => {
     resolvedConnectionName: null,
     availability: { status: "missing_default" },
   };
+  defaultProviderGetCalls = 0;
   putBodies = [];
   putShouldFail = false;
   deleteCalls = [];
+  // The marker UI is version-gated (assistants < 0.10.8 lack the routes).
+  useAssistantIdentityStore.getState().setIdentity("test-asst", "0.10.8");
 });
 
 afterEach(() => {
+  useAssistantIdentityStore.getState().clearIdentity();
   cleanup();
 });
 
@@ -230,6 +240,22 @@ describe("default marker", () => {
       "can't run on this provider",
     );
     expect(putBodies).toEqual([]);
+  });
+
+  test("assistants without the routes get no marker UI and no query", async () => {
+    useAssistantIdentityStore.getState().setIdentity("test-asst", "0.10.7");
+    connectionsState = [
+      makeConnection({ name: "openai-personal", provider: "openai" }),
+    ];
+
+    const result = renderModal();
+    await waitFor(() => {
+      expect(result.baseElement.textContent).toContain("openai-personal");
+    });
+
+    expect(result.baseElement.textContent).not.toContain("Set as default");
+    expect(result.baseElement.textContent).not.toContain("Default");
+    expect(defaultProviderGetCalls).toBe(0);
   });
 
   test("PUT failure renders the inline row error", async () => {

--- a/clients/web/src/domains/settings/ai/manage-providers-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/manage-providers-modal.test.tsx
@@ -1,0 +1,258 @@
+/**
+ * Tests for `ManageProvidersModal` — the "use as default" marker (M7 PR 2).
+ *
+ * Mocks the generated SDK boundary; the default-provider GET/PUT flow runs
+ * through the real generated react-query wrappers.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { createElement } from "react";
+
+import type {
+  DefaultProviderStatus,
+  ProviderConnection,
+} from "@/generated/daemon/types.gen";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+let connectionsState: ProviderConnection[] = [];
+let defaultProviderState: DefaultProviderStatus = {
+  provider: null,
+  resolvedConnectionName: null,
+  availability: { status: "missing_default" },
+};
+let putBodies: Array<{ provider: string; connectionName?: string }> = [];
+let putShouldFail = false;
+let deleteCalls: string[] = [];
+
+const actualSdk = await import("@/generated/daemon/sdk.gen");
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...actualSdk,
+  inferenceProviderconnectionsGet: async () => ({
+    data: { connections: connectionsState },
+  }),
+  configLlmDefaultproviderGet: async () => ({ data: defaultProviderState }),
+  configLlmDefaultproviderPut: async (options?: {
+    body?: { provider: string; connectionName?: string };
+  }) => {
+    if (options?.body) {
+      putBodies.push(options.body);
+    }
+    if (putShouldFail) {
+      throw new Error("put failed");
+    }
+    defaultProviderState = {
+      provider: (options?.body?.provider ??
+        null) as DefaultProviderStatus["provider"],
+      connectionName: options?.body?.connectionName,
+      resolvedConnectionName: options?.body?.connectionName ?? null,
+      availability: { status: "ok" },
+    };
+    return { data: defaultProviderState };
+  },
+  inferenceProviderconnectionsByNameDelete: async (options?: {
+    path?: { name?: string };
+  }) => {
+    if (options?.path?.name) {
+      deleteCalls.push(options.path.name);
+    }
+    return { response: { ok: true, status: 200 } };
+  },
+  configGet: async () => ({ data: {} }),
+}));
+
+const { ManageProvidersModal } =
+  await import("@/domains/settings/ai/manage-providers-modal");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeConnection(
+  overrides: Partial<ProviderConnection> & { name: string; provider: string },
+): ProviderConnection {
+  return {
+    label: null,
+    auth: {
+      type: "api_key",
+      credential: `credential/${overrides.provider}/api_key`,
+    },
+    baseUrl: null,
+    models: null,
+    createdAt: 1,
+    updatedAt: 1,
+    isManaged: false,
+    ...overrides,
+  } as ProviderConnection;
+}
+
+function renderModal() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      createElement(ManageProvidersModal, {
+        isOpen: true,
+        assistantId: "assistant-1",
+        onClose: () => {},
+      }),
+    ),
+  );
+}
+
+function rowFor(result: ReturnType<typeof render>, label: string) {
+  const spans = [...result.baseElement.querySelectorAll("span, p")];
+  const labelEl = spans.find((el) => el.textContent === label);
+  if (!labelEl) {
+    throw new Error(`Row "${label}" not found`);
+  }
+  return labelEl.closest("div.flex.items-center.gap-3")?.parentElement ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  connectionsState = [];
+  defaultProviderState = {
+    provider: null,
+    resolvedConnectionName: null,
+    availability: { status: "missing_default" },
+  };
+  putBodies = [];
+  putShouldFail = false;
+  deleteCalls = [];
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("default marker", () => {
+  test("renders the Default tag on the resolved connection and disables its delete", async () => {
+    connectionsState = [
+      makeConnection({ name: "anthropic-personal", provider: "anthropic" }),
+      makeConnection({ name: "openai-personal", provider: "openai" }),
+    ];
+    defaultProviderState = {
+      provider: "anthropic",
+      resolvedConnectionName: "anthropic-personal",
+      availability: { status: "ok" },
+    };
+
+    const result = renderModal();
+    await waitFor(() => {
+      expect(result.baseElement.textContent).toContain("Default");
+    });
+
+    const defaultRow = rowFor(result, "anthropic-personal");
+    expect(defaultRow?.textContent).toContain("Default");
+    const otherRow = rowFor(result, "openai-personal");
+    expect(otherRow?.textContent).not.toContain("Default");
+
+    const deleteButton = defaultRow?.querySelector<HTMLButtonElement>(
+      'button[aria-label="Delete anthropic-personal"]',
+    );
+    expect(deleteButton?.disabled).toBe(true);
+    expect(deleteButton?.title).toContain("default provider");
+  });
+
+  test("Set as default PUTs explicit provider + connectionName and moves the tag", async () => {
+    connectionsState = [
+      makeConnection({ name: "anthropic-personal", provider: "anthropic" }),
+      makeConnection({ name: "work-openai", provider: "openai" }),
+    ];
+    defaultProviderState = {
+      provider: "anthropic",
+      resolvedConnectionName: "anthropic-personal",
+      availability: { status: "ok" },
+    };
+
+    const result = renderModal();
+    await waitFor(() => {
+      expect(result.baseElement.textContent).toContain("work-openai");
+    });
+
+    const otherRow = rowFor(result, "work-openai");
+    const setDefaultButton = [
+      ...(otherRow?.querySelectorAll("button") ?? []),
+    ].find((b) => b.textContent === "Set as default");
+    expect(setDefaultButton).toBeDefined();
+    fireEvent.click(setDefaultButton as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(putBodies).toEqual([
+        { provider: "openai", connectionName: "work-openai" },
+      ]);
+    });
+
+    // Invalidation refetches the GET (now pointing at work-openai) and the
+    // tag moves to the new row.
+    await waitFor(() => {
+      const refreshedRow = rowFor(result, "work-openai");
+      expect(refreshedRow?.textContent).toContain("Default");
+    });
+  });
+
+  test("non-matrix providers get a disabled action with an explanatory tooltip", async () => {
+    connectionsState = [
+      makeConnection({ name: "local-ollama", provider: "ollama" }),
+    ];
+
+    const result = renderModal();
+    await waitFor(() => {
+      expect(result.baseElement.textContent).toContain("local-ollama");
+    });
+
+    const row = rowFor(result, "local-ollama");
+    const setDefaultButton = [...(row?.querySelectorAll("button") ?? [])].find(
+      (b) => b.textContent === "Set as default",
+    );
+    expect((setDefaultButton as HTMLButtonElement).disabled).toBe(true);
+    expect((setDefaultButton as HTMLButtonElement).title).toContain(
+      "can't run on this provider",
+    );
+    expect(putBodies).toEqual([]);
+  });
+
+  test("PUT failure renders the inline row error", async () => {
+    connectionsState = [
+      makeConnection({ name: "openai-personal", provider: "openai" }),
+    ];
+    putShouldFail = true;
+
+    const result = renderModal();
+    await waitFor(() => {
+      expect(result.baseElement.textContent).toContain("openai-personal");
+    });
+
+    const row = rowFor(result, "openai-personal");
+    const setDefaultButton = [...(row?.querySelectorAll("button") ?? [])].find(
+      (b) => b.textContent === "Set as default",
+    );
+    fireEvent.click(setDefaultButton as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(result.baseElement.textContent).toContain(
+        "Failed to set default provider",
+      );
+    });
+  });
+});

--- a/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
+++ b/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
@@ -22,6 +22,7 @@ import type {
   ProviderConnection,
 } from "@/generated/daemon/types.gen";
 import { PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
+import { useSupportsDefaultProviderSettings } from "@/lib/backwards-compat/default-provider-settings";
 import { ProviderEditorContent } from "@/domains/settings/ai/provider-editor-modal";
 // ---------------------------------------------------------------------------
 // Helpers
@@ -91,11 +92,14 @@ export function ManageProvidersModal({
     enabled: isOpen,
   });
 
+  // Older assistants 404 the default-provider routes; the gate keeps the
+  // query dark and the marker UI hidden against them.
+  const supportsDefaultProvider = useSupportsDefaultProviderSettings();
   const { data: defaultProviderStatus } = useQuery({
     ...configLlmDefaultproviderGetOptions({
       path: { assistant_id: assistantId },
     }),
-    enabled: isOpen,
+    enabled: isOpen && supportsDefaultProvider,
   });
 
   const connections = useMemo(() => data?.connections ?? [], [data]);
@@ -174,8 +178,11 @@ export function ManageProvidersModal({
             loading={loading}
             isError={isError}
             assistantId={assistantId}
+            supportsDefaultProvider={supportsDefaultProvider}
             defaultConnectionName={
-              defaultProviderStatus?.resolvedConnectionName ?? null
+              supportsDefaultProvider
+                ? (defaultProviderStatus?.resolvedConnectionName ?? null)
+                : null
             }
             onDefaultChanged={handleDefaultChanged}
             onClose={onClose}
@@ -210,6 +217,8 @@ interface ManageProvidersModalInnerProps {
   loading: boolean;
   isError: boolean;
   assistantId: string;
+  /** False against assistants that predate the default-provider routes. */
+  supportsDefaultProvider: boolean;
   /** Connection the default provider resolves to, or null when unknown. */
   defaultConnectionName: string | null;
   onDefaultChanged: () => void;
@@ -224,6 +233,7 @@ function ManageProvidersModalInner({
   loading,
   isError,
   assistantId,
+  supportsDefaultProvider,
   defaultConnectionName,
   onDefaultChanged,
   onClose,
@@ -402,7 +412,7 @@ function ManageProvidersModalInner({
 
                     {/* Actions */}
                     <div className="flex shrink-0 items-center gap-2">
-                      {!isDefault && (
+                      {supportsDefaultProvider && !isDefault && (
                         <Button
                           variant="ghost"
                           size="compact"

--- a/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
+++ b/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
@@ -1,24 +1,48 @@
 import { Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@vellumai/design-library/components/button";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { Tag } from "@vellumai/design-library/components/tag";
 import { Typography } from "@vellumai/design-library/components/typography";
 
 import {
-    inferenceProviderconnectionsGetOptions,
-    inferenceProviderconnectionsGetQueryKey,
+  configGetQueryKey,
+  configLlmDefaultproviderGetOptions,
+  configLlmDefaultproviderGetQueryKey,
+  configLlmDefaultproviderPutMutation,
+  inferenceProviderconnectionsGetOptions,
+  inferenceProviderconnectionsGetQueryKey,
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import { inferenceProviderconnectionsByNameDelete } from "@/generated/daemon/sdk.gen";
 
-import type { ProviderConnection } from "@/generated/daemon/types.gen";
+import type {
+  DefaultProviderStatus,
+  ProviderConnection,
+} from "@/generated/daemon/types.gen";
 import { PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
 import { ProviderEditorContent } from "@/domains/settings/ai/provider-editor-modal";
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+type DefaultProviderId = NonNullable<DefaultProviderStatus["provider"]>;
+
+// Exhaustive against the generated union: a provider added to or removed
+// from the daemon's default-provider enum fails compilation here.
+const DEFAULT_PROVIDER_ELIGIBLE: Record<DefaultProviderId, true> = {
+  anthropic: true,
+  openai: true,
+  gemini: true,
+  fireworks: true,
+  openrouter: true,
+  vellum: true,
+};
+
+function isDefaultProviderId(provider: string): provider is DefaultProviderId {
+  return provider in DEFAULT_PROVIDER_ELIGIBLE;
+}
 
 function formatAuthSummary(auth: ProviderConnection["auth"]): string {
   switch (auth.type) {
@@ -51,21 +75,43 @@ export function ManageProvidersModal({
   onClose,
 }: ManageProvidersModalProps) {
   const [editorOpen, setEditorOpen] = useState(false);
-  const [editingConnection, setEditingConnection] = useState<ProviderConnection | null>(null);
+  const [editingConnection, setEditingConnection] =
+    useState<ProviderConnection | null>(null);
 
   const queryClient = useQueryClient();
   const queryOpts = inferenceProviderconnectionsGetOptions({
     path: { assistant_id: assistantId },
   });
-  const { data, isLoading: loading, isError } = useQuery({
+  const {
+    data,
+    isLoading: loading,
+    isError,
+  } = useQuery({
     ...queryOpts,
     enabled: isOpen,
   });
 
-  const connections = useMemo(
-    () => data?.connections ?? [],
-    [data],
-  );
+  const { data: defaultProviderStatus } = useQuery({
+    ...configLlmDefaultproviderGetOptions({
+      path: { assistant_id: assistantId },
+    }),
+    enabled: isOpen,
+  });
+
+  const connections = useMemo(() => data?.connections ?? [], [data]);
+
+  function handleDefaultChanged() {
+    void queryClient.invalidateQueries({
+      queryKey: configLlmDefaultproviderGetQueryKey({
+        path: { assistant_id: assistantId },
+      }),
+    });
+    void queryClient.invalidateQueries({
+      queryKey: configGetQueryKey({
+        path: { assistant_id: assistantId },
+      }),
+    });
+  }
 
   function handleEditorSave(_saved: ProviderConnection) {
     void queryClient.invalidateQueries({
@@ -96,7 +142,9 @@ export function ManageProvidersModal({
     <Modal.Root
       open={isOpen}
       onOpenChange={(next) => {
-        if (next) return;
+        if (next) {
+          return;
+        }
         if (editorOpen) {
           cancelEditor();
         } else {
@@ -126,6 +174,10 @@ export function ManageProvidersModal({
             loading={loading}
             isError={isError}
             assistantId={assistantId}
+            defaultConnectionName={
+              defaultProviderStatus?.resolvedConnectionName ?? null
+            }
+            onDefaultChanged={handleDefaultChanged}
             onClose={onClose}
             onEditClick={(conn) => {
               setEditingConnection(conn);
@@ -158,6 +210,9 @@ interface ManageProvidersModalInnerProps {
   loading: boolean;
   isError: boolean;
   assistantId: string;
+  /** Connection the default provider resolves to, or null when unknown. */
+  defaultConnectionName: string | null;
+  onDefaultChanged: () => void;
   onClose: () => void;
   onEditClick: (conn: ProviderConnection) => void;
   onNewClick: () => void;
@@ -169,17 +224,55 @@ function ManageProvidersModalInner({
   loading,
   isError,
   assistantId,
+  defaultConnectionName,
+  onDefaultChanged,
   onClose,
   onEditClick,
   onNewClick,
   onConnectionDeleted,
 }: ManageProvidersModalInnerProps) {
-  const [deleteErrors, setDeleteErrors] = useState<Record<string, string>>({});
+  const [rowErrors, setRowErrors] = useState<Record<string, string>>({});
   const [deleting, setDeleting] = useState<Record<string, boolean>>({});
+
+  const setDefault = useMutation({
+    ...configLlmDefaultproviderPutMutation(),
+    onMutate: (variables) => {
+      const name = variables.body?.connectionName;
+      if (!name) {
+        return;
+      }
+      setRowErrors((prev) => {
+        const next = { ...prev };
+        delete next[name];
+        return next;
+      });
+    },
+    onSuccess: onDefaultChanged,
+    onError: (_error, variables) => {
+      const name = variables.body?.connectionName;
+      if (!name) {
+        return;
+      }
+      setRowErrors((prev) => ({
+        ...prev,
+        [name]: "Failed to set default provider. Please try again.",
+      }));
+    },
+  });
+
+  function handleSetDefault(conn: ProviderConnection) {
+    if (!isDefaultProviderId(conn.provider)) {
+      return;
+    }
+    setDefault.mutate({
+      path: { assistant_id: assistantId },
+      body: { provider: conn.provider, connectionName: conn.name },
+    });
+  }
 
   async function handleDelete(name: string) {
     setDeleting((prev) => ({ ...prev, [name]: true }));
-    setDeleteErrors((prev) => {
+    setRowErrors((prev) => {
       const next = { ...prev };
       delete next[name];
       return next;
@@ -192,19 +285,19 @@ function ManageProvidersModalInner({
         // 404 means already gone — still remove from local list.
         onConnectionDeleted(name);
       } else if (response?.status === 409) {
-        setDeleteErrors((prev) => ({
+        setRowErrors((prev) => ({
           ...prev,
           [name]:
             "Connection is in use by one or more profiles. Remove those references first.",
         }));
       } else {
-        setDeleteErrors((prev) => ({
+        setRowErrors((prev) => ({
           ...prev,
           [name]: "Failed to delete connection. Please try again.",
         }));
       }
     } catch {
-      setDeleteErrors((prev) => ({
+      setRowErrors((prev) => ({
         ...prev,
         [name]: "Failed to delete connection. Please try again.",
       }));
@@ -222,8 +315,8 @@ function ManageProvidersModalInner({
       <Modal.Header>
         <Modal.Title>Provider Connections</Modal.Title>
         <Modal.Description>
-          Manage inference provider connections. Each connection binds a name to a
-          provider and auth configuration.
+          Manage inference provider connections. Each connection binds a name to
+          a provider and auth configuration.
         </Modal.Description>
       </Modal.Header>
 
@@ -257,8 +350,13 @@ function ManageProvidersModalInner({
           <div className="space-y-1">
             {connections.map((conn) => {
               const isDeleting = deleting[conn.name] ?? false;
-              const deleteError = deleteErrors[conn.name];
+              const rowError = rowErrors[conn.name];
               const isManaged = conn.isManaged ?? false;
+              const isDefault = conn.name === defaultConnectionName;
+              const eligibleForDefault = isDefaultProviderId(conn.provider);
+              const isSettingDefault =
+                setDefault.isPending &&
+                setDefault.variables?.body?.connectionName === conn.name;
 
               return (
                 <div key={conn.name}>
@@ -281,6 +379,14 @@ function ManageProvidersModalInner({
                             Platform
                           </Tag>
                         )}
+                        {isDefault && (
+                          <Tag
+                            tone="info"
+                            title="Built-in profiles (Balanced, Quality, Speed) run through this connection."
+                          >
+                            Default
+                          </Tag>
+                        )}
                       </div>
                       <Typography
                         variant="body-medium-lighter"
@@ -296,6 +402,21 @@ function ManageProvidersModalInner({
 
                     {/* Actions */}
                     <div className="flex shrink-0 items-center gap-2">
+                      {!isDefault && (
+                        <Button
+                          variant="ghost"
+                          size="compact"
+                          disabled={!eligibleForDefault || isSettingDefault}
+                          title={
+                            eligibleForDefault
+                              ? "Run the built-in profiles through this connection."
+                              : "Built-in profiles can't run on this provider."
+                          }
+                          onClick={() => handleSetDefault(conn)}
+                        >
+                          Set as default
+                        </Button>
+                      )}
                       <Button
                         variant="ghost"
                         size="compact"
@@ -308,11 +429,13 @@ function ManageProvidersModalInner({
                         size="compact"
                         iconOnly={<Trash2 />}
                         aria-label={`Delete ${conn.name}`}
-                        disabled={isManaged || isDeleting}
+                        disabled={isManaged || isDefault || isDeleting}
                         title={
                           isManaged
                             ? "Managed connections cannot be deleted"
-                            : undefined
+                            : isDefault
+                              ? "This connection serves your default provider. Set another connection as default first."
+                              : undefined
                         }
                         onClick={() => void handleDelete(conn.name)}
                         tintColor="var(--system-negative-strong)"
@@ -320,13 +443,13 @@ function ManageProvidersModalInner({
                     </div>
                   </div>
 
-                  {deleteError ? (
+                  {rowError ? (
                     <Typography
                       variant="body-small-default"
                       as="p"
                       className="px-2 pb-1 text-(--system-negative-strong)"
                     >
-                      {deleteError}
+                      {rowError}
                     </Typography>
                   ) : null}
                 </div>

--- a/clients/web/src/lib/backwards-compat/default-provider-settings.test.ts
+++ b/clients/web/src/lib/backwards-compat/default-provider-settings.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { renderHook } from "@testing-library/react";
+
+import { useSupportsDefaultProviderSettings } from "@/lib/backwards-compat/default-provider-settings";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+
+function setVersion(version: string | null) {
+  useAssistantIdentityStore.getState().setIdentity("test-asst", version);
+}
+
+beforeEach(() => {
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+afterEach(() => {
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+// Exhaustive truth-table for the underlying semver gate lives in
+// `utils.test.ts`. Here we verify each side of the 0.10.8 boundary
+// plus the conservative-on-unknown policy.
+describe("useSupportsDefaultProviderSettings", () => {
+  test("false when version is unknown", () => {
+    setVersion(null);
+    const { result } = renderHook(() => useSupportsDefaultProviderSettings());
+    expect(result.current).toBe(false);
+  });
+
+  test("false for assistants on 0.10.7 and older", () => {
+    setVersion("0.10.7");
+    const { result } = renderHook(() => useSupportsDefaultProviderSettings());
+    expect(result.current).toBe(false);
+  });
+
+  test("true for assistants on 0.10.8+", () => {
+    setVersion("0.10.8");
+    const { result } = renderHook(() => useSupportsDefaultProviderSettings());
+    expect(result.current).toBe(true);
+  });
+
+  test("true for RC builds of the cutover patch", () => {
+    setVersion("0.10.8-rc.1");
+    const { result } = renderHook(() => useSupportsDefaultProviderSettings());
+    expect(result.current).toBe(true);
+  });
+});

--- a/clients/web/src/lib/backwards-compat/default-provider-settings.ts
+++ b/clients/web/src/lib/backwards-compat/default-provider-settings.ts
@@ -1,0 +1,17 @@
+/**
+ * Backwards-compat gate: default-provider settings surface.
+ *
+ * Vellum Assistant 0.10.8 added `GET/PUT /v1/config/llm/default-provider`
+ * (the persisted `llm.defaultProvider` plus an availability status).
+ * Older assistants 404 both routes, so the web app hides the "Default"
+ * marker and "Set as default" action in the Providers modal and skips
+ * the status query entirely — the modal behaves exactly as it did
+ * before the feature.
+ */
+import { useAssistantSupports } from "@/lib/backwards-compat/utils";
+
+const MIN_VERSION = "0.10.8";
+
+export function useSupportsDefaultProviderSettings(): boolean {
+  return useAssistantSupports(MIN_VERSION);
+}


### PR DESCRIPTION
## Summary

- Adds a "use as default" flow to the Providers modal: the connection that `llm.defaultProvider` resolves to (from `GET /v1/config/llm/default-provider`, #37579) gets a "Default" tag and a guarded Delete button; every other eligible row gets a "Set as default" action.
- Setting a default always PUTs an explicit `{ provider, connectionName }` — convention-based resolution dangles for web-onboarded connections named bare `anthropic`/`openai`, so the UI pins the clicked row's name.
- Providers outside the default-provider matrix (ollama, together, openai-compatible, …) show a disabled action with an explanatory tooltip, enforced by a compile-time-exhaustive map over the generated `DefaultProviderStatus["provider"]` union; PUT failures render in the per-row inline error slot.

Part of M7 (Inference Management Refactor) — plan attached to #37579. Follow-ups: availability notice in the Language Model card (PR 3), server-message delete-guard errors (PR 4).

## Original prompt

Execute PR 2 of the M7 plan (`.private/plans/m7-settings-ui-default-provider.md`): the web control for choosing the default provider. Per the design decision made during planning, this lives as a per-connection marker in the Providers modal — not a second "Default ___" dropdown in the Language Model card, which would compete with the existing Default Profile (activeProfile) selector. The marker consumes the default-provider routes shipped in #37579 via the regenerated daemon client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->