### PR TITLE
refactor(plugins): export marketplaceMatch + manifest schema for reuse

### DIFF
--- a/assistant/src/cli/lib/plugin-marketplace.ts
+++ b/assistant/src/cli/lib/plugin-marketplace.ts
@@ -100,7 +100,7 @@ const marketplaceEntrySchema = z.object({
   license: z.string().optional(),
 });
 
-const marketplaceManifestSchema = z.object({
+export const marketplaceManifestSchema = z.object({
   name: z.string(),
   owner: z
     .object({

--- a/assistant/src/cli/lib/search-plugins.ts
+++ b/assistant/src/cli/lib/search-plugins.ts
@@ -192,8 +192,11 @@ export async function loadPluginCatalog(
 /**
  * Project a marketplace entry onto the catalog match shape, building a
  * `github:owner/repo[/path]@ref` locator for display.
+ *
+ * Shared by the platform fetcher and bundled reader so all catalog sources
+ * project entries identically.
  */
-function marketplaceMatch(entry: MarketplaceEntry): PluginSearchMatch {
+export function marketplaceMatch(entry: MarketplaceEntry): PluginSearchMatch {
   const { repo, path, ref } = entry.source;
   const locator = `github:${repo}${path ? `/${path}` : ""}@${ref}`;
   return {


### PR DESCRIPTION
## Summary
- Export `marketplaceManifestSchema` from plugin-marketplace.ts and `marketplaceMatch` from search-plugins.ts for reuse by the upcoming bundled reader and platform fetcher.
- Purely additive; no behavior change.

Part of plan: plugins-catalog-platform-first.md (PR 1 of 6)