### PR TITLE
fix(stt): drop the late finalize flush after its request was fallback-settled

### DIFF
--- a/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
@@ -730,6 +730,118 @@ describe("DeepgramRealtimeTranscriber", () => {
       expect(events).toEqual([{ type: "finalized" }]);
     });
 
+    test("a late flush after a fallback settlement emits neither final nor finalized", async () => {
+      const { transcriber, events } = await startSession({
+        finalizeFallbackMs: 20,
+      });
+
+      transcriber.finalizeUtterance();
+      await new Promise((resolve) => setTimeout(resolve, 40));
+      expect(events).toEqual([{ type: "finalized" }]);
+
+      // The request already settled — its slow flush is stale, and its
+      // text must not surface as a fresh flush.
+      mockWs.simulateMessage(
+        resultsFrame("late tail", { is_final: true, from_finalize: true }),
+      );
+
+      expect(events).toEqual([{ type: "finalized" }]);
+    });
+
+    test("a stale flush does not consume a newer request's settlement", async () => {
+      const { transcriber, events } = await startSession({
+        finalizeFallbackMs: 20,
+      });
+
+      // Request one settles via the fallback (its flush is running late).
+      transcriber.finalizeUtterance();
+      await new Promise((resolve) => setTimeout(resolve, 40));
+      expect(events).toEqual([{ type: "finalized" }]);
+
+      // Request two goes out, then request one's LATE flush finally lands.
+      transcriber.finalizeUtterance();
+      mockWs.simulateMessage(
+        resultsFrame("previous turn tail", {
+          is_final: true,
+          from_finalize: true,
+        }),
+      );
+      // The stale flush is dropped: no final, and request two stays live.
+      expect(events).toEqual([{ type: "finalized" }]);
+
+      // Request two's own flush settles it normally.
+      mockWs.simulateMessage(
+        resultsFrame("current turn", { is_final: true, from_finalize: true }),
+      );
+      expect(events).toEqual([
+        { type: "finalized" },
+        {
+          type: "final",
+          text: "current turn",
+          confidence: 0.95,
+          fromFinalize: true,
+        },
+        { type: "finalized" },
+      ]);
+    });
+
+    test("teardown with a fallback-settled request pending resets cleanly", async () => {
+      const { transcriber, events } = await startSession({
+        finalizeFallbackMs: 20,
+      });
+
+      // Request one settles via the fallback; its flush never arrives
+      // before teardown. Request two is still outstanding at stop().
+      transcriber.finalizeUtterance();
+      await new Promise((resolve) => setTimeout(resolve, 40));
+      transcriber.finalizeUtterance();
+
+      transcriber.stop();
+      mockWs.simulateClose(1000, "normal");
+
+      const types = events.map((e) => e.type);
+      expect(types.filter((t) => t === "finalized")).toHaveLength(2);
+      expect(types.at(-1)).toBe("closed");
+
+      // Frames after close are ignored — no stale bookkeeping survives.
+      mockWs.simulateMessage(
+        resultsFrame("post-close tail", {
+          is_final: true,
+          from_finalize: true,
+        }),
+      );
+      expect(events.map((e) => e.type)).toEqual(types);
+    });
+
+    test("utteranceBoundaryFinals: a stale flush is dropped and a timely flush still forces the boundary", async () => {
+      const { transcriber, events } = await startSession({
+        utteranceBoundaryFinals: true,
+        finalizeFallbackMs: 20,
+      });
+
+      mockWs.simulateMessage(resultsFrame("first part", { is_final: true }));
+      transcriber.finalizeUtterance();
+      await new Promise((resolve) => setTimeout(resolve, 40));
+      expect(events).toEqual([{ type: "finalized" }]);
+
+      transcriber.finalizeUtterance();
+      // Request one's late flush: dropped — withheld text stays withheld.
+      mockWs.simulateMessage(
+        resultsFrame("stale tail", { is_final: true, from_finalize: true }),
+      );
+      expect(events).toEqual([{ type: "finalized" }]);
+
+      // Request two's timely flush forces the boundary as usual.
+      mockWs.simulateMessage(
+        resultsFrame("live tail", { is_final: true, from_finalize: true }),
+      );
+      expect(events).toEqual([
+        { type: "finalized" },
+        { type: "final", text: "first part live tail" },
+        { type: "finalized" },
+      ]);
+    });
+
     test("a pending finalize completes as finalized before closed on teardown", async () => {
       const { transcriber, events } = await startSession({
         finalizeFallbackMs: 60_000,

--- a/assistant/src/providers/speech-to-text/deepgram-realtime.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.ts
@@ -322,6 +322,16 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
   private outstandingFinalizes = 0;
 
   /**
+   * Number of Finalize requests the fallback timer settled whose
+   * `from_finalize` flush has not yet arrived. Flushes arrive in request
+   * order, so while this is positive the next `from_finalize` frame
+   * answers a fallback-settled request: it is dropped as stale instead of
+   * being emitted as — and settling — a newer request's flush. Reset on
+   * close alongside the outstanding-request drain.
+   */
+  private fallbackSettledFinalizes = 0;
+
+  /**
    * Fallback timer for in-flight Finalize requests. Deepgram omits the
    * `from_finalize` flush when nothing significant is buffered, so this
    * timer emits `finalized` after {@link FINALIZE_FALLBACK_MS} to keep the
@@ -466,10 +476,17 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
    * flushing buffered audio as a Results frame with `from_finalize: true`
    * (possibly with an empty transcript). The adapter emits the resulting
    * `final` (when non-empty) followed by one `finalized` event, and the
-   * stream stays open for more audio. Overlapping requests are answered
-   * in order — one `finalized` per request. When the socket is not open
-   * there is nothing buffered provider-side, so `finalized` is emitted
-   * immediately. {@link stop} remains the session-teardown path.
+   * stream stays open for more audio.
+   *
+   * Every request settles exactly once, oldest first: by its
+   * `from_finalize` flush when one arrives in time, or by a fallback
+   * timer ({@link DeepgramRealtimeOptions.finalizeFallbackMs}) when
+   * Deepgram omits the flush (nothing significant buffered) or answers
+   * too slowly. A flush arriving after its request was fallback-settled
+   * is dropped as stale — no `final`, no second `finalized` — so its
+   * text can never be attributed to a newer request. When the socket is
+   * not open there is nothing buffered provider-side, so `finalized` is
+   * emitted immediately. {@link stop} remains the session-teardown path.
    */
   finalizeUtterance(): void {
     const ws = this.ws;
@@ -637,7 +654,9 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
    * - `final` for `is_final: true` frames.
    * - `finalized` after the `final` of a `from_finalize: true` flush frame
    *   (the response to {@link finalizeUtterance}). An empty flush emits
-   *   only `finalized` — silence flushes carry no transcript to commit.
+   *   only `finalized` — silence flushes carry no transcript to commit. A
+   *   flush whose request the fallback timer already settled is dropped
+   *   entirely (no `final`, no `finalized`) — see {@link finalizeUtterance}.
    */
   private handleTranscriptFrame(frame: DeepgramStreamResponse): void {
     const alternative = frame.channel?.alternatives?.[0];
@@ -646,6 +665,20 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
 
     // Extract text, defaulting to empty string for silence segments.
     const text = typeof transcript === "string" ? transcript.trim() : "";
+
+    // A flush whose request the fallback timer already settled is stale:
+    // flushes arrive in request order, so it pairs with the oldest
+    // fallback-settled request, whose `finalized` was already emitted.
+    // Emitting its text (or another `finalized`) here would attribute it
+    // to a newer request's utterance.
+    if (fromFinalize && this.fallbackSettledFinalizes > 0) {
+      this.fallbackSettledFinalizes -= 1;
+      log.debug(
+        { droppedTextLength: text.length },
+        "Dropped a stale from_finalize flush: its request was fallback-settled",
+      );
+      return;
+    }
 
     const speakerLabel = this.diarize
       ? extractSpeakerLabel(alternative)
@@ -808,6 +841,11 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
       log.debug(
         "Deepgram sent no from_finalize flush — emitting finalized fallback",
       );
+      if (this.outstandingFinalizes > 0) {
+        // The request settles without its flush; a flush that still
+        // arrives later is dropped as stale in handleTranscriptFrame.
+        this.fallbackSettledFinalizes += 1;
+      }
       this.settleOneFinalize();
     }, this.finalizeFallbackMs);
   }
@@ -839,6 +877,9 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
     while (this.outstandingFinalizes > 0) {
       this.settleOneFinalize();
     }
+    // Closed sessions process no further frames, so pending stale-flush
+    // bookkeeping resets with the drained requests.
+    this.fallbackSettledFinalizes = 0;
     this.emitEvent({ type: "closed" });
     this.onEvent = null;
   }


### PR DESCRIPTION
## Summary
Fixes a round-2 review gap for voice-mode-latency.md (follow-up to #37677).

**Gap:** a finalize answered slower than the 2 s fallback had its slot freed early; the late flush was then attributed to the next cycle's request, bleeding the previous turn's tail into it.
**Fix:** the adapter counts fallback-settled requests and drops the corresponding late from_finalize frames instead of emitting them as fresh flushes.