### PR TITLE
fix(config): compact sparse arrays left by stripping invalid elements

### DIFF
--- a/assistant/src/config/__tests__/loader-sparse-array-cleanup.test.ts
+++ b/assistant/src/config/__tests__/loader-sparse-array-cleanup.test.ts
@@ -103,7 +103,10 @@ describe("config recovery compacts arrays after stripping invalid elements", () 
     expect(config.tools.exclude).toEqual(["tool-a", "tool-b"]);
   });
 
-  test("a fully-invalid array collapses to empty, not to a parse failure", () => {
+  test("an array emptied by stripping all invalid elements reverts to its schema default", () => {
+    // `tools.exclude` defaults to `[]`, so a fully-invalid array reverting to
+    // the default still resolves to `[]` — but it must not parse-fail, and the
+    // rest of the config must survive.
     writeConfig({
       tools: { exclude: [1, 2] },
       maxStepsPerSession: 66,
@@ -113,5 +116,51 @@ describe("config recovery compacts arrays after stripping invalid elements", () 
 
     expect(config.tools.exclude).toEqual([]);
     expect(config.maxStepsPerSession).toBe(66);
+  });
+
+  test("emptied-by-compaction array reverts to a non-empty schema default (backup.offsite.destinations)", () => {
+    // `backup.offsite.destinations` defaults to `null`, where `null` means "use
+    // the iCloud default destination" and `[]` means "no offsite destinations".
+    // Stripping the sole invalid element must NOT leave an explicit `[]` that
+    // overrides the default — it must fall back to the schema default `null`.
+    writeConfig({
+      backup: { offsite: { destinations: [123] } },
+      maxStepsPerSession: 66,
+    });
+
+    const config = loadConfig();
+
+    expect(config.backup.offsite.destinations).toBeNull();
+    expect(config.maxStepsPerSession).toBe(66);
+  });
+
+  test("emptied-by-compaction array reverts to a non-empty schema default (skills.allowBundled)", () => {
+    // `skills.allowBundled` defaults to `null` (load all bundled skills); an
+    // explicit `[]` would exclude ALL bundled skills. Stripping every invalid
+    // element must revert to the default, not silently disable all skills.
+    writeConfig({
+      skills: { allowBundled: [1, 2] },
+      maxStepsPerSession: 66,
+    });
+
+    const config = loadConfig();
+
+    expect(config.skills.allowBundled).toBeNull();
+    expect(config.maxStepsPerSession).toBe(66);
+  });
+
+  test("an explicitly-empty array on disk is preserved as the user's choice", () => {
+    // `backup.offsite.destinations: []` has no invalid elements to strip, so it
+    // is never touched by compaction. An unrelated invalid field forces the
+    // cleanup path to run over the whole tree; the empty array must survive as
+    // the user's explicit "no offsite destinations" choice.
+    writeConfig({
+      backup: { offsite: { destinations: [] } },
+      maxStepsPerSession: "not-a-number",
+    });
+
+    const config = loadConfig();
+
+    expect(config.backup.offsite.destinations).toEqual([]);
   });
 });

--- a/assistant/src/config/__tests__/loader-sparse-array-cleanup.test.ts
+++ b/assistant/src/config/__tests__/loader-sparse-array-cleanup.test.ts
@@ -1,0 +1,117 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+const WORKSPACE_DIR = process.env.VELLUM_WORKSPACE_DIR!;
+const CONFIG_PATH = join(WORKSPACE_DIR, "config.json");
+
+function ensureTestDir(): void {
+  const dirs = [
+    WORKSPACE_DIR,
+    join(WORKSPACE_DIR, "data"),
+    join(WORKSPACE_DIR, "data", "memory"),
+    join(WORKSPACE_DIR, "data", "logs"),
+  ];
+  for (const dir of dirs) {
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+  }
+}
+
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of [
+    "info",
+    "warn",
+    "error",
+    "debug",
+    "trace",
+    "fatal",
+    "silent",
+    "child",
+  ]) {
+    stub[m] = m === "child" ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () => makeLoggerStub(),
+}));
+
+afterAll(() => {
+  mock.restore();
+});
+
+import { invalidateConfigCache, loadConfig } from "../loader.js";
+
+function writeConfig(obj: unknown): void {
+  writeFileSync(CONFIG_PATH, JSON.stringify(obj, null, 2) + "\n");
+}
+
+describe("config recovery compacts arrays after stripping invalid elements", () => {
+  beforeEach(() => {
+    ensureTestDir();
+    if (existsSync(CONFIG_PATH)) {
+      rmSync(CONFIG_PATH, { force: true });
+    }
+    delete process.env.IS_PLATFORM;
+    invalidateConfigCache();
+  });
+
+  afterEach(() => {
+    delete process.env.IS_PLATFORM;
+    if (existsSync(CONFIG_PATH)) {
+      rmSync(CONFIG_PATH, { force: true });
+    }
+    invalidateConfigCache();
+  });
+
+  test("one invalid array element is dropped and the valid elements survive", () => {
+    // `tools.exclude` is z.array(z.string()); the numeric element is invalid.
+    // Stripping it leaves a sparse hole, which re-parse reads as `undefined`
+    // and rejects unless the array is compacted first.
+    writeConfig({
+      tools: { exclude: ["tool-a", 123, "tool-b"] },
+      maxStepsPerSession: 77,
+    });
+
+    const config = loadConfig();
+
+    expect(config.tools.exclude).toEqual(["tool-a", "tool-b"]);
+    // The rest of the config survives — cleanup succeeded, so recovery never
+    // reaches the drop-everything fallbacks.
+    expect(config.maxStepsPerSession).toBe(77);
+  });
+
+  test("multiple invalid elements in one array are all dropped", () => {
+    writeConfig({
+      tools: { exclude: [1, "tool-a", 2, "tool-b", 3] },
+    });
+
+    const config = loadConfig();
+
+    expect(config.tools.exclude).toEqual(["tool-a", "tool-b"]);
+  });
+
+  test("a fully-invalid array collapses to empty, not to a parse failure", () => {
+    writeConfig({
+      tools: { exclude: [1, 2] },
+      maxStepsPerSession: 66,
+    });
+
+    const config = loadConfig();
+
+    expect(config.tools.exclude).toEqual([]);
+    expect(config.maxStepsPerSession).toBe(66);
+  });
+});

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -324,6 +324,13 @@ function validateWithSchema(raw: Record<string, unknown>): AssistantConfig {
     deleteNestedKey(cleaned, issue.path as (string | number)[], true);
   }
 
