### PR TITLE
feat(live-voice): require sustained speech before barge-in interrupts playback

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -918,6 +918,7 @@ describe("AssistantConfigSchema", () => {
         speechEnergyThreshold: 800,
         silenceThresholdMs: 800,
         maxTurnDurationMs: 30000,
+        bargeInMinSpeechMs: 60,
       },
       maxSessionDurationSeconds: 1800,
     });
@@ -927,16 +928,42 @@ describe("AssistantConfigSchema", () => {
     const result = AssistantConfigSchema.parse({
       liveVoice: {
         mode: "ptt",
-        vad: { speechEnergyThreshold: 1500, silenceThresholdMs: 1000 },
+        vad: {
+          speechEnergyThreshold: 1500,
+          silenceThresholdMs: 1000,
+          bargeInMinSpeechMs: 120,
+        },
         maxSessionDurationSeconds: 900,
       },
     });
     expect(result.liveVoice.mode).toBe("ptt");
     expect(result.liveVoice.vad.speechEnergyThreshold).toBe(1500);
     expect(result.liveVoice.vad.silenceThresholdMs).toBe(1000);
+    expect(result.liveVoice.vad.bargeInMinSpeechMs).toBe(120);
     // Unspecified vad fields still get defaults
     expect(result.liveVoice.vad.maxTurnDurationMs).toBe(30000);
     expect(result.liveVoice.maxSessionDurationSeconds).toBe(900);
+  });
+
+  test("accepts a liveVoice.vad.bargeInMinSpeechMs of 0 (guard disabled)", () => {
+    const result = AssistantConfigSchema.parse({
+      liveVoice: { vad: { bargeInMinSpeechMs: 0 } },
+    });
+    expect(result.liveVoice.vad.bargeInMinSpeechMs).toBe(0);
+  });
+
+  test("rejects negative liveVoice.vad.bargeInMinSpeechMs", () => {
+    const result = AssistantConfigSchema.safeParse({
+      liveVoice: { vad: { bargeInMinSpeechMs: -1 } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-integer liveVoice.vad.bargeInMinSpeechMs", () => {
+    const result = AssistantConfigSchema.safeParse({
+      liveVoice: { vad: { bargeInMinSpeechMs: 60.5 } },
+    });
+    expect(result.success).toBe(false);
   });
 
   test("accepts partial calls config with defaults for missing fields", () => {

--- a/assistant/src/config/schemas/__tests__/live-voice.test.ts
+++ b/assistant/src/config/schemas/__tests__/live-voice.test.ts
@@ -13,6 +13,7 @@ describe("LiveVoiceVadConfigSchema", () => {
       speechEnergyThreshold: 800,
       silenceThresholdMs: 800,
       maxTurnDurationMs: 30_000,
+      bargeInMinSpeechMs: 60,
     });
   });
 
@@ -21,10 +22,24 @@ describe("LiveVoiceVadConfigSchema", () => {
       speechEnergyThreshold: 1200,
       silenceThresholdMs: 500,
       maxTurnDurationMs: 60_000,
+      bargeInMinSpeechMs: 120,
     });
     expect(parsed.speechEnergyThreshold).toBe(1200);
     expect(parsed.silenceThresholdMs).toBe(500);
     expect(parsed.maxTurnDurationMs).toBe(60_000);
+    expect(parsed.bargeInMinSpeechMs).toBe(120);
+  });
+
+  test("accepts a bargeInMinSpeechMs of 0 (guard disabled)", () => {
+    const parsed = LiveVoiceVadConfigSchema.parse({ bargeInMinSpeechMs: 0 });
+    expect(parsed.bargeInMinSpeechMs).toBe(0);
+  });
+
+  test("rejects negative bargeInMinSpeechMs", () => {
+    const result = LiveVoiceVadConfigSchema.safeParse({
+      bargeInMinSpeechMs: -1,
+    });
+    expect(result.success).toBe(false);
   });
 
   test("rejects non-positive speechEnergyThreshold", () => {
@@ -51,6 +66,7 @@ describe("LiveVoiceConfigSchema", () => {
         speechEnergyThreshold: 800,
         silenceThresholdMs: 800,
         maxTurnDurationMs: 30_000,
+        bargeInMinSpeechMs: 60,
       },
       maxSessionDurationSeconds: 1800,
     });

--- a/assistant/src/config/schemas/live-voice.ts
+++ b/assistant/src/config/schemas/live-voice.ts
@@ -32,6 +32,16 @@ export const LiveVoiceVadConfigSchema = z
       .describe(
         "Maximum duration (ms) of a single user turn before it is force-ended",
       ),
+    bargeInMinSpeechMs: z
+      .number({ error: "liveVoice.vad.bargeInMinSpeechMs must be a number" })
+      .int("liveVoice.vad.bargeInMinSpeechMs must be an integer")
+      .nonnegative(
+        "liveVoice.vad.bargeInMinSpeechMs must be a nonnegative integer",
+      )
+      .default(60)
+      .describe(
+        "Sustained speech (ms) required before speech during assistant playback interrupts it; 0 disables the guard",
+      ),
   })
   .describe(
     "Voice-activity-detection tuning for live voice sessions (open-mic turn segmentation)",

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -1342,4 +1342,60 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
     await session.handleBinaryAudio(LOUD_CHUNK);
     await waitFor(() => countType(frames, "speech_started") === 1);
   });
