### PR TITLE
fix(config): disable thinking on the memoryV3SelectL2 call-site default

### DIFF
--- a/assistant/src/config/call-site-defaults.ts
+++ b/assistant/src/config/call-site-defaults.ts
@@ -38,7 +38,11 @@ export const CALL_SITE_DEFAULTS: Record<LLMCallSite, CallSiteDefaultConfig> = {
     profile: "cost-optimized",
     contextWindow: { maxInputTokens: 1000000 },
   },
-  memoryV3SelectL2: { profile: "balanced", temperature: 0 },
+  memoryV3SelectL2: {
+    profile: "balanced",
+    temperature: 0,
+    thinking: { enabled: false, streamThinking: false },
+  },
   recall: {
     profile: "balanced",
     maxTokens: 4096,


### PR DESCRIPTION
## Summary
- Pin `thinking: { enabled: false, streamThinking: false }` on the shipped `memoryV3SelectL2` call-site default, mirroring the adjacent `recall` entry. The L2 memory selector is a forced-tool selection call and shouldn't spend reasoning tokens.
- Fleet usage telemetry (`llm_usage_raw`) showed the selector inheriting thinking from the balanced profile and emitting up to ~2.2k output tokens per call for a routing decision, at ~30k uncached input tokens per call.
- Scope note: on Fireworks-backed profiles a non-`none` `effort` still maps to `reasoning_effort` (see the cost-optimized profile comment in `default-profile-catalog.ts`), so fully stopping paid reasoning on the managed balanced path needs a follow-up effort change — deliberately deferred, as is `memoryV2Consolidation`.

## Original prompt
From a BigQuery cost decomposition of a heavy user's memory spend (30% of their bill was background memory jobs), the `memoryV3SelectL2` call site was identified as burning reasoning output tokens on a per-turn selection decision because the balanced profile enables thinking and the shipped call-site default didn't override it. Request: pin thinking off on `memoryV3SelectL2` only, explicitly leaving `effort` and `memoryV2Consolidation` untouched for now.