### PR TITLE
refactor(memory): remove memory_scope_id from the Qdrant layer

### DIFF
--- a/assistant/src/__tests__/file-write-tool.test.ts
+++ b/assistant/src/__tests__/file-write-tool.test.ts
@@ -24,16 +24,11 @@ import {
 const enqueueCalls: Array<{
   pkbRoot: string;
   absPath: string;
-  memoryScopeId: string;
 }> = [];
 let enqueueThrows = false;
 
 mock.module("../plugins/defaults/memory/jobs/embed-pkb-file.js", () => ({
-  enqueuePkbIndexJob: (input: {
-    pkbRoot: string;
-    absPath: string;
-    memoryScopeId: string;
-  }) => {
+  enqueuePkbIndexJob: (input: { pkbRoot: string; absPath: string }) => {
     if (enqueueThrows) {
       throw new Error("simulated enqueue failure");
     }
@@ -49,7 +44,6 @@ function setWorkspaceDir(dir: string): void {
   process.env.VELLUM_WORKSPACE_DIR = dir;
 }
 
-import { PKB_WORKSPACE_SCOPE } from "../plugins/defaults/memory/pkb/types.js";
 import { finalizeTool } from "../tools/tool-defaults.js";
 import type { Tool, ToolContext } from "../tools/types.js";
 
@@ -194,25 +188,27 @@ describe("file_write tool PKB re-index hook", () => {
     expect(enqueueCalls[0]).toEqual({
       pkbRoot: join(workingDir, "pkb"),
       absPath: join(workingDir, "pkb", "note.md"),
-      memoryScopeId: PKB_WORKSPACE_SCOPE,
     });
   });
 
-  test("always uses PKB_WORKSPACE_SCOPE", async () => {
+  test("payload identifies the file alone — the PKB index is workspace-shared", async () => {
     const workingDir = makeTempDir();
     setWorkspaceDir(workingDir);
     mkdirSync(join(workingDir, "pkb"), { recursive: true });
 
     const result = await fileWriteTool.execute(
       { path: "pkb/private.md", content: "secret\n" },
-      makeContext(workingDir),
+      { ...makeContext(workingDir), conversationId: "another-conversation" },
     );
 
     expect(result.isError).toBe(false);
     expect(enqueueCalls).toHaveLength(1);
-    // PKB files are workspace-level — points are keyed by PKB_WORKSPACE_SCOPE
-    // so all conversations share one PKB index.
-    expect(enqueueCalls[0]?.memoryScopeId).toBe(PKB_WORKSPACE_SCOPE);
+    // All conversations share one PKB index — the job payload carries no
+    // conversation or scope discriminator.
+    expect(Object.keys(enqueueCalls[0]!).sort()).toEqual([
+      "absPath",
+      "pkbRoot",
+    ]);
   });
 
   test("does NOT enqueue when writing outside pkb/", async () => {

--- a/assistant/src/persistence/embeddings/qdrant-client.ts
+++ b/assistant/src/persistence/embeddings/qdrant-client.ts
@@ -68,7 +68,6 @@ export interface QdrantPointPayload {
   last_seen_at?: number;
   conversation_id?: string;
   message_id?: string;
-  memory_scope_id?: string;
   modality?: "text" | "image" | "audio" | "video";
 }
 
@@ -684,15 +683,12 @@ export class VellumQdrantClient {
   }
 
   /**
-   * Delete all vectors matching target_type, payload path, and memory scope.
-   * Used to remove every chunk belonging to a single PKB file within a scope.
-   * The memory_scope_id filter is required — omitting it would wipe that
-   * path's chunks across every scope that happens to index the same relpath.
+   * Delete all vectors matching target_type and payload path. Used to remove
+   * every chunk belonging to a single PKB file.
    */
   async deleteByTargetTypeAndPath(
     targetType: string,
     path: string,
-    memoryScopeId: string,
   ): Promise<void> {
     await this.ensureCollection();
 
@@ -703,7 +699,6 @@ export class VellumQdrantClient {
           must: [
             { key: "target_type", match: { value: targetType } },
             { key: "path", match: { value: path } },
-            { key: "memory_scope_id", match: { value: memoryScopeId } },
           ],
         },
       });
@@ -827,10 +822,6 @@ export class VellumQdrantClient {
         field_schema: "keyword",
       }),
       this.client.createPayloadIndex(this.collection, {
-        field_name: "memory_scope_id",
-        field_schema: "keyword",
-      }),
-      this.client.createPayloadIndex(this.collection, {
         field_name: "path",
         field_schema: "keyword",
       }),
@@ -879,7 +870,6 @@ export class VellumQdrantClient {
   async scrollByTargetType(
     targetType: string,
     options?: {
-      memoryScopeId?: string;
       path?: string;
       batchSize?: number;
     },
@@ -890,12 +880,6 @@ export class VellumQdrantClient {
     const must: Array<Record<string, unknown>> = [
       { key: "target_type", match: { value: targetType } },
     ];
-    if (options?.memoryScopeId) {
-      must.push({
-        key: "memory_scope_id",
-        match: { value: options.memoryScopeId },
-      });
-    }
     if (options?.path) {
       must.push({ key: "path", match: { value: options.path } });
     }

--- a/assistant/src/plugins/defaults/memory/graph/__tests__/handle-remember-v2.test.ts
+++ b/assistant/src/plugins/defaults/memory/graph/__tests__/handle-remember-v2.test.ts
@@ -25,15 +25,10 @@ let previousWorkspaceEnv: string | undefined;
 const enqueueCalls: Array<{
   pkbRoot: string;
   absPath: string;
-  memoryScopeId: string;
 }> = [];
 
 mock.module("../../jobs/embed-pkb-file.js", () => ({
-  enqueuePkbIndexJob: (input: {
-    pkbRoot: string;
-    absPath: string;
-    memoryScopeId: string;
-  }) => {
+  enqueuePkbIndexJob: (input: { pkbRoot: string; absPath: string }) => {
     enqueueCalls.push(input);
     return "job-mock-id";
   },
@@ -89,7 +84,6 @@ describe("handleRemember — memory.v2.enabled on", () => {
     const result = handleRemember(
       { content: "do not save this" },
       "conv-memory-off",
-      "default",
       CONFIG_MEMORY_OFF,
     );
 
@@ -104,7 +98,6 @@ describe("handleRemember — memory.v2.enabled on", () => {
     const result = handleRemember(
       { content: "Alice prefers VS Code over Vim" },
       "conv-test-1",
-      "default",
       CONFIG,
     );
 
@@ -128,7 +121,6 @@ describe("handleRemember — memory.v2.enabled on", () => {
     const result = handleRemember(
       { content: "Bob lives in Austin" },
       "conv-test-2",
-      "default",
       CONFIG,
     );
 
@@ -140,7 +132,6 @@ describe("handleRemember — memory.v2.enabled on", () => {
     handleRemember(
       { content: "First entry of the day" },
       "conv-test-3",
-      "default",
       CONFIG,
     );
 
@@ -158,8 +149,8 @@ describe("handleRemember — memory.v2.enabled on", () => {
   });
 
   test("appends multiple entries to the same buffer", () => {
-    handleRemember({ content: "first" }, "c", "default", CONFIG);
-    handleRemember({ content: "second" }, "c", "default", CONFIG);
+    handleRemember({ content: "first" }, "c", CONFIG);
+    handleRemember({ content: "second" }, "c", CONFIG);
 
     const buffer = readFileSync(
       join(tmpWorkspace, "memory", "buffer.md"),
@@ -170,12 +161,7 @@ describe("handleRemember — memory.v2.enabled on", () => {
   });
 
   test("rejects empty content without writing", () => {
-    const result = handleRemember(
-      { content: "   " },
-      "conv-test-4",
-      "default",
-      CONFIG,
-    );
+    const result = handleRemember({ content: "   " }, "conv-test-4", CONFIG);
 
     expect(result.success).toBe(false);
     expect(existsSync(join(tmpWorkspace, "memory", "buffer.md"))).toBe(false);
@@ -188,7 +174,6 @@ describe("handleRemember — memory.v2.enabled off (v1 PKB path)", () => {
     const result = handleRemember(
       { content: "v1 path still works" },
       "conv-v1-1",
-      "default",
       CONFIG_V2_OFF,
     );
 
@@ -209,7 +194,6 @@ describe("handleRemember — memory.v2.enabled off (v1 PKB path)", () => {
     const result = handleRemember(
       { content: "index me" },
       "conv-v1-2",
-      "default",
       CONFIG_V2_OFF,
     );
 
@@ -233,7 +217,6 @@ describe("handleRemember — batch (array) content", () => {
     const result = handleRemember(
       { content: ["fact one", "fact two", "fact three"] },
       "conv-batch-1",
-      "default",
       CONFIG,
     );
 
@@ -260,7 +243,6 @@ describe("handleRemember — batch (array) content", () => {
     const result = handleRemember(
       { content: ["alpha", "beta", "gamma"] },
       "conv-batch-2",
-      "default",
       CONFIG_V2_OFF,
     );
 
@@ -281,7 +263,6 @@ describe("handleRemember — batch (array) content", () => {
     const ok = handleRemember(
       { content: ["   ", "kept fact", ""] },
       "conv-batch-3",
-      "default",
       CONFIG,
     );
     expect(ok.success).toBe(true);
@@ -295,7 +276,6 @@ describe("handleRemember — batch (array) content", () => {
     const empty = handleRemember(
       { content: ["   ", ""] },
       "conv-batch-4",
-      "default",
       CONFIG,
     );
     expect(empty.success).toBe(false);
@@ -306,7 +286,6 @@ describe("handleRemember — batch (array) content", () => {
     const result = handleRemember(
       { content: "lone fact" },
       "conv-batch-5",
-      "default",
       CONFIG,
     );
     expect(result.success).toBe(true);

--- a/assistant/src/plugins/defaults/memory/graph/graph-search.ts
+++ b/assistant/src/plugins/defaults/memory/graph/graph-search.ts
@@ -178,7 +178,6 @@ export async function embedGraphNodeDirect(node: MemoryNode): Promise<void> {
   const text = formatNodeForEmbedding(node);
   const extraPayload: Record<string, unknown> = {
     created_at: node.created,
-    memory_scope_id: node.scopeId,
     confidence: node.confidence,
     importance: node.significance,
     kind: node.type,

--- a/assistant/src/plugins/defaults/memory/graph/tool-handlers.test.ts
+++ b/assistant/src/plugins/defaults/memory/graph/tool-handlers.test.ts
@@ -54,10 +54,6 @@ mock.module("../jobs/embed-pkb-file.js", () => ({
   enqueuePkbIndexJob: () => {},
 }));
 
-mock.module("../pkb/types.js", () => ({
-  PKB_WORKSPACE_SCOPE: "workspace",
-}));
-
 // ── Import handlers after mocks are set up ─────────────────────────────────────
 import type { AssistantConfig } from "../../../../config/types.js";
 import {

--- a/assistant/src/plugins/defaults/memory/graph/tool-handlers.ts
+++ b/assistant/src/plugins/defaults/memory/graph/tool-handlers.ts
@@ -14,7 +14,6 @@ import { enqueueMemoryJob } from "../../../../persistence/jobs-store.js";
 import { getLogger } from "../../../../util/logger.js";
 import { getWorkspaceDir } from "../../../../util/platform.js";
 import { enqueuePkbIndexJob } from "../jobs/embed-pkb-file.js";
-import { PKB_WORKSPACE_SCOPE } from "../pkb/types.js";
 import { deleteNode, queryNodes, recordNodeEdit, updateNode } from "./store.js";
 
 const log = getLogger("graph-tool-handlers");
@@ -61,7 +60,6 @@ function rememberSuccessMessage(count: number): string {
 export function handleRemember(
   input: RememberInput,
   _conversationId: string,
-  _scopeId: string,
   config: AssistantConfig,
 ): RememberResult {
   const facts = normalizeFacts(input.content);
@@ -177,9 +175,6 @@ export function appendBufferAndArchive(args: {
 /**
  * Fire-and-forget enqueue of a PKB re-index job for a file we just wrote.
  *
- * Always indexes under {@link PKB_WORKSPACE_SCOPE}. See the comment on that
- * constant for why PKB points are not per-conversation-scoped.
- *
  * Wrapped in try/catch so an enqueue failure (e.g. DB hiccup) cannot break
  * the remember call — the write has already succeeded and the user's fact
  * is safe on disk.
@@ -189,7 +184,6 @@ function enqueuePkbReindex(pkbRoot: string, absPath: string): void {
     enqueuePkbIndexJob({
       pkbRoot,
       absPath,
-      memoryScopeId: PKB_WORKSPACE_SCOPE,
     });
   } catch (err) {
     log.warn({ err, absPath }, "Failed to enqueue PKB re-index job");

--- a/assistant/src/plugins/defaults/memory/injectors.ts
+++ b/assistant/src/plugins/defaults/memory/injectors.ts
@@ -39,7 +39,7 @@ import { getLiveGraphMemory } from "./graph/conversation-graph-memory.js";
 import { getPkbAutoInjectList } from "./pkb/autoinject.js";
 import { readPkbContext } from "./pkb/context.js";
 import { searchPkbFiles } from "./pkb/pkb-search.js";
-import { getPkbRoot, PKB_WORKSPACE_SCOPE } from "./pkb/types.js";
+import { getPkbRoot } from "./pkb/types.js";
 import { readMemoryV2StaticContent } from "./v2/static-context.js";
 
 const pkbReminderLog = getLogger("pkb-reminder");
@@ -256,7 +256,6 @@ async function buildPkbReminderWithHints(
         queryVector,
         graphMemory?.pkbSparseVector,
         8,
-        [PKB_WORKSPACE_SCOPE],
       );
       const inContext = getInContextPkbPaths(
         { messages: runMessages },

--- a/assistant/src/plugins/defaults/memory/job-handlers/embedding.test.ts
+++ b/assistant/src/plugins/defaults/memory/job-handlers/embedding.test.ts
@@ -150,7 +150,6 @@ describe("embedMediaJob", () => {
     expect(call.extraPayload).toEqual({
       created_at: now,
       kind: "image",
-      memory_scope_id: "default",
       subject: "My Screenshot",
     });
   });

--- a/assistant/src/plugins/defaults/memory/job-handlers/embedding.ts
+++ b/assistant/src/plugins/defaults/memory/job-handlers/embedding.ts
@@ -33,7 +33,6 @@ export async function embedSegmentJob(job: MemoryJob): Promise<void> {
     conversation_id: segment.conversationId,
     message_id: segment.messageId,
     created_at: segment.createdAt,
-    memory_scope_id: segment.scopeId,
   });
 }
 
@@ -59,7 +58,6 @@ export async function embedSummaryJob(job: MemoryJob): Promise<void> {
       kind: summary.scope,
       created_at: summary.startAt,
       last_seen_at: summary.endAt,
-      memory_scope_id: summary.scopeId,
     },
   );
 }
@@ -94,7 +92,6 @@ export async function embedMediaJob(job: MemoryJob): Promise<void> {
     created_at: asset.createdAt,
     kind: asset.mediaType,
     subject: asset.title,
-    memory_scope_id: "default",
   });
 }
 
@@ -133,6 +130,5 @@ export async function embedAttachmentJob(job: MemoryJob): Promise<void> {
     created_at: message.createdAt,
     message_id: messageId,
     conversation_id: message.conversationId,
-    memory_scope_id: "default",
   });
 }

--- a/assistant/src/plugins/defaults/memory/jobs/embed-pkb-file.test.ts
+++ b/assistant/src/plugins/defaults/memory/jobs/embed-pkb-file.test.ts
@@ -12,16 +12,11 @@ mock.module("../../../../util/logger.js", () => ({
 const indexPkbFileCalls: Array<{
   pkbRoot: string;
   absPath: string;
-  memoryScopeId: string;
 }> = [];
 
 mock.module("../pkb/pkb-index.js", () => ({
-  indexPkbFile: async (
-    pkbRoot: string,
-    absPath: string,
-    memoryScopeId: string,
-  ) => {
-    indexPkbFileCalls.push({ pkbRoot, absPath, memoryScopeId });
+  indexPkbFile: async (pkbRoot: string, absPath: string) => {
+    indexPkbFileCalls.push({ pkbRoot, absPath });
   },
 }));
 
@@ -77,7 +72,6 @@ describe("embedPkbFileJob", () => {
       makeJob({
         pkbRoot: "/pkb/root",
         absPath: "/pkb/root/note.md",
-        memoryScopeId: "scope-123",
       }),
       TEST_CONFIG,
     );
@@ -86,32 +80,39 @@ describe("embedPkbFileJob", () => {
     expect(indexPkbFileCalls[0]).toEqual({
       pkbRoot: "/pkb/root",
       absPath: "/pkb/root/note.md",
-      memoryScopeId: "scope-123",
     });
   });
 
   test("skips when pkbRoot is missing", async () => {
     await embedPkbFileJob(
-      makeJob({ absPath: "/pkb/root/note.md", memoryScopeId: "scope-123" }),
+      makeJob({ absPath: "/pkb/root/note.md" }),
       TEST_CONFIG,
     );
     expect(indexPkbFileCalls).toHaveLength(0);
   });
 
   test("skips when absPath is missing", async () => {
-    await embedPkbFileJob(
-      makeJob({ pkbRoot: "/pkb/root", memoryScopeId: "scope-123" }),
-      TEST_CONFIG,
-    );
+    await embedPkbFileJob(makeJob({ pkbRoot: "/pkb/root" }), TEST_CONFIG);
     expect(indexPkbFileCalls).toHaveLength(0);
   });
 
-  test("skips when memoryScopeId is missing", async () => {
+  test("processes a legacy payload that still carries a memoryScopeId key", async () => {
+    // Rows enqueued before scope removal persist in the job queue with the
+    // extra key; the handler reads only pkbRoot/absPath and must not skip.
     await embedPkbFileJob(
-      makeJob({ pkbRoot: "/pkb/root", absPath: "/pkb/root/note.md" }),
+      makeJob({
+        pkbRoot: "/pkb/root",
+        absPath: "/pkb/root/note.md",
+        memoryScopeId: "legacy-scope",
+      }),
       TEST_CONFIG,
     );
-    expect(indexPkbFileCalls).toHaveLength(0);
+
+    expect(indexPkbFileCalls).toHaveLength(1);
+    expect(indexPkbFileCalls[0]).toEqual({
+      pkbRoot: "/pkb/root",
+      absPath: "/pkb/root/note.md",
+    });
   });
 });
 
@@ -130,7 +131,6 @@ describe("enqueuePkbIndexJob", () => {
     const id = enqueuePkbIndexJob({
       pkbRoot: "/pkb/root",
       absPath: "/pkb/root/note.md",
-      memoryScopeId: "scope-abc",
     });
     expect(id).toBeTruthy();
 
@@ -142,7 +142,6 @@ describe("enqueuePkbIndexJob", () => {
     expect(job.payload).toEqual({
       pkbRoot: "/pkb/root",
       absPath: "/pkb/root/note.md",
-      memoryScopeId: "scope-abc",
     });
   });
 
@@ -150,7 +149,6 @@ describe("enqueuePkbIndexJob", () => {
     enqueuePkbIndexJob({
       pkbRoot: "/pkb/root",
       absPath: "/pkb/root/note.md",
-      memoryScopeId: "scope-rt",
     });
 
     const claimed = claimMemoryJobs({ slowLlm: 10, fast: 10, embed: 10 });
@@ -163,7 +161,6 @@ describe("enqueuePkbIndexJob", () => {
     expect(indexPkbFileCalls[0]).toEqual({
       pkbRoot: "/pkb/root",
       absPath: "/pkb/root/note.md",
-      memoryScopeId: "scope-rt",
     });
   });
 });

--- a/assistant/src/plugins/defaults/memory/jobs/embed-pkb-file.ts
+++ b/assistant/src/plugins/defaults/memory/jobs/embed-pkb-file.ts
@@ -13,7 +13,6 @@ import { indexPkbFile } from "../pkb/pkb-index.js";
 export interface EmbedPkbFileJobInput {
   pkbRoot: string;
   absPath: string;
-  memoryScopeId: string;
 }
 
 /**
@@ -28,11 +27,10 @@ export async function embedPkbFileJob(
 ): Promise<void> {
   const pkbRoot = asString(job.payload.pkbRoot);
   const absPath = asString(job.payload.absPath);
-  const memoryScopeId = asString(job.payload.memoryScopeId);
-  if (!pkbRoot || !absPath || !memoryScopeId) return;
+  if (!pkbRoot || !absPath) return;
 
   try {
-    await indexPkbFile(pkbRoot, absPath, memoryScopeId);
+    await indexPkbFile(pkbRoot, absPath);
   } catch (error) {
     if (
       error !== null &&
@@ -54,6 +52,5 @@ export function enqueuePkbIndexJob(input: EmbedPkbFileJobInput): string {
   return enqueueMemoryJob("embed_pkb_file", {
     pkbRoot: input.pkbRoot,
     absPath: input.absPath,
-    memoryScopeId: input.memoryScopeId,
   });
 }

--- a/assistant/src/plugins/defaults/memory/pkb/pkb-index.test.ts
+++ b/assistant/src/plugins/defaults/memory/pkb/pkb-index.test.ts
@@ -46,7 +46,6 @@ mock.module("../../../../config/loader.js", () => ({
 const qdrantDeleteCalls: Array<{
   targetType: string;
   path: string;
-  memoryScopeId: string;
 }> = [];
 
 // Track per-target deletes (used by write-then-cleanup in indexPkbFile).
@@ -63,18 +62,13 @@ let scrollReturnPoints: Array<{
 }> = [];
 const qdrantScrollCalls: Array<{
   targetType: string;
-  memoryScopeId?: string;
   path?: string;
 }> = [];
 
 mock.module("../../../../persistence/embeddings/qdrant-client.js", () => ({
   getQdrantClient: () => ({
-    deleteByTargetTypeAndPath: async (
-      targetType: string,
-      path: string,
-      memoryScopeId: string,
-    ) => {
-      qdrantDeleteCalls.push({ targetType, path, memoryScopeId });
+    deleteByTargetTypeAndPath: async (targetType: string, path: string) => {
+      qdrantDeleteCalls.push({ targetType, path });
     },
     deleteByTarget: async (targetType: string, targetId: string) => {
       qdrantDeleteByTargetCalls.push({ targetType, targetId });
@@ -82,14 +76,12 @@ mock.module("../../../../persistence/embeddings/qdrant-client.js", () => ({
     scrollByTargetType: async (
       targetType: string,
       options?: {
-        memoryScopeId?: string;
         path?: string;
         batchSize?: number;
       },
     ) => {
       qdrantScrollCalls.push({
         targetType,
-        memoryScopeId: options?.memoryScopeId,
         path: options?.path,
       });
       return scrollReturnPoints;
@@ -235,17 +227,17 @@ describe("indexPkbFile", () => {
     const filePath = join(root, "doc.md");
     await writeFile(filePath, "# hello\nworld");
 
-    await indexPkbFile(root, filePath, "scope-xyz");
+    await indexPkbFile(root, filePath);
 
     expect(embedAndUpsertCalls).toHaveLength(1);
     const call = embedAndUpsertCalls[0];
     expect(call.targetType).toBe("pkb_file");
-    expect(call.targetId).toBe("scope-xyz:doc.md#0");
+    expect(call.targetId).toBe("doc.md#0");
     expect(call.input).toEqual({ type: "text", text: "# hello\nworld" });
     const payload = call.extraPayload as Record<string, unknown>;
     expect(payload.path).toBe("doc.md");
     expect(payload.chunk_index).toBe(0);
-    expect(payload.memory_scope_id).toBe("scope-xyz");
+    expect(payload).not.toHaveProperty("memory_scope_id");
     expect(typeof payload.mtime_ms).toBe("number");
     expect(typeof payload.content_hash).toBe("string");
     expect((payload.content_hash as string).length).toBe(16);
@@ -261,40 +253,39 @@ describe("indexPkbFile", () => {
       "b".repeat(5990);
     await writeFile(filePath, content);
 
-    await indexPkbFile(root, filePath, "scope-1");
+    await indexPkbFile(root, filePath);
 
     expect(embedAndUpsertCalls).toHaveLength(2);
-    expect(embedAndUpsertCalls[0].targetId).toBe("scope-1:big.md#0");
-    expect(embedAndUpsertCalls[1].targetId).toBe("scope-1:big.md#1");
+    expect(embedAndUpsertCalls[0].targetId).toBe("big.md#0");
+    expect(embedAndUpsertCalls[1].targetId).toBe("big.md#1");
     expect(embedAndUpsertCalls.every((c) => c.targetType === "pkb_file")).toBe(
       true,
     );
   });
 
-  test("scope-namespaces target ids so two scopes indexing the same path do not collide", async () => {
-    const root = await mkdtemp(join(tmpdir(), "pkb-index-scope-"));
+  test("re-indexing the same path regenerates identical target ids so upsert replaces in place", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pkb-index-rerun-"));
     const filePath = join(root, "shared.md");
     await writeFile(filePath, "# shared");
 
-    await indexPkbFile(root, filePath, "alpha");
-    await indexPkbFile(root, filePath, "beta");
+    await indexPkbFile(root, filePath);
+    await indexPkbFile(root, filePath);
 
     expect(embedAndUpsertCalls).toHaveLength(2);
     const ids = embedAndUpsertCalls.map((c) => c.targetId);
-    expect(ids).toEqual(["alpha:shared.md#0", "beta:shared.md#0"]);
+    expect(ids).toEqual(["shared.md#0", "shared.md#0"]);
   });
 
-  test("scrolls existing chunks scoped to (target_type, scope, path) before upserting", async () => {
+  test("scrolls existing chunks scoped to (target_type, path) before upserting", async () => {
     const root = await mkdtemp(join(tmpdir(), "pkb-index-scroll-"));
     const filePath = join(root, "noted.md");
     await writeFile(filePath, "# one");
 
-    await indexPkbFile(root, filePath, "scope-xyz");
+    await indexPkbFile(root, filePath);
 
     expect(qdrantScrollCalls).toHaveLength(1);
     expect(qdrantScrollCalls[0]).toEqual({
       targetType: "pkb_file",
-      memoryScopeId: "scope-xyz",
       path: "noted.md",
     });
   });
@@ -308,31 +299,28 @@ describe("indexPkbFile", () => {
     scrollReturnPoints = [
       {
         id: "point-0",
-        payload: { target_id: "scope-xyz:shrinking.md#0" },
+        payload: { target_id: "shrinking.md#0" },
       },
       {
         id: "point-1",
-        payload: { target_id: "scope-xyz:shrinking.md#1" },
+        payload: { target_id: "shrinking.md#1" },
       },
       {
         id: "point-2",
-        payload: { target_id: "scope-xyz:shrinking.md#2" },
+        payload: { target_id: "shrinking.md#2" },
       },
     ];
 
-    await indexPkbFile(root, filePath, "scope-xyz");
+    await indexPkbFile(root, filePath);
 
     // Exactly one upsert for the surviving chunk.
     expect(embedAndUpsertCalls).toHaveLength(1);
-    expect(embedAndUpsertCalls[0].targetId).toBe("scope-xyz:shrinking.md#0");
+    expect(embedAndUpsertCalls[0].targetId).toBe("shrinking.md#0");
 
     // The pre-delete is gone; only the two stale chunks are removed.
     expect(qdrantDeleteCalls).toHaveLength(0);
     const staleTargetIds = qdrantDeleteByTargetCalls.map((c) => c.targetId);
-    expect(staleTargetIds.sort()).toEqual([
-      "scope-xyz:shrinking.md#1",
-      "scope-xyz:shrinking.md#2",
-    ]);
+    expect(staleTargetIds.sort()).toEqual(["shrinking.md#1", "shrinking.md#2"]);
   });
 
   test("does not delete points whose target_id is regenerated", async () => {
@@ -342,11 +330,11 @@ describe("indexPkbFile", () => {
     scrollReturnPoints = [
       {
         id: "point-0",
-        payload: { target_id: "scope-xyz:stable.md#0" },
+        payload: { target_id: "stable.md#0" },
       },
     ];
 
-    await indexPkbFile(root, filePath, "scope-xyz");
+    await indexPkbFile(root, filePath);
 
     expect(embedAndUpsertCalls).toHaveLength(1);
     expect(qdrantDeleteByTargetCalls).toHaveLength(0);
@@ -358,14 +346,13 @@ describe("deletePkbFilePoints", () => {
     qdrantDeleteCalls.length = 0;
   });
 
-  test("sends a filter with target_type, path, and memory_scope_id predicates", async () => {
-    await deletePkbFilePoints("notes/todo.md", "scope-xyz");
+  test("sends a filter with target_type and path predicates", async () => {
+    await deletePkbFilePoints("notes/todo.md");
 
     expect(qdrantDeleteCalls).toHaveLength(1);
     expect(qdrantDeleteCalls[0]).toEqual({
       targetType: "pkb_file",
       path: "notes/todo.md",
-      memoryScopeId: "scope-xyz",
     });
   });
 });

--- a/assistant/src/plugins/defaults/memory/pkb/pkb-index.ts
+++ b/assistant/src/plugins/defaults/memory/pkb/pkb-index.ts
@@ -176,8 +176,8 @@ export function chunkPkbFile(content: string): string[] {
  * `pkbRoot`.
  *
  * Write-then-cleanup: enumerate the existing chunk target_ids for this
- * (scope, path), upsert every new chunk, then delete only the stale
- * target_ids (those the fresh content no longer produces). Upsert dedupes on
+ * path, upsert every new chunk, then delete only the stale target_ids
+ * (those the fresh content no longer produces). Upsert dedupes on
  * (target_type, target_id), so matching chunk indexes are replaced in place
  * and the prior index stays queryable if any embed/upsert call throws. A
  * pre-delete would instead leave the file unsearchable on transient failure
@@ -186,7 +186,6 @@ export function chunkPkbFile(content: string): string[] {
 export async function indexPkbFile(
   pkbRoot: string,
   absPath: string,
-  memoryScopeId: string,
 ): Promise<void> {
   const content = await readFile(absPath, "utf8");
   const st = await stat(absPath);
@@ -198,7 +197,6 @@ export async function indexPkbFile(
   const qdrant = getQdrantClient();
   const existing = await withQdrantBreaker(() =>
     qdrant.scrollByTargetType(PKB_TARGET_TYPE, {
-      memoryScopeId,
       path: relPath,
     }),
   );
@@ -206,11 +204,7 @@ export async function indexPkbFile(
   const newTargetIds = new Set<string>();
   for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) {
     const chunk = chunks[chunkIndex];
-    // Scope-namespace the target_id so `qdrant.upsert` — which dedupes on
-    // (target_type, target_id) — cannot collapse distinct scopes' chunks of
-    // the same relpath into a single point. Without the scope prefix, the
-    // second scope to index a shared path would overwrite the first's vectors.
-    const targetId = `${memoryScopeId}:${relPath}#${chunkIndex}`;
+    const targetId = `${relPath}#${chunkIndex}`;
     newTargetIds.add(targetId);
     await embedAndUpsert(
       PKB_TARGET_TYPE,
@@ -221,7 +215,6 @@ export async function indexPkbFile(
         mtime_ms: mtimeMs,
         chunk_index: chunkIndex,
         content_hash: contentHash,
-        memory_scope_id: memoryScopeId,
       },
     );
   }
@@ -243,18 +236,13 @@ export async function indexPkbFile(
 }
 
 /**
- * Remove every Qdrant point belonging to a given PKB file (all chunks) within
- * a single memory scope. `relPath` must match the `path` payload written by
- * `indexPkbFile`. The `memoryScopeId` filter is required — omitting it would
- * wipe that relpath's chunks across every scope that indexes the same file.
+ * Remove every Qdrant point belonging to a given PKB file (all chunks).
+ * `relPath` must match the `path` payload written by `indexPkbFile`.
  */
-export async function deletePkbFilePoints(
-  relPath: string,
-  memoryScopeId: string,
-): Promise<void> {
+export async function deletePkbFilePoints(relPath: string): Promise<void> {
   const qdrant = getQdrantClient();
   await withQdrantBreaker(() =>
-    qdrant.deleteByTargetTypeAndPath(PKB_TARGET_TYPE, relPath, memoryScopeId),
+    qdrant.deleteByTargetTypeAndPath(PKB_TARGET_TYPE, relPath),
   );
 }
 

--- a/assistant/src/plugins/defaults/memory/pkb/pkb-reconcile.test.ts
+++ b/assistant/src/plugins/defaults/memory/pkb/pkb-reconcile.test.ts
@@ -13,15 +13,10 @@ mock.module("../../../../util/logger.js", () => ({
 const enqueuedJobs: Array<{
   pkbRoot: string;
   absPath: string;
-  memoryScopeId: string;
 }> = [];
 
 mock.module("../jobs/embed-pkb-file.js", () => ({
-  enqueuePkbIndexJob: (input: {
-    pkbRoot: string;
-    absPath: string;
-    memoryScopeId: string;
-  }) => {
+  enqueuePkbIndexJob: (input: { pkbRoot: string; absPath: string }) => {
     enqueuedJobs.push(input);
     return "job-id";
   },
@@ -29,20 +24,13 @@ mock.module("../jobs/embed-pkb-file.js", () => ({
 
 // Capture calls into the fake Qdrant client.
 let scrollPoints: Array<{ id: string; payload: Record<string, unknown> }> = [];
-const deleteCalls: Array<{ path: string; memoryScopeId: string }> = [];
+const deleteCalls: Array<{ path: string }> = [];
 
 mock.module("../../../../persistence/embeddings/qdrant-client.js", () => ({
   getQdrantClient: () => ({
-    scrollByTargetType: async (
-      _targetType: string,
-      _options?: { memoryScopeId?: string },
-    ) => scrollPoints,
-    deleteByTargetTypeAndPath: async (
-      _targetType: string,
-      path: string,
-      memoryScopeId: string,
-    ) => {
-      deleteCalls.push({ path, memoryScopeId });
+    scrollByTargetType: async (_targetType: string) => scrollPoints,
+    deleteByTargetTypeAndPath: async (_targetType: string, path: string) => {
+      deleteCalls.push({ path });
     },
   }),
   resolveQdrantUrl: () => "http://127.0.0.1:6333",
@@ -81,6 +69,8 @@ function pkbPoint(
       path,
       chunk_index: chunkIndex,
       content_hash: contentHash,
+      // Pre-existing points may carry a legacy memory_scope_id key;
+      // reconciliation must tolerate it.
       memory_scope_id: "default",
     },
   };
@@ -120,7 +110,7 @@ describe("reconcilePkbIndex", () => {
     // Qdrant empty.
     scrollPoints = [];
 
-    const result = await reconcilePkbIndex(root, "default");
+    const result = await reconcilePkbIndex(root);
 
     expect(result.enqueued).toBe(2);
     expect(result.deleted).toBe(0);
@@ -130,7 +120,6 @@ describe("reconcilePkbIndex", () => {
     expect(paths.has(join(root, "b.md"))).toBe(true);
     for (const job of enqueuedJobs) {
       expect(job.pkbRoot).toBe(root);
-      expect(job.memoryScopeId).toBe("default");
     }
     expect(deleteCalls).toHaveLength(0);
   });
@@ -147,10 +136,41 @@ describe("reconcilePkbIndex", () => {
       pkbPoint("b.md", hashes.get("b.md")!),
     ];
 
-    const result = await reconcilePkbIndex(root, "default");
+    const result = await reconcilePkbIndex(root);
 
     expect(result.enqueued).toBe(0);
     expect(result.deleted).toBe(0);
+    expect(enqueuedJobs).toHaveLength(0);
+    expect(deleteCalls).toHaveLength(0);
+  });
+
+  test("legacy-format points with scope-prefixed target ids do not trigger re-indexing", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pkb-reconcile-legacy-"));
+    const hashes = await seedPkbAndHash(root, [
+      { path: "notes.md", content: "# Notes" },
+    ]);
+
+    // Point indexed before scope removal: `_pkb_workspace:`-prefixed
+    // target_id plus a legacy memory_scope_id payload key. Reconciliation
+    // diffs on payload path + content_hash only, so a legacy point whose
+    // hash matches disk must read as up to date.
+    scrollPoints = [
+      {
+        id: "_pkb_workspace:notes.md#0",
+        payload: {
+          target_type: "pkb_file",
+          target_id: "_pkb_workspace:notes.md#0",
+          path: "notes.md",
+          chunk_index: 0,
+          content_hash: hashes.get("notes.md")!,
+          memory_scope_id: "_pkb_workspace",
+        },
+      },
+    ];
+
+    const result = await reconcilePkbIndex(root);
+
+    expect(result).toEqual({ enqueued: 0, deleted: 0 });
     expect(enqueuedJobs).toHaveLength(0);
     expect(deleteCalls).toHaveLength(0);
   });
@@ -168,7 +188,7 @@ describe("reconcilePkbIndex", () => {
       pkbPoint("b.md", hashes.get("b.md")!),
     ];
 
-    const result = await reconcilePkbIndex(root, "default");
+    const result = await reconcilePkbIndex(root);
 
     expect(result.enqueued).toBe(1);
     expect(result.deleted).toBe(0);
@@ -189,13 +209,11 @@ describe("reconcilePkbIndex", () => {
       pkbPoint("gone.md", "dead00dead00dead"),
     ];
 
-    const result = await reconcilePkbIndex(root, "default");
+    const result = await reconcilePkbIndex(root);
 
     expect(result.enqueued).toBe(0);
     expect(result.deleted).toBe(1);
-    expect(deleteCalls).toEqual([
-      { path: "gone.md", memoryScopeId: "default" },
-    ]);
+    expect(deleteCalls).toEqual([{ path: "gone.md" }]);
     expect(enqueuedJobs).toHaveLength(0);
   });
 
@@ -212,7 +230,7 @@ describe("reconcilePkbIndex", () => {
       pkbPoint("notes/c.md", "cccccccccccccccc"),
     ];
 
-    const result = await reconcilePkbIndex(missing, "default");
+    const result = await reconcilePkbIndex(missing);
 
     expect(result.enqueued).toBe(0);
     expect(result.deleted).toBe(0);
@@ -227,7 +245,7 @@ describe("reconcilePkbIndex", () => {
 
     scrollPoints = [pkbPoint("a.md", "aaaaaaaaaaaaaaaa")];
 
-    const result = await reconcilePkbIndex(root, "default");
+    const result = await reconcilePkbIndex(root);
 
     expect(result.enqueued).toBe(0);
     expect(result.deleted).toBe(0);
@@ -246,7 +264,7 @@ describe("reconcilePkbIndex", () => {
       pkbPoint("a.md", hashes.get("a.md")!, 1),
     ];
 
-    const result = await reconcilePkbIndex(root, "default");
+    const result = await reconcilePkbIndex(root);
 
     expect(result.enqueued).toBe(0);
     expect(result.deleted).toBe(0);

--- a/assistant/src/plugins/defaults/memory/pkb/pkb-reconcile.ts
+++ b/assistant/src/plugins/defaults/memory/pkb/pkb-reconcile.ts
@@ -37,7 +37,6 @@ export interface ReconcilePkbIndexResult {
  */
 export async function reconcilePkbIndex(
   pkbRoot: string,
-  memoryScopeId: string,
 ): Promise<ReconcilePkbIndexResult> {
   // Build the on-disk view keyed by relative path. `scanPkbFiles` emits one
   // entry per chunk — every chunk of the same file shares the same
@@ -52,7 +51,7 @@ export async function reconcilePkbIndex(
   const diskEntries = await scanPkbFiles(pkbRoot);
   if (diskEntries === null) {
     log.warn(
-      { pkbRoot, memoryScopeId },
+      { pkbRoot },
       "PKB root directory missing — skipping reconciliation to avoid wiping the index",
     );
     return { enqueued: 0, deleted: 0 };
@@ -72,9 +71,7 @@ export async function reconcilePkbIndex(
   // chunks remain searchable as long as the first chunk's hash happened to
   // match the current disk content.
   const qdrant = getQdrantClient();
-  const points = await qdrant.scrollByTargetType(PKB_TARGET_TYPE, {
-    memoryScopeId,
-  });
+  const points = await qdrant.scrollByTargetType(PKB_TARGET_TYPE);
   const indexedByPath = new Map<
     string,
     { contentHash: string; mixed: boolean }
@@ -105,7 +102,6 @@ export async function reconcilePkbIndex(
       enqueuePkbIndexJob({
         pkbRoot,
         absPath: join(pkbRoot, relPath),
-        memoryScopeId,
       });
       enqueued++;
     }
@@ -115,7 +111,7 @@ export async function reconcilePkbIndex(
   for (const relPath of indexedByPath.keys()) {
     if (!diskByPath.has(relPath)) {
       try {
-        await deletePkbFilePoints(relPath, memoryScopeId);
+        await deletePkbFilePoints(relPath);
         deleted++;
       } catch (err) {
         log.warn(
@@ -130,7 +126,6 @@ export async function reconcilePkbIndex(
     log.info(
       {
         pkbRoot,
-        memoryScopeId,
         enqueued,
         deleted,
         diskCount: diskByPath.size,

--- a/assistant/src/plugins/defaults/memory/pkb/pkb-search.test.ts
+++ b/assistant/src/plugins/defaults/memory/pkb/pkb-search.test.ts
@@ -564,14 +564,11 @@ describe("searchPkbFiles", () => {
     expect(results[1]?.path).toBe("/a.md");
   });
 
-  test("adds memory_scope_id clause when scopeIds provided (both queries)", async () => {
+  test("filters carry no memory_scope_id clause — search spans the whole PKB index (both queries)", async () => {
     hybridResults = [];
     denseResults = [];
 
-    await searchPkbFiles([0.1], { indices: [1], values: [1] }, 5, [
-      "scope-a",
-      "scope-b",
-    ]);
+    await searchPkbFiles([0.1], { indices: [1], values: [1] }, 5);
 
     const hybridFilter = hybridSearchCalls[0]?.filter as {
       must: Array<Record<string, unknown>>;
@@ -580,10 +577,7 @@ describe("searchPkbFiles", () => {
       must: Array<Record<string, unknown>>;
     };
     for (const filter of [hybridFilter, denseFilter]) {
-      const scopeClause = filter.must.find(
-        (c) => c.key === "memory_scope_id",
-      ) as { match: { any: string[] } } | undefined;
-      expect(scopeClause?.match.any).toEqual(["scope-a", "scope-b"]);
+      expect(filter.must.map((c) => c.key)).toEqual(["target_type"]);
     }
   });
 });

--- a/assistant/src/plugins/defaults/memory/pkb/pkb-search.ts
+++ b/assistant/src/plugins/defaults/memory/pkb/pkb-search.ts
@@ -39,7 +39,6 @@ export async function searchPkbFiles(
   queryVector: number[],
   sparseVector: QdrantSparseVector | undefined,
   limit: number,
-  scopeIds?: string[],
 ): Promise<PkbSearchResult[]> {
   // v2 owns the read path when enabled; v2 absorbs PKB as a read source,
   // so PKB hint search short-circuits to keep traffic off the v1 collection
@@ -57,14 +56,8 @@ export async function searchPkbFiles(
   // from the same file collapse to a single result.
   const prefetchLimit = Math.max(limit * 3, limit);
 
-  const baseMust: Record<string, unknown>[] = [
-    { key: "target_type", match: { value: PKB_TARGET_TYPE } },
-    ...(scopeIds && scopeIds.length > 0
-      ? [{ key: "memory_scope_id", match: { any: scopeIds } }]
-      : []),
-  ];
   const filter = {
-    must: baseMust,
+    must: [{ key: "target_type", match: { value: PKB_TARGET_TYPE } }],
     must_not: [{ key: "_meta", match: { value: true } }],
   };
 

--- a/assistant/src/plugins/defaults/memory/pkb/types.ts
+++ b/assistant/src/plugins/defaults/memory/pkb/types.ts
@@ -21,16 +21,6 @@ export function getPkbRoot(): string {
   return join(getWorkspaceDir(), "pkb");
 }
 
-/**
- * Sentinel `memory_scope_id` under which ALL PKB points are indexed and
- * searched. PKB files are a workspace-shared resource: one copy on disk is
- * visible to every conversation in the workspace, so every writer — the
- * `remember` tool, file writes, startup reconciliation — pins to this scope
- * so search returns a single coherent view of the workspace's knowledge base
- * instead of a per-conversation fragment.
- */
-export const PKB_WORKSPACE_SCOPE = "_pkb_workspace" as const;
-
 export interface PkbSearchResult {
   path: string;
   /**
@@ -63,5 +53,4 @@ export interface PkbIndexPayload {
   mtime_ms: number;
   chunk_index: number;
   content_hash: string;
-  memory_scope_id: string;
 }

--- a/assistant/src/plugins/defaults/memory/startup.ts
+++ b/assistant/src/plugins/defaults/memory/startup.ts
@@ -184,9 +184,8 @@ export async function runMemoryStartup(config: AssistantConfig): Promise<void> {
       void (async () => {
         try {
           const { reconcilePkbIndex } = await import("./pkb/pkb-reconcile.js");
-          const { PKB_WORKSPACE_SCOPE } = await import("./pkb/types.js");
           const pkbRoot = join(getWorkspaceDir(), "pkb");
-          await reconcilePkbIndex(pkbRoot, PKB_WORKSPACE_SCOPE);
+          await reconcilePkbIndex(pkbRoot);
         } catch (err) {
           log.warn(
             { err },

--- a/assistant/src/plugins/defaults/memory/tools.test.ts
+++ b/assistant/src/plugins/defaults/memory/tools.test.ts
@@ -12,7 +12,6 @@ import {
 } from "bun:test";
 
 import type { ToolContext } from "../../../tools/types.js";
-import { PKB_WORKSPACE_SCOPE } from "./pkb/types.js";
 
 // This test exercises v1 PKB re-index enqueue. `config.memory.v2.enabled`
 // (default `true`) makes the enqueue path skipped — force it off so the
@@ -31,7 +30,6 @@ let previousWorkspaceEnv: string | undefined;
 const enqueueCalls: Array<{
   pkbRoot: string;
   absPath: string;
-  memoryScopeId: string;
 }> = [];
 let enqueueShouldThrow = false;
 
@@ -42,11 +40,7 @@ const recallCalls: Array<{
 let recallContent = "agentic recall answer";
 
 mock.module("./jobs/embed-pkb-file.js", () => ({
-  enqueuePkbIndexJob: (input: {
-    pkbRoot: string;
-    absPath: string;
-    memoryScopeId: string;
-  }) => {
+  enqueuePkbIndexJob: (input: { pkbRoot: string; absPath: string }) => {
     enqueueCalls.push(input);
     if (enqueueShouldThrow) {
       throw new Error("simulated enqueue failure");
@@ -301,12 +295,10 @@ describe("rememberTool.execute — PKB re-index enqueue", () => {
     expect(enqueueCalls[0]).toEqual({
       pkbRoot,
       absPath: bufferPath,
-      memoryScopeId: PKB_WORKSPACE_SCOPE,
     });
     expect(enqueueCalls[1]).toEqual({
       pkbRoot,
       absPath: archivePath,
-      memoryScopeId: PKB_WORKSPACE_SCOPE,
     });
   });
 

--- a/assistant/src/plugins/defaults/memory/tools.ts
+++ b/assistant/src/plugins/defaults/memory/tools.ts
@@ -41,7 +41,6 @@ export const rememberTool = {
     const result = handleRemember(
       typedInput,
       context.conversationId,
-      "default",
       getConfig(),
     );
     return {

--- a/assistant/src/tools/filesystem/write.ts
+++ b/assistant/src/tools/filesystem/write.ts
@@ -3,7 +3,6 @@ import { join, resolve, sep } from "node:path";
 import { getAppsDir } from "../../apps/app-store.js";
 import { RiskLevel } from "../../permissions/types.js";
 import { enqueuePkbIndexJob } from "../../plugins/defaults/memory/jobs/embed-pkb-file.js";
-import { PKB_WORKSPACE_SCOPE } from "../../plugins/defaults/memory/pkb/types.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
 import { FileSystemOps } from "../shared/filesystem/file-ops-service.js";
@@ -160,7 +159,6 @@ export const fileWriteTool = {
         enqueuePkbIndexJob({
           pkbRoot,
           absPath: filePath,
-          memoryScopeId: PKB_WORKSPACE_SCOPE,
         });
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- Remove the `memory_scope_id` Qdrant payload key from all writers (PKB chunks, segments, summaries, media, attachments, graph nodes) and every filter that consumed it (pkb-search, scroll, delete-by-path) — atomically, so partial states (filter kept / write dropped) can't orphan points or re-enqueue-loop at boot.
- Drop the scope-prefixed PKB target-id format (`_pkb_workspace:path#n` → `path#n`), the `PKB_WORKSPACE_SCOPE` sentinel, and the scope params threaded through `indexPkbFile`/`deletePkbFilePoints`/`reconcilePkbIndex`/`searchPkbFiles`/`embed_pkb_file` jobs/`handleRemember`. Legacy points stay searchable (reconcile matches payload `path`+`content_hash`, never id shape) and are cleaned up lazily on next file change; new regression test covers this.
- Old queued `embed_pkb_file` rows keep processing — the handler guard no longer requires the removed key.

## Original prompt
Sidd asked for a thorough cleanup deleting the vestigial memoryScopeId concept (a fossil of the conversation memory-scope system removed in #29607) while keeping the v1 memory system functional. Every surviving scope value is a constant, so removal is behavior-preserving. This is PR 1 of a planned 4-PR series: (1) Qdrant layer, (2) SQL-side scope_id threading + hygiene migration, (3) conversations/task_runs/ToolContext fossils + docs, (4) v2-gating the PKB write hook.