### PR TITLE
refactor(memory): resolve memory config plugin-internally from workspace config.json (F6)

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -10,6 +10,10 @@ import { eq } from "drizzle-orm";
 // injection chain assertions stay meaningful.
 const realLoaderForAssemblyTest = await import("../config/loader.js");
 const realGetConfigForAssemblyTest = realLoaderForAssemblyTest.getConfig;
+const realMemoryConfigForAssemblyTest =
+  await import("../plugins/defaults/memory/config.js");
+const realGetMemoryConfigForAssemblyTest =
+  realMemoryConfigForAssemblyTest.getMemoryConfig;
 // Per-test overrides for `ui.userTimezone` / `ui.detectedTimezone` so the
 // config self-resolution inside `applyRuntimeInjections` can be exercised.
 let assemblyConfiguredUserTimezone: string | null | undefined;
@@ -30,6 +34,15 @@ mock.module("../config/loader.js", () => ({
       memory: { ...real.memory, v2: { ...real.memory.v2, enabled: false } },
       slack: { ...real.slack, botUserId: "U_BOT" },
     };
+  },
+}));
+
+// Memory code resolves its config through the plugin's own accessor, not
+// getConfig(); mirror the v2-disabled override there.
+mock.module("../plugins/defaults/memory/config.js", () => ({
+  getMemoryConfig: () => {
+    const real = realGetMemoryConfigForAssemblyTest();
+    return { ...real, v2: { ...real.v2, enabled: false } };
   },
 }));
 
