### PR TITLE
fix(daemon): requeue drained messages on processing-lock contention

### DIFF
--- a/assistant/src/__tests__/drain-requeue-on-contention.test.ts
+++ b/assistant/src/__tests__/drain-requeue-on-contention.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Queue-drain behavior under processing-lock contention.
+ *
+ * When another turn (e.g. a barged-in voice turn woken by the idle
+ * transition) takes the lock between a drain's dequeue and its persist,
+ * the dequeued message must be requeued at the FRONT of the queue — not
+ * dropped through the generic persist-failure path. The lock holder's own
+ * finally block re-drains the queue.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { CONVERSATION_BUSY_MESSAGE } from "../daemon/conversation-messaging.js";
+import { drainQueue } from "../daemon/conversation-process.js";
+import {
+  MessageQueue,
+  type QueuedMessage,
+} from "../daemon/conversation-queue-manager.js";
+
+interface FakeEvent {
+  type: string;
+  message?: string;
+}
+
+function makeQueued(
+  content: string,
+  requestId: string,
+  events: FakeEvent[],
+): QueuedMessage {
+  return {
+    content,
+    attachments: [],
+    requestId,
+    onEvent: (event: FakeEvent) => {
+      events.push(event);
+    },
+    sentAt: Date.now(),
+  } as unknown as QueuedMessage;
+}
+
+function makeFakeConversation(options: {
+  persistError?: Error;
+  persistErrors?: Error[];
+}) {
+  const queue = new MessageQueue();
+  const persistCalls: string[] = [];
+  const persistErrors = options.persistErrors ?? [];
+  const conversation = {
+    conversationId: "conv-drain-requeue",
+    queue,
+    pendingSteerRepair: false,
+    preactivatedSkillIds: undefined as string[] | undefined,
+    messages: [] as unknown[],
+    surfaceActionRequestIds: new Set<string>(),
+    activeSurfaceId: undefined,
+    ensureHostProxiesForTurn: async () => {},
+    usageStats: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
+    getTurnChannelContext: () => null,
+    setTurnChannelContext: () => {},
+    getTurnInterfaceContext: () => null,
+    setTurnInterfaceContext: () => {},
+    emitActivityState: () => {},
+    isProcessing: () => false,
+    persistUserMessage: async (opts: { content: string }) => {
+      persistCalls.push(opts.content);
+      const err = persistErrors.shift() ?? options.persistError;
+      if (err) {
+        throw err;
+      }
+      return { id: `msg-${persistCalls.length}`, deduplicated: true };
+    },
+  };
+  return { conversation, queue, persistCalls };
+}
+
+describe("drainQueue under processing-lock contention", () => {
+  test("a busy persist requeues the message at the front instead of dropping it", async () => {
+    const events: FakeEvent[] = [];
+    const { conversation, queue, persistCalls } = makeFakeConversation({
+      persistError: new Error(CONVERSATION_BUSY_MESSAGE),
+    });
+    queue.push(makeQueued("hello there", "r1", events));
+    queue.push(makeQueued("and another", "r2", events));
+
+    await drainQueue(conversation as never);
+
+    // Exactly one persist attempt; the message is back at the head and the
+    // second message was not drained past it.
+    expect(persistCalls.length).toBe(1);
+    expect(queue.length).toBe(2);
+    expect(queue.peek(0)?.requestId).toBe("r1");
+    expect(queue.peek(1)?.requestId).toBe("r2");
+    // No error event reached the client — the message is not dropped.
+    expect(events.filter((event) => event.type === "error")).toEqual([]);
+  });
+
+  test("a non-busy persist failure keeps the drop-and-continue behavior", async () => {
+    const events: FakeEvent[] = [];
+    const { conversation, queue, persistCalls } = makeFakeConversation({
+      persistErrors: [new Error("disk exploded")],
+    });
+    queue.push(makeQueued("hello there", "r1", events));
+
+    await drainQueue(conversation as never);
+
+    expect(persistCalls.length).toBe(1);
+    expect(queue.length).toBe(0);
+    expect(
+      events.filter(
+        (event) => event.type === "error" && event.message === "disk exploded",
+      ).length,
+    ).toBe(1);
+  });
+});

--- a/assistant/src/__tests__/message-queue.test.ts
+++ b/assistant/src/__tests__/message-queue.test.ts
@@ -117,6 +117,46 @@ describe("MessageQueue.shiftN", () => {
   });
 });
 
