### PR TITLE
fix(calls): compare-and-restore race-loss state and restore on exhausted-budget busy losses

### DIFF
--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -11,7 +11,7 @@
  * strings, so those are pinned here too. `waitForIdle`'s own semantics are
  * covered by `src/__tests__/conversation-wait-for-idle.test.ts`.
  */
-import { describe, expect, mock, test } from "bun:test";
+import { describe, expect, mock, setSystemTime, test } from "bun:test";
 
 // ---------------------------------------------------------------------------
 // Mocks — declared before importing voice-session-bridge
@@ -538,11 +538,22 @@ describe("startVoiceTurn queued-message drain race", () => {
     });
     // Record install/uninstall markers for the state the drained turn must
     // never see: the phone control prompt and the caller trust context.
-    fake.conversation.setVoiceCallControlPrompt = (prompt) => {
+    // The markers also store the value: the bridge's per-field
+    // compare-and-restore only reverts a field that still holds the value
+    // this turn installed.
+    const conv = fake.conversation as unknown as {
+      voiceCallControlPrompt?: string;
+      trustContext?: unknown;
+      setVoiceCallControlPrompt: (prompt: string | null) => void;
+      setTrustContext: (ctx: unknown) => void;
+    };
+    conv.setVoiceCallControlPrompt = (prompt) => {
+      conv.voiceCallControlPrompt = prompt ?? undefined;
       events.push(prompt === null ? "prompt:clear" : "prompt:install");
     };
-    fake.conversation.setTrustContext = (ctx) => {
-      events.push(ctx === null ? "trust:clear" : "trust:install");
+    conv.setTrustContext = (ctx) => {
+      conv.trustContext = ctx ?? undefined;
+      events.push(ctx === null || ctx === undefined ? "trust:clear" : "trust:install");
     };
     fakeConversation = fake.conversation;
 
@@ -780,5 +791,99 @@ describe("startVoiceTurn race-loss state restore", () => {
       "Turn aborted while waiting for conversation",
     );
     expect(readState()).toEqual(winnerState);
+  });
+
+  test("a busy persist with the wait budget already exhausted still restores the winner", async () => {
+    // The wait loop can consume the entire budget before the persist's busy
+    // throw; the busy failure must still route to restore (a live winner
+    // holds the lock), not to cleanup's reset-to-defaults.
+    const winnerState = makeWinnerState();
+    const fake = makeFakeConversation({
+      processing: true,
+      waitForIdle: async () => {
+        // The lock releases, but only after the full wait budget elapsed.
+        setSystemTime(new Date(Date.now() + 100 + ABORT_WATCHDOG_MS + 1001));
+        fake.setProcessingFlag(false);
+        return true;
+      },
+      onPersist: () => {
+        fake.setProcessingFlag(true);
+        throw new Error("Conversation is already processing a message");
+      },
+    });
+    const readState = wireTurnState(fake.conversation, winnerState);
+    fakeConversation = fake.conversation;
+
+    try {
+      await expect(
+        startVoiceTurn({
+          ...makeTurnOptions(undefined, "conv-race-zero-budget-restore"),
+          trustContext: { sourceChannel: "phone", trustClass: "guardian" },
+        }),
+      ).rejects.toThrow("Conversation is already processing a message");
+    } finally {
+      setSystemTime();
+    }
+    expect(fake.persistCount()).toBe(1);
+    expect(readState()).toEqual(winnerState);
+  });
+
+  test("fields the winner overwrote mid-persist are left with the winner's values", async () => {
+    // persistUserMessage yields before its busy check, so the winner can
+    // install its own values AFTER this turn's install. The restore must be
+    // per-field: revert only fields still holding this turn's values.
+    const winnerState = makeWinnerState();
+    const overwrittenTrust = {
+      sourceChannel: "web",
+      trustClass: "owner-overwrite",
+    };
+    const overwrittenChannelContext = {
+      userMessageChannel: "vellum",
+      assistantMessageChannel: "vellum",
+    };
+    const statesDuringWait: FakeTurnState[] = [];
+    const fake = makeFakeConversation({
+      processing: false,
+      waitForIdle: async () => {
+        statesDuringWait.push(readState());
+        fake.setProcessingFlag(false);
+        return true;
+      },
+      onPersist: (attempt) => {
+        if (attempt === 1) {
+          // The winner installs its own trust + turn channel context during
+          // the persist await, then the busy throw lands here.
+          const conv = fake.conversation as unknown as {
+            setTrustContext: (ctx: unknown) => void;
+            setTurnChannelContext: (ctx: unknown) => void;
+          };
+          conv.setTrustContext(overwrittenTrust);
+          conv.setTurnChannelContext(overwrittenChannelContext);
+          fake.setProcessingFlag(true);
+          throw new Error("Conversation is already processing a message");
+        }
+      },
+    });
+    const readState = wireTurnState(fake.conversation, winnerState);
+    fakeConversation = fake.conversation;
+
+    await startVoiceTurn({
+      ...makeTurnOptions(undefined, "conv-race-partial-overwrite"),
+      callSessionId: "session-voice-loser",
+      trustContext: { sourceChannel: "phone", trustClass: "guardian" },
+    });
+
+    // During the wait: fields the winner overwrote keep the WINNER's values;
+    // fields only this turn touched are restored to the pre-install state.
+    expect(statesDuringWait.length).toBe(1);
+    const waited = statesDuringWait[0]!;
+    expect(waited.trustContext).toBe(overwrittenTrust);
+    expect(waited.turnChannelContext).toBe(overwrittenChannelContext);
+    expect(waited.voiceCallControlPrompt).toBe(
+      winnerState.voiceCallControlPrompt,
+    );
+    expect(waited.channelCapabilities).toBe(winnerState.channelCapabilities);
+    expect(waited.callSessionId).toBe(winnerState.callSessionId);
+    expect(waited.assistantId).toBe(winnerState.assistantId);
   });
 });

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -549,22 +549,34 @@ export async function startVoiceTurn(
    * restores the prior owner's values via `restoreTurnState` for the
    * duration of its wait, then re-installs before retrying.
    */
+  // The exact values this turn installs, computed once: `restoreTurnState`
+  // recognizes by identity whether a field still holds THIS turn's value —
+  // a field a concurrent winner overwrote is the winner's to keep.
+  const voiceTurnValues = {
+    assistantId: opts.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
+    callSessionId: voiceSessionId,
+    trustContext: opts.trustContext ?? null,
+    turnChannelContext,
+    turnInterfaceContext,
+    channelCapabilities: resolveChannelCapabilities(
+      turnChannelContext.userMessageChannel,
+      turnInterfaceContext.userMessageInterface,
+    ),
+    voiceCallControlPrompt,
+  };
   const installVoiceTurnState = () => {
-    conversation.setAssistantId(
-      opts.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
-    );
-    conversation.callSessionId = voiceSessionId;
-    conversation.setTrustContext(opts.trustContext ?? null);
+    conversation.setAssistantId(voiceTurnValues.assistantId);
+    conversation.callSessionId = voiceTurnValues.callSessionId;
+    conversation.setTrustContext(voiceTurnValues.trustContext);
     conversation.setCommandIntent(null);
-    conversation.setTurnChannelContext(turnChannelContext);
-    conversation.setTurnInterfaceContext?.(turnInterfaceContext);
-    conversation.setChannelCapabilities(
-      resolveChannelCapabilities(
-        turnChannelContext.userMessageChannel,
-        turnInterfaceContext.userMessageInterface,
-      ),
+    conversation.setTurnChannelContext(voiceTurnValues.turnChannelContext);
+    conversation.setTurnInterfaceContext?.(
+      voiceTurnValues.turnInterfaceContext,
     );
-    conversation.setVoiceCallControlPrompt(voiceCallControlPrompt);
+    conversation.setChannelCapabilities(voiceTurnValues.channelCapabilities);
+    conversation.setVoiceCallControlPrompt(
+      voiceTurnValues.voiceCallControlPrompt,
+    );
   };
   /**
    * Capture every conversation value `installVoiceTurnState` overwrites
@@ -593,14 +605,62 @@ export async function startVoiceTurn(
    * prompt).
    */
   const restoreTurnState = (snap: ReturnType<typeof snapshotTurnState>) => {
-    conversation.setChannelCapabilities(snap.channelCapabilities ?? null);
-    conversation.setTrustContext(snap.trustContext ?? null);
-    conversation.setCommandIntent(snap.commandIntent ?? null);
-    conversation.setAssistantId(snap.assistantId ?? null);
-    conversation.setTurnChannelContext(snap.turnChannelContext);
-    conversation.setTurnInterfaceContext?.(snap.turnInterfaceContext);
-    conversation.setVoiceCallControlPrompt(snap.voiceCallControlPrompt ?? null);
-    conversation.callSessionId = snap.callSessionId;
+    // Per-field compare-and-restore: `persistUserMessage` awaits actor-scoped
+    // history BEFORE its busy check, so a concurrent winner can install its
+    // own values between this turn's install and the busy throw. Revert a
+    // field only while it still holds this turn's value (identity match
+    // against `voiceTurnValues`) — anything the winner overwrote stays.
+    // Reads are normalized with `?? null` on both sides: setters store null
+    // vs undefined inconsistently for cleared values, and a normalization
+    // miss here would either skip a restore (leaking this turn's value) or
+    // clobber a winner.
+    if (
+      (conversation.channelCapabilities ?? null) ===
+      (voiceTurnValues.channelCapabilities ?? null)
+    ) {
+      conversation.setChannelCapabilities(snap.channelCapabilities ?? null);
+    }
+    if (
+      (conversation.trustContext ?? null) ===
+      (voiceTurnValues.trustContext ?? null)
+    ) {
+      conversation.setTrustContext(snap.trustContext ?? null);
+    }
+    if ((conversation.commandIntent ?? null) === null) {
+      conversation.setCommandIntent(snap.commandIntent ?? null);
+    }
+    if (
+      (conversation.assistantId ?? null) ===
+      (voiceTurnValues.assistantId ?? null)
+    ) {
+      conversation.setAssistantId(snap.assistantId ?? null);
+    }
+    if (
+      (conversation.getTurnChannelContext?.() ?? null) ===
+      voiceTurnValues.turnChannelContext
+    ) {
+      conversation.setTurnChannelContext(snap.turnChannelContext);
+    }
+    if (
+      (conversation.getTurnInterfaceContext?.() ?? null) ===
+      voiceTurnValues.turnInterfaceContext
+    ) {
+      conversation.setTurnInterfaceContext?.(snap.turnInterfaceContext);
+    }
+    if (
+      (conversation.voiceCallControlPrompt ?? null) ===
+      (voiceTurnValues.voiceCallControlPrompt ?? null)
+    ) {
+      conversation.setVoiceCallControlPrompt(
+        snap.voiceCallControlPrompt ?? null,
+      );
+    }
+    if (
+      (conversation.callSessionId ?? null) ===
+      (voiceTurnValues.callSessionId ?? null)
+    ) {
+      conversation.callSessionId = snap.callSessionId;
+    }
     conversation.forcePromptSideEffects = snap.forcePromptSideEffects;
   };
   let messageId: string;
@@ -623,17 +683,17 @@ export async function startVoiceTurn(
     // microtasks after the idle transition that released this turn.
     // Within the remaining budget, wait the drained turn out and retry
     // the persist once instead of failing the barge-in.
-    if (
-      !(err instanceof Error) ||
-      err.message !== CONVERSATION_BUSY_MESSAGE ||
-      remainingWaitMs <= 0
-    ) {
+    if (!(err instanceof Error) || err.message !== CONVERSATION_BUSY_MESSAGE) {
       // Non-busy persist failure: no concurrent turn took the lock, so
       // this turn still owns the state it installed. Release it to
       // defaults, matching the agent-loop finally of a turn that ran.
       cleanup();
       throw err;
     }
+    // A busy failure ALWAYS means a live winner holds the lock — even with
+    // the wait budget exhausted, its state must be restored rather than
+    // reset to defaults; `waitOutProcessingLock` throws the byte-identical
+    // busy error immediately when nothing remains of the budget.
     // The busy error means a concurrent turn won the lock race and is
     // running. It must not run with this turn's phone prompt, caller
     // trust, or turn channel/interface contexts, so the winner's values


### PR DESCRIPTION
## Summary
Fixes the two round-4 review residuals for voice-mode-latency.md (follow-up to #37702).

- Per-field compare-and-restore: a field the lock winner overwrote during the persist await stays the winner's; only fields still holding this turn's values revert to the snapshot
- A busy persist with the wait budget already exhausted now restores the winner's state (the old disjunct routed it to cleanup's reset-to-defaults)
- Both regression tests red-green verified