### PR TITLE
feat(plugins): recover from vision-not-supported rejections by captioning and retrying

### DIFF
--- a/assistant/src/plugins/defaults/image-fallback/__tests__/vision-recovery.test.ts
+++ b/assistant/src/plugins/defaults/image-fallback/__tests__/vision-recovery.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Tests for the image-fallback plugin's vision-not-supported recovery: the
+ * `post-model-call` hook that captions raw image blocks after a provider
+ * vision rejection and retries once per turn, and the `stop` hook that clears
+ * the per-conversation recovery bound.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  ContentBlock,
+  ImageContent,
+  Message,
+  ModelProfileInfo,
+  PluginLogger,
+  PostModelCallContext,
+  StopContext,
+} from "@vellumai/plugin-api";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+let mockProfiles: ModelProfileInfo[];
+let visionProfiles: Set<string>;
+
+const fakeProvider = {
+  name: "mock-vision-provider",
+  async sendMessage() {
+    return { content: [{ type: "text", text: "A bar chart of Q3 revenue." }] };
+  },
+};
+
+const mockResolveMediaSourceData = (source: ImageContent["source"]) =>
+  source.type === "base64"
+    ? { data: source.data, media_type: source.media_type }
+    : null;
+
+mock.module("@vellumai/plugin-api", () => ({
+  doesSupportVision: (arg: ModelProfileInfo | string) =>
+    typeof arg === "string" ? false : visionProfiles.has(arg.key),
+  getModelProfiles: () => mockProfiles,
+  resolveMediaSourceData: mockResolveMediaSourceData,
+  getConfiguredProvider: async () => fakeProvider,
+}));
+
+mock.module("../src/image-persist.js", () => ({
+  persistImage: () => "/workspace/data/attachments/mock-hash.png",
+}));
+
+// ─── Imports (after mocks are registered) ───────────────────────────────────
+
+const postModelCall = (await import("../hooks/post-model-call.js")).default;
+const stop = (await import("../hooks/stop.js")).default;
+const { resetVisionRecoveryStoreForTests, isVisionRecoveryAttempted } =
+  await import("../src/recovery-state.js");
+const { closeCaptionStore, initCaptionStore, resetCaptionCacheForTests } =
+  await import("../src/caption-cache.js");
+
+const STORAGE_DIR = mkdtempSync(join(tmpdir(), "vision-recovery-test-"));
+initCaptionStore(STORAGE_DIR);
+
+afterAll(() => {
+  closeCaptionStore();
+  rmSync(STORAGE_DIR, { recursive: true, force: true });
+});
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const VISION_ERROR_MESSAGE =
+  "This model (glm-5p2) doesn't support image input. Remove the image or switch to a vision-capable model.";
+
+const noopLogger: PluginLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+let imageSeq = 0;
+
+/** A distinct inline image block per call, so the content-hash cache never collides across cases. */
+function makeImage(): ImageContent {
+  imageSeq += 1;
+  return {
+    type: "image",
+    source: {
+      type: "base64",
+      media_type: "image/png",
+      data: Buffer.from(`image-bytes-${imageSeq}`).toString("base64"),
+    },
+  };
+}
+
+function userMessage(...blocks: ContentBlock[]): Message {
+  return { role: "user", content: blocks };
+}
+
+function makeCtx(
+  overrides: Partial<PostModelCallContext> = {},
+): PostModelCallContext {
+  return {
+    conversationId: "conv-vision",
+    callSite: "mainAgent",
+    content: [],
+    messages: [],
+    stopReason: null,
+    decision: "stop",
+    logger: noopLogger,
+    broadcast: () => {},
+    ...overrides,
+  };
+}
+
+function makeStopCtx(): StopContext {
+  return {
+    conversationId: "conv-vision",
+    messages: [],
+    exitReason: "no_tool_calls",
+    logger: noopLogger,
+    broadcast: () => {},
+  };
+}
+
+beforeEach(() => {
+  resetVisionRecoveryStoreForTests();
+  resetCaptionCacheForTests();
+  mockProfiles = [
+    { key: "vision-profile", isDisabled: false } as ModelProfileInfo,
+  ];
+  visionProfiles = new Set(["vision-profile"]);
+});
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("image-fallback post-model-call vision recovery", () => {
+  test("captions history images and retries on a vision-not-supported rejection", async () => {
+    const messages = [
+      userMessage({ type: "text", text: "look at this" }, makeImage()),
+    ];
+    const ctx = makeCtx({ messages, error: new Error(VISION_ERROR_MESSAGE) });
+
+    await postModelCall(ctx);
+
+    expect(ctx.decision).toBe("continue");
+    const blocks = ctx.messages[0].content;
+    expect(blocks.some((b) => b.type === "image")).toBe(false);
+    const captioned = blocks.find(
+      (b) => b.type === "text" && b.text.includes("[Image auto-described"),
+    );
+    expect(captioned).toBeDefined();
+    expect(isVisionRecoveryAttempted("conv-vision")).toBe(true);
+  });
+
+  test("captions images nested in tool_result contentBlocks", async () => {
+    const messages = [
+      userMessage({
+        type: "tool_result",
+        tool_use_id: "tu-1",
+        content: "screenshot taken",
+        contentBlocks: [makeImage()],
+      } as ContentBlock),
+    ];
+    const ctx = makeCtx({ messages, error: new Error(VISION_ERROR_MESSAGE) });
+
+    await postModelCall(ctx);
+
+    expect(ctx.decision).toBe("continue");
+    const nested = (
+      ctx.messages[0].content[0] as ContentBlock & {
+        contentBlocks: ContentBlock[];
+      }
+    ).contentBlocks;
+    expect(nested.some((b) => b.type === "image")).toBe(false);
+    expect(nested[0].type).toBe("text");
+  });
+
+  test("substitutes a fail-open placeholder when no vision profile exists", async () => {
+    mockProfiles = [];
+    visionProfiles = new Set();
+    const messages = [userMessage(makeImage())];
+    const ctx = makeCtx({ messages, error: new Error(VISION_ERROR_MESSAGE) });
+
+    await postModelCall(ctx);
+
+    // The request must still be cleared of image input so the retry can land.
+    expect(ctx.decision).toBe("continue");
+    const block = ctx.messages[0].content[0];
+    expect(block.type).toBe("text");
+    expect((block as { text: string }).text).toContain(
+      "no vision-capable model",
+    );
+  });
+
+  test("recovers only once per turn", async () => {
+    const first = makeCtx({
+      messages: [userMessage(makeImage())],
+      error: new Error(VISION_ERROR_MESSAGE),
+    });
+    await postModelCall(first);
+    expect(first.decision).toBe("continue");
+
+    const second = makeCtx({
+      messages: [userMessage(makeImage())],
+      error: new Error(VISION_ERROR_MESSAGE),
+    });
+    await postModelCall(second);
+
+    expect(second.decision).toBe("stop");
+    expect(second.messages[0].content[0].type).toBe("image");
+  });
+
+  test("stop hook clears the bound so the next turn recovers afresh", async () => {
+    await postModelCall(
+      makeCtx({
+        messages: [userMessage(makeImage())],
+        error: new Error(VISION_ERROR_MESSAGE),
+      }),
+    );
+    expect(isVisionRecoveryAttempted("conv-vision")).toBe(true);
+
+    await stop(makeStopCtx());
+    expect(isVisionRecoveryAttempted("conv-vision")).toBe(false);
+
+    const next = makeCtx({
+      messages: [userMessage(makeImage())],
+      error: new Error(VISION_ERROR_MESSAGE),
+    });
+    await postModelCall(next);
+    expect(next.decision).toBe("continue");
+  });
+
+  test("does not retry when the rejection matches but history has no images", async () => {
+    const ctx = makeCtx({
+      messages: [userMessage({ type: "text", text: "just text" })],
+      error: new Error(VISION_ERROR_MESSAGE),
+    });
+
+    await postModelCall(ctx);
+
+    expect(ctx.decision).toBe("stop");
+  });
+
+  test("ignores non-vision rejections", async () => {
+    const messages = [userMessage(makeImage())];
+    const ctx = makeCtx({
+      messages,
+      error: new Error("Provider returned error (500): upstream unavailable"),
+    });
+
+    await postModelCall(ctx);
+
+    expect(ctx.decision).toBe("stop");
+    expect(ctx.messages[0].content[0].type).toBe("image");
+    expect(isVisionRecoveryAttempted("conv-vision")).toBe(false);
+  });
+
+  test("leaves a finalized reply untouched", async () => {
+    const messages = [userMessage(makeImage())];
+    const ctx = makeCtx({ messages });
+
+    await postModelCall(ctx);
+
+    expect(ctx.decision).toBe("stop");
+    expect(ctx.messages[0].content[0].type).toBe("image");
+  });
+});

