### PR TITLE
feat(plugin-api): bless embedAndUpsert + selectedBackendSupportsMultimodal; migrate memory (F2 round 1)

### DIFF
--- a/assistant/src/persistence/embeddings/plugin-facade.ts
+++ b/assistant/src/persistence/embeddings/plugin-facade.ts
@@ -1,0 +1,37 @@
+import { getConfig } from "../../config/loader.js";
+import type { EmbeddingInput } from "./embedding-types.js";
+
+/**
+ * Plugin-facing facade over the embeddings subsystem: self-contained
+ * operations that resolve the live workspace config internally, so callers
+ * (plugins importing via `@vellumai/plugin-api`) hold no host config.
+ *
+ * The operations are loaded via dynamic `import()` inside each wrapper so
+ * that importing this module — which every `@vellumai/plugin-api` consumer
+ * does transitively — does not eagerly pull the embed/vector import graph
+ * (`job-utils`, `embedding-backend`). An eager pull would force those
+ * modules' named exports to resolve at instantiation, which breaks the
+ * intentional partial module mocks in tests.
+ */
+
+type EmbeddingTargetType = Parameters<
+  typeof import("../job-utils.js").embedAndUpsert
+>[1];
+
+/** Embed a target and upsert its vector into the vector store. */
+export async function embedAndUpsert(
+  targetType: EmbeddingTargetType,
+  targetId: string,
+  input: EmbeddingInput,
+  extraPayload?: Record<string, unknown>,
+): Promise<void> {
+  const { embedAndUpsert: withConfig } = await import("../job-utils.js");
+  return withConfig(getConfig(), targetType, targetId, input, extraPayload);
+}
+
+/** Whether the active embedding backend handles multimodal inputs. */
+export async function selectedBackendSupportsMultimodal(): Promise<boolean> {
+  const { selectedBackendSupportsMultimodal: withConfig } =
+    await import("./embedding-backend.js");
+  return withConfig(getConfig());
+}

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -180,3 +180,11 @@ export {
   getAssistantName,
   resolveUserName,
 } from "../daemon/identity-helpers.js";
+// Embeddings — self-contained operations on the host's shared embedding /
+// vector-store subsystem. Host-resolved: each reads the live workspace config
+// internally, so plugins hold no config. Async because the facade loads the
+// embed graph lazily on first call.
+export {
+  embedAndUpsert,
+  selectedBackendSupportsMultimodal,
+} from "../persistence/embeddings/plugin-facade.js";

