### PR TITLE
fix(stt): clear stale-flush debt when the next finalize request is sent

### DIFF
--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -331,8 +331,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
    * stream, oldest first. Flush finals and `finalized` signals carry no
    * request identity, so at most one `Finalize` request is in flight at a
    * time (the head's, marked `finalizeRequested` — see pumpFinalizeQueue):
-   * the head owns the next flush/`finalized`, and a stale flush can never
-   * be attributed to a newer cycle's request.
+   * the head owns the next flush/`finalized`. The transcriber drops a
+   * fallback-settled request's stale flush until the next `Finalize` goes
+   * out; one landing after that surfaces as the new head's flush, bounded
+   * by the dispatched-turn drop-guard in the `final` handler.
    */
   private finalizeQueue: UtteranceCycle[] = [];
   private finalizeGraceTimer: ReturnType<typeof setTimeout> | null = null;

--- a/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.test.ts
@@ -748,28 +748,21 @@ describe("DeepgramRealtimeTranscriber", () => {
       expect(events).toEqual([{ type: "finalized" }]);
     });
 
-    test("a stale flush does not consume a newer request's settlement", async () => {
+    test("an omitted flush does not poison the next request's flush", async () => {
       const { transcriber, events } = await startSession({
         finalizeFallbackMs: 20,
       });
 
-      // Request one settles via the fallback (its flush is running late).
+      // Request one settles via the fallback because Deepgram OMITTED the
+      // flush (nothing significant buffered) — no stale frame ever arrives
+      // to consume the debt.
       transcriber.finalizeUtterance();
       await new Promise((resolve) => setTimeout(resolve, 40));
       expect(events).toEqual([{ type: "finalized" }]);
 
-      // Request two goes out, then request one's LATE flush finally lands.
+      // Sending request two clears the debt, so its legitimate flush is
+      // emitted and settles it — not dropped as stale.
       transcriber.finalizeUtterance();
-      mockWs.simulateMessage(
-        resultsFrame("previous turn tail", {
-          is_final: true,
-          from_finalize: true,
-        }),
-      );
-      // The stale flush is dropped: no final, and request two stays live.
-      expect(events).toEqual([{ type: "finalized" }]);
-
-      // Request two's own flush settles it normally.
       mockWs.simulateMessage(
         resultsFrame("current turn", { is_final: true, from_finalize: true }),
       );
@@ -778,6 +771,36 @@ describe("DeepgramRealtimeTranscriber", () => {
         {
           type: "final",
           text: "current turn",
+          confidence: 0.95,
+          fromFinalize: true,
+        },
+        { type: "finalized" },
+      ]);
+    });
+
+    test("repeated omitted flushes never accumulate stale-flush debt", async () => {
+      const { transcriber, events } = await startSession({
+        finalizeFallbackMs: 20,
+      });
+
+      // Requests one and two each get no flush; each settles via fallback.
+      for (let i = 0; i < 2; i += 1) {
+        transcriber.finalizeUtterance();
+        await new Promise((resolve) => setTimeout(resolve, 40));
+      }
+      expect(events).toEqual([{ type: "finalized" }, { type: "finalized" }]);
+
+      // Request three is answered — its flush lands normally.
+      transcriber.finalizeUtterance();
+      mockWs.simulateMessage(
+        resultsFrame("third turn", { is_final: true, from_finalize: true }),
+      );
+      expect(events).toEqual([
+        { type: "finalized" },
+        { type: "finalized" },
+        {
+          type: "final",
+          text: "third turn",
           confidence: 0.95,
           fromFinalize: true,
         },
@@ -824,14 +847,15 @@ describe("DeepgramRealtimeTranscriber", () => {
       await new Promise((resolve) => setTimeout(resolve, 40));
       expect(events).toEqual([{ type: "finalized" }]);
 
-      transcriber.finalizeUtterance();
-      // Request one's late flush: dropped — withheld text stays withheld.
+      // Request one's late flush lands before any new request: dropped —
+      // withheld text stays withheld and no boundary is forced.
       mockWs.simulateMessage(
         resultsFrame("stale tail", { is_final: true, from_finalize: true }),
       );
       expect(events).toEqual([{ type: "finalized" }]);
 
       // Request two's timely flush forces the boundary as usual.
+      transcriber.finalizeUtterance();
       mockWs.simulateMessage(
         resultsFrame("live tail", { is_final: true, from_finalize: true }),
       );

--- a/assistant/src/providers/speech-to-text/deepgram-realtime.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-realtime.ts
@@ -326,8 +326,13 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
    * `from_finalize` flush has not yet arrived. Flushes arrive in request
    * order, so while this is positive the next `from_finalize` frame
    * answers a fallback-settled request: it is dropped as stale instead of
-   * being emitted as — and settling — a newer request's flush. Reset on
-   * close alongside the outstanding-request drain.
+   * being emitted as — and settling — a newer request's flush.
+   *
+   * The debt lives only until the next Finalize send —
+   * {@link finalizeUtterance} resets it (rationale at the reset) — and is
+   * also reset on close alongside the outstanding-request drain. The
+   * live-voice session serializes requests (at most one in flight), so in
+   * practice the counter is 0 or 1; no code path relies on larger values.
    */
   private fallbackSettledFinalizes = 0;
 
@@ -483,10 +488,12 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
    * timer ({@link DeepgramRealtimeOptions.finalizeFallbackMs}) when
    * Deepgram omits the flush (nothing significant buffered) or answers
    * too slowly. A flush arriving after its request was fallback-settled
-   * is dropped as stale — no `final`, no second `finalized` — so its
-   * text can never be attributed to a newer request. When the socket is
-   * not open there is nothing buffered provider-side, so `finalized` is
-   * emitted immediately. {@link stop} remains the session-teardown path.
+   * but before the next Finalize is sent is dropped as stale — no
+   * `final`, no second `finalized` — so its text is not attributed to a
+   * newer request. Sending the next Finalize clears that stale-flush debt
+   * (see {@link fallbackSettledFinalizes}). When the socket is not open
+   * there is nothing buffered provider-side, so `finalized` is emitted
+   * immediately. {@link stop} remains the session-teardown path.
    */
   finalizeUtterance(): void {
     const ws = this.ws;
@@ -503,6 +510,15 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
       this.emitEvent({ type: "finalized" });
       return;
     }
+    // Stream ordering means a slow flush for an earlier fallback-settled
+    // request reaches us before Deepgram processes the Finalize just
+    // sent, so any debt still unconsumed here is for a flush Deepgram
+    // omitted (the common fallback cause) and would otherwise sit forever,
+    // wrongly dropping this request's legitimate flush. A >fallback-window
+    // provider flush racing an immediate re-release could in theory land
+    // after this send and be misattributed to this request; the session's
+    // queue-head drop-guard bounds that case.
+    this.fallbackSettledFinalizes = 0;
     this.outstandingFinalizes += 1;
     this.armFinalizeFallbackTimer();
   }
@@ -655,8 +671,9 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
    * - `finalized` after the `final` of a `from_finalize: true` flush frame
    *   (the response to {@link finalizeUtterance}). An empty flush emits
    *   only `finalized` — silence flushes carry no transcript to commit. A
-   *   flush whose request the fallback timer already settled is dropped
-   *   entirely (no `final`, no `finalized`) — see {@link finalizeUtterance}.
+   *   flush arriving while a fallback-settled request still awaits its
+   *   flush is dropped entirely (no `final`, no `finalized`) — see
+   *   {@link finalizeUtterance}.
    */
   private handleTranscriptFrame(frame: DeepgramStreamResponse): void {
     const alternative = frame.channel?.alternatives?.[0];
@@ -666,11 +683,12 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
     // Extract text, defaulting to empty string for silence segments.
     const text = typeof transcript === "string" ? transcript.trim() : "";
 
-    // A flush whose request the fallback timer already settled is stale:
-    // flushes arrive in request order, so it pairs with the oldest
+    // A flush arriving while fallback-settled requests await theirs is
+    // stale: flushes arrive in request order, so it pairs with the oldest
     // fallback-settled request, whose `finalized` was already emitted.
     // Emitting its text (or another `finalized`) here would attribute it
-    // to a newer request's utterance.
+    // to a newer request's utterance. The debt window closes when the
+    // next Finalize is sent — see finalizeUtterance.
     if (fromFinalize && this.fallbackSettledFinalizes > 0) {
       this.fallbackSettledFinalizes -= 1;
       log.debug(
@@ -843,7 +861,8 @@ export class DeepgramRealtimeTranscriber implements StreamingTranscriber {
       );
       if (this.outstandingFinalizes > 0) {
         // The request settles without its flush; a flush that still
-        // arrives later is dropped as stale in handleTranscriptFrame.
+        // arrives before the next Finalize send is dropped as stale in
+        // handleTranscriptFrame.
         this.fallbackSettledFinalizes += 1;
       }
       this.settleOneFinalize();


### PR DESCRIPTION
## Summary
Fixes the round-3 P1 for voice-mode-latency.md (follow-up to #37686).

**Gap:** an omitted flush left fallback debt outstanding forever, dropping every subsequent legitimate flush on the long-lived shared stream.
**Fix:** the debt window now closes when the next Finalize is sent — stream ordering means a genuinely late flush can only arrive inside that window.