@@ -75,7 +88,9 @@ let pkbSearchResults: Array<{
 let pkbSearchThrows: Error | null = null;
 mock.module("../plugins/defaults/memory/pkb/pkb-search.js", () => ({
   searchPkbFiles: async () => {
-    if (pkbSearchThrows) throw pkbSearchThrows;
+    if (pkbSearchThrows) {
+      throw pkbSearchThrows;
+    }
     return pkbSearchResults;
   },
 }));
@@ -3194,7 +3209,9 @@ describe("Slack channel chronological rendering — multi-thread", () => {
     const outer: Record<string, unknown> = {
       ...(opts.extraOuterMetadata ?? {}),
     };
-    if (opts.slackMeta) outer.slackMeta = writeSlackMetadata(opts.slackMeta);
+    if (opts.slackMeta) {
+      outer.slackMeta = writeSlackMetadata(opts.slackMeta);
+    }
     return {
       id: opts.id,
       conversationId: "conv-1",
@@ -3213,7 +3230,9 @@ describe("Slack channel chronological rendering — multi-thread", () => {
     slackMeta?: SlackMessageMetadata;
   }): MessageRow {
     const outer: Record<string, unknown> = {};
-    if (opts.slackMeta) outer.slackMeta = writeSlackMetadata(opts.slackMeta);
+    if (opts.slackMeta) {
+      outer.slackMeta = writeSlackMetadata(opts.slackMeta);
+    }
     return {
       id: opts.id,
       conversationId: "conv-1",
@@ -3261,7 +3280,9 @@ describe("Slack channel chronological rendering — multi-thread", () => {
     return messages.map((m) => {
       for (let i = m.content.length - 1; i >= 0; i--) {
         const block = m.content[i];
-        if (block.type === "text") return block.text;
+        if (block.type === "text") {
+          return block.text;
+        }
       }
       return "";
     });
@@ -4811,7 +4832,9 @@ describe("assembleSlackActiveThreadFocusBlock", () => {
 
   function envelope(meta: SlackMessageMetadata | null): string {
     const outer: Record<string, unknown> = {};
-    if (meta) outer.slackMeta = writeSlackMetadata(meta);
+    if (meta) {
+      outer.slackMeta = writeSlackMetadata(meta);
+    }
     return JSON.stringify(outer);
   }
 

--- a/assistant/src/__tests__/injector-chain.test.ts
+++ b/assistant/src/__tests__/injector-chain.test.ts
@@ -39,6 +39,18 @@ mock.module("../config/loader.js", () => ({
   },
 }));
 
+// Memory code resolves its config through the plugin's own accessor, not
+// getConfig(); mirror the v2-disabled override there.
+const realMemoryConfigModule =
+  await import("../plugins/defaults/memory/config.js");
+const realGetMemoryConfig = realMemoryConfigModule.getMemoryConfig;
+mock.module("../plugins/defaults/memory/config.js", () => ({
+  getMemoryConfig: () => {
+    const real = realGetMemoryConfig();
+    return { ...real, v2: { ...real.v2, enabled: false } };
+  },
+}));
+
 // `applyRuntimeInjections` computes the `<turn_context>` `current_time` live
 // via `formatTurnTimestamp`; pin it so the rendered block matches the
 // deterministic `buildUnifiedTurnContextBlock` expectations below. The rest of

--- a/assistant/src/__tests__/injector-pkb-v2-silenced.test.ts
+++ b/assistant/src/__tests__/injector-pkb-v2-silenced.test.ts
@@ -30,6 +30,14 @@ mock.module("../config/loader.js", () => ({
   }),
 }));
 
+// The PKB silencing gate reads the plugin's own config accessor.
+mock.module("../plugins/defaults/memory/config.js", () => ({
+  getMemoryConfig: () => ({
+    v2: { enabled: v2Active },
+    retrieval: { scratchpadInjection: { enabled: true } },
+  }),
+}));
+
 mock.module("../plugins/defaults/memory/pkb/pkb-search.js", () => ({
   searchPkbFiles: async () => [],
 }));

--- a/assistant/src/__tests__/memory-config-file-parity.test.ts
+++ b/assistant/src/__tests__/memory-config-file-parity.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Locks the memory plugin's file-based config resolution (`getMemoryConfig`)
+ * to the host loader's memory slice (`getConfig().memory`): same schema
+ * defaults, same per-field invalid fallback, same deployment-context fill.
+ *
+ * The plugin reads workspace/config.json's `memory` field itself; these
+ * cases document that both resolutions agree on every file state. If the
+ * loader's semantics change, this is the tripwire.
+ */
+
+import { existsSync, rmSync, writeFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { getConfig } from "../config/loader.js";
+import { getMemoryConfig } from "../plugins/defaults/memory/config.js";
+import { getWorkspaceConfigPath } from "../util/platform.js";
+
+const configPath = getWorkspaceConfigPath();
+const savedIsPlatform = process.env.IS_PLATFORM;
+
+function writeConfig(value: unknown): void {
+  writeFileSync(configPath, JSON.stringify(value, null, 2));
+}
+
+function resetState(): void {
+  rmSync(configPath, { force: true });
+  delete process.env.IS_PLATFORM;
+}
+
+/** Assert the plugin resolution deep-equals the host loader's slice. */
+function expectParity(): ReturnType<typeof getMemoryConfig> {
+  const plugin = getMemoryConfig();
+  expect(plugin).toEqual(getConfig().memory);
+  return plugin;
+}
+
+describe("memory config file parity", () => {
+  beforeEach(resetState);
+  afterEach(() => {
+    resetState();
+    if (savedIsPlatform !== undefined) {
+      process.env.IS_PLATFORM = savedIsPlatform;
+    }
+  });
+
+  test("absent config.json resolves to schema defaults, without creating the file", () => {
+    const memory = getMemoryConfig();
+    expect(existsSync(configPath)).toBe(false); // side-effect-free read
+    expect(memory.enabled).not.toBeUndefined();
+    expectParity(); // getConfig() may seed the file; values still agree
+  });
+
+  test("custom knobs are visible and identical", () => {
+    writeConfig({ memory: { enabled: false, v2: { bm25_b: 0.9 } } });
+    const memory = expectParity();
+    expect(memory.enabled).toBe(false);
+    expect(memory.v2.bm25_b).toBe(0.9);
+  });
+
+  test("an invalid leaf falls back per-field; valid siblings survive", () => {
+    writeConfig({ memory: { enabled: false, v2: { bm25_b: "high" } } });
+    const memory = expectParity();
+    expect(memory.enabled).toBe(false); // sibling customization survives
+    expect(typeof memory.v2.bm25_b).toBe("number"); // invalid leaf → default
+  });
+
+  test("unknown keys strip silently", () => {
+    writeConfig({ memory: { retiredKnob: 123, enabled: false } });
+    const memory = expectParity();
+    expect(memory.enabled).toBe(false);
+    expect("retiredKnob" in memory).toBe(false);
+  });
+
+  test("a non-object memory field resolves to defaults", () => {
+    writeConfig({ memory: 5 });
+    expectParity();
+  });
+
+  test("unparseable config.json resolves to defaults", () => {
+    writeFileSync(configPath, "{ not json");
+    const memory = getMemoryConfig();
+    expect(memory.enabled).not.toBeUndefined();
+    // getConfig() quarantines the corrupt file (a host-owned side effect);
+    // after that both resolutions see the same absent-file state.
+    expectParity();
+  });
+
+  test("platform deployment fill applies when the leaf is absent on disk", () => {
+    process.env.IS_PLATFORM = "true";
+    writeConfig({ memory: {} });
+    const memory = expectParity();
+    expect(memory.embeddings.provider).toBe("gemini");
+  });
+
+  test("an explicit on-disk provider beats the platform fill", () => {
+    process.env.IS_PLATFORM = "true";
+    writeConfig({ memory: { embeddings: { provider: "openai" } } });
+    const memory = expectParity();
+    expect(memory.embeddings.provider).toBe("openai");
+  });
+
+  test("the cache serves the same object until the file changes", () => {
+    writeConfig({ memory: { enabled: false } });
+    const first = getMemoryConfig();
+    expect(getMemoryConfig()).toBe(first);
+    writeConfig({ memory: { enabled: true } });
+    const second = getMemoryConfig();
+    expect(second).not.toBe(first);
+    expect(second.enabled).toBe(true);
+    expectParity();
+  });
+});

--- a/assistant/src/__tests__/memory-config-file-parity.test.ts
+++ b/assistant/src/__tests__/memory-config-file-parity.test.ts
@@ -8,7 +8,9 @@
  * loader's semantics change, this is the tripwire.
  */
 
-import { existsSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { getConfig } from "../config/loader.js";
@@ -146,6 +148,30 @@ describe("memory config file parity", () => {
     expect(ctxLoad.capabilityReserve + ctxLoad.serendipitySlots).toBeLessThan(
       ctxLoad.maxNodes,
     );
+  });
+
+  test("switching VELLUM_WORKSPACE_DIR busts the cache (path is part of the key)", () => {
+    const savedWorkspace = process.env.VELLUM_WORKSPACE_DIR;
+    try {
+      writeConfig({ memory: { enabled: false } });
+      expect(getMemoryConfig().enabled).toBe(false);
+
+      const otherWorkspace = mkdtempSync(join(tmpdir(), "vellum-parity-ws-"));
+      process.env.VELLUM_WORKSPACE_DIR = otherWorkspace;
+      // The other workspace has no config.json → schema defaults, not the
+      // previous workspace's cached slice.
+      expect(getMemoryConfig().enabled).toBe(true);
+      expectParity();
+
+      writeFileSync(
+        join(otherWorkspace, "config.json"),
+        JSON.stringify({ memory: { v2: { enabled: false } } }),
+      );
+      expect(getMemoryConfig().v2.enabled).toBe(false);
+      expectParity();
+    } finally {
+      process.env.VELLUM_WORKSPACE_DIR = savedWorkspace;
+    }
   });
 
   test("the cache serves the same object until the file changes", () => {

--- a/assistant/src/__tests__/memory-config-file-parity.test.ts
+++ b/assistant/src/__tests__/memory-config-file-parity.test.ts
@@ -99,6 +99,55 @@ describe("memory config file parity", () => {
     expect(memory.embeddings.provider).toBe("openai");
   });
 
+  test("cross-field invariant: segmentation overlap >= target falls back like the loader", () => {
+    writeConfig({
+      memory: {
+        enabled: false,
+        segmentation: { targetTokens: 100, overlapTokens: 200 },
+      },
+    });
+    const memory = expectParity();
+    expect(memory.enabled).toBe(false); // valid sibling survives
+    expect(memory.segmentation.overlapTokens).toBeLessThan(
+      memory.segmentation.targetTokens,
+    );
+  });
+
+  test("cross-field invariant: dynamicBudget min > max falls back like the loader", () => {
+    writeConfig({
+      memory: {
+        retrieval: {
+          dynamicBudget: { minInjectTokens: 5000, maxInjectTokens: 100 },
+        },
+      },
+    });
+    const memory = expectParity();
+    expect(memory.retrieval.dynamicBudget.minInjectTokens).toBeLessThanOrEqual(
+      memory.retrieval.dynamicBudget.maxInjectTokens,
+    );
+  });
+
+  test("cross-field invariant: injection reserves >= maxNodes fall back like the loader", () => {
+    writeConfig({
+      memory: {
+        retrieval: {
+          injection: {
+            contextLoad: {
+              capabilityReserve: 10,
+              serendipitySlots: 10,
+              maxNodes: 5,
+            },
+          },
+        },
+      },
+    });
+    const memory = expectParity();
+    const ctxLoad = memory.retrieval.injection.contextLoad;
+    expect(ctxLoad.capabilityReserve + ctxLoad.serendipitySlots).toBeLessThan(
+      ctxLoad.maxNodes,
+    );
+  });
+
   test("the cache serves the same object until the file changes", () => {
     writeConfig({ memory: { enabled: false } });
     const first = getMemoryConfig();

--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -161,6 +161,7 @@ const BASELINE: Record<string, readonly string[]> = {
     "../../../config/memory-v3-gate.js",
     "../../../config/schema.js",
     "../../../config/schemas/memory-v2.js",
+    "../../../config/schemas/memory.js",
     "../../../config/types.js",
     "../../../contacts/guardian-delivery-reader.js",
     "../../../context/compactor.js",

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -194,55 +194,6 @@ export const AssistantConfigSchema = z
           "llm.default.contextWindow.targetBudgetRatio must be greater than llm.default.contextWindow.summaryBudgetRatio",
       });
     }
-    const segmentation = config.memory?.segmentation;
-    if (
-      segmentation &&
-      segmentation.overlapTokens >= segmentation.targetTokens
-    ) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["memory", "segmentation", "overlapTokens"],
-        message:
-          "memory.segmentation.overlapTokens must be less than memory.segmentation.targetTokens",
-      });
-    }
-    const dynamicBudget = config.memory?.retrieval?.dynamicBudget;
-    if (
-      dynamicBudget &&
-      dynamicBudget.minInjectTokens > dynamicBudget.maxInjectTokens
-    ) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["memory", "retrieval", "dynamicBudget"],
-        message:
-          "memory.retrieval.dynamicBudget.minInjectTokens must be <= memory.retrieval.dynamicBudget.maxInjectTokens",
-      });
-    }
-    const injection = config.memory?.retrieval?.injection;
-    const ctxLoad = injection?.contextLoad;
-    if (
-      ctxLoad &&
-      ctxLoad.capabilityReserve + ctxLoad.serendipitySlots >= ctxLoad.maxNodes
-    ) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["memory", "retrieval", "injection", "contextLoad"],
-        message:
-          "memory.retrieval.injection.contextLoad.capabilityReserve + serendipitySlots must be less than maxNodes",
-      });
-    }
-    const perTurn = injection?.perTurn;
-    if (
-      perTurn &&
-      perTurn.capabilityReserve + perTurn.serendipitySlots >= perTurn.maxNodes
-    ) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["memory", "retrieval", "injection", "perTurn"],
-        message:
-          "memory.retrieval.injection.perTurn.capabilityReserve + serendipitySlots must be less than maxNodes",
-      });
-    }
   });
 
 export type AssistantConfig = z.infer<typeof AssistantConfigSchema>;

