### PR TITLE
Add plant-doctor to the plugin marketplace

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -250,7 +250,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/plant-doctor",
-        "ref": "ccb5058589e589de019602776aac728c6adcda1b"
+        "ref": "1115ac07a5b7f731600f037b743e011a84bd0597"
       },
       "description": "Diagnose plants from photos. Identifies the species, assesses health with visible evidence, and returns a care plan. Named plants get a persistent checkup history so you can track whether they are improving.",
       "category": "lifestyle",

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -244,6 +244,18 @@
       "category": "lifestyle",
       "homepage": "https://github.com/vellum-ai/coffee-aficionado",
       "license": "MIT"
+    },
+    {
+      "name": "plant-doctor",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/plant-doctor",
+        "ref": "ccb5058589e589de019602776aac728c6adcda1b"
+      },
+      "description": "Diagnose plants from photos. Identifies the species, assesses health with visible evidence, and returns a care plan. Named plants get a persistent checkup history so you can track whether they are improving.",
+      "category": "lifestyle",
+      "homepage": "https://github.com/vellum-ai/plant-doctor",
+      "license": "MIT"
     }
   ]
 }


### PR DESCRIPTION
## What

Adds **plant-doctor** to the plugin marketplace: photo-based plant diagnosis with care instructions and per-plant health history.

- Repo: https://github.com/vellum-ai/plant-doctor
- Pinned: `ccb5058589e589de019602776aac728c6adcda1b` (v0.1.0 + MIT license)

## Surfaces

- `plant_diagnose` tool: photo path in, structured diagnosis out (species, health verdict, issues with visible evidence, care plan). Runs on the workspace's configured inference credentials via `getConfiguredProvider`, force-pinning a vision-capable profile resolved with `getModelProfiles` + `doesSupportVision` (same pattern as the image-fallback plugin). Logs to history when a plant name is given.
- `plant_history` tool: plant roster with latest status, or one plant's full checkup history.
- `plant-doctor` skill: diagnosis and checkup workflows, including trend comparison across checkups.
- `init` hook: prepares the data dir and CSV files (plants.csv, diagnoses.csv, preserved across upgrades).

## Review checklist

- `package.json` declares `@vellumai/plugin-api` `^0.10.0` peer dep.
- Loads cleanly: `assistant plugins list` reports `ok`, all four surfaces contribute on boot.
- Exercised end to end on a real photo: correct species identification, evidence-grounded issues, history write + readback verified.
- No credentials handled in plugin code; no network calls outside the provider handle.
