### PR TITLE
feat(assistant): write LLM request logs to ClickHouse when it's the configured source

### DIFF
--- a/assistant/src/__tests__/llm-request-log-clickhouse-routing.test.ts
+++ b/assistant/src/__tests__/llm-request-log-clickhouse-routing.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests that the store's write path routes to ClickHouse instead of local
+ * SQLite when a ClickHouse sink is configured — and stays on SQLite
+ * otherwise. The sink module is mocked so the routing decision is observable
+ * without a live ClickHouse.
+ */
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+// Logging stays enabled; `getConfigReadOnly` is only consulted by the store's
+// disabled gate here (the sink factory itself is mocked below).
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({ llmRequestLogs: { readSource: "local" } }),
+  getConfigReadOnly: () => ({ llmRequestLogs: { readSource: "local" } }),
+}));
+
+// Mutable fake sink: when non-null, the store must route to it.
+interface CapturedRow {
+  id: string;
+  conversationId: string;
+  callSite: string | null;
+}
+let capturedRows: CapturedRow[] = [];
+let sinkActive = false;
+mock.module("../persistence/llm-request-log-sink-clickhouse.js", () => ({
+  getClickHouseLlmRequestLogSink: () =>
+    sinkActive
+      ? {
+          recordBestEffort: (row: CapturedRow) => {
+            capturedRows.push(row);
+          },
+        }
+      : null,
+}));
+
+afterAll(() => {
+  sinkActive = false;
+});
+
+import { getLogsDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import {
+  getRequestLogsByConversationId,
+  recordRequestLog,
+  recordSyntheticAgentErrorMessageLog,
+} from "../persistence/llm-request-log-store.js";
+import { llmRequestLogs } from "../persistence/schema/index.js";
+
+await initializeDb();
+
+function resetLogs(): void {
+  getLogsDb()!.delete(llmRequestLogs).run();
+}
+
+describe("write routing between SQLite and ClickHouse", () => {
+  beforeEach(() => {
+    resetLogs();
+    capturedRows = [];
+    sinkActive = false;
+  });
+
+  test("writes to local SQLite when no ClickHouse sink is configured", () => {
+    const id = recordRequestLog(
+      "conv-local",
+      '{"req":1}',
+      '{"res":1}',
+      undefined,
+      "anthropic",
+      "mainAgent",
+    );
+    expect(id).not.toBe("");
+    expect(capturedRows).toHaveLength(0);
+    const rows = getRequestLogsByConversationId("conv-local");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.provider).toBe("anthropic");
+  });
+
+  test("routes to ClickHouse and skips SQLite when a sink is configured", () => {
+    sinkActive = true;
+    const id = recordRequestLog(
+      "conv-ch",
+      '{"req":1}',
+      '{"res":1}',
+      "msg-ch",
+      "openai",
+      "mainAgent",
+    );
+    expect(id).not.toBe("");
+    // Nothing landed in the local table.
+    expect(getRequestLogsByConversationId("conv-ch")).toEqual([]);
+    // The row went to the sink, carrying the same id and call site.
+    expect(capturedRows).toHaveLength(1);
+    expect(capturedRows[0]!.id).toBe(id);
+    expect(capturedRows[0]!.conversationId).toBe("conv-ch");
+    expect(capturedRows[0]!.callSite).toBe("mainAgent");
+  });
+
+  test("routes synthetic error rows to ClickHouse too", () => {
+    sinkActive = true;
+    const id = recordSyntheticAgentErrorMessageLog({
+      conversationId: "conv-ch-2",
+      messageId: "msg-ch-2",
+      exitReason: "budget_yield_unrecovered",
+      noticeText: "Out of budget.",
+      preparedRequest: null,
+      createdAt: 1_700_000_000_000,
+    });
+    expect(id).not.toBe("");
+    expect(getRequestLogsByConversationId("conv-ch-2")).toEqual([]);
+    expect(capturedRows).toHaveLength(1);
+    expect(capturedRows[0]!.callSite).toBe("syntheticAgentErrorMessage");
+  });
+});

