### PR TITLE
refactor(home): eject oauth-store from the daemon-core cycle

### DIFF
--- a/assistant/src/home/__tests__/suggested-prompts.test.ts
+++ b/assistant/src/home/__tests__/suggested-prompts.test.ts
@@ -74,11 +74,10 @@ mock.module("../../runtime/assistant-event-hub.js", () => ({
   assistantEventHub: { publish: async () => {} },
 }));
 
-const {
-  getSuggestedPrompts,
-  refreshAssistantSuggestedPrompts,
-  invalidateAssistantSuggestedPromptsCache,
-} = await import("../suggested-prompts.js");
+const { getSuggestedPrompts, refreshAssistantSuggestedPrompts } =
+  await import("../suggested-prompts.js");
+const { invalidateAssistantSuggestedPromptsCache } =
+  await import("../suggested-prompts-cache.js");
 
 // ─── Tests ─────────────────────────────────────────────────────────────
 

--- a/assistant/src/home/suggested-prompts-cache.ts
+++ b/assistant/src/home/suggested-prompts-cache.ts
@@ -1,0 +1,91 @@
+/**
+ * Checkpoint-backed cache for the Home feed's assistant-generated suggested
+ * prompts.
+ *
+ * Split out from `suggested-prompts.ts` (the LLM generation path) so the cache
+ * read/write/invalidate surface stays dependency-light: OAuth connect/disconnect
+ * paths invalidate the cache without pulling in the heavy prompt-generation
+ * subtree (system-prompt builder, provider send, sidechain).
+ *
+ * The cache persists in the `memory_checkpoints` table so a daemon restart does
+ * not force a regeneration.
+ */
+
+import {
+  deleteMemoryCheckpoint,
+  getMemoryCheckpoint,
+  setMemoryCheckpoint,
+} from "../persistence/checkpoints.js";
+import { buildAssistantEvent } from "../runtime/assistant-event.js";
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { getLogger } from "../util/logger.js";
+import type { SuggestedPrompt } from "./feed-types.js";
+
+const log = getLogger("suggested-prompts-cache");
+
+const LLM_CACHE_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
+
+const CHECKPOINT_KEY_JSON = "home:suggested_prompts:json";
+const CHECKPOINT_KEY_TIMESTAMP = "home:suggested_prompts:cached_at";
+
+export function readCachedPrompts(): SuggestedPrompt[] | null {
+  try {
+    const json = getMemoryCheckpoint(CHECKPOINT_KEY_JSON);
+    const timestampStr = getMemoryCheckpoint(CHECKPOINT_KEY_TIMESTAMP);
+    if (!json || !timestampStr) {
+      return null;
+    }
+    const cachedAt = Number(timestampStr);
+    if (isNaN(cachedAt) || Date.now() - cachedAt > LLM_CACHE_TTL_MS) {
+      return null;
+    }
+    const parsed = JSON.parse(json);
+    if (!Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as SuggestedPrompt[];
+  } catch {
+    return null;
+  }
+}
+
+export function writeCachedPrompts(prompts: SuggestedPrompt[]): boolean {
+  try {
+    setMemoryCheckpoint(CHECKPOINT_KEY_JSON, JSON.stringify(prompts));
+    setMemoryCheckpoint(CHECKPOINT_KEY_TIMESTAMP, String(Date.now()));
+    return true;
+  } catch {
+    // Cache write failure is non-fatal — the next refresh regenerates.
+    return false;
+  }
+}
+
+/**
+ * Drops the suggestion cache so the next on-demand refresh regenerates
+ * prompts with current integration state.
+ *
+ * Called from OAuth connect/disconnect paths so suggestions reflect the
+ * new state within one reload instead of waiting for the TTL.
+ */
+export function invalidateAssistantSuggestedPromptsCache(): void {
+  try {
+    deleteMemoryCheckpoint(CHECKPOINT_KEY_JSON);
+    deleteMemoryCheckpoint(CHECKPOINT_KEY_TIMESTAMP);
+  } catch {
+    // Invalidation failure is non-fatal — the TTL still bounds staleness.
+  }
+  assistantEventHub
+    .publish(
+      buildAssistantEvent({
+        type: "home_feed_updated",
+        updatedAt: new Date().toISOString(),
+        newItemCount: 0,
+      }),
+    )
+    .catch((err) => {
+      log.warn(
+        { err },
+        "Failed to publish home_feed_updated after prompt cache invalidation",
+      );
+    });
+}

--- a/assistant/src/home/suggested-prompts.ts
+++ b/assistant/src/home/suggested-prompts.ts
@@ -17,63 +17,20 @@
 
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
-import {
-  deleteMemoryCheckpoint,
-  getMemoryCheckpoint,
-  setMemoryCheckpoint,
-} from "../persistence/checkpoints.js";
 import { buildSystemPrompt } from "../prompts/system-prompt.js";
 import { getConfiguredProvider } from "../providers/provider-send-message.js";
-import { buildAssistantEvent } from "../runtime/assistant-event.js";
-import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { runBtwSidechain } from "../runtime/btw-sidechain.js";
 import { formatIntegrationSummary } from "../schedule/integration-status.js";
 import { getLogger } from "../util/logger.js";
 import type { SuggestedPrompt } from "./feed-types.js";
+import {
+  readCachedPrompts,
+  writeCachedPrompts,
+} from "./suggested-prompts-cache.js";
 
 const log = getLogger("suggested-prompts");
 
 const LLM_SUGGESTIONS_TIMEOUT_MS = 5_000;
-const LLM_CACHE_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
-
-const CHECKPOINT_KEY_JSON = "home:suggested_prompts:json";
-const CHECKPOINT_KEY_TIMESTAMP = "home:suggested_prompts:cached_at";
-
-// ---------------------------------------------------------------------------
-// Checkpoint-backed cache for LLM-generated suggestions
-// ---------------------------------------------------------------------------
-
-function readCachedPrompts(): SuggestedPrompt[] | null {
-  try {
-    const json = getMemoryCheckpoint(CHECKPOINT_KEY_JSON);
-    const timestampStr = getMemoryCheckpoint(CHECKPOINT_KEY_TIMESTAMP);
-    if (!json || !timestampStr) {
-      return null;
-    }
-    const cachedAt = Number(timestampStr);
-    if (isNaN(cachedAt) || Date.now() - cachedAt > LLM_CACHE_TTL_MS) {
-      return null;
-    }
-    const parsed = JSON.parse(json);
-    if (!Array.isArray(parsed)) {
-      return null;
-    }
-    return parsed as SuggestedPrompt[];
-  } catch {
-    return null;
-  }
-}
-
-function writeCachedPrompts(prompts: SuggestedPrompt[]): boolean {
-  try {
-    setMemoryCheckpoint(CHECKPOINT_KEY_JSON, JSON.stringify(prompts));
-    setMemoryCheckpoint(CHECKPOINT_KEY_TIMESTAMP, String(Date.now()));
-    return true;
-  } catch {
-    // Cache write failure is non-fatal — the next refresh regenerates.
-    return false;
-  }
-}
 
 /**
  * Return cached assistant-generated prompts. No LLM calls happen in
@@ -82,36 +39,6 @@ function writeCachedPrompts(prompts: SuggestedPrompt[]): boolean {
  */
 export async function getSuggestedPrompts(): Promise<SuggestedPrompt[]> {
   return readCachedPrompts() ?? [];
-}
-
-/**
- * Drops the suggestion cache so the next on-demand refresh regenerates
- * prompts with current integration state.
- *
- * Called from OAuth connect/disconnect paths so suggestions reflect the
- * new state within one reload instead of waiting for the TTL.
- */
-export function invalidateAssistantSuggestedPromptsCache(): void {
-  try {
-    deleteMemoryCheckpoint(CHECKPOINT_KEY_JSON);
-    deleteMemoryCheckpoint(CHECKPOINT_KEY_TIMESTAMP);
-  } catch {
-    // Invalidation failure is non-fatal — the TTL still bounds staleness.
-  }
-  assistantEventHub
-    .publish(
-      buildAssistantEvent({
-        type: "home_feed_updated",
-        updatedAt: new Date().toISOString(),
-        newItemCount: 0,
-      }),
-    )
-    .catch((err) => {
-      log.warn(
-        { err },
-        "Failed to publish home_feed_updated after prompt cache invalidation",
-      );
-    });
 }
 
 /**

--- a/assistant/src/oauth/connect-orchestrator.ts
+++ b/assistant/src/oauth/connect-orchestrator.ts
@@ -20,7 +20,7 @@
  */
 
 import { emitPostConnectNudge } from "../home/post-connect-feed.js";
-import { invalidateAssistantSuggestedPromptsCache } from "../home/suggested-prompts.js";
+import { invalidateAssistantSuggestedPromptsCache } from "../home/suggested-prompts-cache.js";
 import type { TokenEndpointAuthMethod } from "../security/oauth2.js";
 import { prepareOAuth2Flow, startOAuth2Flow } from "../security/oauth2.js";
 import { getLogger } from "../util/logger.js";

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -19,6 +19,7 @@ import {
 import { and, desc, eq, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import { invalidateAssistantSuggestedPromptsCache } from "../home/suggested-prompts-cache.js";
 import { getDb } from "../persistence/db-connection.js";
 import { rawChanges } from "../persistence/raw-query.js";
 import {
@@ -1133,17 +1134,9 @@ export async function disconnectOAuthProvider(
 
   deleteConnection(conn.id);
 
-  // Dynamic import: `suggested-prompts.ts` imports from this module, so a
-  // static import here would create a cycle. The cache invalidation is
-  // best-effort — failures must not block disconnect.
-  void import("../home/suggested-prompts.js")
-    .then((m) => m.invalidateAssistantSuggestedPromptsCache())
-    .catch((err) => {
-      log.warn(
-        { err: err instanceof Error ? err.message : String(err) },
-        "Failed to invalidate suggested-prompts cache after disconnect",
-      );
-    });
+  // Best-effort cache invalidation so Home suggestions track the disconnect;
+  // the call swallows its own failures and never blocks disconnect.
+  invalidateAssistantSuggestedPromptsCache();
 
   return "disconnected";
 }


### PR DESCRIPTION
## Prompt / plan

Continuing the campaign to dismantle the daemon-core import cycle in `/assistant`. With the giant hubs gone (after the event-hub PR the core flattened — top in-degrees are now 6–18), the biggest remaining single lever is `oauth/oauth-store.ts`.

The OAuth connect/disconnect paths reach into `home/suggested-prompts.ts` to invalidate the Home-feed suggestion cache (so suggestions track integration state). Meanwhile `suggested-prompts.ts` loops back to `oauth-store` **transitively** through its heavy generation deps (`buildSystemPrompt → prompts/sections → … → oauth-store`). That mutual reachability trapped `oauth-store` plus ~22 downstream modules in the core SCC. (The comment in `oauth-store` claiming `suggested-prompts.ts` imports it *directly* was stale — the back-edge is transitive.)

`suggested-prompts.ts` mixed two concerns: a small checkpoint-backed **cache** (`readCachedPrompts` / `writeCachedPrompts` / `invalidateAssistantSuggestedPromptsCache`) and the **heavy LLM generation**. The OAuth side only needs the cache. So:

- Extract the cache into a dependency-light leaf, `home/suggested-prompts-cache.ts`, depending only on the checkpoint store and the event hub (neither reaches `oauth-store`).
- Repoint `oauth/oauth-store.ts` and `oauth/connect-orchestrator.ts` at the leaf. `oauth-store`'s invalidation becomes a plain **static** import + direct call — the cycle-dodging dynamic `import()` and its stale comment are gone (the function already swallows its own errors, so the outer `.catch` was redundant).
- `suggested-prompts.ts` imports its own cache helpers from the leaf.

No behavioral change — same functions, same call sites, just relocated.

**Core SCC: 287 → 264 files (−23).** `oauth-store`, `suggested-prompts`, and the new cache leaf are all out of every cycle.

## Test plan

- `bunx tsc --noEmit` — clean (0 errors)
- Full-graph Tarjan SCC recomputed: core 287 → 264; `oauth-store`, `suggested-prompts`, and `suggested-prompts-cache` all ejected
- `bun test` on affected suites, all green:
  - `home/__tests__/suggested-prompts.test.ts` (9) — cache round-trip + invalidation, repointed to the leaf
  - `oauth-connect-orchestrator.test.ts` (28), `oauth/byo-connection.test.ts` (19), `oauth/connection-resolver.test.ts` (34)
- Pre-commit + pre-push hooks (prettier, eslint, tsc) green

## CLI verb checklist

No new routes — pure module split + import repointing. Section N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWL4FYZVRGkJkMwL46PY3m)_