### PR TITLE
fix: guardian-label lookup uses a real per-call IPC timeout

### DIFF
--- a/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
@@ -52,7 +52,11 @@ mock.module("../db/assistant-db-proxy.js", () => ({
 }));
 
 // ── IPC assistant client mock ─────────────────────────────────────────────────
-type IpcCallFn = (method: string, params: unknown) => Promise<unknown>;
+type IpcCallFn = (
+  method: string,
+  params: unknown,
+  opts?: { timeoutMs?: number },
+) => Promise<unknown>;
 let ipcCallAssistantMock: ReturnType<typeof mock<IpcCallFn>> = mock(
   async () => ({}),
 );
@@ -376,8 +380,9 @@ mock.module("../verification/invite-redemption.js", () => ({
     null,
 }));
 
-const { createContactsControlPlaneProxyHandler, bustGuardianLabelCache } =
-  await import("../http/routes/contacts-control-plane-proxy.js");
+const { createContactsControlPlaneProxyHandler } = await import(
+  "../http/routes/contacts-control-plane-proxy.js"
+);
 
 // The delete-contact guard reads the guardian role from the gateway DB (source
 // of truth), so the delete tests below run against a real in-memory gateway DB.
@@ -423,7 +428,6 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
 }
 
 afterEach(() => {
-  bustGuardianLabelCache();
   fetchMock = mock(async () => new Response());
   assistantDbQueryMock = mock(async () => []);
   assistantDbRunMock = mock(async () => ({ changes: 1, lastInsertRowid: 0 }));
@@ -1043,6 +1047,7 @@ describe("guardian label overlay (gateway-native reads)", () => {
     expect(ipcCallAssistantMock).toHaveBeenCalledWith(
       "resolve_guardian_label",
       { body: { storedDisplayName: "Stored Guardian" } },
+      { timeoutMs: 1500 },
     );
   });
 
@@ -1109,9 +1114,24 @@ describe("guardian label overlay (gateway-native reads)", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  test("list: slow IPC is bounded — the stored displayName is served promptly", async () => {
+  test("list: slow IPC is bounded by the per-call timeout — the stored displayName is served promptly", async () => {
     contactStoreListMock = mock(async () => [GUARDIAN_CONTACT]);
-    ipcCallAssistantMock = mock(() => new Promise<never>(() => {}));
+    // Honor opts.timeoutMs the way the real client does: reject with a
+    // transport timeout after the per-call deadline, never resolve otherwise.
+    ipcCallAssistantMock = mock(
+      (_method: string, _params: unknown, opts?: { timeoutMs?: number }) =>
+        new Promise<never>((_, reject) => {
+          setTimeout(
+            () =>
+              reject(
+                new actualAssistantClient.IpcTransportError(
+                  `Call timed out after ${opts?.timeoutMs}ms`,
+                ),
+              ),
+            opts?.timeoutMs ?? 30_000,
+          );
+        }),
+    );
 
     jest.useFakeTimers();
     try {
@@ -1119,8 +1139,8 @@ describe("guardian label overlay (gateway-native reads)", () => {
       const resPromise = handler.handleListContacts(
         new Request("http://localhost:7830/v1/contacts"),
       );
-      // Flush microtasks so the bounded lookup registers its timeout, then
-      // fire it — the never-resolving IPC must not stall the response.
+      // Flush microtasks so the lookup passes its 1500ms deadline to the IPC
+      // client, then fire it — the wedged IPC must not stall the response.
       for (let i = 0; i < 50; i++) await Promise.resolve();
       jest.advanceTimersByTime(2_000);
       const res = await resPromise;
@@ -1128,6 +1148,11 @@ describe("guardian label overlay (gateway-native reads)", () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.contacts[0].displayName).toBe("Stored Guardian");
+      expect(ipcCallAssistantMock).toHaveBeenCalledWith(
+        "resolve_guardian_label",
+        { body: { storedDisplayName: "Stored Guardian" } },
+        { timeoutMs: 1500 },
+      );
 
       // The fallback is negative-cached: a follow-up read serves the stored
       // name without re-probing the wedged daemon.
@@ -1140,6 +1165,47 @@ describe("guardian label overlay (gateway-native reads)", () => {
     } finally {
       jest.useRealTimers();
     }
+  });
+
+  test("list: concurrent cold reads share one in-flight IPC call", async () => {
+    contactStoreListMock = mock(async () => [GUARDIAN_CONTACT]);
+    let resolveIpc: ((v: unknown) => void) | undefined;
+    ipcCallAssistantMock = mock(
+      () =>
+        new Promise<unknown>((resolve) => {
+          resolveIpc = resolve;
+        }),
+    );
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const first = handler.handleListContacts(
+      new Request("http://localhost:7830/v1/contacts"),
+    );
+    const second = handler.handleListContacts(
+      new Request("http://localhost:7830/v1/contacts"),
+    );
+    // Flush microtasks so both reads reach the label lookup while in flight.
+    for (let i = 0; i < 50; i++) await Promise.resolve();
+    expect(ipcCallAssistantMock).toHaveBeenCalledTimes(1);
+    resolveIpc?.({ label: "Preferred Name" });
+
+    const [res1, res2] = await Promise.all([first, second]);
+    expect((await res1.json()).contacts[0].displayName).toBe("Preferred Name");
+    expect((await res2.json()).contacts[0].displayName).toBe("Preferred Name");
+  });
+
+  test("list: label cache is scoped to the handler — a fresh handler re-resolves", async () => {
+    contactStoreListMock = mock(async () => [GUARDIAN_CONTACT]);
+    ipcCallAssistantMock = mock(async () => ({ label: "Preferred Name" }));
+
+    await createContactsControlPlaneProxyHandler(
+      makeConfig(),
+    ).handleListContacts(new Request("http://localhost:7830/v1/contacts"));
+    await createContactsControlPlaneProxyHandler(
+      makeConfig(),
+    ).handleListContacts(new Request("http://localhost:7830/v1/contacts"));
+
+    expect(ipcCallAssistantMock).toHaveBeenCalledTimes(2);
   });
 
   test("get: IPC failure soft-fails to the stored displayName (no proxy fallback)", async () => {

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -640,106 +640,11 @@ const GUARDIAN_LABEL_IPC_TIMEOUT_MS = 1500;
  */
 const GUARDIAN_LABEL_FALLBACK_TTL_MS = 30 * 1000;
 
-const GUARDIAN_LABEL_IPC_TIMED_OUT = Symbol("guardian-label-ipc-timed-out");
-
-let guardianLabelCache: {
+interface GuardianLabelCacheEntry {
   storedDisplayName: string | null;
-  label: string | null;
+  label: Promise<string | null>;
   ttlMs: number;
   at: number;
-} | null = null;
-
-/** Drop the cached label so the next read re-resolves over IPC. */
-export function bustGuardianLabelCache(): void {
-  guardianLabelCache = null;
-}
-
-/**
- * Resolve the guardian's display label via the `resolve_guardian_label`
- * daemon IPC (persona preferred name → stored displayName → default
- * reference), cached with a short TTL. Best-effort: any IPC failure, slow
- * response, or malformed response serves the stored displayName unchanged —
- * a contact read never fails or stalls because the daemon is unreachable.
- */
-async function resolveGuardianLabelCached(
-  storedDisplayName: string | null,
-): Promise<string | null> {
-  const now = Date.now();
-  if (
-    guardianLabelCache &&
-    guardianLabelCache.storedDisplayName === storedDisplayName &&
-    now - guardianLabelCache.at < guardianLabelCache.ttlMs
-  ) {
-    return guardianLabelCache.label;
-  }
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    const ipc = ipcCallAssistant("resolve_guardian_label", {
-      body: { storedDisplayName },
-    });
-    // The timeout may win the race; never let the losing IPC promise reject
-    // unhandled.
-    ipc.catch(() => {});
-    const raced = await Promise.race([
-      ipc,
-      new Promise<typeof GUARDIAN_LABEL_IPC_TIMED_OUT>((resolve) => {
-        timer = setTimeout(
-          () => resolve(GUARDIAN_LABEL_IPC_TIMED_OUT),
-          GUARDIAN_LABEL_IPC_TIMEOUT_MS,
-        );
-      }),
-    ]);
-    if (raced === GUARDIAN_LABEL_IPC_TIMED_OUT) {
-      log.warn(
-        "resolve_guardian_label: daemon resolve timed out (best-effort)",
-      );
-    } else {
-      const result = raced as { label?: unknown } | null;
-      if (typeof result?.label === "string" && result.label.trim()) {
-        guardianLabelCache = {
-          storedDisplayName,
-          label: result.label,
-          ttlMs: GUARDIAN_LABEL_TTL_MS,
-          at: now,
-        };
-        return result.label;
-      }
-      log.warn(
-        "resolve_guardian_label: daemon response missing label (best-effort)",
-      );
-    }
-  } catch (err) {
-    log.warn(
-      { err },
-      "resolve_guardian_label: daemon resolve failed (best-effort)",
-    );
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
-  guardianLabelCache = {
-    storedDisplayName,
-    label: storedDisplayName,
-    ttlMs: GUARDIAN_LABEL_FALLBACK_TTL_MS,
-    at: now,
-  };
-  return storedDisplayName;
-}
-
-/**
- * Overlay the resolved guardian label onto a serialized contact payload so
- * gateway-native reads present the same guardian displayName as the daemon's
- * read relay. Non-guardian rows pass through untouched.
- */
-async function withGuardianLabelOverlay(
-  payload: Record<string, unknown>,
-): Promise<Record<string, unknown>> {
-  if (payload.role !== "guardian") {
-    return payload;
-  }
-  const stored =
-    typeof payload.displayName === "string" ? payload.displayName : null;
-  const label = await resolveGuardianLabelCached(stored);
-  return label == null ? payload : { ...payload, displayName: label };
 }
 
 const VALID_ASSISTANT_SPECIES = ["vellum"] as const;
@@ -977,6 +882,78 @@ function extractContactsArray(
 }
 
 export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
+  let guardianLabelCache: GuardianLabelCacheEntry | null = null;
+
+  /**
+   * Resolve the guardian's display label via the `resolve_guardian_label`
+   * daemon IPC (persona preferred name → stored displayName → default
+   * reference), cached with a short TTL. The in-flight promise is cached, so
+   * concurrent cold reads share one IPC call. Best-effort: any IPC failure,
+   * timeout, or malformed response serves the stored displayName unchanged —
+   * a contact read never fails or stalls because the daemon is unreachable.
+   */
+  function resolveGuardianLabelCached(
+    storedDisplayName: string | null,
+  ): Promise<string | null> {
+    const now = Date.now();
+    if (
+      guardianLabelCache &&
+      guardianLabelCache.storedDisplayName === storedDisplayName &&
+      now - guardianLabelCache.at < guardianLabelCache.ttlMs
+    ) {
+      return guardianLabelCache.label;
+    }
+    async function resolveLabel(): Promise<string | null> {
+      try {
+        const result = (await ipcCallAssistant(
+          "resolve_guardian_label",
+          { body: { storedDisplayName } },
+          { timeoutMs: GUARDIAN_LABEL_IPC_TIMEOUT_MS },
+        )) as { label?: unknown } | null;
+        if (typeof result?.label === "string" && result.label.trim()) {
+          entry.ttlMs = GUARDIAN_LABEL_TTL_MS;
+          return result.label;
+        }
+        log.warn(
+          "resolve_guardian_label: daemon response missing label (best-effort)",
+        );
+      } catch (err) {
+        log.warn(
+          { err },
+          "resolve_guardian_label: daemon resolve failed (best-effort)",
+        );
+      }
+      return storedDisplayName;
+    }
+    // Fallback TTL until a positive resolution upgrades it, so a wedged
+    // daemon is not re-probed on every read but recovers quickly.
+    const entry: GuardianLabelCacheEntry = {
+      storedDisplayName,
+      ttlMs: GUARDIAN_LABEL_FALLBACK_TTL_MS,
+      at: now,
+      label: resolveLabel(),
+    };
+    guardianLabelCache = entry;
+    return entry.label;
+  }
+
+  /**
+   * Overlay the resolved guardian label onto a serialized contact payload so
+   * gateway-native reads present the same guardian displayName as the daemon's
+   * read relay. Non-guardian rows pass through untouched.
+   */
+  async function withGuardianLabelOverlay(
+    payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    if (payload.role !== "guardian") {
+      return payload;
+    }
+    const stored =
+      typeof payload.displayName === "string" ? payload.displayName : null;
+    const label = await resolveGuardianLabelCached(stored);
+    return label == null ? payload : { ...payload, displayName: label };
+  }
+
   async function forward(
     req: Request,
     upstreamPath: string,

--- a/gateway/src/ipc/assistant-client.test.ts
+++ b/gateway/src/ipc/assistant-client.test.ts
@@ -218,6 +218,48 @@ describe("ipcCallAssistant", () => {
     expect(receivedMethod).toBe("my_method");
     expect(receivedParams).toEqual({ x: 1, y: "hello" });
   });
+
+  test("opts.timeoutMs rejects promptly and tears down the socket when the server never responds", async () => {
+    const sockPath = setupWorkspace();
+    let serverSocket: Socket | undefined;
+
+    await startServer(sockPath, (_id, _method, _params, socket) => {
+      // Wedged daemon: accept the request, never respond.
+      serverSocket = socket;
+    });
+
+    const start = Date.now();
+    const promise = ipcCallAssistant("slow_method", undefined, {
+      timeoutMs: 50,
+    });
+    await expect(promise).rejects.toBeInstanceOf(IpcTransportError);
+    await expect(promise).rejects.toThrow("Call timed out after 50ms");
+    expect(Date.now() - start).toBeLessThan(5_000);
+
+    // The timed-out client socket is destroyed — the server observes the
+    // close instead of holding a leaked connection.
+    expect(serverSocket).toBeDefined();
+    const closed = await new Promise<boolean>((resolve) => {
+      if (serverSocket!.destroyed) return resolve(true);
+      serverSocket!.on("close", () => resolve(true));
+      setTimeout(() => resolve(false), 2_000);
+    });
+    expect(closed).toBe(true);
+  });
+
+  test("opts.timeoutMs does not fire on a call that responds in time", async () => {
+    const sockPath = setupWorkspace();
+
+    await startServer(sockPath, (id, _method, _params, socket) => {
+      sendResult(socket, id, { ok: true });
+      socket.end();
+    });
+
+    const result = await ipcCallAssistant("fast_method", undefined, {
+      timeoutMs: 5_000,
+    });
+    expect(result).toEqual({ ok: true });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/gateway/src/ipc/assistant-client.ts
+++ b/gateway/src/ipc/assistant-client.ts
@@ -94,24 +94,26 @@ function getAssistantSocketPath(): string {
  * - On transport failure (socket not found, timeout, parse error, closed
  *   before response): throws {@link IpcTransportError}.
  *
- * Uses a 30-second call timeout to accommodate LLM latency on the
- * assistant side.
+ * `opts.timeoutMs` bounds the whole call (connect + response) and tears the
+ * socket down on expiry; defaults to 30 seconds to accommodate LLM latency
+ * on the assistant side.
  */
 export async function ipcCallAssistant(
   method: string,
   params?: Record<string, unknown>,
+  opts?: { timeoutMs?: number },
 ): Promise<unknown> {
   const socketPath = getAssistantSocketPath();
+  const callTimeoutMs = opts?.timeoutMs ?? CALL_TIMEOUT_MS;
 
   return new Promise<unknown>((resolve, reject) => {
     let settled = false;
-    let callTimer: ReturnType<typeof setTimeout> | undefined;
 
     const finish = (value: unknown, error?: Error) => {
       if (settled) return;
       settled = true;
       clearTimeout(connectTimer);
-      if (callTimer) clearTimeout(callTimer);
+      clearTimeout(callTimer);
       socket.destroy();
       if (error) {
         reject(error);
@@ -129,6 +131,13 @@ export async function ipcCallAssistant(
       );
     }, CONNECT_TIMEOUT_MS);
 
+    const callTimer = setTimeout(() => {
+      finish(
+        undefined,
+        new IpcTransportError(`Call timed out after ${callTimeoutMs}ms`),
+      );
+    }, callTimeoutMs);
+
     const socket: Socket = connect(socketPath);
     socket.unref();
 
@@ -139,13 +148,6 @@ export async function ipcCallAssistant(
       clearTimeout(connectTimer);
       const req: IpcRequest = { id: reqId, method, params };
       socket.write(JSON.stringify(req) + "\n");
-
-      callTimer = setTimeout(() => {
-        finish(
-          undefined,
-          new IpcTransportError(`Call timed out after ${CALL_TIMEOUT_MS}ms`),
-        );
-      }, CALL_TIMEOUT_MS);
 
       socket.on("data", (chunk) => {
         buffer += chunk.toString();


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for flatten-macos-contact-routes.md.

**Gap:** hand-rolled Promise.race timeout leaked the losing IPC socket for up to 30s; no in-flight dedup; module-level cache forced a test-only bustGuardianLabelCache export.
**Fix:** ipcCallAssistant gains opts.timeoutMs (socket torn down on timeout); label lookup passes 1500ms; in-flight promise caching dedups concurrent cold reads; cache lives in the handler factory closure and the test-only export is gone.