### PR TITLE
fix(calls): restore the lock winner's state when a voice turn loses the persist race

### DIFF
--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -135,6 +135,113 @@ function makeFakeConversation(opts: {
   };
 }
 
+/**
+ * The full set of per-turn conversation values the bridge snapshots and
+ * restores when it loses the persist race (see `restoreTurnState` in
+ * voice-session-bridge.ts).
+ */
+interface FakeTurnState {
+  assistantId: string | undefined;
+  callSessionId: string | undefined;
+  trustContext: unknown;
+  commandIntent: unknown;
+  turnChannelContext: unknown;
+  turnInterfaceContext: unknown;
+  channelCapabilities: unknown;
+  voiceCallControlPrompt: string | undefined;
+  forcePromptSideEffects: boolean;
+}
+
+/**
+ * Wire stateful setters/getters onto a fake conversation, mirroring the real
+ * Conversation's field semantics (a null setter argument clears the field to
+ * undefined; turn contexts store null as-is), so the bridge's
+ * snapshot/restore logic reads and writes live values. Returns a reader for
+ * the conversation's current turn state.
+ */
+function wireTurnState(
+  fake: FakeConversation,
+  initial: Partial<FakeTurnState>,
+): () => FakeTurnState {
+  const conv = fake as FakeConversation & {
+    assistantId?: string;
+    trustContext?: unknown;
+    commandIntent?: unknown;
+    channelCapabilities?: unknown;
+    voiceCallControlPrompt?: string;
+    getTurnChannelContext?: () => unknown;
+    getTurnInterfaceContext?: () => unknown;
+  };
+  conv.assistantId = initial.assistantId;
+  conv.callSessionId = initial.callSessionId;
+  conv.trustContext = initial.trustContext;
+  conv.commandIntent = initial.commandIntent;
+  conv.channelCapabilities = initial.channelCapabilities;
+  conv.voiceCallControlPrompt = initial.voiceCallControlPrompt;
+  conv.forcePromptSideEffects = initial.forcePromptSideEffects ?? false;
+  let turnChannelContext: unknown = initial.turnChannelContext ?? null;
+  let turnInterfaceContext: unknown = initial.turnInterfaceContext ?? null;
+  conv.setAssistantId = (id: string | null) => {
+    conv.assistantId = id ?? undefined;
+  };
+  conv.setTrustContext = (ctx: unknown) => {
+    conv.trustContext = ctx ?? undefined;
+  };
+  conv.setCommandIntent = (intent: unknown) => {
+    conv.commandIntent = intent ?? undefined;
+  };
+  conv.setChannelCapabilities = (caps: unknown) => {
+    conv.channelCapabilities = caps ?? undefined;
+  };
+  conv.setVoiceCallControlPrompt = (prompt: string | null) => {
+    conv.voiceCallControlPrompt = prompt ?? undefined;
+  };
+  conv.setTurnChannelContext = (ctx: unknown) => {
+    turnChannelContext = ctx;
+  };
+  conv.setTurnInterfaceContext = (ctx: unknown) => {
+    turnInterfaceContext = ctx;
+  };
+  conv.getTurnChannelContext = () => turnChannelContext;
+  conv.getTurnInterfaceContext = () => turnInterfaceContext;
+  return () => ({
+    assistantId: conv.assistantId,
+    callSessionId: conv.callSessionId,
+    trustContext: conv.trustContext,
+    commandIntent: conv.commandIntent,
+    turnChannelContext,
+    turnInterfaceContext,
+    channelCapabilities: conv.channelCapabilities,
+    voiceCallControlPrompt: conv.voiceCallControlPrompt,
+    forcePromptSideEffects: conv.forcePromptSideEffects,
+  });
+}
+
+/**
+ * Winner-like per-turn state: the values a concurrent turn (e.g. a drained
+ * text turn from an iMessage channel) would have installed before this voice
+ * turn's persist lost the race to it.
+ */
+function makeWinnerState(): FakeTurnState {
+  return {
+    assistantId: "assistant-winner",
+    callSessionId: "session-winner",
+    trustContext: { sourceChannel: "imessage", trustClass: "trusted_contact" },
+    commandIntent: undefined,
+    turnChannelContext: {
+      userMessageChannel: "imessage",
+      assistantMessageChannel: "imessage",
+    },
+    turnInterfaceContext: {
+      userMessageInterface: "channel",
+      assistantMessageInterface: "channel",
+    },
+    channelCapabilities: { channel: "imessage", supportsDynamicUi: false },
+    voiceCallControlPrompt: "winner control prompt",
+    forcePromptSideEffects: false,
+  };
+}
+
 function makeTurnOptions(signal?: AbortSignal, conversationId?: string) {
   return {
     conversationId: conversationId ?? "conv-voice-bridge-test",
@@ -536,5 +643,142 @@ describe("startVoiceTurn queued-message drain race", () => {
       "Turn aborted while waiting for conversation",
     );
     expect(fake.persistCount()).toBe(1);
+  });
+});
+
+describe("startVoiceTurn race-loss state restore", () => {
+  // A busy persist means a concurrent turn (the lock winner) is running with
+  // per-turn state it installed. Every race-loss path must put the winner's
+  // values back — clearing to defaults would null the winner's trust context
+  // and capabilities mid-run and reset its assistantId to "self".
+
+  test("losing the persist race restores the winner's values for the duration of the retry wait", async () => {
+    const winnerState = makeWinnerState();
+    const statesDuringWait: FakeTurnState[] = [];
+    const statesAtRetryPersist: FakeTurnState[] = [];
+    const fake = makeFakeConversation({
+      processing: false,
+      waitForIdle: async () => {
+        statesDuringWait.push(readState());
+        fake.setProcessingFlag(false);
+        return true;
+      },
+      onPersist: (attempt) => {
+        if (attempt === 1) {
+          fake.setProcessingFlag(true);
+          throw new Error("Conversation is already processing a message");
+        }
+        statesAtRetryPersist.push(readState());
+      },
+    });
+    const readState = wireTurnState(fake.conversation, winnerState);
+    fakeConversation = fake.conversation;
+
+    await startVoiceTurn({
+      ...makeTurnOptions(undefined, "conv-race-loss-restore"),
+      callSessionId: "session-voice-loser",
+      trustContext: { sourceChannel: "phone", trustClass: "guardian" },
+    });
+
+    // During the retry wait the conversation reads back the WINNER's values
+    // — including the turn channel/interface contexts — not nulls/defaults.
+    expect(statesDuringWait).toEqual([winnerState]);
+    // After the wait and the successful retry, the voice turn's values are
+    // installed again.
+    expect(statesAtRetryPersist.length).toBe(1);
+    const retryState = statesAtRetryPersist[0]!;
+    expect(retryState.assistantId).toBe("self");
+    expect(retryState.callSessionId).toBe("session-voice-loser");
+    expect(retryState.trustContext).toEqual({
+      sourceChannel: "phone",
+      trustClass: "guardian",
+    });
+    expect(retryState.turnChannelContext).toEqual({
+      userMessageChannel: "phone",
+      assistantMessageChannel: "phone",
+    });
+    expect(retryState.turnInterfaceContext).toEqual({
+      userMessageInterface: "phone",
+      assistantMessageInterface: "phone",
+    });
+    expect(retryState.voiceCallControlPrompt).toContain("voice_call_control");
+  });
+
+  test("a busy persist whose retry wait exhausts the budget leaves the winner's values in place", async () => {
+    const winnerState = makeWinnerState();
+    const fake = makeFakeConversation({
+      processing: false,
+      waitForIdle: async () => false,
+      onPersist: () => {
+        fake.setProcessingFlag(true);
+        throw new Error("Conversation is already processing a message");
+      },
+    });
+    const readState = wireTurnState(fake.conversation, winnerState);
+    fakeConversation = fake.conversation;
+
+    await expect(
+      startVoiceTurn({
+        ...makeTurnOptions(undefined, "conv-race-budget-restore"),
+        callSessionId: "session-voice-loser",
+        trustContext: { sourceChannel: "phone", trustClass: "guardian" },
+      }),
+    ).rejects.toThrow("Conversation is already processing a message");
+    // The voice turn never ran, so it leaves zero trace: the conversation is
+    // exactly as the winner had it, not reset to defaults.
+    expect(readState()).toEqual(winnerState);
+  });
+
+  test("a retry persist that stays busy leaves the winner's values in place", async () => {
+    const winnerState = makeWinnerState();
+    const fake = makeFakeConversation({
+      processing: false,
+      waitForIdle: async () => true,
+      onPersist: () => {
+        throw new Error("Conversation is already processing a message");
+      },
+    });
+    const readState = wireTurnState(fake.conversation, winnerState);
+    fakeConversation = fake.conversation;
+
+    await expect(
+      startVoiceTurn({
+        ...makeTurnOptions(undefined, "conv-race-retry-busy-restore"),
+        trustContext: { sourceChannel: "phone", trustClass: "guardian" },
+      }),
+    ).rejects.toThrow("Conversation is already processing a message");
+    expect(fake.persistCount()).toBe(2);
+    expect(readState()).toEqual(winnerState);
+  });
+
+  test("an abort during the busy-persist retry wait leaves the winner's values in place", async () => {
+    const winnerState = makeWinnerState();
+    const controller = new AbortController();
+    const fake = makeFakeConversation({
+      processing: false,
+      waitForIdle: ({ signal }) =>
+        new Promise<boolean>((_resolve, reject) => {
+          signal?.addEventListener("abort", () => reject(signal.reason), {
+            once: true,
+          });
+        }),
+      onPersist: () => {
+        fake.setProcessingFlag(true);
+        throw new Error("Conversation is already processing a message");
+      },
+    });
+    const readState = wireTurnState(fake.conversation, winnerState);
+    fakeConversation = fake.conversation;
+
+    const turnPromise = startVoiceTurn({
+      ...makeTurnOptions(controller.signal, "conv-race-abort-restore"),
+      trustContext: { sourceChannel: "phone", trustClass: "guardian" },
+    });
+    await flushMicrotasks();
+    controller.abort();
+    await expect(turnPromise).rejects.toThrow(
+      "Turn aborted while waiting for conversation",
+    );
+    expect(readState()).toEqual(winnerState);
   });
 });

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -507,12 +507,16 @@ export async function startVoiceTurn(
     break;
   }
 
