### PR TITLE
feat(providers): add forward-guard cache-read rates to OpenRouter xAI catalog entries

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1008,6 +1008,11 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         },
       },
       // xAI
+      // OpenRouter lists an `input_cache_read` rate for xAI models but its
+      // xAI endpoints report `supports_implicit_caching: false`, and observed
+      // usage never includes cached tokens. `supportsCaching` therefore stays
+      // false; the `cacheReadPer1mTokens` rates below only apply if OpenRouter
+      // starts reporting cached tokens in usage.
       {
         id: "x-ai/grok-4.5",
         displayName: "Grok 4.5",
@@ -1019,7 +1024,11 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: false,
         supportsVision: true,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 2, outputPer1mTokens: 6 },
+        pricing: {
+          inputPer1mTokens: 2,
+          outputPer1mTokens: 6,
+          cacheReadPer1mTokens: 0.5,
+        },
       },
       {
         id: "x-ai/grok-4.3",
@@ -1030,7 +1039,11 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: false,
         supportsVision: true,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 1.25, outputPer1mTokens: 2.5 },
+        pricing: {
+          inputPer1mTokens: 1.25,
+          outputPer1mTokens: 2.5,
+          cacheReadPer1mTokens: 0.2,
+        },
       },
       {
         id: "x-ai/grok-4.20",
@@ -1041,7 +1054,11 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: false,
         supportsVision: true,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 1.25, outputPer1mTokens: 2.5 },
+        pricing: {
+          inputPer1mTokens: 1.25,
+          outputPer1mTokens: 2.5,
+          cacheReadPer1mTokens: 0.2,
+        },
       },
       // DeepSeek
       {

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -954,7 +954,8 @@
           "supportsToolUse": true,
           "pricing": {
             "inputPer1mTokens": 2,
-            "outputPer1mTokens": 6
+            "outputPer1mTokens": 6,
+            "cacheReadPer1mTokens": 0.5
           }
         },
         {
@@ -970,7 +971,8 @@
           "supportsToolUse": true,
           "pricing": {
             "inputPer1mTokens": 1.25,
-            "outputPer1mTokens": 2.5
+            "outputPer1mTokens": 2.5,
+            "cacheReadPer1mTokens": 0.2
           }
         },
         {
@@ -986,7 +988,8 @@
           "supportsToolUse": true,
           "pricing": {
             "inputPer1mTokens": 1.25,
-            "outputPer1mTokens": 2.5
+            "outputPer1mTokens": 2.5,
+            "cacheReadPer1mTokens": 0.2
           }
         },
         {


### PR DESCRIPTION
## Summary
- Add `cacheReadPer1mTokens` to the OpenRouter xAI entries — grok-4.5: $0.50/M, grok-4.3: $0.20/M, grok-4.20: $0.20/M — matching OpenRouter's declared `input_cache_read` rates (verified 2026-07-09 against `/api/v1/models`). `meta/llm-provider-catalog.json` regenerated; the web mirror carries no pricing fields, so no client changes.
- `supportsCaching` stays `false`: OpenRouter's xAI endpoints report `supports_implicit_caching: false`, and observed usage (80 grok calls in a live workspace) has never included cached tokens. A group comment documents this state so the flag/rate combination doesn't read as contradictory.
- Behavior today is unchanged — `resolvePricingForUsage` bills cached tokens at `cacheReadPer1M ?? inputPer1M`, and grok usage has no cached tokens. If OpenRouter starts propagating xAI's implicit caching, cost estimates apply the discount automatically instead of overcounting cached tokens at the full input rate.

## Original prompt
Follow-up from the Grok 4.5 rollout (#37682, #37685): xAI supports implicit prompt caching ($0.50/M cached vs $2/M input on grok-4.5) and OpenRouter's pricing metadata lists the discounted rate, but its endpoint metadata and observed usage show the caching never materializes through OpenRouter. Sidd asked to pre-add the cache-read rates now so that if OpenRouter ever enables caching for xAI (the tell: nonzero `cache_read_input_tokens` appearing in `llm_usage_events`), our cost accounting picks up the discount with no further change.