### PR TITLE
feat(marketplace): add twitch plugin

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -352,6 +352,18 @@
       "category": "marketing",
       "homepage": "https://github.com/ZeebBoyBlue/influencer",
       "license": "MIT"
+    },
+    {
+      "name": "twitch",
+      "source": {
+        "source": "github",
+        "repo": "garrison-faridi/vellum-twitch-plugin",
+        "ref": "38b052ae0565747b0c38e8afd56a81b6a8c16e70"
+      },
+      "description": "Twitch chat + stream tooling. Send chat, check live status, read buffered inbound messages.",
+      "category": "hobby",
+      "homepage": "https://github.com/garrison-faridi/vellum-twitch-plugin",
+      "license": "MIT"
     }
   ]
 }

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -358,7 +358,7 @@
       "source": {
         "source": "github",
         "repo": "garrison-faridi/vellum-twitch-plugin",
-        "ref": "38b052ae0565747b0c38e8afd56a81b6a8c16e70"
+        "ref": "66f35b29195841d7587fc7173d58bdeaa9c7c04e"
       },
       "description": "Twitch chat + stream tooling. Send chat, check live status, read buffered inbound messages.",
       "category": "hobby",


### PR DESCRIPTION
## Prompt / plan
Adds a marketplace catalog entry for the **twitch** plugin (a Vellum plugin providing Twitch chat + stream tooling: send chat, check live status, read buffered inbound messages, and an optional auto-reply engine). This PR is a single-entry addition to `plugins/marketplace.json` — no runtime/core code changes. The plugin itself lives in an external public repo (`garrison-faridi/vellum-twitch-plugin`) and is pinned to a full commit SHA per the whitelisting rules in `plugins/README.md`.

AI was used to author both the plugin and this entry.

## Test plan
- Entry follows the documented schema: single kebab-case `name`, `source.source: github`, `source.repo`, and a full 40-char `ref` SHA (tags/branches avoided per the mutability rule).
- Pinned SHA `38b052ae0565747b0c38e8afd56a81b6a8c16e70` verified reachable on the public source repo (GitHub API returns 200).
- `category: hobby` chosen from the existing category set (no invalid/new category introduced).
- `plugins/marketplace.json` validated as well-formed JSON after the addition (30 entries total).
- Plugin loads clean in a live workspace: `assistant plugins list` reports `twitch 0.2.0 ok`; all three tools register and were exercised against real Twitch (outbound send, stream status, buffered inbound reads).