### PR TITLE
feat(plugins): fetch installable catalog from the platform endpoint

### DIFF
--- a/assistant/src/cli/lib/__tests__/plugin-catalog-platform.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-catalog-platform.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for {@link fetchPluginCatalogFromPlatform}.
+ *
+ * The platform `/v1/plugins/` endpoint is replaced with an in-memory fixture
+ * passed via the injected `fetch` dependency — no globals are patched. Each
+ * case asserts that a well-formed response maps to a sorted match list and that
+ * every failure mode throws {@link PluginCatalogUnavailableError} rather than
+ * returning a partial or empty catalog.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { FetchLike } from "../fetch-like.js";
+import { fetchPluginCatalogFromPlatform } from "../plugin-catalog-platform.js";
+import { PluginCatalogUnavailableError } from "../search-plugins.js";
+
+const SHA_A = "63a91ecadbf4c4719a4602a5abb00883f9966034";
+const SHA_B = "0123456789abcdef0123456789abcdef01234567";
+
+/** Serve `body` (object or raw string) at the `/v1/plugins/` endpoint. */
+function platformFetch(body: unknown, status = 200): FetchLike {
+  return (async () =>
+    new Response(typeof body === "string" ? body : JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    })) as FetchLike;
+}
+
+describe("fetchPluginCatalogFromPlatform", () => {
+  test("maps well-formed rows to sorted matches", async () => {
+    const catalog = await fetchPluginCatalogFromPlatform({
+      fetch: platformFetch({
+        plugins: [
+          {
+            name: "memory-graph",
+            repo: "acme/memory-graph",
+            ref: SHA_B,
+            path: "packages/plugin",
+            description: "graph memory",
+            category: "productivity",
+            // dropped keys
+            id: "abc",
+            display_name: "Memory Graph",
+            icon: "🧠",
+            homepage: "https://example.com",
+            license: "MIT",
+          },
+          {
+            name: "alpha-tool",
+            repo: "vellum-ai/alpha-tool",
+            ref: SHA_A,
+          },
+        ],
+      }),
+    });
+
+    expect(catalog.ref).toBe("platform");
+    expect(catalog.matches.map((m) => m.name)).toEqual([
+      "alpha-tool",
+      "memory-graph",
+    ]);
+
+    const graph = catalog.matches[1];
+    expect(graph).toMatchObject({
+      name: "memory-graph",
+      path: `github:acme/memory-graph/packages/plugin@${SHA_B}`,
+      description: "graph memory",
+      category: "productivity",
+      source: {
+        kind: "github",
+        repo: "acme/memory-graph",
+        path: "packages/plugin",
+        ref: SHA_B,
+      },
+    });
+
+    const alpha = catalog.matches[0];
+    expect(alpha.category).toBeNull();
+    expect(alpha.source).toEqual({
+      kind: "github",
+      repo: "vellum-ai/alpha-tool",
+      path: undefined,
+      ref: SHA_A,
+    });
+  });
+
+  test("honors an explicit ref label", async () => {
+    const catalog = await fetchPluginCatalogFromPlatform(
+      { fetch: platformFetch({ plugins: [] }) },
+      { ref: "v1.2.3" },
+    );
+    expect(catalog.ref).toBe("v1.2.3");
+    expect(catalog.matches).toEqual([]);
+  });
+
+  test("skips rows missing repo or ref", async () => {
+    const catalog = await fetchPluginCatalogFromPlatform({
+      fetch: platformFetch({
+        plugins: [
+          { name: "no-repo", ref: SHA_A },
+          { name: "no-ref", repo: "acme/no-ref" },
+          { name: "null-repo", repo: null, ref: SHA_A },
+          { name: "good", repo: "acme/good", ref: SHA_B },
+        ],
+      }),
+    });
+    expect(catalog.matches.map((m) => m.name)).toEqual(["good"]);
+  });
+
+  test("dedupes by name, keeping the first occurrence", async () => {
+    const catalog = await fetchPluginCatalogFromPlatform({
+      fetch: platformFetch({
+        plugins: [
+          { name: "dup", repo: "acme/first", ref: SHA_A },
+          { name: "dup", repo: "acme/second", ref: SHA_B },
+        ],
+      }),
+    });
+    expect(catalog.matches).toHaveLength(1);
+    expect(catalog.matches[0].source.repo).toBe("acme/first");
+  });
+
+  test.each([503, 500, 404])(
+    "throws on a non-2xx response (%i)",
+    async (status) => {
+      const promise = fetchPluginCatalogFromPlatform({
+        fetch: platformFetch("upstream broken", status),
+      });
+      await expect(promise).rejects.toBeInstanceOf(
+        PluginCatalogUnavailableError,
+      );
+      await expect(promise).rejects.toMatchObject({ status });
+    },
+  );
+
+  test("throws on a malformed JSON body", async () => {
+    const promise = fetchPluginCatalogFromPlatform({
+      fetch: platformFetch("{ not json", 200),
+    });
+    await expect(promise).rejects.toBeInstanceOf(PluginCatalogUnavailableError);
+    await expect(promise).rejects.toMatchObject({ status: 502 });
+  });
+
+  test("throws on a schema violation", async () => {
+    const promise = fetchPluginCatalogFromPlatform({
+      fetch: platformFetch({ plugins: [{ repo: "acme/x", ref: SHA_A }] }),
+    });
+    await expect(promise).rejects.toBeInstanceOf(PluginCatalogUnavailableError);
+    await expect(promise).rejects.toMatchObject({ status: 502 });
+  });
+
+  test("throws when fetch rejects (network error / abort)", async () => {
+    const promise = fetchPluginCatalogFromPlatform({
+      fetch: (async () => {
+        throw new Error("network down");
+      }) as FetchLike,
+    });
+    await expect(promise).rejects.toBeInstanceOf(PluginCatalogUnavailableError);
+    await expect(promise).rejects.toMatchObject({ status: 503 });
+  });
+});

