### PR TITLE
feat(assistant): mint message-ingress request ids as UUIDv7

### DIFF
--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -6,6 +6,8 @@
  * simple callbacks suitable for real-time TTS streaming.
  */
 
+import { v7 as uuidv7 } from "uuid";
+
 import { consumeGrantForInvocation } from "../approvals/approval-primitive.js";
 import type {
   ChannelId,
@@ -401,7 +403,7 @@ export async function startVoiceTurn(
     }
   };
 
-  const requestId = crypto.randomUUID();
+  const requestId = uuidv7();
   const turnId = crypto.randomUUID();
   let messageId: string;
   try {

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -1,4 +1,4 @@
-import { v4 as uuid } from "uuid";
+import { v4 as uuid, v7 as uuidv7 } from "uuid";
 import { z } from "zod";
 
 import { SurfaceActionSchema } from "../api/events/ui-surface-show.js";
@@ -2080,7 +2080,7 @@ export async function handleSurfaceAction(
       "Surface action: preparing to send message to model",
     );
 
-    const requestId = uuid();
+    const requestId = uuidv7();
     ctx.surfaceActionRequestIds.add(requestId);
     // Pass conversationId so events without an inline conversationId (e.g.
     // text_delta) are published with the correct conversation scope and
@@ -2307,7 +2307,7 @@ export async function handleSurfaceAction(
         surfaceData,
       );
 
-  const requestId = uuid();
+  const requestId = uuidv7();
   ctx.surfaceActionRequestIds.add(requestId);
   // Pass conversationId so events without an inline conversationId (e.g.
   // text_delta) are published with the correct conversation scope and

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -5,6 +5,8 @@
  * it through DI. The DaemonServer methods delegate here.
  */
 
+import { v7 as uuidv7 } from "uuid";
+
 import { enrichMessageWithSourcePaths } from "../agent/attachments.js";
 import {
   createAssistantMessage,
@@ -549,7 +551,7 @@ export async function processMessage(
 
   const resolvedContent = slashResult.content;
 
-  const requestId = crypto.randomUUID();
+  const requestId = uuidv7();
   const persistMetadata = options?.slackInbound
     ? { slackInbound: options.slackInbound }
     : undefined;
@@ -615,7 +617,7 @@ export async function processMessageInBackground(
   );
   const emitEvent = buildEventEmitter(options?.onEvent);
 
-  const requestId = crypto.randomUUID();
+  const requestId = uuidv7();
   const persistMetadata = options?.slackInbound
     ? { slackInbound: options.slackInbound }
     : undefined;

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -8,6 +8,7 @@ import {
   type ClientMetadataField,
   sanitizeClientMetadataValue,
 } from "@vellumai/service-contracts/client-metadata";
+import { v7 as uuidv7 } from "uuid";
 import { z } from "zod";
 
 import { enrichMessageWithSourcePaths } from "../../agent/attachments.js";
@@ -1858,7 +1859,7 @@ export async function handleSendMessage(
       const persisted = await persistQueuedMessageBody(conversation, {
         content: rawContent,
         attachments,
-        requestId: crypto.randomUUID(),
+        requestId: uuidv7(),
         metadata: greetingMeta,
         clientMessageId,
       });
@@ -2020,7 +2021,7 @@ export async function handleSendMessage(
 
   if (conversation.isProcessing()) {
     // Queue the message so it's processed when the current turn completes
-    const requestId = crypto.randomUUID();
+    const requestId = uuidv7();
     const enqueueResult = conversation.enqueueMessage({
       content: contentAfterScan,
       attachments,
@@ -2174,7 +2175,7 @@ export async function handleSendMessage(
       const persisted = await persistQueuedMessageBody(conversation, {
         content: rawContent,
         attachments,
-        requestId: crypto.randomUUID(),
+        requestId: uuidv7(),
         metadata: withClientMetadata(slashMeta, clientMetadata),
         clientMessageId,
       });
@@ -2273,7 +2274,7 @@ export async function handleSendMessage(
       persisted = await persistQueuedMessageBody(conversation, {
         content: rawContent,
         attachments,
-        requestId: crypto.randomUUID(),
+        requestId: uuidv7(),
         metadata: withClientMetadata(slashMeta, clientMetadata),
         clientMessageId,
       });
@@ -2364,7 +2365,7 @@ export async function handleSendMessage(
       const persisted = await persistQueuedMessageBody(conversation, {
         content: rawContent,
         attachments,
-        requestId: crypto.randomUUID(),
+        requestId: uuidv7(),
         metadata: withClientMetadata(slashMeta, clientMetadata),
         clientMessageId,
       });
@@ -2421,7 +2422,7 @@ export async function handleSendMessage(
 
   const resolvedContent = slashResult.content;
 
-  const requestId = crypto.randomUUID();
+  const requestId = uuidv7();
   const persistResult = await conversation.persistUserMessage({
     content: resolvedContent,
     attachments,

--- a/assistant/src/signals/user-message.ts
+++ b/assistant/src/signals/user-message.ts
@@ -14,6 +14,8 @@
 import { readFileSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { v7 as uuidv7 } from "uuid";
+
 import { getOrCreateConversation } from "../daemon/conversation-store.js";
 import { supersedePendingInteractionsOnEnqueue } from "../daemon/handlers/conversations.js";
 import type { UserMessageAttachment } from "../daemon/message-types/shared.js";
@@ -118,7 +120,7 @@ async function dispatchUserMessage(params: {
         }
       }
     }
-    const requestId = crypto.randomUUID();
+    const requestId = uuidv7();
     const resolvedChannel = resolveTurnChannel(params.sourceChannel);
     const resolvedInterface = resolveTurnInterface(params.sourceInterface);
     const result = conversation.enqueueMessage({


### PR DESCRIPTION
## Prompt / plan

Follow-up to #37638. That PR switched the persistence-layer id **defaults** (`insertMessageCore`, `createConversation`) to UUIDv7 — but the actual message ingress paths mint their own `requestId` and pass it into `persistUserMessage` / `enqueueMessage` / `persistQueuedMessageBody` as the row id. Because the caller supplies the id, the `?? uuidv7()` default never fires on those paths, so user-visible message writes were still getting random UUIDv4 ids.

This audit traced every caller that generates an id which becomes a `messages` row id and switches it to `v7` (of the already-present `uuid` package):

- **`runtime/routes/conversation-routes.ts`** — all six HTTP send/queue sites in `handleSendMessage` (the primary `POST /v1/messages` path).
- **`daemon/process-message.ts`** — the inbound/channel sink (`processMessage` + `processMessageInBackground`, incl. Slack inbound).
- **`daemon/conversation-surfaces.ts`** — surface-action messages.
- **`signals/user-message.ts`** — CLI/signal-driven messages.
- **`calls/voice-session-bridge.ts`** — voice turns.

Callers that pass **no** `requestId` (subagent spawn/notify, pointer-turn-runner, ACP) already fall through to the #37638 v7 default, and the queue drain (`conversation-process.ts`) just propagates the already-minted id — so those needed no change.

### Deliberately left on v4 / random (not row ids)
- `voice-session-bridge` **`turnId`** — per-turn correlation id.
- `conversation-surfaces` **`surfaceId`** — surface identifier.
- `conversation-routes` **`conversationKey`** (the `? crypto.randomUUID()` at the top of the send handler) — an external lookup key that maps to a conversation, not the `conversations.id` primary key.

No schema change and no migration — existing rows keep their ids; this only affects writes going forward.

## Test plan

- `bunx tsc --noEmit`: clean. `eslint` / `prettier`: no new errors (pre-commit + pre-push hooks passed).
- Ran the touched paths: `voice-session-bridge`, `conversation-message-id-uuidv7` (from #37638), `conversation-routes-hidden-queue`, `conversation-routes-slash-commands`, `conversation-surfaces-action-delivery` → **52 pass, 0 fail.**
- Verified each converted site feeds a `messages` row id, and that the three intentionally-skipped ids (`turnId`, `surfaceId`, `conversationKey`) are not primary keys.

## CLI verb checklist

N/A — no new IPC routes; this only changes the id generator behind existing message ingress.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXicp54CSP3THf2k51poAq)_