### PR TITLE
feat(assistant): typed gateway guardian-request client over IPC

### DIFF
--- a/assistant/src/channels/__tests__/gateway-guardian-requests.test.ts
+++ b/assistant/src/channels/__tests__/gateway-guardian-requests.test.ts
@@ -1,0 +1,668 @@
+/**
+ * Tests for the gateway-backed guardian-request client.
+ *
+ * The IPC transport is stubbed; wrappers are exercised for method/param
+ * mapping, contract-schema validation of responses, and error posture:
+ * lifecycle writes throw fail-closed, while the `...OrNull` / `...OrEmpty` /
+ * `...OrFalse` read variants log and degrade to the empty value.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  GuardianRequestDeliveryWire,
+  GuardianRequestWire,
+} from "@vellumai/gateway-client";
+
+type IpcCall = { method: string; params?: Record<string, unknown> };
+
+let ipcCalls: IpcCall[] = [];
+let ipcResponse: unknown;
+let ipcError: Error | null = null;
+
+const ipcCallPersistentMock = mock(
+  async (method: string, params?: Record<string, unknown>) => {
+    ipcCalls.push({ method, params });
+    if (ipcError) {
+      throw ipcError;
+    }
+    return ipcResponse;
+  },
+);
+const actualGatewayClient = await import("../../ipc/gateway-client.js");
+mock.module("../../ipc/gateway-client.js", () => ({
+  ...actualGatewayClient,
+  ipcCallPersistent: ipcCallPersistentMock,
+}));
+
+// Delegating logger mock: only the client's own logger has its `warn`
+// captured; every other module keeps its real logger.
+let warnCalls: unknown[][] = [];
+const actualLoggerModule = await import("../../util/logger.js");
+// Captured before mock.module: the namespace binding is live post-mock.
+const realGetLogger = actualLoggerModule.getLogger;
+mock.module("../../util/logger.js", () => ({
+  ...actualLoggerModule,
+  getLogger: (name: string) => {
+    const logger = realGetLogger(name);
+    if (name !== "gateway-guardian-requests") {
+      return logger;
+    }
+    return new Proxy(logger, {
+      get(target, prop, receiver) {
+        if (prop === "warn") {
+          return (...args: unknown[]) => {
+            warnCalls.push(args);
+          };
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+  },
+}));
+
+const client = await import("../gateway-guardian-requests.js");
+
+function makeWireRequest(
+  overrides: Partial<GuardianRequestWire> = {},
+): GuardianRequestWire {
+  return {
+    id: "req-1",
+    kind: "access_request",
+    sourceType: "channel",
+    sourceChannel: "telegram",
+    sourceConversationId: "conv-1",
+    requesterExternalUserId: "user-123",
+    requesterChatId: "chat-456",
+    guardianExternalUserId: "guardian-789",
+    guardianPrincipalId: "principal-1",
+    callSessionId: null,
+    pendingQuestionId: null,
+    questionText: null,
+    requestCode: "AB12",
+    toolName: null,
+    inputDigest: null,
+    commandPreview: null,
+    riskLevel: null,
+    activityText: "wants to chat",
+    executionTarget: null,
+    requesterSignals: null,
+    requestTrigger: "denied",
+    status: "pending",
+    answerText: null,
+    decidedByExternalUserId: null,
+    decidedByPrincipalId: null,
+    followupState: null,
+    expiresAt: 1_700_000_600_000,
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+function makeWireDelivery(
+  overrides: Partial<GuardianRequestDeliveryWire> = {},
+): GuardianRequestDeliveryWire {
+  return {
+    id: "del-1",
+    requestId: "req-1",
+    destinationChannel: "telegram",
+    destinationConversationId: null,
+    destinationChatId: "chat-456",
+    destinationMessageId: "msg-1",
+    status: "sent",
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  ipcCalls = [];
+  ipcResponse = undefined;
+  ipcError = null;
+  warnCalls = [];
+});
+
+describe("createGuardianRequest", () => {
+  test("passes create params through and returns the created wire DTO", async () => {
+    const created = makeWireRequest();
+    ipcResponse = created;
+
+    const result = await client.createGuardianRequest({
+      id: "req-1",
+      kind: "access_request",
+      sourceChannel: "telegram",
+      sourceConversationId: "conv-1",
+      requesterExternalUserId: "user-123",
+      guardianPrincipalId: "principal-1",
+      requestTrigger: "denied",
+    });
+
+    expect(ipcCalls).toEqual([
+      {
+        method: "guardian_requests_create",
+        params: {
+          id: "req-1",
+          kind: "access_request",
+          sourceChannel: "telegram",
+          sourceConversationId: "conv-1",
+          requesterExternalUserId: "user-123",
+          guardianPrincipalId: "principal-1",
+          requestTrigger: "denied",
+        },
+      },
+    ]);
+    expect(result).toEqual(created);
+  });
+
+  test("throws on transport failure (fail-closed)", async () => {
+    ipcError = new Error("gateway unavailable");
+    await expect(
+      client.createGuardianRequest({
+        id: "req-1",
+        kind: "access_request",
+        guardianPrincipalId: "principal-1",
+      }),
+    ).rejects.toThrow("gateway unavailable");
+  });
+
+  test("throws on a malformed response", async () => {
+    ipcResponse = { id: "req-1" };
+    await expect(
+      client.createGuardianRequest({
+        id: "req-1",
+        kind: "access_request",
+        guardianPrincipalId: "principal-1",
+      }),
+    ).rejects.toThrow("guardian_requests_create");
+  });
+});
+
+describe("decideGuardianRequest", () => {
+  test("round-trips a decision with an ACL outcome", async () => {
+    const decided = makeWireRequest({
+      status: "approved",
+      decidedByPrincipalId: "principal-1",
+    });
+    ipcResponse = { applied: true, request: decided };
+
+    const result = await client.decideGuardianRequest({
+      id: "req-1",
+      expectedStatus: "pending",
+      status: "approved",
+      decidedByPrincipalId: "principal-1",
+      answerText: "approved",
+      aclOutcome: {
+        type: "activate_member",
+        sourceChannel: "telegram",
+        externalUserId: "user-123",
+        externalChatId: "chat-456",
+        displayName: "Alice",
+        verifiedVia: "guardian_approval",
+      },
+    });
+
+    expect(ipcCalls).toEqual([
+      {
+        method: "guardian_requests_decide",
+        params: {
+          id: "req-1",
+          expectedStatus: "pending",
+          status: "approved",
+          decidedByPrincipalId: "principal-1",
+          answerText: "approved",
+          aclOutcome: {
+            type: "activate_member",
+            sourceChannel: "telegram",
+            externalUserId: "user-123",
+            externalChatId: "chat-456",
+            displayName: "Alice",
+            verifiedVia: "guardian_approval",
+          },
+        },
+      },
+    ]);
+    expect(result).toEqual({ applied: true, request: decided });
+  });
+
+  test("passes the minted outbound session back on a mint outcome", async () => {
+    const mintedSession = {
+      sessionId: "sess-1",
+      secret: "123456",
+      challengeHash: "a".repeat(64),
+      expiresAt: 1_700_000_600_000,
+      ttlSeconds: 600,
+    };
+    ipcResponse = {
+      applied: true,
+      request: makeWireRequest({ status: "approved" }),
+      mintedSession,
+    };
+
+    const result = await client.decideGuardianRequest({
+      id: "req-1",
+      expectedStatus: "pending",
+      status: "approved",
+      aclOutcome: {
+        type: "mint_outbound_session",
+        channel: "phone",
+        expectedPhoneE164: "+15555550123",
+        destinationAddress: "+15555550123",
+        codeDigits: 6,
+        verificationPurpose: "guardian",
+      },
+    });
+
+    expect(result.applied).toBe(true);
+    if (result.applied) {
+      expect(result.mintedSession).toEqual(mintedSession);
+    }
+    expect(ipcCalls[0]?.params?.aclOutcome).toEqual({
+      type: "mint_outbound_session",
+      channel: "phone",
+      expectedPhoneE164: "+15555550123",
+      destinationAddress: "+15555550123",
+      codeDigits: 6,
+      verificationPurpose: "guardian",
+    });
+  });
+
+  test("passes the CAS-miss conflict marker through", async () => {
+    ipcResponse = { applied: false, reason: "status_conflict" };
+    const result = await client.decideGuardianRequest({
+      id: "req-1",
+      expectedStatus: "pending",
+      status: "denied",
+    });
+    expect(result).toEqual({ applied: false, reason: "status_conflict" });
+  });
+
+  test("throws on transport failure — a decision must never fake success", async () => {
+    ipcError = new Error("gateway unavailable");
+    await expect(
+      client.decideGuardianRequest({
+        id: "req-1",
+        expectedStatus: "pending",
+        status: "approved",
+      }),
+    ).rejects.toThrow("gateway unavailable");
+  });
+
+  test("throws on a malformed response", async () => {
+    ipcResponse = { applied: true };
+    await expect(
+      client.decideGuardianRequest({
+        id: "req-1",
+        expectedStatus: "pending",
+        status: "approved",
+      }),
+    ).rejects.toThrow("guardian_requests_decide");
+  });
+});
+
+describe("request lookups", () => {
+  test("getGuardianRequest maps the method and returns the DTO or null", async () => {
+    const request = makeWireRequest();
+    ipcResponse = request;
+    expect(await client.getGuardianRequest("req-1")).toEqual(request);
+    expect(ipcCalls[0]).toEqual({
+      method: "guardian_requests_get",
+      params: { id: "req-1" },
+    });
+
+    ipcResponse = null;
+    expect(await client.getGuardianRequest("req-404")).toBeNull();
+  });
+
+  test("getGuardianRequestByCode maps the method and params", async () => {
+    const request = makeWireRequest();
+    ipcResponse = request;
+    expect(await client.getGuardianRequestByCode("AB12")).toEqual(request);
+    expect(ipcCalls[0]).toEqual({
+      method: "guardian_requests_get_by_code",
+      params: { code: "AB12" },
+    });
+  });
+
+  test("getPendingRequestByDestinationMessage maps the destination triple", async () => {
+    ipcResponse = null;
+    expect(
+      await client.getPendingRequestByDestinationMessage(
+        "telegram",
+        "chat-456",
+        "msg-1",
+      ),
+    ).toBeNull();
+    expect(ipcCalls[0]).toEqual({
+      method: "guardian_requests_get_by_destination_message",
+      params: { channel: "telegram", chatId: "chat-456", messageId: "msg-1" },
+    });
+  });
+
+  test("getPendingRequestByCallSession and getRequestByPendingQuestion map params", async () => {
+    const request = makeWireRequest({ callSessionId: "call-1" });
+    ipcResponse = request;
+    expect(await client.getPendingRequestByCallSession("call-1")).toEqual(
+      request,
+    );
+    expect(ipcCalls[0]).toEqual({
+      method: "guardian_requests_get_by_call_session",
+      params: { callSessionId: "call-1" },
+    });
+
+    ipcResponse = makeWireRequest({ pendingQuestionId: "pq-1" });
+    await client.getRequestByPendingQuestion("pq-1");
+    expect(ipcCalls[1]).toEqual({
+      method: "guardian_requests_get_by_pending_question",
+      params: { pendingQuestionId: "pq-1" },
+    });
+  });
+
+  test("throwing lookups throw on a malformed payload", async () => {
+    ipcResponse = { id: "req-1" };
+    await expect(client.getGuardianRequest("req-1")).rejects.toThrow(
+      "guardian_requests_get",
+    );
+    await expect(client.getGuardianRequestByCode("AB12")).rejects.toThrow(
+      "guardian_requests_get_by_code",
+    );
+  });
+
+  test("OrNull variants degrade to null and log instead of throwing", async () => {
+    ipcResponse = { id: "req-1" };
+    expect(await client.getGuardianRequestOrNull("req-1")).toBeNull();
+    expect(warnCalls).toHaveLength(1);
+
+    ipcError = new Error("gateway unavailable");
+    expect(await client.getGuardianRequestByCodeOrNull("AB12")).toBeNull();
+    expect(
+      await client.getPendingRequestByDestinationMessageOrNull(
+        "telegram",
+        "chat-456",
+        "msg-1",
+      ),
+    ).toBeNull();
+    expect(
+      await client.getPendingRequestByCallSessionOrNull("call-1"),
+    ).toBeNull();
+    expect(await client.getRequestByPendingQuestionOrNull("pq-1")).toBeNull();
+    expect(warnCalls).toHaveLength(5);
+  });
+
+  test("OrNull variants pass successful reads through untouched", async () => {
+    const request = makeWireRequest();
+    ipcResponse = request;
+    expect(await client.getGuardianRequestOrNull("req-1")).toEqual(request);
+    expect(warnCalls).toHaveLength(0);
+  });
+});
+
+describe("request lists", () => {
+  test("listGuardianRequests passes filters through and validates the array", async () => {
+    const requests = [makeWireRequest(), makeWireRequest({ id: "req-2" })];
+    ipcResponse = requests;
+
+    const result = await client.listGuardianRequests({
+      status: "pending",
+      guardianPrincipalId: "principal-1",
+      sourceType: "channel",
+    });
+
+    expect(ipcCalls).toEqual([
+      {
+        method: "guardian_requests_list",
+        params: {
+          status: "pending",
+          guardianPrincipalId: "principal-1",
+          sourceType: "channel",
+        },
+      },
+    ]);
+    expect(result).toEqual(requests);
+  });
+
+  test("listPendingRequestsByDestination and listPendingRequestsByScope map params", async () => {
+    ipcResponse = [];
+    await client.listPendingRequestsByDestination({
+      channel: "telegram",
+      chatId: "chat-456",
+    });
+    expect(ipcCalls[0]).toEqual({
+      method: "guardian_requests_list_pending_by_destination",
+      params: { channel: "telegram", chatId: "chat-456" },
+    });
+
+    await client.listPendingRequestsByScope("conv-1", "telegram");
+    expect(ipcCalls[1]).toEqual({
+      method: "guardian_requests_list_pending_by_scope",
+      params: { conversationId: "conv-1", channel: "telegram" },
+    });
+  });
+
+  test("throwing lists throw on transport failure and malformed payloads", async () => {
+    ipcError = new Error("gateway unavailable");
+    await expect(client.listGuardianRequests()).rejects.toThrow(
+      "gateway unavailable",
+    );
+
+    ipcError = null;
+    ipcResponse = [{ id: "req-1" }];
+    await expect(client.listGuardianRequests()).rejects.toThrow(
+      "guardian_requests_list",
+    );
+  });
+
+  test("OrEmpty variants degrade to [] and log instead of throwing", async () => {
+    ipcError = new Error("gateway unavailable");
+    expect(await client.listGuardianRequestsOrEmpty()).toEqual([]);
+    expect(
+      await client.listPendingRequestsByDestinationOrEmpty({
+        conversationId: "conv-1",
+      }),
+    ).toEqual([]);
+    expect(await client.listPendingRequestsByScopeOrEmpty("conv-1")).toEqual(
+      [],
+    );
+    expect(warnCalls).toHaveLength(3);
+  });
+});
+
+describe("mutations", () => {
+  test("updateGuardianRequest sends the id and patch and resolves on ok", async () => {
+    ipcResponse = { ok: true };
+    await client.updateGuardianRequest("req-1", {
+      status: "cancelled",
+      followupState: null,
+    });
+    expect(ipcCalls).toEqual([
+      {
+        method: "guardian_requests_update",
+        params: {
+          id: "req-1",
+          patch: { status: "cancelled", followupState: null },
+        },
+      },
+    ]);
+  });
+
+  test("reopenGuardianRequest and expireGuardianRequest map params", async () => {
+    ipcResponse = { ok: true };
+    await client.reopenGuardianRequest("req-1", "expired");
+    expect(ipcCalls[0]).toEqual({
+      method: "guardian_requests_reopen",
+      params: { id: "req-1", fromStatus: "expired" },
+    });
+
+    await client.expireGuardianRequest("req-1");
+    expect(ipcCalls[1]).toEqual({
+      method: "guardian_requests_expire",
+      params: { id: "req-1" },
+    });
+  });
+
+  test("mutations throw on transport failure (fail-closed)", async () => {
+    ipcError = new Error("gateway unavailable");
+    await expect(
+      client.updateGuardianRequest("req-1", { status: "cancelled" }),
+    ).rejects.toThrow("gateway unavailable");
+    await expect(client.expireGuardianRequest("req-1")).rejects.toThrow(
+      "gateway unavailable",
+    );
+  });
+
+  test("mutations throw when the gateway does not ack ok", async () => {
+    ipcResponse = { ok: false };
+    await expect(
+      client.reopenGuardianRequest("req-1", "expired"),
+    ).rejects.toThrow("guardian_requests_reopen");
+  });
+});
+
+describe("expiry lifecycle", () => {
+  test("expireInteractionBoundGuardianRequests returns the expired count", async () => {
+    ipcResponse = { expired: 3 };
+    expect(await client.expireInteractionBoundGuardianRequests()).toBe(3);
+    expect(ipcCalls).toEqual([
+      { method: "guardian_requests_expire_interaction_bound", params: {} },
+    ]);
+  });
+
+  test("sweepExpiredGuardianRequests passes now and returns the expired ids", async () => {
+    ipcResponse = { expired: ["req-1", "req-2"] };
+    expect(
+      await client.sweepExpiredGuardianRequests(1_700_000_500_000),
+    ).toEqual(["req-1", "req-2"]);
+    expect(ipcCalls).toEqual([
+      {
+        method: "guardian_requests_sweep_expired",
+        params: { now: 1_700_000_500_000 },
+      },
+    ]);
+  });
+
+  test("sweeps throw on transport failure and malformed responses", async () => {
+    ipcError = new Error("gateway unavailable");
+    await expect(client.sweepExpiredGuardianRequests()).rejects.toThrow(
+      "gateway unavailable",
+    );
+
+    ipcError = null;
+    ipcResponse = { expired: 3 };
+    await expect(client.sweepExpiredGuardianRequests()).rejects.toThrow(
+      "guardian_requests_sweep_expired",
+    );
+  });
+});
+
+describe("deliveries", () => {
+  test("createGuardianRequestDelivery returns the created delivery", async () => {
+    const delivery = makeWireDelivery();
+    ipcResponse = delivery;
+
+    const result = await client.createGuardianRequestDelivery({
+      requestId: "req-1",
+      destinationChannel: "telegram",
+      destinationChatId: "chat-456",
+      status: "sent",
+    });
+
+    expect(ipcCalls).toEqual([
+      {
+        method: "guardian_requests_create_delivery",
+        params: {
+          requestId: "req-1",
+          destinationChannel: "telegram",
+          destinationChatId: "chat-456",
+          status: "sent",
+        },
+      },
+    ]);
+    expect(result).toEqual(delivery);
+  });
+
+  test("createGuardianRequestDelivery throws on a malformed response", async () => {
+    ipcResponse = { id: "del-1" };
+    await expect(
+      client.createGuardianRequestDelivery({
+        requestId: "req-1",
+        destinationChannel: "telegram",
+      }),
+    ).rejects.toThrow("guardian_requests_create_delivery");
+  });
+
+  test("updateGuardianRequestDelivery sends the id and patch", async () => {
+    ipcResponse = { ok: true };
+    await client.updateGuardianRequestDelivery("del-1", {
+      status: "delivered",
+      destinationMessageId: "msg-2",
+    });
+    expect(ipcCalls).toEqual([
+      {
+        method: "guardian_requests_update_delivery",
+        params: {
+          id: "del-1",
+          patch: { status: "delivered", destinationMessageId: "msg-2" },
+        },
+      },
+    ]);
+  });
+
+  test("listGuardianRequestDeliveries validates the array; OrEmpty degrades", async () => {
+    const deliveries = [makeWireDelivery()];
+    ipcResponse = deliveries;
+    expect(await client.listGuardianRequestDeliveries("req-1")).toEqual(
+      deliveries,
+    );
+    expect(ipcCalls[0]).toEqual({
+      method: "guardian_requests_list_deliveries",
+      params: { requestId: "req-1" },
+    });
+
+    ipcError = new Error("gateway unavailable");
+    await expect(client.listGuardianRequestDeliveries("req-1")).rejects.toThrow(
+      "gateway unavailable",
+    );
+    expect(await client.listGuardianRequestDeliveriesOrEmpty("req-1")).toEqual(
+      [],
+    );
+    expect(warnCalls).toHaveLength(1);
+  });
+});
+
+describe("isGuardianRequestInScope", () => {
+  test("returns the gateway scope verdict", async () => {
+    ipcResponse = { inScope: true };
+    expect(
+      await client.isGuardianRequestInScope("req-1", "conv-1", "telegram"),
+    ).toBe(true);
+    expect(ipcCalls).toEqual([
+      {
+        method: "guardian_requests_in_scope",
+        params: {
+          requestId: "req-1",
+          conversationId: "conv-1",
+          channel: "telegram",
+        },
+      },
+    ]);
+
+    ipcResponse = { inScope: false };
+    expect(await client.isGuardianRequestInScope("req-1", "conv-2")).toBe(
+      false,
+    );
+  });
+
+  test("throws on a malformed response; OrFalse degrades to not-in-scope", async () => {
+    ipcResponse = { allowed: true };
+    await expect(
+      client.isGuardianRequestInScope("req-1", "conv-1"),
+    ).rejects.toThrow("guardian_requests_in_scope");
+
+    ipcError = new Error("gateway unavailable");
+    expect(
+      await client.isGuardianRequestInScopeOrFalse("req-1", "conv-1"),
+    ).toBe(false);
+    expect(warnCalls).toHaveLength(1);
+  });
+});

--- a/assistant/src/channels/gateway-guardian-requests.ts
+++ b/assistant/src/channels/gateway-guardian-requests.ts
@@ -1,0 +1,423 @@
+/**
+ * Gateway-backed guardian-request client.
+ *
+ * Typed async wrappers over the gateway's `guardian_requests_*` IPC routes.
+ * The gateway owns the `guardian_requests` and `guardian_request_deliveries`
+ * tables and applies decision ACL outcomes in the same transaction as the
+ * status CAS; the daemon relays lifecycle operations here and keeps
+ * notifications, card withdrawal, and other daemon-domain side effects.
+ * Responses are validated against the shared contract schemas in
+ * `@vellumai/gateway-client` — the same schemas the gateway routes are
+ * pinned to.
+ *
+ * Error posture (fail-closed — there is no local fallback):
+ * - Lifecycle writes (create, update, decide, reopen, expire, sweep,
+ *   delivery writes) THROW on any transport failure or malformed response.
+ *   A guardian decision that cannot persist must fail loudly, never fake
+ *   success.
+ * - Reads used for hints/dedup/scope export a throwing default plus a
+ *   degrading variant (`...OrNull` / `...OrEmpty` / `...OrFalse`) that logs
+ *   the failure and returns the empty value — for deny-path callers that
+ *   must degrade to "no data" instead of blocking.
+ */
+
+import {
+  type CreateGuardianRequestDeliveryIpcParams,
+  CreateGuardianRequestDeliveryIpcResponseSchema,
+  type CreateGuardianRequestIpcParams,
+  CreateGuardianRequestIpcResponseSchema,
+  type DecideGuardianRequestIpcParams,
+  type DecideGuardianRequestIpcResponse,
+  DecideGuardianRequestIpcResponseSchema,
+  ExpireInteractionBoundIpcResponseSchema,
+  GUARDIAN_REQUESTS_IPC_METHODS,
+  GuardianRequestDeliveryListIpcResponseSchema,
+  type GuardianRequestDeliveryWire,
+  GuardianRequestInScopeIpcResponseSchema,
+  GuardianRequestListIpcResponseSchema,
+  GuardianRequestLookupIpcResponseSchema,
+  GuardianRequestMutationIpcResponseSchema,
+  type GuardianRequestPatch,
+  type GuardianRequestsIpcMethod,
+  type GuardianRequestStatus,
+  type GuardianRequestWire,
+  type ListGuardianRequestsIpcParams,
+  type ListPendingGuardianRequestsByDestinationIpcParams,
+  SweepExpiredGuardianRequestsIpcResponseSchema,
+  type UpdateGuardianRequestDeliveryIpcParams,
+} from "@vellumai/gateway-client";
+import type { ZodType } from "zod";
+
+import { ipcCallPersistentValidated } from "../ipc/gateway-validated-call.js";
+import { getLogger } from "../util/logger.js";
+
+export type {
+  CreateGuardianRequestIpcParams,
+  DecideGuardianRequestIpcParams,
+  DecideGuardianRequestIpcResponse,
+  GuardianRequestAclOutcome,
+  GuardianRequestDeliveryWire,
+  GuardianRequestPatch,
+  GuardianRequestStatus,
+  GuardianRequestWire,
+} from "@vellumai/gateway-client";
+
+const log = getLogger("gateway-guardian-requests");
+
+/**
+ * Call a gateway guardian-request route and validate the response against
+ * its contract schema. Throws on transport failure or a malformed response
+ * (shared helper; typed to the guardian-request method union).
+ */
+async function callGateway<T>(
+  method: GuardianRequestsIpcMethod,
+  params: Record<string, unknown>,
+  responseSchema: ZodType<T>,
+): Promise<T> {
+  return ipcCallPersistentValidated(method, params, responseSchema);
+}
+
+/** Call a mutation route; throws unless the gateway acks `{ ok: true }`. */
+async function callMutation(
+  method: GuardianRequestsIpcMethod,
+  params: Record<string, unknown>,
+): Promise<void> {
+  await callGateway(method, params, GuardianRequestMutationIpcResponseSchema);
+}
+
+/**
+ * Wrap a read so any failure — transport included — degrades to `fallback`
+ * (logged) instead of throwing, for deny-path callers.
+ */
+function degradeOnFailure<Args extends unknown[], T>(
+  read: (...args: Args) => Promise<T>,
+  fallback: T,
+): (...args: Args) => Promise<T> {
+  return async (...args: Args): Promise<T> => {
+    try {
+      return await read(...args);
+    } catch (err) {
+      log.warn(
+        { err, read: read.name },
+        "gateway guardian-request read degraded to fallback",
+      );
+      return fallback;
+    }
+  };
+}
+
+/**
+ * Create a guardian request. `id` and `guardianPrincipalId` are required —
+ * request ids are caller-supplied and load-bearing. Throws on any failure
+ * (fail-closed).
+ */
+export async function createGuardianRequest(
+  params: CreateGuardianRequestIpcParams,
+): Promise<GuardianRequestWire> {
+  return callGateway(
+    GUARDIAN_REQUESTS_IPC_METHODS.create,
+    params as unknown as Record<string, unknown>,
+    CreateGuardianRequestIpcResponseSchema,
+  );
+}
+
+/** Look up a guardian request by id. Throws on transport failure. */
+export async function getGuardianRequest(
+  id: string,
+): Promise<GuardianRequestWire | null> {
+  return callGateway(
+    GUARDIAN_REQUESTS_IPC_METHODS.get,
+    { id },
+    GuardianRequestLookupIpcResponseSchema,
+  );
+}
+
+/** `getGuardianRequest` for deny-path callers: failures degrade to null. */
+export const getGuardianRequestOrNull = degradeOnFailure(
+  getGuardianRequest,
+  null,
+);
+
+/**
+ * Look up a PENDING guardian request by its short request code. Throws on
+ * transport failure.
+ */
+export async function getGuardianRequestByCode(
+  code: string,
+): Promise<GuardianRequestWire | null> {
+  return callGateway(
+    GUARDIAN_REQUESTS_IPC_METHODS.getByCode,
+    { code },
+    GuardianRequestLookupIpcResponseSchema,
+  );
+}
+
+/** `getGuardianRequestByCode` for deny-path callers: degrades to null. */
+export const getGuardianRequestByCodeOrNull = degradeOnFailure(
+  getGuardianRequestByCode,
+  null,
+);
+
+/** List guardian requests matching the filters. Throws on transport failure. */
+export async function listGuardianRequests(
+  filters: ListGuardianRequestsIpcParams = {},
+): Promise<GuardianRequestWire[]> {
+  return callGateway(
+    GUARDIAN_REQUESTS_IPC_METHODS.list,
+    filters as unknown as Record<string, unknown>,
+    GuardianRequestListIpcResponseSchema,
+  );
+}
+
+/** `listGuardianRequests` for deny-path callers: degrades to []. */
+export const listGuardianRequestsOrEmpty = degradeOnFailure(
+  listGuardianRequests,
+  [],
+);
+
+/** Apply a partial patch to a guardian request. Throws on any failure. */
+export async function updateGuardianRequest(
+  id: string,
+  patch: GuardianRequestPatch,
+): Promise<void> {
+  await callMutation(GUARDIAN_REQUESTS_IPC_METHODS.update, { id, patch });
+}
+
+/**
+ * Decide a pending guardian request: status CAS plus the optional ACL
+ * outcome, committed in one gateway transaction. A CAS miss returns
+ * `{ applied: false, reason: "status_conflict" }` with zero side effects;
+ * on success `mintedSession` carries the raw outbound-session secret when
+ * the outcome minted one. Throws on any transport failure or malformed
+ * response (fail-closed — a decision that cannot persist fails loudly).
+ */
+export async function decideGuardianRequest(
+  params: DecideGuardianRequestIpcParams,
+): Promise<DecideGuardianRequestIpcResponse> {
+  return callGateway(
+    GUARDIAN_REQUESTS_IPC_METHODS.decide,
+    params as unknown as Record<string, unknown>,
+    DecideGuardianRequestIpcResponseSchema,
+  );
+}
+
+/**
+ * Reopen a terminal request back to pending (CAS from `fromStatus`). Throws
+ * on any failure (fail-closed).
+ */
+export async function reopenGuardianRequest(
+  id: string,
+  fromStatus: GuardianRequestStatus,
+): Promise<void> {
+  await callMutation(GUARDIAN_REQUESTS_IPC_METHODS.reopen, { id, fromStatus });
+}
+
+/**
+ * Expire a pending request (CAS pending → expired; the gateway also expires
+ * its deliveries). Throws on any failure (fail-closed).
+ */
+export async function expireGuardianRequest(id: string): Promise<void> {
+  await callMutation(GUARDIAN_REQUESTS_IPC_METHODS.expire, { id });
+}
+
+/**
+ * Daemon-boot expiry: interaction-bound kinds die with the daemon's
+ * in-memory pendingInteractions map, plus persistent kinds already past
+ * `expiresAt`. Returns the expired count. Throws on any failure
+ * (fail-closed).
+ */
+export async function expireInteractionBoundGuardianRequests(): Promise<number> {
+  const response = await callGateway(
+    GUARDIAN_REQUESTS_IPC_METHODS.expireInteractionBound,
+    {},
+    ExpireInteractionBoundIpcResponseSchema,
+  );
+  return response.expired;
+}
+
+/**
+ * Sweep persistent requests past their `expiresAt` (gateway CAS-expires;
+ * `now` defaults gateway-side). Returns the expired ids for daemon-side
+ * notification and card-withdrawal fan-out. Throws on any failure
+ * (fail-closed).
+ */
+export async function sweepExpiredGuardianRequests(
+  now?: number,
+): Promise<string[]> {
+  const response = await callGateway(
+    GUARDIAN_REQUESTS_IPC_METHODS.sweepExpired,
+    { now },
+    SweepExpiredGuardianRequestsIpcResponseSchema,
+  );
+  return response.expired;
+}
+
+/**
+ * Record a delivery of a guardian-request card to a destination. Throws on
+ * any failure (fail-closed).
+ */
+export async function createGuardianRequestDelivery(
+  params: CreateGuardianRequestDeliveryIpcParams,
+): Promise<GuardianRequestDeliveryWire> {
+  return callGateway(
+    GUARDIAN_REQUESTS_IPC_METHODS.createDelivery,
+    params as unknown as Record<string, unknown>,
+    CreateGuardianRequestDeliveryIpcResponseSchema,
+  );
+}
+
+/** Patch a delivery record. Throws on any failure (fail-closed). */
+export async function updateGuardianRequestDelivery(
+  id: string,
+  patch: UpdateGuardianRequestDeliveryIpcParams["patch"],
+): Promise<void> {
+  await callMutation(GUARDIAN_REQUESTS_IPC_METHODS.updateDelivery, {
+    id,
+    patch,
+  });
+}
+
+/** List a request's delivery records. Throws on transport failure. */
+export async function listGuardianRequestDeliveries(
+  requestId: string,
+): Promise<GuardianRequestDeliveryWire[]> {
+  return callGateway(
+    GUARDIAN_REQUESTS_IPC_METHODS.listDeliveries,
+    { requestId },
+    GuardianRequestDeliveryListIpcResponseSchema,
+  );
+}
+
+/** `listGuardianRequestDeliveries` for deny-path callers: degrades to []. */
+export const listGuardianRequestDeliveriesOrEmpty = degradeOnFailure(
+  listGuardianRequestDeliveries,
+  [],
+);
+
+/**
+ * Reaction routing: the pending request whose delivered card is the
+ * reacted-to message. Throws on transport failure.
+ */
+export async function getPendingRequestByDestinationMessage(
+  channel: string,
+  chatId: string,
+  messageId: string,
+): Promise<GuardianRequestWire | null> {
+  return callGateway(
+    GUARDIAN_REQUESTS_IPC_METHODS.getByDestinationMessage,
+    { channel, chatId, messageId },
+    GuardianRequestLookupIpcResponseSchema,
+  );
+}
+
+/** `getPendingRequestByDestinationMessage` deny-path variant: degrades to null. */
+export const getPendingRequestByDestinationMessageOrNull = degradeOnFailure(
+  getPendingRequestByDestinationMessage,
+  null,
+);
+
+/**
+ * Reply routing: pending requests delivered to a destination conversation
+ * (`conversationId`, optionally narrowed by `channel`) or chat
+ * (`channel` + `chatId`). Throws on transport failure.
+ */
+export async function listPendingRequestsByDestination(
+  params: ListPendingGuardianRequestsByDestinationIpcParams,
+): Promise<GuardianRequestWire[]> {
+  return callGateway(
+    GUARDIAN_REQUESTS_IPC_METHODS.listPendingByDestination,
+    params as unknown as Record<string, unknown>,
+    GuardianRequestListIpcResponseSchema,
+  );
+}
+
+/** `listPendingRequestsByDestination` deny-path variant: degrades to []. */
+export const listPendingRequestsByDestinationOrEmpty = degradeOnFailure(
+  listPendingRequestsByDestination,
+  [],
+);
+
+/**
+ * Pending requests sourced from OR delivered to the conversation,
+ * deduplicated, non-expired. Throws on transport failure.
+ */
+export async function listPendingRequestsByScope(
+  conversationId: string,
+  channel?: string,
+): Promise<GuardianRequestWire[]> {
+  return callGateway(
+    GUARDIAN_REQUESTS_IPC_METHODS.listPendingByScope,
+    { conversationId, channel },
+    GuardianRequestListIpcResponseSchema,
+  );
+}
+
+/** `listPendingRequestsByScope` deny-path variant: degrades to []. */
+export const listPendingRequestsByScopeOrEmpty = degradeOnFailure(
+  listPendingRequestsByScope,
+  [],
+);
+
+/**
+ * Is a decision from this conversation allowed for the request (source
+ * match, or delivery match optionally narrowed by `channel`)? Throws on
+ * transport failure.
+ */
+export async function isGuardianRequestInScope(
+  requestId: string,
+  conversationId: string,
+  channel?: string,
+): Promise<boolean> {
+  const response = await callGateway(
+    GUARDIAN_REQUESTS_IPC_METHODS.inScope,
+    { requestId, conversationId, channel },
+    GuardianRequestInScopeIpcResponseSchema,
+  );
+  return response.inScope;
+}
+
+/** `isGuardianRequestInScope` deny-path variant: degrades to false (not in scope). */
+export const isGuardianRequestInScopeOrFalse = degradeOnFailure(
+  isGuardianRequestInScope,
+  false,
+);
+
+/**
+ * Latest pending request for a live voice call session (mid-call guardian
+ * wait polling). Throws on transport failure.
+ */
+export async function getPendingRequestByCallSession(
+  callSessionId: string,
+): Promise<GuardianRequestWire | null> {
+  return callGateway(
+    GUARDIAN_REQUESTS_IPC_METHODS.getByCallSession,
+    { callSessionId },
+    GuardianRequestLookupIpcResponseSchema,
+  );
+}
+
+/** `getPendingRequestByCallSession` deny-path variant: degrades to null. */
+export const getPendingRequestByCallSessionOrNull = degradeOnFailure(
+  getPendingRequestByCallSession,
+  null,
+);
+
+/**
+ * The request carrying a specific voice pending-question id. Throws on
+ * transport failure.
+ */
+export async function getRequestByPendingQuestion(
+  pendingQuestionId: string,
+): Promise<GuardianRequestWire | null> {
+  return callGateway(
+    GUARDIAN_REQUESTS_IPC_METHODS.getByPendingQuestion,
+    { pendingQuestionId },
+    GuardianRequestLookupIpcResponseSchema,
+  );
+}
+
+/** `getRequestByPendingQuestion` deny-path variant: degrades to null. */
+export const getRequestByPendingQuestionOrNull = degradeOnFailure(
+  getRequestByPendingQuestion,
+  null,
+);


### PR DESCRIPTION
## Summary
- Adds assistant/src/channels/gateway-guardian-requests.ts: typed async wrappers for all 19 guardian_requests_* IPC methods over ipcCallPersistentValidated
- Fail postures per the plan: lifecycle writes throw fail-closed; hint/dedup reads ship OrNull/OrEmpty degrade variants for deny-path callers
- Additive only — nothing consumes the client yet

Part of plan: guardian-requests-gateway-native.md (PR 6 of 10)