### PR TITLE
marketplace: add youtube-manager plugin

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -352,6 +352,18 @@
       "category": "marketing",
       "homepage": "https://github.com/ZeebBoyBlue/influencer",
       "license": "MIT"
+    },
+    {
+      "name": "youtube-manager",
+      "source": {
+        "source": "github",
+        "repo": "ZeebBoyBlue/youtube-manager",
+        "ref": "0edc6e2fdf4a1c6e3c3e71120199b3e3bb018a23"
+      },
+      "description": "YouTube manager for your assistant: search, video and channel analytics, comment mining, trending research, and a persistent channel watchlist with digests. Auths through the managed Google OAuth connection (youtube.readonly) with API-key fallback.",
+      "category": "lifestyle",
+      "homepage": "https://github.com/ZeebBoyBlue/youtube-manager",
+      "license": "MIT"
     }
   ]
 }


### PR DESCRIPTION
Adds **youtube-manager** to the plugin marketplace.

**Repo:** https://github.com/ZeebBoyBlue/youtube-manager
**Pinned commit:** `8c9cd9e63907d84ac10dacc30d4e8e3c350d13df`

YouTube research and channel management for the Vellum assistant:
- Seven tools: `youtube_search`, `youtube_video`, `youtube_channel`, `youtube_playlist`, `youtube_comments`, `youtube_trending`, `youtube_watchlist` (persistent competitor watchlist with since-last-check digests)
- One skill with report workflows (performance breakdowns, competitor snapshots, comment idea mining)
- Auth: managed Google OAuth first via `assistant oauth request` (needs `youtube.readonly` scope — the error message walks users through adding it), YouTube Data API key fallback. No raw tokens handled, no secrets in chat.
- Quota-aware: search (100 units) discouraged in favor of ID lookups (1 unit); quota errors surface with guidance
- Manifest: unscoped kebab-case name, MIT license, `@vellumai/plugin-api` peerDep `^0.10.0`

Verified locally: `assistant plugins list` shows status `ok`, tools exercised end-to-end over managed OAuth (channel overview + recent uploads with stats).