### PR TITLE
refactor(plugins): share catalog projection, dead export, URL normalization

### DIFF
--- a/assistant/src/cli/lib/__tests__/search-plugins.test.ts
+++ b/assistant/src/cli/lib/__tests__/search-plugins.test.ts
@@ -16,6 +16,7 @@ import {
   InvalidSearchPatternError,
   marketplaceMatch,
   type PluginCatalog,
+  projectMarketplaceEntries,
 } from "../search-plugins.js";
 
 // External marketplace refs must be full commit SHAs (immutable). Fixtures use
@@ -188,5 +189,31 @@ describe("marketplaceMatch", () => {
       marketplaceMatch(entry("plain-plugin", "acme/plain-plugin", SHA_B))
         .category,
     ).toBeNull();
+  });
+});
+
+describe("projectMarketplaceEntries", () => {
+  test("dedupes by name (first wins) and sorts alphabetically", () => {
+    const matches = projectMarketplaceEntries([
+      entry("git-tools", "acme/git-tools", SHA_C),
+      entry("memory-graph", "acme/memory-graph", SHA_B),
+      entry("git-tools", "acme/other-git-tools", SHA_A),
+    ]);
+    expect(matches.map((m) => m.name)).toEqual(["git-tools", "memory-graph"]);
+    // First occurrence wins on a name collision.
+    expect(matches[0]!.source.repo).toBe("acme/git-tools");
+  });
+
+  test("projects each entry via marketplaceMatch", () => {
+    const [match] = projectMarketplaceEntries([
+      entry("simple-memory", "vellum-ai/simple-memory", SHA_A),
+    ]);
+    expect(match).toEqual(
+      marketplaceMatch(entry("simple-memory", "vellum-ai/simple-memory", SHA_A)),
+    );
+  });
+
+  test("returns an empty list for no entries", () => {
+    expect(projectMarketplaceEntries([])).toEqual([]);
   });
 });

--- a/assistant/src/cli/lib/plugin-catalog-local.ts
+++ b/assistant/src/cli/lib/plugin-catalog-local.ts
@@ -15,34 +15,38 @@ import {
   type ResolvedPluginSource,
   resolveMarketplaceSource,
 } from "./plugin-marketplace.js";
-import { marketplaceMatch, type PluginCatalog } from "./search-plugins.js";
+import {
+  type PluginCatalog,
+  projectMarketplaceEntries,
+} from "./search-plugins.js";
 
 // Re-exported so `local`-tagged CLI commands can gate on platform features
 // without importing `platform/` directly (cli/no-daemon-internals allows lib).
 export { arePlatformFeaturesEnabled } from "../../platform/feature-gate.js";
 
+let memoizedEntries: readonly MarketplaceEntry[] | undefined;
+
+/** Validated bundled manifest entries, parsed once and reused. */
+function bundledEntries(): readonly MarketplaceEntry[] {
+  memoizedEntries ??= marketplaceManifestSchema.parse(bundledManifest).plugins;
+  return memoizedEntries;
+}
+
 /**
- * Validate and project the bundled manifest into a {@link PluginCatalog}:
- * every entry deduped by name, mapped via {@link marketplaceMatch}, sorted
- * alphabetically. A malformed bundled manifest is a build defect, so parsing
- * throws rather than silently degrading.
+ * Validate and project a marketplace manifest into a {@link PluginCatalog}:
+ * every entry deduped by name, projected, and sorted alphabetically. A
+ * malformed bundled manifest is a build defect, so parsing throws rather than
+ * silently degrading. Defaults to the bundled manifest (parsed once); tests
+ * pass an override to assert it throws on invalid input.
  */
 export function buildBundledPluginCatalog(
   rawManifest: unknown = bundledManifest,
 ): PluginCatalog {
-  const { plugins } = marketplaceManifestSchema.parse(rawManifest);
-
-  const matches = [];
-  const seen = new Set<string>();
-  for (const entry of plugins) {
-    if (seen.has(entry.name)) {continue;}
-    matches.push(marketplaceMatch(entry));
-    seen.add(entry.name);
-  }
-
-  matches.sort((a, b) => a.name.localeCompare(b.name));
-
-  return { ref: "bundled", matches };
+  const plugins =
+    rawManifest === bundledManifest
+      ? bundledEntries()
+      : marketplaceManifestSchema.parse(rawManifest).plugins;
+  return { ref: "bundled", matches: projectMarketplaceEntries(plugins) };
 }
 
 let memoized: PluginCatalog | undefined;
