### PR TITLE
feat(daemon): reconcile and auto-resume turns interrupted by a previous process

### DIFF
--- a/assistant/src/__tests__/db-processing-resume-attempts-migration.test.ts
+++ b/assistant/src/__tests__/db-processing-resume-attempts-migration.test.ts
@@ -1,0 +1,116 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { getSqliteFrom } from "../persistence/db-connection.js";
+import { migrateAddProcessingResumeAttempts } from "../persistence/migrations/322-add-processing-resume-attempts.js";
+import * as schema from "../persistence/schema/index.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  return drizzle(sqlite, { schema });
+}
+
+function bootstrapPreResumeAttemptsConversations(raw: Database): void {
+  raw.exec(/*sql*/ `
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      title TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      conversation_type TEXT NOT NULL DEFAULT 'standard',
+      source TEXT NOT NULL DEFAULT 'user',
+      memory_scope_id TEXT NOT NULL DEFAULT 'default',
+      is_auto_title INTEGER NOT NULL DEFAULT 1,
+      processing_started_at INTEGER
+    )
+  `);
+}
+
+function getResumeAttemptsColumn(raw: Database) {
+  return (
+    raw.query(`PRAGMA table_info(conversations)`).all() as Array<{
+      name: string;
+      notnull: number;
+      dflt_value: string | null;
+    }>
+  ).find((column) => column.name === "processing_resume_attempts");
+}
+
+describe("processing resume attempts migration", () => {
+  test("adds a NOT NULL column defaulting to 0", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+
+    bootstrapPreResumeAttemptsConversations(raw);
+    migrateAddProcessingResumeAttempts(db);
+
+    const column = getResumeAttemptsColumn(raw);
+    expect(column).toBeDefined();
+    expect(column?.notnull).toBe(1);
+    expect(column?.dflt_value).toBe("0");
+  });
+
+  test("existing rows are undisturbed and default to 0 attempts", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    const now = Date.now();
+
+    bootstrapPreResumeAttemptsConversations(raw);
+    raw.exec(/*sql*/ `
+      INSERT INTO conversations (id, title, created_at, updated_at, processing_started_at)
+      VALUES ('conv-existing', 'Existing conversation', ${now}, ${now}, ${now})
+    `);
+
+    migrateAddProcessingResumeAttempts(db);
+
+    const row = raw
+      .query(
+        `SELECT id, title, processing_started_at, processing_resume_attempts
+         FROM conversations WHERE id = 'conv-existing'`,
+      )
+      .get() as {
+      id: string;
+      title: string | null;
+      processing_started_at: number | null;
+      processing_resume_attempts: number;
+    } | null;
+
+    expect(row).toEqual({
+      id: "conv-existing",
+      title: "Existing conversation",
+      processing_started_at: now,
+      processing_resume_attempts: 0,
+    });
+  });
+
+  test("re-running the migration is a no-op and preserves stored values", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    const now = Date.now();
+
+    bootstrapPreResumeAttemptsConversations(raw);
+    raw.exec(/*sql*/ `
+      INSERT INTO conversations (id, created_at, updated_at)
+      VALUES ('conv-rerun', ${now}, ${now})
+    `);
+
+    migrateAddProcessingResumeAttempts(db);
+    raw.exec(/*sql*/ `
+      UPDATE conversations SET processing_resume_attempts = 2 WHERE id = 'conv-rerun'
+    `);
+
+    expect(() => migrateAddProcessingResumeAttempts(db)).not.toThrow();
+
+    const row = raw
+      .query(
+        `SELECT processing_resume_attempts FROM conversations WHERE id = 'conv-rerun'`,
+      )
+      .get() as { processing_resume_attempts: number } | null;
+
+    expect(row).toEqual({ processing_resume_attempts: 2 });
+  });
+});

