### PR TITLE
feat(skills): add gmail-trigger (beta)

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -310,7 +310,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-10T10:02:00.000Z"
+      "updatedAt": "2026-07-10T10:29:14.000Z"
     },
     {
       "id": "google-calendar",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -287,6 +287,32 @@
       "updatedAt": "2026-07-07T04:41:23.000Z"
     },
     {
+      "id": "gmail-trigger",
+      "name": "gmail-trigger",
+      "description": "Beta. Act on new Gmail as it arrives: get pinged only for urgent mail, digest newsletters, forward invoices — any standing instruction, across one or several accounts.",
+      "metadata": {
+        "emoji": "📬",
+        "vellum": {
+          "category": "email",
+          "display-name": "Gmail Triggers (Beta)",
+          "includes": [
+            "schedule"
+          ],
+          "activation-hints": [
+            "User wants hands-off monitoring of their Gmail inbox",
+            "Ping me / tell me when a new email arrives",
+            "Watch my inbox for new messages"
+          ],
+          "avoid-when": [
+            "Recurring inbox cleanup, archiving, triage, or reply drafting — use inbox-management",
+            "A one-time inbox summary or search, or reading a specific email"
+          ]
+        }
+      },
+      "compatibility": "Designed for Vellum personal assistants",
+      "updatedAt": "2026-07-10T10:02:00.000Z"
+    },
+    {
       "id": "google-calendar",
       "name": "google-calendar",
       "description": "View, create, and manage Google Calendar events and check availability",
@@ -1173,7 +1199,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-10T04:58:09.000Z"
+      "updatedAt": "2026-07-10T05:05:47.000Z"
     },
     {
       "id": "vercel-token-setup",

--- a/skills/gmail-trigger/SKILL.md
+++ b/skills/gmail-trigger/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: gmail-trigger
+description: "Beta. Act on new Gmail as it arrives: get pinged only for urgent mail, digest newsletters, forward invoices — any standing instruction, across one or several accounts."
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "📬"
+  vellum:
+    category: "email"
+    display-name: "Gmail Triggers (Beta)"
+    includes: ["schedule"]
+    activation-hints:
+      - "User wants hands-off monitoring of their Gmail inbox"
+      - "Ping me / tell me when a new email arrives"
+      - "Watch my inbox for new messages"
+    avoid-when:
+      - "Recurring inbox cleanup, archiving, triage, or reply drafting — use inbox-management"
+      - "A one-time inbox summary or search, or reading a specific email"
+---
+
+# Gmail Triggers (Beta)
+
+Polls the user's Gmail inbox on a cron and escalates to the assistant **only when a new message arrives** — an empty poll spends zero LLM tokens. Installing it means creating a script-mode schedule that runs the schedule's own copy of the shipped poll script. Schedule mechanics (script mode, the `schedules/<id>/` convention, waking the agent loop) are documented in the included `schedule` skill.
+
+## Why this instead of a watcher
+
+A watcher could only be configured through its prompt and its cadence. This
+one is a script that belongs to the schedule, so the assistant can change
+anything about how it behaves by simply editing the script. And because it
+runs as a schedule, its runs, errors, and cost all show up on the Schedules
+page in the app.
+
+## Setup
+
+### 1. Ensure Google is connected
+
+The trigger reads Gmail through the user's Google OAuth connection with Gmail read access. Check with:
+
+```bash
+assistant oauth status google
+```
+
+If no connection is found, load the `vellum-oauth-integrations` skill — it evaluates whether managed or your-own mode is appropriate and guides the user through connecting. Managed (proxy) and your-own OAuth both work — `poll.ts` calls Gmail via `assistant oauth request`, which resolves either automatically.
+
+### 2. Choose the accounts to watch
+
+If `oauth status` shows **more than one** active Google connection, ask the user which inboxes to watch and pass one `--account <email>` flag per chosen inbox. With a single connection the flag can be omitted. One schedule watches all chosen accounts and delivers one combined digest.
+
+### 3. Collect the action prompt
+
+Ask the user what should happen when new email arrives — e.g. "notify me only about emails needing a reply" or "summarize newsletters, flag anything from my boss". If the user doesn't care, omit the flag and the default applies: summarize what's new and flag anything urgent.
+
+### 4. Ask about the first sync
+
+By default the trigger starts from now and never escalates pre-existing email. Ask the user whether the first sync should instead include recent mail; if yes, append `--lookback <duration>` (`90m`/`4h`/`2d`/`1w`).
+
+### 5. Create the schedule
+
+Create a recurring **script-mode** schedule (default cadence every 15 minutes unless the user asks for a different one) whose command runs the schedule's own copy of the poll script with the flags chosen above:
+
+```
+bun "$VELLUM_WORKSPACE_DIR/schedules/$__SCHEDULE_ID/poll.ts" --account you@example.com --action-prompt 'Summarize new email; flag anything urgent'
+```
+
+Pass `timeout_ms: 900000` — the poll's runtime includes the woken assistant turn. Single-quote the action prompt (the command runs through `sh`). All configuration lives in this command string, so it is visible in the schedule and editable later with `assistant schedules update <id> --script "..."`.
+
+### 6. Copy the poll script into the schedule's directory
+
+Read the schedule id from the create result, then:
+
+```bash
+mkdir -p "$VELLUM_WORKSPACE_DIR/schedules/<id>"
+cp "$VELLUM_WORKSPACE_DIR/skills/gmail-trigger/scripts/poll.ts" "$VELLUM_WORKSPACE_DIR/schedules/<id>/poll.ts"
+```
+
+The schedule owns this copy — customizations made to it are never touched by skill upgrades. `poll.ts` self-provisions its state on first run; create nothing else.
+
+### 7. Verify
+
+```bash
+assistant schedules execute <id>
+assistant schedules runs <id> --limit 1
+```
+
+The first run records `{"ok":true,"new":0,"accounts":[{"account":"you@example.com","baselined":true,...}]}`; later empty polls record `"new":0` without `baselined`.
+
+## How it works
+
+- **Deterministic poll, LLM only on new mail.** `poll.ts` syncs incrementally with Gmail's History API via `assistant oauth request --provider google` (no raw token in the script). Each mailbox's watermark is a Gmail `historyId`, advanced only past history records actually processed, so a truncated poll resumes where it left off. No model call on an empty poll.
+- **Per-mailbox state.** Watermarks and dedup are keyed by the email address Gmail reports for the connection, in SQLite under `schedules/<id>/state/`. Accounts baseline, advance, fail, and recover independently — one broken connection doesn't stop the others, and an account switch behind the schedule starts cleanly instead of misreading another mailbox's watermark.
+- **At-most-once escalation.** Each account's watermark and reported-message ledger commit _before_ the digest is escalated, so a retried or restarted run never escalates the same message twice; a failed wake surfaces as a failed run instead of a duplicate digest. The ledger is script-local bookkeeping — nothing is written to Gmail, and read/unread state is untouched.
+- **Expiry recovery.** Gmail keeps history for roughly a week. If a stored `historyId` has expired, that account re-baselines and catches up with a one-day inbox search; the ledger absorbs the overlap.
+- **Fenced escalation.** New mail wakes a fresh conversation with the digest passed via `--external-content` (fenced as untrusted data, never instructions); the user's action prompt goes in `--hint` as the trusted framing. The digest carries full metadata for the 50 newest messages across all accounts (sorted by `internalDate`) plus per-account totals.
+- **Self-contained.** Built-ins + the `assistant` CLI only — no dependencies.
+
+## Managing it
+
+- Change cadence: update the schedule's expression.
+- Add or remove a watched account: edit the schedule's command string (`--account` flags).
+- Customize behavior: edit the schedule's copy of `poll.ts` directly.
+- Update to a newer shipped script: re-copy `poll.ts` from the skill directory into `schedules/<id>/`, re-applying any custom edits.
+- Pause / resume: disable / enable the schedule.
+- Remove: delete the schedule; optionally clean up its `schedules/<id>/` directory.
+- If polls start failing on auth, try `assistant oauth ping google` (often refreshes an expired token); if that fails, load the `vellum-oauth-integrations` skill to reconnect.

--- a/skills/gmail-trigger/scripts/poll.ts
+++ b/skills/gmail-trigger/scripts/poll.ts
@@ -1,0 +1,549 @@
+/**
+ * Gmail trigger poll. Runs as a script-mode schedule and escalates to the
+ * assistant only when new inbox mail arrives. Gmail is read via
+ * `assistant oauth request`, so no OAuth token ever touches this script.
+ *
+ * State is kept per mailbox, keyed by the email address /profile reports: a
+ * historyId watermark plus a ledger of already-reported message ids. State
+ * commits before the digest is escalated, so a retried or restarted run never
+ * escalates the same message twice.
+ *
+ * Flags, baked into the schedule command at install:
+ *   --account <email>    mailbox to poll; repeat to watch several. Omitted,
+ *                        the single auto-resolved connection is polled.
+ *   --lookback <dur>     first-sync backfill window (90m/4h/2d/1w or seconds)
+ *   --action-prompt <s>  instruction for the woken assistant
+ */
+
+import { Database } from "bun:sqlite";
+import { existsSync, mkdirSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+
+const workspace = process.env.VELLUM_WORKSPACE_DIR;
+const scheduleId = process.env.__SCHEDULE_ID;
+if (!workspace || !scheduleId) {
+  console.error(
+    "VELLUM_WORKSPACE_DIR and __SCHEDULE_ID must be set — run as a script-mode schedule.",
+  );
+  process.exit(1);
+}
+
+// State lives outside the skill dir so it survives skill reinstall.
+const SCHEDULE_DIR = `${workspace}/schedules/${scheduleId}`;
+const STATE_DIR = `${SCHEDULE_DIR}/state`;
+const DB_FILE = `${STATE_DIR}/state.db`;
+const GMAIL_BASE = "https://gmail.googleapis.com/gmail/v1/users/me";
+const PAGE_SIZE = 100;
+// Per-account cap per poll. A poll that hits it stops paginating, reports
+// truncated, and resumes from the un-advanced watermark next run.
+const MAX_IDS = 1000;
+const META_CAP = 200;
+// Each metadata fetch forks a full assistant CLI process, so an unbounded
+// fan-out can OOM a memory-limited host.
+const META_CONCURRENCY = 6;
+const DIGEST_CAP = 50;
+const LEDGER_RETENTION_SEC = 30 * 86400;
+const EXPIRY_CATCHUP_QUERY = "in:inbox newer_than:1d";
+const DEFAULT_ACTION_PROMPT =
+  "New email arrived in your inbox. Summarize what's new (sender + subject) and flag anything urgent or needing a reply.";
+
+function parseLookbackSeconds(value: string): number {
+  const m = /^(\d+)([smhdw]?)$/.exec(value.trim());
+  if (!m) {
+    console.error(
+      `Invalid --lookback "${value}" — use e.g. 90m, 4h, 2d, 1w, or 0 to disable.`,
+    );
+    process.exit(1);
+  }
+  const units: Record<string, number> = {
+    "": 1,
+    s: 1,
+    m: 60,
+    h: 3600,
+    d: 86400,
+    w: 604800,
+  };
+  return Number(m[1]) * units[m[2]];
+}
+
+function flagValue(name: string): string | undefined {
+  const idx = process.argv.indexOf(name);
+  if (idx < 0) return undefined;
+  const value = process.argv[idx + 1]?.trim();
+  if (!value) {
+    console.error(`${name} requires a value.`);
+    process.exit(1);
+  }
+  return value;
+}
+
+function flagValues(name: string): string[] {
+  const values: string[] = [];
+  for (let i = 0; i < process.argv.length; i++) {
+    if (process.argv[i] !== name) continue;
+    const value = process.argv[i + 1]?.trim();
+    if (!value) {
+      console.error(`${name} requires a value.`);
+      process.exit(1);
+    }
+    values.push(value);
+  }
+  return values;
+}
+
+const lookbackFlag = flagValue("--lookback");
+const lookbackSec =
+  lookbackFlag !== undefined ? parseLookbackSeconds(lookbackFlag) : 0;
+const accountFlags = flagValues("--account");
+const actionPrompt = flagValue("--action-prompt") ?? DEFAULT_ACTION_PROMPT;
+
+/** Run fn over items with at most `limit` in flight at once. */
+async function mapConcurrent<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  const workers = Array.from(
+    { length: Math.min(limit, items.length) },
+    async () => {
+      while (next < items.length) {
+        const i = next++;
+        results[i] = await fn(items[i]);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+async function ensureGitignore(): Promise<void> {
+  const path = `${SCHEDULE_DIR}/.gitignore`;
+  if (!existsSync(path)) await writeFile(path, "state/\n");
+}
+
+function openDb(): Database {
+  mkdirSync(STATE_DIR, { recursive: true });
+  const db = new Database(DB_FILE);
+  db.exec(
+    `CREATE TABLE IF NOT EXISTS accounts (
+       email TEXT PRIMARY KEY,
+       history_id TEXT NOT NULL
+     );
+     CREATE TABLE IF NOT EXISTS reported (
+       account TEXT NOT NULL,
+       id TEXT NOT NULL,
+       reported_at INTEGER NOT NULL,
+       PRIMARY KEY (account, id)
+     );`,
+  );
+  return db;
+}
+
+function getAccountHistoryId(db: Database, email: string): string | null {
+  const row = db
+    .query<{ history_id: string }, [string]>(
+      "SELECT history_id FROM accounts WHERE email = ?",
+    )
+    .get(email);
+  return row?.history_id ?? null;
+}
+
+function filterUnreported(
+  db: Database,
+  email: string,
+  ids: string[],
+): string[] {
+  const exists = db.query<{ id: string }, [string, string]>(
+    "SELECT id FROM reported WHERE account = ? AND id = ?",
+  );
+  return ids.filter((id) => !exists.get(email, id));
+}
+
+/** Advance one account's watermark and ledger atomically. Runs before escalation. */
+function commitAccount(
+  db: Database,
+  email: string,
+  historyId: string,
+  ids: string[],
+): void {
+  const nowSec = Math.floor(Date.now() / 1000);
+  const insert = db.query(
+    "INSERT OR IGNORE INTO reported (account, id, reported_at) VALUES (?, ?, ?)",
+  );
+  db.transaction(() => {
+    db.query(
+      "INSERT OR REPLACE INTO accounts (email, history_id) VALUES (?, ?)",
+    ).run(email, historyId);
+    for (const id of ids) insert.run(email, id, nowSec);
+    db.query("DELETE FROM reported WHERE reported_at < ?").run(
+      nowSec - LEDGER_RETENTION_SEC,
+    );
+  })();
+}
+
+class GmailStatusError extends Error {
+  constructor(
+    public status: number,
+    body: string,
+  ) {
+    super(`Gmail ${status}: ${body}`);
+  }
+}
+
+async function gmailGet<T>(
+  url: string,
+  account: string | undefined,
+): Promise<T> {
+  const proc = Bun.spawn(
+    [
+      "assistant",
+      "oauth",
+      "request",
+      "--provider",
+      "google",
+      ...(account ? ["--account", account] : []),
+      url,
+      "--json",
+    ],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+  const [out, err, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  let result: { ok: boolean; status: number; body: unknown };
+  try {
+    result = JSON.parse(out);
+  } catch {
+    throw new Error(
+      `oauth request failed (exit ${code}): ${(err || out).slice(0, 200)}`,
+    );
+  }
+  if (result.status < 200 || result.status >= 300) {
+    throw new GmailStatusError(
+      result.status,
+      JSON.stringify(result.body).slice(0, 200),
+    );
+  }
+  return result.body as T;
+}
+
+async function cli<T>(args: string[]): Promise<T> {
+  const proc = Bun.spawn(["assistant", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [out, err, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (code !== 0) {
+    throw new Error(
+      `assistant ${args.slice(0, 2).join(" ")} exited ${code}: ${err.slice(0, 200)}`,
+    );
+  }
+  return JSON.parse(out) as T;
+}
+
+async function getProfile(
+  account: string | undefined,
+): Promise<{ emailAddress: string; historyId: string }> {
+  const profile = await gmailGet<{
+    emailAddress?: string;
+    historyId?: string | number;
+  }>(`${GMAIL_BASE}/profile`, account);
+  if (!profile.emailAddress || profile.historyId === undefined) {
+    throw new Error("Gmail profile did not return emailAddress and historyId");
+  }
+  return {
+    emailAddress: profile.emailAddress,
+    historyId: String(profile.historyId),
+  };
+}
+
+interface HistoryRecord {
+  id: string;
+  messagesAdded?: Array<{ message: { id: string; threadId: string } }>;
+}
+
+/**
+ * New INBOX message ids after the given historyId. With records, the returned
+ * watermark is the last processed record's id, never the mailbox's current
+ * historyId, which would skip the remainder of a truncated drain.
+ */
+async function listHistoryIds(
+  startHistoryId: string,
+  account: string | undefined,
+): Promise<{ ids: string[]; watermark: string; truncated: boolean }> {
+  const ids = new Set<string>();
+  let watermark = startHistoryId;
+  let sawRecords = false;
+  let pageToken: string | undefined;
+  let truncated = false;
+  do {
+    const page = await gmailGet<{
+      history?: HistoryRecord[];
+      nextPageToken?: string;
+      historyId?: string | number;
+    }>(
+      `${GMAIL_BASE}/history?startHistoryId=${encodeURIComponent(startHistoryId)}` +
+        `&historyTypes=messageAdded&labelId=INBOX&maxResults=${PAGE_SIZE}` +
+        (pageToken ? `&pageToken=${encodeURIComponent(pageToken)}` : ""),
+      account,
+    );
+    for (const record of page.history ?? []) {
+      sawRecords = true;
+      for (const added of record.messagesAdded ?? []) ids.add(added.message.id);
+      watermark = record.id;
+    }
+    if (!sawRecords && page.historyId !== undefined) {
+      watermark = String(page.historyId);
+    }
+    pageToken = page.nextPageToken;
+    if (ids.size >= MAX_IDS && pageToken) {
+      truncated = true;
+      pageToken = undefined;
+    }
+  } while (pageToken);
+  return { ids: [...ids], watermark, truncated };
+}
+
+async function searchIds(
+  q: string,
+  account: string | undefined,
+): Promise<{ ids: string[]; truncated: boolean }> {
+  const ids: string[] = [];
+  let pageToken: string | undefined;
+  let truncated = false;
+  do {
+    const page = await gmailGet<{
+      messages?: Array<{ id: string }>;
+      nextPageToken?: string;
+    }>(
+      `${GMAIL_BASE}/messages?q=${encodeURIComponent(q)}&maxResults=${PAGE_SIZE}` +
+        (pageToken ? `&pageToken=${encodeURIComponent(pageToken)}` : ""),
+      account,
+    );
+    ids.push(...(page.messages ?? []).map((m) => m.id));
+    pageToken = page.nextPageToken;
+    if (ids.length >= MAX_IDS && pageToken) {
+      truncated = true;
+      pageToken = undefined;
+    }
+  } while (pageToken);
+  return { ids: ids.slice(0, MAX_IDS), truncated };
+}
+
+function header(
+  headers: Array<{ name: string; value: string }> | undefined,
+  name: string,
+): string {
+  return (
+    headers?.find((h) => h.name.toLowerCase() === name.toLowerCase())?.value ??
+    ""
+  );
+}
+
+interface DigestEntry {
+  account: string;
+  id: string;
+  threadId: string;
+  from: string;
+  subject: string;
+  date: string;
+  snippet: string;
+  internalDate: number;
+}
+
+async function buildDigestEntries(
+  ids: string[],
+  account: string | undefined,
+  email: string,
+): Promise<DigestEntry[]> {
+  const metaUrl = (id: string) =>
+    `${GMAIL_BASE}/messages/${id}?format=metadata&metadataHeaders=From&metadataHeaders=Subject&metadataHeaders=Date`;
+  return mapConcurrent(ids.slice(0, META_CAP), META_CONCURRENCY, async (id) => {
+    const msg = await gmailGet<{
+      id: string;
+      threadId: string;
+      snippet?: string;
+      internalDate?: string;
+      payload?: { headers?: Array<{ name: string; value: string }> };
+    }>(metaUrl(id), account);
+    return {
+      account: email,
+      id: msg.id,
+      threadId: msg.threadId,
+      from: header(msg.payload?.headers, "From"),
+      subject: header(msg.payload?.headers, "Subject"),
+      date: header(msg.payload?.headers, "Date"),
+      snippet: msg.snippet ?? "",
+      internalDate: Number(msg.internalDate ?? 0),
+    };
+  });
+}
+
+/** Open a fresh conversation and wake it with the fenced digest. */
+async function escalate(
+  entries: DigestEntry[],
+  totals: Array<{ account: string; new: number }>,
+): Promise<string> {
+  // Sort by internalDate; list and history order carry no guarantee.
+  entries.sort((a, b) => b.internalDate - a.internalDate);
+  const digest = entries.slice(0, DIGEST_CAP);
+  const total = totals.reduce((n, t) => n + t.new, 0);
+  const conv = await cli<{ ok: boolean; id: string }>([
+    "conversations",
+    "new",
+    "Gmail Triggers",
+    "--json",
+  ]);
+  await cli<{ invoked: boolean }>([
+    "conversations",
+    "wake",
+    conv.id,
+    "--source",
+    "gmail-trigger",
+    "--hint",
+    actionPrompt,
+    "--external-content",
+    JSON.stringify({
+      total,
+      showing: digest.length,
+      accounts: totals,
+      messages: digest,
+    }),
+    "--json",
+  ]);
+  return conv.id;
+}
+
+function friendlyError(err: unknown): string {
+  if (
+    err instanceof GmailStatusError &&
+    (err.status === 401 || err.status === 403)
+  ) {
+    return `Google authorization failed (HTTP ${err.status}). Gmail Triggers cannot read this mailbox until the Google connection is repaired — reconnect Google and it resumes on its own.`;
+  }
+  return String((err as Error)?.message ?? err);
+}
+
+interface AccountResult {
+  account: string;
+  new: number;
+  baselined?: boolean;
+  rebaselined?: boolean;
+  truncated?: boolean;
+  error?: string;
+}
+
+async function syncAccount(
+  db: Database,
+  account: string | undefined,
+): Promise<{ result: AccountResult; entries: DigestEntry[] }> {
+  const profile = await getProfile(account);
+  const email = profile.emailAddress;
+  const stored = getAccountHistoryId(db, email);
+
+  if (!stored) {
+    // First sight of this mailbox. Baseline at its current historyId,
+    // backfilling the lookback window once if one was requested.
+    let ids: string[] = [];
+    let truncated = false;
+    if (lookbackSec > 0) {
+      const since = Math.floor(Date.now() / 1000) - lookbackSec;
+      ({ ids, truncated } = await searchIds(
+        `in:inbox after:${since}`,
+        account,
+      ));
+    }
+    commitAccount(db, email, profile.historyId, ids);
+    const entries =
+      ids.length > 0 ? await buildDigestEntries(ids, account, email) : [];
+    return {
+      result: { account: email, new: ids.length, baselined: true, truncated },
+      entries,
+    };
+  }
+
+  let ids: string[];
+  let watermark: string;
+  let truncated = false;
+  let rebaselined = false;
+  try {
+    ({ ids, watermark, truncated } = await listHistoryIds(stored, account));
+  } catch (err) {
+    if (err instanceof GmailStatusError && err.status === 404) {
+      // The stored historyId expired. Re-baseline and catch up by search;
+      // the ledger absorbs the overlap.
+      rebaselined = true;
+      watermark = profile.historyId;
+      ({ ids, truncated } = await searchIds(EXPIRY_CATCHUP_QUERY, account));
+    } else {
+      throw err;
+    }
+  }
+
+  const fresh = filterUnreported(db, email, ids);
+  commitAccount(db, email, watermark, fresh);
+  const entries =
+    fresh.length > 0 ? await buildDigestEntries(fresh, account, email) : [];
+  return {
+    result: { account: email, new: fresh.length, truncated, rebaselined },
+    entries,
+  };
+}
+
+async function main(): Promise<void> {
+  const db = openDb();
+  await ensureGitignore();
+
+  // One account's failure must not block the others.
+  const passes: Array<string | undefined> =
+    accountFlags.length > 0 ? accountFlags : [undefined];
+  const results: AccountResult[] = [];
+  const entries: DigestEntry[] = [];
+  let anyError = false;
+
+  for (const account of passes) {
+    try {
+      const synced = await syncAccount(db, account);
+      results.push(synced.result);
+      entries.push(...synced.entries);
+    } catch (err) {
+      anyError = true;
+      results.push({
+        account: account ?? "(default connection)",
+        new: 0,
+        error: friendlyError(err),
+      });
+    }
+  }
+
+  let conversationId: string | undefined;
+  if (entries.length > 0) {
+    const totals = results
+      .filter((r) => r.new > 0)
+      .map((r) => ({ account: r.account, new: r.new }));
+    conversationId = await escalate(entries, totals);
+  }
+
+  console.log(
+    JSON.stringify({
+      ok: !anyError,
+      new: results.reduce((n, r) => n + r.new, 0),
+      accounts: results,
+      conversationId,
+    }),
+  );
+  if (anyError) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error(friendlyError(err));
+  process.exit(1);
+});

--- a/skills/gmail-trigger/scripts/poll.ts
+++ b/skills/gmail-trigger/scripts/poll.ts
@@ -402,7 +402,7 @@ async function escalate(
     "Gmail Triggers",
     "--json",
   ]);
-  await cli<{ invoked: boolean }>([
+  const wake = await cli<{ invoked: boolean; reason?: string }>([
     "conversations",
     "wake",
     conv.id,
@@ -419,6 +419,13 @@ async function escalate(
     }),
     "--json",
   ]);
+  // A skipped wake exits 0 with invoked:false; treating it as success would
+  // report ok while the digest was never delivered.
+  if (!wake.invoked) {
+    throw new Error(
+      `wake skipped (${wake.reason ?? "unknown"}) — digest of ${total} message(s) was not delivered`,
+    );
+  }
   return conv.id;
 }
 


### PR DESCRIPTION
First-party `gmail-trigger` catalog skill ("Gmail Triggers (Beta)"): act on new Gmail as it arrives with a standing instruction — a script-schedule replacement for the native Gmail watcher. The install interview collects accounts, an action prompt, and an optional first-sync lookback, then creates a script-mode schedule and copies the shipped `poll.ts` into the schedule's directory, so the schedule owns its copy and the assistant can customize behavior by editing it.

`poll.ts` syncs incrementally with the Gmail History API via `assistant oauth request` (no token in the script), keyed per mailbox in SQLite: per-account historyId watermarks plus a reported-message ledger, committed before the digest wakes the assistant so delivery is at-most-once — a failed wake is a visible failed run, never a duplicate digest. One schedule can watch several accounts (`--account` is repeatable) with one combined digest; a broken account doesn't block the others. Expired historyIds re-baseline with a one-day search catch-up, and metadata fetches run through a bounded worker pool since each forks a CLI process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)