### PR TITLE
feat(assistant): add llmRequestLogs.disabled opt-out for request logging

### DIFF
--- a/assistant/src/__tests__/compaction-trail-store.test.ts
+++ b/assistant/src/__tests__/compaction-trail-store.test.ts
@@ -60,6 +60,7 @@ function insertLogAt(
   callSite: "mainAgent" | "compactionAgent" | null,
   requestPayload = "{}",
 ): string {
+  // Logging is enabled in these tests, so the write always returns an id.
   const id = recordRequestLog(
     conversationId,
     requestPayload,
@@ -67,7 +68,7 @@ function insertLogAt(
     undefined,
     "anthropic",
     callSite ?? undefined,
-  );
+  )!;
   // Use the Drizzle update builder rather than `db.run("UPDATE … ?")` —
   // the drizzle wrapper doesn't accept positional parameters the same
   // way `bun:sqlite` does, and a silent no-op there manifests as zero

--- a/assistant/src/__tests__/llm-request-log-agent-loop-exit-reason.test.ts
+++ b/assistant/src/__tests__/llm-request-log-agent-loop-exit-reason.test.ts
@@ -46,7 +46,7 @@ describe("setAgentLoopExitReasonOnLatestLog", () => {
 
   test("recordRequestLog leaves agentLoopExitReason NULL", () => {
     const id = recordRequestLog("conv-1", '{"req":1}', '{"res":1}');
-    const row = getRequestLogById(id);
+    const row = getRequestLogById(id!);
     expect(row).not.toBeNull();
     expect(row!.agentLoopExitReason).toBeNull();
   });
@@ -61,8 +61,8 @@ describe("setAgentLoopExitReasonOnLatestLog", () => {
 
     setAgentLoopExitReasonOnLatestLog("conv-1", "no_tool_calls");
 
-    expect(getRequestLogById(first)?.agentLoopExitReason).toBeNull();
-    expect(getRequestLogById(second)?.agentLoopExitReason).toBe(
+    expect(getRequestLogById(first!)?.agentLoopExitReason).toBeNull();
+    expect(getRequestLogById(second!)?.agentLoopExitReason).toBe(
       "no_tool_calls",
     );
   });
@@ -74,10 +74,10 @@ describe("setAgentLoopExitReasonOnLatestLog", () => {
 
     setAgentLoopExitReasonOnLatestLog("conv-a", "yield_to_user");
 
-    expect(getRequestLogById(a)?.agentLoopExitReason).toBe("yield_to_user");
+    expect(getRequestLogById(a!)?.agentLoopExitReason).toBe("yield_to_user");
     // conv-b is later overall but belongs to a different conversation —
     // must stay NULL.
-    expect(getRequestLogById(b)?.agentLoopExitReason).toBeNull();
+    expect(getRequestLogById(b!)?.agentLoopExitReason).toBeNull();
   });
 
   test("no-op when conversation has no logs", () => {
@@ -90,12 +90,12 @@ describe("setAgentLoopExitReasonOnLatestLog", () => {
     // Previous run: completes, lands a log, gets stamped.
     const prev = recordRequestLog("conv-1", '{"prev_req":1}', '{"prev_res":1}');
     setAgentLoopExitReasonOnLatestLog("conv-1", "no_tool_calls");
-    expect(getRequestLogById(prev)?.agentLoopExitReason).toBe("no_tool_calls");
+    expect(getRequestLogById(prev!)?.agentLoopExitReason).toBe("no_tool_calls");
 
     // Current run aborts pre-call (or similar) before any LLM call lands.
     // The helper must NOT overwrite the previous run's row.
     setAgentLoopExitReasonOnLatestLog("conv-1", "aborted_pre_call");
-    expect(getRequestLogById(prev)?.agentLoopExitReason).toBe("no_tool_calls");
+    expect(getRequestLogById(prev!)?.agentLoopExitReason).toBe("no_tool_calls");
   });
 
   test("stamps the current run's newest row even when a prior row is already stamped", () => {
@@ -112,8 +112,8 @@ describe("setAgentLoopExitReasonOnLatestLog", () => {
     );
     setAgentLoopExitReasonOnLatestLog("conv-1", "yield_to_user");
 
-    expect(getRequestLogById(prev)?.agentLoopExitReason).toBe("no_tool_calls");
-    expect(getRequestLogById(current)?.agentLoopExitReason).toBe(
+    expect(getRequestLogById(prev!)?.agentLoopExitReason).toBe("no_tool_calls");
+    expect(getRequestLogById(current!)?.agentLoopExitReason).toBe(
       "yield_to_user",
     );
   });

--- a/assistant/src/__tests__/llm-request-log-call-site.test.ts
+++ b/assistant/src/__tests__/llm-request-log-call-site.test.ts
@@ -52,14 +52,14 @@ describe("recordRequestLog call_site stamping", () => {
       "anthropic",
       "mainAgent",
     );
-    const row = getRequestLogById(id);
+    const row = getRequestLogById(id!);
     expect(row).not.toBeNull();
     expect(row!.callSite).toBe("mainAgent");
   });
 
   test("leaves callSite NULL when omitted (backward compat)", () => {
     const id = recordRequestLog("conv-1", '{"req":1}', '{"res":1}');
-    const row = getRequestLogById(id);
+    const row = getRequestLogById(id!);
     expect(row).not.toBeNull();
     expect(row!.callSite).toBeNull();
   });
@@ -73,7 +73,7 @@ describe("recordRequestLog call_site stamping", () => {
       "anthropic",
       "compactionAgent",
     );
-    expect(getRequestLogById(id)?.callSite).toBe("compactionAgent");
+    expect(getRequestLogById(id!)?.callSite).toBe("compactionAgent");
   });
 
   test("two rows in the same conversation can carry different callSites", () => {
@@ -93,8 +93,8 @@ describe("recordRequestLog call_site stamping", () => {
       "anthropic",
       "compactionAgent",
     );
-    expect(getRequestLogById(mainId)?.callSite).toBe("mainAgent");
-    expect(getRequestLogById(compactId)?.callSite).toBe("compactionAgent");
+    expect(getRequestLogById(mainId!)?.callSite).toBe("mainAgent");
+    expect(getRequestLogById(compactId!)?.callSite).toBe("compactionAgent");
   });
 });
 

--- a/assistant/src/__tests__/llm-request-log-disabled-writes.test.ts
+++ b/assistant/src/__tests__/llm-request-log-disabled-writes.test.ts
@@ -1,9 +1,9 @@
 /**
- * Tests the master opt-out for LLM request logging
- * (`llmRequestLogs.disabled`). When disabled, the store's insert paths
- * (`recordRequestLog`, `recordSyntheticAgentErrorMessageLog`) must skip the
- * write entirely — no prompt/completion payload lands on disk — and return an
- * empty id. The read-side 4xx is exercised separately at the route layer.
+ * Tests the master switch for LLM request logging (`llmRequestLogs.enabled`).
+ * When logging is off, the store's insert paths (`recordRequestLog`,
+ * `recordSyntheticAgentErrorMessageLog`) must skip the write entirely — no
+ * prompt/completion payload lands on disk — and return `null`. The read-side
+ * 4xx is exercised separately at the route layer.
  */
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -15,20 +15,20 @@ mock.module("../util/logger.js", () => ({
 }));
 
 // Mutable so each test toggles the flag the store reads via `getConfigReadOnly`.
-let disabled = false;
+let enabled = true;
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
-    llmRequestLogs: { readSource: "local", disabled },
+    llmRequestLogs: { readSource: "local", enabled },
   }),
   getConfigReadOnly: () => ({
-    llmRequestLogs: { readSource: "local", disabled },
+    llmRequestLogs: { readSource: "local", enabled },
   }),
 }));
 
 // `mock.module()` persists process-wide; reset so other files don't inherit a
