### PR TITLE
feat(live-voice): overlap STT connection with client mic startup at session start

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -10,10 +10,7 @@ import {
   LiveVoiceSession,
   type LiveVoiceStreamingTranscriberResolver,
 } from "../live-voice-session.js";
-import {
-  type LiveVoiceSessionFactoryContext,
-  LiveVoiceSessionStartupError,
-} from "../live-voice-session-manager.js";
+import type { LiveVoiceSessionFactoryContext } from "../live-voice-session-manager.js";
 import {
   createLiveVoiceServerFrameSequencer,
   type LiveVoiceClientStartFrame,
@@ -98,6 +95,27 @@ class FinalizingMockStreamingTranscriber extends MockStreamingTranscriber {
     });
     this.emit({ type: "finalized" });
   }
+}
+
+// A transcriber whose start() (the provider WS handshake) resolves only when
+// the test releases it, holding the session in the ready→arm gap.
+function createGatedStartTranscriber(): {
+  transcriber: MockStreamingTranscriber;
+  releaseStart: () => void;
+} {
+  let releaseStart: () => void = () => {};
+  const startGate = new Promise<void>((resolve) => {
+    releaseStart = resolve;
+  });
+  class GatedStartTranscriber extends MockStreamingTranscriber {
+    override async start(
+      onEvent: (event: SttStreamServerEvent) => void,
+    ): Promise<void> {
+      await startGate;
+      await super.start(onEvent);
+    }
+  }
+  return { transcriber: new GatedStartTranscriber(), releaseStart };
 }
 
 function completingVoiceTurnStarter() {
@@ -500,33 +518,95 @@ describe("LiveVoiceSession STT", () => {
     expect(frames.filter((frame) => frame.type === "error")).toEqual([]);
   });
 
-  test("returns a readable error frame when streaming STT is unavailable", async () => {
+  test("sends ready before the transcriber arm completes and transcribes gap audio after arm (server_vad)", async () => {
+    const { transcriber, releaseStart } = createGatedStartTranscriber();
+    const { context, frames } = createContext({ turnDetection: "server_vad" });
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: mock(async () => transcriber),
+    });
+
+    await session.start();
+
+    // Ready went out while the STT provider handshake is still in flight.
+    expect(transcriber.started).toBe(false);
+    expect(frames).toEqual([
+      {
+        type: "ready",
+        seq: 1,
+        sessionId: "session-123",
+        conversationId: "conversation-123",
+        turnDetection: "server_vad",
+      },
+    ]);
+
+    // Speech in the ready→arm gap buffers instead of dropping or erroring.
+    await session.handleBinaryAudio(loudPcmChunk());
+    expect(transcriber.audioChunks).toEqual([]);
+    expect(frames.filter((frame) => frame.type === "error")).toEqual([]);
+
+    releaseStart();
+    await waitFor(() => transcriber.audioChunks.length === 1);
+
+    expect(transcriber.started).toBe(true);
+    expect(transcriber.audioChunks.map((chunk) => [...chunk])).toEqual([
+      [...loudPcmChunk()],
+    ]);
+    expect(frames.filter((frame) => frame.type === "error")).toEqual([]);
+  });
+
+  test("buffers manual-mode audio sent in the ready→arm gap and flushes it on arm", async () => {
+    const { transcriber, releaseStart } = createGatedStartTranscriber();
+    const { frames, session } = createSessionWithTranscriber(transcriber);
+
+    await session.start();
+
+    expect(transcriber.started).toBe(false);
+    expect(frames.map((frame) => frame.type)).toEqual(["ready"]);
+
+    await session.handleBinaryAudio(new Uint8Array([1, 2]));
+    await session.handleBinaryAudio(new Uint8Array([3]));
+    expect(transcriber.audioChunks).toEqual([]);
+
+    releaseStart();
+    await waitFor(() => transcriber.audioChunks.length === 2);
+
+    expect(transcriber.audioChunks.map((chunk) => [...chunk])).toEqual([
+      [1, 2],
+      [3],
+    ]);
+    expect(frames.filter((frame) => frame.type === "error")).toEqual([]);
+  });
+
+  test("sends ready then a non-recoverable error frame when streaming STT is unavailable", async () => {
     const { context, frames } = createContext();
     const resolver = mock(async () => null);
     const session = new LiveVoiceSession(context, {
       resolveTranscriber: resolver,
     });
 
-    await expect(session.start()).rejects.toBeInstanceOf(
-      LiveVoiceSessionStartupError,
-    );
+    await session.start();
+    await waitFor(() => frames.some((frame) => frame.type === "error"));
 
-    expect(frames).toHaveLength(1);
-    expect(frames[0]).toMatchObject({
-      type: "error",
-      code: "credentials_unavailable",
-    });
-    const [errorFrame] = frames;
+    expect(frames[0]).toMatchObject({ type: "ready", seq: 1 });
+    const errorFrame = frames.find((frame) => frame.type === "error");
     if (errorFrame?.type !== "error") {
       throw new Error("Expected a live voice error frame");
     }
+    expect(errorFrame.code).toBe("credentials_unavailable");
     expect(errorFrame.message).toContain(
       "Live voice transcription is unavailable",
     );
     expect(errorFrame.message).toContain("credentials configured");
+    expect(errorFrame).not.toHaveProperty("recoverable");
+
+    // The failed session ignores further frames instead of silently hanging.
+    const frameCount = frames.length;
+    await session.handleBinaryAudio(new Uint8Array([1]));
+    await session.handleClientFrame({ type: "ptt_release" });
+    expect(frames).toHaveLength(frameCount);
   });
 
-  test("returns a readable error frame when provider setup throws", async () => {
+  test("sends ready then a non-recoverable error frame when provider setup throws", async () => {
     const { context, frames } = createContext();
     const resolver: LiveVoiceStreamingTranscriberResolver = mock(async () => {
       throw new Error("provider credentials rejected");
@@ -535,14 +615,20 @@ describe("LiveVoiceSession STT", () => {
       resolveTranscriber: resolver,
     });
 
-    await expect(session.start()).rejects.toBeInstanceOf(
-      LiveVoiceSessionStartupError,
-    );
+    await session.start();
+    await waitFor(() => frames.some((frame) => frame.type === "error"));
 
     expect(frames).toEqual([
       {
-        type: "error",
+        type: "ready",
         seq: 1,
+        sessionId: "session-123",
+        conversationId: "conversation-123",
+        turnDetection: "manual",
+      },
+      {
+        type: "error",
+        seq: 2,
         code: "invalid_field",
         message:
           "Live voice transcription could not be started: provider credentials rejected",

--- a/assistant/src/live-voice/__tests__/runtime-websocket-shell.test.ts
+++ b/assistant/src/live-voice/__tests__/runtime-websocket-shell.test.ts
@@ -444,6 +444,13 @@ describe("RuntimeHttpServer live voice WebSocket shell", () => {
     await waitForOpen(ws);
 
     ws.send(startFrame("conversation-failed"));
+    // ready precedes the arm: the STT connection is established in the
+    // background, so its failure surfaces as a post-ready error frame.
+    const readyBeforeFailure = await waitForJsonFrame(ws);
+    expect(readyBeforeFailure).toMatchObject({
+      type: "ready",
+      conversationId: "conversation-failed",
+    });
     const error = await waitForJsonFrame(ws);
     expect(error).toMatchObject({
       type: "error",

--- a/assistant/src/live-voice/live-voice-session-manager.ts
+++ b/assistant/src/live-voice/live-voice-session-manager.ts
@@ -31,6 +31,13 @@ export interface LiveVoiceSessionFactoryContext {
   sessionId: string;
   startFrame: LiveVoiceClientStartFrame;
   sendFrame(frame: LiveVoiceServerFramePayload): Promise<LiveVoiceServerFrame>;
+  /**
+   * Releases this session's manager slot after a failure that happens once
+   * `start()` has already resolved (e.g. the background STT arm failing
+   * post-`ready`). Without it a failed session would hold the singleton
+   * slot until the client closes the WebSocket.
+   */
+  releaseAfterFailure?(): Promise<void>;
 }
 
 export type LiveVoiceSessionFactory = (
@@ -131,6 +138,9 @@ export class LiveVoiceSessionManager {
         await sink.sendFrame(frame);
         return frame;
       },
+      releaseAfterFailure: async () => {
+        await this.releaseAfterSessionError(sessionId);
+      },
     };
     const session = this.createSession(context);
     this.activeSession = { sessionId, session, closing: false };
@@ -208,6 +218,15 @@ export class LiveVoiceSessionManager {
       }
     }
     return { released: true, sessionId };
+  }
+
+  /**
+   * Whether the given session still holds the manager slot. Transports use
+   * this to heal a stale per-connection binding: a session that failed
+   * after `ready` releases its slot without any frame crossing the socket.
+   */
+  isSessionActive(sessionId: string): boolean {
+    return this.findActiveSession(sessionId) !== null;
   }
 
   private findActiveSession(sessionId: string): ActiveLiveVoiceSession | null {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -330,26 +330,25 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       }
     }
 
-    const result = await this.beginUtterance();
-    switch (result.status) {
-      case "stale":
-        return;
-      case "unavailable":
-        return await this.failStartup(
-          result.message,
-          LiveVoiceProtocolErrorCode.CredentialsUnavailable,
-        );
-      case "error":
-        return await this.failStartup(result.message);
-      case "started":
-        this.metrics.markReady();
-        await this.sendFrame({
-          type: "ready",
-          sessionId: this.context.sessionId,
-          conversationId: this.conversationId,
-          turnDetection: this.turnDetector ? "server_vad" : "manual",
-        });
+    // The session may have been closed while the preflight was awaited.
+    if (this.isClosed) {
+      return;
     }
+
+    // Ready goes out as soon as the preflight passes so the client's mic
+    // acquisition overlaps the STT provider handshake. The session is active
+    // immediately: audio arriving before the first utterance arms buffers
+    // through the pending/pre-roll paths and flushes on arm. An arm failure
+    // surfaces as a non-recoverable error frame instead of a start rejection.
+    this.state = "active";
+    void this.armUtterance().catch(() => {});
+    this.metrics.markReady();
+    await this.sendFrame({
+      type: "ready",
+      sessionId: this.context.sessionId,
+      conversationId: this.conversationId,
+      turnDetection: this.turnDetector ? "server_vad" : "manual",
+    });
   }
 
   async handleClientFrame(frame: LiveVoiceClientFrame): Promise<void> {
@@ -396,9 +395,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
   // Creates the next utterance record and arms a streaming transcriber for
   // it: the session-shared instance when persistent mode is active (a
-  // synchronous re-arm), otherwise a freshly resolved one. Called once from
-  // start() and, in server_vad mode, again after every finalized turn
-  // (per-utterance phase tracks the cycle).
+  // synchronous re-arm), otherwise a freshly resolved one. Called once at
+  // session start (without blocking the ready frame) and, in server_vad
+  // mode, again after every finalized turn (per-utterance phase tracks the
+  // cycle).
   private async beginUtterance(): Promise<UtteranceStartResult> {
     const utterance: UtteranceCycle = {
       phase: "pending",
@@ -570,7 +570,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.state = "failed";
     await this.sendFrame({
       type: "error",
-      code: LiveVoiceProtocolErrorCode.InvalidField,
+      code:
+        result.status === "unavailable"
+          ? LiveVoiceProtocolErrorCode.CredentialsUnavailable
+          : LiveVoiceProtocolErrorCode.InvalidField,
       message: result.message,
     });
   }
@@ -591,13 +594,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return;
     }
 
-    if (this.state === "initializing") {
-      return;
-    }
-
     this.collectUserAudio(utterance, chunk);
     if (utterance.phase === "pending") {
-      utterance.pendingAudioChunks.push(Buffer.from(chunk));
+      // The transcriber is still arming (session start overlaps the STT
+      // handshake with client mic startup); buffer until it flushes on arm.
+      this.bufferPendingUtteranceAudio(utterance, chunk);
       return;
     }
     await this.forwardAudioToTranscriber(utterance, chunk);
@@ -1976,7 +1977,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
   private async failStartup(
     message: string,
-    code: LiveVoiceProtocolErrorCode = LiveVoiceProtocolErrorCode.InvalidField,
+    code: LiveVoiceProtocolErrorCode,
   ): Promise<never> {
     this.state = "failed";
     await this.sendFrame({

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -576,6 +576,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           : LiveVoiceProtocolErrorCode.InvalidField,
       message: result.message,
     });
+    // The manager only observes failures thrown from start(); an arm that
+    // fails after the early `ready` must release the session slot itself,
+    // or the next start frame on this (or a reconnecting) socket gets
+    // `busy` until the client tears the WebSocket down.
+    await this.context.releaseAfterFailure?.();
   }
 
   private async handleAudio(chunk: Buffer): Promise<void> {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -940,8 +940,17 @@ export class RuntimeHttpServer {
   ): Promise<void> {
     if (frame.type === "start") {
       if (ws.data.sessionId) {
-        this.sendLiveVoiceStateError(ws, "Live voice session already started");
-        return;
+        // A session that failed after `ready` releases its manager slot
+        // without a frame crossing this socket — heal the stale binding so
+        // the client can retry on the same connection.
+        if (this.liveVoiceSessionManager.isSessionActive(ws.data.sessionId)) {
+          this.sendLiveVoiceStateError(
+            ws,
+            "Live voice session already started",
+          );
+          return;
+        }
+        ws.data.sessionId = undefined;
       }
 
       const result = await this.liveVoiceSessionManager.startSession(frame, {


### PR DESCRIPTION
## Summary
- start() sends ready right after the credential preflight and arms the first utterance in the background; audio in the gap buffers via the existing pending/pre-roll paths
- Post-ready arm failures surface as error frames; preflight and busy rejections still precede ready

Part of plan: voice-mode-latency.md (PR 6 of 13)