### PR TITLE
Re-pin admin-copilot to the skills-only build; document skill-scoped plugin tools

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -36,10 +36,12 @@ wired surface.
 
 The external plugin loader extends the assistant by wiring these contribution surfaces.
 
-| Surface             | Directory         | Discovery                                     |
-| ------------------- | ----------------- | --------------------------------------------- |
-| Lifecycle hooks     | `hooks/<name>.ts` | filename → `plugin.hooks[<name>]`             |
-| Model-visible tools | `tools/<name>.ts` | each file's default export → `plugin.tools[]` |
+| Surface             | Directory                | Discovery                                                       |
+| ------------------- | ------------------------ | --------------------------------------------------------------- |
+| Lifecycle hooks     | `hooks/<name>.ts`        | filename → `plugin.hooks[<name>]`                               |
+| Model-visible tools | `tools/<name>.ts`        | each file's default export → `plugin.tools[]`                   |
+| Skills              | `skills/<id>/SKILL.md`   | picked up on disk by the skill catalog loader                   |
+| Skill-scoped tools  | `skills/<id>/TOOLS.json` | registered only while the skill is active (see [Tools](#tools)) |
 
 ---
 
@@ -503,6 +505,19 @@ derives the model-visible tool name from the file basename (for example,
 `tools/recall.ts` becomes `recall`). Plugin tools land in the same registry
 as built-in tools and are visible to the model through the standard tool
 catalog.
+
+**Always-on cost — prefer skill-scoped tools.** A `tools/<name>.ts` tool sits
+on every conversation's tool catalog on every turn, whether or not the plugin
+is relevant. When a tool only matters while one of the plugin's skills is
+active, declare it in that skill's `TOOLS.json` instead: it registers when the
+skill loads, unregisters when the skill deactivates, and is invoked through
+`skill_execute` (its schema is rendered into the `skill_load` output). Skill
+tools in plugin skills must declare `execution_target: "sandbox"` — host
+execution is reserved for first-party bundled skills — and a tool name may be
+owned by only one skill, so share a single carrier skill via the parents'
+`includes` rather than duplicating the entry. See the `plugin-builder` skill's
+`references/skills.md` for the manifest shape; `admin-copilot` is the
+reference implementation.
 
 ```ts
 // tools/my_tool.ts

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -94,7 +94,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/admin-copilot",
-        "ref": "3d375a31c910448e45723487d18358b78bf3ddb0"
+        "ref": "d30596aa50a1c702f5d74e05c45bd965d14e2107"
       },
       "description": "Proactive chief-of-staff: a morning digest, propose-then-confirm inbox triage, calendar prep, and a weekly competitor brief.",
       "category": "productivity",

--- a/skills/plugin-builder/references/skills.md
+++ b/skills/plugin-builder/references/skills.md
@@ -45,9 +45,12 @@ plugins/my-plugin/
 └── skills/
     └── standup-notes/
         ├── SKILL.md        # Frontmatter + instructions (required)
+        ├── TOOLS.json      # Optional skill-scoped tool manifest
         ├── references/     # Optional docs the instructions cite
-        └── scripts/        # Optional helper scripts the skill runs
-            └── post_summary.ts
+        ├── scripts/        # Optional helper scripts the skill runs
+        │   └── post_summary.ts
+        └── tools/          # Executors for TOOLS.json entries
+            └── save_note.ts
 ```
 
 The `SKILL.md` itself is frontmatter plus the procedure the Assistant follows once the skill is active:
@@ -85,3 +88,38 @@ The `scripts/` and `references/` directories are optional companions to `SKILL.m
 
 - **Scripts:** Reference a script by its path relative to the skill directory. The assistant runs it via the `bash` tool when the instructions call for it. For example, a body that says "Run `scripts/post_summary.ts` to submit the summary" tells the assistant to execute `bun run scripts/post_summary.ts` from the skill directory.
 - **References:** Cite a reference file by relative path when the body needs to defer detail. For example, "See `references/api-fields.md` for the full field contract" tells the assistant to read that file when it needs the details, rather than inlining them in the body. This keeps the body short and loads the detail only when relevant.
+
+## Skill-scoped tools (`TOOLS.json`)
+
+A skill can carry real, schema-validated tools that exist only while the skill is active — unlike `tools/<name>.ts` plugin tools, which sit on every conversation's catalog on every turn (see [tools.md](tools.md)). Declare them in a `TOOLS.json` at the skill root:
+
+```json
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "save_note",
+      "description": "Persist a standup note. Write this for the model.",
+      "category": "productivity",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": { "text": { "type": "string" } },
+        "required": ["text"]
+      },
+      "executor": "tools/save_note.ts",
+      "execution_target": "sandbox"
+    }
+  ]
+}
+```
+
+The executor is a module inside the skill directory exporting `run(input, context)` that returns `{ content: string, isError: boolean }`. It executes in the skill sandbox — a subprocess with a sanitized environment (`VELLUM_WORKSPACE_DIR` is available for locating plugin data) — so it must be self-contained: node stdlib only, no imports from outside the skill directory, no shared module state with hooks.
+
+Rules the host enforces:
+
+- **Sandbox only.** Plugin skills must declare `execution_target: "sandbox"`; `"host"` is refused for anything that is not a first-party bundled skill.
+- **One owner per tool name.** Registering the same tool name from two different skills throws. When several sibling skills need one tool, put it in a single carrier skill and list that skill in each sibling's `metadata.vellum.includes` — loading any parent projects the child's tools automatically.
+- **Dispatch via `skill_execute`.** The tools are not sent as top-level wire tools; `skill_load` renders their schemas into its output and the model calls them as `{"tool": "<name>", "input": {...}, "activity": "..."}` through `skill_execute`. Tools register when the skill activates and unregister when it deactivates, and execution is blocked if the skill directory changed since it was loaded (version-hash guard).
+
+The `admin-copilot` marketplace plugin's `admin-copilot-prefs` skill is the reference implementation.

--- a/skills/plugin-builder/references/tools.md
+++ b/skills/plugin-builder/references/tools.md
@@ -4,6 +4,8 @@ Add new actions the model can call. A plugin tool lands in the same catalog as t
 
 A tool is a default-exported object from `tools/<name>.ts`. The loader derives the model-visible tool name from the file basename, so `tools/example.ts` becomes the `example` tool. Plugin tools register in the same catalog as built-in tools and are offered to the model through the standard tool-calling interface.
 
+**Always-on cost — prefer skill-scoped tools.** A `tools/<name>.ts` tool is offered to the model on every turn of every conversation, whether or not the plugin is relevant, so each one adds permanent prompt weight for every user of the plugin. When a tool only matters while one of the plugin's skills is active, declare it in that skill's `TOOLS.json` instead — it registers only while the skill is loaded and costs nothing the rest of the time. See "Skill-scoped tools" in [skills.md](skills.md). Reserve `tools/` for actions the model must be able to reach without any skill in play.
+
 ## What a tool is
 
 A tool is something the model chooses to call. You describe what it does and what arguments it takes, and the model decides when to invoke it. When it does, the Assistant runs your `execute` function and feeds the result back into the turn.


### PR DESCRIPTION
## Summary
- Bump the `admin-copilot` marketplace pin to `d30596aa` ([vellum-ai/admin-copilot#7](https://github.com/vellum-ai/admin-copilot/pull/7)): the plugin no longer registers an always-on `admin_copilot_prefs` tool — it now ships an `admin-copilot-prefs` skill whose `TOOLS.json` registers the tool only while an admin-copilot skill is active (sandbox execution, `skill_execute` dispatch). Since admin-copilot is the universal always-install plugin, this removes a permanent per-turn tool-catalog entry for every user.
- Document the skill-scoped tool pattern in the plugin authoring docs: `plugins/README.md` (contribution table + Tools section) and `skills/plugin-builder/references/{tools,skills}.md` previously described always-on `tools/<name>.ts` as the only tool surface; they now cover `TOOLS.json` in plugin skills (sandbox-only, one owner per tool name, `includes` carrier-skill pattern).

## Verification
- `bun test src/cli/lib/__tests__/plugin-marketplace.test.ts` — 12 pass (pin format/whitelist rules).
- Host integration against the new plugin build: `loadSkillCatalog` discovers all 4 plugin skills; `skill_load("competitor-brief")` renders the prefs tool schemas and include markers; `projectSkillTools` registers the tool skill-owned/sandboxed; executing it runs the real sandbox subprocess and persists state. Existing user data is unaffected (same `plugins-data/admin-copilot` path).

## Original prompt
Sidd asked for the admin-copilot plugin to stop exposing always-on tools and instead bundle a skill that carries those tools. The plugin-side change shipped as vellum-ai/admin-copilot#7 (new `admin-copilot-prefs` skill with `TOOLS.json` + sandbox executor, included by the three existing skills, always-on tool/hook/src deleted). This PR is the vellum-assistant half: the marketplace re-pin plus authoring-doc updates so plugin authors know the skill-scoped pattern exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)