--- a/assistant/src/config/schemas/memory.ts
+++ b/assistant/src/config/schemas/memory.ts
@@ -66,6 +66,62 @@ export const MemoryConfigSchema = z
   })
   .describe(
     "Long-term memory system — stores, retrieves, and manages persistent knowledge across conversations",
-  );
+  )
+  // Cross-field memory invariants live on this schema (not the assistant
+  // schema's refinement) so every parse of the memory slice enforces them —
+  // the full-config parse via AssistantConfigSchema and the memory plugin's
+  // own slice parse alike. Parent parses prefix issue paths with "memory",
+  // preserving the loader's per-field fallback paths.
+  .superRefine((config, ctx) => {
+    const segmentation = config.segmentation;
+    if (
+      segmentation &&
+      segmentation.overlapTokens >= segmentation.targetTokens
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["segmentation", "overlapTokens"],
+        message:
+          "memory.segmentation.overlapTokens must be less than memory.segmentation.targetTokens",
+      });
+    }
+    const dynamicBudget = config.retrieval?.dynamicBudget;
+    if (
+      dynamicBudget &&
+      dynamicBudget.minInjectTokens > dynamicBudget.maxInjectTokens
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["retrieval", "dynamicBudget"],
+        message:
+          "memory.retrieval.dynamicBudget.minInjectTokens must be <= memory.retrieval.dynamicBudget.maxInjectTokens",
+      });
+    }
+    const injection = config.retrieval?.injection;
+    const ctxLoad = injection?.contextLoad;
+    if (
+      ctxLoad &&
+      ctxLoad.capabilityReserve + ctxLoad.serendipitySlots >= ctxLoad.maxNodes
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["retrieval", "injection", "contextLoad"],
+        message:
+          "memory.retrieval.injection.contextLoad.capabilityReserve + serendipitySlots must be less than maxNodes",
+      });
+    }
+    const perTurn = injection?.perTurn;
+    if (
+      perTurn &&
+      perTurn.capabilityReserve + perTurn.serendipitySlots >= perTurn.maxNodes
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["retrieval", "injection", "perTurn"],
+        message:
+          "memory.retrieval.injection.perTurn.capabilityReserve + serendipitySlots must be less than maxNodes",
+      });
+    }
+  });
 
 export type MemoryConfig = z.infer<typeof MemoryConfigSchema>;

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-startup-cleanup.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-startup-cleanup.test.ts
@@ -121,11 +121,9 @@ let activeJobSourceConvIds = new Set<string>();
 let injectedNowMinusOrphanAgeMs = 0;
 let mockKeepSupersededRuns = false;
 
