### PR TITLE
feat(live-voice): prefetch the next TTS segment while the current one streams

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
@@ -109,7 +109,9 @@ async function waitFor(
   message = "Timed out waiting for live voice test condition",
 ): Promise<void> {
   for (let attempt = 0; attempt < 40; attempt += 1) {
-    if (predicate()) return;
+    if (predicate()) {
+      return;
+    }
     await new Promise((resolve) => setTimeout(resolve, 5));
   }
   throw new Error(message);
@@ -163,6 +165,56 @@ function makeMessageComplete(): Parameters<
     messageId: "assistant-message-123",
   };
 }
+
+function b64(text: string): string {
+  return Buffer.from(text).toString("base64");
+}
+
+function ttsAudioPayloads(frames: LiveVoiceServerFrame[]): string[] {
+  return frames.flatMap((frame) =>
+    frame.type === "tts_audio" ? [frame.dataBase64] : [],
+  );
+}
+
+interface ControlledSynthesis {
+  options: LiveVoiceTtsOptions;
+  finish: () => void;
+  fail: (err: Error) => void;
+}
+
+// A TTS streamer whose per-call completion is driven by the test: chunks are
+// injected via `calls[n].options.onAudioChunk` and the provider promise
+// settles on `finish`/`fail`. `events` records call starts and settles so
+// synthesis overlap can be asserted deterministically.
+function createControlledTtsStreamer(): {
+  streamTtsAudio: LiveVoiceTtsStreamer;
+  calls: ControlledSynthesis[];
+  events: string[];
+} {
+  const calls: ControlledSynthesis[] = [];
+  const events: string[] = [];
+  const streamTtsAudio = mock((options: LiveVoiceTtsOptions) => {
+    events.push(`start:${options.text}`);
+    return new Promise<LiveVoiceTtsResult>((resolve, reject) => {
+      calls.push({
+        options,
+        finish: () => {
+          events.push(`end:${options.text}`);
+          resolve(makeTtsResult(options.text));
+        },
+        fail: (err) => {
+          events.push(`fail:${options.text}`);
+          reject(err);
+        },
+      });
+    });
+  });
+  return { streamTtsAudio, calls, events };
+}
+
+const FIRST_SENTENCE = "This is the first spoken sentence.";
+const SECOND_SENTENCE = "Here comes the second spoken sentence.";
+const THIRD_SENTENCE = "And now a third spoken sentence arrives.";
 
 describe("LiveVoiceSession TTS", () => {
   test("starts streaming TTS audio before the assistant message completes at a segment boundary", async () => {
@@ -224,7 +276,9 @@ describe("LiveVoiceSession TTS", () => {
 
     await startReleasedTurn(session);
     callbacks?.assistant_text_delta?.(
-      makeTextDelta("Sure, I can help with that, and here is more text to say."),
+      makeTextDelta(
+        "Sure, I can help with that, and here is more text to say.",
+      ),
     );
     await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
 
@@ -439,5 +493,251 @@ describe("LiveVoiceSession TTS", () => {
     expect(frames).toHaveLength(frameCountAfterInterrupt);
     expect(frames.some((frame) => frame.type === "tts_audio")).toBe(false);
     expect(frames.some((frame) => frame.type === "tts_done")).toBe(false);
+  });
+
+  test("prefetches the next segment while the current one streams and emits frames strictly in order", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { streamTtsAudio, calls, events } = createControlledTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(makeTextDelta(FIRST_SENTENCE));
+    callbacks?.assistant_text_delta?.(makeTextDelta(` ${SECOND_SENTENCE}`));
+
+    // Both provider calls are in flight before either stream settles.
+    expect(events).toEqual([
+      `start:${FIRST_SENTENCE}`,
+      `start:${SECOND_SENTENCE}`,
+    ]);
+
+    // A chunk from the prefetching second segment buffers instead of
+    // jumping ahead of the still-streaming first segment.
+    calls[1]?.options.onAudioChunk(makeTtsChunk("audio:second-1"));
+    await flushAsyncCallbacks();
+    expect(ttsAudioPayloads(frames)).toEqual([]);
+
+    calls[0]?.options.onAudioChunk(makeTtsChunk("audio:first-1"));
+    calls[0]?.options.onAudioChunk(makeTtsChunk("audio:first-2"));
+    calls[0]?.finish();
+    await waitFor(() =>
+      frames.some(
+        (frame) =>
+          frame.type === "tts_audio" &&
+          frame.dataBase64 === b64("audio:second-1"),
+      ),
+    );
+
+    calls[1]?.options.onAudioChunk(makeTtsChunk("audio:second-2"));
+    calls[1]?.finish();
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(streamTtsAudio).toHaveBeenCalledTimes(2);
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64("audio:first-1"),
+      b64("audio:first-2"),
+      b64("audio:second-1"),
+      b64("audio:second-2"),
+    ]);
+    expect(frames.at(-1)).toMatchObject({
+      type: "tts_done",
+      turnId: "live-turn-1",
+    });
+  });
+
+  test("holds further segments as text until a slot frees and defers tts_done until every job drains", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { streamTtsAudio, calls } = createControlledTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(makeTextDelta(FIRST_SENTENCE));
+    callbacks?.assistant_text_delta?.(makeTextDelta(` ${SECOND_SENTENCE}`));
+    callbacks?.assistant_text_delta?.(makeTextDelta(` ${THIRD_SENTENCE}`));
+    callbacks?.message_complete?.(makeMessageComplete());
+
+    // Two lookahead slots: the third segment stays queued as text.
+    expect(calls).toHaveLength(2);
+
+    calls[0]?.options.onAudioChunk(makeTtsChunk("audio:one"));
+    calls[0]?.finish();
+    await waitFor(() => calls.length === 3);
+    expect(frames.some((frame) => frame.type === "tts_done")).toBe(false);
+
+    calls[1]?.options.onAudioChunk(makeTtsChunk("audio:two"));
+    calls[1]?.finish();
+    await flushAsyncCallbacks();
+    expect(frames.some((frame) => frame.type === "tts_done")).toBe(false);
+
+    calls[2]?.options.onAudioChunk(makeTtsChunk("audio:three"));
+    calls[2]?.finish();
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64("audio:one"),
+      b64("audio:two"),
+      b64("audio:three"),
+    ]);
+    expect(frames.at(-1)).toMatchObject({
+      type: "tts_done",
+      turnId: "live-turn-1",
+    });
+  });
+
+  test("overlapped synthesis finishes two delayed segments in about one delay, not two", async () => {
+    const synthesisDelayMs = 150;
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const events: string[] = [];
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      events.push(`start:${options.text}`);
+      await new Promise((resolve) => setTimeout(resolve, synthesisDelayMs));
+      options.onAudioChunk(makeTtsChunk(`audio:${options.text}`));
+      events.push(`end:${options.text}`);
+      return makeTtsResult(options.text);
+    });
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    const startedAt = performance.now();
+    callbacks?.assistant_text_delta?.(makeTextDelta(FIRST_SENTENCE));
+    callbacks?.assistant_text_delta?.(makeTextDelta(` ${SECOND_SENTENCE}`));
+    callbacks?.message_complete?.(makeMessageComplete());
+    const deadline = startedAt + synthesisDelayMs * 4;
+    while (
+      !frames.some((frame) => frame.type === "tts_done") &&
+      performance.now() < deadline
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    const elapsedMs = performance.now() - startedAt;
+
+    // Both provider calls start before either finishes, so the two
+    // first-chunk delays overlap instead of stacking.
+    expect(events.slice(0, 2)).toEqual([
+      `start:${FIRST_SENTENCE}`,
+      `start:${SECOND_SENTENCE}`,
+    ]);
+    expect(elapsedMs).toBeLessThan(synthesisDelayMs * 2);
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64(`audio:${FIRST_SENTENCE}`),
+      b64(`audio:${SECOND_SENTENCE}`),
+    ]);
+    expect(frames.at(-1)).toMatchObject({
+      type: "tts_done",
+      turnId: "live-turn-1",
+    });
+  });
+
+  test("drops buffered prefetch audio when the turn is cancelled mid-prefetch", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const abort = mock();
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort };
+    });
+    const { streamTtsAudio, calls } = createControlledTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(makeTextDelta(FIRST_SENTENCE));
+    callbacks?.assistant_text_delta?.(makeTextDelta(` ${SECOND_SENTENCE}`));
+    calls[0]?.options.onAudioChunk(makeTtsChunk("audio:first-1"));
+    calls[1]?.options.onAudioChunk(makeTtsChunk("audio:second-1"));
+    await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
+
+    // Cancellation runs the same abort path as a VAD barge-in: the shared
+    // turn signal aborts both in-flight provider streams at once.
+    await session.handleClientFrame({ type: "interrupt" });
+    const frameCountAfterInterrupt = frames.length;
+    expect(calls[0]?.options.signal?.aborted).toBe(true);
+    expect(calls[1]?.options.signal?.aborted).toBe(true);
+
+    calls[1]?.options.onAudioChunk(makeTtsChunk("audio:second-2"));
+    calls[0]?.finish();
+    calls[1]?.finish();
+    await flushAsyncCallbacks();
+
+    expect(frames).toHaveLength(frameCountAfterInterrupt);
+    expect(ttsAudioPayloads(frames)).toEqual([b64("audio:first-1")]);
+    expect(frames.some((frame) => frame.type === "tts_done")).toBe(false);
+  });
+
+  test("emits a recoverable error for a failed prefetch and keeps later segments in order", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const abort = mock();
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort };
+    });
+    const { streamTtsAudio, calls } = createControlledTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(makeTextDelta(FIRST_SENTENCE));
+    callbacks?.assistant_text_delta?.(makeTextDelta(` ${SECOND_SENTENCE}`));
+    callbacks?.assistant_text_delta?.(makeTextDelta(` ${THIRD_SENTENCE}`));
+    callbacks?.message_complete?.(makeMessageComplete());
+
+    // The prefetch fails while the first segment is still streaming.
+    calls[1]?.fail(new Error("prefetch exploded"));
+    calls[0]?.options.onAudioChunk(makeTtsChunk("audio:one"));
+    calls[0]?.finish();
+    await waitFor(() => calls.length === 3);
+    calls[2]?.options.onAudioChunk(makeTtsChunk("audio:three"));
+    calls[2]?.finish();
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(abort).not.toHaveBeenCalled();
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64("audio:one"),
+      b64("audio:three"),
+    ]);
+    const firstAudioIndex = frames.findIndex(
+      (frame) =>
+        frame.type === "tts_audio" && frame.dataBase64 === b64("audio:one"),
+    );
+    const errorIndex = frames.findIndex((frame) => frame.type === "error");
+    const thirdAudioIndex = frames.findIndex(
+      (frame) =>
+        frame.type === "tts_audio" && frame.dataBase64 === b64("audio:three"),
+    );
+    expect(frames[errorIndex]).toMatchObject({
+      type: "error",
+      message: expect.stringContaining("prefetch exploded"),
+      recoverable: true,
+    });
+    expect(firstAudioIndex).toBeLessThan(errorIndex);
+    expect(errorIndex).toBeLessThan(thirdAudioIndex);
+    expect(frames.at(-1)).toMatchObject({
+      type: "tts_done",
+      turnId: "live-turn-1",
+    });
   });
 });

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -45,6 +45,7 @@ import {
   LiveVoiceSessionStartupError,
 } from "./live-voice-session-manager.js";
 import type {
+  LiveVoiceTtsAudioChunk,
   LiveVoiceTtsOptions,
   LiveVoiceTtsResult,
 } from "./live-voice-tts.js";
