### PR TITLE
fix(runtime): re-check the processing lock before agent-wake acquires it

### DIFF
--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -121,6 +121,12 @@ interface WakeConversationProbe {
    * conversation's event-driven wait.
    */
   waitForIdleCalls: Array<{ timeoutMs: number }>;
+  /**
+   * Count of `setProcessing(true)` calls that landed while the lock was
+   * already held — a stomp on a competing turn's just-acquired lock. Must
+   * stay 0: the wake re-checks `isProcessing()` before acquiring.
+   */
+  processingLockStomps: number;
 }
 
 const wakeConvRegistry = new Map<string, WakeConversationProbe>();
@@ -437,6 +443,7 @@ function makeWakeConversation(options: {
     maybeCompactOrders: [],
     maybeCompactSizings: [],
     waitForIdleCalls: [],
+    processingLockStomps: 0,
   };
   wakeConvRegistry.set(conversationId, probe);
 
@@ -534,6 +541,9 @@ function makeWakeConversation(options: {
     getMessages: () => messages,
     isProcessing: () => processing,
     setProcessing: (on: boolean) => {
+      if (on && processing) {
+        probe.processingLockStomps += 1;
+      }
       processing = on;
       probe.processingToggles.push(on);
       probe.callSequence.push(on ? "processing:true" : "processing:false");
@@ -1831,6 +1841,157 @@ describe("wakeAgentForOpportunity", () => {
     expect(result.invoked).toBe(true);
     expect(result.producedToolCalls).toBe(false);
     expect(conversation.waitForIdleCalls).toEqual([{ timeoutMs: 30_000 }]);
+  });
+
+  test("re-waits when a competing idle waiter takes the lock before the wake's continuation runs", async () => {
+    // Idle waiters are notified FIFO from the same `setProcessing(false)`
+    // transition. A waiter registered before the wake (e.g. a queued voice
+    // turn) can take the lock synchronously in its continuation — the wake
+    // must observe the re-taken lock, re-wait, and acquire only after the
+    // competitor's real release.
+    const conversation = makeWakeConversation({
+      conversationId: "conv-contended",
+      isProcessing: true,
+      scriptedAssistant: {
+        role: "assistant",
+        content: [{ type: "text", text: "reply" }],
+      },
+    });
+
+    // Competing turn: registered FIRST, so it is notified first and grabs
+    // the lock synchronously in its continuation.
+    void conversation.waitForIdle({ timeoutMs: 30_000 }).then(() => {
+      conversation.setProcessing(true);
+    });
+
+    const wakePromise = wakeAgentForOpportunity(
+      {
+        conversationId: "conv-contended",
+        hint: "co-woken opportunity",
+        source: "unit-test",
+      },
+      { resolveTarget: async () => conversation },
+    );
+    // Let the wake reach its waitForIdle registration (behind the competitor's).
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(conversation.waitForIdleCalls).toHaveLength(2);
+
+    // The original turn releases. The competitor is notified first and
+    // re-takes the lock; the wake must NOT start its agent loop.
+    conversation.setProcessing(false);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(conversation.runCalls).toHaveLength(0);
+    expect(conversation.isProcessing()).toBe(true);
+    // The wake went back to waiting, on the remaining budget.
+    expect(conversation.waitForIdleCalls).toHaveLength(3);
+    expect(conversation.waitForIdleCalls[2]!.timeoutMs).toBeGreaterThan(0);
+    expect(conversation.waitForIdleCalls[2]!.timeoutMs).toBeLessThanOrEqual(
+      30_000,
+    );
+
+    // The competitor's real release lets the wake proceed.
+    conversation.setProcessing(false);
+    const result = await wakePromise;
+    expect(result.invoked).toBe(true);
+    expect(conversation.runCalls).toHaveLength(1);
+    // Lock hand-offs stayed clean — release, competitor take, competitor
+    // release, wake take, wake release — with no acquisition landing while
+    // the lock was already held.
+    expect(conversation.processingToggles).toEqual([
+      false,
+      true,
+      false,
+      true,
+      false,
+    ]);
+    expect(conversation.processingLockStomps).toBe(0);
+  });
+
+  test("acquires the lock only after a passing isProcessing() re-check, on the remaining budget", async () => {
+    // Scripted waitForIdle resolves `true` while the lock is still held —
+    // the exact state a wake continuation observes when a competing waiter
+    // was notified first. The wake must not trust the resolution alone: it
+    // re-checks `isProcessing()`, re-waits on the remaining budget, and
+    // acquires only once the check passes.
+    let fakeNow = 1_000_000;
+    let waitCalls = 0;
+    const conversation = makeWakeConversation({
+      conversationId: "conv-recheck",
+      isProcessing: true,
+      scriptedAssistant: {
+        role: "assistant",
+        content: [{ type: "text", text: "reply" }],
+      },
+      waitForIdleImpl: async () => {
+        waitCalls += 1;
+        if (waitCalls === 1) {
+          // Resolve true with the lock still held (a competitor re-took
+          // it), burning 5s of the wake's 30s budget.
+          fakeNow += 5_000;
+          return true;
+        }
+        // The competitor releases for real before the second wait resolves.
+        conversation.setProcessing(false);
+        return true;
+      },
+    });
+
+    const result = await wakeAgentForOpportunity(
+      {
+        conversationId: "conv-recheck",
+        hint: "co-woken opportunity",
+        source: "unit-test",
+      },
+      { resolveTarget: async () => conversation, now: () => fakeNow },
+    );
+
+    expect(result.invoked).toBe(true);
+    // The lying first resolution did not start the loop — the wake re-waited
+    // on the remaining budget (30s total minus the 5s already burned).
+    expect(waitCalls).toBe(2);
+    expect(conversation.waitForIdleCalls).toEqual([
+      { timeoutMs: 30_000 },
+      { timeoutMs: 25_000 },
+    ]);
+    expect(conversation.runCalls).toHaveLength(1);
+    // setProcessing(true) never landed while the lock was held.
+    expect(conversation.processingLockStomps).toBe(0);
+  });
+
+  test("returns reason 'timeout' when the lock stays contended past the wait budget", async () => {
+    // The re-check loop is budget-bounded: when every wakeup finds the lock
+    // re-taken and the 30s total budget runs out, the wake skips with the
+    // same "timeout" outcome as a plain busy conversation.
+    let fakeNow = 0;
+    const conversation = makeWakeConversation({
+      conversationId: "conv-contended-timeout",
+      isProcessing: true,
+      runImpl: async (input) => runResult(input),
+      waitForIdleImpl: async () => {
+        // Always resolves true with the lock still held, burning 20s each
+        // time — the second wakeup lands past the 30s deadline.
+        fakeNow += 20_000;
+        return true;
+      },
+    });
+
+    const result = await wakeAgentForOpportunity(
+      { conversationId: "conv-contended-timeout", hint: "x", source: "y" },
+      { resolveTarget: async () => conversation, now: () => fakeNow },
+    );
+
+    expect(result).toEqual({
+      invoked: false,
+      producedToolCalls: false,
+      reason: "timeout",
+    });
+    // The agent loop never ran and the lock was never touched.
+    expect(conversation.runCalls).toHaveLength(0);
+    expect(conversation.processingToggles).toEqual([]);
+    expect(conversation.waitForIdleCalls).toEqual([
+      { timeoutMs: 30_000 },
+      { timeoutMs: 10_000 },
+    ]);
   });
 
   test("returns invoked: false with reason 'not_found' when the conversation cannot be resolved", async () => {

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -682,10 +682,21 @@ export async function wakeAgentForOpportunity(
     // Wait for any independently started user turn to release the processing
     // lock so we don't run a second agent loop concurrently. With no abort
     // signal, waitForIdle never rejects — `false` means the budget elapsed
-    // with the lock still held.
-    const idle = await conversation.waitForIdle({
+    // with the lock still held. Idle waiters are notified FIFO from the same
+    // `setProcessing(false)` transition, so a competing waiter registered
+    // earlier (e.g. a voice turn) can re-take the lock before this
+    // continuation runs — re-check `isProcessing()` after every wakeup and
+    // re-wait on the remaining budget until the lock is observed free.
+    const idleDeadline = nowFn() + WAKE_IDLE_TIMEOUT_MS;
+    let idle = await conversation.waitForIdle({
       timeoutMs: WAKE_IDLE_TIMEOUT_MS,
     });
+    while (idle && conversation.isProcessing()) {
+      const remainingMs = idleDeadline - nowFn();
+      idle =
+        remainingMs > 0 &&
+        (await conversation.waitForIdle({ timeoutMs: remainingMs }));
+    }
     if (!idle) {
       log.warn(
         { conversationId, source },
@@ -757,7 +768,10 @@ export async function wakeAgentForOpportunity(
     // message arriving while the flag is set is queued by `enqueueMessage()`
     // and drained after the wake's tail is pushed + persisted. This happens
     // before applying a wake-scoped tool allowlist so a concurrent user turn
-    // cannot start under the wake's restricted tool set.
+    // cannot start under the wake's restricted tool set. The idle gate above
+    // observed the lock free, and nothing between its final `isProcessing()`
+    // check and this acquisition awaits — keep that stretch await-free so
+    // the lock cannot change hands in between.
     conversation.setProcessing(true);
 
     // ── Pre-run auto-compaction gate ──────────────────────────────────


### PR DESCRIPTION
## Summary
Fixes a round-2 review gap for voice-mode-latency.md (follow-up to #37676).

**Gap:** after waitForIdle, agent-wake blindly setProcessing(true) with no re-check — a co-woken voice turn's just-acquired lock could be stomped, running two concurrent agent loops.
**Fix:** budget-bounded re-check loop; acquisition only happens with no awaits after a passing isProcessing() check.