### PR TITLE
fix(web): profile editor reflects snapshot-at-save semantics (M7 PR 5)

### DIFF
--- a/clients/web/docs/BACKWARDS_COMPAT.md
+++ b/clients/web/docs/BACKWARDS_COMPAT.md
@@ -1,6 +1,6 @@
 # Web App — Backwards Compatibility
 
-How the web client copes with talking to an assistant that may be running an older version 
+How the web client copes with talking to an assistant that may be running an older version
 than the bundle the browser just loaded.
 
 See also [`clients/web/AGENTS.md`](../AGENTS.md), the umbrella
@@ -31,14 +31,14 @@ informing us of live clients in use so we can delete old cold paths incrementall
 
 ## Where it lives
 
-| Module | Role |
-|---|---|
-| `src/lib/backwards-compat/` | The centralized registry. One file per gated feature, each declaring its own `MIN_VERSION`. `grep` this path to find everything that can eventually be deleted. |
-| `src/lib/backwards-compat/utils.ts` | The shared gate primitives: `useAssistantSupports`, `assistantSupports`, `whenAssistantVersionKnown`. Every gate uses these so semver parsing and pre-release handling are uniform. |
-| `src/utils/semver.ts` | Low-level `parseSemver` / `compareParsed` / `comparePreRelease`. No app knowledge — just version-string math. |
-| `src/stores/assistant-identity-store.ts` | Zustand store holding the active assistant's `{ name, version }`. The source of truth every gate reads. |
-| `src/assistant/identity.ts` | Fetches identity from the assistant's `/identity` endpoint and refreshes it on the SSE `identity_changed` event. |
-| `src/lib/backwards-compat/impersonate-version-flag.ts` | Debug flag for overriding the reported version locally, so a single dev can exercise old and new code paths without juggling installs. |
+| Module                                                 | Role                                                                                                                                                                                |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/lib/backwards-compat/`                            | The centralized registry. One file per gated feature, each declaring its own `MIN_VERSION`. `grep` this path to find everything that can eventually be deleted.                     |
+| `src/lib/backwards-compat/utils.ts`                    | The shared gate primitives: `useAssistantSupports`, `assistantSupports`, `whenAssistantVersionKnown`. Every gate uses these so semver parsing and pre-release handling are uniform. |
+| `src/utils/semver.ts`                                  | Low-level `parseSemver` / `compareParsed` / `comparePreRelease`. No app knowledge — just version-string math.                                                                       |
+| `src/stores/assistant-identity-store.ts`               | Zustand store holding the active assistant's `{ name, version }`. The source of truth every gate reads.                                                                             |
+| `src/assistant/identity.ts`                            | Fetches identity from the assistant's `/identity` endpoint and refreshes it on the SSE `identity_changed` event.                                                                    |
+| `src/lib/backwards-compat/impersonate-version-flag.ts` | Debug flag for overriding the reported version locally, so a single dev can exercise old and new code paths without juggling installs.                                              |
 
 ## How a gate is detected
 
@@ -65,14 +65,14 @@ knowing before you add a gate:
 - **Unknown version returns `false`.** The version starts `null` and
   hydrates asynchronously after identity fetches. Until then, every gate
   reports "not supported" and the app falls back to the legacy path. That
-  fallback must be something *any* assistant understands.
+  fallback must be something _any_ assistant understands.
 - **Pre-release suffixes on the patch are ignored.** `0.8.5-rc.1` counts
   as `0.8.5`, so RC/beta/alpha testers get the new path the moment the
   patch version bumps.
 - **`dev` builds are treated as AHEAD of the stable release with the same
   base** — the opposite of strict semver. A build like
   `0.10.0-dev.202606211252.5cf8576` contains unreleased commits on top of
-  `0.10.0`, so it's considered *newer* than `0.10.0` stable. Two dev
+  `0.10.0`, so it's considered _newer_ than `0.10.0` stable. Two dev
   builds with the same base compare by their pre-release string, which
   encodes a `dev.YYYYMMDDHHMM.sha` timestamp. This lets a gate target a
   specific dev build by passing the exact dev version string as
@@ -108,23 +108,24 @@ awaits `resolveSupportsAvatarStateManifest()` before branching).
    `whenAssistantVersionKnown()` first.
 5. Add a colocated `<feature>.test.ts`.
 
-Keep the old code path until the gate is removed — the gate *is* the
+Keep the old code path until the gate is removed — the gate _is_ the
 contract that says it still has callers.
 
 ## The gates
 
 Each module owns one feature's old/new split. Current registry:
 
-| Gate (`src/lib/backwards-compat/…`) | `MIN_VERSION` | Old behavior (< version) | New behavior (≥ version) |
-|---|---|---|---|
-| `flag-query-freshness.ts` | `0.8.5` | 5 s poll interval on feature-flag queries | Push-based invalidation via `sync_changed` + SSE reconnect (60 s stale, no poll) |
-| `conversation-id-wire-field.ts` | `0.8.6` | Send `conversationKey` (create-or-lookup) on `POST /v1/messages` | Send strict `conversationId` (direct internal-id lookup) |
-| `server-minted-conversation.ts` | `0.8.6` | Mint a draft UUID locally, send as `conversationKey` | Omit both id fields; assistant mints the id and echoes it back on first send |
-| `avatar-state-manifest.ts` | `0.8.7` | Infer render mode from workspace sidecar files; write via generic `workspace/write` + `workspace/delete` | Authoritative `GET /avatar/state` + atomic `POST /avatar/image` |
-| `conversation-processing-state.ts` | `0.8.8` | Client-side optimistic mirror (`processingConversationIds`), cleared manually on terminal events | Trust the server `isProcessing` flag on the conversation row |
-| `llm-context-summary-view.ts` | `0.8.12` | Inline context sections from the list response | `view=summary` light list + lazy per-log detail via `GET /v1/llm-request-logs/:id/context` |
-| `vision-attachment-gate.ts` | `0.10.0-dev.202606211252.5cf8576` | Client filters images out for non-vision models | Allow any file type; the image-fallback plugin filters/captions server-side |
-| `default-provider-settings.ts` | `0.10.8` | No default-provider marker UI in the Providers modal; status query never fires | "Default" tag + "Set as default" via `GET/PUT /v1/config/llm/default-provider` |
+| Gate (`src/lib/backwards-compat/…`) | `MIN_VERSION`                     | Old behavior (< version)                                                                                 | New behavior (≥ version)                                                                   |
+| ----------------------------------- | --------------------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `flag-query-freshness.ts`           | `0.8.5`                           | 5 s poll interval on feature-flag queries                                                                | Push-based invalidation via `sync_changed` + SSE reconnect (60 s stale, no poll)           |
+| `conversation-id-wire-field.ts`     | `0.8.6`                           | Send `conversationKey` (create-or-lookup) on `POST /v1/messages`                                         | Send strict `conversationId` (direct internal-id lookup)                                   |
+| `server-minted-conversation.ts`     | `0.8.6`                           | Mint a draft UUID locally, send as `conversationKey`                                                     | Omit both id fields; assistant mints the id and echoes it back on first send               |
+| `avatar-state-manifest.ts`          | `0.8.7`                           | Infer render mode from workspace sidecar files; write via generic `workspace/write` + `workspace/delete` | Authoritative `GET /avatar/state` + atomic `POST /avatar/image`                            |
+| `conversation-processing-state.ts`  | `0.8.8`                           | Client-side optimistic mirror (`processingConversationIds`), cleared manually on terminal events         | Trust the server `isProcessing` flag on the conversation row                               |
+| `llm-context-summary-view.ts`       | `0.8.12`                          | Inline context sections from the list response                                                           | `view=summary` light list + lazy per-log detail via `GET /v1/llm-request-logs/:id/context` |
+| `vision-attachment-gate.ts`         | `0.10.0-dev.202606211252.5cf8576` | Client filters images out for non-vision models                                                          | Allow any file type; the image-fallback plugin filters/captions server-side                |
+| `default-provider-settings.ts`      | `0.10.8`                          | No default-provider marker UI in the Providers modal; status query never fires                           | "Default" tag + "Set as default" via `GET/PUT /v1/config/llm/default-provider`             |
+| `complete-profile-snapshots.ts`     | `0.10.8`                          | Blank profile fields live-inherit (deep merge); no snapshot copy in the editor                           | Blanks are baked at save time; editor shows the snapshot helper line                       |
 
 When you delete a row here, also delete its module, its test, and the now-dead
 legacy branch at the call site.
@@ -136,7 +137,7 @@ with the code they protect:
 
 - **SSE event parsing** — `src/lib/streaming/event-parser.ts` accepts both
   the enveloped event shape (`{ id, conversationId, seq, emittedAt,
-  message }`, 0.8.5+) and the flat legacy shape (`{ type, … }`), wrapping
+message }`, 0.8.5+) and the flat legacy shape (`{ type, … }`), wrapping
   the legacy form in a synthetic envelope so downstream callers never see
   the difference.
 - **Message normalization** — `src/domains/chat/api/messages.ts`