+
+  test("the guard also covers the client playback tail after tts_done", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const abort = mock();
+    const startVoiceTurn = mock(async (turnOptions: VoiceTurnOptions) => {
+      callbacks ??= turnOptions.callbacks;
+      return { turnId: "bridge-turn", abort };
+    });
+    // One full second of PCM: the server clears the turn on tts_done while
+    // the client is still audibly draining this tail.
+    const longTailChunk: LiveVoiceTtsAudioChunk = {
+      type: "tts_audio",
+      contentType: "audio/pcm",
+      sampleRate: SAMPLE_RATE,
+      dataBase64: Buffer.alloc(2 * SAMPLE_RATE).toString("base64"),
+    };
+    const streamTtsAudio = mock(async (ttsOptions: LiveVoiceTtsOptions) => {
+      ttsOptions.onAudioChunk(longTailChunk);
+      return makeTtsResult("assistant audio");
+    });
+    const { frames, session } = createHarness({
+      finals: ["what's the weather", "   "],
+      startVoiceTurn,
+      streamTtsAudio,
+      bargeInMinSpeechMs: 60,
+      turnDetectorConfig: { silenceThresholdMs: 5_000 },
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+    callbacks?.assistant_text_delta?.(makeTextDelta("It is sunny today."));
+    await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    const baseline = countType(frames, "speech_started");
+
+    // A sub-guard noise blip during the drain window must not flush the
+    // audible tail.
+    for (let index = 0; index < 3; index += 1) {
+      await session.handleBinaryAudio(LOUD_CHUNK);
+    }
+    await session.handleBinaryAudio(SILENT_CHUNK);
+    await flushAsyncCallbacks();
+    expect(countType(frames, "speech_started")).toBe(baseline);
+
+    // Sustained speech during the drain window trips the guard: the tail
+    // flushes (speech_started) — with no turn left to cancel.
+    for (let index = 0; index < 6; index += 1) {
+      await session.handleBinaryAudio(LOUD_CHUNK);
+    }
+    await waitFor(() => countType(frames, "speech_started") === baseline + 1);
+    expect(countType(frames, "turn_cancelled")).toBe(0);
+    expect(abort).not.toHaveBeenCalled();
+  });
 });

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -61,7 +61,11 @@ function pcm(amplitude: number, sampleCount = 240): Uint8Array {
   return new Uint8Array(buffer);
 }
 
+// 10 ms of speech at 24 kHz.
 const LOUD_CHUNK = pcm(8_000);
