### PR TITLE
fix(onboarding): make suggestions calendar-connection aware

### DIFF
--- a/assistant/src/__tests__/integration-status.test.ts
+++ b/assistant/src/__tests__/integration-status.test.ts
@@ -6,6 +6,7 @@ const secureKeyValues = new Map<string, string>();
 let mockTwilioAccountSid: string | undefined;
 
 const connectedProviders = new Set<string>();
+const grantedScopesByProvider = new Map<string, string[]>();
 const managedProviders = new Set<string>();
 const platformConnectedProviders = new Set<string>();
 
@@ -35,6 +36,15 @@ mock.module("../oauth/oauth-store.js", () => ({
     connectedProviders.has(provider)
       ? { id: `conn-${provider}`, status: "active" }
       : undefined,
+  listConnections: (provider?: string) =>
+    [...connectedProviders]
+      .filter((p) => !provider || p === provider)
+      .map((p) => ({
+        id: `conn-${p}`,
+        provider: p,
+        status: "active",
+        grantedScopes: JSON.stringify(grantedScopesByProvider.get(p) ?? []),
+      })),
   getProvider: (provider: string) => {
     const managedKeys: Record<string, string> = {
       google: "google",
@@ -64,8 +74,11 @@ mock.module("../platform/client.js", () => ({
   },
 }));
 
-function setOAuthConnected(provider: string): void {
+function setOAuthConnected(provider: string, grantedScopes?: string[]): void {
   connectedProviders.add(provider);
+  if (grantedScopes) {
+    grantedScopesByProvider.set(provider, grantedScopes);
+  }
 }
 
 function setPlatformConnected(provider: string, configKey: string): void {
@@ -80,6 +93,7 @@ describe("integration-status", () => {
   beforeEach(() => {
     secureKeyValues.clear();
     connectedProviders.clear();
+    grantedScopesByProvider.clear();
     managedProviders.clear();
     platformConnectedProviders.clear();
     mockTwilioAccountSid = undefined;
@@ -90,6 +104,7 @@ describe("integration-status", () => {
       const summary = await getIntegrationSummary();
       expect(summary).toEqual([
         { name: "Gmail", category: "email", connected: false },
+        { name: "Google Calendar", category: "calendar", connected: false },
         { name: "Slack", category: "messaging", connected: false },
         { name: "Twilio", category: "telephony", connected: false },
         { name: "Telegram", category: "messaging", connected: false },
@@ -128,6 +143,7 @@ describe("integration-status", () => {
       ]);
       expect(disconnected.map((s: { name: string }) => s.name)).toEqual([
         "Gmail",
+        "Google Calendar",
         "Slack",
       ]);
     });
@@ -147,6 +163,52 @@ describe("integration-status", () => {
       );
       expect(telegram?.connected).toBe(false);
     });
+
+    test("Google Calendar disconnected when the google grant lacks calendar scopes", async () => {
+      setOAuthConnected("google", [
+        "https://www.googleapis.com/auth/gmail.readonly",
+      ]);
+
+      const summary = await getIntegrationSummary();
+      const byName = new Map(
+        summary.map((s: { name: string; connected: boolean }) => [
+          s.name,
+          s.connected,
+        ]),
+      );
+      expect(byName.get("Gmail")).toBe(true);
+      expect(byName.get("Google Calendar")).toBe(false);
+    });
+
+    test("Gmail disconnected when the google grant is calendar-only", async () => {
+      setOAuthConnected("google", [
+        "https://www.googleapis.com/auth/calendar.events",
+      ]);
+
+      const summary = await getIntegrationSummary();
+      const byName = new Map(
+        summary.map((s: { name: string; connected: boolean }) => [
+          s.name,
+          s.connected,
+        ]),
+      );
+      expect(byName.get("Gmail")).toBe(false);
+      expect(byName.get("Google Calendar")).toBe(true);
+    });
+
+    test("google connection with no scope data counts as both Gmail and Google Calendar", async () => {
+      setOAuthConnected("google");
+
+      const summary = await getIntegrationSummary();
+      const byName = new Map(
+        summary.map((s: { name: string; connected: boolean }) => [
+          s.name,
+          s.connected,
+        ]),
+      );
+      expect(byName.get("Gmail")).toBe(true);
+      expect(byName.get("Google Calendar")).toBe(true);
+    });
   });
 
   describe("formatIntegrationSummary", () => {
@@ -157,14 +219,14 @@ describe("integration-status", () => {
 
       const result = await formatIntegrationSummary();
       expect(result).toBe(
-        "Gmail \u2717 | Slack \u2717 | Twilio \u2713 | Telegram \u2713",
+        "Gmail \u2717 | Google Calendar \u2717 | Slack \u2717 | Twilio \u2713 | Telegram \u2713",
       );
     });
 
     test("all disconnected", async () => {
       const result = await formatIntegrationSummary();
       expect(result).toBe(
-        "Gmail \u2717 | Slack \u2717 | Twilio \u2717 | Telegram \u2717",
+        "Gmail \u2717 | Google Calendar \u2717 | Slack \u2717 | Twilio \u2717 | Telegram \u2717",
       );
     });
 
@@ -177,7 +239,7 @@ describe("integration-status", () => {
 
       const result = await formatIntegrationSummary();
       expect(result).toBe(
-        "Gmail \u2713 | Slack \u2713 | Twilio \u2713 | Telegram \u2713",
+        "Gmail \u2713 | Google Calendar \u2713 | Slack \u2713 | Twilio \u2713 | Telegram \u2713",
       );
     });
   });

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -93,10 +93,12 @@ const mockOauthConnections: Array<{
   provider: string;
   status: string;
   accountInfo?: string | null;
+  grantedScopes?: string | null;
 }> = [];
 const mockManagedConnections: Array<{
   provider: string;
   accountInfo?: string | null;
+  scopesGranted?: string[];
 }> = [];
 
 mock.module("../oauth/oauth-store.js", () => ({
@@ -192,6 +194,49 @@ describe("buildSystemPrompt", () => {
     expect(staticIdx).toBeGreaterThan(-1);
     expect(dynamicIdx).toBeGreaterThan(-1);
     expect(dynamicIdx).toBeGreaterThan(staticIdx);
+  });
+
+  test("names Google service access on a managed connected-services line", () => {
+    // A managed Google connection with no reported scopes falls back to the
+    // default bundle, so the model sees that calendar access is included.
+    mockManagedConnections.push({
+      provider: "google",
+      accountInfo: "user@example.com",
+    });
+
+    const result = buildSystemPrompt();
+
+    expect(result).toContain(
+      "- **google**: Connected (user@example.com — Gmail, Calendar, Drive access)",
+    );
+  });
+
+  test("derives Google services from a BYO connection's granted scopes", () => {
+    mockOauthConnections.push({
+      provider: "google",
+      status: "active",
+      accountInfo: "byo@example.com",
+      grantedScopes: JSON.stringify([
+        "https://www.googleapis.com/auth/calendar.events",
+      ]),
+    });
+
+    const result = buildSystemPrompt();
+
+    expect(result).toContain(
+      "- **google**: Connected (byo@example.com — Calendar access)",
+    );
+  });
+
+  test("leaves non-Google connected-services lines unchanged", () => {
+    mockManagedConnections.push({
+      provider: "slack",
+      accountInfo: "team@example.com",
+    });
+
+    const result = buildSystemPrompt();
+
+    expect(result).toContain("- **slack**: Connected (team@example.com)");
   });
 
   test("side-chain prompt options still include IDENTITY.md and SOUL.md", () => {

--- a/assistant/src/credential-execution/managed-catalog.ts
+++ b/assistant/src/credential-execution/managed-catalog.ts
@@ -76,6 +76,12 @@ export interface FetchManagedCatalogResult {
 export interface CachedManagedConnection {
   provider: string;
   accountInfo: string | null;
+  /**
+   * Granted OAuth scopes reported by the platform, when available. Absent or
+   * empty means the platform did not report scope data — callers treat that as
+   * unknown (assume the default service set), never as "no access".
+   */
+  scopesGranted?: string[];
 }
 
 let cachedConnections: CachedManagedConnection[] = [];
@@ -100,6 +106,7 @@ export async function refreshManagedConnectionCache(): Promise<void> {
       .map((d) => ({
         provider: d.provider,
         accountInfo: d.accountInfo,
+        scopesGranted: d.grantedScopes,
       }));
   }
 }

--- a/assistant/src/home/job-handlers/conversation-starters.ts
+++ b/assistant/src/home/job-handlers/conversation-starters.ts
@@ -24,6 +24,7 @@ import {
   getConfiguredProvider,
   userMessage,
 } from "../../providers/provider-send-message.js";
+import { formatIntegrationSummary } from "../../schedule/integration-status.js";
 import { getLogger } from "../../util/logger.js";
 import { truncate } from "../../util/truncate.js";
 import {
@@ -191,6 +192,13 @@ async function generateStarters(scopeId: string): Promise<GeneratedStarter[]> {
   const diff = buildNewItemsDiff(scopeId);
   const skills = buildSkillsSummary();
 
+  let integrationContext = "";
+  try {
+    integrationContext = `\n## Connected services\n${await formatIntegrationSummary()}\nFocus on what these connected services let you do right now; never suggest connecting a service that is already connected.`;
+  } catch {
+    // Best-effort — continue without integration info.
+  }
+
   const now = new Date();
   const timeContext = `Current time: ${now.toLocaleString("en-US", {
     weekday: "long",
@@ -224,6 +232,7 @@ ${
 ${rollup}
 ${diff}
 ${skills}
+${integrationContext}
 
 ## Selection
 

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -12,7 +12,7 @@ import { getConnectionAccessTokenResult } from "./credential-token-resolver.js";
 import { syncManualTokenConnection } from "./manual-token-connection.js";
 import { getActiveConnections, getProvider } from "./oauth-store.js";
 import { PlatformOAuthConnection } from "./platform-connection.js";
-import { scopeDifference } from "./scope-utils.js";
+import { parseGrantedScopes, scopeDifference } from "./scope-utils.js";
 
 const log = getLogger("connection-resolver");
 
@@ -472,19 +472,6 @@ function partitionByScopes<T>(
     eligible: [...satisfying, ...scopeUnknown],
     missingScopes: Array.from(new Set(missingPerItem.flat())),
   };
-}
-
-/** Best-effort parse of a connection row's JSON-encoded granted-scopes column. */
-function parseGrantedScopes(raw: string | null | undefined): string[] {
-  if (!raw) return [];
-  try {
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed)
-      ? parsed.filter((s): s is string => typeof s === "string")
-      : [];
-  } catch {
-    return [];
-  }
 }
 
 /** Actionable error shown when a connection is missing required scopes. */

--- a/assistant/src/oauth/google-service-labels.test.ts
+++ b/assistant/src/oauth/google-service-labels.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_GOOGLE_SERVICES,
+  deriveGoogleServices,
+  GOOGLE_SERVICE_CALENDAR,
+  GOOGLE_SERVICE_GMAIL,
+  isGoogleServiceGranted,
+} from "./google-service-labels.js";
+
+const CALENDAR_EVENTS = "https://www.googleapis.com/auth/calendar.events";
+const GMAIL_MODIFY = "https://www.googleapis.com/auth/gmail.modify";
+const DRIVE = "https://www.googleapis.com/auth/drive";
+
+describe("deriveGoogleServices", () => {
+  test("assumes the default bundle when scopes are missing", () => {
+    expect(deriveGoogleServices()).toEqual(DEFAULT_GOOGLE_SERVICES);
+    expect(deriveGoogleServices([])).toEqual(DEFAULT_GOOGLE_SERVICES);
+  });
+
+  test("maps known scopes to their service labels", () => {
+    expect(deriveGoogleServices([CALENDAR_EVENTS])).toEqual([
+      GOOGLE_SERVICE_CALENDAR,
+    ]);
+    expect(
+      deriveGoogleServices([GMAIL_MODIFY, CALENDAR_EVENTS, DRIVE]),
+    ).toEqual(["Gmail", "Calendar", "Drive"]);
+  });
+
+  test("collapses duplicate scopes for the same service", () => {
+    expect(
+      deriveGoogleServices([
+        GMAIL_MODIFY,
+        "https://www.googleapis.com/auth/gmail.send",
+      ]),
+    ).toEqual([GOOGLE_SERVICE_GMAIL]);
+  });
+
+  test("falls back to the default bundle when nothing maps", () => {
+    expect(
+      deriveGoogleServices(["https://www.googleapis.com/auth/unknown.scope"]),
+    ).toEqual(DEFAULT_GOOGLE_SERVICES);
+  });
+});
+
+describe("isGoogleServiceGranted", () => {
+  test("treats unknown scopes as granted (unknown → assume granted)", () => {
+    expect(isGoogleServiceGranted(GOOGLE_SERVICE_CALENDAR)).toBe(true);
+    expect(isGoogleServiceGranted(GOOGLE_SERVICE_CALENDAR, [])).toBe(true);
+  });
+
+  test("gates on a positive denial when scopes are known", () => {
+    expect(
+      isGoogleServiceGranted(GOOGLE_SERVICE_CALENDAR, [GMAIL_MODIFY]),
+    ).toBe(false);
+    expect(
+      isGoogleServiceGranted(GOOGLE_SERVICE_CALENDAR, [CALENDAR_EVENTS]),
+    ).toBe(true);
+  });
+});

--- a/assistant/src/oauth/google-service-labels.ts
+++ b/assistant/src/oauth/google-service-labels.ts
@@ -1,0 +1,62 @@
+/**
+ * Derives human-readable Google service labels (Gmail, Calendar, Drive) from
+ * the OAuth scopes granted to a Google connection.
+ *
+ * A single Google OAuth app bundles several products behind one provider key,
+ * and a connection may have been granted only a subset of them. When scope
+ * data is missing or empty the grant is treated as the full default bundle —
+ * unknown is "assume the standard services", never "no access". Callers that
+ * need to gate on a real denial must inspect the scopes directly.
+ */
+
+export const GOOGLE_SERVICE_GMAIL = "Gmail";
+export const GOOGLE_SERVICE_CALENDAR = "Calendar";
+export const GOOGLE_SERVICE_DRIVE = "Drive";
+
+/** Service set assumed when a Google connection reports no scope data. */
+export const DEFAULT_GOOGLE_SERVICES: string[] = [
+  GOOGLE_SERVICE_GMAIL,
+  GOOGLE_SERVICE_CALENDAR,
+  GOOGLE_SERVICE_DRIVE,
+];
+
+const SCOPE_SERVICE_MAP: Record<string, string> = {
+  "gmail.readonly": GOOGLE_SERVICE_GMAIL,
+  "gmail.modify": GOOGLE_SERVICE_GMAIL,
+  "gmail.send": GOOGLE_SERVICE_GMAIL,
+  "gmail.settings.basic": GOOGLE_SERVICE_GMAIL,
+  "calendar.readonly": GOOGLE_SERVICE_CALENDAR,
+  "calendar.events": GOOGLE_SERVICE_CALENDAR,
+  drive: GOOGLE_SERVICE_DRIVE,
+};
+
+/**
+ * Map a set of granted Google scopes to their display service labels. Returns
+ * the default bundle when scopes are absent, empty, or map to nothing known.
+ */
+export function deriveGoogleServices(scopes?: string[]): string[] {
+  if (!scopes?.length) {
+    return [...DEFAULT_GOOGLE_SERVICES];
+  }
+  const services = new Set<string>();
+  for (const scope of scopes) {
+    const suffix = scope.replace("https://www.googleapis.com/auth/", "");
+    const service = SCOPE_SERVICE_MAP[suffix];
+    if (service) {
+      services.add(service);
+    }
+  }
+  return services.size > 0 ? [...services] : [...DEFAULT_GOOGLE_SERVICES];
+}
+
+/**
+ * Whether a specific Google service is granted by the given scopes. Missing or
+ * empty scope data resolves to `true` (unknown → assume granted), matching
+ * {@link deriveGoogleServices}.
+ */
+export function isGoogleServiceGranted(
+  service: string,
+  scopes?: string[],
+): boolean {
+  return deriveGoogleServices(scopes).includes(service);
+}

--- a/assistant/src/oauth/scope-utils.ts
+++ b/assistant/src/oauth/scope-utils.ts
@@ -9,6 +9,25 @@
  */
 
 /**
+ * Parse a stored granted-scopes value (a JSON array string, as persisted on an
+ * OAuth connection row) into a string array. Returns `[]` for null/undefined,
+ * malformed JSON, or non-array payloads.
+ */
+export function parseGrantedScopes(raw: string | null | undefined): string[] {
+  if (!raw) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((s): s is string => typeof s === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Return the required scopes that are NOT present in the granted set.
  * An empty result means every required scope is granted.
  */

--- a/assistant/src/prompts/normalize-onboarding.ts
+++ b/assistant/src/prompts/normalize-onboarding.ts
@@ -1,3 +1,4 @@
+import { deriveGoogleServices } from "../oauth/google-service-labels.js";
 import type { OnboardingContext } from "../types/onboarding-context.js";
 
 /**
@@ -93,27 +94,6 @@ export interface NormalizedOnboarding {
   cohort?: string;
   websiteUrl?: string;
   contentSourceUrl?: string;
-}
-
-const SCOPE_SERVICE_MAP: Record<string, string> = {
-  "gmail.readonly": "Gmail",
-  "gmail.modify": "Gmail",
-  "gmail.send": "Gmail",
-  "gmail.settings.basic": "Gmail",
-  "calendar.readonly": "Calendar",
-  "calendar.events": "Calendar",
-  drive: "Drive",
-};
-
-export function deriveGoogleServices(scopes?: string[]): string[] {
-  if (!scopes?.length) return ["Gmail", "Calendar", "Drive"];
-  const services = new Set<string>();
-  for (const scope of scopes) {
-    const suffix = scope.replace("https://www.googleapis.com/auth/", "");
-    const service = SCOPE_SERVICE_MAP[suffix];
-    if (service) services.add(service);
-  }
-  return services.size > 0 ? [...services] : ["Gmail", "Calendar", "Drive"];
 }
 
 /**

--- a/assistant/src/prompts/templates/system-sections.ts
+++ b/assistant/src/prompts/templates/system-sections.ts
@@ -28,7 +28,9 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { getCachedManagedConnections } from "../../credential-execution/managed-catalog.js";
+import { deriveGoogleServices } from "../../oauth/google-service-labels.js";
 import { listConnections } from "../../oauth/oauth-store.js";
+import { parseGrantedScopes } from "../../oauth/scope-utils.js";
 import type { OnboardingContext } from "../../types/onboarding-context.js";
 import { stripCommentLines } from "../../util/strip-comment-lines.js";
 import { normalizeOnboardingContext } from "../normalize-onboarding.js";
@@ -127,17 +129,33 @@ function renderFirstRunUserContext(onboarding: OnboardingContext): string {
  * `14-connected-services` transform gates the section off entirely.
  */
 function renderConnectedServices(): string | null {
-  const entries: { provider: string; accountInfo?: string | null }[] = [];
+  const entries: {
+    provider: string;
+    accountInfo?: string | null;
+    scopes?: string[];
+  }[] = [];
 
   try {
-    entries.push(...listConnections().filter((c) => c.status === "active"));
+    entries.push(
+      ...listConnections()
+        .filter((c) => c.status === "active")
+        .map((c) => ({
+          provider: c.provider,
+          accountInfo: c.accountInfo,
+          scopes: parseGrantedScopes(c.grantedScopes),
+        })),
+    );
   } catch {
     // OAuth DB unavailable — local connections skipped.
   }
 
   for (const mc of getCachedManagedConnections()) {
     if (!entries.some((e) => e.provider === mc.provider)) {
-      entries.push(mc);
+      entries.push({
+        provider: mc.provider,
+        accountInfo: mc.accountInfo,
+        scopes: mc.scopesGranted,
+      });
     }
   }
 
@@ -145,9 +163,15 @@ function renderConnectedServices(): string | null {
 
   const lines = ["# Connected Services", ""];
   for (const conn of entries) {
-    const state = conn.accountInfo
-      ? `Connected (${conn.accountInfo})`
-      : "Connected";
+    // Google bundles Gmail/Calendar/Drive behind one provider key, so name the
+    // granted services explicitly — otherwise the model can't tell that a
+    // "google" connection already includes calendar access.
+    const detail =
+      conn.provider === "google"
+        ? `${deriveGoogleServices(conn.scopes).join(", ")} access`
+        : null;
+    const inside = [conn.accountInfo, detail].filter(Boolean).join(" — ");
+    const state = inside ? `Connected (${inside})` : "Connected";
     lines.push(`- **${conn.provider}**: ${state}`);
   }
   return lines.join("\n");

--- a/assistant/src/schedule/integration-status.ts
+++ b/assistant/src/schedule/integration-status.ts
@@ -1,10 +1,18 @@
 import { hasTwilioCredentials } from "../calls/twilio-rest.js";
 import type { Services } from "../config/schemas/services.js";
+import { getCachedManagedConnections } from "../credential-execution/managed-catalog.js";
+import {
+  GOOGLE_SERVICE_CALENDAR,
+  GOOGLE_SERVICE_GMAIL,
+  isGoogleServiceGranted,
+} from "../oauth/google-service-labels.js";
 import {
   getConnectionByProvider,
   getProvider,
   isProviderConnected,
+  listConnections,
 } from "../oauth/oauth-store.js";
+import { parseGrantedScopes } from "../oauth/scope-utils.js";
 
 /**
  * Check whether a provider has an active connection, handling both BYO
@@ -70,6 +78,35 @@ async function isProviderConnectedOnPlatform(
   }
 }
 
+/**
+ * Union of granted scopes across every active Google connection (BYO SQLite +
+ * platform-managed cache). Returns `undefined` when no scope data is available
+ * so callers apply the unknown → assume-granted rule. Best-effort: a store
+ * being unavailable contributes nothing rather than throwing.
+ */
+function collectGrantedGoogleScopes(): string[] | undefined {
+  const scopes: string[] = [];
+  try {
+    for (const row of listConnections("google")) {
+      if (row.status === "active") {
+        scopes.push(...parseGrantedScopes(row.grantedScopes));
+      }
+    }
+  } catch {
+    // BYO OAuth store unavailable — contribute no scopes.
+  }
+  try {
+    for (const mc of getCachedManagedConnections()) {
+      if (mc.provider === "google" && mc.scopesGranted?.length) {
+        scopes.push(...mc.scopesGranted);
+      }
+    }
+  } catch {
+    // Managed cache unavailable — contribute no scopes.
+  }
+  return scopes.length > 0 ? scopes : undefined;
+}
+
 interface IntegrationProbe {
   name: string;
   category: string;
@@ -81,7 +118,28 @@ const INTEGRATION_PROBES: IntegrationProbe[] = [
   {
     name: "Gmail",
     category: "email",
-    isConnected: () => isOAuthProviderConnected("google"),
+    isConnected: async () => {
+      if (!(await isOAuthProviderConnected("google"))) {
+        return false;
+      }
+      return isGoogleServiceGranted(
+        GOOGLE_SERVICE_GMAIL,
+        collectGrantedGoogleScopes(),
+      );
+    },
+  },
+  {
+    name: "Google Calendar",
+    category: "calendar",
+    isConnected: async () => {
+      if (!(await isOAuthProviderConnected("google"))) {
+        return false;
+      }
+      return isGoogleServiceGranted(
+        GOOGLE_SERVICE_CALENDAR,
+        collectGrantedGoogleScopes(),
+      );
+    },
   },
   {
     name: "Slack",

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -246,6 +246,12 @@ export function ResearchOnboardingRoute() {
   // entirely and go straight to the research reveal. Vellum-cloud onboarding
   // keeps them: a managed hatch implies a platform session.
   const skipCheckinSteps = adoptExistingAssistant;
+  // The calendar-connect steps run for exactly the flows that DON'T skip them,
+  // and those flows connect the user's Google Calendar one screen after the
+  // research turn fires. The research/suggestion prompt is told this so it never
+  // offers to connect a calendar that's about to be (or already) connected. A
+  // local-hosting flow skips the calendar steps, so the flag is false there.
+  const calendarConnectedByFlow = !skipCheckinSteps;
   const {
     start: startHatch,
     ready: hatchReady,
@@ -401,6 +407,7 @@ export function ResearchOnboardingRoute() {
         : {}),
       onConversationCreated: setResearchConversationId,
       includeSuggestions: !personalityEnabled,
+      calendarConnectedByFlow,
     });
   }, [
     restored,
@@ -410,6 +417,7 @@ export function ResearchOnboardingRoute() {
     startResearch,
     awaitHatchReady,
     personalityEnabled,
+    calendarConnectedByFlow,
   ]);
 
   // If we're sitting on the results step when the research turn resolves empty
@@ -461,12 +469,16 @@ export function ResearchOnboardingRoute() {
         : {
             initialMessage:
               entryPrompt ??
-              buildResearchPrompt({
-                firstName,
-                lastName,
-                occupation: role,
-                hobby: hobbies.join(", "),
-              }),
+              buildResearchPrompt(
+                {
+                  firstName,
+                  lastName,
+                  occupation: role,
+                  hobby: hobbies.join(", "),
+                },
+                [],
+                { calendarConnectedByFlow },
+              ),
             // A hidden kickoff (the "Let's chat" handoff) drives the first reply
             // without rendering a user bubble, so the chat opens as a proactive
             // greeting in the configured persona.
@@ -545,6 +557,7 @@ export function ResearchOnboardingRoute() {
       // The "Let's chat" final step replaces suggestions when personality
       // onboarding is on, so don't ask the model to generate any.
       includeSuggestions: !personalityEnabled,
+      calendarConnectedByFlow,
     });
     goForwardTo("face");
   }

--- a/clients/web/src/domains/onboarding/research-prompt.test.ts
+++ b/clients/web/src/domains/onboarding/research-prompt.test.ts
@@ -103,6 +103,58 @@ describe("buildResearchPrompt — suggestions toggle", () => {
   });
 });
 
+describe("buildResearchPrompt — calendarConnectedByFlow", () => {
+  const caps: AvailableCapability[] = [
+    { name: "marketing-expert", description: "Full-stack marketing." },
+  ];
+
+  test("is byte-for-byte unchanged when the flag is off or absent", () => {
+    const absent = buildResearchPrompt(SUBJECT, caps);
+    const explicitOff = buildResearchPrompt(SUBJECT, caps, {
+      calendarConnectedByFlow: false,
+    });
+
+    expect(explicitOff).toBe(absent);
+    // The legacy integration list (with Gmail/Calendar as connectable) stays.
+    expect(absent).toContain(
+      "an integration (GitHub, Gmail, Calendar, Slack, Linear) connected with a first action",
+    );
+    expect(absent).not.toContain("connected as part of this setup flow");
+  });
+
+  test("suppresses calendar-connect offers and assumes access when the flag is on", () => {
+    const prompt = buildResearchPrompt(SUBJECT, caps, {
+      calendarConnectedByFlow: true,
+    });
+
+    expect(prompt).toContain(
+      "the user's Google Calendar is already connected",
+    );
+    expect(prompt).toContain('NEVER produce a "Connect your calendar"-style');
+    // The user-voiced prompt must name Google Calendar so the downstream agent
+    // doesn't ask which provider to use.
+    expect(prompt).toContain("Prep my day each morning using my Google Calendar.");
+    // Google/Gmail/Calendar drop out of the connectable-integration list.
+    expect(prompt).toContain(
+      "an integration you're NOT already connected to (GitHub, Slack, Linear)",
+    );
+    expect(prompt).not.toContain(
+      "an integration (GitHub, Gmail, Calendar, Slack, Linear)",
+    );
+  });
+
+  test("has no effect when suggestions are disabled", () => {
+    const prompt = buildResearchPrompt(SUBJECT, caps, {
+      includeSuggestions: false,
+      calendarConnectedByFlow: true,
+    });
+
+    // Calendar guidance rides inside the suggestion rules, which are omitted.
+    expect(prompt).not.toContain("connected as part of this setup flow");
+    expect(prompt).not.toContain('Rules for "suggestions":');
+  });
+});
+
 describe("buildResearchPrompt — identity gate & confidence calibration", () => {
   test("states the identity gate and the honest no-match fallback", () => {
     const prompt = buildResearchPrompt(SUBJECT);

--- a/clients/web/src/domains/onboarding/research-prompt.ts
+++ b/clients/web/src/domains/onboarding/research-prompt.ts
@@ -89,12 +89,25 @@ export interface BuildResearchPromptOptions {
    * guidance. Defaults to true so the legacy suggestions flow is unchanged.
    */
   includeSuggestions?: boolean;
+  /**
+   * Whether the onboarding flow itself connects the user's Google Calendar (a
+   * dedicated connect step runs one screen after the research turn fires). When
+   * true, the suggestion rules assume Google Calendar is already connected and
+   * suppress any "connect your calendar / Google / Gmail" offers, so a
+   * calendar suggestion reads as using the calendar rather than connecting it.
+   * Only meaningful with `includeSuggestions`. Defaults to false so callers
+   * outside that flow (and snapshots) are byte-for-byte unchanged.
+   */
+  calendarConnectedByFlow?: boolean;
 }
 
 export function buildResearchPrompt(
   { firstName, lastName, occupation, hobby, timezone }: ResearchSubject,
   availableCapabilities: AvailableCapability[] = [],
-  { includeSuggestions = true }: BuildResearchPromptOptions = {},
+  {
+    includeSuggestions = true,
+    calendarConnectedByFlow = false,
+  }: BuildResearchPromptOptions = {},
 ): string {
   const fullName = [firstName.trim(), lastName.trim()]
     .filter(Boolean)
@@ -144,6 +157,18 @@ export function buildResearchPrompt(
     ? "claims and suggestions"
     : "claims";
 
+  const integrationClause = calendarConnectedByFlow
+    ? "an integration you're NOT already connected to (GitHub, Slack, Linear) connected with a first action"
+    : "an integration (GitHub, Gmail, Calendar, Slack, Linear) connected with a first action";
+  // The onboarding flow connects Google Calendar one screen after this turn
+  // fires, so by the time these cards show it is already connected. Suppress
+  // any connect-my-calendar offer and force calendar suggestions to name Google
+  // Calendar in the user-voiced prompt so the downstream agent doesn't ask which
+  // provider to use.
+  const calendarGuidance = calendarConnectedByFlow
+    ? `\nGoogle Calendar is connected as part of this setup flow, so by the time these suggestions are shown the user's Google Calendar is already connected. NEVER produce a "Connect your calendar"-style suggestion, or any suggestion asking to connect Google, Gmail, or Calendar. A calendar-based suggestion must assume Google Calendar access and be phrased as using it — e.g. suggestion "I'll prep your day each morning from your calendar", prompt "Prep my day each morning using my Google Calendar." (The user-voiced prompt must name Google Calendar explicitly so the downstream assistant never asks which calendar provider to use.)`
+    : "";
+
   const suggestionRules = includeSuggestions
     ? `Rules for "suggestions":
 
@@ -151,7 +176,7 @@ Each suggestion is an object with two fields:
 "suggestion": the offer in YOUR voice (the assistant), exactly as it appears on the clickable card — first-person "I" refers to you (whatever your name). Pattern: "I'll [verb] [specific artifact]" or "Connect me to [integration] and I'll [verb] [artifact]." Lead with the offer; no intake question in front of it — you gather the details in the follow-up conversation after the click.
 "prompt": the same offer re-voiced as the message sent on the user's behalf when they click, in the USER's first person ("I"/"my" = the user) — what they'd say to take you up on it (suggestion "I'll find you 3 papers" → prompt "Find me 3 papers worth reading"). State the request; don't echo the assistant-voiced wording and don't ask a question back.
 
-Generate EXACTLY 4 suggestions covering four DIFFERENT capabilities, each making me think "wait, you can do that?" Draw on your range — a quick researched answer, a recurring brief or monitor, a doc drafted in a live editor, an integration (GitHub, Gmail, Calendar, Slack, Linear) connected with a first action, or a hobby hook if research surfaced one — but pick what genuinely fits; don't force a fixed set.
+Generate EXACTLY 4 suggestions covering four DIFFERENT capabilities, each making me think "wait, you can do that?" Draw on your range — a quick researched answer, a recurring brief or monitor, a doc drafted in a live editor, ${integrationClause}, or a hobby hook if research surfaced one — but pick what genuinely fits; don't force a fixed set.${calendarGuidance}
 Ground every suggestion in what you actually learned about me — my real role, stack, industry, and (if given) hobby. Specific to me, not generic assistant stuff; skip bare "summarize" or "draft a post."
 CRITICAL: every suggestion must be a fast win you can deliver in the first reply, never a long-running build. NEVER suggest building an app, dashboard, tool, site, or tracker, or any multi-step "build me a ___" project — those kill the first impression. The ambitious build can come later in the conversation, never on the first card.
 Keep each SHORT and skimmable: under 10 words, ONE clause, ONE artifact, no lists of three ("X, Y, and Z"). The reader scans four cards in seconds — a long line loses them.

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -246,6 +246,13 @@ export interface StartResearchOptions {
    * true so the legacy suggestions flow is unchanged.
    */
   includeSuggestions?: boolean;
+  /**
+   * Whether the onboarding flow connects the user's Google Calendar (a
+   * dedicated connect step runs one screen after this turn fires). Forwarded to
+   * `buildResearchPrompt` so calendar suggestions assume the connection instead
+   * of offering to make it. Defaults to false.
+   */
+  calendarConnectedByFlow?: boolean;
 }
 
 export interface UseResearchRunner extends ResearchRunnerState {
@@ -358,6 +365,7 @@ export function useResearchRunner(): UseResearchRunner {
       resumeConversationId,
       onConversationCreated,
       includeSuggestions = true,
+      calendarConnectedByFlow = false,
     }: StartResearchOptions) => {
       const subjectKey = JSON.stringify(subject);
       if (subjectKeyRef.current === subjectKey) return;
@@ -439,6 +447,7 @@ export function useResearchRunner(): UseResearchRunner {
               conversationId: cid,
               content: buildResearchPrompt(subject, capabilities, {
                 includeSuggestions,
+                calendarConnectedByFlow,
               }),
               sourceChannel: "vellum",
               // `interface` is the transport ("web"); the real OS travels in


### PR DESCRIPTION
## Problem

Session replay of a real onboarding: the user connected Google Calendar during onboarding, yet the "Here's what we could do first" cards offered **"Connect your calendar and I'll prep your day each morning."** Clicking it sent "Connect to my calendar…" to the assistant, which asked **"Which calendar do you use, google or outlook?"** — the user dismissed the card without answering.

Three compounding gaps:

1. **The research turn fires before the calendar-connect step** (deliberately, to hide latency behind the calendar page), and its prompt even offers "Connect me to [integration] … Calendar …" as a suggestion pattern — it has no idea the flow connects Google Calendar one screen later.
2. **The main agent's Connected Services section is provider-granular** (`- **google**: Connected`) — nothing says calendar access rides on that connection, so the agent asks which provider to use.
3. **Daemon-side suggestion generators are calendar-blind**: the integration summary probes Gmail/Slack/Twilio/Telegram only, and conversation starters get no connection context at all.

## Changes

- **web**: `buildResearchPrompt` gains `calendarConnectedByFlow`. When set (exactly the flows that run the calendar-connect steps; false for local-hosting/adopt flows), the suggestion rules ban connect-calendar/Google/Gmail offers and require calendar suggestions to name Google Calendar in the user-voiced prompt — so the downstream agent never asks which provider. Prompt is byte-for-byte unchanged when the flag is off.
- **daemon**: Google scope → service-label derivation (`Gmail`/`Calendar`/`Drive`) extracted from `normalize-onboarding.ts` into shared `oauth/google-service-labels.ts`; `parseGrantedScopes` moved to `oauth/scope-utils.ts` (now three consumers). Unknown/empty scope data ⇒ assume the default bundle, never "no access".
- **daemon**: managed-connection cache (`CachedManagedConnection`) now carries `scopesGranted` from the platform catalog instead of dropping it.
- **daemon**: Connected Services renders Google service access — `- **google**: Connected (user@example.com — Gmail, Calendar, Drive access)`.
- **daemon**: integration summary gains a scope-aware **Google Calendar** probe (Gmail probe also scope-aware now); conversation-starter generation receives the connected-services line with "never suggest connecting an already-connected service".

## Verification

- `assistant`: `tsgo --noEmit` clean; `integration-status`, `system-prompt`, `google-service-labels`, `suggested-prompts` tests pass; lint 0 errors.
- `clients/web`: `tsc --noEmit` clean; `research-prompt` tests pass (both flag states + byte-for-byte-off guarantee).
- Note: co-running `integration-status.test.ts` + `system-prompt.test.ts` in one bun process fails on `main` too (cross-file `mock.module` bleed) — pre-existing, each file passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)