### PR TITLE
fix(onboarding): gate research claims on identity corroboration and real sources

### DIFF
--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -84,6 +84,7 @@ import {
   OnboardingStageSizeProvider,
   useElementSize,
 } from "@/domains/onboarding/hooks/use-onboarding-stage-size";
+import { getBrowserTimezone } from "@/utils/browser-timezone";
 
 /** Build the research subject from the collected form values. */
 function researchSubjectFrom(values: ResearchOnboardingValues): ResearchSubject {
@@ -92,6 +93,7 @@ function researchSubjectFrom(values: ResearchOnboardingValues): ResearchSubject 
     lastName: values.lastName,
     occupation: values.role,
     hobby: values.hobbies.join(", "),
+    timezone: getBrowserTimezone(),
   };
 }
 

--- a/clients/web/src/domains/onboarding/research-prompt.test.ts
+++ b/clients/web/src/domains/onboarding/research-prompt.test.ts
@@ -102,3 +102,69 @@ describe("buildResearchPrompt — suggestions toggle", () => {
     expect(prompt).not.toContain("broadly useful suggestions");
   });
 });
+
+describe("buildResearchPrompt — identity gate & confidence calibration", () => {
+  test("states the identity gate and the honest no-match fallback", () => {
+    const prompt = buildResearchPrompt(SUBJECT);
+
+    expect(prompt).toContain("IDENTITY GATE");
+    expect(prompt).toContain(
+      "a name match alone is NEVER enough to attribute a page to me",
+    );
+    expect(prompt).toContain('each labeled "guessing" with "sources": []');
+  });
+
+  test("skips research entirely on placeholder or joke input", () => {
+    const prompt = buildResearchPrompt(SUBJECT);
+
+    expect(prompt).toContain("placeholder or joke input");
+    expect(prompt).toContain(
+      "skip the web search and return an empty claims array",
+    );
+  });
+
+  test("ties confidence tiers to evidence instead of demanding a spread", () => {
+    const prompt = buildResearchPrompt(SUBJECT);
+
+    // The old instruction manufactured false confidence for people with no
+    // public footprint — it must not come back.
+    expect(prompt).not.toContain("Aim for at least one");
+    expect(prompt).toContain(
+      '"confident" needs 2+ independent gate-passing sources',
+    );
+    expect(prompt).toContain('must be "guessing"');
+  });
+
+  test("bans aggregator sources and synthesized specifics", () => {
+    const prompt = buildResearchPrompt(SUBJECT);
+
+    expect(prompt).toContain(
+      "Never fetch or cite people-search or background-check aggregators",
+    );
+    expect(prompt).toContain("never synthesize or embellish specifics");
+  });
+
+  test("renders the timezone line only when a timezone is given", () => {
+    const withTz = buildResearchPrompt({
+      ...SUBJECT,
+      timezone: "America/Denver",
+    });
+
+    expect(withTz).toContain("My timezone is America/Denver.");
+    expect(buildResearchPrompt(SUBJECT)).not.toContain("My timezone is");
+  });
+
+  test("an empty form still yields the get-to-know-me fallback, not a bare timezone", () => {
+    const prompt = buildResearchPrompt({
+      firstName: "",
+      lastName: "",
+      occupation: "",
+      timezone: "America/Denver",
+    });
+
+    expect(prompt).toContain(
+      "I'd like you to get to know me before we start working together.",
+    );
+    expect(prompt).not.toContain("My timezone is");
+  });
+});

