### PR TITLE
feat(gateway): guardian_requests_decide — decision CAS and ACL side effects in one transaction

### DIFF
--- a/gateway/src/__tests__/guardian-request-decide.test.ts
+++ b/gateway/src/__tests__/guardian-request-decide.test.ts
@@ -1,0 +1,534 @@
+/**
+ * Tests for `decideGuardianRequest` — the atomic decision CAS + in-engine ACL
+ * outcomes (ATL-463).
+ *
+ * Runs against a real (temp-dir) gateway DB; only the assistant-side IPC
+ * boundary is mocked (identity-mirror reads and writes). Properties pinned:
+ *
+ * - each ACL outcome (verified-channel activation, unverified seed, block,
+ *   outbound-session mint) commits in the SAME transaction as the
+ *   pending→approved/denied CAS — one call, both rows;
+ * - a CAS miss returns status_conflict with ZERO side effects, so replayed
+ *   or racing decides never double-apply an outcome;
+ * - THE ATL-463 PIN: a failed outcome write rolls the CAS back — the request
+ *   stays `pending` with no partial ACL write, and a retry decide succeeds.
+ *   The crash window between "row says approved" and "ACL write landed"
+ *   cannot exist because the two are one commit;
+ * - daemon-domain kinds decide as a plain CAS (no outcome, no ACL writes);
+ * - post-commit assistant mirrors are best-effort: their failure never
+ *   disturbs the committed decision.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { and, eq } from "drizzle-orm";
+
+import { hashVerificationSecret } from "@vellumai/gateway-client";
+import type { DecideGuardianRequestIpcParams } from "@vellumai/gateway-client";
+
+import "./test-preload.js";
+
+// ---------------------------------------------------------------------------
+// Assistant-side boundary mocks (must precede the dynamic imports below)
+// ---------------------------------------------------------------------------
+
+// Identity-mirror IPC — recorded and acked; a flag turns it into a thrower to
+// model an unreachable daemon mirror.
+const mirrorCalls: { method: string; body: Record<string, unknown> }[] = [];
+let mirrorThrow = false;
+mock.module("../ipc/assistant-client.js", () => ({
+  IpcHandlerError: class IpcHandlerError extends Error {},
+  IpcTransportError: class IpcTransportError extends Error {},
+  ipcCallAssistant: async (
+    method: string,
+    params?: { body?: Record<string, unknown> },
+  ) => {
+    mirrorCalls.push({ method, body: params?.body ?? {} });
+    if (mirrorThrow) {
+      throw new Error(`assistant mirror unreachable: ${method}`);
+    }
+    return { ok: true };
+  },
+}));
+
+// Contact-info reads (daemon-backed) — no known mirror contacts by default;
+// the lookup impl is mutable so a test can induce an assistant-IPC failure.
+let lookupImpl: () => Promise<null> = async () => null;
+mock.module("../ipc/contacts-info-client.js", () => ({
+  lookupContactChannelIdentity: () => lookupImpl(),
+  probeContactMirror: async () => ({ exists: false, hasChannels: false }),
+  fetchContactsInfoBatch: async () => [],
+  listContactUserFileSlugs: async () => [],
+}));
+
+const { getGatewayDb, initGatewayDb, resetGatewayDb } =
+  await import("../db/connection.js");
+const {
+  channelVerificationSessions,
+  contactChannels,
+  contacts,
+  guardianRequestDeliveries,
+  guardianRequests,
+} = await import("../db/schema.js");
+const { createGuardianRequest } = await import("../db/guardian-request-store.js");
+const { decideGuardianRequest } = await import(
+  "../approvals/guardian-request-service.js"
+);
+const { createOutboundSession } = await import(
+  "../verification/session-service.js"
+);
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const CHANNEL = "telegram";
+const SENDER = "tg-sender-1";
+const SENDER_CHAT = "chat-100";
+
+let reqSeq = 0;
+
+function seedRequest(overrides: Record<string, unknown> = {}) {
+  return createGuardianRequest({
+    id: `req-${++reqSeq}`,
+    kind: "access_request",
+    sourceChannel: CHANNEL,
+    requesterExternalUserId: SENDER,
+    requesterChatId: SENDER_CHAT,
+    guardianPrincipalId: "principal-1",
+    ...overrides,
+  });
+}
+
+function requestRow(id: string) {
+  return getGatewayDb()
+    .select()
+    .from(guardianRequests)
+    .where(eq(guardianRequests.id, id))
+    .get();
+}
+
+function channelRows(address = SENDER) {
+  return getGatewayDb()
+    .select()
+    .from(contactChannels)
+    .where(
+      and(
+        eq(contactChannels.type, CHANNEL),
+        eq(contactChannels.address, address),
+      ),
+    )
+    .all();
+}
+
+function sessionRows() {
+  return getGatewayDb().select().from(channelVerificationSessions).all();
+}
+
+function seedGatewayChannel(status: string, opts: { role?: string } = {}) {
+  const db = getGatewayDb();
+  const now = Date.now();
+  db.insert(contacts)
+    .values({
+      id: "co-seeded",
+      displayName: "Seeded",
+      role: opts.role ?? "contact",
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+  db.insert(contactChannels)
+    .values({
+      id: "ch-seeded",
+      contactId: "co-seeded",
+      type: CHANNEL,
+      address: SENDER,
+      isPrimary: false,
+      status,
+      policy: "allow",
+      interactionCount: 0,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function activateDecision(
+  requestId: string,
+  overrides: Partial<DecideGuardianRequestIpcParams> = {},
+): DecideGuardianRequestIpcParams {
+  return {
+    id: requestId,
+    expectedStatus: "pending",
+    status: "approved",
+    decidedByPrincipalId: "principal-1",
+    aclOutcome: {
+      type: "activate_member",
+      sourceChannel: CHANNEL,
+      externalUserId: SENDER,
+      externalChatId: SENDER_CHAT,
+      displayName: "Alice",
+      verifiedVia: "manual_channel_claim",
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  mirrorCalls.length = 0;
+  mirrorThrow = false;
+  lookupImpl = async () => null;
+
+  resetGatewayDb();
+  await initGatewayDb();
+  const db = getGatewayDb();
+  db.delete(guardianRequestDeliveries).run();
+  db.delete(guardianRequests).run();
+  db.delete(channelVerificationSessions).run();
+  db.delete(contactChannels).run();
+  db.delete(contacts).run();
+});
+
+afterEach(() => {
+  resetGatewayDb();
+});
+
+// ---------------------------------------------------------------------------
+// Per-outcome success: CAS + ACL write in one call
+// ---------------------------------------------------------------------------
+
+describe("decide — per-outcome success", () => {
+  test("approve + activate_member: request approved AND channel verified in one call", async () => {
+    const request = seedRequest();
+
+    const result = await decideGuardianRequest(activateDecision(request.id));
+
+    expect(result.applied).toBe(true);
+    if (result.applied) {
+      expect(result.request.status).toBe("approved");
+      expect(result.request.decidedByPrincipalId).toBe("principal-1");
+      expect(result.mintedSession).toBeUndefined();
+    }
+    expect(requestRow(request.id)?.status).toBe("approved");
+
+    const channels = channelRows();
+    expect(channels).toHaveLength(1);
+    expect(channels[0]).toMatchObject({
+      status: "active",
+      policy: "allow",
+      verifiedVia: "manual_channel_claim",
+      externalChatId: SENDER_CHAT,
+    });
+    expect(channels[0]!.verifiedAt).toEqual(expect.any(Number));
+
+    // Post-commit identity mirror fired (identity/info only).
+    const upserts = mirrorCalls.filter(
+      (c) => c.method === "contacts_mirror_upsert_channel",
+    );
+    expect(upserts).toHaveLength(1);
+    expect(upserts[0]!.body).toMatchObject({
+      type: CHANNEL,
+      address: SENDER,
+      displayName: "Alice",
+    });
+    expect(upserts[0]!.body.status).toBeUndefined();
+  });
+
+  test("deny + seed_unverified: request denied AND sender seeded as an unverified contact", async () => {
+    const request = seedRequest();
+
+    const result = await decideGuardianRequest({
+      id: request.id,
+      expectedStatus: "pending",
+      status: "denied",
+      decidedByPrincipalId: "principal-1",
+      aclOutcome: {
+        type: "seed_unverified",
+        sourceChannel: CHANNEL,
+        externalUserId: SENDER,
+        displayName: "Alice",
+      },
+    });
+
+    expect(result.applied).toBe(true);
+    expect(requestRow(request.id)?.status).toBe("denied");
+
+    const channels = channelRows();
+    expect(channels).toHaveLength(1);
+    expect(channels[0]).toMatchObject({ status: "unverified", policy: "allow" });
+
+    const contact = getGatewayDb()
+      .select()
+      .from(contacts)
+      .where(eq(contacts.id, channels[0]!.contactId))
+      .get();
+    expect(contact).toMatchObject({ displayName: "Alice", role: "contact" });
+
+    // Post-commit full-contact mirror fired.
+    expect(
+      mirrorCalls.filter((c) => c.method === "contacts_mirror_upsert_full"),
+    ).toHaveLength(1);
+  });
+
+  test("deny + block: request denied AND channel revoked with the audit reason", async () => {
+    const request = seedRequest();
+
+    const result = await decideGuardianRequest({
+      id: request.id,
+      expectedStatus: "pending",
+      status: "denied",
+      aclOutcome: {
+        type: "block",
+        sourceChannel: CHANNEL,
+        externalUserId: SENDER,
+        reason: "introduction_block",
+      },
+    });
+
+    expect(result.applied).toBe(true);
+    expect(requestRow(request.id)?.status).toBe("denied");
+
+    const channels = channelRows();
+    expect(channels).toHaveLength(1);
+    expect(channels[0]).toMatchObject({
+      status: "revoked",
+      revokedReason: "introduction_block",
+    });
+  });
+
+  test("deny + block over an existing seeded channel revokes it in place", async () => {
+    seedGatewayChannel("unverified");
+    const request = seedRequest();
+
+    const result = await decideGuardianRequest({
+      id: request.id,
+      expectedStatus: "pending",
+      status: "denied",
+      aclOutcome: {
+        type: "block",
+        sourceChannel: CHANNEL,
+        externalUserId: SENDER,
+        reason: "introduction_block",
+      },
+    });
+
+    expect(result.applied).toBe(true);
+    const channels = channelRows();
+    expect(channels).toHaveLength(1);
+    expect(channels[0]).toMatchObject({ id: "ch-seeded", status: "revoked" });
+  });
+
+  test("approve + mint_outbound_session: session row exists and the response carries the secret", async () => {
+    const request = seedRequest();
+
+    const result = await decideGuardianRequest({
+      id: request.id,
+      expectedStatus: "pending",
+      status: "approved",
+      aclOutcome: {
+        type: "mint_outbound_session",
+        channel: CHANNEL,
+        expectedExternalUserId: SENDER,
+        expectedChatId: SENDER_CHAT,
+        identityBindingStatus: "bound",
+        destinationAddress: SENDER_CHAT,
+        verificationPurpose: "trusted_contact",
+      },
+    });
+
+    expect(result.applied).toBe(true);
+    if (!result.applied) return;
+    expect(requestRow(request.id)?.status).toBe("approved");
+
+    const minted = result.mintedSession!;
+    expect(minted.secret).toMatch(/^\d{6}$/);
+
+    const sessions = sessionRows();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      id: minted.sessionId,
+      channel: CHANNEL,
+      status: "awaiting_response",
+      expectedExternalUserId: SENDER,
+      challengeHash: hashVerificationSecret(minted.secret),
+      verificationPurpose: "trusted_contact",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CAS miss / idempotency
+// ---------------------------------------------------------------------------
+
+describe("decide — CAS conflict semantics", () => {
+  test("a pre-decided request returns status_conflict with ZERO ACL writes", async () => {
+    const request = seedRequest({ status: "denied" });
+
+    const result = await decideGuardianRequest(activateDecision(request.id));
+
+    expect(result).toEqual({ applied: false, reason: "status_conflict" });
+    expect(requestRow(request.id)?.status).toBe("denied");
+    expect(channelRows()).toHaveLength(0);
+    expect(sessionRows()).toHaveLength(0);
+    expect(mirrorCalls).toHaveLength(0);
+  });
+
+  test("idempotent re-delivery: a retried decide after success conflicts and never double-applies", async () => {
+    const request = seedRequest();
+
+    const first = await decideGuardianRequest(activateDecision(request.id));
+    expect(first.applied).toBe(true);
+    const verifiedAt = channelRows()[0]!.verifiedAt;
+
+    const replay = await decideGuardianRequest(activateDecision(request.id));
+    expect(replay).toEqual({ applied: false, reason: "status_conflict" });
+
+    // One channel row, untouched by the replay; one mirror upsert total.
+    const channels = channelRows();
+    expect(channels).toHaveLength(1);
+    expect(channels[0]!.verifiedAt).toBe(verifiedAt);
+    expect(
+      mirrorCalls.filter((c) => c.method === "contacts_mirror_upsert_channel"),
+    ).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// THE ATL-463 PIN — the crash window does not exist
+// ---------------------------------------------------------------------------
+
+describe("decide — ATL-463 crash-window closure", () => {
+  test("a failed ACL outcome rolls the whole decision back: the request stays pending, no partial write, and a retry succeeds", async () => {
+    // Induce the failure via the blocked-channel guard: the gateway refuses
+    // to activate a blocked actor, which throws inside the transaction.
+    seedGatewayChannel("blocked");
+    const request = seedRequest();
+
+    await expect(
+      decideGuardianRequest(activateDecision(request.id)),
+    ).rejects.toThrow("gateway refused the member activation");
+
+    // The CAS rolled back with the outcome: the row never says "approved"
+    // without its ACL write — there is no window, only one commit.
+    const row = requestRow(request.id);
+    expect(row?.status).toBe("pending");
+    expect(row?.decidedByPrincipalId).toBeNull();
+    expect(channelRows()[0]!.status).toBe("blocked");
+    expect(mirrorCalls).toHaveLength(0);
+
+    // The request is still decidable: once the inducement clears, the SAME
+    // decide call succeeds end-to-end (no reopen machinery required).
+    getGatewayDb()
+      .update(contactChannels)
+      .set({ status: "unverified" })
+      .where(eq(contactChannels.id, "ch-seeded"))
+      .run();
+
+    const retry = await decideGuardianRequest(activateDecision(request.id));
+    expect(retry.applied).toBe(true);
+    expect(requestRow(request.id)?.status).toBe("approved");
+    expect(channelRows()[0]!.status).toBe("active");
+  });
+
+  test("a thrown outcome write (guardian-downgrade guard on block) rolls the denial back", async () => {
+    seedGatewayChannel("active", { role: "guardian" });
+    const request = seedRequest();
+
+    await expect(
+      decideGuardianRequest({
+        id: request.id,
+        expectedStatus: "pending",
+        status: "denied",
+        aclOutcome: {
+          type: "block",
+          sourceChannel: CHANNEL,
+          externalUserId: SENDER,
+          reason: "introduction_block",
+        },
+      }),
+    ).rejects.toThrow("Cannot downgrade a guardian channel");
+
+    expect(requestRow(request.id)?.status).toBe("pending");
+    expect(channelRows()[0]!.status).toBe("active");
+  });
+
+  test("a conflicted outbound-session mint rolls the approval back", async () => {
+    // A guarded mint (ifNoneActive) against a channel that already has an
+    // active session conflicts — the approval must not commit codeless.
+    const existing = createOutboundSession({
+      channel: CHANNEL,
+      expectedExternalUserId: "someone-else",
+      verificationPurpose: "trusted_contact",
+    });
+    const request = seedRequest();
+
+    await expect(
+      decideGuardianRequest({
+        id: request.id,
+        expectedStatus: "pending",
+        status: "approved",
+        aclOutcome: {
+          type: "mint_outbound_session",
+          channel: CHANNEL,
+          expectedExternalUserId: SENDER,
+          verificationPurpose: "trusted_contact",
+          ifNoneActive: true,
+        },
+      }),
+    ).rejects.toThrow("outbound session mint conflicted");
+
+    expect(requestRow(request.id)?.status).toBe("pending");
+    const sessions = sessionRows();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]!.id).toBe(existing.sessionId);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Plain CAS (daemon-domain kinds) + mirror posture
+// ---------------------------------------------------------------------------
+
+describe("decide — without an outcome and mirror posture", () => {
+  test("daemon-domain kinds decide as a plain CAS with no ACL writes", async () => {
+    const request = seedRequest({ kind: "tool_approval", toolName: "bash" });
+
+    const result = await decideGuardianRequest({
+      id: request.id,
+      expectedStatus: "pending",
+      status: "approved",
+      answerText: "yes",
+      decidedByPrincipalId: "principal-1",
+    });
+
+    expect(result.applied).toBe(true);
+    const row = requestRow(request.id);
+    expect(row?.status).toBe("approved");
+    expect(row?.answerText).toBe("yes");
+    expect(channelRows()).toHaveLength(0);
+    expect(sessionRows()).toHaveLength(0);
+    expect(mirrorCalls).toHaveLength(0);
+  });
+
+  test("a post-commit mirror failure does not disturb the committed decision", async () => {
+    mirrorThrow = true;
+    const request = seedRequest();
+
+    const result = await decideGuardianRequest(activateDecision(request.id));
+
+    expect(result.applied).toBe(true);
+    expect(requestRow(request.id)?.status).toBe("approved");
+    expect(channelRows()[0]!.status).toBe("active");
+  });
+
+  test("a failed pre-transaction mirror lookup degrades to gateway-only activation", async () => {
+    lookupImpl = async () => {
+      throw new Error("identity lookup IPC failed");
+    };
+    const request = seedRequest();
+
+    const result = await decideGuardianRequest(activateDecision(request.id));
+
+    expect(result.applied).toBe(true);
+    expect(requestRow(request.id)?.status).toBe("approved");
+    expect(channelRows()[0]!.status).toBe("active");
+  });
+});

--- a/gateway/src/approvals/guardian-request-service.ts
+++ b/gateway/src/approvals/guardian-request-service.ts
@@ -11,14 +11,23 @@
  * when a decisionable kind lacks `guardianPrincipalId`; the create IPC schema
  * enforces the same invariant at the boundary.
  *
- * The decision path (`guardian_requests_decide`) is not part of this
- * surface.
+ * `decideGuardianRequest` commits the pending→approved/denied status CAS and
+ * the decision's ACL side effect (verified-channel activation, unverified
+ * contact seed, channel block, or outbound-session mint) in ONE gateway
+ * transaction: a crash or failed outcome write can never leave an approved
+ * request without its ACL write — the outcome throw rolls the CAS back and
+ * the request stays pending and retryable. Assistant info-mirrors run
+ * post-commit, best-effort.
  */
 
 import type {
   CreateGuardianRequestDeliveryIpcParams,
   CreateGuardianRequestIpcParams,
+  CreateOutboundSessionIpcResponse,
+  DecideGuardianRequestIpcParams,
+  DecideGuardianRequestIpcResponse,
   ExpireInteractionBoundIpcResponse,
+  GuardianRequestAclOutcome,
   GuardianRequestDeliveryWire,
   GuardianRequestPatch,
   GuardianRequestStatus,
@@ -29,6 +38,8 @@ import type {
   UpdateGuardianRequestDeliveryIpcParams,
 } from "@vellumai/gateway-client";
 
+import { getGatewayDb } from "../db/connection.js";
+import { ContactStore } from "../db/contact-store.js";
 import type { GuardianRequest } from "../db/guardian-request-store.js";
 import {
   createDelivery,
@@ -52,6 +63,19 @@ import {
   updateDelivery,
   updateGuardianRequest as storeUpdateGuardianRequest,
 } from "../db/guardian-request-store.js";
+import { getLogger } from "../logger.js";
+import {
+  applyVerifiedChannelGatewayWrites,
+  findContactChannelByAddress,
+  mirrorVerifiedChannel,
+} from "../verification/contact-helpers.js";
+import { canonicalizeInboundIdentity } from "../verification/identity.js";
+import { createOutboundSessionGuarded } from "../verification/session-service.js";
+
+const log = getLogger("guardian-request-service");
+
+// Stateless facade over the gateway DB (the connection resolves per call).
+const contactStore = new ContactStore();
 
 /** Map a store row onto the wire DTO by computing `sourceType`. */
 export function toGuardianRequestWire(
@@ -214,4 +238,275 @@ export function getRequestByPendingQuestion(
   pendingQuestionId: string,
 ): GuardianRequestWire | null {
   return toWireOrNull(getByPendingQuestionId(pendingQuestionId));
+}
+
+// ---------------------------------------------------------------------------
+// Decide — status CAS + ACL outcome in one transaction
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when a decision's ACL outcome cannot be applied. Raised inside the
+ * decide transaction, so the status CAS rolls back with it — the request
+ * stays `pending` and the guardian can decide again. The IPC error envelope
+ * mirrors `statusCode`/`code`.
+ */
+export class GuardianRequestOutcomeError extends Error {
+  readonly statusCode = 409;
+  readonly code = "acl_outcome_failed";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "GuardianRequestOutcomeError";
+  }
+}
+
+/** Gateway writes applied for an ACL outcome inside the decide transaction. */
+interface OutcomeGatewayWrites {
+  mintedSession?: CreateOutboundSessionIpcResponse;
+  /** Post-commit assistant info-mirror (best-effort; run by the caller). */
+  postCommit?: () => Promise<void>;
+}
+
+type ActivateMemberOutcome = Extract<
+  GuardianRequestAclOutcome,
+  { type: "activate_member" }
+>;
+
+type ContactSeedOutcome = Pick<
+  Extract<GuardianRequestAclOutcome, { type: "seed_unverified" }>,
+  "sourceChannel" | "externalUserId" | "displayName"
+>;
+
+/**
+ * Decide a pending guardian request: the pending→approved/denied CAS and the
+ * optional ACL outcome commit in ONE gateway transaction (invariant 1 of the
+ * gateway-native plan — the ATL-463 crash window between "row says approved"
+ * and "ACL write landed" cannot exist). A CAS miss returns `status_conflict`
+ * with zero side effects; a thrown outcome write rolls the CAS back, leaving
+ * the request pending and retryable. Assistant info-mirrors run post-commit,
+ * best-effort — a mirror failure never disturbs the committed decision.
+ */
+export async function decideGuardianRequest(
+  params: DecideGuardianRequestIpcParams,
+): Promise<DecideGuardianRequestIpcResponse> {
+  const outcome = params.aclOutcome;
+
+  // The assistant-mirror identity lookup is async IPC, so it runs before the
+  // transaction (bun:sqlite transactions are synchronous). Best-effort: a
+  // failed lookup degrades to gateway-only resolution by logical key.
+  const existingMirrorChannel =
+    outcome?.type === "activate_member"
+      ? await lookupActivationMirrorChannel(outcome)
+      : null;
+
+  const txn = getGatewayDb().transaction(() => {
+    const cas = resolveGuardianRequest(params.id, params.expectedStatus, {
+      status: params.status,
+      answerText: params.answerText,
+      decidedByExternalUserId: params.decidedByExternalUserId,
+      decidedByPrincipalId: params.decidedByPrincipalId,
+    });
+    if (!cas.applied) {
+      return { applied: false as const };
+    }
+
+    const writes = outcome
+      ? applyAclOutcomeGatewayWrites(outcome, existingMirrorChannel)
+      : undefined;
+
+    return {
+      applied: true as const,
+      request: cas.request,
+      mintedSession: writes?.mintedSession,
+      postCommit: writes?.postCommit,
+    };
+  });
+
+  if (!txn.applied) {
+    return { applied: false, reason: "status_conflict" };
+  }
+
+  if (txn.postCommit) {
+    try {
+      await txn.postCommit();
+    } catch (err) {
+      log.warn(
+        { err, requestId: params.id },
+        "Guardian-request decide: post-commit assistant mirror failed (best-effort); the committed decision stands",
+      );
+    }
+  }
+
+  return {
+    applied: true,
+    request: toGuardianRequestWire(txn.request),
+    ...(txn.mintedSession ? { mintedSession: txn.mintedSession } : {}),
+  };
+}
+
+/**
+ * Pre-transaction identity read for the activation outcome: the existing
+ * assistant-mirror channel (id + parent contact) for the (type, address) key,
+ * or null when absent/unreachable — the gateway pre-check owns the ACL
+ * decision either way.
+ */
+async function lookupActivationMirrorChannel(
+  outcome: ActivateMemberOutcome,
+): Promise<{ channelId: string; contactId: string } | null> {
+  const identity = outcome.externalUserId ?? outcome.externalChatId;
+  if (!identity) {
+    return null;
+  }
+  const address =
+    canonicalizeInboundIdentity(outcome.sourceChannel, identity) ?? identity;
+  try {
+    const channel = await findContactChannelByAddress(
+      outcome.sourceChannel,
+      address,
+    );
+    return channel
+      ? { channelId: channel.channelId, contactId: channel.contactId }
+      : null;
+  } catch (err) {
+    log.warn(
+      { err, sourceChannel: outcome.sourceChannel },
+      "Assistant mirror lookup failed; resolving activation gateway-only",
+    );
+    return null;
+  }
+}
+
+/**
+ * Apply the outcome's gateway writes synchronously (inside the decide
+ * transaction). Throws {@link GuardianRequestOutcomeError} — or a typed
+ * store error like the guardian-downgrade guard — when the outcome cannot
+ * land, rolling back the decision CAS.
+ */
+function applyAclOutcomeGatewayWrites(
+  outcome: GuardianRequestAclOutcome,
+  existingMirrorChannel: { channelId: string; contactId: string } | null,
+): OutcomeGatewayWrites {
+  switch (outcome.type) {
+    case "activate_member":
+      return applyActivateMemberOutcome(outcome, existingMirrorChannel);
+    case "seed_unverified":
+      return applyContactSeedOutcome(outcome);
+    case "block":
+      return applyBlockOutcome(outcome);
+    case "mint_outbound_session": {
+      const { type: _type, ...mintParams } = outcome;
+      const minted = createOutboundSessionGuarded(mintParams);
+      if ("conflict" in minted) {
+        throw new GuardianRequestOutcomeError(
+          `outbound session mint conflicted: ${minted.reason}`,
+        );
+      }
+      return { mintedSession: minted };
+    }
+  }
+}
+
+/**
+ * Verified-channel activation (approve → trusted contact / voice caller).
+ * Address and chat id backfill each other, `verifiedVia` defaults to
+ * "invite", and revoked members may be reactivated; blocked actors are
+ * refused by the gateway guard, and that refusal throws here, rolling back
+ * the approval.
+ */
+function applyActivateMemberOutcome(
+  outcome: ActivateMemberOutcome,
+  existingMirrorChannel: { channelId: string; contactId: string } | null,
+): OutcomeGatewayWrites {
+  const address = outcome.externalUserId ?? outcome.externalChatId;
+  const externalChatId = outcome.externalChatId ?? outcome.externalUserId;
+  if (!address || !externalChatId) {
+    throw new GuardianRequestOutcomeError(
+      "activate_member outcome carries no channel identity (externalUserId or externalChatId required)",
+    );
+  }
+
+  const result = applyVerifiedChannelGatewayWrites({
+    sourceChannel: outcome.sourceChannel,
+    externalUserId: address,
+    externalChatId,
+    displayName: outcome.displayName,
+    username: outcome.username,
+    verifiedVia: outcome.verifiedVia ?? "invite",
+    contactId: outcome.contactId,
+    allowRevokedReactivation: true,
+    existingMirrorChannel,
+  });
+  if (!result.verified) {
+    throw new GuardianRequestOutcomeError(
+      "gateway refused the member activation (channel blocked)",
+    );
+  }
+
+  return { postCommit: () => mirrorVerifiedChannel(result.mirror) };
+}
+
+/**
+ * Unverified contact seed (deny → leave_unverified). A brand-new channel
+ * lands at status `unverified`; an existing channel's status is preserved,
+ * so a blocked/revoked/active row is never reactivated or downgraded.
+ */
+function applyContactSeedOutcome(
+  outcome: ContactSeedOutcome,
+): OutcomeGatewayWrites & { contactId: string; canonicalAddress: string } {
+  const store = contactStore;
+  const canonicalAddress =
+    canonicalizeInboundIdentity(outcome.sourceChannel, outcome.externalUserId) ??
+    outcome.externalUserId.trim();
+
+  const { contactId, mirrorParams } = store.upsertContactGatewayWrites({
+    displayName: outcome.displayName,
+    channels: [
+      {
+        type: outcome.sourceChannel,
+        address: canonicalAddress,
+        isPrimary: true,
+      },
+    ],
+  });
+
+  return {
+    contactId,
+    canonicalAddress,
+    postCommit: () => store.mirrorContactUpsertBestEffort(contactId, mirrorParams),
+  };
+}
+
+/**
+ * Channel block (deny → block): seed the contact/channel row, then mark it
+ * revoked so future inbound from the sender resolves as `unknown`.
+ * Idempotent: an already-revoked/blocked row is a no-op success; the
+ * guardian-downgrade guard throws, rolling back the denial.
+ */
+function applyBlockOutcome(
+  outcome: Extract<GuardianRequestAclOutcome, { type: "block" }>,
+): OutcomeGatewayWrites {
+  const seeded = applyContactSeedOutcome(outcome);
+
+  const store = contactStore;
+  const channel = store
+    .getChannelsForContact(seeded.contactId)
+    .find(
+      (ch) =>
+        ch.type === outcome.sourceChannel &&
+        ch.address.toLowerCase() === seeded.canonicalAddress.toLowerCase(),
+    );
+  if (!channel) {
+    throw new GuardianRequestOutcomeError(
+      "block outcome produced no gateway channel row to revoke",
+    );
+  }
+
+  const revoked = store.markChannelRevokedById(channel.id, outcome.reason);
+  if (!revoked) {
+    throw new GuardianRequestOutcomeError(
+      "block outcome: gateway channel row missing at revoke",
+    );
+  }
+
+  return { postCommit: seeded.postCommit };
 }

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -240,9 +240,7 @@ export class ContactStore {
    * by channel `id`. Empty input → empty map. Contacts/channels absent from the
    * gateway are simply absent from the map (the caller leaves them untouched).
    */
-  async getAclByContactIds(
-    ids: string[],
-  ): Promise<Map<string, ContactAcl>> {
+  async getAclByContactIds(ids: string[]): Promise<Map<string, ContactAcl>> {
     const result = new Map<string, ContactAcl>();
     if (ids.length === 0) return result;
 
@@ -1180,13 +1178,15 @@ export class ContactStore {
     // gateway DB — the just-written source of truth — and overlay assistant-
     // owned info. The assistant mirror would report stale unverified/allow/
     // contact defaults for fresh creates.
-    const fullContact = await this.getContactWithInfo(contactId).catch((err) => {
-      log.warn(
-        { contactId, err },
-        "upsertContact: gateway read-back failed; returning gateway fallback",
-      );
-      return null;
-    });
+    const fullContact = await this.getContactWithInfo(contactId).catch(
+      (err) => {
+        log.warn(
+          { contactId, err },
+          "upsertContact: gateway read-back failed; returning gateway fallback",
+        );
+        return null;
+      },
+    );
 
     if (fullContact) {
       return { contact: fullContact, created };
@@ -1704,7 +1704,6 @@ export class ContactStore {
     }
     return `${slug}-${crypto.randomUUID().slice(0, 8)}.md`;
   }
-
 }
 
 // ---------------------------------------------------------------------------

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -789,7 +789,9 @@ export class ContactStore {
       .from(contactChannels)
       .where(eq(contactChannels.id, gwChannelId))
       .get();
-    if (!channel) return null;
+    if (!channel) {
+      return null;
+    }
 
     const contact = this.getContact(channel.contactId);
     if (
@@ -836,7 +838,9 @@ export class ContactStore {
       .from(contactChannels)
       .where(eq(contactChannels.id, gwChannelId))
       .get();
-    if (!after) return null;
+    if (!after) {
+      return null;
+    }
 
     return { channel: after, didWrite: true };
   }

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -770,7 +770,26 @@ export class ContactStore {
     // returns null.
     const channel = await this.resolveGatewayChannel(channelId);
     if (!channel) return null;
-    const gwChannelId = channel.id;
+    return this.markChannelRevokedById(channel.id, reason);
+  }
+
+  /**
+   * Synchronous core of {@link markChannelRevoked}, keyed on an
+   * already-resolved GATEWAY channel id (no assistant-side id fallback) —
+   * plain statements over the gateway DB, composable inside a caller-owned
+   * transaction. Same guards: guardian downgrade rejection, blocked no-op,
+   * idempotent re-revoke.
+   */
+  markChannelRevokedById(
+    gwChannelId: string,
+    reason?: string,
+  ): { channel: ContactChannel; didWrite: boolean } | null {
+    const channel = this.db
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, gwChannelId))
+      .get();
+    if (!channel) return null;
 
     const contact = this.getContact(channel.contactId);
     if (
@@ -778,10 +797,10 @@ export class ContactStore {
       reason !== GUARDIAN_BINDING_REVOKE_REASON
     ) {
       log.warn(
-        { channelId, reason },
+        { channelId: gwChannelId, reason },
         "markChannelRevoked: rejected guardian channel downgrade",
       );
-      throw new CannotDowngradeGuardianError(channelId);
+      throw new CannotDowngradeGuardianError(gwChannelId);
     }
 
     // A blocked channel stays blocked: blocked is stricter than revoked, and
@@ -1146,6 +1165,69 @@ export class ContactStore {
       blockedReason?: string | null;
     }>;
   }): Promise<{ contact: ContactWithInfo; created: boolean }> {
+    const { contactId, created, mirrorParams } =
+      this.upsertContactGatewayWrites(params);
+
+    // ── Mirror to assistant DB (best-effort typed op) ──────────────────
+    await this.mirrorContactUpsertBestEffort(contactId, mirrorParams);
+
+    // ── Read back full contact shape (best-effort) ─────────────────────
+    // Source ACL (role/principalId, channel status/policy/verified_*) from the
+    // gateway DB — the just-written source of truth — and overlay assistant-
+    // owned info. The assistant mirror would report stale unverified/allow/
+    // contact defaults for fresh creates.
+    const fullContact = await this.getContactWithInfo(contactId).catch((err) => {
+      log.warn(
+        { contactId, err },
+        "upsertContact: gateway read-back failed; returning gateway fallback",
+      );
+      return null;
+    });
+
+    if (fullContact) {
+      return { contact: fullContact, created };
+    }
+
+    // Fallback: synthesize from gateway row + provided params.
+    const gatewayRow = this.db
+      .select()
+      .from(contacts)
+      .where(eq(contacts.id, contactId))
+      .get()!;
+    return {
+      contact: {
+        id: gatewayRow.id,
+        displayName: gatewayRow.displayName,
+        role: gatewayRow.role,
+        principalId: gatewayRow.principalId,
+        notes: params.notes ?? null,
+        contactType: params.contactType ?? "human",
+        userFile: null,
+        createdAt: gatewayRow.createdAt,
+        updatedAt: gatewayRow.updatedAt,
+        interactionCount: 0,
+        lastInteraction: null,
+        channels: [],
+        assistantMetadata: null,
+      },
+      created,
+    };
+  }
+
+  /**
+   * Synchronous gateway-DB core of {@link upsertContact}: contact resolution
+   * (explicit id → channel logical key → create) plus channel sync, as plain
+   * statements with no assistant IO — composable inside a caller-owned
+   * transaction. `mirrorParams` is the canonicalized input for the
+   * post-commit {@link mirrorContactUpsertBestEffort}.
+   */
+  upsertContactGatewayWrites(
+    params: Parameters<ContactStore["upsertContact"]>[0],
+  ): {
+    contactId: string;
+    created: boolean;
+    mirrorParams: Parameters<ContactStore["upsertContact"]>[0];
+  } {
     const now = Date.now();
     let contactId = params.id;
     let created = false;
@@ -1248,12 +1330,23 @@ export class ContactStore {
       this.syncChannels(contactId, canonicalChannels, now);
     }
 
-    // ── 5. Mirror to assistant DB (best-effort typed op) ──────────────
-    const canonicalParams = canonicalChannels
+    const mirrorParams = canonicalChannels
       ? { ...params, channels: canonicalChannels }
       : params;
+    return { contactId, created, mirrorParams };
+  }
+
+  /**
+   * Best-effort assistant-DB mirror for a committed gateway contact upsert.
+   * Failures are logged (a daemon missing the typed op escalates via the
+   * watchdog reporter) and never thrown.
+   */
+  async mirrorContactUpsertBestEffort(
+    contactId: string,
+    params: Parameters<ContactStore["upsertContact"]>[0],
+  ): Promise<void> {
     try {
-      await this.mirrorContactToAssistantDb(contactId, canonicalParams);
+      await this.mirrorContactToAssistantDb(contactId, params);
     } catch (err) {
       // Unknown method = old daemon without the typed op: the gateway write
       // stands with no mirror and no fallback — escalate loudly.
@@ -1266,48 +1359,6 @@ export class ContactStore {
         );
       }
     }
-
-    // ── 6. Read back full contact shape (best-effort) ─────────────────
-    // Source ACL (role/principalId, channel status/policy/verified_*) from the
-    // gateway DB — the just-written source of truth — and overlay assistant-
-    // owned info. The assistant mirror would report stale unverified/allow/
-    // contact defaults for fresh creates.
-    const fullContact = await this.getContactWithInfo(contactId).catch((err) => {
-      log.warn(
-        { contactId, err },
-        "upsertContact: gateway read-back failed; returning gateway fallback",
-      );
-      return null;
-    });
-
-    if (fullContact) {
-      return { contact: fullContact, created };
-    }
-
-    // Fallback: synthesize from gateway row + provided params.
-    const gatewayRow = this.db
-      .select()
-      .from(contacts)
-      .where(eq(contacts.id, contactId))
-      .get()!;
-    return {
-      contact: {
-        id: gatewayRow.id,
-        displayName: gatewayRow.displayName,
-        role: gatewayRow.role,
-        principalId: gatewayRow.principalId,
-        notes: params.notes ?? null,
-        contactType: params.contactType ?? "human",
-        userFile: null,
-        createdAt: gatewayRow.createdAt,
-        updatedAt: gatewayRow.updatedAt,
-        interactionCount: 0,
-        lastInteraction: null,
-        channels: [],
-        assistantMetadata: null,
-      },
-      created,
-    };
   }
 
   /**

--- a/gateway/src/ipc/__tests__/guardian-request-routes.test.ts
+++ b/gateway/src/ipc/__tests__/guardian-request-routes.test.ts
@@ -6,8 +6,9 @@
  * relay hits them: schema validation on the server, guardian-request-store
  * writes, and wire-shaped responses pinned by the shared contract.
  *
- * `guardian_requests_decide` is asserted ABSENT (unknown method): decisions
- * are not part of this route set.
+ * `guardian_requests_decide` is exercised here as a plain status CAS (no
+ * `aclOutcome`); outcome side effects and the rollback contract are pinned in
+ * `gateway/src/__tests__/guardian-request-decide.test.ts`.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -17,6 +18,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  DecideGuardianRequestIpcResponseSchema,
   GUARDIAN_REQUESTS_IPC_METHODS,
   GuardianRequestDeliveryListIpcResponseSchema,
   GuardianRequestDeliverySchema,
@@ -140,25 +142,57 @@ afterEach(() => {
 });
 
 describe("route registration", () => {
-  test("registers every contract method except decide, each with a schema", () => {
-    const expected = Object.values(METHODS)
-      .filter((m) => m !== METHODS.decide)
-      .sort();
+  test("registers every contract method, each with a schema", () => {
+    const expected = Object.values(METHODS).sort();
     expect(guardianRequestRoutes.map((r) => r.method).sort()).toEqual(expected);
     for (const route of guardianRequestRoutes) {
       expect(route.schema).toBeDefined();
     }
   });
+});
 
-  test("guardian_requests_decide is not registered (unknown method)", async () => {
-    const res = await rpc(METHODS.decide, {
-      id: "req-x",
+describe("guardian_requests_decide", () => {
+  test("plain CAS decide resolves the request and stamps the decision fields", async () => {
+    const created = await createRequest({ kind: "tool_approval", toolName: "bash" });
+
+    const decided = DecideGuardianRequestIpcResponseSchema.parse(
+      await call(METHODS.decide, {
+        id: created.id,
+        expectedStatus: "pending",
+        status: "approved",
+        answerText: "yes",
+        decidedByPrincipalId: "principal-1",
+      }),
+    );
+    expect(decided.applied).toBe(true);
+    if (decided.applied) {
+      expect(decided.request.status).toBe("approved");
+      expect(decided.request.answerText).toBe("yes");
+      expect(decided.mintedSession).toBeUndefined();
+    }
+
+    const row = getRequestRow(created.id);
+    expect(row?.status).toBe("approved");
+    expect(row?.decidedByPrincipalId).toBe("principal-1");
+  });
+
+  test("a second decide loses the CAS: status_conflict, row untouched", async () => {
+    const created = await createRequest({ kind: "tool_approval", toolName: "bash" });
+    await call(METHODS.decide, {
+      id: created.id,
       expectedStatus: "pending",
       status: "approved",
     });
-    expect(res.statusCode).toBe(404);
-    expect(res.errorCode).toBe("UNKNOWN_METHOD");
-    expect(String(res.error)).toContain("Unknown method");
+
+    const replay = DecideGuardianRequestIpcResponseSchema.parse(
+      await call(METHODS.decide, {
+        id: created.id,
+        expectedStatus: "pending",
+        status: "denied",
+      }),
+    );
+    expect(replay).toEqual({ applied: false, reason: "status_conflict" });
+    expect(getRequestRow(created.id)?.status).toBe("approved");
   });
 });
 
@@ -672,6 +706,26 @@ describe("schema rejection", () => {
       [METHODS.list, { sourceType: "carrier-pigeon" }],
       [METHODS.update, { id: "req-x" }], // patch required
       [METHODS.update, { id: "req-x", patch: { status: "not-a-status" } }],
+      [METHODS.decide, { id: "req-x", status: "approved" }], // expectedStatus required
+      [
+        METHODS.decide,
+        { id: "req-x", expectedStatus: "pending", status: "expired" },
+      ], // decisions resolve to approved/denied only
+      [
+        // The outcome type must agree with the decision status: seeding pairs
+        // with denial, never approval.
+        METHODS.decide,
+        {
+          id: "req-x",
+          expectedStatus: "pending",
+          status: "approved",
+          aclOutcome: {
+            type: "seed_unverified",
+            sourceChannel: "telegram",
+            externalUserId: "tg-1",
+          },
+        },
+      ],
       [METHODS.reopen, { id: "req-x" }], // fromStatus required
       [METHODS.expire, {}],
       [METHODS.sweepExpired, { now: "yesterday" }],

--- a/gateway/src/ipc/guardian-request-handlers.ts
+++ b/gateway/src/ipc/guardian-request-handlers.ts
@@ -9,13 +9,14 @@
  * return the wire DTO (or null / an array); mutations return a minimal
  * `{ ok: true }` ack.
  *
- * `guardian_requests_decide` (decision CAS + in-transaction ACL outcomes) is
- * not registered here.
+ * `guardian_requests_decide` commits the decision CAS and the ACL outcome in
+ * one gateway transaction (see `decideGuardianRequest`).
  */
 
 import {
   CreateGuardianRequestDeliveryIpcParamsSchema,
   CreateGuardianRequestIpcParamsSchema,
+  DecideGuardianRequestIpcParamsSchema,
   ExpireGuardianRequestIpcParamsSchema,
   ExpireInteractionBoundIpcParamsSchema,
   GUARDIAN_REQUESTS_IPC_METHODS,
@@ -39,6 +40,7 @@ import { z } from "zod";
 import {
   createGuardianRequest,
   createGuardianRequestDelivery,
+  decideGuardianRequest,
   expireGuardianRequest,
   expireInteractionBoundRequests,
   getGuardianRequest,
@@ -120,6 +122,17 @@ export const guardianRequestRoutes: IpcRoute[] = [
       const { id, patch } = UpdateGuardianRequestIpcParamsSchema.parse(params);
       updateGuardianRequest(id, patch);
       return { ok: true };
+    },
+  },
+  {
+    // Decision CAS + ACL outcome in ONE gateway transaction; a CAS miss
+    // returns status_conflict with zero side effects, a failed outcome write
+    // rolls the CAS back (request stays pending, retryable).
+    method: GUARDIAN_REQUESTS_IPC_METHODS.decide,
+    schema: DecideGuardianRequestIpcParamsSchema,
+    handler: async (params?: Record<string, unknown>) => {
+      const input = DecideGuardianRequestIpcParamsSchema.parse(params);
+      return decideGuardianRequest(input);
     },
   },
   {

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -457,6 +457,253 @@ export function getGatewayChannelByExternalChatId(
 // ---------------------------------------------------------------------------
 
 /**
+ * Assistant-mirror upsert produced by {@link applyVerifiedChannelGatewayWrites}
+ * and executed post-commit by {@link mirrorVerifiedChannel}. Carries
+ * identity/info fields only — ACL columns are gateway-owned.
+ */
+export interface VerifiedChannelMirrorPlan {
+  contactId: string;
+  /** Present when the gateway minted the channel id (create path); the mirror adopts it. */
+  channelId?: string;
+  type: string;
+  address: string;
+  externalChatId: string;
+  displayName: string;
+  reassignConflictingChannels: boolean;
+}
+
+export type VerifiedChannelGatewayResult =
+  | { verified: false }
+  | { verified: true; mirror: VerifiedChannelMirrorPlan };
+
+/**
+ * Synchronous gateway-DB writes for a verified contact channel — plain
+ * statements over the gateway DB, no assistant IO, so callers can compose it
+ * inside a single SQLite transaction (e.g. atomically with a guardian-request
+ * decision CAS). The caller owns the transaction boundary and any post-commit
+ * mirror via the returned plan.
+ *
+ * `existingMirrorChannel` is the pre-resolved assistant-mirror identity for
+ * the (type, address) key (id + parent contact), or null when the mirror has
+ * no row / is unreachable — the ACL/status decision is owned by the gateway
+ * pre-check here either way.
+ *
+ * Returns `{ verified: false }` when the authoritative gateway row is
+ * blocked/revoked (nothing written). A thrown gateway write propagates so a
+ * transactional caller rolls back.
+ */
+export function applyVerifiedChannelGatewayWrites(params: {
+  sourceChannel: string;
+  externalUserId: string;
+  externalChatId: string;
+  displayName?: string;
+  username?: string;
+  verifiedVia?: string;
+  contactId?: string;
+  allowRevokedReactivation?: boolean;
+  existingMirrorChannel: { channelId: string; contactId: string } | null;
+}): VerifiedChannelGatewayResult {
+  const now = Date.now();
+  const {
+    sourceChannel,
+    externalChatId,
+    displayName,
+    username,
+    contactId: targetContactId,
+    allowRevokedReactivation,
+    existingMirrorChannel: existing,
+  } = params;
+  const verifiedVia = params.verifiedVia ?? "challenge";
+
+  const address =
+    canonicalizeInboundIdentity(sourceChannel, params.externalUserId) ??
+    params.externalUserId;
+  const contactDisplayName = displayName ?? username ?? address;
+
+  // The gateway is the source of truth: a blocked/revoked gateway row rejects
+  // the verification, gating BOTH the existing-channel update and the
+  // new-insert path so no active mirror is created for a blocked actor. A
+  // missing gateway row is the legitimate happy path (legacy/unmirrored).
+  const gwStatus = gatewayChannelStatus(sourceChannel, address);
+  if (
+    gwStatus === "blocked" ||
+    (gwStatus === "revoked" && !allowRevokedReactivation)
+  ) {
+    log.warn(
+      { sourceChannel, address, status: gwStatus },
+      "Skipping upsert: authoritative gateway channel is blocked or revoked",
+    );
+    return { verified: false };
+  }
+
+  if (existing) {
+    const row = existing;
+
+    // The block/revoke decision is owned by the authoritative gateway row,
+    // already gated above. The assistant mirror's status is not consulted: it
+    // can lag the gateway (e.g. a gateway reactivation leaves a stale revoked
+    // mirror), and gating on it would falsely reject a gateway-active channel.
+
+    // Bind to the invite's target contact when supplied: an invite can attach a
+    // redeemer's existing channel to a different contact, so reassign the
+    // channel's gateway parent here; the assistant mirror re-parent lands with
+    // the post-commit activation upsert.
+    const boundContactId =
+      targetContactId && targetContactId !== row.contactId
+        ? targetContactId
+        : row.contactId;
+    // The gateway reparents the channel only on a genuine target-contact bind;
+    // the mirror must mirror THAT decision (not the call path) so the two stores
+    // never disagree about channel ownership.
+    const gatewayReparented = boundContactId !== row.contactId;
+    if (gatewayReparented) {
+      reassignChannelContact({
+        type: sourceChannel,
+        address,
+        toContactId: boundContactId,
+        displayName: contactDisplayName,
+        now,
+      });
+    }
+
+    // The assistant channel id may not exist in the gateway DB
+    // (legacy/unmirrored) or live under a different gateway UUID, so the
+    // helper resolves by logical key.
+    const wrote = writeVerifiedGatewayChannel({
+      assistantChannelId: row.channelId,
+      contactId: boundContactId,
+      type: sourceChannel,
+      address,
+      externalChatId,
+      verifiedVia,
+      now,
+      allowRevokedReactivation,
+    });
+    // The pre-check passed, so a write is expected. A false means a
+    // blocked/revoked row appeared between the pre-check and the write —
+    // reject WITHOUT activating the assistant mirror so a blocked actor is
+    // never left active locally.
+    if (!wrote) {
+      log.warn(
+        { sourceChannel, address },
+        "Gateway write ignored after pre-check: channel became blocked/revoked",
+      );
+      return { verified: false };
+    }
+
+    return {
+      verified: true,
+      mirror: {
+        contactId: boundContactId,
+        type: sourceChannel,
+        address,
+        externalChatId,
+        displayName: contactDisplayName,
+        reassignConflictingChannels: gatewayReparented,
+      },
+    };
+  }
+
+  // No existing mirror channel: create contact + channel. Bind to the
+  // invite's target contact when supplied so the new channel lands under it.
+  const contactId = targetContactId ?? crypto.randomUUID();
+  const channelId = crypto.randomUUID();
+  // Gateway reparents a raced (type,address) row only on a target-contact bind
+  // (reassignChannelContact below). Plain verification with no target leaves any
+  // raced seed row under its seed contact (writeVerifiedGatewayChannel omits
+  // contactId), so the mirror must NOT reparent either or the stores disagree.
+  const gatewayReparented = Boolean(targetContactId);
+
+  // The parent contact is conflict-tolerant (a pre-existing contact is fine).
+  // For the channel, resolve by logical key so an existing non-blocked gateway
+  // row (e.g. a gateway-created unverified contact) is UPDATED to active/verified
+  // rather than silently no-op'd by the (type,address) unique index.
+  if (targetContactId) {
+    // The assistant mirror missed, but the gateway may already hold this
+    // (type,address) row under a different contact. Re-parent it to the
+    // target by logical key (writeVerifiedGatewayChannel's update set omits
+    // contactId), so the gateway source of truth lands under the invite's
+    // contact. No-ops when no gateway row exists.
+    reassignChannelContact({
+      type: sourceChannel,
+      address,
+      toContactId: contactId,
+      displayName: contactDisplayName,
+      now,
+    });
+  } else {
+    getGatewayDb()
+      .insert(gwContacts)
+      .values({
+        id: contactId,
+        displayName: contactDisplayName,
+        role: "contact",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoNothing()
+      .run();
+  }
+
+  const wrote = writeVerifiedGatewayChannel({
+    assistantChannelId: channelId,
+    contactId,
+    type: sourceChannel,
+    address,
+    externalChatId,
+    verifiedVia,
+    now,
+    allowRevokedReactivation,
+  });
+  // A blocked/revoked gateway row appeared after the pre-check — reject
+  // without creating an active assistant mirror for a blocked actor.
+  if (!wrote) {
+    log.warn(
+      { sourceChannel, address },
+      "Gateway write ignored after pre-check: channel became blocked/revoked",
+    );
+    return { verified: false };
+  }
+
+  return {
+    verified: true,
+    mirror: {
+      contactId,
+      // channelId is shared so the mirror row and the gateway row key the
+      // channel identically.
+      channelId,
+      type: sourceChannel,
+      address,
+      externalChatId,
+      displayName: contactDisplayName,
+      reassignConflictingChannels: gatewayReparented,
+    },
+  };
+}
+
+/**
+ * Assistant-mirror activation for committed verified-channel gateway writes.
+ * Identity/info columns only (ACL columns are gateway-owned); idempotent
+ * under retries. Throws on IPC failure — callers choose the soft/hard
+ * posture.
+ */
+export async function mirrorVerifiedChannel(
+  plan: VerifiedChannelMirrorPlan,
+): Promise<void> {
+  await ipcCallAssistant("contacts_mirror_upsert_channel", {
+    body: {
+      contactId: plan.contactId,
+      ...(plan.channelId ? { channelId: plan.channelId } : {}),
+      type: plan.type,
+      address: plan.address,
+      externalChatId: plan.externalChatId,
+      displayName: plan.displayName,
+      reassignConflictingChannels: plan.reassignConflictingChannels,
+    },
+  });
+}
+
+/**
  * Upsert a contact + channel for a verified user.
  *
  * If a contact channel with the same (type, address) exists, updates it.
@@ -489,43 +736,19 @@ export async function upsertVerifiedContactChannel(params: {
    */
   softMirrorFailures?: boolean;
 }): Promise<{ verified: boolean }> {
-  const now = Date.now();
-  const {
-    sourceChannel,
-    externalChatId,
-    displayName,
-    username,
-    contactId: targetContactId,
-    allowRevokedReactivation,
-  } = params;
-  const verifiedVia = params.verifiedVia ?? "challenge";
+  const { sourceChannel } = params;
   const mirrorSoft = params.softMirrorFailures === true;
-  const runMirror = async (
-    op: () => Promise<unknown>,
-    what: string,
-  ): Promise<void> => {
-    try {
-      await op();
-    } catch (mirrorErr) {
-      if (!mirrorSoft) throw mirrorErr;
-      log.warn(
-        { err: mirrorErr, sourceChannel },
-        `Assistant mirror ${what} failed (soft); gateway ACL result stands`,
-      );
-    }
-  };
 
   const address =
     canonicalizeInboundIdentity(sourceChannel, params.externalUserId) ??
     params.externalUserId;
-  const contactDisplayName = displayName ?? username ?? address;
 
   // Resolve the existing channel's identity (id, parent contact) only. The
-  // ACL/status decision is owned by the gateway pre-check below; the most
-  // recently updated mirror row is preferred (the typed lookup orders by
-  // updated_at DESC). In soft mode a failed lookup falls through to the create
-  // path: the gateway write resolves by logical key either way, and the mirror
-  // writes below are soft too.
+  // ACL/status decision is owned by the gateway pre-check in the writes core;
+  // the most recently updated mirror row is preferred (the typed lookup
+  // orders by updated_at DESC). In soft mode a failed lookup falls through to
+  // the create path: the gateway write resolves by logical key either way,
+  // and the mirror writes below are soft too.
   let existing: { channelId: string; contactId: string } | null;
   try {
     const channel = await lookupContactChannelIdentity({
@@ -544,183 +767,21 @@ export async function upsertVerifiedContactChannel(params: {
     existing = null;
   }
 
-  // The gateway is the source of truth: a blocked/revoked gateway row rejects
-  // the verification, gating BOTH the existing-channel update and the
-  // new-insert path so no active mirror is created for a blocked actor. A
-  // missing gateway row is the legitimate happy path (legacy/unmirrored).
-  const gwStatus = gatewayChannelStatus(sourceChannel, address);
-  if (
-    gwStatus === "blocked" ||
-    (gwStatus === "revoked" && !allowRevokedReactivation)
-  ) {
-    log.warn(
-      { sourceChannel, address, status: gwStatus },
-      "Skipping upsert: authoritative gateway channel is blocked or revoked",
-    );
-    return { verified: false };
-  }
-
-  if (existing) {
-    const row = existing;
-
-    // The block/revoke decision is owned by the authoritative gateway row,
-    // already gated above. The assistant mirror's status is not consulted: it
-    // can lag the gateway (e.g. a gateway reactivation leaves a stale revoked
-    // mirror), and gating on it would falsely reject a gateway-active channel.
-
-    // Bind to the invite's target contact when supplied: an invite can attach a
-    // redeemer's existing channel to a different contact, so reassign the
-    // channel's gateway parent here; the assistant mirror re-parent lands with
-    // the activation upsert below.
-    const boundContactId =
-      targetContactId && targetContactId !== row.contactId
-        ? targetContactId
-        : row.contactId;
-    // The gateway reparents the channel only on a genuine target-contact bind;
-    // the mirror must mirror THAT decision (not the call path) so the two stores
-    // never disagree about channel ownership.
-    const gatewayReparented = boundContactId !== row.contactId;
-    if (gatewayReparented) {
-      reassignChannelContact({
-        type: sourceChannel,
-        address,
-        toContactId: boundContactId,
-        displayName: contactDisplayName,
-        now,
-      });
-    }
-
-    // Gateway is source of truth: write it FIRST, then activate the assistant
-    // mirror only if the gateway accepted the write. The assistant channel id
-    // may not exist in the gateway DB (legacy/unmirrored) or live under a
-    // different gateway UUID, so the helper resolves by logical key.
-    let gatewayRejected = false;
-    try {
-      const wrote = writeVerifiedGatewayChannel({
-        assistantChannelId: row.channelId,
-        contactId: boundContactId,
-        type: sourceChannel,
-        address,
-        externalChatId,
-        verifiedVia,
-        now,
-        allowRevokedReactivation,
-      });
-      // The pre-check passed, so a write is expected. A false means a
-      // blocked/revoked row appeared between the pre-check and the write —
-      // reject WITHOUT activating the assistant mirror so a blocked actor is
-      // never left active locally.
-      if (!wrote) {
-        log.warn(
-          { sourceChannel, address },
-          "Gateway write ignored after pre-check: channel became blocked/revoked",
-        );
-        gatewayRejected = true;
-      }
-    } catch (gwErr) {
-      // The gateway DB is the source of truth and the assistant mirror carries
-      // identity/info only, so a thrown gateway write means no DB recorded an
-      // active verified channel. Fail closed rather than reply success off the
-      // mirror.
-      log.error(
-        { err: gwErr },
-        "Gateway DB contact channel update failed; failing verification closed",
-      );
-      gatewayRejected = true;
-    }
-
-    if (gatewayRejected) {
-      return { verified: false };
-    }
-
-    // Activate the assistant mirror. ACL columns are gateway-owned; only
-    // identity/info columns are written here. reassignConflictingChannels
-    // tracks the gateway's actual reparent decision above: true only on a real
-    // target-contact bind, so the mirror never moves a channel the gateway
-    // left in place.
-    await runMirror(
-      () =>
-        ipcCallAssistant("contacts_mirror_upsert_channel", {
-          body: {
-            contactId: boundContactId,
-            type: sourceChannel,
-            address,
-            externalChatId,
-            displayName: contactDisplayName,
-            reassignConflictingChannels: gatewayReparented,
-          },
-        }),
-      "update",
-    );
-
-    return { verified: true };
-  }
-
-  // No existing channel: create contact + channel. Gateway is source of truth,
-  // so write it FIRST and create the assistant mirror only if the gateway
-  // accepted the write — never leave an active assistant channel for an actor
-  // the gateway has blocked/revoked. Bind to the invite's target contact when
-  // supplied so the new channel lands under it.
-  const contactId = targetContactId ?? crypto.randomUUID();
-  const channelId = crypto.randomUUID();
-  // Gateway reparents a raced (type,address) row only on a target-contact bind
-  // (reassignChannelContact below). Plain verification with no target leaves any
-  // raced seed row under its seed contact (writeVerifiedGatewayChannel omits
-  // contactId), so the mirror must NOT reparent either or the stores disagree.
-  const gatewayReparented = Boolean(targetContactId);
-
-  // The parent contact is conflict-tolerant (a pre-existing contact is fine).
-  // For the channel, resolve by logical key so an existing non-blocked gateway
-  // row (e.g. a gateway-created unverified contact) is UPDATED to active/verified
-  // rather than silently no-op'd by the (type,address) unique index.
-  let gatewayRejected = false;
+  // Gateway is source of truth: write it FIRST, then activate the assistant
+  // mirror only if the gateway accepted the write.
+  let result: VerifiedChannelGatewayResult;
   try {
-    if (targetContactId) {
-      // The assistant mirror missed, but the gateway may already hold this
-      // (type,address) row under a different contact. Re-parent it to the
-      // target by logical key (writeVerifiedGatewayChannel's update set omits
-      // contactId), so the gateway source of truth lands under the invite's
-      // contact. No-ops when no gateway row exists.
-      reassignChannelContact({
-        type: sourceChannel,
-        address,
-        toContactId: contactId,
-        displayName: contactDisplayName,
-        now,
-      });
-    } else {
-      getGatewayDb()
-        .insert(gwContacts)
-        .values({
-          id: contactId,
-          displayName: contactDisplayName,
-          role: "contact",
-          createdAt: now,
-          updatedAt: now,
-        })
-        .onConflictDoNothing()
-        .run();
-    }
-
-    const wrote = writeVerifiedGatewayChannel({
-      assistantChannelId: channelId,
-      contactId,
-      type: sourceChannel,
-      address,
-      externalChatId,
-      verifiedVia,
-      now,
-      allowRevokedReactivation,
+    result = applyVerifiedChannelGatewayWrites({
+      sourceChannel,
+      externalUserId: params.externalUserId,
+      externalChatId: params.externalChatId,
+      displayName: params.displayName,
+      username: params.username,
+      verifiedVia: params.verifiedVia,
+      contactId: params.contactId,
+      allowRevokedReactivation: params.allowRevokedReactivation,
+      existingMirrorChannel: existing,
     });
-    // A blocked/revoked gateway row appeared after the pre-check — reject
-    // without creating an active assistant mirror for a blocked actor.
-    if (!wrote) {
-      log.warn(
-        { sourceChannel, address },
-        "Gateway write ignored after pre-check: channel became blocked/revoked",
-      );
-      gatewayRejected = true;
-    }
   } catch (gwErr) {
     // The gateway DB is the source of truth and the assistant mirror carries
     // identity/info only, so a thrown gateway write means no DB recorded an
@@ -728,37 +789,24 @@ export async function upsertVerifiedContactChannel(params: {
     // mirror.
     log.error(
       { err: gwErr },
-      "Gateway DB contact create failed; failing verification closed",
+      "Gateway DB verified-channel write failed; failing verification closed",
     );
-    gatewayRejected = true;
-  }
-
-  if (gatewayRejected) {
     return { verified: false };
   }
 
-  // Create the assistant mirror. Idempotent under retries; ACL columns are
-  // gateway-owned, so the mirror carries identity/info only and relies on the
-  // schema defaults (status='unverified', policy='allow'). channelId is shared
-  // so the mirror row and the gateway row key the channel identically.
-  await runMirror(
-    () =>
-      ipcCallAssistant("contacts_mirror_upsert_channel", {
-        body: {
-          contactId,
-          channelId,
-          type: sourceChannel,
-          address,
-          displayName: contactDisplayName,
-          externalChatId,
-          // Mirror the gateway's actual reparent decision: true only when a
-          // target contact drove reassignChannelContact above. Plain
-          // verification (no target) does not reparent, matching the gateway.
-          reassignConflictingChannels: gatewayReparented,
-        },
-      }),
-    "create",
-  );
+  if (!result.verified) {
+    return { verified: false };
+  }
+
+  try {
+    await mirrorVerifiedChannel(result.mirror);
+  } catch (mirrorErr) {
+    if (!mirrorSoft) throw mirrorErr;
+    log.warn(
+      { err: mirrorErr, sourceChannel },
+      "Assistant mirror upsert failed (soft); gateway ACL result stands",
+    );
+  }
 
   return { verified: true };
 }

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -759,7 +759,9 @@ export async function upsertVerifiedContactChannel(params: {
       ? { channelId: channel.id, contactId: channel.contactId }
       : null;
   } catch (mirrorErr) {
-    if (!mirrorSoft) throw mirrorErr;
+    if (!mirrorSoft) {
+      throw mirrorErr;
+    }
     log.warn(
       { err: mirrorErr, sourceChannel },
       "Assistant mirror lookup failed (soft); proceeding gateway-only",
@@ -801,7 +803,9 @@ export async function upsertVerifiedContactChannel(params: {
   try {
     await mirrorVerifiedChannel(result.mirror);
   } catch (mirrorErr) {
-    if (!mirrorSoft) throw mirrorErr;
+    if (!mirrorSoft) {
+      throw mirrorErr;
+    }
     log.warn(
       { err: mirrorErr, sourceChannel },
       "Assistant mirror upsert failed (soft); gateway ACL result stands",


### PR DESCRIPTION
## Summary
- guardian_requests_decide commits the pending→approved/denied CAS and the ACL outcome (verified-channel activation, unverified seed, block, or outbound-session mint) in ONE gateway transaction — the ATL-463 crash window between 'row says approved' and 'ACL write landed' no longer exists
- Outcome-write failure rolls back the CAS; the request stays pending and retryable (replaces the daemon's reopen-on-failed-persist)
- Assistant info-mirrors run post-commit best-effort; CAS miss returns status_conflict with zero side effects

Part of plan: guardian-requests-gateway-native.md (PR 5 of 10)