### PR TITLE
fix(onboarding): guard against silently re-onboarding an established assistant

### DIFF
--- a/clients/web/src/domains/onboarding/established-assistant.test.ts
+++ b/clients/web/src/domains/onboarding/established-assistant.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the established-assistant guard's detection logic (dependency-
+ * injected — no module mocks, so this file is safe in a shared `bun test` run).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  checkEstablishedAssistant,
+  FRESH_ASSISTANT_CHECK,
+} from "@/domains/onboarding/established-assistant";
+
+type Deps = NonNullable<Parameters<typeof checkEstablishedAssistant>[1]>;
+
+function makeDeps(overrides: Partial<Deps> = {}): Deps {
+  return {
+    hasAnyActiveConversation: async () => false,
+    fetchAssistantIdentity: async () => null,
+    ...overrides,
+  } as Deps;
+}
+
+describe("checkEstablishedAssistant", () => {
+  test("no conversations → fresh, without fetching identity", async () => {
+    let identityFetched = false;
+    const result = await checkEstablishedAssistant(
+      "asst-1",
+      makeDeps({
+        fetchAssistantIdentity: async () => {
+          identityFetched = true;
+          return null;
+        },
+      }),
+    );
+
+    expect(result).toEqual(FRESH_ASSISTANT_CHECK);
+    expect(identityFetched).toBe(false);
+  });
+
+  test("conversations present → established, with the trimmed identity name", async () => {
+    const result = await checkEstablishedAssistant(
+      "asst-1",
+      makeDeps({
+        hasAnyActiveConversation: async () => true,
+        fetchAssistantIdentity: async () =>
+          ({ name: "  Viper  " }) as Awaited<
+            ReturnType<Deps["fetchAssistantIdentity"]>
+          >,
+      }),
+    );
+
+    expect(result).toEqual({ established: true, assistantName: "Viper" });
+  });
+
+  test("established with an unavailable or blank identity still gates", async () => {
+    const nullIdentity = await checkEstablishedAssistant(
+      "asst-1",
+      makeDeps({ hasAnyActiveConversation: async () => true }),
+    );
+    expect(nullIdentity).toEqual({ established: true, assistantName: null });
+
+    const blankName = await checkEstablishedAssistant(
+      "asst-1",
+      makeDeps({
+        hasAnyActiveConversation: async () => true,
+        fetchAssistantIdentity: async () =>
+          ({ name: "   " }) as Awaited<
+            ReturnType<Deps["fetchAssistantIdentity"]>
+          >,
+      }),
+    );
+    expect(blankName).toEqual({ established: true, assistantName: null });
+  });
+
+  test("a positive history signal gates even when the identity lookup throws", async () => {
+    const result = await checkEstablishedAssistant(
+      "asst-1",
+      makeDeps({
+        hasAnyActiveConversation: async () => true,
+        fetchAssistantIdentity: async () => {
+          throw new Error("identity route down");
+        },
+      }),
+    );
+
+    expect(result).toEqual({ established: true, assistantName: null });
+  });
+
+  test("fails open to fresh when the conversation probe throws", async () => {
+    const result = await checkEstablishedAssistant(
+      "asst-1",
+      makeDeps({
+        hasAnyActiveConversation: async () => {
+          throw new Error("daemon unreachable");
+        },
+      }),
+    );
+
+    expect(result).toEqual(FRESH_ASSISTANT_CHECK);
+  });
+});

