### PR TITLE
feat(live-voice): reuse one streaming transcriber across server-VAD utterance cycles

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-integration.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-integration.test.ts
@@ -81,6 +81,41 @@ class FakeStreamingTranscriber implements StreamingTranscriber {
   }
 }
 
+// Finalize-capable fake: with server_vad the session keeps this single
+// stream for every cycle (persistent mode). Each finalize flushes
+// "utterance <n>" as a final followed by finalized; stop() remains the
+// session-teardown path.
+class PersistentFakeStreamingTranscriber implements StreamingTranscriber {
+  readonly providerId = "deepgram" as const;
+  readonly boundaryId = "daemon-streaming" as const;
+  readonly audioChunks: Buffer[] = [];
+  startCalls = 0;
+  stopCalls = 0;
+  finalizeCalls = 0;
+  private onEvent: ((event: SttStreamServerEvent) => void) | null = null;
+
+  async start(onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
+    this.startCalls += 1;
+    this.onEvent = onEvent;
+  }
+
+  sendAudio(audio: Buffer): void {
+    this.audioChunks.push(Buffer.from(audio));
+    this.onEvent?.({ type: "partial", text: "hel" });
+  }
+
+  finalizeUtterance(): void {
+    this.finalizeCalls += 1;
+    this.onEvent?.({ type: "final", text: `utterance ${this.finalizeCalls}` });
+    this.onEvent?.({ type: "finalized" });
+  }
+
+  stop(): void {
+    this.stopCalls += 1;
+    this.onEvent?.({ type: "closed" });
+  }
+}
+
 function createContext(startFrame: LiveVoiceClientStartFrame = START_FRAME): {
   context: LiveVoiceSessionFactoryContext;
   frames: LiveVoiceServerFrame[];
@@ -482,6 +517,91 @@ describe("LiveVoiceSession integration smoke harness", () => {
     expect(transcribers[0]?.stopped).toBe(true);
     expect(transcribers[1]?.stopped).toBe(true);
     expect(transcribers[2]?.stopped).toBe(false);
+  });
+
+  test("runs two utterance cycles over one persistent transcriber without teardown between turns", async () => {
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      options.callbacks?.persisted_user_message_id?.("user-message-123");
+      options.callbacks?.assistant_text_delta?.(
+        makeTextDelta(`Reply to ${options.content}.`),
+      );
+      options.callbacks?.message_complete?.(makeMessageComplete());
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const transcriber = new PersistentFakeStreamingTranscriber();
+    const resolveTranscriber = mock(async () => transcriber);
+    const archiveAudio = mock(
+      async (input: LiveVoiceSessionArchiveAudioInput) =>
+        makeArchiveResult(input),
+    );
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk(`audio:${options.text}`));
+      return makeTtsResult(options.text);
+    });
+    const { context, frames } = createContext(VAD_START_FRAME);
+    let turnCount = 0;
+    const session = createLiveVoiceSession(context, {
+      resolveCredentialReadiness: null,
+      resolveTranscriber,
+      startVoiceTurn,
+      streamTtsAudio,
+      archiveAudio,
+      metricsClock: createClock(),
+      createTurnId: () => {
+        turnCount += 1;
+        return `live-turn-${turnCount}`;
+      },
+    });
+    const firstUtteranceAudio = loudPcmChunk(8_000);
+    const secondUtteranceAudio = loudPcmChunk(9_000);
+
+    await session.start();
+    await session.handleBinaryAudio(firstUtteranceAudio);
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(
+      () => frames.filter((frame) => frame.type === "tts_done").length === 1,
+    );
+
+    await session.handleBinaryAudio(secondUtteranceAudio);
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(
+      () => frames.filter((frame) => frame.type === "tts_done").length === 2,
+    );
+
+    expect(resolveTranscriber).toHaveBeenCalledTimes(1);
+    expect(transcriber.startCalls).toBe(1);
+    expect(transcriber.stopCalls).toBe(0);
+    expect(transcriber.finalizeCalls).toBe(2);
+    expect(startVoiceTurn.mock.calls.map((call) => call[0].content)).toEqual([
+      "utterance 1",
+      "utterance 2",
+    ]);
+    expect(transcriber.audioChunks).toEqual([
+      Buffer.from(firstUtteranceAudio),
+      Buffer.from(secondUtteranceAudio),
+    ]);
+    expect(
+      archiveAudio.mock.calls.map((call) => [call[0].role, call[0].turnId]),
+    ).toEqual([
+      ["user", "live-turn-1"],
+      ["assistant", "live-turn-1"],
+      ["user", "live-turn-2"],
+      ["assistant", "live-turn-2"],
+    ]);
+    // utteranceEnd → finalTranscript (the sttMs role in server_vad mode)
+    // measures the finalize flush and still populates on every turn.
+    const completedTurnMetrics = frames.flatMap((frame) =>
+      frame.type === "metrics" && frame.event === "turn_completed"
+        ? [frame]
+        : [],
+    );
+    expect(completedTurnMetrics).toHaveLength(2);
+    for (const frame of completedTurnMetrics) {
+      expect(frame.sttMs).not.toBeNull();
+    }
+
+    await session.close("websocket_close");
+    expect(transcriber.stopCalls).toBe(1);
   });
 
   test("completes a full second cycle after an interrupt mid-turn", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -730,6 +730,53 @@ describe("LiveVoiceSession STT", () => {
     expect(secondContent).not.toContain("first utterance");
   });
 
+  test("a stale flush arriving after the next cycle released is dropped, not absorbed", async () => {
+    const transcriber = new FinalizingMockStreamingTranscriber();
+    transcriber.respondToFinalize = false;
+    const startVoiceTurn = completingVoiceTurnStarter();
+    const { context, frames } = createContext({ turnDetection: "server_vad" });
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: mock(async () => transcriber),
+      startVoiceTurn,
+      finalizeGraceMs: 25,
+    });
+
+    // Cycle A: dispatched by grace timeout, its flush still outstanding.
+    await session.start();
+    await session.handleBinaryAudio(loudPcmChunk());
+    transcriber.emit({ type: "final", text: "first utterance" });
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(
+      () => frames.filter((frame) => frame.type === "tts_done").length === 1,
+    );
+
+    // Cycle B releases while A's request is still open (two queued
+    // requests). A's stale flush then arrives — it must be attributed to
+    // A's request (and dropped), never appended to B.
+    await session.handleBinaryAudio(loudPcmChunk());
+    transcriber.emit({ type: "final", text: "second utterance" });
+    await session.handleClientFrame({ type: "ptt_release" });
+    transcriber.emit({
+      type: "final",
+      text: "stale first flush",
+      fromFinalize: true,
+    });
+    transcriber.emit({ type: "finalized" });
+    // B's own flush completes its request.
+    transcriber.emit({ type: "final", text: "flush b", fromFinalize: true });
+    transcriber.emit({ type: "finalized" });
+    await waitFor(
+      () => frames.filter((frame) => frame.type === "tts_done").length === 2,
+    );
+
+    expect(startVoiceTurn).toHaveBeenCalledTimes(2);
+    const secondContent = startVoiceTurn.mock.calls[1]?.[0]?.content ?? "";
+    expect(secondContent).toContain("second utterance");
+    expect(secondContent).toContain("flush b");
+    expect(secondContent).not.toContain("stale first flush");
+    expect(secondContent).not.toContain("first utterance");
+  });
+
   test("falls back to a fresh transcriber when the shared stream closes unexpectedly", async () => {
     const transcribers: FinalizingMockStreamingTranscriber[] = [];
     const resolver = mock(async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -91,7 +91,11 @@ class FinalizingMockStreamingTranscriber extends MockStreamingTranscriber {
     if (!this.respondToFinalize) {
       return;
     }
-    this.emit({ type: "final", text: `utterance ${this.finalizeCalls}` });
+    this.emit({
+      type: "final",
+      text: `utterance ${this.finalizeCalls}`,
+      fromFinalize: true,
+    });
     this.emit({ type: "finalized" });
   }
 }
@@ -672,7 +676,7 @@ describe("LiveVoiceSession STT", () => {
 
     // A flush landing after the grace-timeout fallback must not mutate the
     // dispatched transcript.
-    transcriber.emit({ type: "final", text: "late flush" });
+    transcriber.emit({ type: "final", text: "late flush", fromFinalize: true });
     transcriber.emit({ type: "finalized" });
     await new Promise((resolve) => setTimeout(resolve, 10));
 
@@ -682,6 +686,48 @@ describe("LiveVoiceSession STT", () => {
         frame.type === "stt_final" ? [frame.text] : [],
       ),
     ).toEqual(["collected before release"]);
+  });
+
+  test("speech after a grace-timeout dispatch routes to the next cycle, not the timed-out one", async () => {
+    const transcriber = new FinalizingMockStreamingTranscriber();
+    transcriber.respondToFinalize = false;
+    const startVoiceTurn = completingVoiceTurnStarter();
+    const { context, frames } = createContext({ turnDetection: "server_vad" });
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: mock(async () => transcriber),
+      startVoiceTurn,
+      finalizeGraceMs: 25,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(loudPcmChunk());
+    transcriber.emit({ type: "final", text: "first utterance" });
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(
+      () => frames.filter((frame) => frame.type === "tts_done").length === 1,
+    );
+
+    // The user speaks again while the timed-out cycle's finalize slot is
+    // still pending (the provider never flushed). The new speech must
+    // reach the new cycle — not be dropped against the dead one.
+    await session.handleBinaryAudio(loudPcmChunk());
+    transcriber.emit({ type: "final", text: "second utterance" });
+    // The stale flush pair finally arrives: the flagged flush is dropped,
+    // the finalized signal clears the slot.
+    transcriber.emit({ type: "final", text: "stale tail", fromFinalize: true });
+    transcriber.emit({ type: "finalized" });
+
+    transcriber.respondToFinalize = true;
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(
+      () => frames.filter((frame) => frame.type === "tts_done").length === 2,
+    );
+
+    expect(startVoiceTurn).toHaveBeenCalledTimes(2);
+    const secondContent = startVoiceTurn.mock.calls[1]?.[0]?.content ?? "";
+    expect(secondContent).toContain("second utterance");
+    expect(secondContent).not.toContain("stale tail");
+    expect(secondContent).not.toContain("first utterance");
   });
 
   test("falls back to a fresh transcriber when the shared stream closes unexpectedly", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -64,6 +64,49 @@ class MockStreamingTranscriber implements StreamingTranscriber {
   }
 }
 
+// Finalize-capable fake: with server_vad this flips the session into
+// persistent mode (one shared stream across utterance cycles). Each
+// finalize flushes "utterance <n>" as a final followed by finalized.
+class FinalizingMockStreamingTranscriber extends MockStreamingTranscriber {
+  startCalls = 0;
+  stopCalls = 0;
+  finalizeCalls = 0;
+  // When false the flush never arrives, exercising the grace-timeout path.
+  respondToFinalize = true;
+
+  override async start(
+    onEvent: (event: SttStreamServerEvent) => void,
+  ): Promise<void> {
+    this.startCalls += 1;
+    await super.start(onEvent);
+  }
+
+  override stop(): void {
+    this.stopCalls += 1;
+    super.stop();
+  }
+
+  finalizeUtterance(): void {
+    this.finalizeCalls += 1;
+    if (!this.respondToFinalize) {
+      return;
+    }
+    this.emit({ type: "final", text: `utterance ${this.finalizeCalls}` });
+    this.emit({ type: "finalized" });
+  }
+}
+
+function completingVoiceTurnStarter() {
+  return mock(async (options: VoiceTurnOptions) => {
+    options.callbacks?.message_complete?.({
+      type: "message_complete",
+      conversationId: options.conversationId,
+      messageId: "assistant-message-123",
+    });
+    return { turnId: "bridge-turn-1", abort: mock() };
+  });
+}
+
 function createContext(overrides: Partial<LiveVoiceClientStartFrame> = {}): {
   context: LiveVoiceSessionFactoryContext;
   frames: LiveVoiceServerFrame[];
@@ -558,6 +601,125 @@ describe("LiveVoiceSession STT", () => {
     await session.handleClientFrame({ type: "interrupt" });
 
     expect(transcriber.stopCalls).toBe(2);
+  });
+
+  test("reuses one streaming transcriber across server_vad cycles without stop or reconnect", async () => {
+    const transcriber = new FinalizingMockStreamingTranscriber();
+    const resolver = mock(async () => transcriber);
+    const startVoiceTurn = completingVoiceTurnStarter();
+    const { context, frames } = createContext({ turnDetection: "server_vad" });
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: resolver,
+      startVoiceTurn,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(loudPcmChunk());
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(
+      () => frames.filter((frame) => frame.type === "tts_done").length === 1,
+    );
+
+    await session.handleBinaryAudio(loudPcmChunk());
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(
+      () => frames.filter((frame) => frame.type === "tts_done").length === 2,
+    );
+
+    expect(resolver).toHaveBeenCalledTimes(1);
+    expect(transcriber.startCalls).toBe(1);
+    // The turn starts on the finalized flush — the stream is never torn
+    // down between cycles.
+    expect(transcriber.stopCalls).toBe(0);
+    expect(transcriber.finalizeCalls).toBe(2);
+    expect(startVoiceTurn.mock.calls.map((call) => call[0].content)).toEqual([
+      "utterance 1",
+      "utterance 2",
+    ]);
+    expect(
+      frames.flatMap((frame) =>
+        frame.type === "stt_final" ? [frame.text] : [],
+      ),
+    ).toEqual(["utterance 1", "utterance 2"]);
+
+    await session.close("websocket_close");
+    expect(transcriber.stopCalls).toBe(1);
+  });
+
+  test("grace timeout starts the turn with collected segments when the finalize flush never arrives", async () => {
+    const transcriber = new FinalizingMockStreamingTranscriber();
+    transcriber.respondToFinalize = false;
+    const startVoiceTurn = completingVoiceTurnStarter();
+    const { context, frames } = createContext({ turnDetection: "server_vad" });
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: mock(async () => transcriber),
+      startVoiceTurn,
+      finalizeGraceMs: 25,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(loudPcmChunk());
+    transcriber.emit({ type: "final", text: "collected before release" });
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(transcriber.finalizeCalls).toBe(1);
+    expect(transcriber.stopCalls).toBe(0);
+    expect(startVoiceTurn).toHaveBeenCalledTimes(1);
+    expect(startVoiceTurn.mock.calls[0]?.[0]).toMatchObject({
+      content: "collected before release",
+    });
+
+    // A flush landing after the grace-timeout fallback must not mutate the
+    // dispatched transcript.
+    transcriber.emit({ type: "final", text: "late flush" });
+    transcriber.emit({ type: "finalized" });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(startVoiceTurn).toHaveBeenCalledTimes(1);
+    expect(
+      frames.flatMap((frame) =>
+        frame.type === "stt_final" ? [frame.text] : [],
+      ),
+    ).toEqual(["collected before release"]);
+  });
+
+  test("falls back to a fresh transcriber when the shared stream closes unexpectedly", async () => {
+    const transcribers: FinalizingMockStreamingTranscriber[] = [];
+    const resolver = mock(async () => {
+      const transcriber = new FinalizingMockStreamingTranscriber();
+      transcribers.push(transcriber);
+      return transcriber;
+    });
+    const startVoiceTurn = completingVoiceTurnStarter();
+    const { context, frames } = createContext({ turnDetection: "server_vad" });
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: resolver,
+      startVoiceTurn,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(loudPcmChunk());
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(
+      () => frames.filter((frame) => frame.type === "tts_done").length === 1,
+    );
+
+    // Provider drops the shared stream between utterances.
+    transcribers[0]?.emit({ type: "closed" });
+    await session.handleBinaryAudio(loudPcmChunk());
+    await waitFor(() => transcribers.length === 2);
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(
+      () => frames.filter((frame) => frame.type === "tts_done").length === 2,
+    );
+
+    expect(resolver).toHaveBeenCalledTimes(2);
+    expect(transcribers[1]?.startCalls).toBe(1);
+    expect(startVoiceTurn.mock.calls.map((call) => call[0].content)).toEqual([
+      "utterance 1",
+      "utterance 1",
+    ]);
   });
 
   test("uses the production streaming transcriber resolver by default", () => {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1022,7 +1022,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     switch (event.type) {
       case "partial": {
-        const target = this.finalizingUtterance ?? this.currentUtterance;
+        // A finalizing cycle owns the stream only until its turn
+        // dispatches (grace timeout); after that, partials belong to the
+        // user's next utterance on the current cycle.
+        const finalizing = this.finalizingUtterance;
+        const target =
+          finalizing && !finalizing.assistantTurnStarted
+            ? finalizing
+            : this.currentUtterance;
         if (!target || target.assistantTurnStarted || target.completed) {
           return;
         }
@@ -1031,7 +1038,34 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         return;
       }
       case "final": {
-        const target = this.finalizingUtterance ?? this.currentUtterance;
+        const finalizing = this.finalizingUtterance;
+        if (event.fromFinalize) {
+          // A finalize flush commits audio buffered before the finalize
+          // request — it belongs to the finalizing cycle, never to new
+          // speech. After a grace-timeout dispatch the transcript is
+          // sealed, so a late flush is dropped rather than mutating a
+          // dispatched turn or polluting the next cycle.
+          if (
+            finalizing &&
+            !finalizing.assistantTurnStarted &&
+            !finalizing.completed
+          ) {
+            await this.recordFinalTranscript(finalizing, event.text);
+          } else {
+            log.warn(
+              "Dropping a late finalize flush segment: its assistant turn already dispatched",
+            );
+          }
+          return;
+        }
+        // Ordinary finals: the finalizing cycle owns the stream until its
+        // turn dispatches; afterwards new speech belongs to the current
+        // cycle (the finalize flush is flagged, so it can never be
+        // mistaken for new speech).
+        const target =
+          finalizing && !finalizing.assistantTurnStarted && !finalizing.completed
+            ? finalizing
+            : this.currentUtterance;
         if (!target || target.assistantTurnStarted || target.completed) {
           log.warn(
             "Dropping a late final transcript segment: its assistant turn already dispatched",

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -21,9 +21,11 @@ import { publishConversationListAndMetadataChanged } from "../runtime/sync/resou
 import { detectPcm16SpeechActivity } from "../stt/speech-energy.js";
 import type {
   StreamingTranscriber,
+  SttStreamServerErrorEvent,
   SttStreamServerEvent,
 } from "../stt/types.js";
 import { extractSpeakableSegments } from "../tts/speakable-segments.js";
+import { getLogger } from "../util/logger.js";
 import type {
   LiveVoiceAudioArchiveResult,
   LiveVoiceAudioArchiveRole,
@@ -52,6 +54,8 @@ import {
   type LiveVoiceServerFramePayload,
 } from "./protocol.js";
 
+const log = getLogger("live-voice-session");
+
 type LiveVoiceSessionState =
   | "initializing"
   | "active"
@@ -66,6 +70,11 @@ const SERVER_VAD_PENDING_AUDIO_MAX_SECONDS = 10;
 // onset so the transcriber gets leading context without streaming an open
 // quiet mic.
 const SERVER_VAD_PRE_ROLL_MAX_CHUNKS = 25;
+// Bounded wait for the shared transcriber's finalize flush; on expiry the
+// assistant turn proceeds with the transcript collected so far. This is the
+// strict upper bound on the release→turn-start tail in persistent mode (the
+// provider keeps its own, longer, finalize fallback).
+const FINALIZE_GRACE_MS = 1_000;
 
 export type LiveVoiceStreamingTranscriberResolver = (
   options: ResolveStreamingTranscriberOptions,
@@ -126,17 +135,27 @@ export interface LiveVoiceSessionOptions {
    * `DEFAULT_SPEECH_ENERGY_THRESHOLD`.
    */
   speechEnergyThreshold?: number;
+  /**
+   * Overrides the bounded wait for the shared transcriber's finalize
+   * flush in persistent mode (test hook). Defaults to `FINALIZE_GRACE_MS`.
+   */
+  finalizeGraceMs?: number;
 }
 
 type LiveVoiceUtterancePhase =
   | "pending"
   | "streaming"
   | "released"
+  // The cycle's transcript is complete and the assistant turn may start.
+  // In per-cycle mode the transcriber socket has closed; in persistent
+  // (shared-transcriber) mode the stream stays open — the finalize flush
+  // (or its grace timeout) completed instead.
   | "transcriber_closed";
 
 // One capture→transcribe→turn cycle. A session runs many of these back to
-// back: each cycle owns its transcriber, transcript, audio buffers, and
-// metrics-turn flags so consecutive turns stay isolated.
+// back: each cycle owns its transcript, audio buffers, and metrics-turn
+// flags so consecutive turns stay isolated. The transcriber is per-cycle in
+// manual mode and a session-shared instance in persistent server-VAD mode.
 interface UtteranceCycle {
   phase: LiveVoiceUtterancePhase;
   released: boolean;
@@ -231,6 +250,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // replayed once the parked speech flushes into the next armed utterance.
   private vadPendingTurnEnd: "silence" | "max-duration" | null = null;
   private readonly metricsClock: LiveVoiceMetricsClock;
+  // Persistent mode: server-VAD sessions with a finalize-capable provider
+  // keep one streaming transcriber for the whole session. Utterance release
+  // flushes via finalizeUtterance() instead of tearing the stream down, and
+  // re-arm reuses this instance synchronously. Null in manual mode, for
+  // providers without finalizeUtterance, and after an unexpected stream
+  // close (the next arm resolves a fresh transcriber).
+  private sharedTranscriber: StreamingTranscriber | null = null;
+  // The released cycle whose finalize flush is awaited. Shared-transcriber
+  // partial/final events route here ahead of currentUtterance; kept set
+  // through a grace timeout so a late flush still attributes to (and is
+  // dropped for) the cycle that owns the audio.
+  private finalizingUtterance: UtteranceCycle | null = null;
+  private finalizeGraceTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly finalizeGraceMs: number;
 
   constructor(
     context: LiveVoiceSessionFactoryContext,
@@ -255,6 +288,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       ...(options.metricsClock ? { clock: options.metricsClock } : {}),
     });
     this.speechEnergyThreshold = options.speechEnergyThreshold;
+    this.finalizeGraceMs = options.finalizeGraceMs ?? FINALIZE_GRACE_MS;
     this.turnDetector =
       context.startFrame.turnDetection === "server_vad"
         ? new MediaTurnDetector(options.turnDetectorConfig ?? {}, {
@@ -343,11 +377,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     const shouldEmitSessionEndMetrics = this.state !== "failed";
     this.state = "closed";
     this.turnDetector?.dispose();
-    const utterance = this.currentUtterance;
-    if (utterance) {
-      stopTranscriberBestEffort(utterance.transcriber);
-      utterance.transcriber = null;
-    }
+    this.stopSessionTranscriber();
     await this.cancelAssistantTurn("session_closed");
     if (shouldEmitSessionEndMetrics) {
       await this.emitSessionEndMetrics();
@@ -355,9 +385,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     await this.drainOutboundFrames();
   }
 
-  // Creates the next utterance record and arms a fresh streaming transcriber
-  // for it. Called once from start() and, in server_vad mode, again after
-  // every finalized turn (per-utterance phase tracks the cycle).
+  // Creates the next utterance record and arms a streaming transcriber for
+  // it: the session-shared instance when persistent mode is active (a
+  // synchronous re-arm), otherwise a freshly resolved one. Called once from
+  // start() and, in server_vad mode, again after every finalized turn
+  // (per-utterance phase tracks the cycle).
   private async beginUtterance(): Promise<UtteranceStartResult> {
     const utterance: UtteranceCycle = {
       phase: "pending",
@@ -389,6 +421,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     const replayTurnEnd = this.vadPendingTurnEnd;
     this.vadPendingTurnEnd = null;
 
+    const shared = this.sharedTranscriber;
+    if (shared) {
+      // Persistent re-arm: the shared stream is already open, so the cycle
+      // goes straight to streaming with no resolve/start round-trip.
+      utterance.transcriber = shared;
+      return await this.activateUtterance(utterance, replayTurnEnd);
+    }
+
     try {
       const transcriber = await this.resolveTranscriber({
         sampleRate: this.context.startFrame.audio.sampleRate,
@@ -407,29 +447,33 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       }
 
       utterance.transcriber = transcriber;
-      await transcriber.start((event) => {
-        void this.handleTranscriberEvent(utterance, event);
-      });
+      if (
+        this.turnDetector &&
+        typeof transcriber.finalizeUtterance === "function"
+      ) {
+        // Adopt persistent mode: this stream serves the whole session, so
+        // its events route by cycle ownership instead of binding to this
+        // one cycle.
+        this.sharedTranscriber = transcriber;
+        await transcriber.start((event) => {
+          void this.handleSharedTranscriberEvent(transcriber, event);
+        });
+      } else {
+        await transcriber.start((event) => {
+          void this.handleTranscriberEvent(utterance, event);
+        });
+      }
 
       if (this.isUtteranceStale(utterance)) {
+        this.releaseSharedTranscriber(transcriber);
         stopTranscriberBestEffort(transcriber);
         utterance.transcriber = null;
         return { status: "stale" };
       }
 
-      utterance.phase = "streaming";
-      this.state = "active";
-      await this.flushPendingUtteranceAudio(utterance);
-      if (utterance.released) {
-        await this.stopUtteranceForRelease(utterance);
-      } else if (replayTurnEnd) {
-        // The parked utterance completed during the window (detector already
-        // idle): replay its boundary so it turns without more speech.
-        await this.sendFrame({ type: "utterance_end", reason: replayTurnEnd });
-        await this.releaseUtterance();
-      }
-      return { status: "started" };
+      return await this.activateUtterance(utterance, replayTurnEnd);
     } catch (err) {
+      this.releaseSharedTranscriber(utterance.transcriber);
       stopTranscriberBestEffort(utterance.transcriber);
       utterance.transcriber = null;
       if (this.isUtteranceStale(utterance)) {
@@ -441,6 +485,35 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           err,
         )}`,
       };
+    }
+  }
+
+  // Transitions an armed cycle to streaming: flush buffered audio, complete
+  // a release that landed while the cycle was pending, and replay a parked
+  // detector boundary.
+  private async activateUtterance(
+    utterance: UtteranceCycle,
+    replayTurnEnd: "silence" | "max-duration" | null,
+  ): Promise<UtteranceStartResult> {
+    utterance.phase = "streaming";
+    this.state = "active";
+    await this.flushPendingUtteranceAudio(utterance);
+    if (utterance.released) {
+      await this.stopUtteranceForRelease(utterance);
+    } else if (replayTurnEnd) {
+      // The parked utterance completed during the window (detector already
+      // idle): replay its boundary so it turns without more speech.
+      await this.sendFrame({ type: "utterance_end", reason: replayTurnEnd });
+      await this.releaseUtterance();
+    }
+    return { status: "started" };
+  }
+
+  private releaseSharedTranscriber(
+    transcriber: StreamingTranscriber | null,
+  ): void {
+    if (transcriber && this.sharedTranscriber === transcriber) {
+      this.sharedTranscriber = null;
     }
   }
 
@@ -789,6 +862,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private async stopUtteranceForRelease(
     utterance: UtteranceCycle,
   ): Promise<void> {
+    const shared = this.sharedTranscriber;
+    if (shared && utterance.transcriber === shared) {
+      await this.finalizeUtteranceForRelease(utterance, shared);
+      return;
+    }
+
     utterance.phase = "released";
     try {
       utterance.transcriber?.stop();
@@ -804,6 +883,74 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
     await this.startAssistantTurnIfReady();
     await this.drainOutboundFrames();
+  }
+
+  // Persistent-mode release: flush the shared stream's buffered audio with
+  // finalizeUtterance() instead of tearing the stream down. The assistant
+  // turn starts on the `finalized` event; the grace timer bounds a flush
+  // that never arrives.
+  private async finalizeUtteranceForRelease(
+    utterance: UtteranceCycle,
+    shared: StreamingTranscriber,
+  ): Promise<void> {
+    if (
+      utterance.phase === "released" ||
+      utterance.phase === "transcriber_closed"
+    ) {
+      return;
+    }
+    utterance.phase = "released";
+    this.finalizingUtterance = utterance;
+    this.armFinalizeGraceTimer(utterance);
+    try {
+      shared.finalizeUtterance?.();
+    } catch (err) {
+      log.warn(
+        { err },
+        "Live voice utterance finalize failed; proceeding with the transcript collected so far",
+      );
+      this.clearFinalizeGraceTimer();
+      this.finalizingUtterance = null;
+      utterance.phase = "transcriber_closed";
+    }
+    await this.startAssistantTurnIfReady();
+    await this.drainOutboundFrames();
+  }
+
+  private armFinalizeGraceTimer(utterance: UtteranceCycle): void {
+    this.clearFinalizeGraceTimer();
+    this.finalizeGraceTimer = setTimeout(() => {
+      this.finalizeGraceTimer = null;
+      void this.handleFinalizeGraceTimeout(utterance).catch(() => {});
+    }, this.finalizeGraceMs);
+  }
+
+  private clearFinalizeGraceTimer(): void {
+    if (this.finalizeGraceTimer !== null) {
+      clearTimeout(this.finalizeGraceTimer);
+      this.finalizeGraceTimer = null;
+    }
+  }
+
+  // The finalize flush never arrived: proceed with the segments collected
+  // so far. finalizingUtterance stays set so a late flush still routes to
+  // (and is dropped for) this cycle instead of polluting the next one.
+  private async handleFinalizeGraceTimeout(
+    utterance: UtteranceCycle,
+  ): Promise<void> {
+    if (
+      this.finalizingUtterance !== utterance ||
+      this.isClosed ||
+      this.state === "failed" ||
+      this.state === "interrupted"
+    ) {
+      return;
+    }
+    log.warn(
+      "Live voice finalize flush timed out; starting the turn with the transcript collected so far",
+    );
+    utterance.phase = "transcriber_closed";
+    await this.startAssistantTurnIfReady();
   }
 
   private async handleTranscriberEvent(
@@ -824,31 +971,16 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         this.markFirstPartial(utterance);
         await this.sendFrame({ type: "stt_partial", text: event.text });
         return;
-      case "final": {
-        const transcript = event.text.trim();
-        if (transcript.length > 0) {
-          utterance.finalTranscriptSegments.push(transcript);
-        }
-        this.markFinalTranscript(utterance);
-        await this.sendFrame({ type: "stt_final", text: event.text });
-        await this.startAssistantTurnIfReady();
+      case "final":
+        await this.recordFinalTranscript(utterance, event.text);
         return;
-      }
-      case "error": {
-        // Providers emit `error` mid-stream and may keep streaming; `closed`
-        // / `final` still drive turn lifecycle. Only transient categories are
-        // recoverable — auth/rate-limit/invalid-audio will not self-heal, so
-        // hands-free clients must surface them instead of suppressing them.
-        const recoverable =
-          event.category === "timeout" || event.category === "provider-error";
-        await this.sendFrame({
-          type: "error",
-          code: LiveVoiceProtocolErrorCode.InvalidField,
-          message: event.message,
-          ...(recoverable ? { recoverable: true } : {}),
-        });
+      case "finalized":
+        // Per-cycle transcribers are torn down with stop(); the finalize
+        // completion signal has no cycle to advance here.
         return;
-      }
+      case "error":
+        await this.sendTranscriberErrorFrame(event);
+        return;
       case "closed":
         utterance.phase = "transcriber_closed";
         utterance.transcriber = null;
@@ -870,6 +1002,131 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
   }
 
+  // Persistent-mode event routing. One shared stream serves many cycles, so
+  // events route dynamically: the cycle awaiting its finalize flush owns
+  // the audio being flushed; otherwise the current cycle does. Flush events
+  // for a transcript that already dispatched its assistant turn are dropped
+  // — a dispatched transcript is never mutated.
+  private async handleSharedTranscriberEvent(
+    transcriber: StreamingTranscriber,
+    event: SttStreamServerEvent,
+  ): Promise<void> {
+    if (
+      this.sharedTranscriber !== transcriber ||
+      this.isClosed ||
+      this.state === "failed" ||
+      this.state === "interrupted"
+    ) {
+      return;
+    }
+
+    switch (event.type) {
+      case "partial": {
+        const target = this.finalizingUtterance ?? this.currentUtterance;
+        if (!target || target.assistantTurnStarted || target.completed) {
+          return;
+        }
+        this.markFirstPartial(target);
+        await this.sendFrame({ type: "stt_partial", text: event.text });
+        return;
+      }
+      case "final": {
+        const target = this.finalizingUtterance ?? this.currentUtterance;
+        if (!target || target.assistantTurnStarted || target.completed) {
+          log.warn(
+            "Dropping a late final transcript segment: its assistant turn already dispatched",
+          );
+          return;
+        }
+        await this.recordFinalTranscript(target, event.text);
+        return;
+      }
+      case "finalized": {
+        const target = this.finalizingUtterance;
+        this.clearFinalizeGraceTimer();
+        this.finalizingUtterance = null;
+        if (!target) {
+          return;
+        }
+        if (target.phase === "released") {
+          // In persistent mode "transcriber_closed" means the cycle's
+          // transcript is complete — the shared stream stays open.
+          target.phase = "transcriber_closed";
+        }
+        await this.startAssistantTurnIfReady();
+        return;
+      }
+      case "error":
+        await this.sendTranscriberErrorFrame(event);
+        return;
+      case "closed": {
+        // The shared stream closed under the session: fall back to the
+        // per-cycle path — the next arm resolves a fresh transcriber.
+        this.sharedTranscriber = null;
+        this.clearFinalizeGraceTimer();
+        const finalizing = this.finalizingUtterance;
+        this.finalizingUtterance = null;
+        const current = this.currentUtterance;
+        if (finalizing && finalizing.transcriber === transcriber) {
+          finalizing.transcriber = null;
+          if (finalizing.phase === "released") {
+            finalizing.phase = "transcriber_closed";
+          }
+        }
+        if (
+          current &&
+          current !== finalizing &&
+          current.transcriber === transcriber
+        ) {
+          current.transcriber = null;
+          current.phase = "transcriber_closed";
+          // An unreleased cycle with nothing captured: retire it so the
+          // next speech chunk lazily arms a fresh utterance.
+          if (
+            !current.released &&
+            !current.completed &&
+            current.finalTranscriptSegments.length === 0
+          ) {
+            await this.finalizePendingUtterance(current, "transcriber_closed");
+            return;
+          }
+        }
+        await this.startAssistantTurnIfReady();
+        return;
+      }
+    }
+  }
+
+  private async recordFinalTranscript(
+    utterance: UtteranceCycle,
+    text: string,
+  ): Promise<void> {
+    const transcript = text.trim();
+    if (transcript.length > 0) {
+      utterance.finalTranscriptSegments.push(transcript);
+    }
+    this.markFinalTranscript(utterance);
+    await this.sendFrame({ type: "stt_final", text });
+    await this.startAssistantTurnIfReady();
+  }
+
+  // Providers emit `error` mid-stream and may keep streaming; `closed` /
+  // `final` still drive turn lifecycle. Only transient categories are
+  // recoverable — auth/rate-limit/invalid-audio will not self-heal, so
+  // hands-free clients must surface them instead of suppressing them.
+  private async sendTranscriberErrorFrame(
+    event: SttStreamServerErrorEvent,
+  ): Promise<void> {
+    const recoverable =
+      event.category === "timeout" || event.category === "provider-error";
+    await this.sendFrame({
+      type: "error",
+      code: LiveVoiceProtocolErrorCode.InvalidField,
+      message: event.message,
+      ...(recoverable ? { recoverable: true } : {}),
+    });
+  }
+
   private async interrupt(): Promise<void> {
     if (this.isClosed || this.state === "failed") {
       return;
@@ -880,9 +1137,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.takeVadPreRoll();
     this.vadPendingTurnEnd = null;
     const utterance = this.currentUtterance;
+    this.stopSessionTranscriber();
     if (utterance) {
-      stopTranscriberBestEffort(utterance.transcriber);
-      utterance.transcriber = null;
       // In server_vad mode the current utterance may be the lazily armed
       // next cycle, distinct from the in-flight turn's — finalize it too so
       // the post-turn re-arm can replace it.
@@ -893,6 +1149,25 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
     await this.cancelAssistantTurn("interrupt");
     await this.drainOutboundFrames();
+  }
+
+  // Stops whichever streaming transcriber the session holds (shared or
+  // per-cycle) and clears the finalize bookkeeping. Used by interrupt() and
+  // close(); persistent mode re-establishes itself on the next arm.
+  private stopSessionTranscriber(): void {
+    this.clearFinalizeGraceTimer();
+    this.finalizingUtterance = null;
+    const shared = this.sharedTranscriber;
+    this.sharedTranscriber = null;
+    const utterance = this.currentUtterance;
+    const transcriber = utterance?.transcriber ?? null;
+    if (utterance) {
+      utterance.transcriber = null;
+    }
+    stopTranscriberBestEffort(transcriber);
+    if (shared && shared !== transcriber) {
+      stopTranscriberBestEffort(shared);
+    }
   }
 
   private async startAssistantTurnIfReady(): Promise<void> {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -261,8 +261,17 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // partial/final events route here ahead of currentUtterance; kept set
   // through a grace timeout so a late flush still attributes to (and is
   // dropped for) the cycle that owns the audio.
-  private finalizingUtterance: UtteranceCycle | null = null;
+  /**
+   * FIFO of cycles with an outstanding finalize request on the shared
+   * stream, oldest first. Flush finals and `finalized` signals carry no
+   * request identity, but the provider answers requests in order — so the
+   * queue head owns the next flush/`finalized`, and a stale flush can
+   * never be attributed to a newer cycle's request.
+   */
+  private finalizeQueue: UtteranceCycle[] = [];
   private finalizeGraceTimer: ReturnType<typeof setTimeout> | null = null;
+  /** The cycle whose grace timer is armed (only the newest release has one). */
+  private finalizeGraceCycle: UtteranceCycle | null = null;
   private readonly finalizeGraceMs: number;
 
   constructor(
@@ -900,7 +909,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return;
     }
     utterance.phase = "released";
-    this.finalizingUtterance = utterance;
+    this.finalizeQueue.push(utterance);
     this.armFinalizeGraceTimer(utterance);
     try {
       shared.finalizeUtterance?.();
@@ -910,7 +919,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         "Live voice utterance finalize failed; proceeding with the transcript collected so far",
       );
       this.clearFinalizeGraceTimer();
-      this.finalizingUtterance = null;
+      this.finalizeQueue = this.finalizeQueue.filter((c) => c !== utterance);
       utterance.phase = "transcriber_closed";
     }
     await this.startAssistantTurnIfReady();
@@ -919,8 +928,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
   private armFinalizeGraceTimer(utterance: UtteranceCycle): void {
     this.clearFinalizeGraceTimer();
+    this.finalizeGraceCycle = utterance;
     this.finalizeGraceTimer = setTimeout(() => {
       this.finalizeGraceTimer = null;
+      this.finalizeGraceCycle = null;
       void this.handleFinalizeGraceTimeout(utterance).catch(() => {});
     }, this.finalizeGraceMs);
   }
@@ -930,16 +941,18 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       clearTimeout(this.finalizeGraceTimer);
       this.finalizeGraceTimer = null;
     }
+    this.finalizeGraceCycle = null;
   }
 
   // The finalize flush never arrived: proceed with the segments collected
-  // so far. finalizingUtterance stays set so a late flush still routes to
-  // (and is dropped for) this cycle instead of polluting the next one.
+  // so far. The cycle stays in the finalize queue so its late flush is
+  // still attributed to (and dropped for) it instead of polluting a newer
+  // cycle's request.
   private async handleFinalizeGraceTimeout(
     utterance: UtteranceCycle,
   ): Promise<void> {
     if (
-      this.finalizingUtterance !== utterance ||
+      !this.finalizeQueue.includes(utterance) ||
       this.isClosed ||
       this.state === "failed" ||
       this.state === "interrupted"
@@ -1002,6 +1015,17 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
   }
 
+  // The cycle that should receive new (non-flush) transcript events: the
+  // oldest queued finalize request whose turn has not dispatched, falling
+  // back to the current cycle once every queued request has dispatched.
+  private pendingTranscriptCycle(): UtteranceCycle | null {
+    return (
+      this.finalizeQueue.find(
+        (cycle) => !cycle.assistantTurnStarted && !cycle.completed,
+      ) ?? this.currentUtterance
+    );
+  }
+
   // Persistent-mode event routing. One shared stream serves many cycles, so
   // events route dynamically: the cycle awaiting its finalize flush owns
   // the audio being flushed; otherwise the current cycle does. Flush events
@@ -1022,14 +1046,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     switch (event.type) {
       case "partial": {
-        // A finalizing cycle owns the stream only until its turn
-        // dispatches (grace timeout); after that, partials belong to the
-        // user's next utterance on the current cycle.
-        const finalizing = this.finalizingUtterance;
-        const target =
-          finalizing && !finalizing.assistantTurnStarted
-            ? finalizing
-            : this.currentUtterance;
+        // Partials belong to the oldest cycle still awaiting its
+        // transcript; after every queued request has dispatched, they
+        // belong to the user's next utterance on the current cycle.
+        const target = this.pendingTranscriptCycle();
         if (!target || target.assistantTurnStarted || target.completed) {
           return;
         }
@@ -1038,19 +1058,17 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         return;
       }
       case "final": {
-        const finalizing = this.finalizingUtterance;
         if (event.fromFinalize) {
-          // A finalize flush commits audio buffered before the finalize
-          // request — it belongs to the finalizing cycle, never to new
-          // speech. After a grace-timeout dispatch the transcript is
-          // sealed, so a late flush is dropped rather than mutating a
-          // dispatched turn or polluting the next cycle.
-          if (
-            finalizing &&
-            !finalizing.assistantTurnStarted &&
-            !finalizing.completed
-          ) {
-            await this.recordFinalTranscript(finalizing, event.text);
+          // A finalize flush commits audio buffered before its finalize
+          // request. The provider answers requests in order, so the flush
+          // belongs to the OLDEST outstanding request — never to a newer
+          // cycle's request and never to new speech. After a grace-timeout
+          // dispatch the owning transcript is sealed, so a late flush is
+          // dropped rather than mutating a dispatched turn or polluting a
+          // newer cycle.
+          const owner = this.finalizeQueue[0];
+          if (owner && !owner.assistantTurnStarted && !owner.completed) {
+            await this.recordFinalTranscript(owner, event.text);
           } else {
             log.warn(
               "Dropping a late finalize flush segment: its assistant turn already dispatched",
@@ -1058,14 +1076,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           }
           return;
         }
-        // Ordinary finals: the finalizing cycle owns the stream until its
-        // turn dispatches; afterwards new speech belongs to the current
-        // cycle (the finalize flush is flagged, so it can never be
-        // mistaken for new speech).
-        const target =
-          finalizing && !finalizing.assistantTurnStarted && !finalizing.completed
-            ? finalizing
-            : this.currentUtterance;
+        // Ordinary finals: new speech for the oldest still-pending cycle,
+        // or the current one once every queued request has dispatched.
+        const target = this.pendingTranscriptCycle();
         if (!target || target.assistantTurnStarted || target.completed) {
           log.warn(
             "Dropping a late final transcript segment: its assistant turn already dispatched",
@@ -1076,16 +1089,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         return;
       }
       case "finalized": {
-        const target = this.finalizingUtterance;
-        this.clearFinalizeGraceTimer();
-        this.finalizingUtterance = null;
-        if (!target) {
+        // Completes the oldest outstanding finalize request, whether or
+        // not its flush final arrived (the provider may omit an empty
+        // flush; its own fallback still emits `finalized`).
+        const owner = this.finalizeQueue.shift() ?? null;
+        if (owner && owner === this.finalizeGraceCycle) {
+          this.clearFinalizeGraceTimer();
+        }
+        if (!owner) {
           return;
         }
-        if (target.phase === "released") {
+        if (owner.phase === "released") {
           // In persistent mode "transcriber_closed" means the cycle's
           // transcript is complete — the shared stream stays open.
-          target.phase = "transcriber_closed";
+          owner.phase = "transcriber_closed";
         }
         await this.startAssistantTurnIfReady();
         return;
@@ -1098,18 +1115,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         // per-cycle path — the next arm resolves a fresh transcriber.
         this.sharedTranscriber = null;
         this.clearFinalizeGraceTimer();
-        const finalizing = this.finalizingUtterance;
-        this.finalizingUtterance = null;
-        const current = this.currentUtterance;
-        if (finalizing && finalizing.transcriber === transcriber) {
-          finalizing.transcriber = null;
+        const drained = this.finalizeQueue;
+        this.finalizeQueue = [];
+        for (const finalizing of drained) {
+          if (finalizing.transcriber === transcriber) {
+            finalizing.transcriber = null;
+          }
           if (finalizing.phase === "released") {
             finalizing.phase = "transcriber_closed";
           }
         }
+        const current = this.currentUtterance;
         if (
           current &&
-          current !== finalizing &&
+          !drained.includes(current) &&
           current.transcriber === transcriber
         ) {
           current.transcriber = null;
@@ -1190,7 +1209,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // close(); persistent mode re-establishes itself on the next arm.
   private stopSessionTranscriber(): void {
     this.clearFinalizeGraceTimer();
-    this.finalizingUtterance = null;
+    this.finalizeQueue = [];
     const shared = this.sharedTranscriber;
     this.sharedTranscriber = null;
     const utterance = this.currentUtterance;

--- a/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
@@ -689,7 +689,12 @@ describe("DeepgramRealtimeTranscriber", () => {
       );
 
       expect(events).toEqual([
-        { type: "final", text: "buffered tail", confidence: 0.95 },
+        {
+          type: "final",
+          text: "buffered tail",
+          confidence: 0.95,
+          fromFinalize: true,
+        },
         { type: "finalized" },
       ]);
     });
@@ -801,6 +806,7 @@ describe("DeepgramRealtimeTranscriber", () => {
         type: "final",
         text: "flush two",
         confidence: 0.95,
+        fromFinalize: true,
       });
     });
 

--- a/assistant/src/providers/speech-to-text/deepgram-realtime.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.ts
@@ -676,6 +676,9 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
           text,
           ...(speakerLabel !== undefined ? { speakerLabel } : {}),
           ...(confidence !== undefined ? { confidence } : {}),
+          // Mark the finalize flush so consumers can attribute it to the
+          // utterance that requested the flush rather than new speech.
+          ...(fromFinalize ? { fromFinalize: true } : {}),
         });
       }
     } else if (this.interimResults) {

--- a/assistant/src/stt/types.ts
+++ b/assistant/src/stt/types.ts
@@ -264,6 +264,13 @@ export interface SttStreamServerFinalEvent {
    * provider does not surface confidence on this chunk.
    */
   readonly confidence?: number;
+  /**
+   * True when this final is the flush response to
+   * {@link StreamingTranscriber.finalizeUtterance} — i.e. it commits audio
+   * that was buffered before the finalize request, not new speech.
+   * Undefined on ordinary finals and on providers without finalize.
+   */
+  readonly fromFinalize?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Server-VAD sessions with a finalize-capable transcriber keep one STT stream for the whole session: utterance end sends Finalize instead of CloseStream, and the agent turn starts on the finalized event — no per-turn socket close wait, no per-turn reconnect
- 1s finalize grace fallback bounds the tail; unexpected stream close falls back to per-cycle reconnect; manual mode unchanged

Part of plan: voice-mode-latency.md (PR 5 of 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)