### PR TITLE
feat(web): render tool-result images by attachment id on history reload

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -17542,6 +17542,10 @@ paths:
                                 type: array
                                 items:
                                   type: string
+                              imageAttachmentIds:
+                                type: array
+                                items:
+                                  type: string
                               startedAt:
                                 type: number
                               previewStartedAt:
@@ -17971,6 +17975,10 @@ paths:
                                       imageData:
                                         type: string
                                       imageDataList:
+                                        type: array
+                                        items:
+                                          type: string
+                                      imageAttachmentIds:
                                         type: array
                                         items:
                                           type: string

--- a/assistant/src/__tests__/server-history-render.test.ts
+++ b/assistant/src/__tests__/server-history-render.test.ts
@@ -257,7 +257,7 @@ describe("renderHistoryContent", () => {
     ]);
   });
 
-  test("resolves a workspace_ref tool-result image back to base64", () => {
+  test("emits the attachment id for a workspace_ref tool-result image", () => {
     // "aGVsbG8=" = "hello" — a stand-in for screenshot bytes.
     const stored = uploadAttachment("shot.png", "image/png", "aGVsbG8=");
     const output = renderHistoryContent([
@@ -281,10 +281,40 @@ describe("renderHistoryContent", () => {
       },
     ]);
 
-    // The persisted reference is resolved to base64 so the wire contract
-    // (imageDataList base64) is unchanged for the client.
+    // Referenced media emits its attachment id so clients fetch the bytes by
+    // id on render instead of inlining base64 into the history wire; the
+    // base64 fields stay empty for referenced images.
+    expect(output.toolCalls[0].imageAttachmentIds).toEqual([stored.id]);
+    expect(output.toolCalls[0].imageDataList).toBeUndefined();
+    expect(output.toolCalls[0].imageData).toBeUndefined();
+  });
+
+  test("resolves an inline base64 tool-result image without an id", () => {
+    const output = renderHistoryContent([
+      { type: "tool_use", id: "tu_1", name: "browser_screenshot", input: {} },
+      {
+        type: "tool_result",
+        tool_use_id: "tu_1",
+        content: "captured",
+        is_error: false,
+        contentBlocks: [
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: "aGVsbG8=",
+            },
+          },
+        ],
+      },
+    ]);
+
+    // Legacy inline base64 (no workspace reference) still resolves to the
+    // base64 wire fields and carries no attachment id.
     expect(output.toolCalls[0].imageDataList).toEqual(["aGVsbG8="]);
     expect(output.toolCalls[0].imageData).toBe("aGVsbG8=");
+    expect(output.toolCalls[0].imageAttachmentIds).toBeUndefined();
   });
 
   test("marks error tool results", () => {

--- a/assistant/src/api/responses/conversation-message.ts
+++ b/assistant/src/api/responses/conversation-message.ts
@@ -153,6 +153,15 @@ export const ConversationMessageToolCallSchema = z.object({
   imageData: z.string().optional(),
   /** Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot, image generation). */
   imageDataList: z.array(z.string()).optional(),
+  /**
+   * Workspace attachment ids for tool-result images persisted as workspace
+   * references. When present, clients fetch the image bytes by id on render
+   * (lazy) rather than embedding base64 in the history wire. Positionally
+   * aligned with the tool's rendered images; a row emits either these ids
+   * (referenced media) or `imageDataList` (legacy inline base64), not both for
+   * the same image.
+   */
+  imageAttachmentIds: z.array(z.string()).optional(),
   /** Unix ms when the tool started executing (the `tool_use_start` time). */
   startedAt: z.number().optional(),
   /**

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -659,15 +659,21 @@ export function renderHistoryContent(
         typeof block.content === "string" ? block.content : "";
       const isError = block.is_error === true;
       // Extract image data from persisted contentBlocks (e.g. browser_screenshot,
-      // image generation) as base64. The source may be inline base64 or a
-      // workspace reference; resolveMediaSourceData reads either back to base64.
+      // image generation). Referenced media (a workspace_ref source) emits its
+      // attachment id so clients fetch the bytes by id on render instead of
+      // inlining base64 into the history wire; legacy inline base64 sources are
+      // resolved and carried as base64. A given image goes to exactly one list.
       const imageDataList: string[] = [];
+      const imageAttachmentIds: string[] = [];
       if (Array.isArray(block.contentBlocks)) {
         for (const cb of block.contentBlocks) {
           if (isRecord(cb) && cb.type === "image" && isRecord(cb.source)) {
-            const resolved = resolveMediaSourceData(
-              cb.source as unknown as MediaSource,
-            );
+            const source = cb.source as unknown as MediaSource;
+            if (source.type === "workspace_ref" && source.attachmentId) {
+              imageAttachmentIds.push(source.attachmentId);
+              continue;
+            }
+            const resolved = resolveMediaSourceData(source);
             if (resolved) imageDataList.push(resolved.data);
           }
         }
@@ -679,6 +685,9 @@ export function renderHistoryContent(
         if (imageDataList.length > 0) {
           matched.imageData = imageDataList[0];
           matched.imageDataList = imageDataList;
+        }
+        if (imageAttachmentIds.length > 0) {
+          matched.imageAttachmentIds = imageAttachmentIds;
         }
       }
       // Orphan tool_result with no matching tool_use — drop it. Synthesizing

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -349,6 +349,8 @@ interface HistoryResponseToolCall {
   imageData?: string;
   /** Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot, image generation). */
   imageDataList?: string[];
+  /** Workspace attachment ids for tool-result images persisted as references; clients fetch bytes by id on render instead of embedding base64. */
+  imageAttachmentIds?: string[];
   /** Unix ms when the tool started executing. */
   startedAt?: number;
   /** Unix ms when the tool completed. */

--- a/clients/web/src/domains/chat/components/chat-attachments/tool-result-images.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/tool-result-images.test.tsx
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactElement } from "react";
+
+import * as daemonSdk from "@/generated/daemon/sdk.gen";
+import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
+
+type ContentResult = { data: Blob | null; error: { message: string } | null };
+
+// Mock only the daemon content endpoint; keep the rest of the generated SDK
+// real so any other consumer in the module graph is unaffected.
+const attachmentsByIdContentGet = mock(
+  async (_opts: {
+    path: { assistant_id: string; id: string };
+    parseAs?: string;
+    throwOnError?: boolean;
+  }): Promise<ContentResult> => ({
+    data: new Blob(["image-bytes"]),
+    error: null,
+  }),
+);
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...daemonSdk,
+  attachmentsByIdContentGet,
+}));
+
+// happy-dom doesn't implement object URLs.
+globalThis.URL.createObjectURL = mock(
+  (_obj: Blob | MediaSource): string => "blob:tool-image-mock",
+);
+globalThis.URL.revokeObjectURL = mock((_url: string): void => undefined);
+
+// Downloads lazily import the native-file bridge; stub it so clicking Download
+// records the call without touching Capacitor / DOM anchors.
+const saveFileMock = mock(
+  async (_data: Blob | string, _filename: string): Promise<void> => undefined,
+);
+mock.module("@/runtime/native-file", () => ({
+  saveFile: saveFileMock,
+}));
+
+const { ToolResultImages } = await import(
+  "@/domains/chat/components/chat-attachments/tool-result-images"
+);
+
+function renderStrip(
+  toolCalls: ChatMessageToolCall[],
+  opts: { hasAttachments?: boolean; assistantId?: string | null } = {},
+): void {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const assistantId = "assistantId" in opts ? opts.assistantId : "asst-1";
+  const ui: ReactElement = (
+    <QueryClientProvider client={client}>
+      <ToolResultImages
+        toolCalls={toolCalls}
+        hasAttachments={opts.hasAttachments ?? false}
+        assistantId={assistantId}
+      />
+    </QueryClientProvider>
+  );
+  render(ui);
+}
+
+afterEach(() => {
+  cleanup();
+  attachmentsByIdContentGet.mockClear();
+  saveFileMock.mockClear();
+});
+
+describe("ToolResultImages referenced media", () => {
+  test("renders inline base64 images without hitting the daemon", () => {
+    const toolCall: ChatMessageToolCall = {
+      id: "tc-b64",
+      name: "media_generate_image",
+      input: {},
+      result: "Generated 1 image",
+      imageDataList: ["img-a"],
+      completedAt: 1,
+    };
+    renderStrip([toolCall]);
+
+    const img = screen.getByTestId("tool-result-image");
+    expect(img.getAttribute("src")).toBe("data:image/png;base64,img-a");
+    expect(attachmentsByIdContentGet).not.toHaveBeenCalled();
+  });
+
+  test("fetches referenced images by id and renders the object URL", async () => {
+    const toolCall: ChatMessageToolCall = {
+      id: "tc-ref",
+      name: "media_generate_image",
+      input: {},
+      result: "Generated 1 image",
+      imageAttachmentIds: ["att-xyz"],
+      completedAt: 1,
+    };
+    renderStrip([toolCall]);
+
+    const img = await screen.findByTestId("tool-result-image");
+    expect(img.getAttribute("src")).toBe("blob:tool-image-mock");
+    expect(attachmentsByIdContentGet).toHaveBeenCalledTimes(1);
+    expect(attachmentsByIdContentGet.mock.calls[0]![0]).toMatchObject({
+      path: { assistant_id: "asst-1", id: "att-xyz" },
+    });
+  });
+
+  test("shows a placeholder and never fetches when no assistantId is known", () => {
+    const toolCall: ChatMessageToolCall = {
+      id: "tc-ref-noassistant",
+      name: "media_generate_image",
+      input: {},
+      result: "Generated 1 image",
+      imageAttachmentIds: ["att-xyz"],
+      completedAt: 1,
+    };
+    renderStrip([toolCall], { assistantId: null });
+
+    expect(screen.getByTestId("tool-result-image-placeholder")).toBeDefined();
+    expect(screen.queryByTestId("tool-result-image")).toBeNull();
+    expect(attachmentsByIdContentGet).not.toHaveBeenCalled();
+  });
+
+  test("downloading a referenced image fetches its bytes by id", async () => {
+    const toolCall: ChatMessageToolCall = {
+      id: "tc-ref-dl",
+      name: "file_read",
+      input: {},
+      result: "Read 1 image",
+      imageAttachmentIds: ["att-dl"],
+      completedAt: 1,
+    };
+    renderStrip([toolCall]);
+
+    const download = screen.getByLabelText("Download file-read.png");
+    fireEvent.click(download);
+
+    await waitFor(() => {
+      expect(saveFileMock).toHaveBeenCalledTimes(1);
+    });
+    // Saved from the fetched blob (referenced media has no inline data URL).
+    expect(saveFileMock.mock.calls[0]![0]).toBeInstanceOf(Blob);
+    expect(saveFileMock.mock.calls[0]![1]).toBe("file-read.png");
+  });
+
+  test("suppresses itself once end-of-turn attachments have arrived", () => {
+    const toolCall: ChatMessageToolCall = {
+      id: "tc-suppressed",
+      name: "media_generate_image",
+      input: {},
+      result: "Generated 1 image",
+      imageAttachmentIds: ["att-xyz"],
+      completedAt: 1,
+    };
+    renderStrip([toolCall], { hasAttachments: true });
+
+    expect(screen.queryByTestId("tool-result-image")).toBeNull();
+    expect(screen.queryByTestId("tool-result-image-placeholder")).toBeNull();
+    expect(attachmentsByIdContentGet).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/domains/chat/components/chat-attachments/tool-result-images.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/tool-result-images.tsx
@@ -1,10 +1,14 @@
-import { Download } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import { Download, Loader2 } from "lucide-react";
 import type { FC } from "react";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Tooltip } from "@vellumai/design-library";
 
-import { downloadAttachment } from "@/domains/chat/components/chat-attachments/download-attachment";
+import {
+  downloadAttachment,
+  fetchAttachmentContentBlob,
+} from "@/domains/chat/components/chat-attachments/download-attachment";
 import { estimateBase64Bytes } from "@/domains/chat/components/chat-attachments/utils";
 import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments/use-attachment-preview";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
@@ -78,13 +82,24 @@ function toolNameToFilePrefix(toolName?: string): string {
 }
 
 /**
- * Project a message's tool-result images into synthetic {@link DisplayAttachment}
- * objects. The base64 payload is embedded directly as a data-URL `previewUrl`,
- * so the preview modal renders it without a daemon fetch and downloads save the
- * bytes straight from the URL. Filenames use the server's `<tool-prefix>.<ext>`
- * naming; a tool that emits more than one image additionally gets an index
- * suffix so the names stay distinct (the server keeps same-named attachments
- * apart by id instead).
+ * Project a message's tool-result images into {@link DisplayAttachment}
+ * objects.
+ *
+ * Two shapes flow in. A tool-result image persisted as a workspace reference
+ * arrives as an entry in `imageAttachmentIds` — a real attachment id with no
+ * inline bytes, so the attachment carries `previewUrl: null` and the strip
+ * fetches the content by id on render (mirroring the preview modal's lazy
+ * fetch). Legacy inline base64 (`imageDataList` / the deprecated `imageData`)
+ * is embedded directly as a data-URL `previewUrl`, rendered without a daemon
+ * fetch. A daemon emits ids for referenced media and base64 for legacy rows,
+ * never both for the same image.
+ *
+ * Filenames use the server's `<tool-prefix>.<ext>` naming; a tool that emits
+ * more than one image additionally gets an index suffix so the names stay
+ * distinct (the server keeps same-named attachments apart by id instead).
+ * Referenced entries have no wire-carried MIME/size, so they default to a
+ * generic image type — the fetched blob supplies the real bytes for preview
+ * and download.
  */
 function buildToolResultAttachments(
   toolCalls: ChatMessageToolCall[],
@@ -92,21 +107,39 @@ function buildToolResultAttachments(
   const attachments: DisplayAttachment[] = [];
   let globalIndex = 0;
   for (const tc of toolCalls) {
-    const images = tc.imageDataList?.length
+    const refIds = tc.imageAttachmentIds ?? [];
+    const base64Images = tc.imageDataList?.length
       ? tc.imageDataList
       : tc.imageData
         ? [tc.imageData]
         : [];
+    const total = refIds.length + base64Images.length;
     const prefix = toolNameToFilePrefix(tc.name);
-    images.forEach((imageData, i) => {
+    let localIndex = 0;
+    const nameFor = (ext: string): string => {
+      const base = tc.name ? prefix : `image-${globalIndex}`;
+      const suffix = total > 1 ? `-${localIndex}` : "";
+      return `${base}${suffix}.${ext}`;
+    };
+    refIds.forEach((attachmentId) => {
       globalIndex += 1;
+      localIndex += 1;
+      attachments.push({
+        id: attachmentId,
+        filename: nameFor("png"),
+        mimeType: "image/png",
+        sizeBytes: 0,
+        previewUrl: null,
+      });
+    });
+    base64Images.forEach((imageData) => {
+      globalIndex += 1;
+      localIndex += 1;
       const { mimeType, base64, src } = normalizeToolResultImage(imageData);
       const ext = mimeType.split("/")[1] ?? "png";
-      const base = tc.name ? prefix : `image-${globalIndex}`;
-      const suffix = images.length > 1 ? `-${i + 1}` : "";
       attachments.push({
-        id: `tool-image:${tc.id}:${i}`,
-        filename: `${base}${suffix}.${ext}`,
+        id: `tool-image:${tc.id}:${localIndex}`,
+        filename: nameFor(ext),
         mimeType,
         sizeBytes: estimateBase64Bytes(base64),
         previewUrl: src,
@@ -115,6 +148,102 @@ function buildToolResultAttachments(
   }
   return attachments;
 }
+
+const IMAGE_CLASS =
+  "max-h-72 max-w-full rounded-md border border-[var(--border-base)] bg-[var(--surface-base)] object-contain sm:max-w-[28rem]";
+
+/**
+ * Renders the inline `<img>` for one tool-result image. An attachment with an
+ * inline `previewUrl` (legacy base64) renders straight from that data URL with
+ * no daemon round-trip — and, crucially, without depending on a React Query
+ * context. A workspace-referenced attachment (`previewUrl: null` + a real id)
+ * defers to {@link ReferencedToolResultImage}, which owns the lazy fetch.
+ */
+const ToolResultImageThumb: FC<{
+  attachment: DisplayAttachment;
+  assistantId?: string | null;
+}> = ({ attachment, assistantId }) => {
+  if (attachment.previewUrl) {
+    return (
+      <img
+        data-testid="tool-result-image"
+        src={attachment.previewUrl}
+        alt={attachment.filename}
+        className={IMAGE_CLASS}
+      />
+    );
+  }
+  return (
+    <ReferencedToolResultImage attachment={attachment} assistantId={assistantId} />
+  );
+};
+
+/**
+ * Lazily fetches a workspace-referenced tool-result image by attachment id and
+ * renders it from an object URL, revoked on unmount. Uses the same fetch/cache
+ * key as the preview modal, so opening the modal reuses the already-fetched
+ * blob. Until the fetch resolves (or when no assistant id is available to fetch
+ * with), a spinner placeholder holds the slot.
+ */
+const ReferencedToolResultImage: FC<{
+  attachment: DisplayAttachment;
+  assistantId?: string | null;
+}> = ({ attachment, assistantId }) => {
+  const shouldFetch = !!assistantId && !!attachment.id;
+
+  const { data: blob, isError } = useQuery({
+    queryKey: ["attachmentContent", assistantId, attachment.id],
+    queryFn: async () => {
+      const data = await fetchAttachmentContentBlob(
+        assistantId!,
+        attachment.id,
+      );
+      if (!data) {
+        throw new Error("Failed to load image");
+      }
+      return data;
+    },
+    enabled: shouldFetch,
+    staleTime: Infinity,
+    retry: false,
+  });
+
+  const [objectUrl, setObjectUrl] = useState<string | null>(null);
+  useEffect(() => {
+    if (!blob) {
+      setObjectUrl(null);
+      return;
+    }
+    const url = URL.createObjectURL(blob);
+    setObjectUrl(url);
+    return () => {
+      URL.revokeObjectURL(url);
+      setObjectUrl(null);
+    };
+  }, [blob]);
+
+  if (!objectUrl) {
+    return (
+      <div
+        data-testid="tool-result-image-placeholder"
+        className={`flex h-40 w-40 items-center justify-center ${IMAGE_CLASS}`}
+      >
+        {!isError && (
+          <Loader2 className="h-6 w-6 animate-spin text-[var(--content-tertiary)]" />
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <img
+      data-testid="tool-result-image"
+      src={objectUrl}
+      alt={attachment.filename}
+      className={IMAGE_CLASS}
+    />
+  );
+};
 
 interface ToolResultImagesProps {
   toolCalls: ChatMessageToolCall[];
@@ -129,8 +258,9 @@ interface ToolResultImagesProps {
  * (e.g. `file_read` on an image, generated images). Each image opens the shared
  * full-screen {@link AttachmentPreviewModal} on click and exposes a hover
  * download affordance — the same interactivity end-of-turn attachments get via
- * {@link MessageAttachmentSquare} — while the base64 payloads are not yet
- * persisted attachments with daemon ids.
+ * {@link MessageAttachmentSquare}. Referenced images (from `imageAttachmentIds`)
+ * are daemon-id-backed and fetch their bytes by id on render; legacy inline
+ * base64 images render straight from their data URL.
  */
 export const ToolResultImages: FC<ToolResultImagesProps> = ({
   toolCalls,
@@ -146,11 +276,15 @@ export const ToolResultImages: FC<ToolResultImagesProps> = ({
     attachments,
   );
 
-  const handleDownload = useCallback((att: DisplayAttachment) => {
-    // No daemon id backs these data-URL images, so download saves the
-    // `previewUrl` bytes directly (assistantId omitted skips the fetch path).
-    void downloadAttachment(att, undefined);
-  }, []);
+  const handleDownload = useCallback(
+    (att: DisplayAttachment) => {
+      // Referenced images (no inline `previewUrl`) fetch their bytes by id via
+      // the daemon content endpoint; legacy base64 images have their data URL in
+      // `previewUrl`, so downloading straight from it skips a needless fetch.
+      void downloadAttachment(att, att.previewUrl ? undefined : assistantId);
+    },
+    [assistantId],
+  );
 
   if (attachments.length === 0) {
     return null;
@@ -175,12 +309,7 @@ export const ToolResultImages: FC<ToolResultImagesProps> = ({
             }}
             className="group/toolimg relative w-fit cursor-pointer"
           >
-            <img
-              data-testid="tool-result-image"
-              src={att.previewUrl!}
-              alt={att.filename}
-              className="max-h-72 max-w-full rounded-md border border-[var(--border-base)] bg-[var(--surface-base)] object-contain sm:max-w-[28rem]"
-            />
+            <ToolResultImageThumb attachment={att} assistantId={assistantId} />
             <div className="pointer-events-none absolute inset-0 rounded-md bg-black/50 opacity-0 transition-opacity group-hover/toolimg:pointer-events-auto group-hover/toolimg:opacity-100 group-focus-within/toolimg:pointer-events-auto group-focus-within/toolimg:opacity-100">
               <Tooltip content="Download">
                 <button


### PR DESCRIPTION
## Prompt / plan

Follow-up to the ATL-991 media-reference work (PRs A/B/C, merged). Those PRs stopped serializing uploaded and tool/assistant-generated media as inline base64 in `messages.content` and persist a workspace *reference* (attachment id) instead, resolving back to base64 only at the LLM send boundary. This PR carries that principle onto the **web wire**: tool-result images that are stored as workspace references should travel to the client as an attachment **id** and be fetched by id on render, rather than being re-inlined as base64 into the history payload.

Scope is **history/reload only** — the live SSE `tool_result` event fires before the row is finalized, so it has no attachment id yet and keeps its base64 for immediate display. Web↔daemon are shipped together (the user controls their daemon version, we refresh the frontend with it), so the client keys purely off whether `imageAttachmentIds` is present with no capability gate; legacy inline-base64 history rows continue to render from their data URL.

Architectural principle: *workspace references in the DB and on the UI wire; resolve content only when it's time to render in the UI or send to the LLM.*

## Test plan

- **Daemon** (`bun test` in `assistant/`): `server-history-render.test.ts` split into two cases — a `workspace_ref` tool-result image now emits `imageAttachmentIds` (and no base64), while an inline `base64` source still resolves to `imageDataList`/`imageData` with no id. `conversation-history-web-search.test.ts` structural guard passes; assistant `tsc --noEmit` clean; media suites (`persist-media-references`, `list-messages-tool-merge`, `list-messages-attachments`, `assistant-attachments`) green.
- **Web** (`bun test` + `bun run typecheck` in `clients/web/`): new `tool-result-images.test.tsx` covers inline base64 (no daemon fetch), referenced-by-id (fetches the content endpoint, renders the object URL), the no-assistant-id placeholder (never fetches), download-by-id for referenced media, and end-of-turn suppression. Existing `transcript-message-body.test.tsx` still green after the base64 path was routed so it renders without a React Query context.

### What changed

- Added `imageAttachmentIds` to `ConversationMessageToolCallSchema` (and the daemon `HistoryResponseToolCall` twin); regenerated `assistant/openapi.yaml`. Web generated types rebuild from it at typecheck time (gitignored).
- `renderHistoryContent` (daemon `handlers/shared.ts`): a `workspace_ref` tool-result image contributes its `attachmentId` to `imageAttachmentIds` and skips the base64 resolve; a `base64` source resolves into `imageDataList` as before. An image goes to exactly one list.
- Web `tool-result-images.tsx`: `buildToolResultAttachments` projects referenced images to `previewUrl: null` + the real id; a new `ReferencedToolResultImage` lazily fetches the bytes by id (reusing the preview modal's `["attachmentContent", assistantId, id]` query key and object-URL lifecycle), while inline base64 renders straight from its data URL with no React Query dependency. Download routes referenced images through the content endpoint and base64 rows through their data URL.

<!-- CLI verb checklist section omitted: this PR adds no new routes under assistant/src/runtime/routes/. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013KcQ6J4ggzKmNUP8BnqqvB

---
_Generated by [Claude Code](https://claude.ai/code/session_013KcQ6J4ggzKmNUP8BnqqvB)_