### PR TITLE
chore(openapi): sync tool `source` description after default-owner change

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -29154,12 +29154,12 @@ paths:
       summary: List registered tools with metadata and schemas
       description:
         "Return registered tools. Without `conversationId`, returns every tool in the global registry; `tools`
-        carries per-tool metadata (description, author-asserted risk level, category, and contributing source: core,
-        skill, plugin, or MCP server) and `names`/`schemas` additionally cover skill tools whose manifests are present
-        but not yet loaded, for the permission-simulator catalog. With `conversationId`, scopes the result to the tools
-        available to that conversation as of its most recent turn (including skill/MCP tools registered over its
-        lifecycle); 404 if no such conversation is active. With `agent`, simulates the subagent tool projection for a
-        given role or resolves a live subagent's conversation."
+        carries per-tool metadata (description, author-asserted risk level, category, and contributing source: default
+        (built-in), skill, plugin, or MCP server) and `names`/`schemas` additionally cover skill tools whose manifests
+        are present but not yet loaded, for the permission-simulator catalog. With `conversationId`, scopes the result
+        to the tools available to that conversation as of its most recent turn (including skill/MCP tools registered
+        over its lifecycle); 404 if no such conversation is active. With `agent`, simulates the subagent tool projection
+        for a given role or resolves a live subagent's conversation."
       tags:
         - tools
       parameters:
@@ -29214,8 +29214,8 @@ paths:
                         source:
                           type: string
                           description:
-                            'Tool origin: "core" for built-ins, otherwise "<kind>:<id>" (e.g. "plugin:echo", "skill:my-skill",
-                            "mcp:server").'
+                            Tool origin as "<kind>:<id>" (e.g. "default:default" for built-ins, "plugin:echo", "skill:my-skill",
+                            "mcp:server").
                       required:
                         - name
                         - description


### PR DESCRIPTION
## Prompt / plan

Follow-up loose end from #37595 (merged). That PR changed the `tools_get` catalog `source` field for built-in tools from `"core"` to `"<kind>:<id>"` (i.e. `default:default`) and updated the route/field descriptions in `settings-routes.ts`, but the committed `assistant/openapi.yaml` was not regenerated, so the spec still described the old `"core"` value.

This regenerates it via `bun run generate:openapi`. The only changes are the two descriptions that drifted:
- the `tools_get` route description (`contributing source: core, skill, …` → `default (built-in), skill, …`)
- the `source` response-field description (`"core" for built-ins` → `"<kind>:<id>" … "default:default" for built-ins`)

The web client's `openapi-schemas/daemon.json` and `src/generated/**` are gitignored build artifacts derived from `assistant/openapi.yaml` (via `transform-daemon-spec.ts` + `openapi-ts`), so they regenerate downstream and need no commit here.

## Test plan

- `bun run generate:openapi` — regenerated cleanly (488 paths, 555 operations); the resulting diff is limited to the two descriptions above.
- Verified no `"core"`-for-built-ins tool-source strings remain in `assistant/openapi.yaml`.
- Generated-only, description-only change — no runtime or type surface affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014ok5MKKrM4ZnmqG3AeXWtc)_