### PR TITLE
Move profile identity fields under Advanced

### DIFF
--- a/clients/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/manage-profiles-modal.test.tsx
@@ -218,9 +218,11 @@ describe("ManageProfilesModal — profile-create success toast (Settings surface
     // Open the create editor.
     fireEvent.click(getButton("+ New Profile"));
 
-    // Provider-first create: pick Anthropic, a model, then a name.
+    // Provider-first create: pick Anthropic and a model, then customize the
+    // derived identity fields under Advanced.
     pickOption(providerTrigger(), "Anthropic");
     selectModel("Claude Opus 4.8");
+    fireEvent.click(getButton("Advanced"));
 
     fireEvent.change(getInputByPlaceholder("e.g. fast-cheap"), {
       target: { value: "my-profile" },

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -9,7 +9,7 @@
  * its credential hooks so render doesn't fan out daemon queries.
  *
  * Coverage:
- *  - field order is provider-first (Provider before Name/Key/Description),
+ *  - Name and Key live under the create flow's Advanced disclosure,
  *  - selecting a model pre-fills Name + Key from the model display name,
  *  - editing Name then selecting another model does NOT clobber Name/Key,
  *  - "+ Create new provider" mounts the inline ProviderCreateForm, and a
@@ -146,7 +146,7 @@ function getSaveBtn(): HTMLButtonElement {
 function openInlineProviderAdvanced(): void {
   const button = Array.from(
     document.querySelectorAll<HTMLButtonElement>("button"),
-  ).find((b) => b.textContent?.includes("Display name"));
+  ).find((b) => b.textContent?.trim() === "Advanced");
   if (!button) {
     throw new Error("expected the inline provider Advanced disclosure");
   }
@@ -328,6 +328,7 @@ function topPSlider(): HTMLElement {
 function fillCreateForm(): void {
   selectProvider("Anthropic");
   selectModel("Claude Opus 4.8");
+  fireEvent.click(getButton("Advanced"));
   fireEvent.change(getInputByPlaceholder("e.g. fast-cheap"), {
     target: { value: "my-profile" },
   });
@@ -348,20 +349,29 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("ProfileEditorModal create mode — provider-first", () => {
-  test("renders Provider before Name/Key in create mode", () => {
+  test("keeps Name and Key inside Advanced in create mode", () => {
     renderCreate([makeConnection("anthropic-personal")]);
 
-    const text = document.body.textContent ?? "";
-    const providerIdx = text.indexOf("Provider");
-    const nameIdx = text.indexOf("Name");
-    const keyIdx = text.indexOf("Key");
-    expect(providerIdx).toBeGreaterThanOrEqual(0);
-    expect(nameIdx).toBeGreaterThan(providerIdx);
-    expect(keyIdx).toBeGreaterThan(providerIdx);
+    selectProvider("Anthropic");
+    selectModel("Claude Opus 4.8");
+
+    expect(
+      document.querySelector('input[placeholder="e.g. Fast & Cheap"]'),
+    ).toBeNull();
+    expect(
+      document.querySelector('input[placeholder="e.g. fast-cheap"]'),
+    ).toBeNull();
+
+    fireEvent.click(getButton("Advanced"));
+
+    expect(getInputByPlaceholder("e.g. Fast & Cheap")).toBeDefined();
+    expect(getInputByPlaceholder("e.g. fast-cheap")).toBeDefined();
   });
 
   test("Advanced is hidden until a model is chosen, then collapsed by default", () => {
     renderCreate([makeConnection("anthropic-personal")]);
+
+    expect(document.body.textContent).not.toContain("Pick a provider");
 
     // No model selected yet → the Advanced disclosure is not rendered.
     const hasAdvancedButton = () =>
@@ -383,6 +393,7 @@ describe("ProfileEditorModal create mode — provider-first", () => {
 
     selectProvider("Anthropic");
     selectModel("Claude Opus 4.8");
+    fireEvent.click(getButton("Advanced"));
 
     expect(getInputByPlaceholder("e.g. Fast & Cheap").value).toBe(
       "Claude Opus 4.8",
@@ -397,6 +408,7 @@ describe("ProfileEditorModal create mode — provider-first", () => {
 
     selectProvider("Anthropic");
     selectModel("Claude Opus 4.8");
+    fireEvent.click(getButton("Advanced"));
 
     // User overrides the Name.
     fireEvent.change(getInputByPlaceholder("e.g. Fast & Cheap"), {
@@ -457,6 +469,7 @@ describe("ProfileEditorModal create mode — provider-first", () => {
     expect(triggerLabels).not.toContain("No models available");
 
     selectModel("Llama 3.2");
+    fireEvent.click(getButton("Advanced"));
     expect(getInputByPlaceholder("e.g. Fast & Cheap").value).toBe("Llama 3.2");
     expect(getInputByPlaceholder("e.g. fast-cheap").value).toBe("llama-3-2");
 
@@ -543,6 +556,7 @@ describe("ProfileEditorModal create mode — provider-first", () => {
 
     // Pick a model + key, then save immediately (no connections refetch).
     selectModel("Claude Opus 4.8");
+    fireEvent.click(getButton("Advanced"));
     fireEvent.change(getInputByPlaceholder("e.g. fast-cheap"), {
       target: { value: "my-profile" },
     });

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -1020,6 +1020,12 @@ describe("ProfileEditorModal — invariant managed profiles in view mode", () =>
 
     fireEvent.click(getButton("Save As New"));
 
+    // Clearing the generated key does not surface a validation error before
+    // the user interacts with the collapsed identity fields.
+    expect(getButton("Advanced").getAttribute("aria-expanded")).toBe("false");
+    expect(document.body.textContent).not.toContain("Key is required");
+    fireEvent.click(getButton("Advanced"));
+
     // The duplicate drops the invariant lock: name and key are editable and
     // the Active toggle is back.
     expect(getInputByPlaceholder("e.g. Fast & Cheap").disabled).toBe(false);

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -49,7 +49,6 @@ import type {
 import { ProviderCreateForm } from "@/domains/settings/ai/provider-create-form";
 import { useLabelKeySync } from "@/domains/settings/ai/use-label-key-sync";
 import { useActiveAssistantIsSelfHosted } from "@/hooks/use-platform-gate";
-import { useIsMobile } from "@/hooks/use-is-mobile";
 
 // Sentinel value for the "+ Create new provider" option in the create-mode
 // Provider dropdown. Picking it mounts the inline ProviderCreateForm instead
@@ -206,7 +205,6 @@ function ProfileEditorModalInner({
   // daemon rejects for managed profiles.
   const isReadOnly = effectiveMode === "view" || isInvariant;
   const activeAssistantIsSelfHosted = useActiveAssistantIsSelfHosted();
-  const isMobile = useIsMobile();
 
   // Baseline for `hasViewModeChanges`: the enable flip is the only edit
   // read-only mode permits.
@@ -371,7 +369,7 @@ function ProfileEditorModalInner({
   const queryClient = useQueryClient();
 
   // Create-mode-only UI: whether the inline "+ Create new provider" sub-form
-  // is mounted, and whether the advanced-params disclosure is expanded.
+  // is mounted, and whether the Advanced disclosure is expanded.
   const [creatingProvider, setCreatingProvider] = useState(false);
   const [advancedExpanded, setAdvancedExpanded] = useState(false);
   // One-time helper note shown after an inline provider create succeeds.
@@ -653,9 +651,8 @@ function ProfileEditorModalInner({
         ? "Edit Profile"
         : (initialValues?.label ?? profileName ?? "Profile");
 
-  // Create mode uses the provider-first layout (Provider -> Model -> Name ->
-  // Key -> Description -> collapsed Advanced) with pre-fill. Edit and view
-  // modes use the legacy layout below.
+  // Create mode uses the provider-first layout, with derived identity fields
+  // grouped under Advanced. Edit and view modes use the legacy layout below.
   const useProviderFirst = effectiveMode === "create";
 
   // ---- Reusable field nodes (shared by create + edit/view bodies) ----
@@ -814,19 +811,12 @@ function ProfileEditorModalInner({
   const createProviderSection = (
     <div className="space-y-4">
       <div className="space-y-1">
-        <div className="flex items-center justify-between gap-2">
-          <label
-            id="profile-editor-provider-label"
-            className="block text-body-small-default text-[var(--content-tertiary)]"
-          >
-            Provider
-          </label>
-          {providerMissing && !creatingProvider && !isMobile ? (
-            <span className="rounded-full bg-[var(--surface-warning-subtle)] px-2 py-0.5 text-body-small-default text-[var(--content-warning)]">
-              Pick a provider
-            </span>
-          ) : null}
-        </div>
+        <label
+          id="profile-editor-provider-label"
+          className="block text-body-small-default text-[var(--content-tertiary)]"
+        >
+          Provider
+        </label>
         <Dropdown
           value={creatingProvider ? CREATE_NEW_PROVIDER_SENTINEL : provider}
           onChange={(next) => {
@@ -835,7 +825,9 @@ function ProfileEditorModalInner({
               setNewProviderNote(false);
               return;
             }
-            if (!next) return;
+            if (!next) {
+              return;
+            }
             setCreatingProvider(false);
             handleProviderChange(next);
           }}
@@ -881,25 +873,29 @@ function ProfileEditorModalInner({
     </div>
   );
 
-  // Only surface Advanced once a model is chosen — the advanced params are
-  // model-dependent (effort/thinking/token ranges resolve from the selected
-  // model), so showing the disclosure before then is meaningless.
+  // Only surface Advanced once a model is chosen: Name and Key derive from the
+  // model, and the model controls the available advanced parameters.
+  const createAdvancedOpen = advancedExpanded || Boolean(keyError);
   const createAdvancedDisclosure =
     model !== "" ? (
       <div>
         <button
           type="button"
-          aria-expanded={advancedExpanded}
+          aria-expanded={createAdvancedOpen}
           onClick={() => setAdvancedExpanded((v) => !v)}
           className="flex items-center gap-1 text-body-small-default text-[var(--content-secondary)] w-full text-left"
         >
           <ChevronRight
-            className={`h-4 w-4 transition-transform ${advancedExpanded ? "rotate-90" : ""}`}
+            className={`h-4 w-4 transition-transform ${createAdvancedOpen ? "rotate-90" : ""}`}
           />
           <span>Advanced</span>
         </button>
-        {advancedExpanded ? (
-          <div className="mt-4">{advancedParamsNode}</div>
+        {createAdvancedOpen ? (
+          <div className="mt-4 space-y-4">
+            {displayNameField}
+            {keyField}
+            {advancedParamsNode}
+          </div>
         ) : null}
       </div>
     ) : null;
@@ -920,12 +916,10 @@ function ProfileEditorModalInner({
       <Modal.Body>
         {useProviderFirst ? (
           // Create mode is provider-first: Provider (with inline create) ->
-          // Model -> Name -> Key -> Description -> collapsed Advanced.
+          // Model -> Description -> Active -> collapsed Advanced.
           <div className="space-y-4">
             {createProviderSection}
 
-            {displayNameField}
-            {keyField}
             {descriptionField}
             {activeToggle}
 

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -875,7 +875,8 @@ function ProfileEditorModalInner({
 
   // Only surface Advanced once a model is chosen: Name and Key derive from the
   // model, and the model controls the available advanced parameters.
-  const createAdvancedOpen = advancedExpanded || Boolean(keyError);
+  const createAdvancedOpen =
+    advancedExpanded || (Boolean(keyError) && getDirty());
   const createAdvancedDisclosure =
     model !== "" ? (
       <div>

--- a/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -10,7 +10,6 @@ import {
 
 import { OPENAI_COMPATIBLE_PROVIDER } from "@/domains/settings/ai/constants";
 import { useSelectableCatalogProviders } from "@/domains/settings/ai/provider-availability";
-import { useIsMobile } from "@/hooks/use-is-mobile";
 import type { ConnectionModel, ConnectionProvider, ProviderConnection } from "@/generated/daemon/types.gen";
 
 const CODEX_SUBSCRIPTION_MODEL_IDS = new Set([
@@ -99,8 +98,6 @@ export function ProfileEditorProviderSection({
   connectionNotFound,
   hideProviderField = false,
 }: ProfileEditorProviderSectionProps) {
-  const isMobile = useIsMobile();
-  const providerMissing = provider.length === 0;
   const providerWithoutModel = provider.length > 0 && model.length === 0;
 
   const allProvidersForPicker = useSelectableCatalogProviders();
@@ -251,19 +248,12 @@ export function ProfileEditorProviderSection({
           route. Hidden when the parent renders its own provider picker. */}
       {!hideProviderField && (
         <div className="space-y-1">
-          <div className="flex items-center justify-between gap-2">
-            <label
-              id="profile-editor-provider-label"
-              className="block text-body-small-default text-[var(--content-tertiary)]"
-            >
-              Provider
-            </label>
-            {providerMissing && !isMobile ? (
-              <span className="rounded-full bg-[var(--surface-warning-subtle)] px-2 py-0.5 text-body-small-default text-[var(--content-warning)]">
-                Pick a provider
-              </span>
-            ) : null}
-          </div>
+          <label
+            id="profile-editor-provider-label"
+            className="block text-body-small-default text-[var(--content-tertiary)]"
+          >
+            Provider
+          </label>
           <Dropdown
             value={provider}
             onChange={onProviderChange}

--- a/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -168,9 +168,9 @@ function getButton(label: string): HTMLButtonElement {
 function openAdvancedFields(): void {
   const button = Array.from(
     document.querySelectorAll<HTMLButtonElement>("button"),
-  ).find((b) => b.textContent?.includes("Display name"));
+  ).find((b) => b.textContent?.trim() === "Advanced");
   if (!button) {
-    throw new Error("expected the Advanced (Display name & key) disclosure");
+    throw new Error("expected the Advanced disclosure");
   }
   if (button.getAttribute("aria-expanded") !== "true") {
     fireEvent.click(button);
@@ -661,7 +661,7 @@ describe("ProviderCreateForm submit sequence", () => {
     // keeping the Key field and its validation message visible.
     const disclosure = Array.from(
       document.querySelectorAll<HTMLButtonElement>("button"),
-    ).find((b) => b.textContent?.includes("Display name"));
+    ).find((b) => b.textContent?.trim() === "Advanced");
     if (!disclosure) {
       throw new Error("expected the Advanced disclosure button");
     }

--- a/clients/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.tsx
@@ -299,9 +299,6 @@ export function ProviderCreateForm({
           className={`h-4 w-4 transition-transform ${detailsOpen ? "rotate-90" : ""}`}
         />
         <span>Advanced</span>
-        <span className="text-[var(--content-tertiary)] ml-1">
-          · Display name &amp; key
-        </span>
       </button>
 
       {detailsOpen && (


### PR DESCRIPTION
## Summary
- move model profile Name and Key fields into the collapsed Advanced section
- simplify provider creation disclosure copy to Advanced
- remove the Pick a provider badge from profile provider selectors

## Original prompt
Move Name and Key into Advanced in the model profile creator, simplify the provider modal Advanced label, and remove the Pick a provider prompt.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->