### PR TITLE
fix: keep per-turn state clean under processing-lock contention

### DIFF
--- a/assistant/src/__tests__/drain-requeue-on-contention.test.ts
+++ b/assistant/src/__tests__/drain-requeue-on-contention.test.ts
@@ -47,26 +47,42 @@ function makeQueued(
 function makeFakeConversation(options: {
   persistError?: Error;
   persistErrors?: Error[];
+  processing?: boolean;
+  pendingSteerRepair?: boolean;
 }) {
   const queue = new MessageQueue();
   const persistCalls: string[] = [];
+  // Every per-turn conversation mutation the drain paths perform before
+  // their persist, so tests can assert an early requeue touched none of it.
+  const mutationCalls: string[] = [];
   const persistErrors = options.persistErrors ?? [];
   const conversation = {
     conversationId: "conv-drain-requeue",
     queue,
-    pendingSteerRepair: false,
+    pendingSteerRepair: options.pendingSteerRepair ?? false,
     preactivatedSkillIds: undefined as string[] | undefined,
     messages: [] as unknown[],
     surfaceActionRequestIds: new Set<string>(),
     activeSurfaceId: undefined,
-    ensureHostProxiesForTurn: async () => {},
+    ensureHostProxiesForTurn: () => {
+      mutationCalls.push("ensureHostProxiesForTurn");
+    },
     usageStats: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
     getTurnChannelContext: () => null,
-    setTurnChannelContext: () => {},
+    setTurnChannelContext: () => {
+      mutationCalls.push("setTurnChannelContext");
+    },
     getTurnInterfaceContext: () => null,
-    setTurnInterfaceContext: () => {},
-    emitActivityState: () => {},
-    isProcessing: () => false,
+    setTurnInterfaceContext: () => {
+      mutationCalls.push("setTurnInterfaceContext");
+    },
+    setTransportHints: () => {
+      mutationCalls.push("setTransportHints");
+    },
+    emitActivityState: () => {
+      mutationCalls.push("emitActivityState");
+    },
+    isProcessing: () => options.processing ?? false,
     persistUserMessage: async (opts: { content: string }) => {
       persistCalls.push(opts.content);
       const err = persistErrors.shift() ?? options.persistError;
@@ -76,7 +92,7 @@ function makeFakeConversation(options: {
       return { id: `msg-${persistCalls.length}`, deduplicated: true };
     },
   };
-  return { conversation, queue, persistCalls };
+  return { conversation, queue, persistCalls, mutationCalls };
 }
 
 describe("drainQueue under processing-lock contention", () => {
@@ -97,6 +113,79 @@ describe("drainQueue under processing-lock contention", () => {
     expect(queue.peek(0)?.requestId).toBe("r1");
     expect(queue.peek(1)?.requestId).toBe("r2");
     // No error event reached the client — the message is not dropped.
+    expect(events.filter((event) => event.type === "error")).toEqual([]);
+  });
+
+  test("a lock already held when a single message drains requeues it without touching conversation state", async () => {
+    const events: FakeEvent[] = [];
+    const { conversation, queue, persistCalls, mutationCalls } =
+      makeFakeConversation({ processing: true });
+    queue.push(makeQueued("hello there", "r1", events));
+
+    await drainQueue(conversation as never);
+
+    // Requeued intact, and the drain mutated nothing: no per-turn context
+    // setters, no dequeue events to the client, no persist attempt.
+    expect(queue.length).toBe(1);
+    expect(queue.peek(0)?.requestId).toBe("r1");
+    expect(persistCalls).toEqual([]);
+    expect(mutationCalls).toEqual([]);
+    expect(events).toEqual([]);
+    expect(conversation.preactivatedSkillIds).toBeUndefined();
+  });
+
+  test("a lock already held when a batch drains requeues it in order without touching conversation state", async () => {
+    const events: FakeEvent[] = [];
+    const { conversation, queue, persistCalls, mutationCalls } =
+      makeFakeConversation({ processing: true });
+    queue.push(makeQueued("hello there", "r1", events));
+    queue.push(makeQueued("and another", "r2", events));
+
+    await drainQueue(conversation as never);
+
+    expect(queue.length).toBe(2);
+    expect(queue.peek(0)?.requestId).toBe("r1");
+    expect(queue.peek(1)?.requestId).toBe("r2");
+    expect(persistCalls).toEqual([]);
+    expect(mutationCalls).toEqual([]);
+    expect(events).toEqual([]);
+  });
+
+  test("a steered drain requeued by the early lock check restores the steer promotion", async () => {
+    const events: FakeEvent[] = [];
+    const { conversation, queue, persistCalls, mutationCalls } =
+      makeFakeConversation({ processing: true, pendingSteerRepair: true });
+    queue.push(makeQueued("steered head", "r1", events));
+    queue.push(makeQueued("queued tail", "r2", events));
+
+    await drainQueue(conversation as never);
+
+    // The re-drain must see pendingSteerRepair=true so it promotes the
+    // steered head alone instead of batching it with the tail.
+    expect(conversation.pendingSteerRepair).toBe(true);
+    expect(queue.length).toBe(2);
+    expect(queue.peek(0)?.requestId).toBe("r1");
+    expect(queue.peek(1)?.requestId).toBe("r2");
+    expect(persistCalls).toEqual([]);
+    expect(mutationCalls).toEqual([]);
+  });
+
+  test("a steered drain requeued by a busy persist restores the steer promotion", async () => {
+    const events: FakeEvent[] = [];
+    const { conversation, queue, persistCalls } = makeFakeConversation({
+      persistError: new Error(CONVERSATION_BUSY_MESSAGE),
+      pendingSteerRepair: true,
+    });
+    queue.push(makeQueued("steered head", "r1", events));
+    queue.push(makeQueued("queued tail", "r2", events));
+
+    await drainQueue(conversation as never);
+
+    expect(conversation.pendingSteerRepair).toBe(true);
+    expect(persistCalls.length).toBe(1);
+    expect(queue.length).toBe(2);
+    expect(queue.peek(0)?.requestId).toBe("r1");
+    expect(queue.peek(1)?.requestId).toBe("r2");
     expect(events.filter((event) => event.type === "error")).toEqual([]);
   });
 

--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -110,8 +110,11 @@ function makeFakeConversation(opts: {
     setVoiceCallControlPrompt: () => {},
     persistUserMessage: async () => {
       persistCount += 1;
-      opts.onPersist?.(persistCount);
+      // Recorded before `onPersist` so scripted persist FAILURES also
+      // appear in the event stream — ordering tests need the losing
+      // attempt visible.
       opts.events?.push("persist");
+      opts.onPersist?.(persistCount);
       return { id: `msg-${persistCount}` };
     },
     // The install (reset falsy) / reset (reset true) pair marks a turn
@@ -406,11 +409,15 @@ describe("startVoiceTurn queued-message drain race", () => {
   test("a persist that loses the lock race to the drain waits and retries once", async () => {
     // TOCTOU: the wait loop saw an idle conversation with no visible queued
     // work, but the drain's persist took the lock before this turn's persist
-    // ran. The first persist throws the exact busy error; the bridge waits
-    // for idle again and retries the persist once.
+    // ran. The first persist throws the exact busy error; the bridge
+    // uninstalls its voice turn state, waits for idle, re-installs, and
+    // retries the persist once.
+    const events: string[] = [];
     const fake = makeFakeConversation({
       processing: false,
+      events,
       waitForIdle: async () => {
+        events.push("wait:resolved");
         // The drained turn completes during the retry wait.
         fake.setProcessingFlag(false);
         return true;
@@ -422,17 +429,47 @@ describe("startVoiceTurn queued-message drain race", () => {
         }
       },
     });
+    // Record install/uninstall markers for the state the drained turn must
+    // never see: the phone control prompt and the caller trust context.
+    fake.conversation.setVoiceCallControlPrompt = (prompt) => {
+      events.push(prompt === null ? "prompt:clear" : "prompt:install");
+    };
+    fake.conversation.setTrustContext = (ctx) => {
+      events.push(ctx === null ? "trust:clear" : "trust:install");
+    };
     fakeConversation = fake.conversation;
 
     const persistedIds: string[] = [];
     const handle = await startVoiceTurn({
       ...makeTurnOptions(),
+      trustContext: { sourceChannel: "phone", trustClass: "guardian" },
       callbacks: {
         persisted_user_message_id: (id) => persistedIds.push(id),
       },
     });
+    await flushMicrotasks();
 
     expect(handle.turnId).toBeString();
+    expect(events).toEqual([
+      // Initial install, then the losing persist attempt.
+      "trust:install",
+      "prompt:install",
+      "persist",
+      // Uninstalled BEFORE the retry wait resolves — the drained turn that
+      // holds the lock must not run with the phone prompt or caller trust.
+      "trust:clear",
+      "prompt:clear",
+      "wait:resolved",
+      // Re-installed before the successful retry persist.
+      "trust:install",
+      "prompt:install",
+      "persist",
+      "client:install",
+      // The turn's own finally releases the state again.
+      "trust:clear",
+      "prompt:clear",
+      "client:reset",
+    ]);
     expect(fake.persistCount()).toBe(2);
     expect(fake.waitForIdleCalls.length).toBe(1);
     // The retried persist's row id is the one reported to the client.

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -15,6 +15,7 @@ import type {
 } from "../channels/types.js";
 import { getConfig } from "../config/loader.js";
 import { ABORT_WATCHDOG_MS } from "../daemon/abort-watchdog.js";
+import { CONVERSATION_BUSY_MESSAGE } from "../daemon/conversation-messaging.js";
 import { resolveChannelCapabilities } from "../daemon/conversation-runtime-assembly.js";
 import { getOrCreateConversation } from "../daemon/conversation-store.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
@@ -46,20 +47,19 @@ export const TURN_ABORTED_WAITING_MESSAGE =
 
 /**
  * Exact message thrown when the processing-wait budget elapses without the
- * conversation becoming available. The call controller's lock-contention
- * re-prompt matches on this string — keep the value byte-identical across
- * every throw site.
+ * conversation becoming available. Shared with the daemon's persist-time
+ * throw site (`conversation-messaging.ts`); the call controller's
+ * lock-contention re-prompt matches on this string.
  */
-export const CONVERSATION_BUSY_MESSAGE =
-  "Conversation is already processing a message";
+export { CONVERSATION_BUSY_MESSAGE };
 
 const PROCESSING_WAIT_MARGIN_MS = 1000;
 /**
  * How long startVoiceTurn waits for a prior turn to release the processing
  * lock before giving up. The prior turn can hold the lock for the abort
  * unwind budget PLUS the awaited turn-boundary commit window, so the wait
- * must cover both (+ margin) or a barge-in can still surface
- * "Conversation is already processing a message".
+ * must cover both (+ margin) or a barge-in can still fail with
+ * CONVERSATION_BUSY_MESSAGE.
  */
 export function resolveProcessingWaitMs(
   turnCommitMaxWaitMs: number,
@@ -538,8 +538,13 @@ export async function startVoiceTurn(
     });
     return persistResult.id;
   };
-  let messageId: string;
-  try {
+  /**
+   * Install this turn's per-conversation state (caller trust, call session
+   * id, channel capabilities, voice control prompt). Runs before every
+   * persist attempt: the busy-retry path below uninstalls via `cleanup()`
+   * for the duration of its wait, then re-installs before retrying.
+   */
+  const installVoiceTurnState = () => {
     conversation.setAssistantId(
       opts.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
     );
@@ -555,6 +560,10 @@ export async function startVoiceTurn(
       ),
     );
     conversation.setVoiceCallControlPrompt(voiceCallControlPrompt);
+  };
+  let messageId: string;
+  try {
+    installVoiceTurnState();
 
     try {
       messageId = await persistTurnUserMessage();
@@ -563,7 +572,10 @@ export async function startVoiceTurn(
       // above and this persist — the drain reaches its own persist a few
       // microtasks after the idle transition that released this turn.
       // Within the remaining budget, wait the drained turn out and retry
-      // the persist once instead of failing the barge-in.
+      // the persist once instead of failing the barge-in. The drained turn
+      // must not run with this turn's phone prompt or caller trust, so the
+      // voice state is uninstalled while it holds the lock and re-installed
+      // before the retry.
       if (
         !(err instanceof Error) ||
         err.message !== CONVERSATION_BUSY_MESSAGE ||
@@ -571,7 +583,9 @@ export async function startVoiceTurn(
       ) {
         throw err;
       }
+      cleanup();
       await waitOutProcessingLock();
+      installVoiceTurnState();
       messageId = await persistTurnUserMessage();
     }
   } catch (err) {

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -380,6 +380,36 @@ function repairPendingToolUseBlocks(conversation: Conversation): void {
 // ── drainQueue ───────────────────────────────────────────────────────
 
 /**
+ * Restore drained messages to the front of the queue, in their original
+ * order, when another turn (e.g. a barged-in voice turn woken by the idle
+ * transition) owns the processing lock. The lock holder's own finally block
+ * re-drains the queue. A steered drain also re-arms `pendingSteerRepair` so
+ * the re-drain promotes the steered head on its own instead of batching it
+ * with tails; the tool-use repair it re-triggers is idempotent.
+ */
+function requeueOnLockContention(
+  conversation: Conversation,
+  messages: QueuedMessage[],
+  steered: boolean,
+  logMessage: string,
+): void {
+  log.info(
+    {
+      conversationId: conversation.conversationId,
+      requestId: messages[0].requestId,
+      batchSize: messages.length,
+    },
+    logMessage,
+  );
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    conversation.queue.unshift(messages[i]);
+  }
+  if (steered) {
+    conversation.pendingSteerRepair = true;
+  }
+}
+
+/**
  * Process the next message in the queue, if any.
  * Called from the `runAgentLoop` finally block after processing completes.
  *
@@ -406,7 +436,7 @@ export async function drainQueue(
     if (!next) {
       return;
     }
-    return drainSingleMessage(conversation, next, reason);
+    return drainSingleMessage(conversation, next, reason, true);
   }
 
   const batch = await buildPassthroughBatch(conversation);
@@ -430,7 +460,24 @@ async function drainSingleMessage(
   conversation: Conversation,
   next: QueuedMessage,
   reason: QueueDrainReason,
+  steered = false,
 ): Promise<void> {
+  // Another turn already owns the processing lock: requeue before touching
+  // ANY conversation state. The lock holder installed its own per-turn
+  // context (turn channel/interface, trust, transport hints) and a drain
+  // that proceeded past this point would clobber it. The persist-busy
+  // requeue below stays as the TOCTOU backstop for a lock taken after
+  // this check.
+  if (conversation.isProcessing()) {
+    requeueOnLockContention(
+      conversation,
+      [next],
+      steered,
+      "Requeueing drained message: processing lock is held",
+    );
+    return;
+  }
+
   // Reset per-turn preactivation so a prior iteration (e.g. an unknown-slash
   // from a desktop source that skips runAgentLoop) can't leak CU preactivation
   // into the next queued message.
@@ -845,18 +892,15 @@ async function drainSingleMessage(
     // runAgentLoop never ran, so its finally block won't clear this
     conversation.preactivatedSkillIds = undefined;
     if (message === CONVERSATION_BUSY_MESSAGE) {
-      // Another turn (e.g. a barged-in voice turn woken by the idle
-      // transition) took the lock between this drain's dequeue and its
+      // Another turn took the lock between this drain's dequeue and its
       // persist. The message is still valid — requeue it at the front and
       // stop; the lock holder's own finally re-drains the queue.
-      log.info(
-        {
-          conversationId: conversation.conversationId,
-          requestId: next.requestId,
-        },
+      requeueOnLockContention(
+        conversation,
+        [next],
+        steered,
         "Requeueing drained message: processing lock was retaken",
       );
-      conversation.queue.unshift(next);
       return;
     }
     log.error(
@@ -1004,6 +1048,20 @@ async function drainBatch(
   batch: QueuedMessage[],
   reason: QueueDrainReason,
 ): Promise<void> {
+  // Another turn already owns the processing lock: requeue the whole batch
+  // before touching ANY conversation state, mirroring `drainSingleMessage`.
+  // The head persist-busy requeue below stays as the TOCTOU backstop.
+  // Steered drains never batch, so there is no steer promotion to restore.
+  if (conversation.isProcessing()) {
+    requeueOnLockContention(
+      conversation,
+      batch,
+      false,
+      "Requeueing drained batch: processing lock is held",
+    );
+    return;
+  }
+
   // Head-wins: the batch-builder guarantees identical userMessageInterface
   // across the batch; channel/transport divergence is accepted with the head's
   // environment.
@@ -1213,18 +1271,13 @@ async function drainBatch(
         // another turn took the lock between dequeue and persist. The
         // whole batch is still valid — requeue it at the front in order
         // and stop; the lock holder's finally re-drains the queue.
-        log.info(
-          {
-            conversationId: conversation.conversationId,
-            requestId: qm.requestId,
-            batchSize: batch.length,
-          },
+        conversation.preactivatedSkillIds = undefined;
+        requeueOnLockContention(
+          conversation,
+          batch,
+          false,
           "Requeueing drained batch: processing lock was retaken",
         );
-        conversation.preactivatedSkillIds = undefined;
-        for (let j = batch.length - 1; j >= 0; j -= 1) {
-          conversation.queue.unshift(batch[j]);
-        }
         return;
       }
       log.error(

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -21,6 +21,7 @@ import {
   getGuardianDelivery,
   guardianForChannel,
 } from "../../../contacts/guardian-delivery-reader.js";
+import { CONVERSATION_BUSY_MESSAGE } from "../../../daemon/conversation-messaging.js";
 import type { ServerMessage } from "../../../daemon/message-protocol.js";
 import type { TrustContext } from "../../../daemon/trust-context-types.js";
 import {
@@ -297,7 +298,7 @@ export function processChannelMessageInBackground(
         if (
           slackMappingMutated &&
           err instanceof Error &&
-          err.message.includes("already processing a message")
+          err.message.includes(CONVERSATION_BUSY_MESSAGE)
         ) {
           if (priorSlackMapping) {
             setThreadTs(


### PR DESCRIPTION
## Summary
Fixes round-2 review gaps for voice-mode-latency.md (follow-up to #37679/#37681).

- Bridge busy-retry now uninstalls voice turn state before waiting and re-installs before the retry, so a drained text turn never runs with the phone prompt or caller trust
- Drains check the lock before any conversation mutation and requeue early; steered requeues restore pendingSteerRepair
- CONVERSATION_BUSY_MESSAGE has a single daemon definition; background-dispatch matches the constant