### PR TITLE
fix(watcher): notify the user when a watcher's account auth breaks

### DIFF
--- a/assistant/src/watcher/__tests__/engine-auth-notify.test.ts
+++ b/assistant/src/watcher/__tests__/engine-auth-notify.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Tests for the watcher engine's auth-failure notification behavior.
+ *
+ * Covers the two paths that surface a broken account connection to the
+ * user: the pre-poll credential-health skip gate and auth-shaped poll
+ * failures in the catch block. Asserts once-per-episode semantics
+ * (notify once while the problem persists; re-notify after a recovery).
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Module mocks (controllable via mutable state) ─────────────────────
+
+interface FakeWatcher {
+  id: string;
+  name: string;
+  providerId: string;
+  enabled: boolean;
+  pollIntervalMs: number;
+  actionPrompt: string;
+  watermark: string | null;
+  conversationId: string | null;
+  status: string;
+  consecutiveErrors: number;
+  lastError: string | null;
+  lastPollAt: number | null;
+  nextPollAt: number;
+  configJson: string | null;
+  credentialService: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+let fakeWatchers: FakeWatcher[] = [];
+const skipCalls: Array<{ watcherId: string; reason: string }> = [];
+const disableCalls: Array<{ watcherId: string; reason: string }> = [];
+let completeShouldClearErrors = true;
+
+mock.module("../watcher-store.js", () => ({
+  // Return per-tick snapshot copies so the engine's circuit-breaker check
+  // (`watcher.consecutiveErrors + 1`) reads the pre-poll stored count, as it
+  // does in production where the claimed row is a DB snapshot.
+  claimDueWatchers: () => fakeWatchers.map((w) => ({ ...w })),
+  completeWatcherPoll: () => {
+    // A real successful poll resets the consecutive-error counter.
+    if (completeShouldClearErrors) {
+      for (const w of fakeWatchers) {
+        w.consecutiveErrors = 0;
+      }
+    }
+  },
+  failWatcherPoll: (watcherId: string) => {
+    // Mirror the store's real behavior: bump the consecutive-error count so
+    // the circuit breaker can trip across ticks.
+    for (const w of fakeWatchers) {
+      if (w.id === watcherId) {
+        w.consecutiveErrors += 1;
+      }
+    }
+  },
+  skipWatcherPoll: (watcherId: string, reason: string) => {
+    skipCalls.push({ watcherId, reason });
+  },
+  disableWatcher: (watcherId: string, reason: string) => {
+    disableCalls.push({ watcherId, reason });
+    // A disabled watcher is no longer claimed on later ticks.
+    fakeWatchers = fakeWatchers.filter((w) => w.id !== watcherId);
+  },
+  insertWatcherEvent: () => true,
+  getPendingEvents: () => [],
+  resetStuckWatchers: () => 0,
+  setWatcherConversationId: () => {},
+  updateEventDisposition: () => {},
+}));
+
+let providerFetchImpl: () => Promise<{
+  items: Array<Record<string, unknown>>;
+  watermark: string;
+}> = async () => ({ items: [], watermark: "wm" });
+
+mock.module("../provider-registry.js", () => ({
+  getWatcherProvider: () => ({
+    fetchNew: () => providerFetchImpl(),
+    getInitialWatermark: async () => "wm",
+  }),
+}));
+
+mock.module("../../sequence/reply-matcher.js", () => ({
+  checkForSequenceReplies: () => [],
+}));
+
+let credentialHealthImpl: () => Promise<{
+  status: string;
+  details: string;
+  canAutoRecover: boolean;
+} | null> = async () => null;
+
+mock.module("../../credential-health/credential-health-service.js", () => ({
+  checkCredentialForProvider: () => credentialHealthImpl(),
+}));
+
+mock.module("../../runtime/background-job-runner.js", () => ({
+  runBackgroundJob: async () => ({ conversationId: "conv-stub", ok: true }),
+}));
+
+mock.module("../telemetry.js", () => ({
+  recordWatcherInventoryIfDue: () => {},
+  recordWatcherLlmProcessed: () => {},
+}));
+
+// Import after mocks are in place.
+const { runWatchersOnce, _resetAuthNotificationStateForTests } =
+  await import("../engine.js");
+
+// ── Fixtures ──────────────────────────────────────────────────────────
+
+function makeWatcher(overrides: Partial<FakeWatcher> = {}): FakeWatcher {
+  const now = Date.now();
+  return {
+    id: "watcher-1",
+    name: "Outlook inbox",
+    providerId: "outlook",
+    enabled: true,
+    pollIntervalMs: 60_000,
+    actionPrompt: "Triage and respond.",
+    watermark: "wm",
+    conversationId: null,
+    status: "polling",
+    consecutiveErrors: 0,
+    lastError: null,
+    lastPollAt: now,
+    nextPollAt: now + 60_000,
+    configJson: null,
+    credentialService: "outlook",
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+const authError = new Error(
+  'No active OAuth connection found for "outlook". The outlook service needs to be connected before it can be used.',
+);
+
+type Notification = { title: string; body: string };
+
+function reconnectNotifications(all: Notification[]): Notification[] {
+  return all.filter((n) => n.title.startsWith("Reconnect needed:"));
+}
+
+function disableNotifications(all: Notification[]): Notification[] {
+  return all.filter((n) => n.title.startsWith("Watcher disabled:"));
+}
+
+beforeEach(() => {
+  fakeWatchers = [];
+  skipCalls.length = 0;
+  disableCalls.length = 0;
+  completeShouldClearErrors = true;
+  providerFetchImpl = async () => ({ items: [], watermark: "wm" });
+  credentialHealthImpl = async () => null;
+  _resetAuthNotificationStateForTests();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("runWatchersOnce — auth-failure notifications", () => {
+  test("auth-shaped poll failure notifies once across ticks, then disable notification mentions reconnect", async () => {
+    fakeWatchers = [makeWatcher()];
+    providerFetchImpl = async () => {
+      throw authError;
+    };
+
+    const notifications: Notification[] = [];
+    const notify = (n: Notification) => notifications.push(n);
+
+    // Five consecutive failing ticks: reconnect notice fires once; the
+    // circuit breaker trips on the fifth (consecutiveErrors 0→4).
+    for (let i = 0; i < 5; i++) {
+      await runWatchersOnce(notify);
+    }
+
+    const reconnects = reconnectNotifications(notifications);
+    expect(reconnects).toHaveLength(1);
+    expect(reconnects[0].body).toContain("outlook");
+    expect(reconnects[0].body.toLowerCase()).toContain("reconnect");
+
+    const disables = disableNotifications(notifications);
+    expect(disables).toHaveLength(1);
+    expect(disables[0].body.toLowerCase()).toContain("reconnect");
+    expect(disables[0].body).toContain("outlook");
+  });
+
+  test("auth error → success → auth error again produces two reconnect notifications", async () => {
+    fakeWatchers = [makeWatcher()];
+    const notifications: Notification[] = [];
+    const notify = (n: Notification) => notifications.push(n);
+
+    // Tick 1: auth failure.
+    providerFetchImpl = async () => {
+      throw authError;
+    };
+    await runWatchersOnce(notify);
+
+    // Tick 2: success (clears the episode).
+    providerFetchImpl = async () => ({ items: [], watermark: "wm" });
+    await runWatchersOnce(notify);
+
+    // Tick 3: auth failure again (new episode).
+    providerFetchImpl = async () => {
+      throw authError;
+    };
+    await runWatchersOnce(notify);
+
+    expect(reconnectNotifications(notifications)).toHaveLength(2);
+  });
+
+  test("non-auth poll failure does not produce a reconnect notification", async () => {
+    fakeWatchers = [makeWatcher()];
+    providerFetchImpl = async () => {
+      throw new Error("network timeout (ETIMEDOUT)");
+    };
+
+    const notifications: Notification[] = [];
+    const notify = (n: Notification) => notifications.push(n);
+
+    await runWatchersOnce(notify);
+    await runWatchersOnce(notify);
+    await runWatchersOnce(notify);
+
+    expect(reconnectNotifications(notifications)).toHaveLength(0);
+  });
+
+  test("credential-health skip gate notifies once per episode and skips the poll", async () => {
+    fakeWatchers = [makeWatcher()];
+    credentialHealthImpl = async () => ({
+      status: "revoked",
+      details:
+        "outlook token was rejected (401/403). Re-authorization required.",
+      canAutoRecover: false,
+    });
+
+    const notifications: Notification[] = [];
+    const notify = (n: Notification) => notifications.push(n);
+
+    await runWatchersOnce(notify);
+    await runWatchersOnce(notify);
+    await runWatchersOnce(notify);
+
+    // Poll is skipped every tick, but the user is told exactly once.
+    expect(skipCalls).toHaveLength(3);
+    const reconnects = reconnectNotifications(notifications);
+    expect(reconnects).toHaveLength(1);
+    expect(reconnects[0].body).toContain("outlook");
+    expect(reconnects[0].body.toLowerCase()).toContain("reconnect");
+  });
+});

--- a/assistant/src/watcher/__tests__/engine-auth-notify.test.ts
+++ b/assistant/src/watcher/__tests__/engine-auth-notify.test.ts
@@ -215,6 +215,65 @@ describe("runWatchersOnce — auth-failure notifications", () => {
     expect(reconnectNotifications(notifications)).toHaveLength(2);
   });
 
+  test("alternating credential-health and auth-error paths notify only once per outage", async () => {
+    fakeWatchers = [makeWatcher()];
+    const notifications: Notification[] = [];
+    const notify = (n: Notification) => notifications.push(n);
+
+    // Tick 1: credential health reports the account revoked → skip gate
+    // path raises the episode under "credential-unhealthy".
+    credentialHealthImpl = async () => ({
+      status: "revoked",
+      details:
+        "outlook token was rejected (401/403). Re-authorization required.",
+      canAutoRecover: false,
+    });
+    await runWatchersOnce(notify);
+
+    // Tick 2: the health check itself throws (so the skip gate is bypassed
+    // and the poll proceeds), then the poll fails with an auth-shaped error
+    // → catch-block path under a different status key ("auth-error").
+    credentialHealthImpl = async () => {
+      throw new Error("health check unavailable");
+    };
+    providerFetchImpl = async () => {
+      throw authError;
+    };
+    await runWatchersOnce(notify);
+
+    // The status key flipped between ticks, but suppression is per watcher
+    // outage: exactly one reconnect notification total.
+    expect(reconnectNotifications(notifications)).toHaveLength(1);
+  });
+
+  test("circuit-breaker disable clears the episode so a re-enabled watcher notifies again", async () => {
+    fakeWatchers = [makeWatcher()];
+    providerFetchImpl = async () => {
+      throw authError;
+    };
+
+    const notifications: Notification[] = [];
+    const notify = (n: Notification) => notifications.push(n);
+
+    // Drive to the circuit-breaker disable (consecutiveErrors 0→4 over five
+    // failing ticks). One reconnect notification fires; disable clears the
+    // episode entry.
+    for (let i = 0; i < 5; i++) {
+      await runWatchersOnce(notify);
+    }
+    expect(reconnectNotifications(notifications)).toHaveLength(1);
+    expect(disableNotifications(notifications)).toHaveLength(1);
+
+    // Simulate the user re-enabling the still-broken watcher: it becomes
+    // claimable again with a fresh error counter. Because disable cleared
+    // the episode, the next auth failure raises a brand-new notification
+    // rather than being suppressed by a stale entry.
+    fakeWatchers = [makeWatcher()];
+    await runWatchersOnce(notify);
+
+    expect(reconnectNotifications(notifications)).toHaveLength(2);
+  });
+
   test("non-auth poll failure does not produce a reconnect notification", async () => {
     fakeWatchers = [makeWatcher()];
     providerFetchImpl = async () => {

--- a/assistant/src/watcher/engine.ts
+++ b/assistant/src/watcher/engine.ts
@@ -36,6 +36,58 @@ export type WatcherNotifier = (notification: {
   body: string;
 }) => void;
 
+/**
+ * Classify auth-shaped errors: broken OAuth connections and rejected
+ * tokens. Deterministic and conservative — mechanical error classification
+ * used to decide whether the user needs to reconnect an account.
+ */
+function isAuthConnectionError(err: unknown): boolean {
+  const message = (
+    err instanceof Error ? err.message : String(err)
+  ).toLowerCase();
+  return (
+    message.includes("no active oauth connection") ||
+    message.includes("needs to be connected") ||
+    message.includes("needs to be reconnected") ||
+    message.includes("invalid_grant") ||
+    message.includes("unauthorized") ||
+    /\b401\b/.test(message)
+  );
+}
+
+/**
+ * Per-process record of watchers already notified about an ongoing auth
+ * problem, keyed by watcher id. The value is a status key identifying the
+ * episode ("credential-unhealthy" / "auth-error"). An entry means the user
+ * has been told once; it is cleared when the watcher's poll succeeds so a
+ * later new outage notifies again.
+ */
+const authNotifiedEpisodes = new Map<string, string>();
+
+/** Test-only: clear the auth-notification episode tracker. */
+export function _resetAuthNotificationStateForTests(): void {
+  authNotifiedEpisodes.clear();
+}
+
+/**
+ * Send an auth-reconnect notification for a watcher at most once per
+ * episode. Returns true if a notification was sent, false if suppressed
+ * because the same episode was already reported.
+ */
+function notifyAuthEpisodeOnce(
+  notify: WatcherNotifier,
+  watcherId: string,
+  statusKey: string,
+  notification: { title: string; body: string },
+): boolean {
+  if (authNotifiedEpisodes.get(watcherId) === statusKey) {
+    return false;
+  }
+  authNotifiedEpisodes.set(watcherId, statusKey);
+  notify(notification);
+  return true;
+}
+
 export interface WatcherEngineHandle {
   runOnce(): Promise<number>;
   stop(): void;
@@ -100,6 +152,10 @@ export async function runWatchersOnce(
           (health.status === "expired" && !health.canAutoRecover))
       ) {
         skipWatcherPoll(watcher.id, `Credential unhealthy: ${health.details}`);
+        notifyAuthEpisodeOnce(notify, watcher.id, "credential-unhealthy", {
+          title: `Reconnect needed: ${watcher.name}`,
+          body: `Your ${watcher.credentialService} account's authorization is no longer valid, so ${watcher.name} is paused. Reconnect the account to resume monitoring. (${health.details})`,
+        });
         continue;
       }
     } catch {
@@ -171,6 +227,9 @@ export async function runWatchersOnce(
         watermark: result.watermark,
         conversationId: watcher.conversationId ?? undefined,
       });
+      // A successful poll ends any active auth-failure episode so a later
+      // new outage notifies the user again.
+      authNotifiedEpisodes.delete(watcher.id);
       processed++;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -179,6 +238,17 @@ export async function runWatchersOnce(
         "Watcher poll failed",
       );
       failWatcherPoll(watcher.id, message);
+
+      // Auth-shaped failures point at a broken account connection. Tell the
+      // user to reconnect immediately (once per episode) rather than waiting
+      // for the circuit breaker to disable the watcher.
+      const authShaped = isAuthConnectionError(err);
+      if (authShaped) {
+        notifyAuthEpisodeOnce(notify, watcher.id, "auth-error", {
+          title: `Reconnect needed: ${watcher.name}`,
+          body: `Your ${watcher.credentialService} account's authorization is no longer valid, so ${watcher.name} can't check for updates. Reconnect the account to resume monitoring.`,
+        });
+      }
 
       // Circuit breaker: disable after too many consecutive errors
       if (watcher.consecutiveErrors + 1 >= MAX_CONSECUTIVE_ERRORS) {
@@ -192,9 +262,12 @@ export async function runWatchersOnce(
           { watcherId: watcher.id, name: watcher.name },
           "Watcher disabled by circuit breaker",
         );
+        const body = authShaped
+          ? `${reason} This is an account authorization problem — reconnect your ${watcher.credentialService} account and re-enable the watcher to restore monitoring.`
+          : reason;
         notify({
           title: `Watcher disabled: ${watcher.name}`,
-          body: reason,
+          body,
         });
       }
     }
@@ -208,7 +281,9 @@ export async function runWatchersOnce(
   // notifications on the home feed.
   for (const watcher of claimed) {
     const pendingEvents = getPendingEvents(watcher.id);
-    if (pendingEvents.length === 0) continue;
+    if (pendingEvents.length === 0) {
+      continue;
+    }
 
     const eventSummaries = pendingEvents
       .map(

--- a/assistant/src/watcher/engine.ts
+++ b/assistant/src/watcher/engine.ts
@@ -57,10 +57,12 @@ function isAuthConnectionError(err: unknown): boolean {
 
 /**
  * Per-process record of watchers already notified about an ongoing auth
- * problem, keyed by watcher id. The value is a status key identifying the
- * episode ("credential-unhealthy" / "auth-error"). An entry means the user
- * has been told once; it is cleared when the watcher's poll succeeds so a
- * later new outage notifies again.
+ * problem, keyed by watcher id. The value is the status key of the tick that
+ * first raised the episode ("credential-unhealthy" / "auth-error"), retained
+ * for diagnostics only. The presence of an entry — regardless of its value —
+ * means the user has been told once for this outage; it is cleared when the
+ * watcher's poll succeeds or the circuit breaker disables it, so a later new
+ * outage notifies again.
  */
 const authNotifiedEpisodes = new Map<string, string>();
 
@@ -71,8 +73,11 @@ export function _resetAuthNotificationStateForTests(): void {
 
 /**
  * Send an auth-reconnect notification for a watcher at most once per
- * episode. Returns true if a notification was sent, false if suppressed
- * because the same episode was already reported.
+ * outage. Suppression is keyed on watcher id alone: once any auth
+ * notification has been sent for an ongoing episode, no more are sent until
+ * the episode is cleared (by a successful poll or by circuit-breaker
+ * disable), even if a later tick classifies the failure under a different
+ * status key. Returns true if a notification was sent, false if suppressed.
  */
 function notifyAuthEpisodeOnce(
   notify: WatcherNotifier,
@@ -80,7 +85,7 @@ function notifyAuthEpisodeOnce(
   statusKey: string,
   notification: { title: string; body: string },
 ): boolean {
-  if (authNotifiedEpisodes.get(watcherId) === statusKey) {
+  if (authNotifiedEpisodes.has(watcherId)) {
     return false;
   }
   authNotifiedEpisodes.set(watcherId, statusKey);
@@ -254,6 +259,11 @@ export async function runWatchersOnce(
       if (watcher.consecutiveErrors + 1 >= MAX_CONSECUTIVE_ERRORS) {
         const reason = `Disabled after ${MAX_CONSECUTIVE_ERRORS} consecutive errors. Last: ${message}`;
         disableWatcher(watcher.id, reason);
+        // Close out the auth episode: the disable notification below is the
+        // final word for this outage. Clearing lets a fresh episode (and a
+        // fresh reconnect notification) start if the user re-enables the
+        // watcher while the account is still broken.
+        authNotifiedEpisodes.delete(watcher.id);
         // Do NOT call provider.cleanup() here — auto-disable is reversible.
         // If the watcher is re-enabled later, it must diff against the same
         // baseline to avoid missing events that occurred while disabled.


### PR DESCRIPTION
## Problem

When a watcher's OAuth connection breaks (feedback-019f447d):

- The pre-poll credential-health gate (`revoked` / `missing_token` / unrecoverable `expired`) skips the poll **silently, forever** — the user is never told their account needs reconnecting.
- Auth-shaped poll failures ("No active OAuth connection found…") only WARN-log every poll interval until the circuit breaker disables the watcher after 5 consecutive errors — and that notification just says "Watcher disabled: <name>" without telling the user the fix is reconnecting the account.

In the incident, a user's inbox watcher failed with auth errors for 8 minutes, got disabled with the generic message, and the user discovered the broken connection only when a later request failed — fueling a "it says connected one minute, errors the next" complaint.

## Fix

All in `assistant/src/watcher/engine.ts`:

- `isAuthConnectionError()` — deterministic, conservative classifier for auth-shaped errors (missing/broken OAuth connection, `invalid_grant`, `unauthorized`, word-bounded `401`).
- In-memory once-per-episode tracker keyed by watcher id: the user is notified when an auth problem is first observed, not on every tick; a successful poll clears the episode so a later new outage notifies again.
- Credential-health skip path now emits a "Reconnect needed: <watcher>" notification naming the account/credential service.
- Auth-shaped poll failures emit the same notification immediately instead of waiting for the circuit breaker.
- The circuit-breaker disable notification, when the last error was auth-shaped, now states that reconnecting the account and re-enabling the watcher restores monitoring.

No `WatcherNotifier` signature change, no DB columns.

## Testing

New `engine-auth-notify.test.ts` (4 tests): once-per-episode across 5 ticks + reconnect wording on the circuit-breaker disable; episode reset on success (auth → ok → auth ⇒ two notifications); non-auth errors don't trigger reconnect notifications; credential-health skip path notifies once while skipping every tick. With existing engine tests: 10 pass, 0 fail. `bun run typecheck:fast` clean.

Part of a 5-PR series from the feedback-019f447d investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->