### PR TITLE
fix(tests): bump timeout on max-size attachment upload test

### DIFF
--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -192,6 +192,8 @@ describe("uploadAttachment", () => {
     expect(() => uploadAttachment("ok.txt", "text/plain", "AAA")).not.toThrow();
   });
 
+  // Inserting the 100 MB payload into SQLite can take several seconds on
+  // slow CI runners, so this test needs more than the default 5s timeout.
   test("accepts payload exactly at MAX_UPLOAD_BYTES", () => {
     // MAX_UPLOAD_BYTES (100 MB) is divisible by 3, so (MAX/3)*4 base64 chars
     // decodes to exactly MAX bytes with no padding.
@@ -201,7 +203,7 @@ describe("uploadAttachment", () => {
     expect(() =>
       uploadAttachment("exact.bin", "application/octet-stream", exactData),
     ).not.toThrow();
-  });
+  }, 30_000);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Give `uploadAttachment > accepts payload exactly at MAX_UPLOAD_BYTES` (`assistant/src/__tests__/attachments-store.test.ts`) an explicit 30s timeout, matching the `}, 30_000)` convention used by other DB-heavy tests.
- The test inserts a 100 MB payload into SQLite; on the failing main run the insert alone took ~3.9s on a slow runner (the job log shows a slow-query warning), pushing the test past bun's default 5s timeout. The triggering commit was an unrelated providers change — this is a slow-runner flake, not a regression.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/28983380785/job/86006977809 (the `Test` job of "CI Main Assistant Checks" on main, which failed with a single test timeout in `attachments-store.test.ts`).