--- a/assistant/src/plugins/defaults/image-fallback/hooks/post-model-call.ts
+++ b/assistant/src/plugins/defaults/image-fallback/hooks/post-model-call.ts
@@ -1,0 +1,80 @@
+/**
+ * Default `post-model-call` hook: recovers from a provider vision-not-supported
+ * rejection.
+ *
+ * The turn-start sweep captions history images when the turn's profile is
+ * text-only, but raw images can still reach a non-vision model through paths
+ * the sweep does not cover — messages that join an in-flight turn (rapid-fire
+ * batches, subagent completions), catalog entries that call a model
+ * vision-capable when the serving endpoint rejects images, or provider
+ * fallback to a text-only model after the sweep decided. The provider's
+ * rejection is ground truth that image input cannot be sent, regardless of
+ * what the catalog claims. This hook recognizes the rejection class, captions
+ * every image block in the working history via the plugin's shared
+ * substitution (fail-open placeholders when captioning fails), and asks the
+ * loop to retry the call.
+ *
+ * Unlike the image-recovery plugin's image-too-large flow, nothing is
+ * persisted: the stored rows keep the raw image, which clients render and
+ * vision-capable profiles can still consume on later turns. The caption cache
+ * makes the re-sweeps on those turns lookup-only.
+ *
+ * Bounded to one pass per turn via the per-conversation recovery state: a
+ * second consecutive vision rejection means captioning could not clear the
+ * request of image input, so the hook leaves the error to surface rather than
+ * looping. The loop's per-run backstop caps these retries globally; this
+ * one-shot mark keeps a single recovery attempt per turn. This hook only ever
+ * marks the conversation; the sibling `stop` hook (see `./stop.ts`) clears the
+ * mark when the turn terminates, so the next turn recovers afresh.
+ *
+ * A finalized reply (the model returned content) is left untouched; only a
+ * provider rejection is this hook's to act on.
+ */
+
+import type { HookFunction, PostModelCallContext } from "@vellumai/plugin-api";
+
+import { captionImagesInMessages } from "../src/caption-blocks.js";
+import {
+  isVisionRecoveryAttempted,
+  markVisionRecoveryAttempted,
+} from "../src/recovery-state.js";
+import { findVisionProfile } from "../src/vision-caption.js";
+import { isVisionNotSupportedError } from "../src/vision-error.js";
+
+const postModelCall: HookFunction<PostModelCallContext> = async (ctx) => {
+  if (
+    !ctx.error ||
+    !isVisionNotSupportedError(ctx.error.message) ||
+    isVisionRecoveryAttempted(ctx.conversationId)
+  ) {
+    return;
+  }
+  markVisionRecoveryAttempted(ctx.conversationId);
+
+  const visionProfileKey = findVisionProfile();
+  const captioned = await captionImagesInMessages(
+    ctx.messages,
+    ctx.conversationId,
+    visionProfileKey,
+    ctx.logger,
+  );
+
+  if (captioned === 0) {
+    // The rejection names image input but the working history holds no image
+    // blocks to caption — retrying the identical request would just re-reject,
+    // so leave the error to surface.
+    ctx.logger.warn(
+      { plugin: "image-fallback" },
+      "Provider vision-not-supported error but no image blocks found in history; not retrying",
+    );
+    return;
+  }
+
+  ctx.decision = "continue";
+  ctx.logger.warn(
+    { plugin: "image-fallback", captioned },
+    "Provider vision-not-supported error — captioned image blocks and retrying",
+  );
+};
+
+export default postModelCall;