-mock.module("../../../../config/loader.js", () => ({
-  getConfig: () => ({
-    memory: {
-      retrospective: { keepSupersededRuns: mockKeepSupersededRuns },
-    },
+mock.module("../config.js", () => ({
+  getMemoryConfig: () => ({
+    retrospective: { keepSupersededRuns: mockKeepSupersededRuns },
   }),
 }));
 

--- a/assistant/src/plugins/defaults/memory/config.ts
+++ b/assistant/src/plugins/defaults/memory/config.ts
@@ -1,11 +1,148 @@
-import { getConfig } from "../../../config/loader.js";
-import type { MemoryConfig } from "../../../config/types.js";
+import { readFileSync, statSync } from "node:fs";
+
+import type { MemoryConfig } from "../../../config/schemas/memory.js";
+import { MemoryConfigSchema } from "../../../config/schemas/memory.js";
+import { getLogger } from "../../../util/logger.js";
+import { getWorkspaceConfigPath } from "../../../util/platform.js";
+
+const log = getLogger("memory-config");
+
+let cached: MemoryConfig | null = null;
+let cachedSignature: string | null = null;
 
 /**
- * The `memory` slice of the live assistant config. Memory code reads its own
- * configuration through this accessor rather than the full `getConfig()`, so its
- * config dependency is a narrow slice of `AssistantConfig`.
+ * Cheap freshness key for the config file, mirroring the host loader's
+ * signature check (size + mtime + ctime). "absent" when the file is missing
+ * or unreadable.
+ */
+function configFileSignature(path: string): string {
+  try {
+    const s = statSync(path);
+    return `${s.size}:${s.mtimeMs}:${s.ctimeMs}`;
+  } catch {
+    return "absent";
+  }
+}
+
+/**
+ * The raw `memory` field of workspace/config.json, or `{}` when the file is
+ * missing, unparseable, or the field is not a plain object. Matches the host
+ * loader's effective outcome for those cases (it quarantines a corrupt file
+ * and proceeds with defaults); quarantine itself stays host-owned — this is
+ * a side-effect-free read.
+ */
+function readRawMemoryField(path: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return {};
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return {};
+  }
+  const memory = (parsed as Record<string, unknown>).memory;
+  if (memory === null || typeof memory !== "object" || Array.isArray(memory)) {
+    return {};
+  }
+  return memory as Record<string, unknown>;
+}
+
+/**
+ * Parse the raw memory field through the schema, mirroring the host loader's
+ * per-field fallback: an invalid leaf is stripped so its schema default
+ * applies while valid sibling customizations survive. Results are
+ * structured-cloned because zod returns its precomputed default sub-objects
+ * by reference on every parse.
+ *
+ * No empty-ancestor pruning (unlike the host's full-config cleanup): every
+ * memory sub-schema parses `{}` to its full defaults, so an emptied object is
+ * equivalent to an absent one.
+ */
+function parseMemorySlice(raw: Record<string, unknown>): MemoryConfig {
+  const result = MemoryConfigSchema.safeParse(raw);
+  if (result.success) return structuredClone(result.data);
+
+  const cleaned = structuredClone(raw);
+  for (const issue of result.error.issues) {
+    const path = issue.path.join(".");
+    log.warn(
+      `Invalid memory config${path ? ` at "${path}"` : ""}: ${issue.message}. Falling back to default.`,
+    );
+    if (issue.path.length === 0) {
+      return structuredClone(MemoryConfigSchema.parse({}));
+    }
+    deleteLeaf(cleaned, issue.path as (string | number)[]);
+  }
+
+  const retry = MemoryConfigSchema.safeParse(cleaned);
+  if (retry.success) return structuredClone(retry.data);
+
+  log.warn("Memory config validation failed after cleanup. Using defaults.");
+  return structuredClone(MemoryConfigSchema.parse({}));
+}
+
+/** Delete the leaf at `path`, tolerating already-missing ancestors. */
+function deleteLeaf(
+  obj: Record<string, unknown>,
+  path: (string | number)[],
+): void {
+  let node: unknown = obj;
+  for (const key of path.slice(0, -1)) {
+    if (node === null || typeof node !== "object") return;
+    node = (node as Record<string | number, unknown>)[key];
+  }
+  if (node === null || typeof node !== "object") return;
+  delete (node as Record<string | number, unknown>)[path.at(-1)!];
+}
+
+/**
+ * Deployment-context fill for the memory slice, mirroring the memory entry of
+ * the host loader's `getDeploymentContextDefaults()`: platform-managed
+ * assistants (IS_PLATFORM) embed via the managed gemini backend unless the
+ * provider leaf is explicitly set on disk. Kept local so this module does not
+ * import the host loader (whose partial test mocks would otherwise break the
+ * import); the parity test compares against the real loader under
+ * IS_PLATFORM, so a divergent fill fails loudly there.
+ */
+function applyDeploymentContextFill(
+  memory: MemoryConfig,
+  raw: Record<string, unknown>,
+): void {
+  if (process.env.IS_PLATFORM !== "true" && process.env.IS_PLATFORM !== "1") {
+    return;
+  }
+  const rawEmbeddings = raw.embeddings;
+  const explicitProvider =
+    rawEmbeddings !== null &&
+    typeof rawEmbeddings === "object" &&
+    !Array.isArray(rawEmbeddings) &&
+    (rawEmbeddings as Record<string, unknown>).provider !== undefined;
+  if (!explicitProvider) {
+    memory.embeddings.provider = "gemini";
+  }
+}
+
+/**
+ * The `memory` slice of the workspace config, resolved by the plugin itself:
+ * reads workspace/config.json's `memory` field directly (signature-cached),
+ * applies schema defaults with the host loader's per-field invalid fallback,
+ * and layers the deployment-context fill for leaves absent on disk.
+ *
+ * Resolution agrees with the host loader's `getConfig().memory` —
+ * `memory-config-file-parity.test.ts` locks the two together. Unlike
+ * `getConfig()`, this never creates directories or seeds a config file.
  */
 export function getMemoryConfig(): MemoryConfig {
-  return getConfig().memory;
+  const path = getWorkspaceConfigPath();
+  const signature = configFileSignature(path);
+  if (cached && cachedSignature === signature) return cached;
+
+  const raw = readRawMemoryField(path);
+  const memory = parseMemorySlice(raw);
+  applyDeploymentContextFill(memory, raw);
+
+  cached = memory;
+  cachedSignature = signature;
+  return memory;
 }

--- a/assistant/src/plugins/defaults/memory/config.ts
+++ b/assistant/src/plugins/defaults/memory/config.ts
@@ -12,15 +12,17 @@ let cachedSignature: string | null = null;
 
 /**
  * Cheap freshness key for the config file, mirroring the host loader's
- * signature check (size + mtime + ctime). "absent" when the file is missing
+ * signature check (path + size + mtime + ctime). The path is part of the key
+ * so a process that switches workspaces (tests, CLI helpers) never serves one
+ * workspace's cached slice for another's. "absent" when the file is missing
  * or unreadable.
  */
 function configFileSignature(path: string): string {
   try {
     const s = statSync(path);
-    return `${s.size}:${s.mtimeMs}:${s.ctimeMs}`;
+    return `${path}:${s.size}:${s.mtimeMs}:${s.ctimeMs}`;
   } catch {
-    return "absent";
+    return `${path}:absent`;
   }
 }
 
@@ -61,7 +63,9 @@ function readRawMemoryField(path: string): Record<string, unknown> {
  */
 function parseMemorySlice(raw: Record<string, unknown>): MemoryConfig {
   const result = MemoryConfigSchema.safeParse(raw);
-  if (result.success) return structuredClone(result.data);
+  if (result.success) {
+    return structuredClone(result.data);
+  }
 
   const cleaned = structuredClone(raw);
   for (const issue of result.error.issues) {
@@ -76,7 +80,9 @@ function parseMemorySlice(raw: Record<string, unknown>): MemoryConfig {
   }
 
   const retry = MemoryConfigSchema.safeParse(cleaned);
-  if (retry.success) return structuredClone(retry.data);
+  if (retry.success) {
+    return structuredClone(retry.data);
+  }
 
   log.warn("Memory config validation failed after cleanup. Using defaults.");
   return structuredClone(MemoryConfigSchema.parse({}));
@@ -89,10 +95,14 @@ function deleteLeaf(
 ): void {
   let node: unknown = obj;
   for (const key of path.slice(0, -1)) {
-    if (node === null || typeof node !== "object") return;
+    if (node === null || typeof node !== "object") {
+      return;
+    }
     node = (node as Record<string | number, unknown>)[key];
   }
-  if (node === null || typeof node !== "object") return;
+  if (node === null || typeof node !== "object") {
+    return;
+  }
   delete (node as Record<string | number, unknown>)[path.at(-1)!];
 }
 
@@ -136,7 +146,9 @@ function applyDeploymentContextFill(
 export function getMemoryConfig(): MemoryConfig {
   const path = getWorkspaceConfigPath();
   const signature = configFileSignature(path);
-  if (cached && cachedSignature === signature) return cached;
+  if (cached && cachedSignature === signature) {
+    return cached;
+  }
 
   const raw = readRawMemoryField(path);
   const memory = parseMemorySlice(raw);

--- a/assistant/src/plugins/defaults/memory/pkb/pkb-search.test.ts
+++ b/assistant/src/plugins/defaults/memory/pkb/pkb-search.test.ts
@@ -5,8 +5,8 @@ import { makeMockLogger } from "../../../../__tests__/helpers/mock-logger.js";
 // This test exercises the v1 PKB search path. `config.memory.v2.enabled`
 // (default `true`) makes pkb-search short-circuit to keep traffic off the
 // legacy collection — force it off so the v1 path stays under test.
-mock.module("../../../../config/loader.js", () => ({
-  getConfig: () => ({ memory: { v2: { enabled: false } } }),
+mock.module("../config.js", () => ({
+  getMemoryConfig: () => ({ v2: { enabled: false } }),
 }));
 
 mock.module("../../../../util/logger.js", () => ({

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/static-context.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/static-context.test.ts
@@ -36,17 +36,20 @@ let configMemoryEnabled = true;
 
 mock.module("../../../../../config/loader.js", () => ({
   getConfig: () => ({}),
-  loadConfig: () => ({
-    memory: {
-      enabled: configMemoryEnabled,
-      v2: { enabled: configMemoryV2Enabled },
-    },
-  }),
+  loadConfig: () => ({}),
   loadRawConfig: () => ({}),
   saveRawConfig: () => {},
   invalidateConfigCache: () => {},
   getNestedValue: () => undefined,
   setNestedValue: () => {},
+}));
+
+// static-context reads its gates through the plugin's own config accessor.
+mock.module("../../config.js", () => ({
+  getMemoryConfig: () => ({
+    enabled: configMemoryEnabled,
+    v2: { enabled: configMemoryV2Enabled },
+  }),
 }));
 
 const { readMemoryV2StaticContent, shouldExposePersonalMemory } =

--- a/assistant/src/plugins/defaults/memory/v2/static-context.ts
+++ b/assistant/src/plugins/defaults/memory/v2/static-context.ts
@@ -18,9 +18,9 @@
 // matching the existing PKB auto-inject pattern.
 
 import type { ChannelId } from "../../../../channels/types.js";
-import { loadConfig } from "../../../../config/loader.js";
 import { readPromptFile } from "../../../../prompts/system-prompt.js";
 import { getWorkspacePromptPath } from "../../../../util/platform.js";
+import { getMemoryConfig } from "../config.js";
 
 interface MemoryV2StaticBlock {
   heading: string;
@@ -35,9 +35,9 @@ const MEMORY_V2_STATIC_BLOCKS: readonly MemoryV2StaticBlock[] = [
 ];
 
 /**
- * Build the v2 static memory block, gated on `config.memory.enabled` and
- * `config.memory.v2.enabled`. Empty/missing files are skipped; returns `null`
- * when either gate is off or every file is empty.
+ * Build the v2 static memory block, gated on the memory config's `enabled`
+ * and `v2.enabled`. Empty/missing files are skipped; returns `null` when
+ * either gate is off or every file is empty.
  *
  * `excludeBuffer` drops the `## Buffer` section. The consolidation run sets
  * it: the agent's contract there is the `memory/buffer.md` FILE — it reads,
@@ -49,13 +49,8 @@ const MEMORY_V2_STATIC_BLOCKS: readonly MemoryV2StaticBlock[] = [
 export function readMemoryV2StaticContent(
   options: { excludeBuffer?: boolean } = {},
 ): string | null {
-  let config;
-  try {
-    config = loadConfig();
-  } catch {
-    return null;
-  }
-  if (config.memory.enabled === false || !config.memory.v2.enabled) {
+  const memoryConfig = getMemoryConfig();
+  if (memoryConfig.enabled === false || !memoryConfig.v2.enabled) {
     return null;
   }
 

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/carry-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/carry-integration.test.ts
@@ -89,6 +89,7 @@ const realFlags = {
 const realConfigLoader = {
   ...(await import("../../../../../config/loader.js")),
 };
+const realMemoryConfig = { ...(await import("../../config.js")) };
 const realDbConnection = {
   ...(await import("../../../../../persistence/db-connection.js")),
 };
@@ -186,6 +187,24 @@ mock.module("../../../../../config/loader.js", () => ({
           },
         }
       : realConfigLoader.getConfig(),
+}));
+
+// Memory code resolves its config through the plugin's own accessor, not
+// getConfig(); stub the same conditional slice there.
+mock.module("../../config.js", () => ({
+  getMemoryConfig: () =>
+    carryMockActive
+      ? {
+          v3: {
+            live: true,
+            spotlight: {
+              n: SPOTLIGHT_N,
+              windowTurns: SPOTLIGHT_WINDOW_TURNS,
+            },
+            prune: pruneConfig ?? undefined,
+          },
+        }
+      : realMemoryConfig.getMemoryConfig(),
 }));
 
 mock.module("../../../../../config/assistant-feature-flags.js", () => ({

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/injection.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/injection.test.ts
@@ -44,6 +44,7 @@ import {
 const realConfigLoader = {
   ...(await import("../../../../../config/loader.js")),
 };
+const realMemoryConfig = { ...(await import("../../config.js")) };
 const realFlags = {
   ...(await import("../../../../../config/assistant-feature-flags.js")),
 };
@@ -140,6 +141,22 @@ mock.module("../../../../../config/loader.js", () => ({
           },
         }
       : realConfigLoader.getConfig(),
+}));
+
+// Memory code resolves its config through the plugin's own accessor, not
+// getConfig(); stub the same conditional slice there.
+mock.module("../../config.js", () => ({
+  getMemoryConfig: () =>
+    injectionMockActive
+      ? {
+          enabled: memoryEnabled,
+          v3: {
+            live: liveEnabled,
+            spotlight: spotlightConfig,
+            prune: pruneConfig ?? undefined,
+          },
+        }
+      : realMemoryConfig.getMemoryConfig(),
 }));
 
 // The prune valve resolves the live conversation through the daemon registry

--- a/assistant/src/plugins/defaults/memory/v3/prune.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/prune.test.ts
@@ -40,6 +40,7 @@ const realDb = {
   ...(await import("../../../../persistence/db-connection.js")),
 };
 const realConfigLoader = { ...(await import("../../../../config/loader.js")) };
+const realMemoryConfig = { ...(await import("../config.js")) };
 
 let pruneMockActive = false;
 let pruneConfig: {
@@ -84,6 +85,15 @@ mock.module("../../../../config/loader.js", () => ({
     pruneMockActive
       ? { memory: { v3: { prune: pruneConfig ?? undefined } } }
       : realConfigLoader.getConfig(),
+}));
+
+// Memory code resolves its config through the plugin's own accessor, not
+// getConfig(); stub the same conditional slice there.
+mock.module("../config.js", () => ({
+  getMemoryConfig: () =>
+    pruneMockActive
+      ? { v3: { prune: pruneConfig ?? undefined } }
+      : realMemoryConfig.getMemoryConfig(),
 }));
 
 const {


### PR DESCRIPTION
## Summary

**F6 (config) — the memory plugin resolves its own config; nothing added to the contract.** Per Vargas's round-2 call ("resolve internally to the plugin instead of the api — in the meantime it can just read the workspace/config.json's memory field"), `getMemoryConfig()` no longer calls the host loader: it reads `workspace/config.json`'s `memory` field itself — signature-cached (size+mtime+ctime, the loader's own freshness scheme), schema defaults via `MemoryConfigSchema`, the loader's per-field invalid fallback (an invalid leaf falls back to its default while valid siblings survive), and the deployment-context fill (`IS_PLATFORM` → managed gemini embedding backend unless the leaf is explicit on disk). Unlike `getConfig()`, the reader is side-effect-free: no directory creation, no config seeding, no quarantine (those stay host-owned).

**Parity is enforced, not asserted:** `memory-config-file-parity.test.ts` deep-compares the plugin resolution against `getConfig().memory` across nine file states — absent file, custom knobs, invalid leaf, unknown keys, non-object field, unparseable JSON, platform fill, explicit-beats-fill, cache invalidation. If the loader's semantics drift from the reader's (including the deliberately-local platform fill mirror), this test is the tripwire.

**`v2/static-context.ts`** folds its `loadConfig()` call into the same accessor (`loadConfig()` === `getConfig()` — the "fresh read" framing in the round-2 doc was wrong); its try/catch drops because the reader never throws.

## Test conversions (the #36754 inversion)

#36754 made loader mocks resolve *through* the wrapper; this PR inverts that — `getMemoryConfig` no longer sees `mock.module("config/loader")` stubs. Swept **all 120 test files** whose loader stubs carry a `memory:` slice, each in isolation: 7 genuinely depended on the stub reaching memory code (`prune`, `pkb-search`, `carry-integration`, `injection`, `static-context`, `memory-retrospective-startup-cleanup`, `injector-pkb-v2-silenced`). Each now mocks the plugin's own accessor (`plugins/defaults/memory/config.js`) with the same mutable-flag conditionals — the "mock what the code under test imports" pattern from F1. The other 113 pass unchanged (their memory stubs gate non-wrapper consumers or match defaults).

Known pre-existing failure, not this PR: `conversation-fork-crud.test.ts` "compacted-away prefix" fails intermittently on fast machines — reproduced 3/3 on unmodified main.

## Behavior notes

- `getMemoryConfig()` and `getConfig().memory` no longer share object identity (values stay deep-equal; nothing mutates or reference-compares the slice — audited).
- Hot-path cost is unchanged: one `statSync` per call on the cached path, the same freshness check `getConfig()` performs.
- The platform fill is a deliberate 12-line local mirror of the loader's `getDeploymentContextDefaults().memory` — importing the loader for it would re-couple this module to loader mocks (the exact partial-mock breakage F2 hit). The parity test exercises the fill against the real loader under `IS_PLATFORM`, so divergence fails loudly.

## Gate (all green)

`typecheck:fast`, eslint, knip, prettier, all five boundary guards (plugin-import baseline +1: `config/schemas/memory.js`), the new parity test, the 7 converted test files, and the full 120-file loader-mock sweep in isolation.

Part of the memory-as-a-plugin effort (Vargas facet migration — F6 resolved plugin-internally per review; zero `@vellumai/plugin-api` changes). Pre-stages roadmap #6 (plugin-internal config.json — the reader later just changes which file it reads).