### PR TITLE
fix(config): resolve explicit default-profile references through the default provider

### DIFF
--- a/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
+++ b/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
@@ -395,9 +395,8 @@ describe("flag-on / flag-off parity on materialized workspaces", () => {
 });
 
 describe("explicit default-profile references resolve through the default provider", () => {
-  // Regression: a conversation/schedule pin, activeProfile, or callSites
-  // reference to a default key resolved the vellum catalog column regardless
-  // of llm.defaultProvider, dispatching vellum model ids to BYOK connections.
+  // Regressed failure mode: the vellum column's model ids dispatched to
+  // BYOK connections.
   const managedStubs = {
     balanced: { source: "managed" as const },
     "cost-optimized": { source: "managed" as const },
@@ -471,9 +470,7 @@ describe("explicit default-profile references resolve through the default provid
 });
 
 describe("hatch-era disabled stubs on default keys", () => {
-  // Fresh BYOK hatches persist disabled managed stubs; a stale stub must not
-  // suppress an explicit pin — the code-owned body stands, as on the intent
-  // rung.
+  // Fresh BYOK hatches persist disabled managed stubs.
   const disabledStubs = {
     balanced: { source: "managed" as const, status: "disabled" as const },
     "cost-optimized": {
@@ -500,8 +497,7 @@ describe("hatch-era disabled stubs on default keys", () => {
       ...anthropicDp,
     });
     const resolved = resolveCallSiteConfig("mainAgent", llm);
-    // The default key wins its rung; it must not fall through to the
-    // call-site pin below it.
+    // The call-site pin below the active rung must not capture the turn.
     expect(resolved.provider).toBe("anthropic");
     expect(resolved.model).not.toBe(completeCustom.model);
   });
@@ -547,8 +543,8 @@ describe("user shadows of default keys keep their intent", () => {
       requested: "balanced",
       reason: "disabled",
     });
-    // Falls to the balanced intent through the default provider — but via the
-    // anchor rung, after the disabled shadow reported.
+    // The anchor lands on the same intent either way; the report above is
+    // what distinguishes fall-through from silent replacement.
     expect(resolved.provider).toBe("anthropic");
     expect(resolved.model).not.toBe("gpt-5.4");
   });

--- a/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
+++ b/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
@@ -393,3 +393,79 @@ describe("flag-on / flag-off parity on materialized workspaces", () => {
     expect(flagOn).toEqual(flagOff);
   });
 });
+
+describe("explicit default-profile references resolve through the default provider", () => {
+  // Regression: a conversation/schedule pin, activeProfile, or callSites
+  // reference to a default key resolved the vellum catalog column regardless
+  // of llm.defaultProvider, dispatching vellum model ids to BYOK connections.
+  const managedStubs = {
+    balanced: { source: "managed" as const },
+    "cost-optimized": { source: "managed" as const },
+  };
+
+  test("an override pin to a default key matches the intent-rung resolution", () => {
+    const llm = LLMSchema.parse({ profiles: managedStubs, ...anthropicDp });
+    const pinned = resolveCallSiteConfig("mainAgent", llm, {
+      overrideProfile: "cost-optimized",
+    });
+    // conversationSummarization's call-site default is the same intent.
+    const viaIntent = resolveCallSiteConfig("conversationSummarization", llm);
+    expect(pinned.provider).toBe("anthropic");
+    expect(pinned.model).toBe(viaIntent.model);
+    expect(pinned.provider_connection).toBe(viaIntent.provider_connection);
+    expect(pinned.model).not.toBe(
+      CODE_DEFAULT_PROFILE_ENTRIES["cost-optimized"].model as string,
+    );
+  });
+
+  test("activeProfile set to a default key resolves the default provider's column", () => {
+    const llm = LLMSchema.parse({
+      profiles: managedStubs,
+      activeProfile: "balanced",
+      ...anthropicDp,
+    });
+    const resolved = resolveCallSiteConfig("mainAgent", llm);
+    expect(resolved.provider).toBe("anthropic");
+    expect(resolved.provider_connection).toBe("anthropic-personal");
+    expect(resolved.model).not.toBe(
+      CODE_DEFAULT_PROFILE_ENTRIES.balanced.model as string,
+    );
+  });
+
+  test("a vellum default provider keeps the vellum bodies", () => {
+    const llm = LLMSchema.parse({
+      profiles: managedStubs,
+      defaultProvider: { provider: "vellum" },
+    });
+    const pinned = resolveCallSiteConfig("mainAgent", llm, {
+      overrideProfile: "cost-optimized",
+    });
+    const vellumBody = CODE_DEFAULT_PROFILE_ENTRIES["cost-optimized"];
+    expect(pinned.model).toBe(vellumBody.model as string);
+    expect(pinned.provider_connection).toBe(vellumBody.provider_connection);
+  });
+
+  test("a mix arm naming a default key expands through the default provider", () => {
+    const llm = LLMSchema.parse({
+      profiles: {
+        ...managedStubs,
+        blend: {
+          source: "user" as const,
+          mix: [
+            { profile: "cost-optimized", weight: 1 },
+            { profile: "cost-optimized", weight: 1 },
+          ],
+        },
+      },
+      ...anthropicDp,
+    });
+    const resolved = resolveCallSiteConfig("mainAgent", llm, {
+      overrideProfile: "blend",
+      selectionSeed: "seed",
+    });
+    expect(resolved.provider).toBe("anthropic");
+    expect(resolved.model).not.toBe(
+      CODE_DEFAULT_PROFILE_ENTRIES["cost-optimized"].model as string,
+    );
+  });
+});

