### PR TITLE
fix(memory): trust-gate memory-v3 card rehydration on reload

### DIFF
--- a/assistant/src/__tests__/conversation-lifecycle.test.ts
+++ b/assistant/src/__tests__/conversation-lifecycle.test.ts
@@ -1039,6 +1039,54 @@ describe("loadFromDb metadata injection rehydration", () => {
     expect(messages[0].content).toEqual([{ type: "text", text: "First" }]);
   });
 
+  test("untrusted-actor view does not rehydrate memoryV3InjectedBlock (including the tail)", async () => {
+    mockConversation = defaultConv();
+    // v3 cards carry personal memory and rehydrate on ALL rows including the
+    // tail (see the positive test above), so the trust gate must suppress both
+    // the historical and the tail block. `trusted_contact` provenance keeps the
+    // rows past the untrusted-actor row filter, isolating the rehydrate gate.
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "First" }]),
+        metadata: JSON.stringify({
+          provenanceTrustClass: "trusted_contact",
+          memoryV3InjectedBlock:
+            "header line\n\n# memory/concepts/page-a.md\nhead a",
+        }),
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+        metadata: JSON.stringify({ provenanceTrustClass: "unknown" }),
+      },
+      {
+        id: "m3",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "Tail" }]),
+        metadata: JSON.stringify({
+          provenanceTrustClass: "trusted_contact",
+          memoryV3InjectedBlock: "# memory/concepts/page-b.md\nhead b",
+        }),
+      },
+    ];
+
+    const conversation = makeConversation();
+    conversation.setTrustContext({
+      trustClass: "trusted_contact",
+      sourceChannel: "telegram",
+    });
+    await conversation.loadFromDb();
+    const messages = conversation.getMessages();
+
+    expect(messages).toHaveLength(3);
+    // Neither the historical nor the tail v3 card block is prepended.
+    expect(messages[0].content).toEqual([{ type: "text", text: "First" }]);
+    expect(messages[2].content).toEqual([{ type: "text", text: "Tail" }]);
+  });
+
   test("ensureActorScopedHistory reloads when sourceChannel changes within the same trust class", async () => {
     // Regression: cache invalidation previously keyed only on trust class.
     // `loadFromDb` gates `memoryV2StaticBlock` rehydration on `sourceChannel`

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -1131,7 +1131,16 @@ export class Conversation {
           // itself is never rewritten — auditable and reversible); an
           // all-pruned block is skipped entirely, matching the live strip in
           // `memory/v3/prune.ts`.
-          if (typeof meta[MEMORY_V3_INJECTED_BLOCK_METADATA_KEY] === "string") {
+          // Trust-gated on `personalMemoryAllowed`, mirroring the v2 static
+          // block below and the live v3 injector: v3 cards carry personal user
+          // memory (memory pages, PKB, matched sections), so an untrusted-actor
+          // view must not read them back through persisted metadata. The tail
+          // is still rehydrated for trusted views (unlike v2) — the gate is the
+          // only constraint added here.
+          if (
+            personalMemoryAllowed &&
+            typeof meta[MEMORY_V3_INJECTED_BLOCK_METADATA_KEY] === "string"
+          ) {
             const v3Block = meta[
               MEMORY_V3_INJECTED_BLOCK_METADATA_KEY
             ] as string;


### PR DESCRIPTION
## Summary
- `Conversation.loadFromDb` rehydrated the persisted memory-v3 card block (`memoryV3InjectedBlock`) into model-facing history with **no** personal-memory trust gate, while the adjacent v2 static block and the live v3 injector both gate on `isPersonalMemoryAllowed`. On reload/eviction/fork an untrusted-actor view could read private user memory (memory pages, PKB, matched sections) back through message metadata.
- Gate the v3 rehydration on `personalMemoryAllowed`, mirroring the v2 static block (`assistant/src/daemon/conversation.ts`). The tail row is still rehydrated for trusted views (frozen cards ride the provider prefix cache), so only the trust gate is added — **not** v2's `!isTail` condition.
- Add a regression test: an untrusted-actor reload suppresses the v3 block on both historical and tail rows. Verified it fails without the gate; the existing guardian-context test pins that trusted views still rehydrate. `loadFromDb` is the only model-facing site lacking the gate — post-compaction re-injection and both fork paths reach context through it, so this one change covers them.

## Original prompt
Investigating a security finding ("Memory-v3 cards rehydrate without trust gating", flagged High): the memory-v3 metadata rehydration path in `loadFromDb` omits the personal-memory trust gate that the live injector and the v2 static block apply, so persisted v3 cards could re-enter the prompt for an untrusted actor. Confirmed the code-level defect is real and scoped to a single model-facing site, then asked to implement the fix mirroring the v2 gate with a regression test.