--- a/clients/web/src/domains/onboarding/established-assistant.ts
+++ b/clients/web/src/domains/onboarding/established-assistant.ts
@@ -1,0 +1,63 @@
+/**
+ * Detects whether the assistant the research-onboarding flow is about to run
+ * against is already established — it has lived conversations — so the flow
+ * can offer an explicit off-ramp instead of silently re-onboarding (and
+ * rewriting the persona of) an assistant the user already customized.
+ *
+ * Conversation history is the establishment signal: a fresh hatch has none,
+ * and the flow's own side conversations (research, personality) are archived
+ * once they settle, so they don't count against a genuinely-new user who
+ * abandoned a prior attempt. The identity name is fetched only for the guard
+ * screen's copy and is best-effort.
+ *
+ * Fail-open: a genuine fetch failure treats the assistant as fresh — the
+ * guard exists to stop silent persona rewrites of real assistants, not to
+ * block onboarding when the daemon hiccups.
+ */
+
+import { fetchAssistantIdentity } from "@/assistant/identity";
+import { captureError } from "@/lib/sentry/capture-error";
+import { hasAnyActiveConversation } from "@/utils/conversation-list-fetchers";
+
+export interface EstablishedAssistantCheck {
+  established: boolean;
+  /** Current assistant name for the guard screen's copy; null when unknown. */
+  assistantName: string | null;
+}
+
+/** The no-gate verdict: a fresh assistant (or an undeterminable one). */
+export const FRESH_ASSISTANT_CHECK: EstablishedAssistantCheck = {
+  established: false,
+  assistantName: null,
+};
+
+interface CheckDeps {
+  hasAnyActiveConversation: typeof hasAnyActiveConversation;
+  fetchAssistantIdentity: typeof fetchAssistantIdentity;
+}
+
+/**
+ * Resolve the guard verdict for the hatched assistant. Deps are injectable for
+ * tests; production callers use the defaults.
+ */
+export async function checkEstablishedAssistant(
+  assistantId: string,
+  deps: CheckDeps = { hasAnyActiveConversation, fetchAssistantIdentity },
+): Promise<EstablishedAssistantCheck> {
+  try {
+    if (!(await deps.hasAnyActiveConversation(assistantId))) {
+      return FRESH_ASSISTANT_CHECK;
+    }
+  } catch (err) {
+    captureError(err, { context: "research_onboarding_established_check" });
+    return FRESH_ASSISTANT_CHECK;
+  }
+  // Established — pull the current name so the guard screen can say who it is
+  // protecting. Best-effort and isolated from the verdict: a positive
+  // has-history signal gates even when the identity lookup fails.
+  const identity = await deps
+    .fetchAssistantIdentity(assistantId)
+    .catch(() => null);
+  const name = typeof identity?.name === "string" ? identity.name.trim() : "";
+  return { established: true, assistantName: name || null };
+}

--- a/clients/web/src/domains/onboarding/funnel-events.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.ts
@@ -72,6 +72,11 @@ export const RESEARCH_ONBOARDING_FUNNEL_STEPS = {
   // don't emit for it — the flow's completion is recorded on `suggestions` — but
   // it's a `ResearchStep`, so the exhaustive record needs an entry.
   finishing: { stepName: "research_finishing", stepIndex: 11 },
+  // Established-assistant guard — an off-ramp branch after the form, not a
+  // sequential stage, so it takes the next free index rather than renumbering
+  // the funnel. Outcome: "completed" = kept the assistant (left for chat),
+  // "skipped" = declined the off-ramp and redid onboarding anyway.
+  existing: { stepName: "research_existing_assistant", stepIndex: 12 },
 } as const satisfies Record<ResearchStep, OnboardingFunnelStepDescriptor>;
 
 export type ResearchOnboardingFunnelStep =

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -85,6 +85,19 @@ import {
   useElementSize,
 } from "@/domains/onboarding/hooks/use-onboarding-stage-size";
 import { getBrowserTimezone } from "@/utils/browser-timezone";