+  // Deleting an invalid array element via `deleteNestedKey` uses `delete
+  // arr[i]` semantics, which leaves a sparse hole that the re-parse reads as
+  // `undefined` and rejects — one bad element in any array field would
+  // otherwise invalidate the whole cleaned config. Compact the holes away
+  // before re-parsing.
+  compactSparseArrays(cleaned);
+
   const retry = AssistantConfigSchema.safeParse(cleaned);
   if (retry.success) {
     return applyNestedDefaults(retry.data);
@@ -332,6 +339,29 @@ function validateWithSchema(raw: Record<string, unknown>): AssistantConfig {
   // If still failing, fall back to full defaults
   log.warn("Config validation failed after cleanup. Using full defaults.");
   return cloneDefaultConfig();
+}
+
+/**
+ * Recursively remove holes from every array reachable inside `value`,
+ * mutating in place. Config values come from `JSON.parse`, which cannot
+ * encode holes (or `undefined`), so any hole is the residue of a
+ * `deleteNestedKey` strip of an invalid array element and is safe to drop.
+ * Surviving elements are recursed into so nested arrays are compacted too.
+ */
+function compactSparseArrays(value: unknown): void {
+  if (Array.isArray(value)) {
+    for (let i = value.length - 1; i >= 0; i--) {
+      if (i in value) {
+        compactSparseArrays(value[i]);
+      } else {
+        value.splice(i, 1);
+      }
+    }
+  } else if (isPlainObject(value)) {
+    for (const child of Object.values(value)) {
+      compactSparseArrays(child);
+    }
+  }
 }
 
 /**

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -328,7 +328,12 @@ function validateWithSchema(raw: Record<string, unknown>): AssistantConfig {
   // arr[i]` semantics, which leaves a sparse hole that the re-parse reads as
   // `undefined` and rejects — one bad element in any array field would
   // otherwise invalidate the whole cleaned config. Compact the holes away
-  // before re-parsing.
+  // before re-parsing. An array that is emptied purely by stripping invalid
+  // elements is removed from its parent (and any ancestor object the removal
+  // empties is pruned too) so the schema default applies, matching how
+  // `deleteNestedKey` prunes emptied objects — `[]` is not equivalent to the
+  // default for fields like `backup.offsite.destinations` (default `null` =
+  // iCloud) or `skills.allowBundled` (default `null` = all bundled skills).
   compactSparseArrays(cleaned);
 
   const retry = AssistantConfigSchema.safeParse(cleaned);
@@ -342,26 +347,56 @@ function validateWithSchema(raw: Record<string, unknown>): AssistantConfig {
 }
 
 /**
- * Recursively remove holes from every array reachable inside `value`,
- * mutating in place. Config values come from `JSON.parse`, which cannot
- * encode holes (or `undefined`), so any hole is the residue of a
- * `deleteNestedKey` strip of an invalid array element and is safe to drop.
- * Surviving elements are recursed into so nested arrays are compacted too.
+ * Recursively remove holes from every array reachable inside `value`, mutating
+ * in place, and report whether `value` should be removed from its parent.
+ *
+ * Config values come from `JSON.parse`, which cannot encode holes (or
+ * `undefined`), so any hole is the residue of a `deleteNestedKey` strip of an
+ * invalid array element and is safe to drop. Surviving elements are recursed
+ * into so nested arrays are compacted too.
+ *
+ * `removeFromParent` is set for a value the parent must drop so the schema
+ * default applies:
+ *
+ * - An **array** that had at least one element removed by compaction (a hole
+ *   from a stripped invalid element, or a nested child array that itself
+ *   collapsed) and is now empty. An array that was already `[]` on disk keeps
+ *   `removeFromParent` false — no element was stripped, so `[]` is the user's
+ *   explicit choice and is preserved.
+ * - A **plain object** that a compaction removal emptied. This mirrors
+ *   `deleteNestedKey(…, true)` pruning emptied ancestor objects: an emptied
+ *   wrapper left behind can still read as a present, non-default override. An
+ *   object that was already empty on disk removed no child, so it is left alone.
  */
-function compactSparseArrays(value: unknown): void {
+function compactSparseArrays(value: unknown): { removeFromParent: boolean } {
   if (Array.isArray(value)) {
+    let removedElement = false;
     for (let i = value.length - 1; i >= 0; i--) {
       if (i in value) {
-        compactSparseArrays(value[i]);
+        if (compactSparseArrays(value[i]).removeFromParent) {
+          value.splice(i, 1);
+          removedElement = true;
+        }
       } else {
         value.splice(i, 1);
+        removedElement = true;
       }
     }
-  } else if (isPlainObject(value)) {
-    for (const child of Object.values(value)) {
-      compactSparseArrays(child);
-    }
+    return { removeFromParent: removedElement && value.length === 0 };
   }
+  if (isPlainObject(value)) {
+    let removedChild = false;
+    for (const key of Object.keys(value)) {
+      if (compactSparseArrays(value[key]).removeFromParent) {
+        delete value[key];
+        removedChild = true;
+      }
+    }
+    return {
+      removeFromParent: removedChild && Object.keys(value).length === 0,
+    };
+  }
+  return { removeFromParent: false };
 }
 
 /**


### PR DESCRIPTION
## Problem

During config schema-recovery cleanup, `deleteNestedKey` strips an invalid array element with `delete arr[i]` semantics, leaving a sparse hole. The cleanup's re-parse reads the hole as `undefined` and rejects it — so a single bad element in any array field (e.g. `tools.exclude: ["valid", 123]`) fails the *entire* cleaned config instead of just dropping the bad element.

Today that lands in the drop-everything fallback ("Config validation failed after cleanup. Using full defaults") — the exact path that wiped a user's effective config in the feedback-019f447d incident. This is the most plausible cleanup-resistant shape for that incident's mystery trigger, confirmed reproducible in tests during the investigation for #37624.

## Fix

Compact every array reachable in the cleaned config before the re-parse. Config values come from `JSON.parse`, which cannot encode holes or `undefined`, so every hole is the residue of a stripped element and is safe to drop; valid sibling elements survive.

## Testing

New `loader-sparse-array-cleanup.test.ts`: one invalid element dropped with valid siblings and the rest of the config intact; multiple invalid elements in one array; fully-invalid array collapses to `[]` rather than a parse failure. 6 pass (with the sibling strip-fallback suite), `bun run typecheck:fast` clean.

Companion to #37624 (last-known-good recovery ladder): this PR makes cleanup *succeed* in the common array case so recovery is rarely needed; #37624 makes recovery non-destructive when cleanup still fails. Both touch `loader.ts` in adjacent regions — whichever merges second may need a trivial rebase.

Part of the feedback-019f447d incident series (#37623–#37627).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37628" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->