@@ -163,8 +164,8 @@ overrides the version every gate sees:
 ```js
 // In the browser console (debug builds expose window._vellumDebug.flags):
 impersonateVersion("0.8.6"); // pretend the assistant is 0.8.6, then reload
-impersonateVersion(null);    // clear the override, then reload
-impersonateVersion();        // log the current override, no reload
+impersonateVersion(null); // clear the override, then reload
+impersonateVersion(); // log the current override, no reload
 ```
 
 It persists to `localStorage` (`vellum:debug:impersonateAssistantVersion`)

--- a/clients/web/docs/BACKWARDS_COMPAT.md
+++ b/clients/web/docs/BACKWARDS_COMPAT.md
@@ -136,10 +136,10 @@ A few backwards-compat concerns don't fit the version-gate shape and live
 with the code they protect:
 
 - **SSE event parsing** — `src/lib/streaming/event-parser.ts` accepts both
-  the enveloped event shape (`{ id, conversationId, seq, emittedAt,
-message }`, 0.8.5+) and the flat legacy shape (`{ type, … }`), wrapping
-  the legacy form in a synthetic envelope so downstream callers never see
-  the difference.
+  the enveloped event shape of 0.8.5+
+  (`{ id, conversationId, seq, emittedAt, message }`) and the flat legacy
+  shape (`{ type, … }`), wrapping the legacy form in a synthetic envelope
+  so downstream callers never see the difference.
 - **Message normalization** — `src/domains/chat/api/messages.ts`
   reconstructs the unified `contentBlocks` discriminated union from the
   pre-0.8.8 positional arrays (`textSegments`, `thinkingSegments`,

--- a/clients/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
@@ -135,7 +135,9 @@ function getButton(label: string): HTMLButtonElement {
   const match = Array.from(
     document.querySelectorAll<HTMLButtonElement>("button"),
   ).find((b) => b.textContent?.trim() === label);
-  if (!match) throw new Error(`expected a "${label}" button`);
+  if (!match) {
+    throw new Error(`expected a "${label}" button`);
+  }
   return match;
 }
 
@@ -143,7 +145,9 @@ function getSaveBtn(): HTMLButtonElement {
   const btn = document.querySelector<HTMLButtonElement>(
     '[data-testid="modal-save-btn"]',
   );
-  if (!btn) throw new Error("expected a modal-save-btn");
+  if (!btn) {
+    throw new Error("expected a modal-save-btn");
+  }
   return btn;
 }
 
@@ -151,7 +155,9 @@ function providerTrigger(): HTMLButtonElement {
   const trigger = document.querySelector<HTMLButtonElement>(
     'button[role="combobox"][aria-labelledby="profile-editor-provider-label"]',
   );
-  if (!trigger) throw new Error("expected the Provider dropdown trigger");
+  if (!trigger) {
+    throw new Error("expected the Provider dropdown trigger");
+  }
   return trigger;
 }
 
@@ -171,7 +177,9 @@ function selectModel(label: string): void {
   for (const trigger of Array.from(
     document.querySelectorAll<HTMLButtonElement>('button[role="combobox"]'),
   )) {
-    if (trigger === provTrigger) continue;
+    if (trigger === provTrigger) {
+      continue;
+    }
     fireEvent.click(trigger);
     const option = Array.from(
       document.querySelectorAll<HTMLElement>('[role="option"]'),
@@ -337,7 +345,10 @@ describe("ManageProfilesModal — invariant managed profiles in the list", () =>
     const row = deleteBtn!.closest("div.relative")!;
     const actionBtn = Array.from(
       row.querySelectorAll<HTMLButtonElement>("button"),
-    ).find((b) => b.textContent?.trim() === "View" || b.textContent?.trim() === "Edit");
+    ).find(
+      (b) =>
+        b.textContent?.trim() === "View" || b.textContent?.trim() === "Edit",
+    );
     expect(actionBtn?.textContent?.trim()).toBe("Edit");
   });
 
@@ -367,5 +378,91 @@ describe("ManageProfilesModal — invariant managed profiles in the list", () =>
       document.querySelectorAll<HTMLButtonElement>("button"),
     ).find((b) => b.textContent?.trim() === "Save As New");
     expect(saveAsNew).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// M7 PR 5 — read-only default profiles stay locked; complete custom profiles
+// round-trip with their stored (snapshot) values.
+// ---------------------------------------------------------------------------
+
+describe("ManageProfilesModal — read-only defaults and complete-override round-trip", () => {
+  test("managed profiles are not draggable and their delete stays disabled", () => {
+    profilesState = {
+      balanced: {
+        label: "Balanced",
+        source: "managed",
+        invariant: true,
+        provider: "anthropic",
+        model: "claude-opus-4-8",
+      },
+      "my-custom": {
+        label: "My Custom",
+        source: "user",
+        provider: "anthropic",
+        model: "claude-opus-4-8",
+        provider_connection: "anthropic-personal",
+      },
+    };
+    render(
+      <Wrapper>
+        <ManageProfilesModal isOpen assistantId="asst-1" onClose={() => {}} />
+      </Wrapper>,
+    );
+
+    const managedDelete = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Delete Balanced"]',
+    );
+    expect(managedDelete?.disabled).toBe(true);
+    expect(managedDelete?.title).toContain("cannot be deleted");
+
+    const customDelete = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Delete My Custom"]',
+    );
+    expect(customDelete?.disabled).toBe(false);
+
+    // Drag-reorder is a user-profile affordance only.
+    const rows = Array.from(
+      document.querySelectorAll<HTMLElement>("[draggable]"),
+    );
+    const managedRow = rows.find((r) => r.textContent?.includes("Balanced"));
+    const customRow = rows.find((r) => r.textContent?.includes("My Custom"));
+    expect(managedRow?.getAttribute("draggable")).toBe("false");
+    expect(customRow?.getAttribute("draggable")).toBe("true");
+  });
+
+  test("a complete custom profile opens in edit with its stored values, not blanks", async () => {
+    // Post-M6, stored custom profiles are complete overrides — the editor
+    // must show the baked values rather than empty inherit placeholders.
+    profilesState = {
+      "my-custom": {
+        label: "My Custom",
+        source: "user",
+        provider: "anthropic",
+        model: "claude-opus-4-8",
+        provider_connection: "anthropic-personal",
+        maxTokens: 12345,
+      },
+    };
+    render(
+      <Wrapper>
+        <ManageProfilesModal isOpen assistantId="asst-1" onClose={() => {}} />
+      </Wrapper>,
+    );
+
+    fireEvent.click(getButton("Edit"));
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Max Output Tokens");
+    });
+
+    // The stored explicit budget renders as the field value — not as an
+    // empty input reading "Default".
+    const maxTokensInput = Array.from(
+      document.querySelectorAll<HTMLInputElement>('input[type="number"]'),
+    ).find((el) => el.value === "12345");
+    expect(maxTokensInput).toBeDefined();
+
+    // Fields the stored profile genuinely lacks still read as defaults.
+    expect(document.body.textContent).toContain("Default · 200K");
   });
 });