--- a/assistant/src/__tests__/interrupted-turn-reconciler.test.ts
+++ b/assistant/src/__tests__/interrupted-turn-reconciler.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  MAX_RESUME_ATTEMPTS,
+  reconcileInterruptedConversations,
+} from "../daemon/interrupted-turn-reconciler.js";
+import {
+  createConversation,
+  incrementProcessingResumeAttempts,
+  listInterruptedConversations,
+  setConversationProcessingStartedAt,
+} from "../persistence/conversation-crud.js";
+import { getDb, getSqliteFrom } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+
+await initializeDb();
+
+function readRow(id: string): {
+  processing_started_at: number | null;
+  processing_resume_attempts: number;
+} {
+  const row = getSqliteFrom(getDb())
+    .query(
+      `SELECT processing_started_at, processing_resume_attempts
+       FROM conversations WHERE id = ?`,
+    )
+    .get(id) as {
+    processing_started_at: number | null;
+    processing_resume_attempts: number;
+  } | null;
+  if (!row) {
+    throw new Error(`conversation row missing: ${id}`);
+  }
+  return row;
+}
+
+function seedInterrupted(id: string, resumeAttempts = 0): void {
+  createConversation({ id });
+  setConversationProcessingStartedAt(id, Date.now());
+  for (let i = 0; i < resumeAttempts; i++) {
+    incrementProcessingResumeAttempts(id);
+  }
+}
+
+describe("interrupted-turn reconciler", () => {
+  beforeEach(() => {
+    getDb().run("DELETE FROM messages");
+    getDb().run("DELETE FROM conversations");
+  });
+
+  test("resume disabled: clears every stale flag and resumes nothing", () => {
+    seedInterrupted("conv-a");
+    seedInterrupted("conv-b");
+    createConversation({ id: "conv-idle" });
+
+    const result = reconcileInterruptedConversations(false);
+
+    expect(result.cleared).toBe(2);
+    expect(result.resume).toEqual([]);
+    expect(result.capped).toEqual([]);
+    expect(readRow("conv-a").processing_started_at).toBeNull();
+    expect(readRow("conv-b").processing_started_at).toBeNull();
+    expect(readRow("conv-a").processing_resume_attempts).toBe(0);
+  });
+
+  test("resume enabled: clears flags, selects interrupted conversations, and charges an attempt", () => {
+    seedInterrupted("conv-a");
+    createConversation({ id: "conv-idle" });
+
+    const result = reconcileInterruptedConversations(true);
+
+    expect(result.cleared).toBe(1);
+    expect(result.resume).toEqual(["conv-a"]);
+    expect(result.capped).toEqual([]);
+    expect(readRow("conv-a").processing_started_at).toBeNull();
+    expect(readRow("conv-a").processing_resume_attempts).toBe(1);
+    expect(readRow("conv-idle").processing_resume_attempts).toBe(0);
+  });
+
+  test("conversations at the attempt cap are cleared but not resumed", () => {
+    seedInterrupted("conv-fresh");
+    seedInterrupted("conv-capped", MAX_RESUME_ATTEMPTS);
+
+    const result = reconcileInterruptedConversations(true);
+
+    expect(result.cleared).toBe(2);
+    expect(result.resume).toEqual(["conv-fresh"]);
+    expect(result.capped).toEqual(["conv-capped"]);
+    expect(readRow("conv-capped").processing_started_at).toBeNull();
+    expect(readRow("conv-capped").processing_resume_attempts).toBe(
+      MAX_RESUME_ATTEMPTS,
+    );
+  });
+
+  test("attempt counter survives the flag clear so the cap holds across boots", () => {
+    seedInterrupted("conv-a");
+
+    expect(reconcileInterruptedConversations(true).resume).toEqual(["conv-a"]);
+    // Simulate the resumed turn dying mid-flight on the next boot.
+    setConversationProcessingStartedAt("conv-a", Date.now());
+    expect(reconcileInterruptedConversations(true).resume).toEqual(["conv-a"]);
+    setConversationProcessingStartedAt("conv-a", Date.now());
+
+    const third = reconcileInterruptedConversations(true);
+    expect(third.resume).toEqual([]);
+    expect(third.capped).toEqual(["conv-a"]);
+  });
+
+  test("a clean turn end resets the attempt counter", () => {
+    seedInterrupted("conv-a", 1);
+
+    setConversationProcessingStartedAt("conv-a", null);
+
+    expect(readRow("conv-a").processing_resume_attempts).toBe(0);
+    expect(listInterruptedConversations()).toEqual([]);
+  });
+
+  test("listInterruptedConversations reports only flagged conversations with their attempts", () => {
+    seedInterrupted("conv-a", 1);
+    createConversation({ id: "conv-idle" });
+
+    expect(listInterruptedConversations()).toEqual([
+      { id: "conv-a", resumeAttempts: 1 },
+    ]);
+  });
+});