--- a/clients/web/src/domains/onboarding/research-prompt.ts
+++ b/clients/web/src/domains/onboarding/research-prompt.ts
@@ -25,6 +25,12 @@ export interface ResearchSubject {
   lastName: string;
   occupation: string;
   hobby?: string;
+  /**
+   * IANA timezone of the user's browser (e.g. "America/Denver"). A soft
+   * location signal the prompt's identity gate checks candidate matches
+   * against; the line is omitted when absent.
+   */
+  timezone?: string;
 }
 
 /**
@@ -86,7 +92,7 @@ export interface BuildResearchPromptOptions {
 }
 
 export function buildResearchPrompt(
-  { firstName, lastName, occupation, hobby }: ResearchSubject,
+  { firstName, lastName, occupation, hobby, timezone }: ResearchSubject,
   availableCapabilities: AvailableCapability[] = [],
   { includeSuggestions = true }: BuildResearchPromptOptions = {},
 ): string {
@@ -95,6 +101,7 @@ export function buildResearchPrompt(
     .join(" ");
   const role = occupation.trim();
   const hobbyText = hobby?.trim() ?? "";
+  const timezoneText = timezone?.trim() ?? "";
   const capabilitiesBlock = renderCapabilitiesBlock(
     availableCapabilities,
     includeSuggestions,
@@ -106,15 +113,20 @@ export function buildResearchPrompt(
     ? `"plugins": ["<exact name from the list above>"], `
     : "";
 
-  const identity =
-    [
-      fullName ? `My name is ${fullName}.` : "",
-      role ? `I work as ${role}.` : "",
-      hobbyText ? `My hobby is ${hobbyText}.` : "",
-    ]
-      .filter(Boolean)
-      .join(" ") ||
-    "I'd like you to get to know me before we start working together.";
+  const statedDetails = [
+    fullName ? `My name is ${fullName}.` : "",
+    role ? `I work as ${role}.` : "",
+    hobbyText ? `My hobby is ${hobbyText}.` : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  // The timezone only augments real stated details — on an empty form the
+  // fallback line must still win, not a bare timezone.
+  const identity = statedDetails
+    ? [statedDetails, timezoneText ? `My timezone is ${timezoneText}.` : ""]
+        .filter(Boolean)
+        .join(" ")
+    : "I'd like you to get to know me before we start working together.";
 
   // The clickable-suggestions block is optional: the "Let's chat" final step
   // (personality-onboarding flag) installs the picked plugins and drops the
@@ -122,7 +134,7 @@ export function buildResearchPrompt(
   const suggestionsArrayExample = includeSuggestions
     ? ` "suggestions": [ { "suggestion": "I'll find the 3 newest arXiv eval papers worth your time", "prompt": "Find me the 3 newest arXiv eval papers worth reading." }, { "suggestion": "I'll draft a crisp summary of the latest model-serving trade-offs", "prompt": "Draft me a short summary of the latest model-serving trade-offs." }, { "suggestion": "Connect GitHub and I'll triage your stalest issues", "prompt": "Connect to GitHub and triage my oldest open issues." }, { "suggestion": "I'll plan a weekend climbing trip near Boulder", "prompt": "Plan me a weekend climbing trip near Boulder." } ]`
     : "";
-  const claimsExample = `"claims": [ { "claim": "Senior engineer at an AI infra startup", "confidence": "confident", "sources": ["https://linkedin.com/in/example-user"] }, { "claim": "Based in Boulder, CO", "confidence": "confident", "sources": ["https://linkedin.com/in/example-user"] }, { "claim": "Active climber on Mountain Project", "confidence": "maybe", "sources": [] }, { "claim": "Focused on evals or model serving infrastructure", "confidence": "guessing", "sources": ["https://github.com/example-user"] } ]`;
+  const claimsExample = `"claims": [ { "claim": "Senior engineer at an AI infra startup", "confidence": "confident", "sources": ["https://linkedin.com/in/example-user", "https://example-infra.com/about"] }, { "claim": "Based in Boulder, CO", "confidence": "maybe", "sources": ["https://linkedin.com/in/example-user"] }, { "claim": "Into climbing and the outdoors", "confidence": "guessing", "sources": [] } ]`;
   const shapeExample = `{ ${pluginsExample}${claimsExample}${
     suggestionsArrayExample ? `,${suggestionsArrayExample}` : ""
   } }`;
@@ -147,12 +159,14 @@ Keep each SHORT and skimmable: under 10 words, ONE clause, ONE artifact, no list
     : "";
 
   const closingFallback = includeSuggestions
-    ? `Don't include anything sensitive or private. If you found very little, lean on "guessing" claims and broadly useful suggestions for my role.`
-    : `Don't include anything sensitive or private. If you found very little, lean on "guessing" claims.`;
+    ? `Don't include anything sensitive or private. If the identity gate leaves you with very little, return only the honest "guessing" claims my stated details support, and lean on broadly useful suggestions for my role.`
+    : `Don't include anything sensitive or private. If the identity gate leaves you with very little, return only the honest "guessing" claims my stated details support.`;
 
   return `${identity}
 
-Get to know me. Search the web for what's publicly known about the person matching my name and role, and infer a handful of things about who I am: what I do, my role, where I'm based, what I'm into, anything that would help you assist me better. Lean on public sources (LinkedIn, company pages, social profiles, articles, personal sites, GitHub). It's fine to make reasonable inferences and label them honestly.
+Get to know me. Search the web for what's publicly known about me, and infer a handful of things about who I am: what I do, my role, where I'm based, what I'm into, anything that would help you assist me better. Prefer sources people author about themselves — LinkedIn, a personal site, GitHub, an employer's team page, published work, public social profiles. Never fetch or cite people-search or background-check aggregators (Instant Checkmate, Spokeo, BeenVerified, TruePeopleSearch, Whitepages, and similar); data-broker directories (ZoomInfo, RocketReach, Apollo) may corroborate another source but must never be a claim's only basis.
+
+IDENTITY GATE — decide who a page is about before you use it: a name match alone is NEVER enough to attribute a page to me. Attribute it to me only when it also corroborates something I stated — my role, my hobby, or a location consistent with my timezone if I gave one. If several people share my name and none clears that bar, or you find no verifiable match at all, then I have no public profile you can use: return ONLY inferences from what I stated above, each labeled "guessing" with "sources": []. An honest near-empty card beats a stranger's biography. If my details above read as placeholder or joke input rather than a real identity, skip the web search and return an empty claims array.
 
 Treat the name, role, and hobby I provided above as first-party context from me. Use public sources to enrich that context, not to override or correct it. If public sources use a different title or omit part of my stated role, do not frame my stated role as wrong; mention the public title only as supporting nuance when it is useful, and keep ${alignedArtifacts} aligned with my stated role.
 
@@ -162,10 +176,11 @@ ${shapeExample}
 
 Rules for "claims":
 
-AT MOST 5 claims, typically 3 to 4. Aim for at least one "confident" and at least one "guessing"; the rest "maybe".
+AT MOST 5 claims, typically 3 to 4. Never pad the list or inflate a confidence tier to seem thorough.
 Phrase each claim in third person as a short headline ("Senior engineer at an AI infra startup", "Based in Boulder, CO", "Active climber on Mountain Project"). No multi-clause sentences, no em-dash asides, no explanations. Good: "Contributed to Chirps (vector-DB security)". Bad: "You've done real work in vector database security. You contributed to Chirps, a tool for scanning vector DBs for sensitive data".
 Each claim must be independently true-or-false so I can remove the ones that are wrong.
-"confidence" is one of: "confident" (well supported by what you found), "maybe" (plausible but unverified), "guessing" (a hunch from limited signal).
+Every specific in a claim (employer, title, publication, city) must appear in a source you actually fetched this turn — never synthesize or embellish specifics a source doesn't state.
+"confidence" is earned per the identity gate: "confident" needs 2+ independent gate-passing sources, "maybe" needs exactly one, and a claim with no sources is an inference from my stated details and must be "guessing".
 "sources": 0 to 3 URLs you actually used as evidence for that specific claim. Use [] for pure inferences.
 ${suggestionRules}${capabilitiesBlock}
 ${closingFallback}

--- a/clients/web/src/utils/domains.ts
+++ b/clients/web/src/utils/domains.ts
@@ -16,7 +16,12 @@ export const PLATFORM_HOSTED_HOSTNAMES: readonly string[] = [
   APEX_DOMAIN,
 ];
 
+/** True when `host` is `domain` itself or any subdomain of it. */
+export function hostMatchesDomain(host: string, domain: string): boolean {
+  return host === domain || host.endsWith(`.${domain}`);
+}
+
 /** Check if a hostname belongs to the vellum.ai domain family. */
 export function isVellumDomain(host: string): boolean {
-  return host === APEX_DOMAIN || host.endsWith(`.${APEX_DOMAIN}`);
+  return hostMatchesDomain(host, APEX_DOMAIN);
 }