+import {
+  checkEstablishedAssistant,
+  FRESH_ASSISTANT_CHECK,
+  type EstablishedAssistantCheck,
+} from "@/domains/onboarding/established-assistant";
+import { ExistingAssistantStep } from "@/domains/onboarding/screens/existing-assistant-step";
+
+/**
+ * How long a submit waits for the established-assistant verdict before failing
+ * open. The check starts at mount (it needs only the hatch), so by submit time
+ * it has usually settled; the race keeps a slow daemon from holding the form.
+ */
+const ESTABLISHED_CHECK_SUBMIT_WAIT_MS = 4000;
 
 /** Build the research subject from the collected form values. */
 function researchSubjectFrom(values: ResearchOnboardingValues): ResearchSubject {
@@ -179,6 +192,20 @@ export function ResearchOnboardingRoute() {
   const [formValues, setFormValues] = useState<ResearchOnboardingValues | null>(
     null,
   );
+  // Established-assistant guard. The verdict resolves in the background once
+  // the hatch lands (see the effect below); an intercepted submit parks its
+  // values in `gatedFormValues` — deliberately NOT `formValues`, so neither
+  // the persistence snapshot nor the resume research-refire effect can act on
+  // a journey the user hasn't confirmed. `guardOverriddenRef` releases the
+  // gate for the rest of the visit once the user explicitly chooses to redo.
+  const establishedCheckRef = useRef<Promise<EstablishedAssistantCheck> | null>(
+    null,
+  );
+  const [establishedCheck, setEstablishedCheck] =
+    useState<EstablishedAssistantCheck | null>(null);
+  const [gatedFormValues, setGatedFormValues] =
+    useState<ResearchOnboardingValues | null>(null);
+  const guardOverriddenRef = useRef(false);
   const [faceValues, setFaceValues] = useState<GiveMeAFaceValues | null>(null);
   // Personality sliders live here (not in the step) so they survive a step-back
   // and stay shown once locked. `personalityLocked` flips true on the first
@@ -291,6 +318,21 @@ export function ResearchOnboardingRoute() {
     setPendingAvatarTraits(null);
     startHatch();
   }, [exitFocus, setPendingAvatarTraits, startHatch]);
+
+  // Resolve whether the hatched assistant already has a life BEFORE the flow
+  // can fire anything at it: the research turn writes memory and the
+  // personality step rewrites the persona, so an already-customized assistant
+  // must never be run through them silently. The submit handler awaits this
+  // verdict (briefly) and branches to the "existing" guard step.
+  useEffect(() => {
+    if (establishedCheckRef.current) return;
+    const check = awaitHatchReady()
+      .then((id) => checkEstablishedAssistant(id))
+      // A failed hatch surfaces its own error downstream; the guard fails open.
+      .catch(() => FRESH_ASSISTANT_CHECK);
+    establishedCheckRef.current = check;
+    void check.then(setEstablishedCheck);
+  }, [awaitHatchReady]);
 
   // Resume a journey saved by a previous session (a page refresh). Runs once,
   // as soon as the user id is known, BEFORE the persistence write / research
@@ -533,10 +575,9 @@ export function ResearchOnboardingRoute() {
     );
   }
 
-  function handleFormSubmit(values: ResearchOnboardingValues) {
-    setFormValues(values);
-    // Fire the research turn now; the runner awaits hatch readiness internally,
-    // so it starts at the later of this submit and the background hatch.
+  // Fire the research turn; the runner awaits hatch readiness internally, so
+  // it starts at the later of the caller's submit and the background hatch.
+  function fireResearch(values: ResearchOnboardingValues) {
     research.start({
       awaitAssistantId: awaitHatchReady,
       subject: researchSubjectFrom(values),
@@ -546,6 +587,30 @@ export function ResearchOnboardingRoute() {
       // onboarding is on, so don't ask the model to generate any.
       includeSuggestions: !personalityEnabled,
     });
+  }
+
+  async function handleFormSubmit(values: ResearchOnboardingValues) {
+    // Established-assistant guard: never run the flow's side effects against
+    // an assistant that already has a life without an explicit choice. Uses
+    // the settled verdict when available, otherwise waits briefly for the
+    // in-flight check — failing open so a slow daemon can't hold the form.
+    if (!guardOverriddenRef.current) {
+      const check =
+        establishedCheck ??
+        (await Promise.race([
+          establishedCheckRef.current ?? Promise.resolve(null),
+          new Promise<null>((resolve) => {
+            setTimeout(() => resolve(null), ESTABLISHED_CHECK_SUBMIT_WAIT_MS);
+          }),
+        ]));
+      if (check?.established) {
+        setGatedFormValues(values);
+        goForwardTo("existing");
+        return;
+      }
+    }
+    setFormValues(values);
+    fireResearch(values);
     goForwardTo("face");
   }
 
@@ -841,6 +906,54 @@ export function ResearchOnboardingRoute() {
         )}
         </OnboardingStageSizeProvider>
       </div>
+    );
+  }
+
+  // Established-assistant guard: an explicit keep-or-overwrite choice. Renders
+  // instead of advancing to "face" when the submitted-to assistant already has
+  // a life (see handleFormSubmit); a genuinely new user never lands here.
+  if (step === "existing") {
+    return (
+      <ExistingAssistantStep
+        assistantName={establishedCheck?.assistantName ?? null}
+        onKeep={() => {
+          // Terminal off-ramp: leaves via navigation, not goForwardTo, so emit
+          // the step outcome here (mirrors the suggestions terminal steps).
+          emitResearchOnboardingStepCompleted(
+            RESEARCH_ONBOARDING_FUNNEL_STEPS.existing,
+            { userId, outcome: "completed" },
+          );
+          clearResearchSnapshot(userId);
+          // Pin the selection to the adopted assistant, then enter the app —
+          // with no pre-chat context, kickoff, or persona write of any kind.
+          void lifecycleService
+            .checkAssistant(hatchedAssistantId ?? undefined)
+            .finally(() => {
+              void navigate(routes.assistant, { replace: true });
+            });
+        }}
+        onRedo={() => {
+          const values = gatedFormValues;
+          if (!values) return;
+          // Deliberate overwrite: release the gate for the rest of this visit
+          // and continue exactly where the intercepted submit left off.
+          guardOverriddenRef.current = true;
+          emitResearchOnboardingStepCompleted(
+            RESEARCH_ONBOARDING_FUNNEL_STEPS.existing,
+            { userId, outcome: "skipped" },
+          );
+          setFormValues(values);
+          fireResearch(values);
+          // Mirrors goForwardTo("face") minus the step-completion emit — the
+          // guard records its own outcome above instead.
+          setForwardStack([]);
+          navTo("face");
+        }}
+        onBack={() => {
+          setGatedFormValues(null);
+          goBackTo("form");
+        }}
+      />
     );
   }
 