--- a/assistant/src/config/schemas/conversations.ts
+++ b/assistant/src/config/schemas/conversations.ts
@@ -26,7 +26,7 @@ export const ConversationsConfigSchema = z
       })
       .default(false)
       .describe(
-        "Controls how conversations left mid-turn by a previous shutdown are handled on startup. When false (default), their stale processing flag is cleared so they come up idle. When true, the daemon will instead automatically resume the interrupted turn for each such conversation.",
+        "Controls how conversations left mid-turn by a previous shutdown are handled on startup. Their stale processing flags are always cleared so they come up idle. When true, the assistant additionally resumes each interrupted turn in the background after startup completes, at most 2 consecutive times per conversation (the budget refills whenever a turn completes cleanly) so a turn that repeatedly interrupts the process is eventually left idle.",
       ),
   })
   .describe("Conversation behavior configuration");

--- a/assistant/src/daemon/interrupted-turn-reconciler.ts
+++ b/assistant/src/daemon/interrupted-turn-reconciler.ts
@@ -1,0 +1,134 @@
+/**
+ * Startup reconciliation for conversations left mid-turn by the previous
+ * process. Their `processing_started_at` is still set even though the
+ * in-memory agent loop that owned the turn died with that process, so the
+ * flag is stale: clients would render the conversation as busy forever and
+ * background jobs (e.g. memory retrospectives) would skip it.
+ *
+ * The reconciler always clears the stale flags. When
+ * `conversations.resumeProcessingOnStartup` is enabled it additionally
+ * selects conversations to resume through the conversation-wake machinery —
+ * a normal background turn that shows the model an interruption notice and
+ * lets it decide what still needs doing, rather than mechanically replaying
+ * the dead turn (tool side effects are not idempotent, and the transcript
+ * already contains whatever the interrupted turn persisted).
+ */
+
+import {
+  clearStaleProcessingFlags,
+  incrementProcessingResumeAttempts,
+  listInterruptedConversations,
+} from "../persistence/conversation-crud.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("interrupted-turns");
+
+/**
+ * Maximum consecutive auto-resume attempts per conversation. The persisted
+ * counter survives `clearStaleProcessingFlags()` and resets only on a clean
+ * turn end, so a resumed turn that keeps taking the process down is left
+ * idle after this many boots instead of resume-looping forever.
+ */
+export const MAX_RESUME_ATTEMPTS = 2;
+
+/**
+ * Wake hint injected into the resumed turn. Deliberately instructs the model
+ * to judge what remains unfinished instead of redoing the turn wholesale —
+ * effects of already-executed tools are visible in the transcript and must
+ * not be repeated.
+ */
+const INTERRUPTED_TURN_RESUME_HINT =
+  "Your previous turn in this conversation was interrupted by an assistant " +
+  "restart before it finished. Review the recent messages and complete " +
+  "whatever was left unfinished. Do not repeat actions whose effects are " +
+  "already visible in the conversation. If nothing actionable remains, send " +
+  "a brief note acknowledging the reply was cut short so the conversation " +
+  "isn't left hanging.";
+
+export interface InterruptedTurnReconciliation {
+  /** Rows whose stale processing flag was cleared. */
+  cleared: number;
+  /** Conversation ids selected for an auto-resume wake. */
+  resume: string[];
+  /** Conversation ids left idle because they hit {@link MAX_RESUME_ATTEMPTS}. */
+  capped: string[];
+}
+
+/**
+ * Clear every stale processing flag and, when `resumeEnabled` is set, pick
+ * the conversations to resume. Each selected conversation's persisted
+ * resume-attempt counter is bumped before its id is returned, so a resume
+ * that dies mid-turn is charged even though the wake itself happens later.
+ *
+ * Pure DB work — safe to run during startup as soon as migrations settle.
+ * The wakes themselves must wait for full startup (providers, CES) and run
+ * via {@link resumeInterruptedConversations}.
+ */
+export function reconcileInterruptedConversations(
+  resumeEnabled: boolean,
+): InterruptedTurnReconciliation {
+  const interrupted = resumeEnabled ? listInterruptedConversations() : [];
+  const cleared = clearStaleProcessingFlags();
+  if (!resumeEnabled) {
+    return { cleared, resume: [], capped: [] };
+  }
+  const resume: string[] = [];
+  const capped: string[] = [];
+  for (const row of interrupted) {
+    if (row.resumeAttempts >= MAX_RESUME_ATTEMPTS) {
+      capped.push(row.id);
+      continue;
+    }
+    incrementProcessingResumeAttempts(row.id);
+    resume.push(row.id);
+  }
+  return { cleared, resume, capped };
+}
+
+/**
+ * Resume interrupted conversations sequentially through the conversation
+ * wake machinery. Sequential on purpose: a boot after a mid-turn crash can
+ * carry several interrupted conversations, and running them one at a time
+ * avoids a thundering herd of concurrent LLM turns right after startup.
+ *
+ * Each wake runs clientless (background policy: side-effecting tools are
+ * denied at the default threshold instead of stalling on an absent client)
+ * and without a trust elevation — the turn runs under the conversation's own
+ * resting trust, so resuming an interrupted low-trust turn can never grant
+ * it guardian-class capability. Failures are logged and skipped so one bad
+ * conversation doesn't block the rest.
+ *
+ * `agent-wake` is imported lazily: this module is loaded during early daemon
+ * startup, and the wake machinery statically pulls in the agent-loop stack,
+ * which must not join the lifecycle import graph (daemon ↔ runtime cycles).
+ */
+export async function resumeInterruptedConversations(
+  conversationIds: string[],
+): Promise<void> {
+  const { wakeAgentForOpportunity } = await import("../runtime/agent-wake.js");
+  for (const conversationId of conversationIds) {
+    try {
+      const result = await wakeAgentForOpportunity({
+        conversationId,
+        hint: INTERRUPTED_TURN_RESUME_HINT,
+        source: "interrupted-turn-resume",
+        clientless: true,
+        persistTriggerAsEvent: true,
+      });
+      log.info(
+        {
+          conversationId,
+          invoked: result.invoked,
+          producedToolCalls: result.producedToolCalls,
+          reason: result.reason,
+        },
+        "Interrupted-turn resume wake finished",
+      );
+    } catch (err) {
+      log.warn(
+        { err, conversationId },
+        "Interrupted-turn resume wake failed — continuing with remaining conversations",
+      );
+    }
+  }
+}

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -21,7 +21,6 @@ import { startGatewayFlagListener } from "../ipc/gateway-flag-listener.js";
 import { startMonitoring } from "../monitoring/control.js";
 import { backfillManualTokenConnections } from "../oauth/manual-token-connection.js";
 import { seedOAuthProviders } from "../oauth/seed-providers.js";