--- a/clients/web/src/domains/settings/ai/profile-advanced-params.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-advanced-params.test.tsx
@@ -24,6 +24,7 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 import { ProfileAdvancedParams } from "@/domains/settings/ai/profile-advanced-params";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import {
   type ProfileParamVisibility,
   VISIBILITY_NONE,
@@ -554,5 +555,35 @@ describe("ProfileAdvancedParams read-only segment controls", () => {
     expect(onEffortChange).toHaveBeenLastCalledWith("high");
     fireEvent.click(screen.getByRole("radio", { name: "fast" }));
     expect(onSpeedChange).toHaveBeenLastCalledWith("fast");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// M7 PR 5 — snapshot copy is version-gated (write-time completion is 0.10.8+)
+// ---------------------------------------------------------------------------
+
+describe("snapshot helper copy", () => {
+  const SNAPSHOT_COPY = "saved with the values shown";
+
+  afterEach(() => {
+    useAssistantIdentityStore.getState().clearIdentity();
+  });
+
+  test("renders on assistants with write-time completion (0.10.8+)", () => {
+    useAssistantIdentityStore.getState().setIdentity("test-asst", "0.10.8");
+    renderParams({ visibility: maxTokensOnly });
+    expect(document.body.textContent).toContain(SNAPSHOT_COPY);
+  });
+
+  test("hidden against pre-0.10.8 assistants (blanks still live-inherit there)", () => {
+    useAssistantIdentityStore.getState().setIdentity("test-asst", "0.10.7");
+    renderParams({ visibility: maxTokensOnly });
+    expect(document.body.textContent).not.toContain(SNAPSHOT_COPY);
+  });
+
+  test("hidden in read-only view mode", () => {
+    useAssistantIdentityStore.getState().setIdentity("test-asst", "0.10.8");
+    renderParams({ visibility: maxTokensOnly, isReadOnly: true });
+    expect(document.body.textContent).not.toContain(SNAPSHOT_COPY);
   });
 });

--- a/clients/web/src/domains/settings/ai/profile-advanced-params.tsx
+++ b/clients/web/src/domains/settings/ai/profile-advanced-params.tsx
@@ -20,6 +20,7 @@ import {
   geminiThinkingLevels,
   type ProfileParamVisibility,
 } from "@/domains/settings/ai/profile-param-visibility";
+import { useSupportsCompleteProfileSnapshots } from "@/lib/backwards-compat/complete-profile-snapshots";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -275,6 +276,8 @@ export function ProfileAdvancedParams({
   thinkingLevel,
   onThinkingLevelChange,
 }: ProfileAdvancedParamsProps) {
+  const supportsSnapshots = useSupportsCompleteProfileSnapshots();
+
   // Each model's hard ceiling doubles as that field's slider/input max. The
   // resolved runtime defaults, however, are what a profile inherits when it
   // omits the override: `llm.default.maxTokens` and
@@ -295,13 +298,22 @@ export function ProfileAdvancedParams({
     contextWindowCeiling,
   );
 
-
   return (
     // space-y-4 matches the modal body's rhythm so each advanced param gets
     // the same vertical breathing room as the "normal" fields above. Without
     // a spacing wrapper the fragment stacked these blocks flush against each
     // other (and against the disclosure edges).
     <div className="space-y-4">
+      {!isReadOnly && supportsSnapshots && (
+        // Profiles are complete overrides: fields left at their default are
+        // baked into the profile at save time and do not track later changes
+        // to the assistant defaults. Pre-0.10.8 assistants still live-inherit
+        // (deep merge), so the line is hidden against them.
+        <p className="text-body-small-default text-[var(--content-tertiary)]">
+          Fields left at their default are saved with the values shown and won’t
+          change if the assistant defaults change later.
+        </p>
+      )}
       {visibility.maxTokens && (
         <TokenBudgetField
           label="Max Output Tokens"
@@ -333,7 +345,9 @@ export function ProfileAdvancedParams({
           <SegmentControl
             items={EFFORT_OPTIONS.map((v) => ({
               value: v,
-              label: v,
+              // "inherit" is a wire sentinel; post-M6 the saved profile bakes
+              // the current default, so the UI says "default", not "inherit".
+              label: v === "inherit" ? "default" : v,
               disabled: isReadOnly,
             }))}
             value={effort}
@@ -452,7 +466,9 @@ export function ProfileAdvancedParams({
             checked={thinkingEnabled}
             onChange={(v) => {
               onThinkingEnabledChange(v);
-              if (!v) onThinkingStreamThinkingChange(false);
+              if (!v) {
+                onThinkingStreamThinkingChange(false);
+              }
             }}
             label="Enable extended thinking"
             disabled={isReadOnly}

--- a/clients/web/src/lib/backwards-compat/complete-profile-snapshots.test.ts
+++ b/clients/web/src/lib/backwards-compat/complete-profile-snapshots.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { renderHook } from "@testing-library/react";
+
+import { useSupportsCompleteProfileSnapshots } from "@/lib/backwards-compat/complete-profile-snapshots";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+
+function setVersion(version: string | null) {
+  useAssistantIdentityStore.getState().setIdentity("test-asst", version);
+}
+
+beforeEach(() => {
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+afterEach(() => {
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+// Exhaustive truth-table for the underlying semver gate lives in
+// `utils.test.ts`. Here we verify each side of the 0.10.8 boundary
+// plus the conservative-on-unknown policy.
+describe("useSupportsCompleteProfileSnapshots", () => {
+  test("false when version is unknown", () => {
+    setVersion(null);
+    const { result } = renderHook(() => useSupportsCompleteProfileSnapshots());
+    expect(result.current).toBe(false);
+  });
+
+  test("false for assistants on 0.10.7 and older (blanks still live-inherit)", () => {
+    setVersion("0.10.7");
+    const { result } = renderHook(() => useSupportsCompleteProfileSnapshots());
+    expect(result.current).toBe(false);
+  });
+
+  test("true for assistants on 0.10.8+", () => {
+    setVersion("0.10.8");
+    const { result } = renderHook(() => useSupportsCompleteProfileSnapshots());
+    expect(result.current).toBe(true);
+  });
+
+  test("true for RC builds of the cutover patch", () => {
+    setVersion("0.10.8-rc.1");
+    const { result } = renderHook(() => useSupportsCompleteProfileSnapshots());
+    expect(result.current).toBe(true);
+  });
+});

--- a/clients/web/src/lib/backwards-compat/complete-profile-snapshots.ts
+++ b/clients/web/src/lib/backwards-compat/complete-profile-snapshots.ts
@@ -1,0 +1,17 @@
+/**
+ * Backwards-compat gate: complete-override profile snapshots.
+ *
+ * Vellum Assistant 0.10.8 (M6) completes custom profiles at write time:
+ * fields left blank in the editor are baked with the current defaults and
+ * no longer track later default changes. Older assistants still deep-merge
+ * at resolution time, so blanks DO live-inherit there — the editor's
+ * snapshot copy ("saved with the values shown") would be wrong and is
+ * hidden against them.
+ */
+import { useAssistantSupports } from "@/lib/backwards-compat/utils";
+
+const MIN_VERSION = "0.10.8";
+
+export function useSupportsCompleteProfileSnapshots(): boolean {
+  return useAssistantSupports(MIN_VERSION);
+}


### PR DESCRIPTION
## Summary

- Profile-editor copy now reflects M6's complete-override semantics: a version-gated helper line in the advanced params ("Fields left at their default are saved with the values shown and won't change if the assistant defaults change later"), and the effort segment's `inherit` sentinel displays as "default" (regime-neutral wording, accurate both pre- and post-M6). No wire-payload or flow changes.
- The helper line rides a new backwards-compat gate (`complete-profile-snapshots.ts`, `0.10.8`): pre-M6 assistants still live-inherit blanks via deep merge, so the snapshot claim is hidden against them.
- Regression tests lock in the milestone's read-only requirement: managed profiles not draggable/deletable, complete custom profiles round-trip showing stored explicit values (with genuinely-absent fields still reading as defaults), and the gate's three states. The editor's existing invariant-profile suite already pins view-mode/enable-only/Save-As-New behavior.

`use-sticky-profiles.ts` needs no change: managed profiles remain in every `GET /v1/config` via the effective-catalog overlay, so its "never legitimately empty" assumption holds.

Final PR of M7 (Inference Management Refactor) — plan attached to #37579.

## Original prompt

Execute PR 5 of the M7 plan (`.private/plans/m7-settings-ui-default-provider.md`), the follow-up M6 explicitly flagged for M7: with `completeCustomProfile` baking blank editor fields at save time, the editor's "inherit" framing became misleading — blanks are snapshots now, not live references. Scope was copy + regression tests only, calibrated to reword only what promises live inheritance, and version-gated per `docs/BACKWARDS_COMPAT.md` since older assistants still deep-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->