### PR TITLE
feat(gateway): overlay the resolved guardian label on native contact reads

### DIFF
--- a/assistant/src/ipc/assistant-server.ts
+++ b/assistant/src/ipc/assistant-server.ts
@@ -58,6 +58,7 @@ import {
 import { CONTACTS_INFO_IPC_METHODS } from "./routes/contacts-info-ipc-routes.js";
 import { CONTACTS_MIRROR_IPC_METHODS } from "./routes/contacts-mirror-ipc-routes.js";
 import { type DbProxyParams, handleDbProxy } from "./routes/db-proxy.js";
+import { GUARDIAN_LABEL_IPC_METHODS } from "./routes/guardian-label-ipc-routes.js";
 import { INVITE_IPC_METHODS } from "./routes/invite-ipc-routes.js";
 import { routeDefinitionsToIpcMethods } from "./routes/route-adapter.js";
 import { ensureSocketPathFree } from "./socket-cleanup.js";
@@ -224,6 +225,16 @@ export class AssistantIpcServer {
     // gateway-owned ACL write. No HTTP surface; never in ROUTES.
     for (const [operationId, handler] of Object.entries(
       CONTACTS_MIRROR_IPC_METHODS,
+    )) {
+      this.methods.set(operationId, handler);
+    }
+
+    // IPC-only guardian-label method (see ipc/routes/guardian-label-ipc-routes.ts).
+    // The gateway calls this to resolve the guardian's display label (persona
+    // preferred name) for its native contact reads. No HTTP surface; never in
+    // ROUTES.
+    for (const [operationId, handler] of Object.entries(
+      GUARDIAN_LABEL_IPC_METHODS,
     )) {
       this.methods.set(operationId, handler);
     }

--- a/assistant/src/ipc/routes/__tests__/guardian-label-ipc-routes.test.ts
+++ b/assistant/src/ipc/routes/__tests__/guardian-label-ipc-routes.test.ts
@@ -1,0 +1,75 @@
+/**
+ * The gateway-facing guardian-label method is IPC-only: registered on the
+ * assistant IPC server by operationId and absent from the shared HTTP route
+ * set. The persona content is driven through a persona-resolver mock so the
+ * tests exercise the real `resolveGuardianName` priority chain without disk.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Mutable persona content — the value `resolveGuardianPersonaStrict()`
+// returns (comment-stripped string, or null when no guardian / missing file).
+let mockGuardianPersona: string | null = null;
+
+// Snapshot-spread the real module so untouched exports (used elsewhere in the
+// import chain) stay intact.
+const actualPersonaResolver = await import(
+  "../../../prompts/persona-resolver.js"
+);
+mock.module("../../../prompts/persona-resolver.js", () => ({
+  ...actualPersonaResolver,
+  resolveGuardianPersona: () => mockGuardianPersona,
+  resolveGuardianPersonaStrict: () => mockGuardianPersona,
+}));
+
+const { GUARDIAN_LABEL_IPC_METHODS, handleResolveGuardianLabel } =
+  await import("../guardian-label-ipc-routes.js");
+const { ROUTES: contactRoutes } = await import(
+  "../../../runtime/routes/contact-routes.js"
+);
+
+describe("resolve_guardian_label", () => {
+  beforeEach(() => {
+    mockGuardianPersona = null;
+  });
+
+  test("is reachable on the IPC surface by operationId", () => {
+    expect(typeof GUARDIAN_LABEL_IPC_METHODS.resolve_guardian_label).toBe(
+      "function",
+    );
+  });
+
+  test("is NOT in the shared contact ROUTES array", () => {
+    const sharedIds = new Set(contactRoutes.map((r) => r.operationId));
+    expect(sharedIds.has("resolve_guardian_label")).toBe(false);
+  });
+
+  test("returns the persona preferred name when present", () => {
+    mockGuardianPersona = "- Preferred name/reference: John\n";
+    expect(
+      handleResolveGuardianLabel({ body: { storedDisplayName: "Stored" } }),
+    ).toEqual({ label: "John" });
+  });
+
+  test("falls back to the stored displayName when no preferred name is set", () => {
+    mockGuardianPersona = "- Preferred name/reference:\n";
+    expect(
+      handleResolveGuardianLabel({ body: { storedDisplayName: "Stored" } }),
+    ).toEqual({ label: "Stored" });
+  });
+
+  test("falls back to the default reference when neither is set", () => {
+    expect(handleResolveGuardianLabel({ body: {} })).toEqual({
+      label: "my human",
+    });
+    expect(
+      handleResolveGuardianLabel({ body: { storedDisplayName: null } }),
+    ).toEqual({ label: "my human" });
+  });
+
+  test("rejects a non-string storedDisplayName", () => {
+    expect(() =>
+      handleResolveGuardianLabel({ body: { storedDisplayName: 42 } }),
+    ).toThrow();
+  });
+});

--- a/assistant/src/ipc/routes/guardian-label-ipc-routes.ts
+++ b/assistant/src/ipc/routes/guardian-label-ipc-routes.ts
@@ -1,0 +1,42 @@
+/**
+ * IPC-only guardian display-label method called by the gateway over the
+ * assistant IPC socket (`ipcCallAssistant`).
+ *
+ * The gateway's native contact reads serve rows from the gateway DB, but the
+ * guardian's display label is derived from assistant-side state (the guardian
+ * persona file's preferred name). This method exposes that resolution so the
+ * gateway can present the same guardian label the daemon's read relay does.
+ *
+ * Like the other gateway-facing methods here, it has no HTTP surface: it is
+ * registered directly on the IPC server (see `assistant-server.ts`) and never
+ * enters the shared `ROUTES` array.
+ */
+
+import { z } from "zod";
+
+import { resolveGuardianName } from "../../prompts/user-reference.js";
+import type { RouteHandlerArgs } from "../../runtime/routes/types.js";
+
+const ResolveGuardianLabelParamsSchema = z.object({
+  storedDisplayName: z.string().nullable().optional(),
+});
+
+/**
+ * Resolve the guardian's display label: the persona-file preferred name when
+ * set, else the stored displayName, else the default user reference.
+ */
+export function handleResolveGuardianLabel({ body = {} }: RouteHandlerArgs) {
+  const { storedDisplayName } = ResolveGuardianLabelParamsSchema.parse(body);
+  return { label: resolveGuardianName(storedDisplayName ?? null) };
+}
+
+/**
+ * IPC-only guardian-label methods, keyed by IPC operationId. Registered
+ * directly on the assistant IPC server (see `assistant-server.ts`).
+ */
+export const GUARDIAN_LABEL_IPC_METHODS: Record<
+  string,
+  (args: RouteHandlerArgs) => unknown
+> = {
+  resolve_guardian_label: handleResolveGuardianLabel,
+};

--- a/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
@@ -2,6 +2,7 @@ import {
   describe,
   test,
   expect,
+  jest,
   mock,
   afterEach,
   beforeAll,
@@ -1106,6 +1107,39 @@ describe("guardian label overlay (gateway-native reads)", () => {
     const body = await res.json();
     expect(body.contact.displayName).toBe("Preferred Name");
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("list: slow IPC is bounded — the stored displayName is served promptly", async () => {
+    contactStoreListMock = mock(async () => [GUARDIAN_CONTACT]);
+    ipcCallAssistantMock = mock(() => new Promise<never>(() => {}));
+
+    jest.useFakeTimers();
+    try {
+      const handler = createContactsControlPlaneProxyHandler(makeConfig());
+      const resPromise = handler.handleListContacts(
+        new Request("http://localhost:7830/v1/contacts"),
+      );
+      // Flush microtasks so the bounded lookup registers its timeout, then
+      // fire it — the never-resolving IPC must not stall the response.
+      for (let i = 0; i < 50; i++) await Promise.resolve();
+      jest.advanceTimersByTime(2_000);
+      const res = await resPromise;
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.contacts[0].displayName).toBe("Stored Guardian");
+
+      // The fallback is negative-cached: a follow-up read serves the stored
+      // name without re-probing the wedged daemon.
+      const res2 = await handler.handleListContacts(
+        new Request("http://localhost:7830/v1/contacts"),
+      );
+      const body2 = await res2.json();
+      expect(body2.contacts[0].displayName).toBe("Stored Guardian");
+      expect(ipcCallAssistantMock).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   test("get: IPC failure soft-fails to the stored displayName (no proxy fallback)", async () => {

--- a/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
@@ -375,7 +375,7 @@ mock.module("../verification/invite-redemption.js", () => ({
     null,
 }));
 
-const { createContactsControlPlaneProxyHandler } =
+const { createContactsControlPlaneProxyHandler, bustGuardianLabelCache } =
   await import("../http/routes/contacts-control-plane-proxy.js");
 
 // The delete-contact guard reads the guardian role from the gateway DB (source
@@ -422,6 +422,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
 }
 
 afterEach(() => {
+  bustGuardianLabelCache();
   fetchMock = mock(async () => new Response());
   assistantDbQueryMock = mock(async () => []);
   assistantDbRunMock = mock(async () => ({ changes: 1, lastInsertRowid: 0 }));
@@ -1009,6 +1010,120 @@ describe("handleListContacts (gateway-native)", () => {
 
     const body = await res.json();
     expect(body.contacts[0].channels[0].externalUserId).toBe("@alice");
+  });
+});
+
+describe("guardian label overlay (gateway-native reads)", () => {
+  const GUARDIAN_CONTACT = {
+    ...DEFAULT_MOCK_CONTACT,
+    id: "ct_guardian",
+    displayName: "Stored Guardian",
+    role: "guardian",
+  };
+
+  test("list: guardian rows get the daemon-resolved label; others untouched", async () => {
+    contactStoreListMock = mock(async () => [
+      GUARDIAN_CONTACT,
+      { ...DEFAULT_MOCK_CONTACT, id: "ct_friend", displayName: "Friend" },
+    ]);
+    ipcCallAssistantMock = mock(async (method: string) =>
+      method === "resolve_guardian_label" ? { label: "Preferred Name" } : {},
+    );
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleListContacts(
+      new Request("http://localhost:7830/v1/contacts"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.contacts[0].displayName).toBe("Preferred Name");
+    expect(body.contacts[1].displayName).toBe("Friend");
+    expect(ipcCallAssistantMock).toHaveBeenCalledWith(
+      "resolve_guardian_label",
+      { body: { storedDisplayName: "Stored Guardian" } },
+    );
+  });
+
+  test("list: IPC failure soft-fails to the stored displayName", async () => {
+    contactStoreListMock = mock(async () => [GUARDIAN_CONTACT]);
+    ipcCallAssistantMock = mock(async () => {
+      throw new Error("daemon unreachable");
+    });
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleListContacts(
+      new Request("http://localhost:7830/v1/contacts"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.contacts[0].displayName).toBe("Stored Guardian");
+  });
+
+  test("list: no IPC call when the page has no guardian row", async () => {
+    contactStoreListMock = mock(async () => [
+      { ...DEFAULT_MOCK_CONTACT, id: "ct_friend", displayName: "Friend" },
+    ]);
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    await handler.handleListContacts(
+      new Request("http://localhost:7830/v1/contacts"),
+    );
+
+    expect(ipcCallAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("list: resolved label is cached across reads (single IPC round-trip)", async () => {
+    contactStoreListMock = mock(async () => [GUARDIAN_CONTACT]);
+    ipcCallAssistantMock = mock(async () => ({ label: "Preferred Name" }));
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    await handler.handleListContacts(
+      new Request("http://localhost:7830/v1/contacts"),
+    );
+    const res = await handler.handleListContacts(
+      new Request("http://localhost:7830/v1/contacts"),
+    );
+
+    const body = await res.json();
+    expect(body.contacts[0].displayName).toBe("Preferred Name");
+    expect(ipcCallAssistantMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("get: guardian contact gets the daemon-resolved label", async () => {
+    contactStoreGetMock = mock(async () => GUARDIAN_CONTACT);
+    ipcCallAssistantMock = mock(async () => ({ label: "Preferred Name" }));
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleGetContact(
+      new Request("http://localhost:7830/v1/contacts/ct_guardian"),
+      "ct_guardian",
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.contact.displayName).toBe("Preferred Name");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("get: IPC failure soft-fails to the stored displayName (no proxy fallback)", async () => {
+    contactStoreGetMock = mock(async () => GUARDIAN_CONTACT);
+    ipcCallAssistantMock = mock(async () => {
+      throw new Error("daemon unreachable");
+    });
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleGetContact(
+      new Request("http://localhost:7830/v1/contacts/ct_guardian"),
+      "ct_guardian",
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.contact.displayName).toBe("Stored Guardian");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });
 

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -628,9 +628,24 @@ function toContactPayload(c: ContactWithInfo): Record<string, unknown> {
  */
 const GUARDIAN_LABEL_TTL_MS = 5 * 60 * 1000;
 
+/**
+ * Bound on the best-effort label IPC so a wedged daemon cannot add a long
+ * stall to contact reads just to decorate a cosmetic label.
+ */
+const GUARDIAN_LABEL_IPC_TIMEOUT_MS = 1500;
+
+/**
+ * Short TTL on fallback (failed/timed-out) resolutions so a wedged daemon is
+ * not re-probed on every read, but recovers quickly once healthy.
+ */
+const GUARDIAN_LABEL_FALLBACK_TTL_MS = 30 * 1000;
+
+const GUARDIAN_LABEL_IPC_TIMED_OUT = Symbol("guardian-label-ipc-timed-out");
+
 let guardianLabelCache: {
   storedDisplayName: string | null;
-  label: string;
+  label: string | null;
+  ttlMs: number;
   at: number;
 } | null = null;
 
@@ -642,9 +657,9 @@ export function bustGuardianLabelCache(): void {
 /**
  * Resolve the guardian's display label via the `resolve_guardian_label`
  * daemon IPC (persona preferred name → stored displayName → default
- * reference), cached with a short TTL. Best-effort: any IPC failure or
- * malformed response serves the stored displayName unchanged — a contact
- * read never fails because the daemon is unreachable.
+ * reference), cached with a short TTL. Best-effort: any IPC failure, slow
+ * response, or malformed response serves the stored displayName unchanged —
+ * a contact read never fails or stalls because the daemon is unreachable.
  */
 async function resolveGuardianLabelCached(
   storedDisplayName: string | null,
@@ -653,27 +668,60 @@ async function resolveGuardianLabelCached(
   if (
     guardianLabelCache &&
     guardianLabelCache.storedDisplayName === storedDisplayName &&
-    now - guardianLabelCache.at < GUARDIAN_LABEL_TTL_MS
+    now - guardianLabelCache.at < guardianLabelCache.ttlMs
   ) {
     return guardianLabelCache.label;
   }
+  let timer: ReturnType<typeof setTimeout> | undefined;
   try {
-    const result = (await ipcCallAssistant("resolve_guardian_label", {
+    const ipc = ipcCallAssistant("resolve_guardian_label", {
       body: { storedDisplayName },
-    })) as { label?: unknown } | null;
-    if (typeof result?.label === "string" && result.label.trim()) {
-      guardianLabelCache = { storedDisplayName, label: result.label, at: now };
-      return result.label;
+    });
+    // The timeout may win the race; never let the losing IPC promise reject
+    // unhandled.
+    ipc.catch(() => {});
+    const raced = await Promise.race([
+      ipc,
+      new Promise<typeof GUARDIAN_LABEL_IPC_TIMED_OUT>((resolve) => {
+        timer = setTimeout(
+          () => resolve(GUARDIAN_LABEL_IPC_TIMED_OUT),
+          GUARDIAN_LABEL_IPC_TIMEOUT_MS,
+        );
+      }),
+    ]);
+    if (raced === GUARDIAN_LABEL_IPC_TIMED_OUT) {
+      log.warn(
+        "resolve_guardian_label: daemon resolve timed out (best-effort)",
+      );
+    } else {
+      const result = raced as { label?: unknown } | null;
+      if (typeof result?.label === "string" && result.label.trim()) {
+        guardianLabelCache = {
+          storedDisplayName,
+          label: result.label,
+          ttlMs: GUARDIAN_LABEL_TTL_MS,
+          at: now,
+        };
+        return result.label;
+      }
+      log.warn(
+        "resolve_guardian_label: daemon response missing label (best-effort)",
+      );
     }
-    log.warn(
-      "resolve_guardian_label: daemon response missing label (best-effort)",
-    );
   } catch (err) {
     log.warn(
       { err },
       "resolve_guardian_label: daemon resolve failed (best-effort)",
     );
+  } finally {
+    if (timer) clearTimeout(timer);
   }
+  guardianLabelCache = {
+    storedDisplayName,
+    label: storedDisplayName,
+    ttlMs: GUARDIAN_LABEL_FALLBACK_TTL_MS,
+    at: now,
+  };
   return storedDisplayName;
 }
 

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -573,9 +573,10 @@ export async function triggerInviteCallNative(
  * UI expects (matching assistant/src/daemon/message-types/contacts.ts).
  *
  * Includes the `withChannelCompat` transform: older macOS clients expect
- * `externalUserId` on each channel (= address). The guardian-name override
- * (`withGuardianNameOverride`) is not applied — it reads the guardian persona
- * file which is assistant-side state, not available to the gateway process.
+ * `externalUserId` on each channel (= address). The guardian display-name
+ * override is not applied here — it derives from the guardian persona file,
+ * which is assistant-side state; the native read handlers layer it on via
+ * `withGuardianLabelOverlay` (daemon IPC).
  */
 function toContactPayload(c: ContactWithInfo): Record<string, unknown> {
   return {
@@ -615,6 +616,84 @@ function toContactPayload(c: ContactWithInfo): Record<string, unknown> {
     })),
   };
 }
+
+// ---------------------------------------------------------------------------
+// Guardian display-name overlay (gateway-native read paths)
+// ---------------------------------------------------------------------------
+
+/**
+ * TTL on the resolved guardian label so a contact list costs at most one
+ * daemon IPC round-trip per window. The label changes only when the guardian
+ * edits their persona preferred name, so short staleness is acceptable.
+ */
+const GUARDIAN_LABEL_TTL_MS = 5 * 60 * 1000;
+
+let guardianLabelCache: {
+  storedDisplayName: string | null;
+  label: string;
+  at: number;
+} | null = null;
+
+/** Drop the cached label so the next read re-resolves over IPC. */
+export function bustGuardianLabelCache(): void {
+  guardianLabelCache = null;
+}
+
+/**
+ * Resolve the guardian's display label via the `resolve_guardian_label`
+ * daemon IPC (persona preferred name → stored displayName → default
+ * reference), cached with a short TTL. Best-effort: any IPC failure or
+ * malformed response serves the stored displayName unchanged — a contact
+ * read never fails because the daemon is unreachable.
+ */
+async function resolveGuardianLabelCached(
+  storedDisplayName: string | null,
+): Promise<string | null> {
+  const now = Date.now();
+  if (
+    guardianLabelCache &&
+    guardianLabelCache.storedDisplayName === storedDisplayName &&
+    now - guardianLabelCache.at < GUARDIAN_LABEL_TTL_MS
+  ) {
+    return guardianLabelCache.label;
+  }
+  try {
+    const result = (await ipcCallAssistant("resolve_guardian_label", {
+      body: { storedDisplayName },
+    })) as { label?: unknown } | null;
+    if (typeof result?.label === "string" && result.label.trim()) {
+      guardianLabelCache = { storedDisplayName, label: result.label, at: now };
+      return result.label;
+    }
+    log.warn(
+      "resolve_guardian_label: daemon response missing label (best-effort)",
+    );
+  } catch (err) {
+    log.warn(
+      { err },
+      "resolve_guardian_label: daemon resolve failed (best-effort)",
+    );
+  }
+  return storedDisplayName;
+}
+
+/**
+ * Overlay the resolved guardian label onto a serialized contact payload so
+ * gateway-native reads present the same guardian displayName as the daemon's
+ * read relay. Non-guardian rows pass through untouched.
+ */
+async function withGuardianLabelOverlay(
+  payload: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  if (payload.role !== "guardian") {
+    return payload;
+  }
+  const stored =
+    typeof payload.displayName === "string" ? payload.displayName : null;
+  const label = await resolveGuardianLabelCached(stored);
+  return label == null ? payload : { ...payload, displayName: label };
+}
+
 const VALID_ASSISTANT_SPECIES = ["vellum"] as const;
 const VALID_CHANNEL_STATUSES = [
   "active",
@@ -1004,7 +1083,9 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
         );
         return Response.json({
           ok: true,
-          contacts: contacts.map(toContactPayload),
+          contacts: await Promise.all(
+            contacts.map((c) => withGuardianLabelOverlay(toContactPayload(c))),
+          ),
         });
       } catch (err) {
         log.error(
@@ -1282,7 +1363,9 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
         log.info({ contactId }, "get_contact: handled natively");
 
         // Match the daemon's response shape: { ok, contact, assistantMetadata }
-        const payload = toContactPayload(contact);
+        const payload = await withGuardianLabelOverlay(
+          toContactPayload(contact),
+        );
         const assistantMetadata =
           contact.contactType === "assistant" && contact.assistantMetadata
             ? {


### PR DESCRIPTION
## Summary
- New daemon IPC-only route resolve_guardian_label exposing resolveGuardianName (USER.md preferred name) to the gateway
- Gateway-native contact list/get reads overlay the guardian row displayName via a cached, soft-fail IPC lookup
- Closes the guardian display-name parity gap between the daemon relay and gateway-native read paths (cloud gets the fix too)

Part of plan: flatten-macos-contact-routes.md (PR 1 of 5)