### PR TITLE
chore(plugins): bump cofounder to skill-scoped tools revision

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -106,7 +106,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/cofounder",
-        "ref": "9c7d8febcd3bd2c04d7e063724383046ae88ce78"
+        "ref": "547adf1c0db0cbb32855ff0e4ef46c056248bdea"
       },
       "description": "AI co-founder that remembers your company context, challenges your thinking, and tracks your decisions.",
       "category": "productivity",


### PR DESCRIPTION
Bumps the `cofounder` marketplace pin to [`547adf1`](https://github.com/vellum-ai/cofounder/commit/547adf1c0db0cbb32855ff0e4ef46c056248bdea), which restructures the plugin so it no longer exposes always-on tools.

## What changed in the plugin

- The five `cofounder_*` tools (profile, decision, blindspot, briefing, okr) moved from always-on plugin tool registrations into a new **`cofounder-tools` skill** carrying a `TOOLS.json` manifest with sandboxed executors (`execution_target: "sandbox"`, as required for non-bundled skills). They no longer occupy tool-catalog space in every conversation — they project only while a cofounder skill is active.
- The existing `cofounder-onboarding`, `strategy-session`, and `weekly-review` skills declare `metadata.vellum.includes: [cofounder-tools]`, so loading any of them also loads the tool manifest and emits the child `<loaded_skill>` marker. The tools skill also activates standalone for ad-hoc operations ("log this decision", "update my OKRs", "what did I decide about...").
- Because skill tool executors run in short-lived sandbox subprocesses, the plugin's state layer became stateless: executors and daemon hooks read `data/company-state.json` fresh per call and mutations save atomically (temp file + rename) in the same call. The dirty-flag + `stop`-hook persistence path is gone.

## Verification

Against the assistant's real parsers and the sandbox runner contract (`__skill_runner.ts` wrapper, env-passed input/context, fresh subprocess per call):

- `parseToolManifestFile` parses the new TOOLS.json (5 tools, all sandbox-targeted).
- `loadSkillCatalog()` over a throwaway workspace discovers all 4 plugin skills with the `includes` wiring intact.
- Full executor lifecycle across separate subprocesses (16/16): profile update/get, decision log/list/search/review + required-field errors, OKR objective/KR add/update with status derivation, blindspot with past-decision matching, briefing aggregation, atomic on-disk state.
- Daemon hooks (4/4): init provisions the state file, user-prompt-submit injects fresh-from-disk context, post-model-call gates on `mainAgent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)