### PR TITLE
feat(gateway): guardian-request service + guardian_requests_* lifecycle IPC routes

### DIFF
--- a/gateway/src/approvals/guardian-request-service.ts
+++ b/gateway/src/approvals/guardian-request-service.ts
@@ -1,0 +1,217 @@
+/**
+ * Gateway-native guardian-request service (ATL-463).
+ *
+ * Thin lifecycle layer over the guardian-request store, serving the
+ * `guardian_requests_*` IPC routes. Store-row ↔ wire-DTO mapping lives here:
+ * the row type is the wire DTO minus `sourceType`, which the mapper computes
+ * from `sourceChannel` (phone → voice, vellum → desktop, else channel).
+ *
+ * Create integrity: the store throws `GuardianRequestIntegrityError` (with a
+ * machine-readable `code` the IPC error envelope mirrors into `errorCode`)
+ * when a decisionable kind lacks `guardianPrincipalId`; the create IPC schema
+ * enforces the same invariant at the boundary.
+ *
+ * The decision path (`guardian_requests_decide`) is not part of this
+ * surface.
+ */
+
+import type {
+  CreateGuardianRequestDeliveryIpcParams,
+  CreateGuardianRequestIpcParams,
+  ExpireInteractionBoundIpcResponse,
+  GuardianRequestDeliveryWire,
+  GuardianRequestPatch,
+  GuardianRequestStatus,
+  GuardianRequestWire,
+  ListGuardianRequestsIpcParams,
+  ListPendingGuardianRequestsByDestinationIpcParams,
+  SweepExpiredGuardianRequestsIpcResponse,
+  UpdateGuardianRequestDeliveryIpcParams,
+} from "@vellumai/gateway-client";
+
+import type { GuardianRequest } from "../db/guardian-request-store.js";
+import {
+  createDelivery,
+  createGuardianRequest as storeCreateGuardianRequest,
+  deriveSourceType,
+  expireAllPendingInteractionBound,
+  expireGuardianRequest as storeExpireGuardianRequest,
+  getByPendingQuestionId,
+  getGuardianRequest as storeGetGuardianRequest,
+  getGuardianRequestByCode as storeGetGuardianRequestByCode,
+  getPendingByCallSessionId,
+  getPendingByDestinationMessage,
+  isRequestInConversationScope,
+  listDeliveries,
+  listGuardianRequests as storeListGuardianRequests,
+  listPendingByConversationScope,
+  listPendingByDestinationChat,
+  listPendingByDestinationConversation,
+  resolveGuardianRequest,
+  sweepExpiredGuardianRequests,
+  updateDelivery,
+  updateGuardianRequest as storeUpdateGuardianRequest,
+} from "../db/guardian-request-store.js";
+
+/** Map a store row onto the wire DTO by computing `sourceType`. */
+export function toGuardianRequestWire(
+  row: GuardianRequest,
+): GuardianRequestWire {
+  return { ...row, sourceType: deriveSourceType(row.sourceChannel) };
+}
+
+function toWireOrNull(row: GuardianRequest | null): GuardianRequestWire | null {
+  return row ? toGuardianRequestWire(row) : null;
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+export function createGuardianRequest(
+  params: CreateGuardianRequestIpcParams,
+): GuardianRequestWire {
+  return toGuardianRequestWire(storeCreateGuardianRequest(params));
+}
+
+export function getGuardianRequest(id: string): GuardianRequestWire | null {
+  return toWireOrNull(storeGetGuardianRequest(id));
+}
+
+/** Pending requests only — resolved requests never match by code. */
+export function getGuardianRequestByCode(
+  code: string,
+): GuardianRequestWire | null {
+  return toWireOrNull(storeGetGuardianRequestByCode(code));
+}
+
+export function listGuardianRequests(
+  filters: ListGuardianRequestsIpcParams,
+): GuardianRequestWire[] {
+  return storeListGuardianRequests(filters).map(toGuardianRequestWire);
+}
+
+export function updateGuardianRequest(
+  id: string,
+  patch: GuardianRequestPatch,
+): void {
+  storeUpdateGuardianRequest(id, patch);
+}
+
+/** CAS reopen (`fromStatus` → pending); a missed swap is a no-op. */
+export function reopenGuardianRequest(
+  id: string,
+  fromStatus: GuardianRequestStatus,
+): void {
+  resolveGuardianRequest(id, fromStatus, { status: "pending" });
+}
+
+export function expireGuardianRequest(id: string): void {
+  storeExpireGuardianRequest(id);
+}
+
+/**
+ * Daemon-boot expiry: interaction-bound kinds unconditionally, persistent
+ * kinds only past their `expiresAt`. Returns the expired-row count.
+ */
+export function expireInteractionBoundRequests(): ExpireInteractionBoundIpcResponse {
+  return { expired: expireAllPendingInteractionBound() };
+}
+
+/**
+ * Deadline sweep: CAS-expires past-`expiresAt` pending requests and returns
+ * their ids for daemon-side card-withdrawal / notification fan-out.
+ */
+export function sweepExpiredRequests(
+  now?: number,
+): SweepExpiredGuardianRequestsIpcResponse {
+  return { expired: sweepExpiredGuardianRequests(now) };
+}
+
+// ---------------------------------------------------------------------------
+// Deliveries
+// ---------------------------------------------------------------------------
+
+export function createGuardianRequestDelivery(
+  params: CreateGuardianRequestDeliveryIpcParams,
+): GuardianRequestDeliveryWire {
+  return createDelivery(params);
+}
+
+export function updateGuardianRequestDelivery(
+  id: string,
+  patch: UpdateGuardianRequestDeliveryIpcParams["patch"],
+): void {
+  updateDelivery(id, patch);
+}
+
+export function listGuardianRequestDeliveries(
+  requestId: string,
+): GuardianRequestDeliveryWire[] {
+  return listDeliveries(requestId);
+}
+
+// ---------------------------------------------------------------------------
+// Destination + scope lookups
+// ---------------------------------------------------------------------------
+
+/** Reaction routing: the pending request delivered as a specific message. */
+export function getPendingRequestByDestinationMessage(
+  channel: string,
+  chatId: string,
+  messageId: string,
+): GuardianRequestWire | null {
+  return toWireOrNull(
+    getPendingByDestinationMessage(channel, chatId, messageId),
+  );
+}
+
+/**
+ * Reply routing: pending requests delivered to a destination conversation
+ * (optionally narrowed by channel) or to a channel + chat pair.
+ */
+export function listPendingRequestsByDestination(
+  params: ListPendingGuardianRequestsByDestinationIpcParams,
+): GuardianRequestWire[] {
+  if (params.conversationId) {
+    return listPendingByDestinationConversation(
+      params.conversationId,
+      params.channel,
+    ).map(toGuardianRequestWire);
+  }
+  if (params.channel && params.chatId) {
+    return listPendingByDestinationChat(params.channel, params.chatId).map(
+      toGuardianRequestWire,
+    );
+  }
+  throw new Error("conversationId or channel+chatId required");
+}
+
+export function listPendingRequestsByScope(
+  conversationId: string,
+  channel?: string,
+): GuardianRequestWire[] {
+  return listPendingByConversationScope(conversationId, channel).map(
+    toGuardianRequestWire,
+  );
+}
+
+export function isGuardianRequestInScope(
+  requestId: string,
+  conversationId: string,
+  channel?: string,
+): boolean {
+  return isRequestInConversationScope(requestId, conversationId, channel);
+}
+
+export function getPendingRequestByCallSession(
+  callSessionId: string,
+): GuardianRequestWire | null {
+  return toWireOrNull(getPendingByCallSessionId(callSessionId));
+}
+
+export function getRequestByPendingQuestion(
+  pendingQuestionId: string,
+): GuardianRequestWire | null {
+  return toWireOrNull(getByPendingQuestionId(pendingQuestionId));
+}

--- a/gateway/src/db/guardian-request-store.ts
+++ b/gateway/src/db/guardian-request-store.ts
@@ -19,6 +19,14 @@ import {
   or,
 } from "drizzle-orm";
 
+import type {
+  GuardianRequestDeliveryWire,
+  GuardianRequestKind,
+  GuardianRequestSourceType,
+  GuardianRequestStatus,
+  GuardianRequestWire,
+} from "@vellumai/gateway-client";
+
 import { getGatewayDb } from "./connection.js";
 import { guardianRequestDeliveries, guardianRequests } from "./schema.js";
 
@@ -31,62 +39,22 @@ function rawClient(): Database {
 }
 
 // ---------------------------------------------------------------------------
-// Types
+// Types (single-sourced from the shared contract)
 // ---------------------------------------------------------------------------
 
-export type GuardianRequestStatus =
-  | "pending"
-  | "approved"
-  | "denied"
-  | "expired"
-  | "cancelled";
+export type {
+  GuardianRequestSourceType,
+  GuardianRequestStatus,
+} from "@vellumai/gateway-client";
 
-export type GuardianRequestSourceType = "voice" | "desktop" | "channel";
+/**
+ * Request row as the store returns it — the wire DTO minus `sourceType`,
+ * which is computed by the service mapper (the column is not stored).
+ */
+export type GuardianRequest = Omit<GuardianRequestWire, "sourceType">;
 
-export interface GuardianRequest {
-  id: string;
-  kind: string;
-  sourceChannel: string | null;
-  sourceConversationId: string | null;
-  requesterExternalUserId: string | null;
-  requesterChatId: string | null;
-  guardianExternalUserId: string | null;
-  guardianPrincipalId: string | null;
-  callSessionId: string | null;
-  pendingQuestionId: string | null;
-  questionText: string | null;
-  requestCode: string | null;
-  toolName: string | null;
-  inputDigest: string | null;
-  commandPreview: string | null;
-  riskLevel: string | null;
-  activityText: string | null;
-  executionTarget: string | null;
-  /** JSON-encoded requester identity signals. */
-  requesterSignals: string | null;
-  /** What prompted an access request: `denied` (default) or `admitted`. */
-  requestTrigger: string | null;
-  status: GuardianRequestStatus;
-  answerText: string | null;
-  decidedByExternalUserId: string | null;
-  decidedByPrincipalId: string | null;
-  followupState: string | null;
-  expiresAt: number | null;
-  createdAt: number;
-  updatedAt: number;
-}
-
-export interface GuardianRequestDelivery {
-  id: string;
-  requestId: string;
-  destinationChannel: string;
-  destinationConversationId: string | null;
-  destinationChatId: string | null;
-  destinationMessageId: string | null;
-  status: string;
-  createdAt: number;
-  updatedAt: number;
-}
+/** Delivery row as the store returns it — identical to the wire DTO. */
+export type GuardianRequestDelivery = GuardianRequestDeliveryWire;
 
 /**
  * Thrown when a create violates a store integrity invariant. Carries a
@@ -184,7 +152,7 @@ function rowToRequest(
 ): GuardianRequest {
   return {
     id: row.id,
-    kind: row.kind,
+    kind: row.kind as GuardianRequestKind,
     sourceChannel: row.sourceChannel,
     sourceConversationId: row.sourceConversationId,
     requesterExternalUserId: row.requesterExternalUserId,

--- a/gateway/src/db/guardian-request-store.ts
+++ b/gateway/src/db/guardian-request-store.ts
@@ -21,7 +21,6 @@ import {
 
 import type {
   GuardianRequestDeliveryWire,
-  GuardianRequestKind,
   GuardianRequestSourceType,
   GuardianRequestStatus,
   GuardianRequestWire,
@@ -152,7 +151,7 @@ function rowToRequest(
 ): GuardianRequest {
   return {
     id: row.id,
-    kind: row.kind as GuardianRequestKind,
+    kind: row.kind,
     sourceChannel: row.sourceChannel,
     sourceConversationId: row.sourceConversationId,
     requesterExternalUserId: row.requesterExternalUserId,

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -192,6 +192,7 @@ import { GatewayIpcServer } from "./ipc/server.js";
 import { contactRoutes } from "./ipc/contact-handlers.js";
 import { inviteRoutes } from "./ipc/invite-handlers.js";
 import { verificationSessionRoutes } from "./ipc/verification-session-handlers.js";
+import { guardianRequestRoutes } from "./ipc/guardian-request-handlers.js";
 import { featureFlagRoutes } from "./ipc/feature-flag-handlers.js";
 import { admissionPolicyRoutes } from "./ipc/admission-policy-handlers.js";
 import { channelPermissionRoutes } from "./ipc/channel-permission-handlers.js";
@@ -2665,6 +2666,7 @@ async function main() {
     ...contactRoutes,
     ...inviteRoutes,
     ...verificationSessionRoutes,
+    ...guardianRequestRoutes,
     ...slackThreadRoutes,
     ...thresholdRoutes,
     ...admissionPolicyRoutes,

--- a/gateway/src/ipc/__tests__/guardian-request-routes.test.ts
+++ b/gateway/src/ipc/__tests__/guardian-request-routes.test.ts
@@ -378,6 +378,16 @@ describe("guardian_requests_expire_interaction_bound", () => {
     expect(getRequestRow(staleAccess.id)?.status).toBe("expired");
     expect(getRequestRow(freshAccess.id)?.status).toBe("pending");
   });
+
+  test("accepts the omitted-params call shape", async () => {
+    const toolApproval = await createRequest({
+      kind: "tool_approval",
+      toolName: "bash",
+    });
+
+    expect(await call(METHODS.expireInteractionBound)).toEqual({ expired: 1 });
+    expect(getRequestRow(toolApproval.id)?.status).toBe("expired");
+  });
 });
 
 describe("guardian_requests_sweep_expired", () => {
@@ -387,7 +397,7 @@ describe("guardian_requests_sweep_expired", () => {
     const noDeadline = await createRequest({});
 
     const swept = SweepExpiredGuardianRequestsIpcResponseSchema.parse(
-      await call(METHODS.sweepExpired, {}),
+      await call(METHODS.sweepExpired),
     );
     expect(swept.expired).toEqual([stale.id]);
     expect(getRequestRow(stale.id)?.status).toBe("expired");

--- a/gateway/src/ipc/__tests__/guardian-request-routes.test.ts
+++ b/gateway/src/ipc/__tests__/guardian-request-routes.test.ts
@@ -33,6 +33,7 @@ import {
   initGatewayDb,
   resetGatewayDb,
 } from "../../db/connection.js";
+import { createGuardianRequest } from "../../db/guardian-request-store.js";
 import { guardianRequestDeliveries, guardianRequests } from "../../db/schema.js";
 import { guardianRequestRoutes } from "../guardian-request-handlers.js";
 import { GatewayIpcServer } from "../server.js";
@@ -242,6 +243,24 @@ describe("guardian_requests_get / get_by_code", () => {
       patch: { status: "approved" },
     });
     expect(await call(METHODS.getByCode, { code })).toBeNull();
+  });
+});
+
+describe("legacy kinds", () => {
+  test("rows outside the kind enum round-trip through get and list", async () => {
+    // Not creatable over IPC (create restricts kind), but legacy/backfilled
+    // rows can carry any kind and reads must still serialize them.
+    createGuardianRequest({ id: "req-legacy", kind: "status_update" });
+
+    const fetched = GuardianRequestSchema.parse(
+      await call(METHODS.get, { id: "req-legacy" }),
+    );
+    expect(fetched.kind).toBe("status_update");
+
+    const listed = GuardianRequestListIpcResponseSchema.parse(
+      await call(METHODS.list),
+    );
+    expect(listed.map((r) => r.id)).toContain("req-legacy");
   });
 });
 

--- a/gateway/src/ipc/__tests__/guardian-request-routes.test.ts
+++ b/gateway/src/ipc/__tests__/guardian-request-routes.test.ts
@@ -1,0 +1,671 @@
+/**
+ * Socket-level tests for the guardian_requests_* lifecycle IPC routes.
+ *
+ * Each request travels over a real Unix-domain-socket round-trip against a
+ * real (temp-dir) gateway DB, exercising the routes exactly as the daemon
+ * relay hits them: schema validation on the server, guardian-request-store
+ * writes, and wire-shaped responses pinned by the shared contract.
+ *
+ * `guardian_requests_decide` is asserted ABSENT (unknown method): decisions
+ * are not part of this route set.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { connect } from "node:net";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  GUARDIAN_REQUESTS_IPC_METHODS,
+  GuardianRequestDeliveryListIpcResponseSchema,
+  GuardianRequestDeliverySchema,
+  GuardianRequestInScopeIpcResponseSchema,
+  GuardianRequestListIpcResponseSchema,
+  GuardianRequestSchema,
+  SweepExpiredGuardianRequestsIpcResponseSchema,
+} from "@vellumai/gateway-client";
+import { eq } from "drizzle-orm";
+
+import "../../__tests__/test-preload.js";
+import {
+  getGatewayDb,
+  initGatewayDb,
+  resetGatewayDb,
+} from "../../db/connection.js";
+import { guardianRequestDeliveries, guardianRequests } from "../../db/schema.js";
+import { guardianRequestRoutes } from "../guardian-request-handlers.js";
+import { GatewayIpcServer } from "../server.js";
+
+const METHODS = GUARDIAN_REQUESTS_IPC_METHODS;
+
+const FUTURE = () => Date.now() + 10 * 60 * 1000;
+const PAST = () => Date.now() - 10_000;
+
+let server: GatewayIpcServer;
+let socketDir: string;
+let prevEnv: string | undefined;
+let reqSeq = 0;
+
+async function rpc(
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const id = `rpc-${++reqSeq}`;
+  const line = JSON.stringify({ id, method, params });
+  return await new Promise((resolve, reject) => {
+    const sock = connect(server.getSocketPath());
+    let buf = "";
+    sock.on("connect", () => sock.write(line + "\n"));
+    sock.on("data", (chunk) => {
+      buf += chunk.toString();
+      const nl = buf.indexOf("\n");
+      if (nl !== -1) {
+        sock.end();
+        resolve(JSON.parse(buf.slice(0, nl)));
+      }
+    });
+    sock.on("error", reject);
+  });
+}
+
+/** rpc() for calls expected to succeed; returns the unwrapped result. */
+async function call(
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<unknown> {
+  const res = await rpc(method, params);
+  if (res.error !== undefined) {
+    throw new Error(`unexpected IPC error: ${String(res.error)}`);
+  }
+  return res.result;
+}
+
+/** Create a request over the socket; every decisionable kind needs a principal. */
+async function createRequest(overrides: Record<string, unknown> = {}) {
+  return GuardianRequestSchema.parse(
+    await call(METHODS.create, {
+      id: `req-${++reqSeq}`,
+      kind: "access_request",
+      guardianPrincipalId: "principal-1",
+      ...overrides,
+    }),
+  );
+}
+
+function getRequestRow(id: string) {
+  return getGatewayDb()
+    .select()
+    .from(guardianRequests)
+    .where(eq(guardianRequests.id, id))
+    .get();
+}
+
+function getDeliveryRow(id: string) {
+  return getGatewayDb()
+    .select()
+    .from(guardianRequestDeliveries)
+    .where(eq(guardianRequestDeliveries.id, id))
+    .get();
+}
+
+beforeEach(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+  getGatewayDb().delete(guardianRequestDeliveries).run();
+  getGatewayDb().delete(guardianRequests).run();
+
+  socketDir = mkdtempSync(join(tmpdir(), "vellum-ipc-test-"));
+  prevEnv = process.env.GATEWAY_IPC_SOCKET_DIR;
+  process.env.GATEWAY_IPC_SOCKET_DIR = socketDir;
+  // Disable the watchdog so the test has a single deterministic listener.
+  server = new GatewayIpcServer(guardianRequestRoutes, {
+    watchdogIntervalMs: 0,
+  });
+  server.start();
+  // Wait for the listener to bind.
+  const { existsSync } = await import("node:fs");
+  for (let i = 0; i < 100 && !existsSync(server.getSocketPath()); i++) {
+    await new Promise((r) => setTimeout(r, 5));
+  }
+});
+
+afterEach(() => {
+  server.stop();
+  if (prevEnv === undefined) delete process.env.GATEWAY_IPC_SOCKET_DIR;
+  else process.env.GATEWAY_IPC_SOCKET_DIR = prevEnv;
+  rmSync(socketDir, { recursive: true, force: true });
+  resetGatewayDb();
+});
+
+describe("route registration", () => {
+  test("registers every contract method except decide, each with a schema", () => {
+    const expected = Object.values(METHODS)
+      .filter((m) => m !== METHODS.decide)
+      .sort();
+    expect(guardianRequestRoutes.map((r) => r.method).sort()).toEqual(expected);
+    for (const route of guardianRequestRoutes) {
+      expect(route.schema).toBeDefined();
+    }
+  });
+
+  test("guardian_requests_decide is not registered (unknown method)", async () => {
+    const res = await rpc(METHODS.decide, {
+      id: "req-x",
+      expectedStatus: "pending",
+      status: "approved",
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.errorCode).toBe("UNKNOWN_METHOD");
+    expect(String(res.error)).toContain("Unknown method");
+  });
+});
+
+describe("guardian_requests_create", () => {
+  test("persists the row, preserves the caller-supplied id, generates a code", async () => {
+    const created = await createRequest({
+      id: "access-req-self-telegram-alice-123",
+      sourceChannel: "telegram",
+      sourceConversationId: "conv-1",
+      requesterExternalUserId: "tg-user-1",
+      questionText: "Can Alice reach you?",
+    });
+
+    expect(created.id).toBe("access-req-self-telegram-alice-123");
+    expect(created.status).toBe("pending");
+    expect(created.requestCode).toMatch(/^[0-9A-F]{6}$/);
+    expect(created.sourceType).toBe("channel");
+
+    const row = getRequestRow(created.id);
+    expect(row?.kind).toBe("access_request");
+    expect(row?.sourceConversationId).toBe("conv-1");
+    expect(row?.guardianPrincipalId).toBe("principal-1");
+    expect(row?.requestCode).toBe(created.requestCode);
+  });
+
+  test("honors a caller-supplied requestCode", async () => {
+    const created = await createRequest({ requestCode: "ABC123" });
+    expect(created.requestCode).toBe("ABC123");
+    expect(getRequestRow(created.id)?.requestCode).toBe("ABC123");
+  });
+
+  test("computes sourceType from sourceChannel: phone→voice, vellum→desktop, else channel", async () => {
+    const voice = await createRequest({
+      kind: "pending_question",
+      sourceChannel: "phone",
+      requesterExternalUserId: "+15555550101",
+    });
+    const desktop = await createRequest({
+      kind: "tool_approval",
+      sourceChannel: "vellum",
+      toolName: "bash",
+    });
+    const bare = await createRequest({});
+
+    expect(voice.sourceType).toBe("voice");
+    expect(desktop.sourceType).toBe("desktop");
+    expect(bare.sourceType).toBe("channel");
+  });
+
+  test("rejects a create without guardianPrincipalId at the schema", async () => {
+    // The contract requires guardianPrincipalId (every admitted kind is
+    // decisionable), so the store-level integrity guard is unreachable over
+    // IPC — the schema rejection is the pinned behavior.
+    const res = await rpc(METHODS.create, {
+      id: "req-no-principal",
+      kind: "access_request",
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.errorCode).toBe("BAD_REQUEST");
+    expect(getRequestRow("req-no-principal")).toBeUndefined();
+  });
+});
+
+describe("guardian_requests_get / get_by_code", () => {
+  test("get returns the wire DTO, null for unknown ids", async () => {
+    const created = await createRequest({ sourceChannel: "telegram" });
+    expect(await call(METHODS.get, { id: created.id })).toEqual(created);
+    expect(await call(METHODS.get, { id: "nope" })).toBeNull();
+  });
+
+  test("get_by_code matches pending requests only", async () => {
+    const created = await createRequest({});
+    const code = created.requestCode!;
+
+    const found = GuardianRequestSchema.parse(
+      await call(METHODS.getByCode, { code }),
+    );
+    expect(found.id).toBe(created.id);
+
+    await call(METHODS.update, {
+      id: created.id,
+      patch: { status: "approved" },
+    });
+    expect(await call(METHODS.getByCode, { code })).toBeNull();
+  });
+});
+
+describe("guardian_requests_list", () => {
+  test("filters by the derived sourceType and by stored columns", async () => {
+    const voice = await createRequest({
+      kind: "pending_question",
+      sourceChannel: "phone",
+    });
+    const desktop = await createRequest({
+      kind: "tool_approval",
+      sourceChannel: "vellum",
+      toolName: "bash",
+    });
+    const channel = await createRequest({ sourceChannel: "telegram" });
+
+    const all = GuardianRequestListIpcResponseSchema.parse(
+      await call(METHODS.list, {}),
+    );
+    expect(all).toHaveLength(3);
+
+    const voiceOnly = GuardianRequestListIpcResponseSchema.parse(
+      await call(METHODS.list, { sourceType: "voice" }),
+    );
+    expect(voiceOnly.map((r) => r.id)).toEqual([voice.id]);
+
+    const desktopOnly = GuardianRequestListIpcResponseSchema.parse(
+      await call(METHODS.list, { sourceType: "desktop" }),
+    );
+    expect(desktopOnly.map((r) => r.id)).toEqual([desktop.id]);
+
+    const channelOnly = GuardianRequestListIpcResponseSchema.parse(
+      await call(METHODS.list, { sourceType: "channel" }),
+    );
+    expect(channelOnly.map((r) => r.id)).toEqual([channel.id]);
+
+    const byKind = GuardianRequestListIpcResponseSchema.parse(
+      await call(METHODS.list, { kind: "tool_approval", toolName: "bash" }),
+    );
+    expect(byKind.map((r) => r.id)).toEqual([desktop.id]);
+
+    await call(METHODS.update, { id: voice.id, patch: { status: "denied" } });
+    const pending = GuardianRequestListIpcResponseSchema.parse(
+      await call(METHODS.list, { status: "pending" }),
+    );
+    expect(pending.map((r) => r.id).sort()).toEqual(
+      [desktop.id, channel.id].sort(),
+    );
+  });
+});
+
+describe("guardian_requests_update", () => {
+  test("applies the patch and acks", async () => {
+    const created = await createRequest({});
+
+    const ack = await call(METHODS.update, {
+      id: created.id,
+      patch: {
+        status: "approved",
+        answerText: "yes",
+        decidedByPrincipalId: "principal-1",
+        followupState: "inline_wait_active:123",
+        expiresAt: 456,
+      },
+    });
+    expect(ack).toEqual({ ok: true });
+
+    const row = getRequestRow(created.id);
+    expect(row?.status).toBe("approved");
+    expect(row?.answerText).toBe("yes");
+    expect(row?.decidedByPrincipalId).toBe("principal-1");
+    expect(row?.followupState).toBe("inline_wait_active:123");
+    expect(row?.expiresAt).toBe(456);
+
+    // A nullable followupState patch clears the stamp.
+    await call(METHODS.update, {
+      id: created.id,
+      patch: { followupState: null },
+    });
+    expect(getRequestRow(created.id)?.followupState).toBeNull();
+  });
+});
+
+describe("guardian_requests_expire / reopen", () => {
+  test("expire CAS-expires the request and bulk-expires its deliveries", async () => {
+    const created = await createRequest({});
+    const delivery = GuardianRequestDeliverySchema.parse(
+      await call(METHODS.createDelivery, {
+        requestId: created.id,
+        destinationChannel: "telegram",
+        destinationChatId: "chat-1",
+      }),
+    );
+
+    expect(await call(METHODS.expire, { id: created.id })).toEqual({
+      ok: true,
+    });
+    expect(getRequestRow(created.id)?.status).toBe("expired");
+    expect(getDeliveryRow(delivery.id)?.status).toBe("expired");
+  });
+
+  test("reopen CAS-transitions fromStatus back to pending; a missed swap is a no-op", async () => {
+    const created = await createRequest({});
+    await call(METHODS.expire, { id: created.id });
+
+    // Wrong fromStatus: acks without touching the row.
+    expect(
+      await call(METHODS.reopen, { id: created.id, fromStatus: "denied" }),
+    ).toEqual({ ok: true });
+    expect(getRequestRow(created.id)?.status).toBe("expired");
+
+    expect(
+      await call(METHODS.reopen, { id: created.id, fromStatus: "expired" }),
+    ).toEqual({ ok: true });
+    expect(getRequestRow(created.id)?.status).toBe("pending");
+  });
+});
+
+describe("guardian_requests_expire_interaction_bound", () => {
+  test("expires interaction-bound kinds unconditionally, persistent kinds only past deadline", async () => {
+    const toolApproval = await createRequest({
+      kind: "tool_approval",
+      toolName: "bash",
+    });
+    const pendingQuestion = await createRequest({ kind: "pending_question" });
+    const freshAccess = await createRequest({ expiresAt: FUTURE() });
+    const staleAccess = await createRequest({ expiresAt: PAST() });
+
+    expect(await call(METHODS.expireInteractionBound, {})).toEqual({
+      expired: 3,
+    });
+    expect(getRequestRow(toolApproval.id)?.status).toBe("expired");
+    expect(getRequestRow(pendingQuestion.id)?.status).toBe("expired");
+    expect(getRequestRow(staleAccess.id)?.status).toBe("expired");
+    expect(getRequestRow(freshAccess.id)?.status).toBe("pending");
+  });
+});
+
+describe("guardian_requests_sweep_expired", () => {
+  test("expires past-deadline pending requests and returns their ids", async () => {
+    const stale = await createRequest({ expiresAt: PAST() });
+    const fresh = await createRequest({ expiresAt: FUTURE() });
+    const noDeadline = await createRequest({});
+
+    const swept = SweepExpiredGuardianRequestsIpcResponseSchema.parse(
+      await call(METHODS.sweepExpired, {}),
+    );
+    expect(swept.expired).toEqual([stale.id]);
+    expect(getRequestRow(stale.id)?.status).toBe("expired");
+    expect(getRequestRow(fresh.id)?.status).toBe("pending");
+    expect(getRequestRow(noDeadline.id)?.status).toBe("pending");
+  });
+
+  test("honors an explicit `now`", async () => {
+    const fresh = await createRequest({ expiresAt: FUTURE() });
+
+    const swept = SweepExpiredGuardianRequestsIpcResponseSchema.parse(
+      await call(METHODS.sweepExpired, { now: fresh.expiresAt! + 1 }),
+    );
+    expect(swept.expired).toEqual([fresh.id]);
+    expect(getRequestRow(fresh.id)?.status).toBe("expired");
+  });
+});
+
+describe("delivery routes: create / update / list", () => {
+  test("create + update + list round-trip", async () => {
+    const created = await createRequest({});
+
+    const first = GuardianRequestDeliverySchema.parse(
+      await call(METHODS.createDelivery, {
+        id: "delivery-1",
+        requestId: created.id,
+        destinationChannel: "telegram",
+        destinationChatId: "chat-1",
+        destinationConversationId: "conv-9",
+      }),
+    );
+    expect(first.id).toBe("delivery-1");
+    expect(first.status).toBe("pending");
+
+    const second = GuardianRequestDeliverySchema.parse(
+      await call(METHODS.createDelivery, {
+        requestId: created.id,
+        destinationChannel: "slack",
+        destinationChatId: "C123",
+        status: "sent",
+      }),
+    );
+    expect(second.status).toBe("sent");
+
+    const ack = await call(METHODS.updateDelivery, {
+      id: first.id,
+      patch: { status: "sent", destinationMessageId: "msg-42" },
+    });
+    expect(ack).toEqual({ ok: true });
+    expect(getDeliveryRow(first.id)?.status).toBe("sent");
+    expect(getDeliveryRow(first.id)?.destinationMessageId).toBe("msg-42");
+
+    const listed = GuardianRequestDeliveryListIpcResponseSchema.parse(
+      await call(METHODS.listDeliveries, { requestId: created.id }),
+    );
+    expect(listed.map((d) => d.id).sort()).toEqual(
+      [first.id, second.id].sort(),
+    );
+  });
+});
+
+describe("destination lookups", () => {
+  test("get_by_destination_message resolves the pending request behind a delivered card", async () => {
+    const created = await createRequest({});
+    await call(METHODS.createDelivery, {
+      requestId: created.id,
+      destinationChannel: "telegram",
+      destinationChatId: "chat-1",
+      destinationMessageId: "msg-7",
+    });
+
+    const found = GuardianRequestSchema.parse(
+      await call(METHODS.getByDestinationMessage, {
+        channel: "telegram",
+        chatId: "chat-1",
+        messageId: "msg-7",
+      }),
+    );
+    expect(found.id).toBe(created.id);
+
+    // Resolved requests no longer match (pending-only).
+    await call(METHODS.update, {
+      id: created.id,
+      patch: { status: "approved" },
+    });
+    expect(
+      await call(METHODS.getByDestinationMessage, {
+        channel: "telegram",
+        chatId: "chat-1",
+        messageId: "msg-7",
+      }),
+    ).toBeNull();
+  });
+
+  test("list_pending_by_destination: chat form and conversation form with channel narrowing", async () => {
+    const a = await createRequest({});
+    const b = await createRequest({});
+    await call(METHODS.createDelivery, {
+      requestId: a.id,
+      destinationChannel: "telegram",
+      destinationChatId: "chat-1",
+      destinationConversationId: "conv-1",
+    });
+    await call(METHODS.createDelivery, {
+      requestId: b.id,
+      destinationChannel: "slack",
+      destinationChatId: "chat-1",
+      destinationConversationId: "conv-1",
+    });
+
+    const byChat = GuardianRequestListIpcResponseSchema.parse(
+      await call(METHODS.listPendingByDestination, {
+        channel: "telegram",
+        chatId: "chat-1",
+      }),
+    );
+    expect(byChat.map((r) => r.id)).toEqual([a.id]);
+
+    const byConversation = GuardianRequestListIpcResponseSchema.parse(
+      await call(METHODS.listPendingByDestination, {
+        conversationId: "conv-1",
+      }),
+    );
+    expect(byConversation.map((r) => r.id).sort()).toEqual(
+      [a.id, b.id].sort(),
+    );
+
+    const narrowed = GuardianRequestListIpcResponseSchema.parse(
+      await call(METHODS.listPendingByDestination, {
+        conversationId: "conv-1",
+        channel: "slack",
+      }),
+    );
+    expect(narrowed.map((r) => r.id)).toEqual([b.id]);
+  });
+});
+
+describe("scope reads", () => {
+  test("list_pending_by_scope unions source + delivery matches, deduplicated", async () => {
+    const bySource = await createRequest({ sourceConversationId: "conv-1" });
+    const byDelivery = await createRequest({});
+    const both = await createRequest({ sourceConversationId: "conv-1" });
+    await call(METHODS.createDelivery, {
+      requestId: byDelivery.id,
+      destinationChannel: "telegram",
+      destinationConversationId: "conv-1",
+    });
+    await call(METHODS.createDelivery, {
+      requestId: both.id,
+      destinationChannel: "telegram",
+      destinationConversationId: "conv-1",
+    });
+    await createRequest({ sourceConversationId: "conv-other" });
+
+    const scoped = GuardianRequestListIpcResponseSchema.parse(
+      await call(METHODS.listPendingByScope, { conversationId: "conv-1" }),
+    );
+    expect(scoped.map((r) => r.id).sort()).toEqual(
+      [bySource.id, byDelivery.id, both.id].sort(),
+    );
+  });
+
+  test("in_scope matches by source or delivery, honoring channel narrowing", async () => {
+    const created = await createRequest({ sourceConversationId: "conv-src" });
+    await call(METHODS.createDelivery, {
+      requestId: created.id,
+      destinationChannel: "telegram",
+      destinationConversationId: "conv-dst",
+    });
+
+    const cases: Array<[Record<string, unknown>, boolean]> = [
+      [{ requestId: created.id, conversationId: "conv-src" }, true],
+      [{ requestId: created.id, conversationId: "conv-dst" }, true],
+      [
+        {
+          requestId: created.id,
+          conversationId: "conv-dst",
+          channel: "telegram",
+        },
+        true,
+      ],
+      [
+        { requestId: created.id, conversationId: "conv-dst", channel: "slack" },
+        false,
+      ],
+      [{ requestId: created.id, conversationId: "conv-nope" }, false],
+      [{ requestId: "nope", conversationId: "conv-src" }, false],
+    ];
+    for (const [params, inScope] of cases) {
+      expect(
+        GuardianRequestInScopeIpcResponseSchema.parse(
+          await call(METHODS.inScope, params),
+        ),
+      ).toEqual({ inScope });
+    }
+  });
+});
+
+describe("call-session + pending-question lookups", () => {
+  test("get_by_call_session returns the latest pending request for the session", async () => {
+    expect(
+      await call(METHODS.getByCallSession, { callSessionId: "call-1" }),
+    ).toBeNull();
+
+    const created = await createRequest({
+      kind: "pending_question",
+      sourceChannel: "phone",
+      callSessionId: "call-1",
+    });
+    const found = GuardianRequestSchema.parse(
+      await call(METHODS.getByCallSession, { callSessionId: "call-1" }),
+    );
+    expect(found.id).toBe(created.id);
+
+    await call(METHODS.update, { id: created.id, patch: { status: "denied" } });
+    expect(
+      await call(METHODS.getByCallSession, { callSessionId: "call-1" }),
+    ).toBeNull();
+  });
+
+  test("get_by_pending_question resolves the linked request", async () => {
+    const created = await createRequest({
+      kind: "pending_question",
+      sourceChannel: "phone",
+      pendingQuestionId: "pq-1",
+    });
+    const found = GuardianRequestSchema.parse(
+      await call(METHODS.getByPendingQuestion, { pendingQuestionId: "pq-1" }),
+    );
+    expect(found.id).toBe(created.id);
+    expect(
+      await call(METHODS.getByPendingQuestion, { pendingQuestionId: "pq-2" }),
+    ).toBeNull();
+  });
+});
+
+describe("schema rejection", () => {
+  test("malformed params → 400 BAD_REQUEST without touching the store", async () => {
+    const badCalls: Array<[string, Record<string, unknown>]> = [
+      [METHODS.create, {}], // id, kind, guardianPrincipalId required
+      [
+        METHODS.create,
+        { id: "req-x", kind: "not-a-kind", guardianPrincipalId: "p" },
+      ],
+      [METHODS.create, { id: "", kind: "access_request", guardianPrincipalId: "p" }],
+      [METHODS.get, {}],
+      [METHODS.getByCode, { code: "" }],
+      [METHODS.list, { sourceType: "carrier-pigeon" }],
+      [METHODS.update, { id: "req-x" }], // patch required
+      [METHODS.update, { id: "req-x", patch: { status: "not-a-status" } }],
+      [METHODS.reopen, { id: "req-x" }], // fromStatus required
+      [METHODS.expire, {}],
+      [METHODS.sweepExpired, { now: "yesterday" }],
+      [METHODS.createDelivery, { requestId: "req-x" }], // channel required
+      [METHODS.updateDelivery, { id: "d-1" }], // patch required
+      [METHODS.listDeliveries, {}],
+      [METHODS.getByDestinationMessage, { channel: "telegram", chatId: "c" }],
+      [METHODS.listPendingByDestination, {}], // refine: conversationId or channel+chatId
+      [METHODS.listPendingByDestination, { channel: "telegram" }],
+      [METHODS.listPendingByScope, {}],
+      [METHODS.inScope, { requestId: "req-x" }],
+      [METHODS.getByCallSession, { callSessionId: "" }],
+      [METHODS.getByPendingQuestion, {}],
+    ];
+
+    for (const [method, params] of badCalls) {
+      const res = await rpc(method, params);
+      expect(res.statusCode).toBe(400);
+      expect(res.errorCode).toBe("BAD_REQUEST");
+      expect(String(res.error)).toContain("Invalid params");
+    }
+
+    // Nothing was written by any of the rejected calls.
+    expect(getGatewayDb().select().from(guardianRequests).all()).toHaveLength(
+      0,
+    );
+    expect(
+      getGatewayDb().select().from(guardianRequestDeliveries).all(),
+    ).toHaveLength(0);
+  });
+});

--- a/gateway/src/ipc/__tests__/guardian-request-routes.test.ts
+++ b/gateway/src/ipc/__tests__/guardian-request-routes.test.ts
@@ -263,6 +263,11 @@ describe("guardian_requests_list", () => {
     );
     expect(all).toHaveLength(3);
 
+    const omittedParams = GuardianRequestListIpcResponseSchema.parse(
+      await call(METHODS.list),
+    );
+    expect(omittedParams).toHaveLength(3);
+
     const voiceOnly = GuardianRequestListIpcResponseSchema.parse(
       await call(METHODS.list, { sourceType: "voice" }),
     );

--- a/gateway/src/ipc/guardian-request-handlers.ts
+++ b/gateway/src/ipc/guardian-request-handlers.ts
@@ -1,0 +1,234 @@
+/**
+ * IPC route definitions for the gateway-native guardian-request lifecycle
+ * (ATL-463).
+ *
+ * The gateway owns the `guardian_requests` + `guardian_request_deliveries`
+ * tables; the daemon relays its guardian-request lifecycle operations here.
+ * Request/response shapes are pinned by the shared contract in
+ * `@vellumai/gateway-client` (guardian-request-contract.ts). Read methods
+ * return the wire DTO (or null / an array); mutations return a minimal
+ * `{ ok: true }` ack.
+ *
+ * `guardian_requests_decide` (decision CAS + in-transaction ACL outcomes) is
+ * not registered here.
+ */
+
+import {
+  CreateGuardianRequestDeliveryIpcParamsSchema,
+  CreateGuardianRequestIpcParamsSchema,
+  ExpireGuardianRequestIpcParamsSchema,
+  ExpireInteractionBoundIpcParamsSchema,
+  GUARDIAN_REQUESTS_IPC_METHODS,
+  GetGuardianRequestByCallSessionIpcParamsSchema,
+  GetGuardianRequestByCodeIpcParamsSchema,
+  GetGuardianRequestByDestinationMessageIpcParamsSchema,
+  GetGuardianRequestByPendingQuestionIpcParamsSchema,
+  GetGuardianRequestIpcParamsSchema,
+  GuardianRequestInScopeIpcParamsSchema,
+  ListGuardianRequestDeliveriesIpcParamsSchema,
+  ListGuardianRequestsIpcParamsSchema,
+  ListPendingGuardianRequestsByDestinationIpcParamsSchema,
+  ListPendingGuardianRequestsByScopeIpcParamsSchema,
+  ReopenGuardianRequestIpcParamsSchema,
+  SweepExpiredGuardianRequestsIpcParamsSchema,
+  UpdateGuardianRequestDeliveryIpcParamsSchema,
+  UpdateGuardianRequestIpcParamsSchema,
+} from "@vellumai/gateway-client";
+
+import {
+  createGuardianRequest,
+  createGuardianRequestDelivery,
+  expireGuardianRequest,
+  expireInteractionBoundRequests,
+  getGuardianRequest,
+  getGuardianRequestByCode,
+  getPendingRequestByCallSession,
+  getPendingRequestByDestinationMessage,
+  getRequestByPendingQuestion,
+  isGuardianRequestInScope,
+  listGuardianRequestDeliveries,
+  listGuardianRequests,
+  listPendingRequestsByDestination,
+  listPendingRequestsByScope,
+  reopenGuardianRequest,
+  sweepExpiredRequests,
+  updateGuardianRequest,
+  updateGuardianRequestDelivery,
+} from "../approvals/guardian-request-service.js";
+import type { IpcRoute } from "./server.js";
+
+export const guardianRequestRoutes: IpcRoute[] = [
+  {
+    // Caller-supplied ids are load-bearing (deterministic access-request
+    // ids; tool_approval rows reuse the pending-interaction requestId).
+    method: GUARDIAN_REQUESTS_IPC_METHODS.create,
+    schema: CreateGuardianRequestIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const input = CreateGuardianRequestIpcParamsSchema.parse(params);
+      return createGuardianRequest(input);
+    },
+  },
+  {
+    method: GUARDIAN_REQUESTS_IPC_METHODS.get,
+    schema: GetGuardianRequestIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const { id } = GetGuardianRequestIpcParamsSchema.parse(params);
+      return getGuardianRequest(id);
+    },
+  },
+  {
+    // Pending requests only — a resolved request's code never matches.
+    method: GUARDIAN_REQUESTS_IPC_METHODS.getByCode,
+    schema: GetGuardianRequestByCodeIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const { code } = GetGuardianRequestByCodeIpcParamsSchema.parse(params);
+      return getGuardianRequestByCode(code);
+    },
+  },
+  {
+    // `sourceType` filters translate into source_channel predicates
+    // gateway-side (the column is not stored).
+    method: GUARDIAN_REQUESTS_IPC_METHODS.list,
+    schema: ListGuardianRequestsIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const filters = ListGuardianRequestsIpcParamsSchema.parse(params);
+      return listGuardianRequests(filters);
+    },
+  },
+  {
+    method: GUARDIAN_REQUESTS_IPC_METHODS.update,
+    schema: UpdateGuardianRequestIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const { id, patch } = UpdateGuardianRequestIpcParamsSchema.parse(params);
+      updateGuardianRequest(id, patch);
+      return { ok: true };
+    },
+  },
+  {
+    // CAS `fromStatus` → pending; a missed swap acks without reopening.
+    method: GUARDIAN_REQUESTS_IPC_METHODS.reopen,
+    schema: ReopenGuardianRequestIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const { id, fromStatus } =
+        ReopenGuardianRequestIpcParamsSchema.parse(params);
+      reopenGuardianRequest(id, fromStatus);
+      return { ok: true };
+    },
+  },
+  {
+    // CAS pending → expired; the request's deliveries expire with it.
+    method: GUARDIAN_REQUESTS_IPC_METHODS.expire,
+    schema: ExpireGuardianRequestIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const { id } = ExpireGuardianRequestIpcParamsSchema.parse(params);
+      expireGuardianRequest(id);
+      return { ok: true };
+    },
+  },
+  {
+    // Daemon-boot expiry (daemon-keyed — never run on gateway restart).
+    method: GUARDIAN_REQUESTS_IPC_METHODS.expireInteractionBound,
+    schema: ExpireInteractionBoundIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      ExpireInteractionBoundIpcParamsSchema.parse(params);
+      return expireInteractionBoundRequests();
+    },
+  },
+  {
+    // Returns the expired ids for daemon-side notification fan-out.
+    method: GUARDIAN_REQUESTS_IPC_METHODS.sweepExpired,
+    schema: SweepExpiredGuardianRequestsIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const { now } =
+        SweepExpiredGuardianRequestsIpcParamsSchema.parse(params);
+      return sweepExpiredRequests(now);
+    },
+  },
+  {
+    method: GUARDIAN_REQUESTS_IPC_METHODS.createDelivery,
+    schema: CreateGuardianRequestDeliveryIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const input = CreateGuardianRequestDeliveryIpcParamsSchema.parse(params);
+      return createGuardianRequestDelivery(input);
+    },
+  },
+  {
+    method: GUARDIAN_REQUESTS_IPC_METHODS.updateDelivery,
+    schema: UpdateGuardianRequestDeliveryIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const { id, patch } =
+        UpdateGuardianRequestDeliveryIpcParamsSchema.parse(params);
+      updateGuardianRequestDelivery(id, patch);
+      return { ok: true };
+    },
+  },
+  {
+    method: GUARDIAN_REQUESTS_IPC_METHODS.listDeliveries,
+    schema: ListGuardianRequestDeliveriesIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const { requestId } =
+        ListGuardianRequestDeliveriesIpcParamsSchema.parse(params);
+      return listGuardianRequestDeliveries(requestId);
+    },
+  },
+  {
+    // Reaction routing: the pending request whose delivered card is the
+    // reacted-to message.
+    method: GUARDIAN_REQUESTS_IPC_METHODS.getByDestinationMessage,
+    schema: GetGuardianRequestByDestinationMessageIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const { channel, chatId, messageId } =
+        GetGuardianRequestByDestinationMessageIpcParamsSchema.parse(params);
+      return getPendingRequestByDestinationMessage(channel, chatId, messageId);
+    },
+  },
+  {
+    // Reply routing: by destination conversation (optionally narrowed by
+    // channel) or by channel + chat pair.
+    method: GUARDIAN_REQUESTS_IPC_METHODS.listPendingByDestination,
+    schema: ListPendingGuardianRequestsByDestinationIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const input =
+        ListPendingGuardianRequestsByDestinationIpcParamsSchema.parse(params);
+      return listPendingRequestsByDestination(input);
+    },
+  },
+  {
+    method: GUARDIAN_REQUESTS_IPC_METHODS.listPendingByScope,
+    schema: ListPendingGuardianRequestsByScopeIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const { conversationId, channel } =
+        ListPendingGuardianRequestsByScopeIpcParamsSchema.parse(params);
+      return listPendingRequestsByScope(conversationId, channel);
+    },
+  },
+  {
+    method: GUARDIAN_REQUESTS_IPC_METHODS.inScope,
+    schema: GuardianRequestInScopeIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const { requestId, conversationId, channel } =
+        GuardianRequestInScopeIpcParamsSchema.parse(params);
+      return {
+        inScope: isGuardianRequestInScope(requestId, conversationId, channel),
+      };
+    },
+  },
+  {
+    method: GUARDIAN_REQUESTS_IPC_METHODS.getByCallSession,
+    schema: GetGuardianRequestByCallSessionIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const { callSessionId } =
+        GetGuardianRequestByCallSessionIpcParamsSchema.parse(params);
+      return getPendingRequestByCallSession(callSessionId);
+    },
+  },
+  {
+    method: GUARDIAN_REQUESTS_IPC_METHODS.getByPendingQuestion,
+    schema: GetGuardianRequestByPendingQuestionIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const { pendingQuestionId } =
+        GetGuardianRequestByPendingQuestionIpcParamsSchema.parse(params);
+      return getRequestByPendingQuestion(pendingQuestionId);
+    },
+  },
+];

