### PR TITLE
fix(oauth): list active account labels when a connection lookup misses

### DIFF
--- a/assistant/src/oauth/byo-connection.test.ts
+++ b/assistant/src/oauth/byo-connection.test.ts
@@ -592,7 +592,7 @@ describe("resolveOAuthConnection", () => {
 
   test("throws when no credential metadata exists", async () => {
     await expect(resolveOAuthConnection("unknown")).rejects.toThrow(
-      /No active OAuth connection found for "unknown"/,
+      /No active OAuth connection found for provider "unknown"/,
     );
   });
 

--- a/assistant/src/oauth/connection-resolver.test.ts
+++ b/assistant/src/oauth/connection-resolver.test.ts
@@ -78,6 +78,7 @@ mock.module("../platform/client.js", () => ({
 
 import { BYOOAuthConnection } from "./byo-connection.js";
 import {
+  formatNoConnectionError,
   resolveEffectiveBaseUrl,
   resolveOAuthConnection,
   resolveOAuthConnectionWithMeta,
@@ -573,6 +574,145 @@ describe("resolveOAuthConnectionWithMeta multi-account visibility", () => {
 
     expect(ambiguous).toBe(false);
     expect(allAccounts).toEqual(["user@example.com"]);
+  });
+});
+
+describe("no-match error lists available accounts", () => {
+  function clientReturning(results: unknown[]) {
+    return {
+      ...makeMockClient(),
+      fetch: mock(
+        async (path: string) =>
+          new Response(
+            JSON.stringify({
+              // Filtered lookups (account_identifier present) return nothing;
+              // the unfiltered fallback returns the real connections.
+              results: path.includes("account_identifier=") ? [] : results,
+            }),
+            { status: 200 },
+          ),
+      ),
+    };
+  }
+
+  beforeEach(() => {
+    setupDefaults();
+  });
+
+  test("BYO: names the provider's active accounts when the requested account misses", async () => {
+    mockConnections = [
+      {
+        id: "conn-personal",
+        provider: "google",
+        accountInfo: "user@example.com",
+        grantedScopes: JSON.stringify([]),
+        status: "active",
+      },
+      {
+        id: "conn-work",
+        provider: "google",
+        accountInfo: "other@example.org",
+        grantedScopes: JSON.stringify([]),
+        status: "active",
+      },
+    ];
+
+    let message = "";
+    try {
+      await resolveOAuthConnection("google", {
+        account: "missing@example.com",
+      });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+
+    expect(message).toContain('account "missing@example.com"');
+    expect(message).toContain(
+      "Active google connections: user@example.com, other@example.org",
+    );
+    expect(message).toContain("Check the account spelling.");
+  });
+
+  test("BYO: zero connections keeps the plain 'needs to be connected' shape", async () => {
+    mockConnections = [];
+
+    let message = "";
+    try {
+      await resolveOAuthConnection("google", {
+        account: "missing@example.com",
+      });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+
+    expect(message).not.toContain("Active google connections:");
+    expect(message).toContain(
+      "The google service needs to be connected before it can be used.",
+    );
+  });
+
+  test("managed: names the provider's active accounts when the requested account misses", async () => {
+    mockProvider!.managedServiceConfigKey = "google-oauth";
+    mockPlatformClient = clientReturning([
+      { id: "conn-personal", account_label: "user@example.com" },
+      { id: "conn-work", account_label: "other@example.org" },
+    ]);
+
+    let message = "";
+    try {
+      await resolveOAuthConnection("google", {
+        account: "missing@example.com",
+      });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+
+    expect(message).toContain('account "missing@example.com"');
+    expect(message).toContain(
+      "Active google connections: user@example.com, other@example.org",
+    );
+    expect(message).toContain("Check the account spelling.");
+  });
+});
+
+describe("formatNoConnectionError", () => {
+  test("appends available account labels when the provider has active connections", () => {
+    // The requested account is a one-letter misspelling of an active one.
+    const message = formatNoConnectionError({
+      provider: "outlook",
+      account: "usr@example.com",
+      availableLabels: ["user@example.com", "other@example.org"],
+    });
+    expect(message).toBe(
+      'No active OAuth connection found for provider "outlook" with account ' +
+        '"usr@example.com". Active outlook connections: user@example.com, ' +
+        "other@example.org. Check the account spelling.",
+    );
+  });
+
+  test("keeps the plain message shape when no active connections exist", () => {
+    const message = formatNoConnectionError({
+      provider: "outlook",
+      account: "user@example.com",
+      availableLabels: [],
+    });
+    expect(message).toBe(
+      'No active OAuth connection found for provider "outlook" with account ' +
+        '"user@example.com". The outlook service needs to be connected before ' +
+        "it can be used.",
+    );
+  });
+
+  test("includes both account and client ID qualifiers when present", () => {
+    const message = formatNoConnectionError({
+      provider: "outlook",
+      account: "user@example.com",
+      clientId: "client-1",
+      availableLabels: [],
+    });
+    expect(message).toContain(
+      'with account "user@example.com" and client ID "client-1"',
+    );
   });
 });
 

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -147,15 +147,18 @@ export async function resolveOAuthConnectionWithMeta(
 
   const candidates = getActiveConnections(provider, { clientId, account });
   if (candidates.length === 0) {
-    const filters = [
-      account && `account "${account}"`,
-      clientId && `client ID "${clientId}"`,
-    ].filter(Boolean);
-    const qualifier = filters.length
-      ? ` matching ${filters.join(" and ")}`
-      : "";
+    // When a filter produced zero matches, enumerate the provider's other
+    // active connections so the error can name the accounts that DO exist —
+    // a one-letter account typo should be self-correctable, not read as a
+    // disconnection.
+    const availableLabels =
+      account || clientId
+        ? getActiveConnections(provider).map(
+            (row) => (row.accountInfo as string | null) ?? (row.id as string),
+          )
+        : [];
     throw new Error(
-      `No active OAuth connection found for "${provider}"${qualifier}. The ${provider} service needs to be connected before it can be used.`,
+      formatNoConnectionError({ provider, account, clientId, availableLabels }),
     );
   }
 
@@ -365,8 +368,11 @@ async function resolvePlatformConnectionId(
     accountIdentifier: account,
   });
 
+  // Holds the provider's full active-connection list once a filtered lookup
+  // comes back empty, so the no-match error can name the accounts that exist.
+  let unfilteredConnections: PlatformConnectionEntry[] | undefined;
   if (account && connections.length === 0) {
-    const unfilteredConnections = await fetchPlatformConnections({
+    unfilteredConnections = await fetchPlatformConnections({
       client,
       provider,
     });
@@ -377,10 +383,11 @@ async function resolvePlatformConnectionId(
   }
 
   if (connections.length === 0) {
+    const availableLabels = (unfilteredConnections ?? []).map(
+      platformConnectionLabel,
+    );
     throw new Error(
-      `No active OAuth connection found for provider "${provider}"` +
-        (account ? ` with account "${account}"` : "") +
-        `. The ${provider} service needs to be connected.`,
+      formatNoConnectionError({ provider, account, availableLabels }),
     );
   }
 
@@ -485,6 +492,35 @@ function parseGrantedScopes(raw: string | null | undefined): string[] {
   } catch {
     return [];
   }
+}
+
+/**
+ * Actionable error thrown when no active connection matches the requested
+ * provider (optionally narrowed by account/clientId).
+ *
+ * When the provider has other active connections whose labels are known, the
+ * message names them so a mistyped account can be self-corrected rather than
+ * mistaken for a disconnection. Labels are the user's own account identifiers
+ * that already appear in logs — nothing beyond them is surfaced. When no other
+ * active connection exists, the message keeps the "needs to be connected" shape.
+ */
+export function formatNoConnectionError(params: {
+  provider: string;
+  account?: string;
+  clientId?: string;
+  availableLabels: string[];
+}): string {
+  const { provider, account, clientId, availableLabels } = params;
+  const filters = [
+    account && `account "${account}"`,
+    clientId && `client ID "${clientId}"`,
+  ].filter(Boolean);
+  const qualifier = filters.length ? ` with ${filters.join(" and ")}` : "";
+  const base = `No active OAuth connection found for provider "${provider}"${qualifier}.`;
+  if (availableLabels.length > 0) {
+    return `${base} Active ${provider} connections: ${availableLabels.join(", ")}. Check the account spelling.`;
+  }
+  return `${base} The ${provider} service needs to be connected before it can be used.`;
 }
 
 /** Actionable error shown when a connection is missing required scopes. */


### PR DESCRIPTION
## Problem

When a caller passes an `account` (or `clientId`) that matches no active connection, `connection-resolver.ts` throws "No active OAuth connection found for provider X with account Y. The X service needs to be connected." — implying the whole service is disconnected.

In a feedback incident (feedback-019f447d), the model typo'd an account address by one letter in a tool call. The provider actually had 3 active connections including the correctly-spelled account, but the error gave no hint, so the assistant told the user their account was disconnected — the proximate cause of a "it flip-flops on whether my email is connected" complaint. One line of context in the error would have let the model self-correct.

## Fix

Both no-match sites (managed platform path and BYO local-store path) route through a shared `formatNoConnectionError()` helper. When the filtered lookup misses but the provider has other active connections, the error names them:

> `No active OAuth connection found for provider "outlook" with account "usr@example.com". Active outlook connections: user@example.com, other@example.org. Check the account spelling.`

When the provider truly has zero connections, the message keeps its existing "needs to be connected" shape. The managed path reuses the unfiltered `fetchPlatformConnections` result it already fetches for the label fallback; the BYO path enumerates `getActiveConnections(provider)` unfiltered. Account labels are the user's own identifiers and already appear in daemon logs.

## Testing

`bun test src/oauth/connection-resolver.test.ts` → 40 pass, 0 fail (new cases: BYO miss lists labels, BYO zero-connections keeps plain shape, managed miss lists labels, plus `formatNoConnectionError` unit tests). `bun run typecheck:fast` clean.

Part of a 5-PR series from the feedback-019f447d investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->