-import { clearStaleProcessingFlags } from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { startEmbeddingRuntimeManager } from "../persistence/embeddings/embedding-backend.js";
@@ -80,6 +79,11 @@ import { startEventLoopWatchdog } from "./event-loop-watchdog.js";
 import { initializePlugins } from "./external-plugins-bootstrap.js";
 import { backfillSlackInjectionTemplates } from "./handlers/config-slack-channel.js";
 import { installAssistantSymlink } from "./install-symlink.js";
+import {
+  MAX_RESUME_ATTEMPTS,
+  reconcileInterruptedConversations,
+  resumeInterruptedConversations,
+} from "./interrupted-turn-reconciler.js";
 import { startOrphanReaper } from "./orphan-reaper.js";
 import { runProfilerSweep } from "./profiler-run-store.js";
 import {
@@ -506,26 +510,41 @@ export async function runDaemon(): Promise<void> {
 
   // Reconcile conversations left mid-turn by the previous shutdown. Their
   // `processing_started_at` is still set even though the in-memory agent loop
-  // that owned the turn is gone.
+  // that owned the turn is gone. Stale flags are always cleared so no
+  // conversation stays visibly stuck "processing"; when
+  // `conversations.resumeProcessingOnStartup` is enabled the reconciler also
+  // selects conversations to resume once startup completes (the wakes need
+  // providers/CES, so they are kicked off next to `setStartupComplete()`).
+  let conversationsToResume: string[] = [];
   if (dbReady) {
-    if (config.conversations.resumeProcessingOnStartup) {
-      // TODO: automatically resume the interrupted turn for each conversation
-      // whose processing flag is still set instead of clearing it.
-    } else {
-      try {
-        const cleared = clearStaleProcessingFlags();
-        if (cleared > 0) {
-          log.info(
-            { count: cleared },
-            "Cleared stale conversation processing flags from previous process",
-          );
-        }
-      } catch (err) {
-        log.warn(
-          { err },
-          "Failed to clear stale conversation processing flags — continuing startup",
+    try {
+      const reconciled = reconcileInterruptedConversations(
+        config.conversations.resumeProcessingOnStartup,
+      );
+      conversationsToResume = reconciled.resume;
+      if (reconciled.cleared > 0) {
+        log.info(
+          {
+            count: reconciled.cleared,
+            resuming: reconciled.resume.length,
+          },
+          "Cleared stale conversation processing flags from previous process",
         );
       }
+      if (reconciled.capped.length > 0) {
+        log.warn(
+          {
+            conversationIds: reconciled.capped,
+            maxAttempts: MAX_RESUME_ATTEMPTS,
+          },
+          "Left interrupted conversations un-resumed after repeated interruptions",
+        );
+      }
+    } catch (err) {
+      log.warn(
+        { err },
+        "Failed to reconcile interrupted conversations — continuing startup",
+      );
     }
   }
 
@@ -710,6 +729,19 @@ export async function runDaemon(): Promise<void> {
   // signal handlers installed at the top of startup from their minimal
   // early-exit mode to the full graceful shutdown.
   setStartupComplete();
+
+  // Resume conversations whose turn the previous process interrupted. Kicked
+  // off only now — the wakes run full agent-loop turns and need providers and
+  // CES, which the startup sequence above just brought up. Fire-and-forget:
+  // the resumes run sequentially in the background while the daemon serves
+  // requests; per-conversation failures are logged inside.
+  if (conversationsToResume.length > 0) {
+    log.info(
+      { count: conversationsToResume.length },
+      "Resuming conversations interrupted by the previous process",
+    );
+    void resumeInterruptedConversations(conversationsToResume);
+  }
 
   log.info(
     {

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -86,6 +86,7 @@ import {
   enqueuePurgeConversationLexical,
 } from "./job-handlers/message-lexical.js";
 import {
+  rawAll,
   rawExec,
   rawGet,
   rawLogsRun,
@@ -2377,12 +2378,21 @@ export function unarchiveConversation(id: string): boolean {
  * Persist the processing-start timestamp for a conversation. Called by
  * `Conversation.setProcessing(true)` so out-of-process callers can detect
  * mid-turn state by reading the `conversations` row directly. Pass `null`
- * to clear (turn ended).
+ * to clear (turn ended); a clean turn end also closes any interruption
+ * streak, so the startup auto-resume budget refills.
  */
 export function setConversationProcessingStartedAt(
   id: string,
   startedAt: number | null,
 ): void {
+  if (startedAt == null) {
+    rawRun(
+      "conversation:setProcessingStartedAt",
+      "UPDATE conversations SET processing_started_at = NULL, processing_resume_attempts = 0 WHERE id = ?",
+      id,
+    );
+    return;
+  }
   rawRun(
     "conversation:setProcessingStartedAt",
     "UPDATE conversations SET processing_started_at = ? WHERE id = ?",
@@ -2402,6 +2412,43 @@ export function clearStaleProcessingFlags(): number {
   return rawRun(
     "conversation:clearStaleProcessingFlags",
     "UPDATE conversations SET processing_started_at = NULL WHERE processing_started_at IS NOT NULL",
+  );
+}
+
+export interface InterruptedConversationRow {
+  id: string;
+  /** Consecutive startup auto-resume attempts since the last clean turn end. */
+  resumeAttempts: number;
+}
+
+/**
+ * Conversations whose persisted processing flag is still set. Read at daemon
+ * startup before {@link clearStaleProcessingFlags} so the interrupted-turn
+ * reconciler knows which conversations were mid-turn when the previous
+ * process exited.
+ */
+export function listInterruptedConversations(): InterruptedConversationRow[] {
+  return rawAll<{ id: string; processing_resume_attempts: number }>(
+    "conversation:listInterrupted",
+    "SELECT id, processing_resume_attempts FROM conversations WHERE processing_started_at IS NOT NULL",
+  ).map((row) => ({
+    id: row.id,
+    resumeAttempts: row.processing_resume_attempts,
+  }));
+}
+
+/**
+ * Bump the persisted auto-resume counter for a conversation the startup
+ * reconciler is about to resume. Intentionally left set by
+ * {@link clearStaleProcessingFlags} — the counter must survive the flag clear
+ * so the resume cap holds across boots. Reset to 0 by the clean turn-end
+ * write in {@link setConversationProcessingStartedAt}.
+ */
+export function incrementProcessingResumeAttempts(id: string): void {
+  rawRun(
+    "conversation:incrementResumeAttempts",
+    "UPDATE conversations SET processing_resume_attempts = processing_resume_attempts + 1 WHERE id = ?",
+    id,
   );
 }
 

--- a/assistant/src/persistence/migrations/322-add-processing-resume-attempts.ts
+++ b/assistant/src/persistence/migrations/322-add-processing-resume-attempts.ts
@@ -1,0 +1,31 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
+
+const COLUMN_NAME = "processing_resume_attempts";
+const COLUMN_DEFINITION =
+  "processing_resume_attempts INTEGER NOT NULL DEFAULT 0";
+
+/**
+ * Add `processing_resume_attempts` column to the `conversations` table.
+ *
+ * Counts consecutive startup auto-resumes of an interrupted turn. The startup
+ * reconciler (`daemon/interrupted-turn-reconciler.ts`) increments it when it
+ * wakes a conversation whose `processing_started_at` was left set by a
+ * previous process, and refuses to resume once the counter reaches the cap —
+ * a turn that repeatedly takes the process down with it cannot resume-loop
+ * across boots. A clean turn end (`setConversationProcessingStartedAt(id,
+ * null)`) resets the counter to 0.
+ *
+ * No backfill is needed — all existing rows default to 0 (no resume attempts),
+ * which is correct for any conversation that has never been auto-resumed.
+ *
+ * Idempotent: guarded with `tableHasColumn` so a crash between the `ALTER
+ * TABLE` and the checkpoint write doesn't cause a duplicate-column error on
+ * the next boot.
+ */
+export function migrateAddProcessingResumeAttempts(database: DrizzleDb): void {
+  if (tableHasColumn(database, "conversations", COLUMN_NAME)) {
+    return;
+  }
+  database.run(`ALTER TABLE conversations ADD COLUMN ${COLUMN_DEFINITION}`);
+}

--- a/assistant/src/persistence/schema/conversations.ts
+++ b/assistant/src/persistence/schema/conversations.ts
@@ -64,6 +64,16 @@ export const conversations = sqliteTable(
      */
     processingStartedAt: integer("processing_started_at"),
     /**
+     * Count of consecutive startup auto-resume attempts for this
+     * conversation's interrupted turn. Incremented by the startup reconciler
+     * when it wakes a conversation whose `processing_started_at` survived the
+     * previous process; reset to 0 whenever a turn ends cleanly. Caps
+     * resume-loops for turns that repeatedly take the process down.
+     */
+    processingResumeAttempts: integer("processing_resume_attempts")
+      .notNull()
+      .default(0),
+    /**
      * Highest stream `seq` whose content is durably persisted to this
      * conversation's message rows. Seeded with the global high-water seq when
      * the row is inserted and advanced on each persistence flush

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -429,6 +429,7 @@ import { migrateDropContactChannelTelemetry } from "./migrations/318-drop-contac
 import { migrateRemoveLegacyManagedConnections } from "./migrations/319-remove-legacy-managed-connections.js";
 import { migrateDropTraceEventsTable } from "./migrations/320-drop-trace-events-table.js";
 import { migrateCanonicalGuardianRequestTrigger } from "./migrations/321-canonical-guardian-request-trigger.js";
+import { migrateAddProcessingResumeAttempts } from "./migrations/322-add-processing-resume-attempts.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1329,4 +1330,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateRemoveLegacyManagedConnections,
   migrateDropTraceEventsTable,
   migrateCanonicalGuardianRequestTrigger,
+  migrateAddProcessingResumeAttempts,
 ];


### PR DESCRIPTION
## Summary
- Stale `processing_started_at` flags are now **always cleared at startup** — the `resumeProcessingOnStartup: true` branch was an empty TODO that also skipped the clearing, stranding conversations as perpetually "processing" (busy in every client, skipped by memory retrospectives) until some later turn on the same conversation completed.
- When `conversations.resumeProcessingOnStartup` is enabled (default stays `false`), each interrupted conversation is resumed after startup completes via the existing conversation-wake machinery: a clientless background turn carrying an interruption notice, run under the conversation's own resting trust (no guardian elevation), so the model decides what still needs doing instead of mechanically replaying tool calls whose side effects may already have landed.
- New `processing_resume_attempts` column (migration 322, idempotent, no backfill) caps consecutive auto-resumes at 2 per conversation; a clean turn end resets the budget. A resumed turn that keeps killing the process is left idle with a warning instead of resume-looping across boots.

## Design notes
Resume-via-wake rather than agent-loop replay is deliberate: tool executions are not idempotent, the transcript already contains everything the interrupted turn persisted, and `wakeAgentForOpportunity` already handles single-flight, archived conversations, pinned inference profiles, and busy-wait. Wakes kick off fire-and-forget only after `setStartupComplete()` (they need providers/CES up) and run sequentially to avoid a thundering herd of LLM turns at boot. The default path does zero LLM work at startup. The detection half (persisted flag + clear-on-startup) shipped in #36395; this completes the deferred resume half. The fatal-error policy in `shutdown-handlers.ts` is intentionally untouched.

## Original prompt
Investigated a finding that turns in flight at daemon crash/shutdown silently die (the `lifecycle.ts` TODO) and confirmed it real, including a latent bug where enabling the schema-documented `resumeProcessingOnStartup` option stranded processing flags forever. Asked to implement the reconciliation: always clear stale flags, add capped auto-resume through the existing wake machinery with model-mediated redo per the Assistant-Driven Judgement rule, and leave the shutdown-handler fatal-error policy out of scope.