### PR TITLE
fix(web): render the LLM inspector copy/download buttons (iconOnly misuse)

### DIFF
--- a/clients/web/src/domains/chat/inspector/components/copy-button.test.tsx
+++ b/clients/web/src/domains/chat/inspector/components/copy-button.test.tsx
@@ -1,0 +1,27 @@
+/**
+ * Regression tests for the inspector copy button. `Button` takes the icon
+ * element itself via `iconOnly`; a bare boolean there renders an empty,
+ * invisible button, so these tests pin that a real icon reaches the markup.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { CopyButton } from "./copy-button";
+
+describe("CopyButton", () => {
+  test("renders a visible icon and the accessible label", () => {
+    const html = renderToStaticMarkup(
+      <CopyButton text="payload" ariaLabel="Copy request payload" />,
+    );
+    expect(html).toContain("<svg");
+    expect(html).toContain('aria-label="Copy request payload"');
+  });
+
+  test("applies the caller's positioning className", () => {
+    const html = renderToStaticMarkup(
+      <CopyButton text="x" ariaLabel="Copy" className="absolute right-2 top-3" />,
+    );
+    expect(html).toContain("absolute right-2 top-3");
+  });
+});

--- a/clients/web/src/domains/chat/inspector/components/copy-button.tsx
+++ b/clients/web/src/domains/chat/inspector/components/copy-button.tsx
@@ -1,0 +1,35 @@
+import { Check, Copy } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
+import { Button } from "@vellumai/design-library";
+
+interface CopyButtonProps {
+  text: string;
+  ariaLabel: string;
+  className?: string;
+}
+
+/**
+ * Ghost icon button that copies `text` to the clipboard, flashing a
+ * positive-tinted check while the transient copied state is active.
+ */
+export function CopyButton({
+  text,
+  ariaLabel,
+  className,
+}: CopyButtonProps): ReactNode {
+  const { copy, copied } = useCopyToClipboard();
+
+  return (
+    <Button
+      variant="ghost"
+      size="compact"
+      iconOnly={copied ? <Check aria-hidden /> : <Copy aria-hidden />}
+      tintColor={copied ? "var(--system-positive-strong)" : undefined}
+      aria-label={copied ? "Copied" : ariaLabel}
+      className={className}
+      onClick={() => copy(text)}
+    />
+  );
+}

--- a/clients/web/src/domains/chat/inspector/components/tabs/prompt-tab.tsx
+++ b/clients/web/src/domains/chat/inspector/components/tabs/prompt-tab.tsx
@@ -1,9 +1,10 @@
-import { ChevronRight, Copy } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import { useState, type ReactNode } from "react";
 
 import { CacheBreakpointMapCard } from "@/domains/chat/inspector/components/cache-breakpoint-map-card";
 import { CacheDiffCard } from "@/domains/chat/inspector/components/cache-diff-card";
 import { CacheHealthCard } from "@/domains/chat/inspector/components/cache-health-card";
