### PR TITLE
Add Influencer Marketing plugin to marketplace

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -340,6 +340,18 @@
       "description": "Cognee knowledge graph memory for Vellum Assistant: session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
       "category": "memory",
       "homepage": "https://github.com/topoteretes/cognee-integrations/tree/main/integrations/vellum-assistant"
+    },
+    {
+      "name": "influencer-marketing",
+      "source": {
+        "source": "github",
+        "repo": "ZeebBoyBlue/influencer",
+        "ref": "8629b0dcfdacf62246122af2dcd7320baa6db04e"
+      },
+      "description": "Find and research influencers on Instagram, TikTok, and X/Twitter. Includes a strategy builder that walks from campaign brief to research criteria, a research skill that discovers real profiles via browser automation, scores candidates, and exports ranked shortlists, and a dashboard skill that turns the shortlist into an interactive outreach tracker.",
+      "category": "marketing",
+      "homepage": "https://github.com/ZeebBoyBlue/influencer",
+      "license": "MIT"
     }
   ]
 }


### PR DESCRIPTION
## What

Adds the **influencer-marketing** plugin to `plugins/marketplace.json` (pinned to [`8629b0d`](https://github.com/ZeebBoyBlue/influencer/commit/8629b0dcfdacf62246122af2dcd7320baa6db04e)).

Repo: https://github.com/ZeebBoyBlue/influencer · MIT · category: marketing

## What the plugin does

Three skills for influencer marketing research:

- **influencer-strategy** — walks a campaign brief (goals, budget, audience) into concrete research criteria
- **influencer** — discovers real creator profiles on Instagram/TikTok/X via the assistant's browser (extension mode preferred, Playwright fallback), computes engagement from recent posts, scores and flags candidates (dormant, low engagement, suspicious follower patterns), exports ranked CSV/JSON shortlists
- **influencer-dashboard** — builds an interactive dashboard app from the shortlist: sortable table, engagement-vs-score chart, per-creator outreach status tracker

No fabricated data anywhere in the pipeline — profiles come from live browser extraction, and every skill enforces that rule explicitly.

## Testing

- 34 unit tests across 7 files, all passing (`bun test`)
- Full pipeline live-tested end to end: leather-goods niche discovery run on Instagram via Chrome extension mode → engagement computation → scoring → CSV/JSON export → dashboard build
- Install path verified: `assistant plugins install` from the GitHub repo, all three skills register and load