--- a/assistant/src/__tests__/llm-request-log-disabled-writes.test.ts
+++ b/assistant/src/__tests__/llm-request-log-disabled-writes.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests the master opt-out for LLM request logging
+ * (`llmRequestLogs.disabled`). When disabled, the store's insert paths
+ * (`recordRequestLog`, `recordSyntheticAgentErrorMessageLog`) must skip the
+ * write entirely — no prompt/completion payload lands on disk — and return an
+ * empty id. The read-side 4xx is exercised separately at the route layer.
+ */
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Mutable so each test toggles the flag the store reads via `getConfigReadOnly`.
+let disabled = false;
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    llmRequestLogs: { readSource: "local", disabled },
+  }),
+  getConfigReadOnly: () => ({
+    llmRequestLogs: { readSource: "local", disabled },
+  }),
+}));
+
+// `mock.module()` persists process-wide; reset so other files don't inherit a
+// stale disabled state.
+afterAll(() => {
+  disabled = false;
+});
+
+import { getLogsDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import {
+  getRequestLogById,
+  getRequestLogsByConversationId,
+  recordRequestLog,
+  recordSyntheticAgentErrorMessageLog,
+} from "../persistence/llm-request-log-store.js";
+import { llmRequestLogs } from "../persistence/schema/index.js";
+
+await initializeDb();
+
+function resetLogs(): void {
+  getLogsDb()!.delete(llmRequestLogs).run();
+}
+
+describe("llmRequestLogs.disabled write gate", () => {
+  beforeEach(() => {
+    resetLogs();
+    disabled = false;
+  });
+
+  test("recordRequestLog writes normally when logging is enabled", () => {
+    const id = recordRequestLog("conv-1", '{"req":1}', '{"res":1}');
+    expect(id).not.toBe("");
+    expect(getRequestLogById(id)).not.toBeNull();
+  });
+
+  test("recordRequestLog skips the write when logging is disabled", () => {
+    disabled = true;
+    const id = recordRequestLog("conv-1", '{"req":1}', '{"res":1}');
+    expect(id).toBe("");
+    expect(getRequestLogsByConversationId("conv-1")).toEqual([]);
+  });
+
+  test("recordSyntheticAgentErrorMessageLog skips the write when disabled", () => {
+    disabled = true;
+    const id = recordSyntheticAgentErrorMessageLog({
+      conversationId: "conv-2",
+      messageId: "msg-2",
+      exitReason: "budget_yield_unrecovered",
+      noticeText: "Out of budget.",
+      preparedRequest: null,
+      createdAt: Date.now(),
+    });
+    expect(id).toBe("");
+    expect(getRequestLogsByConversationId("conv-2")).toEqual([]);
+  });
+
+  test("re-enabling logging restores writes", () => {
+    disabled = true;
+    expect(recordRequestLog("conv-3", '{"req":1}', '{"res":1}')).toBe("");
+    disabled = false;
+    const id = recordRequestLog("conv-3", '{"req":2}', '{"res":2}');
+    expect(id).not.toBe("");
+    expect(getRequestLogsByConversationId("conv-3")).toHaveLength(1);
+  });
+});

--- a/assistant/src/__tests__/llm-request-log-sink-clickhouse.test.ts
+++ b/assistant/src/__tests__/llm-request-log-sink-clickhouse.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests the ClickHouse WRITE sink for LLM request logs: the wire shape it
+ * POSTs (lazy CREATE TABLE + JSONEachRow INSERT, null → '' sentinels,
+ * assistant_id injected from credentials) and the config-gated factory.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of [
+    "info",
+    "warn",
+    "error",
+    "debug",
+    "trace",
+    "fatal",
+    "silent",
+    "child",
+  ]) {
+    stub[m] = m === "child" ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeLoggerStub(),
+}));
+
+// Mutable config the factory reads via `getConfigReadOnly`.
+let currentConfig: unknown = { llmRequestLogs: { readSource: "local" } };
+mock.module("../config/loader.js", () => ({
+  getConfigReadOnly: () => currentConfig,
+}));
+
+afterEach(() => {
+  currentConfig = { llmRequestLogs: { readSource: "local" } };
+  resetClickHouseLlmRequestLogSinkForTests();
+});
+
+import {
+  ClickHouseLlmRequestLogSink,
+  getClickHouseLlmRequestLogSink,
+  resetClickHouseLlmRequestLogSinkForTests,
+} from "../persistence/llm-request-log-sink-clickhouse.js";
+
+const DEFAULT_CONFIG = {
+  database: "default",
+  table: "llm_request_logs",
+  user: "default",
+};
+
+interface FakeFetchCall {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+function fakeFetch(recorder: FakeFetchCall[], status = 200): typeof fetch {
+  return ((url: string | URL | Request, init?: RequestInit) => {
+    recorder.push({
+      url: typeof url === "string" ? url : url.toString(),
+      init,
+    });
+    return Promise.resolve(new Response("", { status }));
+  }) as typeof fetch;
+}
+
+function makeSink(recorder: FakeFetchCall[], status = 200) {
+  return new ClickHouseLlmRequestLogSink(DEFAULT_CONFIG, {
+    resolveUrl: async () => "https://ch.example.test:8443",
+    resolvePassword: async () => "hunter2",
+    resolveAssistantId: async () => "asst-fixture-001",
+    fetchImpl: fakeFetch(recorder, status),
+  });
+}
+
+describe("ClickHouseLlmRequestLogSink.insert", () => {
+  test("creates the table then inserts the JSONEachRow wire shape", async () => {
+    const calls: FakeFetchCall[] = [];
+    const sink = makeSink(calls);
+
+    await sink.insert({
+      id: "log-1",
+      conversationId: "conv-1",
+      messageId: "msg-1",
+      provider: "anthropic",
+      requestPayload: '{"req":1}',
+      responsePayload: '{"res":1}',
+      createdAt: 1_700_000_000_123,
+      agentLoopExitReason: "no_tool_calls",
+      callSite: "mainAgent",
+    });
+
+    expect(calls).toHaveLength(2);
+    // 1) DDL as the request body, no `query` param.
+    expect(String(calls[0]!.init?.body)).toContain(
+      "CREATE TABLE IF NOT EXISTS",
+    );
+    expect(new URL(calls[0]!.url).searchParams.get("query")).toBeNull();
+
+    // 2) INSERT statement in the `query` param, row JSON in the body.
+    const insertUrl = new URL(calls[1]!.url);
+    expect(insertUrl.searchParams.get("query")).toContain(
+      "INSERT INTO `llm_request_logs` FORMAT JSONEachRow",
+    );
+    expect(insertUrl.searchParams.get("database")).toBe("default");
+    const row = JSON.parse(String(calls[1]!.init?.body));
+    expect(row).toEqual({
+      assistant_id: "asst-fixture-001",
+      id: "log-1",
+      conversation_id: "conv-1",
+      message_id: "msg-1",
+      provider: "anthropic",
+      request_payload: '{"req":1}',
+      response_payload: '{"res":1}',
+      created_at: 1_700_000_000_123,
+      agent_loop_exit_reason: "no_tool_calls",
+      call_site: "mainAgent",
+    });
+    // Basic auth is sent.
+    expect(
+      (calls[1]!.init?.headers as Record<string, string>).Authorization,
+    ).toStartWith("Basic ");
+  });
+
+  test("maps null string fields to the '' sentinel", async () => {
+    const calls: FakeFetchCall[] = [];
+    const sink = makeSink(calls);
+
+    await sink.insert({
+      id: "log-2",
+      conversationId: "conv-2",
+      messageId: null,
+      provider: null,
+      requestPayload: "{}",
+      responsePayload: "{}",
+      createdAt: 1,
+      agentLoopExitReason: null,
+      callSite: null,
+    });
+
+    const row = JSON.parse(String(calls[1]!.init?.body));
+    expect(row.message_id).toBe("");
+    expect(row.provider).toBe("");
+    expect(row.agent_loop_exit_reason).toBe("");
+    expect(row.call_site).toBe("");
+  });
+
+  test("insert rejects on a ClickHouse error status", async () => {
+    const calls: FakeFetchCall[] = [];
+    const sink = makeSink(calls, 500);
+    await expect(
+      sink.insert({
+        id: "log-3",
+        conversationId: "conv-3",
+        messageId: null,
+        provider: null,
+        requestPayload: "{}",
+        responsePayload: "{}",
+        createdAt: 1,
+        agentLoopExitReason: null,
+        callSite: null,
+      }),
+    ).rejects.toThrow(/ClickHouse llm-request-log write failed/);
+  });
+
+  test("recordBestEffort never throws synchronously on a failing backend", () => {
+    const calls: FakeFetchCall[] = [];
+    const sink = makeSink(calls, 500);
+    expect(() =>
+      sink.recordBestEffort({
+        id: "log-4",
+        conversationId: "conv-4",
+        messageId: null,
+        provider: null,
+        requestPayload: "{}",
+        responsePayload: "{}",
+        createdAt: 1,
+        agentLoopExitReason: null,
+        callSite: null,
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("getClickHouseLlmRequestLogSink factory", () => {
+  test("returns null when readSource is 'local'", () => {
+    currentConfig = { llmRequestLogs: { readSource: "local" } };
+    expect(getClickHouseLlmRequestLogSink()).toBeNull();
+  });
+
+  test("returns null when llmRequestLogs is absent", () => {
+    currentConfig = {};
+    expect(getClickHouseLlmRequestLogSink()).toBeNull();
+  });
+
+  test("returns a sink when readSource is 'clickhouse'", () => {
+    currentConfig = {
+      llmRequestLogs: { readSource: "clickhouse", clickhouse: DEFAULT_CONFIG },
+    };
+    expect(getClickHouseLlmRequestLogSink()).toBeInstanceOf(
+      ClickHouseLlmRequestLogSink,
+    );
+  });
+
+  test("re-instantiates when the clickhouse config changes", () => {
+    currentConfig = {
+      llmRequestLogs: { readSource: "clickhouse", clickhouse: DEFAULT_CONFIG },
+    };
+    const first = getClickHouseLlmRequestLogSink();
+    currentConfig = {
+      llmRequestLogs: {
+        readSource: "clickhouse",
+        clickhouse: { ...DEFAULT_CONFIG, table: "other_logs" },
+      },
+    };
+    const second = getClickHouseLlmRequestLogSink();
+    expect(second).not.toBe(first);
+  });
+});

--- a/assistant/src/config/schemas/__tests__/llm-request-logs.test.ts
+++ b/assistant/src/config/schemas/__tests__/llm-request-logs.test.ts
@@ -3,16 +3,18 @@ import { describe, expect, test } from "bun:test";
 import { LlmRequestLogsConfigSchema } from "../llm-request-logs.js";
 
 describe("LlmRequestLogsConfigSchema", () => {
-  test("parses undefined to the local default", () => {
+  test("parses undefined to the local default with logging enabled", () => {
     expect(LlmRequestLogsConfigSchema.parse(undefined)).toEqual({
       readSource: "local",
+      disabled: false,
     });
   });
 
-  test("parses an explicit local readSource", () => {
-    expect(
-      LlmRequestLogsConfigSchema.parse({ readSource: "local" }),
-    ).toEqual({ readSource: "local" });
+  test("parses an explicit local readSource with logging enabled by default", () => {
+    expect(LlmRequestLogsConfigSchema.parse({ readSource: "local" })).toEqual({
+      readSource: "local",
+      disabled: false,
+    });
   });
 
   test("parses an explicit clickhouse readSource with defaulted connection fields", () => {
@@ -20,12 +22,38 @@ describe("LlmRequestLogsConfigSchema", () => {
       LlmRequestLogsConfigSchema.parse({ readSource: "clickhouse" }),
     ).toEqual({
       readSource: "clickhouse",
+      disabled: false,
       clickhouse: {
         database: "default",
         table: "llm_request_logs",
         user: "default",
       },
     });
+  });
+
+  test("carries an explicit disabled flag on the local branch", () => {
+    expect(
+      LlmRequestLogsConfigSchema.parse({ readSource: "local", disabled: true }),
+    ).toEqual({ readSource: "local", disabled: true });
+  });
+
+  test("defaults a missing readSource to local so a disabled-only write still parses", () => {
+    // `config set llmRequestLogs.disabled true` writes `{ disabled: true }`
+    // with no discriminator; it must parse (on the local branch) rather than
+    // collapse the whole config to defaults via leaf-deletion recovery.
+    expect(LlmRequestLogsConfigSchema.parse({ disabled: true })).toEqual({
+      readSource: "local",
+      disabled: true,
+    });
+  });
+
+  test("rejects a non-boolean disabled flag", () => {
+    expect(() =>
+      LlmRequestLogsConfigSchema.parse({
+        readSource: "local",
+        disabled: "yes",
+      }),
+    ).toThrow();
   });
 
   test("rejects an unknown readSource", () => {

--- a/assistant/src/config/schemas/llm-request-logs.ts
+++ b/assistant/src/config/schemas/llm-request-logs.ts
@@ -1,8 +1,17 @@
 /**
- * Configuration for LLM request log read source.
+ * Configuration for LLM request logging.
  *
- * Writes always land in the local SQLite `llm_request_logs` table; reads
- * can be switched between local and ClickHouse via `readSource`.
+ * Two independent concerns live here:
+ *
+ * 1. `disabled` — the master opt-out. When `true`, the daemon skips every
+ *    `llm_request_logs` write and the inspector read routes return a 4xx
+ *    (`LLM_REQUEST_LOGS_DISABLED`) instead of serving rows. Defaults to
+ *    `false` (logging on). Existing rows are left untouched — this is a
+ *    write/read gate, not a delete.
+ *
+ * 2. `readSource` — where reads are served from. Writes land in the local
+ *    SQLite `llm_request_logs` table; reads can be switched between local
+ *    and ClickHouse via `readSource`.
  *
  * When `readSource === "clickhouse"` the URL and password are resolved
  * from the credential store (`clickhouse:url`, `clickhouse:password`).
@@ -10,14 +19,30 @@
  *
  * The shape is a discriminated union on `readSource` so the `clickhouse`
  * block only exists on the ClickHouse branch — there's no stray defaults
- * sitting around when the source is local.
+ * sitting around when the source is local. A `preprocess` step defaults a
+ * missing `readSource` to `"local"` so a partial write (e.g. `config set
+ * llmRequestLogs.disabled true`, which never mentions `readSource`) still
+ * parses instead of collapsing the whole config to defaults on the next load.
  *
  * Note: the existing retention setting lives under
  * `memory.cleanup.llmRequestLogRetentionMs` and is independent of this block.
- * That covers when local rows get pruned; this block governs where reads
- * are served from.
+ * That covers when local rows get pruned; this block governs whether logging
+ * happens at all and where reads are served from.
  */
 import { z } from "zod";
+
+/**
+ * Master opt-out for LLM request logging. Shared by both read-source
+ * branches so `llmRequestLogs.disabled` is a stable top-level path
+ * regardless of `readSource`.
+ */
+const DisabledFieldSchema = z
+  .boolean({ error: "llmRequestLogs.disabled must be a boolean" })
+  .default(false)
+  .describe(
+    "When true, disable LLM request logging entirely: skip all writes and " +
+      "return a 4xx from inspector read routes. Existing rows are not deleted.",
+  );
 
 export const LlmRequestLogsClickHouseConfigSchema = z
   .object({
@@ -44,12 +69,14 @@ export const LlmRequestLogsClickHouseConfigSchema = z
 const LocalLlmRequestLogsConfigSchema = z
   .object({
     readSource: z.literal("local"),
+    disabled: DisabledFieldSchema,
   })
   .describe("Read LLM request logs from local SQLite (default).");
 
 const ClickHouseLlmRequestLogsConfigSchema = z
   .object({
     readSource: z.literal("clickhouse"),
+    disabled: DisabledFieldSchema,
     clickhouse: LlmRequestLogsClickHouseConfigSchema.default(
       LlmRequestLogsClickHouseConfigSchema.parse({}),
     ),
@@ -57,6 +84,27 @@ const ClickHouseLlmRequestLogsConfigSchema = z
   .describe(
     "Read LLM request logs from the ClickHouse mirror. Requires the `clickhouse:url` and `clickhouse:password` credentials to be set.",
   );
+
+/**
+ * Inject `readSource: "local"` when a caller supplies an object without it.
+ * A discriminated union cannot pick a branch without its discriminator, so a
+ * partial write like `{ disabled: true }` (from `config set
+ * llmRequestLogs.disabled true`) would otherwise fail to parse and — via the
+ * loader's leaf-deletion recovery — take the whole config down to defaults.
+ * Defaulting the discriminator keeps such writes on the `local` branch while
+ * preserving any sibling fields (e.g. `disabled`).
+ */
+function defaultReadSourceToLocal(value: unknown): unknown {
+  if (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    !("readSource" in value)
+  ) {
+    return { readSource: "local", ...value };
+  }
+  return value;
+}
 
 // The default is baked into the export so the schema matches the sibling
 // pattern across `assistant/src/config/schemas/*` — `Schema.parse(undefined)`
@@ -68,12 +116,15 @@ const ClickHouseLlmRequestLogsConfigSchema = z
 // union cannot pick a branch without a discriminator. Use `parse(undefined)`
 // or omit the field entirely to get the default.
 export const LlmRequestLogsConfigSchema = z
-  .discriminatedUnion("readSource", [
-    LocalLlmRequestLogsConfigSchema,
-    ClickHouseLlmRequestLogsConfigSchema,
-  ])
-  .default({ readSource: "local" })
-  .describe("LLM request log read source configuration");
+  .preprocess(
+    defaultReadSourceToLocal,
+    z.discriminatedUnion("readSource", [
+      LocalLlmRequestLogsConfigSchema,
+      ClickHouseLlmRequestLogsConfigSchema,
+    ]),
+  )
+  .default({ readSource: "local", disabled: false })
+  .describe("LLM request logging configuration");
 
 export type LlmRequestLogsConfig = z.infer<typeof LlmRequestLogsConfigSchema>;
 export type LlmRequestLogsClickHouseConfig = z.infer<

--- a/assistant/src/persistence/llm-request-log-sink-clickhouse.ts
+++ b/assistant/src/persistence/llm-request-log-sink-clickhouse.ts
@@ -1,0 +1,306 @@
+/**
+ * ClickHouse-backed LLM request log WRITE sink.
+ *
+ * The counterpart to `llm-request-log-source-clickhouse.ts` (reads). When
+ * `llmRequestLogs.readSource === "clickhouse"`, `recordRequestLog` writes
+ * request/response rows directly here instead of the local SQLite
+ * `llm_request_logs` table — so ClickHouse is the source of truth for the
+ * write, not a downstream mirror.
+ *
+ * Wire shape matches what the read source expects (see
+ * `llm-request-log-source-clickhouse.ts`): the same columns, scoped to the
+ * running assistant's own `assistant_id`, with `''` string sentinels for
+ * unset `message_id` / `provider` / `agent_loop_exit_reason` / `call_site`
+ * (the read source maps `''` back to `null`). URL and password resolve from
+ * the credential store (`clickhouse:url`, `clickhouse:password`);
+ * database/table/user come from config. The table is created lazily with
+ * `CREATE TABLE IF NOT EXISTS` on first write so opting in needs no
+ * out-of-band DDL, and is a no-op against a table the mirror cron already
+ * created.
+ *
+ * Known limitation, inherited from the ClickHouse mirror design: the sink is
+ * INSERT-only. Post-write stamps that the local store applies to existing
+ * rows — `setAgentLoopExitReasonOnLatestLog`, `backfillMessageIdOnLogs`,
+ * `relinkLlmRequestLogs` — have no ClickHouse equivalent, so a row's
+ * `agent_loop_exit_reason` / `message_id` reflect only what was known at
+ * insert time. `latency_breakdown` is likewise not carried (the read source
+ * already treats ClickHouse-sourced rows as having no latency waterfall).
+ *
+ * Writes are best-effort: a ClickHouse outage logs and is swallowed so it
+ * can never abort a turn.
+ */
+import { getConfigReadOnly } from "../config/loader.js";
+import type { LlmRequestLogsClickHouseConfig } from "../config/schemas/llm-request-logs.js";
+import { credentialKey } from "../security/credential-key.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("clickhouse-llm-request-log-sink");
+
+/**
+ * A request-log row to insert, in the store's domain shape. `null` string
+ * fields are written as the `''` sentinel; `assistant_id` is resolved
+ * internally from the credential store, so callers never supply it.
+ */
+export interface LlmRequestLogSinkRow {
+  id: string;
+  conversationId: string;
+  messageId: string | null;
+  provider: string | null;
+  requestPayload: string;
+  responsePayload: string;
+  createdAt: number;
+  agentLoopExitReason: string | null;
+  callSite: string | null;
+}
+
+/** Wire row written as one JSONEachRow line. */
+interface ClickHouseInsertRow {
+  assistant_id: string;
+  id: string;
+  conversation_id: string;
+  message_id: string;
+  provider: string;
+  request_payload: string;
+  response_payload: string;
+  created_at: number;
+  agent_loop_exit_reason: string;
+  call_site: string;
+}
+
+async function readCredentialOrNull(
+  service: string,
+  field: string,
+): Promise<string | null> {
+  const value = await getSecureKeyAsync(credentialKey(service, field));
+  return value ?? null;
+}
+
+/** Injectable fetch override for tests. Defaults to globalThis.fetch. */
+export type ClickHouseSinkFetch = typeof fetch;
+
+export interface ClickHouseLlmRequestLogSinkDeps {
+  /** Override the credential read for `clickhouse:url`. */
+  resolveUrl?: () => Promise<string | null>;
+  /** Override the credential read for `clickhouse:password`. */
+  resolvePassword?: () => Promise<string | null>;
+  /** Override the credential read for `vellum:platform_assistant_id`. */
+  resolveAssistantId?: () => Promise<string | null>;
+  /** Override fetch for testing. */
+  fetchImpl?: ClickHouseSinkFetch;
+}
+
+export class ClickHouseLlmRequestLogSink {
+  private cachedUrl: string | null = null;
+  private cachedPassword: string | null = null;
+  private cachedAssistantId: string | null = null;
+  private ensureTablePromise: Promise<void> | null = null;
+
+  private readonly resolveUrl: () => Promise<string | null>;
+  private readonly resolvePassword: () => Promise<string | null>;
+  private readonly resolveAssistantId: () => Promise<string | null>;
+  private readonly fetchImpl: ClickHouseSinkFetch;
+
+  constructor(
+    private readonly config: LlmRequestLogsClickHouseConfig,
+    deps: ClickHouseLlmRequestLogSinkDeps = {},
+  ) {
+    this.resolveUrl =
+      deps.resolveUrl ?? (() => readCredentialOrNull("clickhouse", "url"));
+    this.resolvePassword =
+      deps.resolvePassword ??
+      (() => readCredentialOrNull("clickhouse", "password"));
+    this.resolveAssistantId =
+      deps.resolveAssistantId ??
+      (() => readCredentialOrNull("vellum", "platform_assistant_id"));
+    this.fetchImpl = deps.fetchImpl ?? globalThis.fetch.bind(globalThis);
+  }
+
+  /**
+   * Fire-and-forget insert. Returns immediately; the write runs on a detached
+   * promise whose rejection is logged and swallowed so a ClickHouse outage
+   * never propagates into the turn. Mirrors the compaction-log store's
+   * best-effort recording contract.
+   */
+  recordBestEffort(row: LlmRequestLogSinkRow): void {
+    this.insert(row).catch((err: unknown) => {
+      log.warn(
+        { err, conversationId: row.conversationId, callSite: row.callSite },
+        "Failed to write LLM request log to ClickHouse (non-fatal)",
+      );
+    });
+  }
+
+  async insert(row: LlmRequestLogSinkRow): Promise<void> {
+    const assistantId = await this.assistantId();
+    await this.ensureTable();
+    const wire: ClickHouseInsertRow = {
+      assistant_id: assistantId,
+      id: row.id,
+      conversation_id: row.conversationId,
+      // Non-Nullable columns use `''` for "unset"; the read source maps it back.
+      message_id: row.messageId ?? "",
+      provider: row.provider ?? "",
+      request_payload: row.requestPayload,
+      response_payload: row.responsePayload,
+      created_at: row.createdAt,
+      agent_loop_exit_reason: row.agentLoopExitReason ?? "",
+      call_site: row.callSite ?? "",
+    };
+    await this.exec(
+      `INSERT INTO ${this.tableRef()} FORMAT JSONEachRow`,
+      JSON.stringify(wire),
+    );
+  }
+
+  /**
+   * Create the table on first write so opting in is self-serve. Idempotent
+   * (`IF NOT EXISTS`, so a no-op against the mirror cron's existing table)
+   * and memoized per instance; a rejected attempt clears the memo so the
+   * next write retries.
+   */
+  private ensureTable(): Promise<void> {
+    if (!this.ensureTablePromise) {
+      this.ensureTablePromise = this.exec(
+        `CREATE TABLE IF NOT EXISTS ${this.tableRef()} (
+          assistant_id String,
+          id String,
+          conversation_id String,
+          message_id String,
+          provider String,
+          request_payload String,
+          response_payload String,
+          created_at DateTime64(3),
+          agent_loop_exit_reason String,
+          call_site String
+        ) ENGINE = MergeTree
+        ORDER BY (assistant_id, conversation_id, created_at, id)`,
+      ).then(
+        () => undefined,
+        (err: unknown) => {
+          this.ensureTablePromise = null;
+          throw err;
+        },
+      );
+    }
+    return this.ensureTablePromise;
+  }
+
+  private tableRef(): string {
+    // Database is set via the `database=` URL param in `exec`, so only the
+    // table identifier needs quoting. Backtick-quote to tolerate non-default
+    // names with special characters.
+    return `\`${this.config.table.replace(/`/g, "``")}\``;
+  }
+
+  private async exec(sql: string, body?: string): Promise<string> {
+    const baseUrl = await this.url();
+    const password = await this.password();
+
+    let target: URL;
+    try {
+      target = new URL(baseUrl);
+    } catch (err) {
+      throw new Error(
+        `clickhouse:url is not a valid URL: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    target.searchParams.set("database", this.config.database);
+    // For INSERTs the statement goes in the `query` param and the row data in
+    // the body; DDL ships as the body itself. ClickHouse treats integers
+    // inserted into DateTime64(3) as epoch millis, so `created_at` maps 1:1.
+    if (body !== undefined) {
+      target.searchParams.set("query", sql);
+    }
+
+    const auth =
+      "Basic " +
+      Buffer.from(`${this.config.user}:${password}`, "utf8").toString("base64");
+
+    const res = await this.fetchImpl(target.toString(), {
+      method: "POST",
+      headers: { Authorization: auth, "Content-Type": "text/plain" },
+      body: body ?? sql,
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(
+        `ClickHouse llm-request-log write failed (HTTP ${res.status}): ${text.slice(0, 500)}`,
+      );
+    }
+    return res.text();
+  }
+
+  private async assistantId(): Promise<string> {
+    if (this.cachedAssistantId) return this.cachedAssistantId;
+    const val = await this.resolveAssistantId();
+    if (!val) {
+      throw new Error(
+        "vellum:platform_assistant_id credential is required when readSource=clickhouse",
+      );
+    }
+    this.cachedAssistantId = val;
+    return val;
+  }
+
+  private async url(): Promise<string> {
+    if (this.cachedUrl) return this.cachedUrl;
+    const val = await this.resolveUrl();
+    if (!val) {
+      throw new Error(
+        "clickhouse:url credential is required when readSource=clickhouse",
+      );
+    }
+    this.cachedUrl = val;
+    return val;
+  }
+
+  private async password(): Promise<string> {
+    if (this.cachedPassword) return this.cachedPassword;
+    const val = await this.resolvePassword();
+    if (!val) {
+      throw new Error(
+        "clickhouse:password credential is required when readSource=clickhouse",
+      );
+    }
+    this.cachedPassword = val;
+    return val;
+  }
+}
+
+/**
+ * Sink cache keyed by the serialized connection config so config edits take
+ * effect on the next write without a restart, while steady-state writes reuse
+ * one instance (and its cached credentials / ensured table).
+ */
+let cachedSink: { key: string; sink: ClickHouseLlmRequestLogSink } | null =
+  null;
+
+/**
+ * Resolve the configured ClickHouse write sink, or `null` when
+ * `llmRequestLogs.readSource` is not `"clickhouse"` (i.e. writes stay on
+ * local SQLite). Read-only config access keeps this off the disk-write path,
+ * matching the write hot path's `getConfigReadOnly` usage. Returns `null` on
+ * any config resolution error so a config hiccup falls back to SQLite rather
+ * than dropping the write.
+ */
+export function getClickHouseLlmRequestLogSink(): ClickHouseLlmRequestLogSink | null {
+  let cfg;
+  try {
+    cfg = getConfigReadOnly().llmRequestLogs;
+  } catch {
+    return null;
+  }
+  if (!cfg || cfg.readSource !== "clickhouse") return null;
+  const key = JSON.stringify(cfg.clickhouse);
+  if (!cachedSink || cachedSink.key !== key) {
+    cachedSink = { key, sink: new ClickHouseLlmRequestLogSink(cfg.clickhouse) };
+  }
+  return cachedSink.sink;
+}
+
+/** Test hook: drop the memoized sink so config/dep changes are picked up. */
+export function resetClickHouseLlmRequestLogSinkForTests(): void {
+  cachedSink = null;
+}

--- a/assistant/src/persistence/llm-request-log-store.ts
+++ b/assistant/src/persistence/llm-request-log-store.ts
@@ -16,6 +16,7 @@ import {
 import { v4 as uuid } from "uuid";
 
 import { CALL_SITE_SYNTHETIC_AGENT_ERROR_MESSAGE } from "../api/constants/call-sites.js";
+import { getConfigReadOnly } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { AssistantError, ProviderError } from "../util/errors.js";
 import {
@@ -40,6 +41,22 @@ function logsDb(): DrizzleDb {
     throw new Error("logs database unavailable");
   }
   return db;
+}
+
+/**
+ * True when the operator has opted out of LLM request logging via
+ * `llmRequestLogs.disabled`. Gates every `llm_request_logs` insert so no
+ * prompt/completion payload is written while logging is off. Read-only config
+ * access (no `ensureDataDir`/disk write) because this sits on the per-LLM-call
+ * critical path; defaults to "enabled" if config resolution throws so a config
+ * hiccup never silently drops logs.
+ */
+export function llmRequestLoggingDisabled(): boolean {
+  try {
+    return getConfigReadOnly().llmRequestLogs?.disabled === true;
+  } catch {
+    return false;
+  }
 }
 
 export type LogRow = {
@@ -166,6 +183,13 @@ export function recordRequestLog(
   callSite?: LLMCallSite,
   latencyBreakdown?: string,
 ): string {
+  // Master opt-out: when logging is disabled, skip the write entirely so no
+  // prompt/completion payload lands on disk. Returns an empty id — no
+  // production caller consumes the return value, and the row does not exist to
+  // be stamped/backfilled later.
+  if (llmRequestLoggingDisabled()) {
+    return "";
+  }
   const db = logsDb();
   const id = uuid();
   // Synchronous insert of the full request/response payloads (an entire
@@ -251,6 +275,11 @@ export function recordSyntheticAgentErrorMessageLog(args: {
   preparedRequest: unknown | null;
   createdAt: number;
 }): string {
+  // Synthetic error rows are `llm_request_logs` rows too — honour the same
+  // master opt-out so nothing is written while logging is disabled.
+  if (llmRequestLoggingDisabled()) {
+    return "";
+  }
   const db = logsDb();
   const id = uuid();
   const requestPayload = JSON.stringify({

--- a/assistant/src/persistence/llm-request-log-store.ts
+++ b/assistant/src/persistence/llm-request-log-store.ts
@@ -26,6 +26,7 @@ import {
   messageMetadataSchema,
 } from "./conversation-crud.js";
 import { type DrizzleDb, getDb, getLogsDb } from "./db-connection.js";
+import { getClickHouseLlmRequestLogSink } from "./llm-request-log-sink-clickhouse.js";
 import { llmRequestLogs, messages } from "./schema/index.js";
 import { timeSyncSection } from "./slow-sync-log.js";
 
@@ -190,8 +191,27 @@ export function recordRequestLog(
   if (llmRequestLoggingDisabled()) {
     return "";
   }
-  const db = logsDb();
   const id = uuid();
+  // When ClickHouse is the configured source, it is also the write target:
+  // send the row there instead of local SQLite (fire-and-forget). The id is
+  // still returned for signature parity, though no local row exists for the
+  // post-loop stamping helpers to update — an accepted ClickHouse limitation.
+  const clickHouseSink = getClickHouseLlmRequestLogSink();
+  if (clickHouseSink) {
+    clickHouseSink.recordBestEffort({
+      id,
+      conversationId,
+      messageId: messageId ?? null,
+      provider: provider ?? null,
+      requestPayload,
+      responsePayload,
+      createdAt: Date.now(),
+      agentLoopExitReason: null,
+      callSite: callSite ?? null,
+    });
+    return id;
+  }
+  const db = logsDb();
   // Synchronous insert of the full request/response payloads (an entire
   // context window for main-agent calls) into the append-only logs DB, on the
   // per-LLM-call critical path. Timed so an event-loop freeze the watchdog
@@ -280,7 +300,6 @@ export function recordSyntheticAgentErrorMessageLog(args: {
   if (llmRequestLoggingDisabled()) {
     return "";
   }
-  const db = logsDb();
   const id = uuid();
   const requestPayload = JSON.stringify({
     syntheticAgentErrorMessage: {
@@ -294,6 +313,25 @@ export function recordSyntheticAgentErrorMessageLog(args: {
       noticeText: args.noticeText,
     },
   });
+  // Route to ClickHouse when it is the configured target. The exit reason is
+  // already known here, so it is carried on the row directly (unlike real
+  // calls, which stamp it post-loop against a local row that ClickHouse lacks).
+  const clickHouseSink = getClickHouseLlmRequestLogSink();
+  if (clickHouseSink) {
+    clickHouseSink.recordBestEffort({
+      id,
+      conversationId: args.conversationId,
+      messageId: args.messageId,
+      provider: null,
+      requestPayload,
+      responsePayload,
+      createdAt: args.createdAt,
+      agentLoopExitReason: args.exitReason,
+      callSite: CALL_SITE_SYNTHETIC_AGENT_ERROR_MESSAGE,
+    });
+    return id;
+  }
+  const db = logsDb();
   db.insert(llmRequestLogs)
     .values({
       id,

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 mock.module("../../../util/logger.js", () => ({
   getLogger: () =>
@@ -292,6 +292,72 @@ describe("GET /v1/conversations/llm-context", () => {
 
     expect(body.conversationId).toBeNull();
     expect(body.conversationKey).toBe("missing-key");
+    expect(body.logs).toEqual([]);
+  });
+});
+
+describe("inspector reads when llmRequestLogs.disabled is true", () => {
+  const payloadRoute = ROUTES.find(
+    (r) => r.operationId === "llm_request_logs_payload_get",
+  )!;
+  const contextRoute = ROUTES.find(
+    (r) => r.operationId === "llm_request_logs_context_get",
+  )!;
+
+  beforeEach(() => {
+    clearTables();
+    rawConfigFixture = {
+      llmRequestLogs: { readSource: "local", disabled: true },
+    };
+  });
+
+  afterEach(() => {
+    // Restore the neutral default so read blocks that rely on it (and don't
+    // reset the fixture themselves) aren't polluted by the disabled state.
+    rawConfigFixture = {};
+  });
+
+  async function expectDisabled(promise: unknown): Promise<void> {
+    // The handler throws a RouteError; assert on its wire-facing fields so the
+    // client can key on the stable code / 403 status.
+    let thrown: unknown;
+    try {
+      await promise;
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeDefined();
+    expect((thrown as { code: string }).code).toBe("LLM_REQUEST_LOGS_DISABLED");
+    expect((thrown as { statusCode: number }).statusCode).toBe(403);
+  }
+
+  test("message llm-context is rejected", async () => {
+    await expectDisabled(dispatchLlmContext("msg-1"));
+  });
+
+  test("conversation llm-context is rejected", async () => {
+    await expectDisabled(
+      dispatchConversationLlmContext({ conversationId: "conv-1" }),
+    );
+  });
+
+  test("single-log payload is rejected", async () => {
+    await expectDisabled(payloadRoute.handler({ pathParams: { id: "log-a" } }));
+  });
+
+  test("single-log context is rejected", async () => {
+    await expectDisabled(contextRoute.handler({ pathParams: { id: "log-a" } }));
+  });
+
+  test("reads succeed again once logging is re-enabled", async () => {
+    rawConfigFixture = {
+      llmRequestLogs: { readSource: "local", disabled: false },
+    };
+    // An unresolved conversation key returns an empty inspector response
+    // (no throw), proving the disabled guard no longer short-circuits.
+    const body = (await dispatchConversationLlmContext({
+      conversationKey: "missing-key",
+    })) as { logs: unknown[] };
     expect(body.logs).toEqual([]);
   });
 });

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -105,7 +105,12 @@ import {
   resolvePricingForUsage,
   usesAnthropicPricingRules,
 } from "../../util/pricing.js";
-import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
+import {
+  BadRequestError,
+  InternalError,
+  LlmRequestLogsDisabledError,
+  NotFoundError,
+} from "./errors.js";
 import {
   type LlmContextSummary,
   normalizeLlmContextPayloads,
@@ -1772,10 +1777,24 @@ function resolveConversationKind(
   return "user";
 }
 
+/**
+ * Guard every inspector read on the master `llmRequestLogs.disabled`
+ * opt-out. When logging is off there is nothing to serve (and any rows that
+ * predate the opt-out are intentionally withheld), so we fail fast with the
+ * distinct `LLM_REQUEST_LOGS_DISABLED` code the client keys on to render an
+ * enable-logging affordance instead of a generic error.
+ */
+function assertLlmRequestLoggingEnabled(): void {
+  if (getConfig().llmRequestLogs?.disabled === true) {
+    throw new LlmRequestLogsDisabledError();
+  }
+}
+
 async function handleGetLlmContext({
   pathParams = {},
   queryParams = {},
 }: RouteHandlerArgs) {
+  assertLlmRequestLoggingEnabled();
   const messageId = pathParams.id;
   if (!messageId) {
     throw new BadRequestError("message id is required");
@@ -1819,6 +1838,7 @@ async function handleGetLlmContext({
 async function handleGetConversationLlmContext({
   queryParams = {},
 }: RouteHandlerArgs) {
+  assertLlmRequestLoggingEnabled();
   const conversationKey = queryParams.conversationKey;
   const requestedConversationId = queryParams.conversationId;
   const view = resolveLlmContextView(queryParams.view);
@@ -1888,6 +1908,7 @@ async function handleGetConversationLlmContext({
 async function handleGetLlmRequestLogPayload({
   pathParams = {},
 }: RouteHandlerArgs) {
+  assertLlmRequestLoggingEnabled();
   const logId = pathParams.id;
   if (!logId) {
     throw new BadRequestError("log id is required");
@@ -1915,6 +1936,7 @@ async function handleGetLlmRequestLogPayload({
 async function handleGetLlmRequestLogContext({
   pathParams = {},
 }: RouteHandlerArgs) {
+  assertLlmRequestLoggingEnabled();
   const logId = pathParams.id;
   if (!logId) {
     throw new BadRequestError("log id is required");

--- a/assistant/src/runtime/routes/errors.ts
+++ b/assistant/src/runtime/routes/errors.ts
@@ -145,3 +145,20 @@ export class InternalError extends RouteError {
     this.name = "InternalError";
   }
 }
+
+/**
+ * LLM request logging is turned off via `llmRequestLogs.disabled`, so the
+ * inspector read routes have nothing to serve. Carries a distinct, stable
+ * `code` (`LLM_REQUEST_LOGS_DISABLED`) so clients can branch on it — the web
+ * inspector renders a "logging is off" state with an enable toggle rather than
+ * a generic failure. 403 (rather than 404) so the condition reads as
+ * "deliberately withheld", not "missing".
+ */
+export class LlmRequestLogsDisabledError extends RouteError {
+  constructor(
+    message = "LLM request logging is disabled. Enable it to view request logs.",
+  ) {
+    super(message, "LLM_REQUEST_LOGS_DISABLED", 403);
+    this.name = "LlmRequestLogsDisabledError";
+  }
+}

--- a/clients/web/src/domains/chat/inspector/inspect-page.test.tsx
+++ b/clients/web/src/domains/chat/inspector/inspect-page.test.tsx
@@ -152,6 +152,12 @@ mock.module("@/stores/assistant-feature-flag-store", () => ({
 }));
 
 mock.module("@/domains/chat/inspector/inspector-api", () => ({
+  isLlmRequestLogsDisabledError: (error: unknown) =>
+    Boolean(
+      error &&
+      typeof error === "object" &&
+      (error as { code?: string }).code === "LLM_REQUEST_LOGS_DISABLED",
+    ),
   useLlmContext: (
     _assistantId: string | undefined,
     _conversationId: string | undefined,
@@ -400,6 +406,29 @@ describe("InspectPage — data-loading branches", () => {
     expect(html).toContain("Failed to load");
     expect(html).toContain("boom");
     expect(html).toContain("Retry");
+  });
+
+  test("renders the enable-logging state when request logging is disabled", () => {
+    paramsStub = { conversationId: "conv-disabled" };
+    const disabledError = Object.assign(
+      new Error("LLM request logging is disabled."),
+      { code: "LLM_REQUEST_LOGS_DISABLED", status: 403 },
+    );
+    contextStub = {
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: disabledError,
+      refetch: () => {},
+    };
+    const html = renderInspector();
+    expect(html).toContain("LLM request logging is off");
+    expect(html).toContain("Enable logging");
+    // The enable control is the design-library Toggle (role="switch").
+    expect(html).toContain('role="switch"');
+    // The generic error chrome must not show for this branch.
+    expect(html).not.toContain("Failed to load");
+    expect(html).not.toContain("Retry");
   });
 });
 

--- a/clients/web/src/domains/chat/inspector/inspect-page.tsx
+++ b/clients/web/src/domains/chat/inspector/inspect-page.tsx
@@ -6,23 +6,26 @@ import { Link, useNavigate, useParams, useSearchParams } from "react-router";
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { useCanUseLlmInspector } from "@/domains/chat/inspector/access";
 import {
-    useConversationCallNumbering,
-    useConversationMessageList,
-    useLlmContext,
+  isLlmRequestLogsDisabledError,
+  useConversationCallNumbering,
+  useConversationMessageList,
+  useLlmContext,
 } from "@/domains/chat/inspector/inspector-api";
+import { configGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
+import { configPatch } from "@/generated/daemon/sdk.gen";
 import {
-    buildInspectorExportFilename,
-    buildInspectorExportZipBlobBatched,
+  buildInspectorExportFilename,
+  buildInspectorExportZipBlobBatched,
 } from "@/domains/chat/inspector/inspector-export";
 import {
-    llmCallDetailQueryOptions,
-    useLlmCallDetail,
+  llmCallDetailQueryOptions,
+  useLlmCallDetail,
 } from "@/domains/chat/inspector/inspector-detail-api";
 import { llmLogPayloadQueryOptions } from "@/domains/chat/inspector/inspector-payload-api";
 import { normalizeContentBlocks } from "@/domains/chat/api/messages";
 import {
-    supportsLlmContextSummaryView,
-    useSupportsLlmContextSummaryView,
+  supportsLlmContextSummaryView,
+  useSupportsLlmContextSummaryView,
 } from "@/lib/backwards-compat/llm-context-summary-view";
 import { isElectron } from "@/runtime/is-electron";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
@@ -35,11 +38,13 @@ import type {
   LLMRequestLogEntry,
 } from "@vellumai/assistant-api";
 import { Button } from "@vellumai/design-library";
+import { toast } from "@vellumai/design-library/components/toast";
+import { Toggle } from "@vellumai/design-library/components/toggle";
 
 import { CallRail } from "./components/call-rail";
 import {
-    ExportProgressModal,
-    type ExportPhase,
+  ExportProgressModal,
+  type ExportPhase,
 } from "./components/export-progress-modal";
 import { MobileCallSelector } from "./components/mobile-call-selector";
 import { TabBar, type InspectorTab } from "./components/tab-bar";
@@ -102,9 +107,7 @@ export function InspectPage(): ReactNode {
     return <CenteredMessage tone="muted">Loading…</CenteredMessage>;
   }
 
-  return (
-    <Inspector conversationId={conversationId} messageId={messageId} />
-  );
+  return <Inspector conversationId={conversationId} messageId={messageId} />;
 }
 
 interface InspectorProps {
@@ -214,7 +217,14 @@ function Inspector({ conversationId, messageId }: InspectorProps): ReactNode {
         {isLoadingContext ? (
           <CenteredMessage tone="muted">Loading…</CenteredMessage>
         ) : isError ? (
-          <ErrorState error={error} onRetry={() => void refetch()} />
+          isLlmRequestLogsDisabledError(error) ? (
+            <LoggingDisabledState
+              assistantId={assistantId}
+              onEnabled={() => void refetch()}
+            />
+          ) : (
+            <ErrorState error={error} onRetry={() => void refetch()} />
+          )
         ) : !logs.length ? (
           <EmptyState messageId={messageId} />
         ) : (
@@ -269,8 +279,7 @@ function Header({
     conversationId,
   );
   const turnPosition = useMemo(
-    () =>
-      messageId ? findTurnPosition(scopeMessages ?? [], messageId) : null,
+    () => (messageId ? findTurnPosition(scopeMessages ?? [], messageId) : null),
     [scopeMessages, messageId],
   );
 
@@ -294,9 +303,7 @@ function Header({
       // the modal's determinate progress bar.
       const blob = await buildInspectorExportZipBlobBatched(context, {
         fetchPayload: (logId) =>
-          queryClient.fetchQuery(
-            llmLogPayloadQueryOptions(assistantId, logId),
-          ),
+          queryClient.fetchQuery(llmLogPayloadQueryOptions(assistantId, logId)),
         fetchCallSections: (logId) =>
           supportsLlmContextSummaryView()
             ? queryClient.fetchQuery(
@@ -315,9 +322,7 @@ function Header({
       const { saveFile } = await import("@/runtime/native-file");
       await saveFile(
         blob,
-        buildInspectorExportFilename(
-          context.conversationId ?? conversationId,
-        ),
+        buildInspectorExportFilename(context.conversationId ?? conversationId),
       );
       setExportRun((prev) => (prev ? { ...prev, phase: "done" } : prev));
     } catch (err) {
@@ -548,7 +553,9 @@ interface ScopeOption {
 // A "turn" is headed by a user message: the user message plus every
 // assistant response it produced map to the same group of LLM calls,
 // so only user messages are offered as scope options.
-function buildMessageScopeOptions(messages: ConversationMessage[]): ScopeOption[] {
+function buildMessageScopeOptions(
+  messages: ConversationMessage[],
+): ScopeOption[] {
   const seen = new Set<string>();
   const options: ScopeOption[] = [];
   let index = 1;
@@ -646,7 +653,8 @@ function Loaded({
   // return sections inline and the list entry is used as-is.
   const supportsSummaryView = useSupportsLlmContextSummaryView();
   const selectedLogHasSections = Boolean(
-    selectedLog && (selectedLog.requestSections || selectedLog.responseSections),
+    selectedLog &&
+    (selectedLog.requestSections || selectedLog.responseSections),
   );
   const shouldFetchDetail = supportsSummaryView && !selectedLogHasSections;
   const {
@@ -859,6 +867,84 @@ function EmptyState({ messageId }: EmptyStateProps): ReactNode {
       >
         {body}
       </p>
+    </div>
+  );
+}
+
+interface LoggingDisabledStateProps {
+  assistantId: string | undefined;
+  onEnabled: () => void;
+}
+
+/**
+ * Rendered when the daemon reports that LLM request logging is turned off
+ * (`llmRequestLogs.disabled`). There's nothing to inspect, so instead of the
+ * generic error state we explain the situation and offer a toggle that flips
+ * the setting back on for future calls. Enabling patches the daemon config,
+ * invalidates the cached config view, and re-runs the inspector query.
+ */
+function LoggingDisabledState({
+  assistantId,
+  onEnabled,
+}: LoggingDisabledStateProps): ReactNode {
+  const queryClient = useQueryClient();
+  const [enabling, setEnabling] = useState(false);
+
+  async function handleEnable(next: boolean): Promise<void> {
+    // The toggle starts off; only act on the off → on transition.
+    if (!next || enabling || !assistantId) return;
+    setEnabling(true);
+    try {
+      const { response } = await configPatch({
+        path: { assistant_id: assistantId },
+        body: { llmRequestLogs: { disabled: false } },
+        throwOnError: false,
+      });
+      if (!response?.ok) {
+        throw new Error(`HTTP ${response?.status ?? "?"}`);
+      }
+      void queryClient.invalidateQueries({
+        queryKey: configGetQueryKey({ path: { assistant_id: assistantId } }),
+      });
+      toast.success("LLM request logging enabled");
+      onEnabled();
+    } catch (err) {
+      toast.error(
+        err instanceof Error
+          ? `Failed to enable logging (${err.message})`
+          : "Failed to enable logging",
+      );
+    } finally {
+      setEnabling(false);
+    }
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-3 p-8 text-center">
+      <AlertCircle
+        size={32}
+        aria-hidden
+        style={{ color: "var(--content-secondary)" }}
+      />
+      <h2
+        className="text-body-medium-default"
+        style={{ color: "var(--content-default)" }}
+      >
+        LLM request logging is off
+      </h2>
+      <p
+        className="max-w-md text-label-default"
+        style={{ color: "var(--content-secondary)" }}
+      >
+        Request and response payloads aren’t being recorded, so there’s nothing
+        to inspect. Enable logging to capture future LLM calls.
+      </p>
+      <Toggle
+        checked={false}
+        disabled={enabling || !assistantId}
+        onChange={(next) => void handleEnable(next)}
+        label={enabling ? "Enabling…" : "Enable logging"}
+      />
     </div>
   );
 }

--- a/clients/web/src/domains/chat/inspector/inspector-api.test.ts
+++ b/clients/web/src/domains/chat/inspector/inspector-api.test.ts
@@ -25,6 +25,8 @@ interface FakeRequest {
 interface FakeResponse {
   status: number;
   body?: LlmContextResponse | null;
+  /** Parsed error envelope the SDK exposes as `error` on non-2xx responses. */
+  error?: unknown;
 }
 
 const requests: FakeRequest[] = [];
@@ -59,19 +61,23 @@ mock.module("@/generated/daemon/client.gen", () => ({
           return { text: async () => "error-body" };
         },
       };
-      return { data: next.body, response };
+      return { data: next.body, error: next.error, response };
     },
   },
 }));
 
 mock.module("@/domains/chat/api/messages", () => ({
-  fetchConversationMessages: async () => ({ messages: mockMessages, seq: null }),
+  fetchConversationMessages: async () => ({
+    messages: mockMessages,
+    seq: null,
+  }),
 }));
 
 // Subject imported after mocks.
 import {
   fetchConversationLlmContext,
   fetchMessageLlmContextOrThrow,
+  isLlmRequestLogsDisabledError,
 } from "@/domains/chat/inspector/inspector-api";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 
@@ -158,6 +164,37 @@ describe("fetchConversationLlmContext — happy path", () => {
     expect(caught).toBeDefined();
     expect((caught as { status: number; message: string }).status).toBe(500);
     expect((caught as { name: string }).name).toBe("LlmContextRequestError");
+  });
+
+  test("surfaces the disabled code + message from the daemon error envelope", async () => {
+    nextResponses = [
+      {
+        status: 403,
+        body: null,
+        error: {
+          error: {
+            code: "LLM_REQUEST_LOGS_DISABLED",
+            message:
+              "LLM request logging is disabled. Enable it to view request logs.",
+          },
+        },
+      },
+    ];
+
+    let caught: unknown;
+    try {
+      await fetchConversationLlmContext("asst-1", "conv-1", undefined);
+    } catch (err) {
+      caught = err;
+    }
+    expect(isLlmRequestLogsDisabledError(caught)).toBe(true);
+    expect((caught as { status: number }).status).toBe(403);
+    expect((caught as { code?: string }).code).toBe(
+      "LLM_REQUEST_LOGS_DISABLED",
+    );
+    expect((caught as { message: string }).message).toContain(
+      "LLM request logging is disabled",
+    );
   });
 });
 

--- a/clients/web/src/domains/chat/inspector/inspector-api.ts
+++ b/clients/web/src/domains/chat/inspector/inspector-api.ts
@@ -46,14 +46,47 @@ function summaryViewQuery(): { view?: "summary" } {
   return supportsLlmContextSummaryView() ? { view: "summary" } : {};
 }
 
+/**
+ * Stable error code the daemon returns (in the standard `{ error: { code } }`
+ * envelope) when `llmRequestLogs.disabled` is set. The inspector branches on
+ * it to render an "enable logging" affordance instead of a generic failure.
+ */
+export const LLM_REQUEST_LOGS_DISABLED_CODE = "LLM_REQUEST_LOGS_DISABLED";
+
 export class LlmContextRequestError extends Error {
   status: number;
+  /**
+   * Machine-readable `error.code` from the daemon envelope when present.
+   * `undefined` for network errors and responses without a coded body.
+   */
+  code: string | undefined;
 
-  constructor(status: number, message: string) {
+  constructor(status: number, message: string, code?: string) {
     super(message);
     this.name = "LlmContextRequestError";
     this.status = status;
+    this.code = code;
   }
+}
+
+/** Pull `error.code` out of the daemon's `{ error: { code, message } }` envelope. */
+function extractErrorCode(error: unknown): string | undefined {
+  if (error && typeof error === "object" && "error" in error) {
+    const inner = (error as { error?: unknown }).error;
+    if (inner && typeof inner === "object" && "code" in inner) {
+      const code = (inner as { code?: unknown }).code;
+      if (typeof code === "string") return code;
+    }
+  }
+  return undefined;
+}
+
+/** True when the failure is the daemon's "logging is disabled" signal. */
+export function isLlmRequestLogsDisabledError(error: unknown): boolean {
+  return (
+    error instanceof LlmContextRequestError &&
+    error.code === LLM_REQUEST_LOGS_DISABLED_CODE
+  );
 }
 
 export function llmContextQueryOptions(
@@ -132,9 +165,7 @@ export function useConversationCallNumbering(
       "llm-context-call-numbering",
       conversationId,
     ] as const,
-    queryFn: async ({
-      signal,
-    }): Promise<LLMRequestLogEntry[] | null> => {
+    queryFn: async ({ signal }): Promise<LLMRequestLogEntry[] | null> => {
       if (!assistantId || !conversationId) return null;
       const { data, response } = await conversationsLlmcontextGet({
         path: { assistant_id: assistantId },
@@ -226,7 +257,11 @@ export async function fetchConversationLlmContext(
       response,
       "Failed to load LLM context",
     );
-    throw new LlmContextRequestError(response.status, msg);
+    throw new LlmContextRequestError(
+      response.status,
+      msg,
+      extractErrorCode(error),
+    );
   }
 
   if (!data) {
@@ -263,7 +298,11 @@ export async function fetchMessageLlmContextOrThrow(
       response,
       "Failed to load LLM context",
     );
-    throw new LlmContextRequestError(response.status, msg);
+    throw new LlmContextRequestError(
+      response.status,
+      msg,
+      extractErrorCode(error),
+    );
   }
   if (!data) {
     throw new LlmContextRequestError(
@@ -290,10 +329,7 @@ async function fetchConversationLlmContextFromPerMessage(
   conversationId: string,
   signal: AbortSignal | undefined,
 ): Promise<LlmContextResponse> {
-  const snapshot = await fetchConversationMessages(
-    assistantId,
-    conversationId,
-  );
+  const snapshot = await fetchConversationMessages(assistantId, conversationId);
   const messages = snapshot?.messages ?? [];
 
   const messageIds: string[] = [];


### PR DESCRIPTION
**PR 3 of 3** in the LLM request logging opt-out series. Base: `main` (PR #37649 and #37650 are merged). Rebased onto `main`, so the diff is just the ClickHouse write path.

## Prompt / plan

> Update our writes so that if a user has ClickHouse defined it no longer writes to SQLite but writes to ClickHouse instead.

Previously every LLM request log was written to local SQLite, and ClickHouse (when `llmRequestLogs.readSource === "clickhouse"`) was only populated out-of-band by the mirror cron.

## What this does

- New `llm-request-log-sink-clickhouse.ts`: a best-effort write sink mirroring the compaction-log store — lazy `CREATE TABLE IF NOT EXISTS` (a no-op against the mirror's existing table), JSONEachRow INSERT with the same columns the read source expects, `null → ''` sentinels, and `assistant_id` scoping from the credential store. Fire-and-forget: a ClickHouse outage is logged and swallowed so it never aborts a turn. Gated on `readSource === "clickhouse"`, returning null (→ SQLite) otherwise.
- The store routes writes to the sink when configured, so reads and writes share one store.
- Added the sink to the `secure-keys` `ALLOWED_IMPORTERS` allowlist (flagged by the bot review) — it reads `clickhouse:url` / `clickhouse:password` / `vellum:platform_assistant_id`.
- The sink uses the same namespace `config/loader` import as the store (from PR #37649) so the partial-mock tests that reach it transitively keep linking. The PR4 follow-up reverts both namespace imports and cleans up those test mocks.

**Known limitation** (consistent with the existing ClickHouse read path): the sink is INSERT-only, so the post-loop stamps — `agent_loop_exit_reason` backfill, `message_id` backfill, relink — have no ClickHouse equivalent; a row reflects only what was known at insert time. Synthetic error rows carry their exit reason at insert.

## Test plan

- `bun test`: `llm-request-log-sink-clickhouse.test.ts` (wire shape — CREATE + JSONEachRow INSERT, `null → ''`, auth, error handling — and factory gating), `llm-request-log-clickhouse-routing.test.ts` (SQLite when no sink; ClickHouse + no SQLite row when a sink is configured; synthetic rows too), and `credential-security-invariants.test.ts` (allowlist). Also verified `tool-execution-abort-cleanup.test.ts` still links.
- `bunx tsgo --noEmit` clean; eslint clean (0 errors).

## CLI verb checklist

No new routes — internal persistence change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5EQ7hFW26ndg21csTCZJq