### PR TITLE
fix(memory): scope v2 consolidation tool surface to local file tools (drop network/host egress)

### DIFF
--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -67,6 +67,7 @@ import {
   shouldAttachHostProxyForCapability,
 } from "./host-proxy-preactivation.js";
 import type { ServerMessage } from "./message-protocol.js";
+import type { SubagentToolGateMode } from "./tool-setup-types.js";
 
 const log = getLogger("process-message");
 
@@ -93,6 +94,19 @@ type ProcessMessageOptions = ConversationCreateOptions & {
    * not stored on the long-lived conversation.
    */
   cronRunId?: string | null;
+  /**
+   * Restrict this turn's tool surface to the given allowlist. Threaded from
+   * `runBackgroundJob` so an unattended guardian-trust job (e.g. memory
+   * consolidation) cannot reach tools it does not need. Applied to the live
+   * conversation for the turn and restored afterward. Omitted = the full
+   * conversation tool surface (unchanged for every normal caller).
+   */
+  allowedTools?: readonly string[];
+  /**
+   * How {@link allowedTools} is enforced (default `"wire"` — excluded tools
+   * are not presented to the model). Ignored when `allowedTools` is absent.
+   */
+  toolGateMode?: SubagentToolGateMode;
 };
 
 function buildEventEmitter(
@@ -106,6 +120,37 @@ function buildEventEmitter(
     } catch (err) {
       log.warn({ err, messageType: msg.type }, "Agent event observer failed");
     }
+  };
+}
+
+/**
+ * Scope the live conversation's tool surface to `options.allowedTools` for the
+ * duration of a turn, returning a closure that restores the prior scope. A
+ * no-op (returns an empty restore) when no allowlist is supplied, so ordinary
+ * turns are byte-for-byte unaffected.
+ *
+ * The `runBackgroundJob` → `processMessage` path does not run through the wake
+ * machinery, so it cannot use {@link scopeWakeAllowedTools}; this mirrors that
+ * helper's set-and-restore over the same two conversation fields. Default
+ * `"wire"` gate mode filters the excluded tools out of the definitions sent to
+ * the provider, so a scoped turn (e.g. unattended memory consolidation) can
+ * never call a tool outside the allowlist — no reliance on the permission
+ * checker's background auto-approve threshold.
+ */
+function applyTurnToolAllowlist(
+  conversation: Conversation,
+  options?: ProcessMessageOptions,
+): () => void {
+  if (!options?.allowedTools) {
+    return () => {};
+  }
+  const previousTools = conversation.subagentAllowedTools;
+  const previousGateMode = conversation.subagentToolGateMode;
+  conversation.setSubagentAllowedTools(new Set(options.allowedTools));
+  conversation.subagentToolGateMode = options.toolGateMode ?? "wire";
+  return () => {
+    conversation.setSubagentAllowedTools(previousTools);
+    conversation.subagentToolGateMode = previousGateMode;
   };
 }
 