--- a/assistant/src/plugins/defaults/image-fallback/hooks/stop.ts
+++ b/assistant/src/plugins/defaults/image-fallback/hooks/stop.ts
@@ -1,0 +1,23 @@
+/**
+ * Default `stop` hook: clears the per-conversation vision-recovery bound when
+ * a turn terminates.
+ *
+ * The `post-model-call` hook (see `./post-model-call.ts`) marks the bound when
+ * it captions raw image blocks after a vision-not-supported rejection and asks
+ * the loop to retry. `stop` is the definitive terminal hook — it fires exactly
+ * once when the turn is truly ending, after every retry decision has been made
+ * — so clearing the bound here unconditionally guarantees the next turn always
+ * recovers afresh, no matter how the turn ended (a finalized reply, an
+ * unrecovered rejection, an abort, or a retry the loop's per-run backstop
+ * refused).
+ */
+
+import type { HookFunction, StopContext } from "@vellumai/plugin-api";
+
+import { clearVisionRecoveryAttempted } from "../src/recovery-state.js";
+
+const stop: HookFunction<StopContext> = async (ctx) => {
+  clearVisionRecoveryAttempted(ctx.conversationId);
+};
+
+export default stop;

--- a/assistant/src/plugins/defaults/image-fallback/src/recovery-state.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/recovery-state.ts
@@ -1,0 +1,49 @@
+/**
+ * Per-conversation vision-recovery state for the image-fallback plugin.
+ *
+ * The `post-model-call` hook recovers from a provider vision-not-supported
+ * rejection by captioning the raw image blocks in the working history and
+ * asking the loop to retry. That recovery is bounded to one pass per turn: a
+ * second consecutive vision rejection means captioning could not clear the
+ * request of image input (e.g. a path the sweep cannot reach), so the hook
+ * lets the error surface rather than looping.
+ *
+ * The `post-model-call` hook marks a conversation when it issues a
+ * recovery-retry and the `stop` hook clears the mark on any terminal stop —
+ * a finalized reply, an unrecovered rejection, or an abort — i.e. whenever
+ * the loop is leaving rather than retrying. A conversation therefore only
+ * holds an entry while a recovery is in flight, so the store stays bounded
+ * without a separate teardown step.
+ *
+ * This module is side-effect free: importing it only initializes an empty
+ * store and registers no plugin.
+ */
+
+/** Conversations with a vision-recovery pass in flight for the current turn. */
+const recoveryInFlight = new Set<string>();
+
+/** Whether the conversation already attempted a vision recovery this turn. */
+export function isVisionRecoveryAttempted(conversationId: string): boolean {
+  return recoveryInFlight.has(conversationId);
+}
+
+/** Record that the conversation issued its one vision-recovery retry this turn. */
+export function markVisionRecoveryAttempted(conversationId: string): void {
+  recoveryInFlight.add(conversationId);
+}
+
+/**
+ * Clear the conversation's recovery mark so the next turn (or run) recovers
+ * afresh. The `stop` hook calls this on every terminal stop.
+ */
+export function clearVisionRecoveryAttempted(conversationId: string): void {
+  recoveryInFlight.delete(conversationId);
+}
+
+/**
+ * Test-only: drop every conversation's recovery state so a suite that drives
+ * the hook directly starts each case from an empty store.
+ */
+export function resetVisionRecoveryStoreForTests(): void {
+  recoveryInFlight.clear();
+}

