### PR TITLE
fix(plugins): preserve curated adapter stub on offline bundled install

### DIFF
--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -213,7 +213,7 @@ Examples:
                     {
                       name: nameOrUrl,
                       force: opts.force,
-                      directSource: {
+                      trustedSource: {
                         owner: source.owner,
                         repo: source.repo,
                         rootPath: source.path,

--- a/assistant/src/cli/lib/__tests__/install-from-github.test.ts
+++ b/assistant/src/cli/lib/__tests__/install-from-github.test.ts
@@ -686,6 +686,52 @@ describe("installPlugin — marketplace resolution", () => {
     expect(hook).not.toContain("description: terse mode");
   });
 
+  test("a trusted pre-resolved source still overlays the curated adapter stub", async () => {
+    // GIVEN caveman's pin already resolved (as the offline bundled catalog
+    // does) — so no marketplace manifest is served — but the real curated
+    // adapter stub IS available to overlay
+    const fetch = makeContentsFetch({ tree: readRealCavemanStub() });
+    const runGit = fakeGitRunner({
+      tree: {
+        "package.json": JSON.stringify({
+          name: "caveman-installer",
+          version: "0.1.0",
+        }),
+        "skills/caveman/SKILL.md":
+          "---\nname: caveman\n---\n\nCAVEMAN MODE. Drop filler words.",
+      },
+      commit: CAVEMAN_SHA,
+    });
+
+    // WHEN we install from trusted pre-resolved coordinates
+    const result = await installPlugin(
+      {
+        name: "caveman",
+        trustedSource: {
+          owner: "JuliusBrussee",
+          repo: "caveman",
+          rootPath: "",
+          ref: CAVEMAN_SHA,
+        },
+      },
+      { fetch, runGit, workspacePluginsDir: pluginsDir },
+    );
+
+    // THEN the adapter overlay ran (the stub was NOT skipped): the manifest was
+    // normalized and the pre-model-call hook synthesized from the ruleset
+    const target = join(pluginsDir, "caveman");
+    expect(result.commit).toBe(CAVEMAN_SHA);
+    const pkg = JSON.parse(readFileSync(join(target, "package.json"), "utf-8"));
+    expect(pkg.name).toBe("caveman");
+    expect(pkg.peerDependencies["@vellumai/plugin-api"]).toBeString();
+    expect(pkg.scripts?.postinstall).toBeUndefined();
+    const hook = readFileSync(
+      join(target, "hooks", "pre-model-call.ts"),
+      "utf-8",
+    );
+    expect(hook).toContain("CAVEMAN MODE. Drop filler words.");
+  });
+
   test("falls back to the stub manifest when the upstream ships no package.json", async () => {
     // GIVEN caveman is whitelisted with the real curated adapter stub
     const fetch = makeContentsFetch({

--- a/assistant/src/cli/lib/__tests__/plugins-install-offline.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugins-install-offline.test.ts
@@ -3,7 +3,8 @@
  *
  * With `VELLUM_DISABLE_PLATFORM=true` there is no platform to serve a verified
  * tarball, so `assistant plugins install <name>` resolves the pin from the
- * bundled marketplace catalog and installs through the GitHub path — with zero
+ * bundled marketplace catalog and installs through the trusted GitHub path
+ * (`trustedSource`, which preserves the curated adapter stub) — with zero
  * platform calls. A name absent from the bundled catalog fails clearly. With
  * platform features enabled, the platform install endpoint is used unchanged.
  */
@@ -36,7 +37,7 @@ mock.module("../install-from-github.js", () => ({
       name: opts.name,
       target: `/plugins/${opts.name}`,
       fileCount: 3,
-      ref: opts.directSource?.ref ?? "main",
+      ref: opts.trustedSource?.ref ?? opts.directSource?.ref ?? "main",
       commit: "abc1234def",
       committedAt: null,
     };
@@ -96,7 +97,7 @@ describe("plugins install by name — disable-platform mode", () => {
     mock.restore();
   });
 
-  test("installs a bundled plugin via the GitHub path with no platform call", async () => {
+  test("installs a bundled plugin via the trusted GitHub path with no platform call", async () => {
     process.env.VELLUM_DISABLE_PLATFORM = "true";
     delete process.env.IS_PLATFORM;
 
@@ -106,12 +107,15 @@ describe("plugins install by name — disable-platform mode", () => {
     expect(installPluginCalls.length).toBe(1);
     const opts = installPluginCalls[0]!;
     expect(opts.name).toBe(BUNDLED_PLUGIN);
-    expect(opts.directSource).toEqual({
+    // A trusted pre-resolved source (not `directSource`) so the curated adapter
+    // stub — caveman ships one — is still overlaid on the offline install.
+    expect(opts.trustedSource).toEqual({
       owner: "JuliusBrussee",
       repo: "caveman",
       rootPath: "",
       ref: "63a91ecadbf4c4719a4602a5abb00883f9966034",
     });
+    expect(opts.directSource).toBeUndefined();
     expect(process.exitCode).not.toBe(1);
   });
 

--- a/assistant/src/cli/lib/install-from-github.ts
+++ b/assistant/src/cli/lib/install-from-github.ts
@@ -132,6 +132,19 @@ export interface InstallPluginOptions {
    * commit to clone (a branch, tag, `HEAD`, or full SHA).
    */
   readonly directSource?: PluginFetchSource;
+  /**
+   * Install from these PRE-RESOLVED, TRUSTED GitHub coordinates while STILL
+   * overlaying the curated `plugins/<name>` adapter stub. This is the offline
+   * analogue of a marketplace install: the pin came from the reviewed bundled
+   * catalog instead of a live marketplace fetch, so — unlike
+   * {@link InstallPluginOptions.directSource} — the source is trusted and the
+   * adapter stub is kept. The stub is fetched from the canonical repo at
+   * {@link InstallPluginOptions.ref} (default {@link DEFAULT_PLUGIN_REF}), the
+   * same ref the online trusted path uses. When set, marketplace resolution and
+   * {@link InstallPluginOptions.commitOverride} are skipped; `trustedSource.ref`
+   * selects the commit to clone (the reviewed pin).
+   */
+  readonly trustedSource?: PluginFetchSource;
 }
 
 /** Dependencies injected by the caller. */
@@ -383,13 +396,21 @@ export async function installPlugin(
 
   // A direct install bypasses the marketplace whitelist entirely: the source is
   // supplied by the caller and the tree is materialized verbatim (no curated
-  // adapter stub). Otherwise the name is resolved against the reviewed manifest.
+  // adapter stub). A trusted pre-resolved source (offline bundled-catalog
+  // install) supplies its coordinates too but keeps the curated overlay.
+  // Otherwise the name is resolved against the reviewed manifest.
   let effectiveSource: PluginFetchSource;
   // Ref the curated adapter stub is fetched at, or `null` to skip the overlay.
   let stubRef: string | null;
   if (opts.directSource) {
     effectiveSource = opts.directSource;
     stubRef = null;
+  } else if (opts.trustedSource) {
+    // Trusted, pre-resolved coordinates: keep the curated adapter overlay,
+    // fetched from the canonical repo at `marketplaceRef` exactly as the online
+    // trusted path does.
+    effectiveSource = opts.trustedSource;
+    stubRef = marketplaceRef;
   } else {
     const source = await resolvePluginSource(name, marketplaceRef, deps.fetch);
     if (!source) {


### PR DESCRIPTION
## Summary
Fixes a gap from plan review (plugins-catalog-platform-first.md): under VELLUM_DISABLE_PLATFORM, name-installs used directSource which nulls stubRef and skips the curated plugins/<name> adapter overlay, silently breaking stub plugins (caveman). Offline bundled installs now resolve coordinates from the bundled manifest but install through a trusted pinned path that preserves the adapter stub — zero platform calls.