### PR TITLE
feat(web): consume live-voice metrics and measure client-side heard latency

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -23,6 +23,7 @@
 
 import { create } from "zustand";
 
+import type { LiveVoiceMetricsServerFrame } from "@/domains/chat/voice/live-voice/protocol";
 import { createSelectors } from "@/utils/create-selectors";
 
 // ---------------------------------------------------------------------------
@@ -99,6 +100,25 @@ export interface LiveVoiceSessionControls {
 }
 
 /**
+ * Latency pair for the most recent live-voice turn.
+ *
+ * - `server` — the daemon's `metrics` frame for the turn, `null` until it
+ *   arrives (its `roundTripMs` is normalized to `null` by the controller when
+ *   an older daemon omits the field).
+ * - `clientHeardLatencyMs` — the client-perceived end-of-speech → first
+ *   TTS-audio-enqueued delta measured by the controller (includes network +
+ *   queueing the server can't see); `null` when the turn produced no audio or
+ *   had no pending end-of-speech stamp.
+ *
+ * Written wholesale as one object so the atomic `use.lastTurnLatency()`
+ * selector never observes a torn pair (see docs/STATE_MANAGEMENT.md).
+ */
+export interface LiveVoiceTurnLatency {
+  readonly server: LiveVoiceMetricsServerFrame | null;
+  readonly clientHeardLatencyMs: number | null;
+}
+
+/**
  * Starts a live-voice session for `assistantId`, attaching `conversationId`
  * when non-null. Registered into the store by the persistently mounted
  * session-controller hook (see `use-live-voice-session-controller.ts`) so any
@@ -146,6 +166,14 @@ export interface LiveVoiceState {
   assistantTranscript: string;
   /** Smoothed RMS mic amplitude in [0, 1] for UI / barge-in. */
   inputAmplitude: number;
+  /**
+   * Latency measurements for the last turn, `null` until a turn is measured.
+   * Debug surface only — per the minimal-treatment note on
+   * {@link LIVE_VOICE_STATE_LABELS}, no surface renders this: the controller
+   * logs one `console.debug("[live-voice] turn latency", …)` line per
+   * completed turn and this field waits for a future debug panel.
+   */
+  lastTurnLatency: LiveVoiceTurnLatency | null;
   /** Human-readable error message when `state === "failed"`, `null` otherwise. */
   error: string | null;
 }
@@ -183,6 +211,11 @@ export interface LiveVoiceActions {
    */
   clearUserTranscripts: () => void;
   setInputAmplitude: (amplitude: number) => void;
+  /**
+   * Replace the last turn's latency pair wholesale (never patch a member in
+   * place) so subscribers of the atomic selector see one consistent object.
+   */
+  setLastTurnLatency: (lastTurnLatency: LiveVoiceTurnLatency) => void;
   /** Transition to `failed` with a message. */
   fail: (message: string) => void;
   /**
@@ -275,6 +308,7 @@ const INITIAL_SESSION_STATE: Omit<LiveVoiceState, "starter"> = {
   finalTranscript: "",
   assistantTranscript: "",
   inputAmplitude: 0,
+  lastTurnLatency: null,
   error: null,
 };
 
@@ -295,6 +329,7 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
   clearAssistantTranscript: () => set({ assistantTranscript: "" }),
   clearUserTranscripts: () => set({ partialTranscript: "", finalTranscript: "" }),
   setInputAmplitude: (inputAmplitude) => set({ inputAmplitude }),
+  setLastTurnLatency: (lastTurnLatency) => set({ lastTurnLatency }),
   fail: (message) => set({ state: "failed", error: message }),
   reset: () => set({ ...INITIAL_SESSION_STATE }),
 }));

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.ts
@@ -193,6 +193,12 @@ export interface LiveVoiceTurnCancelledServerFrame extends LiveVoiceServerFrameB
 
 export interface LiveVoiceMetricsServerFrame extends LiveVoiceServerFrameBase {
   readonly type: "metrics";
+  /**
+   * What the frame reports: `"turn_completed"`, `"turn_cancelled"`, or
+   * `"session_ended"`. Optional: daemons predating the field omit it, and
+   * readers treat absent as a completed turn.
+   */
+  readonly event?: string;
   readonly turnId: string;
   readonly sttMs: number | null;
   readonly llmFirstDeltaMs: number | null;

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.ts
@@ -197,6 +197,13 @@ export interface LiveVoiceMetricsServerFrame extends LiveVoiceServerFrameBase {
   readonly sttMs: number | null;
   readonly llmFirstDeltaMs: number | null;
   readonly ttsFirstAudioMs: number | null;
+  /**
+   * End-of-speech (utterance_end, or ptt_release in manual mode) to first
+   * TTS audio, measured server-side. Optional: daemons predating the field
+   * omit it — readers treat absent as null (read fallback, no compat gate
+   * for a read-only debug surface; see docs/BACKWARDS_COMPAT.md).
+   */
+  readonly roundTripMs?: number | null;
   readonly totalMs: number | null;
 }
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -7,7 +7,7 @@
  * AudioContext is touched.
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { act, cleanup, renderHook } from "@testing-library/react";
 
 // The default client factory in use-live-voice statically imports the real
@@ -915,6 +915,263 @@ describe("utterance_discarded", () => {
       });
     });
     expect(h.view.result.current.state).toBe("thinking");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Turn latency (server metrics frame + client-heard measurement)
