### PR TITLE
fix: post-review cleanup nits (assistant IPC registration, web interceptor)

### DIFF
--- a/assistant/src/ipc/assistant-server.ts
+++ b/assistant/src/ipc/assistant-server.ts
@@ -203,40 +203,17 @@ export class AssistantIpcServer {
       handleDbProxy(params as unknown as DbProxyParams),
     );
 
-    // IPC-only invite methods (see ipc/routes/invite-ipc-routes.ts). The
-    // gateway calls these back over IPC to mirror redeemed-invite contact
-    // info locally. No HTTP surface; never in ROUTES.
-    for (const [operationId, handler] of Object.entries(INVITE_IPC_METHODS)) {
-      this.methods.set(operationId, handler);
-    }
-
-    // IPC-only contact INFO-READ methods (see ipc/routes/contacts-info-ipc-routes.ts).
-    // The gateway calls these to read assistant-owned info fields + channel
-    // identity, replacing raw db_proxy SELECTs. No HTTP surface; never in ROUTES.
-    for (const [operationId, handler] of Object.entries(
+    // IPC-only gateway-facing method maps (see each map's route file in
+    // ipc/routes/ for its contract). No HTTP surface; never in ROUTES.
+    for (const methodMap of [
+      INVITE_IPC_METHODS,
       CONTACTS_INFO_IPC_METHODS,
-    )) {
-      this.methods.set(operationId, handler);
-    }
-
-    // IPC-only contact identity-mirror methods (see
-    // ipc/routes/contacts-mirror-ipc-routes.ts). The gateway calls these back
-    // over IPC to mirror single-row contact/channel identity locally after a
-    // gateway-owned ACL write. No HTTP surface; never in ROUTES.
-    for (const [operationId, handler] of Object.entries(
       CONTACTS_MIRROR_IPC_METHODS,
-    )) {
-      this.methods.set(operationId, handler);
-    }
-
-    // IPC-only guardian-label method (see ipc/routes/guardian-label-ipc-routes.ts).
-    // The gateway calls this to resolve the guardian's display label (persona
-    // preferred name) for its native contact reads. No HTTP surface; never in
-    // ROUTES.
-    for (const [operationId, handler] of Object.entries(
       GUARDIAN_LABEL_IPC_METHODS,
-    )) {
-      this.methods.set(operationId, handler);
+    ]) {
+      for (const [operationId, handler] of Object.entries(methodMap)) {
+        this.methods.set(operationId, handler);
+      }
     }
 
     this.methods.set("$cancel", (params) => {

--- a/assistant/src/ipc/routes/__tests__/guardian-label-ipc-routes.test.ts
+++ b/assistant/src/ipc/routes/__tests__/guardian-label-ipc-routes.test.ts
@@ -18,7 +18,6 @@ const actualPersonaResolver = await import(
 );
 mock.module("../../../prompts/persona-resolver.js", () => ({
   ...actualPersonaResolver,
-  resolveGuardianPersona: () => mockGuardianPersona,
   resolveGuardianPersonaStrict: () => mockGuardianPersona,
 }));
 

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -100,7 +100,10 @@ const RUNTIME_PROXIED_FIRST_SEGMENTS = new Set<string>([
   // assistant-scoped requests without this list — that is the paved road
   // for new endpoints. Deliberately NOT listed: `artifacts` (no
   // gateway/daemon route exists) and `a2a` (platform broker route); those
-  // stay on the platform.
+  // stay on the platform. The contact family (`contacts`,
+  // `contact-channels`) is forwarded via {@link FLATTENED_FIRST_SEGMENTS}
+  // with the assistant prefix stripped — it does not belong in this
+  // allowlist.
   "config",
 ]);
 
@@ -152,11 +155,9 @@ export async function rewriteForSelfHostedIngress(
   if (!match) return null;
   const [, subPath, firstSegment] = match;
   if (
-    !subPath ||
-    !firstSegment ||
-    (!skipSegmentAllowlist &&
-      !RUNTIME_PROXIED_FIRST_SEGMENTS.has(firstSegment) &&
-      !FLATTENED_FIRST_SEGMENTS.has(firstSegment))
+    !skipSegmentAllowlist &&
+    !RUNTIME_PROXIED_FIRST_SEGMENTS.has(firstSegment) &&
+    !FLATTENED_FIRST_SEGMENTS.has(firstSegment)
   ) {
     return null;
   }


### PR DESCRIPTION
## Summary
Fixes small gaps identified during plan review for flatten-macos-contact-routes.md.

**Gaps:** inert resolveGuardianPersona mock line; four copy-pasted IPC method-map registration loops; unreachable guard and a now-misleading allowlist comment in the self-hosted rewrite.
**Fix:** dropped the dead mock, collapsed registration to one loop, removed the dead guard and cross-referenced FLATTENED_FIRST_SEGMENTS from the allowlist comment.