### PR TITLE
feat(plugins): resolve name installs from bundled catalog when platform disabled

### DIFF
--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -645,7 +645,7 @@ $ assistant plugins publish --json`,
             category?: string;
           }) => {
             const ok = await runPublish(opts, { confirmPrompt });
-            if (!ok) process.exitCode = 1;
+            if (!ok) {process.exitCode = 1;}
           },
         );
 
@@ -1037,9 +1037,9 @@ function shortSha(sha: string | null): string {
  * fall back to `unknown`, with the SHA still shown alongside as the precise id.
  */
 function formatTimestamp(iso: string | null): string {
-  if (!iso) return "unknown";
+  if (!iso) {return "unknown";}
   const ms = Date.parse(iso);
-  if (!Number.isFinite(ms)) return "unknown";
+  if (!Number.isFinite(ms)) {return "unknown";}
   return new Date(ms).toISOString().slice(0, 19);
 }
 
@@ -1049,9 +1049,9 @@ function formatTimestamp(iso: string | null): string {
  */
 function formatAllPluginStatus(p: AllPluginInfo): string {
   const parts: string[] = [];
-  if (p.disabled) parts.push("disabled");
-  if (p.issues.length > 0) parts.push(p.issues.join("; "));
-  if (parts.length === 0) parts.push("enabled");
+  if (p.disabled) {parts.push("disabled");}
+  if (p.issues.length > 0) {parts.push(p.issues.join("; "));}
+  if (parts.length === 0) {parts.push("enabled");}
   return parts.join(", ");
 }
 
@@ -1081,8 +1081,8 @@ function statusLine(status: PluginInspection["status"]): string {
  */
 function driftLine(changes: FingerprintComparison | null): string {
   if (!changes)
-    return "unknown (no recorded baseline; reinstall to record one)";
-  if (changes.clean) return "none";
+    {return "unknown (no recorded baseline; reinstall to record one)";}
+  if (changes.clean) {return "none";}
   const parts = [
     `${changes.modified.length} modified`,
     `${changes.added.length} added`,
@@ -1114,9 +1114,9 @@ function formatInspection(inspection: PluginInspection): string[] {
   // under it. Omitted entirely when the plugin contributes none of that type,
   // so the listing only ever shows what the plugin actually contributes.
   const surfaceBlock = (label: string, items: readonly string[]) => {
-    if (items.length === 0) return;
+    if (items.length === 0) {return;}
     lines.push(label);
-    for (const item of items) lines.push(`  ${item}`);
+    for (const item of items) {lines.push(`  ${item}`);}
   };
 
   topRow("status", statusLine(status));
@@ -1142,15 +1142,15 @@ function formatInspection(inspection: PluginInspection): string[] {
   }
 
   const pkgVersion = local?.version ?? null;
-  if (pkgVersion) topRow("pkg version", pkgVersion);
+  if (pkgVersion) {topRow("pkg version", pkgVersion);}
 
   const license = remote?.license ?? null;
   const homepage = remote?.homepage ?? null;
-  if (license) topRow("license", license);
-  if (homepage) topRow("homepage", homepage);
+  if (license) {topRow("license", license);}
+  if (homepage) {topRow("homepage", homepage);}
 
   const description = remote?.description ?? local?.description ?? null;
-  if (description) topRow("description", description);
+  if (description) {topRow("description", description);}
 
   if (surfaces) {
     surfaceBlock("skills", surfaces.skills);
@@ -1158,7 +1158,7 @@ function formatInspection(inspection: PluginInspection): string[] {
     surfaceBlock("tools", surfaces.tools);
   }
 
-  for (const issue of local?.issues ?? []) topRow("issue", issue);
+  for (const issue of local?.issues ?? []) {topRow("issue", issue);}
 
   return lines;
 }
@@ -1188,7 +1188,7 @@ function formatUpgrade(result: PluginUpgradeResult): string[] {
         "",
         "dry run; no changes made.",
       ];
-      if (provenanceNote) lines.push(provenanceNote);
+      if (provenanceNote) {lines.push(provenanceNote);}
       return lines;
     }
     case "upgraded": {
@@ -1229,7 +1229,7 @@ function formatUpgrade(result: PluginUpgradeResult): string[] {
           "",
           "Resolve the conflicts, then the upgrade will be picked up live on the next read (no restart required).",
         );
-        if (provenanceNote) lines.push(provenanceNote);
+        if (provenanceNote) {lines.push(provenanceNote);}
         return lines;
       }
 
@@ -1245,8 +1245,8 @@ function formatUpgrade(result: PluginUpgradeResult): string[] {
         `${count}→ ${result.target}`,
         "Restart the assistant to pick up the upgrade.",
       ];
-      if (mergeNote) lines.push(mergeNote);
-      if (provenanceNote) lines.push(provenanceNote);
+      if (mergeNote) {lines.push(mergeNote);}
+      if (provenanceNote) {lines.push(provenanceNote);}
       return lines;
     }
   }

--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -8,7 +8,6 @@
 
 import type { Command } from "commander";
 
-import { arePlatformFeaturesEnabled } from "../../platform/feature-gate.js";
 import { yellow } from "../lib/cli-colors.js";
 import { confirmPrompt } from "../lib/confirm-prompt.js";
 import {
@@ -44,7 +43,10 @@ import {
   looksLikeGitHubSpec,
   parseGitHubPluginSpec,
 } from "../lib/parse-github-plugin-spec.js";
-import { resolveBundledPluginSource } from "../lib/plugin-catalog-local.js";
+import {
+  arePlatformFeaturesEnabled,
+  resolveBundledPluginSource,
+} from "../lib/plugin-catalog-local.js";
 import type { FingerprintComparison } from "../lib/plugin-fingerprint.js";
 import {
   DEFAULT_PIN_HISTORY_LIMIT,

--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -8,6 +8,7 @@
 
 import type { Command } from "commander";
 
+import { arePlatformFeaturesEnabled } from "../../platform/feature-gate.js";
 import { yellow } from "../lib/cli-colors.js";
 import { confirmPrompt } from "../lib/confirm-prompt.js";
 import {
@@ -43,6 +44,7 @@ import {
   looksLikeGitHubSpec,
   parseGitHubPluginSpec,
 } from "../lib/parse-github-plugin-spec.js";
+import { resolveBundledPluginSource } from "../lib/plugin-catalog-local.js";
 import type { FingerprintComparison } from "../lib/plugin-fingerprint.js";
 import {
   DEFAULT_PIN_HISTORY_LIMIT,
@@ -184,10 +186,38 @@ Examples:
               let result;
               let untrusted = false;
               if (!direct && !usesMarketplaceGit) {
-                result = await installPluginViaPlatform(
-                  { name: nameOrUrl, force: opts.force },
-                  { fetch: globalThis.fetch.bind(globalThis) },
-                );
+                // Platform-managed install serves a verified tarball from the
+                // pinned commit. With platform features disabled (air-gapped /
+                // self-hosted) there is no platform to call, so resolve the pin
+                // from the bundled catalog and install through the GitHub path.
+                if (arePlatformFeaturesEnabled()) {
+                  result = await installPluginViaPlatform(
+                    { name: nameOrUrl, force: opts.force },
+                    { fetch: globalThis.fetch.bind(globalThis) },
+                  );
+                } else {
+                  const source = resolveBundledPluginSource(nameOrUrl);
+                  if (!source) {
+                    console.error(
+                      `Plugin "${nameOrUrl}" is not in the bundled marketplace catalog.`,
+                    );
+                    process.exitCode = 1;
+                    return;
+                  }
+                  result = await installPlugin(
+                    {
+                      name: nameOrUrl,
+                      force: opts.force,
+                      directSource: {
+                        owner: source.owner,
+                        repo: source.repo,
+                        rootPath: source.path,
+                        ref: source.ref,
+                      },
+                    },
+                    { fetch: globalThis.fetch.bind(globalThis) },
+                  );
+                }
               } else {
                 const installOpts = direct
                   ? resolveDirectInstallOptions(nameOrUrl, opts)

--- a/assistant/src/cli/lib/__tests__/plugins-install-offline.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugins-install-offline.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Install-by-name in disable-platform (air-gapped / self-hosted) mode.
+ *
+ * With `VELLUM_DISABLE_PLATFORM=true` there is no platform to serve a verified
+ * tarball, so `assistant plugins install <name>` resolves the pin from the
+ * bundled marketplace catalog and installs through the GitHub path — with zero
+ * platform calls. A name absent from the bundled catalog fails clearly. With
+ * platform features enabled, the platform install endpoint is used unchanged.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+
+import { Command } from "commander";
+
+import type { InstallPluginOptions } from "../install-from-github.js";
+
+const installPluginCalls: InstallPluginOptions[] = [];
+const platformInstallCalls: Array<{ name: string; force?: boolean }> = [];
+
+const realGithub = await import("../install-from-github.js");
+const realPlatform = await import("../install-from-platform.js");
+
+mock.module("../install-from-github.js", () => ({
+  ...realGithub,
+  installPlugin: async (opts: InstallPluginOptions) => {
+    installPluginCalls.push(opts);
+    return {
+      name: opts.name,
+      target: `/plugins/${opts.name}`,
+      fileCount: 3,
+      ref: opts.directSource?.ref ?? "main",
+      commit: "abc1234def",
+      committedAt: null,
+    };
+  },
+}));
+
+mock.module("../install-from-platform.js", () => ({
+  ...realPlatform,
+  installPluginViaPlatform: async (opts: { name: string; force?: boolean }) => {
+    platformInstallCalls.push(opts);
+    return {
+      name: opts.name,
+      target: `/plugins/${opts.name}`,
+      fileCount: 3,
+      ref: "main",
+      commit: "def5678abc",
+      committedAt: null,
+    };
+  },
+}));
+
+const { registerPluginsCommand } = await import("../../commands/plugins.js");
+
+/** A plugin known to live in the bundled marketplace manifest. */
+const BUNDLED_PLUGIN = "caveman";
+
+function buildProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  registerPluginsCommand(program);
+  return program;
+}
+
+async function runInstall(name: string): Promise<void> {
+  await buildProgram().parseAsync(["node", "assistant", "plugins", "install", name]);
+}
+
+describe("plugins install by name — disable-platform mode", () => {
+  const savedDisable = process.env.VELLUM_DISABLE_PLATFORM;
+  const savedIsPlatform = process.env.IS_PLATFORM;
+  const savedExitCode = process.exitCode;
+
+  beforeEach(() => {
+    installPluginCalls.length = 0;
+    platformInstallCalls.length = 0;
+    process.exitCode = undefined;
+    spyOn(console, "log").mockImplementation(() => {});
+    spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (savedDisable === undefined) {delete process.env.VELLUM_DISABLE_PLATFORM;}
+    else {process.env.VELLUM_DISABLE_PLATFORM = savedDisable;}
+    if (savedIsPlatform === undefined) {delete process.env.IS_PLATFORM;}
+    else {process.env.IS_PLATFORM = savedIsPlatform;}
+    process.exitCode = savedExitCode;
+    mock.restore();
+  });
+
+  test("installs a bundled plugin via the GitHub path with no platform call", async () => {
+    process.env.VELLUM_DISABLE_PLATFORM = "true";
+    delete process.env.IS_PLATFORM;
+
+    await runInstall(BUNDLED_PLUGIN);
+
+    expect(platformInstallCalls.length).toBe(0);
+    expect(installPluginCalls.length).toBe(1);
+    const opts = installPluginCalls[0]!;
+    expect(opts.name).toBe(BUNDLED_PLUGIN);
+    expect(opts.directSource).toEqual({
+      owner: "JuliusBrussee",
+      repo: "caveman",
+      rootPath: "",
+      ref: "63a91ecadbf4c4719a4602a5abb00883f9966034",
+    });
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  test("errors clearly for a name absent from the bundled catalog", async () => {
+    process.env.VELLUM_DISABLE_PLATFORM = "true";
+    delete process.env.IS_PLATFORM;
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    await runInstall("definitely-not-a-real-plugin");
+
+    expect(installPluginCalls.length).toBe(0);
+    expect(platformInstallCalls.length).toBe(0);
+    expect(process.exitCode).toBe(1);
+    const message = errSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(message).toContain("not in the bundled marketplace catalog");
+  });
+
+  test("uses the platform install endpoint when platform features are enabled", async () => {
+    delete process.env.VELLUM_DISABLE_PLATFORM;
+    delete process.env.IS_PLATFORM;
+
+    await runInstall(BUNDLED_PLUGIN);
+
+    expect(installPluginCalls.length).toBe(0);
+    expect(platformInstallCalls.length).toBe(1);
+    expect(platformInstallCalls[0]!.name).toBe(BUNDLED_PLUGIN);
+    expect(process.exitCode).not.toBe(1);
+  });
+});

--- a/assistant/src/cli/lib/plugin-catalog-local.ts
+++ b/assistant/src/cli/lib/plugin-catalog-local.ts
@@ -31,7 +31,7 @@ export function buildBundledPluginCatalog(
   const matches = [];
   const seen = new Set<string>();
   for (const entry of plugins) {
-    if (seen.has(entry.name)) continue;
+    if (seen.has(entry.name)) {continue;}
     matches.push(marketplaceMatch(entry));
     seen.add(entry.name);
   }

--- a/assistant/src/cli/lib/plugin-catalog-local.ts
+++ b/assistant/src/cli/lib/plugin-catalog-local.ts
@@ -9,7 +9,12 @@
  */
 
 import bundledManifest from "./bundled-marketplace.json" with { type: "json" };
-import { marketplaceManifestSchema } from "./plugin-marketplace.js";
+import {
+  type MarketplaceEntry,
+  marketplaceManifestSchema,
+  type ResolvedPluginSource,
+  resolveMarketplaceSource,
+} from "./plugin-marketplace.js";
 import { marketplaceMatch, type PluginCatalog } from "./search-plugins.js";
 
 /**
@@ -42,4 +47,25 @@ let memoized: PluginCatalog | undefined;
 export function readBundledPluginCatalog(): PluginCatalog {
   memoized ??= buildBundledPluginCatalog();
   return memoized;
+}
+
+let memoizedEntries: readonly MarketplaceEntry[] | undefined;
+
+/** Validated bundled manifest entries, parsed once and reused. */
+function bundledEntries(): readonly MarketplaceEntry[] {
+  memoizedEntries ??= marketplaceManifestSchema.parse(bundledManifest).plugins;
+  return memoizedEntries;
+}
+
+/**
+ * Resolve an install name to its pinned GitHub source from the bundled manifest,
+ * or `null` when no bundled entry claims the name. The offline analogue of
+ * resolving against the remote-fetched marketplace — used when platform
+ * features are disabled and `assistant plugins install <name>` must resolve the
+ * pin without any network call.
+ */
+export function resolveBundledPluginSource(
+  name: string,
+): ResolvedPluginSource | null {
+  return resolveMarketplaceSource(name, bundledEntries());
 }

--- a/assistant/src/cli/lib/plugin-catalog-local.ts
+++ b/assistant/src/cli/lib/plugin-catalog-local.ts
@@ -17,6 +17,10 @@ import {
 } from "./plugin-marketplace.js";
 import { marketplaceMatch, type PluginCatalog } from "./search-plugins.js";
 
+// Re-exported so `local`-tagged CLI commands can gate on platform features
+// without importing `platform/` directly (cli/no-daemon-internals allows lib).
+export { arePlatformFeaturesEnabled } from "../../platform/feature-gate.js";
+
 /**
  * Validate and project the bundled manifest into a {@link PluginCatalog}:
  * every entry deduped by name, mapped via {@link marketplaceMatch}, sorted


### PR DESCRIPTION
## Summary
- Add resolveBundledPluginSource(name) to resolve a name → pinned GitHub source from the bundled manifest.
- In disable-platform mode, install-by-name resolves from the bundled catalog and installs via the GitHub path (zero platform calls); unknown names error clearly. Platform mode unchanged.

Part of plan: plugins-catalog-platform-first.md (PR 6 of 6)