--- a/clients/web/src/domains/onboarding/research-onboarding-persistence.ts
+++ b/clients/web/src/domains/onboarding/research-onboarding-persistence.ts
@@ -57,7 +57,10 @@ export type ResearchStep =
   | "looking"
   | "results"
   | "suggestions"
-  | "finishing";
+  | "finishing"
+  // Established-assistant guard: the off-ramp offered when the flow would run
+  // against an assistant that already has a life (see the route's guard).
+  | "existing";
 
 /** Completed research output — only snapshotted once the turn settles "done". */
 export interface PersistedResearchResults {
@@ -166,5 +169,9 @@ export function resolveResumeStep(
   if (snapshot.step === "meeting") {
     return snapshot.checkinBooked ? "looking" : "letschat";
   }
+  // The established-assistant guard holds an intercepted submit in transient
+  // state that a snapshot can't restore, so a saved journey never resumes onto
+  // it — land on the form and let a resubmit re-evaluate the guard.
+  if (snapshot.step === "existing") return "form";
   return snapshot.step;
 }

--- a/clients/web/src/domains/onboarding/screens/existing-assistant-step.test.tsx
+++ b/clients/web/src/domains/onboarding/screens/existing-assistant-step.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * Tests for the established-assistant guard step: name-aware copy and the
+ * keep / redo choice wiring.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { ExistingAssistantStep } from "@/domains/onboarding/screens/existing-assistant-step";
+
+function renderStep(
+  props: Partial<Parameters<typeof ExistingAssistantStep>[0]> = {},
+) {
+  return render(
+    <ExistingAssistantStep
+      assistantName="Viper"
+      onKeep={() => {}}
+      onRedo={() => {}}
+      onBack={() => {}}
+      {...props}
+    />,
+  );
+}
+
+afterEach(cleanup);
+
+describe("ExistingAssistantStep", () => {
+  test("names the assistant it is protecting", () => {
+    renderStep();
+
+    expect(
+      screen.getByText("Viper is already up and running"),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /Keep Viper and start chatting/ }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", {
+        name: /Start over and rebuild Viper's personality/,
+      }),
+    ).toBeTruthy();
+  });
+
+  test("falls back to generic copy when the name is unknown", () => {
+    renderStep({ assistantName: null });
+
+    expect(
+      screen.getByText("Your assistant is already up and running"),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", {
+        name: /Keep your assistant and start chatting/,
+      }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", {
+        name: /Start over and rebuild its personality/,
+      }),
+    ).toBeTruthy();
+  });
+
+  test("keep and redo fire their callbacks", () => {
+    const onKeep = mock(() => {});
+    const onRedo = mock(() => {});
+    renderStep({ onKeep, onRedo });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Keep Viper and start chatting/ }),
+    );
+    expect(onKeep).toHaveBeenCalledTimes(1);
+    expect(onRedo).not.toHaveBeenCalled();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Start over and rebuild Viper's personality/,
+      }),
+    );
+    expect(onRedo).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/web/src/domains/onboarding/screens/existing-assistant-step.tsx
+++ b/clients/web/src/domains/onboarding/screens/existing-assistant-step.tsx
@@ -1,0 +1,91 @@
+/**
+ * Guard step shown when the research-onboarding flow is about to run against
+ * an assistant that already has a life — lived conversations and (usually) a
+ * customized persona. Re-running the flow researches the user again and
+ * REWRITES the persona, so it never proceeds silently: the primary action
+ * keeps the assistant as-is and enters the app; redoing is an explicit,
+ * consequence-labeled choice. A genuinely new user never sees this screen.
+ */
+
+import { ArrowRight } from "lucide-react";
+import { Button } from "@vellumai/design-library/components/button";
+
+import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
+import { ONBOARDING_STEP_CONTENT } from "@/domains/onboarding/onboarding-step-layout";
+
+interface ExistingAssistantStepProps {
+  /** Current name of the established assistant, when known. */
+  assistantName: string | null;
+  /** Keep the assistant untouched and enter the app. */
+  onKeep: () => void;
+  /** Deliberately redo onboarding, overwriting the current persona. */
+  onRedo: () => void;
+  onBack: () => void;
+}
+
+export function ExistingAssistantStep({
+  assistantName,
+  onKeep,
+  onRedo,
+  onBack,
+}: ExistingAssistantStepProps) {
+  const name = assistantName?.trim() || "";
+  const subject = name || "your assistant";
+  const possessive = name ? `${name}'s` : "its";
+
+  return (
+    <div
+      data-theme="dark"
+      className="relative h-full overflow-hidden"
+      style={{
+        backgroundColor: "var(--surface-base)",
+        color: "var(--content-primary)",
+      }}
+    >
+      <OnboardingTopBar onBack={onBack} tone="light" />
+
+      <div className={`${ONBOARDING_STEP_CONTENT} max-w-xl`}>
+        <div className="flex flex-col items-center gap-3">
+          <h1
+            className="text-[2.2rem] leading-none"
+            style={{ fontFamily: "var(--font-serif)" }}
+          >
+            {name
+              ? `${name} is already up and running`
+              : "Your assistant is already up and running"}
+          </h1>
+          <p
+            className="text-[15px]"
+            style={{ color: "var(--content-secondary)" }}
+          >
+            You two have history — a personality, memories, and past
+            conversations. Running setup again would overwrite who {subject} is
+            now.
+          </p>
+        </div>
+
+        <div className="flex w-full max-w-sm flex-col items-center gap-3">
+          <Button
+            variant="primary"
+            size="regular"
+            fullWidth
+            onClick={onKeep}
+            className="h-11 text-base"
+          >
+            Keep {subject} and start chatting
+            <ArrowRight className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="regular"
+            fullWidth
+            onClick={onRedo}
+            className="h-11 text-base"
+          >
+            Start over and rebuild {possessive} personality
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/clients/web/src/utils/conversation-list-fetchers.ts
+++ b/clients/web/src/utils/conversation-list-fetchers.ts
@@ -262,6 +262,20 @@ export async function listConversations(
 }
 
 /**
+ * Whether the assistant has ANY active (non-archived) foreground conversation.
+ * One page answers existence, so this never walks the full list. Used by the
+ * onboarding established-assistant guard to detect a lived-in assistant before
+ * the flow fires anything at it. Throws on fetch failure — callers own the
+ * fail-open policy.
+ */
+export async function hasAnyActiveConversation(
+  assistantId: string,
+): Promise<boolean> {
+  const { conversations } = await fetchConversationListPage(assistantId, 0);
+  return conversations.length > 0;
+}
+
+/**
  * Fetch all active (non-archived) background conversations for a given
  * assistant, sorted newest-first.
  *

--- a/clients/web/src/utils/conversation-transforms-list.test.ts
+++ b/clients/web/src/utils/conversation-transforms-list.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import { client as daemonClient } from "@/generated/daemon/client.gen";
 import {
+  hasAnyActiveConversation,
   listBackgroundConversations,
   listConversations,
 } from "@/utils/conversation-list-fetchers";
@@ -481,5 +482,70 @@ describe("listBackgroundConversations — pagination", () => {
     expect(
       calls.every((c) => c.query?.conversationType === "background"),
     ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasAnyActiveConversation — single-page existence probe
+// ---------------------------------------------------------------------------
+
+describe("hasAnyActiveConversation", () => {
+  const originalGet = daemonClient.get;
+
+  afterEach(() => {
+    daemonClient.get = originalGet;
+  });
+
+  function setupSinglePage(conversationIds: string[]): {
+    calls: Array<{ query: Record<string, unknown> | undefined }>;
+  } {
+    const calls: Array<{ query: Record<string, unknown> | undefined }> = [];
+    daemonClient.get = mock(
+      async (options: { query?: Record<string, unknown> }) => {
+        calls.push({ query: options.query });
+        return {
+          data: {
+            conversations: conversationIds.map((id) => ({
+              id,
+              title: "",
+              createdAt: 0,
+              updatedAt: 0,
+              lastMessageAt: 0,
+              conversationType: "standard",
+              source: "vellum",
+              groupId: "",
+            })),
+            // Existence needs one page — hasMore must never trigger a walk.
+            hasMore: true,
+          },
+          error: null,
+          response: new Response(null, { status: 200 }),
+        };
+      },
+    ) as typeof daemonClient.get;
+    return { calls };
+  }
+
+  test("true when the first page has any conversation, fetching exactly one page", async () => {
+    const { calls } = setupSinglePage(["conv-1"]);
+
+    await expect(hasAnyActiveConversation("assistant-1")).resolves.toBe(true);
+    expect(calls).toHaveLength(1);
+  });
+
+  test("false when the assistant has no active conversations", async () => {
+    setupSinglePage([]);
+
+    await expect(hasAnyActiveConversation("assistant-1")).resolves.toBe(false);
+  });
+
+  test("throws on a failed fetch (callers own the fail-open policy)", async () => {
+    daemonClient.get = mock(async () => ({
+      data: null,
+      error: { message: "boom" },
+      response: new Response(null, { status: 500 }),
+    })) as typeof daemonClient.get;
+
+    await expect(hasAnyActiveConversation("assistant-1")).rejects.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- Adds an **established-assistant guard** to research/personality onboarding: before the flow fires anything at the hatched assistant, it resolves whether that assistant already has a life (any active foreground conversation — the flow's own side conversations are archived, so they don't count) and, if so, intercepts the form submit with an explicit choice step: **keep the assistant and go straight to chat** (primary — no research turn, no personality rewrite, no kickoff) or **deliberately start over**, labeled with the consequence ("Start over and rebuild <name>'s personality").
- Detection (`established-assistant.ts`) runs once at hatch-ready off a new single-page `hasAnyActiveConversation` probe + the existing `identityGet` for name-aware copy. It fails open only on genuine fetch failure; a positive history signal always gates (even if the identity lookup fails). Intercepted form values are deliberately parked outside `formValues` so neither the resume snapshot nor the research-refire effect can act on an unconfirmed journey.
- New `existing` funnel step (`research_existing_assistant`, appended index; outcome `completed` = kept, `skipped` = redid) so we can measure how many users hit the guard and which way they go.

## Why (P0 from the 2026-07-08 analysis)
The 18h post-v0.10.7 deep-dive (`.private/vellum-usage-analysis-2026-07-08.md`) caught the new default onboarding flow (#37142) running against an existing user's months-old assistant and **rewriting its persona** — IDENTITY.md/SOUL.md overwritten ("Viper" → "Ziggy"); the user only recovered because their assistant restored the files from its own git history (user hash 26beea). A second user (0d8c31) ran the entire flow twice. The personality step applies via a system message that rewrites identity files, so any re-entry into onboarding was silently destructive. This guard makes that impossible regardless of how the user ended up in the flow.

## Notes for follow-up
- The **entry-routing question** — why an established user was routed into new-user onboarding at all (suspected: fresh browser/device login where localStorage consent/completion markers are absent while the platform hatch returns the existing assistant with 200) — is deliberately out of scope and may warrant a platform-side follow-up.
- The multi-device local-vs-cloud instance split ("Earl vs Ziggy") is a separate issue, also out of scope.

## Original prompt
From the post-release telemetry conversation: implement the populated-identity guard recommended in the deep-dive — investigate how onboarding entry is decided and what signals exist to detect an established assistant, then gate the flow at entry with an explicit keep-vs-overwrite choice (keep = default, runs nothing), reusing existing endpoints and onboarding UI patterns, web client only, no feature flags, no daemon changes, with tests for detection and branch behavior.