### PR TITLE
feat(web): surface default-provider availability in the Language Model card

### DIFF
--- a/clients/web/src/domains/settings/ai/language-model-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/language-model-card.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * Tests for `LanguageModelCard` — the default-provider availability notice
+ * (M7 PR 3).
+ *
+ * Mocks the generated SDK boundary; the availability GET flows through the
+ * real generated react-query wrappers, and the server's message renders
+ * verbatim (the daemon owns the explainable wording).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { createElement } from "react";
+
+import type { DefaultProviderStatus } from "@/generated/daemon/types.gen";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+let defaultProviderState: DefaultProviderStatus = {
+  provider: null,
+  resolvedConnectionName: null,
+  availability: { status: "missing_default" },
+};
+let defaultProviderGetCalls = 0;
+
+mock.module("@/assistant/use-active-assistant-id", () => ({
+  useActiveAssistantId: () => "assistant-1",
+}));
+
+const actualSdk = await import("@/generated/daemon/sdk.gen");
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...actualSdk,
+  configGet: async () => ({
+    data: { llm: { profiles: {}, profileOrder: [], callSites: {} } },
+  }),
+  configLlmDefaultproviderGet: async () => {
+    defaultProviderGetCalls += 1;
+    return { data: defaultProviderState };
+  },
+  inferenceProviderconnectionsGet: async () => ({
+    data: { connections: [] },
+  }),
+}));
+
+const { LanguageModelCard } =
+  await import("@/domains/settings/ai/language-model-card");
+const { useAssistantIdentityStore } =
+  await import("@/stores/assistant-identity-store");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setAvailability(
+  status: DefaultProviderStatus["availability"]["status"],
+  message?: string,
+) {
+  defaultProviderState = {
+    provider: "anthropic",
+    resolvedConnectionName: "anthropic-personal",
+    availability: { status, ...(message ? { message } : {}) },
+  };
+}
+
+function renderCard() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      createElement(LanguageModelCard),
+    ),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  defaultProviderState = {
+    provider: "anthropic",
+    resolvedConnectionName: "anthropic-personal",
+    availability: { status: "ok" },
+  };
+  defaultProviderGetCalls = 0;
+  // The notice is version-gated (assistants < 0.10.8 lack the route).
+  useAssistantIdentityStore.getState().setIdentity("test-asst", "0.10.8");
+});
+
+afterEach(() => {
+  useAssistantIdentityStore.getState().clearIdentity();
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("default-provider availability notice", () => {
+  test("hidden when availability is ok", async () => {
+    const result = renderCard();
+    await waitFor(() => {
+      expect(defaultProviderGetCalls).toBeGreaterThan(0);
+    });
+    expect(result.baseElement.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  test("renders the server's message verbatim as an error for config problems", async () => {
+    setAvailability(
+      "missing_credential",
+      'Connection "anthropic-personal" has no API key stored. Add one in Settings → Models & Services.',
+    );
+
+    const result = renderCard();
+    await waitFor(() => {
+      expect(result.baseElement.textContent).toContain(
+        'Connection "anthropic-personal" has no API key stored',
+      );
+    });
+    // Error tone renders role="alert".
+    expect(
+      result.baseElement.querySelector('[role="alert"]')?.textContent,
+    ).toContain("has no API key stored");
+  });
+
+  test("renders unknown (credential store unreachable) as a soft warning", async () => {
+    setAvailability(
+      "unknown",
+      "The credential store is unreachable, so the credential could not be verified. Try again shortly.",
+    );
+
+    const result = renderCard();
+    await waitFor(() => {
+      expect(result.baseElement.textContent).toContain("unreachable");
+    });
+    // Warning tone renders role="status", not role="alert".
+    expect(result.baseElement.querySelector('[role="alert"]')).toBeNull();
+    expect(
+      result.baseElement.querySelector('[role="status"]')?.textContent,
+    ).toContain("unreachable");
+  });
+
+  test("hidden with no query against assistants that predate the route", async () => {
+    useAssistantIdentityStore.getState().setIdentity("test-asst", "0.10.7");
+    setAvailability("missing_credential", "should never render");
+
+    const result = renderCard();
+    // Give the (gated-off) query a beat to definitely not fire.
+    await waitFor(() => {
+      expect(result.baseElement.textContent).toContain("Language Model");
+    });
+    expect(result.baseElement.textContent).not.toContain("should never render");
+    expect(defaultProviderGetCalls).toBe(0);
+  });
+
+  test("clears after the Providers modal closes once the problem is fixed", async () => {
+    setAvailability(
+      "missing_credential",
+      'Connection "anthropic-personal" has no API key stored.',
+    );
+
+    const result = renderCard();
+    await waitFor(() => {
+      expect(result.baseElement.textContent).toContain("has no API key stored");
+    });
+
+    // Open the Providers modal, "fix" the problem server-side, then close —
+    // the close-triggered refetch must clear the notice without a reload.
+    const providersButton = [
+      ...result.baseElement.querySelectorAll("button"),
+    ].find((b) => b.textContent === "Providers");
+    fireEvent.click(providersButton as HTMLButtonElement);
+    await waitFor(() => {
+      expect(result.baseElement.textContent).toContain("Provider Connections");
+    });
+
+    setAvailability("ok");
+    const doneButton = [...result.baseElement.querySelectorAll("button")].find(
+      (b) => b.textContent === "Done",
+    );
+    fireEvent.click(doneButton as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(result.baseElement.textContent).not.toContain(
+        "has no API key stored",
+      );
+    });
+  });
+});

--- a/clients/web/src/domains/settings/ai/language-model-card.tsx
+++ b/clients/web/src/domains/settings/ai/language-model-card.tsx
@@ -7,6 +7,7 @@ import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { captureError } from "@/lib/sentry/capture-error";
 import { Button } from "@vellumai/design-library/components/button";
 import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Notice } from "@vellumai/design-library/components/notice";
 import { toast } from "@vellumai/design-library/components/toast";
 import { Typography } from "@vellumai/design-library/components/typography";
 
@@ -23,8 +24,10 @@ import { useStickyProfiles } from "@/assistant/use-sticky-profiles";
 import {
   configGetOptions,
   configGetSetQueryData,
+  configLlmDefaultproviderGetOptions,
   useConfigPatchMutation,
 } from "@/generated/daemon/@tanstack/react-query.gen";
+import { useSupportsDefaultProviderSettings } from "@/lib/backwards-compat/default-provider-settings";
 import { useDraftOverride } from "@/domains/settings/ai/use-draft-override";
 import { useQuery } from "@tanstack/react-query";
 
@@ -36,6 +39,18 @@ export function LanguageModelCard() {
     ...configGetOptions({ path: { assistant_id: assistantId } }),
     staleTime: 30_000,
   });
+
+  // Older assistants 404 the default-provider route; the gate keeps the
+  // query dark and the notice hidden against them.
+  const supportsDefaultProvider = useSupportsDefaultProviderSettings();
+  const { data: defaultProviderStatus, refetch: refetchDefaultProvider } =
+    useQuery({
+      ...configLlmDefaultproviderGetOptions({
+        path: { assistant_id: assistantId },
+      }),
+      enabled: supportsDefaultProvider,
+    });
+  const availability = defaultProviderStatus?.availability;
 
   const activeProfile = config?.llm?.activeProfile ?? null;
   const advisorProfile = config?.llm?.advisorProfile ?? null;
@@ -109,8 +124,12 @@ export function LanguageModelCard() {
         activeProfile?: string | null;
         advisorProfile?: string | null;
       } = {};
-      if (isProfileDirty) llm.activeProfile = effectiveActiveProfile;
-      if (isAdvisorProfileDirty) llm.advisorProfile = effectiveAdvisorProfile;
+      if (isProfileDirty) {
+        llm.activeProfile = effectiveActiveProfile;
+      }
+      if (isAdvisorProfileDirty) {
+        llm.advisorProfile = effectiveAdvisorProfile;
+      }
       await configMutation.mutateAsync({
         path: { assistant_id: assistantId },
         body: { llm },
@@ -136,6 +155,17 @@ export function LanguageModelCard() {
         subtitle="Configure the LLMs that power your assistant"
       >
         <div className="space-y-4">
+          {availability && availability.status !== "ok" && (
+            // The server owns the explainable wording — render its message
+            // verbatim. `unknown` is transient (credential store unreachable),
+            // everything else is a config problem the user must fix.
+            <Notice
+              tone={availability.status === "unknown" ? "warning" : "error"}
+            >
+              {availability.message ??
+                "Your default provider is not available."}
+            </Notice>
+          )}
           <div className="space-y-1">
             <label className="block text-body-small-default text-[var(--content-tertiary)]">
               Default Profile
@@ -244,7 +274,14 @@ export function LanguageModelCard() {
         <ManageProvidersModal
           isOpen={manageProvidersOpen}
           assistantId={assistantId}
-          onClose={() => setManageProvidersOpen(false)}
+          onClose={() => {
+            setManageProvidersOpen(false);
+            // Fixing the problem (adding a key/connection, changing the
+            // default) should clear the notice without a reload.
+            if (supportsDefaultProvider) {
+              void refetchDefaultProvider();
+            }
+          }}
         />
       )}
     </>


### PR DESCRIPTION
## Summary

- Shows a Notice in Settings → Language Model when the default provider is unavailable, rendering the daemon's `availability.message` verbatim (`GET /v1/config/llm/default-provider`, #37579) — the server owns the explainable wording.
- Tone maps by failure class: `unknown` (credential store unreachable — transient) renders as a soft warning; every config problem (`missing_connection`, `missing_credential`, `provider_mismatch`, `unsupported_auth`, `vellum_unauthenticated`, `missing_default`) renders as an error.
- Closing the Providers modal refetches availability, so fixing the problem (adding a key/connection, changing the default via #37591's marker) clears the notice without a reload. Reuses PR 2's `0.10.8` version gate — older assistants get no query and no notice.

Part of M7 (Inference Management Refactor) — plan attached to #37579. Remaining: PR 4 (server-message delete-guard errors), PR 5 (profile-editor snapshot copy).

## Original prompt

Execute PR 3 of the M7 plan (`.private/plans/m7-settings-ui-default-provider.md`): surface "your default provider is broken" in settings. The availability statuses come from M7 PR 1's route (including the review-hardened `provider_mismatch`/`unsupported_auth` cases); the design principle from planning is that the daemon names the broken thing and the fix, and clients render that message verbatim rather than re-deriving it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37652" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->