--- a/assistant/src/plugins/defaults/memory/embeddings.ts
+++ b/assistant/src/plugins/defaults/memory/embeddings.ts
@@ -7,45 +7,20 @@ import type {
 import { resolveQdrantUrl as resolveQdrantUrlWithConfig } from "../../../persistence/embeddings/qdrant-client.js";
 
 /**
- * Memory-internal accessor for the shared embeddings / vector subsystem.
+ * Memory-internal accessor for the embeddings operations that stay off
+ * `@vellumai/plugin-api` (the self-contained ops live there — see
+ * `persistence/embeddings/plugin-facade.ts`).
  *
- * The embeddings operations live in `persistence/embeddings` (and
- * `persistence/job-utils`) and take the full `AssistantConfig` as their first
- * argument — they read both the `memory` slice (Qdrant collection and vector
- * settings) and the `llm` slice (embedding-backend selection). Memory code
- * reaches those operations through this accessor: the self-contained ones
- * (`embedAndUpsert`, `selectedBackendSupportsMultimodal`, `resolveQdrantUrl`)
- * resolve the live config internally, so their call sites need not hold it.
  * `embedWithBackend` keeps its `config` parameter — it is a primitive whose
  * vectors the caller stores alongside its own config-derived metadata (cache
  * keys, vector-size checks, Qdrant collection), so it must embed with the
  * caller's exact config snapshot rather than a re-read that could diverge from
- * that metadata mid-operation.
- *
- * The embed operations are loaded via dynamic `import()` inside each wrapper so
- * that importing this module for a single operation does not eagerly pull the
- * whole embed/vector import graph (`job-utils`, `embedding-backend`) into the
- * consumer. An eager pull would force every one of those modules' named exports
- * to resolve at instantiation, which breaks the intentional partial module
- * mocks in memory tests (a store that mocks only the exports it uses). Only the
- * synchronous `resolveQdrantUrl` is imported statically.
+ * that metadata mid-operation. It is loaded via dynamic `import()` inside the
+ * wrapper so importing this module does not eagerly pull the embed graph
+ * (`embedding-backend`), which would break intentional partial module mocks
+ * in memory tests. `resolveQdrantUrl` is synchronous — its consumers are
+ * memoized client getters — so it is imported statically.
  */
-
-type EmbeddingTargetType = Parameters<
-  typeof import("../../../persistence/job-utils.js").embedAndUpsert
->[1];
-
-/** Embed a target and upsert its vector to Qdrant. */
-export async function embedAndUpsert(
-  targetType: EmbeddingTargetType,
-  targetId: string,
-  input: EmbeddingInput,
-  extraPayload?: Record<string, unknown>,
-): Promise<void> {
-  const { embedAndUpsert: withConfig } =
-    await import("../../../persistence/job-utils.js");
-  return withConfig(getConfig(), targetType, targetId, input, extraPayload);
-}
 
 /** Embed one or more inputs via the selected embedding backend. */
 export async function embedWithBackend(
@@ -62,13 +37,6 @@ export async function embedWithBackend(
   const { embedWithBackend: withConfig } =
     await import("../../../persistence/embeddings/embedding-backend.js");
   return withConfig(config, inputs, options);
-}
-
-/** Whether the active embedding backend handles multimodal inputs. */
-export async function selectedBackendSupportsMultimodal(): Promise<boolean> {
-  const { selectedBackendSupportsMultimodal: withConfig } =
-    await import("../../../persistence/embeddings/embedding-backend.js");
-  return withConfig(getConfig());
 }
 
 /** Resolve the Qdrant base URL for this process. */

--- a/assistant/src/plugins/defaults/memory/graph/graph-search.ts
+++ b/assistant/src/plugins/defaults/memory/graph/graph-search.ts
@@ -2,6 +2,11 @@
 // Memory Graph — Qdrant vector search for graph nodes
 // ---------------------------------------------------------------------------
 
+import {
+  embedAndUpsert,
+  selectedBackendSupportsMultimodal,
+} from "@vellumai/plugin-api";
+
 import { getConfig } from "../../../../config/loader.js";
 import type { AssistantConfig } from "../../../../config/types.js";
 import type { EmbeddingInput } from "../../../../persistence/embeddings/embedding-types.js";
@@ -19,10 +24,6 @@ import {
   type MemoryJob,
 } from "../../../../persistence/jobs-store.js";
 import { getLogger } from "../../../../util/logger.js";
-import {
-  embedAndUpsert,
-  selectedBackendSupportsMultimodal,
-} from "../embeddings.js";
 import { loadImageRefData } from "./image-ref-utils.js";
 import { getNode } from "./store.js";
 import type { MemoryNode } from "./types.js";
@@ -55,7 +56,9 @@ export async function searchGraphNodes(
   // active retirement and a corrupted sparse segment can OOM-crash the
   // shared Qdrant process — short-circuiting here keeps v1 background work
   // and stale callers from taking v2 down with them.
-  if (getConfig().memory.v2.enabled) return [];
+  if (getConfig().memory.v2.enabled) {
+    return [];
+  }
 
   if (isQdrantBreakerOpen()) {
     log.warn("Qdrant circuit breaker open, skipping graph search");
@@ -168,7 +171,9 @@ function formatNodeForEmbedding(node: MemoryNode): string {
  * to text embedding with image description suffixes otherwise.
  */
 export async function embedGraphNodeDirect(node: MemoryNode): Promise<void> {
-  if (node.fidelity === "gone") return;
+  if (node.fidelity === "gone") {
+    return;
+  }
 
   const text = formatNodeForEmbedding(node);
   const extraPayload: Record<string, unknown> = {
@@ -220,10 +225,14 @@ export async function embedGraphNodeDirect(node: MemoryNode): Promise<void> {
  */
 export async function embedGraphNodeJob(job: MemoryJob): Promise<void> {
   const nodeId = asString(job.payload.nodeId);
-  if (!nodeId) return;
+  if (!nodeId) {
+    return;
+  }
 
   const node = getNode(nodeId);
-  if (!node) return;
+  if (!node) {
+    return;
+  }
 
   await embedGraphNodeDirect(node);
 }
@@ -232,7 +241,9 @@ export async function embedGraphNodeJob(job: MemoryJob): Promise<void> {
  * Enqueue an embedding job for a graph node (async, for live conversations).
  */
 export function enqueueGraphNodeEmbed(nodeId: string): void {
-  if (!isMemoryEnabled()) return;
+  if (!isMemoryEnabled()) {
+    return;
+  }
   enqueueMemoryJob("embed_graph_node", { nodeId });
 }
 
@@ -245,7 +256,9 @@ export async function embedGraphTriggerJob(
   config: AssistantConfig,
 ): Promise<void> {
   const triggerId = asString(job.payload.triggerId);
-  if (!triggerId) return;
+  if (!triggerId) {
+    return;
+  }
 
   // Import here to avoid circular dependency
   const { getDb } = await import("../../../../persistence/db-connection.js");
@@ -261,11 +274,15 @@ export async function embedGraphTriggerJob(
     .where(eq(memoryGraphTriggers.id, triggerId))
     .get();
 
-  if (!row || !row.condition) return;
+  if (!row || !row.condition) {
+    return;
+  }
 
   const result = await embedWithBackend(config, [row.condition]);
   const vector = result.vectors[0];
-  if (!vector) return;
+  if (!vector) {
+    return;
+  }
 
   const buffer = Buffer.from(new Float32Array(vector).buffer);
   db.update(memoryGraphTriggers)
@@ -278,6 +295,8 @@ export async function embedGraphTriggerJob(
  * Enqueue a trigger embedding job.
  */
 export function enqueueGraphTriggerEmbed(triggerId: string): void {
-  if (!isMemoryEnabled()) return;
+  if (!isMemoryEnabled()) {
+    return;
+  }
   enqueueMemoryJob("graph_trigger_embed", { triggerId });
 }

--- a/assistant/src/plugins/defaults/memory/graph/retriever.test.ts
+++ b/assistant/src/plugins/defaults/memory/graph/retriever.test.ts
@@ -30,7 +30,9 @@ mock.module("../../../../persistence/embeddings/embed.js", () => ({
     _opts?: unknown,
   ) => {
     embedCallCount++;
-    if (embedShouldThrow) throw new Error("embedding backend down");
+    if (embedShouldThrow) {
+      throw new Error("embedding backend down");
+    }
     const vectors = texts.map((t) => {
       const text = typeof t === "string" ? t : "";
       return embedRouter ? embedRouter(text) : embedVector;
@@ -54,7 +56,9 @@ let searchRouter: ((vector: number[]) => SearchHit[]) | null = null;
 
 mock.module("./graph-search.js", () => ({
   searchGraphNodes: async (vector: number[]) => {
-    if (searchRouter) return searchRouter(vector);
+    if (searchRouter) {
+      return searchRouter(vector);
+    }
     return [];
   },
 }));
@@ -62,7 +66,9 @@ mock.module("./graph-search.js", () => ({
 // Returning `null` from getConfiguredProvider causes rerankAndDedup and
 // dedupCrossCategory to fall back to the candidate list without calling an
 // LLM, keeping these tests fully offline.
+const realPluginApi = await import("@vellumai/plugin-api");
 mock.module("@vellumai/plugin-api", () => ({
+  ...realPluginApi,
   getConfiguredProvider: async () => null,
 }));
 
@@ -258,8 +264,12 @@ describe("retrieveForTurn — topic-pivot recovery", () => {
     const lowered = text.toLowerCase();
     const cakeHits = (lowered.match(/cake/g) ?? []).length;
     const shirtHits = (lowered.match(/shirt/g) ?? []).length;
-    if (cakeHits > shirtHits) return [0, 1, 0];
-    if (shirtHits > cakeHits) return [1, 0, 0];
+    if (cakeHits > shirtHits) {
+      return [0, 1, 0];
+    }
+    if (shirtHits > cakeHits) {
+      return [1, 0, 0];
+    }
     return [0.1, 0.1, 0.1];
   }
 
@@ -268,8 +278,12 @@ describe("retrieveForTurn — topic-pivot recovery", () => {
 
   function vectorSearchRouter(vector: number[]): SearchHit[] {
     const [a = 0, b = 0] = vector;
-    if (a === 1 && b === 0) return [{ nodeId: shirtNodeId, score: 0.9 }];
-    if (a === 0 && b === 1) return [{ nodeId: cakeNodeId, score: 0.9 }];
+    if (a === 1 && b === 0) {
+      return [{ nodeId: shirtNodeId, score: 0.9 }];
+    }
+    if (a === 0 && b === 1) {
+      return [{ nodeId: cakeNodeId, score: 0.9 }];
+    }
     return [];
   }
 
@@ -416,11 +430,15 @@ describe("loadContextMemory — dual-query capability ranking", () => {
   // driving the capability-reserve decision.
   function keywordEmbedRouter(text: string): number[] {
     const lowered = text.toLowerCase();
-    if (lowered.includes("inbox")) return [1, 0, 0];
-    if (lowered.includes("heartbeat") || lowered.includes("readiness"))
+    if (lowered.includes("inbox")) {
+      return [1, 0, 0];
+    }
+    if (lowered.includes("heartbeat") || lowered.includes("readiness")) {
       return [0, 1, 0];
-    if (lowered.includes("bridgerton") || lowered.includes("watch"))
+    }
+    if (lowered.includes("bridgerton") || lowered.includes("watch")) {
       return [0, 0, 1];
+    }
     return [0.1, 0.1, 0.1];
   }
 

--- a/assistant/src/plugins/defaults/memory/graph/retriever.ts
+++ b/assistant/src/plugins/defaults/memory/graph/retriever.ts
@@ -11,13 +11,13 @@ import {
   getConfiguredProvider,
   resolveMediaSourceData,
 } from "@vellumai/plugin-api";
+import { selectedBackendSupportsMultimodal } from "@vellumai/plugin-api";
 
 import type { AssistantConfig } from "../../../../config/types.js";
 import { embedWithRetry } from "../../../../persistence/embeddings/embed.js";
 import { generateSparseEmbedding } from "../../../../persistence/embeddings/embedding-backend.js";
 import type { QdrantSparseVector } from "../../../../persistence/embeddings/qdrant-client.js";
 import { getLogger } from "../../../../util/logger.js";
-import { selectedBackendSupportsMultimodal } from "../embeddings.js";
 import { extractToolUse, userMessage } from "../llm-helpers.js";
 import { searchGraphNodes } from "./graph-search.js";
 import type { InContextTracker } from "./injection.js";
@@ -93,11 +93,15 @@ async function rerankAndDedup(
   maxNodes: number,
   _config: AssistantConfig,
 ): Promise<ScoredNode[]> {
-  if (candidates.length <= maxNodes) return candidates;
+  if (candidates.length <= maxNodes) {
+    return candidates;
+  }
 
   try {
     const provider = await getConfiguredProvider("memoryRetrieval");
-    if (!provider) return candidates.slice(0, maxNodes);
+    if (!provider) {
+      return candidates.slice(0, maxNodes);
+    }
 
     // Numbered listing for the LLM: index + age + full content
     const now = Date.now();
@@ -132,10 +136,14 @@ Your job:
     });
 
     const toolBlock = extractToolUse(response);
-    if (!toolBlock) return candidates.slice(0, maxNodes);
+    if (!toolBlock) {
+      return candidates.slice(0, maxNodes);
+    }
 
     const input = toolBlock.input as { selected?: number[] };
-    if (!input.selected?.length) return candidates.slice(0, maxNodes);
+    if (!input.selected?.length) {
+      return candidates.slice(0, maxNodes);
+    }
 
     // Rebuild scored list in the LLM's chosen order (1-indexed → 0-indexed)
     const reranked: ScoredNode[] = [];
@@ -148,7 +156,9 @@ Your job:
       }
     }
 
-    if (reranked.length === 0) return candidates.slice(0, maxNodes);
+    if (reranked.length === 0) {
+      return candidates.slice(0, maxNodes);
+    }
     return reranked.slice(0, maxNodes);
   } catch (err) {
     log.warn(
@@ -193,8 +203,9 @@ async function dedupForTurn(
 ): Promise<{ nodes: ScoredNode[]; llmApplied: boolean }> {
   try {
     const provider = await getConfiguredProvider("memoryRetrieval");
-    if (!provider)
+    if (!provider) {
       return { nodes: candidates.slice(0, maxNodes), llmApplied: false };
+    }
 
     const now = Date.now();
     const listing = candidates
@@ -223,12 +234,14 @@ async function dedupForTurn(
     );
 
     const toolBlock = extractToolUse(response);
-    if (!toolBlock)
+    if (!toolBlock) {
       return { nodes: candidates.slice(0, maxNodes), llmApplied: false };
+    }
 
     const input = toolBlock.input as { items?: number[] };
-    if (!input.items?.length)
+    if (!input.items?.length) {
       return { nodes: candidates.slice(0, maxNodes), llmApplied: false };
+    }
 
     const reranked: ScoredNode[] = [];
     const seen = new Set<number>();
@@ -286,7 +299,9 @@ async function dedupCrossCategory(
 ): Promise<ScoredNode[]> {
   try {
     const provider = await getConfiguredProvider("memoryRetrieval");
-    if (!provider) return candidates.slice(0, maxNodes);
+    if (!provider) {
+      return candidates.slice(0, maxNodes);
+    }
 
     const now = Date.now();
     const listing = candidates
@@ -312,10 +327,14 @@ async function dedupCrossCategory(
     });
 
     const toolBlock = extractToolUse(response);
-    if (!toolBlock) return candidates.slice(0, maxNodes);
+    if (!toolBlock) {
+      return candidates.slice(0, maxNodes);
+    }
 
     const input = toolBlock.input as { items?: number[] };
-    if (!input.items?.length) return candidates.slice(0, maxNodes);
+    if (!input.items?.length) {
+      return candidates.slice(0, maxNodes);
+    }
 
     const reranked: ScoredNode[] = [];
     const seen = new Set<number>();
@@ -575,7 +594,9 @@ export async function loadContextMemory(
     limit: maxNodes,
   });
   for (const node of recentNodes) {
-    if (isCapabilityNode(node)) continue;
+    if (isCapabilityNode(node)) {
+      continue;
+    }
     if (!semanticCandidateIds.has(node.id)) {
       semanticCandidateIds.set(node.id, 0);
     }
@@ -651,7 +672,9 @@ export async function loadContextMemory(
   // 5. Score all candidates
   const scored: ScoredNode[] = [];
   for (const [nodeId, node] of nodeMap) {
-    if (node.fidelity === "gone") continue;
+    if (node.fidelity === "gone") {
+      continue;
+    }
 
     const semanticSim = semanticCandidateIds.get(nodeId) ?? 0;
     const effectiveSig = computeEffectiveSignificance(node, nowMs);
@@ -697,16 +720,23 @@ export async function loadContextMemory(
     const uniqueCapabilityIds = new Set<string>();
     let untaggedCount = 0;
     for (const [nodeId, node] of nodeMap) {
-      if (node.fidelity === "gone") continue;
-      if (!isCapabilityNode(node)) continue;
+      if (node.fidelity === "gone") {
+        continue;
+      }
+      if (!isCapabilityNode(node)) {
+        continue;
+      }
       const sim =
         userQueryCandidateIds.get(nodeId) ??
         semanticCandidateIds.get(nodeId) ??
         0;
       capabilityEntries.push({ node, sim });
       const capId = extractCapabilityId(node);
-      if (capId) uniqueCapabilityIds.add(capId);
-      else untaggedCount++;
+      if (capId) {
+        uniqueCapabilityIds.add(capId);
+      } else {
+        untaggedCount++;
+      }
     }
 
     // Gate the fallback on distinct capability IDs (plus any entries
@@ -722,7 +752,9 @@ export async function loadContextMemory(
         capabilityReserve * 4,
       );
       for (const node of fallback) {
-        if (alreadySeen.has(node.id)) continue;
+        if (alreadySeen.has(node.id)) {
+          continue;
+        }
         const sim =
           userQueryCandidateIds.get(node.id) ??
           semanticCandidateIds.get(node.id) ??
@@ -739,10 +771,14 @@ export async function loadContextMemory(
   const seenCapabilityIds = new Set<string>();
   const selectedCapabilities: MemoryNode[] = [];
   for (const { node } of capabilityEntries) {
-    if (selectedCapabilities.length >= capabilityReserve) break;
+    if (selectedCapabilities.length >= capabilityReserve) {
+      break;
+    }
     const capId = extractCapabilityId(node);
     if (capId) {
-      if (seenCapabilityIds.has(capId)) continue;
+      if (seenCapabilityIds.has(capId)) {
+        continue;
+      }
       seenCapabilityIds.add(capId);
     }
     selectedCapabilities.push(node);
@@ -751,7 +787,9 @@ export async function loadContextMemory(
   const reservedCapabilities: ScoredNode[] = selectedCapabilities.map(
     (node) => {
       const existing = scored.find((s) => s.node.id === node.id);
-      if (existing) return existing;
+      if (existing) {
+        return existing;
+      }
       return scoreCandidate(
         node,
         {
@@ -986,7 +1024,9 @@ export async function retrieveForTurn(
           // Resolve the image bytes whether stored inline or as a workspace
           // reference; skip when the bytes can't be read.
           const resolved = resolveMediaSourceData(img.source);
-          if (!resolved) continue;
+          if (!resolved) {
+            continue;
+          }
           const imageInput = {
             type: "image" as const,
             data: Buffer.from(resolved.data, "base64"),
@@ -1053,13 +1093,17 @@ export async function retrieveForTurn(
       let current = "";
       for (const p of paragraphs) {
         if (current.length + p.length > maxQueryChars) {
-          if (current.length > 0) chunks.push(current);
+          if (current.length > 0) {
+            chunks.push(current);
+          }
           current = p;
         } else {
           current += (current ? "\n\n" : "") + p;
         }
       }
-      if (current.length > 0) chunks.push(current);
+      if (current.length > 0) {
+        chunks.push(current);
+      }
     }
   }
 
@@ -1180,7 +1224,9 @@ export async function retrieveForTurn(
   const capabilityCandidates: { node: MemoryNode; sim: number }[] = [];
 
   for (const node of nodes) {
-    if (node.fidelity === "gone") continue;
+    if (node.fidelity === "gone") {
+      continue;
+    }
     // Capability nodes (auto-seeded skills/CLI) are excluded from the general
     // scoring pool — they compete in the dedicated procedural reserve below.
     if (isCapabilityNode(node)) {
@@ -1234,7 +1280,9 @@ export async function retrieveForTurn(
       );
       const capId = match?.[1] ?? match?.[2] ?? match?.[3] ?? match?.[4];
       if (capId) {
-        if (seenProcCapIds.has(capId)) return false;
+        if (seenProcCapIds.has(capId)) {
+          return false;
+        }
         seenProcCapIds.add(capId);
       }
       return true;

--- a/assistant/src/plugins/defaults/memory/indexer.ts
+++ b/assistant/src/plugins/defaults/memory/indexer.ts
@@ -1,3 +1,4 @@
+import { selectedBackendSupportsMultimodal } from "@vellumai/plugin-api";
 import { createHash } from "crypto";
 import { eq } from "drizzle-orm";
 
@@ -23,7 +24,6 @@ import type { TrustClass } from "../../../runtime/actor-trust-resolver.js";
 import { enqueueAutoAnalysisIfEnabled } from "../../../runtime/services/auto-analysis-enqueue.js";
 import { isAutoAnalysisConversation } from "../../../runtime/services/auto-analysis-guard.js";
 import { getLogger } from "../../../util/logger.js";
-import { selectedBackendSupportsMultimodal } from "./embeddings.js";
 import { isMemoryRetrospectiveConversation } from "./memory-retrospective-enqueue.js";
 import { maybeEnqueueRetrospective } from "./memory-retrospective-trigger-check.js";
 import { segmentText } from "./segmenter.js";
@@ -60,7 +60,9 @@ export async function indexMessageNow(
   input: IndexMessageInput,
   config: MemoryConfig,
 ): Promise<IndexMessageResult> {
-  if (!config.enabled) return { indexedSegments: 0, enqueuedJobs: 0 };
+  if (!config.enabled) {
+    return { indexedSegments: 0, enqueuedJobs: 0 };
+  }
 
   // Provenance-based trust gating: only guardian and legacy (undefined) actors
   // are trusted for extraction.
@@ -394,12 +396,16 @@ export async function indexMessageNow(
 }
 
 export function enqueueBackfillJob(force = false): string {
-  if (!isMemoryEnabled()) return "";
+  if (!isMemoryEnabled()) {
+    return "";
+  }
   return enqueueMemoryJob("backfill", { force });
 }
 
 export function enqueueRebuildIndexJob(): string {
-  if (!isMemoryEnabled()) return "";
+  if (!isMemoryEnabled()) {
+    return "";
+  }
   return enqueueMemoryJob("rebuild_index", {});
 }
 

--- a/assistant/src/plugins/defaults/memory/job-handlers/embedding.ts
+++ b/assistant/src/plugins/defaults/memory/job-handlers/embedding.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 
+import { embedAndUpsert } from "@vellumai/plugin-api";
 import { eq } from "drizzle-orm";
 
 import { getDb } from "../../../../persistence/db-connection.js";
@@ -13,18 +14,21 @@ import {
   memorySummaries,
   messages,
 } from "../../../../persistence/schema/index.js";
-import { embedAndUpsert } from "../embeddings.js";
 
 export async function embedSegmentJob(job: MemoryJob): Promise<void> {
   const segmentId = asString(job.payload.segmentId);
-  if (!segmentId) return;
+  if (!segmentId) {
+    return;
+  }
   const db = getDb();
   const segment = db
     .select()
     .from(memorySegments)
     .where(eq(memorySegments.id, segmentId))
     .get();
-  if (!segment) return;
+  if (!segment) {
+    return;
+  }
   await embedAndUpsert("segment", segment.id, segment.text, {
     conversation_id: segment.conversationId,
     message_id: segment.messageId,
@@ -35,14 +39,18 @@ export async function embedSegmentJob(job: MemoryJob): Promise<void> {
 
 export async function embedSummaryJob(job: MemoryJob): Promise<void> {
   const summaryId = asString(job.payload.summaryId);
-  if (!summaryId) return;
+  if (!summaryId) {
+    return;
+  }
   const db = getDb();
   const summary = db
     .select()
     .from(memorySummaries)
     .where(eq(memorySummaries.id, summaryId))
     .get();
-  if (!summary) return;
+  if (!summary) {
+    return;
+  }
   await embedAndUpsert(
     "summary",
     summary.id,
@@ -58,7 +66,9 @@ export async function embedSummaryJob(job: MemoryJob): Promise<void> {
 
 export async function embedMediaJob(job: MemoryJob): Promise<void> {
   const assetId = asString(job.payload.assetId);
-  if (!assetId) return;
+  if (!assetId) {
+    return;
+  }
 
   const db = getDb();
   const asset = db
@@ -66,7 +76,9 @@ export async function embedMediaJob(job: MemoryJob): Promise<void> {
     .from(mediaAssets)
     .where(eq(mediaAssets.id, assetId))
     .get();
-  if (!asset || asset.status !== "indexed") return;
+  if (!asset || asset.status !== "indexed") {
+    return;
+  }
 
   // Read the media file from disk
   const fileData = await readFile(asset.filePath);
@@ -89,7 +101,9 @@ export async function embedMediaJob(job: MemoryJob): Promise<void> {
 export async function embedAttachmentJob(job: MemoryJob): Promise<void> {
   const messageId = asString(job.payload.messageId);
   const blockIndex = job.payload.blockIndex as number;
-  if (!messageId || typeof blockIndex !== "number") return;
+  if (!messageId || typeof blockIndex !== "number") {
+    return;
+  }
 
   const db = getDb();
   const message = db
@@ -97,11 +111,15 @@ export async function embedAttachmentJob(job: MemoryJob): Promise<void> {
     .from(messages)
     .where(eq(messages.id, messageId))
     .get();
-  if (!message) return;
+  if (!message) {
+    return;
+  }
 
   const mediaBlocks = extractMediaBlocks(message.content);
   const block = mediaBlocks.find((b) => b.index === blockIndex);
-  if (!block) return;
+  if (!block) {
+    return;
+  }
 
   const input: EmbeddingInput = {
     type: block.type,

--- a/assistant/src/plugins/defaults/memory/job-handlers/index-maintenance.ts
+++ b/assistant/src/plugins/defaults/memory/job-handlers/index-maintenance.ts
@@ -1,3 +1,4 @@
+import { selectedBackendSupportsMultimodal } from "@vellumai/plugin-api";
 import { eq, isNotNull, like, ne } from "drizzle-orm";
 
 import { getDb } from "../../../../persistence/db-connection.js";
@@ -22,7 +23,6 @@ import {
   messages,
 } from "../../../../persistence/schema/index.js";
 import { getLogger } from "../../../../util/logger.js";
-import { selectedBackendSupportsMultimodal } from "../embeddings.js";
 
 const log = getLogger("memory-jobs-worker");
 
@@ -99,7 +99,9 @@ export async function rebuildIndexJob(): Promise<void> {
 export async function deleteQdrantVectorsJob(job: MemoryJob): Promise<void> {
   const targetType = asString(job.payload.targetType);
   const targetId = asString(job.payload.targetId);
-  if (!targetType || !targetId) return;
+  if (!targetType || !targetId) {
+    return;
+  }
 
   let qdrant;
   try {

--- a/assistant/src/plugins/defaults/memory/pkb/pkb-index.ts
+++ b/assistant/src/plugins/defaults/memory/pkb/pkb-index.ts
@@ -15,9 +15,10 @@ import { createHash } from "node:crypto";
 import { readdir, readFile, stat } from "node:fs/promises";
 import { join, relative } from "node:path";
 
+import { embedAndUpsert } from "@vellumai/plugin-api";
+
 import { withQdrantBreaker } from "../../../../persistence/embeddings/qdrant-circuit-breaker.js";
 import { getQdrantClient } from "../../../../persistence/embeddings/qdrant-client.js";
-import { embedAndUpsert } from "../embeddings.js";
 import type { PkbIndexEntry } from "./types.js";
 import { PKB_TARGET_TYPE } from "./types.js";
 
@@ -74,8 +75,12 @@ export async function scanPkbFiles(
         await walk(absPath);
         continue;
       }
-      if (!dirent.isFile()) continue;
-      if (!dirent.name.toLowerCase().endsWith(".md")) continue;
+      if (!dirent.isFile()) {
+        continue;
+      }
+      if (!dirent.name.toLowerCase().endsWith(".md")) {
+        continue;
+      }
 
       let content: string;
       let mtimeMs: number;
@@ -134,7 +139,9 @@ export function chunkPkbFile(content: string): string[] {
       continue;
     }
     const nextNewline = content.indexOf("\n## ", cursor);
-    if (nextNewline === -1) break;
+    if (nextNewline === -1) {
+      break;
+    }
     headingIndices.push(nextNewline + 1);
     cursor = nextNewline + 1;
   }
@@ -223,8 +230,12 @@ export async function indexPkbFile(
   // did not regenerate (e.g. the file shrunk from 4 chunks to 2).
   for (const point of existing) {
     const staleTargetId = point.payload.target_id;
-    if (typeof staleTargetId !== "string") continue;
-    if (newTargetIds.has(staleTargetId)) continue;
+    if (typeof staleTargetId !== "string") {
+      continue;
+    }
+    if (newTargetIds.has(staleTargetId)) {
+      continue;
+    }
     await withQdrantBreaker(() =>
       qdrant.deleteByTarget(PKB_TARGET_TYPE, staleTargetId),
     );

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/live-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/live-integration.test.ts
@@ -48,7 +48,9 @@ import type { MemoryRoutingTurn, SectionIndex, Slug } from "../types.js";
 
 let providerStub: Provider | null = null;
 
+const realPluginApi = await import("@vellumai/plugin-api");
 mock.module("@vellumai/plugin-api", () => ({
+  ...realPluginApi,
   getConfiguredProvider: async () => providerStub,
 }));
 
@@ -177,7 +179,9 @@ function candidateSlugs(messages: Message[]): Slug[] {
   const entries: Array<{ id: number; slug: string }> = [];
   for (const msg of messages) {
     for (const block of msg.content) {
-      if (block.type !== "text") continue;
+      if (block.type !== "text") {
+        continue;
+      }
       const cards = /<candidate_cards>\n([\s\S]*?)\n<\/candidate_cards>/.exec(
         block.text,
       );
@@ -194,7 +198,9 @@ function candidateSlugs(messages: Message[]): Slug[] {
       if (finder) {
         for (const line of finder[1].split("\n")) {
           const m = /^\[(\d+)\] (?:\([^)]*\) )?(\S+)(?: — |$)/.exec(line);
-          if (m) entries.push({ id: Number(m[1]), slug: m[2]! });
+          if (m) {
+            entries.push({ id: Number(m[1]), slug: m[2]! });
+          }
         }
       }
     }
@@ -211,8 +217,12 @@ function selectProvider(keep: Slug[], pin: Slug[] = []): Provider {
       const ids: number[] = [];
       const pinned_ids: number[] = [];
       pool.forEach((slug, i) => {
-        if (keep.includes(slug)) ids.push(i + 1);
-        if (pin.includes(slug)) pinned_ids.push(i + 1);
+        if (keep.includes(slug)) {
+          ids.push(i + 1);
+        }
+        if (pin.includes(slug)) {
+          pinned_ids.push(i + 1);
+        }
       });
       return toolUseResponse({ ids, pinned_ids });
     },

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
@@ -36,7 +36,9 @@ import type { MemoryRoutingTurn, SectionIndex, Slug } from "../types.js";
 
 let providerStub: Provider | null = null;
 
+const realPluginApi = await import("@vellumai/plugin-api");
 mock.module("@vellumai/plugin-api", () => ({
+  ...realPluginApi,
   getConfiguredProvider: async () => providerStub,
 }));
 
@@ -60,7 +62,9 @@ let denseCalls: Array<{ query: string; k: number }> = [];
 mock.module("../dense.js", () => ({
   ...realDense,
   denseLane: async (...args: Parameters<typeof realDense.denseLane>) => {
-    if (!denseMockActive) return realDense.denseLane(...args);
+    if (!denseMockActive) {
+      return realDense.denseLane(...args);
+    }
     denseCalls.push({ query: args[1], k: args[2] });
     return args[2] <= 0 ? [] : denseHits;
   },
@@ -71,7 +75,9 @@ mock.module("../dense.js", () => ({
   denseLaneScored: async (
     ...args: Parameters<typeof realDense.denseLaneScored>
   ) => {
-    if (!denseMockActive) return realDense.denseLaneScored(...args);
+    if (!denseMockActive) {
+      return realDense.denseLaneScored(...args);
+    }
     denseCalls.push({ query: args[1], k: args[2] });
     return args[2] <= 0
       ? []
@@ -228,7 +234,9 @@ function parsePool(messages: Message[]): {
   let prefixBlock: string | null = null;
   for (const msg of messages) {
     for (const block of msg.content) {
-      if (block.type !== "text") continue;
+      if (block.type !== "text") {
+        continue;
+      }
       const cards = /<candidate_cards>\n([\s\S]*?)\n<\/candidate_cards>/.exec(
         block.text,
       );
@@ -246,7 +254,9 @@ function parsePool(messages: Message[]): {
       if (finder) {
         for (const line of finder[1].split("\n")) {
           const m = /^\[(\d+)\] (?:\([^)]*\) )?(\S+)(?: — |$)/.exec(line);
-          if (m) entries.push({ id: Number(m[1]), slug: m[2]!, line });
+          if (m) {
+            entries.push({ id: Number(m[1]), slug: m[2]!, line });
+          }
         }
       }
     }
@@ -280,8 +290,12 @@ function selectProvider(keep: Slug[], pin: Slug[] = []): Provider {
       const ids: number[] = [];
       const pinned_ids: number[] = [];
       parsed.slugs.forEach((slug, i) => {
-        if (keep.includes(slug)) ids.push(i + 1);
-        if (pin.includes(slug)) pinned_ids.push(i + 1);
+        if (keep.includes(slug)) {
+          ids.push(i + 1);
+        }
+        if (pin.includes(slug)) {
+          pinned_ids.push(i + 1);
+        }
       });
       return toolUseResponse({ ids, pinned_ids });
     },

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/pool-select.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/pool-select.test.ts
@@ -58,7 +58,9 @@ interface ProviderCall {
 const providerCalls: ProviderCall[] = [];
 const warnCalls: Array<{ args: unknown[] }> = [];
 
+const realPluginApi = await import("@vellumai/plugin-api");
 mock.module("@vellumai/plugin-api", () => ({
+  ...realPluginApi,
   getConfiguredProvider: async () => providerStub,
 }));
 


### PR DESCRIPTION
## Summary

**F2 (embeddings), round 1 — the first two blessed embeddings re-exports.** Per the ratified facet plan (flat re-exports; embeddings shape mirrors the #36759 split), the contract gains the two self-contained embeddings operations:

```ts
export { embedAndUpsert, selectedBackendSupportsMultimodal }
  from "../persistence/embeddings/plugin-facade.js";
```

Backed by a new host facade (`persistence/embeddings/plugin-facade.ts`): each op resolves the live workspace config internally (plugins hold no host config) and **lazy-loads the embed graph inside the wrapper**. The lazy load is load-bearing, not style: `@vellumai/plugin-api` is imported transitively by nearly everything, and 8 test files intentionally partial-mock `qdrant-client`/`job-utils`/`embedding-backend` — a static facade import would force all their named exports to resolve wherever the contract loads (the exact class Codex flagged in #36759, promoted to contract level).

**Memory migration (6 files, pure path-swap):** `graph/graph-search`, `graph/retriever`, `job-handlers/embedding`, `job-handlers/index-maintenance`, `indexer`, `pkb/pkb-index` now import the two ops from `@vellumai/plugin-api`. The plugin accessor (`plugins/defaults/memory/embeddings.ts`) shrinks to the two deliberately-off-contract ops.

**Deliberately NOT in this round (scoping honesty):**
- `embedWithBackend` — per the round-2 thread: with config now plugin-internal (#37668) there is no blessed source for its `AssistantConfig` param; it needs the snapshot-handle design. Stays on the plugin accessor, allowlisted.
- `resolveQdrantUrl` — its three real consumers are **synchronous memoized client getters** (`v2/qdrant`, `section-dense-store`, `graph/bootstrap`), and a contract facade must lazy-load `qdrant-client` (see above) — sync + lazy is a contradiction, and forcing the getters async is churn without behavior payoff. It stays sync on the plugin accessor and joins the full-F2 design round, whose real surface is the wider qdrant client machinery (getters/init across ~17 memory files).

**Test hardening (F7 lesson applied proactively):** the four remaining *minimal* `@vellumai/plugin-api` mocks in memory tests (`retriever`, `orchestrate`, `live-integration`, `v3/pool-select`) are converted to spread-real — this facet round would have broken them, and so would every future one; the class is now closed in memory.

## Gate (all green)
`typecheck:fast`, eslint, knip, prettier, all five boundary guards (boundary baseline unchanged — the accessor's `job-utils` specifier is retained by `jobs-worker.ts`), and 16 affected test files in isolation (graph-search, retriever, extraction, pkb×3, job-handlers/embedding, v3×5, v2/qdrant, memory-item-routes, upsert-concurrency, graph-memory-v2-routing).

## For review
- **Vargas:** the contract delta is the 8-line block above (2 re-exports + doc comment) — same flat shape as F1/F7. The facade is host-internal. Risk: **low** — pure import migration for the two ops; behavior byte-identical; the lazy-load rationale is comment-documented in the facade.

Part of the memory-as-a-plugin effort (facet migration — F2 round 1; follows F7 #36752 and F6 #37668).