### PR TITLE
feat(web): show the daemon's delete-guard reason when a connection can't be deleted

### DIFF
--- a/clients/web/src/domains/settings/ai/manage-providers-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/manage-providers-modal.test.tsx
@@ -30,6 +30,14 @@ let defaultProviderGetCalls = 0;
 let putBodies: Array<{ provider: string; connectionName?: string }> = [];
 let putShouldFail = false;
 let deleteCalls: string[] = [];
+let deleteResult: { status: number; body?: unknown } = { status: 200 };
+let capturedErrors: unknown[] = [];
+
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: (error: unknown) => {
+    capturedErrors.push(error);
+  },
+}));
 
 const actualSdk = await import("@/generated/daemon/sdk.gen");
 
@@ -66,7 +74,13 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
     if (options?.path?.name) {
       deleteCalls.push(options.path.name);
     }
-    return { response: { ok: true, status: 200 } };
+    return {
+      error: deleteResult.body,
+      response: {
+        ok: deleteResult.status >= 200 && deleteResult.status < 300,
+        status: deleteResult.status,
+      },
+    };
   },
   configGet: async () => ({ data: {} }),
 }));
@@ -142,6 +156,8 @@ beforeEach(() => {
   putBodies = [];
   putShouldFail = false;
   deleteCalls = [];
+  deleteResult = { status: 200 };
+  capturedErrors = [];
   // The marker UI is version-gated (assistants < 0.10.8 lack the routes).
   useAssistantIdentityStore.getState().setIdentity("test-asst", "0.10.8");
 });
@@ -279,6 +295,83 @@ describe("default marker", () => {
       expect(result.baseElement.textContent).toContain(
         "Failed to set default provider",
       );
+    });
+  });
+});
+
+describe("delete-guard errors", () => {
+  async function clickDelete(name: string) {
+    connectionsState = [makeConnection({ name, provider: "openai" })];
+    const result = renderModal();
+    await waitFor(() => {
+      expect(result.baseElement.textContent).toContain(name);
+    });
+    const deleteButton = result.baseElement.querySelector<HTMLButtonElement>(
+      `button[aria-label="Delete ${name}"]`,
+    );
+    fireEvent.click(deleteButton as HTMLButtonElement);
+    return result;
+  }
+
+  test("409 renders the daemon's guard message verbatim", async () => {
+    deleteResult = {
+      status: 409,
+      body: {
+        error: {
+          code: "CONFLICT",
+          message:
+            'Connection "work-openai" is referenced by llm.defaultProvider. Update llm.defaultProvider before deleting.',
+          details: { referencedBy: ["llm.defaultProvider"] },
+        },
+      },
+    };
+
+    const result = await clickDelete("work-openai");
+    await waitFor(() => {
+      expect(result.baseElement.textContent).toContain(
+        "is referenced by llm.defaultProvider",
+      );
+    });
+  });
+
+  test("409 without a parseable envelope falls back to the generic string", async () => {
+    deleteResult = { status: 409, body: "not-an-envelope" };
+
+    const result = await clickDelete("work-openai");
+    await waitFor(() => {
+      expect(result.baseElement.textContent).toContain(
+        "Connection is in use by one or more profiles",
+      );
+    });
+  });
+
+  test("non-guarded connections still delete cleanly", async () => {
+    deleteResult = { status: 200 };
+
+    const result = await clickDelete("work-openai");
+    await waitFor(() => {
+      expect(deleteCalls).toEqual(["work-openai"]);
+    });
+    expect(result.baseElement.textContent).not.toContain("Failed to delete");
+  });
+
+  test("set-default failure reports to Sentry via captureError", async () => {
+    putShouldFail = true;
+    connectionsState = [
+      makeConnection({ name: "openai-personal", provider: "openai" }),
+    ];
+
+    const result = renderModal();
+    await waitFor(() => {
+      expect(result.baseElement.textContent).toContain("openai-personal");
+    });
+    const setDefaultButton = [
+      ...result.baseElement.querySelectorAll("button"),
+    ].find((b) => b.textContent === "Set as default");
+    fireEvent.click(setDefaultButton as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(capturedErrors.length).toBe(1);
     });
   });
 });

