### PR TITLE
feat(design-library): translate-safe Button label + loading prop

### DIFF
--- a/clients/web/src/domains/chat/components/surfaces/dynamic-page-surface.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/dynamic-page-surface.test.tsx
@@ -47,7 +47,9 @@ function isOpenAppEnabled(html: string): boolean {
   const openAppMatch = html.match(
     /<button([^>]*)>(?:(?!<\/button>)[\s\S])*?Open App/,
   );
-  if (!openAppMatch) return false;
+  if (!openAppMatch) {
+    return false;
+  }
   return !openAppMatch[1].includes('disabled=""');
 }
 

--- a/clients/web/src/domains/chat/components/surfaces/dynamic-page-surface.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/dynamic-page-surface.test.tsx
@@ -40,9 +40,15 @@ function surface(data: Record<string, unknown>): Surface {
 }
 
 function isOpenAppEnabled(html: string): boolean {
-  const openAppMatch = html.match(/<button[^>]*>(?:<[^>]*>)*Open App<\/button>/);
+  // Match the <button> that contains the "Open App" label, tolerating any
+  // child markup between the open tag and the text (icon spans and the
+  // translate-safe label span the design-library Button wraps text in), then
+  // check the button tag's own attributes for the disabled flag.
+  const openAppMatch = html.match(
+    /<button([^>]*)>(?:(?!<\/button>)[\s\S])*?Open App/,
+  );
   if (!openAppMatch) return false;
-  return !openAppMatch[0].includes('disabled=""');
+  return !openAppMatch[1].includes('disabled=""');
 }
 
 describe("DynamicPageSurface", () => {

--- a/packages/design-library/src/components/button.stories.tsx
+++ b/packages/design-library/src/components/button.stories.tsx
@@ -16,6 +16,7 @@ const meta: Meta<typeof Button> = {
       options: ["regular", "compact"],
     },
     disabled: { control: "boolean" },
+    loading: { control: "boolean" },
     fullWidth: { control: "boolean" },
     active: { control: "boolean" },
   },
@@ -64,6 +65,10 @@ export const Compact: Story = {
 
 export const Disabled: Story = {
   args: { variant: "primary", disabled: true, children: "Disabled" },
+};
+
+export const Loading: Story = {
+  args: { variant: "primary", loading: true, children: "Connecting" },
 };
 
 export const WithIcons: Story = {

--- a/packages/design-library/src/components/button.test.tsx
+++ b/packages/design-library/src/components/button.test.tsx
@@ -177,6 +177,20 @@ describe("Button rendering", () => {
     expect(html).toContain(">Link</a>");
     expect(html).not.toContain('data-slot="button-label"');
   });
+
+  test("does not wrap structured (multi-element) children, keeping them as direct flex items", () => {
+    const html = renderToStaticMarkup(
+      <Button>
+        <span data-testid="title">Title</span>
+        <span data-testid="pill">3</span>
+      </Button>,
+    );
+    // Only plain text labels are wrapped; structured content stays as direct
+    // children so `justify-between`/flex layouts are preserved.
+    expect(html).not.toContain('data-slot="button-label"');
+    expect(html).toContain('data-testid="title"');
+    expect(html).toContain('data-testid="pill"');
+  });
 });
 
 describe("Button loading state", () => {
@@ -215,6 +229,16 @@ describe("Button loading state", () => {
     );
     expect(html).toContain("animate-spin");
     expect(html).not.toContain('data-testid="left-icon"');
+  });
+
+  test("preserves a caller-provided aria-busy when not loading", () => {
+    const html = renderToStaticMarkup(<Button aria-busy>Busy</Button>);
+    expect(html).toContain('aria-busy="true"');
+  });
+
+  test("sets no aria-busy when neither loading nor caller-provided", () => {
+    const html = renderToStaticMarkup(<Button>Idle</Button>);
+    expect(html).not.toContain("aria-busy");
   });
 });
 

