### PR TITLE
fix(risk): classify assistant config set of llm/services paths as high risk

### DIFF
--- a/gateway/src/risk/bash-risk-classifier.test.ts
+++ b/gateway/src/risk/bash-risk-classifier.test.ts
@@ -987,6 +987,14 @@ describe("assistant subcommand classification", () => {
     expect(result.riskLevel).toBe("high");
   });
 
+  test("assistant config set ingress.publicBaseUrl → high", async () => {
+    const result = await classifier.classify({
+      command: "assistant config set ingress.publicBaseUrl https://example.com",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+
   test("assistant conversations clear → medium", async () => {
     const result = await classifier.classify({
       command: "assistant conversations clear --confirm",

--- a/gateway/src/risk/bash-risk-classifier.test.ts
+++ b/gateway/src/risk/bash-risk-classifier.test.ts
@@ -955,12 +955,36 @@ describe("assistant subcommand classification", () => {
     expect(result.riskLevel).toBe("high");
   });
 
-  test("assistant config set → low", async () => {
+  test("assistant config set (ordinary path) → medium", async () => {
     const result = await classifier.classify({
-      command: "assistant config set key value",
+      command: "assistant config set ui.theme dark",
       toolName: "bash",
     });
-    expect(result.riskLevel).toBe("low");
+    expect(result.riskLevel).toBe("medium");
+  });
+
+  test("assistant config set llm.activeProfile → high", async () => {
+    const result = await classifier.classify({
+      command: "assistant config set llm.activeProfile foo",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+
+  test("assistant config set services.*.mode → high", async () => {
+    const result = await classifier.classify({
+      command: "assistant config set services.outlook-oauth.mode your-own",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+
+  test("assistant config set gateway.* → high", async () => {
+    const result = await classifier.classify({
+      command: "assistant config set gateway.publicBaseUrl https://example.com",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
   });
 
   test("assistant conversations clear → medium", async () => {

--- a/gateway/src/risk/command-registry.test.ts
+++ b/gateway/src/risk/command-registry.test.ts
@@ -584,7 +584,7 @@ describe("command-registry", () => {
     });
 
     test("expanded assistant operations have expected risk levels", () => {
-      expect(getAssistantPath("config set").baseRisk).toBe("low");
+      expect(getAssistantPath("config set").baseRisk).toBe("medium");
       expect(getAssistantPath("oauth providers register").baseRisk).toBe(
         "medium",
       );
@@ -619,6 +619,28 @@ describe("command-registry", () => {
       expect(getAssistantPath("plugins uninstall").baseRisk).toBe("medium");
       expect(getAssistantPath("plugins enable").baseRisk).toBe("medium");
       expect(getAssistantPath("plugins disable").baseRisk).toBe("medium");
+    });
+
+    test("assistant config set escalates to high for privileged config paths", () => {
+      const configSetSpec = getAssistantPath("config set");
+      expect(configSetSpec.baseRisk).toBe("medium");
+      expect(configSetSpec.argRules).toBeDefined();
+
+      const pathRule = configSetSpec.argRules!.find(
+        (r) => r.id === "assistant-config-set:privileged-path",
+      );
+      expect(pathRule).toBeDefined();
+      expect(pathRule!.risk).toBe("high");
+
+      const re = new RegExp(pathRule!.valuePattern!);
+      expect(re.test("llm.activeProfile")).toBe(true);
+      expect(re.test("llm.callSites.mainAgent.model")).toBe(true);
+      expect(re.test("llm")).toBe(true);
+      expect(re.test("services.outlook-oauth.mode")).toBe(true);
+      expect(re.test("services")).toBe(true);
+      expect(re.test("gateway.publicBaseUrl")).toBe(true);
+      expect(re.test("ui.theme")).toBe(false);
+      expect(re.test("llmfoo")).toBe(false);
     });
 
     test("assistant schedules update escalates to high for script payloads", () => {

--- a/gateway/src/risk/command-registry.test.ts
+++ b/gateway/src/risk/command-registry.test.ts
@@ -639,8 +639,11 @@ describe("command-registry", () => {
       expect(re.test("services.outlook-oauth.mode")).toBe(true);
       expect(re.test("services")).toBe(true);
       expect(re.test("gateway.publicBaseUrl")).toBe(true);
+      expect(re.test("ingress.publicBaseUrl")).toBe(true);
+      expect(re.test("ingress")).toBe(true);
       expect(re.test("ui.theme")).toBe(false);
       expect(re.test("llmfoo")).toBe(false);
+      expect(re.test("ingressfoo")).toBe(false);
     });
 
     test("assistant schedules update escalates to high for script payloads", () => {

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -420,7 +420,11 @@ const riskOverrides: AssistantRiskOverride[] = [
   { path: "channel-verification-sessions resend", risk: "high" },
   { path: "channel-verification-sessions cancel", risk: "low" },
   { path: "channel-verification-sessions revoke", risk: "low" },
-  { path: "config set", risk: "low" },
+  {
+    path: "config set",
+    risk: "medium",
+    reason: "Writes a value into the assistant's runtime configuration",
+  },
   { path: "contacts prompt", risk: "medium" },
   { path: "contacts channels update-status", risk: "medium" },
   { path: "contacts invites create", risk: "high" },
@@ -745,6 +749,24 @@ const oauthModeArgRules: ArgRule[] = [
   },
 ];
 getExistingPath(spec, "oauth mode").argRules = oauthModeArgRules;
+
+// `config set` is a medium-risk state mutation, but writing an `llm.*`,
+// `services.*`, or `gateway.*` config path rewires the assistant's own model
+// routing, service modes, or gateway behavior. Self-misconfiguration of these
+// paths can silently break integrations, so classify them as high — a
+// privilege/trust-relevant mutation. The pattern
+// matches the config-path positional (the first non-flag argument to
+// `config set`), including bare domain roots and any dotted subpath.
+const configSetArgRules: ArgRule[] = [
+  {
+    id: "assistant-config-set:privileged-path",
+    valuePattern: String.raw`^(llm|services|gateway)(\.|$)`,
+    risk: "high",
+    reason:
+      "Rewires the assistant's own model routing (llm.*), service modes (services.*), or gateway behavior; self-misconfiguration can silently break integrations",
+  },
+];
+getExistingPath(spec, "config set").argRules = configSetArgRules;
 
 const assistantBashArgRules: ArgRule[] = [
   {

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -751,19 +751,20 @@ const oauthModeArgRules: ArgRule[] = [
 getExistingPath(spec, "oauth mode").argRules = oauthModeArgRules;
 
 // `config set` is a medium-risk state mutation, but writing an `llm.*`,
-// `services.*`, or `gateway.*` config path rewires the assistant's own model
-// routing, service modes, or gateway behavior. Self-misconfiguration of these
-// paths can silently break integrations, so classify them as high — a
-// privilege/trust-relevant mutation. The pattern
-// matches the config-path positional (the first non-flag argument to
+// `services.*`, `gateway.*`, or `ingress.*` config path rewires the assistant's
+// own model routing, service modes, gateway behavior, or public-URL/webhook/
+// OAuth-callback routing (ingress.publicBaseUrl). Self-misconfiguration of these
+// paths can silently break integrations or redirect inbound webhook/callback
+// traffic, so classify them as high — a privilege/trust-relevant mutation. The
+// pattern matches the config-path positional (the first non-flag argument to
 // `config set`), including bare domain roots and any dotted subpath.
 const configSetArgRules: ArgRule[] = [
   {
     id: "assistant-config-set:privileged-path",
-    valuePattern: String.raw`^(llm|services|gateway)(\.|$)`,
+    valuePattern: String.raw`^(llm|services|gateway|ingress)(\.|$)`,
     risk: "high",
     reason:
-      "Rewires the assistant's own model routing (llm.*), service modes (services.*), or gateway behavior; self-misconfiguration can silently break integrations",
+      "Rewires the assistant's own model routing (llm.*), service modes (services.*), gateway behavior (gateway.*), or public-URL/webhook/OAuth-callback routing (ingress.publicBaseUrl); self-misconfiguration can silently break integrations or redirect inbound traffic",
   },
 ];
 getExistingPath(spec, "config set").argRules = configSetArgRules;


### PR DESCRIPTION
## Problem

`assistant config set` was classified `low` risk in the gateway command registry, so it auto-approved within default thresholds. In a feedback incident (feedback-019f447d), an assistant self-issued `config set llm.callSites …` (with call-site keys its deployed daemon's schema didn't know) and `config set llm.activeProfile …` commands that rewired its own model routing and pushed its runtime config into the loader's full-defaults fallback — which broke the user's email integrations.

Self-reconfiguration of model routing, service modes, and gateway behavior is a privilege/trust-relevant mutation per the registry's own guidelines ("high: … privilege/trust changes … potentially irreversible effects").

## Fix

The classifier supports matching positional argument values via `valuePattern`-only arg rules, so this is path-sensitive rather than a blanket escalation:

- `config set` base risk: `low` → `medium` (it's a state mutation).
- New high-risk arg rule `assistant-config-set:privileged-path` matching the config-path positional against `^(llm|services|gateway)(\.|$)` — bare roots and any dotted subpath.
- Read-only config commands (`get`, `list`, `schema`, `validate-allowlist`) unchanged.

`assistant config set ui.theme dark` → medium. `assistant config set llm.activeProfile foo` / `services.outlook-oauth.mode your-own` / `gateway.publicBaseUrl …` → high.

## Testing

From `gateway/`: `bun test src/risk/command-registry.test.ts src/risk/bash-risk-classifier.test.ts src/risk/risk-classifier-parity.test.ts src/__tests__/bash-risk-classifier.test.ts` → 375 pass, 0 fail (parity 56/56). `bunx tsc --noEmit` clean.

Note: users who have raised their auto-approve threshold to `high` will still auto-approve these; this PR corrects the classification so default-threshold users get prompted.

Part of a 5-PR series from the feedback-019f447d investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37626" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->