### PR TITLE
Add family-briefing plugin

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -298,7 +298,7 @@
       "source": {
         "source": "github",
         "repo": "AnitaKirkovska/family-briefing",
-        "ref": "8d363835f752992a397e350825f229902fc4a5ff"
+        "ref": "8eefa41f991279a0f25e3992730cf0ce65c6845d"
       },
       "description": "Daily morning briefing for parents: merges family calendars, triages school emails, and detects scheduling conflicts.",
       "category": "productivity",

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -298,7 +298,7 @@
       "source": {
         "source": "github",
         "repo": "AnitaKirkovska/family-briefing",
-        "ref": "8eefa41f991279a0f25e3992730cf0ce65c6845d"
+        "ref": "145f341db7d06ffa81e2052033f187679b8bda4d"
       },
       "description": "Daily morning briefing for parents: merges family calendars, triages school emails, and detects scheduling conflicts.",
       "category": "productivity",

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -292,6 +292,18 @@
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/smb-inbox-brief",
       "license": "MIT"
+    },
+    {
+      "name": "family-briefing",
+      "source": {
+        "source": "github",
+        "repo": "AnitaKirkovska/family-briefing",
+        "ref": "8d363835f752992a397e350825f229902fc4a5ff"
+      },
+      "description": "Daily morning briefing for parents: merges family calendars, triages school emails, and detects scheduling conflicts.",
+      "category": "productivity",
+      "homepage": "https://github.com/AnitaKirkovska/family-briefing",
+      "license": "MIT"
     }
   ]
 }


### PR DESCRIPTION
Daily morning briefing for parents. Merges family calendars, triages school emails (deadlines, pickup changes, permission slips, spirit days), and detects scheduling conflicts across calendars. Pinned to commit 8d363835f752992a397e350825f229902fc4a5ff. Repo: https://github.com/AnitaKirkovska/family-briefing