--- a/packages/design-library/src/components/button.test.tsx
+++ b/packages/design-library/src/components/button.test.tsx
@@ -13,11 +13,13 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { Button } from "./button";
 
 describe("Button rendering", () => {
-  test("renders a <button> by default with type=button and children", () => {
+  test("renders a <button> by default with type=button and a wrapped label", () => {
     const html = renderToStaticMarkup(<Button>Hello</Button>);
     expect(html).toContain("<button");
     expect(html).toContain('type="button"');
-    expect(html).toContain(">Hello</button>");
+    // The label is wrapped in a stable element so browser page translation
+    // never re-parents a bare text node React owns (translate-dom-guard).
+    expect(html).toContain('<span data-slot="button-label">Hello</span>');
   });
 
   test("asChild renders the slotted element instead of <button>", () => {
@@ -155,6 +157,64 @@ describe("Button rendering", () => {
     expect(() =>
       renderToStaticMarkup(<Button ref={ref}>Ref</Button>),
     ).not.toThrow();
+  });
+
+  test("icon+label path wraps the label in a stable element", () => {
+    const html = renderToStaticMarkup(
+      <Button leftIcon={<svg data-testid="left-icon" aria-hidden />}>Save</Button>,
+    );
+    expect(html).toContain('data-testid="left-icon"');
+    expect(html).toContain('<span data-slot="button-label">Save</span>');
+  });
+
+  test("asChild does not wrap the label (Slot needs its single element child)", () => {
+    const html = renderToStaticMarkup(
+      <Button asChild>
+        <a href="/x">Link</a>
+      </Button>,
+    );
+    expect(html).toContain("<a");
+    expect(html).toContain(">Link</a>");
+    expect(html).not.toContain('data-slot="button-label"');
+  });
+});
+
+describe("Button loading state", () => {
+  test("loading renders a spinner, disables the button, and sets aria-busy", () => {
+    const html = renderToStaticMarkup(<Button loading>Connect</Button>);
+    expect(html).toContain("animate-spin");
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toMatch(/<button[^>]*\sdisabled(?:=""|\s|>)/);
+    // The label still renders (wrapped), alongside the spinner.
+    expect(html).toContain('<span data-slot="button-label">Connect</span>');
+  });
+
+  test("loading disables interaction even without an explicit disabled prop", () => {
+    const onClick = mock(() => {});
+    const html = renderToStaticMarkup(
+      <Button loading onClick={onClick}>
+        Go
+      </Button>,
+    );
+    expect(html).toMatch(/<button[^>]*\sdisabled(?:=""|\s|>)/);
+  });
+
+  test("loading replaces the icon of an icon-only button with the spinner", () => {
+    const html = renderToStaticMarkup(
+      <Button loading iconOnly={<svg data-testid="only-icon" />} aria-label="a" />,
+    );
+    expect(html).toContain("animate-spin");
+    expect(html).not.toContain('data-testid="only-icon"');
+  });
+
+  test("loading takes precedence over a provided leftIcon", () => {
+    const html = renderToStaticMarkup(
+      <Button loading leftIcon={<svg data-testid="left-icon" />}>
+        Save
+      </Button>,
+    );
+    expect(html).toContain("animate-spin");
+    expect(html).not.toContain('data-testid="left-icon"');
   });
 });
 

--- a/packages/design-library/src/components/button.tsx
+++ b/packages/design-library/src/components/button.tsx
@@ -303,6 +303,17 @@ export function Button({
   // icon-only button); everything else keeps its normal layout.
   const effectiveLeftIcon = isLoading && !isIconOnly ? spinner : leftIcon;
   const effectiveIconOnly = isLoading && isIconOnly ? spinner : iconOnly;
+  // Wrap only plain text labels in a stable element so browser page
+  // translation mutates a node React owns rather than a bare text sibling of
+  // the icons (see translate-dom-guard). Structured children (elements /
+  // arrays) stay as direct flex children so callers relying on the button as a
+  // flex container — e.g. `justify-between` layouts — are unaffected.
+  const label =
+    typeof children === "string" || typeof children === "number" ? (
+      <span data-slot="button-label">{children}</span>
+    ) : (
+      children
+    );
   const iconStyle: CSSProperties = {
     width: iconPx,
     height: iconPx,
@@ -341,7 +352,7 @@ export function Button({
       ref={ref}
       type={asChild ? undefined : (type ?? "button")}
       disabled={asChild ? undefined : isDisabled}
-      aria-busy={isLoading || undefined}
+      aria-busy={isLoading ? true : rest["aria-busy"]}
       aria-disabled={isSlotDisabled ? true : rest["aria-disabled"]}
       data-disabled={isSlotDisabled ? "" : undefined}
       data-slot="button"
@@ -373,35 +384,23 @@ export function Button({
           </span>
         )
       ) : effectiveLeftIcon == null && rightIcon == null ? (
-        // Label wrapped in a stable element (non-asChild) so browser page
-        // translation mutates text nodes React does not own directly — see
-        // translate-dom-guard. `asChild` keeps its single element child intact
-        // for Slot.
-        asChild ? (
-          children
-        ) : (
-          <span data-slot="button-label">{children}</span>
-        )
+        // `asChild` keeps its single element child intact for Slot; otherwise
+        // render the (translate-safe) label.
+        asChild ? children : label
       ) : (
         // When `asChild` is set, `Comp` is Radix's `Slot`, which forwards its
         // props (e.g. `type`, `disabled`) onto its single React-element child.
         // A bare Fragment can't accept those props — React 19 hard-errors with
         // "Invalid prop `type` supplied to React.Fragment". `Slottable` marks
         // `children` as the prop target so Slot clones the caller's element
-        // and re-parents the icons as its children. In the non-asChild path
-        // (`Comp === "button"`) the label is wrapped in a stable element so
-        // page translation never re-parents a bare text sibling of the icons.
+        // and re-parents the icons as its children.
         <>
           {effectiveLeftIcon != null ? (
             <span aria-hidden="true" style={iconStyle}>
               {effectiveLeftIcon}
             </span>
           ) : null}
-          {asChild ? (
-            <Slottable>{children}</Slottable>
-          ) : children != null ? (
-            <span data-slot="button-label">{children}</span>
-          ) : null}
+          {asChild ? <Slottable>{children}</Slottable> : label}
           {rightIcon != null ? (
             <span aria-hidden="true" style={iconStyle}>
               {rightIcon}

--- a/packages/design-library/src/components/button.tsx
+++ b/packages/design-library/src/components/button.tsx
@@ -1,5 +1,6 @@
 import { Slot, Slottable } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
+import { Loader2 } from "lucide-react";
 import {
   cloneElement,
   isValidElement,
@@ -21,6 +22,8 @@ import { Tooltip } from "./tooltip";
  *
  * - Pass `variant` for chrome style and `size` for dimensions.
  * - Pass `leftIcon` / `rightIcon` for text+icon layouts.
+ * - Pass `loading` to show a spinner in place of the left icon (or the icon of
+ *   an icon-only button), disable interaction, and set `aria-busy`.
  * - Pass `iconOnly` to render a square icon-only button (the icon is centered
  *   at the correct size for the chosen `size`). Without `asChild` the children
  *   are ignored; with `asChild` the caller's element (e.g. a `Link`) becomes
@@ -236,6 +239,11 @@ export interface ButtonProps
   leftIcon?: ReactNode;
   rightIcon?: ReactNode;
   iconOnly?: ReactNode;
+  /**
+   * Render a spinner and disable the button. Replaces `leftIcon` (or, for an
+   * icon-only button, the icon) with a spinner and sets `aria-busy`.
+   */
+  loading?: boolean;
   fullWidth?: boolean;
   active?: boolean;
   /**
@@ -266,6 +274,7 @@ export function Button({
   leftIcon,
   rightIcon,
   iconOnly,
+  loading = false,
   fullWidth = false,
   active = false,
   expandOnMobile = true,
@@ -283,9 +292,17 @@ export function Button({
   ...rest
 }: ButtonProps) {
   const isIconOnly = iconOnly != null && iconOnly !== false;
-  const isDisabled = disabled === true;
+  const isLoading = loading === true;
+  const isDisabled = disabled === true || isLoading;
   const isSlotDisabled = asChild && isDisabled;
   const iconPx = iconPxForSize(size);
+  const spinner = (
+    <Loader2 className="animate-spin" width={iconPx} height={iconPx} aria-hidden />
+  );
+  // When loading, the spinner stands in for the left icon (or the icon of an
+  // icon-only button); everything else keeps its normal layout.
+  const effectiveLeftIcon = isLoading && !isIconOnly ? spinner : leftIcon;
+  const effectiveIconOnly = isLoading && isIconOnly ? spinner : iconOnly;
   const iconStyle: CSSProperties = {
     width: iconPx,
     height: iconPx,
@@ -323,7 +340,8 @@ export function Button({
       {...rest}
       ref={ref}
       type={asChild ? undefined : (type ?? "button")}
-      disabled={asChild ? undefined : disabled}
+      disabled={asChild ? undefined : isDisabled}
+      aria-busy={isLoading || undefined}
       aria-disabled={isSlotDisabled ? true : rest["aria-disabled"]}
       data-disabled={isSlotDisabled ? "" : undefined}
       data-slot="button"
@@ -346,16 +364,24 @@ export function Button({
             children,
             undefined,
             <span aria-hidden="true" className={iconOnlyClass}>
-              {iconOnly}
+              {effectiveIconOnly}
             </span>,
           )
         ) : (
           <span aria-hidden="true" className={iconOnlyClass}>
-            {iconOnly}
+            {effectiveIconOnly}
           </span>
         )
-      ) : leftIcon == null && rightIcon == null ? (
-        children
+      ) : effectiveLeftIcon == null && rightIcon == null ? (
+        // Label wrapped in a stable element (non-asChild) so browser page
+        // translation mutates text nodes React does not own directly — see
+        // translate-dom-guard. `asChild` keeps its single element child intact
+        // for Slot.
+        asChild ? (
+          children
+        ) : (
+          <span data-slot="button-label">{children}</span>
+        )
       ) : (
         // When `asChild` is set, `Comp` is Radix's `Slot`, which forwards its
         // props (e.g. `type`, `disabled`) onto its single React-element child.
@@ -363,15 +389,19 @@ export function Button({
         // "Invalid prop `type` supplied to React.Fragment". `Slottable` marks
         // `children` as the prop target so Slot clones the caller's element
         // and re-parents the icons as its children. In the non-asChild path
-        // (`Comp === "button"`) Slottable is a transparent Fragment, so this
-        // is safe for both branches.
+        // (`Comp === "button"`) the label is wrapped in a stable element so
+        // page translation never re-parents a bare text sibling of the icons.
         <>
-          {leftIcon != null ? (
+          {effectiveLeftIcon != null ? (
             <span aria-hidden="true" style={iconStyle}>
-              {leftIcon}
+              {effectiveLeftIcon}
             </span>
           ) : null}
-          <Slottable>{children}</Slottable>
+          {asChild ? (
+            <Slottable>{children}</Slottable>
+          ) : children != null ? (
+            <span data-slot="button-label">{children}</span>
+          ) : null}
           {rightIcon != null ? (
             <span aria-hidden="true" style={iconStyle}>
               {rightIcon}

--- a/packages/design-library/src/components/confirm-dialog.tsx
+++ b/packages/design-library/src/components/confirm-dialog.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, Loader2 } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { Button } from "./button";
@@ -84,8 +84,7 @@ function ConfirmDialog({
           <Button
             variant={destructive ? "danger" : "primary"}
             onClick={onConfirm}
-            disabled={isPending}
-            leftIcon={isPending ? <Loader2 className="animate-spin" /> : undefined}
+            loading={isPending}
             {...{ [CONFIRM_BUTTON_ATTR]: "" }}
           >
             {confirmLabel}


### PR DESCRIPTION
## Context

Part of the browser-translation crash work (see #37578, #37596). Under Chrome/Safari page translation, React's reconciler crashes when it removes/reorders a bare text node the translator has re-parented ([facebook/react#11538](https://github.com/facebook/react/issues/11538)). The shared `Button`'s icon+label path rendered the label as a **bare text node sibling of the icon spans** — i.e. every icon+label button was an instance of the crash pattern.

## Changes

1. **Translate-safe label** — wrap the label in a stable `<span data-slot="button-label">` in the non-`asChild` render paths. Translation now mutates text nodes React doesn't own directly. `asChild` keeps its single element child intact for Radix `Slot`. This hardens **every existing Button consumer** at the component level.
2. **`loading` prop** — renders a spinner in place of the left icon (or an icon-only button's icon), sets `disabled` + `aria-busy`. Gives the copy-pasted `<Loader2 className="animate-spin"/>` + `disabled` idiom one canonical home (single-source-of-truth).
3. **Proof migration** — `ConfirmDialog` now uses `loading={isPending}` instead of the manual `leftIcon`/`disabled` combo (drops the duplicated idiom; no visual change). Added a `Loading` story + `loading` control.

## Scope note

The bespoke Figma-styled onboarding OAuth buttons are raw `<button>`s, not the design-library `Button` — folding them in is a visual-regression-prone refactor and is deliberately **not** in this PR. It belongs in the careful sweep (the planned ESLint-rule + `settings/` sweep PR), done with pixel-level verification.

## Verification

- `bunx tsc --noEmit` clean for `packages/design-library`.
- `button.test.tsx`: 33/33 pass, including new coverage for the wrapped label (icon and no-icon paths), `asChild` staying unwrapped, and the `loading` state (spinner, disabled, aria-busy, icon-only replacement, precedence over `leftIcon`).

## Reviewer note

The behavioral change consumers see is the label being wrapped in a span. I checked the layout-sensitive cases (`link` variant, `truncate`, flex `gap`) — the label span is inline, so it stays in the button's line box and ellipsis/gap behavior is preserved. Worth a second look at any consumer with unusual button-label CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->