### PR TITLE
feat(providers): explainable resolution preflight at dispatch (M6 PR7)

### DIFF
--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -1098,6 +1098,31 @@ describe("ConnectionResolutionError classification", () => {
     expect(result.userMessage).toContain("Restart the assistant");
   });
 
+  it("classifies missing_credential naming the connection and fix", () => {
+    const err = new ConnectionResolutionError(
+      "anthropic-personal",
+      "missing_credential",
+      "no key",
+      { profileName: "custom-fast" },
+    );
+    const result = classifyConversationError(err, errCtx);
+    expect(result.code).toBe("PROVIDER_NOT_CONFIGURED");
+    expect(result.userMessage).toContain('"anthropic-personal"');
+    expect(result.userMessage).toContain("no API key stored");
+    expect(result.userMessage).toContain('profile "custom-fast"');
+  });
+
+  it("classifies platform_unauthenticated with a log-in fix", () => {
+    const err = new ConnectionResolutionError(
+      "vellum",
+      "platform_unauthenticated",
+      "not logged in",
+    );
+    const result = classifyConversationError(err, errCtx);
+    expect(result.userMessage).toContain("platform login");
+    expect(result.userMessage).toContain("Log in");
+  });
+
   it("is a structured VellumError (ConfigError) for logging/monitoring", () => {
     const err = new ConnectionResolutionError("x", "not_found", "m");
     expect(err).toBeInstanceOf(VellumError);

--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -1108,7 +1108,7 @@ describe("ConnectionResolutionError classification", () => {
     const result = classifyConversationError(err, errCtx);
     expect(result.code).toBe("PROVIDER_NOT_CONFIGURED");
     expect(result.userMessage).toContain('"anthropic-personal"');
-    expect(result.userMessage).toContain("no API key stored");
+    expect(result.userMessage).toContain("no stored credential");
     expect(result.userMessage).toContain('profile "custom-fast"');
   });
 

--- a/assistant/src/daemon/approval-generators.ts
+++ b/assistant/src/daemon/approval-generators.ts
@@ -1,12 +1,7 @@
-import {
-  isOverrideOrDefaultResolutionEnabled,
-  resolveCallSiteConfig,
-  selectWinningProfile,
-} from "../config/llm-resolver.js";
 import { loadConfig } from "../config/loader.js";
 import { wrapWithCallSiteRouting } from "../providers/call-site-routing.js";
 import {
-  preflightResolvedConfig,
+  mainAgentResolutionError,
   resolveDefaultProvider,
 } from "../providers/connection-resolution.js";
 import { listProviders } from "../providers/registry.js";
@@ -25,7 +20,6 @@ import type {
   ApprovalConversationResult,
   ApprovalCopyGenerator,
 } from "../runtime/http-types.js";
-import { ProviderNotConfiguredError } from "../util/errors.js";
 
 // ---------------------------------------------------------------------------
 // Approval conversation generator constants
@@ -95,7 +89,9 @@ export function createApprovalCopyGenerator(): ApprovalCopyGenerator {
     // failures (vault miss, transient auth) — we treat null as "no
     // provider available" and skip generating copy.
     const baseProvider: Provider | null = await resolveDefaultProvider(config);
-    if (!baseProvider) return null;
+    if (!baseProvider) {
+      return null;
+    }
     // Wrap so per-call `callSite` can route to an alternative provider
     // transport when `llm.callSites.<id>.provider` overrides the default.
     // The `wrapWithCallSiteRouting` helper threads `config` through so the
@@ -130,13 +126,19 @@ export function createApprovalCopyGenerator(): ApprovalCopyGenerator {
 
     const block = response.content.find((entry) => entry.type === "text");
     const text = block && "text" in block ? block.text.trim() : "";
-    if (!text) return null;
+    if (!text) {
+      return null;
+    }
     const cleaned = text
       .replace(/^["'`]+/, "")
       .replace(/["'`]+$/, "")
       .trim();
-    if (!cleaned) return null;
-    if (!includesRequiredKeywords(cleaned, requiredKeywords)) return null;
+    if (!cleaned) {
+      return null;
+    }
+    if (!includesRequiredKeywords(cleaned, requiredKeywords)) {
+      return null;
+    }
     return cleaned;
   };
 }
@@ -155,20 +157,7 @@ export function createApprovalConversationGenerator(): ApprovalConversationGener
     // failures (missing credential, platform auth unavailable).
     const baseProvider = await resolveDefaultProvider(config);
     if (!baseProvider) {
-      const resolved = resolveCallSiteConfig("mainAgent", config.llm);
-      if (isOverrideOrDefaultResolutionEnabled()) {
-        // Statically pinpoint the breakage (missing credential, platform
-        // login, deleted connection) so the banner names the fix; falls
-        // through to the generic retryable error when indeterminate.
-        await preflightResolvedConfig(resolved, {
-          profileName:
-            selectWinningProfile("mainAgent", config.llm, {}).profileName ??
-            undefined,
-        });
-      }
-      throw new ProviderNotConfiguredError(resolved.provider, listProviders(), {
-        connectionName: resolved.provider_connection,
-      });
+      throw await mainAgentResolutionError(config.llm, listProviders());
     }
     const provider = wrapWithCallSiteRouting(baseProvider, config);
 

--- a/assistant/src/daemon/approval-generators.ts
+++ b/assistant/src/daemon/approval-generators.ts
@@ -1,7 +1,14 @@
-import { resolveCallSiteConfig } from "../config/llm-resolver.js";
+import {
+  isOverrideOrDefaultResolutionEnabled,
+  resolveCallSiteConfig,
+  selectWinningProfile,
+} from "../config/llm-resolver.js";
 import { loadConfig } from "../config/loader.js";
 import { wrapWithCallSiteRouting } from "../providers/call-site-routing.js";
-import { resolveDefaultProvider } from "../providers/connection-resolution.js";
+import {
+  preflightResolvedConfig,
+  resolveDefaultProvider,
+} from "../providers/connection-resolution.js";
 import { listProviders } from "../providers/registry.js";
 import type { Provider } from "../providers/types.js";
 import {
@@ -149,6 +156,16 @@ export function createApprovalConversationGenerator(): ApprovalConversationGener
     const baseProvider = await resolveDefaultProvider(config);
     if (!baseProvider) {
       const resolved = resolveCallSiteConfig("mainAgent", config.llm);
+      if (isOverrideOrDefaultResolutionEnabled()) {
+        // Statically pinpoint the breakage (missing credential, platform
+        // login, deleted connection) so the banner names the fix; falls
+        // through to the generic retryable error when indeterminate.
+        await preflightResolvedConfig(resolved, {
+          profileName:
+            selectWinningProfile("mainAgent", config.llm, {}).profileName ??
+            undefined,
+        });
+      }
       throw new ProviderNotConfiguredError(resolved.provider, listProviders(), {
         connectionName: resolved.provider_connection,
       });

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -314,6 +314,10 @@ function connectionResolutionUserMessage(
       return `${connection}${usedBy} is bound to a different provider than the profile declares. Update the profile's connection in ${fixPath}.`;
     case "missing_connection":
       return `No provider connection is configured${usedBy}. Add an API key or log in via ${fixPath}.`;
+    case "missing_credential":
+      return `${connection}${usedBy} has no API key stored. Add one in ${fixPath}.`;
+    case "platform_unauthenticated":
+      return `${connection}${usedBy} requires a Vellum platform login. Log in, or pick a different provider in ${fixPath}.`;
     case "model_incompatible":
       return `${error.model ? `Model "${error.model}"` : "The requested model"} isn't available on ${connectionName ? `connection "${connectionName}"` : "the configured connection"}${usedBy}. Pick a different model or connection in ${fixPath}.`;
   }

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -315,7 +315,10 @@ function connectionResolutionUserMessage(
     case "missing_connection":
       return `No provider connection is configured${usedBy}. Add an API key or log in via ${fixPath}.`;
     case "missing_credential":
-      return `${connection}${usedBy} has no API key stored. Add one in ${fixPath}.`;
+      // Provider-neutral: api_key connections store keys, oauth_subscription
+      // connections store login tokens — the fix differs but the location
+      // doesn't.
+      return `${connection}${usedBy} has no stored credential. Add an API key or reconnect it in ${fixPath}.`;
     case "platform_unauthenticated":
       return `${connection}${usedBy} requires a Vellum platform login. Log in, or pick a different provider in ${fixPath}.`;
     case "model_incompatible":

--- a/assistant/src/daemon/conversation-store.ts
+++ b/assistant/src/daemon/conversation-store.ts
@@ -12,21 +12,15 @@
  * `conversation-evictor`.
  */
 
-import {
-  isOverrideOrDefaultResolutionEnabled,
-  resolveCallSiteConfig,
-  selectWinningProfile,
-} from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import { wrapWithCallSiteRouting } from "../providers/call-site-routing.js";
 import {
-  preflightResolvedConfig,
+  mainAgentResolutionError,
   resolveDefaultProvider,
 } from "../providers/connection-resolution.js";
 import { RateLimitProvider } from "../providers/ratelimit.js";
 import { listProviders } from "../providers/registry.js";
 import { getSubagentManager } from "../subagent/index.js";
-import { ProviderNotConfiguredError } from "../util/errors.js";
 import { getSandboxWorkingDir } from "../util/platform.js";
 import { Conversation } from "./conversation.js";
 import {
@@ -79,7 +73,9 @@ function applyTransportMetadata(
   options: ConversationCreateOptions | undefined,
 ): void {
   const transport = options?.transport;
-  if (!transport) return;
+  if (!transport) {
+    return;
+  }
   conversation.setTransportHints(buildTransportHints(transport));
   conversation.applyHostEnvFromTransport(transport);
   conversation.applyClientTimezoneFromTransport(transport);
@@ -130,24 +126,7 @@ export async function getOrCreateConversation(
       // credential, platform auth unavailable).
       const baseProvider = await resolveDefaultProvider(config);
       if (!baseProvider) {
-        const resolved = resolveCallSiteConfig("mainAgent", config.llm);
-        if (isOverrideOrDefaultResolutionEnabled()) {
-          // Statically pinpoint the breakage (missing credential, platform
-          // login, deleted connection) so the banner names the fix; falls
-          // through to the generic retryable error when indeterminate.
-          await preflightResolvedConfig(resolved, {
-            profileName:
-              selectWinningProfile("mainAgent", config.llm, {}).profileName ??
-              undefined,
-          });
-        }
-        throw new ProviderNotConfiguredError(
-          resolved.provider,
-          listProviders(),
-          {
-            connectionName: resolved.provider_connection,
-          },
-        );
+        throw await mainAgentResolutionError(config.llm, listProviders());
       }
       // Per-call `callSite` routing layered on top, with connection-awareness
       // for alternate profiles (matches the canonical dispatch path).
@@ -222,7 +201,9 @@ export async function getOrCreateConversation(
  */
 export function destroyActiveConversation(conversationId: string): void {
   const conversation = findConversation(conversationId);
-  if (!conversation) return;
+  if (!conversation) {
+    return;
+  }
   removeFromEvictor(conversationId);
   getSubagentManager().abortAllForParent(conversationId);
   conversation.dispose();

--- a/assistant/src/daemon/conversation-store.ts
+++ b/assistant/src/daemon/conversation-store.ts
@@ -12,10 +12,17 @@
  * `conversation-evictor`.
  */
 
-import { resolveCallSiteConfig } from "../config/llm-resolver.js";
+import {
+  isOverrideOrDefaultResolutionEnabled,
+  resolveCallSiteConfig,
+  selectWinningProfile,
+} from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import { wrapWithCallSiteRouting } from "../providers/call-site-routing.js";
-import { resolveDefaultProvider } from "../providers/connection-resolution.js";
+import {
+  preflightResolvedConfig,
+  resolveDefaultProvider,
+} from "../providers/connection-resolution.js";
 import { RateLimitProvider } from "../providers/ratelimit.js";
 import { listProviders } from "../providers/registry.js";
 import { getSubagentManager } from "../subagent/index.js";
@@ -124,6 +131,16 @@ export async function getOrCreateConversation(
       const baseProvider = await resolveDefaultProvider(config);
       if (!baseProvider) {
         const resolved = resolveCallSiteConfig("mainAgent", config.llm);
+        if (isOverrideOrDefaultResolutionEnabled()) {
+          // Statically pinpoint the breakage (missing credential, platform
+          // login, deleted connection) so the banner names the fix; falls
+          // through to the generic retryable error when indeterminate.
+          await preflightResolvedConfig(resolved, {
+            profileName:
+              selectWinningProfile("mainAgent", config.llm, {}).profileName ??
+              undefined,
+          });
+        }
         throw new ProviderNotConfiguredError(
           resolved.provider,
           listProviders(),

--- a/assistant/src/providers/__tests__/preflight-resolved-config.test.ts
+++ b/assistant/src/providers/__tests__/preflight-resolved-config.test.ts
@@ -15,18 +15,22 @@ mock.module("../inference/connections.js", () => ({
   listConnections: () => [],
 }));
 
-mock.module("../../security/secure-keys.js", () => ({
-  getSecureKeyResultAsync: async (account: string) =>
+mock.module("../provider-availability.js", () => ({
+  checkCredentialPresence: async (account: string) =>
     cesUnreachable
-      ? { value: undefined, unreachable: true }
-      : { value: secureKeys[account], unreachable: false },
+      ? "indeterminate"
+      : secureKeys[account] != null
+        ? "present"
+        : "absent",
 }));
 
 mock.module("../platform-proxy/context.js", () => ({
   hasManagedProxyPrereqs: async () => platformLoggedIn,
   resolveManagedProxyContext: async () => ({
     enabled: platformLoggedIn,
-    platformBaseUrl: platformLoggedIn ? "https://platform" : "",
+    // Base URL configured: an unauthenticated result must come from the
+    // credential probe, so CES outages stay distinguishable.
+    platformBaseUrl: "https://platform",
     assistantApiKey: platformLoggedIn ? "key" : "",
   }),
 }));
@@ -56,6 +60,7 @@ async function preflightError(
 }
 
 beforeEach(() => {
+  secureKeys = {};
   connectionsByName = {
     "anthropic-personal": {
       name: "anthropic-personal",
@@ -160,6 +165,16 @@ describe("preflightResolvedConfig", () => {
     expect(err?.reason).toBe("platform_unauthenticated");
 
     platformLoggedIn = true;
+    expect(await preflightError(resolved())).toBeUndefined();
+  });
+
+  test("a credential-store outage on platform auth passes silently — never reported as logout", async () => {
+    connectionsByName["anthropic-personal"] = {
+      name: "anthropic-personal",
+      provider: "anthropic",
+      auth: { type: "platform" },
+    };
+    cesUnreachable = true;
     expect(await preflightError(resolved())).toBeUndefined();
   });
 

--- a/assistant/src/providers/__tests__/preflight-resolved-config.test.ts
+++ b/assistant/src/providers/__tests__/preflight-resolved-config.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let connectionsByName: Record<string, unknown> = {};
+let secureKeys: Record<string, string | undefined> = {};
+let cesUnreachable = false;
+let platformLoggedIn = false;
+
+mock.module("../../persistence/db-connection.js", () => ({
+  getDb: () => ({}),
+}));
+
+mock.module("../inference/connections.js", () => ({
+  getConnection: (_db: unknown, name: string) =>
+    connectionsByName[name] ?? null,
+  listConnections: () => [],
+}));
+
+mock.module("../../security/secure-keys.js", () => ({
+  getSecureKeyResultAsync: async (account: string) =>
+    cesUnreachable
+      ? { value: undefined, unreachable: true }
+      : { value: secureKeys[account], unreachable: false },
+}));
+
+mock.module("../platform-proxy/context.js", () => ({
+  hasManagedProxyPrereqs: async () => platformLoggedIn,
+  resolveManagedProxyContext: async () => ({
+    enabled: platformLoggedIn,
+    platformBaseUrl: platformLoggedIn ? "https://platform" : "",
+    assistantApiKey: platformLoggedIn ? "key" : "",
+  }),
+}));
+
+import {
+  ConnectionResolutionError,
+  preflightResolvedConfig,
+} from "../connection-resolution.js";
+
+const resolved = (overrides: Partial<Record<string, string>> = {}) => ({
+  provider: "anthropic",
+  provider_connection: "anthropic-personal",
+  model: "claude-opus-4-8",
+  ...overrides,
+});
+
+async function preflightError(
+  config: ReturnType<typeof resolved>,
+): Promise<ConnectionResolutionError | undefined> {
+  try {
+    await preflightResolvedConfig(config, { profileName: "custom-fast" });
+    return undefined;
+  } catch (err) {
+    expect(err).toBeInstanceOf(ConnectionResolutionError);
+    return err as ConnectionResolutionError;
+  }
+}
+
+beforeEach(() => {
+  connectionsByName = {
+    "anthropic-personal": {
+      name: "anthropic-personal",
+      provider: "anthropic",
+      auth: {
+        type: "api_key",
+        credential: "credential/anthropic/api_key",
+      },
+    },
+  };
+  secureKeys = { "credential/anthropic/api_key": "sk-ant" };
+  cesUnreachable = false;
+  platformLoggedIn = false;
+});
+
+describe("preflightResolvedConfig", () => {
+  test("healthy config passes silently", async () => {
+    expect(await preflightError(resolved())).toBeUndefined();
+  });
+
+  test("no provider_connection on the config is not the preflight's concern", async () => {
+    await preflightResolvedConfig(
+      { provider: "anthropic", model: "claude-opus-4-8" },
+      {},
+    );
+  });
+
+  test("deleted connection throws not_found naming profile and model", async () => {
+    connectionsByName = {};
+    const err = await preflightError(resolved());
+    expect(err?.reason).toBe("not_found");
+    expect(err?.profileName).toBe("custom-fast");
+    expect(err?.model).toBe("claude-opus-4-8");
+    expect(err?.message).toContain("anthropic-personal");
+  });
+
+  test("missing credential throws missing_credential", async () => {
+    secureKeys = {};
+    const err = await preflightError(resolved());
+    expect(err?.reason).toBe("missing_credential");
+    expect(err?.message).toContain("API key");
+  });
+
+  test("CES-unreachable passes silently — never misreported as a missing credential", async () => {
+    secureKeys = {};
+    cesUnreachable = true;
+    expect(await preflightError(resolved())).toBeUndefined();
+  });
+
+  test("provider mismatch throws provider_mismatch", async () => {
+    connectionsByName["anthropic-personal"] = {
+      name: "anthropic-personal",
+      provider: "openai",
+      auth: { type: "api_key", credential: "credential/openai/api_key" },
+    };
+    const err = await preflightError(resolved());
+    expect(err?.reason).toBe("provider_mismatch");
+  });
+
+  test("the vellum managed connection serves managed-routable providers when logged in", async () => {
+    connectionsByName = {
+      vellum: {
+        name: "vellum",
+        provider: "vellum",
+        auth: { type: "platform" },
+      },
+    };
+    platformLoggedIn = true;
+    expect(
+      await preflightError(resolved({ provider_connection: "vellum" })),
+    ).toBeUndefined();
+
+    platformLoggedIn = false;
+    const err = await preflightError(
+      resolved({ provider_connection: "vellum" }),
+    );
+    expect(err?.reason).toBe("platform_unauthenticated");
+  });
+
+  test("the vellum managed connection rejects non-managed-routable providers", async () => {
+    connectionsByName = {
+      vellum: {
+        name: "vellum",
+        provider: "vellum",
+        auth: { type: "platform" },
+      },
+    };
+    platformLoggedIn = true;
+    const err = await preflightError(
+      resolved({ provider: "openrouter", provider_connection: "vellum" }),
+    );
+    expect(err?.reason).toBe("provider_mismatch");
+  });
+
+  test("platform-auth connections require a platform login", async () => {
+    connectionsByName["anthropic-personal"] = {
+      name: "anthropic-personal",
+      provider: "anthropic",
+      auth: { type: "platform" },
+    };
+    const err = await preflightError(resolved());
+    expect(err?.reason).toBe("platform_unauthenticated");
+
+    platformLoggedIn = true;
+    expect(await preflightError(resolved())).toBeUndefined();
+  });
+
+  test("keyless and unknown auth types pass through to dispatch", async () => {
+    connectionsByName["anthropic-personal"] = {
+      name: "anthropic-personal",
+      provider: "anthropic",
+      auth: { type: "none" },
+    };
+    expect(await preflightError(resolved())).toBeUndefined();
+  });
+});

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -29,6 +29,7 @@
 
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { getDb } from "../persistence/db-connection.js";
+import { getSecureKeyResultAsync } from "../security/secure-keys.js";
 import { ConfigError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import {
@@ -36,6 +37,7 @@ import {
   isConnectionCompatibleWithModel,
 } from "./connection-model-compat.js";
 import { getConnection, listConnections } from "./inference/connections.js";
+import { hasManagedProxyPrereqs } from "./platform-proxy/context.js";
 import type { ProvidersConfig } from "./registry.js";
 import { resolveProviderFromConnection } from "./registry.js";
 import type { Provider } from "./types.js";
@@ -64,7 +66,9 @@ export class ConnectionResolutionError extends ConfigError {
       | "not_found"
       | "provider_mismatch"
       | "missing_connection"
-      | "model_incompatible",
+      | "model_incompatible"
+      | "missing_credential"
+      | "platform_unauthenticated",
     message: string,
     options?: { cause?: unknown; model?: string; profileName?: string },
   ) {
@@ -295,4 +299,118 @@ export async function resolveDefaultProvider(
     resolved.provider,
     resolved.model,
   );
+}
+
+/**
+ * Statically verify a resolved config can dispatch, throwing a
+ * reason-carrying `ConnectionResolutionError` that names the profile,
+ * connection, and fix when it provably cannot:
+ *
+ *   - connection row missing (`not_found`)
+ *   - connection bound to a different provider (`provider_mismatch`), with
+ *     the provider-agnostic Vellum-managed exception for managed-routable
+ *     providers
+ *   - API-key/subscription credential absent from the vault
+ *     (`missing_credential`)
+ *   - platform auth without a platform login (`platform_unauthenticated`)
+ *   - model not servable by the connection (`model_incompatible`)
+ *
+ * Returns silently when the config is healthy AND when it is indeterminate:
+ * a credential store that is unreachable must never be reported as a missing
+ * credential, so the caller falls through to its existing retryable
+ * handling. Purely a read — never mutates, never auto-recovers.
+ */
+export async function preflightResolvedConfig(
+  resolved: {
+    provider: string;
+    provider_connection?: string;
+    model: string;
+  },
+  attribution: { profileName?: string } = {},
+): Promise<void> {
+  const connectionName = resolved.provider_connection;
+  if (!connectionName) {
+    return;
+  }
+  const errorOptions = {
+    model: resolved.model,
+    ...(attribution.profileName != null
+      ? { profileName: attribution.profileName }
+      : {}),
+  };
+
+  let connection;
+  try {
+    connection = getConnection(getDb(), connectionName);
+  } catch {
+    // DB unavailable — indeterminate, not a config error.
+    return;
+  }
+  if (!connection) {
+    throw new ConnectionResolutionError(
+      connectionName,
+      "not_found",
+      `provider_connection "${connectionName}" does not exist — add a connection for provider "${resolved.provider}" or pick a different default in Settings`,
+      errorOptions,
+    );
+  }
+
+  if (isVellumManagedConnection(connection)) {
+    if (!MANAGED_ROUTABLE_PROVIDERS.has(resolved.provider)) {
+      throw new ConnectionResolutionError(
+        connectionName,
+        "provider_mismatch",
+        `provider_connection "${connectionName}" is the Vellum-managed connection, which cannot serve provider "${resolved.provider}"`,
+        errorOptions,
+      );
+    }
+    if (!(await hasManagedProxyPrereqs())) {
+      throw new ConnectionResolutionError(
+        connectionName,
+        "platform_unauthenticated",
+        `provider_connection "${connectionName}" routes through the Vellum platform, but no platform login is available — log in or pick a different provider`,
+        errorOptions,
+      );
+    }
+    return;
+  }
+  if (connection.provider !== resolved.provider) {
+    throw new ConnectionResolutionError(
+      connectionName,
+      "provider_mismatch",
+      `provider_connection "${connectionName}" has provider="${connection.provider}" but the resolved config declares provider="${resolved.provider}"`,
+      errorOptions,
+    );
+  }
+
+  switch (connection.auth.type) {
+    case "api_key":
+    case "oauth_subscription": {
+      const key = await getSecureKeyResultAsync(connection.auth.credential);
+      if (key.unreachable || key.value != null) {
+        // Unreachable is indeterminate: the key may exist. Never claim
+        // `missing_credential` here.
+        return;
+      }
+      throw new ConnectionResolutionError(
+        connectionName,
+        "missing_credential",
+        `provider_connection "${connectionName}" has no ${connection.auth.type === "api_key" ? "API key" : "credential"} stored — add one in Settings`,
+        errorOptions,
+      );
+    }
+    case "platform": {
+      if (await hasManagedProxyPrereqs()) {
+        return;
+      }
+      throw new ConnectionResolutionError(
+        connectionName,
+        "platform_unauthenticated",
+        `provider_connection "${connectionName}" uses platform auth, but no platform login is available — log in to use it`,
+        errorOptions,
+      );
+    }
+    default:
+      return;
+  }
 }

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -27,17 +27,22 @@
  *      a conversation offline.
  */
 
-import { resolveCallSiteConfig } from "../config/llm-resolver.js";
+import {
+  isOverrideOrDefaultResolutionEnabled,
+  resolveCallSiteConfig,
+  selectWinningProfile,
+} from "../config/llm-resolver.js";
 import { getDb } from "../persistence/db-connection.js";
-import { getSecureKeyResultAsync } from "../security/secure-keys.js";
-import { ConfigError } from "../util/errors.js";
+import { credentialKey } from "../security/credential-key.js";
+import { ConfigError, ProviderNotConfiguredError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import {
   describeSubscriptionModelIncompatibility,
   isConnectionCompatibleWithModel,
 } from "./connection-model-compat.js";
 import { getConnection, listConnections } from "./inference/connections.js";
-import { hasManagedProxyPrereqs } from "./platform-proxy/context.js";
+import { resolveManagedProxyContext } from "./platform-proxy/context.js";
+import { checkCredentialPresence } from "./provider-availability.js";
 import type { ProvidersConfig } from "./registry.js";
 import { resolveProviderFromConnection } from "./registry.js";
 import type { Provider } from "./types.js";
@@ -364,7 +369,7 @@ export async function preflightResolvedConfig(
         errorOptions,
       );
     }
-    if (!(await hasManagedProxyPrereqs())) {
+    if ((await platformLoginPresence()) === "unauthenticated") {
       throw new ConnectionResolutionError(
         connectionName,
         "platform_unauthenticated",
@@ -386,10 +391,12 @@ export async function preflightResolvedConfig(
   switch (connection.auth.type) {
     case "api_key":
     case "oauth_subscription": {
-      const key = await getSecureKeyResultAsync(connection.auth.credential);
-      if (key.unreachable || key.value != null) {
-        // Unreachable is indeterminate: the key may exist. Never claim
-        // `missing_credential` here.
+      const presence = await checkCredentialPresence(
+        connection.auth.credential,
+      );
+      if (presence !== "absent") {
+        // `indeterminate` (credential store unreachable) must never be
+        // claimed as a missing credential.
         return;
       }
       throw new ConnectionResolutionError(
@@ -400,17 +407,70 @@ export async function preflightResolvedConfig(
       );
     }
     case "platform": {
-      if (await hasManagedProxyPrereqs()) {
-        return;
+      if ((await platformLoginPresence()) === "unauthenticated") {
+        throw new ConnectionResolutionError(
+          connectionName,
+          "platform_unauthenticated",
+          `provider_connection "${connectionName}" uses platform auth, but no platform login is available — log in to use it`,
+          errorOptions,
+        );
       }
-      throw new ConnectionResolutionError(
-        connectionName,
-        "platform_unauthenticated",
-        `provider_connection "${connectionName}" uses platform auth, but no platform login is available — log in to use it`,
-        errorOptions,
-      );
+      return;
     }
     default:
       return;
   }
+}
+
+/**
+ * Platform-login state with the credential-store-outage case kept distinct:
+ * `resolveManagedProxyContext` collapses an unreachable key read into
+ * "no key", which must not be reported as a logout. A missing platform base
+ * URL is definitively unauthenticated (it is config, not a credential read).
+ */
+async function platformLoginPresence(): Promise<
+  "ok" | "unauthenticated" | "indeterminate"
+> {
+  const ctx = await resolveManagedProxyContext();
+  if (ctx.enabled) {
+    return "ok";
+  }
+  if (!ctx.platformBaseUrl) {
+    return "unauthenticated";
+  }
+  const presence = await checkCredentialPresence(
+    credentialKey("vellum", "assistant_api_key"),
+  );
+  if (presence === "present") {
+    return "ok";
+  }
+  return presence === "indeterminate" ? "indeterminate" : "unauthenticated";
+}
+
+/**
+ * Shared guard for the call sites that must fail loudly when the default
+ * provider resolves to no usable adapter: the flag-gated preflight throws a
+ * reason-carrying error when it can statically pinpoint the breakage;
+ * otherwise the returned generic retryable error is for the caller to
+ * throw (returned rather than thrown so `throw await …` keeps TypeScript's
+ * reachability narrowing at the call site).
+ */
+export async function mainAgentResolutionError(
+  llm: Parameters<typeof resolveCallSiteConfig>[1],
+  registeredProviders: string[],
+): Promise<ProviderNotConfiguredError> {
+  const resolved = resolveCallSiteConfig("mainAgent", llm);
+  if (isOverrideOrDefaultResolutionEnabled()) {
+    await preflightResolvedConfig(resolved, {
+      profileName:
+        selectWinningProfile("mainAgent", llm, {}).profileName ?? undefined,
+    });
+  }
+  return new ProviderNotConfiguredError(
+    resolved.provider,
+    registeredProviders,
+    {
+      connectionName: resolved.provider_connection,
+    },
+  );
 }

--- a/assistant/src/providers/provider-availability.ts
+++ b/assistant/src/providers/provider-availability.ts
@@ -6,7 +6,10 @@
  */
 
 import { getConfig } from "../config/loader.js";
-import { getProviderKeyAsync } from "../security/secure-keys.js";
+import {
+  getProviderKeyAsync,
+  getSecureKeyResultAsync,
+} from "../security/secure-keys.js";
 import { PROVIDER_CATALOG } from "./model-catalog.js";
 import { managedFallbackEnabledFor } from "./platform-proxy/context.js";
 import { getVisibleProviderCatalog } from "./provider-catalog-visibility.js";
@@ -58,4 +61,23 @@ export async function getConfiguredProviders(): Promise<string[]> {
     configured.push("ollama");
   }
   return configured;
+}
+
+export type CredentialPresence = "present" | "absent" | "indeterminate";
+
+/**
+ * Non-plaintext existence probe for a stored credential. Never returns the
+ * secret — modules that only need "is a key stored?" use this instead of
+ * importing secure-keys (which the credential-security invariant restricts
+ * to an allowlist). `indeterminate` means the credential store was
+ * unreachable: callers must not treat it as absent.
+ */
+export async function checkCredentialPresence(
+  account: string,
+): Promise<CredentialPresence> {
+  const result = await getSecureKeyResultAsync(account);
+  if (result.unreachable) {
+    return "indeterminate";
+  }
+  return result.value != null ? "present" : "absent";
 }

--- a/assistant/src/providers/provider-send-message.ts
+++ b/assistant/src/providers/provider-send-message.ts
@@ -166,8 +166,13 @@ export async function resolveConfiguredProvider(
       }
     }
     if (!connectionName) {
-      log.debug(
-        { callSite, inferenceProvider },
+      log.warn(
+        {
+          callSite,
+          inferenceProvider,
+          model: resolved.model,
+          reason: "no_connection",
+        },
         "resolveCallSiteConfig yielded no provider_connection — returning null so callsite can fall back",
       );
       return null;
@@ -183,7 +188,18 @@ export async function resolveConfiguredProvider(
   if (!connectionProvider) {
     // Soft credential failure — the connection resolved to no usable
     // adapter (credential missing, transient auth failure, etc.).
-    // Callers handle null as "no provider available" rather than crash.
+    // Callers handle null as "no provider available" rather than crash;
+    // the structured warn keeps every silent degradation observable.
+    log.warn(
+      {
+        callSite,
+        connectionName,
+        inferenceProvider,
+        model: resolved.model,
+        reason: "credential_unavailable",
+      },
+      "Connection resolved to no usable adapter — returning null so the call site can degrade",
+    );
     return null;
   }
   return {

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -10,11 +10,7 @@
 
 import { v4 as uuid } from "uuid";
 
-import {
-  isOverrideOrDefaultResolutionEnabled,
-  resolveCallSiteConfig,
-  selectWinningProfile,
-} from "../config/llm-resolver.js";
+import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import { Conversation } from "../daemon/conversation.js";
 import {
@@ -31,14 +27,13 @@ import {
 } from "../persistence/subagent-store.js";
 import { wrapWithCallSiteRouting } from "../providers/call-site-routing.js";
 import {
-  preflightResolvedConfig,
+  mainAgentResolutionError,
   resolveDefaultProvider,
 } from "../providers/connection-resolution.js";
 import { RateLimitProvider } from "../providers/ratelimit.js";
 import { listProviders } from "../providers/registry.js";
 import type { Message, TextContent } from "../providers/types.js";
 import { createAbortReason } from "../util/abort-reasons.js";
-import { ProviderNotConfiguredError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import { getSandboxWorkingDir } from "../util/platform.js";
 import { injectMessageIntoParent } from "./notify.js";
@@ -378,20 +373,7 @@ export class SubagentManager {
     // platform auth unavailable).
     const baseProvider = await resolveDefaultProvider(appConfig);
     if (!baseProvider) {
-      const resolved = resolveCallSiteConfig("mainAgent", appConfig.llm);
-      if (isOverrideOrDefaultResolutionEnabled()) {
-        // Statically pinpoint the breakage (missing credential, platform
-        // login, deleted connection) so the banner names the fix; falls
-        // through to the generic retryable error when indeterminate.
-        await preflightResolvedConfig(resolved, {
-          profileName:
-            selectWinningProfile("mainAgent", appConfig.llm, {}).profileName ??
-            undefined,
-        });
-      }
-      throw new ProviderNotConfiguredError(resolved.provider, listProviders(), {
-        connectionName: resolved.provider_connection,
-      });
+      throw await mainAgentResolutionError(appConfig.llm, listProviders());
     }
     // Per-call `options.config.callSite` (e.g. `subagentSpawn`) can resolve
     // to a profile that differs from `llm.default`. The shared wrapper

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -10,7 +10,11 @@
 
 import { v4 as uuid } from "uuid";
 
-import { resolveCallSiteConfig } from "../config/llm-resolver.js";
+import {
+  isOverrideOrDefaultResolutionEnabled,
+  resolveCallSiteConfig,
+  selectWinningProfile,
+} from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import { Conversation } from "../daemon/conversation.js";
 import {
@@ -26,7 +30,10 @@ import {
   upsertSubagentRecord,
 } from "../persistence/subagent-store.js";
 import { wrapWithCallSiteRouting } from "../providers/call-site-routing.js";
-import { resolveDefaultProvider } from "../providers/connection-resolution.js";
+import {
+  preflightResolvedConfig,
+  resolveDefaultProvider,
+} from "../providers/connection-resolution.js";
 import { RateLimitProvider } from "../providers/ratelimit.js";
 import { listProviders } from "../providers/registry.js";
 import type { Message, TextContent } from "../providers/types.js";
@@ -372,6 +379,16 @@ export class SubagentManager {
     const baseProvider = await resolveDefaultProvider(appConfig);
     if (!baseProvider) {
       const resolved = resolveCallSiteConfig("mainAgent", appConfig.llm);
+      if (isOverrideOrDefaultResolutionEnabled()) {
+        // Statically pinpoint the breakage (missing credential, platform
+        // login, deleted connection) so the banner names the fix; falls
+        // through to the generic retryable error when indeterminate.
+        await preflightResolvedConfig(resolved, {
+          profileName:
+            selectWinningProfile("mainAgent", appConfig.llm, {}).profileName ??
+            undefined,
+        });
+      }
       throw new ProviderNotConfiguredError(resolved.provider, listProviders(), {
         connectionName: resolved.provider_connection,
       });


### PR DESCRIPTION
## Summary
- Adds `preflightResolvedConfig` to `connection-resolution.ts`: an async, read-only static check of a resolved config that throws a reason-carrying `ConnectionResolutionError` naming the profile, connection, model, and fix when dispatch provably cannot succeed — deleted connection (`not_found`), wrong-provider connection (`provider_mismatch`, with the provider-agnostic vellum/managed-routable exception), vault-confirmed missing key (`missing_credential`, a new reason), and platform auth without a login (`platform_unauthenticated`, also new). A credential store that is *unreachable* passes silently — indeterminate must never be reported as missing (test-asserted), so callers fall through to their existing retryable handling.
- Wires the preflight into the three paths that already throw for users (conversation store, subagent manager, approval conversation generator), **gated behind the `override-or-default-resolution` flag** so the kill switch reverts M6 as one unit; the generic `ProviderNotConfiguredError` remains the final fallback. `profileName` attribution comes from the resolver's own winner selection. The classifier gains messages for the two new reasons.
- Satellite call sites keep degrading gracefully, but every silent null at the dispatch boundary now emits one structured `log.warn` (`callSite`, `connectionName`, `model`, `reason`) — the observability spine the resolution-failure reporting milestone extends.
- This completes M6's "missing provider/credential/model gives explainable error" scope bullet (PR 7 of the plan attached to #37518): a BYOK default with a deleted API key now produces "Connection X has no API key stored — add one in Settings → Models & Services" instead of a generic provider-not-configured banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->