### PR TITLE
feat(plugins): platform-first catalog with offline gate, fail hard

### DIFF
--- a/assistant/src/cli/lib/__tests__/plugin-catalog-cache.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-catalog-cache.test.ts
@@ -1,9 +1,10 @@
 /**
  * Tests for {@link getPluginCatalog}.
  *
- * The underlying `loadPluginCatalog` is mocked so we exercise the cache's
- * TTL window, refresh-on-expiry, and stale-on-error fallback in isolation —
- * no network and no dependence on the real GitHub-backed loader.
+ * Exercises the gate between the platform fetcher and the bundled reader plus
+ * the per-ref TTL cache. Platform paths drive a fake `deps.fetch` returning a
+ * `/v1/plugins/` payload (no real network); the offline path reads the bundled
+ * manifest and must touch the network zero times.
  */
 
 import {
@@ -11,191 +12,154 @@ import {
   beforeEach,
   describe,
   expect,
-  mock,
   setSystemTime,
   test,
 } from "bun:test";
 
-import type { PluginCatalog, SearchPluginsDeps } from "../search-plugins.js";
-import { PluginCatalogUnavailableError } from "../search-plugins.js";
-
-// Mock the loader the cache wraps. `loadSpy` records every call and returns
-// (or throws) whatever the test configures. The real error class is passed
-// through so propagation preserves its identity.
-const loadSpy = mock(
-  async (
-    _opts: { ref: string },
-    _deps: SearchPluginsDeps,
-  ): Promise<PluginCatalog> => {
-    throw new Error("loadSpy default impl not configured");
-  },
-);
-
-mock.module("../search-plugins.js", () => ({
-  PluginCatalogUnavailableError,
-  loadPluginCatalog: loadSpy,
-}));
-
-const {
+import type { FetchLike } from "../fetch-like.js";
+import { readBundledPluginCatalog } from "../plugin-catalog-local.js";
+import type { SearchPluginsDeps } from "../search-plugins.js";
+import {
   PLUGIN_CATALOG_CACHE_TTL_MS,
   getPluginCatalog,
   invalidatePluginCatalogCache,
-} = await import("../plugin-catalog-cache.js");
-
-const deps: SearchPluginsDeps = {
-  fetch: (async () => new Response("", { status: 200 })) as never,
-};
+} from "../plugin-catalog-cache.js";
 
 // A non-zero base time. Bun treats `setSystemTime(new Date(0))` as "reset to
 // the real clock", so the fake clock must start from a positive epoch.
 const BASE_TIME_MS = 1_700_000_000_000;
 
-function catalog(ref: string, names: string[]): PluginCatalog {
-  return {
-    ref,
-    matches: names.map((name) => ({
+/** A `deps.fetch` that serves a `/v1/plugins/` payload and counts its calls. */
+function platformFetch(names: string[]): {
+  fetch: FetchLike;
+  calls: () => number;
+} {
+  let calls = 0;
+  const body = JSON.stringify({
+    plugins: names.map((name) => ({
       name,
-      path: `github:acme/${name}@${"0".repeat(40)}`,
-      category: null,
-      source: {
-        kind: "github" as const,
-        repo: `acme/${name}`,
-        ref: "0".repeat(40),
-      },
+      repo: `acme/${name}`,
+      ref: "0".repeat(40),
     })),
-  };
+  });
+  const fetch: FetchLike = (async () => {
+    calls += 1;
+    return new Response(body, { status: 200 });
+  }) as never;
+  return { fetch, calls: () => calls };
 }
+
+/** A `deps.fetch` that always fails with a non-2xx (→ unavailable). */
+function failingFetch(): { fetch: FetchLike; calls: () => number } {
+  let calls = 0;
+  const fetch: FetchLike = (async () => {
+    calls += 1;
+    return new Response("", { status: 503 });
+  }) as never;
+  return { fetch, calls: () => calls };
+}
+
+const ORIGINAL_ENV = {
+  IS_PLATFORM: process.env.IS_PLATFORM,
+  VELLUM_DISABLE_PLATFORM: process.env.VELLUM_DISABLE_PLATFORM,
+};
 
 describe("getPluginCatalog", () => {
   beforeEach(() => {
-    loadSpy.mockClear();
     invalidatePluginCatalogCache();
+    // Default: platform features enabled (neither flag set).
+    delete process.env.IS_PLATFORM;
+    delete process.env.VELLUM_DISABLE_PLATFORM;
   });
 
   afterEach(() => {
-    // Restore real time in case a test installed a fake clock.
     setSystemTime();
+    for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
   });
 
-  test("loads once and serves the cached catalog within the TTL window", async () => {
-    // GIVEN a loader that returns a catalog
-    loadSpy.mockImplementation(async ({ ref }) => catalog(ref, ["a"]));
+  test("fetches from the platform once, then serves cache within the TTL", async () => {
+    // GIVEN platform features enabled and a platform fetcher returning ["a"]
+    const { fetch, calls } = platformFetch(["a"]);
+    const deps: SearchPluginsDeps = { fetch };
 
     // WHEN we request the same ref twice in quick succession
     const first = await getPluginCatalog("main", deps);
     const second = await getPluginCatalog("main", deps);
 
-    // THEN the loader is consulted exactly once — the second call is cached
-    expect(loadSpy).toHaveBeenCalledTimes(1);
+    // THEN the platform is fetched exactly once — the second call is cached
+    expect(calls()).toBe(1);
     expect(first).toBe(second);
     expect(first.matches.map((m) => m.name)).toEqual(["a"]);
+    expect(first.ref).toBe("main");
   });
 
-  test("caches per ref independently", async () => {
-    // GIVEN a loader that echoes the requested ref
-    loadSpy.mockImplementation(async ({ ref }) => catalog(ref, [ref]));
-
-    // WHEN we request two different refs
-    const main = await getPluginCatalog("main", deps);
-    const branch = await getPluginCatalog("feature", deps);
-
-    // THEN each ref triggers its own load and is keyed separately
-    expect(loadSpy).toHaveBeenCalledTimes(2);
-    expect(main.ref).toBe("main");
-    expect(branch.ref).toBe("feature");
-  });
-
-  test("refreshes after the TTL elapses", async () => {
-    // GIVEN a fresh load at t0
-    setSystemTime(new Date(BASE_TIME_MS));
-    loadSpy.mockImplementation(async ({ ref }) => catalog(ref, ["v1"]));
+  test("refetches after invalidation", async () => {
+    // GIVEN a first successful load
+    const { fetch, calls } = platformFetch(["a"]);
+    const deps: SearchPluginsDeps = { fetch };
     await getPluginCatalog("main", deps);
 
-    // AND the loader now returns updated data
-    loadSpy.mockImplementation(async ({ ref }) => catalog(ref, ["v2"]));
+    // WHEN the cache is invalidated and we request again
+    invalidatePluginCatalogCache();
+    await getPluginCatalog("main", deps);
+
+    // THEN the platform is fetched a second time
+    expect(calls()).toBe(2);
+  });
+
+  test("refetches after the TTL elapses", async () => {
+    // GIVEN a fresh load at t0
+    setSystemTime(new Date(BASE_TIME_MS));
+    const { fetch, calls } = platformFetch(["a"]);
+    const deps: SearchPluginsDeps = { fetch };
+    await getPluginCatalog("main", deps);
 
     // WHEN the TTL has elapsed and we request again
     setSystemTime(new Date(BASE_TIME_MS + PLUGIN_CATALOG_CACHE_TTL_MS + 1));
-    const refreshed = await getPluginCatalog("main", deps);
+    await getPluginCatalog("main", deps);
 
-    // THEN the loader is consulted again and the new catalog is returned
-    expect(loadSpy).toHaveBeenCalledTimes(2);
-    expect(refreshed.matches.map((m) => m.name)).toEqual(["v2"]);
+    // THEN the platform is fetched again
+    expect(calls()).toBe(2);
   });
 
-  test("serves the stale catalog when a refresh fails", async () => {
+  test("fails hard on refresh failure — does NOT serve the stale cache", async () => {
     // GIVEN a good catalog cached at t0
     setSystemTime(new Date(BASE_TIME_MS));
-    loadSpy.mockImplementation(async ({ ref }) => catalog(ref, ["good"]));
-    const fresh = await getPluginCatalog("main", deps);
-
-    // AND the upstream later fails (rate-limited)
-    loadSpy.mockImplementation(async () => {
-      throw new PluginCatalogUnavailableError("rate limited", 403);
-    });
+    const good = platformFetch(["good"]);
+    const cached = await getPluginCatalog("main", { fetch: good.fetch });
+    expect(cached.matches.map((m) => m.name)).toEqual(["good"]);
 
     // WHEN the TTL has elapsed and the refresh fails
     setSystemTime(new Date(BASE_TIME_MS + PLUGIN_CATALOG_CACHE_TTL_MS + 1));
-    const stale = await getPluginCatalog("main", deps);
+    const failing = failingFetch();
+    const err = await getPluginCatalog("main", { fetch: failing.fetch }).catch(
+      (e: unknown) => e,
+    );
 
-    // THEN the last good catalog is served instead of throwing
-    expect(stale).toBe(fresh);
-    expect(stale.matches.map((m) => m.name)).toEqual(["good"]);
-  });
-
-  test("resets the TTL window after serving stale so it doesn't re-fetch every call", async () => {
-    // GIVEN a cached catalog and a now-failing upstream
-    setSystemTime(new Date(BASE_TIME_MS));
-    loadSpy.mockImplementation(async ({ ref }) => catalog(ref, ["good"]));
-    await getPluginCatalog("main", deps);
-    loadSpy.mockImplementation(async () => {
-      throw new PluginCatalogUnavailableError("rate limited", 403);
-    });
-
-    // WHEN the TTL elapses (one failed refresh) and we immediately ask again
-    setSystemTime(new Date(BASE_TIME_MS + PLUGIN_CATALOG_CACHE_TTL_MS + 1));
-    await getPluginCatalog("main", deps);
-    const callsAfterFirstStale = loadSpy.mock.calls.length;
-    await getPluginCatalog("main", deps);
-
-    // THEN the second request is served from the reset window without
-    // re-entering the failing loader
-    expect(loadSpy.mock.calls.length).toBe(callsAfterFirstStale);
-  });
-
-  test("propagates a hard error even with a cache, and does not serve stale", async () => {
-    // GIVEN a good catalog cached at t0
-    setSystemTime(new Date(BASE_TIME_MS));
-    loadSpy.mockImplementation(async ({ ref }) => catalog(ref, ["good"]));
-    await getPluginCatalog("main", deps);
-
-    // AND the upstream later fails with a HARD error (e.g. the prefix is
-    // gone), NOT a transient PluginCatalogUnavailableError
-    loadSpy.mockImplementation(async () => {
-      throw new Error("GitHub contents listing failed: HTTP 404");
-    });
-
-    // WHEN the TTL has elapsed and the refresh hard-fails
-    setSystemTime(new Date(BASE_TIME_MS + PLUGIN_CATALOG_CACHE_TTL_MS + 1));
-    const err = await getPluginCatalog("main", deps).catch((e: unknown) => e);
-
-    // THEN the hard error propagates instead of masking the misconfiguration
-    // with stale data
+    // THEN the failure propagates instead of serving the stale catalog
     expect(err).toBeInstanceOf(Error);
-    expect(err).not.toBeInstanceOf(PluginCatalogUnavailableError);
-    expect((err as Error).message).toMatch(/HTTP 404/);
+    expect(failing.calls()).toBe(1);
   });
 
-  test("propagates the error when there is no cache to fall back on", async () => {
-    // GIVEN no prior successful load and a failing upstream
-    loadSpy.mockImplementation(async () => {
-      throw new PluginCatalogUnavailableError("rate limited", 403);
-    });
+  test("reads the bundled catalog with zero network when platform is disabled", async () => {
+    // GIVEN platform features disabled (offline / self-hosted)
+    process.env.VELLUM_DISABLE_PLATFORM = "true";
+    delete process.env.IS_PLATFORM;
 
-    // WHEN we request a cold catalog
-    const err = await getPluginCatalog("main", deps).catch((e: unknown) => e);
+    const { fetch, calls } = platformFetch(["ignored"]);
+    const deps: SearchPluginsDeps = { fetch };
 
-    // THEN the failure propagates so the caller can map it to 503
-    expect(err).toBeInstanceOf(PluginCatalogUnavailableError);
+    // WHEN we request the catalog
+    const result = await getPluginCatalog("main", deps);
+
+    // THEN it comes from the bundled manifest and no fetch is made
+    expect(calls()).toBe(0);
+    const bundled = readBundledPluginCatalog();
+    expect(result.matches).toEqual(bundled.matches);
+    // The requested ref is echoed onto the wire contract.
+    expect(result.ref).toBe("main");
   });
 });

--- a/assistant/src/cli/lib/__tests__/plugin-catalog-cache.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-catalog-cache.test.ts
@@ -17,13 +17,13 @@ import {
 } from "bun:test";
 
 import type { FetchLike } from "../fetch-like.js";
-import { readBundledPluginCatalog } from "../plugin-catalog-local.js";
-import type { SearchPluginsDeps } from "../search-plugins.js";
 import {
-  PLUGIN_CATALOG_CACHE_TTL_MS,
   getPluginCatalog,
   invalidatePluginCatalogCache,
+  PLUGIN_CATALOG_CACHE_TTL_MS,
 } from "../plugin-catalog-cache.js";
+import { readBundledPluginCatalog } from "../plugin-catalog-local.js";
+import type { SearchPluginsDeps } from "../search-plugins.js";
 
 // A non-zero base time. Bun treats `setSystemTime(new Date(0))` as "reset to
 // the real clock", so the fake clock must start from a positive epoch.
@@ -75,8 +75,8 @@ describe("getPluginCatalog", () => {
   afterEach(() => {
     setSystemTime();
     for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
-      if (value === undefined) delete process.env[key];
-      else process.env[key] = value;
+      if (value === undefined) {delete process.env[key];}
+      else {process.env[key] = value;}
     }
   });
 

--- a/assistant/src/cli/lib/plugin-catalog-cache.ts
+++ b/assistant/src/cli/lib/plugin-catalog-cache.ts
@@ -1,30 +1,17 @@
 /**
  * In-memory cache for the installable plugin catalog.
  *
- * The catalog (`loadPluginCatalog`) is built from a single unauthenticated
- * GitHub Contents API call — the `marketplace.json` manifest. GitHub's
- * unauthenticated rate limit is 60 requests/hour per IP, so a long-lived
- * daemon that hit GitHub on every catalog search (on web mount, on every
- * keystroke, across reloads and multiple clients) would exhaust that budget
- * and start getting HTTP 403s.
- *
- * Because the GitHub responses are **query-independent** — `searchPlugins`
- * applies the regex filter in memory — one catalog load serves any number of
- * searches. This cache holds that load per git ref for a short TTL and, on an
- * upstream failure, serves the last good catalog so a transient rate-limit or
- * outage is invisible to callers. Mirrors the skills catalog cache
- * (`src/skills/catalog-cache.ts`).
+ * Platform-first: when platform features are enabled the catalog is fetched
+ * from the Vellum platform and any fetch failure propagates (fail hard — no
+ * stale-cache smoothing). Successful loads are held per git ref for a short
+ * TTL. When `VELLUM_DISABLE_PLATFORM` disables platform features the bundled
+ * offline manifest is read instead, with zero network calls.
  */
 
-import { getLogger } from "../../util/logger.js";
-import {
-  loadPluginCatalog,
-  type PluginCatalog,
-  PluginCatalogUnavailableError,
-  type SearchPluginsDeps,
-} from "./search-plugins.js";
-
-const log = getLogger("plugin-catalog-cache");
+import { arePlatformFeaturesEnabled } from "../../platform/feature-gate.js";
+import { readBundledPluginCatalog } from "./plugin-catalog-local.js";
+import { fetchPluginCatalogFromPlatform } from "./plugin-catalog-platform.js";
+import type { PluginCatalog, SearchPluginsDeps } from "./search-plugins.js";
 
 /** How long a fetched catalog is served before a refresh is attempted. */
 export const PLUGIN_CATALOG_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
@@ -37,45 +24,30 @@ interface CacheEntry {
 const cache = new Map<string, CacheEntry>();
 
 /**
- * Resolve the full plugin catalog at {@link ref} with in-memory caching.
+ * Resolve the full plugin catalog at {@link ref}.
  *
- * Within the TTL window the cached catalog is returned without touching the
- * network. After the TTL elapses a refresh is attempted; if it fails with a
- * transient upstream error ({@link PluginCatalogUnavailableError} — rate
- * limiting or a 5xx) and a cached catalog exists, the stale catalog is served
- * (and its TTL window is reset so a sustained outage doesn't re-enter the
- * failing fetch on every call). A hard error (e.g. a malformed manifest, or a
- * deleted ref) always propagates — serving stale there would silently mask a
- * real misconfiguration. With no cache to fall
- * back on, the underlying error propagates regardless so the caller can
- * surface it (e.g. the route maps a rate-limit failure to 503).
+ * With platform features disabled the bundled manifest is returned directly —
+ * an in-memory constant, no network and no TTL. Otherwise the catalog is
+ * fetched from the platform and, on success, cached per ref for the TTL; a
+ * fetch failure propagates so the caller can surface it (e.g. map a rate-limit
+ * to 503) — no stale catalog is ever served.
  */
 export async function getPluginCatalog(
   ref: string,
   deps: SearchPluginsDeps,
 ): Promise<PluginCatalog> {
+  if (!arePlatformFeaturesEnabled()) {
+    return { ...readBundledPluginCatalog(), ref };
+  }
+
   const cached = cache.get(ref);
   if (cached && Date.now() - cached.timestamp < PLUGIN_CATALOG_CACHE_TTL_MS) {
     return cached.catalog;
   }
 
-  try {
-    const catalog = await loadPluginCatalog({ ref }, deps);
-    cache.set(ref, { catalog, timestamp: Date.now() });
-    return catalog;
-  } catch (err) {
-    if (cached && err instanceof PluginCatalogUnavailableError) {
-      log.warn(
-        { err, ref },
-        "Failed to refresh plugin catalog, serving stale cache",
-      );
-      // Reset the TTL window so subsequent calls during the outage are served
-      // from cache instead of re-entering loadPluginCatalog() every time.
-      cached.timestamp = Date.now();
-      return cached.catalog;
-    }
-    throw err;
-  }
+  const catalog = await fetchPluginCatalogFromPlatform(deps, { ref });
+  cache.set(ref, { catalog, timestamp: Date.now() });
+  return catalog;
 }
 
 /** Invalidate the cache (for testing or forced refresh). */


### PR DESCRIPTION
## Summary
- Rewrite getPluginCatalog to source from the platform fetcher when platform features are enabled (TTL-cached successes only, fail hard on failure — no stale smoothing) and from the bundled manifest when VELLUM_DISABLE_PLATFORM disables platform features (zero network).
- Update cache tests for both paths + the fail-hard-on-expired case.

Part of plan: plugins-catalog-platform-first.md (PR 4 of 6)