### PR TITLE
refactor(plugins): retire the GitHub Contents API catalog listing path

### DIFF
--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -43,6 +43,7 @@ import {
   looksLikeGitHubSpec,
   parseGitHubPluginSpec,
 } from "../lib/parse-github-plugin-spec.js";
+import { getPluginCatalog } from "../lib/plugin-catalog-cache.js";
 import {
   arePlatformFeaturesEnabled,
   resolveBundledPluginSource,
@@ -58,8 +59,10 @@ import {
 import { runPublish } from "../lib/publish-plugin.js";
 import { registerCommand } from "../lib/register-command.js";
 import {
+  assertValidSearchPattern,
+  filterPluginCatalog,
   InvalidSearchPatternError,
-  searchPlugins,
+  PluginCatalogUnavailableError,
 } from "../lib/search-plugins.js";
 import {
   disablePlugin,
@@ -550,10 +553,12 @@ Examples:
         .option("--json", "Emit machine-readable JSON instead of a table")
         .action(async (query: string, opts: { json?: boolean }) => {
           try {
-            const result = await searchPlugins(
-              { query },
-              { fetch: globalThis.fetch.bind(globalThis) },
-            );
+            assertValidSearchPattern(query);
+            const catalog = await getPluginCatalog(DEFAULT_PLUGIN_REF, {
+              fetch: globalThis.fetch.bind(globalThis),
+            });
+            const matches = filterPluginCatalog(catalog, query);
+            const result = { query, ref: catalog.ref, matches };
 
             if (opts.json) {
               process.stdout.write(JSON.stringify(result, null, 2) + "\n");
@@ -592,6 +597,13 @@ Examples:
           } catch (err) {
             if (err instanceof InvalidSearchPatternError) {
               console.error(err.message);
+              process.exitCode = 1;
+              return;
+            }
+            if (err instanceof PluginCatalogUnavailableError) {
+              console.error(
+                "The plugin catalog is temporarily unavailable. Try again shortly.",
+              );
               process.exitCode = 1;
               return;
             }

--- a/assistant/src/cli/lib/__tests__/search-plugins.test.ts
+++ b/assistant/src/cli/lib/__tests__/search-plugins.test.ts
@@ -1,24 +1,22 @@
 /**
- * Tests for {@link searchPlugins}.
+ * Tests for the catalog query helpers: {@link filterPluginCatalog},
+ * {@link assertValidSearchPattern}, and {@link marketplaceMatch}.
  *
- * The catalog is the whitelisted external plugins in the curated
- * `plugins/marketplace.json` manifest. Network is replaced with an in-memory
- * fixture passed via the `fetch` dependency — no globals are monkey-patched and
- * no `--test-hook` exports leak into production code.
+ * These operate purely in memory on a resolved catalog — the catalog itself
+ * is resolved elsewhere (`getPluginCatalog`), so there is no network here.
  */
 
 import { describe, expect, test } from "bun:test";
 
-import type { FetchLike } from "../fetch-like.js";
-import { MarketplaceFetchError } from "../plugin-marketplace.js";
+import { buildBundledPluginCatalog } from "../plugin-catalog-local.js";
+import type { MarketplaceEntry } from "../plugin-marketplace.js";
 import {
+  assertValidSearchPattern,
+  filterPluginCatalog,
   InvalidSearchPatternError,
-  PluginCatalogUnavailableError,
-  searchPlugins,
+  marketplaceMatch,
+  type PluginCatalog,
 } from "../search-plugins.js";
-
-const MANIFEST_URL_PREFIX =
-  "https://api.github.com/repos/vellum-ai/vellum-assistant/contents/plugins/marketplace.json";
 
 // External marketplace refs must be full commit SHAs (immutable). Fixtures use
 // realistic 40-char hex object names rather than tags/branches.
@@ -26,34 +24,13 @@ const SHA_A = "63a91ecadbf4c4719a4602a5abb00883f9966034";
 const SHA_B = "0123456789abcdef0123456789abcdef01234567";
 const SHA_C = "89abcdef0123456789abcdef0123456789abcdef";
 
-interface ManifestPlugin {
-  name: string;
-  source: { source: "github"; repo: string; path?: string; ref: string };
-  description?: string;
-  category?: string;
-}
-
-/** Serve `plugins` as the raw marketplace manifest at the manifest URL. */
-function manifestFetch(plugins: ManifestPlugin[]): FetchLike {
-  return (async (input: RequestInfo | URL) => {
-    const url = typeof input === "string" ? input : input.toString();
-    if (!url.startsWith(MANIFEST_URL_PREFIX)) {
-      return new Response("unexpected url: " + url, { status: 500 });
-    }
-    return new Response(JSON.stringify({ name: "vellum-assistant", plugins }), {
-      status: 200,
-      headers: { "content-type": "application/json" },
-    });
-  }) as FetchLike;
-}
-
-/** A github-sourced manifest entry, with optional path/description. */
+/** A github-sourced marketplace entry, with optional path/description. */
 function entry(
   name: string,
   repo: string,
   ref: string,
   extra?: { path?: string; description?: string; category?: string },
-): ManifestPlugin {
+): MarketplaceEntry {
   return {
     name,
     source: {
@@ -67,329 +44,149 @@ function entry(
   };
 }
 
-describe("searchPlugins", () => {
-  test("matches the query as a case-insensitive regex against plugin names", async () => {
-    const result = await searchPlugins(
-      { query: "memory" },
-      {
-        fetch: manifestFetch([
-          entry("simple-memory", "vellum-ai/simple-memory", SHA_A),
-          entry("memory-graph", "acme/memory-graph", SHA_B),
-          entry("git-tools", "acme/git-tools", SHA_C),
-        ]),
-      },
-    );
+/** Build a resolved {@link PluginCatalog} from raw entries the way the catalog
+ * sources do (dedupe by name, project, sort), reusing the real projection. */
+function catalog(entries: MarketplaceEntry[], ref = "main"): PluginCatalog {
+  return {
+    ...buildBundledPluginCatalog({ name: "vellum-assistant", plugins: entries }),
+    ref,
+  };
+}
 
-    expect(result.matches.map((m) => m.name)).toEqual([
+describe("filterPluginCatalog", () => {
+  test("matches the query as a case-insensitive regex against plugin names", () => {
+    const matches = filterPluginCatalog(
+      catalog([
+        entry("simple-memory", "vellum-ai/simple-memory", SHA_A),
+        entry("memory-graph", "acme/memory-graph", SHA_B),
+        entry("git-tools", "acme/git-tools", SHA_C),
+      ]),
+      "memory",
+    );
+    expect(matches.map((m) => m.name)).toEqual([
       "memory-graph",
       "simple-memory",
     ]);
-    expect(result.matches[0]!.path).toBe(`github:acme/memory-graph@${SHA_B}`);
-    expect(result.query).toBe("memory");
-    expect(result.ref).toBe("main");
+    expect(matches[0]!.path).toBe(`github:acme/memory-graph@${SHA_B}`);
   });
 
-  test("matches regardless of query casing (case-insensitive)", async () => {
-    const result = await searchPlugins(
-      { query: "MEMORY" },
-      {
-        fetch: manifestFetch([
-          entry("simple-memory", "vellum-ai/simple-memory", SHA_A),
-        ]),
-      },
+  test("matches regardless of query casing (case-insensitive)", () => {
+    const matches = filterPluginCatalog(
+      catalog([entry("simple-memory", "vellum-ai/simple-memory", SHA_A)]),
+      "MEMORY",
     );
-    expect(result.matches.map((m) => m.name)).toEqual(["simple-memory"]);
+    expect(matches.map((m) => m.name)).toEqual(["simple-memory"]);
   });
 
-  test("anchored patterns work without escaping", async () => {
-    const result = await searchPlugins(
-      { query: "^memory-" },
-      {
-        fetch: manifestFetch([
-          entry("memory-graph", "acme/memory-graph", SHA_B),
-          entry("simple-memory", "vellum-ai/simple-memory", SHA_A),
-        ]),
-      },
+  test("anchored patterns work without escaping", () => {
+    const matches = filterPluginCatalog(
+      catalog([
+        entry("memory-graph", "acme/memory-graph", SHA_B),
+        entry("simple-memory", "vellum-ai/simple-memory", SHA_A),
+      ]),
+      "^memory-",
     );
-    expect(result.matches.map((m) => m.name)).toEqual(["memory-graph"]);
+    expect(matches.map((m) => m.name)).toEqual(["memory-graph"]);
   });
 
-  test("empty query matches every whitelisted entry", async () => {
-    const result = await searchPlugins(
-      { query: "" },
-      {
-        fetch: manifestFetch([
-          entry("simple-memory", "vellum-ai/simple-memory", SHA_A),
-          entry("memory-graph", "acme/memory-graph", SHA_B),
-          entry("git-tools", "acme/git-tools", SHA_C),
-        ]),
-      },
+  test("empty query matches every catalog entry", () => {
+    const matches = filterPluginCatalog(
+      catalog([
+        entry("simple-memory", "vellum-ai/simple-memory", SHA_A),
+        entry("memory-graph", "acme/memory-graph", SHA_B),
+        entry("git-tools", "acme/git-tools", SHA_C),
+      ]),
+      "",
     );
-    expect(result.matches.map((m) => m.name)).toEqual([
+    expect(matches.map((m) => m.name)).toEqual([
       "git-tools",
       "memory-graph",
       "simple-memory",
     ]);
   });
 
-  test("projects each entry onto a github source with a display locator", async () => {
-    // GIVEN a whitelisted external plugin nested in a subdirectory
-    // WHEN we search
-    const result = await searchPlugins(
-      { query: "nested" },
-      {
-        fetch: manifestFetch([
-          entry("nested", "acme/monorepo", SHA_B, {
-            path: "packages/nested",
-            description: "A nested plugin.",
-          }),
-        ]),
-      },
+  test("empty result set on no matches", () => {
+    const matches = filterPluginCatalog(
+      catalog([entry("simple-memory", "vellum-ai/simple-memory", SHA_A)]),
+      "nothing-matches",
     );
-
-    // THEN the match carries the github coordinates and a human locator
-    expect(result.matches).toEqual([
-      {
-        name: "nested",
-        path: `github:acme/monorepo/packages/nested@${SHA_B}`,
-        description: "A nested plugin.",
-        category: null,
-        source: {
-          kind: "github",
-          repo: "acme/monorepo",
-          path: "packages/nested",
-          ref: SHA_B,
-        },
-      },
-    ]);
+    expect(matches).toEqual([]);
   });
 
-  test("carries the marketplace entry category, defaulting to null", async () => {
-    // GIVEN one entry that declares a category and one that does not
-    // WHEN we search
-    const result = await searchPlugins(
-      { query: "" },
-      {
-        fetch: manifestFetch([
-          entry("calendar-sync", "acme/calendar-sync", SHA_A, {
-            category: "calendar",
-          }),
-          entry("plain-plugin", "acme/plain-plugin", SHA_B),
-        ]),
-      },
-    );
+  test("throws InvalidSearchPatternError on a malformed pattern", () => {
+    expect(() =>
+      filterPluginCatalog(catalog([]), "(unterminated"),
+    ).toThrow(InvalidSearchPatternError);
+  });
+});
 
-    // THEN the declared category flows through and a missing one is null
+describe("assertValidSearchPattern", () => {
+  test("accepts a valid regex", () => {
+    expect(() => assertValidSearchPattern("^memory-")).not.toThrow();
+  });
+
+  test("accepts an empty pattern (matches everything)", () => {
+    expect(() => assertValidSearchPattern("")).not.toThrow();
+  });
+
+  test("throws InvalidSearchPatternError on a malformed pattern", () => {
+    expect(() => assertValidSearchPattern("(unterminated")).toThrow(
+      InvalidSearchPatternError,
+    );
+  });
+});
+
+describe("marketplaceMatch", () => {
+  test("projects a root entry onto a github source with a display locator", () => {
     expect(
-      result.matches.map((m) => ({ name: m.name, category: m.category })),
-    ).toEqual([
-      { name: "calendar-sync", category: "calendar" },
-      { name: "plain-plugin", category: null },
-    ]);
+      marketplaceMatch(entry("simple-memory", "vellum-ai/simple-memory", SHA_A)),
+    ).toEqual({
+      name: "simple-memory",
+      path: `github:vellum-ai/simple-memory@${SHA_A}`,
+      description: undefined,
+      category: null,
+      source: {
+        kind: "github",
+        repo: "vellum-ai/simple-memory",
+        path: undefined,
+        ref: SHA_A,
+      },
+    });
   });
 
-  test("rejects invalid regex patterns up front (no network call)", async () => {
-    let fetchCalled = false;
-    const fetch: FetchLike = (async () => {
-      fetchCalled = true;
-      return new Response("", { status: 200 });
-    }) as FetchLike;
-
-    await expect(
-      searchPlugins({ query: "(unterminated" }, { fetch }),
-    ).rejects.toBeInstanceOf(InvalidSearchPatternError);
-    expect(fetchCalled).toBe(false);
+  test("projects a nested entry with its sub-path in the locator", () => {
+    expect(
+      marketplaceMatch(
+        entry("nested", "acme/monorepo", SHA_B, {
+          path: "packages/nested",
+          description: "A nested plugin.",
+        }),
+      ),
+    ).toEqual({
+      name: "nested",
+      path: `github:acme/monorepo/packages/nested@${SHA_B}`,
+      description: "A nested plugin.",
+      category: null,
+      source: {
+        kind: "github",
+        repo: "acme/monorepo",
+        path: "packages/nested",
+        ref: SHA_B,
+      },
+    });
   });
 
-  test("empty result set on no matches", async () => {
-    const result = await searchPlugins(
-      { query: "nothing-matches" },
-      {
-        fetch: manifestFetch([
-          entry("simple-memory", "vellum-ai/simple-memory", SHA_A),
-        ]),
-      },
-    );
-    expect(result.matches).toEqual([]);
-  });
-
-  test("respects `ref` option by forwarding to GitHub", async () => {
-    // The CLI does not surface a `--ref` flag (the source-path convention
-    // may change), but the underlying function keeps `ref` for test
-    // injection and future internal callers.
-    let seenRef: string | undefined;
-    const result = await searchPlugins(
-      { query: "memory", ref: "feat-branch" },
-      {
-        fetch: (async (input: RequestInfo | URL) => {
-          const url = typeof input === "string" ? input : input.toString();
-          const m = /[?&]ref=([^&]+)/.exec(url);
-          seenRef = m ? decodeURIComponent(m[1]!) : undefined;
-          return new Response(
-            JSON.stringify({
-              name: "vellum-assistant",
-              plugins: [
-                entry("simple-memory", "vellum-ai/simple-memory", SHA_A),
-              ],
-            }),
-            { status: 200, headers: { "content-type": "application/json" } },
-          );
-        }) as FetchLike,
-      },
-    );
-
-    expect(seenRef).toBe("feat-branch");
-    expect(result.ref).toBe("feat-branch");
-    expect(result.matches.map((m) => m.name)).toEqual(["simple-memory"]);
-  });
-
-  test("HTTP 5xx is a transient PluginCatalogUnavailableError", async () => {
-    // GIVEN GitHub returns a 5xx (upstream outage)
-    // WHEN we search
-    // THEN the failure is classified transient so the caller can serve a
-    // stale cache and the route can map it to 503 (not a misleading 500).
-    const err = await searchPlugins(
-      { query: "memory" },
-      {
-        fetch: (async () =>
-          new Response("upstream broken", { status: 503 })) as FetchLike,
-      },
-    ).catch((e: unknown) => e);
-    expect(err).toBeInstanceOf(PluginCatalogUnavailableError);
-    expect((err as PluginCatalogUnavailableError).status).toBe(503);
-  });
-
-  test("rate-limited 403 (x-ratelimit-remaining: 0) is transient", async () => {
-    // GIVEN GitHub returns 403 with the rate-limit budget exhausted
-    // WHEN we search
-    // THEN it's transient — this is exactly the unauthenticated 60 req/hr
-    // exhaustion that empties the catalog, and it must surface as 503.
-    const err = await searchPlugins(
-      { query: "memory" },
-      {
-        fetch: (async () =>
-          new Response("rate limit exceeded", {
-            status: 403,
-            headers: { "x-ratelimit-remaining": "0" },
-          })) as FetchLike,
-      },
-    ).catch((e: unknown) => e);
-    expect(err).toBeInstanceOf(PluginCatalogUnavailableError);
-    expect((err as PluginCatalogUnavailableError).status).toBe(403);
-  });
-
-  test("a 403 without the rate-limit signal is a hard error", async () => {
-    // GIVEN a bare 403 (genuine permissions problem, not rate limiting)
-    // WHEN we search
-    // THEN it is NOT transient — serving a stale catalog would mask a real
-    // misconfiguration, so it propagates as a plain error.
-    const err = await searchPlugins(
-      { query: "memory" },
-      {
-        fetch: (async () =>
-          new Response("forbidden", { status: 403 })) as FetchLike,
-      },
-    ).catch((e: unknown) => e);
-    expect(err).toBeInstanceOf(Error);
-    expect(err).not.toBeInstanceOf(PluginCatalogUnavailableError);
-    expect((err as Error).message).toMatch(/HTTP 403/);
-  });
-
-  test("a missing manifest (404) is a clean empty catalog", async () => {
-    // Unlike a 5xx or a bare 403, a 404 on `marketplace.json` means no
-    // whitelist has been published at this ref yet — a normal empty catalog,
-    // not a misconfiguration. The search returns no matches without error.
-    const result = await searchPlugins(
-      { query: "memory" },
-      {
-        fetch: (async () =>
-          new Response("not found", { status: 404 })) as FetchLike,
-      },
-    );
-    expect(result.matches).toEqual([]);
-  });
-
-  test("a malformed manifest is a hard error (not silently empty)", async () => {
-    // GIVEN the manifest body is not valid JSON
-    // WHEN we search
-    // THEN it surfaces as a hard MarketplaceFetchError — the catalog is the
-    // source of truth, so a broken whitelist must not masquerade as empty,
-    // and it is NOT transient (retrying won't fix malformed bytes).
-    const err = await searchPlugins(
-      { query: "" },
-      {
-        fetch: (async () =>
-          new Response("{ not json", { status: 200 })) as FetchLike,
-      },
-    ).catch((e: unknown) => e);
-    expect(err).toBeInstanceOf(MarketplaceFetchError);
-    expect(err).not.toBeInstanceOf(PluginCatalogUnavailableError);
-  });
-
-  test("returns matches sorted by name", async () => {
-    const result = await searchPlugins(
-      { query: "" },
-      {
-        fetch: manifestFetch([
-          entry("zeta-plugin", "acme/zeta", SHA_A),
-          entry("alpha-plugin", "acme/alpha", SHA_B),
-          entry("mu-plugin", "acme/mu", SHA_C),
-        ]),
-      },
-    );
-    expect(result.matches.map((m) => m.name)).toEqual([
-      "alpha-plugin",
-      "mu-plugin",
-      "zeta-plugin",
-    ]);
-  });
-
-  test("dedupes entries that repeat a name, keeping the first", async () => {
-    // GIVEN a manifest that lists the same name twice (e.g. a bad edit)
-    // WHEN we search
-    // THEN the name surfaces once, from the first entry, so a duplicate can't
-    // inflate the catalog or shadow the reviewed source
-    const result = await searchPlugins(
-      { query: "caveman" },
-      {
-        fetch: manifestFetch([
-          entry("caveman", "JuliusBrussee/caveman", SHA_A),
-          entry("caveman", "impostor/caveman", SHA_B),
-        ]),
-      },
-    );
-    expect(result.matches).toEqual([
-      {
-        name: "caveman",
-        path: `github:JuliusBrussee/caveman@${SHA_A}`,
-        category: null,
-        source: {
-          kind: "github",
-          repo: "JuliusBrussee/caveman",
-          ref: SHA_A,
-        },
-      },
-    ]);
-  });
-
-  test("sends no Authorization header (canonical source is a public repo)", async () => {
-    let seenAuth: string | undefined;
-    let seenUserAgent: string | undefined;
-    await searchPlugins(
-      { query: "memory" },
-      {
-        fetch: (async (_input: RequestInfo | URL, init?: RequestInit) => {
-          const headers = init?.headers as Record<string, string> | undefined;
-          seenAuth = headers?.Authorization;
-          seenUserAgent = headers?.["User-Agent"];
-          return new Response(
-            JSON.stringify({ name: "vellum-assistant", plugins: [] }),
-            { status: 200, headers: { "content-type": "application/json" } },
-          );
-        }) as FetchLike,
-      },
-    );
-    expect(seenAuth).toBeUndefined();
-    expect(seenUserAgent).toBe("vellum-assistant-cli");
+  test("carries the marketplace category, defaulting to null when absent", () => {
+    expect(
+      marketplaceMatch(
+        entry("calendar-sync", "acme/calendar-sync", SHA_A, {
+          category: "calendar",
+        }),
+      ).category,
+    ).toBe("calendar");
+    expect(
+      marketplaceMatch(entry("plain-plugin", "acme/plain-plugin", SHA_B))
+        .category,
+    ).toBeNull();
   });
 });

--- a/assistant/src/cli/lib/search-plugins.ts
+++ b/assistant/src/cli/lib/search-plugins.ts
@@ -1,28 +1,19 @@
 /**
- * Search the installable plugin catalog in the canonical GitHub source.
+ * Filtering and projection helpers for the installable plugin catalog.
  *
- * The catalog is the set of whitelisted external ecosystem plugins listed in
- * the curated `plugins/marketplace.json` manifest, fetched from the repo at
- * the configured git ref (see {@link ./plugin-marketplace}).
+ * The catalog itself is resolved by {@link ./plugin-catalog-cache}
+ * (`getPluginCatalog`), which is platform-first with a bundled offline
+ * fallback. This module owns the query semantics on top of a resolved
+ * catalog: compile a pattern, filter entries by name, and project a raw
+ * marketplace entry onto the catalog match shape.
  *
  * Entries are filtered by case-insensitive ECMAScript regex against the
  * plugin name. A plain query like `"memory"` matches anywhere in the name;
  * anchors like `"^simple"` work without escaping.
- *
- * Designed for direct programmatic use. The CLI command
- * `assistant plugins search <query>` is a thin wrapper that supplies
- * production deps (`globalThis.fetch`) and formats the result for the
- * terminal; downstream callers may supply their own `fetch` (e.g. a
- * retry-decorated client, or a test fixture).
  */
 
 import type { FetchLike } from "./fetch-like.js";
-import { DEFAULT_PLUGIN_REF } from "./install-from-github.js";
-import {
-  fetchMarketplaceEntries,
-  type MarketplaceEntry,
-  MarketplaceFetchError,
-} from "./plugin-marketplace.js";
+import type { MarketplaceEntry } from "./plugin-marketplace.js";
 
 /** Options that control the search. */
 export interface SearchPluginsOptions {
@@ -31,7 +22,7 @@ export interface SearchPluginsOptions {
    * names. Empty string matches everything.
    */
   readonly query: string;
-  /** Git ref to list from. Defaults to {@link DEFAULT_PLUGIN_REF}. */
+  /** Git ref to list from. */
   readonly ref?: string;
 }
 
@@ -72,13 +63,6 @@ export interface PluginSearchMatch {
   readonly source: PluginMatchSource;
 }
 
-/** Search result envelope. */
-export interface SearchPluginsResult {
-  readonly query: string;
-  readonly ref: string;
-  readonly matches: readonly PluginSearchMatch[];
-}
-
 /** Caller passed a query that doesn't compile as an ECMAScript regex. */
 export class InvalidSearchPatternError extends Error {
   constructor(pattern: string, cause: unknown) {
@@ -89,10 +73,9 @@ export class InvalidSearchPatternError extends Error {
 }
 
 /**
- * The catalog source (GitHub) was reachable but refused or could not serve
- * the request right now — rate limiting (HTTP 403 with the rate-limit budget
- * exhausted, or 429) or an upstream 5xx. Distinct from a hard 404 on the
- * plugins prefix (a real "source gone" misconfiguration): a transient
+ * The catalog source was reachable but refused or could not serve the request
+ * right now — rate limiting or an upstream 5xx. Distinct from a hard 404 on
+ * the plugins prefix (a real "source gone" misconfiguration): a transient
  * upstream failure should surface as a retryable "temporarily unavailable"
  * rather than a generic internal error, and is a candidate for serving a
  * stale cached catalog.
@@ -108,31 +91,10 @@ export class PluginCatalogUnavailableError extends Error {
 }
 
 /**
- * Build the catalog at {@link opts.ref} and return the entries whose name
- * matches {@link opts.query} (case-insensitive ECMAScript regex; an empty
- * query matches everything).
- */
-export async function searchPlugins(
-  opts: SearchPluginsOptions,
-  deps: SearchPluginsDeps,
-): Promise<SearchPluginsResult> {
-  const ref = opts.ref ?? DEFAULT_PLUGIN_REF;
-
-  // Compile the matcher up front so an invalid regex fails before we hit
-  // the network — keeps "user typo" cheap to recover from.
-  const matcher = buildMatcher(opts.query);
-
-  const { matches: catalog } = await loadPluginCatalog({ ref }, deps);
-  const matches = catalog.filter((m) => matcher(m.name));
-
-  return { query: opts.query, ref, matches };
-}
-
-/**
  * Validate that {@link query} compiles as a case-insensitive ECMAScript regex,
- * throwing {@link InvalidSearchPatternError} if not. Lets a caching caller
- * (the daemon) reject a malformed query before loading the catalog, so a typo
- * is a cheap deterministic 400 rather than a wasted GitHub request.
+ * throwing {@link InvalidSearchPatternError} if not. Lets a caller reject a
+ * malformed query before loading the catalog, so a typo is a cheap
+ * deterministic error rather than a wasted catalog fetch.
  */
 export function assertValidSearchPattern(query: string): void {
   buildMatcher(query);
@@ -141,8 +103,8 @@ export function assertValidSearchPattern(query: string): void {
 /**
  * Filter a pre-loaded {@link PluginCatalog} by {@link query}, compiling it as
  * a case-insensitive ECMAScript regex (an empty query matches everything).
- * Lets a caching caller (the daemon) reuse one catalog load across many
- * searches. Throws {@link InvalidSearchPatternError} on a malformed pattern.
+ * Lets a caller reuse one catalog load across many searches. Throws
+ * {@link InvalidSearchPatternError} on a malformed pattern.
  */
 export function filterPluginCatalog(
   catalog: PluginCatalog,
@@ -157,36 +119,6 @@ export interface PluginCatalog {
   readonly ref: string;
   /** Every catalog entry, deduped and sorted alphabetically by name. */
   readonly matches: readonly PluginSearchMatch[];
-}
-
-/**
- * Build the full catalog at {@link opts.ref}: every whitelisted external
- * entry in the marketplace manifest, deduped by name.
- *
- * The result is **query-independent** — `searchPlugins` applies the regex
- * filter in memory afterwards. That separation is what lets a long-lived
- * caller (the daemon) cache one catalog load and serve any number of
- * searches from it without re-hitting GitHub (see {@link ./plugin-catalog-cache}).
- */
-export async function loadPluginCatalog(
-  opts: { readonly ref?: string },
-  deps: SearchPluginsDeps,
-): Promise<PluginCatalog> {
-  const ref = opts.ref ?? DEFAULT_PLUGIN_REF;
-
-  const marketplace = await fetchMarketplaceCatalog(deps.fetch, ref);
-
-  const matches: PluginSearchMatch[] = [];
-  const seen = new Set<string>();
-  for (const entry of marketplace) {
-    if (seen.has(entry.name)) continue;
-    matches.push(marketplaceMatch(entry));
-    seen.add(entry.name);
-  }
-
-  matches.sort((a, b) => a.name.localeCompare(b.name));
-
-  return { ref, matches };
 }
 
 /**
@@ -206,27 +138,6 @@ export function marketplaceMatch(entry: MarketplaceEntry): PluginSearchMatch {
     category: entry.category ?? null,
     source: { kind: "github", repo, path, ref },
   };
-}
-
-/**
- * Fetch the marketplace entries, mapping a transient upstream failure to
- * {@link PluginCatalogUnavailableError} so the cache can serve a stale catalog
- * and the route can surface a retryable 503. A missing manifest is a normal
- * empty catalog; a hard failure (malformed or invalid manifest) propagates
- * as-is, since the catalog is the source of truth for installable plugins.
- */
-async function fetchMarketplaceCatalog(
-  fetchFn: FetchLike,
-  ref: string,
-): Promise<readonly MarketplaceEntry[]> {
-  try {
-    return await fetchMarketplaceEntries({ fetch: fetchFn }, { ref });
-  } catch (err) {
-    if (err instanceof MarketplaceFetchError && err.transient) {
-      throw new PluginCatalogUnavailableError(err.message, err.status ?? 503);
-    }
-    throw err;
-  }
 }
 
 function buildMatcher(query: string): (name: string) => boolean {

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -14,7 +14,7 @@
  *   - A catalog fetch failure degrades `category` to null without erroring
  *
  * GET /v1/plugins/search (catalog search):
- *   - Forwards `?q=` and `?ref=` to the `searchPlugins` lib
+ *   - Resolves the catalog for `?ref=` and filters it by `?q=`
  *   - Empty / missing `?q=` is passed through as the empty-regex
  *     ("match-all") query — the lib's documented contract
  *   - Wraps `InvalidSearchPatternError` into a 400 (BadRequestError)


### PR DESCRIPTION
## Summary
- Route `plugins search` through the gated `getPluginCatalog` (platform-first, bundled offline).
- Remove the dead direct-GitHub listing functions (loadPluginCatalog, fetchMarketplaceCatalog, searchPlugins) and now-unused imports; update tests.

Part of plan: plugins-catalog-platform-first.md (PR 5 of 6)