### PR TITLE
fix(memory): unconditional skill-creation cards + mid-turn retrospective requeue + gate observability

### DIFF
--- a/assistant/src/__tests__/job-handler-registration-guard.test.ts
+++ b/assistant/src/__tests__/job-handler-registration-guard.test.ts
@@ -32,6 +32,7 @@ const MEMORY_JOB_TYPES = [
   "memory_v2_activation_recompute",
   "memory_v3_maintain",
   "memory_retrospective",
+  "skill_card_insert",
   "pkb_filing",
   "pkb_compaction",
 ].sort();

--- a/assistant/src/persistence/jobs-store.ts
+++ b/assistant/src/persistence/jobs-store.ts
@@ -67,6 +67,7 @@ export type MemoryJobType =
   | "purge_conversation_lexical"
   | "delete_message_lexical"
   | "backfill_lexical_index"
+  | "skill_card_insert"
   // Retired/legacy — no live handler; persisted rows drop via LEGACY_JOB_TYPES.
   | "memory_v3_consolidate"
   | "memory_v3_index_maintenance"
@@ -357,6 +358,51 @@ export function upsertMemoryRetrospectiveJob(
     return;
   }
   enqueueMemoryJob("memory_retrospective", payload, runAfter, dbOverride);
+}
+
+/**
+ * Upsert a pending `skill_card_insert` job — the deferred delivery of a
+ * retrospective run's skill card into a source conversation that was mid-turn
+ * at insert time (see `memory-retrospective-skill-card.ts`). Keyed by
+ * `runConversationId`: one pending delivery exists per authoring run, so the
+ * handler's own still-mid-turn re-upsert (and any duplicate enqueue) coalesces
+ * into a single row instead of stacking deliveries — the message-level
+ * `clientMessageId` dedup remains the final backstop against a double card.
+ * The earliest `runAfter` wins, mirroring `upsertMemoryRetrospectiveJob`; the
+ * stored payload is kept as-is since every enqueue for a given run carries the
+ * same snapshot (the skill list is derived from that run's persisted
+ * messages).
+ */
+export function upsertSkillCardInsertJob(
+  payload: {
+    sourceConversationId: string;
+    runConversationId: string;
+  } & Record<string, unknown>,
+  runAfter: number = Date.now(),
+): void {
+  const db = memoryDb();
+  const existing = db
+    .select()
+    .from(memoryJobs)
+    .where(
+      and(
+        eq(memoryJobs.type, "skill_card_insert"),
+        eq(memoryJobs.status, "pending"),
+        sql`json_extract(${memoryJobs.payload}, '$.runConversationId') = ${payload.runConversationId}`,
+      ),
+    )
+    .get();
+  if (existing) {
+    const nextRunAfter = Math.min(existing.runAfter, runAfter);
+    if (nextRunAfter !== existing.runAfter) {
+      db.update(memoryJobs)
+        .set({ runAfter: nextRunAfter, updatedAt: Date.now() })
+        .where(eq(memoryJobs.id, existing.id))
+        .run();
+    }
+    return;
+  }
+  enqueueMemoryJob("skill_card_insert", payload, runAfter);
 }
 
 /**

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
@@ -264,8 +264,20 @@ mock.module("../../../../runtime/agent-wake.js", () => ({
   },
 }));
 
+// Mid-turn fallback requeue recorder (`upsertMemoryRetrospectiveJob` is the
+// same coalescing upsert the enqueue helper uses).
+let retrospectiveJobUpserts: Array<{
+  payload: { conversationId: string };
+  runAfter: number;
+}> = [];
 mock.module("../../../../persistence/jobs-store.js", () => ({
   enqueueMemoryJob: () => "follow-up-job-id",
+  upsertMemoryRetrospectiveJob: (
+    payload: { conversationId: string },
+    runAfter: number,
+  ) => {
+    retrospectiveJobUpserts.push({ payload, runAfter });
+  },
 }));
 
 // proc-to-skills gate. Drives both `buildForkInstruction`'s skill-authoring
@@ -278,7 +290,10 @@ mock.module("../../../../config/memory-v3-gate.js", () => ({
 }));
 
 import type { MemoryJob } from "../../../../persistence/jobs-store.js";
-import { memoryRetrospectiveJob } from "../memory-retrospective-job.js";
+import {
+  memoryRetrospectiveJob,
+  SOURCE_PROCESSING_REQUEUE_DELAY_MS,
+} from "../memory-retrospective-job.js";
 
 function makeConfig(
   overrides: {
@@ -371,6 +386,7 @@ describe("memoryRetrospectiveJob", () => {
     forkedConversationId = "fork-conv-1";
     forkCalls = [];
     addMessageCalls = [];
+    retrospectiveJobUpserts = [];
     conversationOverrides = {};
     messagesByConversationId = {};
     loadedConversations = {};
@@ -736,19 +752,36 @@ describe("memoryRetrospectiveJob", () => {
   });
 
   // -------------------------------------------------------------------------
-  // Mid-turn skip gate
+  // Mid-turn requeue gate
   // -------------------------------------------------------------------------
 
-  test("source mid-turn → skipped outcome, pointer unchanged, lastRunAt bumped, no fork", async () => {
+  test("source mid-turn → skipped outcome, state fully untouched, job re-upserted with the fallback delay, no fork", async () => {
     loadedConversations["src-conv-1"] = { processing: true };
 
+    const before = Date.now();
     const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+    const after = Date.now();
 
     expect(outcome.kind).toBe("source_processing");
-    // `lastProcessedMessageId` untouched — only the cooldown timestamp moves.
+    // BOTH pointers untouched. `lastRunAt` must stay unbumped so the
+    // turn-end message-indexing trigger check re-enqueues immediately (the
+    // primary, event-driven requeue) instead of being cooldown-suppressed —
+    // a fresh single-turn conversation would otherwise burn its first run
+    // forever.
     expect(stateUpserts).toHaveLength(0);
-    expect(lastRunAtBumps).toHaveLength(1);
-    expect(lastRunAtBumps[0]!.conversationId).toBe("src-conv-1");
+    expect(lastRunAtBumps).toHaveLength(0);
+    // Timed fallback row for a turn that aborts without indexing another
+    // message: coalescing re-upsert at the named delay.
+    expect(retrospectiveJobUpserts).toHaveLength(1);
+    expect(retrospectiveJobUpserts[0]!.payload).toEqual({
+      conversationId: "src-conv-1",
+    });
+    expect(retrospectiveJobUpserts[0]!.runAfter).toBeGreaterThanOrEqual(
+      before + SOURCE_PROCESSING_REQUEUE_DELAY_MS,
+    );
+    expect(retrospectiveJobUpserts[0]!.runAfter).toBeLessThanOrEqual(
+      after + SOURCE_PROCESSING_REQUEUE_DELAY_MS,
+    );
     // No fork, no instruction, no wake, no cleanup side effects.
     expect(forkCalls).toHaveLength(0);
     expect(addMessageCalls).toHaveLength(0);
@@ -756,7 +789,7 @@ describe("memoryRetrospectiveJob", () => {
     expect(deletedConversationIds).toEqual([]);
   });
 
-  test("source loaded but idle → normal run", async () => {
+  test("source loaded but idle → normal run, no requeue upsert", async () => {
     loadedConversations["src-conv-1"] = { processing: false };
 
     const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
@@ -765,6 +798,7 @@ describe("memoryRetrospectiveJob", () => {
     expect(forkCalls).toHaveLength(1);
     expect(lastRunAtBumps).toHaveLength(0);
     expect(stateUpserts).toHaveLength(1);
+    expect(retrospectiveJobUpserts).toHaveLength(0);
   });
 
   test("source unloaded (not in registry) → normal run", async () => {

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
@@ -278,6 +278,9 @@ mock.module("../../../../persistence/jobs-store.js", () => ({
   ) => {
     retrospectiveJobUpserts.push({ payload, runAfter });
   },
+  // The skill-card module's mid-turn deferral path; exercised in
+  // memory-retrospective-skill-card.test.ts, inert here.
+  upsertSkillCardInsertJob: () => {},
 }));
 
 // proc-to-skills gate. Drives both `buildForkInstruction`'s skill-authoring

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-skill-card.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-skill-card.test.ts
@@ -162,13 +162,32 @@ mock.module("../../../../prompts/persona-resolver.js", () => ({
   resolveUserSlug: (_trustContext: unknown) => "alice",
 }));
 
+// Optional hook run inside the wake mock, before it reports success. Lets a
+// test flip the source conversation to mid-turn DURING the retrospective run
+// (the real race: a user turn starts while the fork wake is in flight).
+let onWake: (() => void) | null = null;
 mock.module("../../../../runtime/agent-wake.js", () => ({
-  wakeAgentForOpportunity: async (_opts: unknown) => ({ invoked: true }),
+  wakeAgentForOpportunity: async (_opts: unknown) => {
+    onWake?.();
+    return { invoked: true };
+  },
 }));
 
+// Deferred-insert job recorder (`upsertSkillCardInsertJob` is the coalescing
+// upsert the mid-turn branch and the handler's re-upsert both call).
+let skillCardJobUpserts: Array<{
+  payload: Record<string, unknown>;
+  runAfter: number;
+}> = [];
 mock.module("../../../../persistence/jobs-store.js", () => ({
   enqueueMemoryJob: () => "follow-up-job-id",
   upsertMemoryRetrospectiveJob: () => {},
+  upsertSkillCardInsertJob: (
+    payload: Record<string, unknown>,
+    runAfter: number,
+  ) => {
+    skillCardJobUpserts.push({ payload, runAfter });
+  },
 }));
 
 import type { MemoryJob } from "../../../../persistence/jobs-store.js";
@@ -176,6 +195,8 @@ import { memoryRetrospectiveJob } from "../memory-retrospective-job.js";
 import {
   extractRetrospectiveRunSkillScaffolds,
   insertSkillCardMessage,
+  SKILL_CARD_INSERT_RETRY_DELAY_MS,
+  skillCardInsertJob,
 } from "../memory-retrospective-skill-card.js";
 
 // ---------------------------------------------------------------------------
@@ -268,6 +289,23 @@ function makeJob(conversationId = "src-conv-1"): MemoryJob<{
   };
 }
 
+/** A claimed `skill_card_insert` job carrying the given payload. */
+function makeInsertJob(payload: Record<string, unknown>): MemoryJob {
+  return {
+    id: "insert-job-1",
+    type: "skill_card_insert",
+    payload,
+    status: "running",
+    attempts: 0,
+    deferrals: 0,
+    runAfter: 0,
+    lastError: null,
+    startedAt: null,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
 /** Card messages persisted to the given conversation (assistant role). */
 function cardMessagesFor(conversationId: string) {
   return addMessageCalls.filter(
@@ -314,6 +352,8 @@ describe("memory-retrospective skill card", () => {
     messagesByConversationId = {};
     mockFlagEnabled = false;
     mockProcToSkillsActive = false;
+    onWake = null;
+    skillCardJobUpserts = [];
   });
 
   // -------------------------------------------------------------------------
@@ -558,22 +598,31 @@ describe("memory-retrospective skill card", () => {
     expect(publishedConversationIds).toHaveLength(0);
   });
 
-  test("insert still writes the card when the source conversation is mid-turn", async () => {
-    // A skill-created card must land EVERY time a retrospective authors
-    // skills, mid-turn included: the message is provider-safe (fallback text
-    // block; placeholder splice + ensureToolPairing tolerate an assistant
-    // row between tool_use/tool_result) and the accounting excludes card
-    // rows from re-trigger counting.
+  test("mid-turn insert defers: no message is written, a skill_card_insert job is upserted with the full payload", async () => {
+    // A card row landing between a persisted tool_use and its later
+    // tool_result would wedge strict linear-translation providers, so a
+    // mid-turn source must queue the delivery instead of inserting — the
+    // durable job carries everything needed to insert once the turn ends.
     processingConversationIds = ["src-conv-9"];
-
-    await insertSkillCardMessage("src-conv-9", "run-conv-1", [
+    const skills = [
       { skillId: "skill-a", name: "Skill A", description: "Does A" },
-    ]);
+    ];
+    const before = Date.now();
 
-    expect(addMessageCalls).toHaveLength(1);
-    expect(addMessageCalls[0]!.conversationId).toBe("src-conv-9");
-    expect(syncedToDisk).toHaveLength(1);
-    expect(publishedConversationIds).toEqual(["src-conv-9"]);
+    await insertSkillCardMessage("src-conv-9", "run-conv-1", skills);
+
+    expect(addMessageCalls).toHaveLength(0);
+    expect(syncedToDisk).toHaveLength(0);
+    expect(publishedConversationIds).toHaveLength(0);
+    expect(skillCardJobUpserts).toHaveLength(1);
+    expect(skillCardJobUpserts[0]!.payload).toEqual({
+      sourceConversationId: "src-conv-9",
+      runConversationId: "run-conv-1",
+      skills,
+    });
+    expect(skillCardJobUpserts[0]!.runAfter).toBeGreaterThanOrEqual(
+      before + SKILL_CARD_INSERT_RETRY_DELAY_MS,
+    );
   });
 
   test("distinct run ids on the same source produce one card each; a retried run id stays deduped", async () => {
@@ -631,6 +680,128 @@ describe("memory-retrospective skill card", () => {
   });
 
   // -------------------------------------------------------------------------
+  // skillCardInsertJob (deferred delivery handler)
+  // -------------------------------------------------------------------------
+
+  function insertJobPayload(): Record<string, unknown> {
+    return {
+      sourceConversationId: "src-conv-9",
+      runConversationId: "run-conv-1",
+      skills: [
+        {
+          skillId: "skill-a",
+          name: "Skill A",
+          description: "Does A",
+          emoji: "🧭",
+        },
+      ],
+    };
+  }
+
+  test("handler with an idle source inserts the card with the contract shape intact", async () => {
+    await skillCardInsertJob(makeInsertJob(insertJobPayload()));
+
+    expect(addMessageCalls).toHaveLength(1);
+    const call = addMessageCalls[0]!;
+    expect(call.conversationId).toBe("src-conv-9");
+    expect(call.role).toBe("assistant");
+    expect(JSON.parse(call.content)).toEqual([
+      {
+        type: "ui_surface",
+        surfaceId: "skill-card-run-conv-1",
+        surfaceType: "skill_card",
+        title: "New skill learned",
+        display: "inline",
+        data: {
+          skills: [
+            {
+              skillId: "skill-a",
+              name: "Skill A",
+              description: "Does A",
+              emoji: "🧭",
+            },
+          ],
+        },
+      },
+      {
+        type: "text",
+        text: "New skill learned: Skill A",
+        _surfaceFallback: true,
+      },
+    ]);
+    expect(call.options).toEqual({
+      metadata: { kind: "skill-authored-card", automated: true },
+      skipIndexing: true,
+      clientMessageId: "skill-card-run-conv-1",
+    });
+    expect(syncedToDisk).toHaveLength(1);
+    expect(publishedConversationIds).toEqual(["src-conv-9"]);
+    expect(skillCardJobUpserts).toHaveLength(0);
+  });
+
+  test("handler with a still-mid-turn source re-upserts itself at the same delay and inserts nothing", async () => {
+    processingConversationIds = ["src-conv-9"];
+    const before = Date.now();
+
+    await skillCardInsertJob(makeInsertJob(insertJobPayload()));
+
+    expect(addMessageCalls).toHaveLength(0);
+    expect(publishedConversationIds).toHaveLength(0);
+    expect(skillCardJobUpserts).toHaveLength(1);
+    expect(skillCardJobUpserts[0]!.payload).toEqual(insertJobPayload());
+    expect(skillCardJobUpserts[0]!.runAfter).toBeGreaterThanOrEqual(
+      before + SKILL_CARD_INSERT_RETRY_DELAY_MS,
+    );
+  });
+
+  test("handler with a deleted source drops the delivery without re-upserting", async () => {
+    conversationOverrides["gone-conv"] = null;
+
+    await skillCardInsertJob(
+      makeInsertJob({
+        ...insertJobPayload(),
+        sourceConversationId: "gone-conv",
+      }),
+    );
+
+    expect(addMessageCalls).toHaveLength(0);
+    expect(publishedConversationIds).toHaveLength(0);
+    expect(skillCardJobUpserts).toHaveLength(0);
+  });
+
+  test("handler retried after a successful insert is deduped by clientMessageId", async () => {
+    await skillCardInsertJob(makeInsertJob(insertJobPayload()));
+    await skillCardInsertJob(makeInsertJob(insertJobPayload()));
+
+    // The idempotent addMessage runs both times (the second detects the
+    // dup)...
+    expect(addMessageCalls).toHaveLength(2);
+    // ...but the disk-view append and client broadcast fire exactly once.
+    expect(syncedToDisk).toHaveLength(1);
+    expect(publishedConversationIds).toEqual(["src-conv-9"]);
+  });
+
+  test("handler drops a malformed payload without inserting, re-upserting, or throwing", async () => {
+    await skillCardInsertJob(
+      makeInsertJob({ sourceConversationId: "src-conv-9", skills: [] }),
+    );
+
+    expect(addMessageCalls).toHaveLength(0);
+    expect(skillCardJobUpserts).toHaveLength(0);
+  });
+
+  test("handler propagates persistence failures so the jobs worker retries", async () => {
+    // Unlike the best-effort finalize entry point, the deferred handler must
+    // surface transient insert errors to the worker's retry machinery — the
+    // card is only droppable when the source conversation is gone.
+    addMessageThrowsFor = "src-conv-9";
+
+    await expect(
+      skillCardInsertJob(makeInsertJob(insertJobPayload())),
+    ).rejects.toThrow("insert failed for src-conv-9");
+  });
+
+  // -------------------------------------------------------------------------
   // Finalize wiring (flag + proc-to-skills gates), via the job handler
   // -------------------------------------------------------------------------
 
@@ -669,6 +840,39 @@ describe("memory-retrospective skill card", () => {
       _surfaceFallback: true,
     });
     expect(publishedConversationIds).toEqual(["src-conv-1"]);
+  });
+
+  test("a source turn starting during the run defers the finalize card into a skill_card_insert job", async () => {
+    // The real race: the source is idle when the retrospective job starts
+    // (so the run proceeds), but a user turn begins while the fork wake is
+    // in flight. Finalize must queue the card, not splice it into the
+    // in-progress turn's history.
+    mockFlagEnabled = true;
+    mockProcToSkillsActive = true;
+    stageForkTail([
+      scaffoldMsg("tu-1", skillInput("skill-a"), { createdAt: 2000 }),
+      toolResultMsg("tu-1", { createdAt: 2001 }),
+    ]);
+    onWake = () => {
+      processingConversationIds = ["src-conv-1"];
+    };
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), makeConfig());
+
+    expect(outcome.kind).toBe("invoked");
+    expect(cardMessagesFor("src-conv-1")).toHaveLength(0);
+    expect(skillCardJobUpserts).toHaveLength(1);
+    expect(skillCardJobUpserts[0]!.payload).toEqual({
+      sourceConversationId: "src-conv-1",
+      runConversationId: "fork-conv-1",
+      skills: [
+        {
+          skillId: "skill-a",
+          name: "Skill skill-a",
+          description: "Does skill-a",
+        },
+      ],
+    });
   });
 
   test("flag off (default): finalize inserts nothing even when scaffolds occurred", async () => {

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-skill-card.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-skill-card.test.ts
@@ -21,6 +21,9 @@ let addMessageCalls: Array<{
 }> = [];
 let addMessageThrowsFor: string | null = null;
 let addMessageDeduplicatesFor: string | null = null;
+// Mirrors the real persistence layer's `clientMessageId` idempotency: a
+// repeated (conversationId, clientMessageId) pair reports `deduplicated`.
+let seenClientMessageIds = new Set<string>();
 let processingConversationIds: string[] = [];
 
 let syncedToDisk: Array<{
@@ -78,13 +81,24 @@ mock.module("../../../../persistence/conversation-crud.js", () => ({
       throw new Error(`insert failed for ${conversationId}`);
     }
     addMessageCalls.push({ conversationId, role, content, options });
+    const clientMessageId = options?.clientMessageId;
+    const dedupKey =
+      typeof clientMessageId === "string"
+        ? `${conversationId}:${clientMessageId}`
+        : null;
+    const deduplicated =
+      addMessageDeduplicatesFor === conversationId ||
+      (dedupKey !== null && seenClientMessageIds.has(dedupKey));
+    if (dedupKey !== null) {
+      seenClientMessageIds.add(dedupKey);
+    }
     return {
       id: `persisted-msg-${addMessageCalls.length}`,
       conversationId,
       role,
       content,
       createdAt: 42,
-      deduplicated: addMessageDeduplicatesFor === conversationId,
+      deduplicated,
     };
   },
   deleteConversation: (_id: string) => {},
@@ -154,6 +168,7 @@ mock.module("../../../../runtime/agent-wake.js", () => ({
 
 mock.module("../../../../persistence/jobs-store.js", () => ({
   enqueueMemoryJob: () => "follow-up-job-id",
+  upsertMemoryRetrospectiveJob: () => {},
 }));
 
 import type { MemoryJob } from "../../../../persistence/jobs-store.js";
@@ -291,6 +306,7 @@ describe("memory-retrospective skill card", () => {
     addMessageCalls = [];
     addMessageThrowsFor = null;
     addMessageDeduplicatesFor = null;
+    seenClientMessageIds = new Set();
     processingConversationIds = [];
     syncedToDisk = [];
     publishedConversationIds = [];
@@ -542,16 +558,51 @@ describe("memory-retrospective skill card", () => {
     expect(publishedConversationIds).toHaveLength(0);
   });
 
-  test("insert is a no-op when the source conversation is mid-turn", async () => {
+  test("insert still writes the card when the source conversation is mid-turn", async () => {
+    // A skill-created card must land EVERY time a retrospective authors
+    // skills, mid-turn included: the message is provider-safe (fallback text
+    // block; placeholder splice + ensureToolPairing tolerate an assistant
+    // row between tool_use/tool_result) and the accounting excludes card
+    // rows from re-trigger counting.
     processingConversationIds = ["src-conv-9"];
 
     await insertSkillCardMessage("src-conv-9", "run-conv-1", [
       { skillId: "skill-a", name: "Skill A", description: "Does A" },
     ]);
 
-    expect(addMessageCalls).toHaveLength(0);
-    expect(syncedToDisk).toHaveLength(0);
-    expect(publishedConversationIds).toHaveLength(0);
+    expect(addMessageCalls).toHaveLength(1);
+    expect(addMessageCalls[0]!.conversationId).toBe("src-conv-9");
+    expect(syncedToDisk).toHaveLength(1);
+    expect(publishedConversationIds).toEqual(["src-conv-9"]);
+  });
+
+  test("distinct run ids on the same source produce one card each; a retried run id stays deduped", async () => {
+    const skills = [
+      { skillId: "skill-a", name: "Skill A", description: "Does A" },
+    ];
+
+    await insertSkillCardMessage("src-conv-9", "run-conv-1", skills);
+    await insertSkillCardMessage("src-conv-9", "run-conv-2", skills);
+    // Retried finalize of run 1: same clientMessageId → persistence dedups.
+    await insertSkillCardMessage("src-conv-9", "run-conv-1", skills);
+
+    // Multiple cards over a conversation's life are expected — one per
+    // authoring run, keyed by the run-derived clientMessageId.
+    expect(
+      addMessageCalls.map(
+        (c) => (c.options as Record<string, unknown>).clientMessageId,
+      ),
+    ).toEqual([
+      "skill-card-run-conv-1",
+      "skill-card-run-conv-2",
+      "skill-card-run-conv-1",
+    ]);
+    // Only the two distinct runs reach the disk view and client broadcast.
+    expect(syncedToDisk.map((s) => s.messageId)).toEqual([
+      "persisted-msg-1",
+      "persisted-msg-2",
+    ]);
+    expect(publishedConversationIds).toEqual(["src-conv-9", "src-conv-9"]);
   });
 
   test("deduplicated insert (retried finalize) skips disk sync and publish", async () => {

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-trigger-check.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-trigger-check.test.ts
@@ -105,6 +105,36 @@ describe("shouldEnqueueRetrospective", () => {
     expect(result).toBe("interval");
   });
 
+  test("mid-turn job skip leaves lastRunAt unbumped, so the turn-end trigger check fires immediately (event-driven requeue)", () => {
+    // The job's `source_processing` skip does NOT bump `lastRunAt` (see
+    // memory-retrospective-job.ts) precisely so the indexing pass on the
+    // turn's final assistant message re-enqueues with no cooldown block.
+    const now = Date.now();
+
+    // Fresh conversation: the burned first run left no state row at all →
+    // the first-run interval fires as soon as any message indexes.
+    expect(
+      shouldEnqueueRetrospective({
+        state: null,
+        newMessageCount: 1,
+        now,
+        ...THRESHOLDS,
+      }),
+    ).toBe("interval");
+
+    // Established conversation: `lastRunAt` still reflects the run BEFORE
+    // the skipped one, so the same threshold that tripped the skipped
+    // enqueue trips again immediately.
+    expect(
+      shouldEnqueueRetrospective({
+        state: { lastProcessedMessageId: "m1", lastRunAt: now - 31 * 60_000 },
+        newMessageCount: 1,
+        now,
+        ...THRESHOLDS,
+      }),
+    ).toBe("interval");
+  });
+
   test("message threshold prefers 'message_count' label when both could fire (interval also at boundary)", () => {
     // When the interval is also at threshold AND there are also enough
     // new messages, interval wins because it's evaluated first — the

--- a/assistant/src/plugins/defaults/memory/job-handlers.ts
+++ b/assistant/src/plugins/defaults/memory/job-handlers.ts
@@ -41,6 +41,7 @@ import {
 import { embedConceptPageJob } from "./jobs/embed-concept-page.js";
 import { embedPkbFileJob } from "./jobs/embed-pkb-file.js";
 import { memoryRetrospectiveJob } from "./memory-retrospective-job.js";
+import { skillCardInsertJob } from "./memory-retrospective-skill-card.js";
 import {
   memoryV2ActivationRecomputeJob,
   memoryV2MigrateJob,
@@ -209,5 +210,9 @@ export const memoryJobHandlers: readonly JobHandlerEntry[] = [
   {
     type: "memory_retrospective",
     handler: (job, config) => memoryRetrospectiveJob(job, config),
+  },
+  {
+    type: "skill_card_insert",
+    handler: (job) => skillCardInsertJob(job),
   },
 ];

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -681,7 +681,9 @@ async function finalizeSuccessfulRetrospective(args: {
   // source conversation. Gated on proc-to-skills being active (the run can
   // only author skills when it is) AND the `skill-creation-card` flag.
   // `insertSkillCardMessage` is best-effort — a card failure never fails the
-  // job. Every gate outcome logs at info level so a missing card is
+  // job — and defers delivery through a durable `skill_card_insert` job when
+  // the source is mid-turn, so the card still always lands once the turn
+  // ends. Every gate outcome logs at info level so a missing card is
   // one-grep diagnosable in the field ("skill-card:" / "skill card:").
   const procToSkillsActive = isProcToSkillsActive(config);
   const skillCardFlagEnabled = isAssistantFeatureFlagEnabled(

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -28,9 +28,12 @@
 //   - `lastProcessedMessageId` advances ONLY on `result.invoked === true`.
 //     Wake failures keep it unchanged so the next attempt re-processes the
 //     same messages. This is the load-bearing correctness invariant.
-//   - `lastRunAt` advances on EVERY job end (success or failure) via a
-//     `try/finally` write, so the per-conversation cooldown gate applies to
-//     subsequent trigger-driven enqueues.
+//   - `lastRunAt` advances at the end of every job that actually attempted a
+//     run (success or wake failure), so the per-conversation cooldown gate
+//     applies to subsequent trigger-driven enqueues. The mid-turn skip
+//     deliberately leaves it untouched — see the guard in
+//     `runForkBasedRetrospective` — so the turn-end trigger check can
+//     requeue the run immediately instead of burning it.
 //
 // Daemon crash recovery: `resetRunningJobsToPending` (in jobs-store.ts) flips
 // crashed `running` rows back to `pending` at startup. The orphan background
@@ -67,6 +70,7 @@ import {
   enqueueMemoryJob,
   type MemoryJob,
   type MemoryJobType,
+  upsertMemoryRetrospectiveJob,
 } from "../../../persistence/jobs-store.js";
 import { resolveUserSlug } from "../../../prompts/persona-resolver.js";
 import type { SystemPromptPersonaOverride } from "../../../prompts/system-prompt.js";
@@ -102,6 +106,17 @@ const log = getLogger("memory-retrospective-job");
  * touching the handler body.
  */
 const FOLLOW_UP_JOB_TYPES: readonly MemoryJobType[] = [] as const;
+
+/**
+ * Fallback delay for re-upserting a run that was skipped because the source
+ * conversation was mid-turn. The PRIMARY requeue is event-driven: the
+ * mid-turn skip leaves `lastRunAt` unbumped, so the message-indexing pass on
+ * the turn's final assistant message re-enqueues immediately. This timed row
+ * only covers a turn that aborts without ever persisting another message.
+ * Each retried attempt re-checks the processing flag and re-upserts at the
+ * same cadence, so the loop self-resolves when the turn ends.
+ */
+export const SOURCE_PROCESSING_REQUEUE_DELAY_MS = 60_000;
 
 export type MemoryRetrospectiveOutcome =
   | { kind: "disabled" }
@@ -161,17 +176,40 @@ export async function runForkBasedRetrospective(
   // agent loop is still running. Check the persisted `processing_started_at`
   // column (the cross-process source of truth) instead of the in-memory
   // registry, so this guard works even when running in a separate CLI
-  // process with an empty conversation registry. Bump `lastRunAt` so the
-  // cooldown gate applies, leave `lastProcessedMessageId` untouched so the
-  // next interval/message-count trigger re-processes the same messages —
-  // nothing is lost. Returning (not throwing) keeps the jobs-worker from
+  // process with an empty conversation registry.
+  //
+  // The skipped run is RETRIED, not burned. `lastRunAt` is deliberately not
+  // bumped: the message-indexing hook runs the trigger check on every
+  // persisted message — including the turn's final assistant message — so an
+  // unbumped `lastRunAt` lets that turn-end pass re-enqueue with no cooldown
+  // suppression. That is the primary, event-driven requeue: the retrospective
+  // runs right after the colliding turn completes. Mid-turn attempts are
+  // cheap no-ops (existence + processing check) that recur at most once per
+  // persisted message and coalesce into a single pending row via the upsert.
+  // The timed re-upsert below is a fallback for a turn that aborts without
+  // ever indexing another message (the lifecycle/disposal enqueue remains
+  // the last-resort net). Both state pointers stay untouched, so nothing is
+  // lost. Returning (not throwing) keeps the jobs-worker from
   // retry-with-backoff.
   if (isConversationProcessing(sourceConversationId)) {
-    await bumpRetrospectiveLastRunAt(sourceConversationId, Date.now());
-    log.info(
-      { sourceConversationId },
-      "memory-retrospective (fork): source conversation is mid-turn; skipping",
-    );
+    try {
+      upsertMemoryRetrospectiveJob(
+        { conversationId: sourceConversationId },
+        Date.now() + SOURCE_PROCESSING_REQUEUE_DELAY_MS,
+      );
+      log.info(
+        {
+          sourceConversationId,
+          requeueDelayMs: SOURCE_PROCESSING_REQUEUE_DELAY_MS,
+        },
+        "memory-retrospective (fork): source conversation is mid-turn; requeued",
+      );
+    } catch (err) {
+      log.warn(
+        { err, sourceConversationId },
+        "memory-retrospective (fork): mid-turn fallback requeue failed; relying on the turn-end trigger check",
+      );
+    }
     return { kind: "source_processing" };
   }
 
@@ -643,13 +681,24 @@ async function finalizeSuccessfulRetrospective(args: {
   // source conversation. Gated on proc-to-skills being active (the run can
   // only author skills when it is) AND the `skill-creation-card` flag.
   // `insertSkillCardMessage` is best-effort — a card failure never fails the
-  // job.
-  if (
-    isProcToSkillsActive(config) &&
-    isAssistantFeatureFlagEnabled(SKILL_CREATION_CARD_FLAG, config)
-  ) {
+  // job. Every gate outcome logs at info level so a missing card is
+  // one-grep diagnosable in the field ("skill-card:" / "skill card:").
+  const procToSkillsActive = isProcToSkillsActive(config);
+  const skillCardFlagEnabled = isAssistantFeatureFlagEnabled(
+    SKILL_CREATION_CARD_FLAG,
+    config,
+  );
+  if (procToSkillsActive && skillCardFlagEnabled) {
     const authoredSkills = extractRetrospectiveRunSkillScaffolds(
       retrospectiveConversationId,
+    );
+    log.info(
+      {
+        sourceConversationId,
+        retrospectiveConversationId,
+        scaffoldCount: authoredSkills.length,
+      },
+      "skill-card: gate passed; extracted skill scaffolds from the run",
     );
     if (authoredSkills.length > 0) {
       await insertSkillCardMessage(
@@ -658,6 +707,18 @@ async function finalizeSuccessfulRetrospective(args: {
         authoredSkills,
       );
     }
+  } else {
+    log.info(
+      {
+        sourceConversationId,
+        retrospectiveConversationId,
+        procToSkillsActive,
+        skillCardFlagEnabled,
+      },
+      procToSkillsActive
+        ? "skill-card: skipped — skill-creation-card flag off"
+        : "skill-card: skipped — proc-to-skills inactive",
+    );
   }
 
   await deleteSupersededPriorRetrospective(config, prior, sourceConversationId);

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-skill-card.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-skill-card.ts
@@ -11,14 +11,33 @@
 // blocks still send a non-empty assistant turn and flat-text consumers (CLI,
 // search, channel replies) see readable content.
 //
-// Everything here is best-effort: a card failure must never fail the
-// retrospective job.
+// A source conversation that is MID-TURN never gets the card inserted
+// directly — incremental checkpoint persistence writes tool turns to the DB
+// while the agent loop is still running, so a card row could land between a
+// persisted `tool_use` and its later `tool_result`. Providers that translate
+// history linearly (the OpenAI-compatible chat-completions provider) would
+// then emit `assistant(tool_calls) → assistant(text) → tool(...)`, and strict
+// backends reject `tool` messages that don't directly follow their
+// `tool_calls` message — wedging the conversation. Instead, the insert is
+// DEFERRED via a durable `skill_card_insert` job that re-checks on a short
+// cadence and re-upserts itself until the turn ends, so the card is still
+// always delivered (queue-until-turn-end).
+//
+// The finalize entry point (`insertSkillCardMessage`) is best-effort: a card
+// failure must never fail the retrospective job. Once queued, the job handler
+// (`skillCardInsertJob`) lets persistence errors propagate so the jobs
+// worker's retry machinery covers transient failures.
 
 import {
   addMessage,
   getConversation,
+  isConversationProcessing,
 } from "../../../persistence/conversation-crud.js";
 import { syncMessageToDisk } from "../../../persistence/conversation-disk-view.js";
+import {
+  type MemoryJob,
+  upsertSkillCardInsertJob,
+} from "../../../persistence/jobs-store.js";
 import { publishConversationMessagesChanged } from "../../../runtime/sync/resource-sync-events.js";
 import { getLogger } from "../../../util/logger.js";
 import { SKILL_CARD_MESSAGE_KIND } from "./memory-retrospective-constants.js";
@@ -187,24 +206,24 @@ function readScaffoldInput(input: unknown): AuthoredSkill | null {
 }
 
 /**
- * Append the `skill_card` ui_surface message (plus its `_surfaceFallback`
- * text sibling) to the source conversation and notify connected clients. The
- * `surfaceId` (doubling as the insert's idempotency nonce via
- * `clientMessageId`) is derived from the run conversation id, so a retried
- * finalize cannot produce two cards for one run — a deduplicated insert also
- * skips the disk-view sync and client broadcast. Distinct runs get distinct
- * ids, so a conversation accumulates one card per authoring run over its
- * life, by design.
+ * Delay before a deferred `skill_card_insert` job (re-)checks the source
+ * conversation's turn state. Each still-mid-turn attempt re-upserts itself at
+ * this cadence, so the loop self-resolves as soon as the turn ends; there is
+ * no attempt cap because the exit conditions (turn ended → insert, source
+ * deleted → drop) are guaranteed to be reached.
+ */
+export const SKILL_CARD_INSERT_RETRY_DELAY_MS = 30_000;
+
+/**
+ * Insert the skill card into the source conversation — or, when the source is
+ * mid-turn, queue a durable `skill_card_insert` job so the card lands after
+ * the turn ends (see the module header for why a mid-turn insert must never
+ * happen). Delivery is guaranteed once queued; a card is never dropped except
+ * when the source conversation itself no longer exists.
  *
- * Inserts unconditionally with respect to turn state — a source conversation
- * that is mid-turn still gets its card. Mid-turn insertion is safe: the
- * message carries a `_surfaceFallback` text block, the Anthropic client's
- * placeholder splice + `ensureToolPairing` tolerate an assistant row landing
- * between a tool_use and its tool_result, and the retrospective accounting
- * excludes `SKILL_CARD_MESSAGE_KIND` rows from re-trigger counting so the
- * card never wakes another pass. The only skip is a source conversation that
- * no longer exists (deleted mid-run). Best-effort — failures are logged and
- * never thrown.
+ * This finalize entry point is best-effort — failures (insert AND enqueue)
+ * are logged and never thrown, so a card failure never fails the
+ * retrospective job.
  */
 export async function insertSkillCardMessage(
   sourceConversationId: string,
@@ -212,80 +231,10 @@ export async function insertSkillCardMessage(
   skills: AuthoredSkill[],
 ): Promise<void> {
   try {
-    const sourceConversation = getConversation(sourceConversationId);
-    if (!sourceConversation) {
-      log.info(
-        { sourceConversationId, runConversationId },
-        "skill card: source conversation no longer exists; skipping",
-      );
-      return;
-    }
-    const surfaceId = `skill-card-${runConversationId}`;
-    const surfaceBlock = {
-      type: "ui_surface",
-      surfaceId,
-      surfaceType: "skill_card",
-      title: "New skill learned",
-      display: "inline",
-      data: {
-        skills: skills.map((s) => ({
-          skillId: s.skillId,
-          name: s.name,
-          description: s.description,
-          emoji: s.emoji ?? null,
-        })),
-      },
-    };
-    // Plain-text fallback (approval-card pattern): feeds the model, search,
-    // CLI display, and channel replies. Surface-capable clients skip it —
-    // `renderHistoryContent` keeps `_surfaceFallback` text out of the
-    // rendered content blocks so the card is never double-rendered.
-    const fallbackBlock = {
-      type: "text",
-      text: `New skill learned: ${skills.map((s) => s.name).join(", ")}`,
-      _surfaceFallback: true,
-    };
-    const persisted = await addMessage(
+    await insertOrDeferSkillCard(
       sourceConversationId,
-      "assistant",
-      JSON.stringify([surfaceBlock, fallbackBlock]),
-      {
-        metadata: { kind: SKILL_CARD_MESSAGE_KIND, automated: true },
-        skipIndexing: true,
-        clientMessageId: surfaceId,
-      },
-    );
-    if (persisted.deduplicated) {
-      log.info(
-        { sourceConversationId, runConversationId, surfaceId },
-        "skill card: message already exists (deduplicated); skipping sync and publish",
-      );
-      return;
-    }
-    // Mirror `persistWakeTriggerMessage`: keep the conversation's disk view
-    // in sync (its own failure is non-fatal so the client broadcast below
-    // still fires), then tell connected clients the message list changed.
-    try {
-      syncMessageToDisk(
-        sourceConversationId,
-        persisted.id,
-        sourceConversation.createdAt,
-      );
-    } catch (err) {
-      log.warn(
-        { err, sourceConversationId },
-        "skill card: syncMessageToDisk failed (non-fatal)",
-      );
-    }
-    publishConversationMessagesChanged(sourceConversationId);
-    log.info(
-      {
-        sourceConversationId,
-        runConversationId,
-        surfaceId,
-        skillIds: skills.map((s) => s.skillId),
-      },
-      "skill card: inserted into source conversation",
+      runConversationId,
+      skills,
     );
   } catch (err) {
     log.warn(
@@ -293,4 +242,204 @@ export async function insertSkillCardMessage(
       "skill card: failed to insert skill card message; continuing",
     );
   }
+}
+
+/**
+ * Payload of a deferred `skill_card_insert` job. The authored-skill list is
+ * snapshotted at enqueue time: the run conversation may be GC'd as a
+ * superseded prior before the job fires, so the handler must not re-extract
+ * from it.
+ */
+interface SkillCardInsertJobPayload {
+  sourceConversationId: string;
+  runConversationId: string;
+  skills: AuthoredSkill[];
+}
+
+/**
+ * Job handler for `skill_card_insert` (registered in `job-handlers.ts`): the
+ * deferred half of {@link insertSkillCardMessage}. Re-checks the source
+ * conversation — deleted → drop with a log; still mid-turn → re-upsert itself
+ * at {@link SKILL_CARD_INSERT_RETRY_DELAY_MS} (the currently claimed row is
+ * `running`, so the upsert creates a fresh pending row and the attempt
+ * counter never accumulates); idle → insert. A malformed payload is dropped
+ * with a warning. Unlike the finalize entry point, persistence errors
+ * PROPAGATE so the jobs worker's standard retry-with-backoff covers transient
+ * failures; a retried insert after a success is deduplicated by
+ * `clientMessageId`.
+ */
+export async function skillCardInsertJob(job: MemoryJob): Promise<void> {
+  const payload = parseSkillCardInsertPayload(job.payload);
+  if (!payload) {
+    log.warn(
+      { jobId: job.id },
+      "skill card: dropping skill_card_insert job with malformed payload",
+    );
+    return;
+  }
+  await insertOrDeferSkillCard(
+    payload.sourceConversationId,
+    payload.runConversationId,
+    payload.skills,
+  );
+}
+
+/**
+ * Validate a `skill_card_insert` job payload back into its typed shape.
+ * Returns `null` when the ids are missing or the skill list has no
+ * well-formed entry — enqueues always write the full shape, so a miss here
+ * means a corrupted or foreign row that must drop rather than throw (a retry
+ * cannot fix it).
+ */
+function parseSkillCardInsertPayload(
+  payload: Record<string, unknown>,
+): SkillCardInsertJobPayload | null {
+  const { sourceConversationId, runConversationId } = payload;
+  if (
+    typeof sourceConversationId !== "string" ||
+    sourceConversationId.length === 0 ||
+    typeof runConversationId !== "string" ||
+    runConversationId.length === 0 ||
+    !Array.isArray(payload.skills)
+  ) {
+    return null;
+  }
+  const skills: AuthoredSkill[] = [];
+  for (const entry of payload.skills) {
+    if (!entry || typeof entry !== "object") continue;
+    const rec = entry as Record<string, unknown>;
+    if (typeof rec.skillId !== "string" || rec.skillId.length === 0) continue;
+    if (typeof rec.name !== "string" || rec.name.length === 0) continue;
+    skills.push({
+      skillId: rec.skillId,
+      name: rec.name,
+      description: typeof rec.description === "string" ? rec.description : "",
+      ...(typeof rec.emoji === "string" && rec.emoji.length > 0
+        ? { emoji: rec.emoji }
+        : {}),
+    });
+  }
+  if (skills.length === 0) {
+    return null;
+  }
+  return { sourceConversationId, runConversationId, skills };
+}
+
+/**
+ * Shared insert-or-defer core behind both {@link insertSkillCardMessage} and
+ * {@link skillCardInsertJob}. When the source is idle, appends the
+ * `skill_card` ui_surface message (plus its `_surfaceFallback` text sibling)
+ * and notifies connected clients. The `surfaceId` (doubling as the insert's
+ * idempotency nonce via `clientMessageId`) is derived from the run
+ * conversation id, so a retried delivery cannot produce two cards for one
+ * run — a deduplicated insert also skips the disk-view sync and client
+ * broadcast. Distinct runs get distinct ids, so a conversation accumulates
+ * one card per authoring run over its life, by design.
+ *
+ * The retrospective accounting excludes `SKILL_CARD_MESSAGE_KIND` rows from
+ * re-trigger counting, so a delivered card never wakes another pass. Errors
+ * propagate to the caller — the finalize entry point swallows them, the job
+ * handler surfaces them to the worker's retry machinery.
+ */
+async function insertOrDeferSkillCard(
+  sourceConversationId: string,
+  runConversationId: string,
+  skills: AuthoredSkill[],
+): Promise<void> {
+  const sourceConversation = getConversation(sourceConversationId);
+  if (!sourceConversation) {
+    log.info(
+      { sourceConversationId, runConversationId },
+      "skill card: source conversation no longer exists; skipping",
+    );
+    return;
+  }
+  // Mid-turn: defer rather than insert. Incremental checkpoint persistence
+  // means a card row could otherwise land between a persisted `tool_use` and
+  // its later `tool_result` — a history that linear-translation providers
+  // render in an order strict OpenAI-compatible backends reject (see module
+  // header). The durable job re-checks until the turn ends, so the card
+  // still always arrives.
+  if (isConversationProcessing(sourceConversationId)) {
+    upsertSkillCardInsertJob(
+      { sourceConversationId, runConversationId, skills },
+      Date.now() + SKILL_CARD_INSERT_RETRY_DELAY_MS,
+    );
+    log.info(
+      {
+        sourceConversationId,
+        runConversationId,
+        retryDelayMs: SKILL_CARD_INSERT_RETRY_DELAY_MS,
+      },
+      "skill card: source conversation is mid-turn; deferred via skill_card_insert job",
+    );
+    return;
+  }
+  const surfaceId = `skill-card-${runConversationId}`;
+  const surfaceBlock = {
+    type: "ui_surface",
+    surfaceId,
+    surfaceType: "skill_card",
+    title: "New skill learned",
+    display: "inline",
+    data: {
+      skills: skills.map((s) => ({
+        skillId: s.skillId,
+        name: s.name,
+        description: s.description,
+        emoji: s.emoji ?? null,
+      })),
+    },
+  };
+  // Plain-text fallback (approval-card pattern): feeds the model, search,
+  // CLI display, and channel replies. Surface-capable clients skip it —
+  // `renderHistoryContent` keeps `_surfaceFallback` text out of the
+  // rendered content blocks so the card is never double-rendered.
+  const fallbackBlock = {
+    type: "text",
+    text: `New skill learned: ${skills.map((s) => s.name).join(", ")}`,
+    _surfaceFallback: true,
+  };
+  const persisted = await addMessage(
+    sourceConversationId,
+    "assistant",
+    JSON.stringify([surfaceBlock, fallbackBlock]),
+    {
+      metadata: { kind: SKILL_CARD_MESSAGE_KIND, automated: true },
+      skipIndexing: true,
+      clientMessageId: surfaceId,
+    },
+  );
+  if (persisted.deduplicated) {
+    log.info(
+      { sourceConversationId, runConversationId, surfaceId },
+      "skill card: message already exists (deduplicated); skipping sync and publish",
+    );
+    return;
+  }
+  // Mirror `persistWakeTriggerMessage`: keep the conversation's disk view
+  // in sync (its own failure is non-fatal so the client broadcast below
+  // still fires), then tell connected clients the message list changed.
+  try {
+    syncMessageToDisk(
+      sourceConversationId,
+      persisted.id,
+      sourceConversation.createdAt,
+    );
+  } catch (err) {
+    log.warn(
+      { err, sourceConversationId },
+      "skill card: syncMessageToDisk failed (non-fatal)",
+    );
+  }
+  publishConversationMessagesChanged(sourceConversationId);
+  log.info(
+    {
+      sourceConversationId,
+      runConversationId,
+      surfaceId,
+      skillIds: skills.map((s) => s.skillId),
+    },
+    "skill card: inserted into source conversation",
+  );
 }

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-skill-card.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-skill-card.ts
@@ -17,7 +17,6 @@
 import {
   addMessage,
   getConversation,
-  isConversationProcessing,
 } from "../../../persistence/conversation-crud.js";
 import { syncMessageToDisk } from "../../../persistence/conversation-disk-view.js";
 import { publishConversationMessagesChanged } from "../../../runtime/sync/resource-sync-events.js";
@@ -193,10 +192,19 @@ function readScaffoldInput(input: unknown): AuthoredSkill | null {
  * `surfaceId` (doubling as the insert's idempotency nonce via
  * `clientMessageId`) is derived from the run conversation id, so a retried
  * finalize cannot produce two cards for one run — a deduplicated insert also
- * skips the disk-view sync and client broadcast. Skips when the source
- * conversation no longer exists (deleted mid-run) or is mid-turn (inserting
- * would splice the card into an in-flight display turn; the admission check
- * ran minutes earlier). Best-effort — failures are logged and never thrown.
+ * skips the disk-view sync and client broadcast. Distinct runs get distinct
+ * ids, so a conversation accumulates one card per authoring run over its
+ * life, by design.
+ *
+ * Inserts unconditionally with respect to turn state — a source conversation
+ * that is mid-turn still gets its card. Mid-turn insertion is safe: the
+ * message carries a `_surfaceFallback` text block, the Anthropic client's
+ * placeholder splice + `ensureToolPairing` tolerate an assistant row landing
+ * between a tool_use and its tool_result, and the retrospective accounting
+ * excludes `SKILL_CARD_MESSAGE_KIND` rows from re-trigger counting so the
+ * card never wakes another pass. The only skip is a source conversation that
+ * no longer exists (deleted mid-run). Best-effort — failures are logged and
+ * never thrown.
  */
 export async function insertSkillCardMessage(
   sourceConversationId: string,
@@ -206,16 +214,9 @@ export async function insertSkillCardMessage(
   try {
     const sourceConversation = getConversation(sourceConversationId);
     if (!sourceConversation) {
-      log.debug(
+      log.info(
         { sourceConversationId, runConversationId },
         "skill card: source conversation no longer exists; skipping",
-      );
-      return;
-    }
-    if (isConversationProcessing(sourceConversationId)) {
-      log.debug(
-        { sourceConversationId, runConversationId },
-        "skill card: source conversation is mid-turn; skipping",
       );
       return;
     }
@@ -255,8 +256,8 @@ export async function insertSkillCardMessage(
       },
     );
     if (persisted.deduplicated) {
-      log.debug(
-        { sourceConversationId, runConversationId },
+      log.info(
+        { sourceConversationId, runConversationId, surfaceId },
         "skill card: message already exists (deduplicated); skipping sync and publish",
       );
       return;
@@ -277,6 +278,15 @@ export async function insertSkillCardMessage(
       );
     }
     publishConversationMessagesChanged(sourceConversationId);
+    log.info(
+      {
+        sourceConversationId,
+        runConversationId,
+        surfaceId,
+        skillIds: skills.map((s) => s.skillId),
+      },
+      "skill card: inserted into source conversation",
+    );
   } catch (err) {
     log.warn(
       { err, sourceConversationId, runConversationId },

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-state.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-state.ts
@@ -6,9 +6,12 @@
 //   - `lastProcessedMessageId` advances ONLY when a retrospective run
 //     completes successfully (correctness invariant — failures must
 //     re-process the same messages on the next attempt).
-//   - `lastRunAt` advances on EVERY job end (success or failure). Drives the
-//     per-conversation cooldown gate in the trigger-check helper so failing
-//     jobs can't loop in tight retries across trigger types.
+//   - `lastRunAt` advances at the end of every job that actually attempted a
+//     run (success or failure). Drives the per-conversation cooldown gate in
+//     the trigger-check helper so failing jobs can't loop in tight retries
+//     across trigger types. The job's mid-turn skip intentionally leaves it
+//     untouched so the turn-end trigger check can requeue immediately — see
+//     `memory-retrospective-job.ts`.
 //
 // A third column rides along with the success-path pointer write:
 //   - `rememberedLog` (JSON array of strings) — the cumulative `remember`
@@ -228,12 +231,13 @@ export function forkRetrospectiveState(args: {
 }
 
 /**
- * Advance only `lastRunAt`. Used on every failure path so the cooldown gate
- * applies to subsequent trigger-driven enqueues. If no row exists yet (first
- * attempt failed), seed `lastProcessedMessageId` to the empty string — a
- * sentinel meaning "nothing successfully processed yet" that subsequent
- * `getMessagesSince(...)` queries treat the same as a missing row. An
- * existing row's `rememberedLog` is left untouched.
+ * Advance only `lastRunAt`. Used on failure paths that attempted a run (wake
+ * failure, fork failure) so the cooldown gate applies to subsequent
+ * trigger-driven enqueues; the mid-turn skip does NOT call this. If no row
+ * exists yet (first attempt failed), seed `lastProcessedMessageId` to the
+ * empty string — a sentinel meaning "nothing successfully processed yet"
+ * that subsequent `getMessagesSince(...)` queries treat the same as a
+ * missing row. An existing row's `rememberedLog` is left untouched.
  */
 export async function bumpRetrospectiveLastRunAt(
   conversationId: string,


### PR DESCRIPTION
## Summary
- Cards are now inserted whenever a retrospective creates skills — the card-level mid-turn skip is removed (provider-safe: fallback text block + placeholder splice; accounting already excludes card messages from re-triggering)
- A job-level mid-turn collision now requeues the run instead of permanently burning it: `lastRunAt` stays unbumped so the turn-end message-indexing trigger check re-enqueues immediately (event-driven), with a 60s coalescing job re-upsert as a fallback for turns that abort without indexing another message — fixes fresh single-turn conversations whose first-run trigger fires mid-first-turn and never retries
- Every card gate (flag, proc-to-skills, scaffold count, insert/dedup/missing-source) now logs at info level for one-grep field diagnosis
- Multiple cards per conversation are expected across runs; per-run clientMessageId dedup unchanged (test pinned)