### PR TITLE
fix(providers): retry when the model streams unparseable tool-call JSON

### DIFF
--- a/assistant/src/__tests__/provider-error-scenarios.test.ts
+++ b/assistant/src/__tests__/provider-error-scenarios.test.ts
@@ -643,6 +643,21 @@ describe("RetryProvider — streaming corruption retries", () => {
     expect(inner.calls).toBe(2);
   });
 
+  test("retries on 'Unable to parse tool parameter JSON' (invalid tool-args JSON in stream)", async () => {
+    const inner = makeFlaky(
+      1,
+      new ProviderError(
+        'Anthropic request failed: Unable to parse tool parameter JSON from model. Please retry your request or adjust your prompt. Error: SyntaxError: JSON Parse error: Unterminated string. JSON: {"path": "/workspace/config.json", "content',
+        "anthropic",
+      ),
+    );
+    const provider = new RetryProvider(inner);
+
+    const result = await provider.sendMessage(MESSAGES);
+    expect(result.stopReason).toBe("end_turn");
+    expect(inner.calls).toBe(2);
+  });
+
   test("throws after exhausting retries on persistent stream corruption", async () => {
     const inner = makeFailing(
       new ProviderError(

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -96,6 +96,11 @@ const RETRYABLE_STREAM_PATTERNS = [
   "stream ended without producing",
   "request ended without sending any chunks",
   "stream has ended, this shouldn't happen",
+  // The SDK's stream accumulator throws this when the model emits tool-call
+  // arguments that don't parse as JSON (e.g. a raw control character inside a
+  // string). It's a stochastic model degeneration, not a request problem — a
+  // resend almost always succeeds.
+  "Unable to parse tool parameter JSON",
 ];
 
 /**


### PR DESCRIPTION
## Problem

A user's conversation died with:

> Processing failed: Anthropic request failed: Unable to parse tool parameter JSON from model. … SyntaxError: JSON Parse error: Unterminated string.

Root cause (from feedback logs `019f444b`): mid-stream, a `file_write` tool call's accumulated `input_json_delta` buffer contained genuinely invalid JSON — after the complete `content` parameter, a duplicated key with a raw (unescaped) newline character inside the key string:

```
..., "sessionMinutes": 30\n}\n", "content⏎": "\n"}
```

One raw `0x0A` among dozens of correctly escaped newlines — a stochastic model degeneration (~1 bad byte in 2,100 output tokens; the conversation's three prior calls were clean). Verified byte-for-byte that no intermediary introduced it: the platform runtime proxy yields Anthropic SSE bytes verbatim, and the daemon uses the stock SDK with no stream re-framing.

The Anthropic SDK's stream accumulator re-parses the buffer on every delta (tolerantly — truncation never throws; illegal content does) and aborts the stream on failure. That surfaces as a **status-less** `ProviderError` which matched none of our retryable patterns, so the turn hard-failed instead of resending — even though the SSE error event itself was flagged `retryable: true` for the manual retry button.

## Fix

Add `"Unable to parse tool parameter JSON"` to `RETRYABLE_STREAM_PATTERNS` — the pattern family that exists for exactly this class of transient SDK stream corruption. As with the existing patterns, it only applies when the error carries no HTTP status, so a 4xx that happens to contain the phrase is never retried.

## Testing

- New test in `provider-error-scenarios.test.ts` mirroring the existing stream-corruption cases (fails once with the real error message, succeeds on retry, asserts exactly 2 calls).
- `bun test src/__tests__/provider-error-scenarios.test.ts` — 49 pass / 0 fail.
- `typecheck:fast` and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->