@@ -75,6 +76,12 @@ const SERVER_VAD_PRE_ROLL_MAX_CHUNKS = 25;
 // strict upper bound on the release→turn-start tail in persistent mode (the
 // provider keeps its own, longer, finalize fallback).
 const FINALIZE_GRACE_MS = 1_000;
+// At most this many TTS segment jobs are open (provider stream started,
+// frames not yet fully emitted) per turn: the emitting job plus one
+// prefetching job. The prefetch buffers its chunks in memory until promoted;
+// a segment is at most ~180 chars of speech (~10 s of 24 kHz mono PCM
+// ≈ 480 KB), so one buffered segment is an acceptable bound.
+const TTS_MAX_OPEN_SYNTHESIS_JOBS = 2;
 
 export type LiveVoiceStreamingTranscriberResolver = (
   options: ResolveStreamingTranscriberOptions,
@@ -192,6 +199,27 @@ type UtteranceStartResult =
   | { status: "unavailable"; message: string }
   | { status: "error"; message: string };
 
+// One TTS segment flowing through the turn's synthesis pipeline. Synthesis
+// may run ahead of the emission slot (prefetch), but frames only reach the
+// client in job-list order.
+interface TtsSegmentJob {
+  readonly text: string;
+  // The provider stream was started (the job holds an open-job slot).
+  started: boolean;
+  // Emission finished; the slot is free for the next queued segment.
+  settled: boolean;
+  // The job owns the emission slot: provider chunks forward to the client
+  // live instead of buffering.
+  emitting: boolean;
+  // Chunks received while prefetching, flushed in order on promotion.
+  // Dropped with the turn on cancellation.
+  bufferedChunks: LiveVoiceTtsAudioChunk[];
+  // Settles when the provider stream ends; rejects on synthesis failure.
+  synthesis: Promise<void> | null;
+  // Ordered tts_audio frame writes for this job.
+  frames: Promise<void>;
+}
+
 interface ActiveAssistantTurn {
   token: symbol;
   turnId: string;
@@ -208,6 +236,11 @@ interface ActiveAssistantTurn {
   // A non-empty speakable segment reached the TTS queue — gates the eager
   // first-segment flush that trades clause quality for speech onset.
   ttsSegmentEnqueued: boolean;
+  // Ordered TTS segment jobs for the turn; synthesis runs ahead of emission
+  // by at most one job (TTS_MAX_OPEN_SYNTHESIS_JOBS).
+  ttsJobs: TtsSegmentJob[];
+  // Serial emission chain: one job's frames fully precede the next's, and
+  // the tts_done finale runs only after every job has drained.
   ttsQueue: Promise<void>;
   assistantMessageId: string | null;
   assistantAudioChunks: Buffer[];
@@ -1278,6 +1311,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       finalized: false,
       ttsBuffer: "",
       ttsSegmentEnqueued: false,
+      ttsJobs: [],
       ttsQueue: Promise.resolve(),
       assistantMessageId: null,
       assistantAudioChunks: [],
@@ -1555,90 +1589,184 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
   private enqueueTtsSegment(token: symbol, segment: string): void {
     const activeTurn = this.activeAssistantTurn;
-    const streamTtsAudio = this.streamTtsAudio;
-    if (activeTurn?.token !== token || !streamTtsAudio) {
+    if (activeTurn?.token !== token || !this.streamTtsAudio) {
       return;
     }
 
     activeTurn.ttsSegmentEnqueued = true;
+    const job: TtsSegmentJob = {
+      text: segment,
+      started: false,
+      settled: false,
+      emitting: false,
+      bufferedChunks: [],
+      synthesis: null,
+      frames: Promise.resolve(),
+    };
+    activeTurn.ttsJobs.push(job);
+    this.pumpTtsSynthesis(token);
     activeTurn.ttsQueue = activeTurn.ttsQueue
       .catch(() => {})
-      .then(async () => {
-        const currentTurn = this.activeAssistantTurn;
-        if (
-          currentTurn?.token !== token ||
-          currentTurn.abortController.signal.aborted
-        ) {
-          return;
-        }
+      .then(() => this.emitTtsJob(token, job));
+  }
 
-        try {
-          let ttsAudioFrames: Promise<void> = Promise.resolve();
-          await streamTtsAudio({
-            text: segment,
-            signal: currentTurn.abortController.signal,
-            outputFormat: "pcm",
-            sampleRate: this.context.startFrame.audio.sampleRate,
-            onAudioChunk: (chunk) => {
-              if (!this.isForwardingTts(token)) {
-                return;
-              }
-              const activeTurn = this.activeAssistantTurn;
-              if (activeTurn?.token !== token) {
-                return;
-              }
-              activeTurn.assistantAudioChunks.push(
-                Buffer.from(chunk.dataBase64, "base64"),
-              );
-              activeTurn.assistantAudioMimeType = chunk.contentType;
-              activeTurn.assistantAudioSampleRate = chunk.sampleRate;
-              ttsAudioFrames = ttsAudioFrames.then(async () => {
-                const sent = await this.sendFrame(
-                  {
-                    type: "tts_audio",
-                    mimeType: chunk.contentType,
-                    sampleRate: chunk.sampleRate,
-                    dataBase64: chunk.dataBase64,
-                  },
-                  () => this.isForwardingTts(token),
-                );
-                // Arm the barge-in gate only once a tts_audio frame was
-                // actually written — a backed-up outbound queue must not
-                // let speech cancel a still-unspoken reply. Token match
-                // keeps a stale turn's late send from arming a newer turn.
-                if (!sent) {
-                  return;
-                }
-                const turnAfterSend = this.activeAssistantTurn;
-                if (
-                  turnAfterSend?.token !== token ||
-                  turnAfterSend.ttsAudioStarted
-                ) {
-                  return;
-                }
-                turnAfterSend.ttsAudioStarted = true;
-                this.metrics.markFirstTtsAudio(turnAfterSend.turnId);
-              });
-            },
-          });
-          await ttsAudioFrames;
-        } catch (err) {
-          if (!this.isForwardingTts(token)) {
-            return;
-          }
-          // Per-segment failure: the turn (and session) continue, so the
-          // error is recoverable for the client.
-          await this.sendFrame(
-            {
-              type: "error",
-              code: LiveVoiceProtocolErrorCode.InvalidField,
-              message: `Live voice TTS failed: ${errorMessage(err)}`,
-              recoverable: true,
-            },
-            () => this.isForwardingTts(token),
-          );
-        }
-      });
+  // Starts provider streams for queued jobs, in list order, while an
+  // open-job slot is free. The prefetching job's chunks buffer in memory
+  // until the emission chain promotes it, so the next segment's provider
+  // first-chunk latency overlaps the current segment's playback.
+  private pumpTtsSynthesis(token: symbol): void {
+    const activeTurn = this.activeAssistantTurn;
+    const streamTtsAudio = this.streamTtsAudio;
+    if (
+      activeTurn?.token !== token ||
+      !streamTtsAudio ||
+      activeTurn.abortController.signal.aborted ||
+      this.isClosed
+    ) {
+      return;
+    }
+
+    while (
+      activeTurn.ttsJobs.filter((job) => job.started && !job.settled).length <
+      TTS_MAX_OPEN_SYNTHESIS_JOBS
+    ) {
+      const job = activeTurn.ttsJobs.find((candidate) => !candidate.started);
+      if (!job) {
+        return;
+      }
+      job.started = true;
+      let synthesis: Promise<void>;
+      try {
+        synthesis = streamTtsAudio({
+          text: job.text,
+          signal: activeTurn.abortController.signal,
+          outputFormat: "pcm",
+          sampleRate: this.context.startFrame.audio.sampleRate,
+          onAudioChunk: (chunk) => {
+            if (!this.isForwardingTts(token)) {
+              return;
+            }
+            if (job.emitting) {
+              this.forwardTtsChunk(token, job, chunk);
+            } else {
+              job.bufferedChunks.push(chunk);
+            }
+          },
+        }).then(() => undefined);
+      } catch (err) {
+        synthesis = Promise.reject(err);
+      }
+      // The job's emission step observes the rejection; this handler only
+      // keeps a failure on an already-cancelled turn from surfacing as an
+      // unhandled rejection.
+      synthesis.catch(() => {});
+      job.synthesis = synthesis;
+    }
+  }
+
+  // Emission slot for one job, run in strict segment order on the turn's
+  // ttsQueue chain: promotes the job from prefetch to live, flushes what it
+  // buffered, and returns only once every frame write for the job is ordered
+  // ahead of the next segment's.
+  private async emitTtsJob(token: symbol, job: TtsSegmentJob): Promise<void> {
+    try {
+      const currentTurn = this.activeAssistantTurn;
+      if (
+        currentTurn?.token !== token ||
+        currentTurn.abortController.signal.aborted
+      ) {
+        // The turn is gone: release the prefetched audio immediately rather
+        // than holding it until the turn object drops.
+        job.bufferedChunks.length = 0;
+        return;
+      }
+
+      // Both slots can be busy when a job is enqueued; every earlier job has
+      // settled once it reaches the head of the chain, so a slot is free.
+      if (!job.started) {
+        this.pumpTtsSynthesis(token);
+      }
+
+      // Promote synchronously: no provider callback can land between the
+      // flag flip and the buffered flush, so flushed and live chunks stay in
+      // provider order on the job's frame chain.
+      job.emitting = true;
+      for (const chunk of job.bufferedChunks.splice(0)) {
+        this.forwardTtsChunk(token, job, chunk);
+      }
+
+      let failed = false;
+      let synthesisError: unknown;
+      try {
+        await job.synthesis;
+      } catch (err) {
+        failed = true;
+        synthesisError = err;
+      }
+      // The provider stream has settled, so the frame chain is complete;
+      // awaiting it puts every frame of this segment ahead of the next.
+      await job.frames;
+
+      if (failed && this.isForwardingTts(token)) {
+        // Per-segment failure: the turn (and session) continue, so the
+        // error is recoverable for the client.
+        await this.sendFrame(
+          {
+            type: "error",
+            code: LiveVoiceProtocolErrorCode.InvalidField,
+            message: `Live voice TTS failed: ${errorMessage(synthesisError)}`,
+            recoverable: true,
+          },
+          () => this.isForwardingTts(token),
+        );
+      }
+    } finally {
+      job.settled = true;
+      this.pumpTtsSynthesis(token);
+    }
+  }
+
+  private forwardTtsChunk(
+    token: symbol,
+    job: TtsSegmentJob,
+    chunk: LiveVoiceTtsAudioChunk,
+  ): void {
+    if (!this.isForwardingTts(token)) {
+      return;
+    }
+    const activeTurn = this.activeAssistantTurn;
+    if (activeTurn?.token !== token) {
+      return;
+    }
+    activeTurn.assistantAudioChunks.push(
+      Buffer.from(chunk.dataBase64, "base64"),
+    );
+    activeTurn.assistantAudioMimeType = chunk.contentType;
+    activeTurn.assistantAudioSampleRate = chunk.sampleRate;
+    job.frames = job.frames.then(async () => {
+      const sent = await this.sendFrame(
+        {
+          type: "tts_audio",
+          mimeType: chunk.contentType,
+          sampleRate: chunk.sampleRate,
+          dataBase64: chunk.dataBase64,
+        },
+        () => this.isForwardingTts(token),
+      );
+      // Arm the barge-in gate only once a tts_audio frame was actually
+      // written — a backed-up outbound queue must not let speech cancel a
+      // still-unspoken reply. Token match keeps a stale turn's late send
+      // from arming a newer turn.
+      if (!sent) {
+        return;
+      }
+      const turnAfterSend = this.activeAssistantTurn;
+      if (turnAfterSend?.token !== token || turnAfterSend.ttsAudioStarted) {
+        return;
+      }
+      turnAfterSend.ttsAudioStarted = true;
+      this.metrics.markFirstTtsAudio(turnAfterSend.turnId);
+    });
   }
 
   private collectUserAudio(utterance: UtteranceCycle, chunk: Buffer): void {


### PR DESCRIPTION
## Summary
- TTS segments now synthesize with a 2-slot lookahead: the next segment's provider call runs while the current one emits, removing the per-sentence first-chunk stall
- Frame ordering across segments is preserved; barge-in drops buffered prefetch audio; per-segment failures stay recoverable

Part of plan: voice-mode-latency.md (PR 7 of 13)