@@ -170,6 +215,8 @@ async function prepareConversationForMessage(
     onEvent: _onEvent,
     cronRunId: _cronRunId,
     requestOrigin: _requestOrigin,
+    allowedTools: _allowedTools,
+    toolGateMode: _toolGateMode,
     ...conversationOptions
   } = options ?? {};
   const conversation = await getOrCreateActiveConversation(
@@ -585,6 +632,7 @@ export async function processMessage(
     getSubagentManager().updateParentSender(conversationId, broadcastMessage);
   }
 
+  const restoreToolScope = applyTurnToolAllowlist(conversation, options);
   try {
     await conversation.runAgentLoop(resolvedContent, messageId, {
       onEvent: emitEvent,
@@ -600,6 +648,7 @@ export async function processMessage(
       ...(options?.cronRunId ? { cronRunId: options.cronRunId } : {}),
     });
   } finally {
+    restoreToolScope();
     if (
       options?.isInteractive === true &&
       conversation.getCurrentSender() === broadcastMessage
@@ -656,6 +705,7 @@ export async function processMessageInBackground(
     getSubagentManager().updateParentSender(conversationId, broadcastMessage);
   }
 
+  const restoreToolScope = applyTurnToolAllowlist(conversation, options);
   conversation
     .runAgentLoop(content, messageId, {
       onEvent: emitEvent,
@@ -668,6 +718,7 @@ export async function processMessageInBackground(
       ...(options?.cronRunId ? { cronRunId: options.cronRunId } : {}),
     })
     .finally(() => {
+      restoreToolScope();
       if (
         options?.isInteractive === true &&
         conversation.getCurrentSender() === broadcastMessage

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/consolidation-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/consolidation-job.test.ts
@@ -495,6 +495,54 @@ describe("memoryV2ConsolidateJob — non-empty buffer", () => {
     expect(prompt).toMatch(/\b[A-Z][a-z]{2} \d{1,2}, \d{1,2}:\d{2} (AM|PM)\b/);
   });
 
+  test("wire-scopes the run to local memory-file tools — no network egress or host tools", async () => {
+    // Security: the consolidation run is guardian-trust + non-interactive, so
+    // the permission checker auto-approves any tool within the background
+    // threshold (a public web_fetch classifies Low). The run must therefore be
+    // handed an explicit allowlist that excludes every egress/host tool, so
+    // prompt injection embedded in buffer/page content cannot exfiltrate
+    // memory over an auto-approved channel. Wire gate mode (the default) means
+    // the excluded tools are never even presented to the model.
+    await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(runnerCalls).toBe(1);
+    const allowed = runnerLastArgs?.allowedTools as string[] | undefined;
+    expect(allowed).toBeDefined();
+    const allowedSet = new Set(allowed);
+
+    // The local file-reorganization surface the pass actually uses.
+    for (const tool of [
+      "file_read",
+      "file_write",
+      "file_edit",
+      "file_list",
+      "code_search",
+      "bash",
+      "recall",
+    ]) {
+      expect(allowedSet.has(tool)).toBe(true);
+    }
+
+    // Network egress + host-proxy tools must NOT be reachable.
+    for (const tool of [
+      "web_fetch",
+      "web_search",
+      "network_request",
+      "host_bash",
+      "host_file_read",
+      "host_file_write",
+      "host_file_edit",
+      "host_cu",
+    ]) {
+      expect(allowedSet.has(tool)).toBe(false);
+    }
+    // Belt-and-suspenders: nothing host-prefixed slipped in.
+    expect((allowed ?? []).some((t) => t.startsWith("host_"))).toBe(false);
+    // Gate mode is left at the default ("wire") so excluded tools are filtered
+    // off the wire, not merely rejected at execution time.
+    expect(runnerLastArgs?.toolGateMode).toBeUndefined();
+  });
+
   test("honors memory.v2.consolidation_prompt_path override when set", async () => {
     writeFileSync(
       join(tmpWorkspace, "custom-prompt.md"),

--- a/assistant/src/plugins/defaults/memory/v2/consolidation-job.ts
+++ b/assistant/src/plugins/defaults/memory/v2/consolidation-job.ts
@@ -9,10 +9,13 @@
  * Consolidation runs as the assistant: `runBackgroundJob()` bootstraps a
  * background conversation and routes the cutoff-templated prompt through
  * `processMessage`, so the standard system prompt (SOUL.md + IDENTITY.md +
- * persona + memory/* autoloads) and tool surface (read_file, write_file,
- * edit_file, list_files, bash) are loaded. Care, judgment, and the
+ * persona + memory/* autoloads) is loaded. Care, judgment, and the
  * assistant's voice are the point — there is no "consolidator persona" to
  * substitute in.
+ *
+ * The tool surface is wire-scoped to {@link CONSOLIDATION_ALLOWED_TOOLS} — the
+ * local memory-file operations this pass needs. See that constant for why the
+ * run must not carry network egress or host-proxy tools.
  *
  * Lifecycle:
  *   1. Bail if `config.memory.enabled` or `config.memory.v2.enabled` is false
@@ -83,6 +86,40 @@ const log = getLogger("memory-v2-consolidate");
 
 /** Stable identifier surfaced in `runBackgroundJob` logs and notifications. */
 const JOB_NAME = "memory.consolidate";
+
+/**
+ * Tool surface the consolidation run is wire-scoped to. Consolidation is a
+ * purely LOCAL memory-file reorganization pass: it reads `buffer.md` + existing
+ * pages, writes/edits concept pages, rewrites recent/essentials/threads, and
+ * trims the buffer. It has NO legitimate need for network egress or host-proxy
+ * tools.
+ *
+ * Scoping is load-bearing because the run is guardian-trust + non-interactive:
+ * the permission checker auto-approves any tool whose classified risk is within
+ * the background threshold (default `low`), and a public `web_fetch` classifies
+ * Low. An unrestricted surface would therefore let prompt injection embedded in
+ * buffer/page content — which can originate from untrusted material the
+ * assistant ingested (fetched web pages, emails, documents, channel messages) —
+ * exfiltrate memory over an auto-approved egress channel. Wire-gating to this
+ * allowlist removes that channel entirely: the excluded tools (`web_fetch`,
+ * `web_search`, `network_request`, `host_*`, …) are never even presented to
+ * the model, so the fix does not rely on the permission threshold. Mirrors the
+ * hardening the sibling memory-retrospective job already applies.
+ *
+ * `bash` is included because page deletes/renames go through the shell (there
+ * is no dedicated file-delete tool) and corpus operations need it; its
+ * dangerous / networked invocations remain risk-classified and denied in this
+ * background context regardless.
+ */
+const CONSOLIDATION_ALLOWED_TOOLS: readonly string[] = [
+  "file_read",
+  "file_write",
+  "file_edit",
+  "file_list",
+  "code_search",
+  "bash",
+  "recall",
+];
 
 /**
  * Hard timeout for the consolidation run. Consolidation reads the buffer,
@@ -280,6 +317,9 @@ export async function memoryV2ConsolidateJob(
       timeoutMs: CONSOLIDATION_TIMEOUT_MS,
       origin: "memory_consolidation",
       suppressFailureNotifications: true,
+      // Wire-scope the guardian-trust background run to local memory-file
+      // tools only — no network egress, no host proxy. See the constant.
+      allowedTools: CONSOLIDATION_ALLOWED_TOOLS,
     });
 
     if (!runResult.ok) {

--- a/assistant/src/runtime/__tests__/background-job-runner.test.ts
+++ b/assistant/src/runtime/__tests__/background-job-runner.test.ts
@@ -182,6 +182,33 @@ describe("runBackgroundJob", () => {
     });
   });
 
+  test("threads allowedTools + toolGateMode into processMessage options when set", async () => {
+    await runBackgroundJob(
+      baseOpts({
+        allowedTools: ["file_read", "bash"],
+        toolGateMode: "wire",
+      }),
+    );
+
+    expect(processMessageCalls).toHaveLength(1);
+    expect(processMessageCalls[0].options).toMatchObject({
+      allowedTools: ["file_read", "bash"],
+      toolGateMode: "wire",
+    });
+  });
+
+  test("omits allowedTools/toolGateMode from processMessage options when unset (ordinary jobs unchanged)", async () => {
+    await runBackgroundJob(baseOpts());
+
+    expect(processMessageCalls).toHaveLength(1);
+    const opts = processMessageCalls[0].options as {
+      allowedTools?: unknown;
+      toolGateMode?: unknown;
+    };
+    expect(opts.allowedTools).toBeUndefined();
+    expect(opts.toolGateMode).toBeUndefined();
+  });
+
   test("generic exception: returns ok=false with errorKind=exception and emits activity.failed with dedupeKey", async () => {
     processMessageImpl = async () => {
       throw new Error("boom");

--- a/assistant/src/runtime/background-job-runner.ts
+++ b/assistant/src/runtime/background-job-runner.ts
@@ -20,6 +20,7 @@
 
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { processMessage } from "../daemon/process-message.js";
+import type { SubagentToolGateMode } from "../daemon/tool-setup-types.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
 import {
   commitDeferredConversation,
@@ -122,6 +123,25 @@ export interface RunBackgroundJobOptions {
    * keys on. Omitted = no origin-scoped grant can fire for the turn.
    */
   requestOrigin?: string;
+  /**
+   * Restrict the job's agent turn to this exact set of tools. When set, the
+   * turn's tool surface is scoped to the allowlist for the duration of the
+   * run — used by unattended guardian-trust jobs (e.g. memory consolidation)
+   * that must not reach tools they don't need (network egress, host proxy).
+   * The run is non-interactive + guardian, so the permission checker
+   * auto-approves anything within the background threshold; scoping the
+   * surface is what keeps injected buffer/page content from reaching an
+   * auto-approved side-effect tool. Omitted = the full conversation tool
+   * surface (behavior unchanged for every existing caller).
+   */
+  allowedTools?: readonly string[];
+  /**
+   * How {@link allowedTools} is enforced. Defaults to `"wire"` — the excluded
+   * tools are never presented to the model (strongest gate; no reliance on
+   * the permission checker). See {@link SubagentToolGateMode}. Ignored when
+   * `allowedTools` is absent.
+   */
+  toolGateMode?: SubagentToolGateMode;
   /** Conversation type to bootstrap with. Defaults to `"background"`. */
   conversationType?: "background" | "scheduled";
   /**
@@ -319,6 +339,8 @@ export async function runBackgroundJob(
         : {}),
       ...(opts.requestOrigin ? { requestOrigin: opts.requestOrigin } : {}),
       ...(opts.cronRunId ? { cronRunId: opts.cronRunId } : {}),
+      ...(opts.allowedTools ? { allowedTools: opts.allowedTools } : {}),
+      ...(opts.toolGateMode ? { toolGateMode: opts.toolGateMode } : {}),
     });
     // Absorb late rejections: if the timeout wins the race, `work` keeps
     // running and may eventually reject — swallow so it doesn't surface as


### PR DESCRIPTION
## Summary
- The memory v2 consolidation job (`consolidation-job.ts`) runs as guardian trust, non-interactive, via `runBackgroundJob` → `processMessage` with the **full** tool surface. Non-interactive guardian turns auto-approve any tool whose classified risk is within the background threshold (default `low`), and a public `web_fetch` classifies **Low** — so prompt injection embedded in `buffer.md`/memory-page content (which can originate from untrusted material the assistant ingested: fetched web pages, emails, documents, channel messages) could exfiltrate memory over an auto-approved egress channel. The "lethal trifecta": private data + untrusted content + egress.
- **Wire-scope** the consolidation run to the local file tools it actually needs — `file_read`, `file_write`, `file_edit`, `file_list`, `code_search`, `bash`, `recall` — **excluding** `web_fetch`/`web_search`/`network_request` and all `host_*` proxy tools. Wire gate mode means the excluded tools are never even presented to the model, so the fix does not rely on the permission threshold.
- **Plumbing:** an optional `allowedTools` (+ `toolGateMode`, default `"wire"`) threads through `RunBackgroundJobOptions` → `ProcessMessageOptions`, applied to the live conversation for the turn and restored afterward (mirrors `scopeWakeAllowedTools`). Omitted for every other caller, so their behavior is byte-identical. This mirrors the hardening the sibling memory-retrospective job already applies.

## Original prompt
A `[Security]` issue flagged that memory v2 consolidation runs under `INTERNAL_GUARDIAN_TRUST_CONTEXT` over attacker-influenceable buffer content, letting prompt injection reach side-effect tools with no guardian prompt. Investigation confirmed the exfiltration leg is real at default settings — a public `web_fetch` classifies Low and is therefore auto-approved in the non-interactive guardian background context — while the sibling retrospective job was already hardened with a tool allowlist. This PR closes the gap by scoping the consolidation run's tool surface (item 1 of 2; a follow-up PR adds anti-injection framing to the consolidation prompt).

## Review focus (security)
- The tool-scoping seam is `applyTurnToolAllowlist` in `process-message.ts` (applied in both `processMessage` and `processMessageInBackground`, restored in the `finally`). Confirm the allowlist covers everything consolidation legitimately does — `bash` is intentionally kept because page renames/deletes go through the shell (there is no dedicated file-delete tool); its dangerous/networked invocations remain risk-classified and denied in this background context regardless.
- Tests: `consolidation-job.test.ts` asserts the run excludes egress/host tools and includes the local file surface; `background-job-runner.test.ts` asserts the option threads through to `processMessage` and is omitted when unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)