### PR TITLE
feat(web): mark a provider connection as the default provider (M7 PR2)

### DIFF
--- a/clients/web/src/domains/settings/ai/manage-providers-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/manage-providers-modal.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * Tests for `ManageProvidersModal`'s default-provider marker: the "Default"
+ * tag on the resolved connection, the delete guard on that row, and the
+ * "Set as default" action that pins the clicked connection explicitly.
+ *
+ * Mocks the generated SDK boundary (connections list, default-provider
+ * GET/PUT) per the domain's test convention.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { createElement } from "react";
+
+import type {
+  DefaultProviderStatus,
+  ProviderConnection,
+} from "@/generated/daemon/types.gen";
+
+mock.module("@vellumai/design-library/components/toast", () => ({
+  toast: { success: () => {}, error: () => {} },
+  Toaster: () => null,
+  ToastContent: () => null,
+}));
+
+let connectionsState: ProviderConnection[] = [];
+let defaultProviderState: DefaultProviderStatus;
+let putBodies: unknown[] = [];
+let putShouldFail = false;
+let defaultProviderGetCalls = 0;
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  inferenceProviderconnectionsGet: async () => ({
+    data: { connections: connectionsState },
+  }),
+  configLlmDefaultproviderGet: async () => {
+    defaultProviderGetCalls += 1;
+    return { data: defaultProviderState };
+  },
+  configLlmDefaultproviderPut: async (options?: { body?: unknown }) => {
+    if (putShouldFail) {
+      throw new Error("boom");
+    }
+    putBodies.push(options?.body);
+    return { data: defaultProviderState };
+  },
+  inferenceProviderconnectionsByNameDelete: async () => ({
+    response: { ok: true, status: 200 },
+  }),
+  configGet: async () => ({ data: { llm: {} } }),
+}));
+
+import { ManageProvidersModal } from "./manage-providers-modal";
+
+function makeConnection(
+  overrides: Partial<ProviderConnection> & { name: string; provider: string },
+): ProviderConnection {
+  return {
+    label: null,
+    auth: { type: "api_key", credential: `credential/${overrides.provider}/api_key` },
+    baseUrl: null,
+    models: null,
+    createdAt: 0,
+    updatedAt: 0,
+    isManaged: false,
+    ...overrides,
+  } as ProviderConnection;
+}
+
+function renderModal() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      createElement(ManageProvidersModal, {
+        isOpen: true,
+        assistantId: "asst-1",
+        onClose: () => {},
+      }),
+    ),
+  );
+}
+
+beforeEach(() => {
+  putBodies = [];
+  putShouldFail = false;
+  defaultProviderGetCalls = 0;
+  connectionsState = [
+    makeConnection({ name: "anthropic", provider: "anthropic" }),
+    makeConnection({ name: "openai-personal", provider: "openai" }),
+    makeConnection({
+      name: "local-ollama",
+      provider: "ollama",
+      auth: { type: "none" } as ProviderConnection["auth"],
+    }),
+  ];
+  defaultProviderState = {
+    provider: "anthropic",
+    connectionName: "anthropic",
+    resolvedConnectionName: "anthropic",
+    availability: { status: "ok" },
+  };
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("default-provider marker", () => {
+  test("renders the Default tag on the resolved connection and guards its delete", async () => {
+    const { findByText, getByLabelText } = renderModal();
+    await findByText("Default");
+    const deleteButton = getByLabelText(
+      "Delete anthropic",
+    ) as HTMLButtonElement;
+    expect(deleteButton.disabled).toBe(true);
+    expect(deleteButton.title).toContain("serves your default provider");
+  });
+
+  test("Set as default pins the clicked connection's provider AND name explicitly", async () => {
+    const { findAllByText } = renderModal();
+    const buttons = await findAllByText("Set as default");
+    // Rows render in connections order; the first non-default eligible row
+    // is openai-personal.
+    fireEvent.click(buttons[0]!);
+    await waitFor(() => {
+      expect(putBodies).toHaveLength(1);
+    });
+    expect(putBodies[0]).toEqual({
+      provider: "openai",
+      connectionName: "openai-personal",
+    });
+    // The marker refreshes from the server, not from local state.
+    await waitFor(() => {
+      expect(defaultProviderGetCalls).toBeGreaterThan(1);
+    });
+  });
+
+  test("non-matrix providers get a disabled action with an explanatory tooltip", async () => {
+    const { findAllByText } = renderModal();
+    const buttons = (await findAllByText(
+      "Set as default",
+    )) as HTMLButtonElement[];
+    const ollamaButton = buttons.find((b) =>
+      b.title.includes("Built-in profiles"),
+    );
+    expect(ollamaButton).toBeDefined();
+    expect(ollamaButton!.disabled).toBe(true);
+  });
+
+  test("a PUT failure renders the inline row error", async () => {
+    putShouldFail = true;
+    const { findAllByText, findByText } = renderModal();
+    const buttons = await findAllByText("Set as default");
+    fireEvent.click(buttons[0]!);
+    await findByText("Failed to set the default provider. Please try again.");
+  });
+
+  test("no Default tag renders when the default's connection is not in the list", async () => {
+    defaultProviderState = {
+      provider: "gemini",
+      resolvedConnectionName: "gemini-personal",
+      availability: { status: "missing_connection", message: "…" },
+    };
+    const { queryByText, findByText } = renderModal();
+    await findByText("anthropic");
+    expect(queryByText("Default")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/settings/ai/manage-providers-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/manage-providers-modal.test.tsx
@@ -18,6 +18,12 @@ import type {
   ProviderConnection,
 } from "@/generated/daemon/types.gen";
 
+let assistantSupportsDefaultProvider = true;
+mock.module("@/lib/backwards-compat/default-provider-routes", () => ({
+  MIN_VERSION: "0.10.8",
+  useSupportsDefaultProvider: () => assistantSupportsDefaultProvider,
+}));
+
 mock.module("@vellumai/design-library/components/toast", () => ({
   toast: { success: () => {}, error: () => {} },
   Toaster: () => null,
@@ -58,7 +64,10 @@ function makeConnection(
 ): ProviderConnection {
   return {
     label: null,
-    auth: { type: "api_key", credential: `credential/${overrides.provider}/api_key` },
+    auth: {
+      type: "api_key",
+      credential: `credential/${overrides.provider}/api_key`,
+    },
     baseUrl: null,
     models: null,
     createdAt: 0,
@@ -86,6 +95,7 @@ function renderModal() {
 }
 
 beforeEach(() => {
+  assistantSupportsDefaultProvider = true;
   putBodies = [];
   putShouldFail = false;
   defaultProviderGetCalls = 0;
@@ -158,6 +168,14 @@ describe("default-provider marker", () => {
     const buttons = await findAllByText("Set as default");
     fireEvent.click(buttons[0]!);
     await findByText("Failed to set the default provider. Please try again.");
+  });
+
+  test("the marker surface is hidden entirely on assistants that predate the routes", async () => {
+    assistantSupportsDefaultProvider = false;
+    const { queryByText, findByText } = renderModal();
+    await findByText("anthropic");
+    expect(queryByText("Default")).toBeNull();
+    expect(queryByText("Set as default")).toBeNull();
   });
 
   test("no Default tag renders when the default's connection is not in the list", async () => {

--- a/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
+++ b/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
@@ -22,6 +22,8 @@ import type {
   ProviderConnection,
 } from "@/generated/daemon/types.gen";
 import { PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
+import { useSupportsDefaultProvider } from "@/lib/backwards-compat/default-provider-routes";
+import { captureError } from "@/lib/sentry/capture-error";
 import { ProviderEditorContent } from "@/domains/settings/ai/provider-editor-modal";
 // ---------------------------------------------------------------------------
 // Helpers
@@ -100,11 +102,15 @@ export function ManageProvidersModal({
     ...queryOpts,
     enabled: isOpen,
   });
+  // Older installed assistants predate the default-provider routes; hide
+  // the marker surface entirely rather than render actions that can only
+  // fail (see the gate's docstring).
+  const supportsDefaultProvider = useSupportsDefaultProvider();
   const { data: defaultProvider } = useQuery({
     ...configLlmDefaultproviderGetOptions({
       path: { assistant_id: assistantId },
     }),
-    enabled: isOpen,
+    enabled: isOpen && supportsDefaultProvider,
   });
 
   const connections = useMemo(() => data?.connections ?? [], [data]);
@@ -184,7 +190,10 @@ export function ManageProvidersModal({
                 }),
               });
             }}
-            defaultProvider={defaultProvider}
+            defaultProvider={
+              supportsDefaultProvider ? defaultProvider : undefined
+            }
+            supportsDefaultProvider={supportsDefaultProvider}
             onDefaultChanged={() => {
               void queryClient.invalidateQueries({
                 queryKey: configLlmDefaultproviderGetQueryKey({
@@ -218,6 +227,7 @@ interface ManageProvidersModalInnerProps {
   onNewClick: () => void;
   onConnectionDeleted: (name: string) => void;
   defaultProvider: DefaultProviderStatus | undefined;
+  supportsDefaultProvider: boolean;
   onDefaultChanged: () => void;
 }
 
@@ -231,6 +241,7 @@ function ManageProvidersModalInner({
   onNewClick,
   onConnectionDeleted,
   defaultProvider,
+  supportsDefaultProvider,
   onDefaultChanged,
 }: ManageProvidersModalInnerProps) {
   const [deleteErrors, setDeleteErrors] = useState<Record<string, string>>({});
@@ -257,7 +268,11 @@ function ManageProvidersModalInner({
         body: { provider: conn.provider, connectionName: conn.name },
       });
       onDefaultChanged();
-    } catch {
+    } catch (error) {
+      captureError(error, {
+        context: "manage-providers-modal.set-default-provider",
+        bestEffort: true,
+      });
       setDeleteErrors((prev) => ({
         ...prev,
         [conn.name]: "Failed to set the default provider. Please try again.",
@@ -396,7 +411,7 @@ function ManageProvidersModalInner({
 
                     {/* Actions */}
                     <div className="flex shrink-0 items-center gap-2">
-                      {!isDefaultConnection && (
+                      {supportsDefaultProvider && !isDefaultConnection && (
                         <Button
                           variant="ghost"
                           size="compact"

--- a/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
+++ b/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
@@ -1,19 +1,26 @@
 import { Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@vellumai/design-library/components/button";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { Tag } from "@vellumai/design-library/components/tag";
 import { Typography } from "@vellumai/design-library/components/typography";
 
 import {
-    inferenceProviderconnectionsGetOptions,
-    inferenceProviderconnectionsGetQueryKey,
+  configGetQueryKey,
+  configLlmDefaultproviderGetOptions,
+  configLlmDefaultproviderGetQueryKey,
+  configLlmDefaultproviderPutMutation,
+  inferenceProviderconnectionsGetOptions,
+  inferenceProviderconnectionsGetQueryKey,
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import { inferenceProviderconnectionsByNameDelete } from "@/generated/daemon/sdk.gen";
 
-import type { ProviderConnection } from "@/generated/daemon/types.gen";
+import type {
+  DefaultProviderStatus,
+  ProviderConnection,
+} from "@/generated/daemon/types.gen";
 import { PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
 import { ProviderEditorContent } from "@/domains/settings/ai/provider-editor-modal";
 // ---------------------------------------------------------------------------
@@ -35,6 +42,33 @@ function formatAuthSummary(auth: ProviderConnection["auth"]): string {
   }
 }
 
+type DefaultEligibleProvider = NonNullable<DefaultProviderStatus["provider"]>;
+
+// Compile-time mirrored from the generated union: `satisfies` rejects a
+// member the server dropped, and the exhaustiveness check below fails when
+// the server adds one this list is missing.
+const DEFAULT_ELIGIBLE_PROVIDERS = [
+  "anthropic",
+  "openai",
+  "gemini",
+  "fireworks",
+  "openrouter",
+  "vellum",
+] as const satisfies readonly DefaultEligibleProvider[];
+type _AssertAllEligibleProvidersListed = [DefaultEligibleProvider] extends [
+  (typeof DEFAULT_ELIGIBLE_PROVIDERS)[number],
+]
+  ? true
+  : never;
+const _assertAllEligibleProvidersListed: _AssertAllEligibleProvidersListed = true;
+void _assertAllEligibleProvidersListed;
+
+function isDefaultEligibleProvider(
+  provider: string,
+): provider is DefaultEligibleProvider {
+  return (DEFAULT_ELIGIBLE_PROVIDERS as readonly string[]).includes(provider);
+}
+
 // ---------------------------------------------------------------------------
 // ManageProvidersModal
 // ---------------------------------------------------------------------------
@@ -51,21 +85,29 @@ export function ManageProvidersModal({
   onClose,
 }: ManageProvidersModalProps) {
   const [editorOpen, setEditorOpen] = useState(false);
-  const [editingConnection, setEditingConnection] = useState<ProviderConnection | null>(null);
+  const [editingConnection, setEditingConnection] =
+    useState<ProviderConnection | null>(null);
 
   const queryClient = useQueryClient();
   const queryOpts = inferenceProviderconnectionsGetOptions({
     path: { assistant_id: assistantId },
   });
-  const { data, isLoading: loading, isError } = useQuery({
+  const {
+    data,
+    isLoading: loading,
+    isError,
+  } = useQuery({
     ...queryOpts,
     enabled: isOpen,
   });
+  const { data: defaultProvider } = useQuery({
+    ...configLlmDefaultproviderGetOptions({
+      path: { assistant_id: assistantId },
+    }),
+    enabled: isOpen,
+  });
 
-  const connections = useMemo(
-    () => data?.connections ?? [],
-    [data],
-  );
+  const connections = useMemo(() => data?.connections ?? [], [data]);
 
   function handleEditorSave(_saved: ProviderConnection) {
     void queryClient.invalidateQueries({
@@ -142,6 +184,19 @@ export function ManageProvidersModal({
                 }),
               });
             }}
+            defaultProvider={defaultProvider}
+            onDefaultChanged={() => {
+              void queryClient.invalidateQueries({
+                queryKey: configLlmDefaultproviderGetQueryKey({
+                  path: { assistant_id: assistantId },
+                }),
+              });
+              void queryClient.invalidateQueries({
+                queryKey: configGetQueryKey({
+                  path: { assistant_id: assistantId },
+                }),
+              });
+            }}
           />
         )
       ) : null}
@@ -162,6 +217,8 @@ interface ManageProvidersModalInnerProps {
   onEditClick: (conn: ProviderConnection) => void;
   onNewClick: () => void;
   onConnectionDeleted: (name: string) => void;
+  defaultProvider: DefaultProviderStatus | undefined;
+  onDefaultChanged: () => void;
 }
 
 function ManageProvidersModalInner({
@@ -173,9 +230,42 @@ function ManageProvidersModalInner({
   onEditClick,
   onNewClick,
   onConnectionDeleted,
+  defaultProvider,
+  onDefaultChanged,
 }: ManageProvidersModalInnerProps) {
   const [deleteErrors, setDeleteErrors] = useState<Record<string, string>>({});
   const [deleting, setDeleting] = useState<Record<string, boolean>>({});
+  const [settingDefault, setSettingDefault] = useState<string | null>(null);
+  const setDefaultMutation = useMutation(configLlmDefaultproviderPutMutation());
+
+  async function handleSetDefault(conn: ProviderConnection) {
+    if (!isDefaultEligibleProvider(conn.provider)) {
+      return;
+    }
+    setSettingDefault(conn.name);
+    setDeleteErrors((prev) => {
+      const next = { ...prev };
+      delete next[conn.name];
+      return next;
+    });
+    try {
+      // Always pin the clicked connection's name explicitly: convention
+      // resolution (`${provider}-personal`) dangles for web-onboarded
+      // connections named bare `anthropic`/`openai`.
+      await setDefaultMutation.mutateAsync({
+        path: { assistant_id: assistantId },
+        body: { provider: conn.provider, connectionName: conn.name },
+      });
+      onDefaultChanged();
+    } catch {
+      setDeleteErrors((prev) => ({
+        ...prev,
+        [conn.name]: "Failed to set the default provider. Please try again.",
+      }));
+    } finally {
+      setSettingDefault(null);
+    }
+  }
 
   async function handleDelete(name: string) {
     setDeleting((prev) => ({ ...prev, [name]: true }));
@@ -222,8 +312,8 @@ function ManageProvidersModalInner({
       <Modal.Header>
         <Modal.Title>Provider Connections</Modal.Title>
         <Modal.Description>
-          Manage inference provider connections. Each connection binds a name to a
-          provider and auth configuration.
+          Manage inference provider connections. Each connection binds a name to
+          a provider and auth configuration.
         </Modal.Description>
       </Modal.Header>
 
@@ -259,6 +349,11 @@ function ManageProvidersModalInner({
               const isDeleting = deleting[conn.name] ?? false;
               const deleteError = deleteErrors[conn.name];
               const isManaged = conn.isManaged ?? false;
+              const isDefaultConnection =
+                conn.name === defaultProvider?.resolvedConnectionName;
+              const isEligibleDefault = isDefaultEligibleProvider(
+                conn.provider,
+              );
 
               return (
                 <div key={conn.name}>
@@ -281,6 +376,11 @@ function ManageProvidersModalInner({
                             Platform
                           </Tag>
                         )}
+                        {isDefaultConnection && (
+                          <Tag title="This connection serves your default provider.">
+                            Default
+                          </Tag>
+                        )}
                       </div>
                       <Typography
                         variant="body-medium-lighter"
@@ -296,6 +396,25 @@ function ManageProvidersModalInner({
 
                     {/* Actions */}
                     <div className="flex shrink-0 items-center gap-2">
+                      {!isDefaultConnection && (
+                        <Button
+                          variant="ghost"
+                          size="compact"
+                          disabled={
+                            !isEligibleDefault || settingDefault != null
+                          }
+                          title={
+                            isEligibleDefault
+                              ? undefined
+                              : "Built-in profiles can't run on this provider."
+                          }
+                          onClick={() => void handleSetDefault(conn)}
+                        >
+                          {settingDefault === conn.name
+                            ? "Setting…"
+                            : "Set as default"}
+                        </Button>
+                      )}
                       <Button
                         variant="ghost"
                         size="compact"
@@ -308,11 +427,15 @@ function ManageProvidersModalInner({
                         size="compact"
                         iconOnly={<Trash2 />}
                         aria-label={`Delete ${conn.name}`}
-                        disabled={isManaged || isDeleting}
+                        disabled={
+                          isManaged || isDeleting || isDefaultConnection
+                        }
                         title={
-                          isManaged
-                            ? "Managed connections cannot be deleted"
-                            : undefined
+                          isDefaultConnection
+                            ? "This connection serves your default provider. Set another connection as default first."
+                            : isManaged
+                              ? "Managed connections cannot be deleted"
+                              : undefined
                         }
                         onClick={() => void handleDelete(conn.name)}
                         tintColor="var(--system-negative-strong)"

--- a/clients/web/src/lib/backwards-compat/default-provider-routes.ts
+++ b/clients/web/src/lib/backwards-compat/default-provider-routes.ts
@@ -1,0 +1,17 @@
+/**
+ * Backwards-compat gate: the default-provider settings surface (the
+ * "Default" marker and "Set as default" action in the Providers modal).
+ *
+ * Driven by `GET/PUT /v1/config/llm/default-provider`, which first ships in
+ * the assistant version below. Against an older assistant the GET 404s and
+ * every "Set as default" PUT can only fail, so the controls are hidden
+ * (never disabled) on the `false` branch — the older assistant has no
+ * default-provider concept to manage.
+ */
+import { useAssistantSupports } from "./utils";
+
+export const MIN_VERSION = "0.10.8";
+
+export function useSupportsDefaultProvider(): boolean {
+  return useAssistantSupports(MIN_VERSION);
+}


### PR DESCRIPTION
## Summary
- The Providers modal marks the connection serving `llm.defaultProvider` with a "Default" tag (driven by the daemon's `resolvedConnectionName`, so convention-resolved and explicitly-pinned defaults both mark correctly) and disables its Delete with an explanatory tooltip — the proactive twin of the server-side delete guard.
- Every other connection whose provider is in the default-profile matrix gets a "Set as default" action that PUTs `{ provider, connectionName }` with the clicked connection's name **always explicit** — convention resolution (`${provider}-personal`) dangles for web-onboarded connections named bare `anthropic`/`openai`, so the marker never relies on it. Non-matrix providers (ollama, openai-compatible, …) show the action disabled with "Built-in profiles can't run on this provider."
- Success invalidates the default-provider and config queries (TanStack cache stays the single owner); failures render in the existing per-row inline error slot. The eligible-provider list is compile-time-guarded against the generated union in both directions (a `satisfies` check plus an exhaustiveness assertion), so server-side matrix changes surface as type errors, not silent UI drift.

## Original prompt
Milestone 7 of the Inference Management Refactor: settings surfacing for `llm.defaultProvider`. Per the placement decision, the default-provider control is a per-connection marker in the Providers modal (like a default payment method), not a second "Default" dropdown competing with Default Profile in the Language Model card. This is M7 PR 2, consuming the availability route shipped in #37579 (M7 PR 1). Plan papertrail: attached to vellum-assistant#37518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->