### PR TITLE
Add tennis-companion to the plugin marketplace

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -256,6 +256,18 @@
       "category": "lifestyle",
       "homepage": "https://github.com/vellum-ai/plant-doctor",
       "license": "MIT"
+    },
+    {
+      "name": "tennis-companion",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/tennis-companion",
+        "ref": "7ff65ce9ee10e84aaf44d541522bb83b767a445a"
+      },
+      "description": "Tennis journal, drill sessions, court finder, and progress tracking. Log matches with opponent tendencies, generate 30-minute practice sessions with progressions, find nearby courts via OpenStreetMap, and track win rate by surface and conditions.",
+      "category": "lifestyle",
+      "homepage": "https://github.com/vellum-ai/tennis-companion",
+      "license": "MIT"
     }
   ]
 }

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -265,7 +265,7 @@
         "ref": "d519eb9075f6f5225b9063f676fa40889869c749"
       },
       "description": "Tennis journal, drill sessions, court finder, and progress tracking. Log matches with opponent tendencies, generate 30-minute practice sessions with progressions, find nearby courts via OpenStreetMap, and track win rate by surface and conditions.",
-      "category": "lifestyle",
+      "category": "health",
       "homepage": "https://github.com/vellum-ai/tennis-companion",
       "license": "MIT"
     }

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -262,7 +262,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/tennis-companion",
-        "ref": "7ff65ce9ee10e84aaf44d541522bb83b767a445a"
+        "ref": "d519eb9075f6f5225b9063f676fa40889869c749"
       },
       "description": "Tennis journal, drill sessions, court finder, and progress tracking. Log matches with opponent tendencies, generate 30-minute practice sessions with progressions, find nearby courts via OpenStreetMap, and track win rate by surface and conditions.",
       "category": "lifestyle",


### PR DESCRIPTION
Adds the tennis-companion plugin to the marketplace catalog.

**Repo:** https://github.com/vellum-ai/tennis-companion (pinned to `7ff65ce9ee10e84aaf44d541522bb83b767a445a`)

**What it does:**
- Match journal: opponent, result, score, surface, conditions, what worked, opponent tendencies, self-rating. Scouting notes resurface before rematches.
- Drill sessions: structured practice (default 30 min) built from a 25-drill library across 8 categories and 3 levels. Warmup, main drills with progressions, match-play finisher. Sessions logged to practice history.
- Court finder: nearby courts via OpenStreetMap (Nominatim + Overpass, no API key). Unnamed courts are labeled with their surrounding park name.
- Progress tracking: win rate overall and by surface/conditions, streaks, recent form, self-rating trend, head-to-head records, practice focus breakdown.

**Surfaces:** 4 tools (tennis_log_match, tennis_drill_session, tennis_find_courts, tennis_progress), 1 skill, 1 init hook. CSV storage in the plugin data dir, same pattern as fitness-companion and plant-doctor.

**Category:** lifestyle. License: MIT.

All four tools exercised locally: match logging + progress stats verified with sample data, drill builder produces sessions that sum to the requested minutes, court search tested live against Williamsburg (returns McCarren Park, Cooper Park, Pier 42 with surface/lighting tags). Plugin loads with status ok.