--- a/assistant/src/plugins/defaults/image-fallback/src/vision-error.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/vision-error.ts
@@ -1,0 +1,19 @@
+/**
+ * Detection for the vision-not-supported recovery path.
+ *
+ * The provider layer normalizes every raw "model can't take image input"
+ * rejection (OpenRouter's "no endpoints found that support image input",
+ * vLLM-style "this model does not support vision", etc.) into one stable
+ * `ProviderError` message: "This model (X) doesn't support image input.
+ * Remove the image or switch to a vision-capable model." The recovery hook
+ * keys on that normalized message rather than the raw provider phrasings, so
+ * the provider layer stays the single place that understands upstream error
+ * shapes.
+ */
+
+const VISION_NOT_SUPPORTED_ERROR_PATTERN = /doesn't support image input/i;
+
+/** Whether an error message indicates a vision-not-supported rejection. */
+export function isVisionNotSupportedError(message: string): boolean {
+  return VISION_NOT_SUPPORTED_ERROR_PATTERN.test(message);
+}

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -51,8 +51,10 @@ import { resetRepairStateStoreForTests } from "./history-repair/repair-state-sto
 import imageFallbackConversationDeleted from "./image-fallback/hooks/conversation-deleted.js";
 import imageFallbackInit from "./image-fallback/hooks/init.js";
 import imageFallbackPostCompact from "./image-fallback/hooks/post-compact.js";