--- a/assistant/src/cli/lib/plugin-catalog-platform.ts
+++ b/assistant/src/cli/lib/plugin-catalog-platform.ts
@@ -1,0 +1,118 @@
+/**
+ * Fetch the installable plugin catalog from the Vellum platform.
+ *
+ * The platform serves a flattened view of the curated marketplace at
+ * `GET {PLATFORM}/v1/plugins/`. Each row is projected onto the shared
+ * {@link PluginSearchMatch} shape via {@link marketplaceMatch}, so a catalog
+ * sourced from the platform is indistinguishable from one read off GitHub.
+ *
+ * Every failure mode (non-2xx, unreachable/aborted, malformed body) throws
+ * {@link PluginCatalogUnavailableError} — the fetcher never returns a partial
+ * or silently-empty catalog, so a caller can safely fall back to a bundled
+ * offline copy instead of mistaking an outage for "no plugins".
+ */
+
+import { z } from "zod";
+
+import { getPlatformBaseUrl } from "../../config/env.js";
+import {
+  marketplaceMatch,
+  type PluginCatalog,
+  PluginCatalogUnavailableError,
+  type PluginSearchMatch,
+  type SearchPluginsDeps,
+} from "./search-plugins.js";
+
+/**
+ * One flattened row from the platform catalog. Unknown keys (`id`,
+ * `display_name`, `icon`, `homepage`, `license`) are accepted and dropped —
+ * zod strips them by default.
+ */
+const platformPluginRowSchema = z.object({
+  name: z.string(),
+  repo: z.string().nullable().optional(),
+  ref: z.string().nullable().optional(),
+  path: z.string().nullable().optional(),
+  description: z.string().optional(),
+  category: z.string().nullable().optional(),
+});
+
+const platformCatalogSchema = z.object({
+  plugins: z.array(platformPluginRowSchema),
+});
+
+/**
+ * Fetch and project the platform catalog. Rows missing `repo`/`ref` are
+ * skipped; the rest are deduped by name and sorted alphabetically.
+ */
+export async function fetchPluginCatalogFromPlatform(
+  deps: SearchPluginsDeps,
+  opts?: { ref?: string },
+): Promise<PluginCatalog> {
+  const url = `${getPlatformBaseUrl()}/v1/plugins/`;
+
+  let res: Response;
+  try {
+    res = await deps.fetch(url, {
+      signal: AbortSignal.timeout(10_000),
+      headers: { "User-Agent": "vellum-assistant-cli" },
+    });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new PluginCatalogUnavailableError(
+      `Platform plugin catalog fetch failed: ${detail}`,
+      503,
+    );
+  }
+
+  if (!res.ok) {
+    throw new PluginCatalogUnavailableError(
+      `Platform plugin catalog fetch failed: HTTP ${res.status}`,
+      res.status,
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new PluginCatalogUnavailableError(
+      `Platform plugin catalog returned an invalid body: ${detail}`,
+      502,
+    );
+  }
+
+  const parsed = platformCatalogSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new PluginCatalogUnavailableError(
+      `Platform plugin catalog failed validation: ${parsed.error.message}`,
+      502,
+    );
+  }
+
+  const matches: PluginSearchMatch[] = [];
+  const seen = new Set<string>();
+  for (const row of parsed.data.plugins) {
+    if (!row.repo || !row.ref) continue;
+    if (seen.has(row.name)) continue;
+    seen.add(row.name);
+    matches.push(
+      marketplaceMatch({
+        name: row.name,
+        source: {
+          source: "github",
+          repo: row.repo,
+          ref: row.ref,
+          path: row.path ?? undefined,
+        },
+        description: row.description ?? undefined,
+        category: row.category ?? undefined,
+      }),
+    );
+  }
+
+  matches.sort((a, b) => a.name.localeCompare(b.name));
+
+  return { ref: opts?.ref ?? "platform", matches };
+}


### PR DESCRIPTION
## Summary
- Add plugin-catalog-platform.ts: fetches GET {PLATFORM}/v1/plugins/, validates the flattened rows, projects them via marketplaceMatch.
- Every failure mode throws PluginCatalogUnavailableError (fail hard, never partial/empty).

Part of plan: plugins-catalog-platform-first.md (PR 3 of 6)