### PR TITLE
tennis-companion: repin to tool schema fix

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -262,7 +262,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/tennis-companion",
-        "ref": "d519eb9075f6f5225b9063f676fa40889869c749"
+        "ref": "1c6d2bd448ee7b5285d37cfee4e0e413522746d1"
       },
       "description": "Tennis journal, drill sessions, court finder, and progress tracking. Log matches with opponent tendencies, generate 30-minute practice sessions with progressions, find nearby courts via OpenStreetMap, and track win rate by surface and conditions.",
       "category": "health",


### PR DESCRIPTION
Follow-up to #37616, which merged pinned to `d519eb9` where the four tools declared their JSON schema under `parameters` instead of `input_schema`. The loader silently dropped the schemas, so the tools registered with no parameters (court finder could not accept a location, etc.).

Fixed in vellum-ai/tennis-companion@1c6d2bd448ee7b5285d37cfee4e0e413522746d1: renamed the field to `input_schema` in all four tools and added `defaultRiskLevel`. Verified locally that schemas now expose their parameters.

This PR only repins the marketplace ref.