+// ---------------------------------------------------------------------------
+
+describe("turn latency", () => {
+  /** Aggregate fields every server `metrics` frame carries. */
+  const METRICS_FIELDS = {
+    sttMs: 420,
+    llmFirstDeltaMs: 600,
+    ttsFirstAudioMs: 300,
+    totalMs: 2100,
+  };
+
+  // Silence the per-turn `[live-voice] turn latency` debug line and let tests
+  // assert on it.
+  let debugSpy: ReturnType<typeof spyOn>;
+  beforeEach(() => {
+    debugSpy = spyOn(console, "debug").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    debugSpy.mockRestore();
+  });
+
+  const latencyLogs = () =>
+    debugSpy.mock.calls.filter(
+      (call: unknown[]) => call[0] === "[live-voice] turn latency",
+    );
+
+  test("hands-free: utterance_end → first tts_audio produces a positive clientHeardLatencyMs", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    act(() => {
+      h.client.emit("utteranceEnd", {
+        type: "utterance_end",
+        seq: 2,
+        reason: "silence",
+      });
+    });
+    // Real time elapses between end-of-speech and the response's first audio.
+    await act(async () => {
+      await sleep(10);
+    });
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 3, turnId: "t1" });
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 4,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+    });
+
+    const latency = useLiveVoiceStore.getState().lastTurnLatency;
+    expect(latency).not.toBeNull();
+    expect(latency!.clientHeardLatencyMs).toBeGreaterThan(0);
+    // No metrics frame yet: only the client half is known.
+    expect(latency!.server).toBeNull();
+
+    // A second tts_audio frame of the same response does not re-measure:
+    // the store still holds the exact object written on the first frame.
+    act(() => {
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 5,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+    });
+    expect(useLiveVoiceStore.getState().lastTurnLatency).toBe(latency!);
+  });
+
+  test("manual: ptt_release → first tts_audio produces a positive clientHeardLatencyMs", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    act(() => {
+      useLiveVoiceStore.getState().controls?.release();
+    });
+    expect(h.client.pttReleaseCount).toBe(1);
+    await act(async () => {
+      await sleep(10);
+    });
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 3,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+    });
+
+    expect(
+      useLiveVoiceStore.getState().lastTurnLatency?.clientHeardLatencyMs,
+    ).toBeGreaterThan(0);
+  });
+
+  test("a metrics frame pairs the server metrics with the client measurement and logs once", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    act(() => {
+      h.client.emit("utteranceEnd", {
+        type: "utterance_end",
+        seq: 2,
+        reason: "silence",
+      });
+      h.client.emit("sttFinal", { type: "stt_final", seq: 3, text: "hello" });
+    });
+    await act(async () => {
+      await sleep(10);
+    });
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 4, turnId: "t1" });
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 5,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+    });
+    await act(async () => {
+      h.client.emit("ttsDone", { type: "tts_done", seq: 6, turnId: "t1" });
+      h.player.finishPlayback();
+      await Promise.resolve();
+    });
+
+    act(() => {
+      h.client.emit("metrics", {
+        type: "metrics",
+        seq: 7,
+        turnId: "t1",
+        ...METRICS_FIELDS,
+        roundTripMs: 750,
+      });
+    });
+
+    const latency = useLiveVoiceStore.getState().lastTurnLatency;
+    expect(latency?.server?.turnId).toBe("t1");
+    expect(latency?.server?.roundTripMs).toBe(750);
+    expect(latency?.clientHeardLatencyMs).toBeGreaterThan(0);
+
+    // Exactly one debug line per completed turn, carrying both halves.
+    const logs = latencyLogs();
+    expect(logs).toHaveLength(1);
+    expect(logs[0]![1]).toMatchObject({
+      turnId: "t1",
+      roundTripMs: 750,
+      clientHeardLatencyMs: latency!.clientHeardLatencyMs,
+    });
+  });
+
+  test("an absent roundTripMs (older daemon) is stored and logged as null", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    // An older daemon's metrics frame predates the field entirely.
+    act(() => {
+      h.client.emit("metrics", {
+        type: "metrics",
+        seq: 2,
+        turnId: "t1",
+        ...METRICS_FIELDS,
+      });
+    });
+
+    const latency = useLiveVoiceStore.getState().lastTurnLatency;
+    expect(latency?.server?.roundTripMs).toBeNull();
+    expect(latency?.clientHeardLatencyMs).toBeNull();
+    const logs = latencyLogs();
+    expect(logs).toHaveLength(1);
+    expect(logs[0]![1]).toMatchObject({ roundTripMs: null });
+  });
+
+  test("turn_cancelled clears the pending stamp so it never pairs across turns", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    // The utterance ends (stamp set)…
+    act(() => {
+      h.client.emit("utteranceEnd", {
+        type: "utterance_end",
+        seq: 2,
+        reason: "silence",
+      });
+      h.client.emit("sttFinal", { type: "stt_final", seq: 3, text: "hello" });
+      h.client.emit("thinking", { type: "thinking", seq: 4, turnId: "t1" });
+    });
+    // …but the turn is barged in and cancelled before any audio.
+    act(() => {
+      h.client.emit("speechStarted", { type: "speech_started", seq: 5 });
+      h.client.emit("turnCancelled", {
+        type: "turn_cancelled",
+        seq: 6,
+        turnId: "t1",
+      });
+    });
+
+    await act(async () => {
+      await sleep(10);
+    });
+    // The next turn's first audio must not pair with the dead stamp.
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 7, turnId: "t2" });
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 8,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+    });
+    expect(useLiveVoiceStore.getState().lastTurnLatency).toBeNull();
+  });
+
+  test("utterance_discarded clears the pending stamp", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    // A noise-only utterance is closed (stamp set) and then discarded.
+    act(() => {
+      h.client.emit("utteranceEnd", {
+        type: "utterance_end",
+        seq: 2,
+        reason: "silence",
+      });
+      h.client.emit("sttFinal", { type: "stt_final", seq: 3, text: " " });
+      h.client.emit("utteranceDiscarded", {
+        type: "utterance_discarded",
+        seq: 4,
+      });
+    });
+
+    await act(async () => {
+      await sleep(10);
+    });
+    // A later turn's audio (here without its own utterance_end, so no fresh
+    // stamp) must not measure against the discarded utterance's stamp.
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 5, turnId: "t1" });
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 6,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+    });
+    expect(useLiveVoiceStore.getState().lastTurnLatency).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -1173,6 +1173,150 @@ describe("turn latency", () => {
     });
     expect(useLiveVoiceStore.getState().lastTurnLatency).toBeNull();
   });
