### PR TITLE
fix: serialize live-voice finalize requests and count outstanding finalizes in the adapter

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -863,6 +863,110 @@ describe("LiveVoiceSession STT", () => {
     expect(secondContent).not.toContain("first utterance");
   });
 
+  test("holds the next finalize request until the outstanding one settles", async () => {
+    const transcriber = new FinalizingMockStreamingTranscriber();
+    transcriber.respondToFinalize = false;
+    const startVoiceTurn = completingVoiceTurnStarter();
+    const { context, frames } = createContext({ turnDetection: "server_vad" });
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: mock(async () => transcriber),
+      startVoiceTurn,
+      finalizeGraceMs: 25,
+    });
+
+    // Cycle A: released, the provider stays silent, the grace timeout
+    // seals and dispatches it with A's request still outstanding.
+    await session.start();
+    await session.handleBinaryAudio(loudPcmChunk());
+    transcriber.emit({ type: "final", text: "first utterance" });
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(
+      () => frames.filter((frame) => frame.type === "tts_done").length === 1,
+    );
+    expect(transcriber.finalizeCalls).toBe(1);
+
+    // Cycle B releases while A's request is outstanding: B's request must
+    // wait — two in-flight requests can be answered by a single flush and
+    // desync the queue permanently.
+    await session.handleBinaryAudio(loudPcmChunk());
+    transcriber.emit({ type: "final", text: "second utterance" });
+    await session.handleClientFrame({ type: "ptt_release" });
+    expect(transcriber.finalizeCalls).toBe(1);
+
+    // A's answer finally arrives: its stale flush is dropped against A,
+    // and B's request goes out on the pump (the fake answers it
+    // synchronously with "utterance 2").
+    transcriber.emit({ type: "final", text: "stale tail", fromFinalize: true });
+    transcriber.respondToFinalize = true;
+    transcriber.emit({ type: "finalized" });
+    await waitFor(
+      () => frames.filter((frame) => frame.type === "tts_done").length === 2,
+    );
+
+    expect(transcriber.finalizeCalls).toBe(2);
+    expect(startVoiceTurn).toHaveBeenCalledTimes(2);
+    const secondContent = startVoiceTurn.mock.calls[1]?.[0]?.content ?? "";
+    expect(secondContent).toContain("second utterance");
+    expect(secondContent).toContain("utterance 2");
+    expect(secondContent).not.toContain("stale tail");
+    expect(secondContent).not.toContain("first utterance");
+  });
+
+  test("drops a sealed never-requested cycle when the outstanding finalize settles", async () => {
+    const transcriber = new FinalizingMockStreamingTranscriber();
+    transcriber.respondToFinalize = false;
+    const startVoiceTurn = completingVoiceTurnStarter();
+    const { context, frames } = createContext({ turnDetection: "server_vad" });
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: mock(async () => transcriber),
+      startVoiceTurn,
+      finalizeGraceMs: 25,
+    });
+
+    // Cycle A: released, silent provider, grace-sealed and dispatched with
+    // its request outstanding.
+    await session.start();
+    await session.handleBinaryAudio(loudPcmChunk());
+    transcriber.emit({ type: "final", text: "first utterance" });
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(
+      () => frames.filter((frame) => frame.type === "tts_done").length === 1,
+    );
+
+    // Cycle B: releases while A is outstanding (its request never sent),
+    // then its own grace timeout seals and dispatches it too.
+    await session.handleBinaryAudio(loudPcmChunk());
+    transcriber.emit({ type: "final", text: "second utterance" });
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(
+      () => frames.filter((frame) => frame.type === "tts_done").length === 2,
+    );
+    expect(transcriber.finalizeCalls).toBe(1);
+
+    // A's finalized arrives. B is sealed and never sent a request — no
+    // finalized will ever answer it, so the pump drains it without
+    // sending a request for an already-dispatched transcript.
+    transcriber.emit({ type: "finalized" });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(transcriber.finalizeCalls).toBe(1);
+
+    // Cycle C: the request slot is free again — C's request goes out and
+    // its flush is attributed to C.
+    transcriber.respondToFinalize = true;
+    await session.handleBinaryAudio(loudPcmChunk());
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(
+      () => frames.filter((frame) => frame.type === "tts_done").length === 3,
+    );
+
+    expect(transcriber.finalizeCalls).toBe(2);
+    expect(startVoiceTurn).toHaveBeenCalledTimes(3);
+    const thirdContent = startVoiceTurn.mock.calls[2]?.[0]?.content ?? "";
+    expect(thirdContent).toContain("utterance 2");
+    expect(thirdContent).not.toContain("first utterance");
+    expect(thirdContent).not.toContain("second utterance");
+  });
+
   test("falls back to a fresh transcriber when the shared stream closes unexpectedly", async () => {
     const transcribers: FinalizingMockStreamingTranscriber[] = [];
     const resolver = mock(async () => {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -182,6 +182,10 @@ interface UtteranceCycle {
   // The whole cycle (turn included) finalized; the record can no longer
   // accept audio and the session may re-arm over it.
   completed: boolean;
+  // A `Finalize` request for this cycle went out on the shared stream, so
+  // one `finalized` signal is owed to it. At most one queued cycle has
+  // this set at a time — see pumpFinalizeQueue.
+  finalizeRequested: boolean;
   transcriber: StreamingTranscriber | null;
   pendingAudioChunks: Buffer[];
   pendingAudioBytes: number;
@@ -322,16 +326,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // providers without finalizeUtterance, and after an unexpected stream
   // close (the next arm resolves a fresh transcriber).
   private sharedTranscriber: StreamingTranscriber | null = null;
-  // The released cycle whose finalize flush is awaited. Shared-transcriber
-  // partial/final events route here ahead of currentUtterance; kept set
-  // through a grace timeout so a late flush still attributes to (and is
-  // dropped for) the cycle that owns the audio.
   /**
-   * FIFO of cycles with an outstanding finalize request on the shared
+   * FIFO of released cycles awaiting finalize settlement on the shared
    * stream, oldest first. Flush finals and `finalized` signals carry no
-   * request identity, but the provider answers requests in order — so the
-   * queue head owns the next flush/`finalized`, and a stale flush can
-   * never be attributed to a newer cycle's request.
+   * request identity, so at most one `Finalize` request is in flight at a
+   * time (the head's, marked `finalizeRequested` — see pumpFinalizeQueue):
+   * the head owns the next flush/`finalized`, and a stale flush can never
+   * be attributed to a newer cycle's request.
    */
   private finalizeQueue: UtteranceCycle[] = [];
   private finalizeGraceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -472,6 +473,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       released: false,
       assistantTurnStarted: false,
       completed: false,
+      finalizeRequested: false,
       transcriber: null,
       pendingAudioChunks: [],
       pendingAudioBytes: 0,
@@ -891,8 +893,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       guard.speechMs = 0;
       return;
     }
-    guard.speechMs +=
-      (chunk.byteLength / 2 / this.context.startFrame.audio.sampleRate) * 1_000;
+    guard.speechMs += pcm16DurationMs(
+      chunk.byteLength,
+      this.context.startFrame.audio.sampleRate,
+    );
     if (guard.speechMs < this.bargeInMinSpeechMs) {
       return;
     }
@@ -998,7 +1002,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   ): Promise<void> {
     const shared = this.sharedTranscriber;
     if (shared && utterance.transcriber === shared) {
-      await this.finalizeUtteranceForRelease(utterance, shared);
+      await this.finalizeUtteranceForRelease(utterance);
       return;
     }
 
@@ -1025,7 +1029,6 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // that never arrives.
   private async finalizeUtteranceForRelease(
     utterance: UtteranceCycle,
-    shared: StreamingTranscriber,
   ): Promise<void> {
     if (
       utterance.phase === "released" ||
@@ -1036,19 +1039,59 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     utterance.phase = "released";
     this.finalizeQueue.push(utterance);
     this.armFinalizeGraceTimer(utterance);
-    try {
-      shared.finalizeUtterance?.();
-    } catch (err) {
-      log.warn(
-        { err },
-        "Live voice utterance finalize failed; proceeding with the transcript collected so far",
-      );
-      this.clearFinalizeGraceTimer();
-      this.finalizeQueue = this.finalizeQueue.filter((c) => c !== utterance);
-      utterance.phase = "transcriber_closed";
-    }
+    this.pumpFinalizeQueue();
     await this.startAssistantTurnIfReady();
     await this.drainOutboundFrames();
+  }
+
+  // Sends at most one `Finalize` request at a time on the shared stream:
+  // `finalized` carries no request identity, and a provider answering two
+  // overlapping requests with a single flush would desync the FIFO
+  // permanently. While a request is outstanding the queue waits; when the
+  // head settles, cycles that dispatched (grace-sealed) before their
+  // request was ever sent are dropped — no `finalized` will ever answer
+  // them, and their buffered tail arrives as ordinary finals — then the
+  // next awaiting cycle's request goes out.
+  private pumpFinalizeQueue(): void {
+    if (this.finalizeQueue.some((cycle) => cycle.finalizeRequested)) {
+      return;
+    }
+    while (true) {
+      const head = this.finalizeQueue[0];
+      if (!head) {
+        return;
+      }
+      if (head.assistantTurnStarted || head.completed) {
+        this.dropFromFinalizeQueue(head);
+        continue;
+      }
+      const shared = this.sharedTranscriber;
+      if (!shared) {
+        return;
+      }
+      head.finalizeRequested = true;
+      try {
+        shared.finalizeUtterance?.();
+      } catch (err) {
+        log.warn(
+          { err },
+          "Live voice utterance finalize failed; proceeding with the transcript collected so far",
+        );
+        this.dropFromFinalizeQueue(head);
+        if (head.phase === "released") {
+          head.phase = "transcriber_closed";
+        }
+        continue;
+      }
+      return;
+    }
+  }
+
+  private dropFromFinalizeQueue(utterance: UtteranceCycle): void {
+    this.finalizeQueue = this.finalizeQueue.filter((c) => c !== utterance);
+    if (utterance === this.finalizeGraceCycle) {
+      this.clearFinalizeGraceTimer();
+    }
   }
 
   private armFinalizeGraceTimer(utterance: UtteranceCycle): void {
@@ -1214,20 +1257,22 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         return;
       }
       case "finalized": {
-        // Completes the oldest outstanding finalize request, whether or
+        // Completes the head's outstanding finalize request, whether or
         // not its flush final arrived (the provider may omit an empty
         // flush; its own fallback still emits `finalized`).
         const owner = this.finalizeQueue.shift() ?? null;
         if (owner && owner === this.finalizeGraceCycle) {
           this.clearFinalizeGraceTimer();
         }
-        if (!owner) {
-          return;
-        }
-        if (owner.phase === "released") {
+        if (owner && owner.phase === "released") {
           // In persistent mode "transcriber_closed" means the cycle's
           // transcript is complete — the shared stream stays open.
           owner.phase = "transcriber_closed";
+        }
+        // The request slot is free again: send the next awaiting cycle's.
+        this.pumpFinalizeQueue();
+        if (!owner) {
+          return;
         }
         await this.startAssistantTurnIfReady();
         return;
@@ -1857,11 +1902,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // Extend the client playback-tail estimate by this chunk's PCM
       // duration (chunks queue gaplessly client-side, so the tail grows
       // from whichever is later: now or the current estimate).
-      const chunkMs =
-        (Buffer.byteLength(chunk.dataBase64, "base64") /
-          2 /
-          chunk.sampleRate) *
-        1_000;
+      const chunkMs = pcm16DurationMs(
+        Buffer.byteLength(chunk.dataBase64, "base64"),
+        chunk.sampleRate,
+      );
       const now = Date.now();
       this.assistantPlaybackTailUntilMs =
         Math.max(now, this.assistantPlaybackTailUntilMs) + chunkMs;
@@ -2390,6 +2434,11 @@ function takeBufferedAudio(chunks: Buffer[]): Buffer | null {
   return audio.byteLength > 0 ? audio : null;
 }
 
+// Duration (ms) of PCM16 mono audio: 2 bytes per sample.
+function pcm16DurationMs(byteLength: number, sampleRate: number): number {
+  return (byteLength / 2 / sampleRate) * 1_000;
+}
+
 function estimatePcmDurationMs(input: {
   byteLength: number;
   mimeType: string;
@@ -2403,10 +2452,7 @@ function estimatePcmDurationMs(input: {
     return undefined;
   }
 
-  const bytesPerMonoSample = 2;
-  return Math.round(
-    (input.byteLength / (input.sampleRate * bytesPerMonoSample)) * 1000,
-  );
+  return Math.round(pcm16DurationMs(input.byteLength, input.sampleRate));
 }
 
 function unavailableTranscriberMessage(): string {

--- a/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
@@ -827,6 +827,71 @@ describe("DeepgramRealtimeTranscriber", () => {
       ]);
     });
 
+    test("overlapping requests each emit final then finalized, in order", async () => {
+      const { transcriber, events } = await startSession();
+
+      transcriber.finalizeUtterance();
+      transcriber.finalizeUtterance();
+      const textMessages = mockWs.sentData.filter((d) => typeof d === "string");
+      expect(textMessages).toHaveLength(2);
+      expect(events).toHaveLength(0);
+
+      mockWs.simulateMessage(
+        resultsFrame("flush one", { is_final: true, from_finalize: true }),
+      );
+      mockWs.simulateMessage(
+        resultsFrame("flush two", { is_final: true, from_finalize: true }),
+      );
+
+      expect(events).toEqual([
+        {
+          type: "final",
+          text: "flush one",
+          confidence: 0.95,
+          fromFinalize: true,
+        },
+        { type: "finalized" },
+        {
+          type: "final",
+          text: "flush two",
+          confidence: 0.95,
+          fromFinalize: true,
+        },
+        { type: "finalized" },
+      ]);
+    });
+
+    test("fallback emits one finalized per outstanding request when both flushes are omitted", async () => {
+      const { transcriber, events } = await startSession({
+        finalizeFallbackMs: 20,
+      });
+
+      transcriber.finalizeUtterance();
+      transcriber.finalizeUtterance();
+      expect(events).toHaveLength(0);
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(events).toEqual([{ type: "finalized" }, { type: "finalized" }]);
+    });
+
+    test("teardown drains every outstanding finalize before closed", async () => {
+      const { transcriber, events } = await startSession({
+        finalizeFallbackMs: 60_000,
+      });
+
+      transcriber.finalizeUtterance();
+      transcriber.finalizeUtterance();
+      transcriber.stop();
+      mockWs.simulateClose(1000, "normal");
+
+      const types = events.map((e) => e.type);
+      expect(types.filter((t) => t === "finalized")).toHaveLength(2);
+      expect(types.indexOf("closed")).toBeGreaterThan(
+        types.lastIndexOf("finalized"),
+      );
+    });
+
     test("stop() teardown path is unchanged after a finalize cycle", async () => {
       const { transcriber, events } = await startSession();
 

--- a/assistant/src/providers/speech-to-text/deepgram-realtime.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.ts
@@ -312,18 +312,22 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
   private closed = false;
 
   /**
-   * Whether a `Finalize` control frame is in flight — armed when
-   * {@link finalizeUtterance} sends the frame, cleared when the
-   * resulting `from_finalize` flush emits the `finalized` event. Keeps
-   * `finalized` emitted at most once per finalize request.
+   * Number of `Finalize` control frames in flight — incremented when
+   * {@link finalizeUtterance} sends a frame, decremented when a
+   * `from_finalize` flush (or the fallback timer) emits its `finalized`
+   * event. Deepgram answers requests in order, so each settlement pairs
+   * with the oldest outstanding request; counting keeps `finalized`
+   * emitted exactly once per request even when requests overlap.
    */
-  private finalizePending = false;
+  private outstandingFinalizes = 0;
 
   /**
-   * Fallback timer for an in-flight Finalize. Deepgram omits the
+   * Fallback timer for in-flight Finalize requests. Deepgram omits the
    * `from_finalize` flush when nothing significant is buffered, so this
    * timer emits `finalized` after {@link FINALIZE_FALLBACK_MS} to keep the
-   * completion contract. Cleared when the flush arrives or on cleanup.
+   * completion contract, re-arming while requests remain outstanding.
+   * Cleared when a flush arrives (and re-armed if more are pending) or on
+   * cleanup.
    */
   private finalizeFallbackTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -462,8 +466,9 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
    * flushing buffered audio as a Results frame with `from_finalize: true`
    * (possibly with an empty transcript). The adapter emits the resulting
    * `final` (when non-empty) followed by one `finalized` event, and the
-   * stream stays open for more audio. When the socket is not open there
-   * is nothing buffered provider-side, so `finalized` is emitted
+   * stream stays open for more audio. Overlapping requests are answered
+   * in order — one `finalized` per request. When the socket is not open
+   * there is nothing buffered provider-side, so `finalized` is emitted
    * immediately. {@link stop} remains the session-teardown path.
    */
   finalizeUtterance(): void {
@@ -481,16 +486,8 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
       this.emitEvent({ type: "finalized" });
       return;
     }
-    this.finalizePending = true;
-    if (this.finalizeFallbackTimer !== null) {
-      clearTimeout(this.finalizeFallbackTimer);
-    }
-    this.finalizeFallbackTimer = setTimeout(() => {
-      log.debug(
-        "Deepgram sent no from_finalize flush — emitting finalized fallback",
-      );
-      this.emitFinalizedIfPending();
-    }, this.finalizeFallbackMs);
+    this.outstandingFinalizes += 1;
+    this.armFinalizeFallbackTimer();
   }
 
   stop(): void {
@@ -692,7 +689,7 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
     }
 
     if (fromFinalize) {
-      this.emitFinalizedIfPending();
+      this.settleOneFinalize();
     }
   }
 
@@ -780,18 +777,46 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
   }
 
   /**
-   * Emit the `finalized` event for an in-flight {@link finalizeUtterance}
-   * request. No-op unless a Finalize frame is pending, so `finalized` is
-   * emitted at most once per request.
+   * Emit `finalized` for the oldest in-flight {@link finalizeUtterance}
+   * request and re-arm the fallback timer while more remain outstanding.
+   * No-op when no request is in flight, so `finalized` is emitted at most
+   * once per request.
    */
-  private emitFinalizedIfPending(): void {
+  private settleOneFinalize(): void {
+    this.clearFinalizeFallbackTimer();
+    if (this.outstandingFinalizes === 0) {
+      return;
+    }
+    this.outstandingFinalizes -= 1;
+    this.emitEvent({ type: "finalized" });
+    if (this.outstandingFinalizes > 0) {
+      this.armFinalizeFallbackTimer();
+    }
+  }
+
+  /**
+   * (Re)arm the fallback timer that emits `finalized` when Deepgram
+   * omits the `from_finalize` flush for an in-flight Finalize request.
+   */
+  private armFinalizeFallbackTimer(): void {
+    if (this.closed) {
+      return;
+    }
+    this.clearFinalizeFallbackTimer();
+    this.finalizeFallbackTimer = setTimeout(() => {
+      this.finalizeFallbackTimer = null;
+      log.debug(
+        "Deepgram sent no from_finalize flush — emitting finalized fallback",
+      );
+      this.settleOneFinalize();
+    }, this.finalizeFallbackMs);
+  }
+
+  private clearFinalizeFallbackTimer(): void {
     if (this.finalizeFallbackTimer !== null) {
       clearTimeout(this.finalizeFallbackTimer);
       this.finalizeFallbackTimer = null;
     }
-    if (!this.finalizePending) return;
-    this.finalizePending = false;
-    this.emitEvent({ type: "finalized" });
   }
 
   /**
@@ -808,9 +833,12 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
     this.forceClose();
 
     this.flushPendingUtterance();
-    // A Finalize with no flush response must still complete before the
-    // stream reports closed, so waiters see finalized → closed in order.
-    this.emitFinalizedIfPending();
+    // Every Finalize with no flush response must still complete before
+    // the stream reports closed, so waiters see one finalized per request
+    // followed by closed, in order.
+    while (this.outstandingFinalizes > 0) {
+      this.settleOneFinalize();
+    }
     this.emitEvent({ type: "closed" });
     this.onEvent = null;
   }
@@ -847,10 +875,7 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
       clearInterval(this.keepaliveTimer);
       this.keepaliveTimer = null;
     }
-    if (this.finalizeFallbackTimer !== null) {
-      clearTimeout(this.finalizeFallbackTimer);
-      this.finalizeFallbackTimer = null;
-    }
+    this.clearFinalizeFallbackTimer();
   }
 
   /**


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for voice-mode-latency.md.

**Gap:** overlapping finalize requests desync the finalize FIFO permanently (one finalized for two requests).
**Fix:** the session sends at most one Finalize at a time (queue pump on head settle; sealed-unsent cycles drain without a request), and the Deepgram adapter tracks outstanding finalizes as a counter with per-request fallback and teardown draining.