+import { CopyButton } from "@/domains/chat/inspector/components/copy-button";
 import { ToolDefinitionsContent } from "@/domains/chat/inspector/components/tool-definitions-content";
 import { parseToolDefinitions } from "@/domains/chat/inspector/tool-definitions";
 import type {
@@ -214,13 +215,10 @@ function PromptSectionItem({
       </Collapsible.Trigger>
 
       {!toolDefs && (
-        <Button
-          variant="ghost"
-          size="compact"
-          iconOnly={<Copy aria-hidden />}
-          aria-label={`Copy ${title}`}
+        <CopyButton
+          text={text}
+          ariaLabel={`Copy ${title}`}
           className="absolute right-2 top-3"
-          onClick={() => void navigator.clipboard.writeText(text)}
         />
       )}
 

--- a/clients/web/src/domains/chat/inspector/components/tabs/raw-tab.tsx
+++ b/clients/web/src/domains/chat/inspector/components/tabs/raw-tab.tsx
@@ -1,6 +1,7 @@
-import { AlertCircle, Copy, Download, RefreshCw } from "lucide-react";
+import { AlertCircle, Download, RefreshCw } from "lucide-react";
 import { useState, type ReactNode } from "react";
 
+import { CopyButton } from "@/domains/chat/inspector/components/copy-button";
 import { useLlmLogPayload } from "@/domains/chat/inspector/inspector-payload-api";
 import { captureError } from "@/lib/sentry/capture-error";
 import type { LLMRequestLogEntry } from "@vellumai/assistant-api";
@@ -80,20 +81,15 @@ export function RawTab({ entry, assistantId }: RawTabProps): ReactNode {
             <Button
               variant="ghost"
               size="compact"
-              iconOnly
-              leftIcon={<Download size={14} aria-hidden />}
+              iconOnly={<Download aria-hidden />}
               aria-label={`Download ${pane} payload`}
               onClick={() =>
                 void downloadRawPayload(displayText, downloadFilename)
               }
             />
-            <Button
-              variant="ghost"
-              size="compact"
-              iconOnly
-              leftIcon={<Copy size={14} aria-hidden />}
-              aria-label={`Copy ${pane} payload`}
-              onClick={() => void navigator.clipboard.writeText(displayText)}
+            <CopyButton
+              text={displayText}
+              ariaLabel={`Copy ${pane} payload`}
             />
           </div>
         </div>

--- a/clients/web/src/domains/chat/inspector/components/tabs/response-tab.test.tsx
+++ b/clients/web/src/domains/chat/inspector/components/tabs/response-tab.test.tsx
@@ -1,8 +1,9 @@
 /**
- * Tests for the ResponseTab's handling of failed calls. A call the
- * provider rejected carries a structured `error` and no response
- * sections; the tab must surface a failure banner instead of the generic
- * "Section rendering unavailable" fallback.
+ * Tests for the ResponseTab: section rendering (each section header carries
+ * a visible copy affordance) and failed calls. A call the provider rejected
+ * carries a structured `error` and no response sections; the tab must
+ * surface a failure banner instead of the generic "Section rendering
+ * unavailable" fallback.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -28,6 +29,22 @@ function makeEntry(
 function render(entry: LLMRequestLogEntry): string {
   return renderToStaticMarkup(<ResponseTab entry={entry} />);
 }
+
+describe("ResponseTab — sections", () => {
+  test("renders a visible copy icon in the section header", () => {
+    const html = render(
+      makeEntry({
+        responseSections: [
+          { kind: "text", label: "Assistant reply", text: "Hello there" },
+        ],
+      }),
+    );
+    expect(html).toContain("Assistant reply");
+    expect(html).toContain('aria-label="Copy section content"');
+    // The copy affordance must render an actual icon, not an empty button.
+    expect(html).toContain("<svg");
+  });
+});
 
 describe("ResponseTab — failed calls", () => {
   test("renders the failure banner with the provider message and metadata", () => {

--- a/clients/web/src/domains/chat/inspector/components/tabs/response-tab.tsx
+++ b/clients/web/src/domains/chat/inspector/components/tabs/response-tab.tsx
@@ -1,4 +1,4 @@
-import { Copy, FileCode } from "lucide-react";
+import { FileCode } from "lucide-react";
 import { type ReactNode } from "react";
 
 import type {
@@ -6,8 +6,9 @@ import type {
   LLMContextSection,
   LLMRequestLogEntry,
 } from "@vellumai/assistant-api";
-import { Button, Card } from "@vellumai/design-library";
+import { Card } from "@vellumai/design-library";
 
+import { CopyButton } from "@/domains/chat/inspector/components/copy-button";
 import { LlmCallErrorCard } from "@/domains/chat/inspector/components/llm-call-error-card";
 
 interface ResponseTabProps {
@@ -193,14 +194,7 @@ function SectionHeader({
           <MetadataChip label={section.kindLabel} />
         </div>
       </div>
-      <Button
-        variant="ghost"
-        size="compact"
-        iconOnly
-        leftIcon={<Copy size={14} aria-hidden />}
-        aria-label="Copy section content"
-        onClick={() => void navigator.clipboard.writeText(section.copyText)}
-      />
+      <CopyButton text={section.copyText} ariaLabel="Copy section content" />
     </div>
   );
 }

--- a/packages/design-library/src/components/button.tsx
+++ b/packages/design-library/src/components/button.tsx
@@ -21,10 +21,11 @@ import { Tooltip } from "./tooltip";
  *
  * - Pass `variant` for chrome style and `size` for dimensions.
  * - Pass `leftIcon` / `rightIcon` for text+icon layouts.
- * - Pass `iconOnly` to render a square icon-only button (the icon is centered
- *   at the correct size for the chosen `size`). Without `asChild` the children
- *   are ignored; with `asChild` the caller's element (e.g. a `Link`) becomes
- *   the root and the icon is re-parented into it.
+ * - Pass the icon element as `iconOnly` (e.g. `iconOnly={<X />}`) to render a
+ *   square icon-only button (the icon is centered at the correct size for the
+ *   chosen `size`). Without `asChild` the children are ignored; with `asChild`
+ *   the caller's element (e.g. a `Link`) becomes the root and the icon is
+ *   re-parented into it.
  * - Use `asChild` to render as a child element (e.g. a `Link`) while keeping
  *   button styling and accessibility semantics. Uses Radix's `Slot`.
  * - Pass `expandOnMobile={false}` to opt an icon-only button out of the larger
@@ -235,7 +236,13 @@ export interface ButtonProps
   size?: ButtonSize;
   leftIcon?: ReactNode;
   rightIcon?: ReactNode;
-  iconOnly?: ReactNode;
+  /**
+   * The icon element itself, not a flag. `true` is excluded from the type
+   * because a bare `iconOnly` attribute would put the icon-only chrome on a
+   * button with no visible content (`leftIcon`/`rightIcon`/`children` are
+   * ignored in icon-only mode). `false` stays allowed for `cond && <Icon />`.
+   */
+  iconOnly?: Exclude<ReactNode, boolean> | false;
   fullWidth?: boolean;
   active?: boolean;
   /**


### PR DESCRIPTION
## Summary
- Fix the LLM Context Inspector's copy/download buttons rendering invisibly: `Button`'s `iconOnly` prop takes the icon element itself, but the Raw tab (copy + download) and Response tab (per-section copy) passed it as a bare boolean with the icon in `leftIcon`, which the icon-only branch ignores — the buttons were clickable but had no visible content.
- Extract a shared inspector `CopyButton` built on the existing `useCopyToClipboard` hook, used by the Raw, Response, and Prompt tabs; it flashes a positive-tinted check for 1.5s after copying (the Prompt tab's already-working button gains the feedback too).
- Narrow `ButtonProps.iconOnly` to `Exclude<ReactNode, boolean> | false` so a bare `iconOnly` flag is a compile error (`boolean ⊂ ReactNode` made the misuse typecheck-clean); `iconOnly={cond && <Icon />}` stays valid. Regression tests pin that a real `<svg>` reaches the markup.

## Original prompt
Sidd asked for a copy button on the request/response JSONs in the LLM Context Inspector's Raw tab, from a screenshot where the payload card header showed no action buttons. Investigation showed the buttons already existed in code but rendered as empty ghost buttons due to the `iconOnly` boolean misuse (present since the inspector was ported from the platform repo), so the shipped change makes them actually visible, adds copied-state feedback, and hardens the prop type so the bug class can't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)