### PR TITLE
fix(providers): encode disabled thinking as effort none on OpenRouter and Vercel gateways

### DIFF
--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -1622,6 +1622,17 @@ describe("OpenRouterProvider reasoning", () => {
     expect(lastCreateParams!.reasoning).toBeUndefined();
   });
 
+  test("disabled thinking with effort none sends the flat opt-out and no nested reasoning", async () => {
+    const provider = new OpenRouterProvider("or-key", "x-ai/grok-4");
+    await provider.sendMessage([userMsg("hi")], {
+      config: { thinking: { type: "disabled" }, effort: "none" },
+    });
+
+    expect(lastCreateParams).toBeTruthy();
+    expect(lastCreateParams!.reasoning).toBeUndefined();
+    expect(lastCreateParams!.reasoning_effort).toBe("none");
+  });
+
   test("omits reasoning when thinking config is absent", async () => {
     const provider = new OpenRouterProvider("or-key", "x-ai/grok-4");
     await provider.sendMessage([userMsg("hi")], {

--- a/assistant/src/__tests__/openrouter-provider-only.test.ts
+++ b/assistant/src/__tests__/openrouter-provider-only.test.ts
@@ -193,6 +193,17 @@ describe("OpenRouter provider.only plumbing", () => {
       expect(extras.reasoning).toBe(undefined);
     });
 
+    test("disabled thinking with effort none leaves the opt-out to the flat reasoning_effort field", () => {
+      const provider = new ProbeOpenRouterProvider(
+        "fake-key",
+        "x-ai/grok-4.20-beta",
+      );
+      const extras = provider.probeExtras({
+        config: { thinking: { type: "disabled" }, effort: "none" },
+      });
+      expect(extras).toEqual({});
+    });
+
     test("omitting reasoning avoids 400 from reasoning-only models like DeepSeek R1", () => {
       const provider = new ProbeOpenRouterProvider(
         "fake-key",

--- a/assistant/src/__tests__/vercel-ai-gateway-provider.test.ts
+++ b/assistant/src/__tests__/vercel-ai-gateway-provider.test.ts
@@ -190,6 +190,18 @@ describe("VercelAIGatewayProvider", () => {
       ).toEqual({});
     });
 
+    test("disabled thinking with effort none nests an explicit reasoning opt-out", () => {
+      const provider = new ProbeVercelAIGatewayProvider(
+        "fake-key",
+        "openai/gpt-5.5",
+      );
+      expect(
+        provider.probeExtras({
+          config: { thinking: { type: "disabled" }, effort: "none" },
+        }),
+      ).toEqual({ reasoning: { effort: "none" } });
+    });
+
     test("final wire params carry reasoning object and no flat reasoning_effort", async () => {
       const provider = new VercelAIGatewayProvider(
         "fake-key",

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -95,9 +95,10 @@ const VELLUM_PROFILE_IMPLS: Record<DefaultProfileKey, DefaultProfileTemplate> =
       label: "Speed",
       description: "Fastest responses at lower cost (DeepSeek V4 Flash)",
       maxTokens: 8192,
-      // Not "low": Fireworks strips the disabled `thinking` config but would
-      // still send a non-"none" effort as `reasoning_effort`, making this
-      // profile pay for reasoning despite thinking being off.
+      // Explicit reasoning opt-out. OpenAI-compat APIs default reasoning to
+      // "medium" when the field is omitted, and effort-driven providers encode
+      // disabled thinking through this same knob (see
+      // DISABLED_THINKING_USES_EFFORT_PROVIDERS in providers/retry.ts).
       effort: "none",
       thinking: { enabled: false, streamThinking: false },
       contextWindow: {

--- a/assistant/src/providers/__tests__/retry-callsite.test.ts
+++ b/assistant/src/providers/__tests__/retry-callsite.test.ts
@@ -543,6 +543,92 @@ describe("RetryProvider — callSite resolution", () => {
     expect(config.effort).toBe("none");
   });
 
+  test("disabled thinking forces effort none for OpenRouter and keeps the wire thinking config", async () => {
+    setLlmConfig({
+      default: {
+        provider: "openrouter",
+        model: "x-ai/grok-4",
+        effort: "high",
+        thinking: { enabled: false, streamThinking: false },
+      },
+      callSites: { mainAgent: {} },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("openrouter", (options) => {
+        seen = options;
+      }),
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    const config = seen?.config as Record<string, unknown>;
+    expect(config.effort).toBe("none");
+    // OpenRouter is thinking-aware: the wire-shape config still flows down so
+    // the client can decide its nested `reasoning` emission.
+    expect(config.thinking).toEqual({ type: "disabled" });
+  });
+
+  test("disabled thinking forces effort none for the Vercel AI Gateway", async () => {
+    setLlmConfig({
+      default: {
+        provider: "vercel-ai-gateway",
+        model: "xai/grok-4",
+        effort: "max",
+        thinking: { enabled: false, streamThinking: false },
+      },
+      callSites: { mainAgent: {} },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("vercel-ai-gateway", (options) => {
+        seen = options;
+      }),
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    const config = seen?.config as Record<string, unknown>;
+    expect(config.effort).toBe("none");
+    expect(config.thinking).toEqual({ type: "disabled" });
+  });
+
+  test("disabled thinking keeps effort for gateway-delegated anthropic/* models", async () => {
+    setLlmConfig({
+      default: {
+        provider: "openrouter",
+        model: "anthropic/claude-opus-4-8",
+        effort: "high",
+        thinking: { enabled: false, streamThinking: false },
+      },
+      callSites: { mainAgent: {} },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("openrouter", (options) => {
+        seen = options;
+      }),
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    // The Anthropic Messages delegate honors a disabled `thinking` natively;
+    // `effort` keeps its Anthropic meaning and must match the direct
+    // `anthropic` provider's behavior.
+    const config = seen?.config as Record<string, unknown>;
+    expect(config.effort).toBe("high");
+    expect(config.thinking).toEqual({ type: "disabled" });
+  });
+
   test("preserves thinking + level for Gemini provider", async () => {
     setLlmConfig({
       default: {

--- a/assistant/src/providers/openai/__tests__/chat-completions-provider-reasoning.test.ts
+++ b/assistant/src/providers/openai/__tests__/chat-completions-provider-reasoning.test.ts
@@ -528,3 +528,115 @@ describe("OpenAIChatCompletionsProvider reasoning parsing", () => {
     expect(params.messages[0].reasoning_content).toBe("deepseek thinking");
   });
 });
+
+describe("reasoning opt-out rejection fallback", () => {
+  function stubProviderWithErrors(
+    errors: unknown[],
+    chunks: MockChunk[],
+  ): { provider: OpenAIChatCompletionsProvider; requests: unknown[] } {
+    const provider = new OpenAIChatCompletionsProvider(
+      "test-key",
+      "test-model",
+    );
+    const requests: unknown[] = [];
+    const pending = [...errors];
+    (provider as unknown as { client: unknown }).client = {
+      chat: {
+        completions: {
+          create: async (params: unknown) => {
+            // Snapshot: the fallback mutates `params` between attempts.
+            requests.push(JSON.parse(JSON.stringify(params)));
+            const error = pending.shift();
+            if (error !== undefined) {
+              throw error;
+            }
+            return makeStream(chunks);
+          },
+        },
+      },
+    };
+    return { provider, requests };
+  }
+
+  const okChunks: MockChunk[] = [
+    {
+      choices: [{ delta: { content: "ok" }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    },
+  ];
+
+  function rejection(message: string, status = 400): Error {
+    return Object.assign(new Error(message), { status });
+  }
+
+  test("retries once without reasoning params when a model rejects the explicit opt-out", async () => {
+    const { provider, requests } = stubProviderWithErrors(
+      [rejection("reasoning_effort 'none' is not supported for this model")],
+      okChunks,
+    );
+
+    const response = await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      { config: { effort: "none" } },
+    );
+
+    expect(requests).toHaveLength(2);
+    const first = requests[0] as { reasoning_effort?: string };
+    const second = requests[1] as {
+      reasoning_effort?: string;
+      reasoning?: unknown;
+    };
+    expect(first.reasoning_effort).toBe("none");
+    expect(second.reasoning_effort).toBeUndefined();
+    expect(second.reasoning).toBeUndefined();
+    const text = response.content.find((b) => b.type === "text") as
+      | { type: "text"; text: string }
+      | undefined;
+    expect(text?.text).toBe("ok");
+  });
+
+  test("does not retry when the request did not opt out of reasoning", async () => {
+    const { provider, requests } = stubProviderWithErrors(
+      [rejection("reasoning_effort is invalid")],
+      okChunks,
+    );
+
+    await expect(
+      provider.sendMessage(
+        [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+        { config: { effort: "high" } },
+      ),
+    ).rejects.toThrow();
+    expect(requests).toHaveLength(1);
+  });
+
+  test("does not retry a 4xx that does not name reasoning", async () => {
+    const { provider, requests } = stubProviderWithErrors(
+      [rejection("invalid api key")],
+      okChunks,
+    );
+
+    await expect(
+      provider.sendMessage(
+        [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+        { config: { effort: "none" } },
+      ),
+    ).rejects.toThrow();
+    expect(requests).toHaveLength(1);
+  });
+
+  test("does not retry server errors", async () => {
+    const { provider, requests } = stubProviderWithErrors(
+      [rejection("reasoning backend unavailable", 500)],
+      okChunks,
+    );
+
+    await expect(
+      provider.sendMessage(
+        [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+        { config: { effort: "none" } },
+      ),
+    ).rejects.toThrow();
+    expect(requests).toHaveLength(1);
+  });
+});

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -3,6 +3,7 @@ import OpenAI from "openai";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../prompts/cache-boundary.js";
 import { isAbortReason } from "../../util/abort-reasons.js";
 import { ProviderError } from "../../util/errors.js";
+import { getLogger } from "../../util/logger.js";
 import { extractRetryAfterMs } from "../../util/retry.js";
 import { escapeXmlAttr } from "../../util/xml.js";
 import { base64Source, resolveMediaReferences } from "../media-resolve.js";
@@ -150,6 +151,8 @@ export interface OpenAIChatCompletionsProviderOptions {
   coerceObjectArgsToJsonString?: boolean;
 }
 
+const log = getLogger("chat-completions");
+
 /** Wire-level reasoning_effort values. The OpenAI SDK type doesn't include
  *  `"max"`, but Fireworks accepts it for DeepSeek V4; the assignment to
  *  `params.reasoning_effort` casts through this union. */
@@ -186,6 +189,35 @@ export function clampReasoningEffort(
   return REASONING_EFFORT_RANK[value] > REASONING_EFFORT_RANK[ceiling]
     ? ceiling
     : value;
+}
+
+/**
+ * True when the request carried an explicit reasoning opt-out (`"none"` sent
+ * as flat `reasoning_effort` or nested `reasoning.effort`) and the provider
+ * rejected it with a 4xx that names the reasoning field. Reasoning-only
+ * models (e.g. DeepSeek R1) reject the opt-out rather than ignore it; that
+ * one case is worth a single retry with the reasoning params stripped —
+ * model-default reasoning beats a hard failure.
+ */
+function isReasoningOptOutRejection(error: unknown, params: unknown): boolean {
+  const p = params as {
+    reasoning_effort?: unknown;
+    reasoning?: { effort?: unknown } | null;
+  };
+  const optedOut =
+    p.reasoning_effort === "none" ||
+    (typeof p.reasoning === "object" &&
+      p.reasoning !== null &&
+      p.reasoning.effort === "none");
+  if (!optedOut) {
+    return false;
+  }
+  const status = (error as { status?: unknown }).status;
+  if (typeof status !== "number" || status < 400 || status >= 500) {
+    return false;
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  return /reasoning/i.test(message);
 }
 
 /**
@@ -477,12 +509,32 @@ export class OpenAIChatCompletionsProvider implements Provider {
           ...this.requestHeaders,
           ...(usageAttributionHeaders ?? {}),
         };
-        const stream = await this.client.chat.completions.create(params, {
-          signal: timeoutSignal,
-          ...(Object.keys(requestHeaders).length > 0
-            ? { headers: requestHeaders }
-            : {}),
-        });
+        const createStream = () =>
+          this.client.chat.completions.create(params, {
+            signal: timeoutSignal,
+            ...(Object.keys(requestHeaders).length > 0
+              ? { headers: requestHeaders }
+              : {}),
+          });
+        let stream: Awaited<ReturnType<typeof createStream>>;
+        try {
+          stream = await createStream();
+        } catch (error) {
+          if (!isReasoningOptOutRejection(error, params)) {
+            throw error;
+          }
+          log.warn(
+            {
+              provider: this.name,
+              model: modelOverride ?? this.model,
+              error: error instanceof Error ? error.message : String(error),
+            },
+            "Model rejected the explicit reasoning opt-out; retrying without reasoning params",
+          );
+          delete params.reasoning_effort;
+          delete (params as unknown as Record<string, unknown>).reasoning;
+          stream = await createStream();
+        }
 
         for await (const chunk of stream) {
           const choice = chunk.choices[0];

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -59,7 +59,28 @@ const DISABLED_THINKING_USES_EFFORT_PROVIDERS = new Set([
   "openai",
   "fireworks",
   "together",
+  "openrouter",
+  "vercel-ai-gateway",
 ]);
+
+// Whether a disabled `thinking` config must be encoded as `effort: "none"`
+// for this provider/model. Gateway calls that delegate `anthropic/*` models
+// to the Anthropic Messages API are excluded: the delegate honors a disabled
+// `thinking` natively and `effort` keeps its Anthropic meaning there, so
+// forcing it would diverge from the direct `anthropic` provider.
+function disabledThinkingForcesEffortNone(
+  providerName: string,
+  model: unknown,
+): boolean {
+  if (!DISABLED_THINKING_USES_EFFORT_PROVIDERS.has(providerName)) {
+    return false;
+  }
+  return !(
+    isAnthropicDelegatingGateway(providerName) &&
+    typeof model === "string" &&
+    isAnthropicModel(model)
+  );
+}
 
 /**
  * Providers that consume the `thinking` config. Anthropic uses it directly on
@@ -386,7 +407,7 @@ function normalizeSendMessageOptions(
 
   if (
     isThinkingConfigDisabled(nextConfig.thinking) &&
-    DISABLED_THINKING_USES_EFFORT_PROVIDERS.has(providerName)
+    disabledThinkingForcesEffortNone(providerName, nextConfig.model)
   ) {
     nextConfig.effort = "none";
   }


### PR DESCRIPTION
## Summary
- Add `openrouter` and `vercel-ai-gateway` to `DISABLED_THINKING_USES_EFFORT_PROVIDERS` so a disabled `thinking` config forces `effort: "none"` on those transports too. Previously OpenRouter omitted its nested `reasoning` but still emitted flat `reasoning_effort` from the surviving effort, and the Vercel gateway nested `reasoning.effort` regardless of thinking — so thinking-off call sites kept paying for reasoning on BYOK gateway profiles. Gateway calls that delegate `anthropic/*` models are excluded: the Anthropic Messages delegate honors disabled thinking natively and `effort` keeps its Anthropic meaning there.
- Add a one-shot fallback in the OpenAI-compat provider: when a request carried the explicit opt-out (`"none"` flat or nested) and the model rejects it with a 4xx naming the reasoning field, retry once with reasoning params stripped and log a warn. Reasoning-only models (e.g. DeepSeek R1) reject the opt-out rather than ignore it; model-default reasoning beats a hard failure.
- Rewrite the stale comment on the managed cost-optimized profile that described pre-#36284 behavior (the forcing it warned about already exists).

**Preflight evidence** (`llm_usage_raw` since 07-01): glm-5p2 on Fireworks already receives the explicit `reasoning_effort: "none"` at fleet scale under the existing forcing — 9,991 successful thinking-off `recall` calls / 794 users — and deepseek-v4-flash likewise (~30k calls across thinking-off sites). minimax-m3 has no thinking-off production traffic yet, and "none" through the two gateways is exercised for the first time by this change — both are covered by the fallback. Post-deploy: watch the "Model rejected the explicit reasoning opt-out" warn log and gateway error rates.

## Original prompt
Follow-up to the memory-cost investigation and #37603. The intended semantic: `thinking.enabled === false` guarantees zero reasoning spend on every provider, with `effort` as the intensity dial when reasoning is permitted — call sites are provider-blind, so the off-switch must work without knowing which provider a profile resolves to. Investigation showed #36284 already implements this for openai/fireworks/together; the ask was to close the remaining gap (OpenRouter + Vercel AI Gateway), verified via live preflight plus a defensive one-shot fallback, with the call-site `effort: low` cleanup explicitly deferred.