### PR TITLE
feat(telemetry): record per-message model in pii_turn traces

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -1606,6 +1606,31 @@ describe("session-agent-loop", () => {
       expect(mainAgentCall?.[2]).toBe(3);
       expect(mainAgentCall?.[3]).toBe("gpt-4.1-2026-03-01");
     });
+
+    test("persists the served model onto the assistant row's metadata at finalize", async () => {
+      const events: ServerMessage[] = [];
+
+      const ctx = makeCtx({
+        providerResponses: [
+          {
+            content: [{ type: "text", text: "Hi there." }],
+            model: "gpt-4.1-2026-03-01",
+            usage: { inputTokens: 12, outputTokens: 3 },
+            stopReason: "end_turn",
+          },
+        ],
+      });
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
+
+      // The finalize write carries the `message_complete` event's model
+      // (`response.model`) as metadata alongside the content, in one write.
+      const finalizeCall = updateMessageContentMock.mock.calls.find(
+        (call) => (call as unknown[])[2] !== undefined,
+      ) as unknown[] | undefined;
+      expect(finalizeCall).toBeDefined();
+      expect(finalizeCall?.[2]).toEqual({ model: "gpt-4.1-2026-03-01" });
+    });
   });
 
   describe("checkpoint handoff (infinite loop prevention)", () => {

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -240,7 +240,15 @@ export type AgentEvent =
   | { type: "llm_call_started"; callSite?: LLMCallSite }
   | { type: "text_delta"; text: string }
   | { type: "thinking_delta"; thinking: string }
-  | { type: "message_complete"; message: Message }
+  /**
+   * Emitted once per LLM call when the assistant message is finalized.
+   * `model` is the provider-reported model that served the call
+   * (`response.model`) — the same value `llm_usage` records — so downstream
+   * persistence can attribute the message to the model that actually ran,
+   * including per-call reroutes by a `pre-model-call` hook. Absent on
+   * synthesized emissions that have no provider response.
+   */
+  | { type: "message_complete"; message: Message; model?: string }
   | { type: "max_tokens_reached"; stopReason: string }
   | {
       type: "tool_use";
@@ -1902,6 +1910,7 @@ export class AgentLoop {
             await onEvent({
               type: "message_complete",
               message: safeAssistantMessage,
+              model: response.model,
             });
             history = maxTokensMessages;
             continue;
@@ -1914,6 +1923,7 @@ export class AgentLoop {
           await onEvent({
             type: "message_complete",
             message: safeAssistantMessage,
+            model: response.model,
           });
           await stopTurn("max_tokens_reached");
           break;
@@ -1998,7 +2008,11 @@ export class AgentLoop {
 
         history.push(assistantMessage);
 
-        await onEvent({ type: "message_complete", message: assistantMessage });
+        await onEvent({
+          type: "message_complete",
+          message: assistantMessage,
+          model: response.model,
+        });
 
         if (toolUseBlocks.length === 0 || !this.toolExecutor) {
           // The model stopped requesting tools and `post-model-call` settled on

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -589,12 +589,20 @@ async function persistLoopMessageContent(
   contentJson: string,
   op: string,
   rlog: pino.Logger,
+  metadataUpdates?: Record<string, unknown>,
 ): Promise<boolean> {
   try {
-    await withSqliteRetry(() => updateMessageContent(messageId, contentJson), {
-      op,
-      context: { messageId },
-    });
+    // Metadata updates (e.g. the served model at finalize) ride the same
+    // write as the content — `updateMessageContent` commits both atomically —
+    // so a partial write can't leave them out of sync; the updates
+    // shallow-merge onto the channel provenance stamped at reserve.
+    await withSqliteRetry(
+      () => updateMessageContent(messageId, contentJson, metadataUpdates),
+      {
+        op,
+        context: { messageId },
+      },
+    );
     return true;
   } catch (err) {
     rlog.error(
@@ -2074,11 +2082,17 @@ export async function handleMessageComplete(
     );
   }
   const contentJson = JSON.stringify(contentForPersistence);
+  // Stamp the served model carried on the event (`response.model`, the same
+  // value `llm_usage` records) onto the row alongside the content, so turn-trace
+  // assembly can attribute each assistant message to the model that actually
+  // ran it — including per-call reroutes by a `pre-model-call` hook. Absent on
+  // synthesized completions with no provider response; the key is omitted then.
   const persisted = await persistLoopMessageContent(
     assistantMessageId,
     contentJson,
     "finalize_assistant_message",
     deps.rlog,
+    event.model ? { model: event.model } : undefined,
   );
   state.assistantRowAwaitingFinalization = false;
   // The assistant row now holds the authoritative content (text + thinking +

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -193,6 +193,17 @@ export const messageMetadataSchema = z
      * and read gate (conversation history loading) to enforce trust-aware access.
      */
     provenanceTrustClass: trustClassSchema.optional(),
+    /**
+     * Model that actually served this assistant row, carried on the agent
+     * loop's `message_complete` event (the provider's `response.model`, the
+     * same value `llm_usage` records) and persisted with the finalized content.
+     * Reflects per-call reroutes by a `pre-model-call` hook. Present only on
+     * assistant rows produced by a real model call; absent on user rows,
+     * tool-result rows, and synthetic assistant rows (provider-error / yield
+     * notices). Turn-trace assembly surfaces it as the per-message
+     * `TurnTraceMessage.model`.
+     */
+    model: z.string().optional(),
     provenanceSourceChannel: channelIdSchema.optional(),
     provenanceGuardianExternalUserId: z.string().optional(),
     provenanceRequesterIdentifier: z.string().optional(),
@@ -3124,7 +3135,15 @@ export async function reserveMessage(
 export function updateMessageContent(
   messageId: string,
   newContent: string,
+  metadataUpdates?: Record<string, unknown>,
 ): void {
+  // When metadata updates ride along (e.g. the served model stamped at
+  // assistant-row finalize), delegate to the transactional content+metadata
+  // writer so both land atomically.
+  if (metadataUpdates) {
+    updateMessageContentAndMetadata(messageId, newContent, metadataUpdates);
+    return;
+  }
   const db = getDb();
   db.update(messages)
     .set({ content: newContent })

--- a/assistant/src/telemetry/turn-trace-store.test.ts
+++ b/assistant/src/telemetry/turn-trace-store.test.ts
@@ -68,6 +68,8 @@ interface MessageSeed {
   role: "user" | "assistant" | "system";
   content: unknown;
   createdAt: number;
+  /** Persisted `messages.metadata` bag; assistant rows carry `{ model }`. */
+  metadata?: Record<string, unknown>;
 }
 
 function insertMessage(conversationId: string, seed: MessageSeed): void {
@@ -82,6 +84,7 @@ function insertMessage(conversationId: string, seed: MessageSeed): void {
           ? seed.content
           : JSON.stringify(seed.content),
       createdAt: seed.createdAt,
+      metadata: seed.metadata ? JSON.stringify(seed.metadata) : null,
     })
     .run();
 }
@@ -145,6 +148,7 @@ describe("assembleTurnTrace", () => {
         },
       ],
       createdAt: 1100,
+      metadata: { model: "claude-fable-5" },
     });
     insertMessage(conv.id, {
       id: "m-toolresult-1",
@@ -159,6 +163,7 @@ describe("assembleTurnTrace", () => {
       role: "assistant",
       content: [{ type: "text", text: "You have 2 events today." }],
       createdAt: 1300,
+      metadata: { model: "claude-fable-5" },
     });
     insertTool(conv.id, {
       id: "ti-1",
@@ -185,13 +190,22 @@ describe("assembleTurnTrace", () => {
 
     const trace = assembleTurnTrace(boundary(conv.id, "m-user-1", 1000));
 
-    expect(trace.schema_version).toBe(2);
+    expect(trace.schema_version).toBe(3);
     // Window stops before turn 2: only turn-1 message rows, oldest-first.
     expect(trace.messages.map((m) => m.id)).toEqual([
       "m-user-1",
       "m-asst-1a",
       "m-toolresult-1",
       "m-asst-1b",
+    ]);
+    // Model attribution is per message, from `metadata.model` (the served
+    // `response.model` persisted with the finalized content): assistant rows
+    // carry it, user and tool-result rows carry null.
+    expect(trace.messages.map((m) => [m.id, m.model])).toEqual([
+      ["m-user-1", null],
+      ["m-asst-1a", "claude-fable-5"],
+      ["m-toolresult-1", null],
+      ["m-asst-1b", "claude-fable-5"],
     ]);
     // The tool-result row keeps role="user" (faithful to what the model saw).
     const toolResultMsg = trace.messages.find((m) => m.id === "m-toolresult-1");
@@ -209,6 +223,77 @@ describe("assembleTurnTrace", () => {
     });
     // Result is forwarded verbatim.
     expect(trace.tool_calls[0].result).toBe(JSON.stringify({ events: 2 }));
+  });
+
+  test("attributes each assistant row to the model that served it when a hook reroutes mid-turn", () => {
+    // A pre-model-call hook reroutes the SECOND call in the turn, so the two
+    // assistant rows carry different served models — attribution stays faithful
+    // per message.
+    const conv = createConversation({ conversationType: "standard" });
+    insertMessage(conv.id, {
+      id: "m-user-1",
+      role: "user",
+      content: [{ type: "text", text: "hello" }],
+      createdAt: 1000,
+    });
+    insertMessage(conv.id, {
+      id: "m-asst-1a",
+      role: "assistant",
+      content: [{ type: "tool_use", id: "tu-1", name: "noop", input: {} }],
+      createdAt: 1100,
+      metadata: { model: "claude-fable-5" },
+    });
+    insertMessage(conv.id, {
+      id: "m-toolresult-1",
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: "tu-1", content: "ok" }],
+      createdAt: 1200,
+    });
+    insertMessage(conv.id, {
+      id: "m-asst-1b",
+      role: "assistant",
+      content: [{ type: "text", text: "done" }],
+      createdAt: 1300,
+      metadata: { model: "claude-opus-4-8" },
+    });
+
+    const trace = assembleTurnTrace(boundary(conv.id, "m-user-1", 1000));
+
+    expect(trace.messages.map((m) => [m.id, m.model])).toEqual([
+      ["m-user-1", null],
+      ["m-asst-1a", "claude-fable-5"],
+      ["m-toolresult-1", null],
+      ["m-asst-1b", "claude-opus-4-8"],
+    ]);
+  });
+
+  test("per-message model is null for rows with no stamped model (historical / missing metadata)", () => {
+    const conv = createConversation({ conversationType: "standard" });
+    insertMessage(conv.id, {
+      id: "m-user-1",
+      role: "user",
+      content: [{ type: "text", text: "hello" }],
+      createdAt: 1000,
+    });
+    // Assistant row with no metadata at all (historical row before stamping).
+    insertMessage(conv.id, {
+      id: "m-asst-1",
+      role: "assistant",
+      content: [{ type: "text", text: "hi" }],
+      createdAt: 1100,
+    });
+    // Assistant row whose metadata bag omits `model`.
+    insertMessage(conv.id, {
+      id: "m-asst-2",
+      role: "assistant",
+      content: [{ type: "text", text: "again" }],
+      createdAt: 1200,
+      metadata: { provenanceTrustClass: "unknown" },
+    });
+
+    const trace = assembleTurnTrace(boundary(conv.id, "m-user-1", 1000));
+
+    expect(trace.messages.map((m) => m.model)).toEqual([null, null, null]);
   });
 
   test("includes system_prompt and tool_definitions from the live conversation", () => {

--- a/assistant/src/telemetry/turn-trace-store.ts
+++ b/assistant/src/telemetry/turn-trace-store.ts
@@ -51,6 +51,30 @@ function parseStoredContent(raw: string): unknown {
   }
 }
 
+/**
+ * Extract the served model from a stored `messages.metadata` string. The daemon
+ * persists `metadata.model` with the finalized content of each assistant row
+ * (the `message_complete` event's `response.model`); returns null for rows
+ * without it — user rows, tool-result rows, synthetic assistant rows, and
+ * historical rows persisted before model stamping — or when the metadata JSON
+ * is absent/malformed.
+ */
+function parseStoredModel(raw: string | null): string | null {
+  if (raw == null) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed != null && typeof parsed === "object" && "model" in parsed) {
+      const model = (parsed as { model?: unknown }).model;
+      return typeof model === "string" ? model : null;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 /** Compound `(createdAt, id)` boundary of the next real user turn. */
 interface NextTurnBoundary {
   createdAt: number;
@@ -177,6 +201,7 @@ function queryTurnMessages(
       role: messages.role,
       content: messages.content,
       createdAt: messages.createdAt,
+      metadata: messages.metadata,
     })
     .from(messages)
     .where(
@@ -194,6 +219,7 @@ function queryTurnMessages(
     role: r.role,
     created_at: r.createdAt,
     content: parseStoredContent(r.content),
+    model: parseStoredModel(r.metadata),
   }));
 }
 
@@ -311,6 +337,8 @@ export function assembleTurnTrace(boundary: TurnTraceBoundary): TurnTrace {
   // cached state — the same values the agent loop used for this turn. When the
   // conversation has been evicted (e.g. after a daemon restart), these fall
   // back to null / empty, which is faithful: we no longer have the values.
+  // (Model is read durably from `messages.metadata`, not from live state, so it
+  // survives eviction — see `queryTurnMessages`.)
   const systemPrompt = conversation?.getCurrentSystemPrompt() ?? null;
 
   const toolDefinitions: TurnTraceToolDefinition[] = conversation
@@ -322,7 +350,7 @@ export function assembleTurnTrace(boundary: TurnTraceBoundary): TurnTrace {
     : [];
 
   return {
-    schema_version: 2,
+    schema_version: 3,
     messages: queryTurnMessages(boundary, nextTurn),
     tool_calls: queryTurnToolCalls(boundary, nextTurn),
     system_prompt: systemPrompt,

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -170,6 +170,16 @@ export interface TurnTraceMessage {
    * modern rows are `ContentBlock[]`, legacy rows are a plain string.
    */
   content: unknown;
+  /**
+   * Model that served this row — the provider's `response.model`, carried on
+   * the agent loop's `message_complete` event and persisted with the row
+   * (`messages.metadata.model`); matches the turn's `llm_usage.model` and
+   * reflects per-call reroutes by a `pre-model-call` hook. Null on rows with
+   * no model call: user rows, tool-result rows, synthetic assistant rows
+   * (provider-error / yield notices), and historical rows persisted before the
+   * daemon began stamping the model.
+   */
+  model: string | null;
 }
 
 /**
@@ -220,10 +230,12 @@ export interface TurnTraceToolDefinition {
 
 export interface TurnTrace {
   /** Shape version so the platform/dbt can evolve parsing without ambiguity. */
-  schema_version: 2;
+  schema_version: 3;
   /**
    * Ordered message rows for the turn (the user message first, then assistant
    * responses and any tool-result rows), oldest-first by `(created_at, id)`.
+   * Model attribution is per message — each assistant row carries the model
+   * that served it on `TurnTraceMessage.model`.
    */
   messages: TurnTraceMessage[];
   /**

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -126,12 +126,13 @@ mock.module("../config/loader.js", () => ({
 }));
 
 interface MockTurnTrace {
-  schema_version: 2;
+  schema_version: 3;
   messages: {
     id: string;
     role: string;
     created_at: number;
     content: unknown;
+    model: string | null;
   }[];
   tool_calls: unknown[];
   system_prompt: string | null;
@@ -150,13 +151,14 @@ function defaultBoundedTurnTrace(boundary: {
   userMessageCreatedAt: number;
 }): MockTurnTrace | null {
   return {
-    schema_version: 2,
+    schema_version: 3,
     messages: [
       {
         id: boundary.userMessageId,
         role: "user",
         created_at: boundary.userMessageCreatedAt,
         content: [{ type: "text", text: "hello" }],
+        model: null,
       },
     ],
     tool_calls: [],
@@ -1124,8 +1126,9 @@ describe("UsageTelemetryReporter", () => {
     expect(turn.type).toBe("turn");
     expect(turn.daemon_event_id).toBe("evt-turn-trace");
     expect(turn.trace).toBeDefined();
-    expect(turn.trace.schema_version).toBe(2);
+    expect(turn.trace.schema_version).toBe(3);
     expect(turn.trace.messages[0].id).toBe("evt-turn-trace");
+    expect(turn.trace.messages[0].model).toBeNull();
     expect(Array.isArray(turn.trace.tool_calls)).toBe(true);
   });
 
@@ -1332,19 +1335,21 @@ describe("UsageTelemetryReporter", () => {
     // the full trace assembles. The same (still-unreported) turn now ships.
     mockIsTurnSettled.mockReturnValue(true);
     mockAssembleBoundedTurnTrace.mockReturnValue({
-      schema_version: 2,
+      schema_version: 3,
       messages: [
         {
           id: "evt-inflight",
           role: "user",
           created_at: 1700000050000,
           content: [{ type: "text", text: "do a thing" }],
+          model: null,
         },
         {
           id: "asst-1",
           role: "assistant",
           created_at: 1700000051000,
           content: [{ type: "text", text: "done" }],
+          model: "claude-fable-5",
         },
       ],
       tool_calls: [{ id: "ti-1" }],


### PR DESCRIPTION
## Prompt / plan

Follow-up to the question "for a given pii_turn trace, do we send the model used anywhere?" — the answer was no: the model lived only on the sibling `llm_usage` event, so recovering which model served a trace required a join on `conversation_id` + `turn_index`. This PR records the model in the trace itself, per message.

Design (settled after review iteration):

- **The agent loop is the source of truth.** Its `message_complete` event now carries `model` — the provider-reported `response.model` for that call, the same value `llm_usage` records. No resolution in the daemon layer, no conversation state, no reserve-time stamping.
- **Persisted with the content.** `handleMessageComplete` writes `metadata.model` in the same write as the finalized assistant content — `updateMessageContent` gains an optional `metadataUpdates` param that delegates to the transactional content+metadata writer, so both land atomically.
- **Per-message in the trace, no top-level.** `TurnTraceMessage.model` is read from `messages.metadata.model` per row; null on rows with no model call (user rows, tool-result rows, synthetic assistant rows, historical rows persisted before stamping). A `pre-model-call` hook that reroutes an individual call is reflected exactly, since the served model is recorded per call.
- `TurnTrace.schema_version` bumped 2 → 3 for the shape change; platform/dbt parsers should read `messages[].model`.

## Test plan

- `bun test src/telemetry/turn-trace-store.test.ts` — 25 pass (per-message model on assistant rows, mixed models on hook-reroute, null for historical/missing metadata).
- `bun test src/telemetry/usage-telemetry-reporter.test.ts` — 60 pass.
- `bun test src/__tests__/conversation-agent-loop.test.ts` — 66 pass, including a new end-to-end test that runs the real loop against a fake provider and asserts the finalize write carries `{ model: <response.model> }`.
- Adjacent full-loop suites (queue, overflow, secret-redaction, tool-preview, slack persistence, agent-wake, abort, retry-repair, db-lock resilience, inference-profile notification) — all pass.
- `bun run typecheck:fast`, prettier, eslint — clean.

## CLI verb checklist

No new routes added — this PR extends an internal event, message metadata, and a telemetry payload shape. Section intentionally n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R64DUdL1oCoRXd6nJu8L5E