### PR TITLE
feat(gateway): guardian_requests + guardian_request_deliveries tables with a native store

### DIFF
--- a/gateway/src/db/__tests__/guardian-request-store.test.ts
+++ b/gateway/src/db/__tests__/guardian-request-store.test.ts
@@ -1,0 +1,847 @@
+import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { eq } from "drizzle-orm";
+
+import "../../__tests__/test-preload.js";
+import { getGatewayDb, initGatewayDb, resetGatewayDb } from "../connection.js";
+import { guardianRequestDeliveries, guardianRequests } from "../schema.js";
+import {
+  createDelivery,
+  createGuardianRequest,
+  deriveSourceType,
+  expireAllPendingInteractionBound,
+  expireGuardianRequest,
+  generateRequestCode,
+  getByPendingQuestionId,
+  getGuardianRequest,
+  getGuardianRequestByCode,
+  getPendingByCallSessionId,
+  getPendingByDestinationMessage,
+  GuardianRequestIntegrityError,
+  isRequestInConversationScope,
+  listDeliveries,
+  listGuardianRequests,
+  listPendingByConversationScope,
+  listPendingByDestinationChat,
+  listPendingByDestinationConversation,
+  resolveGuardianRequest,
+  sweepExpiredGuardianRequests,
+  updateDelivery,
+  updateGuardianRequest,
+} from "../guardian-request-store.js";
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+const FUTURE = () => Date.now() + 10 * 60 * 1000;
+const PAST = () => Date.now() - 10_000;
+
+// All decisionable kinds require a guardianPrincipalId at creation.
+const TEST_PRINCIPAL = "test-principal-id";
+
+beforeEach(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+  getGatewayDb().delete(guardianRequestDeliveries).run();
+  getGatewayDb().delete(guardianRequests).run();
+});
+
+afterEach(() => {
+  resetGatewayDb();
+});
+
+function createRequest(
+  overrides: Partial<Parameters<typeof createGuardianRequest>[0]> = {},
+) {
+  return createGuardianRequest({
+    kind: "access_request",
+    guardianPrincipalId: TEST_PRINCIPAL,
+    ...overrides,
+  });
+}
+
+/** A uuid whose first 6 hex chars (dashes stripped) form the given code. */
+function uuidForCode(code: string): ReturnType<typeof crypto.randomUUID> {
+  return `${code.toLowerCase()}00-0000-4000-8000-000000000000` as ReturnType<
+    typeof crypto.randomUUID
+  >;
+}
+
+// ---------------------------------------------------------------------------
+// createGuardianRequest
+// ---------------------------------------------------------------------------
+
+describe("createGuardianRequest", () => {
+  test("round-trips a fully populated request", () => {
+    const expiresAt = FUTURE();
+    const req = createRequest({
+      kind: "pending_question",
+      sourceChannel: "phone",
+      sourceConversationId: "conv-1",
+      requesterExternalUserId: "user-1",
+      requesterChatId: "+15555550100",
+      guardianExternalUserId: "guardian-1",
+      callSessionId: "call-1",
+      pendingQuestionId: "pq-1",
+      questionText: "What is the gate code?",
+      requestCode: "A1B2C3",
+      toolName: "file_edit",
+      inputDigest: "sha256:deadbeef",
+      commandPreview: "rm -rf /tmp/test",
+      riskLevel: "high",
+      activityText: "Deleting temporary test files",
+      executionTarget: "host",
+      requesterSignals: '{"isBot":false}',
+      requestTrigger: "admitted",
+      followupState: "none",
+      expiresAt,
+    });
+
+    expect(req.id).toBeTruthy();
+    expect(req.status).toBe("pending");
+    expect(req.createdAt).toBeTruthy();
+
+    const fetched = getGuardianRequest(req.id);
+    expect(fetched).toEqual(req);
+    expect(fetched?.sourceConversationId).toBe("conv-1");
+    expect(fetched?.requestTrigger).toBe("admitted");
+    expect(fetched?.commandPreview).toBe("rm -rf /tmp/test");
+    expect(fetched?.expiresAt).toBe(expiresAt);
+  });
+
+  test("defaults optional fields to null and generates id + code", () => {
+    const req = createRequest();
+
+    expect(req.id).toBeTruthy();
+    expect(req.requestCode).toMatch(/^[0-9A-F]{6}$/);
+    expect(req.sourceChannel).toBeNull();
+    expect(req.sourceConversationId).toBeNull();
+    expect(req.toolName).toBeNull();
+    expect(req.requestTrigger).toBeNull();
+    expect(req.status).toBe("pending");
+  });
+
+  test("honors caller-supplied ids", () => {
+    const id = "access-req-self-telegram-user-1-1234567890";
+    const req = createRequest({ id });
+    expect(req.id).toBe(id);
+    expect(getGuardianRequest(id)?.id).toBe(id);
+  });
+
+  test("rejects decisionable kinds without guardianPrincipalId", () => {
+    for (const kind of [
+      "access_request",
+      "tool_approval",
+      "tool_grant_request",
+      "pending_question",
+    ]) {
+      let thrown: unknown;
+      try {
+        createGuardianRequest({ kind });
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(GuardianRequestIntegrityError);
+      expect((thrown as GuardianRequestIntegrityError).code).toBe(
+        "guardian_principal_required",
+      );
+    }
+    expect(listGuardianRequests()).toHaveLength(0);
+  });
+
+  test("allows non-decisionable kinds without guardianPrincipalId", () => {
+    const req = createGuardianRequest({ kind: "status_update" });
+    expect(req.guardianPrincipalId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateRequestCode
+// ---------------------------------------------------------------------------
+
+describe("generateRequestCode", () => {
+  test("retries when the code collides with a pending request", () => {
+    createRequest({ requestCode: "ABC123" });
+
+    const spy = spyOn(crypto, "randomUUID")
+      .mockReturnValueOnce(uuidForCode("abc123"))
+      .mockReturnValueOnce(uuidForCode("def456"));
+
+    expect(generateRequestCode()).toBe("DEF456");
+    expect(spy).toHaveBeenCalledTimes(2);
+    spy.mockRestore();
+  });
+
+  test("returns the colliding code after exhausting retries", () => {
+    createRequest({ requestCode: "ABC123" });
+
+    const spy = spyOn(crypto, "randomUUID").mockReturnValue(
+      uuidForCode("abc123"),
+    );
+
+    expect(generateRequestCode()).toBe("ABC123");
+    expect(spy).toHaveBeenCalledTimes(6);
+    spy.mockRestore();
+  });
+
+  test("resolved requests do not count as collisions", () => {
+    const req = createRequest({ requestCode: "ABC123" });
+    updateGuardianRequest(req.id, { status: "approved" });
+
+    const spy = spyOn(crypto, "randomUUID").mockReturnValueOnce(
+      uuidForCode("abc123"),
+    );
+
+    expect(generateRequestCode()).toBe("ABC123");
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getGuardianRequest / getGuardianRequestByCode
+// ---------------------------------------------------------------------------
+
+describe("getGuardianRequest", () => {
+  test("returns null for a nonexistent id", () => {
+    expect(getGuardianRequest("missing")).toBeNull();
+  });
+});
+
+describe("getGuardianRequestByCode", () => {
+  test("matches pending requests only", () => {
+    const pending = createRequest({ requestCode: "AAA111" });
+    const resolved = createRequest({ requestCode: "BBB222" });
+    updateGuardianRequest(resolved.id, { status: "approved" });
+
+    expect(getGuardianRequestByCode("AAA111")?.id).toBe(pending.id);
+    expect(getGuardianRequestByCode("BBB222")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listGuardianRequests
+// ---------------------------------------------------------------------------
+
+describe("listGuardianRequests", () => {
+  test("lists all requests with no filters", () => {
+    createRequest();
+    createRequest({ kind: "tool_approval" });
+    expect(listGuardianRequests()).toHaveLength(2);
+  });
+
+  test("filters by status, kind, guardian, requester, and conversation", () => {
+    const match = createRequest({
+      kind: "tool_approval",
+      guardianExternalUserId: "guardian-A",
+      requesterExternalUserId: "requester-A",
+      sourceConversationId: "conv-A",
+      toolName: "execute_code",
+    });
+    createRequest({
+      kind: "tool_approval",
+      guardianExternalUserId: "guardian-B",
+      requesterExternalUserId: "requester-B",
+      sourceConversationId: "conv-B",
+      toolName: "file_edit",
+    });
+    const approved = createRequest({ kind: "tool_approval" });
+    updateGuardianRequest(approved.id, { status: "approved" });
+
+    expect(listGuardianRequests({ status: "pending" })).toHaveLength(2);
+    expect(listGuardianRequests({ status: "approved" })).toHaveLength(1);
+    expect(
+      listGuardianRequests({
+        status: "pending",
+        kind: "tool_approval",
+        guardianExternalUserId: "guardian-A",
+        guardianPrincipalId: TEST_PRINCIPAL,
+        requesterExternalUserId: "requester-A",
+        sourceConversationId: "conv-A",
+        toolName: "execute_code",
+      }).map((r) => r.id),
+    ).toEqual([match.id]);
+  });
+
+  test("filters by sourceChannel", () => {
+    createRequest({ sourceChannel: "telegram" });
+    createRequest({ sourceChannel: "slack" });
+
+    const filtered = listGuardianRequests({ sourceChannel: "telegram" });
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].sourceChannel).toBe("telegram");
+  });
+
+  test("translates the sourceType filter to source_channel predicates", () => {
+    const voice = createRequest({ sourceChannel: "phone" });
+    const desktop = createRequest({ sourceChannel: "vellum" });
+    const telegram = createRequest({ sourceChannel: "telegram" });
+    const channelless = createRequest();
+
+    expect(
+      listGuardianRequests({ sourceType: "voice" }).map((r) => r.id),
+    ).toEqual([voice.id]);
+    expect(
+      listGuardianRequests({ sourceType: "desktop" }).map((r) => r.id),
+    ).toEqual([desktop.id]);
+    expect(
+      listGuardianRequests({ sourceType: "channel" })
+        .map((r) => r.id)
+        .sort(),
+    ).toEqual([telegram.id, channelless.id].sort());
+  });
+});
+
+describe("deriveSourceType", () => {
+  test("maps phone → voice, vellum → desktop, else channel", () => {
+    expect(deriveSourceType("phone")).toBe("voice");
+    expect(deriveSourceType("vellum")).toBe("desktop");
+    expect(deriveSourceType("telegram")).toBe("channel");
+    expect(deriveSourceType(null)).toBe("channel");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateGuardianRequest
+// ---------------------------------------------------------------------------
+
+describe("updateGuardianRequest", () => {
+  test("applies partial updates", () => {
+    const req = createRequest();
+
+    const updated = updateGuardianRequest(req.id, {
+      status: "approved",
+      answerText: "Looks good",
+      decidedByExternalUserId: "guardian-1",
+      decidedByPrincipalId: TEST_PRINCIPAL,
+      followupState: "inline_wait_active:123",
+      expiresAt: 42,
+    });
+
+    expect(updated?.status).toBe("approved");
+    expect(updated?.answerText).toBe("Looks good");
+    expect(updated?.decidedByExternalUserId).toBe("guardian-1");
+    expect(updated?.decidedByPrincipalId).toBe(TEST_PRINCIPAL);
+    expect(updated?.followupState).toBe("inline_wait_active:123");
+    expect(updated?.expiresAt).toBe(42);
+    expect(updated?.updatedAt).toBeGreaterThanOrEqual(req.updatedAt);
+  });
+
+  test("clears followupState with an explicit null", () => {
+    const req = createRequest({ followupState: "none" });
+    const updated = updateGuardianRequest(req.id, { followupState: null });
+    expect(updated?.followupState).toBeNull();
+  });
+
+  test("returns null for a nonexistent request", () => {
+    expect(updateGuardianRequest("missing", { status: "approved" })).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveGuardianRequest (CAS)
+// ---------------------------------------------------------------------------
+
+describe("resolveGuardianRequest", () => {
+  test("resolves a pending request and stamps decision fields", () => {
+    const req = createRequest();
+
+    const result = resolveGuardianRequest(req.id, "pending", {
+      status: "approved",
+      answerText: "Approved by guardian",
+      decidedByExternalUserId: "guardian-1",
+      decidedByPrincipalId: TEST_PRINCIPAL,
+    });
+
+    if (!result.applied) {
+      throw new Error("expected resolve to apply");
+    }
+    expect(result.request.status).toBe("approved");
+    expect(result.request.answerText).toBe("Approved by guardian");
+    expect(result.request.decidedByExternalUserId).toBe("guardian-1");
+    expect(result.request.decidedByPrincipalId).toBe(TEST_PRINCIPAL);
+  });
+
+  test("first writer wins — the second resolve returns applied:false", () => {
+    const req = createRequest();
+
+    const first = resolveGuardianRequest(req.id, "pending", {
+      status: "approved",
+      answerText: "First approver",
+      decidedByExternalUserId: "guardian-1",
+    });
+    const second = resolveGuardianRequest(req.id, "pending", {
+      status: "denied",
+      answerText: "Second denier",
+      decidedByExternalUserId: "guardian-2",
+    });
+
+    expect(first.applied).toBe(true);
+    expect(second).toEqual({ applied: false });
+
+    const final = getGuardianRequest(req.id);
+    expect(final?.status).toBe("approved");
+    expect(final?.answerText).toBe("First approver");
+    expect(final?.decidedByExternalUserId).toBe("guardian-1");
+  });
+
+  test("fails without side effects when expectedStatus does not match", () => {
+    const req = createRequest();
+
+    expect(
+      resolveGuardianRequest(req.id, "approved", { status: "denied" }),
+    ).toEqual({ applied: false });
+    expect(getGuardianRequest(req.id)?.status).toBe("pending");
+  });
+
+  test("supports the terminal → pending reopen path", () => {
+    const req = createRequest();
+    resolveGuardianRequest(req.id, "pending", { status: "approved" });
+
+    const reopened = resolveGuardianRequest(req.id, "approved", {
+      status: "pending",
+    });
+
+    if (!reopened.applied) {
+      throw new Error("expected reopen to apply");
+    }
+    expect(reopened.request.status).toBe("pending");
+    expect(getGuardianRequest(req.id)?.status).toBe("pending");
+  });
+
+  test("returns applied:false for a nonexistent request", () => {
+    expect(
+      resolveGuardianRequest("missing", "pending", { status: "approved" }),
+    ).toEqual({ applied: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// expireAllPendingInteractionBound
+// ---------------------------------------------------------------------------
+
+describe("expireAllPendingInteractionBound", () => {
+  test("expires interaction-bound kinds unconditionally", () => {
+    const toolApproval = createRequest({
+      kind: "tool_approval",
+      expiresAt: FUTURE(),
+    });
+    const pendingQuestion = createRequest({
+      kind: "pending_question",
+      expiresAt: FUTURE(),
+    });
+
+    expect(expireAllPendingInteractionBound()).toBe(2);
+    expect(getGuardianRequest(toolApproval.id)?.status).toBe("expired");
+    expect(getGuardianRequest(pendingQuestion.id)?.status).toBe("expired");
+  });
+
+  test("expires persistent kinds only past their deadline", () => {
+    const staleAccess = createRequest({
+      kind: "access_request",
+      expiresAt: PAST(),
+    });
+    const staleGrant = createRequest({
+      kind: "tool_grant_request",
+      expiresAt: PAST(),
+    });
+    const freshAccess = createRequest({
+      kind: "access_request",
+      expiresAt: FUTURE(),
+    });
+    const deadlineless = createRequest({ kind: "tool_grant_request" });
+
+    expect(expireAllPendingInteractionBound()).toBe(2);
+    expect(getGuardianRequest(staleAccess.id)?.status).toBe("expired");
+    expect(getGuardianRequest(staleGrant.id)?.status).toBe("expired");
+    expect(getGuardianRequest(freshAccess.id)?.status).toBe("pending");
+    expect(getGuardianRequest(deadlineless.id)?.status).toBe("pending");
+  });
+
+  test("leaves already-resolved requests untouched", () => {
+    const approved = createRequest({ kind: "tool_approval" });
+    updateGuardianRequest(approved.id, { status: "approved" });
+
+    expect(expireAllPendingInteractionBound()).toBe(0);
+    expect(getGuardianRequest(approved.id)?.status).toBe("approved");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sweepExpiredGuardianRequests
+// ---------------------------------------------------------------------------
+
+describe("sweepExpiredGuardianRequests", () => {
+  test("expires past-deadline pending rows and returns their ids", () => {
+    const stale1 = createRequest({ expiresAt: PAST() });
+    const stale2 = createRequest({
+      kind: "tool_approval",
+      expiresAt: PAST(),
+    });
+    const fresh = createRequest({ expiresAt: FUTURE() });
+    const deadlineless = createRequest();
+    const resolved = createRequest({ expiresAt: PAST() });
+    updateGuardianRequest(resolved.id, { status: "denied" });
+
+    const expired = sweepExpiredGuardianRequests();
+
+    expect(expired.sort()).toEqual([stale1.id, stale2.id].sort());
+    expect(getGuardianRequest(stale1.id)?.status).toBe("expired");
+    expect(getGuardianRequest(stale2.id)?.status).toBe("expired");
+    expect(getGuardianRequest(fresh.id)?.status).toBe("pending");
+    expect(getGuardianRequest(deadlineless.id)?.status).toBe("pending");
+    expect(getGuardianRequest(resolved.id)?.status).toBe("denied");
+  });
+
+  test("returns an empty list when nothing is stale", () => {
+    createRequest({ expiresAt: FUTURE() });
+    expect(sweepExpiredGuardianRequests()).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// expireGuardianRequest
+// ---------------------------------------------------------------------------
+
+describe("expireGuardianRequest", () => {
+  test("expires a pending request and all its deliveries", () => {
+    const req = createRequest();
+    const d1 = createDelivery({
+      requestId: req.id,
+      destinationChannel: "telegram",
+      destinationChatId: "chat-1",
+    });
+    const d2 = createDelivery({
+      requestId: req.id,
+      destinationChannel: "vellum",
+      destinationConversationId: "conv-1",
+    });
+
+    expireGuardianRequest(req.id);
+
+    expect(getGuardianRequest(req.id)?.status).toBe("expired");
+    const statuses = listDeliveries(req.id).map((d) => d.status);
+    expect(statuses).toEqual(["expired", "expired"]);
+    expect([d1.status, d2.status]).toEqual(["pending", "pending"]);
+  });
+
+  test("does not overwrite an already-resolved request status", () => {
+    const req = createRequest();
+    resolveGuardianRequest(req.id, "pending", { status: "approved" });
+
+    expireGuardianRequest(req.id);
+
+    expect(getGuardianRequest(req.id)?.status).toBe("approved");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deliveries
+// ---------------------------------------------------------------------------
+
+describe("deliveries", () => {
+  test("creates and lists deliveries for a request", () => {
+    const req = createRequest();
+
+    const d1 = createDelivery({
+      requestId: req.id,
+      destinationChannel: "telegram",
+      destinationChatId: "chat-123",
+    });
+    createDelivery({
+      requestId: req.id,
+      destinationChannel: "phone",
+      destinationChatId: "+15555550101",
+    });
+
+    expect(d1.id).toBeTruthy();
+    expect(d1.requestId).toBe(req.id);
+    expect(d1.status).toBe("pending");
+
+    const deliveries = listDeliveries(req.id);
+    expect(deliveries).toHaveLength(2);
+    expect(deliveries.map((d) => d.destinationChannel).sort()).toEqual([
+      "phone",
+      "telegram",
+    ]);
+  });
+
+  test("honors caller-supplied delivery ids", () => {
+    const req = createRequest();
+    const d = createDelivery({
+      id: "delivery-1",
+      requestId: req.id,
+      destinationChannel: "telegram",
+    });
+    expect(d.id).toBe("delivery-1");
+  });
+
+  test("updates delivery status and destinationMessageId", () => {
+    const req = createRequest();
+    const delivery = createDelivery({
+      requestId: req.id,
+      destinationChannel: "telegram",
+    });
+
+    const updated = updateDelivery(delivery.id, {
+      status: "sent",
+      destinationMessageId: "msg-789",
+    });
+
+    expect(updated?.status).toBe("sent");
+    expect(updated?.destinationMessageId).toBe("msg-789");
+  });
+
+  test("returns null when updating a nonexistent delivery", () => {
+    expect(updateDelivery("missing", { status: "sent" })).toBeNull();
+  });
+
+  test("deleting a request cascades to its deliveries", () => {
+    const req = createRequest();
+    createDelivery({ requestId: req.id, destinationChannel: "telegram" });
+    createDelivery({ requestId: req.id, destinationChannel: "vellum" });
+
+    getGatewayDb()
+      .delete(guardianRequests)
+      .where(eq(guardianRequests.id, req.id))
+      .run();
+
+    expect(listDeliveries(req.id)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// By-destination reads
+// ---------------------------------------------------------------------------
+
+describe("getPendingByDestinationMessage", () => {
+  test("recovers the pending request behind a delivered card message", () => {
+    const req = createRequest();
+    const other = createRequest();
+    createDelivery({
+      requestId: req.id,
+      destinationChannel: "telegram",
+      destinationChatId: "chat-1",
+      destinationMessageId: "msg-1",
+    });
+    createDelivery({
+      requestId: other.id,
+      destinationChannel: "telegram",
+      destinationChatId: "chat-1",
+      destinationMessageId: "msg-2",
+    });
+
+    expect(
+      getPendingByDestinationMessage("telegram", "chat-1", "msg-1")?.id,
+    ).toBe(req.id);
+    expect(
+      getPendingByDestinationMessage("telegram", "chat-1", "msg-3"),
+    ).toBeNull();
+    expect(
+      getPendingByDestinationMessage("slack", "chat-1", "msg-1"),
+    ).toBeNull();
+  });
+
+  test("returns null when the matched request is no longer pending", () => {
+    const req = createRequest();
+    createDelivery({
+      requestId: req.id,
+      destinationChannel: "telegram",
+      destinationChatId: "chat-1",
+      destinationMessageId: "msg-1",
+    });
+    resolveGuardianRequest(req.id, "pending", { status: "approved" });
+
+    expect(
+      getPendingByDestinationMessage("telegram", "chat-1", "msg-1"),
+    ).toBeNull();
+  });
+});
+
+describe("listPendingByDestinationChat", () => {
+  test("returns pending requests for the (channel, chatId) pair, deduplicated", () => {
+    const pending = createRequest();
+    const resolved = createRequest();
+    updateGuardianRequest(resolved.id, { status: "approved" });
+
+    createDelivery({
+      requestId: pending.id,
+      destinationChannel: "telegram",
+      destinationChatId: "chat-1",
+      destinationMessageId: "msg-1",
+    });
+    createDelivery({
+      requestId: pending.id,
+      destinationChannel: "telegram",
+      destinationChatId: "chat-1",
+      destinationMessageId: "msg-2",
+    });
+    createDelivery({
+      requestId: resolved.id,
+      destinationChannel: "telegram",
+      destinationChatId: "chat-1",
+    });
+
+    const results = listPendingByDestinationChat("telegram", "chat-1");
+    expect(results.map((r) => r.id)).toEqual([pending.id]);
+    expect(listPendingByDestinationChat("phone", "chat-1")).toHaveLength(0);
+    expect(listPendingByDestinationChat("telegram", "chat-2")).toHaveLength(0);
+  });
+});
+
+describe("listPendingByDestinationConversation", () => {
+  test("returns pending requests, optionally scoped by channel", () => {
+    const pending = createRequest();
+    const resolved = createRequest();
+    updateGuardianRequest(resolved.id, { status: "approved" });
+
+    createDelivery({
+      requestId: pending.id,
+      destinationChannel: "vellum",
+      destinationConversationId: "conv-1",
+    });
+    createDelivery({
+      requestId: resolved.id,
+      destinationChannel: "vellum",
+      destinationConversationId: "conv-1",
+    });
+
+    expect(
+      listPendingByDestinationConversation("conv-1").map((r) => r.id),
+    ).toEqual([pending.id]);
+    expect(
+      listPendingByDestinationConversation("conv-1", "vellum").map((r) => r.id),
+    ).toEqual([pending.id]);
+    expect(
+      listPendingByDestinationConversation("conv-1", "telegram"),
+    ).toHaveLength(0);
+  });
+
+  test("deduplicates multiple deliveries for the same request", () => {
+    const req = createRequest();
+    createDelivery({
+      requestId: req.id,
+      destinationChannel: "vellum",
+      destinationConversationId: "conv-1",
+    });
+    createDelivery({
+      requestId: req.id,
+      destinationChannel: "telegram",
+      destinationConversationId: "conv-1",
+    });
+
+    expect(listPendingByDestinationConversation("conv-1")).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conversation scope
+// ---------------------------------------------------------------------------
+
+describe("listPendingByConversationScope", () => {
+  test("unions source-conversation and delivery-destination matches", () => {
+    const bySource = createRequest({ sourceConversationId: "conv-1" });
+    const byDelivery = createRequest();
+    createDelivery({
+      requestId: byDelivery.id,
+      destinationChannel: "vellum",
+      destinationConversationId: "conv-1",
+    });
+    const both = createRequest({ sourceConversationId: "conv-1" });
+    createDelivery({
+      requestId: both.id,
+      destinationChannel: "vellum",
+      destinationConversationId: "conv-1",
+    });
+
+    const results = listPendingByConversationScope("conv-1");
+    expect(results.map((r) => r.id).sort()).toEqual(
+      [bySource.id, byDelivery.id, both.id].sort(),
+    );
+  });
+
+  test("filters expired requests and honors the channel scope", () => {
+    createRequest({ sourceConversationId: "conv-1", expiresAt: PAST() });
+    const fresh = createRequest({
+      sourceConversationId: "conv-1",
+      expiresAt: FUTURE(),
+    });
+    const otherChannel = createRequest();
+    createDelivery({
+      requestId: otherChannel.id,
+      destinationChannel: "telegram",
+      destinationConversationId: "conv-1",
+    });
+
+    const results = listPendingByConversationScope("conv-1", "vellum");
+    expect(results.map((r) => r.id)).toEqual([fresh.id]);
+  });
+});
+
+describe("isRequestInConversationScope", () => {
+  test("matches the source conversation and delivery destinations", () => {
+    const req = createRequest({ sourceConversationId: "access-req-src" });
+    createDelivery({
+      requestId: req.id,
+      destinationChannel: "slack",
+      destinationChatId: "guardian-chat",
+      destinationConversationId: "guardian-conv",
+    });
+
+    expect(isRequestInConversationScope(req.id, "access-req-src")).toBe(true);
+    expect(isRequestInConversationScope(req.id, "guardian-conv")).toBe(true);
+    expect(isRequestInConversationScope(req.id, "guardian-conv", "slack")).toBe(
+      true,
+    );
+    expect(
+      isRequestInConversationScope(req.id, "guardian-conv", "telegram"),
+    ).toBe(false);
+    expect(isRequestInConversationScope(req.id, "unrelated-conv")).toBe(false);
+    expect(isRequestInConversationScope("missing", "guardian-conv")).toBe(
+      false,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Call-controller convenience reads
+// ---------------------------------------------------------------------------
+
+describe("getPendingByCallSessionId", () => {
+  test("returns the most recent pending request for the call session", () => {
+    const db = getGatewayDb();
+    const now = Date.now();
+    for (const [id, createdAt, status] of [
+      ["older", now - 2000, "pending"],
+      ["newest", now, "pending"],
+      ["resolved", now + 1000, "approved"],
+    ] as const) {
+      db.insert(guardianRequests)
+        .values({
+          id,
+          kind: "pending_question",
+          callSessionId: "call-1",
+          guardianPrincipalId: TEST_PRINCIPAL,
+          status,
+          createdAt,
+          updatedAt: createdAt,
+        })
+        .run();
+    }
+
+    expect(getPendingByCallSessionId("call-1")?.id).toBe("newest");
+    expect(getPendingByCallSessionId("call-2")).toBeNull();
+  });
+});
+
+describe("getByPendingQuestionId", () => {
+  test("finds the request linked to a pending question", () => {
+    const req = createRequest({
+      kind: "pending_question",
+      pendingQuestionId: "pq-1",
+    });
+
+    expect(getByPendingQuestionId("pq-1")?.id).toBe(req.id);
+    expect(getByPendingQuestionId("pq-2")).toBeNull();
+  });
+});

--- a/gateway/src/db/guardian-request-store.ts
+++ b/gateway/src/db/guardian-request-store.ts
@@ -1,9 +1,8 @@
 /**
  * Gateway-owned guardian request store.
  *
- * Drizzle-backed port of the assistant's canonical-guardian-store (guardian
- * requests become gateway-native). Same semantics and status vocabulary;
- * resolution uses compare-and-swap (CAS): the first writer to transition a
+ * Sole access layer for guardian_requests + guardian_request_deliveries.
+ * Resolution uses compare-and-swap (CAS): the first writer to transition a
  * request from the expected status wins.
  */
 

--- a/gateway/src/db/guardian-request-store.ts
+++ b/gateway/src/db/guardian-request-store.ts
@@ -1,0 +1,955 @@
+/**
+ * Gateway-owned guardian request store.
+ *
+ * Drizzle-backed port of the assistant's canonical-guardian-store (guardian
+ * requests become gateway-native). Same semantics and status vocabulary;
+ * resolution uses compare-and-swap (CAS): the first writer to transition a
+ * request from the expected status wins.
+ */
+
+import type { Database } from "bun:sqlite";
+import {
+  and,
+  desc,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  lt,
+  notInArray,
+  or,
+} from "drizzle-orm";
+
+import { getGatewayDb } from "./connection.js";
+import { guardianRequestDeliveries, guardianRequests } from "./schema.js";
+
+/**
+ * Raw bun:sqlite client — needed where drizzle's run() hides the changes
+ * count (CAS guards, bulk-expiry counts).
+ */
+function rawClient(): Database {
+  return (getGatewayDb() as unknown as { $client: Database }).$client;
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type GuardianRequestStatus =
+  | "pending"
+  | "approved"
+  | "denied"
+  | "expired"
+  | "cancelled";
+
+export type GuardianRequestSourceType = "voice" | "desktop" | "channel";
+
+export interface GuardianRequest {
+  id: string;
+  kind: string;
+  sourceChannel: string | null;
+  sourceConversationId: string | null;
+  requesterExternalUserId: string | null;
+  requesterChatId: string | null;
+  guardianExternalUserId: string | null;
+  guardianPrincipalId: string | null;
+  callSessionId: string | null;
+  pendingQuestionId: string | null;
+  questionText: string | null;
+  requestCode: string | null;
+  toolName: string | null;
+  inputDigest: string | null;
+  commandPreview: string | null;
+  riskLevel: string | null;
+  activityText: string | null;
+  executionTarget: string | null;
+  /** JSON-encoded requester identity signals. */
+  requesterSignals: string | null;
+  /** What prompted an access request: `denied` (default) or `admitted`. */
+  requestTrigger: string | null;
+  status: GuardianRequestStatus;
+  answerText: string | null;
+  decidedByExternalUserId: string | null;
+  decidedByPrincipalId: string | null;
+  followupState: string | null;
+  expiresAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface GuardianRequestDelivery {
+  id: string;
+  requestId: string;
+  destinationChannel: string;
+  destinationConversationId: string | null;
+  destinationChatId: string | null;
+  destinationMessageId: string | null;
+  status: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/**
+ * Thrown when a create violates a store integrity invariant. Carries a
+ * stable machine-readable `code` so the IPC layer can map it onto the wire.
+ */
+export class GuardianRequestIntegrityError extends Error {
+  readonly code = "guardian_principal_required";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "GuardianRequestIntegrityError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Expiry / source-type helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when a request has passed its `expiresAt` deadline.
+ * Requests without an `expiresAt` are never considered expired by this check.
+ */
+export function isRequestExpired(
+  request: Pick<GuardianRequest, "expiresAt">,
+): boolean {
+  if (!request.expiresAt) {
+    return false;
+  }
+  return request.expiresAt < Date.now();
+}
+
+/**
+ * Derive the presentation-level source type from the provenance channel.
+ * The gateway table does not store source_type — it is mechanical:
+ * phone → voice, vellum → desktop, everything else (incl. null) → channel.
+ */
+export function deriveSourceType(
+  sourceChannel: string | null,
+): GuardianRequestSourceType {
+  if (sourceChannel === "phone") {
+    return "voice";
+  }
+  if (sourceChannel === "vellum") {
+    return "desktop";
+  }
+  return "channel";
+}
+
+function sourceTypeCondition(sourceType: string) {
+  if (sourceType === "voice") {
+    return eq(guardianRequests.sourceChannel, "phone");
+  }
+  if (sourceType === "desktop") {
+    return eq(guardianRequests.sourceChannel, "vellum");
+  }
+  return or(
+    isNull(guardianRequests.sourceChannel),
+    notInArray(guardianRequests.sourceChannel, ["phone", "vellum"]),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Request code generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a short human-readable request code (6 hex chars, uppercase).
+ *
+ * Checks for collisions against existing PENDING requests and retries up to
+ * 5 times to avoid code reuse among active requests. Resolved requests with
+ * the same code are harmless since getGuardianRequestByCode filters by
+ * status='pending'.
+ */
+export function generateRequestCode(): string {
+  const MAX_RETRIES = 5;
+  const newCode = () =>
+    crypto.randomUUID().replace(/-/g, "").slice(0, 6).toUpperCase();
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    const code = newCode();
+    if (!getGuardianRequestByCode(code)) {
+      return code;
+    }
+  }
+  // Last resort: return the code even if it collides (extremely unlikely
+  // with 16^6 = ~16.7M possible codes).
+  return newCode();
+}
+
+// ---------------------------------------------------------------------------
+// Row mapping
+// ---------------------------------------------------------------------------
+
+function rowToRequest(
+  row: typeof guardianRequests.$inferSelect,
+): GuardianRequest {
+  return {
+    id: row.id,
+    kind: row.kind,
+    sourceChannel: row.sourceChannel,
+    sourceConversationId: row.sourceConversationId,
+    requesterExternalUserId: row.requesterExternalUserId,
+    requesterChatId: row.requesterChatId,
+    guardianExternalUserId: row.guardianExternalUserId,
+    guardianPrincipalId: row.guardianPrincipalId,
+    callSessionId: row.callSessionId,
+    pendingQuestionId: row.pendingQuestionId,
+    questionText: row.questionText,
+    requestCode: row.requestCode,
+    toolName: row.toolName,
+    inputDigest: row.inputDigest,
+    commandPreview: row.commandPreview,
+    riskLevel: row.riskLevel,
+    activityText: row.activityText,
+    executionTarget: row.executionTarget,
+    requesterSignals: row.requesterSignals,
+    requestTrigger: row.requestTrigger,
+    status: row.status as GuardianRequestStatus,
+    answerText: row.answerText,
+    decidedByExternalUserId: row.decidedByExternalUserId,
+    decidedByPrincipalId: row.decidedByPrincipalId,
+    followupState: row.followupState,
+    expiresAt: row.expiresAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function rowToDelivery(
+  row: typeof guardianRequestDeliveries.$inferSelect,
+): GuardianRequestDelivery {
+  return {
+    id: row.id,
+    requestId: row.requestId,
+    destinationChannel: row.destinationChannel,
+    destinationConversationId: row.destinationConversationId,
+    destinationChatId: row.destinationChatId,
+    destinationMessageId: row.destinationMessageId,
+    status: row.status,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Guardian requests
+// ---------------------------------------------------------------------------
+
+export interface CreateGuardianRequestParams {
+  /**
+   * Caller-supplied ids are honored — they are load-bearing (deterministic
+   * `access-req-...` ids, pending-interaction requestIds reused as PK).
+   */
+  id?: string;
+  kind: string;
+  sourceChannel?: string;
+  sourceConversationId?: string;
+  requesterExternalUserId?: string;
+  requesterChatId?: string;
+  guardianExternalUserId?: string;
+  guardianPrincipalId?: string;
+  callSessionId?: string;
+  pendingQuestionId?: string;
+  questionText?: string;
+  requestCode?: string;
+  toolName?: string;
+  inputDigest?: string;
+  commandPreview?: string;
+  riskLevel?: string;
+  activityText?: string;
+  executionTarget?: string;
+  requesterSignals?: string;
+  requestTrigger?: string;
+  status?: GuardianRequestStatus;
+  answerText?: string;
+  decidedByExternalUserId?: string;
+  decidedByPrincipalId?: string;
+  followupState?: string;
+  expiresAt?: number;
+}
+
+/**
+ * Request kinds that require a guardian decision (approve/deny). These kinds
+ * MUST have a `guardianPrincipalId` bound at creation time so the decision
+ * can be attributed to a specific principal. Informational kinds are exempt.
+ */
+const DECISIONABLE_KINDS = new Set([
+  "tool_approval",
+  "tool_grant_request",
+  "pending_question",
+  "access_request",
+]);
+
+export function createGuardianRequest(
+  params: CreateGuardianRequestParams,
+): GuardianRequest {
+  if (DECISIONABLE_KINDS.has(params.kind) && !params.guardianPrincipalId) {
+    throw new GuardianRequestIntegrityError(
+      `Cannot create decisionable guardian request of kind '${params.kind}' without guardianPrincipalId`,
+    );
+  }
+
+  const db = getGatewayDb();
+  const now = Date.now();
+
+  const row = {
+    id: params.id ?? crypto.randomUUID(),
+    kind: params.kind,
+    sourceChannel: params.sourceChannel ?? null,
+    sourceConversationId: params.sourceConversationId ?? null,
+    requesterExternalUserId: params.requesterExternalUserId ?? null,
+    requesterChatId: params.requesterChatId ?? null,
+    guardianExternalUserId: params.guardianExternalUserId ?? null,
+    guardianPrincipalId: params.guardianPrincipalId ?? null,
+    callSessionId: params.callSessionId ?? null,
+    pendingQuestionId: params.pendingQuestionId ?? null,
+    questionText: params.questionText ?? null,
+    requestCode: params.requestCode ?? generateRequestCode(),
+    toolName: params.toolName ?? null,
+    inputDigest: params.inputDigest ?? null,
+    commandPreview: params.commandPreview ?? null,
+    riskLevel: params.riskLevel ?? null,
+    activityText: params.activityText ?? null,
+    executionTarget: params.executionTarget ?? null,
+    requesterSignals: params.requesterSignals ?? null,
+    requestTrigger: params.requestTrigger ?? null,
+    status: params.status ?? ("pending" as const),
+    answerText: params.answerText ?? null,
+    decidedByExternalUserId: params.decidedByExternalUserId ?? null,
+    decidedByPrincipalId: params.decidedByPrincipalId ?? null,
+    followupState: params.followupState ?? null,
+    expiresAt: params.expiresAt ?? null,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  db.insert(guardianRequests).values(row).run();
+  return rowToRequest(row);
+}
+
+export function getGuardianRequest(id: string): GuardianRequest | null {
+  const db = getGatewayDb();
+  const row = db
+    .select()
+    .from(guardianRequests)
+    .where(eq(guardianRequests.id, id))
+    .get();
+  return row ? rowToRequest(row) : null;
+}
+
+/**
+ * Look up a guardian request by its short request code. Scoped to pending
+ * (unresolved) requests so that codes recycled by older, already-resolved
+ * requests do not collide with the active one.
+ */
+export function getGuardianRequestByCode(code: string): GuardianRequest | null {
+  const db = getGatewayDb();
+  const row = db
+    .select()
+    .from(guardianRequests)
+    .where(
+      and(
+        eq(guardianRequests.requestCode, code),
+        eq(guardianRequests.status, "pending"),
+      ),
+    )
+    .get();
+  return row ? rowToRequest(row) : null;
+}
+
+export interface ListGuardianRequestsFilters {
+  status?: GuardianRequestStatus;
+  guardianExternalUserId?: string;
+  guardianPrincipalId?: string;
+  requesterExternalUserId?: string;
+  sourceConversationId?: string;
+  /** Derived filter — translated to a source_channel predicate. */
+  sourceType?: string;
+  sourceChannel?: string;
+  kind?: string;
+  toolName?: string;
+}
+
+export function listGuardianRequests(
+  filters?: ListGuardianRequestsFilters,
+): GuardianRequest[] {
+  const db = getGatewayDb();
+
+  const conditions = [];
+  if (filters?.status) {
+    conditions.push(eq(guardianRequests.status, filters.status));
+  }
+  if (filters?.guardianExternalUserId) {
+    conditions.push(
+      eq(
+        guardianRequests.guardianExternalUserId,
+        filters.guardianExternalUserId,
+      ),
+    );
+  }
+  if (filters?.guardianPrincipalId) {
+    conditions.push(
+      eq(guardianRequests.guardianPrincipalId, filters.guardianPrincipalId),
+    );
+  }
+  if (filters?.requesterExternalUserId) {
+    conditions.push(
+      eq(
+        guardianRequests.requesterExternalUserId,
+        filters.requesterExternalUserId,
+      ),
+    );
+  }
+  if (filters?.sourceConversationId) {
+    conditions.push(
+      eq(guardianRequests.sourceConversationId, filters.sourceConversationId),
+    );
+  }
+  if (filters?.sourceType) {
+    conditions.push(sourceTypeCondition(filters.sourceType));
+  }
+  if (filters?.sourceChannel) {
+    conditions.push(eq(guardianRequests.sourceChannel, filters.sourceChannel));
+  }
+  if (filters?.kind) {
+    conditions.push(eq(guardianRequests.kind, filters.kind));
+  }
+  if (filters?.toolName) {
+    conditions.push(eq(guardianRequests.toolName, filters.toolName));
+  }
+
+  if (conditions.length === 0) {
+    return db.select().from(guardianRequests).all().map(rowToRequest);
+  }
+
+  return db
+    .select()
+    .from(guardianRequests)
+    .where(and(...conditions))
+    .all()
+    .map(rowToRequest);
+}
+
+export interface UpdateGuardianRequestParams {
+  status?: GuardianRequestStatus;
+  answerText?: string;
+  decidedByExternalUserId?: string;
+  decidedByPrincipalId?: string;
+  followupState?: string | null;
+  expiresAt?: number;
+}
+
+export function updateGuardianRequest(
+  id: string,
+  updates: UpdateGuardianRequestParams,
+): GuardianRequest | null {
+  const db = getGatewayDb();
+  const now = Date.now();
+
+  const setValues: Record<string, unknown> = { updatedAt: now };
+  if (updates.status !== undefined) {
+    setValues.status = updates.status;
+  }
+  if (updates.answerText !== undefined) {
+    setValues.answerText = updates.answerText;
+  }
+  if (updates.decidedByExternalUserId !== undefined) {
+    setValues.decidedByExternalUserId = updates.decidedByExternalUserId;
+  }
+  if (updates.decidedByPrincipalId !== undefined) {
+    setValues.decidedByPrincipalId = updates.decidedByPrincipalId;
+  }
+  if (updates.followupState !== undefined) {
+    setValues.followupState = updates.followupState;
+  }
+  if (updates.expiresAt !== undefined) {
+    setValues.expiresAt = updates.expiresAt;
+  }
+
+  db.update(guardianRequests)
+    .set(setValues)
+    .where(eq(guardianRequests.id, id))
+    .run();
+
+  return getGuardianRequest(id);
+}
+
+export interface ResolveGuardianRequestDecision {
+  status: GuardianRequestStatus;
+  answerText?: string;
+  decidedByExternalUserId?: string;
+  decidedByPrincipalId?: string;
+}
+
+export type ResolveGuardianRequestResult =
+  | { applied: true; request: GuardianRequest }
+  | { applied: false };
+
+/**
+ * Compare-and-swap resolve: only transitions the request from
+ * `expectedStatus` to the decision's status atomically — first writer wins.
+ * Supports pending → terminal decisions and terminal → pending reopens.
+ *
+ * Uses the raw bun:sqlite client because drizzle's run() does not surface
+ * the changes count needed for the first-writer-wins guarantee.
+ */
+export function resolveGuardianRequest(
+  id: string,
+  expectedStatus: GuardianRequestStatus,
+  decision: ResolveGuardianRequestDecision,
+): ResolveGuardianRequestResult {
+  const raw = rawClient();
+  const now = Date.now();
+
+  const sets = ["status = ?", "updated_at = ?"];
+  const args: (string | number)[] = [decision.status, now];
+  if (decision.answerText !== undefined) {
+    sets.push("answer_text = ?");
+    args.push(decision.answerText);
+  }
+  if (decision.decidedByExternalUserId !== undefined) {
+    sets.push("decided_by_external_user_id = ?");
+    args.push(decision.decidedByExternalUserId);
+  }
+  if (decision.decidedByPrincipalId !== undefined) {
+    sets.push("decided_by_principal_id = ?");
+    args.push(decision.decidedByPrincipalId);
+  }
+
+  const changes = raw
+    .prepare(
+      `UPDATE guardian_requests
+       SET ${sets.join(", ")}
+       WHERE id = ? AND status = ?`,
+    )
+    .run(...args, id, expectedStatus).changes;
+
+  if (changes === 0) {
+    return { applied: false };
+  }
+
+  const request = getGuardianRequest(id);
+  if (!request) {
+    throw new Error(`Guardian request ${id} missing after resolve`);
+  }
+  return { applied: true, request };
+}
+
+// ---------------------------------------------------------------------------
+// Expiry
+// ---------------------------------------------------------------------------
+
+/**
+ * Request kinds whose resolution depends on the daemon's in-memory
+ * `pendingInteractions` Map. These kinds become unresolvable after a daemon
+ * restart because the Map is wiped, so the daemon expires them at boot.
+ *
+ * Persistent kinds (`access_request`, `tool_grant_request`) resolve without
+ * pending interactions and remain valid across restarts — they must NOT be
+ * expired unconditionally here.
+ */
+const INTERACTION_BOUND_KINDS = ["tool_approval", "pending_question"];
+
+/**
+ * Bulk-expire stale pending guardian requests. Called via IPC at daemon
+ * startup (daemon-keyed — the gateway never runs this on its own restart):
+ *
+ * 1. Interaction-bound kinds (`tool_approval`, `pending_question`) expire
+ *    unconditionally — they can never complete after a daemon restart.
+ * 2. Persistent kinds expire only when already past their `expiresAt`
+ *    deadline, so dedup logic sees fresh rows instead of dead pending ones.
+ *
+ * Returns the number of requests transitioned from pending → expired.
+ */
+export function expireAllPendingInteractionBound(): number {
+  const raw = rawClient();
+  const now = Date.now();
+
+  const placeholders = INTERACTION_BOUND_KINDS.map(() => "?").join(", ");
+  return raw
+    .prepare(
+      `UPDATE guardian_requests
+       SET status = 'expired', updated_at = ?
+       WHERE status = 'pending'
+         AND (kind IN (${placeholders})
+              OR (expires_at IS NOT NULL AND expires_at < ?))`,
+    )
+    .run(now, ...INTERACTION_BOUND_KINDS, now).changes;
+}
+
+/**
+ * Sweep-expire pending requests whose `expiresAt` deadline has passed.
+ * Returns the expired request ids so the daemon can fan out card
+ * withdrawals and expiry notifications.
+ */
+export function sweepExpiredGuardianRequests(now = Date.now()): string[] {
+  const db = getGatewayDb();
+
+  return db.transaction(() => {
+    const stale = db
+      .select({ id: guardianRequests.id })
+      .from(guardianRequests)
+      .where(
+        and(
+          eq(guardianRequests.status, "pending"),
+          isNotNull(guardianRequests.expiresAt),
+          lt(guardianRequests.expiresAt, now),
+        ),
+      )
+      .all()
+      .map((row) => row.id);
+
+    if (stale.length === 0) {
+      return [];
+    }
+
+    db.update(guardianRequests)
+      .set({ status: "expired", updatedAt: Date.now() })
+      .where(
+        and(
+          inArray(guardianRequests.id, stale),
+          eq(guardianRequests.status, "pending"),
+        ),
+      )
+      .run();
+
+    return stale;
+  });
+}
+
+/**
+ * Expire a single guardian request and all its deliveries in one
+ * transaction. CAS-transitions the request from 'pending' to 'expired';
+ * its deliveries are bulk-expired regardless of the request's status.
+ */
+export function expireGuardianRequest(id: string): void {
+  const db = getGatewayDb();
+  const now = Date.now();
+
+  db.transaction(() => {
+    db.update(guardianRequests)
+      .set({ status: "expired", updatedAt: now })
+      .where(
+        and(
+          eq(guardianRequests.id, id),
+          eq(guardianRequests.status, "pending"),
+        ),
+      )
+      .run();
+
+    db.update(guardianRequestDeliveries)
+      .set({ status: "expired", updatedAt: now })
+      .where(eq(guardianRequestDeliveries.requestId, id))
+      .run();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Guardian request deliveries
+// ---------------------------------------------------------------------------
+
+export interface CreateDeliveryParams {
+  id?: string;
+  requestId: string;
+  destinationChannel: string;
+  destinationConversationId?: string;
+  destinationChatId?: string;
+  destinationMessageId?: string;
+  status?: string;
+}
+
+export function createDelivery(
+  params: CreateDeliveryParams,
+): GuardianRequestDelivery {
+  const db = getGatewayDb();
+  const now = Date.now();
+
+  const row = {
+    id: params.id ?? crypto.randomUUID(),
+    requestId: params.requestId,
+    destinationChannel: params.destinationChannel,
+    destinationConversationId: params.destinationConversationId ?? null,
+    destinationChatId: params.destinationChatId ?? null,
+    destinationMessageId: params.destinationMessageId ?? null,
+    status: params.status ?? "pending",
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  db.insert(guardianRequestDeliveries).values(row).run();
+  return rowToDelivery(row);
+}
+
+export function listDeliveries(requestId: string): GuardianRequestDelivery[] {
+  const db = getGatewayDb();
+  return db
+    .select()
+    .from(guardianRequestDeliveries)
+    .where(eq(guardianRequestDeliveries.requestId, requestId))
+    .all()
+    .map(rowToDelivery);
+}
+
+export interface UpdateDeliveryParams {
+  status?: string;
+  destinationMessageId?: string;
+}
+
+export function updateDelivery(
+  id: string,
+  updates: UpdateDeliveryParams,
+): GuardianRequestDelivery | null {
+  const db = getGatewayDb();
+  const now = Date.now();
+
+  const setValues: Record<string, unknown> = { updatedAt: now };
+  if (updates.status !== undefined) {
+    setValues.status = updates.status;
+  }
+  if (updates.destinationMessageId !== undefined) {
+    setValues.destinationMessageId = updates.destinationMessageId;
+  }
+
+  db.update(guardianRequestDeliveries)
+    .set(setValues)
+    .where(eq(guardianRequestDeliveries.id, id))
+    .run();
+
+  const row = db
+    .select()
+    .from(guardianRequestDeliveries)
+    .where(eq(guardianRequestDeliveries.id, id))
+    .get();
+
+  return row ? rowToDelivery(row) : null;
+}
+
+// ---------------------------------------------------------------------------
+// By-destination reads (reply / reaction routing)
+// ---------------------------------------------------------------------------
+
+function pendingRequestsForDeliveries(
+  deliveries: Array<{ requestId: string }>,
+): GuardianRequest[] {
+  const seenRequestIds = new Set<string>();
+  const pendingRequests: GuardianRequest[] = [];
+
+  for (const delivery of deliveries) {
+    if (seenRequestIds.has(delivery.requestId)) {
+      continue;
+    }
+    seenRequestIds.add(delivery.requestId);
+
+    const request = getGuardianRequest(delivery.requestId);
+    if (request && request.status === "pending") {
+      pendingRequests.push(request);
+    }
+  }
+
+  return pendingRequests;
+}
+
+/**
+ * Find the pending request whose guardian-facing delivery landed on a
+ * specific channel message (channel + chat + message id) — the addressing
+ * key for emoji-reaction decisions. Returns null when no delivery matches
+ * or the matched request is no longer pending.
+ */
+export function getPendingByDestinationMessage(
+  destinationChannel: string,
+  destinationChatId: string,
+  destinationMessageId: string,
+): GuardianRequest | null {
+  const db = getGatewayDb();
+
+  const delivery = db
+    .select()
+    .from(guardianRequestDeliveries)
+    .where(
+      and(
+        eq(guardianRequestDeliveries.destinationChannel, destinationChannel),
+        eq(guardianRequestDeliveries.destinationChatId, destinationChatId),
+        eq(
+          guardianRequestDeliveries.destinationMessageId,
+          destinationMessageId,
+        ),
+      ),
+    )
+    .get();
+
+  if (!delivery) {
+    return null;
+  }
+
+  const request = getGuardianRequest(delivery.requestId);
+  return request && request.status === "pending" ? request : null;
+}
+
+/**
+ * List pending requests that were delivered to a specific destination chat
+ * (channel + chatId pair) — the chat-level addressing channel transports
+ * natively provide, critical for voice-originated `pending_question`
+ * requests that lack `guardianExternalUserId`.
+ */
+export function listPendingByDestinationChat(
+  destinationChannel: string,
+  destinationChatId: string,
+): GuardianRequest[] {
+  const db = getGatewayDb();
+
+  const deliveries = db
+    .select()
+    .from(guardianRequestDeliveries)
+    .where(
+      and(
+        eq(guardianRequestDeliveries.destinationChannel, destinationChannel),
+        eq(guardianRequestDeliveries.destinationChatId, destinationChatId),
+      ),
+    )
+    .all();
+
+  return pendingRequestsForDeliveries(deliveries);
+}
+
+/**
+ * List pending requests that were delivered to a specific destination
+ * conversation, optionally scoped by destination channel when the same
+ * conversation ID namespace could exist across channels.
+ */
+export function listPendingByDestinationConversation(
+  destinationConversationId: string,
+  destinationChannel?: string,
+): GuardianRequest[] {
+  const db = getGatewayDb();
+
+  const deliveryConditions = [
+    eq(
+      guardianRequestDeliveries.destinationConversationId,
+      destinationConversationId,
+    ),
+  ];
+  if (destinationChannel) {
+    deliveryConditions.push(
+      eq(guardianRequestDeliveries.destinationChannel, destinationChannel),
+    );
+  }
+
+  const deliveries = db
+    .select()
+    .from(guardianRequestDeliveries)
+    .where(and(...deliveryConditions))
+    .all();
+
+  return pendingRequestsForDeliveries(deliveries);
+}
+
+// ---------------------------------------------------------------------------
+// Conversation scope helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * List pending requests in scope for a conversation, unioning:
+ *   1. Requests whose `sourceConversationId` matches.
+ *   2. Requests that have a delivery whose `destinationConversationId`
+ *      matches (narrowed to `channel` when provided, preventing
+ *      cross-channel leakage when conversation ID namespaces overlap).
+ *
+ * Deduplicates by request ID and filters past-deadline requests out.
+ */
+export function listPendingByConversationScope(
+  conversationId: string,
+  channel?: string,
+): GuardianRequest[] {
+  const bySource = listGuardianRequests({
+    sourceConversationId: conversationId,
+    status: "pending",
+  });
+
+  const byDestination = listPendingByDestinationConversation(
+    conversationId,
+    channel,
+  );
+
+  const seen = new Set<string>();
+  const result: GuardianRequest[] = [];
+
+  for (const req of [...bySource, ...byDestination]) {
+    if (!seen.has(req.id) && !isRequestExpired(req)) {
+      seen.add(req.id);
+      result.push(req);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Check whether a guardian decision's conversation is in scope for a
+ * request: either the request's `sourceConversationId` matches, or any
+ * recorded delivery has a matching `destinationConversationId` (optionally
+ * scoped by `channel`). Returns true when the decision is allowed from the
+ * given conversation.
+ */
+export function isRequestInConversationScope(
+  requestId: string,
+  conversationId: string,
+  channel?: string,
+): boolean {
+  const request = getGuardianRequest(requestId);
+  if (!request) {
+    return false;
+  }
+
+  if (request.sourceConversationId === conversationId) {
+    return true;
+  }
+
+  const deliveries = listDeliveries(requestId);
+  return deliveries.some(
+    (d) =>
+      d.destinationConversationId === conversationId &&
+      (!channel || d.destinationChannel === channel),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Call-controller convenience reads
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the most recent pending guardian request for a given call session.
+ * Used by the call-controller's consultation timeout handler.
+ */
+export function getPendingByCallSessionId(
+  callSessionId: string,
+): GuardianRequest | null {
+  const db = getGatewayDb();
+  const row = db
+    .select()
+    .from(guardianRequests)
+    .where(
+      and(
+        eq(guardianRequests.callSessionId, callSessionId),
+        eq(guardianRequests.status, "pending"),
+      ),
+    )
+    .orderBy(desc(guardianRequests.createdAt))
+    .get();
+  return row ? rowToRequest(row) : null;
+}
+
+/**
+ * Find a guardian request by its linked pending question ID. Used after
+ * async dispatch completes to locate the newly created request.
+ */
+export function getByPendingQuestionId(
+  questionId: string,
+): GuardianRequest | null {
+  const db = getGatewayDb();
+  const row = db
+    .select()
+    .from(guardianRequests)
+    .where(eq(guardianRequests.pendingQuestionId, questionId))
+    .get();
+  return row ? rowToRequest(row) : null;
+}

--- a/gateway/src/db/schema.ts
+++ b/gateway/src/db/schema.ts
@@ -504,10 +504,8 @@ export const channelDenialReplyLog = sqliteTable(
 // ---------------------------------------------------------------------------
 //
 // Unified guardian approval requests across all kinds (access_request,
-// tool_approval, tool_grant_request, pending_question). Column names mirror
-// the assistant's canonical_guardian_requests table 1:1 except
-// conversation_id → source_conversation_id (provenance naming) and
-// source_type, which is derived from source_channel at read time
+// tool_approval, tool_grant_request, pending_question). There is no
+// source_type column: it is derived from source_channel at read time
 // (phone → voice, vellum → desktop, else channel). Accessed via
 // db/guardian-request-store.ts.
 

--- a/gateway/src/db/schema.ts
+++ b/gateway/src/db/schema.ts
@@ -500,6 +500,105 @@ export const channelDenialReplyLog = sqliteTable(
 );
 
 // ---------------------------------------------------------------------------
+// Guardian requests (gateway-owned)
+// ---------------------------------------------------------------------------
+//
+// Unified guardian approval requests across all kinds (access_request,
+// tool_approval, tool_grant_request, pending_question). Column names mirror
+// the assistant's canonical_guardian_requests table 1:1 except
+// conversation_id → source_conversation_id (provenance naming) and
+// source_type, which is derived from source_channel at read time
+// (phone → voice, vellum → desktop, else channel). Accessed via
+// db/guardian-request-store.ts.
+
+export const guardianRequests = sqliteTable(
+  "guardian_requests",
+  {
+    id: text("id").primaryKey(),
+    kind: text("kind").notNull(),
+    sourceChannel: text("source_channel"),
+    sourceConversationId: text("source_conversation_id"),
+    requesterExternalUserId: text("requester_external_user_id"),
+    requesterChatId: text("requester_chat_id"),
+    guardianExternalUserId: text("guardian_external_user_id"),
+    guardianPrincipalId: text("guardian_principal_id"),
+    callSessionId: text("call_session_id"),
+    pendingQuestionId: text("pending_question_id"),
+    questionText: text("question_text"),
+    requestCode: text("request_code"),
+    toolName: text("tool_name"),
+    inputDigest: text("input_digest"),
+    commandPreview: text("command_preview"),
+    riskLevel: text("risk_level"),
+    activityText: text("activity_text"),
+    executionTarget: text("execution_target"),
+    // JSON-encoded RequesterIdentitySignals ({isBot,isStranger,isRestricted})
+    // captured at creation so decision-time policy reads the same identity
+    // facts the introduction card was rendered from.
+    requesterSignals: text("requester_signals"),
+    // What prompted an access request: 'denied' (refused sender awaiting a
+    // let-them-in decision) or 'admitted' (floor-admitted sender nudged for
+    // trust assignment). NULL means 'denied'. Column name avoids the SQL
+    // TRIGGER keyword.
+    requestTrigger: text("request_trigger"),
+    status: text("status").notNull().default("pending"),
+    answerText: text("answer_text"),
+    decidedByExternalUserId: text("decided_by_external_user_id"),
+    decidedByPrincipalId: text("decided_by_principal_id"),
+    followupState: text("followup_state"),
+    expiresAt: integer("expires_at"),
+    createdAt: integer("created_at").notNull(),
+    updatedAt: integer("updated_at").notNull(),
+  },
+  (table) => [
+    index("idx_gw_guardian_requests_status").on(table.status),
+    index("idx_gw_guardian_requests_guardian").on(
+      table.guardianExternalUserId,
+      table.status,
+    ),
+    index("idx_gw_guardian_requests_conversation").on(
+      table.sourceConversationId,
+      table.status,
+    ),
+    index("idx_gw_guardian_requests_source").on(
+      table.sourceChannel,
+      table.status,
+    ),
+    index("idx_gw_guardian_requests_kind").on(table.kind, table.status),
+    index("idx_gw_guardian_requests_request_code").on(table.requestCode),
+  ],
+);
+
+export const guardianRequestDeliveries = sqliteTable(
+  "guardian_request_deliveries",
+  {
+    id: text("id").primaryKey(),
+    requestId: text("request_id")
+      .notNull()
+      .references(() => guardianRequests.id, { onDelete: "cascade" }),
+    destinationChannel: text("destination_channel").notNull(),
+    destinationConversationId: text("destination_conversation_id"),
+    destinationChatId: text("destination_chat_id"),
+    destinationMessageId: text("destination_message_id"),
+    status: text("status").notNull().default("pending"),
+    createdAt: integer("created_at").notNull(),
+    updatedAt: integer("updated_at").notNull(),
+  },
+  (table) => [
+    index("idx_gw_guardian_request_deliveries_request_id").on(table.requestId),
+    index("idx_gw_guardian_request_deliveries_status").on(table.status),
+    index("idx_gw_guardian_request_deliveries_dest_message").on(
+      table.destinationChannel,
+      table.destinationChatId,
+      table.destinationMessageId,
+    ),
+    index("idx_gw_guardian_request_deliveries_dest_conversation").on(
+      table.destinationConversationId,
+    ),
+  ],
+);
+
+// ---------------------------------------------------------------------------
 // Credential requests (one-time credential-collection links)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds gateway-native guardian_requests + guardian_request_deliveries tables (renamed from canonical_guardian_*; conversation_id→source_conversation_id, source_type dropped, request_trigger kept)
- Ports the full canonical-guardian-store function surface to a synchronous gateway store with raw-$client CAS
- Additive only: nothing reads or writes the new tables yet

Part of plan: guardian-requests-gateway-native.md (PR 1 of 10)