### PR TITLE
Add personal-finance and proactive-slacks plugins to marketplace

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -313,8 +313,20 @@
         "ref": "1cf0054fa652a0b981f871e389136fbc22b02cf9"
       },
       "description": "Track expenses, income, recurring bills, and savings funds from your assistant. Multi-currency, receipt OCR, Plaid bank sync, and financial summaries. All data stored locally in SQLite.",
-      "category": "productivity",
+      "category": "finance",
       "homepage": "https://github.com/AnitaKirkovska/personal-finance",
+      "license": "MIT"
+    },
+    {
+      "name": "proactive-slacks",
+      "source": {
+        "source": "github",
+        "repo": "AnitaKirkovska/proactive-slacks",
+        "ref": "a5dd35699455ae7a2db3d2243511a8c7edc49aea"
+      },
+      "description": "Let your assistant reach you on Slack on purpose. Route notifications by topic to the right channel at the right volume, with heartbeat-based change detection so it only pings when something actually changed.",
+      "category": "productivity",
+      "homepage": "https://github.com/AnitaKirkovska/proactive-slacks",
       "license": "MIT"
     }
   ]

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -316,6 +316,18 @@
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/personal-finance",
       "license": "MIT"
+    },
+    {
+      "name": "proactive-slacks",
+      "source": {
+        "source": "github",
+        "repo": "AnitaKirkovska/proactive-slacks",
+        "ref": "a5dd35699455ae7a2db3d2243511a8c7edc49aea"
+      },
+      "description": "Let your assistant reach you on Slack on purpose. Route notifications by topic to the right channel at the right volume, with heartbeat-based change detection so it only pings when something actually changed.",
+      "category": "productivity",
+      "homepage": "https://github.com/AnitaKirkovska/proactive-slacks",
+      "license": "MIT"
     }
   ]
 }

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -310,23 +310,11 @@
       "source": {
         "source": "github",
         "repo": "AnitaKirkovska/personal-finance",
-        "ref": "1cf0054fa652a0b981f871e389136fbc22b02cf9"
+        "ref": "f8f9bfba3d86c943001da894b920e7e867507dd4"
       },
       "description": "Track expenses, income, recurring bills, and savings funds from your assistant. Multi-currency, receipt OCR, Plaid bank sync, and financial summaries. All data stored locally in SQLite.",
-      "category": "finance",
-      "homepage": "https://github.com/AnitaKirkovska/personal-finance",
-      "license": "MIT"
-    },
-    {
-      "name": "proactive-slacks",
-      "source": {
-        "source": "github",
-        "repo": "AnitaKirkovska/proactive-slacks",
-        "ref": "a5dd35699455ae7a2db3d2243511a8c7edc49aea"
-      },
-      "description": "Let your assistant reach you on Slack on purpose. Route notifications by topic to the right channel at the right volume, with heartbeat-based change detection so it only pings when something actually changed.",
       "category": "productivity",
-      "homepage": "https://github.com/AnitaKirkovska/proactive-slacks",
+      "homepage": "https://github.com/AnitaKirkovska/personal-finance",
       "license": "MIT"
     }
   ]

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -313,7 +313,7 @@
         "ref": "1cf0054fa652a0b981f871e389136fbc22b02cf9"
       },
       "description": "Track expenses, income, recurring bills, and savings funds from your assistant. Multi-currency, receipt OCR, Plaid bank sync, and financial summaries. All data stored locally in SQLite.",
-      "category": "finance",
+      "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/personal-finance",
       "license": "MIT"
     }

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -304,6 +304,18 @@
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/family-briefing",
       "license": "MIT"
+    },
+    {
+      "name": "personal-finance",
+      "source": {
+        "source": "github",
+        "repo": "AnitaKirkovska/personal-finance",
+        "ref": "1cf0054fa652a0b981f871e389136fbc22b02cf9"
+      },
+      "description": "Track expenses, income, recurring bills, and savings funds from your assistant. Multi-currency, receipt OCR, Plaid bank sync, and financial summaries. All data stored locally in SQLite.",
+      "category": "finance",
+      "homepage": "https://github.com/AnitaKirkovska/personal-finance",
+      "license": "MIT"
     }
   ]
 }


### PR DESCRIPTION
## personal-finance

Personal finance plugin for Vellum assistants. Track expenses, income, recurring bills, and savings funds. Multi-currency, receipt OCR, Plaid bank sync, and financial summaries. All data stored locally in SQLite.

**Repo:** https://github.com/AnitaKirkovska/personal-finance
**Pinned SHA:** 1cf0054fa652a0b981f871e389136fbc22b02cf9

15 tools, 1 hook, 1 skill. MIT licensed.

---

## proactive-slacks

Let your assistant reach you on Slack on purpose. Route notifications by topic to the right channel at the right volume, with heartbeat-based change detection so it only pings when something actually changed.

**Repo:** https://github.com/AnitaKirkovska/proactive-slacks
**Pinned SHA:** a5dd35699455ae7a2db3d2243511a8c7edc49aea

Notification routing tool, helper script, skill. MIT licensed.