+import imageFallbackPostModelCall from "./image-fallback/hooks/post-model-call.js";
 import imageFallbackPostToolUse from "./image-fallback/hooks/post-tool-use.js";
 import imageFallbackShutdown from "./image-fallback/hooks/shutdown.js";
+import imageFallbackStop from "./image-fallback/hooks/stop.js";
 import imageFallbackUserPromptSubmit from "./image-fallback/hooks/user-prompt-submit.js";
 import imageFallbackPkg from "./image-fallback/package.json" with { type: "json" };
 import { resetCaptionCacheForTests } from "./image-fallback/src/caption-cache.js";
@@ -106,12 +108,18 @@ import workspacePkg from "./workspace/package.json" with { type: "json" };
  * screenshot) nested in the tool result's `contentBlocks`; the `post-compact`
  * hook re-sweeps the rebuilt history after a mid-turn compaction, whose
  * retained images and persistence-restored tool results land after the
- * turn-start sweep. Fail-open with a placeholder when no vision profile is
- * configured or captioning fails. A read-through content-hash cache (in-memory
- * LRU over a plugin-owned SQLite file, opened by `init` in the plugin's
- * storage dir and closed by `shutdown`) avoids re-captioning the same image
- * across turns, compactions, and restarts; `conversation-deleted` removes the
- * deleted conversation's cache rows.
+ * turn-start sweep. The `post-model-call` hook backstops raw images that
+ * reach the provider anyway (messages joining an in-flight turn, catalog
+ * entries that call a model vision-capable when its serving endpoint rejects
+ * images): on a vision-not-supported rejection it captions the working
+ * history and retries, bounded to one pass per turn, with the `stop` hook
+ * clearing the recovery bound on a terminal stop. Fail-open with a
+ * placeholder when no vision profile is configured or captioning fails. A
+ * read-through content-hash cache (in-memory LRU over a plugin-owned SQLite
+ * file, opened by `init` in the plugin's storage dir and closed by
+ * `shutdown`) avoids re-captioning the same image across turns, compactions,
+ * and restarts; `conversation-deleted` removes the deleted conversation's
+ * cache rows.
  */
 export const defaultImageFallbackPlugin: Plugin = {
   manifest: {
@@ -124,6 +132,8 @@ export const defaultImageFallbackPlugin: Plugin = {
     "user-prompt-submit": imageFallbackUserPromptSubmit,
     "post-tool-use": imageFallbackPostToolUse,
     "post-compact": imageFallbackPostCompact,
+    "post-model-call": imageFallbackPostModelCall,
+    stop: imageFallbackStop,
     "conversation-deleted": imageFallbackConversationDeleted,
   },
 };


### PR DESCRIPTION
## Summary
- `image-fallback` gains a `post-model-call` hook: on the provider-normalized "doesn't support image input" rejection it captions every image block in the working history via the plugin's existing substitution (fail-open placeholders), sets `decision: "continue"` to retry, bounded to one pass per turn; a new `stop` hook clears the bound on terminal stops.
- Backstops the paths the turn-start sweep cannot cover: messages joining an in-flight turn (rapid-fire batches, subagent completion injections), catalog entries that call a model vision-capable when its serving endpoint rejects images, and provider fallback after the sweep decided.
- Unlike the image-too-large flow, nothing is persisted — stored rows keep the raw image (clients render it; vision-capable profiles can still use it), and the caption cache keeps later sweeps lookup-only.
- The recovery lives on `image-fallback` rather than `image-recovery`: the plugin import-boundary ratchet forbids cross-plugin imports, and `image-fallback` owns the captioning machinery.

## Original prompt
Telemetry analysis of the 18h after v0.10.7 found ~10 users in one window dead-ending on "This model doesn't support image input" — mostly on text-only turns where an earlier image rode into the request from history (same-second batched turns, subagent completions, tool screenshots), spanning 0.10.4–0.10.7. The simple attach-an-image case is already handled by the image-fallback sweep, but there was no recovery when a raw image reached a non-vision model anyway: image-recovery's post-model-call hook only recovers image-too-large. Asked to add vision-not-supported recovery mirroring that flow, using the image-fallback captioning machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)