### PR TITLE
feat(providers): add Grok 4.5 to the OpenRouter model catalog

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1009,6 +1009,19 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
       },
       // xAI
       {
+        id: "x-ai/grok-4.5",
+        displayName: "Grok 4.5",
+        contextWindowTokens: 500000,
+        // xAI publishes no completion cap; 30K is the tracker-reported
+        // single-response limit.
+        maxOutputTokens: 30000,
+        supportsThinking: true,
+        supportsCaching: false,
+        supportsVision: true,
+        supportsToolUse: true,
+        pricing: { inputPer1mTokens: 2, outputPer1mTokens: 6 },
+      },
+      {
         id: "x-ai/grok-4.20-beta",
         displayName: "Grok 4.20 Beta",
         contextWindowTokens: 256000,

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -401,6 +401,14 @@ export const MODELS_BY_PROVIDER = {
       supportsThinking: true,
     },
     {
+      id: "x-ai/grok-4.5",
+      displayName: "Grok 4.5",
+      contextWindowTokens: 500_000,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 30_000,
+      supportsThinking: true,
+    },
+    {
       id: "x-ai/grok-4.20-beta",
       displayName: "Grok 4.20 Beta",
       contextWindowTokens: 256_000,

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -942,6 +942,22 @@
           }
         },
         {
+          "id": "x-ai/grok-4.5",
+          "displayName": "Grok 4.5",
+          "contextWindowTokens": 500000,
+          "maxOutputTokens": 30000,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": false,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 2,
+            "outputPer1mTokens": 6
+          }
+        },
+        {
           "id": "x-ai/grok-4.20-beta",
           "displayName": "Grok 4.20 Beta",
           "contextWindowTokens": 256000,


### PR DESCRIPTION
## Summary
- Add `x-ai/grok-4.5` to the OpenRouter section of the canonical model catalog (`assistant/src/providers/model-catalog.ts`), regenerate `meta/llm-provider-catalog.json`, and mirror the entry in the web catalog (`clients/web/src/assistant/llm-model-catalog.ts`).
- Specs verified 2026-07-09 against OpenRouter's live `/api/v1/models` API and xAI's model docs (https://docs.x.ai/developers/models/grok-4.5): 500k context, $2/M input, $6/M output, vision + tool use + reasoning (mandatory; efforts low/med/high). xAI publishes no completion cap; 30K `maxOutputTokens` is the tracker-reported single-response limit.
- Deliberately omitted: `adaptiveThinkingOnly` (Fable-specific flag; grok-4.5 relies on the same reasoning-opt-out-rejection retry guard as DeepSeek R1 / MiniMax M3) and cache-read pricing (OpenRouter reports `supports_implicit_caching: false` for this route; no other OpenRouter xAI entry carries cache pricing).

## Original prompt
Sidd asked to add support for https://openrouter.ai/x-ai/grok-4.5 (released 2026-07-08). The change adds the model to the OpenRouter provider catalog across the daemon, generated meta JSON, and web mirror so it can be selected in profiles and priced correctly. A follow-up PR will fix the now-stale `x-ai/grok-4.20-beta` / `x-ai/grok-4` entries that OpenRouter no longer serves.