### PR TITLE
feat(web): move Display Name & Key into Advanced on provider create

### DIFF
--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -139,6 +139,22 @@ function getSaveBtn(): HTMLButtonElement {
   return btn;
 }
 
+/**
+ * The inline ProviderCreateForm keeps its Display Name + Key fields under a
+ * collapsed "Advanced" disclosure. Open it so those inputs mount.
+ */
+function openInlineProviderAdvanced(): void {
+  const button = Array.from(
+    document.querySelectorAll<HTMLButtonElement>("button"),
+  ).find((b) => b.textContent?.includes("Display name"));
+  if (!button) {
+    throw new Error("expected the inline provider Advanced disclosure");
+  }
+  if (button.getAttribute("aria-expanded") !== "true") {
+    fireEvent.click(button);
+  }
+}
+
 /** All Dropdown triggers (custom comboboxes) in document order. */
 function dropdownTriggers(): HTMLButtonElement[] {
   return Array.from(
@@ -468,7 +484,8 @@ describe("ProfileEditorModal create mode — provider-first", () => {
 
     selectProvider("+ Create new provider");
 
-    // Inline ProviderCreateForm is mounted (its Key field placeholder).
+    // Inline ProviderCreateForm is mounted; its Key field lives under Advanced.
+    openInlineProviderAdvanced();
     const inlineKey = getInputByPlaceholder("e.g. anthropic-personal");
     expect(inlineKey).toBeDefined();
 
@@ -512,6 +529,7 @@ describe("ProfileEditorModal create mode — provider-first", () => {
     renderCreate([], onSave);
 
     selectProvider("+ Create new provider");
+    openInlineProviderAdvanced();
     fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
       target: { value: "anthropic-personal" },
     });

--- a/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -161,6 +161,23 @@ function getButton(label: string): HTMLButtonElement {
 }
 
 /**
+ * Display Name + Key live under a collapsed "Advanced" disclosure. Open it
+ * so those inputs mount before a test reads or edits them. Idempotent — a
+ * no-op when the section is already expanded.
+ */
+function openAdvancedFields(): void {
+  const button = Array.from(
+    document.querySelectorAll<HTMLButtonElement>("button"),
+  ).find((b) => b.textContent?.includes("Display name"));
+  if (!button) {
+    throw new Error("expected the Advanced (Display name & key) disclosure");
+  }
+  if (button.getAttribute("aria-expanded") !== "true") {
+    fireEvent.click(button);
+  }
+}
+
+/**
  * Drive the design-library Dropdown (a custom combobox, not a native
  * <select>): click the trigger to open the listbox, then click the option
  * whose visible label matches.
@@ -224,6 +241,7 @@ describe("ProviderCreateForm submit sequence", () => {
 
     // Default provider is anthropic with platform auth — switch to API Key.
     // Type a Key (name) and an API key value.
+    openAdvancedFields();
     fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
       target: { value: "anthropic-personal" },
     });
@@ -278,6 +296,7 @@ describe("ProviderCreateForm submit sequence", () => {
       </ModalWrapper>,
     );
 
+    openAdvancedFields();
     fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
       target: { value: "anthropic-personal" },
     });
@@ -307,6 +326,7 @@ describe("ProviderCreateForm submit sequence", () => {
     // Inline variant drops the modal title.
     expect(document.body.textContent).not.toContain("New Provider Connection");
 
+    openAdvancedFields();
     fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
       target: { value: "anthropic-personal" },
     });
@@ -440,6 +460,7 @@ describe("ProviderCreateForm submit sequence", () => {
       </ModalWrapper>,
     );
 
+    openAdvancedFields();
     fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
       target: { value: "anthropic-personal" },
     });
@@ -470,6 +491,7 @@ describe("ProviderCreateForm submit sequence", () => {
       </ModalWrapper>,
     );
 
+    openAdvancedFields();
     fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
       target: { value: "anthropic-personal" },
     });
@@ -502,6 +524,7 @@ describe("ProviderCreateForm submit sequence", () => {
       </ModalWrapper>,
     );
 
+    openAdvancedFields();
     expect(getInputByPlaceholder("e.g. My Anthropic Key").value).toBe(
       "Anthropic",
     );
@@ -523,6 +546,7 @@ describe("ProviderCreateForm submit sequence", () => {
       </ModalWrapper>,
     );
 
+    openAdvancedFields();
     expect(getInputByPlaceholder("e.g. My Anthropic Key").value).toBe(
       "Anthropic",
     );
@@ -544,6 +568,7 @@ describe("ProviderCreateForm submit sequence", () => {
       </ModalWrapper>,
     );
 
+    openAdvancedFields();
     selectDropdownOption("Provider", "OpenAI");
 
     expect(getInputByPlaceholder("e.g. My Anthropic Key").value).toBe("OpenAI");
@@ -566,6 +591,7 @@ describe("ProviderCreateForm submit sequence", () => {
     );
 
     // User overrides the Name; the Key auto-follows the label edit.
+    openAdvancedFields();
     fireEvent.change(getInputByPlaceholder("e.g. My Anthropic Key"), {
       target: { value: "My Custom Name" },
     });
@@ -593,6 +619,7 @@ describe("ProviderCreateForm submit sequence", () => {
       </ModalWrapper>,
     );
 
+    openAdvancedFields();
     fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
       target: { value: "my-custom-key" },
     });
@@ -602,6 +629,72 @@ describe("ProviderCreateForm submit sequence", () => {
     expect(getInputByPlaceholder("e.g. anthropic-personal").value).toBe(
       "my-custom-key",
     );
+  });
+
+  test("Display Name + Key are collapsed by default and reveal on Advanced", () => {
+    render(
+      <ModalWrapper>
+        <ProviderCreateForm
+          assistantId={ASSISTANT_ID}
+          existingNames={[]}
+          defaultProviderType="anthropic"
+          onCreated={() => {}}
+          onCancel={() => {}}
+        />
+      </ModalWrapper>,
+    );
+
+    // Collapsed: neither the Display Name nor Key input is mounted yet.
+    const isMounted = (placeholder: string) =>
+      Array.from(document.querySelectorAll<HTMLInputElement>("input")).some(
+        (el) => el.placeholder === placeholder,
+      );
+    expect(isMounted("e.g. My Anthropic Key")).toBe(false);
+    expect(isMounted("e.g. anthropic-personal")).toBe(false);
+
+    // Opening the disclosure mounts both.
+    openAdvancedFields();
+    expect(isMounted("e.g. My Anthropic Key")).toBe(true);
+    expect(isMounted("e.g. anthropic-personal")).toBe(true);
+  });
+
+  test("a duplicate Key keeps Advanced open even when the user collapses it", () => {
+    render(
+      <ModalWrapper>
+        <ProviderCreateForm
+          assistantId={ASSISTANT_ID}
+          existingNames={["anthropic"]}
+          defaultProviderType="anthropic"
+          onCreated={() => {}}
+          onCancel={() => {}}
+        />
+      </ModalWrapper>,
+    );
+
+    // The seeded Key dedupes to "anthropic-2", so type the colliding name.
+    openAdvancedFields();
+    fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
+      target: { value: "anthropic" },
+    });
+
+    // Try to collapse the disclosure — the pending error must force it open,
+    // keeping the Key field and its validation message visible.
+    const disclosure = Array.from(
+      document.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((b) => b.textContent?.includes("Display name"));
+    if (!disclosure) {
+      throw new Error("expected the Advanced disclosure button");
+    }
+    fireEvent.click(disclosure);
+
+    expect(document.body.textContent).toContain(
+      'A connection named "anthropic" already exists.',
+    );
+    expect(
+      Array.from(document.querySelectorAll<HTMLInputElement>("input")).some(
+        (el) => el.placeholder === "e.g. anthropic-personal",
+      ),
+    ).toBe(true);
   });
 
   test("clicking Cancel invokes onCancel", () => {

--- a/clients/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.tsx
@@ -7,6 +7,7 @@ import { Input } from "@vellumai/design-library/components/input";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { toast } from "@vellumai/design-library/components/toast";
 import { Typography } from "@vellumai/design-library/components/typography";
+import { ChevronRight } from "lucide-react";
 
 import { credentialPresenceQueryKey, useStoredCredentialPresence } from "@/domains/settings/ai/use-stored-credential-presence";
 import { secretsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
@@ -105,6 +106,7 @@ export function ProviderCreateForm({
   const [connectionModels, setConnectionModels] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isDetailsExpanded, setIsDetailsExpanded] = useState(false);
 
   const isOpenAICompatible = provider === "openai-compatible";
   const connectionProviderOptions = useMemo(() => {
@@ -144,7 +146,9 @@ export function ProviderCreateForm({
   });
 
   const nameError = (() => {
-    if (!name.trim()) return null;
+    if (!name.trim()) {
+      return null;
+    }
     if (existingNames.includes(name.trim())) {
       return `A connection named "${name.trim()}" already exists.`;
     }
@@ -154,7 +158,9 @@ export function ProviderCreateForm({
   const canSave = name.trim().length > 0 && !nameError;
 
   async function handleSave() {
-    if (!canSave) return;
+    if (!canSave) {
+      return;
+    }
     setSaving(true);
     setError(null);
     try {
@@ -286,47 +292,75 @@ export function ProviderCreateForm({
     hasStoredCredential,
   );
 
+  // Display Name + Key are auto-derived from the selected provider and rarely
+  // need editing, so they live under an "Advanced" disclosure. Force it open
+  // when the Key collides with an existing connection so the error is visible.
+  const detailsOpen = isDetailsExpanded || Boolean(nameError);
+
+  const advancedDetailsSection = (
+    <div>
+      <button
+        type="button"
+        aria-expanded={detailsOpen}
+        onClick={() => setIsDetailsExpanded((v) => !v)}
+        className="flex items-center gap-1 text-body-small-default text-[var(--content-secondary)] w-full text-left"
+      >
+        <ChevronRight
+          className={`h-4 w-4 transition-transform ${detailsOpen ? "rotate-90" : ""}`}
+        />
+        <span>Advanced</span>
+        <span className="text-[var(--content-tertiary)] ml-1">
+          · Display name &amp; key
+        </span>
+      </button>
+
+      {detailsOpen && (
+        <div className="mt-2 space-y-4">
+          {/* Display Name */}
+          <div className="space-y-1">
+            <label className="block text-body-small-default text-[var(--content-tertiary)]">
+              Display Name{" "}
+              <span className="text-[var(--content-disabled)]">(optional)</span>
+            </label>
+            <Input
+              value={label}
+              onChange={(e) => handleLabelChange(e.target.value)}
+              placeholder="e.g. My Anthropic Key"
+              fullWidth
+            />
+          </div>
+
+          {/* Key — editable on create, auto-derived from label */}
+          <div className="space-y-1">
+            <label className="block text-body-small-default text-[var(--content-tertiary)]">
+              Key
+            </label>
+            <Input
+              value={name}
+              onChange={(e) => {
+                handleNameChange(e.target.value);
+                setError(null);
+              }}
+              placeholder="e.g. anthropic-personal"
+              fullWidth
+            />
+            {nameError && (
+              <Typography
+                variant="body-small-default"
+                as="p"
+                className="text-(--system-negative-strong)"
+              >
+                {nameError}
+              </Typography>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+
   const body = (
     <div className="space-y-4">
-      {/* Display Name */}
-      <div className="space-y-1">
-        <label className="block text-body-small-default text-[var(--content-tertiary)]">
-          Display Name{" "}
-          <span className="text-[var(--content-disabled)]">(optional)</span>
-        </label>
-        <Input
-          value={label}
-          onChange={(e) => handleLabelChange(e.target.value)}
-          placeholder="e.g. My Anthropic Key"
-          fullWidth
-        />
-      </div>
-
-      {/* Key — editable on create, auto-derived from label */}
-      <div className="space-y-1">
-        <label className="block text-body-small-default text-[var(--content-tertiary)]">
-          Key
-        </label>
-        <Input
-          value={name}
-          onChange={(e) => {
-            handleNameChange(e.target.value);
-            setError(null);
-          }}
-          placeholder="e.g. anthropic-personal"
-          fullWidth
-        />
-        {nameError && (
-          <Typography
-            variant="body-small-default"
-            as="p"
-            className="text-(--system-negative-strong)"
-          >
-            {nameError}
-          </Typography>
-        )}
-      </div>
-
       {/* Provider */}
       <div className="space-y-1">
         <label className="block text-body-small-default text-[var(--content-tertiary)]">
@@ -479,6 +513,8 @@ export function ProviderCreateForm({
           onConnected={onCreated}
         />
       )}
+
+      {advancedDetailsSection}
 
       {error && (
         <Typography


### PR DESCRIPTION
## What

Moves the **Display Name** and **Key** fields into an **Advanced** disclosure on the provider create form.

Both fields are auto-derived from the selected provider (e.g. Anthropic → `Anthropic` / `anthropic`) and rarely need editing, so leading the form with them pushed the fields that actually require input (Provider, Auth Type, API Key) further down. They now sit under an `Advanced · Display name & key` disclosure at the bottom of the form.

## Where it shows

`ProviderCreateForm` is shared, so this affects both entry points the user mentioned:
- The standalone **New Provider Connection** modal (`variant="modal"`).
- The inline **+ Create new provider** step inside the **New Profile** modal (`variant="inline"`).

## Details

- Follows the existing `ChevronRight`-rotate disclosure pattern already used in this area (credential-reference section and the profile advanced params).
- The disclosure **auto-expands** when the Key collides with an existing connection name, so the duplicate-key validation error is never hidden behind a collapsed section.
- Drive-by: added braces to two pre-existing braceless `if` returns flagged by the `curly` rule.

## Review focus

Low risk — pure field reorganization, no behavior/validation/submit changes. Worth a quick look at the auto-expand-on-error branch (`detailsOpen = isDetailsExpanded || Boolean(nameError)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->