### PR TITLE
fix(web): guard DOM reconciliation against browser page translation

### DIFF
--- a/clients/web/src/lib/translate-dom-guard.test.ts
+++ b/clients/web/src/lib/translate-dom-guard.test.ts
@@ -6,22 +6,39 @@ const originalRemoveChild = Node.prototype.removeChild;
 const originalInsertBefore = Node.prototype.insertBefore;
 
 /**
- * Simulate what a page translator does: detach a text node from its parent and
- * re-parent it under a wrapper the translator inserts (Chrome uses `<font>`;
- * the element type is irrelevant here — only the re-parenting matters).
- * React still holds a reference to the detached node and later asks its former
- * parent to remove or insert around it.
+ * The common Google Translate case: a text node is wrapped in place, so the
+ * wrapper (Chrome uses `<font>`; type is irrelevant here) becomes a child of
+ * the original parent and the text node lives one level down. React still holds
+ * the original text-node reference.
  */
-function reparentedNode(): { parent: HTMLElement; orphan: Text } {
+function wrappedInPlace(): { parent: HTMLElement; text: Text; wrapper: HTMLElement } {
+  const parent = document.createElement("div");
+  const text = document.createTextNode("translated");
+  parent.appendChild(text);
+  document.body.appendChild(parent);
+
+  const wrapper = document.createElement("span");
+  originalRemoveChild.call(parent, text);
+  wrapper.appendChild(text);
+  parent.appendChild(wrapper);
+
+  return { parent, text, wrapper };
+}
+
+/**
+ * The rarer case: the translator moves the node out from under its original
+ * parent entirely, so it is no longer recoverable from `parent`.
+ */
+function movedAway(): { parent: HTMLElement; orphan: Text } {
   const parent = document.createElement("div");
   const orphan = document.createTextNode("translated");
   parent.appendChild(orphan);
   document.body.appendChild(parent);
 
-  const wrapper = document.createElement("span");
-  document.body.appendChild(wrapper);
   originalRemoveChild.call(parent, orphan);
-  wrapper.appendChild(orphan);
+  const elsewhere = document.createElement("span");
+  document.body.appendChild(elsewhere);
+  elsewhere.appendChild(orphan);
 
   return { parent, orphan };
 }
@@ -36,9 +53,21 @@ describe("translate-dom-guard", () => {
     Node.prototype.insertBefore = originalInsertBefore;
   });
 
-  test("removeChild no-ops instead of throwing when the child was re-parented", () => {
+  test("removeChild removes the in-place translation wrapper so the label disappears", () => {
     const warn = spyOn(console, "warn").mockImplementation(mock(() => {}));
-    const { parent, orphan } = reparentedNode();
+    const { parent, text, wrapper } = wrappedInPlace();
+
+    expect(() => parent.removeChild(text)).not.toThrow();
+    expect(parent.contains(wrapper)).toBe(false);
+    expect(parent.textContent).toBe("");
+    expect(warn).toHaveBeenCalled();
+
+    warn.mockRestore();
+  });
+
+  test("removeChild no-ops when the node was moved out of the parent entirely", () => {
+    const warn = spyOn(console, "warn").mockImplementation(mock(() => {}));
+    const { parent, orphan } = movedAway();
 
     expect(() => parent.removeChild(orphan)).not.toThrow();
     expect(parent.removeChild(orphan)).toBe(orphan);
@@ -47,9 +76,24 @@ describe("translate-dom-guard", () => {
     warn.mockRestore();
   });
 
-  test("insertBefore appends instead of throwing when the reference was re-parented", () => {
+  test("insertBefore inserts before the in-place wrapper, preserving order", () => {
     const warn = spyOn(console, "warn").mockImplementation(mock(() => {}));
-    const { parent, orphan } = reparentedNode();
+    const { parent, text, wrapper } = wrappedInPlace();
+    const inserted = document.createElement("i");
+
+    // React wants `inserted` before the (now-wrapped) text node.
+    expect(() => parent.insertBefore(inserted, text)).not.toThrow();
+    expect(inserted.parentNode).toBe(parent);
+    expect(parent.firstChild).toBe(inserted);
+    expect(inserted.nextSibling).toBe(wrapper);
+    expect(warn).toHaveBeenCalled();
+
+    warn.mockRestore();
+  });
+
+  test("insertBefore appends when the reference was moved out of the parent entirely", () => {
+    const warn = spyOn(console, "warn").mockImplementation(mock(() => {}));
+    const { parent, orphan } = movedAway();
     const inserted = document.createElement("span");
 
     expect(() => parent.insertBefore(inserted, orphan)).not.toThrow();

--- a/clients/web/src/lib/translate-dom-guard.test.ts
+++ b/clients/web/src/lib/translate-dom-guard.test.ts
@@ -1,0 +1,82 @@
+import { afterAll, beforeAll, describe, expect, mock, spyOn, test } from "bun:test";
+
+import { installTranslateDomGuard } from "@/lib/translate-dom-guard";
+
+const originalRemoveChild = Node.prototype.removeChild;
+const originalInsertBefore = Node.prototype.insertBefore;
+
+/**
+ * Simulate what a page translator does: detach a text node from its parent and
+ * re-parent it under a wrapper the translator inserts (Chrome uses `<font>`;
+ * the element type is irrelevant here — only the re-parenting matters).
+ * React still holds a reference to the detached node and later asks its former
+ * parent to remove or insert around it.
+ */
+function reparentedNode(): { parent: HTMLElement; orphan: Text } {
+  const parent = document.createElement("div");
+  const orphan = document.createTextNode("translated");
+  parent.appendChild(orphan);
+  document.body.appendChild(parent);
+
+  const wrapper = document.createElement("span");
+  document.body.appendChild(wrapper);
+  originalRemoveChild.call(parent, orphan);
+  wrapper.appendChild(orphan);
+
+  return { parent, orphan };
+}
+
+describe("translate-dom-guard", () => {
+  beforeAll(() => {
+    installTranslateDomGuard();
+  });
+
+  afterAll(() => {
+    Node.prototype.removeChild = originalRemoveChild;
+    Node.prototype.insertBefore = originalInsertBefore;
+  });
+
+  test("removeChild no-ops instead of throwing when the child was re-parented", () => {
+    const warn = spyOn(console, "warn").mockImplementation(mock(() => {}));
+    const { parent, orphan } = reparentedNode();
+
+    expect(() => parent.removeChild(orphan)).not.toThrow();
+    expect(parent.removeChild(orphan)).toBe(orphan);
+    expect(warn).toHaveBeenCalled();
+
+    warn.mockRestore();
+  });
+
+  test("insertBefore appends instead of throwing when the reference was re-parented", () => {
+    const warn = spyOn(console, "warn").mockImplementation(mock(() => {}));
+    const { parent, orphan } = reparentedNode();
+    const inserted = document.createElement("span");
+
+    expect(() => parent.insertBefore(inserted, orphan)).not.toThrow();
+    expect(inserted.parentNode).toBe(parent);
+    expect(parent.lastChild).toBe(inserted);
+    expect(warn).toHaveBeenCalled();
+
+    warn.mockRestore();
+  });
+
+  test("normal removeChild / insertBefore still work", () => {
+    const parent = document.createElement("div");
+    const a = document.createElement("span");
+    const b = document.createElement("span");
+    parent.appendChild(b);
+
+    parent.insertBefore(a, b);
+    expect(parent.firstChild).toBe(a);
+
+    parent.removeChild(a);
+    expect(parent.contains(a)).toBe(false);
+    expect(parent.firstChild).toBe(b);
+  });
+
+  test("is idempotent — repeated installs do not re-wrap", () => {
+    const before = Node.prototype.removeChild;
+    installTranslateDomGuard();
+    expect(Node.prototype.removeChild).toBe(before);
+  });
+});

--- a/clients/web/src/lib/translate-dom-guard.ts
+++ b/clients/web/src/lib/translate-dom-guard.ts
@@ -3,24 +3,44 @@
  * nodes by wrapping them in `<font>` elements after React has committed the
  * DOM. React keeps references to the original text nodes, so a later
  * reconciliation can call `removeChild` / `insertBefore` against a node the
- * translator has already re-parented, throwing
+ * translator has re-parented, throwing
  * `DOMException: Failed to execute 'removeChild' on 'Node'` and unmounting the
  * whole app.
  *
  * These guards make the two reconciler-facing `Node` methods tolerant of that
- * one mismatch: when the node the caller expects to operate on no longer lives
- * under `this`, the call recovers (no-op for remove, append for insert) instead
- * of throwing, so the app keeps running while the translator re-translates the
- * subtree. Every other caller behaves normally; a genuine parentage bug in our
- * own code still recovers but is surfaced via `console.warn`, which session
- * recording captures.
+ * mismatch. The translator either wraps a node in place (`this → <font> → text`)
+ * or moves it under a wrapper elsewhere in the tree. In both cases the node
+ * React holds is no longer a direct child of `this`:
  *
- * The guard is installed once, before React first commits. It is idempotent.
+ * - `removeChild`: if the node is now nested under a wrapper that is itself a
+ *   child of `this`, remove that wrapper (so the content React wants gone
+ *   actually disappears); otherwise no-op.
+ * - `insertBefore`: insert before the wrapper that stands in for the stale
+ *   reference (preserving order); fall back to appending if no such wrapper is
+ *   under `this`.
+ *
+ * Every other caller behaves normally; a genuine parentage bug in our own code
+ * still recovers but is surfaced via `console.warn`, which session recording
+ * captures. The guard is installed once, before React first commits, and is
+ * idempotent.
  *
  * Reference: https://github.com/facebook/react/issues/11538
  */
 
 let installed = false;
+
+/**
+ * Walk up from `node` to the ancestor that is a direct child of `parent`
+ * (i.e. the translator wrapper standing in for `node`). Returns `null` when
+ * `node` is not inside `parent` at all.
+ */
+function childOfParent(node: Node, parent: Node): Node | null {
+  let current: Node | null = node;
+  while (current && current.parentNode !== parent) {
+    current = current.parentNode;
+  }
+  return current;
+}
 
 export function installTranslateDomGuard(): void {
   if (installed) {
@@ -36,14 +56,23 @@ export function installTranslateDomGuard(): void {
     this: Node,
     child: T,
   ): T {
-    if (child.parentNode !== this) {
+    if (child.parentNode === this) {
+      return originalRemoveChild.call(this, child) as T;
+    }
+    const wrapper = childOfParent(child, this);
+    if (wrapper) {
       console.warn(
-        "[translate-dom-guard] Skipped removeChild for a node re-parented by page translation",
+        "[translate-dom-guard] removeChild target was wrapped by page translation; removing the wrapper instead",
         child,
       );
+      originalRemoveChild.call(this, wrapper);
       return child;
     }
-    return originalRemoveChild.call(this, child) as T;
+    console.warn(
+      "[translate-dom-guard] Skipped removeChild for a node re-parented by page translation",
+      child,
+    );
+    return child;
   };
 
   const originalInsertBefore = Node.prototype.insertBefore;
@@ -52,13 +81,14 @@ export function installTranslateDomGuard(): void {
     node: T,
     reference: Node | null,
   ): T {
-    if (reference && reference.parentNode !== this) {
-      console.warn(
-        "[translate-dom-guard] Reference node re-parented by page translation; appending instead of insertBefore",
-        reference,
-      );
-      return originalInsertBefore.call(this, node, null) as T;
+    if (!reference || reference.parentNode === this) {
+      return originalInsertBefore.call(this, node, reference) as T;
     }
-    return originalInsertBefore.call(this, node, reference) as T;
+    const anchor = childOfParent(reference, this);
+    console.warn(
+      "[translate-dom-guard] insertBefore reference was re-parented by page translation; inserting before its wrapper",
+      reference,
+    );
+    return originalInsertBefore.call(this, node, anchor) as T;
   };
 }

--- a/clients/web/src/lib/translate-dom-guard.ts
+++ b/clients/web/src/lib/translate-dom-guard.ts
@@ -1,0 +1,64 @@
+/**
+ * Browser page translation (Chrome / Safari / Google Translate) rewrites text
+ * nodes by wrapping them in `<font>` elements after React has committed the
+ * DOM. React keeps references to the original text nodes, so a later
+ * reconciliation can call `removeChild` / `insertBefore` against a node the
+ * translator has already re-parented, throwing
+ * `DOMException: Failed to execute 'removeChild' on 'Node'` and unmounting the
+ * whole app.
+ *
+ * These guards make the two reconciler-facing `Node` methods tolerant of that
+ * one mismatch: when the node the caller expects to operate on no longer lives
+ * under `this`, the call recovers (no-op for remove, append for insert) instead
+ * of throwing, so the app keeps running while the translator re-translates the
+ * subtree. Every other caller behaves normally; a genuine parentage bug in our
+ * own code still recovers but is surfaced via `console.warn`, which session
+ * recording captures.
+ *
+ * The guard is installed once, before React first commits. It is idempotent.
+ *
+ * Reference: https://github.com/facebook/react/issues/11538
+ */
+
+let installed = false;
+
+export function installTranslateDomGuard(): void {
+  if (installed) {
+    return;
+  }
+  if (typeof Node !== "function" || !Node.prototype) {
+    return;
+  }
+  installed = true;
+
+  const originalRemoveChild = Node.prototype.removeChild;
+  Node.prototype.removeChild = function guardedRemoveChild<T extends Node>(
+    this: Node,
+    child: T,
+  ): T {
+    if (child.parentNode !== this) {
+      console.warn(
+        "[translate-dom-guard] Skipped removeChild for a node re-parented by page translation",
+        child,
+      );
+      return child;
+    }
+    return originalRemoveChild.call(this, child) as T;
+  };
+
+  const originalInsertBefore = Node.prototype.insertBefore;
+  Node.prototype.insertBefore = function guardedInsertBefore<T extends Node>(
+    this: Node,
+    node: T,
+    reference: Node | null,
+  ): T {
+    if (reference && reference.parentNode !== this) {
+      console.warn(
+        "[translate-dom-guard] Reference node re-parented by page translation; appending instead of insertBefore",
+        reference,
+      );
+      return originalInsertBefore.call(this, node, null) as T;
+    }
+    return originalInsertBefore.call(this, node, reference) as T;
+  };
+}

--- a/clients/web/src/main.tsx
+++ b/clients/web/src/main.tsx
@@ -14,6 +14,7 @@ import { isChunkLoadError } from "@/lib/chunk-errors";
 import { installConsentRefreshListeners } from "@/lib/consent/consent-refresh";
 import { isLocalMode, loadLockfile } from "@/lib/local-mode";
 import { initSentry } from "@/lib/sentry/sentry-init";
+import { installTranslateDomGuard } from "@/lib/translate-dom-guard";
 import { initSessionReplay } from "@/lib/session-replay/session-replay-init";
 import { setupAuthListeners, useAuthStore } from "@/stores/auth-store";
 import { setupOrganizationStore } from "@/stores/organization-store";
@@ -26,6 +27,10 @@ import { initSafeAreaBridge } from "@/runtime/native-safe-area";
 import { initInputModality } from "@vellumai/design-library";
 
 async function boot() {
+  // Install before React first commits so the reconciler survives DOM
+  // mutations from browser page translation.
+  installTranslateDomGuard();
+
   initInputModality();
   await initSafeAreaBridge();
   initSentry();
@@ -42,7 +47,9 @@ async function boot() {
   setupAuthListeners();
 
   const rootEl = document.getElementById("root");
-  if (!rootEl) throw new Error("Root element #root not found");
+  if (!rootEl) {
+    throw new Error("Root element #root not found");
+  }
 
   createRoot(rootEl).render(
     <StrictMode>


### PR DESCRIPTION
## Problem

Chrome/Safari page translation wraps text nodes in its own elements *after* React commits the DOM. React keeps references to the original text nodes, so a later reconciliation can call `removeChild`/`insertBefore` against a node the translator re-parented → `DOMException: Failed to execute 'removeChild' on 'Node'` → the whole app unmounts to its error screen. Open React bug since 2017, still unfixed in React 19 ([facebook/react#11538](https://github.com/facebook/react/issues/11538)).

A real onboarding user hit this clicking **Connect Calendar** with the UI auto-translated to Vietnamese (confirmed via a LogRocket session).

## Approach

This is the backstop layer of a defense-in-depth plan. Rather than hand-hardening all ~86 vulnerable sites (that continues separately), install a one-time, idempotent guard over `Node.prototype.removeChild` / `insertBefore` at boot, before React's first commit:

- When the target (remove) or reference (insert) node no longer lives under the expected parent, the call **recovers** — no-op for remove, append for insert — instead of throwing.
- Every other call behaves exactly as before.
- A `console.warn` fires on the mismatch so it stays visible in session recordings (LogRocket).

This converts the **entire class** of translation-induced reconciliation crashes — current and future code, plus third-party components — from a full app crash into a momentary translation glitch.

## Follow-ups (separate PRs)

- **#37578** (up) — per-site span-wrapping of the onboarding Connect Calendar step.
- A `loading` prop on the design-library `Button` + one inline-spinner primitive, migrating the copy-pasted `<Loader2/>` + bare-label idiom.
- A repo-local ESLint rule (`error`) flagging bare `JSXText` with a dynamic sibling / string↔JSX conditional branches, then a sweep of the HIGH-risk `settings/` sites.

## Reviewer note

The one bold part is patching `Node.prototype` globally. It's contained in a single documented module (`clients/web/src/lib/translate-dom-guard.ts`), only alters behavior on a genuine parent-mismatch, and keeps the warning so it never silently masks a real parentage bug of our own. Unit-tested for the re-parented remove/insert cases, the normal path, and idempotency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->