--- a/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
+++ b/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
@@ -526,3 +526,42 @@ describe("hatch-era disabled stubs on default keys", () => {
     });
   });
 });
+
+describe("user shadows of default keys keep their intent", () => {
+  test("a disabled user shadow reports and falls through, not silently the catalog", () => {
+    const { fallbacks, opts } = collect();
+    const llm = LLMSchema.parse({
+      profiles: {
+        balanced: {
+          ...completeCustom,
+          status: "disabled" as const,
+          model: "gpt-5.4",
+        },
+      },
+      activeProfile: "balanced",
+      ...anthropicDp,
+    });
+    const resolved = resolveCallSiteConfig("mainAgent", llm, opts);
+    expect(fallbacks).toContainEqual({
+      callSite: "mainAgent",
+      requested: "balanced",
+      reason: "disabled",
+    });
+    // Falls to the balanced intent through the default provider — but via the
+    // anchor rung, after the disabled shadow reported.
+    expect(resolved.provider).toBe("anthropic");
+    expect(resolved.model).not.toBe("gpt-5.4");
+  });
+
+  test("a usable user shadow of a default key wins verbatim", () => {
+    const llm = LLMSchema.parse({
+      profiles: { balanced: { ...completeCustom, model: "gpt-5.4" } },
+      ...anthropicDp,
+    });
+    const pinned = resolveCallSiteConfig("mainAgent", llm, {
+      overrideProfile: "balanced",
+    });
+    expect(pinned.model).toBe("gpt-5.4");
+    expect(pinned.provider).toBe("openai");
+  });
+});

--- a/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
+++ b/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
@@ -469,3 +469,60 @@ describe("explicit default-profile references resolve through the default provid
     );
   });
 });
+
+describe("hatch-era disabled stubs on default keys", () => {
+  // Fresh BYOK hatches persist disabled managed stubs; a stale stub must not
+  // suppress an explicit pin — the code-owned body stands, as on the intent
+  // rung.
+  const disabledStubs = {
+    balanced: { source: "managed" as const, status: "disabled" as const },
+    "cost-optimized": {
+      source: "managed" as const,
+      status: "disabled" as const,
+    },
+  };
+
+  test("an override pin to a disabled default stub still resolves the provider's column", () => {
+    const llm = LLMSchema.parse({ profiles: disabledStubs, ...anthropicDp });
+    const pinned = resolveCallSiteConfig("mainAgent", llm, {
+      overrideProfile: "cost-optimized",
+    });
+    const viaIntent = resolveCallSiteConfig("conversationSummarization", llm);
+    expect(pinned.provider).toBe("anthropic");
+    expect(pinned.model).toBe(viaIntent.model);
+  });
+
+  test("activeProfile pointing at a disabled default stub resolves, not falls through", () => {
+    const llm = LLMSchema.parse({
+      profiles: { ...disabledStubs, mine: completeCustom },
+      activeProfile: "balanced",
+      callSites: { mainAgent: { profile: "mine" } },
+      ...anthropicDp,
+    });
+    const resolved = resolveCallSiteConfig("mainAgent", llm);
+    // The default key wins its rung; it must not fall through to the
+    // call-site pin below it.
+    expect(resolved.provider).toBe("anthropic");
+    expect(resolved.model).not.toBe(completeCustom.model);
+  });
+
+  test("a disabled CUSTOM profile is still skipped", () => {
+    const { fallbacks, opts } = collect();
+    const llm = LLMSchema.parse({
+      profiles: {
+        mine: { ...completeCustom, status: "disabled" as const },
+      },
+      ...anthropicDp,
+    });
+    const resolved = resolveCallSiteConfig("mainAgent", llm, {
+      ...opts,
+      overrideProfile: "mine",
+    });
+    expect(resolved.model).not.toBe(completeCustom.model);
+    expect(fallbacks).toContainEqual({
+      callSite: "mainAgent",
+      requested: "mine",
+      reason: "disabled",
+    });
+  });
+});

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -406,7 +406,7 @@ export function resolveDefaultProfileForProvider(
   );
 }
 
