### PR TITLE
Prevent theme tooltip from opening with Preferences

### DIFF
--- a/clients/web/src/domains/chat/components/preferences-menu.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.tsx
@@ -126,6 +126,7 @@ export function PreferencesMenu({
             side="top"
             align="start"
             sideOffset={8}
+            tabIndex={-1}
             onOpenAutoFocus={(event) => {
               const content = event.currentTarget as HTMLElement | null;
               event.preventDefault();

--- a/clients/web/src/domains/chat/components/preferences-menu.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.tsx
@@ -126,7 +126,10 @@ export function PreferencesMenu({
             side="top"
             align="start"
             sideOffset={8}
-            onOpenAutoFocus={(event) => event.preventDefault()}
+            onOpenAutoFocus={(event) => {
+              event.preventDefault();
+              event.currentTarget.focus();
+            }}
             className="w-64 rounded-lg p-4"
           >
             {content}

--- a/clients/web/src/domains/chat/components/preferences-menu.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.tsx
@@ -126,6 +126,7 @@ export function PreferencesMenu({
             side="top"
             align="start"
             sideOffset={8}
+            onOpenAutoFocus={(event) => event.preventDefault()}
             className="w-64 rounded-lg p-4"
           >
             {content}

--- a/clients/web/src/domains/chat/components/preferences-menu.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.tsx
@@ -127,8 +127,9 @@ export function PreferencesMenu({
             align="start"
             sideOffset={8}
             onOpenAutoFocus={(event) => {
+              const content = event.currentTarget as HTMLElement | null;
               event.preventDefault();
-              event.currentTarget.focus();
+              content?.focus();
             }}
             className="w-64 rounded-lg p-4"
           >


### PR DESCRIPTION
## Summary

- Keep focus on the Preferences trigger when its desktop popover opens.
- Prevent the selected theme segment's focus tooltip from appearing until the user hovers it.

## Original prompt

Fix the light/dark theme tooltip that appears immediately when opening Preferences; it should only appear on hover.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->