### PR TITLE
feat(config): override-or-default profile resolution behind a kill-switch flag (M6 PR6)

### DIFF
--- a/assistant/src/__tests__/agent-loop-override-profile.test.ts
+++ b/assistant/src/__tests__/agent-loop-override-profile.test.ts
@@ -298,6 +298,9 @@ mock.module("../providers/inference/connections.js", () => ({
   }),
 }));
 
+let mockActiveProfile: string | undefined;
+let mockCallSites: Record<string, unknown> = {};
+
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     llm: {
@@ -309,7 +312,14 @@ mock.module("../config/loader.js", () => ({
       profiles: {
         // Disable the catalog default so resolution lands on llm.default.
         balanced: { source: "managed", status: "disabled" },
+        fast: {
+          source: "user",
+          provider: "anthropic",
+          model: "claude-haiku-4-5-20251001",
+        },
       },
+      activeProfile: mockActiveProfile,
+      callSites: mockCallSites,
     },
     rateLimit: { maxRequestsPerMinute: 0 },
   }),
@@ -475,6 +485,48 @@ describe("executeSubagentSpawn — nested inheritance via context.overrideProfil
       expect("overrideProfile" in capturedConfig!).toBe(false);
     } finally {
       manager.spawn = originalSpawn;
+    }
+  });
+
+  test("an explicit subagentSpawn call-site pin suppresses the invoker-default inheritance", async () => {
+    // With an active profile the invoker-default tier resolves ("fast"), so
+    // absent a pin it is forwarded as the inherited override; with an
+    // explicit llm.callSites.subagentSpawn profile the heuristic must yield
+    // so the pin can win under override-or-default resolution.
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+    let capturedConfig: Record<string, unknown> | undefined;
+    manager.spawn = async (config: never) => {
+      capturedConfig = config;
+      return "nested-subagent-id-3";
+    };
+    mockActiveProfile = "fast";
+    try {
+      const baseContext = {
+        workingDir: "/tmp",
+        conversationId: "subagent-conv-id-3",
+        trustClass: "guardian",
+        sendToClient: () => {},
+      } as import("../tools/types.js").ToolContext;
+
+      mockCallSites = {};
+      await executeSubagentSpawn(
+        { label: "nested", objective: "do nested work" },
+        baseContext,
+      );
+      expect(capturedConfig!.overrideProfile).toBe("fast");
+
+      mockCallSites = { subagentSpawn: { profile: "fast" } };
+      capturedConfig = undefined;
+      await executeSubagentSpawn(
+        { label: "nested", objective: "do nested work" },
+        baseContext,
+      );
+      expect("overrideProfile" in capturedConfig!).toBe(false);
+    } finally {
+      manager.spawn = originalSpawn;
+      mockActiveProfile = undefined;
+      mockCallSites = {};
     }
   });
 });

--- a/assistant/src/__tests__/agent-loop-override-profile.test.ts
+++ b/assistant/src/__tests__/agent-loop-override-profile.test.ts
@@ -13,7 +13,18 @@
  * field is omitted from `providerConfig` rather than carrying `undefined`.
  */
 
-import { describe, expect, mock, test } from "bun:test";
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
+
+// These suites exercise override-profile PLUMBING through legacy-shaped
+// fixtures (llm.default-centric, no defaultProvider). Pinned to the
+// flag-off cascade; override-or-default resolution semantics are pinned by
+// llm-resolver-override-or-default.test.ts and the inference-profile loop
+// suite.
+beforeAll(() => {
+  setOverridesForTesting({ "override-or-default-resolution": false });
+});
 
 import { makeMockLogger } from "./helpers/mock-logger.js";
 

--- a/assistant/src/__tests__/agent-wake-override-profile.test.ts
+++ b/assistant/src/__tests__/agent-wake-override-profile.test.ts
@@ -26,7 +26,26 @@
  *      pinned-profile values.
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
+
+// These suites exercise override-profile PLUMBING through legacy-shaped
+// fixtures (llm.default-centric, no defaultProvider). Pinned to the
+// flag-off cascade; override-or-default resolution semantics are pinned by
+// llm-resolver-override-or-default.test.ts and the inference-profile loop
+// suite.
+beforeAll(() => {
+  setOverridesForTesting({ "override-or-default-resolution": false });
+});
 
 let mockOverrideProfile: string | undefined = undefined;
 

