### PR TITLE
feat(assistant): use UUIDv7 for conversation and message ids

### DIFF
--- a/assistant/src/__tests__/conversation-message-id-uuidv7.test.ts
+++ b/assistant/src/__tests__/conversation-message-id-uuidv7.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+  }),
+}));
+
+import {
+  addMessage,
+  createConversation,
+} from "../persistence/conversation-crud.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+
+await initializeDb();
+
+/** The UUID version nibble is the first hex digit of the third dash group. */
+function uuidVersion(id: string): string {
+  return id.split("-")[2]?.[0] ?? "";
+}
+
+describe("conversation & message ids use UUIDv7", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM messages");
+    db.run("DELETE FROM conversations");
+  });
+
+  test("server-generated conversation ids are v7 and monotonic", () => {
+    const ids = Array.from(
+      { length: 5 },
+      (_, i) => createConversation({ title: `c${i}` }).id,
+    );
+
+    for (const id of ids) {
+      expect(uuidVersion(id)).toBe("7");
+    }
+    // Time-ordered: ids sort in creation order (this is the append property).
+    expect([...ids].sort()).toEqual(ids);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("server-generated message ids are v7", async () => {
+    const conv = createConversation({ title: "messages" });
+    const ids: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      const m = await addMessage(conv.id, "assistant", `m${i}`, {
+        skipIndexing: true,
+      });
+      ids.push(m.id);
+    }
+
+    for (const id of ids) {
+      expect(uuidVersion(id)).toBe("7");
+    }
+    expect([...ids].sort()).toEqual(ids);
+  });
+
+  test("an explicitly supplied message id is still adopted verbatim", async () => {
+    const conv = createConversation({ title: "adopt" });
+    const requestId = "11111111-2222-4333-8444-555555555555"; // a v4-shaped id
+    const m = await addMessage(conv.id, "user", "hi", {
+      id: requestId,
+      skipIndexing: true,
+    });
+    expect(m.id).toBe(requestId);
+  });
+});

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -5,7 +5,7 @@
  * Extracted from Conversation to keep the class focused on coordination.
  */
 
