### PR TITLE
fix(web): prevent profile trigger flicker

### DIFF
--- a/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -18,6 +18,7 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -124,6 +125,14 @@ mock.module("@vellumai/design-library", () => {
 const NEW_PROFILE_NAME = "fast-cheap";
 const NEW_PROFILE_LABEL = "Fast & Cheap";
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 // --- generated daemon SDK ----------------------------------------------------
 // Mock the SDK functions used by the component (directly and via generated
 // TanStack Query options). configGetOptions/conversationsByIdGetOptions from
@@ -140,9 +149,15 @@ const configGetMock = mock(
     },
   }),
 );
-const conversationsByIdGetMock = mock(async (_opts: unknown) => ({
-  data: { conversation: { inferenceProfile: null } },
-}));
+const conversationsByIdGetMock = mock(
+  async (
+    _opts: unknown,
+  ): Promise<{
+    data: { conversation: { inferenceProfile: string | null } };
+  }> => ({
+    data: { conversation: { inferenceProfile: null } },
+  }),
+);
 const configPatchMock = mock(
   async (_opts: unknown): Promise<{ data: unknown }> => ({ data: {} }),
 );
@@ -387,6 +402,76 @@ describe("Profile selection after conversation change (LUM-2279)", () => {
       (inferenceprofilePut.mock.calls[0]![0] as { body: { profile: string } })
         .body.profile,
     ).toBe("smart");
+  });
+});
+
+describe("Profile trigger updates", () => {
+  test("keeps the selected label while the conversation refetch settles", async () => {
+    const configData = {
+      llm: {
+        profileOrder: ["balanced", "quality"],
+        profiles: {
+          balanced: { label: "Balanced" },
+          quality: { label: "Quality" },
+        },
+        activeProfile: "balanced",
+      },
+    };
+    const configRefetch = deferred<{ data: unknown }>();
+    let configCallCount = 0;
+    configGetMock.mockImplementation(() => {
+      configCallCount += 1;
+      if (configCallCount === 1) {
+        return Promise.resolve({ data: configData });
+      }
+      return configRefetch.promise;
+    });
+
+    const conversationRefetch = deferred<{
+      data: { conversation: { inferenceProfile: string } };
+    }>();
+    let conversationCallCount = 0;
+    conversationsByIdGetMock.mockImplementation(() => {
+      conversationCallCount += 1;
+      if (conversationCallCount === 1) {
+        return Promise.resolve({
+          data: { conversation: { inferenceProfile: "balanced" } },
+        });
+      }
+      return conversationRefetch.promise;
+    });
+
+    renderMenu();
+    const trigger = await screen.findByLabelText("Model profile");
+    await waitFor(() => expect(trigger.textContent).toContain("Balanced"));
+
+    const qualityItem = screen
+      .getAllByTestId("menu-item")
+      .find((item) => item.textContent?.includes("Quality"));
+    fireEvent.click(qualityItem!);
+
+    await waitFor(() => {
+      expect(inferenceprofilePut).toHaveBeenCalledTimes(1);
+      expect(configCallCount).toBe(2);
+      expect(conversationCallCount).toBe(2);
+    });
+
+    await act(async () => {
+      configRefetch.resolve({ data: configData });
+      await configRefetch.promise;
+      await Promise.resolve();
+    });
+
+    expect(trigger.textContent).toContain("Quality");
+
+    await act(async () => {
+      conversationRefetch.resolve({
+        data: { conversation: { inferenceProfile: "quality" } },
+      });
+      await conversationRefetch.promise;
+    });
+
+    expect(trigger.textContent).toContain("Quality");
   });
 });
 

--- a/clients/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -365,21 +365,21 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
         if (conversationIdRef.current === capturedConversationId) {
           lastConfirmedProfileRef.current = name;
         }
-        // Invalidate shared caches so all consumers refresh.
         const configKey = configGetQueryKey({
           path: { assistant_id: assistantId },
         });
-        void queryClient.invalidateQueries({ queryKey: configKey }).then(() => {
-          // Clear optimistic only after refetch settles — avoids flash of stale value.
-          setOptimisticActiveProfile((current) =>
-            current === name ? null : current,
-          );
-        });
-        void queryClient.invalidateQueries({
-          queryKey: conversationsByIdGetQueryKey({
-            path: { assistant_id: assistantId, id: capturedConversationId },
-          }),
-        });
+        void queryClient.invalidateQueries({ queryKey: configKey });
+        void queryClient
+          .invalidateQueries({
+            queryKey: conversationsByIdGetQueryKey({
+              path: { assistant_id: assistantId, id: capturedConversationId },
+            }),
+          })
+          .then(() => {
+            setOptimisticActiveProfile((current) =>
+              current === name ? null : current,
+            );
+          });
         return true;
       } catch {
         if (conversationIdRef.current === capturedConversationId) {


### PR DESCRIPTION
## Summary
- keep the selected model profile label optimistic until the conversation override refresh completes
- add a regression test covering out-of-order config and conversation refetches

## Original prompt
Fix the brief flicker in the chat composer controls when switching to a different model profile.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->