### PR TITLE
fix: migrate agent-wake's idle wait onto Conversation.waitForIdle

### DIFF
--- a/assistant/src/__tests__/agent-wake-disk-pressure-callsite.test.ts
+++ b/assistant/src/__tests__/agent-wake-disk-pressure-callsite.test.ts
@@ -84,6 +84,7 @@ function makeTarget(): Conversation {
     messages,
     getMessages: () => messages,
     isProcessing: () => processing,
+    waitForIdle: async () => !processing,
     setProcessing: (on: boolean) => {
       processing = on;
     },

--- a/assistant/src/__tests__/agent-wake-override-profile.test.ts
+++ b/assistant/src/__tests__/agent-wake-override-profile.test.ts
@@ -96,6 +96,7 @@ function makeTarget(): {
     messages,
     getMessages: () => messages,
     isProcessing: () => processing,
+    waitForIdle: async () => !processing,
     setProcessing: (on: boolean) => {
       processing = on;
     },

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -6,7 +6,7 @@
  * yields a live `Conversation`. These tests build a lightweight structural
  * double typed as `Conversation` (`makeWakeConversation`) that stubs only the
  * handful of members the wake touches — `getMessages`, `messages.push`,
- * `isProcessing`/`setProcessing`, `currentTurnTrustContext`,
+ * `isProcessing`/`setProcessing`/`waitForIdle`, `currentTurnTrustContext`,
  * `setSubagentAllowedTools`, `drainQueue`, `maybeCompact`,
  * `contextWindowManager.estimateInputTokens`, and a scripted `agentLoop.run()`.
  *
@@ -115,6 +115,12 @@ interface WakeConversationProbe {
    * sizes against the wake's window instead of mainAgent's.
    */
   maybeCompactSizings: unknown[];
+  /**
+   * Options passed to each `conversation.waitForIdle()` call — the wake's
+   * pre-run busy gate. Lets tests pin the wait budget the wake hands to the
+   * conversation's event-driven wait.
+   */
+  waitForIdleCalls: Array<{ timeoutMs: number }>;
 }
 
 const wakeConvRegistry = new Map<string, WakeConversationProbe>();
@@ -400,6 +406,17 @@ function makeWakeConversation(options: {
   estimatedInputTokens?: number;
   /** Seed for the conversation's resting `trustContext`. */
   initialTrustContext?: unknown;
+  /**
+   * Replaces the double's default `waitForIdle` behavior (fast-path `true`
+   * when idle, `true` on the `setProcessing(false)` transition, `false`
+   * after a real `timeoutMs` timer). Lets the timeout test script the
+   * `false` outcome without waiting out the production budget. Calls are
+   * recorded in `waitForIdleCalls` either way.
+   */
+  waitForIdleImpl?: (waitOptions: {
+    timeoutMs: number;
+    signal?: AbortSignal;
+  }) => Promise<boolean>;
 }): WakeConversation {
   const conversationId = options.conversationId ?? "conv-test";
   const probe: WakeConversationProbe = {
@@ -419,10 +436,12 @@ function makeWakeConversation(options: {
     persistedAtEachEmit: [],
     maybeCompactOrders: [],
     maybeCompactSizings: [],
+    waitForIdleCalls: [],
   };
   wakeConvRegistry.set(conversationId, probe);
 
   let processing = options.isProcessing ?? false;
+  const idleWaiters = new Set<() => void>();
   let order = 0;
   let activeAllowedTools = options.initialAllowedTools;
   let wakePersonaOverride: unknown;
@@ -518,6 +537,41 @@ function makeWakeConversation(options: {
       processing = on;
       probe.processingToggles.push(on);
       probe.callSequence.push(on ? "processing:true" : "processing:false");
+      // Mirrors Conversation.setProcessing: a clear releases pending
+      // waitForIdle waiters (copy-and-clear, like the real notifier).
+      if (!on) {
+        const waiters = [...idleWaiters];
+        idleWaiters.clear();
+        for (const notify of waiters) {
+          notify();
+        }
+      }
+    },
+    // Mirrors Conversation.waitForIdle for the signal-less shape the wake
+    // uses: fast-path `true` when idle, `true` on the setProcessing(false)
+    // transition, `false` when `timeoutMs` elapses first.
+    waitForIdle: (waitOptions: {
+      timeoutMs: number;
+      signal?: AbortSignal;
+    }): Promise<boolean> => {
+      probe.waitForIdleCalls.push({ timeoutMs: waitOptions.timeoutMs });
+      if (options.waitForIdleImpl) {
+        return options.waitForIdleImpl(waitOptions);
+      }
+      if (!processing) {
+        return Promise.resolve(true);
+      }
+      return new Promise<boolean>((resolve) => {
+        const timer = setTimeout(() => {
+          idleWaiters.delete(notify);
+          resolve(false);
+        }, waitOptions.timeoutMs);
+        const notify = () => {
+          clearTimeout(timer);
+          resolve(true);
+        };
+        idleWaiters.add(notify);
+      });
     },
     get currentTurnTrustContext() {
       return currentTurnTrustContext;
@@ -1768,11 +1822,15 @@ describe("wakeAgentForOpportunity", () => {
     await new Promise((resolve) => setTimeout(resolve, 20));
     expect(settled).toBe(false);
 
-    // "User turn" completes — wake now proceeds.
+    // "User turn" completes — wake now proceeds. The release notification
+    // resolves the wait; the double's only other exit is its (untriggered)
+    // 30s timeout timer, so the wake proceeding here proves the wait is
+    // event-driven rather than clock-driven.
     conversation.setProcessing(false);
     const result = await wakePromise;
     expect(result.invoked).toBe(true);
     expect(result.producedToolCalls).toBe(false);
+    expect(conversation.waitForIdleCalls).toEqual([{ timeoutMs: 30_000 }]);
   });
 
   test("returns invoked: false with reason 'not_found' when the conversation cannot be resolved", async () => {
@@ -1788,34 +1846,31 @@ describe("wakeAgentForOpportunity", () => {
   });
 
   test("returns invoked: false with reason 'timeout' when the target stays busy past the wait-until-idle window", async () => {
-    // Resolver returns a target that is permanently `processing`. Fast-
-    // forward the injected `now` past the 30s deadline so waitUntilIdle
-    // returns false. Without the distinct `timeout` reason, callers
-    // cannot tell this case apart from "not_found".
+    // Resolver returns a target that is permanently `processing`. The
+    // scripted `waitForIdle` resolves `false` — the real Conversation's
+    // timeout outcome — without holding the test for the 30s production
+    // budget. Without the distinct `timeout` reason, callers cannot tell
+    // this case apart from "not_found".
     const conversation = makeWakeConversation({
       conversationId: "conv-busy",
       isProcessing: true,
       runImpl: async (input) => runResult(input),
+      waitForIdleImpl: async () => false,
     });
-    let t = 0;
-    const now = () => {
-      // First call establishes the deadline at +30_000. Every subsequent
-      // call jumps past the deadline so the polling loop exits after one
-      // 50ms tick.
-      const v = t;
-      t += 31_000;
-      return v;
-    };
 
     const result = await wakeAgentForOpportunity(
       { conversationId: "conv-busy", hint: "x", source: "y" },
-      { resolveTarget: async () => conversation, now },
+      { resolveTarget: async () => conversation },
     );
     expect(result).toEqual({
       invoked: false,
       producedToolCalls: false,
       reason: "timeout",
     });
+    // The wake handed the conversation's event-driven wait its full 30s
+    // budget, and did not start the agent loop on the busy conversation.
+    expect(conversation.waitForIdleCalls).toEqual([{ timeoutMs: 30_000 }]);
+    expect(conversation.runCalls).toHaveLength(0);
   });
 
   test("agent loop error is treated as a no-op", async () => {

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -482,23 +482,13 @@ async function runSingleFlight<T>(
 }
 
 /**
- * Small helper: if a conversation reports `isProcessing()`, poll briefly
- * so we don't try to start a second agent loop concurrently. We rely
- * primarily on the single-flight chain above to serialize *wakes*; this
- * extra check catches the case where a user turn started independently
- * while our wake was queued.
+ * How long a wake waits for an in-flight turn to release the conversation's
+ * processing lock before skipping with reason "timeout". We rely primarily
+ * on the single-flight chain above to serialize *wakes*; the pre-run
+ * `waitForIdle` gate catches the case where a user turn started
+ * independently while our wake was queued.
  */
-async function waitUntilIdle(
-  conversation: Conversation,
-  nowFn: () => number,
-  timeoutMs = 30_000,
-): Promise<boolean> {
-  const deadline = nowFn() + timeoutMs;
-  while (conversation.isProcessing() && nowFn() < deadline) {
-    await new Promise((resolve) => setTimeout(resolve, 50));
-  }
-  return !conversation.isProcessing();
-}
+const WAKE_IDLE_TIMEOUT_MS = 30_000;
 
 function classifyWakeDiskPressurePolicy(opts: WakeOptions): {
   decision: DiskPressureTurnPolicyDecision;
@@ -689,7 +679,13 @@ export async function wakeAgentForOpportunity(
       };
     }
 
-    const idle = await waitUntilIdle(conversation, nowFn);
+    // Wait for any independently started user turn to release the processing
+    // lock so we don't run a second agent loop concurrently. With no abort
+    // signal, waitForIdle never rejects — `false` means the budget elapsed
+    // with the lock still held.
+    const idle = await conversation.waitForIdle({
+      timeoutMs: WAKE_IDLE_TIMEOUT_MS,
+    });
     if (!idle) {
       log.warn(
         { conversationId, source },


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for voice-mode-latency.md.

**Gap:** agent-wake still hand-rolled the 50 ms isProcessing() poll that waitForIdle was built to replace.
**Fix:** waitUntilIdle now delegates to conversation.waitForIdle with identical caller-observable semantics.