--- a/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
+++ b/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
@@ -22,6 +22,7 @@ import type {
   ProviderConnection,
 } from "@/generated/daemon/types.gen";
 import { PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
+import { captureError } from "@/lib/sentry/capture-error";
 import { useSupportsDefaultProviderSettings } from "@/lib/backwards-compat/default-provider-settings";
 import { ProviderEditorContent } from "@/domains/settings/ai/provider-editor-modal";
 // ---------------------------------------------------------------------------
@@ -43,6 +44,24 @@ const DEFAULT_PROVIDER_ELIGIBLE: Record<DefaultProviderId, true> = {
 
 function isDefaultProviderId(provider: string): provider is DefaultProviderId {
   return provider in DEFAULT_PROVIDER_ELIGIBLE;
+}
+
+/**
+ * Extracts the daemon's error-envelope message (`{ error: { message } }`,
+ * per the runtime's http-errors adapter) from a generated-SDK `error` field.
+ */
+function errorEnvelopeMessage(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null) {
+    return undefined;
+  }
+  const inner = (error as { error?: unknown }).error;
+  if (typeof inner !== "object" || inner === null) {
+    return undefined;
+  }
+  const message = (inner as { message?: unknown }).message;
+  return typeof message === "string" && message.length > 0
+    ? message
+    : undefined;
 }
 
 function formatAuthSummary(auth: ProviderConnection["auth"]): string {
@@ -258,7 +277,8 @@ function ManageProvidersModalInner({
       });
     },
     onSuccess: onDefaultChanged,
-    onError: (_error, variables) => {
+    onError: (error, variables) => {
+      captureError(error, { context: "settings-ai-set-default-provider" });
       const name = variables.body?.connectionName;
       if (!name) {
         return;
@@ -288,16 +308,20 @@ function ManageProvidersModalInner({
       return next;
     });
     try {
-      const { response } = await inferenceProviderconnectionsByNameDelete({
-        path: { assistant_id: assistantId, name },
-      });
+      const { error, response } =
+        await inferenceProviderconnectionsByNameDelete({
+          path: { assistant_id: assistantId, name },
+        });
       if (response?.ok || response?.status === 404) {
         // 404 means already gone — still remove from local list.
         onConnectionDeleted(name);
       } else if (response?.status === 409) {
+        // The daemon's guard names what blocks the delete (default provider,
+        // referencing profiles) and the fix — render it verbatim.
         setRowErrors((prev) => ({
           ...prev,
           [name]:
+            errorEnvelopeMessage(error) ??
             "Connection is in use by one or more profiles. Remove those references first.",
         }));
       } else {


### PR DESCRIPTION
## Summary

- The Providers modal now renders the daemon's 409 delete-guard message verbatim (envelope `{ error: { message } }` from the generated SDK's `error` field) instead of a hardcoded generic string — so "this connection serves `llm.defaultProvider`" and profile-reference guards surface with their named fix. Unparseable bodies keep the generic fallback; 404-as-already-gone is unchanged.
- Folds in the orphan from closed duplicate #37653: the set-default mutation's `onError` now reports to Sentry via `captureError` per web conventions.
- Four new tests: verbatim guard message, generic fallback, clean delete, and captureError on set-default failure.

Part of M7 (Inference Management Refactor) — plan attached to #37579. Remaining: PR 5 (profile-editor snapshot copy).

## Original prompt

Execute PR 4 of the M7 plan (`.private/plans/m7-settings-ui-default-provider.md`): stop swallowing the connection delete-guard errors. The daemon's guards (M5 #37446) return explainable 409 messages with `referencedBy` details, but the web modal discarded them. The proactive delete-disable on the default connection shipped in #37591; this covers the reactive path (stale cache, profile references) plus a Sentry-reporting gap flagged by a parallel session's closed PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37672" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->