-import { v4 as uuid } from "uuid";
+import { v7 as uuidv7 } from "uuid";
 
 import {
   type AttachmentReferenceInput,
@@ -554,7 +554,7 @@ export function enqueueMessage(
     content,
     attachments = [],
     onEvent,
-    requestId = crypto.randomUUID(),
+    requestId = uuidv7(),
     activeSurfaceId,
     currentPage,
     metadata,
@@ -642,7 +642,7 @@ export async function persistUserMessage(
     throw new Error("Message content or attachments are required");
   }
 
-  const reqId = options.requestId ?? uuid();
+  const reqId = options.requestId ?? uuidv7();
   ctx.currentRequestId = reqId;
   ctx.abortController = new AbortController();
 
@@ -699,7 +699,7 @@ export async function persistQueuedMessageBody(
   const {
     content,
     attachments = [],
-    requestId = uuid(),
+    requestId = uuidv7(),
     metadata,
     displayContent,
     clientMessageId,

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -17,7 +17,7 @@ import {
   or,
   sql,
 } from "drizzle-orm";
-import { v4 as uuid } from "uuid";
+import { v4 as uuid, v7 as uuidv7 } from "uuid";
 import { z } from "zod";
 
 import type { ChannelId, InterfaceId } from "../channels/types.js";
@@ -495,8 +495,8 @@ interface InsertMessageCoreParams {
   content: string;
   metadata?: Record<string, unknown>;
   clientMessageId?: string;
-  /** Pre-assigned message ID. When omitted, one is generated via
-   *  `uuid()`. Callers that already have a correlation ID (e.g.
+  /** Pre-assigned message ID. When omitted, a time-ordered `uuidv7()` is
+   *  generated. Callers that already have a correlation ID (e.g.
    *  `requestId` for user turns) can pass it here so the persisted
    *  row ID matches the runtime request ID. */
   id?: string;
@@ -529,7 +529,9 @@ async function insertMessageCore(
   const { conversationId, role, content, metadata, clientMessageId, id } =
     params;
   const db = getDb();
-  const messageId = id ?? uuid();
+  // Time-ordered UUIDv7 so server-generated message ids append to the tail of
+  // the WITHOUT ROWID `messages` primary key instead of scattering (v4).
+  const messageId = id ?? uuidv7();
 
   if (metadata) {
     const result = messageMetadataSchema.safeParse(metadata);
@@ -703,7 +705,8 @@ export function createConversation(
     requestedConversationType ?? "standard";
   const source = opts.source ?? "user";
   const groupId = opts.groupId;
-  const id = opts.id ?? uuid();
+  // Time-ordered UUIDv7 for server-minted conversation ids (see message id).
+  const id = opts.id ?? uuidv7();
   const memoryScopeId = "default";
 
   // Ensure group_id column exists for deterministic schema readiness,
@@ -1083,7 +1086,7 @@ export function forkConversation(params: {
     } | null = null;
 
     const forkedMessageValues = messagesToCopy.map((message) => {
-      const forkedMessageId = uuid();
+      const forkedMessageId = uuidv7();
       forkedMessageIds.set(message.id, forkedMessageId);
 
       if (message.role === "assistant") {
@@ -1218,7 +1221,8 @@ function populateForkContentsInProcess(args: PopulateForkContentsArgs): void {
     const uncachedAttachmentLinks = attachmentLinks.filter(
       (link) => !attachmentIdMap.has(link.attachmentId),
     );
-    const stagingMessageId = uncachedAttachmentLinks.length > 0 ? uuid() : null;
+    const stagingMessageId =
+      uncachedAttachmentLinks.length > 0 ? uuidv7() : null;
 
     if (stagingMessageId) {
       db.insert(messages)
@@ -1427,7 +1431,7 @@ export async function forkConversationForRetrospective(params: {
   // the in-process attachment relink that follows.
   const idPairs: ForkIdPair[] = messagesToCopy.map((message) => ({
     oldId: message.id,
-    newId: uuid(),
+    newId: uuidv7(),
   }));
   const forkedMessageIds = new Map<string, string>(
     idPairs.map((pair) => [pair.oldId, pair.newId]),

--- a/assistant/src/runtime/services/analyze-conversation.ts
+++ b/assistant/src/runtime/services/analyze-conversation.ts
@@ -20,6 +20,8 @@
  * against `llm.callSites.analyzeConversation` (falling back to `llm.default`
  * when no override is set).
  */
+import { v7 as uuidv7 } from "uuid";
+
 import { getOrCreateConversation } from "../../daemon/conversation-store.js";
 import {
   AUTO_ANALYSIS_GROUP_ID,
@@ -239,7 +241,7 @@ export async function analyzeConversation(
   // this, `addMessage` would auto-assign a fresh row id while step (k)
   // minted an unrelated `currentRequestId`, leaving `userMessageId` and
   // `requestId` divergent for the analysis turn.
-  const requestId = crypto.randomUUID();
+  const requestId = uuidv7();
   const message = await addMessage(
     analysisConversationId,
     "user",


### PR DESCRIPTION
## Prompt / plan

Follow-up to the SQLite insert-scaling benchmark (#37614), which showed that random UUIDv4 primary keys scatter inserts across the `messages` B-tree — causing page splits and cache misses that worsen as the table grows — while a time-ordered key keeps inserts appending to the tail. In a 5 GiB run, v4 inserts were ~2.8× slower (median) than UUIDv7 on the same schema.

This switches **server-generated** ids for the `conversations` and `messages` tables from `v4` to `v7` of the already-present `uuid` package (`uuid@11` exports `v7`, so no new dependency). UUIDv7 puts a 48-bit millisecond timestamp in the high bits, so new ids are monotonic and inserts stay cache-friendly.

Changed the narrow set of id-generation sites that feed these two tables:

- **`persistence/conversation-crud.ts`** — the two chokepoints `insertMessageCore` (backs `addMessage` + `reserveMessage`) and `createConversation`, plus the three fork message-id sites (`forkConversation`, the in-process staging row, and `forkConversationForRetrospective`).
- **`daemon/conversation-messaging.ts`** — the user-message `requestId` generators (`enqueueMessage`, `persistUserMessage`, `persistQueuedMessageBody`), whose value becomes the message row id.
- **`runtime/services/analyze-conversation.ts`** — the analysis-turn `requestId`.

Deliberately left unchanged:
- **Existing rows** keep their v4 ids. No schema change (both are `TEXT` UUIDs), so no migration — this only affects writes going forward.
- **Client-adopted ids** (web-client drafts, `draft-<ts>-<hex>`, live-voice start-frame ids) are still honored verbatim via `ensureConversationExists`; the server can't dictate a client-minted id's format.
- **Other tables** — `message_attachments` and `lifecycle_events` ids stay on v4 (out of scope).

## Test plan

- New unit test `assistant/src/__tests__/conversation-message-id-uuidv7.test.ts`: asserts server-generated conversation and message ids are version 7, are monotonic (sort in creation order — the append property), and that an explicitly supplied id is still adopted verbatim. **3 pass.**
- Re-ran related suites — `ensure-conversation-exists`, `conversation-attachments`, `auto-analysis-guard`, `retrospective-routes` (fork path): **26 pass, 0 fail.**
- `bunx tsc --noEmit`: clean. `eslint` / `prettier`: no new errors. Pre-commit and pre-push hooks passed.

## CLI verb checklist

N/A — this PR adds no new IPC routes under `assistant/src/runtime/routes/`; it only changes the id generator behind existing conversation/message writes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXicp54CSP3THf2k51poAq)_