--- a/gateway/src/ipc/guardian-request-handlers.ts
+++ b/gateway/src/ipc/guardian-request-handlers.ts
@@ -34,6 +34,7 @@ import {
   UpdateGuardianRequestDeliveryIpcParamsSchema,
   UpdateGuardianRequestIpcParamsSchema,
 } from "@vellumai/gateway-client";
+import { z } from "zod";
 
 import {
   createGuardianRequest,
@@ -56,6 +57,18 @@ import {
   updateGuardianRequestDelivery,
 } from "../approvals/guardian-request-service.js";
 import type { IpcRoute } from "./server.js";
+
+// The server validates req.params BEFORE the handler runs, and no-arg daemon
+// callers (`ipcCallPersistent(method)`) send req.params === undefined — these
+// two routes must accept the omitted-params call shape and default it to {}.
+const ExpireInteractionBoundParamsSchema = z.preprocess(
+  (v) => v ?? {},
+  ExpireInteractionBoundIpcParamsSchema,
+);
+const SweepExpiredParamsSchema = z.preprocess(
+  (v) => v ?? {},
+  SweepExpiredGuardianRequestsIpcParamsSchema,
+);
 
 export const guardianRequestRoutes: IpcRoute[] = [
   {
@@ -128,19 +141,15 @@ export const guardianRequestRoutes: IpcRoute[] = [
   {
     // Daemon-boot expiry (daemon-keyed — never run on gateway restart).
     method: GUARDIAN_REQUESTS_IPC_METHODS.expireInteractionBound,
-    schema: ExpireInteractionBoundIpcParamsSchema,
-    handler: (params?: Record<string, unknown>) => {
-      ExpireInteractionBoundIpcParamsSchema.parse(params);
-      return expireInteractionBoundRequests();
-    },
+    schema: ExpireInteractionBoundParamsSchema,
+    handler: () => expireInteractionBoundRequests(),
   },
   {
     // Returns the expired ids for daemon-side notification fan-out.
     method: GUARDIAN_REQUESTS_IPC_METHODS.sweepExpired,
-    schema: SweepExpiredGuardianRequestsIpcParamsSchema,
+    schema: SweepExpiredParamsSchema,
     handler: (params?: Record<string, unknown>) => {
-      const { now } =
-        SweepExpiredGuardianRequestsIpcParamsSchema.parse(params);
+      const { now } = SweepExpiredParamsSchema.parse(params);
       return sweepExpiredRequests(now);
     },
   },

--- a/gateway/src/ipc/guardian-request-handlers.ts
+++ b/gateway/src/ipc/guardian-request-handlers.ts
@@ -59,8 +59,9 @@ import {
 import type { IpcRoute } from "./server.js";
 
 // The server validates req.params BEFORE the handler runs, and no-arg daemon
-// callers (`ipcCallPersistent(method)`) send req.params === undefined — these
-// two routes must accept the omitted-params call shape and default it to {}.
+// callers (`ipcCallPersistent(method)`) send req.params === undefined — every
+// route whose params are all-optional must accept the omitted-params call
+// shape and default it to {}.
 const ExpireInteractionBoundParamsSchema = z.preprocess(
   (v) => v ?? {},
   ExpireInteractionBoundIpcParamsSchema,
@@ -68,6 +69,10 @@ const ExpireInteractionBoundParamsSchema = z.preprocess(
 const SweepExpiredParamsSchema = z.preprocess(
   (v) => v ?? {},
   SweepExpiredGuardianRequestsIpcParamsSchema,
+);
+const ListGuardianRequestsParamsSchema = z.preprocess(
+  (v) => v ?? {},
+  ListGuardianRequestsIpcParamsSchema,
 );
 
 export const guardianRequestRoutes: IpcRoute[] = [
@@ -102,9 +107,9 @@ export const guardianRequestRoutes: IpcRoute[] = [
     // `sourceType` filters translate into source_channel predicates
     // gateway-side (the column is not stored).
     method: GUARDIAN_REQUESTS_IPC_METHODS.list,
-    schema: ListGuardianRequestsIpcParamsSchema,
+    schema: ListGuardianRequestsParamsSchema,
     handler: (params?: Record<string, unknown>) => {
-      const filters = ListGuardianRequestsIpcParamsSchema.parse(params);
+      const filters = ListGuardianRequestsParamsSchema.parse(params);
       return listGuardianRequests(filters);
     },
   },

--- a/packages/gateway-client/src/__tests__/guardian-request-contract.test.ts
+++ b/packages/gateway-client/src/__tests__/guardian-request-contract.test.ts
@@ -116,15 +116,25 @@ describe("GuardianRequestSchema", () => {
     );
   });
 
-  test("rejects unknown status, kind, and sourceType", () => {
+  test("rejects unknown status and sourceType; kind stays open for legacy rows", () => {
     expect(() =>
       GuardianRequestSchema.parse({ ...accessRequest, status: "answered" }),
     ).toThrow();
-    expect(() =>
-      GuardianRequestSchema.parse({ ...accessRequest, kind: "ask_guardian" }),
-    ).toThrow();
+    // The physical column accepts any kind; reads round-trip legacy rows.
+    expect(
+      GuardianRequestSchema.parse({ ...accessRequest, kind: "status_update" })
+        .kind,
+    ).toBe("status_update");
     expect(() =>
       GuardianRequestSchema.parse({ ...accessRequest, sourceType: "phone" }),
+    ).toThrow();
+    // Creates stay restricted to the decisionable kind enum.
+    expect(() =>
+      CreateGuardianRequestIpcParamsSchema.parse({
+        id: "req-x",
+        kind: "status_update",
+        guardianPrincipalId: "principal-1",
+      }),
     ).toThrow();
   });
 

--- a/packages/gateway-client/src/guardian-request-contract.ts
+++ b/packages/gateway-client/src/guardian-request-contract.ts
@@ -78,7 +78,12 @@ export type GuardianRequestSourceType = z.infer<
  */
 export const GuardianRequestSchema = z.object({
   id: z.string(),
-  kind: GuardianRequestKindSchema,
+  /**
+   * Plain string, not the kind enum: the physical column accepts any value,
+   * and reads must round-trip rows that predate the current kind set.
+   * `guardian_requests_create` still restricts new rows to the enum.
+   */
+  kind: z.string(),
   /** Computed from `sourceChannel` by the gateway mapper — not stored. */
   sourceType: GuardianRequestSourceTypeSchema,
   sourceChannel: z.string().nullable(),


### PR DESCRIPTION
## Summary
- Adds gateway/src/approvals/guardian-request-service.ts (store↔wire mapping incl. computed sourceType) and the guardian_requests_* IPC routes (all lifecycle methods; decide lands in a follow-up)
- Routes registered in gateway/src/index.ts; socket tests pin contract-schema round-trips
- No daemon files changed; nothing consumes the routes yet

Part of plan: guardian-requests-gateway-native.md (PR 4 of 10)