### PR TITLE
feat(web): distinct voice-room listening/responding animations (JARVIS-1267)

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -170,6 +170,16 @@ export interface LiveVoiceState {
   assistantTranscript: string;
   /** Smoothed RMS mic amplitude in [0, 1] for UI / barge-in. */
   inputAmplitude: number;
+  /**
+   * Provider for the assistant's TTS *output* amplitude in [0, 1], registered
+   * by the controller from the active session's {@link LiveVoiceAudioPlayer}
+   * (its output-bus analyser). `null` when there is no session, or on a context
+   * that can't meter. Read via {@link getLiveVoiceOutputAmplitude}; the room
+   * avatar routes between this and the mic amplitude by phase — see
+   * {@link getLiveVoiceAvatarAmplitude}. A registered provider (like `controls`)
+   * so a non-`speaking` read costs nothing and it clears on session reset.
+   */
+  outputAmplitudeProvider: (() => number) | null;
   /** Human-readable error message when `state === "failed"`, `null` otherwise. */
   error: string | null;
 }
@@ -209,6 +219,8 @@ export interface LiveVoiceActions {
    */
   clearUserTranscripts: () => void;
   setInputAmplitude: (amplitude: number) => void;
+  /** Register (or clear) the active player's output-amplitude provider. */
+  setOutputAmplitudeProvider: (provider: (() => number) | null) => void;
   /** Transition to `failed` with a message. */
   fail: (message: string) => void;
   /**
@@ -302,6 +314,7 @@ const INITIAL_SESSION_STATE: Omit<LiveVoiceState, "starter"> = {
   finalTranscript: "",
   assistantTranscript: "",
   inputAmplitude: 0,
+  outputAmplitudeProvider: null,
   error: null,
 };
 
@@ -323,6 +336,8 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
   clearAssistantTranscript: () => set({ assistantTranscript: "" }),
   clearUserTranscripts: () => set({ partialTranscript: "", finalTranscript: "" }),
   setInputAmplitude: (inputAmplitude) => set({ inputAmplitude }),
+  setOutputAmplitudeProvider: (outputAmplitudeProvider) =>
+    set({ outputAmplitudeProvider }),
   fail: (message) => set({ state: "failed", error: message }),
   reset: () => set({ ...INITIAL_SESSION_STATE }),
 }));
@@ -337,6 +352,18 @@ export const useLiveVoiceStore = createSelectors(useLiveVoiceStoreBase);
  */
 export function getLiveVoiceInputAmplitude(): number {
   return useLiveVoiceStore.getState().inputAmplitude;
+}
+
+/**
+ * Assistant TTS *output* amplitude in [0, 1] — the smoothed RMS of the audio the
+ * assistant is speaking right now, read from the active player's output-bus
+ * analyser via the controller-registered provider. Returns 0 when nothing is
+ * playing (or the audio context can't meter). The counterpart to
+ * {@link getLiveVoiceInputAmplitude}: mic pulse for `listening`, output pulse
+ * for `responding`.
+ */
+export function getLiveVoiceOutputAmplitude(): number {
+  return useLiveVoiceStore.getState().outputAmplitudeProvider?.() ?? 0;
 }
 
 /**

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
@@ -65,6 +65,17 @@ const CONTAINER_MIME_TYPES: ReadonlySet<string> = new Set([
 
 const RAW_PCM_MIME_TYPE = "audio/pcm";
 
+/**
+ * Output-amplitude metering tuning for the voice-room avatar's speaking pulse
+ * (see {@link LiveVoiceAudioPlayer.getOutputAmplitude}). Speech RMS sits around
+ * 0.05–0.2, so `GAIN` lifts it into a visible range; `SMOOTHING` is the EMA
+ * weight toward each new read (~60 Hz from the avatar's rAF); `DECAY` eases the
+ * pulse back to rest between turns. These are the visual-feel knobs.
+ */
+const OUTPUT_AMPLITUDE_GAIN = 4;
+const OUTPUT_AMPLITUDE_SMOOTHING = 0.3;
+const OUTPUT_AMPLITUDE_DECAY = 0.85;
+
 /** Normalize a frame's `mimeType` (strip params, lowercase) for dispatch. */
 function normalizeMimeType(mimeType: string): string {
   return mimeType.split(";", 1)[0]?.trim().toLowerCase() ?? "";
@@ -103,6 +114,13 @@ export interface AudioContextLike {
     sampleRate: number,
   ): AudioBuffer;
   createBufferSource(): AudioBufferSourceNode;
+  /**
+   * Create an analyser tapping the output bus for amplitude metering (drives
+   * the voice-room avatar's TTS-reactive pulse). Optional so lightweight test
+   * contexts can omit it — the player then degrades to no metering
+   * ({@link LiveVoiceAudioPlayer.getOutputAmplitude} returns 0).
+   */
+  createAnalyser?(): AnalyserNode;
   /**
    * Decode an encoded container (wav/mp3/opus) into an `AudioBuffer`, deriving
    * sample rate and channel layout from the container header.
@@ -156,6 +174,19 @@ export class LiveVoiceAudioPlayer {
   private playheadTime = 0;
 
   private playingState = false;
+
+  /**
+   * Analyser tapping the output bus for amplitude metering. Sources connect
+   * through it to the destination. Null when the context can't create one
+   * (test mock) — {@link getOutputAmplitude} then reports 0.
+   */
+  private analyser: AnalyserNode | null = null;
+
+  /** Reusable time-domain sample buffer for {@link getOutputAmplitude}. */
+  private analyserSamples: Float32Array<ArrayBuffer> | null = null;
+
+  /** EMA-smoothed output amplitude in [0, 1], advanced on each read. */
+  private smoothedOutputAmplitude = 0;
 
   /**
    * Count of container decodes that have started but not yet been scheduled or
@@ -304,7 +335,10 @@ export class LiveVoiceAudioPlayer {
   private scheduleBuffer(context: AudioContextLike, buffer: AudioBuffer): void {
     const source = context.createBufferSource();
     source.buffer = buffer;
-    source.connect(context.destination);
+
+    // Route through the metering analyser when present (so output amplitude can
+    // drive the room avatar), otherwise straight to the destination.
+    source.connect(this.analyser ?? context.destination);
 
     // Chain start time from the running playhead. Never schedule in the past:
     // if the queue drained the playhead may lag behind currentTime.
@@ -379,6 +413,11 @@ export class LiveVoiceAudioPlayer {
     this.stop();
     const context = this.context;
     this.context = null;
+    // The analyser belongs to the closed context; drop it (and its buffer) so a
+    // reused player rebuilds metering against a fresh context.
+    this.analyser = null;
+    this.analyserSamples = null;
+    this.smoothedOutputAmplitude = 0;
     if (context) await context.close();
   }
 
@@ -398,10 +437,59 @@ export class LiveVoiceAudioPlayer {
 
   private ensureContext(): AudioContextLike {
     if (!this.context) {
-      this.context = this.createContext();
+      const context = this.createContext();
+      this.context = context;
       this.playheadTime = 0;
+      // Tap the output bus for amplitude metering when the context supports it.
+      // Scheduled sources connect through this analyser to the destination; a
+      // context without createAnalyser (test mock) skips metering entirely and
+      // getOutputAmplitude() reports 0.
+      if (context.createAnalyser) {
+        const analyser = context.createAnalyser();
+        analyser.fftSize = 256;
+        analyser.connect(context.destination);
+        this.analyser = analyser;
+        this.analyserSamples = new Float32Array(analyser.fftSize);
+      }
     }
     return this.context;
+  }
+
+  /**
+   * Current smoothed output amplitude in [0, 1], read from the output-bus
+   * analyser — the RMS of the audio the assistant is speaking right now. Drives
+   * the voice-room avatar's `responding` pulse (the mic amplitude that drives
+   * `listening` is near-silent while the assistant speaks, which is why the
+   * avatar previously looked inverted — see JARVIS-1267).
+   *
+   * Polled ~60 Hz from the avatar's rAF loop: it EMA-smooths so the avatar
+   * breathes rather than jitters, and decays toward rest when nothing is
+   * playing. Returns 0 with no analyser (test mock).
+   */
+  getOutputAmplitude(): number {
+    const analyser = this.analyser;
+    const samples = this.analyserSamples;
+    if (!analyser || !samples) return 0;
+
+    if (!this.playingState) {
+      // Nothing scheduled — ease back to rest so the avatar settles between
+      // turns instead of holding the last speaking level.
+      this.smoothedOutputAmplitude *= OUTPUT_AMPLITUDE_DECAY;
+      return this.smoothedOutputAmplitude;
+    }
+
+    analyser.getFloatTimeDomainData(samples);
+    let sumSquares = 0;
+    for (let i = 0; i < samples.length; i++) {
+      const sample = samples[i];
+      sumSquares += sample * sample;
+    }
+    const rms = Math.sqrt(sumSquares / samples.length);
+    const scaled = Math.min(1, rms * OUTPUT_AMPLITUDE_GAIN);
+    this.smoothedOutputAmplitude =
+      OUTPUT_AMPLITUDE_SMOOTHING * scaled +
+      (1 - OUTPUT_AMPLITUDE_SMOOTHING) * this.smoothedOutputAmplitude;
+    return this.smoothedOutputAmplitude;
   }
 
   private handleSourceEnded(source: AudioBufferSourceNode): void {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -452,6 +452,11 @@ export function useLiveVoice(
       // (its lazy creation point) lands outside any gesture, so the browser
       // starts it suspended and the first turn's audio is silently dropped.
       player.prewarm();
+      // Route the room avatar's `responding` pulse to real TTS output. The mic
+      // amplitude (the only prior source) is near-silent while the assistant
+      // speaks, so the avatar looked inverted — pulsing on the user's voice, not
+      // the assistant's. Cleared by the store reset in teardown()/stop().
+      store.setOutputAmplitudeProvider(() => player.getOutputAmplitude());
 
       const session: SessionContext = {
         assistantId,

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar.stories.tsx
@@ -1,0 +1,284 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useCallback, useEffect, useRef } from "react";
+
+// The `.voice-avatar-*` / `.voice-room-*` / `.voice-listening-waves` keyframes
+// are hand-written rules in the app's global stylesheet, not Tailwind utilities
+// — Storybook's preview.css only pulls Tailwind + tokens, so import the app CSS
+// here to get the loops.
+import "@/index.css";
+
+import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
+import { avatarQueryKey } from "@/hooks/use-assistant-avatar";
+import type { CharacterTraits } from "@/types/avatar";
+
+import { VoiceRoomAmbientBackground } from "./voice-room-ambient-background";
+import {
+  VoiceListeningWaves,
+  type VoiceWavePalette,
+  type VoiceWaveStyle,
+} from "./voice-listening-waves";
+import { VoiceAvatar } from "./voice-avatar";
+import type { VoiceAvatarVisual } from "./voice-avatar-state";
+
+/**
+ * Iteration harness for the live-voice room's avatar + state animations. Scrub
+ * `visual` through every session phase and drive the audio-reactive visuals
+ * with the `amplitude` slider or the `oscillate` "simulated speech" toggle — no
+ * live mic / STT / TTS session required.
+ *
+ * `listening` renders the bottom-edge waves (energy coming *in* from the user)
+ * and the avatar stays at rest; `responding` is the avatar's own outward pulse
+ * (energy going *out*). Wave `waveStyle` (fill / line) and `palette` (aurora /
+ * accent) are the design knobs. `realAvatar` swaps the "V" fallback for a real
+ * bundled character.
+ *
+ * Nothing hits the network: the real avatar is seeded into the query cache
+ * below, on the room's own deep-dark `data-theme="dark"` void.
+ */
+
+// Sample avatar color: the seeded character's color drives both the avatar and
+// the `accent` palette, so the harness faithfully shows the waves tinted to the
+// avatar (as in the app, via `--avatar-accent`).
+const SAMPLE_COLOR_ID = "purple";
+const SAMPLE_ACCENT =
+  BUNDLED_COMPONENTS.colors.find((c) => c.id === SAMPLE_COLOR_ID)?.hex ?? "#A665C9";
+const SAMPLE_ASSISTANT_ID = "story-assistant";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: false, refetchOnWindowFocus: false, staleTime: Infinity },
+  },
+});
+
+// Seed a real bundled character so `realAvatar` renders without the daemon: a
+// blob with the sample color, so its accent resolves and the waves tint to
+// match. Seed both manifest-flag key variants so it resolves regardless of how
+// the version gate reads in Storybook.
+const seededAvatar = {
+  components: BUNDLED_COMPONENTS,
+  traits: {
+    bodyShape: "blob",
+    eyeStyle: "grumpy",
+    color: SAMPLE_COLOR_ID,
+  } as CharacterTraits,
+  customImageUrl: null,
+};
+for (const supportsManifest of [false, true]) {
+  queryClient.setQueryData(
+    [...avatarQueryKey(SAMPLE_ASSISTANT_ID), supportsManifest],
+    seededAvatar,
+  );
+}
+
+const VISUALS: VoiceAvatarVisual[] = [
+  "idle",
+  "listening",
+  "thinking",
+  "responding",
+  "reconnecting",
+];
+
+/**
+ * A stable `getAmplitude` backed by a ref: a static slider value, or a
+ * simulated-speech envelope (~3.5 Hz syllabic tremor under a slower phrase
+ * swell, plus jitter) when `oscillate` is on. Amplitude never flows through
+ * React state, matching the real call sites.
+ */
+function useAmplitudeDriver(amplitude: number, oscillate: boolean): () => number {
+  const ampRef = useRef(amplitude);
+
+  useEffect(() => {
+    if (!oscillate) {
+      ampRef.current = amplitude;
+    }
+  }, [amplitude, oscillate]);
+
+  useEffect(() => {
+    if (!oscillate) {
+      return;
+    }
+    let raf = 0;
+    const start = performance.now();
+    const tick = () => {
+      const t = (performance.now() - start) / 1000;
+      const syllable = 0.5 + 0.5 * Math.sin(t * 2 * Math.PI * 3.5);
+      const phrase = 0.6 + 0.4 * Math.sin(t * 2 * Math.PI * 0.4);
+      const jitter = Math.random() * 0.12;
+      ampRef.current = Math.min(1, Math.max(0, syllable * phrase * 0.9 + jitter));
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [oscillate]);
+
+  return useCallback(() => ampRef.current, []);
+}
+
+interface RoomSceneProps {
+  visual: VoiceAvatarVisual;
+  amplitude: number;
+  oscillate: boolean;
+  waveStyle: VoiceWaveStyle;
+  palette: VoiceWavePalette;
+  realAvatar: boolean;
+  size?: number;
+  minHeight?: number;
+}
+
+/**
+ * A full room scene for one visual: the deep-dark void, ambient particles, the
+ * bottom listening waves (only in `listening`), and the centered avatar — all
+ * driven by one shared amplitude source so the avatar and waves move together.
+ */
+function RoomScene({
+  visual,
+  amplitude,
+  oscillate,
+  waveStyle,
+  palette,
+  realAvatar,
+  size = 200,
+  minHeight = 420,
+}: RoomSceneProps) {
+  const getAmplitude = useAmplitudeDriver(amplitude, oscillate);
+  return (
+    <div
+      data-theme="dark"
+      className="relative flex items-center justify-center overflow-hidden rounded-lg"
+      style={{ background: "#05060b", minHeight, ["--avatar-accent" as string]: SAMPLE_ACCENT }}
+    >
+      <VoiceRoomAmbientBackground />
+      {visual === "listening" ? (
+        <VoiceListeningWaves
+          getAmplitude={getAmplitude}
+          waveStyle={waveStyle}
+          palette={palette}
+        />
+      ) : null}
+      <div className="relative z-0 flex items-center justify-center">
+        <VoiceAvatar
+          assistantId={realAvatar ? SAMPLE_ASSISTANT_ID : null}
+          visual={visual}
+          getAmplitude={getAmplitude}
+          size={size}
+        />
+      </div>
+    </div>
+  );
+}
+
+const meta: Meta<typeof RoomScene> = {
+  title: "Chat/Voice/VoiceAvatar",
+  component: RoomScene,
+  parameters: { layout: "fullscreen" },
+  args: {
+    amplitude: 0.5,
+    oscillate: true,
+    waveStyle: "fill",
+    palette: "accent",
+    realAvatar: true,
+    size: 200,
+  },
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <div style={{ padding: 24 }}>
+          <Story />
+        </div>
+      </QueryClientProvider>
+    ),
+  ],
+  argTypes: {
+    visual: { options: VISUALS, control: { type: "select" } },
+    amplitude: {
+      control: { type: "range", min: 0, max: 1, step: 0.01 },
+      description: "Static level (0–1). Ignored while Oscillate is on.",
+    },
+    oscillate: { control: { type: "boolean" } },
+    waveStyle: {
+      options: ["fill", "line"] satisfies VoiceWaveStyle[],
+      control: { type: "inline-radio" },
+      description: "Listening waves: filled water vs stroked ribbon.",
+    },
+    palette: {
+      options: ["aurora", "accent"] satisfies VoiceWavePalette[],
+      control: { type: "inline-radio" },
+      description: "Fixed cyan→indigo vs tinted from the avatar accent.",
+    },
+    realAvatar: {
+      control: { type: "boolean" },
+      description: "Real bundled character vs the “V” fallback.",
+    },
+    size: { control: { type: "range", min: 80, max: 320, step: 4 } },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof RoomScene>;
+
+/** Playground — every knob live. Defaults to the listening state so the waves + wave controls are visible. */
+export const Playground: Story = {
+  args: { visual: "listening" },
+};
+
+/**
+ * The two audio-reactive states side by side (aurora / fill): `listening` reads
+ * as energy coming *in* (waves rising toward a still, receptive avatar),
+ * `responding` as energy going *out* (the avatar's own outward pulse).
+ */
+export const ListeningVsResponding: Story = {
+  render: (args) => (
+    <div className="grid gap-4 sm:grid-cols-2">
+      {(["listening", "responding"] as const).map((visual) => (
+        <div key={visual} className="flex flex-col gap-2">
+          <span className="text-[13px] font-medium text-white/60">{visual}</span>
+          <RoomScene {...args} visual={visual} size={180} />
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+/**
+ * The four wave treatments to choose between — style (fill / line) × palette
+ * (aurora / accent) — all in the listening state, sharing the simulated-speech
+ * driver. The `accent` column is tinted from a sample avatar color.
+ */
+export const WaveVariants: Story = {
+  render: (args) => (
+    <div className="grid gap-4 sm:grid-cols-2">
+      {(["fill", "line"] as const).flatMap((waveStyle) =>
+        (["aurora", "accent"] as const).map((palette) => (
+          <div key={`${waveStyle}-${palette}`} className="flex flex-col gap-2">
+            <span className="text-[13px] font-medium text-white/60">
+              {waveStyle} · {palette}
+            </span>
+            <RoomScene
+              {...args}
+              visual="listening"
+              waveStyle={waveStyle}
+              palette={palette}
+              size={150}
+              minHeight={300}
+            />
+          </div>
+        )),
+      )}
+    </div>
+  ),
+};
+
+/** Every visual side by side, all driven by the same simulated-speech envelope. */
+export const AllStates: Story = {
+  render: (args) => (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {VISUALS.map((visual) => (
+        <div key={visual} className="flex flex-col gap-2">
+          <span className="text-[13px] font-medium text-white/60">{visual}</span>
+          <RoomScene {...args} visual={visual} size={140} minHeight={260} />
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar.tsx
@@ -22,9 +22,15 @@ export interface VoiceAvatarProps {
   size?: number;
 }
 
-/** Visuals whose scale rides live amplitude via the rAF loop. */
+/**
+ * Visuals whose scale rides live amplitude via the rAF loop. Only `responding`
+ * (the assistant is speaking): the avatar emits an outward pulse on its own TTS
+ * output. `listening` deliberately stays at rest — the user's voice is expressed
+ * by the bottom waves coming *in* (see voice-listening-waves.tsx), not by
+ * scaling the avatar.
+ */
 function isAudioReactive(visual: VoiceAvatarVisual): boolean {
-  return visual === "responding" || visual === "listening";
+  return visual === "responding";
 }
 
 /**
@@ -40,10 +46,12 @@ function isAudioReactive(visual: VoiceAvatarVisual): boolean {
  * owned by the room wrapper (see `voice-room.tsx`), not here.
  *
  * For the audio-reactive visuals a requestAnimationFrame loop polls
- * `getAmplitude()` and writes the `--voice-amp` custom property on the avatar
- * wrapper — never through React state, so per-sample updates cause no
- * re-render. Reduced-motion users get the static avatar (CSS loops and the
- * amplitude scale are both disabled).
+ * `getAmplitude()` and writes the `--voice-amp` custom property on the outer
+ * `.voice-avatar` node — never through React state, so per-sample updates cause
+ * no re-render. It's written on the outer node (not the `__amp` child) so the
+ * `::after` emanation ring can read it: only `responding` is reactive, and its
+ * TTS-output amplitude drives the color emanating outward (see index.css).
+ * Reduced-motion users get the static avatar (CSS loops disabled).
  */
 export function VoiceAvatar({
   assistantId,
@@ -99,10 +107,11 @@ export function VoiceAvatar({
 
   return (
     <div
+      ref={ampRef}
       className={`voice-avatar voice-avatar--${visual}`}
       style={{ width: size, height: size }}
     >
-      <div ref={ampRef} className="voice-avatar__amp">
+      <div className="voice-avatar__amp">
         <ChatAvatar
           components={components}
           traits={traits}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-listening-waves.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-listening-waves.tsx
@@ -1,0 +1,122 @@
+/**
+ * Listening-state waves for the voice room: layered sine waves that rise from
+ * the bottom edge of the screen as the user speaks — the visual language of
+ * energy coming *in* (the user's voice arriving), the counterpart to the
+ * assistant's outward `responding` pulse on the avatar.
+ *
+ * The waves always drift horizontally (a slow CSS loop); the user's live mic
+ * amplitude drives how high they rise and how bright they are, written
+ * imperatively to `--voice-amp` from a requestAnimationFrame loop — never React
+ * state, matching `voice-avatar.tsx`. Purely decorative; the cyan→indigo accent
+ * is a fixed constant (like the listening sonar), not a theme token.
+ */
+
+import { useEffect, useRef } from "react";
+
+// Wave geometry is authored in a fixed viewBox; the path spans two viewBox
+// widths so a `-1200px` horizontal drift loops seamlessly (each wave's cycle
+// count over the doubled width is even, so the halves tile).
+const VIEW_W = 1200;
+const VIEW_H = 200;
+
+/** Sample points along a sine wave spanning two viewBox widths. */
+function wavePoints(amplitude: number, cyclesOverDoubleWidth: number, phase: number): string {
+  const width = VIEW_W * 2;
+  const steps = 120;
+  const baseline = VIEW_H - amplitude - 4;
+  let d = "";
+  for (let i = 0; i <= steps; i++) {
+    const x = (i / steps) * width;
+    const y =
+      baseline -
+      amplitude * Math.sin((i / steps) * cyclesOverDoubleWidth * 2 * Math.PI + phase);
+    d += `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)} `;
+  }
+  return d;
+}
+
+/** Filled variant: the sine curve closed down to the bottom edge (a water fill). */
+function wavePathFill(amplitude: number, cycles: number, phase: number): string {
+  return `${wavePoints(amplitude, cycles, phase)}L${VIEW_W * 2},${VIEW_H} L0,${VIEW_H} Z`;
+}
+
+/** Line variant: just the open sine curve, stroked (a luminous ribbon). */
+function wavePathLine(amplitude: number, cycles: number, phase: number): string {
+  return wavePoints(amplitude, cycles, phase).trimEnd();
+}
+
+// Back → front: taller/slower behind, tighter/faster in front, each an even
+// cycle count so the doubled path tiles under the drift.
+const WAVE_LAYERS = [
+  { modifier: "back" as const, amplitude: 26, cycles: 4, phase: 0 },
+  { modifier: "mid" as const, amplitude: 34, cycles: 6, phase: 1.1 },
+  { modifier: "front" as const, amplitude: 22, cycles: 8, phase: 2.3 },
+];
+
+/** Style of the listening waves: filled "water" areas or stroked "ribbon" lines. */
+export type VoiceWaveStyle = "fill" | "line";
+
+/**
+ * Color language: `aurora` is the fixed cyan→indigo accent (matches the
+ * listening sonar); `accent` tints the waves from the assistant's avatar color
+ * (`--avatar-accent`).
+ */
+export type VoiceWavePalette = "aurora" | "accent";
+
+export function VoiceListeningWaves({
+  getAmplitude,
+  waveStyle = "fill",
+  palette = "aurora",
+}: {
+  /** Mic amplitude source (0–1), polled in a rAF loop. */
+  getAmplitude: () => number;
+  waveStyle?: VoiceWaveStyle;
+  palette?: VoiceWavePalette;
+}) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const getAmplitudeRef = useRef(getAmplitude);
+  useEffect(() => {
+    getAmplitudeRef.current = getAmplitude;
+  }, [getAmplitude]);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) {
+      return;
+    }
+    let raf = 0;
+    let lastWritten = "";
+    const tick = () => {
+      const amp = Math.min(1, Math.max(0, getAmplitudeRef.current()));
+      const next = amp.toFixed(3);
+      if (next !== lastWritten) {
+        lastWritten = next;
+        node.style.setProperty("--voice-amp", next);
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  const buildPath = waveStyle === "line" ? wavePathLine : wavePathFill;
+
+  return (
+    <div
+      ref={ref}
+      className={`voice-listening-waves voice-listening-waves--${waveStyle} voice-listening-waves--${palette}`}
+      aria-hidden
+    >
+      {WAVE_LAYERS.map((layer) => (
+        <svg
+          key={layer.modifier}
+          className={`voice-wave voice-wave--${layer.modifier}`}
+          viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+          preserveAspectRatio="none"
+        >
+          <path d={buildPath(layer.amplitude, layer.cycles, layer.phase)} />
+        </svg>
+      ))}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -67,6 +67,25 @@ mock.module("@/domains/chat/voice/voice-room/voice-avatar", () => ({
   ),
 }));
 
+// Stub the listening waves (rAF loop + SVG geometry) so the room-chrome tests
+// stay focused on wiring: we only assert the room mounts them in the right
+// phase, not how they animate.
+mock.module("@/domains/chat/voice/voice-room/voice-listening-waves", () => ({
+  VoiceListeningWaves: () => <div data-testid="listening-waves" />,
+}));
+
+// The room reads the session avatar to tint the waves to the assistant color;
+// stub the hook so these tests don't need the assistant-avatar React Query
+// graph (the room-chrome behavior is independent of avatar data).
+mock.module("@/hooks/use-assistant-avatar", () => ({
+  useAssistantAvatar: () => ({
+    components: null,
+    traits: null,
+    customImageUrl: null,
+  }),
+  avatarQueryKey: (id: string) => ["assistantAvatar", id],
+}));
+
 // Imported after the mocks so the room picks up the mocked modules.
 const { VoiceRoom } = await import("@/domains/chat/voice/voice-room/voice-room");
 
@@ -145,6 +164,31 @@ describe("VoiceRoom — visibility", () => {
     mockSearch = "?popout=1";
     render(<VoiceRoom />);
     expect(roomDialog()).toBeNull();
+  });
+});
+
+describe("VoiceRoom — listening waves", () => {
+  const waves = () => screen.queryByTestId("listening-waves");
+
+  test("mounts the bottom waves while listening (energy coming in)", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    expect(roomDialog()).not.toBeNull();
+    expect(waves()).not.toBeNull();
+  });
+
+  test("hides the waves while responding — the avatar emanates instead", () => {
+    startOwnedSession("speaking");
+    render(<VoiceRoom />);
+    // Room is still open (an active phase), but there are no incoming waves.
+    expect(roomDialog()).not.toBeNull();
+    expect(waves()).toBeNull();
+  });
+
+  test("hides the waves while thinking", () => {
+    startOwnedSession("thinking");
+    render(<VoiceRoom />);
+    expect(waves()).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -25,13 +25,19 @@ import { X } from "lucide-react";
 import {
   endLiveVoiceSession,
   getLiveVoiceInputAmplitude,
+  getLiveVoiceOutputAmplitude,
   liveVoiceStateLabel,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
+import { AVATAR_ACCENT_CSS_VAR } from "@/hooks/use-avatar-accent-var";
+
+import { resolveWaveAccentHex } from "./wave-accent";
 
 import { toVoiceAvatarVisual } from "./voice-avatar-state";
 import { VoiceAmbientTranscript } from "./voice-ambient-transcript";
 import { VoiceAvatar } from "./voice-avatar";
+import { VoiceListeningWaves } from "./voice-listening-waves";
 import { AVATAR_ENTER_SPRING } from "./voice-motion";
 import { VoiceRoomAmbientBackground } from "./voice-room-ambient-background";
 import { useIsVoiceRoomVisible } from "./use-is-voice-room-visible";
@@ -74,6 +80,15 @@ function VoiceRoomOverlay() {
   const visual = toVoiceAvatarVisual(state, reconnecting);
   const stateLabel = liveVoiceStateLabel(state, reconnecting);
 
+  // Publish the session assistant's avatar accent on the room itself (not just
+  // the html-level var, which tracks the *active* assistant) so the listening
+  // waves tint to the avatar shown here even if a session outlives navigating
+  // away. Shares the cached avatar query with VoiceAvatar; null for
+  // custom-image / "none" / still-loading avatars, where the waves fall back to
+  // the aurora indigo via the CSS var fallback.
+  const { components, traits } = useAssistantAvatar(assistantId);
+  const accentHex = resolveWaveAccentHex(components, traits);
+
   // Global Escape exit, live only while the room is mounted. It fires even when
   // the composer textarea (or any other focused element) still holds focus as
   // the room opens, so it is intentionally not guarded by the event target.
@@ -104,6 +119,7 @@ function VoiceRoomOverlay() {
         paddingBottom: SAFE_AREA_BOTTOM,
         paddingLeft: SAFE_AREA_LEFT,
         paddingRight: SAFE_AREA_RIGHT,
+        ...(accentHex ? { [AVATAR_ACCENT_CSS_VAR]: accentHex } : {}),
       }}
       initial={reduce ? false : { opacity: 0 }}
       animate={{ opacity: 1 }}
@@ -111,6 +127,17 @@ function VoiceRoomOverlay() {
       transition={{ duration: reduce ? 0 : 0.4 }}
     >
       <VoiceRoomAmbientBackground />
+
+      {/* Listening waves: the user's voice arriving as energy coming in, rising
+          from the bottom edge with live mic amplitude. Only while listening;
+          responding expresses itself through the avatar's own emanation. Sits
+          above the void, behind the centered avatar (later in DOM, z-0). */}
+      {visual === "listening" ? (
+        <VoiceListeningWaves
+          getAmplitude={getLiveVoiceInputAmplitude}
+          palette="accent"
+        />
+      ) : null}
 
       {/* Optional muted echo of the live transcript, floating above (user) and
           below (assistant) the centered avatar. Pref-gated and absolutely
@@ -148,7 +175,11 @@ function VoiceRoomOverlay() {
         <VoiceAvatar
           assistantId={assistantId}
           visual={visual}
-          getAmplitude={getLiveVoiceInputAmplitude}
+          // Only the `responding` avatar is audio-reactive, and it always rides
+          // TTS output — so the output amplitude is the sole source here. The
+          // user's voice is expressed by the bottom waves in `listening`, not
+          // by the avatar.
+          getAmplitude={getLiveVoiceOutputAmplitude}
           size={AVATAR_SIZE}
         />
       </motion.div>

--- a/clients/web/src/domains/chat/voice/voice-room/wave-accent.test.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/wave-accent.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+import type { CharacterTraits } from "@/types/avatar";
+import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
+
+import { resolveWaveAccentHex } from "./wave-accent";
+
+const traitsWithColor = (color: string) =>
+  ({ bodyShape: "blob", eyeStyle: "grumpy", color }) as CharacterTraits;
+
+describe("resolveWaveAccentHex", () => {
+  test("uses the explicit trait color when the avatar has one", () => {
+    const orange = BUNDLED_COMPONENTS.colors.find((c) => c.id === "orange")!.hex;
+    expect(resolveWaveAccentHex(BUNDLED_COMPONENTS, traitsWithColor("orange"))).toBe(
+      orange,
+    );
+  });
+
+  test("falls back to the first palette color for a default (traits-less) avatar — matching what ChatAvatar renders, so the waves don't drift to indigo", () => {
+    const firstColor = BUNDLED_COMPONENTS.colors[0]!.hex;
+    expect(resolveWaveAccentHex(BUNDLED_COMPONENTS, null)).toBe(firstColor);
+  });
+
+  test("returns null when there is no character to color (custom image / not yet loaded)", () => {
+    expect(resolveWaveAccentHex(null, null)).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-room/wave-accent.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/wave-accent.ts
@@ -1,0 +1,26 @@
+import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
+import { resolveAvatarAccentHex } from "@/hooks/use-avatar-accent-var";
+
+/**
+ * Accent hex for the listening waves, matching the avatar {@link ChatAvatar}
+ * actually renders in the room.
+ *
+ * The app-wide `--avatar-accent` (via `resolveAvatarAccentHex`) resolves only an
+ * *explicit* trait color and returns null otherwise — but the room renders the
+ * default character in color anyway (ChatAvatar falls back to the first palette
+ * color when traits are absent). So the waves must mirror that fallback, or a
+ * default-avatar assistant gets indigo waves that don't match its green avatar.
+ *
+ * Null for custom-image / no-character avatars (no color to match) — the waves
+ * then keep their aurora fallback.
+ */
+export function resolveWaveAccentHex(
+  components: CharacterComponents | null,
+  traits: CharacterTraits | null,
+): string | null {
+  return (
+    resolveAvatarAccentHex(components, traits) ??
+    components?.colors?.[0]?.hex ??
+    null
+  );
+}

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -372,15 +372,20 @@ body {
  * State-driven animation for the enlarged assistant avatar in the voice room.
  * Each live-voice visual (idle / listening / thinking / responding /
  * reconnecting) gets one continuous CSS loop here; the discrete enter/scale
- * transition when the visual changes is a motion spring at the call site. The
- * `responding` (and `listening`) visual additionally rides live mic/TTS
- * amplitude, fed imperatively through the `--voice-amp` custom property by a
- * requestAnimationFrame loop — never React state. See voice-avatar.tsx.
+ * transition when the visual changes is a motion spring at the call site. Only
+ * the `responding` visual rides live amplitude (the assistant's TTS output),
+ * fed imperatively through the `--voice-amp` custom property by a
+ * requestAnimationFrame loop — never React state. `listening` stays at rest;
+ * the user's voice is expressed by the bottom waves coming in (see
+ * voice-listening-waves.tsx). See voice-avatar.tsx.
  *
  * The sonar ripple's cyan→indigo gradient is a deliberate decorative accent
  * that stays constant across all themes (like a data-viz series or annotation
  * overlay), so it is expressed as fixed rgba rather than a theme token. */
 .voice-avatar {
+  /* Live amplitude (0–1) written per frame on this outer node for `responding`
+   * only, so the ::after emanation ring can read it. Defaults to 0. */
+  --voice-amp: 0;
   position: relative;
   display: inline-flex;
   align-items: center;
@@ -388,19 +393,15 @@ body {
   transform-origin: center;
 }
 
-/* Amplitude-reactive inner layer. `--voice-amp` (0–1) is written imperatively
- * per frame; the small coefficient keeps the pulse subtle. Defaults to 0 so
- * non-audio-reactive visuals sit at rest. */
+/* Passive wrapper around the avatar. Body motion now lives on the state class
+ * (a slight constant pulse); amplitude drives the ::after emanation, not this
+ * layer, so the avatar body no longer scales with audio. */
 .voice-avatar__amp {
-  --voice-amp: 0;
   display: inline-flex;
-  transform: scale(calc(1 + var(--voice-amp) * 0.12));
-  transform-origin: center;
-  will-change: transform;
 }
 
-/* Decorative ring/ripple layer shared by idle (invitation pulse) and listening
- * (sonar). Inert until a visual class animates it. */
+/* Decorative ring layer: idle (invitation pulse) and responding (color
+ * emanating outward). Inert until a visual class animates it. */
 .voice-avatar::after {
   content: "";
   position: absolute;
@@ -433,21 +434,17 @@ body {
   animation: voice-avatar-invite-ring 4.5s ease-in-out infinite;
 }
 
-/* Listening — sonar ripple expanding from the avatar surface: cyan at the
- * center fading to indigo at the outer edge. */
-@keyframes voice-avatar-listen-ripple {
-  0% { opacity: 0.55; transform: scale(0.9); }
-  100% { opacity: 0; transform: scale(1.6); }
+/* Listening — the avatar stays receptive: no outward emanation (that moved to
+ * responding), just a slight constant breathing pulse. The user's voice is
+ * carried by the bottom waves coming in (see voice-listening-waves.tsx), not by
+ * the avatar reacting to mic amplitude. */
+@keyframes voice-avatar-soft-pulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.02); }
 }
 
-.voice-avatar--listening::after {
-  background: radial-gradient(
-    circle,
-    rgba(34, 211, 238, 0.45) 0%,
-    rgba(99, 102, 241, 0.28) 60%,
-    rgba(99, 102, 241, 0) 72%
-  );
-  animation: voice-avatar-listen-ripple 1.8s ease-out infinite;
+.voice-avatar--listening {
+  animation: voice-avatar-soft-pulse 3s ease-in-out infinite;
 }
 
 /* Thinking — "stillness with intent": a slow brightness/saturation cycle on
@@ -461,15 +458,35 @@ body {
   animation: voice-avatar-think-glow 2.6s ease-in-out infinite;
 }
 
-/* Responding — subtle baseline energy bounce; the live amplitude scale rides
- * on top via .voice-avatar__amp. */
+/* Responding — the avatar is speaking: a slight baseline bounce (the "pulse")
+ * plus color emanating outward from it (the ::after ring), whose intensity
+ * rides live TTS-output amplitude via `--voice-amp`. Energy going *out*, the
+ * counterpart to listening's waves coming in. */
 @keyframes voice-avatar-respond-bounce {
   0%, 100% { transform: scale(1); }
-  50% { transform: scale(1.04); }
+  50% { transform: scale(1.03); }
 }
 
 .voice-avatar--responding {
-  animation: voice-avatar-respond-bounce 1.1s ease-in-out infinite;
+  animation: voice-avatar-respond-bounce 1.4s ease-in-out infinite;
+}
+
+/* The emanation itself: a ring continuously swelling out and fading (the
+ * "emanating" motion); its color intensity scales with `--voice-amp` so louder
+ * speech radiates more strongly, and it fades to nothing in the gaps. */
+@keyframes voice-avatar-emanate {
+  0% { opacity: 0.75; transform: scale(0.92); }
+  100% { opacity: 0; transform: scale(1.55); }
+}
+
+.voice-avatar--responding::after {
+  background: radial-gradient(
+    circle,
+    rgba(34, 211, 238, calc(0.12 + var(--voice-amp) * 0.5)) 0%,
+    rgba(99, 102, 241, calc(0.08 + var(--voice-amp) * 0.34)) 58%,
+    rgba(99, 102, 241, 0) 72%
+  );
+  animation: voice-avatar-emanate 1.6s ease-out infinite;
 }
 
 /* Reconnecting — dimmed, slow pulse, distinct from idle-breathe (full opacity)
@@ -485,21 +502,19 @@ body {
 
 @media (prefers-reduced-motion: reduce) {
   .voice-avatar--idle,
+  .voice-avatar--listening,
   .voice-avatar--thinking,
   .voice-avatar--responding,
   .voice-avatar--reconnecting {
     animation: none;
   }
   .voice-avatar--idle::after,
-  .voice-avatar--listening::after {
+  .voice-avatar--responding::after {
     animation: none;
     opacity: 0;
   }
   .voice-avatar--reconnecting {
     opacity: 0.6;
-  }
-  .voice-avatar__amp {
-    transform: none;
   }
 }
 
@@ -557,5 +572,126 @@ body {
   .voice-room-particle {
     animation: none;
     opacity: 0.25;
+  }
+}
+
+/* ─── Live-voice listening waves ─────────────────────────────────────────────
+ * The `listening` visual language: layered sine waves along the bottom edge,
+ * the user's voice arriving as energy coming *in* — distinct from `responding`,
+ * where the avatar itself emits an outward pulse. The waves always drift
+ * horizontally; live mic amplitude (`--voice-amp`, written per frame by a rAF
+ * loop — never React state) lifts them up the screen and brightens them as the
+ * user speaks. Cyan→indigo is a fixed decorative accent, matching the listening
+ * sonar, not a theme token. See voice-listening-waves.tsx. */
+.voice-listening-waves {
+  --voice-amp: 0;
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 42%;
+  pointer-events: none;
+  overflow: hidden;
+  /* Rise with the voice: pushed most of the way down when quiet, lifting up as
+   * amplitude grows so the waves reach toward the avatar on louder speech. */
+  transform: translateY(calc((1 - var(--voice-amp)) * 34%));
+  opacity: calc(0.28 + var(--voice-amp) * 0.72);
+  will-change: transform, opacity;
+}
+
+.voice-listening-waves .voice-wave {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.voice-listening-waves path {
+  transform-box: view-box;
+  animation: voice-wave-drift linear infinite;
+}
+
+/* Drift by exactly one viewBox width; the doubled-width path tiles seamlessly.
+ * Per-layer speed (color-agnostic); color comes from the style × palette rules
+ * below. */
+.voice-wave--back path {
+  animation-duration: 13s;
+}
+.voice-wave--mid path {
+  animation-duration: 9s;
+}
+.voice-wave--front path {
+  animation-duration: 6s;
+}
+
+@keyframes voice-wave-drift {
+  to {
+    transform: translateX(-1200px);
+  }
+}
+
+/* Line style: stroke the open curve; no fill. */
+.voice-listening-waves--line path {
+  fill: none;
+  stroke-width: 3;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.voice-listening-waves--fill path {
+  stroke: none;
+}
+
+/* Palette: aurora = fixed cyan→indigo (matches the listening sonar). */
+.voice-listening-waves--aurora.voice-listening-waves--fill .voice-wave--back path {
+  fill: rgba(99, 102, 241, 0.16);
+}
+.voice-listening-waves--aurora.voice-listening-waves--fill .voice-wave--mid path {
+  fill: rgba(79, 140, 255, 0.2);
+}
+.voice-listening-waves--aurora.voice-listening-waves--fill .voice-wave--front path {
+  fill: rgba(34, 211, 238, 0.26);
+}
+.voice-listening-waves--aurora.voice-listening-waves--line .voice-wave--back path {
+  stroke: rgba(99, 102, 241, 0.5);
+}
+.voice-listening-waves--aurora.voice-listening-waves--line .voice-wave--mid path {
+  stroke: rgba(79, 140, 255, 0.62);
+}
+.voice-listening-waves--aurora.voice-listening-waves--line .voice-wave--front path {
+  stroke: rgba(34, 211, 238, 0.78);
+}
+
+/* Palette: accent = tinted from the assistant's avatar color. Falls back to the
+ * aurora indigo when no avatar accent is set. */
+.voice-listening-waves--accent {
+  --wave-accent: var(--avatar-accent, #6366f1);
+}
+.voice-listening-waves--accent.voice-listening-waves--fill .voice-wave--back path {
+  fill: color-mix(in srgb, var(--wave-accent) 16%, transparent);
+}
+.voice-listening-waves--accent.voice-listening-waves--fill .voice-wave--mid path {
+  fill: color-mix(in srgb, var(--wave-accent) 24%, transparent);
+}
+.voice-listening-waves--accent.voice-listening-waves--fill .voice-wave--front path {
+  fill: color-mix(in srgb, var(--wave-accent) 34%, transparent);
+}
+.voice-listening-waves--accent.voice-listening-waves--line .voice-wave--back path {
+  stroke: color-mix(in srgb, var(--wave-accent) 50%, transparent);
+}
+.voice-listening-waves--accent.voice-listening-waves--line .voice-wave--mid path {
+  stroke: color-mix(in srgb, var(--wave-accent) 66%, transparent);
+}
+.voice-listening-waves--accent.voice-listening-waves--line .voice-wave--front path {
+  stroke: color-mix(in srgb, var(--wave-accent) 82%, transparent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .voice-listening-waves path {
+    animation: none;
+  }
+  /* Hold a low, steady band rather than a moving swell. */
+  .voice-listening-waves {
+    transform: none;
+    opacity: 0.4;
   }
 }

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -662,26 +662,38 @@ body {
 }
 
 /* Palette: accent = tinted from the assistant's avatar color. Falls back to the
- * aurora indigo when no avatar accent is set. */
+ * aurora indigo when no avatar accent is set.
+ *
+ * Each rule declares an aurora rgba() first, then the color-mix() tint: engines
+ * without color-mix() (Safari/iOS < 16.2 — the iOS shell still targets 15.0)
+ * drop the invalid color-mix declaration and keep the rgba, so the waves stay
+ * visible (in aurora colors) rather than falling back to SVG's default black
+ * fill on the dark room. */
 .voice-listening-waves--accent {
   --wave-accent: var(--avatar-accent, #6366f1);
 }
 .voice-listening-waves--accent.voice-listening-waves--fill .voice-wave--back path {
+  fill: rgba(99, 102, 241, 0.16);
   fill: color-mix(in srgb, var(--wave-accent) 16%, transparent);
 }
 .voice-listening-waves--accent.voice-listening-waves--fill .voice-wave--mid path {
+  fill: rgba(79, 140, 255, 0.2);
   fill: color-mix(in srgb, var(--wave-accent) 24%, transparent);
 }
 .voice-listening-waves--accent.voice-listening-waves--fill .voice-wave--front path {
+  fill: rgba(34, 211, 238, 0.26);
   fill: color-mix(in srgb, var(--wave-accent) 34%, transparent);
 }
 .voice-listening-waves--accent.voice-listening-waves--line .voice-wave--back path {
+  stroke: rgba(99, 102, 241, 0.5);
   stroke: color-mix(in srgb, var(--wave-accent) 50%, transparent);
 }
 .voice-listening-waves--accent.voice-listening-waves--line .voice-wave--mid path {
+  stroke: rgba(79, 140, 255, 0.62);
   stroke: color-mix(in srgb, var(--wave-accent) 66%, transparent);
 }
 .voice-listening-waves--accent.voice-listening-waves--line .voice-wave--front path {
+  stroke: rgba(34, 211, 238, 0.78);
   stroke: color-mix(in srgb, var(--wave-accent) 82%, transparent);
 }
 


### PR DESCRIPTION
## What

Reworks the full-screen live-voice room so **listening** and **responding** read as clearly distinct states, and fixes the avatar's audio-reactivity to ride the right signal.

Closes JARVIS-1267.

### The bug this started from
The `responding` avatar's amplitude pulse was fed by **mic input** — near-silent while the *assistant* speaks — so the avatar pulsed on the user's voice and sat still on the assistant's. There was no TTS-output amplitude wired at all.

### Changes
- **Output amplitude:** `LiveVoiceAudioPlayer` now taps the output bus with an `AnalyserNode`; `getLiveVoiceOutputAmplitude` exposes the smoothed RMS, registered per session. The `responding` avatar rides this instead of the mic.
- **Listening = energy coming in:** new `VoiceListeningWaves` — layered waves rising from the bottom edge with live mic amplitude — plus a still, receptive avatar (slight breathing pulse, no mic-driven scaling). The old outward sonar ripple is gone.
- **Responding = energy going out:** the avatar emanates color outward, intensity riding TTS output amplitude, over a slight bounce.
- **Waves follow the avatar color** (`--avatar-accent`). `resolveWaveAccentHex` mirrors `ChatAvatar`'s default-color fallback, so a default (traits-less) avatar matches its rendered color instead of drifting to the aurora indigo.
- **Storybook harness** (`Chat/Voice/VoiceAvatar`): every state, an amplitude driver, and wave style/palette knobs against a seeded real avatar — net-new visual coverage.

## Testing
- `wave-accent.test.ts` — accent resolution (explicit color / default fallback / no-character).
- `voice-room.test.tsx` — waves mount only in `listening`, hidden while responding/thinking.
- `tts-playback`, `live-voice-store`, `use-live-voice` suites updated/green.
- Typecheck + lint clean.

## Note
Visuals were iterated in the Storybook harness; the room mount is covered by tests. Worth a quick eyeball in a live voice session before merge — I couldn't drive a real STT/TTS session locally. The `responding` emanation is intentionally left as the fixed cyan→indigo for now (waves follow the avatar color); tying the emanation to the avatar accent too is a trivial follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
