### PR TITLE
fix: let voice turns wait out the queued-message drain after the idle transition

### DIFF
--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -4,7 +4,10 @@
  * The bridge waits on `conversation.waitForIdle` (event-driven, resolved
  * from `setProcessing(false)`) instead of polling `isProcessing()` every
  * 50 ms, so a barge-in turn starts on the same tick the prior turn releases
- * the lock. The call-controller re-prompt path matches on the exact error
+ * the lock. Because the same transition hands the lock to the prior turn's
+ * queued-message drain, the bridge also re-checks the lock when queued work
+ * is visible and retries a busy persist once — covered by the drain-race
+ * suite below. The call-controller re-prompt path matches on the exact error
  * strings, so those are pinned here too. `waitForIdle`'s own semantics are
  * covered by `src/__tests__/conversation-wait-for-idle.test.ts`.
  */
@@ -54,6 +57,7 @@ interface FakeConversation {
   forcePromptSideEffects: boolean;
   currentRequestId: string | undefined;
   isProcessing: () => boolean;
+  hasQueuedMessages?: () => boolean;
   waitForIdle: (options: WaitForIdleCall) => Promise<boolean>;
   setAssistantId: (id: string) => void;
   setTrustContext: (ctx: unknown) => void;
@@ -76,6 +80,10 @@ function makeFakeConversation(opts: {
   waitForIdle?: (options: WaitForIdleCall) => Promise<boolean>;
   runAgentLoop?: () => Promise<void>;
   events?: string[];
+  /** Mirrors `Conversation.hasQueuedMessages`; undefined models an empty queue. */
+  hasQueuedMessages?: () => boolean;
+  /** Runs before each persist resolves; throw to script a persist failure. */
+  onPersist?: (attempt: number) => void;
 }) {
   const waitForIdleCalls: WaitForIdleCall[] = [];
   let persistCount = 0;
@@ -85,6 +93,7 @@ function makeFakeConversation(opts: {
     forcePromptSideEffects: false,
     currentRequestId: undefined,
     isProcessing: () => opts.processing,
+    hasQueuedMessages: opts.hasQueuedMessages,
     waitForIdle: (options) => {
       waitForIdleCalls.push(options);
       if (!opts.waitForIdle) {
@@ -101,6 +110,7 @@ function makeFakeConversation(opts: {
     setVoiceCallControlPrompt: () => {},
     persistUserMessage: async () => {
       persistCount += 1;
+      opts.onPersist?.(persistCount);
       opts.events?.push("persist");
       return { id: `msg-${persistCount}` };
     },
@@ -355,6 +365,137 @@ describe("startVoiceTurn prior-turn teardown barrier", () => {
     await flushMicrotasks();
     controller.abort();
     await expect(turn2).rejects.toThrow(
+      "Turn aborted while waiting for conversation",
+    );
+    expect(fake.persistCount()).toBe(1);
+  });
+});
+
+describe("startVoiceTurn queued-message drain race", () => {
+  test("a drain that retakes the lock on the idle transition is waited out", async () => {
+    // Models a prior NON-voice turn (no teardown entry) finishing with a
+    // queued text message: the same `finally` that resolves the idle wait
+    // hands the lock straight to `drainQueue`. The barge-in must wait the
+    // drained turn out within its budget — not race the drain's persist or
+    // throw the terminal busy error.
+    let waitCount = 0;
+    const fake = makeFakeConversation({
+      processing: true,
+      hasQueuedMessages: () => waitCount < 2,
+      waitForIdle: async () => {
+        waitCount += 1;
+        if (waitCount === 1) {
+          // The prior turn released, and its queued-message drain retook
+          // the lock in the same window — isProcessing() stays true.
+          return true;
+        }
+        // The drained turn completed; the lock releases for real.
+        fake.setProcessingFlag(false);
+        return true;
+      },
+    });
+    fakeConversation = fake.conversation;
+
+    const handle = await startVoiceTurn(makeTurnOptions());
+
+    expect(handle.turnId).toBeString();
+    expect(fake.waitForIdleCalls.length).toBe(2);
+    expect(fake.persistCount()).toBe(1);
+  });
+
+  test("a persist that loses the lock race to the drain waits and retries once", async () => {
+    // TOCTOU: the wait loop saw an idle conversation with no visible queued
+    // work, but the drain's persist took the lock before this turn's persist
+    // ran. The first persist throws the exact busy error; the bridge waits
+    // for idle again and retries the persist once.
+    const fake = makeFakeConversation({
+      processing: false,
+      waitForIdle: async () => {
+        // The drained turn completes during the retry wait.
+        fake.setProcessingFlag(false);
+        return true;
+      },
+      onPersist: (attempt) => {
+        if (attempt === 1) {
+          fake.setProcessingFlag(true);
+          throw new Error("Conversation is already processing a message");
+        }
+      },
+    });
+    fakeConversation = fake.conversation;
+
+    const persistedIds: string[] = [];
+    const handle = await startVoiceTurn({
+      ...makeTurnOptions(),
+      callbacks: {
+        persisted_user_message_id: (id) => persistedIds.push(id),
+      },
+    });
+
+    expect(handle.turnId).toBeString();
+    expect(fake.persistCount()).toBe(2);
+    expect(fake.waitForIdleCalls.length).toBe(1);
+    // The retried persist's row id is the one reported to the client.
+    expect(persistedIds).toEqual(["msg-2"]);
+  });
+
+  test("a busy persist whose retry wait exhausts the budget throws the exact busy error", async () => {
+    const fake = makeFakeConversation({
+      processing: false,
+      // The retry wait times out — the drained turn holds the lock past
+      // the remaining budget.
+      waitForIdle: async () => false,
+      onPersist: () => {
+        fake.setProcessingFlag(true);
+        throw new Error("Conversation is already processing a message");
+      },
+    });
+    fakeConversation = fake.conversation;
+
+    await expect(startVoiceTurn(makeTurnOptions())).rejects.toThrow(
+      "Conversation is already processing a message",
+    );
+    expect(fake.persistCount()).toBe(1);
+    expect(fake.waitForIdleCalls.length).toBe(1);
+  });
+
+  test("the busy-persist retry happens at most once", async () => {
+    const fake = makeFakeConversation({
+      processing: false,
+      waitForIdle: async () => true,
+      onPersist: () => {
+        throw new Error("Conversation is already processing a message");
+      },
+    });
+    fakeConversation = fake.conversation;
+
+    await expect(startVoiceTurn(makeTurnOptions())).rejects.toThrow(
+      "Conversation is already processing a message",
+    );
+    expect(fake.persistCount()).toBe(2);
+    expect(fake.waitForIdleCalls.length).toBe(1);
+  });
+
+  test("an abort during the busy-persist retry wait throws the turn-aborted error", async () => {
+    const controller = new AbortController();
+    const fake = makeFakeConversation({
+      processing: false,
+      waitForIdle: ({ signal }) =>
+        new Promise<boolean>((_resolve, reject) => {
+          signal?.addEventListener("abort", () => reject(signal.reason), {
+            once: true,
+          });
+        }),
+      onPersist: () => {
+        throw new Error("Conversation is already processing a message");
+      },
+    });
+    fakeConversation = fake.conversation;
+
+    const turnPromise = startVoiceTurn(makeTurnOptions(controller.signal));
+    await flushMicrotasks();
+    controller.abort();
+    await expect(turnPromise).rejects.toThrow(
       "Turn aborted while waiting for conversation",
     );
     expect(fake.persistCount()).toBe(1);

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -73,6 +73,7 @@ import {
   stripInternalSpeechMarkers,
 } from "./voice-control-protocol.js";
 import {
+  CONVERSATION_BUSY_MESSAGE,
   startVoiceTurn,
   type VoiceTurnHandle,
 } from "./voice-session-bridge.js";
@@ -1461,8 +1462,7 @@ export class CallController {
    */
   private isLockContentionError(err: unknown): boolean {
     return (
-      err instanceof Error &&
-      err.message.includes("already processing a message")
+      err instanceof Error && err.message.includes(CONVERSATION_BUSY_MESSAGE)
     );
   }
 

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -35,6 +35,24 @@ import {
 
 const log = getLogger("voice-session-bridge");
 
+/**
+ * Exact message thrown when `opts.signal` aborts while the turn is waiting
+ * for the conversation to become available. The call controller's abort
+ * handling relies on this turn failing with a recognizable error — keep the
+ * value byte-identical across every throw site.
+ */
+export const TURN_ABORTED_WAITING_MESSAGE =
+  "Turn aborted while waiting for conversation";
+
+/**
+ * Exact message thrown when the processing-wait budget elapses without the
+ * conversation becoming available. The call controller's lock-contention
+ * re-prompt matches on this string — keep the value byte-identical across
+ * every throw site.
+ */
+export const CONVERSATION_BUSY_MESSAGE =
+  "Conversation is already processing a message";
+
 const PROCESSING_WAIT_MARGIN_MS = 1000;
 /**
  * How long startVoiceTurn waits for a prior turn to release the processing
@@ -75,7 +93,7 @@ async function waitForPriorTurnTeardown(
   signal?: AbortSignal,
 ): Promise<boolean> {
   if (signal?.aborted) {
-    throw new Error("Turn aborted while waiting for conversation");
+    throw new Error(TURN_ABORTED_WAITING_MESSAGE);
   }
   return await new Promise<boolean>((resolve, reject) => {
     let timer: ReturnType<typeof setTimeout> | null = null;
@@ -88,7 +106,7 @@ async function waitForPriorTurnTeardown(
     };
     const onAbort = () => {
       settleWait();
-      reject(new Error("Turn aborted while waiting for conversation"));
+      reject(new Error(TURN_ABORTED_WAITING_MESSAGE));
     };
     timer = setTimeout(() => {
       settleWait();
@@ -409,17 +427,21 @@ export async function startVoiceTurn(
   );
   const waitStartedAt = Date.now();
 
-  // Two conditions must both clear before this turn may install its
-  // per-turn conversation state, and clearing one can re-raise the other:
+  // Three conditions must all clear before this turn may install its
+  // per-turn conversation state, and clearing one can re-raise another:
   //
   // - The processing lock. `waitForIdle` resolves from the
   //   `setProcessing(false)` transition, so the turn starts on the same
   //   tick the lock releases instead of paying up to a 50 ms poll interval
   //   after every barge-in.
   // - The prior turn's teardown. Its `finally { cleanup() }` runs after
-  //   `setProcessing(false)` (see `pendingTurnTeardowns`), and a queued
-  //   message drained by the prior `runAgentLoop` can retake the lock
-  //   right after that teardown settles.
+  //   `setProcessing(false)` (see `pendingTurnTeardowns`).
+  // - A queued-message drain. The `finally` that releases the lock (waking
+  //   this turn) then calls `drainQueue`, which retakes the lock for any
+  //   queued messages. When queued work is visible after a successful idle
+  //   wait, loop back and wait the drained turn out instead of racing its
+  //   persist; a drain that takes the lock without visible queued work is
+  //   covered by the persist retry below.
   //
   // Hence the re-check loop, bounded by one shared budget. In practice
   // each leg settles within a few microtasks; the bound only guards a
@@ -428,31 +450,46 @@ export async function startVoiceTurn(
   // idle conversation still starts the turn, which the signal wiring below
   // then aborts immediately (pinned by the pre-aborted-signal test).
   let remainingWaitMs = maxWaitMs;
+  const consumeWaitBudget = () => {
+    remainingWaitMs = Math.max(0, maxWaitMs - (Date.now() - waitStartedAt));
+  };
+  /**
+   * Wait for the processing lock to release within the remaining budget.
+   * Maps every exit to the turn's terminal errors: signal abort → the exact
+   * turn-aborted error; timeout or exhausted budget → the exact busy error.
+   */
+  const waitOutProcessingLock = async (): Promise<void> => {
+    if (remainingWaitMs <= 0) {
+      throw new Error(CONVERSATION_BUSY_MESSAGE);
+    }
+    let idle: boolean;
+    try {
+      idle = await conversation.waitForIdle({
+        timeoutMs: remainingWaitMs,
+        signal: opts.signal,
+      });
+    } catch {
+      // waitForIdle rejects only when opts.signal aborted mid-wait.
+      throw new Error(TURN_ABORTED_WAITING_MESSAGE);
+    }
+    if (opts.signal?.aborted) {
+      throw new Error(TURN_ABORTED_WAITING_MESSAGE);
+    }
+    if (!idle) {
+      // Waited the full budget (see resolveProcessingWaitMs) without the
+      // lock releasing, so the prior turn is genuinely wedged. The
+      // controller catches this terminal error and speaks a brief
+      // non-technical re-prompt rather than staying silent.
+      throw new Error(CONVERSATION_BUSY_MESSAGE);
+    }
+    consumeWaitBudget();
+  };
   for (;;) {
     if (conversation.isProcessing()) {
-      let idle: boolean;
-      try {
-        idle = await conversation.waitForIdle({
-          timeoutMs: remainingWaitMs,
-          signal: opts.signal,
-        });
-      } catch {
-        // waitForIdle rejects only when opts.signal aborted mid-wait.
-        throw new Error("Turn aborted while waiting for conversation");
+      await waitOutProcessingLock();
+      if (conversation.hasQueuedMessages?.()) {
+        continue;
       }
-      if (opts.signal?.aborted) {
-        throw new Error("Turn aborted while waiting for conversation");
-      }
-      if (!idle) {
-        // Waited the full budget (see resolveProcessingWaitMs) without the
-        // lock releasing, so the prior turn is genuinely wedged. The
-        // controller catches this terminal error and speaks a brief
-        // non-technical re-prompt rather than staying silent.
-        throw new Error("Conversation is already processing a message");
-      }
-      // A successful idle wait is trusted; fall through to the teardown
-      // leg in the same iteration.
-      remainingWaitMs = Math.max(0, maxWaitMs - (Date.now() - waitStartedAt));
     }
     const priorTeardown = pendingTurnTeardowns.get(opts.conversationId);
     if (priorTeardown) {
@@ -462,9 +499,9 @@ export async function startVoiceTurn(
         opts.signal,
       );
       if (!torndown) {
-        throw new Error("Conversation is already processing a message");
+        throw new Error(CONVERSATION_BUSY_MESSAGE);
       }
-      remainingWaitMs = Math.max(0, maxWaitMs - (Date.now() - waitStartedAt));
+      consumeWaitBudget();
       continue;
     }
     break;
@@ -494,6 +531,13 @@ export async function startVoiceTurn(
 
   const requestId = crypto.randomUUID();
   const turnId = crypto.randomUUID();
+  const persistTurnUserMessage = async (): Promise<string> => {
+    const persistResult = await conversation.persistUserMessage({
+      content: persistedContent,
+      requestId,
+    });
+    return persistResult.id;
+  };
   let messageId: string;
   try {
     conversation.setAssistantId(
@@ -512,11 +556,24 @@ export async function startVoiceTurn(
     );
     conversation.setVoiceCallControlPrompt(voiceCallControlPrompt);
 
-    const persistResult = await conversation.persistUserMessage({
-      content: persistedContent,
-      requestId,
-    });
-    messageId = persistResult.id;
+    try {
+      messageId = await persistTurnUserMessage();
+    } catch (err) {
+      // A queued-message drain can take the lock between the wait loop
+      // above and this persist — the drain reaches its own persist a few
+      // microtasks after the idle transition that released this turn.
+      // Within the remaining budget, wait the drained turn out and retry
+      // the persist once instead of failing the barge-in.
+      if (
+        !(err instanceof Error) ||
+        err.message !== CONVERSATION_BUSY_MESSAGE ||
+        remainingWaitMs <= 0
+      ) {
+        throw err;
+      }
+      await waitOutProcessingLock();
+      messageId = await persistTurnUserMessage();
+    }
   } catch (err) {
     cleanup();
     throw err;


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for voice-mode-latency.md.

**Gap:** the event-driven idle wait wakes on the setProcessing(false) tick and races the same finally-block's drainQueue — a barge-in could drop a queued user message or fail early where the old poll waited it out.
**Fix:** the bridge re-checks the lock after a successful wait and retries an already-processing persist within the remaining budget; error strings hoisted to shared constants.