### PR TITLE
refactor(gateway): retire the assistant-scoped contact route mirrors

### DIFF
--- a/gateway/src/__tests__/contacts-scoped-route-fallthrough.test.ts
+++ b/gateway/src/__tests__/contacts-scoped-route-fallthrough.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Pins that the gateway registers NO assistant-scoped contact routes.
+ *
+ * The generated gateway SDK emits assistant-scoped URLs, but both deployment
+ * boundaries flatten contact-family paths before the gateway routes them
+ * (Django's RuntimeProxyView in cloud; `rewriteForSelfHostedIngress` in
+ * self-hosted), so the gateway serves only the flat contact routes and a
+ * scoped contact request falls through to the runtime-proxy catch-all.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import "./test-preload.js";
+
+import { AuthRateLimiter } from "../auth-rate-limiter.js";
+import type { RouteDefinition } from "../http/router.js";
+import { createRouter } from "../http/router.js";
+
+// ---------------------------------------------------------------------------
+// Source pinning — no scoped contact registrations in index.ts
+// ---------------------------------------------------------------------------
+
+describe("contact route registrations (index.ts)", () => {
+  test("no route path scopes a contact-family path under /v1/assistants", () => {
+    const indexSource = readFileSync(
+      join(import.meta.dir, "..", "index.ts"),
+      "utf8",
+    );
+    const pathLines = indexSource
+      .split("\n")
+      .filter((line) => /^\s*path:/.test(line));
+
+    expect(pathLines.length).toBeGreaterThan(0);
+    const scopedContactPaths = pathLines.filter(
+      (line) => line.includes("assistants") && line.includes("contact"),
+    );
+    expect(scopedContactPaths).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Behavioral — scoped contact writes fall through to the catch-all
+// ---------------------------------------------------------------------------
+
+/**
+ * Router mirroring the contacts control-plane path/method registrations in
+ * index.ts plus the runtime-proxy catch-all. Auth is elided: route matching
+ * happens before auth, and this harness pins matching only.
+ */
+function makeContactsRouter() {
+  const controlPlane = (route: string) => () =>
+    Response.json({ handledBy: "control-plane", route });
+  const routes: RouteDefinition[] = [
+    {
+      path: "/v1/contacts/prompt/submit",
+      method: "POST",
+      handler: controlPlane("prompt-submit"),
+    },
+    { path: "/v1/contacts", method: "GET", handler: controlPlane("list") },
+    { path: "/v1/contacts", method: "POST", handler: controlPlane("upsert") },
+    {
+      path: /^\/v1\/contact-channels\/([^/]+)\/verify$/,
+      method: "POST",
+      handler: controlPlane("verify"),
+    },
+    {
+      path: /^\/v1\/contacts\/(?!invites\/?$)([^/]+)\/?$/,
+      method: "DELETE",
+      handler: controlPlane("delete"),
+    },
+    // Runtime proxy catch-all — must be last, matches everything.
+    {
+      path: /^\//,
+      handler: () => Response.json({ handledBy: "runtime-proxy" }),
+    },
+  ];
+  return createRouter(routes, { authRateLimiter: new AuthRateLimiter() });
+}
+
+const contactsRouter = makeContactsRouter();
+
+async function dispatch(method: string, path: string) {
+  const url = new URL(`http://gateway.local${path}`);
+  const res = await contactsRouter(
+    new Request(url, { method }),
+    url,
+    () => "203.0.113.9",
+  );
+  expect(res).not.toBeNull();
+  return (await res!.json()) as { handledBy: string; route?: string };
+}
+
+const SCOPED_CONTACT_WRITES: Array<[string, string]> = [
+  ["POST", "/v1/assistants/x/contacts"],
+  ["POST", "/v1/assistants/x/contacts/prompt/submit"],
+  ["POST", "/v1/assistants/x/contact-channels/ch-1/verify"],
+  ["DELETE", "/v1/assistants/x/contacts/contact-1"],
+];
+
+describe("scoped contact writes fall through to the runtime proxy", () => {
+  test.each(SCOPED_CONTACT_WRITES)(
+    "%s %s → runtime-proxy catch-all, not the control plane",
+    async (method, path) => {
+      const body = await dispatch(method, path);
+      expect(body.handledBy).toBe("runtime-proxy");
+    },
+  );
+
+  test("flat POST /v1/contacts still hits the control-plane handler", async () => {
+    const body = await dispatch("POST", "/v1/contacts");
+    expect(body).toEqual({ handledBy: "control-plane", route: "upsert" });
+  });
+});

--- a/gateway/src/http/routes/contacts-control-plane-routes.ts
+++ b/gateway/src/http/routes/contacts-control-plane-routes.ts
@@ -9,9 +9,12 @@ import type { GatewayRouteDefinition } from "./types.js";
  * exist ONLY on the gateway (they have no daemon HTTP counterpart, so they
  * are absent from the daemon SDK): contact upsert, contact delete,
  * contact-prompt submit, and manual channel verify. Clients consume them
- * through the generated gateway SDK, which targets the assistant-scoped
- * `/v1/assistants/{assistant_id}/...` variants registered in `index.ts`
- * alongside these flat paths.
+ * through the generated gateway SDK, which emits assistant-scoped
+ * `/v1/assistants/{assistant_id}/...` URLs — but both deployment boundaries
+ * strip the scope before the gateway routes the request (Django's
+ * RuntimeProxyView in cloud; `rewriteForSelfHostedIngress` contact-family
+ * flattening in self-hosted), so the gateway serves exactly the flat paths
+ * in this spec.
  *
  * The handlers live in `contacts-control-plane-proxy.ts` (upsert, delete,
  * verify) and `contact-prompt.ts` (prompt submit); this module is

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -772,13 +772,6 @@ async function main() {
       handler: (req) => handleContactPromptSubmit(req),
     },
     {
-      // Assistant-scoped variant for clients using the auto-prefix.
-      path: /^\/v1\/assistants\/[^/]+\/contacts\/prompt\/submit\/?$/,
-      method: "POST",
-      auth: "edge",
-      handler: (req) => handleContactPromptSubmit(req),
-    },
-    {
       path: "/v1/contacts",
       method: "GET",
       auth: "edge",
@@ -786,13 +779,6 @@ async function main() {
     },
     {
       path: "/v1/contacts",
-      method: "POST",
-      auth: "edge",
-      handler: (req) => contactsControlPlaneProxy.handleUpsertContact(req),
-    },
-    {
-      // Assistant-scoped variant for clients using the auto-prefix.
-      path: /^\/v1\/assistants\/[^/]+\/contacts\/?$/,
       method: "POST",
       auth: "edge",
       handler: (req) => contactsControlPlaneProxy.handleUpsertContact(req),
@@ -812,14 +798,6 @@ async function main() {
     },
     {
       path: /^\/v1\/contact-channels\/([^/]+)\/verify$/,
-      method: "POST",
-      auth: "edge-guardian",
-      handler: (req, params) =>
-        contactsControlPlaneProxy.handleVerifyContactChannel(req, params[0]),
-    },
-    {
-      // Assistant-scoped variant for clients using the auto-prefix.
-      path: /^\/v1\/assistants\/[^/]+\/contact-channels\/([^/]+)\/verify\/?$/,
       method: "POST",
       auth: "edge-guardian",
       handler: (req, params) =>
@@ -869,14 +847,6 @@ async function main() {
       // Keep DELETE on the invite collection unsupported; only /invites/:id
       // should revoke an invite.
       path: /^\/v1\/contacts\/(?!invites\/?$)([^/]+)\/?$/,
-      method: "DELETE",
-      auth: "edge",
-      handler: (_req, params) =>
-        contactsControlPlaneProxy.handleDeleteContact(params[0]),
-    },
-    {
-      // Assistant-scoped variant for clients using the auto-prefix.
-      path: /^\/v1\/assistants\/[^/]+\/contacts\/(?!invites\/?$)([^/]+)\/?$/,
       method: "DELETE",
       auth: "edge",
       handler: (_req, params) =>
@@ -1702,8 +1672,7 @@ async function main() {
     // on mutations (the daemon HTTP handlers were stripped by #28784).
     //
     // Trust rules are gateway-global, so the assistant id is matched and
-    // discarded. Same precedent as the assistant-scoped /v1/assistants/.../
-    // contacts DELETE route above.
+    // discarded. Same precedent as channel-admission-policy above.
     {
       path: /^\/v1\/assistants\/[^/]+\/trust-rules\/?$/,
       method: "GET",


### PR DESCRIPTION
## Summary

- Delete the four assistant-scoped contact mirror registrations from `gateway/src/index.ts` (POST `/v1/assistants/:id/contacts/prompt/submit`, POST `/v1/assistants/:id/contacts`, POST `/v1/assistants/:id/contact-channels/:ch/verify`, DELETE `/v1/assistants/:id/contacts/:cid`). All flat contact routes, `/v1/contacts/guardian/channel`, the invites block, and the other families' scoped mirrors (channel-admission-policy, channel-permission-overrides, trust-rules) are untouched; flat route auth modes are byte-identical.
- Fix the stale doc-comment in `contacts-control-plane-routes.ts`: the generated SDK emits assistant-scoped URLs, but both deployment boundaries strip to flat before the gateway routes them (Django RuntimeProxyView in cloud; `rewriteForSelfHostedIngress` contact-family flattening in self-hosted), so the spec's flat paths are what the gateway serves.
- Update the trust-rules scoped-mirror comment that cited the removed contacts DELETE route as precedent (now cites channel-admission-policy).
- Add `contacts-scoped-route-fallthrough.test.ts`: pins that `index.ts` registers no `/v1/assistants/.../contact...` route, and behaviorally that scoped contact writes fall through to the runtime-proxy catch-all while flat `POST /v1/contacts` still hits the control-plane handler.
- Gateway OpenAPI output is unchanged (regenerated via `generate:openapi`, zero diff — the spec never published scoped paths).

## Version-skew analysis

The scoped-mirror plumbing (#37212/#37218) never shipped in a stable release — v0.10.5 predates it and had broken self-hosted contact control-plane writes anyway (LUM-2705), so removal only affects unreleased staging bundles until Electron auto-update delivers the release carrying the PR-2 client flattening (#37683). Additionally, scoped `contacts/merge` from pre-PR-2 builds always fell through to the daemon-local merge; that pre-existing skew path dies out with client age-out (ATL-987 family).

Part of plan: flatten-macos-contact-routes.md (PR 3 of 5)