-  // Hoisted so the catch below can clear partially-applied turn state
-  // when a setter or `persistUserMessage` throws — otherwise `trustContext`,
-  // `callSessionId`, etc. leak into subsequent non-voice turns on the same
-  // conversation. The client callback is only reset when this turn actually
-  // installed it (tracked via `clientCallbackInstalled`); otherwise cleanup
-  // would detach an active sender installed by a prior turn.
+  // Releases the per-turn state of a voice turn that OWNED the conversation,
+  // so `trustContext`, `callSessionId`, etc. don't leak into subsequent
+  // non-voice turns. Runs on exactly two paths: the agent-loop `finally`
+  // (the turn ran) and the first-persist non-busy failure below (the persist
+  // failed while no concurrent turn held the lock). Paths where this turn
+  // LOST the conversation to a concurrent winner must use `restoreTurnState`
+  // instead — this reset-to-defaults would clobber the winner's live state.
+  // The client callback is only reset when this turn actually installed it
+  // (tracked via `clientCallbackInstalled`); otherwise cleanup would detach
+  // an active sender installed by a prior turn.
   let clientCallbackInstalled = false;
   const cleanup = () => {
     conversation.setChannelCapabilities(null);
@@ -540,9 +544,10 @@ export async function startVoiceTurn(
   };
   /**
    * Install this turn's per-conversation state (caller trust, call session
-   * id, channel capabilities, voice control prompt). Runs before every
-   * persist attempt: the busy-retry path below uninstalls via `cleanup()`
-   * for the duration of its wait, then re-installs before retrying.
+   * id, channel capabilities, voice control prompt, turn channel/interface
+   * contexts). Runs before every persist attempt: the busy-retry path below
+   * restores the prior owner's values via `restoreTurnState` for the
+   * duration of its wait, then re-installs before retrying.
    */
   const installVoiceTurnState = () => {
     conversation.setAssistantId(
@@ -561,36 +566,95 @@ export async function startVoiceTurn(
     );
     conversation.setVoiceCallControlPrompt(voiceCallControlPrompt);
   };
+  /**
+   * Capture every conversation value `installVoiceTurnState` overwrites
+   * (plus `forcePromptSideEffects`, cleared by `cleanup`) so a turn that
+   * never wins the conversation can put them back untouched.
+   */
+  const snapshotTurnState = () => ({
+    assistantId: conversation.assistantId,
+    callSessionId: conversation.callSessionId,
+    trustContext: conversation.trustContext,
+    commandIntent: conversation.commandIntent,
+    turnChannelContext: conversation.getTurnChannelContext?.() ?? null,
+    turnInterfaceContext: conversation.getTurnInterfaceContext?.() ?? null,
+    channelCapabilities: conversation.channelCapabilities,
+    voiceCallControlPrompt: conversation.voiceCallControlPrompt,
+    forcePromptSideEffects: conversation.forcePromptSideEffects,
+  });
+  /**
+   * Put back the values captured by `snapshotTurnState`. Used on every path
+   * where this turn LOST the conversation to a concurrent winner (the busy
+   * persist race and the retry's terminal failures): the winner is mid-run
+   * with its own per-turn state, so `cleanup()`'s reset-to-defaults would
+   * null its trust context and capabilities and leave it running as
+   * assistantId "self". A lost race must leave the conversation exactly as
+   * found. Setter order mirrors `cleanup` (trust released before the voice
+   * prompt).
+   */
+  const restoreTurnState = (snap: ReturnType<typeof snapshotTurnState>) => {
+    conversation.setChannelCapabilities(snap.channelCapabilities ?? null);
+    conversation.setTrustContext(snap.trustContext ?? null);
+    conversation.setCommandIntent(snap.commandIntent ?? null);
+    conversation.setAssistantId(snap.assistantId ?? null);
+    conversation.setTurnChannelContext(snap.turnChannelContext);
+    conversation.setTurnInterfaceContext?.(snap.turnInterfaceContext);
+    conversation.setVoiceCallControlPrompt(snap.voiceCallControlPrompt ?? null);
+    conversation.callSessionId = snap.callSessionId;
+    conversation.forcePromptSideEffects = snap.forcePromptSideEffects;
+  };
   let messageId: string;
+  // Captured before the install so a lost persist race can put the prior
+  // owner's values back (see restoreTurnState).
+  const preInstallState = snapshotTurnState();
   try {
     installVoiceTurnState();
-
-    try {
-      messageId = await persistTurnUserMessage();
-    } catch (err) {
-      // A queued-message drain can take the lock between the wait loop
-      // above and this persist — the drain reaches its own persist a few
-      // microtasks after the idle transition that released this turn.
-      // Within the remaining budget, wait the drained turn out and retry
-      // the persist once instead of failing the barge-in. The drained turn
-      // must not run with this turn's phone prompt or caller trust, so the
-      // voice state is uninstalled while it holds the lock and re-installed
-      // before the retry.
-      if (
-        !(err instanceof Error) ||
-        err.message !== CONVERSATION_BUSY_MESSAGE ||
-        remainingWaitMs <= 0
-      ) {
-        throw err;
-      }
+  } catch (err) {
+    // A partially-applied install never owned the conversation: undo it
+    // value-for-value rather than resetting shared state to defaults.
+    restoreTurnState(preInstallState);
+    throw err;
+  }
+  try {
+    messageId = await persistTurnUserMessage();
+  } catch (err) {
+    // A queued-message drain can take the lock between the wait loop
+    // above and this persist — the drain reaches its own persist a few
+    // microtasks after the idle transition that released this turn.
+    // Within the remaining budget, wait the drained turn out and retry
+    // the persist once instead of failing the barge-in.
+    if (
+      !(err instanceof Error) ||
+      err.message !== CONVERSATION_BUSY_MESSAGE ||
+      remainingWaitMs <= 0
+    ) {
+      // Non-busy persist failure: no concurrent turn took the lock, so
+      // this turn still owns the state it installed. Release it to
+      // defaults, matching the agent-loop finally of a turn that ran.
       cleanup();
-      await waitOutProcessingLock();
+      throw err;
+    }
+    // The busy error means a concurrent turn won the lock race and is
+    // running. It must not run with this turn's phone prompt, caller
+    // trust, or turn channel/interface contexts, so the winner's values
+    // are put back for the duration of the wait.
+    restoreTurnState(preInstallState);
+    // Throws the exact busy error on an exhausted budget and the exact
+    // turn-aborted error on abort; the restore above already left the
+    // conversation exactly as the winner had it.
+    await waitOutProcessingLock();
+    // Re-capture before re-installing: the winner may have changed the
+    // conversation state while it held the lock.
+    const preRetryState = snapshotTurnState();
+    try {
       installVoiceTurnState();
       messageId = await persistTurnUserMessage();
+    } catch (retryErr) {
+      // The retry lost again (or failed outright) without this turn ever
+      // running — leave the conversation exactly as the winner left it.
+      restoreTurnState(preRetryState);
+      throw retryErr;
     }
-  } catch (err) {
-    cleanup();
-    throw err;
   }
   try {
     opts.callbacks?.persisted_user_message_id?.(messageId);

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -2150,7 +2150,7 @@ export class Conversation {
     }
   }
 
-  setTurnChannelContext(ctx: TurnChannelContext): void {
+  setTurnChannelContext(ctx: TurnChannelContext | null): void {
     this.currentTurnChannelContext = ctx;
   }
 
@@ -2158,7 +2158,7 @@ export class Conversation {
     return this.currentTurnChannelContext;
   }
 
-  setTurnInterfaceContext(ctx: TurnInterfaceContext): void {
+  setTurnInterfaceContext(ctx: TurnInterfaceContext | null): void {
     this.currentTurnInterfaceContext = ctx;
   }
 


### PR DESCRIPTION
## Summary
Fixes the round-3 P2 for voice-mode-latency.md (follow-up to #37689).

**Gap:** the busy-retry path reset conversation state to defaults while the lock winner was running, and cleanup never reset the turn channel/interface contexts the install had set.
**Fix:** race-loss paths snapshot-and-restore every value the install touches; a lost race leaves the conversation exactly as found.