-function isDefaultProfileKey(name: string): name is DefaultProfileKey {
+export function isDefaultProfileKey(name: string): name is DefaultProfileKey {
   return (DEFAULT_PROFILE_KEYS as readonly string[]).includes(name);
 }
 

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -373,6 +373,25 @@ export function selectWinningProfile(
 }
 
 /**
+ * Dereference a profile name for the override-or-default rungs. A
+ * default-profile key resolves through the default provider's column of the
+ * intent × provider matrix — an explicit reference (pin, `activeProfile`,
+ * `callSites` profile) must yield the same body the call-site intent rung
+ * would, never the vellum column regardless of `llm.defaultProvider`. Custom
+ * names resolve to their workspace entry either way.
+ */
+function providerAwareEntry(
+  llm: z.infer<typeof LLMSchema>,
+  name: string,
+): ProfileEntry | undefined {
+  return resolveDefaultProfileForProvider(
+    llm.profiles,
+    name,
+    llm.defaultProvider ?? null,
+  );
+}
+
+/**
  * Dereference a named rung: the effective entry must exist, be enabled,
  * expand (for a mix) to an enabled arm, and carry its own provider+model.
  */
@@ -385,7 +404,7 @@ function usableEntry(
   if (name == null) {
     return undefined;
   }
-  const named = getEffectiveProfile(llm.profiles, name);
+  const named = providerAwareEntry(llm, name);
   if (named == null) {
     report(name, "missing");
     return undefined;
@@ -396,7 +415,11 @@ function usableEntry(
   }
   // Mixes expand via the shared seeded pick (fires `onMixSelected`).
   const entry =
-    named.mix == null ? named : resolveProfileFragment(name, llm, opts);
+    named.mix == null
+      ? named
+      : resolveProfileFragment(name, llm, opts, (n) =>
+          providerAwareEntry(llm, n),
+        );
   if (entry == null) {
     report(name, "missing");
     return undefined;
@@ -434,7 +457,9 @@ function usableDefaultIntent(
     defaultProvider,
   );
   if (entry?.mix != null) {
-    entry = resolveProfileFragment(intent, llm, opts);
+    entry = resolveProfileFragment(intent, llm, opts, (n) =>
+      providerAwareEntry(llm, n),
+    );
   }
   if (
     entry != null &&
@@ -615,9 +640,11 @@ function resolveProfileFragment(
   name: string | undefined,
   llm: z.infer<typeof LLMSchema>,
   opts: ResolveCallSiteOpts,
+  lookupEntry: (name: string) => ProfileEntry | undefined = (n) =>
+    getEffectiveProfile(llm.profiles, n),
 ): ProfileEntry | undefined {
   if (name == null) return undefined;
-  const entry = getEffectiveProfile(llm.profiles, name);
+  const entry = lookupEntry(name);
   if (entry?.mix == null) return entry;
 
   // Mix: pick one constituent. Seed by per-conversation seed + the mix's own
@@ -631,7 +658,7 @@ function resolveProfileFragment(
   opts.onMixSelected?.({ mixProfile: name, chosenProfile: chosen.profile });
 
   // The chosen arm must be a standard profile (enforced by superRefine).
-  return getEffectiveProfile(llm.profiles, chosen.profile);
+  return lookupEntry(chosen.profile);
 }
 
 /**

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -375,18 +375,14 @@ export function selectWinningProfile(
 
 /**
  * Dereference a profile name for the override-or-default rungs. A
- * default-profile key resolves through the default provider's column of the
- * intent × provider matrix — an explicit reference (pin, `activeProfile`,
- * `callSites` profile) must yield the same body the call-site intent rung
- * would, never the vellum column regardless of `llm.defaultProvider`. Custom
- * names resolve to their workspace entry either way.
+ * default-profile key must yield the same body the call-site intent rung
+ * would — the default provider's column, never unconditionally the vellum
+ * column.
  *
- * Like `usableDefaultIntent`, a persisted managed stub on a default key never
- * suppresses the code-owned body: defaults cannot be disabled through any
- * write path, so a disabled/thin managed stub carries no user intent and the
- * pure catalog overrides it. User-owned shadows do carry intent: a usable one
- * wins (mixes are expanded by the caller), and an unusable one is returned
- * as-is so the rung reports it and falls through.
+ * A persisted managed stub carries no user intent (defaults cannot be
+ * disabled through any write path), so the pure catalog overrides an
+ * unusable one. An unusable user-owned shadow is returned as-is so the rung
+ * reports it and falls through.
  */
 function providerAwareEntry(
   llm: z.infer<typeof LLMSchema>,

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -12,6 +12,7 @@ import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
 import { CALL_SITE_DEFAULTS } from "./call-site-defaults.js";
 import {
   getEffectiveProfile,
+  isDefaultProfileKey,
   resolveDefaultProfileForProvider,
 } from "./default-profile-catalog.js";
 import {
@@ -379,16 +380,35 @@ export function selectWinningProfile(
  * `callSites` profile) must yield the same body the call-site intent rung
  * would, never the vellum column regardless of `llm.defaultProvider`. Custom
  * names resolve to their workspace entry either way.
+ *
+ * Like `usableDefaultIntent`, a stale workspace stub on a default key never
+ * suppresses the code-owned body: defaults cannot be disabled through any
+ * write path, so a disabled/thin stub is hatch-era state (pre-M5 "no vellum
+ * connection") that the pure catalog overrides. Usable user shadows —
+ * including mixes, which the caller expands — still win.
  */
 function providerAwareEntry(
   llm: z.infer<typeof LLMSchema>,
   name: string,
 ): ProfileEntry | undefined {
-  return resolveDefaultProfileForProvider(
+  const defaultProvider = llm.defaultProvider ?? null;
+  const entry = resolveDefaultProfileForProvider(
     llm.profiles,
     name,
-    llm.defaultProvider ?? null,
+    defaultProvider,
   );
+  if (!isDefaultProfileKey(name) || entry?.mix != null) {
+    return entry;
+  }
+  if (
+    entry != null &&
+    entry.status !== "disabled" &&
+    entry.provider != null &&
+    entry.model != null
+  ) {
+    return entry;
+  }
+  return resolveDefaultProfileForProvider(undefined, name, defaultProvider);
 }
 
 /**

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -381,11 +381,12 @@ export function selectWinningProfile(
  * would, never the vellum column regardless of `llm.defaultProvider`. Custom
  * names resolve to their workspace entry either way.
  *
- * Like `usableDefaultIntent`, a stale workspace stub on a default key never
+ * Like `usableDefaultIntent`, a persisted managed stub on a default key never
  * suppresses the code-owned body: defaults cannot be disabled through any
- * write path, so a disabled/thin stub is hatch-era state (pre-M5 "no vellum
- * connection") that the pure catalog overrides. Usable user shadows —
- * including mixes, which the caller expands — still win.
+ * write path, so a disabled/thin managed stub carries no user intent and the
+ * pure catalog overrides it. User-owned shadows do carry intent: a usable one
+ * wins (mixes are expanded by the caller), and an unusable one is returned
+ * as-is so the rung reports it and falls through.
  */
 function providerAwareEntry(
   llm: z.infer<typeof LLMSchema>,
@@ -406,6 +407,10 @@ function providerAwareEntry(
     entry.provider != null &&
     entry.model != null
   ) {
+    return entry;
+  }
+  const workspace = llm.profiles?.[name];
+  if (workspace != null && workspace.source !== "managed") {
     return entry;
   }
   return resolveDefaultProfileForProvider(undefined, name, defaultProvider);


### PR DESCRIPTION
## Summary
- Pinning a default profile (conversation pin, schedule pin, `activeProfile`, `callSites`) resolved the **vellum** catalog body regardless of `llm.defaultProvider` — on a logged-out BYOK install the dispatch auto-recovery then sent the vellum model id to the BYOK connection (observed: OpenAI API called with `accounts/fireworks/models/deepseek-v4-flash` → 400 on every pinned turn and schedule run).
- `usableEntry` and mix-arm expansion on the override-or-default path now dereference default keys via `resolveDefaultProfileForProvider(..., llm.defaultProvider)`, exactly like the call-site intent rung — the same key now resolves identically on every rung. Custom profile names and the legacy flag-off cascade are untouched.
- Regression tests: pin/activeProfile/mix-arm references to default keys on a BYOK-default workspace resolve the provider's column (and fail against the unfixed resolver); vellum-default workspaces are pinned unchanged.

## Original prompt
Stage-2 release QA for the inference-management refactor (0.10.8, LD flag flips on release day) ran the flag-on resolution matrix on a BYOK canary and found every conversation/schedule pin to a default profile failing with a provider 400. Root cause was the named rungs using the vellum-column `getEffectiveProfile` while only the intent rung was provider-aware. The fix must land tonight so pinned defaults resolve through `llm.defaultProvider` before the fleet flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37726" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->