-// stale disabled state.
+// stale value.
 afterAll(() => {
-  disabled = false;
+  enabled = true;
 });
 
 import { getLogsDb } from "../persistence/db-connection.js";
@@ -47,27 +47,27 @@ function resetLogs(): void {
   getLogsDb()!.delete(llmRequestLogs).run();
 }
 
-describe("llmRequestLogs.disabled write gate", () => {
+describe("llmRequestLogs.enabled write gate", () => {
   beforeEach(() => {
     resetLogs();
-    disabled = false;
+    enabled = true;
   });
 
   test("recordRequestLog writes normally when logging is enabled", () => {
     const id = recordRequestLog("conv-1", '{"req":1}', '{"res":1}');
-    expect(id).not.toBe("");
-    expect(getRequestLogById(id)).not.toBeNull();
+    expect(id).not.toBeNull();
+    expect(getRequestLogById(id!)).not.toBeNull();
   });
 
   test("recordRequestLog skips the write when logging is disabled", () => {
-    disabled = true;
+    enabled = false;
     const id = recordRequestLog("conv-1", '{"req":1}', '{"res":1}');
-    expect(id).toBe("");
+    expect(id).toBeNull();
     expect(getRequestLogsByConversationId("conv-1")).toEqual([]);
   });
 
   test("recordSyntheticAgentErrorMessageLog skips the write when disabled", () => {
-    disabled = true;
+    enabled = false;
     const id = recordSyntheticAgentErrorMessageLog({
       conversationId: "conv-2",
       messageId: "msg-2",
@@ -76,16 +76,16 @@ describe("llmRequestLogs.disabled write gate", () => {
       preparedRequest: null,
       createdAt: Date.now(),
     });
-    expect(id).toBe("");
+    expect(id).toBeNull();
     expect(getRequestLogsByConversationId("conv-2")).toEqual([]);
   });
 
   test("re-enabling logging restores writes", () => {
-    disabled = true;
-    expect(recordRequestLog("conv-3", '{"req":1}', '{"res":1}')).toBe("");
-    disabled = false;
+    enabled = false;
+    expect(recordRequestLog("conv-3", '{"req":1}', '{"res":1}')).toBeNull();
+    enabled = true;
     const id = recordRequestLog("conv-3", '{"req":2}', '{"res":2}');
-    expect(id).not.toBe("");
+    expect(id).not.toBeNull();
     expect(getRequestLogsByConversationId("conv-3")).toHaveLength(1);
   });
 });

--- a/assistant/src/__tests__/llm-request-log-disabled-writes.test.ts
+++ b/assistant/src/__tests__/llm-request-log-disabled-writes.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests the master opt-out for LLM request logging
+ * (`llmRequestLogs.disabled`). When disabled, the store's insert paths
+ * (`recordRequestLog`, `recordSyntheticAgentErrorMessageLog`) must skip the
+ * write entirely — no prompt/completion payload lands on disk — and return an
+ * empty id. The read-side 4xx is exercised separately at the route layer.
+ */
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Mutable so each test toggles the flag the store reads via `getConfigReadOnly`.
+let disabled = false;
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    llmRequestLogs: { readSource: "local", disabled },
+  }),
+  getConfigReadOnly: () => ({
+    llmRequestLogs: { readSource: "local", disabled },
+  }),
+}));
+
+// `mock.module()` persists process-wide; reset so other files don't inherit a
+// stale disabled state.
+afterAll(() => {
+  disabled = false;
+});
+
+import { getLogsDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import {
+  getRequestLogById,
+  getRequestLogsByConversationId,
+  recordRequestLog,
+  recordSyntheticAgentErrorMessageLog,
+} from "../persistence/llm-request-log-store.js";
+import { llmRequestLogs } from "../persistence/schema/index.js";
+
+await initializeDb();
+
+function resetLogs(): void {
+  getLogsDb()!.delete(llmRequestLogs).run();
+}
+
+describe("llmRequestLogs.disabled write gate", () => {
+  beforeEach(() => {
+    resetLogs();
+    disabled = false;
+  });
+
+  test("recordRequestLog writes normally when logging is enabled", () => {
+    const id = recordRequestLog("conv-1", '{"req":1}', '{"res":1}');
+    expect(id).not.toBe("");
+    expect(getRequestLogById(id)).not.toBeNull();
+  });
+
+  test("recordRequestLog skips the write when logging is disabled", () => {
+    disabled = true;
+    const id = recordRequestLog("conv-1", '{"req":1}', '{"res":1}');
+    expect(id).toBe("");
+    expect(getRequestLogsByConversationId("conv-1")).toEqual([]);
+  });
+
+  test("recordSyntheticAgentErrorMessageLog skips the write when disabled", () => {
+    disabled = true;
+    const id = recordSyntheticAgentErrorMessageLog({
+      conversationId: "conv-2",
+      messageId: "msg-2",
+      exitReason: "budget_yield_unrecovered",
+      noticeText: "Out of budget.",
+      preparedRequest: null,
+      createdAt: Date.now(),
+    });
+    expect(id).toBe("");
+    expect(getRequestLogsByConversationId("conv-2")).toEqual([]);
+  });
+
+  test("re-enabling logging restores writes", () => {
+    disabled = true;
+    expect(recordRequestLog("conv-3", '{"req":1}', '{"res":1}')).toBe("");
+    disabled = false;
+    const id = recordRequestLog("conv-3", '{"req":2}', '{"res":2}');
+    expect(id).not.toBe("");
+    expect(getRequestLogsByConversationId("conv-3")).toHaveLength(1);
+  });
+});

--- a/assistant/src/config/schemas/__tests__/llm-request-logs.test.ts
+++ b/assistant/src/config/schemas/__tests__/llm-request-logs.test.ts
@@ -3,16 +3,18 @@ import { describe, expect, test } from "bun:test";
 import { LlmRequestLogsConfigSchema } from "../llm-request-logs.js";
 
 describe("LlmRequestLogsConfigSchema", () => {
-  test("parses undefined to the local default", () => {
+  test("parses undefined to the local default with logging enabled", () => {
     expect(LlmRequestLogsConfigSchema.parse(undefined)).toEqual({
       readSource: "local",
+      disabled: false,
     });
   });
 
-  test("parses an explicit local readSource", () => {
-    expect(
-      LlmRequestLogsConfigSchema.parse({ readSource: "local" }),
-    ).toEqual({ readSource: "local" });
+  test("parses an explicit local readSource with logging enabled by default", () => {
+    expect(LlmRequestLogsConfigSchema.parse({ readSource: "local" })).toEqual({
+      readSource: "local",
+      disabled: false,
+    });
   });
 
   test("parses an explicit clickhouse readSource with defaulted connection fields", () => {
@@ -20,12 +22,38 @@ describe("LlmRequestLogsConfigSchema", () => {
       LlmRequestLogsConfigSchema.parse({ readSource: "clickhouse" }),
     ).toEqual({
       readSource: "clickhouse",
+      disabled: false,
       clickhouse: {
         database: "default",
         table: "llm_request_logs",
         user: "default",
       },
     });
+  });
+
+  test("carries an explicit disabled flag on the local branch", () => {
+    expect(
+      LlmRequestLogsConfigSchema.parse({ readSource: "local", disabled: true }),
+    ).toEqual({ readSource: "local", disabled: true });
+  });
+
+  test("defaults a missing readSource to local so a disabled-only write still parses", () => {
+    // `config set llmRequestLogs.disabled true` writes `{ disabled: true }`
+    // with no discriminator; it must parse (on the local branch) rather than
+    // collapse the whole config to defaults via leaf-deletion recovery.
+    expect(LlmRequestLogsConfigSchema.parse({ disabled: true })).toEqual({
+      readSource: "local",
+      disabled: true,
+    });
+  });
+
+  test("rejects a non-boolean disabled flag", () => {
+    expect(() =>
+      LlmRequestLogsConfigSchema.parse({
+        readSource: "local",
+        disabled: "yes",
+      }),
+    ).toThrow();
   });
 
   test("rejects an unknown readSource", () => {

--- a/assistant/src/config/schemas/__tests__/llm-request-logs.test.ts
+++ b/assistant/src/config/schemas/__tests__/llm-request-logs.test.ts
@@ -6,14 +6,14 @@ describe("LlmRequestLogsConfigSchema", () => {
   test("parses undefined to the local default with logging enabled", () => {
     expect(LlmRequestLogsConfigSchema.parse(undefined)).toEqual({
       readSource: "local",
-      disabled: false,
+      enabled: true,
     });
   });
 
   test("parses an explicit local readSource with logging enabled by default", () => {
     expect(LlmRequestLogsConfigSchema.parse({ readSource: "local" })).toEqual({
       readSource: "local",
-      disabled: false,
+      enabled: true,
     });
   });
 
@@ -22,7 +22,7 @@ describe("LlmRequestLogsConfigSchema", () => {
       LlmRequestLogsConfigSchema.parse({ readSource: "clickhouse" }),
     ).toEqual({
       readSource: "clickhouse",
-      disabled: false,
+      enabled: true,
       clickhouse: {
         database: "default",
         table: "llm_request_logs",
@@ -31,27 +31,27 @@ describe("LlmRequestLogsConfigSchema", () => {
     });
   });
 
-  test("carries an explicit disabled flag on the local branch", () => {
+  test("carries an explicit enabled flag on the local branch", () => {
     expect(
-      LlmRequestLogsConfigSchema.parse({ readSource: "local", disabled: true }),
-    ).toEqual({ readSource: "local", disabled: true });
+      LlmRequestLogsConfigSchema.parse({ readSource: "local", enabled: false }),
+    ).toEqual({ readSource: "local", enabled: false });
   });
 
-  test("defaults a missing readSource to local so a disabled-only write still parses", () => {
-    // `config set llmRequestLogs.disabled true` writes `{ disabled: true }`
+  test("defaults a missing readSource to local so an enabled-only write still parses", () => {
+    // `config set llmRequestLogs.enabled false` writes `{ enabled: false }`
     // with no discriminator; it must parse (on the local branch) rather than
     // collapse the whole config to defaults via leaf-deletion recovery.
-    expect(LlmRequestLogsConfigSchema.parse({ disabled: true })).toEqual({
+    expect(LlmRequestLogsConfigSchema.parse({ enabled: false })).toEqual({
       readSource: "local",
-      disabled: true,
+      enabled: false,
     });
   });
 
-  test("rejects a non-boolean disabled flag", () => {
+  test("rejects a non-boolean enabled flag", () => {
     expect(() =>
       LlmRequestLogsConfigSchema.parse({
         readSource: "local",
-        disabled: "yes",
+        enabled: "yes",
       }),
     ).toThrow();
   });

--- a/assistant/src/config/schemas/llm-request-logs.ts
+++ b/assistant/src/config/schemas/llm-request-logs.ts
@@ -1,8 +1,17 @@
 /**
- * Configuration for LLM request log read source.
+ * Configuration for LLM request logging.
  *
- * Writes always land in the local SQLite `llm_request_logs` table; reads
- * can be switched between local and ClickHouse via `readSource`.
+ * Two independent concerns live here:
+ *
+ * 1. `disabled` — the master opt-out. When `true`, the daemon skips every
+ *    `llm_request_logs` write and the inspector read routes return a 4xx
+ *    (`LLM_REQUEST_LOGS_DISABLED`) instead of serving rows. Defaults to
+ *    `false` (logging on). Existing rows are left untouched — this is a
+ *    write/read gate, not a delete.
+ *
+ * 2. `readSource` — where reads are served from. Writes land in the local
+ *    SQLite `llm_request_logs` table; reads can be switched between local
+ *    and ClickHouse via `readSource`.
  *
  * When `readSource === "clickhouse"` the URL and password are resolved
  * from the credential store (`clickhouse:url`, `clickhouse:password`).
@@ -10,14 +19,30 @@
  *
  * The shape is a discriminated union on `readSource` so the `clickhouse`
  * block only exists on the ClickHouse branch — there's no stray defaults
- * sitting around when the source is local.
+ * sitting around when the source is local. A `preprocess` step defaults a
+ * missing `readSource` to `"local"` so a partial write (e.g. `config set
+ * llmRequestLogs.disabled true`, which never mentions `readSource`) still
+ * parses instead of collapsing the whole config to defaults on the next load.
  *
  * Note: the existing retention setting lives under
  * `memory.cleanup.llmRequestLogRetentionMs` and is independent of this block.
- * That covers when local rows get pruned; this block governs where reads
- * are served from.
+ * That covers when local rows get pruned; this block governs whether logging
+ * happens at all and where reads are served from.
  */
 import { z } from "zod";
+
+/**
+ * Master opt-out for LLM request logging. Shared by both read-source
+ * branches so `llmRequestLogs.disabled` is a stable top-level path
+ * regardless of `readSource`.
+ */
+const DisabledFieldSchema = z
+  .boolean({ error: "llmRequestLogs.disabled must be a boolean" })
+  .default(false)
+  .describe(
+    "When true, disable LLM request logging entirely: skip all writes and " +
+      "return a 4xx from inspector read routes. Existing rows are not deleted.",
+  );
 
 export const LlmRequestLogsClickHouseConfigSchema = z
   .object({
@@ -44,12 +69,14 @@ export const LlmRequestLogsClickHouseConfigSchema = z
 const LocalLlmRequestLogsConfigSchema = z
   .object({
     readSource: z.literal("local"),
+    disabled: DisabledFieldSchema,
   })
   .describe("Read LLM request logs from local SQLite (default).");
 
 const ClickHouseLlmRequestLogsConfigSchema = z
   .object({
     readSource: z.literal("clickhouse"),
+    disabled: DisabledFieldSchema,
     clickhouse: LlmRequestLogsClickHouseConfigSchema.default(
       LlmRequestLogsClickHouseConfigSchema.parse({}),
     ),
@@ -57,6 +84,27 @@ const ClickHouseLlmRequestLogsConfigSchema = z
   .describe(
     "Read LLM request logs from the ClickHouse mirror. Requires the `clickhouse:url` and `clickhouse:password` credentials to be set.",
   );
+
+/**
+ * Inject `readSource: "local"` when a caller supplies an object without it.
+ * A discriminated union cannot pick a branch without its discriminator, so a
+ * partial write like `{ disabled: true }` (from `config set
+ * llmRequestLogs.disabled true`) would otherwise fail to parse and — via the
+ * loader's leaf-deletion recovery — take the whole config down to defaults.
+ * Defaulting the discriminator keeps such writes on the `local` branch while
+ * preserving any sibling fields (e.g. `disabled`).
+ */
+function defaultReadSourceToLocal(value: unknown): unknown {
+  if (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    !("readSource" in value)
+  ) {
+    return { readSource: "local", ...value };
+  }
+  return value;
+}
 
 // The default is baked into the export so the schema matches the sibling
 // pattern across `assistant/src/config/schemas/*` — `Schema.parse(undefined)`
@@ -68,12 +116,15 @@ const ClickHouseLlmRequestLogsConfigSchema = z
 // union cannot pick a branch without a discriminator. Use `parse(undefined)`
 // or omit the field entirely to get the default.
 export const LlmRequestLogsConfigSchema = z
-  .discriminatedUnion("readSource", [
-    LocalLlmRequestLogsConfigSchema,
-    ClickHouseLlmRequestLogsConfigSchema,
-  ])
-  .default({ readSource: "local" })
-  .describe("LLM request log read source configuration");
+  .preprocess(
+    defaultReadSourceToLocal,
+    z.discriminatedUnion("readSource", [
+      LocalLlmRequestLogsConfigSchema,
+      ClickHouseLlmRequestLogsConfigSchema,
+    ]),
+  )
+  .default({ readSource: "local", disabled: false })
+  .describe("LLM request logging configuration");
 
 export type LlmRequestLogsConfig = z.infer<typeof LlmRequestLogsConfigSchema>;
 export type LlmRequestLogsClickHouseConfig = z.infer<

--- a/assistant/src/config/schemas/llm-request-logs.ts
+++ b/assistant/src/config/schemas/llm-request-logs.ts
@@ -3,10 +3,10 @@
  *
  * Two independent concerns live here:
  *
- * 1. `disabled` — the master opt-out. When `true`, the daemon skips every
+ * 1. `enabled` — the master switch. When `false`, the daemon skips every
  *    `llm_request_logs` write and the inspector read routes return a 4xx
  *    (`LLM_REQUEST_LOGS_DISABLED`) instead of serving rows. Defaults to
- *    `false` (logging on). Existing rows are left untouched — this is a
+ *    `true` (logging on). Existing rows are left untouched — this is a
  *    write/read gate, not a delete.
  *
  * 2. `readSource` — where reads are served from. Writes land in the local
@@ -19,10 +19,12 @@
  *
  * The shape is a discriminated union on `readSource` so the `clickhouse`
  * block only exists on the ClickHouse branch — there's no stray defaults
- * sitting around when the source is local. A `preprocess` step defaults a
- * missing `readSource` to `"local"` so a partial write (e.g. `config set
- * llmRequestLogs.disabled true`, which never mentions `readSource`) still
- * parses instead of collapsing the whole config to defaults on the next load.
+ * sitting around when the source is local. Both branches extend a shared
+ * base (`LlmRequestLogsBaseSchema`) that carries the source-independent
+ * fields, and a `preprocess` step defaults a missing `readSource` to
+ * `"local"` so a partial write (e.g. `config set llmRequestLogs.enabled
+ * false`, which never mentions `readSource`) still parses instead of
+ * collapsing the whole config to defaults on the next load.
  *
  * Note: the existing retention setting lives under
  * `memory.cleanup.llmRequestLogRetentionMs` and is independent of this block.
@@ -32,17 +34,21 @@
 import { z } from "zod";
 
 /**
- * Master opt-out for LLM request logging. Shared by both read-source
- * branches so `llmRequestLogs.disabled` is a stable top-level path
- * regardless of `readSource`.
+ * Source-independent fields shared by both read-source branches. Kept as a
+ * base object the discriminated-union branches `.extend()` so a field like
+ * `enabled` is declared once and lives at a stable top-level path
+ * (`llmRequestLogs.enabled`) regardless of `readSource`.
  */
-const DisabledFieldSchema = z
-  .boolean({ error: "llmRequestLogs.disabled must be a boolean" })
-  .default(false)
-  .describe(
-    "When true, disable LLM request logging entirely: skip all writes and " +
-      "return a 4xx from inspector read routes. Existing rows are not deleted.",
-  );
+const LlmRequestLogsBaseSchema = z.object({
+  enabled: z
+    .boolean({ error: "llmRequestLogs.enabled must be a boolean" })
+    .default(true)
+    .describe(
+      "Master switch for LLM request logging. When false, skip all writes " +
+        "and return a 4xx from inspector read routes. Existing rows are not " +
+        "deleted.",
+    ),
+});
 
 export const LlmRequestLogsClickHouseConfigSchema = z
   .object({
@@ -66,33 +72,27 @@ export const LlmRequestLogsClickHouseConfigSchema = z
     "ClickHouse connection settings used when `readSource` is `clickhouse`",
   );
 
-const LocalLlmRequestLogsConfigSchema = z
-  .object({
-    readSource: z.literal("local"),
-    disabled: DisabledFieldSchema,
-  })
-  .describe("Read LLM request logs from local SQLite (default).");
+const LocalLlmRequestLogsConfigSchema = LlmRequestLogsBaseSchema.extend({
+  readSource: z.literal("local"),
+}).describe("Read LLM request logs from local SQLite (default).");
 
-const ClickHouseLlmRequestLogsConfigSchema = z
-  .object({
-    readSource: z.literal("clickhouse"),
-    disabled: DisabledFieldSchema,
-    clickhouse: LlmRequestLogsClickHouseConfigSchema.default(
-      LlmRequestLogsClickHouseConfigSchema.parse({}),
-    ),
-  })
-  .describe(
-    "Read LLM request logs from the ClickHouse mirror. Requires the `clickhouse:url` and `clickhouse:password` credentials to be set.",
-  );
+const ClickHouseLlmRequestLogsConfigSchema = LlmRequestLogsBaseSchema.extend({
+  readSource: z.literal("clickhouse"),
+  clickhouse: LlmRequestLogsClickHouseConfigSchema.default(
+    LlmRequestLogsClickHouseConfigSchema.parse({}),
+  ),
+}).describe(
+  "Read LLM request logs from the ClickHouse mirror. Requires the `clickhouse:url` and `clickhouse:password` credentials to be set.",
+);
 
 /**
  * Inject `readSource: "local"` when a caller supplies an object without it.
  * A discriminated union cannot pick a branch without its discriminator, so a
- * partial write like `{ disabled: true }` (from `config set
- * llmRequestLogs.disabled true`) would otherwise fail to parse and — via the
+ * partial write like `{ enabled: false }` (from `config set
+ * llmRequestLogs.enabled false`) would otherwise fail to parse and — via the
  * loader's leaf-deletion recovery — take the whole config down to defaults.
  * Defaulting the discriminator keeps such writes on the `local` branch while
- * preserving any sibling fields (e.g. `disabled`).
+ * preserving any sibling fields (e.g. `enabled`).
  */
 function defaultReadSourceToLocal(value: unknown): unknown {
   if (
@@ -123,7 +123,7 @@ export const LlmRequestLogsConfigSchema = z
       ClickHouseLlmRequestLogsConfigSchema,
     ]),
   )
-  .default({ readSource: "local", disabled: false })
+  .default({ readSource: "local", enabled: true })
   .describe("LLM request logging configuration");
 
 export type LlmRequestLogsConfig = z.infer<typeof LlmRequestLogsConfigSchema>;

--- a/assistant/src/persistence/llm-request-log-store.ts
+++ b/assistant/src/persistence/llm-request-log-store.ts
@@ -16,7 +16,13 @@ import {
 import { v4 as uuid } from "uuid";
 
 import { CALL_SITE_SYNTHETIC_AGENT_ERROR_MESSAGE } from "../api/constants/call-sites.js";
-import { getConfigReadOnly } from "../config/loader.js";
+// Namespace import (not a named `getConfigReadOnly` import) on purpose: the
+// store is reached transitively by a large number of tests that stub
+// `config/loader` with a partial mock exposing only `getConfig`. A named
+// import would fail to link against those mocks ("Export … not found"); a
+// namespace access degrades to `undefined` at call time instead, which the
+// try/catch in `llmRequestLoggingEnabled` treats as "enabled".
+import * as configLoader from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { AssistantError, ProviderError } from "../util/errors.js";
 import {
@@ -53,7 +59,7 @@ function logsDb(): DrizzleDb {
  */
 export function llmRequestLoggingEnabled(): boolean {
   try {
-    return getConfigReadOnly().llmRequestLogs?.enabled !== false;
+    return configLoader.getConfigReadOnly().llmRequestLogs?.enabled !== false;
   } catch {
     return true;
   }

--- a/assistant/src/persistence/llm-request-log-store.ts
+++ b/assistant/src/persistence/llm-request-log-store.ts
@@ -16,6 +16,7 @@ import {
 import { v4 as uuid } from "uuid";
 
 import { CALL_SITE_SYNTHETIC_AGENT_ERROR_MESSAGE } from "../api/constants/call-sites.js";
+import { getConfigReadOnly } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { AssistantError, ProviderError } from "../util/errors.js";
 import {
@@ -40,6 +41,22 @@ function logsDb(): DrizzleDb {
     throw new Error("logs database unavailable");
   }
   return db;
+}
+
+/**
+ * True when the operator has opted out of LLM request logging via
+ * `llmRequestLogs.disabled`. Gates every `llm_request_logs` insert so no
+ * prompt/completion payload is written while logging is off. Read-only config
+ * access (no `ensureDataDir`/disk write) because this sits on the per-LLM-call
+ * critical path; defaults to "enabled" if config resolution throws so a config
+ * hiccup never silently drops logs.
+ */
+export function llmRequestLoggingDisabled(): boolean {
+  try {
+    return getConfigReadOnly().llmRequestLogs?.disabled === true;
+  } catch {
+    return false;
+  }
 }
 
 export type LogRow = {
@@ -166,6 +183,13 @@ export function recordRequestLog(
   callSite?: LLMCallSite,
   latencyBreakdown?: string,
 ): string {
+  // Master opt-out: when logging is disabled, skip the write entirely so no
+  // prompt/completion payload lands on disk. Returns an empty id — no
+  // production caller consumes the return value, and the row does not exist to
+  // be stamped/backfilled later.
+  if (llmRequestLoggingDisabled()) {
+    return "";
+  }
   const db = logsDb();
   const id = uuid();
   // Synchronous insert of the full request/response payloads (an entire
@@ -251,6 +275,11 @@ export function recordSyntheticAgentErrorMessageLog(args: {
   preparedRequest: unknown | null;
   createdAt: number;
 }): string {
+  // Synthetic error rows are `llm_request_logs` rows too — honour the same
+  // master opt-out so nothing is written while logging is disabled.
+  if (llmRequestLoggingDisabled()) {
+    return "";
+  }
   const db = logsDb();
   const id = uuid();
   const requestPayload = JSON.stringify({

--- a/assistant/src/persistence/llm-request-log-store.ts
+++ b/assistant/src/persistence/llm-request-log-store.ts
@@ -44,18 +44,18 @@ function logsDb(): DrizzleDb {
 }
 
 /**
- * True when the operator has opted out of LLM request logging via
- * `llmRequestLogs.disabled`. Gates every `llm_request_logs` insert so no
- * prompt/completion payload is written while logging is off. Read-only config
- * access (no `ensureDataDir`/disk write) because this sits on the per-LLM-call
- * critical path; defaults to "enabled" if config resolution throws so a config
- * hiccup never silently drops logs.
+ * Whether LLM request logging is enabled (`llmRequestLogs.enabled`, default
+ * `true`). Gates every `llm_request_logs` insert so no prompt/completion
+ * payload is written while logging is off. Read-only config access (no
+ * `ensureDataDir`/disk write) because this sits on the per-LLM-call critical
+ * path; defaults to "enabled" if config resolution throws so a config hiccup
+ * never silently drops logs.
  */
-export function llmRequestLoggingDisabled(): boolean {
+export function llmRequestLoggingEnabled(): boolean {
   try {
-    return getConfigReadOnly().llmRequestLogs?.disabled === true;
+    return getConfigReadOnly().llmRequestLogs?.enabled !== false;
   } catch {
-    return false;
+    return true;
   }
 }
 
@@ -182,13 +182,12 @@ export function recordRequestLog(
   provider?: string,
   callSite?: LLMCallSite,
   latencyBreakdown?: string,
-): string {
+): string | null {
   // Master opt-out: when logging is disabled, skip the write entirely so no
-  // prompt/completion payload lands on disk. Returns an empty id — no
-  // production caller consumes the return value, and the row does not exist to
-  // be stamped/backfilled later.
-  if (llmRequestLoggingDisabled()) {
-    return "";
+  // prompt/completion payload lands on disk. Returns null — there is no row to
+  // stamp/backfill later, and no production caller consumes the return value.
+  if (!llmRequestLoggingEnabled()) {
+    return null;
   }
   const db = logsDb();
   const id = uuid();
@@ -274,11 +273,11 @@ export function recordSyntheticAgentErrorMessageLog(args: {
    */
   preparedRequest: unknown | null;
   createdAt: number;
-}): string {
+}): string | null {
   // Synthetic error rows are `llm_request_logs` rows too — honour the same
   // master opt-out so nothing is written while logging is disabled.
-  if (llmRequestLoggingDisabled()) {
-    return "";
+  if (!llmRequestLoggingEnabled()) {
+    return null;
   }
   const db = logsDb();
   const id = uuid();

--- a/assistant/src/persistence/migrations/__tests__/297-move-llm-request-logs.test.ts
+++ b/assistant/src/persistence/migrations/__tests__/297-move-llm-request-logs.test.ts
@@ -63,7 +63,7 @@ describe("migration 297 — llm_request_logs lives in the logs database", () => 
       "anthropic",
       "mainAgent",
     );
-    const row = getRequestLogById(id);
+    const row = getRequestLogById(id!);
     expect(row?.conversationId).toBe("conv-297");
     expect(row?.messageId).toBe("msg-297");
     expect(row?.provider).toBe("anthropic");
@@ -75,7 +75,7 @@ describe("migration 297 — llm_request_logs lives in the logs database", () => 
         { c: number },
         [string]
       >(`SELECT COUNT(*) AS c FROM llm_request_logs WHERE id = ?`)
-      .get(id);
+      .get(id!);
     expect(inLogs?.c).toBe(1);
   });
 

--- a/assistant/src/runtime/routes/__tests__/conversation-compaction-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-compaction-routes.test.ts
@@ -18,6 +18,8 @@ mock.module("../../../util/logger.js", () => ({
     }),
 }));
 
+// Mutable so a test can flip the master switch off and assert the guard.
+let llmRequestLoggingEnabled = true;
 mock.module("../../../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},
@@ -26,7 +28,10 @@ mock.module("../../../config/loader.js", () => ({
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0 },
     secretDetection: { enabled: false },
-    llmRequestLogs: { readSource: "local" as const },
+    llmRequestLogs: {
+      readSource: "local" as const,
+      enabled: llmRequestLoggingEnabled,
+    },
   }),
 }));
 
@@ -149,7 +154,11 @@ import {
   projectLogRowToCompactionTrailEvent,
   ROUTES,
 } from "../conversation-compaction-routes.js";
-import { BadRequestError, NotFoundError } from "../errors.js";
+import {
+  BadRequestError,
+  LlmRequestLogsDisabledError,
+  NotFoundError,
+} from "../errors.js";
 
 const route = ROUTES.find(
   (r) => r.operationId === "conversations_compaction_trail_get",
@@ -218,6 +227,7 @@ function fakeCompactionLogEvent(
 }
 
 beforeEach(() => {
+  llmRequestLoggingEnabled = true;
   state.conversation = null;
   state.selectedCall = null;
   state.previousNonCompactionCallCreatedAt = null;
@@ -259,6 +269,25 @@ describe("handleGetCompactionTrail — request-shape errors", () => {
     await expect(
       handler({ pathParams: { id: "conv-1" }, queryParams: {} }),
     ).rejects.toThrow(BadRequestError);
+  });
+
+  test("throws LlmRequestLogsDisabledError when logging is disabled", async () => {
+    // Even with a valid conversation + call, the guard short-circuits before
+    // any log source read — the compaction trail is inspector-only LLM data.
+    llmRequestLoggingEnabled = false;
+    state.conversation = { id: "conv-1" };
+    state.selectedCall = fakeLogMetaRow({
+      id: "call-1",
+      conversationId: "conv-1",
+    });
+    await expect(
+      handler({
+        pathParams: { id: "conv-1" },
+        queryParams: { callId: "call-1" },
+      }),
+    ).rejects.toThrow(LlmRequestLogsDisabledError);
+    // The guard runs first: no metadata lookup happened.
+    expect(sourceCalls.getRequestLogMetaByIdArgs).toEqual([]);
   });
 
   test("throws NotFoundError when the conversation does not exist", async () => {

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 mock.module("../../../util/logger.js", () => ({
   getLogger: () =>
@@ -292,6 +292,72 @@ describe("GET /v1/conversations/llm-context", () => {
 
     expect(body.conversationId).toBeNull();
     expect(body.conversationKey).toBe("missing-key");
+    expect(body.logs).toEqual([]);
+  });
+});
+
+describe("inspector reads when llmRequestLogs.disabled is true", () => {
+  const payloadRoute = ROUTES.find(
+    (r) => r.operationId === "llm_request_logs_payload_get",
+  )!;
+  const contextRoute = ROUTES.find(
+    (r) => r.operationId === "llm_request_logs_context_get",
+  )!;
+
+  beforeEach(() => {
+    clearTables();
+    rawConfigFixture = {
+      llmRequestLogs: { readSource: "local", disabled: true },
+    };
+  });
+
+  afterEach(() => {
+    // Restore the neutral default so read blocks that rely on it (and don't
+    // reset the fixture themselves) aren't polluted by the disabled state.
+    rawConfigFixture = {};
+  });
+
+  async function expectDisabled(promise: unknown): Promise<void> {
+    // The handler throws a RouteError; assert on its wire-facing fields so the
+    // client can key on the stable code / 403 status.
+    let thrown: unknown;
+    try {
+      await promise;
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeDefined();
+    expect((thrown as { code: string }).code).toBe("LLM_REQUEST_LOGS_DISABLED");
+    expect((thrown as { statusCode: number }).statusCode).toBe(403);
+  }
+
+  test("message llm-context is rejected", async () => {
+    await expectDisabled(dispatchLlmContext("msg-1"));
+  });
+
+  test("conversation llm-context is rejected", async () => {
+    await expectDisabled(
+      dispatchConversationLlmContext({ conversationId: "conv-1" }),
+    );
+  });
+
+  test("single-log payload is rejected", async () => {
+    await expectDisabled(payloadRoute.handler({ pathParams: { id: "log-a" } }));
+  });
+
+  test("single-log context is rejected", async () => {
+    await expectDisabled(contextRoute.handler({ pathParams: { id: "log-a" } }));
+  });
+
+  test("reads succeed again once logging is re-enabled", async () => {
+    rawConfigFixture = {
+      llmRequestLogs: { readSource: "local", disabled: false },
+    };
+    // An unresolved conversation key returns an empty inspector response
+    // (no throw), proving the disabled guard no longer short-circuits.
+    const body = (await dispatchConversationLlmContext({
+      conversationKey: "missing-key",
+    })) as { logs: unknown[] };
     expect(body.logs).toEqual([]);
   });
 });

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -296,7 +296,7 @@ describe("GET /v1/conversations/llm-context", () => {
   });
 });
 
-describe("inspector reads when llmRequestLogs.disabled is true", () => {
+describe("inspector reads when llmRequestLogs.enabled is false", () => {
   const payloadRoute = ROUTES.find(
     (r) => r.operationId === "llm_request_logs_payload_get",
   )!;
@@ -307,7 +307,7 @@ describe("inspector reads when llmRequestLogs.disabled is true", () => {
   beforeEach(() => {
     clearTables();
     rawConfigFixture = {
-      llmRequestLogs: { readSource: "local", disabled: true },
+      llmRequestLogs: { readSource: "local", enabled: false },
     };
   });
 
@@ -351,7 +351,7 @@ describe("inspector reads when llmRequestLogs.disabled is true", () => {
 
   test("reads succeed again once logging is re-enabled", async () => {
     rawConfigFixture = {
-      llmRequestLogs: { readSource: "local", disabled: false },
+      llmRequestLogs: { readSource: "local", enabled: true },
     };
     // An unresolved conversation key returns an empty inspector response
     // (no throw), proving the disabled guard no longer short-circuits.

--- a/assistant/src/runtime/routes/conversation-compaction-routes.ts
+++ b/assistant/src/runtime/routes/conversation-compaction-routes.ts
@@ -62,6 +62,7 @@ import {
   type LlmContextSummary,
   normalizeLlmContextPayloads,
 } from "./llm-context-normalization.js";
+import { assertLlmRequestLoggingEnabled } from "./llm-request-logs-access.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("conversation-compaction-routes");
@@ -256,6 +257,10 @@ async function handleGetCompactionTrail({
   pathParams = {},
   queryParams = {},
 }: RouteHandlerArgs): Promise<CompactionTrailResponse> {
+  // The compaction trail reads LLM-derived log data (metadata + the
+  // compactionAgent projection over `llm_request_logs`), so it honours the
+  // same opt-out as the other inspector reads.
+  assertLlmRequestLoggingEnabled();
   const conversationId = pathParams.id;
   const callId = queryParams.callId;
 

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -105,16 +105,12 @@ import {
   resolvePricingForUsage,
   usesAnthropicPricingRules,
 } from "../../util/pricing.js";
-import {
-  BadRequestError,
-  InternalError,
-  LlmRequestLogsDisabledError,
-  NotFoundError,
-} from "./errors.js";
+import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
 import {
   type LlmContextSummary,
   normalizeLlmContextPayloads,
 } from "./llm-context-normalization.js";
+import { assertLlmRequestLoggingEnabled } from "./llm-request-logs-access.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const validEmbeddingProviderSet = new Set<string>(
@@ -1775,19 +1771,6 @@ function resolveConversationKind(
     return "scheduled";
   }
   return "user";
-}
-
-/**
- * Guard every inspector read on the master `llmRequestLogs.disabled`
- * opt-out. When logging is off there is nothing to serve (and any rows that
- * predate the opt-out are intentionally withheld), so we fail fast with the
- * distinct `LLM_REQUEST_LOGS_DISABLED` code the client keys on to render an
- * enable-logging affordance instead of a generic error.
- */
-function assertLlmRequestLoggingEnabled(): void {
-  if (getConfig().llmRequestLogs?.disabled === true) {
-    throw new LlmRequestLogsDisabledError();
-  }
 }
 
 async function handleGetLlmContext({

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -105,7 +105,12 @@ import {
   resolvePricingForUsage,
   usesAnthropicPricingRules,
 } from "../../util/pricing.js";
-import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
+import {
+  BadRequestError,
+  InternalError,
+  LlmRequestLogsDisabledError,
+  NotFoundError,
+} from "./errors.js";
 import {
   type LlmContextSummary,
   normalizeLlmContextPayloads,
@@ -1772,10 +1777,24 @@ function resolveConversationKind(
   return "user";
 }
 
+/**
+ * Guard every inspector read on the master `llmRequestLogs.disabled`
+ * opt-out. When logging is off there is nothing to serve (and any rows that
+ * predate the opt-out are intentionally withheld), so we fail fast with the
+ * distinct `LLM_REQUEST_LOGS_DISABLED` code the client keys on to render an
+ * enable-logging affordance instead of a generic error.
+ */
+function assertLlmRequestLoggingEnabled(): void {
+  if (getConfig().llmRequestLogs?.disabled === true) {
+    throw new LlmRequestLogsDisabledError();
+  }
+}
+
 async function handleGetLlmContext({
   pathParams = {},
   queryParams = {},
 }: RouteHandlerArgs) {
+  assertLlmRequestLoggingEnabled();
   const messageId = pathParams.id;
   if (!messageId) {
     throw new BadRequestError("message id is required");
@@ -1819,6 +1838,7 @@ async function handleGetLlmContext({
 async function handleGetConversationLlmContext({
   queryParams = {},
 }: RouteHandlerArgs) {
+  assertLlmRequestLoggingEnabled();
   const conversationKey = queryParams.conversationKey;
   const requestedConversationId = queryParams.conversationId;
   const view = resolveLlmContextView(queryParams.view);
@@ -1888,6 +1908,7 @@ async function handleGetConversationLlmContext({
 async function handleGetLlmRequestLogPayload({
   pathParams = {},
 }: RouteHandlerArgs) {
+  assertLlmRequestLoggingEnabled();
   const logId = pathParams.id;
   if (!logId) {
     throw new BadRequestError("log id is required");
@@ -1915,6 +1936,7 @@ async function handleGetLlmRequestLogPayload({
 async function handleGetLlmRequestLogContext({
   pathParams = {},
 }: RouteHandlerArgs) {
+  assertLlmRequestLoggingEnabled();
   const logId = pathParams.id;
   if (!logId) {
     throw new BadRequestError("log id is required");

--- a/assistant/src/runtime/routes/errors.ts
+++ b/assistant/src/runtime/routes/errors.ts
@@ -145,3 +145,20 @@ export class InternalError extends RouteError {
     this.name = "InternalError";
   }
 }
+
+/**
+ * LLM request logging is turned off via `llmRequestLogs.disabled`, so the
+ * inspector read routes have nothing to serve. Carries a distinct, stable
+ * `code` (`LLM_REQUEST_LOGS_DISABLED`) so clients can branch on it — the web
+ * inspector renders a "logging is off" state with an enable toggle rather than
+ * a generic failure. 403 (rather than 404) so the condition reads as
+ * "deliberately withheld", not "missing".
+ */
+export class LlmRequestLogsDisabledError extends RouteError {
+  constructor(
+    message = "LLM request logging is disabled. Enable it to view request logs.",
+  ) {
+    super(message, "LLM_REQUEST_LOGS_DISABLED", 403);
+    this.name = "LlmRequestLogsDisabledError";
+  }
+}

--- a/assistant/src/runtime/routes/llm-request-logs-access.ts
+++ b/assistant/src/runtime/routes/llm-request-logs-access.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared access guard for the inspector's LLM-request-log read routes.
+ *
+ * When `llmRequestLogs.enabled` is `false` there is nothing to serve (and any
+ * rows that predate the opt-out are intentionally withheld), so every route
+ * that surfaces LLM-derived log data — the message/conversation `llm-context`
+ * routes, the single-log payload/context routes, and the compaction trail
+ * route — calls this first to fail fast with the distinct
+ * `LLM_REQUEST_LOGS_DISABLED` code the client keys on to render an
+ * enable-logging affordance instead of a generic error.
+ */
+import { getConfig } from "../../config/loader.js";
+import { LlmRequestLogsDisabledError } from "./errors.js";
+
+export function assertLlmRequestLoggingEnabled(): void {
+  if (getConfig().llmRequestLogs?.enabled === false) {
+    throw new LlmRequestLogsDisabledError();
+  }
+}


### PR DESCRIPTION
**PR 1 of 3** in the LLM request logging opt-out series. Base: `main`.
Followed by #2 (inspector enable-logging UI) and #3 (write to ClickHouse).

## Prompt / plan

> Add a flag in `assistant/src/config/schemas/llm-request-logs.ts` that is default false that disables writing. On reads, return a 4xx response explaining that LLM request logs are disabled.

Context: today every LLM call is logged unconditionally to local SQLite; the only existing control is retention (delete-after), which still writes the payload first. This adds a true opt-out.

## What this does

- New `llmRequestLogs.disabled` config flag, default `false` (logging on).
- **Writes**: `recordRequestLog` and `recordSyntheticAgentErrorMessageLog` skip the insert entirely when disabled — no prompt/completion payload lands on disk. Gated via read-only config access to stay off the per-LLM-call hot path; fails open to "enabled" if config resolution throws so a config hiccup never silently drops logs.
- **Reads**: the four inspector read routes (message/conversation `llm-context` and the single-log payload/context routes) throw a new `LlmRequestLogsDisabledError` — **403** with a stable `LLM_REQUEST_LOGS_DISABLED` code so clients can branch on it (PR #2 does exactly that).
- **Schema**: `disabled` lives on both branches of the `readSource` discriminated union, and a `preprocess` defaults a missing `readSource` to `local`. Without that, a partial write like `config set llmRequestLogs.disabled true` (which never mentions `readSource`) would fail the union and take the whole config down to defaults via the loader's leaf-deletion recovery.

Existing rows are never deleted — this is a write/read gate, not a purge.

## Test plan

- `bun test` for: the schema (default, explicit branches, partial disabled-only write, non-boolean rejection), the store write-gate (`llm-request-log-disabled-writes.test.ts`), and the route 4xx (new block in `conversation-query-routes.test.ts` covering all four read handlers + re-enable).
- `bunx tsgo --noEmit` clean; eslint clean (0 errors).

## CLI verb checklist

No new routes — this gates existing inspector read routes and adds a config flag, so no new `assistant` CLI verb is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5EQ7hFW26ndg21csTCZJq

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5EQ7hFW26ndg21csTCZJq)_