@@ -51,14 +55,6 @@ let memoized: PluginCatalog | undefined;
 export function readBundledPluginCatalog(): PluginCatalog {
   memoized ??= buildBundledPluginCatalog();
   return memoized;
-}
-
-let memoizedEntries: readonly MarketplaceEntry[] | undefined;
-
-/** Validated bundled manifest entries, parsed once and reused. */
-function bundledEntries(): readonly MarketplaceEntry[] {
-  memoizedEntries ??= marketplaceManifestSchema.parse(bundledManifest).plugins;
-  return memoizedEntries;
 }
 
 /**

--- a/assistant/src/cli/lib/plugin-catalog-platform.ts
+++ b/assistant/src/cli/lib/plugin-catalog-platform.ts
@@ -15,11 +15,11 @@
 import { z } from "zod";
 
 import { getPlatformBaseUrl } from "../../config/env.js";
+import type { MarketplaceEntry } from "./plugin-marketplace.js";
 import {
-  marketplaceMatch,
   type PluginCatalog,
   PluginCatalogUnavailableError,
-  type PluginSearchMatch,
+  projectMarketplaceEntries,
   type SearchPluginsDeps,
 } from "./search-plugins.js";
 
@@ -49,7 +49,7 @@ export async function fetchPluginCatalogFromPlatform(
   deps: SearchPluginsDeps,
   opts?: { ref?: string },
 ): Promise<PluginCatalog> {
-  const url = `${getPlatformBaseUrl()}/v1/plugins/`;
+  const url = `${getPlatformBaseUrl().replace(/\/+$/, "")}/v1/plugins/`;
 
   let res: Response;
   try {
@@ -91,28 +91,21 @@ export async function fetchPluginCatalogFromPlatform(
     );
   }
 
-  const matches: PluginSearchMatch[] = [];
-  const seen = new Set<string>();
+  const entries: MarketplaceEntry[] = [];
   for (const row of parsed.data.plugins) {
     if (!row.repo || !row.ref) continue;
-    if (seen.has(row.name)) continue;
-    seen.add(row.name);
-    matches.push(
-      marketplaceMatch({
-        name: row.name,
-        source: {
-          source: "github",
-          repo: row.repo,
-          ref: row.ref,
-          path: row.path ?? undefined,
-        },
-        description: row.description ?? undefined,
-        category: row.category ?? undefined,
-      }),
-    );
+    entries.push({
+      name: row.name,
+      source: {
+        source: "github",
+        repo: row.repo,
+        ref: row.ref,
+        path: row.path ?? undefined,
+      },
+      description: row.description ?? undefined,
+      category: row.category ?? undefined,
+    });
   }
 
-  matches.sort((a, b) => a.name.localeCompare(b.name));
-
-  return { ref: opts?.ref ?? "platform", matches };
+  return { ref: opts?.ref ?? "platform", matches: projectMarketplaceEntries(entries) };
 }

--- a/assistant/src/cli/lib/search-plugins.ts
+++ b/assistant/src/cli/lib/search-plugins.ts
@@ -15,17 +15,6 @@
 import type { FetchLike } from "./fetch-like.js";
 import type { MarketplaceEntry } from "./plugin-marketplace.js";
 
-/** Options that control the search. */
-export interface SearchPluginsOptions {
-  /**
-   * ECMAScript regex pattern. Matched case-insensitively against directory
-   * names. Empty string matches everything.
-   */
-  readonly query: string;
-  /** Git ref to list from. */
-  readonly ref?: string;
-}
-
 /** Dependencies injected by the caller. */
 export interface SearchPluginsDeps {
   /** HTTP client. Production callers pass `globalThis.fetch.bind(globalThis)`. */
@@ -138,6 +127,28 @@ export function marketplaceMatch(entry: MarketplaceEntry): PluginSearchMatch {
     category: entry.category ?? null,
     source: { kind: "github", repo, path, ref },
   };
+}
+
+/**
+ * Project raw marketplace entries onto catalog matches: dedupe by name
+ * (first occurrence wins), map via {@link marketplaceMatch}, and return
+ * sorted alphabetically by name.
+ *
+ * Shared by every catalog source (platform fetcher, bundled reader) so they
+ * dedupe, project, and order entries identically.
+ */
+export function projectMarketplaceEntries(
+  entries: Iterable<MarketplaceEntry>,
+): PluginSearchMatch[] {
+  const matches: PluginSearchMatch[] = [];
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    if (seen.has(entry.name)) continue;
+    seen.add(entry.name);
+    matches.push(marketplaceMatch(entry));
+  }
+  matches.sort((a, b) => a.name.localeCompare(b.name));
+  return matches;
 }
 
 function buildMatcher(query: string): (name: string) => boolean {


### PR DESCRIPTION
## Summary
Plan-review cleanups (plugins-catalog-platform-first.md):
- Extract shared projectMarketplaceEntries (dedupe+marketplaceMatch+sort) reused by the platform fetcher and bundled reader; collapse the bundled reader's double manifest parse to one memoized parse.
- Delete the orphaned SearchPluginsOptions export.
- Normalize a trailing slash on the platform base URL before appending /v1/plugins/.