### PR TITLE
fix(hooks): prune worktree dirs from session-docs-primer scan

### DIFF
--- a/.claude/hooks/session-docs-primer.sh
+++ b/.claude/hooks/session-docs-primer.sh
@@ -13,7 +13,7 @@ while IFS= read -r entry; do
   [ -n "$entry" ] && index+=("$entry")
 done < <(
   find . \
-    \( -path '*/node_modules' -o -path '*/.git' -o -name generated -o -name dist -o -name build \) -prune -o \
+    \( -path '*/node_modules' -o -path '*/.git' -o -name worktrees -o -name '.worktrees' -o -name '*-worktrees' -o -name generated -o -name dist -o -name build \) -prune -o \
     \( -name AGENTS.md -o -name CLAUDE.md \) -print 2>/dev/null |
     sed 's|^\./||' | sort
 )


### PR DESCRIPTION
## Problem

The `SessionStart` docs-primer hook (`.claude/hooks/session-docs-primer.sh`) globs every `AGENTS.md`/`CLAUDE.md` in the repo to build the convention index it injects into context. It pruned `node_modules`/`.git`/`generated`/`dist`/`build` but **not worktree roots**.

With local worktrees present (`.claude/worktrees/` @ 37GB, top-level `worktrees/` @ 2GB, `.codex-worktrees/` @ 551MB), the scan walked ~40GB of working copies on every session start:

| Metric | Before | After |
|---|---|---|
| Hook runtime | **7.7 s** | **0.6 s** |
| Context injected each boot | **~69 KB** | **~1.5 KB** |
| Files indexed | 1,256 (1,027 worktree dupes) | 29 (real convention docs) |

## Fix

Prune worktree directories **by name** (`worktrees`, `.worktrees`, `*-worktrees`) rather than by path, so the exclusion holds regardless of nesting location — matching the worktree patterns already in `.gitignore`.

## Testing

- Hook still emits valid JSON.
- Index now contains only the 29 real repo convention files, zero worktree paths.
- Runtime measured at ~0.6s across 3 runs (down from 7.7s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->