### PR TITLE
feat(web): render an enable-logging state in the inspector when logging is disabled

### DIFF
--- a/clients/web/src/domains/chat/inspector/inspect-page.test.tsx
+++ b/clients/web/src/domains/chat/inspector/inspect-page.test.tsx
@@ -152,6 +152,12 @@ mock.module("@/stores/assistant-feature-flag-store", () => ({
 }));
 
 mock.module("@/domains/chat/inspector/inspector-api", () => ({
+  isLlmRequestLogsDisabledError: (error: unknown) =>
+    Boolean(
+      error &&
+      typeof error === "object" &&
+      (error as { code?: string }).code === "LLM_REQUEST_LOGS_DISABLED",
+    ),
   useLlmContext: (
     _assistantId: string | undefined,
     _conversationId: string | undefined,
@@ -400,6 +406,29 @@ describe("InspectPage — data-loading branches", () => {
     expect(html).toContain("Failed to load");
     expect(html).toContain("boom");
     expect(html).toContain("Retry");
+  });
+
+  test("renders the enable-logging state when request logging is disabled", () => {
+    paramsStub = { conversationId: "conv-disabled" };
+    const disabledError = Object.assign(
+      new Error("LLM request logging is disabled."),
+      { code: "LLM_REQUEST_LOGS_DISABLED", status: 403 },
+    );
+    contextStub = {
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: disabledError,
+      refetch: () => {},
+    };
+    const html = renderInspector();
+    expect(html).toContain("LLM request logging is off");
+    expect(html).toContain("Enable logging");
+    // The enable control is the design-library Toggle (role="switch").
+    expect(html).toContain('role="switch"');
+    // The generic error chrome must not show for this branch.
+    expect(html).not.toContain("Failed to load");
+    expect(html).not.toContain("Retry");
   });
 });
 

--- a/clients/web/src/domains/chat/inspector/inspect-page.tsx
+++ b/clients/web/src/domains/chat/inspector/inspect-page.tsx
@@ -6,23 +6,26 @@ import { Link, useNavigate, useParams, useSearchParams } from "react-router";
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { useCanUseLlmInspector } from "@/domains/chat/inspector/access";
 import {
-    useConversationCallNumbering,
-    useConversationMessageList,
-    useLlmContext,
+  isLlmRequestLogsDisabledError,
+  useConversationCallNumbering,
+  useConversationMessageList,
+  useLlmContext,
 } from "@/domains/chat/inspector/inspector-api";
+import { configGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
+import { configPatch } from "@/generated/daemon/sdk.gen";
 import {
-    buildInspectorExportFilename,
-    buildInspectorExportZipBlobBatched,
+  buildInspectorExportFilename,
+  buildInspectorExportZipBlobBatched,
 } from "@/domains/chat/inspector/inspector-export";
 import {
-    llmCallDetailQueryOptions,
-    useLlmCallDetail,
+  llmCallDetailQueryOptions,
+  useLlmCallDetail,
 } from "@/domains/chat/inspector/inspector-detail-api";
 import { llmLogPayloadQueryOptions } from "@/domains/chat/inspector/inspector-payload-api";
 import { normalizeContentBlocks } from "@/domains/chat/api/messages";
 import {
-    supportsLlmContextSummaryView,
-    useSupportsLlmContextSummaryView,
+  supportsLlmContextSummaryView,
+  useSupportsLlmContextSummaryView,
 } from "@/lib/backwards-compat/llm-context-summary-view";
 import { isElectron } from "@/runtime/is-electron";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
@@ -35,11 +38,13 @@ import type {
   LLMRequestLogEntry,
 } from "@vellumai/assistant-api";
 import { Button } from "@vellumai/design-library";
+import { toast } from "@vellumai/design-library/components/toast";
+import { Toggle } from "@vellumai/design-library/components/toggle";
 
 import { CallRail } from "./components/call-rail";
 import {
-    ExportProgressModal,
-    type ExportPhase,
+  ExportProgressModal,
+  type ExportPhase,
 } from "./components/export-progress-modal";
 import { MobileCallSelector } from "./components/mobile-call-selector";
 import { TabBar, type InspectorTab } from "./components/tab-bar";
@@ -102,9 +107,7 @@ export function InspectPage(): ReactNode {
     return <CenteredMessage tone="muted">Loading…</CenteredMessage>;
   }
 
-  return (
-    <Inspector conversationId={conversationId} messageId={messageId} />
-  );
+  return <Inspector conversationId={conversationId} messageId={messageId} />;
 }
 
 interface InspectorProps {
@@ -214,7 +217,14 @@ function Inspector({ conversationId, messageId }: InspectorProps): ReactNode {
         {isLoadingContext ? (
           <CenteredMessage tone="muted">Loading…</CenteredMessage>
         ) : isError ? (
-          <ErrorState error={error} onRetry={() => void refetch()} />
+          isLlmRequestLogsDisabledError(error) ? (
+            <LoggingDisabledState
+              assistantId={assistantId}
+              onEnabled={() => void refetch()}
+            />
+          ) : (
+            <ErrorState error={error} onRetry={() => void refetch()} />
+          )
         ) : !logs.length ? (
           <EmptyState messageId={messageId} />
         ) : (
@@ -269,8 +279,7 @@ function Header({
     conversationId,
   );
   const turnPosition = useMemo(
-    () =>
-      messageId ? findTurnPosition(scopeMessages ?? [], messageId) : null,
+    () => (messageId ? findTurnPosition(scopeMessages ?? [], messageId) : null),
     [scopeMessages, messageId],
   );
 
@@ -294,9 +303,7 @@ function Header({
       // the modal's determinate progress bar.
       const blob = await buildInspectorExportZipBlobBatched(context, {
         fetchPayload: (logId) =>
-          queryClient.fetchQuery(
-            llmLogPayloadQueryOptions(assistantId, logId),
-          ),
+          queryClient.fetchQuery(llmLogPayloadQueryOptions(assistantId, logId)),
         fetchCallSections: (logId) =>
           supportsLlmContextSummaryView()
             ? queryClient.fetchQuery(
@@ -315,9 +322,7 @@ function Header({
       const { saveFile } = await import("@/runtime/native-file");
       await saveFile(
         blob,
-        buildInspectorExportFilename(
-          context.conversationId ?? conversationId,
-        ),
+        buildInspectorExportFilename(context.conversationId ?? conversationId),
       );
       setExportRun((prev) => (prev ? { ...prev, phase: "done" } : prev));
     } catch (err) {
@@ -548,7 +553,9 @@ interface ScopeOption {
 // A "turn" is headed by a user message: the user message plus every
 // assistant response it produced map to the same group of LLM calls,
 // so only user messages are offered as scope options.
-function buildMessageScopeOptions(messages: ConversationMessage[]): ScopeOption[] {
+function buildMessageScopeOptions(
+  messages: ConversationMessage[],
+): ScopeOption[] {
   const seen = new Set<string>();
   const options: ScopeOption[] = [];
   let index = 1;
@@ -646,7 +653,8 @@ function Loaded({
   // return sections inline and the list entry is used as-is.
   const supportsSummaryView = useSupportsLlmContextSummaryView();
   const selectedLogHasSections = Boolean(
-    selectedLog && (selectedLog.requestSections || selectedLog.responseSections),
+    selectedLog &&
+    (selectedLog.requestSections || selectedLog.responseSections),
   );
   const shouldFetchDetail = supportsSummaryView && !selectedLogHasSections;
   const {
@@ -859,6 +867,84 @@ function EmptyState({ messageId }: EmptyStateProps): ReactNode {
       >
         {body}
       </p>
+    </div>
+  );
+}
+
+interface LoggingDisabledStateProps {
+  assistantId: string | undefined;
+  onEnabled: () => void;
+}
+
+/**
+ * Rendered when the daemon reports that LLM request logging is turned off
+ * (`llmRequestLogs.enabled === false`). There's nothing to inspect, so instead
+ * of the generic error state we explain the situation and offer a toggle that
+ * flips the setting back on for future calls. Enabling patches the daemon
+ * config, invalidates the cached config view, and re-runs the inspector query.
+ */
+function LoggingDisabledState({
+  assistantId,
+  onEnabled,
+}: LoggingDisabledStateProps): ReactNode {
+  const queryClient = useQueryClient();
+  const [enabling, setEnabling] = useState(false);
+
+  async function handleEnable(next: boolean): Promise<void> {
+    // The toggle starts off; only act on the off → on transition.
+    if (!next || enabling || !assistantId) return;
+    setEnabling(true);
+    try {
+      const { response } = await configPatch({
+        path: { assistant_id: assistantId },
+        body: { llmRequestLogs: { enabled: true } },
+        throwOnError: false,
+      });
+      if (!response?.ok) {
+        throw new Error(`HTTP ${response?.status ?? "?"}`);
+      }
+      void queryClient.invalidateQueries({
+        queryKey: configGetQueryKey({ path: { assistant_id: assistantId } }),
+      });
+      toast.success("LLM request logging enabled");
+      onEnabled();
+    } catch (err) {
+      toast.error(
+        err instanceof Error
+          ? `Failed to enable logging (${err.message})`
+          : "Failed to enable logging",
+      );
+    } finally {
+      setEnabling(false);
+    }
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-3 p-8 text-center">
+      <AlertCircle
+        size={32}
+        aria-hidden
+        style={{ color: "var(--content-secondary)" }}
+      />
+      <h2
+        className="text-body-medium-default"
+        style={{ color: "var(--content-default)" }}
+      >
+        LLM request logging is off
+      </h2>
+      <p
+        className="max-w-md text-label-default"
+        style={{ color: "var(--content-secondary)" }}
+      >
+        Request and response payloads aren’t being recorded, so there’s nothing
+        to inspect. Enable logging to capture future LLM calls.
+      </p>
+      <Toggle
+        checked={false}
+        disabled={enabling || !assistantId}
+        onChange={(next) => void handleEnable(next)}
+        label={enabling ? "Enabling…" : "Enable logging"}
+      />
     </div>
   );
 }

--- a/clients/web/src/domains/chat/inspector/inspector-api.test.ts
+++ b/clients/web/src/domains/chat/inspector/inspector-api.test.ts
@@ -25,6 +25,8 @@ interface FakeRequest {
 interface FakeResponse {
   status: number;
   body?: LlmContextResponse | null;
+  /** Parsed error envelope the SDK exposes as `error` on non-2xx responses. */
+  error?: unknown;
 }
 
 const requests: FakeRequest[] = [];
@@ -59,19 +61,23 @@ mock.module("@/generated/daemon/client.gen", () => ({
           return { text: async () => "error-body" };
         },
       };
-      return { data: next.body, response };
+      return { data: next.body, error: next.error, response };
     },
   },
 }));
 
 mock.module("@/domains/chat/api/messages", () => ({
-  fetchConversationMessages: async () => ({ messages: mockMessages, seq: null }),
+  fetchConversationMessages: async () => ({
+    messages: mockMessages,
+    seq: null,
+  }),
 }));
 
 // Subject imported after mocks.
 import {
   fetchConversationLlmContext,
   fetchMessageLlmContextOrThrow,
+  isLlmRequestLogsDisabledError,
 } from "@/domains/chat/inspector/inspector-api";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 
@@ -158,6 +164,37 @@ describe("fetchConversationLlmContext — happy path", () => {
     expect(caught).toBeDefined();
     expect((caught as { status: number; message: string }).status).toBe(500);
     expect((caught as { name: string }).name).toBe("LlmContextRequestError");
+  });
+
+  test("surfaces the disabled code + message from the daemon error envelope", async () => {
+    nextResponses = [
+      {
+        status: 403,
+        body: null,
+        error: {
+          error: {
+            code: "LLM_REQUEST_LOGS_DISABLED",
+            message:
+              "LLM request logging is disabled. Enable it to view request logs.",
+          },
+        },
+      },
+    ];
+
+    let caught: unknown;
+    try {
+      await fetchConversationLlmContext("asst-1", "conv-1", undefined);
+    } catch (err) {
+      caught = err;
+    }
+    expect(isLlmRequestLogsDisabledError(caught)).toBe(true);
+    expect((caught as { status: number }).status).toBe(403);
+    expect((caught as { code?: string }).code).toBe(
+      "LLM_REQUEST_LOGS_DISABLED",
+    );
+    expect((caught as { message: string }).message).toContain(
+      "LLM request logging is disabled",
+    );
   });
 });
 

--- a/clients/web/src/domains/chat/inspector/inspector-api.ts
+++ b/clients/web/src/domains/chat/inspector/inspector-api.ts
@@ -46,14 +46,48 @@ function summaryViewQuery(): { view?: "summary" } {
   return supportsLlmContextSummaryView() ? { view: "summary" } : {};
 }
 
+/**
+ * Stable error code the daemon returns (in the standard `{ error: { code } }`
+ * envelope) when LLM request logging is disabled (`llmRequestLogs.enabled ===
+ * false`). The inspector branches on it to render an "enable logging"
+ * affordance instead of a generic failure.
+ */
+export const LLM_REQUEST_LOGS_DISABLED_CODE = "LLM_REQUEST_LOGS_DISABLED";
+
 export class LlmContextRequestError extends Error {
   status: number;
+  /**
+   * Machine-readable `error.code` from the daemon envelope when present.
+   * `undefined` for network errors and responses without a coded body.
+   */
+  code: string | undefined;
 
-  constructor(status: number, message: string) {
+  constructor(status: number, message: string, code?: string) {
     super(message);
     this.name = "LlmContextRequestError";
     this.status = status;
+    this.code = code;
   }
+}
+
+/** Pull `error.code` out of the daemon's `{ error: { code, message } }` envelope. */
+function extractErrorCode(error: unknown): string | undefined {
+  if (error && typeof error === "object" && "error" in error) {
+    const inner = (error as { error?: unknown }).error;
+    if (inner && typeof inner === "object" && "code" in inner) {
+      const code = (inner as { code?: unknown }).code;
+      if (typeof code === "string") return code;
+    }
+  }
+  return undefined;
+}
+
+/** True when the failure is the daemon's "logging is disabled" signal. */
+export function isLlmRequestLogsDisabledError(error: unknown): boolean {
+  return (
+    error instanceof LlmContextRequestError &&
+    error.code === LLM_REQUEST_LOGS_DISABLED_CODE
+  );
 }
 
 export function llmContextQueryOptions(
@@ -132,9 +166,7 @@ export function useConversationCallNumbering(
       "llm-context-call-numbering",
       conversationId,
     ] as const,
-    queryFn: async ({
-      signal,
-    }): Promise<LLMRequestLogEntry[] | null> => {
+    queryFn: async ({ signal }): Promise<LLMRequestLogEntry[] | null> => {
       if (!assistantId || !conversationId) return null;
       const { data, response } = await conversationsLlmcontextGet({
         path: { assistant_id: assistantId },
@@ -226,7 +258,11 @@ export async function fetchConversationLlmContext(
       response,
       "Failed to load LLM context",
     );
-    throw new LlmContextRequestError(response.status, msg);
+    throw new LlmContextRequestError(
+      response.status,
+      msg,
+      extractErrorCode(error),
+    );
   }
 
   if (!data) {
@@ -263,7 +299,11 @@ export async function fetchMessageLlmContextOrThrow(
       response,
       "Failed to load LLM context",
     );
-    throw new LlmContextRequestError(response.status, msg);
+    throw new LlmContextRequestError(
+      response.status,
+      msg,
+      extractErrorCode(error),
+    );
   }
   if (!data) {
     throw new LlmContextRequestError(
@@ -290,10 +330,7 @@ async function fetchConversationLlmContextFromPerMessage(
   conversationId: string,
   signal: AbortSignal | undefined,
 ): Promise<LlmContextResponse> {
-  const snapshot = await fetchConversationMessages(
-    assistantId,
-    conversationId,
-  );
+  const snapshot = await fetchConversationMessages(assistantId, conversationId);
   const messages = snapshot?.messages ?? [];
 
   const messageIds: string[] = [];


### PR DESCRIPTION
**PR 2 of 3** in the LLM request logging opt-out series. Base: `main` (PR #37649 is merged, so this now targets main directly). Web-only.

## Prompt / plan

> In the inspect UI, when we get a 4xx response that LLM request logs are disabled, render a UI that shows a toggle for the user to enable it going forward.

Builds on the `403 LLM_REQUEST_LOGS_DISABLED` code and `llmRequestLogs.enabled` flag from #37649.

## What this does

- `inspector-api.ts`: `LlmContextRequestError` now carries the daemon `error.code` (populated from the error envelope in both fetchers). Adds `isLlmRequestLogsDisabledError()` and the shared code constant.
- `inspect-page.tsx`: the error branch renders a new `LoggingDisabledState` for the disabled code instead of the generic error — an explanation plus a design-library `Toggle` that PATCHes `llmRequestLogs.enabled = true`, invalidates the cached config, toasts, and re-runs the inspector query so calls captured going forward appear without a manual reload.

## Test plan

- `bun test`: `inspect-page.test.tsx` (renders the enable-logging state on the disabled code, not the generic "Failed to load" error) and `inspector-api.test.ts` (surfaces the code + message from the daemon envelope).
- `bunx tsc --noEmit` clean; eslint clean (0 errors).

## CLI verb checklist

No new routes — web-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5EQ7hFW26ndg21csTCZJq