+
+  test("an utterance ending mid-thinking keeps its stamp for its own turn", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    // Utterance A ends and its turn t1 starts thinking.
+    act(() => {
+      h.client.emit("utteranceEnd", {
+        type: "utterance_end",
+        seq: 2,
+        reason: "silence",
+      });
+      h.client.emit("thinking", { type: "thinking", seq: 3, turnId: "t1" });
+    });
+    // Utterance B ends while t1 is still thinking (allowed in hands-free —
+    // no turn_cancelled follows a pre-audio overlap).
+    act(() => {
+      h.client.emit("speechStarted", { type: "speech_started", seq: 4 });
+      h.client.emit("utteranceEnd", {
+        type: "utterance_end",
+        seq: 5,
+        reason: "silence",
+      });
+    });
+    await act(async () => {
+      await sleep(10);
+    });
+    // t1's first audio measures against A's bound stamp — it must not
+    // consume B's pending one.
+    act(() => {
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 6,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+    });
+    expect(
+      useLiveVoiceStore.getState().lastTurnLatency?.clientHeardLatencyMs,
+    ).toBeGreaterThan(0);
+
+    // B's own turn still gets a measurement from B's stamp.
+    await act(async () => {
+      await sleep(10);
+    });
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 7, turnId: "t2" });
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 8,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+    });
+    expect(
+      useLiveVoiceStore.getState().lastTurnLatency?.clientHeardLatencyMs,
+    ).toBeGreaterThan(0);
+  });
+
+  test("a cancelled turn leaves the overlapping utterance's pending stamp intact", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    // Utterance A → t1 thinking; utterance B ends mid-thinking; t1 cancelled.
+    act(() => {
+      h.client.emit("utteranceEnd", {
+        type: "utterance_end",
+        seq: 2,
+        reason: "silence",
+      });
+      h.client.emit("thinking", { type: "thinking", seq: 3, turnId: "t1" });
+      h.client.emit("utteranceEnd", {
+        type: "utterance_end",
+        seq: 4,
+        reason: "silence",
+      });
+      h.client.emit("turnCancelled", {
+        type: "turn_cancelled",
+        seq: 5,
+        turnId: "t1",
+      });
+    });
+    await act(async () => {
+      await sleep(10);
+    });
+    // B's turn still measures — cancellation only dropped t1's bound stamp.
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 6, turnId: "t2" });
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 7,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+    });
+    expect(
+      useLiveVoiceStore.getState().lastTurnLatency?.clientHeardLatencyMs,
+    ).toBeGreaterThan(0);
+  });
+
+  test("metrics frames for cancelled turns and session end are ignored", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    act(() => {
+      h.client.emit("metrics", {
+        type: "metrics",
+        seq: 2,
+        event: "turn_cancelled",
+        turnId: "t1",
+        ...METRICS_FIELDS,
+        roundTripMs: 500,
+      });
+      h.client.emit("metrics", {
+        type: "metrics",
+        seq: 3,
+        event: "session_ended",
+        turnId: "t1",
+        ...METRICS_FIELDS,
+        roundTripMs: 500,
+      });
+    });
+    expect(useLiveVoiceStore.getState().lastTurnLatency).toBeNull();
+    expect(latencyLogs()).toHaveLength(0);
+
+    // A completed-turn frame still lands.
+    act(() => {
+      h.client.emit("metrics", {
+        type: "metrics",
+        seq: 4,
+        event: "turn_completed",
+        turnId: "t2",
+        ...METRICS_FIELDS,
+        roundTripMs: 640,
+      });
+    });
+    expect(
+      useLiveVoiceStore.getState().lastTurnLatency?.server?.roundTripMs,
+    ).toBe(640);
+    expect(latencyLogs()).toHaveLength(1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -256,6 +256,22 @@ interface SessionContext {
   speechMs: number;
   /** Accumulated trailing silence (ms) after speech in the current utterance. */
   silenceMs: number;
+  /**
+   * `performance.now()` stamp of the current turn's end-of-speech — the
+   * `utterance_end` frame (hands-free) or the `ptt_release` send (manual).
+   * Consumed by the FIRST `tts_audio` frame of the following response to
+   * derive `clientHeardLatencyMs`; cleared on `turn_cancelled` and
+   * `utterance_discarded` (and dies with the session context on teardown) so
+   * a stale stamp never pairs across turns.
+   */
+  speechEndedAtMs: number | null;
+  /**
+   * Client-perceived end-of-speech → first-TTS-audio latency for the current
+   * response, `null` until measured (and for responses that produced no
+   * audio). Reset with the other per-response flags on `thinking` so a
+   * `metrics` frame always pairs with its own turn's measurement.
+   */
+  clientHeardLatencyMs: number | null;
 }
 
 /** Number of bytes per Int16 PCM sample. */
@@ -479,6 +495,8 @@ export function useLiveVoice(
         releaseInFlight: false,
         speechMs: 0,
         silenceMs: 0,
+        speechEndedAtMs: null,
+        clientHeardLatencyMs: null,
       };
 
       const capture = (opts.createCapture ?? ((o) => new LiveVoiceAudioCapture(o)))({
@@ -528,11 +546,19 @@ export function useLiveVoice(
         }),
         client.on("utteranceEnd", () => {
           if (!live() || !session.handsFree) return;
+          // End of user speech: stamp the client-heard latency start; the
+          // response's first tts_audio consumes it (see
+          // beginAssistantAudioIfNeeded). Manual mode stamps at the
+          // ptt_release send instead (see releasePushToTalk).
+          session.speechEndedAtMs = performance.now();
           // Server VAD closed the utterance; its transcription is finishing.
           useLiveVoiceStore.getState().setState("transcribing");
         }),
         client.on("utteranceDiscarded", () => {
           if (!live() || !session.handsFree) return;
+          // The discarded utterance never becomes a turn — drop its
+          // end-of-speech stamp so it can't pair with a later turn's audio.
+          session.speechEndedAtMs = null;
           // The closed utterance had no usable speech (noise/cough); return
           // to listening. A discarded utterance never reaches `thinking`
           // (empty finals stay in `transcribing`), so any other state belongs
@@ -584,6 +610,10 @@ export function useLiveVoice(
           session.responseEpoch += 1;
           session.responseAudioStarted = false;
           session.interruptSent = false;
+          // The previous response's measurement is spent — a `metrics` frame
+          // for THIS turn must pair with this turn's own first audio (or
+          // null, for a response that produces none).
+          session.clientHeardLatencyMs = null;
           const s = useLiveVoiceStore.getState();
           s.clearAssistantTranscript();
           s.setState("thinking");
@@ -614,8 +644,34 @@ export function useLiveVoice(
         }),
         client.on("turnCancelled", () => {
           if (!live() || !session.handsFree) return;
+          // A turn cancelled before its first tts_audio leaves its
+          // end-of-speech stamp pending — drop it so the next turn's audio
+          // can't pair against it.
+          session.speechEndedAtMs = null;
           // Barge-in aborted the turn; no tts_done follows a cancelled turn.
           flushPlaybackToListening(session);
+        }),
+        client.on("metrics", (frame) => {
+          if (!live()) return;
+          // Turn completion: pair the server's metrics with the client-side
+          // measurement for the same turn. `roundTripMs` is absent on frames
+          // from older daemons — normalize to null (read fallback, no compat
+          // gate for a read-only debug surface; see docs/BACKWARDS_COMPAT.md).
+          const lastTurnLatency = {
+            server: { ...frame, roundTripMs: frame.roundTripMs ?? null },
+            clientHeardLatencyMs: session.clientHeardLatencyMs,
+          };
+          useLiveVoiceStore.getState().setLastTurnLatency(lastTurnLatency);
+          // Debug surface only (no UI): one line per completed turn.
+          console.debug("[live-voice] turn latency", {
+            turnId: frame.turnId,
+            roundTripMs: lastTurnLatency.server.roundTripMs,
+            clientHeardLatencyMs: lastTurnLatency.clientHeardLatencyMs,
+            sttMs: frame.sttMs,
+            llmFirstDeltaMs: frame.llmFirstDeltaMs,
+            ttsFirstAudioMs: frame.ttsFirstAudioMs,
+            totalMs: frame.totalMs,
+          });
         }),
         client.on("archived", () => {
           if (!live()) return;
@@ -893,6 +949,9 @@ function releasePushToTalk(session: SessionContext): void {
   session.releaseInFlight = true;
   session.forwardingAudio = false;
   session.client.pttRelease();
+  // End of user speech (manual mode): stamp the client-heard latency start,
+  // mirroring the hands-free utterance_end stamp.
+  session.speechEndedAtMs = performance.now();
   const s = useLiveVoiceStore.getState();
   if (s.state === "listening") s.setState("transcribing");
   s.setInputAmplitude(0);
@@ -916,11 +975,27 @@ function interruptIfSpeaking(
   teardown();
 }
 
-/** First TTS frame of a response: reset playback flags for the new utterance. */
+/**
+ * First TTS frame of a response: reset playback flags for the new utterance
+ * and resolve the client-heard latency — the end-of-speech stamp → first
+ * audio enqueue delta the user actually perceives (network + queueing
+ * included, which the server-side `roundTripMs` can't see). The stamp is
+ * consumed here so no later frame or turn can pair against it again.
+ */
 function beginAssistantAudioIfNeeded(session: SessionContext): void {
   if (session.responseAudioStarted) return;
   session.responseAudioStarted = true;
   session.interruptSent = false;
+  if (session.speechEndedAtMs === null) return;
+  session.clientHeardLatencyMs = performance.now() - session.speechEndedAtMs;
+  session.speechEndedAtMs = null;
+  // Publish immediately (server half still null) so the measurement exists
+  // even against a daemon that never emits `metrics` frames; the turn's
+  // `metrics` frame overwrites this with the fully paired object.
+  useLiveVoiceStore.getState().setLastTurnLatency({
+    server: null,
+    clientHeardLatencyMs: session.clientHeardLatencyMs,
+  });
 }
 
 /**

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -257,14 +257,24 @@ interface SessionContext {
   /** Accumulated trailing silence (ms) after speech in the current utterance. */
   silenceMs: number;
   /**
-   * `performance.now()` stamp of the current turn's end-of-speech — the
+   * `performance.now()` stamp of the most recent end-of-speech — the
    * `utterance_end` frame (hands-free) or the `ptt_release` send (manual).
-   * Consumed by the FIRST `tts_audio` frame of the following response to
-   * derive `clientHeardLatencyMs`; cleared on `turn_cancelled` and
-   * `utterance_discarded` (and dies with the session context on teardown) so
-   * a stale stamp never pairs across turns.
+   * Pending until a `thinking` frame binds it to that turn (see
+   * `turnHeardStampMs`); cleared on `utterance_discarded` (and dies with
+   * the session context on teardown) so a stale stamp never pairs across
+   * turns. Hands-free allows a new utterance to end while the previous
+   * response is still thinking, so the pending stamp must stay unbound
+   * until its own turn starts.
    */
   speechEndedAtMs: number | null;
+  /**
+   * The end-of-speech stamp bound to the in-flight response — moved from
+   * `speechEndedAtMs` when that response's `thinking` frame arrives.
+   * Consumed by the response's FIRST `tts_audio` frame to derive
+   * `clientHeardLatencyMs`; cleared on `turn_cancelled` so a cancelled
+   * turn's stamp can't pair with a later response's audio.
+   */
+  turnHeardStampMs: number | null;
   /**
    * Client-perceived end-of-speech → first-TTS-audio latency for the current
    * response, `null` until measured (and for responses that produced no
@@ -496,6 +506,7 @@ export function useLiveVoice(
         speechMs: 0,
         silenceMs: 0,
         speechEndedAtMs: null,
+        turnHeardStampMs: null,
         clientHeardLatencyMs: null,
       };
 
@@ -614,6 +625,12 @@ export function useLiveVoice(
           // for THIS turn must pair with this turn's own first audio (or
           // null, for a response that produces none).
           session.clientHeardLatencyMs = null;
+          // Bind the pending end-of-speech stamp to this turn. An utterance
+          // that ends while a previous response is still thinking keeps its
+          // stamp pending here until its own `thinking` arrives, so the
+          // previous response's audio can never consume it.
+          session.turnHeardStampMs = session.speechEndedAtMs;
+          session.speechEndedAtMs = null;
           const s = useLiveVoiceStore.getState();
           s.clearAssistantTranscript();
           s.setState("thinking");
@@ -644,15 +661,22 @@ export function useLiveVoice(
         }),
         client.on("turnCancelled", () => {
           if (!live() || !session.handsFree) return;
-          // A turn cancelled before its first tts_audio leaves its
-          // end-of-speech stamp pending — drop it so the next turn's audio
-          // can't pair against it.
-          session.speechEndedAtMs = null;
+          // Drop the cancelled turn's bound stamp so the next response's
+          // audio can't pair against it. The unbound `speechEndedAtMs` is
+          // left alone — it belongs to a newer overlapping utterance whose
+          // own `thinking` will bind it.
+          session.turnHeardStampMs = null;
           // Barge-in aborted the turn; no tts_done follows a cancelled turn.
           flushPlaybackToListening(session);
         }),
         client.on("metrics", (frame) => {
           if (!live()) return;
+          // The daemon also emits metrics frames for cancelled turns and
+          // session end; only a completed turn carries a pairable latency.
+          // An absent event field (older daemons) is treated as completed.
+          if (frame.event !== undefined && frame.event !== "turn_completed") {
+            return;
+          }
           // Turn completion: pair the server's metrics with the client-side
           // measurement for the same turn. `roundTripMs` is absent on frames
           // from older daemons — normalize to null (read fallback, no compat
@@ -986,9 +1010,9 @@ function beginAssistantAudioIfNeeded(session: SessionContext): void {
   if (session.responseAudioStarted) return;
   session.responseAudioStarted = true;
   session.interruptSent = false;
-  if (session.speechEndedAtMs === null) return;
-  session.clientHeardLatencyMs = performance.now() - session.speechEndedAtMs;
-  session.speechEndedAtMs = null;
+  if (session.turnHeardStampMs === null) return;
+  session.clientHeardLatencyMs = performance.now() - session.turnHeardStampMs;
+  session.turnHeardStampMs = null;
   // Publish immediately (server half still null) so the measurement exists
   // even against a daemon that never emits `metrics` frames; the turn's
   // `metrics` frame overwrites this with the fully paired object.


### PR DESCRIPTION
## Summary
- Mirrors roundTripMs onto the client metrics frame and registers a metrics handler (frames were previously parsed and dropped)
- Measures clientHeardLatencyMs (utterance_end/ptt_release → first tts_audio enqueue) and stores both in the live-voice store; debug log only, no UI
- Closes the browser-mirror gap flagged on #37534

Part of plan: voice-mode-latency.md (PR 2 of 13)