### PR TITLE
marketplace: add kitchen-companion v0.1.0

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -18,6 +18,18 @@
       "license": "MIT"
     },
     {
+      "name": "kitchen-companion",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/kitchen-companion",
+        "ref": "a268f495f8177144477055f7f1956f28c5574669"
+      },
+      "description": "Full kitchen companion. Scan your fridge with a photo to stock a pantry inventory and get 3 makeable-now recipes, get alerts before food expires, clip recipes from any URL into a clean format, and generate meal plans with grocery lists from what you actually have.",
+      "category": "lifestyle",
+      "homepage": "https://github.com/vellum-ai/kitchen-companion",
+      "license": "MIT"
+    },
+    {
       "name": "simple-memory",
       "source": {
         "source": "github",

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -22,7 +22,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/kitchen-companion",
-        "ref": "a268f495f8177144477055f7f1956f28c5574669"
+        "ref": "b6ebdda6992dfa1fd2186a600a642f538fb64584"
       },
       "description": "Full kitchen companion. Scan your fridge with a photo to stock a pantry inventory and get 3 makeable-now recipes, get alerts before food expires, clip recipes from any URL into a clean format, and generate meal plans with grocery lists from what you actually have.",
       "category": "lifestyle",


### PR DESCRIPTION
Adds the kitchen-companion plugin to the marketplace catalog (category: lifestyle).

Repo: https://github.com/vellum-ai/kitchen-companion (pinned to a268f495f8177144477055f7f1956f28c5574669)

What it ships:
- 6 tools: fridge_scan (photo to pantry inventory + 3 makeable-now recipes), pantry_update, pantry_list, recipe_save (URL clipper with JSON-LD parsing and AI fallback), recipe_find (pantry-coverage ranking), meal_plan (expiring-food-first plans with grocery lists)
- 2 hooks: init (storage setup), pre-model-call (expiring-food context alert, silent when nothing is near expiry)
- 1 skill: kitchen-companion flow guidance

Tested end to end: photo scan against a real fridge photo (10 items identified, merged into existing stock), URL clip via structured data, text clip via AI extraction, coverage ranking, and plan generation. Vision routes through a force-pinned vision-capable profile, same pattern as plant-doctor. Tool schemas use input_schema.