--- a/clients/web/src/utils/research-facts.test.ts
+++ b/clients/web/src/utils/research-facts.test.ts
@@ -162,6 +162,111 @@ describe("parseResearchResultStreaming — completeness signal", () => {
   });
 });
 
+describe("parseResearchResultStreaming — claim evidence guards", () => {
+  const payload = (claims: unknown[]): string =>
+    JSON.stringify({ claims, suggestions: [] });
+
+  test("downgrades a sourceless confident claim to maybe", () => {
+    const { claims } = parseResearchResultStreaming(
+      payload([{ claim: "Founder", confidence: "confident", sources: [] }]),
+    );
+
+    expect(claims).toEqual([
+      { claim: "Founder", confidence: "maybe", sources: [] },
+    ]);
+  });
+
+  test("keeps confident when real sources are attached", () => {
+    const { claims } = parseResearchResultStreaming(
+      payload([
+        {
+          claim: "Founder",
+          confidence: "confident",
+          sources: ["https://linkedin.com/in/example-user"],
+        },
+      ]),
+    );
+
+    expect(claims[0]?.confidence).toBe("confident");
+  });
+
+  test("leaves sourceless maybe and guessing tiers untouched", () => {
+    const { claims } = parseResearchResultStreaming(
+      payload([
+        { claim: "Based in Boulder", confidence: "maybe", sources: [] },
+        { claim: "Into climbing", confidence: "guessing", sources: [] },
+      ]),
+    );
+
+    expect(claims.map((c) => c.confidence)).toEqual(["maybe", "guessing"]);
+  });
+
+  test("drops a claim backed only by people-search aggregators", () => {
+    const { claims } = parseResearchResultStreaming(
+      payload([
+        {
+          claim: "Lives in Dallas",
+          confidence: "confident",
+          sources: [
+            "https://www.spokeo.com/example-user",
+            "https://profiles.beenverified.com/example-user",
+          ],
+        },
+        {
+          claim: "Founder",
+          confidence: "confident",
+          sources: ["https://linkedin.com/in/example-user"],
+        },
+      ]),
+    );
+
+    expect(claims).toEqual([
+      {
+        claim: "Founder",
+        confidence: "confident",
+        sources: ["https://linkedin.com/in/example-user"],
+      },
+    ]);
+  });
+
+  test("strips aggregator URLs from a mixed source list, keeping the claim", () => {
+    const { claims } = parseResearchResultStreaming(
+      payload([
+        {
+          claim: "Engineer at Acme",
+          confidence: "confident",
+          sources: [
+            "https://instantcheckmate.com/example-user",
+            "https://acme.example.com/team",
+          ],
+        },
+      ]),
+    );
+
+    expect(claims).toEqual([
+      {
+        claim: "Engineer at Acme",
+        confidence: "confident",
+        sources: ["https://acme.example.com/team"],
+      },
+    ]);
+  });
+
+  test("guards apply on the streaming path too", () => {
+    // Claims surface mid-stream through the same mapper, so a half-delivered
+    // payload must never flash an aggregator-only claim before settling.
+    const partial =
+      '{ "claims": [ { "claim": "Lives in Dallas", "confidence": "confident", "sources": ["https://spokeo.com/x"] }, { "claim": "Founder", "confidence": "confident", "sources": [] }, { "claim": "half-writ';
+
+    const { claims, complete } = parseResearchResultStreaming(partial);
+
+    expect(complete).toBe(false);
+    expect(claims).toEqual([
+      { claim: "Founder", confidence: "maybe", sources: [] },
+    ]);
+  });
+});
+
 describe("pluginDisplayName", () => {
   test("title-cases a hyphenated install name", () => {
     expect(pluginDisplayName("marketing-expert")).toBe("Marketing Expert");

--- a/clients/web/src/utils/research-facts.ts
+++ b/clients/web/src/utils/research-facts.ts
@@ -20,6 +20,8 @@
  * `DisplayMessage`-bound helpers) so existing importers are unaffected.
  */
 
+import { hostMatchesDomain } from "@/utils/domains";
+
 export type ResearchConfidence = "confident" | "maybe" | "guessing";
 
 /** Optional reason a user gives when removing a claim. */
@@ -72,6 +74,44 @@ function normalizeConfidence(raw: unknown): ResearchConfidence {
 function normalizeSources(raw: unknown): string[] {
   if (!Array.isArray(raw)) return [];
   return raw.filter((s): s is string => typeof s === "string" && s.trim().length > 0);
+}
+
+/**
+ * People-search / background-check aggregators. Scraped-data directories are
+ * weak identity evidence and alarming to see cited on the card, so their URLs
+ * are stripped from every claim's sources — and a claim backed ONLY by them is
+ * dropped entirely.
+ */
+const AGGREGATOR_SOURCE_DENYLIST = [
+  "beenverified.com",
+  "checkpeople.com",
+  "clustrmaps.com",
+  "cyberbackgroundchecks.com",
+  "fastpeoplesearch.com",
+  "instantcheckmate.com",
+  "intelius.com",
+  "mylife.com",
+  "nuwber.com",
+  "peekyou.com",
+  "peoplefinders.com",
+  "peoplelooker.com",
+  "radaris.com",
+  "spokeo.com",
+  "thatsthem.com",
+  "truepeoplesearch.com",
+  "truthfinder.com",
+  "usphonebook.com",
+  "ussearch.com",
+  "whitepages.com",
+];
+
+/** True when the URL's host is (or is a subdomain of) a denylisted aggregator. */
+function isAggregatorSource(url: string): boolean {
+  const host = domainFromUrl(url);
+  if (!host) return false;
+  return AGGREGATOR_SOURCE_DENYLIST.some((domain) =>
+    hostMatchesDomain(host, domain),
+  );
 }
 
 /** Strip a (possibly unterminated) ```json fence so the body is raw JSON-ish. */
@@ -127,10 +167,21 @@ function toFact(entry: unknown): ResearchFact | null {
   if (!entry || typeof entry !== "object") return null;
   const claim = (entry as { claim?: unknown }).claim;
   if (typeof claim !== "string" || !claim.trim()) return null;
+  const rawSources = normalizeSources((entry as { sources?: unknown }).sources);
+  const sources = rawSources.filter((s) => !isAggregatorSource(s));
+  // A web-sourced claim whose every source is an aggregator has no evidence
+  // worth showing — drop it rather than render it as if it were sourceless.
+  if (rawSources.length > 0 && sources.length === 0) return null;
+  const confidence = normalizeConfidence(
+    (entry as { confidence?: unknown }).confidence,
+  );
   return {
     claim: claim.trim(),
-    confidence: normalizeConfidence((entry as { confidence?: unknown }).confidence),
-    sources: normalizeSources((entry as { sources?: unknown }).sources),
+    // Sourceless "confident" caps at "maybe" — the deterministic backstop for
+    // a model that inflates tiers past the prompt's evidence rubric.
+    confidence:
+      confidence === "confident" && sources.length === 0 ? "maybe" : confidence,
+    sources,
   };
 }
 


### PR DESCRIPTION
## Summary
- Rewrites the research-onboarding prompt around an explicit **identity gate**: a name match alone never attributes a page to the user — it must corroborate the stated role, hobby, or a timezone-consistent location; when no candidate clears the bar (or input looks like placeholder/joke data) the reply returns honest stated-info "guessing" claims instead of the best-ranked namesake. Confidence tiers are now evidence-calibrated ("confident" = 2+ gate-passing sources, sourceless = "guessing"), replacing the old "aim for at least one confident" instruction that manufactured false confidence; adds an anti-fabrication rule and bans people-search/background-check sources. The browser timezone rides along on `ResearchSubject` as the soft location signal.
- Adds deterministic parser guards in `research-facts.ts` as a model-independent backstop: sourceless "confident" claims downgrade to "maybe"; people-search aggregator URLs are stripped from claim sources (their favicons never render on the card) and claims backed *only* by aggregators are dropped.
- Extracts `hostMatchesDomain` into `utils/domains.ts`, now shared by `isVellumDomain` and the aggregator denylist check.

## Why
The 18h post-v0.10.7 usage analysis measured the research card's wrong-person problem directly: **38% of research-onboarding users had to correct their card and 13.6% rejected it wholesale via "This is not me"** (184 research turns / 169 users, 07-06→07-08, bots and dev builds excluded). Worst cases: fully fabricated biographies (a fake 2024 paper co-authorship), a 13-year-old matched to an adult, and cards citing instantcheckmate.

## Tracking metric
The correction messages are templated (`Correction: none of what you found…` / `Quick correction on what you found about me…`), so the rate is directly measurable in `telemetry.pii_turn_raw` — watch full-rejection and correction rates after the next web deploy against the 13.6% / 38% baseline.

## Original prompt
From the 2026-07-08 post-release telemetry deep-dive: investigate and fix the onboarding research-card wrong-person rate. Agreed approach was a two-layer fix in the web client — rewrite `buildResearchPrompt` (identity gate, evidence-calibrated confidence, anti-fabrication, aggregator source ban, placeholder guard, timezone signal) plus mechanical guards in the claims parser (sourceless-confident downgrade, aggregator strip/drop) — keeping the JSON payload contract unchanged and the added prompt text compact.