+// 60 ms of speech at 24 kHz — meets the default sustained-speech barge-in
+// guard (bargeInMinSpeechMs) in a single chunk.
+const SUSTAINED_LOUD_CHUNK = pcm(8_000, 1_440);
 const SILENT_CHUNK = pcm(0);
 
 class MockStreamingTranscriber implements StreamingTranscriber {
@@ -112,6 +116,7 @@ function createHarness(options: {
   archiveAudio?: LiveVoiceSessionAudioArchiver;
   turnDetectorConfig?: TurnDetectorConfig;
   speechEnergyThreshold?: number;
+  bargeInMinSpeechMs?: number;
   emitMetrics?: boolean;
   metricsClock?: () => number;
   // Return a promise to hold a frame's transport write open (a backed-up
@@ -172,6 +177,7 @@ function createHarness(options: {
       options.turnDetectorConfig ??
       (options.viaFactory ? undefined : { silenceThresholdMs: 40 }),
     speechEnergyThreshold: options.speechEnergyThreshold,
+    bargeInMinSpeechMs: options.bargeInMinSpeechMs,
   };
   const session = options.viaFactory
     ? createLiveVoiceSession(context, {
@@ -335,8 +341,8 @@ describe("LiveVoiceSession server VAD", () => {
     callbacks?.assistant_text_delta?.(makeTextDelta("It is sunny today."));
     await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
 
-    // User speaks over the assistant's audio.
-    await session.handleBinaryAudio(LOUD_CHUNK);
+    // Sustained speech over the assistant's audio meets the default guard.
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
     await waitFor(() =>
       frames.some((frame) => frame.type === "turn_cancelled"),
     );
@@ -423,9 +429,9 @@ describe("LiveVoiceSession server VAD", () => {
     expect(countType(frames, "turn_cancelled")).toBe(0);
     expect(abort).not.toHaveBeenCalled();
 
-    // Once audio has genuinely gone out, a new speech onset barge-ins.
+    // Once audio has genuinely gone out, new sustained speech barge-ins.
     await waitFor(() => countType(frames, "utterance_end") === 2);
-    await session.handleBinaryAudio(LOUD_CHUNK);
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
     await waitFor(() =>
       frames.some((frame) => frame.type === "turn_cancelled"),
     );
@@ -720,7 +726,7 @@ describe("LiveVoiceSession server VAD", () => {
     // The LLM finishes just as the user barges in: message_complete queues
     // the completion continuation and the abort fires before it runs.
     firstTurnCallbacks?.message_complete?.(makeMessageComplete());
-    await session.handleBinaryAudio(LOUD_CHUNK);
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
     await waitFor(() =>
       frames.some((frame) => frame.type === "turn_cancelled"),
     );
@@ -1111,6 +1117,7 @@ describe("LiveVoiceSession VAD threshold configuration", () => {
       speechEnergyThreshold: 800,
       silenceThresholdMs: 800,
       maxTurnDurationMs: 30_000,
+      bargeInMinSpeechMs: 60,
     });
 
     const { frames, session } = createHarness({ viaFactory: true });
@@ -1164,5 +1171,175 @@ describe("LiveVoiceSession VAD threshold configuration", () => {
     } finally {
       saveRawConfig(originalRaw);
     }
+  });
+});
+
+describe("LiveVoiceSession sustained-speech barge-in guard", () => {
+  // Boots a session whose first turn is audibly speaking (its tts_audio
+  // frame reached the client) — the state the guard protects. Utterance
+  // boundaries are driven by ptt_release under a long silence threshold, so
+  // detector timers stay out of the guard's audio-duration accounting.
+  function createSpeakingTurnHarness(options: {
+    bargeInMinSpeechMs: number;
+    finals?: string[];
+  }) {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const abort = mock();
+    const startVoiceTurn = mock(async (turnOptions: VoiceTurnOptions) => {
+      callbacks ??= turnOptions.callbacks;
+      return { turnId: "bridge-turn", abort };
+    });
+    const streamTtsAudio = mock(async (ttsOptions: LiveVoiceTtsOptions) => {
+      ttsOptions.onAudioChunk(makeTtsChunk("assistant audio"));
+      return makeTtsResult("assistant audio");
+    });
+    const harness = createHarness({
+      finals: options.finals ?? ["what's the weather", "actually never mind"],
+      startVoiceTurn,
+      streamTtsAudio,
+      bargeInMinSpeechMs: options.bargeInMinSpeechMs,
+      turnDetectorConfig: { silenceThresholdMs: 5_000 },
+    });
+
+    async function speakFirstReply(): Promise<void> {
+      await harness.session.start();
+      await harness.session.handleBinaryAudio(LOUD_CHUNK);
+      await harness.session.handleClientFrame({ type: "ptt_release" });
+      await waitFor(() =>
+        harness.frames.some((frame) => frame.type === "thinking"),
+      );
+      callbacks?.assistant_text_delta?.(makeTextDelta("It is sunny today."));
+      await waitFor(() =>
+        harness.frames.some((frame) => frame.type === "tts_audio"),
+      );
+    }
+
+    function completeFirstReply(): void {
+      callbacks?.message_complete?.(makeMessageComplete());
+    }
+
+    return { ...harness, abort, speakFirstReply, completeFirstReply };
+  }
+
+  test("speech shorter than the guard leaves the speaking turn untouched", async () => {
+    const { frames, session, abort, speakFirstReply, completeFirstReply } =
+      createSpeakingTurnHarness({
+        bargeInMinSpeechMs: 60,
+        finals: ["what's the weather", "   "],
+      });
+    await speakFirstReply();
+
+    // 30 ms of speech then silence: never reaches the 60 ms guard.
+    for (let index = 0; index < 3; index += 1) {
+      await session.handleBinaryAudio(LOUD_CHUNK);
+    }
+    await session.handleBinaryAudio(SILENT_CHUNK);
+    await flushAsyncCallbacks();
+
+    expect(countType(frames, "turn_cancelled")).toBe(0);
+    expect(countType(frames, "speech_started")).toBe(1);
+    expect(abort).not.toHaveBeenCalled();
+
+    // The reply completes in full; the noise utterance then dies via the
+    // empty-transcript discard path, never having flushed playback.
+    await session.handleClientFrame({ type: "ptt_release" });
+    completeFirstReply();
+    await waitFor(() => countType(frames, "utterance_discarded") === 1);
+    expect(
+      frames.some(
+        (frame) => frame.type === "tts_done" && frame.turnId === "live-turn-1",
+      ),
+    ).toBe(true);
+    expect(countType(frames, "turn_cancelled")).toBe(0);
+    expect(countType(frames, "speech_started")).toBe(1);
+    expect(abort).not.toHaveBeenCalled();
+  });
+
+  test("sustained speech reaching the guard flushes playback and cancels the turn", async () => {
+    const { frames, session, abort, speakFirstReply } =
+      createSpeakingTurnHarness({ bargeInMinSpeechMs: 60 });
+    await speakFirstReply();
+
+    // 50 ms of consecutive speech: one chunk short of the 60 ms guard.
+    for (let index = 0; index < 5; index += 1) {
+      await session.handleBinaryAudio(LOUD_CHUNK);
+    }
+    await flushAsyncCallbacks();
+    expect(countType(frames, "turn_cancelled")).toBe(0);
+    expect(countType(frames, "speech_started")).toBe(1);
+    expect(abort).not.toHaveBeenCalled();
+
+    // The 6th consecutive chunk reaches 60 ms: the deferred speech_started
+    // flushes playback and the turn cancels.
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "turn_cancelled"),
+    );
+
+    const types = frameTypes(frames);
+    expect(countType(frames, "speech_started")).toBe(2);
+    expect(types.lastIndexOf("speech_started")).toBeLessThan(
+      types.indexOf("turn_cancelled"),
+    );
+    expect(
+      frames.find((frame) => frame.type === "turn_cancelled"),
+    ).toMatchObject({ type: "turn_cancelled", turnId: "live-turn-1" });
+    await waitFor(() => abort.mock.calls.length === 1);
+  });
+
+  test("a non-speech chunk resets the sustained-speech run", async () => {
+    const { frames, session, speakFirstReply } = createSpeakingTurnHarness({
+      bargeInMinSpeechMs: 60,
+    });
+    await speakFirstReply();
+
+    // 50 ms of speech, a silence blip, then 50 ms more: neither run reaches
+    // the guard because the blip zeroes the accumulator.
+    for (let index = 0; index < 5; index += 1) {
+      await session.handleBinaryAudio(LOUD_CHUNK);
+    }
+    await session.handleBinaryAudio(SILENT_CHUNK);
+    for (let index = 0; index < 5; index += 1) {
+      await session.handleBinaryAudio(LOUD_CHUNK);
+    }
+    await flushAsyncCallbacks();
+    expect(countType(frames, "turn_cancelled")).toBe(0);
+
+    // A 6th consecutive speech chunk completes a full 60 ms run.
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "turn_cancelled"),
+    );
+  });
+
+  test("bargeInMinSpeechMs 0 restores instant barge-in", async () => {
+    const { frames, session, abort, speakFirstReply } =
+      createSpeakingTurnHarness({ bargeInMinSpeechMs: 0 });
+    await speakFirstReply();
+
+    // A single 10 ms onset chunk cancels immediately — no accumulation.
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "turn_cancelled"),
+    );
+
+    const types = frameTypes(frames);
+    expect(types.lastIndexOf("speech_started")).toBeLessThan(
+      types.indexOf("turn_cancelled"),
+    );
+    await waitFor(() => abort.mock.calls.length === 1);
+  });
+
+  test("onset while listening is instant regardless of the guard", async () => {
+    // A guard no amount of speech in this test could satisfy: any
+    // speech_started at all proves the instant listening path.
+    const { frames, session } = createHarness({
+      finals: ["hello world"],
+      bargeInMinSpeechMs: 10_000,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => countType(frames, "speech_started") === 1);
   });
 });

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -288,9 +288,19 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // speech_started + barge-in fire (at most once per onset). A non-speech
   // chunk zeroes the run; the detector's utterance end discards the guard.
   private pendingBargeIn: {
-    turn: ActiveAssistantTurn;
+    // Null when guarding only the post-tts_done drain window (the turn is
+    // already finalized but the client is still playing its tail).
+    turn: ActiveAssistantTurn | null;
     speechMs: number;
   } | null = null;
+  // Estimated wall-clock ms until the client finishes draining the
+  // assistant audio sent so far. The server clears the turn right after
+  // tts_done while the client keeps playing the buffered tail — the
+  // sustained-speech guard must also cover that window or a noise blip
+  // clips the reply's last words. Advanced per sent tts_audio frame from
+  // the chunk's PCM duration; zeroed whenever the client flushes playback
+  // (speech_started, turn_cancelled, interrupt, close).
+  private assistantPlaybackTailUntilMs = 0;
   private readonly maxPendingAudioBytes: number;
   // Set on VAD speech onset; consumed when the first speech chunk is routed
   // to an utterance so the metric lands on the right turn.
@@ -842,8 +852,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     const turn = this.activeAssistantTurn;
     const speakingTurn =
       turn && !turn.finalized && turn.ttsAudioStarted ? turn : null;
+    // The client can still be draining audible playback after tts_done
+    // (the turn is already cleared server-side) — that tail deserves the
+    // same guard, or a noise blip clips the reply's last words.
+    const drainingPlayback = Date.now() < this.assistantPlaybackTailUntilMs;
 
-    if (speakingTurn && this.bargeInMinSpeechMs > 0) {
+    if ((speakingTurn || drainingPlayback) && this.bargeInMinSpeechMs > 0) {
       // Onset audio keeps flowing into the cycle/pre-roll while the guard
       // accumulates (trackBargeInGuard), so no speech is lost either way.
       this.pendingBargeIn = { turn: speakingTurn, speechMs: 0 };
@@ -851,6 +865,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
 
     this.pendingBargeIn = null;
+    this.assistantPlaybackTailUntilMs = 0;
     void this.sendFrame({ type: "speech_started" });
     if (speakingTurn) {
       this.bargeIn(speakingTurn);
@@ -876,9 +891,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return;
     }
     this.pendingBargeIn = null;
+    this.assistantPlaybackTailUntilMs = 0;
     void this.sendFrame({ type: "speech_started" });
     const { turn } = guard;
-    if (turn === this.activeAssistantTurn && !turn.finalized) {
+    if (turn && turn === this.activeAssistantTurn && !turn.finalized) {
       this.bargeIn(turn);
     }
   }
@@ -886,7 +902,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private bargeIn(turn: ActiveAssistantTurn): void {
     // Abort synchronously so no tts_audio frame can follow turn_cancelled,
     // and settle the cancelled turn's metrics so the next utterance's marks
-    // do not collide with it in the collector.
+    // do not collide with it in the collector. turn_cancelled flushes
+    // client playback, so the drain estimate resets with it.
+    this.assistantPlaybackTailUntilMs = 0;
     turn.abortController.abort();
     this.metrics.markBargeIn(turn.turnId);
     void (async () => {
@@ -1288,6 +1306,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     this.state = "interrupted";
     // A client interrupt also discards speech parked in the pre-roll ring.
+    // The client stopped its own playback, so the drain estimate resets.
+    this.assistantPlaybackTailUntilMs = 0;
     this.takeVadPreRoll();
     this.vadPendingTurnEnd = null;
     const utterance = this.currentUtterance;
@@ -1828,6 +1848,17 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       if (!sent) {
         return;
       }
+      // Extend the client playback-tail estimate by this chunk's PCM
+      // duration (chunks queue gaplessly client-side, so the tail grows
+      // from whichever is later: now or the current estimate).
+      const chunkMs =
+        (Buffer.byteLength(chunk.dataBase64, "base64") /
+          2 /
+          chunk.sampleRate) *
+        1_000;
+      const now = Date.now();
+      this.assistantPlaybackTailUntilMs =
+        Math.max(now, this.assistantPlaybackTailUntilMs) + chunkMs;
       const turnAfterSend = this.activeAssistantTurn;
       if (turnAfterSend?.token !== token || turnAfterSend.ttsAudioStarted) {
         return;

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -75,6 +75,11 @@ const SERVER_VAD_PRE_ROLL_MAX_CHUNKS = 25;
 // strict upper bound on the release→turn-start tail in persistent mode (the
 // provider keeps its own, longer, finalize fallback).
 const FINALIZE_GRACE_MS = 1_000;
+// Consecutive speech (ms) required before speech during assistant playback
+// flushes it (speech_started) and cancels the turn, so a cough or noise blip
+// cannot kill a reply mid-sentence. Mirrors the liveVoice.vad.bargeInMinSpeechMs
+// schema default; 0 disables the guard for instant barge-in.
+const DEFAULT_BARGE_IN_MIN_SPEECH_MS = 60;
 
 export type LiveVoiceStreamingTranscriberResolver = (
   options: ResolveStreamingTranscriberOptions,
@@ -135,6 +140,13 @@ export interface LiveVoiceSessionOptions {
    * `DEFAULT_SPEECH_ENERGY_THRESHOLD`.
    */
   speechEnergyThreshold?: number;
+  /**
+   * Sustained speech (ms) required before speech during assistant playback
+   * interrupts it (barge-in); 0 disables the guard. The production factory
+   * seeds this from `liveVoice.vad.bargeInMinSpeechMs` config when unset;
+   * defaults to `DEFAULT_BARGE_IN_MIN_SPEECH_MS`.
+   */
+  bargeInMinSpeechMs?: number;
   /**
    * Overrides the bounded wait for the shared transcriber's finalize
    * flush in persistent mode (test hook). Defaults to `FINALIZE_GRACE_MS`.
@@ -236,6 +248,16 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // Energy gate for server-VAD speech classification; undefined defers to
   // DEFAULT_SPEECH_ENERGY_THRESHOLD.
   private readonly speechEnergyThreshold: number | undefined;
+  private readonly bargeInMinSpeechMs: number;
+  // Sustained-speech barge-in guard, armed at speech onset while the
+  // assistant turn is audibly speaking: consecutive speech-chunk duration
+  // accumulates until it reaches bargeInMinSpeechMs, then the deferred
+  // speech_started + barge-in fire (at most once per onset). A non-speech
+  // chunk zeroes the run; the detector's utterance end discards the guard.
+  private pendingBargeIn: {
+    turn: ActiveAssistantTurn;
+    speechMs: number;
+  } | null = null;
   private readonly maxPendingAudioBytes: number;
   // Set on VAD speech onset; consumed when the first speech chunk is routed
   // to an utterance so the metric lands on the right turn.
@@ -297,6 +319,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       ...(options.metricsClock ? { clock: options.metricsClock } : {}),
     });
     this.speechEnergyThreshold = options.speechEnergyThreshold;
+    this.bargeInMinSpeechMs =
+      options.bargeInMinSpeechMs ?? DEFAULT_BARGE_IN_MIN_SPEECH_MS;
     this.finalizeGraceMs = options.finalizeGraceMs ?? FINALIZE_GRACE_MS;
     this.turnDetector =
       context.startFrame.turnDetection === "server_vad"
@@ -624,6 +648,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       this.speechEnergyThreshold,
     );
     detector.onMediaChunk(hasSpeech);
+    this.trackBargeInGuard(hasSpeech, chunk);
 
     // Idle mic: hold silent chunks in the bounded pre-roll instead of
     // collecting or streaming them; flushed on speech onset so the
@@ -767,20 +792,60 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
   }
 
-  // VAD speech onset. Contract: speech_started always goes out (the client
-  // flushes tail playback immediately); barge-in then cancels the active
-  // turn only once its first tts_audio chunk was forwarded — speech during
-  // a pre-TTS "thinking" turn never kills the unspoken reply.
+  // VAD speech onset. Contract: speech_started tells the client to flush
+  // tail playback immediately; barge-in then cancels the active turn only
+  // once its first tts_audio chunk was forwarded — speech during a pre-TTS
+  // "thinking" turn never kills the unspoken reply. While a turn is audibly
+  // speaking, both are deferred behind the sustained-speech guard so a
+  // cough or noise blip cannot kill the reply; onset while listening keeps
+  // the instant speech_started (turn-taking latency is untouched).
   private handleVadSpeechStart(): void {
     if (this.isClosed || this.state === "failed") {
       return;
     }
 
-    void this.sendFrame({ type: "speech_started" });
     this.vadSpeechStartPending = true;
 
     const turn = this.activeAssistantTurn;
-    if (turn && !turn.finalized && turn.ttsAudioStarted) {
+    const speakingTurn =
+      turn && !turn.finalized && turn.ttsAudioStarted ? turn : null;
+
+    if (speakingTurn && this.bargeInMinSpeechMs > 0) {
+      // Onset audio keeps flowing into the cycle/pre-roll while the guard
+      // accumulates (trackBargeInGuard), so no speech is lost either way.
+      this.pendingBargeIn = { turn: speakingTurn, speechMs: 0 };
+      return;
+    }
+
+    this.pendingBargeIn = null;
+    void this.sendFrame({ type: "speech_started" });
+    if (speakingTurn) {
+      this.bargeIn(speakingTurn);
+    }
+  }
+
+  // Advances the sustained-speech barge-in guard by one server-VAD chunk:
+  // consecutive speech accumulates toward bargeInMinSpeechMs (a non-speech
+  // chunk zeroes the run) and, once met, the deferred speech_started +
+  // barge-in fire.
+  private trackBargeInGuard(hasSpeech: boolean, chunk: Buffer): void {
+    const guard = this.pendingBargeIn;
+    if (!guard) {
+      return;
+    }
+    if (!hasSpeech) {
+      guard.speechMs = 0;
+      return;
+    }
+    guard.speechMs +=
+      (chunk.byteLength / 2 / this.context.startFrame.audio.sampleRate) * 1_000;
+    if (guard.speechMs < this.bargeInMinSpeechMs) {
+      return;
+    }
+    this.pendingBargeIn = null;
+    void this.sendFrame({ type: "speech_started" });
+    const { turn } = guard;
+    if (turn === this.activeAssistantTurn && !turn.finalized) {
       this.bargeIn(turn);
     }
   }
@@ -811,6 +876,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         return;
       }
       this.vadSpeechStartPending = false;
+      // The detector turn is over: an untripped guard was noise, not
+      // barge-in — leave playback untouched.
+      this.pendingBargeIn = null;
       const utterance = this.currentUtterance;
       if (!utterance || utterance.released || utterance.completed) {
         // The ended turn's speech sits parked in the pre-roll ring (the
@@ -2033,7 +2101,8 @@ export function createLiveVoiceSession(
 ): LiveVoiceSession {
   // Workspace-tunable server-VAD thresholds. The `liveVoice.vad` schema
   // defaults match the code defaults (800 energy / 800 ms silence / 30 s max
-  // turn), so an unset config leaves behavior unchanged. Optional-chained
+  // turn / 60 ms barge-in guard), so an unset config leaves behavior
+  // unchanged. Optional-chained
   // because hand-built test configs may predate the liveVoice namespace;
   // absent config falls through to the in-code defaults.
   const vadConfig = getConfig().liveVoice?.vad;
@@ -2049,6 +2118,8 @@ export function createLiveVoiceSession(
         : {}),
     speechEnergyThreshold:
       options.speechEnergyThreshold ?? vadConfig?.speechEnergyThreshold,
+    bargeInMinSpeechMs:
+      options.bargeInMinSpeechMs ?? vadConfig?.bargeInMinSpeechMs,
     resolveCredentialReadiness:
       options.resolveCredentialReadiness === undefined
         ? defaultResolveLiveVoiceCredentialReadiness


### PR DESCRIPTION
## Summary
- Speech during assistant playback must persist for liveVoice.vad.bargeInMinSpeechMs (default 60 ms) before it flushes playback and cancels the turn — coughs and noise blips no longer kill replies
- Turn-taking while listening keeps the instant speech_started path; 0 disables the guard

Part of plan: voice-mode-latency.md (PR 10 of 13)