--- a/assistant/src/__tests__/call-site-routing-provider.test.ts
+++ b/assistant/src/__tests__/call-site-routing-provider.test.ts
@@ -237,6 +237,7 @@ describe("CallSiteRoutingProvider", () => {
       profiles: {
         legacyOpenai: {
           provider: "openai",
+          model: "gpt-5.5",
           // No provider_connection — alternate-provider routing requires
           // one, so this profile is expected to throw
           // `ConnectionResolutionError(missing_connection)` below.

--- a/assistant/src/__tests__/compaction-events.test.ts
+++ b/assistant/src/__tests__/compaction-events.test.ts
@@ -79,9 +79,15 @@ mock.module("../config/loader.js", () => ({
         "cost-optimized": { source: "managed", status: "disabled" },
       },
       callSites: {
-        // Resolves a SMALLER window than mainAgent (which inherits
-        // llm.default's 100000) — exercised by the maybeCompact gate-sizing
-        // tests below.
+        // This file's blanket assistant-feature-flags mock forces the
+        // override-or-default resolution flag ON, so the windows the
+        // gate-sizing tests depend on live in call-site tweaks (which apply
+        // under both resolution semantics) rather than llm.default.
+        mainAgent: {
+          contextWindow: { maxInputTokens: 100000 },
+        },
+        // Resolves a SMALLER window than mainAgent — exercised by the
+        // maybeCompact gate-sizing tests below.
         memoryRetrospective: {
           contextWindow: { maxInputTokens: 50000 },
         },

--- a/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
@@ -76,7 +76,12 @@ mock.module("../config/loader.js", () => ({
         },
       },
       profiles: {
+        // Complete (materialized) shape: override-or-default semantics skip
+        // profiles that don't carry their own provider+model.
         "quality-optimized": {
+          source: "user",
+          provider: "anthropic",
+          model: "claude-opus-4-8",
           contextWindow: { maxInputTokens: 50000 },
         },
       },

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -12,7 +12,24 @@
  * Tests 2, 8, 9, and 10 are now active and passing against current code.
  */
 import { createRequire } from "node:module";
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
+
+// Legacy-shaped fixtures (llm.default-centric resolution): pinned to the
+// flag-off cascade. Override-or-default (flag-on) semantics are pinned by
+// llm-resolver-override-or-default.test.ts and its companion suites.
+beforeAll(() => {
+  setOverridesForTesting({ "override-or-default-resolution": false });
+});
 
 import type { LoopToolExecutor } from "../agent/loop.js";
 import type { LLMConfig } from "../config/schemas/llm.js";

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -89,7 +89,29 @@ mock.module("../config/loader.js", () => ({
         },
       },
       profiles: mockLlmProfiles,
-      callSites: {},
+      // The call-site tweak applies under BOTH resolution semantics (the
+      // legacy cascade layers it over llm.default; override-or-default
+      // applies it over the winner), so the small context window that the
+      // overflow/compaction tests depend on holds regardless of the
+      // override-or-default-resolution flag.
+      callSites: {
+        mainAgent: {
+          contextWindow: {
+            enabled: true,
+            maxInputTokens: 100000,
+            targetBudgetRatio: 0.3,
+            compactThreshold: 0.8,
+            summaryBudgetRatio: 0.05,
+            overflowRecovery: {
+              enabled: true,
+              safetyMarginRatio: 0.05,
+              maxAttempts: 3,
+              interactiveLatestTurnCompression: "summarize",
+              nonInteractiveLatestTurnCompression: "truncate",
+            },
+          },
+        },
+      },
       activeProfile: mockLlmActiveProfile,
       pricingOverrides: [],
     },

--- a/assistant/src/__tests__/conversation-process-callsite.test.ts
+++ b/assistant/src/__tests__/conversation-process-callsite.test.ts
@@ -10,7 +10,16 @@
  * (heartbeat, filing, scheduler) pass an explicit `callSite` so
  * `RetryProvider` resolves their per-call config from `llm.callSites.<id>`.
  */
-import { describe, expect, mock, test } from "bun:test";
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
+
+// Legacy-shaped fixtures (llm.default-centric resolution): pinned to the
+// flag-off cascade. Override-or-default (flag-on) semantics are pinned by
+// llm-resolver-override-or-default.test.ts and its companion suites.
+beforeAll(() => {
+  setOverridesForTesting({ "override-or-default-resolution": false });
+});
 
 import { CompactionCircuit } from "../agent/compaction-circuit.js";
 import type { Message, ProviderResponse } from "../providers/types.js";

--- a/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
@@ -8,7 +8,24 @@
  */
 import { existsSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
+
+// Legacy-shaped fixtures (llm.default-centric resolution): pinned to the
+// flag-off cascade. Override-or-default (flag-on) semantics are pinned by
+// llm-resolver-override-or-default.test.ts and its companion suites.
+beforeAll(() => {
+  setOverridesForTesting({ "override-or-default-resolution": false });
+});
 
 mock.module("../config/env.js", () => ({ isHttpAuthDisabled: () => true }));
 
@@ -177,9 +194,8 @@ mock.module("../daemon/conversation-process.js", () => ({
   formatCompactResult: formatCompactResultMock,
 }));
 
-const realLocalActorIdentity = await import(
-  "../runtime/local-actor-identity.js"
-);
+const realLocalActorIdentity =
+  await import("../runtime/local-actor-identity.js");
 mock.module("../runtime/local-actor-identity.js", () => ({
   ...realLocalActorIdentity,
 }));
@@ -568,7 +584,9 @@ describe("handleSendMessage canned wake-up greeting", () => {
   });
 
   afterEach(() => {
-    if (existsSync(bootstrapPath)) rmSync(bootstrapPath, { force: true });
+    if (existsSync(bootstrapPath)) {
+      rmSync(bootstrapPath, { force: true });
+    }
   });
 
   test("persists the clientMessageId on the user row", async () => {

--- a/assistant/src/__tests__/conversation-speed-override.test.ts
+++ b/assistant/src/__tests__/conversation-speed-override.test.ts
@@ -73,7 +73,16 @@ mock.module("../config/loader.js", () => ({
         },
       },
       profiles: {},
-      callSites: {},
+      // This file's blanket assistant-feature-flags mock forces the
+      // override-or-default resolution flag ON; the speed under test rides
+      // in the mainAgent call-site tweak (applies under both semantics)
+      // rather than llm.default.
+      callSites: {
+        mainAgent: {
+          speed: mockConfigSpeed,
+          contextWindow: { maxInputTokens: 100000 },
+        },
+      },
       pricingOverrides: [],
     },
     rateLimit: { maxRequestsPerMinute: 0 },
@@ -89,7 +98,9 @@ mock.module("../config/loader.js", () => ({
 // Feature flag mock — fast-mode enabled for all tests in this file.
 mock.module("../config/assistant-feature-flags.js", () => ({
   isAssistantFeatureFlagEnabled: (key: string) => {
-    if (key === "fast-mode") return true;
+    if (key === "fast-mode") {
+      return true;
+    }
     return true;
   },
 }));

--- a/assistant/src/__tests__/conversation-usage.test.ts
+++ b/assistant/src/__tests__/conversation-usage.test.ts
@@ -1,4 +1,13 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
+
+// Legacy-shaped fixtures (llm.default-centric resolution): pinned to the
+// flag-off cascade. Override-or-default (flag-on) semantics are pinned by
+// llm-resolver-override-or-default.test.ts and its companion suites.
+beforeAll(() => {
+  setOverridesForTesting({ "override-or-default-resolution": false });
+});
 
 const updateConversationUsageCalls: Array<{
   conversationId: string;

--- a/assistant/src/__tests__/invite-routes-http.test.ts
+++ b/assistant/src/__tests__/invite-routes-http.test.ts
@@ -1,4 +1,13 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
+
+// Legacy-shaped fixtures (llm.default-centric resolution): pinned to the
+// flag-off cascade. Override-or-default (flag-on) semantics are pinned by
+// llm-resolver-override-or-default.test.ts and its companion suites.
+beforeAll(() => {
+  setOverridesForTesting({ "override-or-default-resolution": false });
+});
 
 mock.module("../util/logger.js", () => ({
   getLogger: () =>

--- a/assistant/src/__tests__/llm-context-resolution.test.ts
+++ b/assistant/src/__tests__/llm-context-resolution.test.ts
@@ -1,4 +1,13 @@
-import { describe, expect, test } from "bun:test";
+import { beforeAll, describe, expect, test } from "bun:test";
+
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
+
+// Legacy-shaped fixtures (llm.default-centric resolution): pinned to the
+// flag-off cascade. Override-or-default (flag-on) semantics are pinned by
+// llm-resolver-override-or-default.test.ts and its companion suites.
+beforeAll(() => {
+  setOverridesForTesting({ "override-or-default-resolution": false });
+});
 
 import { resolveEffectiveContextWindow } from "../config/llm-context-resolution.js";
 import { LLMSchema } from "../config/schemas/llm.js";

--- a/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
+++ b/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
@@ -186,7 +186,7 @@ describe("fallback and completeness", () => {
 });
 
 describe("composition", () => {
-  test("three layers: schema base, winner, call-site tweak (nested merge preserved)", () => {
+  test("base + winner + site-tweak composition (nested tweaks combine leaf-wise)", () => {
     const llm = LLMSchema.parse({
       profiles: { mine: completeCustom },
       callSites: {

--- a/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
+++ b/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
@@ -1,0 +1,381 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+
+import { CODE_DEFAULT_PROFILE_ENTRIES } from "../config/default-profile-catalog.js";
+import {
+  type ResolutionFallbackReason,
+  resolveCallSiteConfig,
+  resolveDefaultProfileKey,
+  selectWinningProfile,
+} from "../config/llm-resolver.js";
+import { LLMConfigBase, LLMSchema } from "../config/schemas/llm.js";
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
+
+// Pins the override-or-default (flag-on, shipped default) semantics. The
+// legacy merge cascade is pinned by llm-resolver.test.ts under flag-off.
+beforeAll(() => {
+  setOverridesForTesting({ "override-or-default-resolution": true });
+});
+
+const schemaBase = LLMConfigBase.parse({});
+
+// A materialized (complete) custom profile, as the ensure pass produces.
+const completeCustom = {
+  source: "user" as const,
+  provider: "openai" as const,
+  provider_connection: "openai-personal",
+  model: "gpt-5.5",
+  maxTokens: 9000,
+  effort: "high" as const,
+  speed: "standard" as const,
+  verbosity: "medium" as const,
+  temperature: 0.4,
+  thinking: { enabled: false, streamThinking: false },
+  contextWindow: schemaBase.contextWindow,
+  openrouter: { only: [] as string[] },
+};
+
+const anthropicDp = { defaultProvider: { provider: "anthropic" as const } };
+
+type Fallback = {
+  callSite: string;
+  requested: string;
+  reason: ResolutionFallbackReason;
+};
+
+const collect = () => {
+  const fallbacks: Fallback[] = [];
+  return {
+    fallbacks,
+    opts: {
+      onResolutionFallback: (info: Fallback) => fallbacks.push(info),
+    },
+  };
+};
+
+describe("selection chain", () => {
+  test("an override pin wins on every call site, forced or not", () => {
+    const llm = LLMSchema.parse({
+      profiles: { mine: completeCustom },
+      callSites: {
+        conversationSummarization: { profile: "quality-optimized" },
+      },
+      ...anthropicDp,
+    });
+    for (const callSite of [
+      "mainAgent",
+      "conversationSummarization",
+    ] as const) {
+      const resolved = resolveCallSiteConfig(callSite, llm, {
+        overrideProfile: "mine",
+      });
+      expect(resolved.model).toBe("gpt-5.5");
+      expect(resolved.provider).toBe("openai");
+    }
+    // forceOverrideProfile is a no-op: same result with and without.
+    const forced = resolveCallSiteConfig("conversationSummarization", llm, {
+      overrideProfile: "mine",
+      forceOverrideProfile: true,
+    });
+    expect(forced.model).toBe("gpt-5.5");
+  });
+
+  test("activeProfile is mainAgent-only", () => {
+    const llm = LLMSchema.parse({
+      profiles: { mine: completeCustom },
+      activeProfile: "mine",
+      ...anthropicDp,
+    });
+    expect(resolveCallSiteConfig("mainAgent", llm).model).toBe("gpt-5.5");
+    // A background call site ignores activeProfile entirely and resolves its
+    // default intent through the default provider.
+    const summarized = resolveCallSiteConfig("conversationSummarization", llm);
+    expect(summarized.model).not.toBe("gpt-5.5");
+    expect(summarized.provider).toBe("anthropic");
+  });
+
+  test("a call-site profile beats the default intent; the default intent resolves through llm.defaultProvider", () => {
+    const llm = LLMSchema.parse({
+      profiles: { mine: completeCustom },
+      callSites: { conversationSummarization: { profile: "mine" } },
+      ...anthropicDp,
+    });
+    expect(resolveCallSiteConfig("conversationSummarization", llm).model).toBe(
+      "gpt-5.5",
+    );
+
+    const noPin = LLMSchema.parse(anthropicDp);
+    const resolved = resolveCallSiteConfig("conversationSummarization", noPin);
+    expect(resolved.provider).toBe("anthropic");
+    expect(resolved.provider_connection).toBe("anthropic-personal");
+  });
+
+  test("a null defaultProvider falls back to the vellum catalog bodies", () => {
+    const llm = LLMSchema.parse({});
+    const resolved = resolveCallSiteConfig("conversationSummarization", llm);
+    const vellumBody = CODE_DEFAULT_PROFILE_ENTRIES["cost-optimized"];
+    expect(resolved.model).toBe(vellumBody.model as string);
+    expect(resolved.provider_connection).toBe(vellumBody.provider_connection);
+  });
+});
+
+describe("fallback and completeness", () => {
+  test("a deleted override pin falls back to the call-site default with a report", () => {
+    const llm = LLMSchema.parse(anthropicDp);
+    const { fallbacks, opts } = collect();
+    const resolved = resolveCallSiteConfig("conversationSummarization", llm, {
+      overrideProfile: "deleted-profile",
+      ...opts,
+    });
+    expect(resolved.provider).toBe("anthropic");
+    expect(fallbacks).toEqual([
+      {
+        callSite: "conversationSummarization",
+        requested: "deleted-profile",
+        reason: "missing",
+      },
+    ]);
+  });
+
+  test("an incomplete profile never wins a rung and never fills from the base", () => {
+    const llm = LLMSchema.parse({
+      profiles: { partial: { source: "user", model: "gpt-5.5" } },
+      ...anthropicDp,
+      activeProfile: "partial",
+    });
+    const { fallbacks, opts } = collect();
+    const resolved = resolveCallSiteConfig("mainAgent", llm, opts);
+    // The base's schema-default identity must not stand in for "partial":
+    // resolution lands on balanced-intent through anthropic.
+    expect(resolved.model).not.toBe("gpt-5.5");
+    expect(resolved.provider).toBe("anthropic");
+    expect(fallbacks[0]).toEqual({
+      callSite: "mainAgent",
+      requested: "partial",
+      reason: "incomplete",
+    });
+  });
+
+  test("a disabled profile reports 'disabled' and falls through", () => {
+    const llm = LLMSchema.parse({
+      profiles: { mine: { ...completeCustom, status: "disabled" } },
+      ...anthropicDp,
+    });
+    const { fallbacks, opts } = collect();
+    resolveCallSiteConfig("mainAgent", llm, {
+      overrideProfile: "mine",
+      ...opts,
+    });
+    expect(fallbacks[0]?.reason).toBe("disabled");
+  });
+
+  test("no custom-* hop: a drifted custom clone does not capture a background call site", () => {
+    const llm = LLMSchema.parse({
+      profiles: {
+        "cost-optimized": { source: "managed", status: "disabled" },
+        "custom-cost-optimized": { ...completeCustom, model: "gpt-5.4" },
+      },
+      ...anthropicDp,
+    });
+    const resolved = resolveCallSiteConfig("conversationSummarization", llm);
+    // The catalog intent through the default provider wins — never the
+    // user-mutable custom-* clone, and the legacy disabled stub on the
+    // default is overridden by the code-owned body.
+    expect(resolved.model).not.toBe("gpt-5.4");
+    expect(resolved.provider).toBe("anthropic");
+  });
+});
+
+describe("composition", () => {
+  test("three layers: schema base, winner, call-site tweak (nested merge preserved)", () => {
+    const llm = LLMSchema.parse({
+      profiles: { mine: completeCustom },
+      callSites: {
+        conversationSummarization: {
+          profile: "mine",
+          maxTokens: 1234,
+          thinking: { enabled: true },
+        },
+      },
+      ...anthropicDp,
+    });
+    const resolved = resolveCallSiteConfig("conversationSummarization", llm);
+    expect(resolved.model).toBe("gpt-5.5");
+    expect(resolved.maxTokens).toBe(1234);
+    // Tweak's nested leaf merges into the winner's thinking without wiping
+    // siblings.
+    expect(resolved.thinking.enabled).toBe(true);
+    expect(resolved.thinking.streamThinking).toBe(false);
+    // Fields nobody set fall to schema defaults, not llm.default.
+    expect(resolved.verbosity).toBe(schemaBase.verbosity);
+  });
+
+  test("winner sampling applies; tweak sampling overrides; tweak logitBias is ignored", () => {
+    const llm = LLMSchema.parse({
+      profiles: { mine: { ...completeCustom, logitBias: "suppress-cjk" } },
+      callSites: {
+        conversationSummarization: {
+          profile: "mine",
+          temperature: 0.9,
+          logitBias: "suppress-cjk",
+        },
+      },
+      ...anthropicDp,
+    });
+    const withTweak = resolveCallSiteConfig("conversationSummarization", llm);
+    expect(withTweak.temperature).toBe(0.9);
+    expect(withTweak.logitBias).toBe("suppress-cjk"); // from the winner
+
+    const noBias = LLMSchema.parse({
+      profiles: { mine: completeCustom },
+      callSites: {
+        conversationSummarization: {
+          profile: "mine",
+          logitBias: "suppress-cjk",
+        },
+      },
+      ...anthropicDp,
+    });
+    const resolved = resolveCallSiteConfig("conversationSummarization", noBias);
+    expect(resolved.temperature).toBe(0.4); // winner's own
+    expect(resolved.logitBias).toBeUndefined(); // tweak bias never applies
+  });
+
+  test("a direct call-site model override implies its catalog provider and drops the winner's connection", () => {
+    const llm = LLMSchema.parse({
+      profiles: { mine: completeCustom },
+      callSites: {
+        conversationSummarization: {
+          profile: "mine",
+          model: "claude-haiku-4-5-20251001",
+        },
+      },
+      ...anthropicDp,
+    });
+    const resolved = resolveCallSiteConfig("conversationSummarization", llm);
+    expect(resolved.model).toBe("claude-haiku-4-5-20251001");
+    expect(resolved.provider).toBe("anthropic");
+    expect(resolved.provider_connection).toBeUndefined();
+  });
+
+  test("profileless call sites anchor on balanced intent through the default provider plus their tweaks", () => {
+    const llm = LLMSchema.parse(anthropicDp);
+    const resolved = resolveCallSiteConfig("workflowLeaf", llm);
+    expect(resolved.provider).toBe("anthropic");
+    expect(resolved.provider_connection).toBe("anthropic-personal");
+    expect(resolved.effort).toBe("low");
+    expect(resolved.thinking.enabled).toBe(false);
+    expect(resolveDefaultProfileKey("workflowLeaf", llm)).toBeUndefined();
+  });
+});
+
+describe("mix profiles", () => {
+  const mixLlm = () =>
+    LLMSchema.parse({
+      profiles: {
+        a: { ...completeCustom, model: "gpt-5.5" },
+        b: { ...completeCustom, model: "gpt-5.4" },
+        ab: {
+          source: "user",
+          mix: [
+            { profile: "a", weight: 1 },
+            { profile: "b", weight: 1 },
+          ],
+        },
+      },
+      ...anthropicDp,
+    });
+
+  test("a mix expands to a seeded arm and the same seed always picks the same arm", () => {
+    const llm = mixLlm();
+    const first = resolveCallSiteConfig("mainAgent", llm, {
+      overrideProfile: "ab",
+      selectionSeed: "conversation-1",
+    });
+    for (let i = 0; i < 5; i++) {
+      const again = resolveCallSiteConfig("mainAgent", llm, {
+        overrideProfile: "ab",
+        selectionSeed: "conversation-1",
+      });
+      expect(again.model).toBe(first.model);
+    }
+    expect(["gpt-5.5", "gpt-5.4"]).toContain(first.model);
+  });
+
+  test("selectWinningProfile reports the mix's own name as the winner", () => {
+    const llm = mixLlm();
+    const selection = selectWinningProfile("mainAgent", llm, {
+      overrideProfile: "ab",
+      selectionSeed: "conversation-1",
+    });
+    expect(selection.profileName).toBe("ab");
+    expect(selection.source).toBe("override");
+    expect(["gpt-5.5", "gpt-5.4"]).toContain(selection.entry?.model as string);
+  });
+});
+
+describe("resolveDefaultProfileKey (flag-on)", () => {
+  test("mainAgent: activeProfile, else the call-site intent", () => {
+    const withActive = LLMSchema.parse({
+      profiles: { mine: completeCustom },
+      activeProfile: "mine",
+      ...anthropicDp,
+    });
+    expect(resolveDefaultProfileKey("mainAgent", withActive)).toBe("mine");
+    const without = LLMSchema.parse(anthropicDp);
+    expect(resolveDefaultProfileKey("mainAgent", without)).toBe("balanced");
+    expect(resolveDefaultProfileKey("conversationSummarization", without)).toBe(
+      "cost-optimized",
+    );
+  });
+
+  test("an incomplete activeProfile is skipped, not returned", () => {
+    const llm = LLMSchema.parse({
+      profiles: { partial: { source: "user", model: "gpt-5.5" } },
+      activeProfile: "partial",
+      ...anthropicDp,
+    });
+    expect(resolveDefaultProfileKey("mainAgent", llm)).toBe("balanced");
+  });
+});
+
+describe("flag-on / flag-off parity on materialized workspaces", () => {
+  // For a workspace the M6 data PRs produced — complete custom profiles,
+  // llm.default equal to what the profiles were materialized against — the
+  // two semantics must resolve identically on the common paths.
+  const materializedLlm = () =>
+    LLMSchema.parse({
+      default: {
+        ...schemaBase,
+        provider: "openai",
+        provider_connection: "openai-personal",
+        model: "gpt-5.5",
+      },
+      profiles: { "custom-balanced": completeCustom },
+      activeProfile: "custom-balanced",
+      defaultProvider: { provider: "openai" },
+    });
+
+  test("mainAgent under an active materialized profile resolves identically", () => {
+    const llm = materializedLlm();
+    const flagOn = resolveCallSiteConfig("mainAgent", llm, {
+      resolutionSemantics: "override-or-default",
+    });
+    const flagOff = resolveCallSiteConfig("mainAgent", llm, {
+      resolutionSemantics: "legacy-merge",
+    });
+    expect(flagOn).toEqual(flagOff);
+  });
+
+  test("an override pin on a materialized profile resolves identically", () => {
+    const llm = materializedLlm();
+    const flagOn = resolveCallSiteConfig("mainAgent", llm, {
+      overrideProfile: "custom-balanced",
+      resolutionSemantics: "override-or-default",
+    });
+    const flagOff = resolveCallSiteConfig("mainAgent", llm, {
+      overrideProfile: "custom-balanced",
+      resolutionSemantics: "legacy-merge",
+    });
+    expect(flagOn).toEqual(flagOff);
+  });
+});

--- a/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
+++ b/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
@@ -257,6 +257,20 @@ describe("composition", () => {
     expect(resolved.provider_connection).toBeUndefined();
   });
 
+  test("a model-only tweak keeps the provider-agnostic vellum connection for managed-routable implied providers", () => {
+    const llm = LLMSchema.parse({
+      callSites: {
+        conversationSummarization: { model: "claude-haiku-4-5-20251001" },
+      },
+      defaultProvider: { provider: "vellum" },
+    });
+    const resolved = resolveCallSiteConfig("conversationSummarization", llm);
+    expect(resolved.provider).toBe("anthropic");
+    // The vellum connection routes anthropic via expectedProvider; dropping
+    // it would leave platform installs with no resolvable connection.
+    expect(resolved.provider_connection).toBe("vellum");
+  });
+
   test("profileless call sites anchor on balanced intent through the default provider plus their tweaks", () => {
     const llm = LLMSchema.parse(anthropicDp);
     const resolved = resolveCallSiteConfig("workflowLeaf", llm);

--- a/assistant/src/__tests__/llm-resolver.test.ts
+++ b/assistant/src/__tests__/llm-resolver.test.ts
@@ -1,4 +1,13 @@
-import { describe, expect, test } from "bun:test";
+import { beforeAll, describe, expect, test } from "bun:test";
+
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
+
+// This suite pins the LEGACY merge-cascade semantics — the kill-switch
+// (flag-off) path. The override-or-default (flag-on, shipped default)
+// semantics are pinned by llm-resolver-override-or-default.test.ts.
+beforeAll(() => {
+  setOverridesForTesting({ "override-or-default-resolution": false });
+});
 
 import { z } from "zod";
 

--- a/assistant/src/__tests__/provider-commit-message-generator.test.ts
+++ b/assistant/src/__tests__/provider-commit-message-generator.test.ts
@@ -1,4 +1,13 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
+
+// Legacy-shaped fixtures (llm.default-centric): pinned to the flag-off
+// cascade; see llm-resolver-override-or-default.test.ts for flag-on
+// resolution semantics.
+beforeAll(() => {
+  setOverridesForTesting({ "override-or-default-resolution": false });
+});
 
 import { DEFAULT_CONFIG } from "../config/defaults.js";
 import type { AssistantConfig } from "../config/types.js";

--- a/assistant/src/__tests__/provider-platform-proxy-integration.test.ts
+++ b/assistant/src/__tests__/provider-platform-proxy-integration.test.ts
@@ -1,4 +1,13 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
+
+// Legacy-shaped fixtures (llm.default-centric resolution): pinned to the
+// flag-off cascade. Override-or-default (flag-on) semantics are pinned by
+// llm-resolver-override-or-default.test.ts and its companion suites.
+beforeAll(() => {
+  setOverridesForTesting({ "override-or-default-resolution": false });
+});
 
 import type { Services } from "../config/schemas/services.js";
 import { PLATFORM_PROVIDER_META } from "../providers/platform-proxy/constants.js";

--- a/assistant/src/__tests__/provider-registry-ollama.test.ts
+++ b/assistant/src/__tests__/provider-registry-ollama.test.ts
@@ -1,4 +1,13 @@
-import { describe, expect, mock, test } from "bun:test";
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
+
+// Legacy-shaped fixtures (llm.default-centric resolution): pinned to the
+// flag-off cascade. Override-or-default (flag-on) semantics are pinned by
+// llm-resolver-override-or-default.test.ts and its companion suites.
+beforeAll(() => {
+  setOverridesForTesting({ "override-or-default-resolution": false });
+});
 
 // Mock secure-keys so tests don't depend on the developer's local secure storage.
 const actualSecureKeys = await import("../security/secure-keys.js");

--- a/assistant/src/__tests__/provider-send-message-override-profile.test.ts
+++ b/assistant/src/__tests__/provider-send-message-override-profile.test.ts
@@ -11,7 +11,18 @@
  * makes per-conversation pinned profiles (PR 6+) work.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
+
+// These suites exercise override-profile PLUMBING through legacy-shaped
+// fixtures (llm.default-centric, no defaultProvider). Pinned to the
+// flag-off cascade; override-or-default resolution semantics are pinned by
+// llm-resolver-override-or-default.test.ts and the inference-profile loop
+// suite.
+beforeAll(() => {
+  setOverridesForTesting({ "override-or-default-resolution": false });
+});
 
 import { makeMockLogger } from "./helpers/mock-logger.js";
 

--- a/assistant/src/__tests__/provider-usage-tracking.test.ts
+++ b/assistant/src/__tests__/provider-usage-tracking.test.ts
@@ -1,4 +1,13 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
+
+// Legacy-shaped fixtures (llm.default-centric resolution): pinned to the
+// flag-off cascade. Override-or-default (flag-on) semantics are pinned by
+// llm-resolver-override-or-default.test.ts and its companion suites.
+beforeAll(() => {
+  setOverridesForTesting({ "override-or-default-resolution": false });
+});
 
 import { makeMockLogger } from "./helpers/mock-logger.js";
 

--- a/assistant/src/__tests__/retry-openrouter-only-normalization.test.ts
+++ b/assistant/src/__tests__/retry-openrouter-only-normalization.test.ts
@@ -5,7 +5,16 @@
  * the unknown field on the wire.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
+
+// Legacy-shaped fixtures (llm.default-centric resolution): pinned to the
+// flag-off cascade. Override-or-default (flag-on) semantics are pinned by
+// llm-resolver-override-or-default.test.ts and its companion suites.
+beforeAll(() => {
+  setOverridesForTesting({ "override-or-default-resolution": false });
+});
 
 mock.module("../util/logger.js", () => ({
   getLogger: () =>

--- a/assistant/src/__tests__/retry-thinking-adaptive-only.test.ts
+++ b/assistant/src/__tests__/retry-thinking-adaptive-only.test.ts
@@ -8,7 +8,16 @@
  * disabling thinking (e.g. Opus) keep their disabled config.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
+
+// Legacy-shaped fixtures (llm.default-centric resolution): pinned to the
+// flag-off cascade. Override-or-default (flag-on) semantics are pinned by
+// llm-resolver-override-or-default.test.ts and its companion suites.
+beforeAll(() => {
+  setOverridesForTesting({ "override-or-default-resolution": false });
+});
 
 mock.module("../util/logger.js", () => ({
   getLogger: () =>

--- a/assistant/src/__tests__/retry-thinking-tool-choice.test.ts
+++ b/assistant/src/__tests__/retry-thinking-tool-choice.test.ts
@@ -10,7 +10,16 @@
  * `tool_choice` without explicitly disabling thinking.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
+
+// Legacy-shaped fixtures (llm.default-centric resolution): pinned to the
+// flag-off cascade. Override-or-default (flag-on) semantics are pinned by
+// llm-resolver-override-or-default.test.ts and its companion suites.
+beforeAll(() => {
+  setOverridesForTesting({ "override-or-default-resolution": false });
+});
 
 mock.module("../util/logger.js", () => ({
   getLogger: () =>

--- a/assistant/src/__tests__/retry-verbosity-normalization.test.ts
+++ b/assistant/src/__tests__/retry-verbosity-normalization.test.ts
@@ -5,7 +5,16 @@
  * the unknown field on the wire.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
+
+// Legacy-shaped fixtures (llm.default-centric resolution): pinned to the
+// flag-off cascade. Override-or-default (flag-on) semantics are pinned by
+// llm-resolver-override-or-default.test.ts and its companion suites.
+beforeAll(() => {
+  setOverridesForTesting({ "override-or-default-resolution": false });
+});
 
 mock.module("../util/logger.js", () => ({
   getLogger: () =>

--- a/assistant/src/__tests__/subagent-call-site-routing.test.ts
+++ b/assistant/src/__tests__/subagent-call-site-routing.test.ts
@@ -15,7 +15,16 @@
  * `Conversation`, then verify it's a `CallSiteRoutingProvider` that selects
  * the right transport for the `subagentSpawn` callSite.
  */
-import { describe, expect, mock, test } from "bun:test";
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
+
+// Legacy-shaped fixtures (llm.default-centric resolution): pinned to the
+// flag-off cascade. Override-or-default (flag-on) semantics are pinned by
+// llm-resolver-override-or-default.test.ts and its companion suites.
+beforeAll(() => {
+  setOverridesForTesting({ "override-or-default-resolution": false });
+});
 
 import type { ServerMessage } from "../daemon/message-protocol.js";
 
@@ -127,8 +136,12 @@ mock.module("../providers/registry.js", () => ({
     throw new Error(`legacy getProvider should not be called: ${name}`);
   },
   resolveProviderFromConnection: async (connection: { name: string }) => {
-    if (connection.name === "anthropic-conn") return anthropicStub;
-    if (connection.name === "openai-conn") return openaiStub;
+    if (connection.name === "anthropic-conn") {
+      return anthropicStub;
+    }
+    if (connection.name === "openai-conn") {
+      return openaiStub;
+    }
     return null;
   },
   clearConnectionProviderCache: () => {},
@@ -138,18 +151,20 @@ mock.module("../providers/registry.js", () => ({
 // is stubbed; tests don't touch SQLite.
 mock.module("../providers/inference/connections.js", () => ({
   getConnection: (_db: unknown, name: string) => {
-    if (name === "anthropic-conn")
+    if (name === "anthropic-conn") {
       return {
         name: "anthropic-conn",
         provider: "anthropic",
         auth: { type: "platform" },
       };
-    if (name === "openai-conn")
+    }
+    if (name === "openai-conn") {
       return {
         name: "openai-conn",
         provider: "openai",
         auth: { type: "platform" },
       };
+    }
     return null;
   },
 }));
@@ -473,7 +488,9 @@ describe("CallSiteRoutingProvider — selectProvider behavior", () => {
     const wrapper = new CallSiteRoutingProvider(
       defaultProvider,
       async (connectionName) => {
-        if (connectionName === "openai-conn") return altProvider;
+        if (connectionName === "openai-conn") {
+          return altProvider;
+        }
         return null;
       },
     );

--- a/assistant/src/__tests__/usage-attribution.test.ts
+++ b/assistant/src/__tests__/usage-attribution.test.ts
@@ -1,4 +1,20 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
+
+// The pre-existing describes pin attribution under the legacy cascade
+// (flag-off); the trailing describe pins the override-or-default mapping.
+beforeAll(() => {
+  setOverridesForTesting({ "override-or-default-resolution": false });
+});
 
 let mockLlmConfig: Record<string, unknown> = {};
 
@@ -245,5 +261,77 @@ describe("sanitizeUsageMetadataValue", () => {
     expect(sanitizeUsageMetadataValue(`profile\n1`)).toBeNull();
     expect(sanitizeUsageMetadataValue("profile\u00851")).toBeNull();
     expect(sanitizeUsageMetadataValue("x".repeat(200))).toHaveLength(128);
+  });
+});
+
+describe("resolveUsageAttribution — override-or-default semantics", () => {
+  const completeProfile = {
+    source: "user",
+    provider: "openai",
+    provider_connection: "openai-personal",
+    model: "gpt-5.5",
+    maxTokens: 9000,
+  };
+
+  beforeAll(() => {
+    // Registry default: the override-or-default flag ships enabled.
+    setOverridesForTesting({});
+  });
+  afterAll(() => {
+    setOverridesForTesting({ "override-or-default-resolution": false });
+  });
+
+  test("a non-forced override wins attribution on a background call site", () => {
+    setLlmConfig({
+      profiles: { mine: completeProfile },
+      callSites: {
+        conversationSummarization: { profile: "quality-optimized" },
+      },
+      defaultProvider: { provider: "anthropic" },
+    });
+    const snapshot = resolveUsageAttribution({
+      callSite: "conversationSummarization",
+      overrideProfile: "mine",
+    });
+    expect(snapshot.appliedProfile).toBe("mine");
+    expect(snapshot.profileSource).toBe("conversation");
+    expect(snapshot.resolvedModel).toBe("gpt-5.5");
+  });
+
+  test("the default intent attributes its profile key with source 'default'", () => {
+    setLlmConfig({ defaultProvider: { provider: "anthropic" } });
+    const snapshot = resolveUsageAttribution({
+      callSite: "conversationSummarization",
+    });
+    expect(snapshot.appliedProfile).toBe("cost-optimized");
+    expect(snapshot.profileSource).toBe("default");
+    expect(snapshot.resolvedProvider).toBe("anthropic");
+  });
+
+  test("activeProfile attributes as 'active' on mainAgent only", () => {
+    setLlmConfig({
+      profiles: { mine: completeProfile },
+      activeProfile: "mine",
+      defaultProvider: { provider: "anthropic" },
+    });
+    expect(resolveUsageAttribution({ callSite: "mainAgent" })).toMatchObject({
+      appliedProfile: "mine",
+      profileSource: "active",
+    });
+    expect(
+      resolveUsageAttribution({ callSite: "conversationSummarization" }),
+    ).toMatchObject({
+      appliedProfile: "cost-optimized",
+      profileSource: "default",
+    });
+  });
+
+  test("attribution provider/model agree with the resolver", () => {
+    setLlmConfig({
+      profiles: { mine: completeProfile },
+      defaultProvider: { provider: "anthropic" },
+    });
+    expectResolvedProviderModelMatchesResolver("conversationSummarization");
+    expectResolvedProviderModelMatchesResolver("mainAgent", "mine");
   });
 });

--- a/assistant/src/config/__tests__/default-profile-catalog.test.ts
+++ b/assistant/src/config/__tests__/default-profile-catalog.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helpers.js";
 import { resolveModelIntent } from "../../providers/model-intents.js";
 import { CALL_SITE_DEFAULTS } from "../call-site-defaults.js";
 import {
@@ -188,9 +189,18 @@ describe("resolver integration", () => {
         },
       },
     });
+    // Legacy cascade: the disabled stub falls through to the custom-* hop.
+    setOverridesForTesting({ "override-or-default-resolution": false });
     expect(resolveDefaultProfileKey("mainAgent", llm)).toBe("custom-balanced");
     const resolved = resolveCallSiteConfig("mainAgent", llm);
     expect(resolved.model).toBe("claude-sonnet-4-6");
+    // Override-or-default: the hop is gone — the fallback anchor is the
+    // code-owned intent, and a legacy disabled stub does not suppress it.
+    setOverridesForTesting({});
+    expect(resolveDefaultProfileKey("mainAgent", llm)).toBe("balanced");
+    expect(resolveCallSiteConfig("mainAgent", llm).model).not.toBe(
+      "claude-sonnet-4-6",
+    );
   });
 });
 

--- a/assistant/src/config/__tests__/profile-materialization.test.ts
+++ b/assistant/src/config/__tests__/profile-materialization.test.ts
@@ -273,6 +273,11 @@ describe("completeCustomProfile — resolver equivalence", () => {
     });
     return resolveCallSiteConfig("vision", llm, {
       overrideProfile: "custom-x",
+      // The equivalence contract is a legacy-cascade property by definition:
+      // materialization pins what the MERGE produced. Under
+      // override-or-default semantics a partial profile falls back instead
+      // of merging (pinned by llm-resolver-override-or-default.test.ts).
+      resolutionSemantics: "legacy-merge",
     });
   };
 

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -297,9 +297,13 @@ export function resolveCallSiteConfig(
 // hop is deliberately absent — a fallback anchor must be code-owned, never
 // user-mutable state.
 //
-// Composition is exactly three layers, deep-merged: schema-default base →
-// winner → the call site's own tweak fragment. `temperature`/`topP` come from
-// the winner (or an explicit tweak); `logitBias` only ever from the winner.
+// The request config is the base + winner + site-tweak composition:
+// code-owned schema defaults, then the single winning profile, then the call
+// site's own tuning fragment. Selection is pure either/or — no profile ever
+// contributes a field to another profile; `deepMerge` here only makes nested
+// tweaks (`thinking.enabled`) combine leaf-wise instead of wiping siblings.
+// `temperature`/`topP` come from the winner (or an explicit tweak);
+// `logitBias` only ever from the winner.
 // `forceOverrideProfile` is a no-op here (the override is already first).
 
 export interface ProfileWinnerSelection {

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -4,8 +4,12 @@ import {
   getCatalogProviderForModel,
   isModelInCatalog,
 } from "../providers/model-catalog.js";
+import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
 import { CALL_SITE_DEFAULTS } from "./call-site-defaults.js";
-import { getEffectiveProfile } from "./default-profile-catalog.js";
+import {
+  getEffectiveProfile,
+  resolveDefaultProfileForProvider,
+} from "./default-profile-catalog.js";
 import {
   type LLMCallSite,
   LLMConfigBase,
@@ -111,6 +115,47 @@ export interface ResolveCallSiteOpts {
    * constituent was chosen. Used by A/B-eval recording (usage attribution).
    */
   onMixSelected?: (info: { mixProfile: string; chosenProfile: string }) => void;
+  /**
+   * Override-or-default semantics only: invoked once per chain rung that
+   * named a profile the resolver could not use, before resolution continues
+   * to the next rung. Fallback is silent to the call but must be visible in
+   * logs — callers on user-facing paths should log at warn.
+   */
+  onResolutionFallback?: (info: {
+    callSite: LLMCallSite;
+    requested: string;
+    reason: ResolutionFallbackReason;
+  }) => void;
+  /**
+   * Test/caller override for the resolution semantics. When absent, the
+   * `override-or-default-resolution` feature flag decides (ships enabled;
+   * disabling it is the kill switch back to the legacy merge cascade).
+   */
+  resolutionSemantics?: "override-or-default" | "legacy-merge";
+}
+
+export type ResolutionFallbackReason = "missing" | "disabled" | "incomplete";
+
+export const OVERRIDE_OR_DEFAULT_RESOLUTION_FLAG =
+  "override-or-default-resolution";
+
+/**
+ * The flag read ignores its config argument (the override cache and registry
+ * are module state), so the resolver stays call-site-compatible without
+ * threading `AssistantConfig` through every consumer.
+ */
+export function isOverrideOrDefaultResolutionEnabled(): boolean {
+  return isAssistantFeatureFlagEnabled(
+    OVERRIDE_OR_DEFAULT_RESOLUTION_FLAG,
+    undefined as never,
+  );
+}
+
+function useOverrideOrDefaultSemantics(opts: ResolveCallSiteOpts): boolean {
+  if (opts.resolutionSemantics != null) {
+    return opts.resolutionSemantics === "override-or-default";
+  }
+  return isOverrideOrDefaultResolutionEnabled();
 }
 
 export function resolveCallSiteConfig(
@@ -118,6 +163,9 @@ export function resolveCallSiteConfig(
   llm: z.infer<typeof LLMSchema>,
   opts: ResolveCallSiteOpts = {},
 ): z.infer<typeof LLMConfigBase> {
+  if (useOverrideOrDefaultSemantics(opts)) {
+    return resolveOverrideOrDefault(callSite, llm, opts);
+  }
   const layers: Mergeable[] = [llm.default as Mergeable];
 
   // Effective logit-bias preset, tracked outside the deep-merge so it ties to
@@ -226,6 +274,249 @@ export function resolveCallSiteConfig(
     resolved.topP = samplingRef.topP;
   }
   return resolved;
+}
+
+// ─── Override-or-default resolution (flag-on path) ──────────────────────────
+//
+// Selection is a single-winner chain — each rung is either a complete
+// explicit choice or skipped with a reported reason — bottoming out on the
+// code-owned default intent resolved through `llm.defaultProvider`:
+//   1. `opts.overrideProfile` (conversation/schedule/per-turn pin)
+//   2. `llm.activeProfile` (mainAgent only — it IS that call site's selection)
+//   3. `llm.callSites[callSite].profile`
+//   4. `CALL_SITE_DEFAULTS[callSite].profile` intent × default provider
+//   5. balanced intent × default provider (profileless sites, or nothing
+//      above usable)
+// A winner must carry its own `provider` AND `model`: the base layer's
+// schema-default identity must never stand in for a selected profile (that
+// would be merge inheritance by the back door). The legacy `custom-${intent}`
+// hop is deliberately absent — a fallback anchor must be code-owned, never
+// user-mutable state.
+//
+// Composition is exactly three layers, deep-merged: schema-default base →
+// winner → the call site's own tweak fragment. `temperature`/`topP` come from
+// the winner (or an explicit tweak); `logitBias` only ever from the winner.
+// `forceOverrideProfile` is a no-op here (the override is already first).
+
+export interface ProfileWinnerSelection {
+  /** Named winner (a mix's own name, not its arm); null → the anchor rung. */
+  profileName: string | null;
+  source: "override" | "active" | "call_site" | "default";
+  /** The concrete (mix-expanded) entry that won; null only if even the code
+   * catalog was unusable, which the load-time catalog validation prevents. */
+  entry: ProfileEntry | null;
+}
+
+export function selectWinningProfile(
+  callSite: LLMCallSite,
+  llm: z.infer<typeof LLMSchema>,
+  opts: ResolveCallSiteOpts = {},
+): ProfileWinnerSelection {
+  const report = (requested: string, reason: ResolutionFallbackReason) =>
+    opts.onResolutionFallback?.({ callSite, requested, reason });
+
+  const override = usableEntry(opts.overrideProfile, llm, opts, report);
+  if (override) {
+    return {
+      profileName: override.name,
+      source: "override",
+      entry: override.entry,
+    };
+  }
+  if (callSite === "mainAgent") {
+    const active = usableEntry(llm.activeProfile, llm, opts, report);
+    if (active) {
+      return {
+        profileName: active.name,
+        source: "active",
+        entry: active.entry,
+      };
+    }
+  }
+  const sitePin = usableEntry(
+    llm.callSites?.[callSite]?.profile,
+    llm,
+    opts,
+    report,
+  );
+  if (sitePin) {
+    return {
+      profileName: sitePin.name,
+      source: "call_site",
+      entry: sitePin.entry,
+    };
+  }
+  const intent = CALL_SITE_DEFAULTS[callSite]?.profile;
+  if (intent != null) {
+    const entry = usableDefaultIntent(intent, llm, opts, report);
+    if (entry) {
+      return { profileName: intent, source: "default", entry };
+    }
+  }
+  // Anchor: profileless call sites (`vision`, `workflowLeaf`) and any
+  // resolution whose every named rung was unusable land on balanced intent
+  // through the default provider. `profileName` stays null — the anchor is
+  // not a selection.
+  return {
+    profileName: null,
+    source: "default",
+    entry: usableDefaultIntent("balanced", llm, opts, report) ?? null,
+  };
+}
+
+/**
+ * Dereference a named rung: the effective entry must exist, be enabled,
+ * expand (for a mix) to an enabled arm, and carry its own provider+model.
+ */
+function usableEntry(
+  name: string | undefined,
+  llm: z.infer<typeof LLMSchema>,
+  opts: ResolveCallSiteOpts,
+  report: (requested: string, reason: ResolutionFallbackReason) => void,
+): { name: string; entry: ProfileEntry } | undefined {
+  if (name == null) {
+    return undefined;
+  }
+  const named = getEffectiveProfile(llm.profiles, name);
+  if (named == null) {
+    report(name, "missing");
+    return undefined;
+  }
+  if (named.status === "disabled") {
+    report(name, "disabled");
+    return undefined;
+  }
+  // Mixes expand via the shared seeded pick (fires `onMixSelected`).
+  const entry =
+    named.mix == null ? named : resolveProfileFragment(name, llm, opts);
+  if (entry == null) {
+    report(name, "missing");
+    return undefined;
+  }
+  if (entry.status === "disabled") {
+    report(name, "disabled");
+    return undefined;
+  }
+  if (entry.provider == null || entry.model == null) {
+    report(name, "incomplete");
+    return undefined;
+  }
+  return { name, entry };
+}
+
+/**
+ * Resolve a default-profile intent through the default provider. A user
+ * shadow that is unusable (disabled/incomplete/a broken mix) is reported and
+ * the pure catalog body stands — the fallback anchor is code-owned and must
+ * always resolve. A legacy disabled stub on a default is likewise reported
+ * and overridden: defaults cannot be disabled through any write path, so a
+ * persisted disabled stub is stale hatch-era state whose meaning ("no vellum
+ * connection") `llm.defaultProvider` expresses properly.
+ */
+function usableDefaultIntent(
+  intent: string,
+  llm: z.infer<typeof LLMSchema>,
+  opts: ResolveCallSiteOpts,
+  report: (requested: string, reason: ResolutionFallbackReason) => void,
+): ProfileEntry | undefined {
+  const defaultProvider = llm.defaultProvider ?? null;
+  let entry = resolveDefaultProfileForProvider(
+    llm.profiles,
+    intent,
+    defaultProvider,
+  );
+  if (entry?.mix != null) {
+    entry = resolveProfileFragment(intent, llm, opts);
+  }
+  if (
+    entry != null &&
+    entry.status !== "disabled" &&
+    entry.provider != null &&
+    entry.model != null
+  ) {
+    return entry;
+  }
+  if (entry == null) {
+    report(intent, "missing");
+  } else {
+    report(intent, entry.status === "disabled" ? "disabled" : "incomplete");
+  }
+  const catalog = resolveDefaultProfileForProvider(
+    undefined,
+    intent,
+    defaultProvider,
+  );
+  if (catalog != null && catalog.provider != null && catalog.model != null) {
+    return catalog;
+  }
+  return undefined;
+}
+
+/**
+ * Schema-default base for composition. Non-identity fields a winner omits
+ * fall to these code-owned defaults (never to `llm.default`); the winner's
+ * identity fields are guaranteed present by `selectWinningProfile`.
+ */
+const CODE_DEFAULT_BASE: z.infer<typeof LLMConfigBase> = LLMConfigBase.parse(
+  {},
+);
+
+function resolveOverrideOrDefault(
+  callSite: LLMCallSite,
+  llm: z.infer<typeof LLMSchema>,
+  opts: ResolveCallSiteOpts,
+): z.infer<typeof LLMConfigBase> {
+  const selection = selectWinningProfile(callSite, llm, opts);
+  const winnerFragment: Mergeable =
+    selection.entry == null ? {} : winnerConfigFragment(selection.entry);
+
+  // The call site's own tweak fragment: the workspace override replaces the
+  // code default wholesale (matching legacy `llm.callSites[site] ??
+  // CALL_SITE_DEFAULTS[site]`). `profile` is the selection discriminator and
+  // `logitBias` is winner-owned, so neither enters the merge.
+  const site = llm.callSites?.[callSite] ?? CALL_SITE_DEFAULTS[callSite];
+  const {
+    profile: _siteProfile,
+    logitBias: _siteBias,
+    ...tweak
+  } = (site ?? {}) as Record<string, unknown>;
+
+  // Direct call-site model overrides are fragments by design: when the tweak
+  // pins a model the winner's provider does not serve, stamp the catalog
+  // owner and drop the winner's connection (it belongs to the replaced
+  // provider; dispatch auto-resolves an absent connection by provider).
+  const applicableProvider =
+    (winnerFragment.provider as string | undefined) ??
+    CODE_DEFAULT_BASE.provider;
+  if (
+    typeof tweak.model === "string" &&
+    tweak.provider === undefined &&
+    !isModelInCatalog(applicableProvider, tweak.model)
+  ) {
+    const implied = getCatalogProviderForModel(tweak.model);
+    if (implied !== undefined) {
+      tweak.provider = implied;
+      delete winnerFragment.provider_connection;
+    }
+  }
+
+  return finalize(
+    deepMerge(CODE_DEFAULT_BASE as unknown as Mergeable, winnerFragment, tweak),
+  );
+}
+
+/** The winner's config fields: metadata stripped, sampling and logitBias
+ * kept — with a single winner there is no cross-profile leakage to guard. */
+function winnerConfigFragment(entry: ProfileEntry): Mergeable {
+  const {
+    source: _source,
+    label: _label,
+    description: _description,
+    status: _status,
+    mix: _mix,
+    ...config
+  } = entry;
+  return config as Mergeable;
 }
 
 type LogitBiasRef = { preset: ProfileEntry["logitBias"] };
@@ -338,6 +629,9 @@ export function resolveDefaultProfileKey(
   callSite: LLMCallSite,
   llm: z.infer<typeof LLMSchema>,
 ): string | undefined {
+  if (useOverrideOrDefaultSemantics({})) {
+    return selectWinningProfile(callSite, llm, {}).profileName ?? undefined;
+  }
   if (callSite === "mainAgent" && llm.activeProfile != null) {
     const active = getEffectiveProfile(llm.profiles, llm.activeProfile);
     if (active != null && active.status !== "disabled") {

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -4,6 +4,10 @@ import {
   getCatalogProviderForModel,
   isModelInCatalog,
 } from "../providers/model-catalog.js";
+import {
+  MANAGED_ROUTABLE_PROVIDERS,
+  VELLUM_MANAGED_CONNECTION_NAME,
+} from "../providers/vellum-model-routing.js";
 import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
 import { CALL_SITE_DEFAULTS } from "./call-site-defaults.js";
 import {
@@ -496,7 +500,19 @@ function resolveOverrideOrDefault(
     const implied = getCatalogProviderForModel(tweak.model);
     if (implied !== undefined) {
       tweak.provider = implied;
-      delete winnerFragment.provider_connection;
+      // A provider-specific connection must not pin a mismatch onto the
+      // implied provider — but the provider-agnostic Vellum managed
+      // connection routes any managed-routable upstream and must survive,
+      // or platform installs lose their only connection.
+      if (
+        !(
+          winnerFragment.provider_connection ===
+            VELLUM_MANAGED_CONNECTION_NAME &&
+          MANAGED_ROUTABLE_PROVIDERS.has(implied)
+        )
+      ) {
+        delete winnerFragment.provider_connection;
+      }
     }
   }
 

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -450,11 +450,23 @@ export async function runAgentLoopImpl(
   });
   let currentEffectiveContextWindow: EffectiveContextWindow =
     effectiveContextWindow;
+  const logResolutionFallback = (info: {
+    callSite: string;
+    requested: string;
+    reason: string;
+  }) => {
+    rlog.warn(
+      { ...info, conversationId: ctx.conversationId },
+      "Inference profile fell back to the call-site default",
+    );
+  };
+
   let currentContextWindowConfig = contextWindowConfigFromEffective(
     resolveCallSiteConfig(turnCallSite, config.llm, {
       overrideProfile: turnOverrideProfile ?? undefined,
       forceOverrideProfile,
       selectionSeed: ctx.conversationId,
+      onResolutionFallback: logResolutionFallback,
     }).contextWindow,
     currentEffectiveContextWindow,
   );

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -27,10 +27,12 @@ import {
   resolveEffectiveContextWindow,
 } from "../config/llm-context-resolution.js";
 import {
+  isOverrideOrDefaultResolutionEnabled,
   resolveCallSiteConfig,
   resolveDefaultProfileKey,
   resolveEffectiveProfileKey,
   resolveProfilelessModelKey,
+  selectWinningProfile,
 } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
@@ -930,10 +932,21 @@ export async function runAgentLoopImpl(
     // `modelProfileKey` is the actual profile used for this turn. The
     // notice key is narrower: it only marks turns where runtime context should
     // remind the model that the profile changed.
+    // Under override-or-default semantics the reported key must come from
+    // the same winner selection dispatch used — a hand-rolled chain would
+    // credit profiles the resolver never consulted (e.g. activeProfile on a
+    // non-mainAgent turn).
     const effectiveProfileKey =
-      turnOverrideProfile ??
-      config.llm.activeProfile ??
-      resolveDefaultProfileKey("mainAgent", config.llm) ??
+      (isOverrideOrDefaultResolutionEnabled()
+        ? selectWinningProfile(turnCallSite, config.llm, {
+            ...(turnOverrideProfile != null
+              ? { overrideProfile: turnOverrideProfile }
+              : {}),
+            selectionSeed: ctx.conversationId,
+          }).profileName
+        : (turnOverrideProfile ??
+          config.llm.activeProfile ??
+          resolveDefaultProfileKey("mainAgent", config.llm))) ??
       resolveProfilelessModelKey(turnCallSite, config.llm, {
         ...(turnOverrideProfile != null
           ? { overrideProfile: turnOverrideProfile }

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -487,6 +487,7 @@ export async function runAgentLoopImpl(
         resolveCallSiteConfig(turnCallSite, config.llm, {
           overrideProfile: currentOverrideProfile,
           forceOverrideProfile,
+          onResolutionFallback: logResolutionFallback,
           selectionSeed: ctx.conversationId,
         }).contextWindow,
         currentEffectiveContextWindow,

--- a/assistant/src/providers/__tests__/dispatch-connection-routing.test.ts
+++ b/assistant/src/providers/__tests__/dispatch-connection-routing.test.ts
@@ -23,7 +23,18 @@
  *      what to do).
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helpers.js";
+
+// Connection-routing plumbing over legacy-shaped fixtures (llm.default /
+// activeProfile-centric, no defaultProvider): pinned to the flag-off
+// cascade. Flag-on dispatch behavior is covered by
+// inference-no-mode-boot-e2e.test.ts and the override-or-default resolver
+// suite.
+beforeAll(() => {
+  setOverridesForTesting({ "override-or-default-resolution": false });
+});
 
 // ---------------------------------------------------------------------------
 // Module mocks (must be declared before the import-under-test).

--- a/assistant/src/providers/__tests__/retry-callsite.test.ts
+++ b/assistant/src/providers/__tests__/retry-callsite.test.ts
@@ -1,4 +1,13 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helpers.js";
+
+// Legacy-shaped fixtures (llm.default-centric resolution): pinned to the
+// flag-off cascade. Override-or-default (flag-on) semantics are pinned by
+// llm-resolver-override-or-default.test.ts and its companion suites.
+beforeAll(() => {
+  setOverridesForTesting({ "override-or-default-resolution": false });
+});
 
 // ── Module mocks ────────────────────────────────────────────────────────────
 //
@@ -28,7 +37,9 @@ const mockProviders = new Map<string, { name: string }>();
 mock.module("../registry.js", () => ({
   getProvider: (name: string) => {
     const p = mockProviders.get(name);
-    if (!p) throw new Error(`unknown provider: ${name}`);
+    if (!p) {
+      throw new Error(`unknown provider: ${name}`);
+    }
     return p;
   },
   initializeProviders: async () => {},

--- a/assistant/src/providers/__tests__/satellite-connection-routing.test.ts
+++ b/assistant/src/providers/__tests__/satellite-connection-routing.test.ts
@@ -22,7 +22,18 @@
  *   - No callSite → straight to default (no resolution work).
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helpers.js";
+
+// Connection-routing plumbing over legacy-shaped fixtures (llm.default /
+// activeProfile-centric, no defaultProvider): pinned to the flag-off
+// cascade. Flag-on dispatch behavior is covered by
+// inference-no-mode-boot-e2e.test.ts and the override-or-default resolver
+// suite.
+beforeAll(() => {
+  setOverridesForTesting({ "override-or-default-resolution": false });
+});
 
 import type { Provider, ProviderResponse } from "../types.js";
 

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -65,8 +65,10 @@ import type {
 import type { InterfaceId } from "../channels/types.js";
 import { resolveEffectiveContextWindow } from "../config/llm-context-resolution.js";
 import {
+  isOverrideOrDefaultResolutionEnabled,
   resolveDefaultProfileKey,
   resolveProfilelessModelKey,
+  selectWinningProfile,
 } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
@@ -724,13 +726,21 @@ export async function wakeAgentForOpportunity(
       overrideProfile,
       forceOverrideProfile,
     });
+    // Same winner-selection sourcing as the agent loop's key: under
+    // override-or-default semantics a hand-mirrored chain would disagree
+    // with dispatch (a non-forced override now wins on every call site).
     const modelProfileKey =
-      (forceOverrideProfile || callSite === "mainAgent"
-        ? overrideProfile
-        : undefined) ??
-      resolveDefaultProfileKey(callSite, config.llm) ??
-      overrideProfile ??
-      resolveDefaultProfileKey("mainAgent", config.llm) ??
+      (isOverrideOrDefaultResolutionEnabled()
+        ? selectWinningProfile(callSite, config.llm, {
+            ...(overrideProfile != null ? { overrideProfile } : {}),
+            selectionSeed: conversationId,
+          }).profileName
+        : ((forceOverrideProfile || callSite === "mainAgent"
+            ? overrideProfile
+            : undefined) ??
+          resolveDefaultProfileKey(callSite, config.llm) ??
+          overrideProfile ??
+          resolveDefaultProfileKey("mainAgent", config.llm))) ??
       resolveProfilelessModelKey(callSite, config.llm, {
         ...(overrideProfile != null ? { overrideProfile } : {}),
         ...(forceOverrideProfile ? { forceOverrideProfile: true } : {}),

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -160,21 +160,25 @@ export async function executeSubagentSpawn(
   // that only surfaces with no `activeProfile` set and a hand-tuned call-site
   // profile.
   //
-  // The fallback is forwarded NON-forced, so an explicit
-  // `llm.callSites.subagentSpawn` profile still wins; an explicit
-  // `inference_profile` argument keeps `forceOverrideProfile` and wins
-  // outright. (The row read short-circuits to `undefined` for the background
-  // subagent conversation and for tool calls outside an agent-loop turn.)
+  // An explicit `llm.callSites.subagentSpawn` profile must still win over
+  // the invoker-default tier: that tier is a matching heuristic, not a user
+  // choice, and any override outranks the call-site pin under
+  // override-or-default resolution — so the heuristic is only forwarded
+  // when no explicit pin exists. (Under the legacy cascade a non-forced
+  // override already lost to the pin, so this guard is behavior-identical
+  // there.) An explicit `inference_profile` argument keeps
+  // `forceOverrideProfile` and wins outright; the row read short-circuits
+  // to `undefined` for the background subagent conversation and for tool
+  // calls outside an agent-loop turn.
   let inheritedOverrideProfile = requestedOverrideProfile;
   if (inheritedOverrideProfile === undefined) {
-    const inheritedCandidate =
+    const llm = getConfig().llm;
+    inheritedOverrideProfile =
       context.overrideProfile ??
       getConversationOverrideProfile(context.conversationId) ??
-      resolveDefaultProfileKey(
-        context.invokingCallSite ?? "mainAgent",
-        getConfig().llm,
-      );
-    inheritedOverrideProfile = inheritedCandidate;
+      (llm.callSites?.subagentSpawn?.profile == null
+        ? resolveDefaultProfileKey(context.invokingCallSite ?? "mainAgent", llm)
+        : undefined);
   }
 
   try {

--- a/assistant/src/usage/attribution.ts
+++ b/assistant/src/usage/attribution.ts
@@ -1,5 +1,9 @@
 import { getEffectiveProfiles } from "../config/default-profile-catalog.js";
-import { resolveCallSiteConfig } from "../config/llm-resolver.js";
+import {
+  isOverrideOrDefaultResolutionEnabled,
+  resolveCallSiteConfig,
+  selectWinningProfile,
+} from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { safeStringSlice } from "../util/unicode.js";
@@ -136,14 +140,19 @@ export function resolveUsageAttribution(
   const callSiteProfile = normalizeProfileId(
     llm.callSites?.[callSite]?.profile,
   );
-  const profile = resolveAppliedProfile({
-    callSite,
-    profiles: getEffectiveProfiles(llm.profiles),
-    activeProfile,
-    overrideProfile,
-    forceOverrideProfile: input.forceOverrideProfile === true,
-    callSiteProfile,
-  });
+  // Under override-or-default semantics the resolver's own winner selection
+  // is the single source of truth for which profile applied — attribution
+  // must never re-derive precedence and drift from dispatch.
+  const profile = isOverrideOrDefaultResolutionEnabled()
+    ? appliedProfileFromWinnerSelection(callSite, llm, overrideProfile, input)
+    : resolveAppliedProfile({
+        callSite,
+        profiles: getEffectiveProfiles(llm.profiles),
+        activeProfile,
+        overrideProfile,
+        forceOverrideProfile: input.forceOverrideProfile === true,
+        callSiteProfile,
+      });
 
   return {
     callSite,
@@ -158,6 +167,30 @@ export function resolveUsageAttribution(
       profile.appliedProfile != null
         ? (mixSelections.get(profile.appliedProfile) ?? null)
         : null,
+  };
+}
+
+function appliedProfileFromWinnerSelection(
+  callSite: LLMCallSite,
+  llm: Parameters<typeof selectWinningProfile>[1],
+  overrideProfile: string | null,
+  input: UsageAttributionInput,
+): Pick<UsageAttributionSnapshot, "appliedProfile" | "profileSource"> {
+  const selection = selectWinningProfile(callSite, llm, {
+    ...(overrideProfile != null ? { overrideProfile } : {}),
+    ...(input.selectionSeed != null
+      ? { selectionSeed: input.selectionSeed }
+      : {}),
+  });
+  const sourceBySelection = {
+    override: "conversation",
+    active: "active",
+    call_site: "call_site",
+    default: "default",
+  } as const;
+  return {
+    appliedProfile: selection.profileName,
+    profileSource: sourceBySelection[selection.source],
   };
 }
 

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -83,38 +83,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "ces-tools",
-      "scope": "assistant",
-      "key": "ces-tools",
-      "label": "CES Tool Exposure",
-      "description": "Register Credential Execution Service tools (credential-grant, credential-revoke, credential-list) in the agent loop",
-      "defaultEnabled": false
-    },
-    {
-      "id": "ces-shell-lockdown",
-      "scope": "assistant",
-      "key": "ces-shell-lockdown",
-      "label": "CES Shell Lockdown",
-      "description": "Enforce untrusted-agent shell lockdown when CES credentials are active, restricting direct shell access to credentialed services",
-      "defaultEnabled": false
-    },
-    {
-      "id": "ces-secure-install",
-      "scope": "assistant",
-      "key": "ces-secure-install",
-      "label": "CES Secure Command Installation",
-      "description": "Enable secure tool/command installation via CES instead of direct shell execution for untrusted agents",
-      "defaultEnabled": false
-    },
-    {
-      "id": "ces-grant-audit",
-      "scope": "assistant",
-      "key": "ces-grant-audit",
-      "label": "CES Grant & Audit Inspection",
-      "description": "Surface credential grant and audit inspection endpoints for reviewing active grants and access logs",
-      "defaultEnabled": false
-    },
-    {
       "id": "settings-embedding-provider",
       "scope": "assistant",
       "key": "settings-embedding-provider",
@@ -440,6 +408,22 @@
       "key": "credential-requests",
       "label": "One-time credential request links",
       "description": "Enable one-time credential-request links: the generate-link action in settings, the public credential entry page, and assistant-initiated links on channels without secure input.",
+      "defaultEnabled": false
+    },
+    {
+      "id": "summarize-up-to-here",
+      "scope": "both",
+      "key": "summarize-up-to-here",
+      "label": "Summarize Up To Here",
+      "description": "Show the per-message Summarize up to here action and enable the conversation summarize endpoint",
+      "defaultEnabled": false
+    },
+    {
+      "id": "skill-creation-card",
+      "scope": "both",
+      "key": "skill-creation-card",
+      "label": "Skill creation card",
+      "description": "Insert an in-chat card into the source conversation when the memory retrospective authors a new skill, and render it in the web client.",
       "defaultEnabled": false
     },
     {

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -83,6 +83,38 @@
       "defaultEnabled": false
     },
     {
+      "id": "ces-tools",
+      "scope": "assistant",
+      "key": "ces-tools",
+      "label": "CES Tool Exposure",
+      "description": "Register Credential Execution Service tools (credential-grant, credential-revoke, credential-list) in the agent loop",
+      "defaultEnabled": false
+    },
+    {
+      "id": "ces-shell-lockdown",
+      "scope": "assistant",
+      "key": "ces-shell-lockdown",
+      "label": "CES Shell Lockdown",
+      "description": "Enforce untrusted-agent shell lockdown when CES credentials are active, restricting direct shell access to credentialed services",
+      "defaultEnabled": false
+    },
+    {
+      "id": "ces-secure-install",
+      "scope": "assistant",
+      "key": "ces-secure-install",
+      "label": "CES Secure Command Installation",
+      "description": "Enable secure tool/command installation via CES instead of direct shell execution for untrusted agents",
+      "defaultEnabled": false
+    },
+    {
+      "id": "ces-grant-audit",
+      "scope": "assistant",
+      "key": "ces-grant-audit",
+      "label": "CES Grant & Audit Inspection",
+      "description": "Surface credential grant and audit inspection endpoints for reviewing active grants and access logs",
+      "defaultEnabled": false
+    },
+    {
       "id": "settings-embedding-provider",
       "scope": "assistant",
       "key": "settings-embedding-provider",
@@ -411,20 +443,12 @@
       "defaultEnabled": false
     },
     {
-      "id": "summarize-up-to-here",
-      "scope": "both",
-      "key": "summarize-up-to-here",
-      "label": "Summarize Up To Here",
-      "description": "Show the per-message Summarize up to here action and enable the conversation summarize endpoint",
-      "defaultEnabled": false
-    },
-    {
-      "id": "skill-creation-card",
-      "scope": "both",
-      "key": "skill-creation-card",
-      "label": "Skill creation card",
-      "description": "Insert an in-chat card into the source conversation when the memory retrospective authors a new skill, and render it in the web client.",
-      "defaultEnabled": false
+      "id": "override-or-default-resolution",
+      "scope": "assistant",
+      "key": "override-or-default-resolution",
+      "label": "Override-or-Default Profile Resolution",
+      "description": "Resolve inference profiles as single complete overrides (or the call site's default intent through the default provider) instead of the legacy deep-merge cascade. Ships enabled; disable as a kill switch to restore merge semantics.",
+      "defaultEnabled": true
     }
   ]
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -83,38 +83,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "ces-tools",
-      "scope": "assistant",
-      "key": "ces-tools",
-      "label": "CES Tool Exposure",
-      "description": "Register Credential Execution Service tools (credential-grant, credential-revoke, credential-list) in the agent loop",
-      "defaultEnabled": false
-    },
-    {
-      "id": "ces-shell-lockdown",
-      "scope": "assistant",
-      "key": "ces-shell-lockdown",
-      "label": "CES Shell Lockdown",
-      "description": "Enforce untrusted-agent shell lockdown when CES credentials are active, restricting direct shell access to credentialed services",
-      "defaultEnabled": false
-    },
-    {
-      "id": "ces-secure-install",
-      "scope": "assistant",
-      "key": "ces-secure-install",
-      "label": "CES Secure Command Installation",
-      "description": "Enable secure tool/command installation via CES instead of direct shell execution for untrusted agents",
-      "defaultEnabled": false
-    },
-    {
-      "id": "ces-grant-audit",
-      "scope": "assistant",
-      "key": "ces-grant-audit",
-      "label": "CES Grant & Audit Inspection",
-      "description": "Surface credential grant and audit inspection endpoints for reviewing active grants and access logs",
-      "defaultEnabled": false
-    },
-    {
       "id": "settings-embedding-provider",
       "scope": "assistant",
       "key": "settings-embedding-provider",
@@ -440,6 +408,22 @@
       "key": "credential-requests",
       "label": "One-time credential request links",
       "description": "Enable one-time credential-request links: the generate-link action in settings, the public credential entry page, and assistant-initiated links on channels without secure input.",
+      "defaultEnabled": false
+    },
+    {
+      "id": "summarize-up-to-here",
+      "scope": "both",
+      "key": "summarize-up-to-here",
+      "label": "Summarize Up To Here",
+      "description": "Show the per-message Summarize up to here action and enable the conversation summarize endpoint",
+      "defaultEnabled": false
+    },
+    {
+      "id": "skill-creation-card",
+      "scope": "both",
+      "key": "skill-creation-card",
+      "label": "Skill creation card",
+      "description": "Insert an in-chat card into the source conversation when the memory retrospective authors a new skill, and render it in the web client.",
       "defaultEnabled": false
     },
     {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -83,6 +83,38 @@
       "defaultEnabled": false
     },
     {
+      "id": "ces-tools",
+      "scope": "assistant",
+      "key": "ces-tools",
+      "label": "CES Tool Exposure",
+      "description": "Register Credential Execution Service tools (credential-grant, credential-revoke, credential-list) in the agent loop",
+      "defaultEnabled": false
+    },
+    {
+      "id": "ces-shell-lockdown",
+      "scope": "assistant",
+      "key": "ces-shell-lockdown",
+      "label": "CES Shell Lockdown",
+      "description": "Enforce untrusted-agent shell lockdown when CES credentials are active, restricting direct shell access to credentialed services",
+      "defaultEnabled": false
+    },
+    {
+      "id": "ces-secure-install",
+      "scope": "assistant",
+      "key": "ces-secure-install",
+      "label": "CES Secure Command Installation",
+      "description": "Enable secure tool/command installation via CES instead of direct shell execution for untrusted agents",
+      "defaultEnabled": false
+    },
+    {
+      "id": "ces-grant-audit",
+      "scope": "assistant",
+      "key": "ces-grant-audit",
+      "label": "CES Grant & Audit Inspection",
+      "description": "Surface credential grant and audit inspection endpoints for reviewing active grants and access logs",
+      "defaultEnabled": false
+    },
+    {
       "id": "settings-embedding-provider",
       "scope": "assistant",
       "key": "settings-embedding-provider",
@@ -411,20 +443,12 @@
       "defaultEnabled": false
     },
     {
-      "id": "summarize-up-to-here",
-      "scope": "both",
-      "key": "summarize-up-to-here",
-      "label": "Summarize Up To Here",
-      "description": "Show the per-message Summarize up to here action and enable the conversation summarize endpoint",
-      "defaultEnabled": false
-    },
-    {
-      "id": "skill-creation-card",
-      "scope": "both",
-      "key": "skill-creation-card",
-      "label": "Skill creation card",
-      "description": "Insert an in-chat card into the source conversation when the memory retrospective authors a new skill, and render it in the web client.",
-      "defaultEnabled": false
+      "id": "override-or-default-resolution",
+      "scope": "assistant",
+      "key": "override-or-default-resolution",
+      "label": "Override-or-Default Profile Resolution",
+      "description": "Resolve inference profiles as single complete overrides (or the call site's default intent through the default provider) instead of the legacy deep-merge cascade. Ships enabled; disable as a kill switch to restore merge semantics.",
+      "defaultEnabled": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- **Override-or-default profile resolution, behind the `override-or-default-resolution` kill-switch flag** (registered `defaultEnabled: true`; disabling instantly restores the legacy merge cascade, which is byte-for-byte untouched). Resolution becomes a single-winner chain — explicit override pin → `activeProfile` (mainAgent only) → call-site profile → the call site's default intent resolved through `llm.defaultProvider` via the code catalog — the request config is then the **base + winner + site-tweak composition**: code-owned schema defaults, the single winning profile, and the call site's own tuning fragment (nested objects like `thinking` combine leaf-wise so a one-leaf tweak doesn't wipe siblings). Selection is pure either/or — no profile ever contributes a field to another profile. No deep-merge cascade, no `samplingRef`/`biasRef` provenance, no mainAgent-flipped precedence on the new path.
- **A winner must carry its own `provider` and `model`**: an incomplete profile is treated like a missing one (skip the rung, report `"incomplete"` via the new `onResolutionFallback` callback, continue toward the code-owned default). The base layer's schema-default identity never stands in for a selected profile. The legacy `custom-${intent}` fallback hop is deliberately absent from the new chain — a fallback anchor must be code-owned, never user-mutable state; profileless call sites anchor on balanced-intent through the default provider.
- **Attribution follows the same winner selection** (`selectWinningProfile` is exported and consumed by `usage/attribution.ts` flag-on — no second hand-rolled precedence copy). Flag-on telemetry nuance: a call-site default now attributes its intent key (e.g. `cost-optimized`) with source `default` instead of null. `forceOverrideProfile` is a documented no-op on the new path (the override is already first); its legacy meaning is unchanged flag-off.
- **Fallbacks are logged**: the conversation agent loop wires `onResolutionFallback` to a structured warn (silent to the call, visible to operators; the resolution-failure reporting milestone builds on this).
- **Test strategy — two matrices**: `llm-resolver.test.ts` (80 tests) pins the legacy cascade flag-off with bodies verbatim; new `llm-resolver-override-or-default.test.ts` (18 tests) pins the flag-on semantics including flag-on/flag-off parity fixtures on materialized workspaces, the dropped custom-* hop, the completeness rule, and mix/seed determinism. Suites whose subject is plumbing or dispatch routing over legacy-shaped fixtures are pinned flag-off with header comments (override trio, dispatch/satellite routing, commit-message generator, PR 1's equivalence contract — which is a legacy-merge property by definition); integration fixtures whose subject survives both semantics were modernized instead (complete profiles, call-site tweaks). Flag-on dispatch behavior is covered by `inference-no-mode-boot-e2e` and the attribution/resolver suites.
- **Companion required before release cut**: a small Terraform PR in vellum-assistant-platform creating the `override-or-default-resolution` flag on the platform (remote kill switch). Noted per meta/feature-flags/AGENTS.md.

## Behavior changes (flag-on)
1. Non-mainAgent call sites no longer consult `activeProfile`; profileless sites (`vision`, `workflowLeaf`) anchor on balanced-intent through the default provider instead of `llm.default`.
2. A non-forced override pin now wins on background call sites (previously the call-site profile outranked it).
3. Legacy BYOK installs' background call sites resolve the catalog intent through their default provider instead of the seeded `custom-*` clones (mainAgent unaffected — `activeProfile` still reaches them).
4. `llm.default` drops out of live resolution; non-identity fields a winner omits fall to schema defaults (materialized profiles carry everything explicitly).

## Original prompt
Milestone 6 of the Inference Management Refactor: replace deep-merge profile resolution with override-or-default semantics behind a kill-switch flag. All prerequisites are merged (M4 catalog, M5 defaultProvider, M6 PRs 1–5: completion helper, write normalization, materialization ensure pass, provider-aware catalog lookup, error groundwork). Design decisions incorporated: code-owned fallback chain (no custom-* hop), winner completeness rule (provider+model or skip), flag ships enabled as a kill switch. Full M6 plan attached to #37518 as the papertrail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