+describe("MessageQueue.unshift", () => {
+  test("requeues at the front and shift returns it first", () => {
+    const q = new MessageQueue();
+    q.push(makeItem("first", "r1"));
+    q.push(makeItem("second", "r2"));
+
+    const popped = q.shift();
+    expect(popped?.requestId).toBe("r1");
+    q.unshift(popped!);
+
+    expect(q.shift()?.requestId).toBe("r1");
+    expect(q.shift()?.requestId).toBe("r2");
+  });
+
+  test("byte accounting round-trips through shift + unshift", () => {
+    const q = new MessageQueue();
+    q.push(makeItem("first", "r1"));
+    const bytesBefore = q.totalBytes;
+
+    const popped = q.shift()!;
+    q.unshift(popped);
+
+    expect(q.totalBytes).toBe(bytesBefore);
+    expect(q.length).toBe(1);
+  });
+
+  test("accepts a requeue even when the queue is at its byte budget", () => {
+    const q = new MessageQueue(8);
+    const item = makeItem("0123456789", "r1");
+    // First push into an empty queue is always accepted.
+    expect(q.push(item)).toBe(true);
+    const popped = q.shift()!;
+    q.push(makeItem("xxxxxxxxxx", "r2"));
+    // A requeue must never reject: the item was already accepted once.
+    q.unshift(popped);
+    expect(q.length).toBe(2);
+    expect(q.shift()?.requestId).toBe("r1");
+  });
+});
+
 describe("MessageQueue exports", () => {
   test("DEFAULT_MAX_QUEUE_BYTES is importable and positive", () => {
     expect(typeof DEFAULT_MAX_QUEUE_BYTES).toBe("number");

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -537,6 +537,14 @@ export interface PersistMessageOptions {
 
 // ── persistUserMessage ───────────────────────────────────────────────
 
+/**
+ * Thrown by user-message persistence when the conversation's processing
+ * lock is held. Callers (voice bridge retry, queue-drain requeue) match on
+ * this exact string — keep it byte-stable.
+ */
+export const CONVERSATION_BUSY_MESSAGE =
+  "Conversation is already processing a message";
+
 export async function persistUserMessage(
   ctx: MessagingConversationContext,
   options: PersistMessageOptions,
@@ -544,7 +552,7 @@ export async function persistUserMessage(
   const { content, attachments = [] } = options;
 
   if (ctx.isProcessing()) {
-    throw new Error("Conversation is already processing a message");
+    throw new Error(CONVERSATION_BUSY_MESSAGE);
   }
 
   if (!content.trim() && attachments.length === 0) {

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -40,6 +40,7 @@ import { stampTurnOutcome } from "../telemetry/turn-outcome.js";
 import { getLogger } from "../util/logger.js";
 import type { CleanResult, Conversation } from "./conversation.js";
 import {
+  CONVERSATION_BUSY_MESSAGE,
   persistQueuedMessageBody,
   serializePersistedUserMessageContent,
 } from "./conversation-messaging.js";
@@ -841,6 +842,23 @@ async function drainSingleMessage(
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    // runAgentLoop never ran, so its finally block won't clear this
+    conversation.preactivatedSkillIds = undefined;
+    if (message === CONVERSATION_BUSY_MESSAGE) {
+      // Another turn (e.g. a barged-in voice turn woken by the idle
+      // transition) took the lock between this drain's dequeue and its
+      // persist. The message is still valid — requeue it at the front and
+      // stop; the lock holder's own finally re-drains the queue.
+      log.info(
+        {
+          conversationId: conversation.conversationId,
+          requestId: next.requestId,
+        },
+        "Requeueing drained message: processing lock was retaken",
+      );
+      conversation.queue.unshift(next);
+      return;
+    }
     log.error(
       {
         err,
@@ -854,8 +872,6 @@ async function drainSingleMessage(
       conversationId: conversation.conversationId,
       message,
     });
-    // runAgentLoop never ran, so its finally block won't clear this
-    conversation.preactivatedSkillIds = undefined;
     // Continue draining — don't strand remaining messages
     await drainQueue(conversation);
     return;
@@ -1192,6 +1208,25 @@ async function drainBatch(
       persistedMessageIds.push(batchPersistResult.id);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
+      if (i === 0 && message === CONVERSATION_BUSY_MESSAGE) {
+        // The head hit lock contention before any batch state was set:
+        // another turn took the lock between dequeue and persist. The
+        // whole batch is still valid — requeue it at the front in order
+        // and stop; the lock holder's finally re-drains the queue.
+        log.info(
+          {
+            conversationId: conversation.conversationId,
+            requestId: qm.requestId,
+            batchSize: batch.length,
+          },
+          "Requeueing drained batch: processing lock was retaken",
+        );
+        conversation.preactivatedSkillIds = undefined;
+        for (let j = batch.length - 1; j >= 0; j -= 1) {
+          conversation.queue.unshift(batch[j]);
+        }
+        return;
+      }
       log.error(
         {
           err,

--- a/assistant/src/daemon/conversation-queue-manager.ts
+++ b/assistant/src/daemon/conversation-queue-manager.ts
@@ -123,6 +123,18 @@ export class MessageQueue {
   }
 
   /**
+   * Requeue a message at the FRONT of the queue. Used when a drained
+   * message hits processing-lock contention and must run on the next
+   * drain instead of being dropped. Deliberately skips the byte-budget
+   * check: the item was already accepted (and just popped), so a requeue
+   * must never reject it.
+   */
+  unshift(item: QueuedMessage): void {
+    this.items.unshift(item);
+    this.currentBytes += estimateItemBytes(item);
+  }
+
+  /**
    * Read-only access to a queued message by index without mutating the queue.
    * Returns `undefined` when the index is out of range.
    */

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -36,6 +36,7 @@ import { getLogger } from "../util/logger.js";
 import type { Conversation } from "./conversation.js";
 import {
   buildSlackMetaForPersistence,
+  CONVERSATION_BUSY_MESSAGE,
   serializePersistedUserMessageContent,
 } from "./conversation-messaging.js";
 import {
@@ -173,7 +174,7 @@ async function prepareConversationForMessage(
   );
 
   if (conversation.isProcessing()) {
-    throw new Error("Conversation is already processing a message");
+    throw new Error(CONVERSATION_BUSY_MESSAGE);
   }
 
   const resolvedChannel = resolveTurnChannel(


### PR DESCRIPTION
## Summary
Fixes the residual gap flagged during plan review for voice-mode-latency.md (follow-up to #37679).

**Gap:** for passthrough drains, the dequeued message was dropped through the persist-failure path when a barged-in voice turn won the lock race.
**Fix:** MessageQueue.unshift + busy-contention requeue at both drain sites (single + batch head); busy error string hoisted to a shared daemon constant used by both throw sites.