### PR TITLE
fix(persistence): de-anonymize and label slow-query attributions

### DIFF
--- a/assistant/src/persistence/__tests__/slow-query-log.test.ts
+++ b/assistant/src/persistence/__tests__/slow-query-log.test.ts
@@ -1,6 +1,8 @@
 import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
 
+import { runWithSqliteQueryLabel } from "../../util/sqlite-query-label.js";
+import { withSqliteRetry } from "../../util/sqlite-retry.js";
 import {
   callerFromStack,
   SLOW_QUERY_THRESHOLD_MS,
@@ -211,6 +213,99 @@ describe("slow-query-log", () => {
     const db = new Database(":memory:");
     expect(wrapSqliteForSlowQueryLogging(db)).toBe(db);
   });
+
+  test("an ambient label tags the event and keeps the derived caller", () => {
+    const events: SlowQueryEvent[] = [];
+    const db = new Database(":memory:");
+    db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)");
+    wrapSqliteForSlowQueryLogging(db, {
+      thresholdMs: 100,
+      now: fakeClock(0, 500),
+      onSlowQuery: (e) => events.push(e),
+    });
+
+    runWithSqliteQueryLabel("memory:upsertRetrospectiveState", () => {
+      db.query("SELECT * FROM t").all();
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].label).toBe("memory:upsertRetrospectiveState");
+    // Unlike an explicit `.label()`, an ambient label marks an outer boundary,
+    // so the statement's own call site is still derived from the stack.
+    expect(events[0].caller).toContain("slow-query-log.test.ts");
+  });
+
+  test("an explicit .label() wins over the ambient label", () => {
+    const events: SlowQueryEvent[] = [];
+    const db = new Database(":memory:");
+    db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)");
+    wrapSqliteForSlowQueryLogging(db, {
+      thresholdMs: 100,
+      now: fakeClock(0, 500),
+      onSlowQuery: (e) => events.push(e),
+    });
+
+    runWithSqliteQueryLabel("ambient:outer", () => {
+      db.label("schedule::claimDue")
+        .query("INSERT INTO t (v) VALUES (?)")
+        .run("a");
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].label).toBe("schedule::claimDue");
+    expect(events[0].caller).toBeUndefined();
+  });
+
+  test("withSqliteRetry's op labels slow queries inside it, retries included", async () => {
+    const events: SlowQueryEvent[] = [];
+    const db = new Database(":memory:");
+    db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)");
+    wrapSqliteForSlowQueryLogging(db, {
+      thresholdMs: 100,
+      now: fakeClock(0, 500),
+      onSlowQuery: (e) => events.push(e),
+    });
+
+    // First attempt loses the write-lock race; the retry (which runs from a
+    // stack truncated by the backoff sleep) issues the slow query.
+    let attempt = 0;
+    await withSqliteRetry(
+      () => {
+        if (attempt++ === 0) {
+          throw Object.assign(new Error("busy"), { code: "SQLITE_BUSY" });
+        }
+        return db.query("SELECT * FROM t").all();
+      },
+      { op: "test:claimRow", baseDelayMs: 1 },
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0].label).toBe("test:claimRow");
+  });
+
+  test("withSqliteRetry's op labels a lazy thenable that runs when awaited", async () => {
+    const events: SlowQueryEvent[] = [];
+    const db = new Database(":memory:");
+    db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)");
+    wrapSqliteForSlowQueryLogging(db, {
+      thresholdMs: 100,
+      now: fakeClock(0, 500),
+      onSlowQuery: (e) => events.push(e),
+    });
+
+    // Mirrors a Drizzle QueryPromise: fn returns immediately and the statement
+    // only executes when the thenable is assimilated by an await. The retry
+    // helper must perform that await inside its label scope.
+    const lazy = {
+      then(resolve: (value: unknown) => void) {
+        resolve(db.query("SELECT * FROM t").all());
+      },
+    } as unknown as Promise<unknown>;
+    await withSqliteRetry(() => lazy, { op: "test:lazyUpdate" });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].label).toBe("test:lazyUpdate");
+  });
 });
 
 describe("callerFromStack", () => {
@@ -251,6 +346,36 @@ describe("callerFromStack", () => {
     ].join("\n");
     expect(callerFromStack(stack)).toBe(
       "plugins/defaults/memory/context-search/sources/conversations.ts:231",
+    );
+  });
+
+  test("prefers the nearest named app frame over an anonymous callback", () => {
+    // A statement run inside `db.transaction((tx) => …)` sits in an anonymous
+    // app frame, with the accountable named function above the ORM plumbing.
+    const stack = [
+      "Error",
+      "    at emit (/repo/assistant/src/persistence/slow-query-log.ts:192:5)",
+      "    at <anonymous> (/repo/assistant/src/persistence/conversation-crud.ts:629:44)",
+      "    at <anonymous> (/root/.bun/install/cache/drizzle-orm@0.45.2@@@1/bun-sqlite/session.js:35:16)",
+      "    at transaction (bun:sqlite:416:27)",
+      "    at transaction (/root/.bun/install/cache/drizzle-orm@0.45.2@@@1/bun-sqlite/session.js:37:33)",
+      "    at insertMessageCore (/repo/assistant/src/persistence/conversation-crud.ts:474:10)",
+    ].join("\n");
+    expect(callerFromStack(stack)).toBe(
+      "persistence/conversation-crud.ts:insertMessageCore:474",
+    );
+  });
+
+  test("falls back to the innermost anonymous app frame when nothing is named", () => {
+    const stack = [
+      "Error",
+      "    at emit (/repo/assistant/src/persistence/slow-query-log.ts:192:5)",
+      "    at <anonymous> (/repo/assistant/src/persistence/conversation-crud.ts:629:44)",
+      "    at <anonymous> (/repo/assistant/src/daemon/lifecycle.ts:88:12)",
+      "    at processTicksAndRejections (native:7:39)",
+    ].join("\n");
+    expect(callerFromStack(stack)).toBe(
+      "persistence/conversation-crud.ts:<anonymous>:629",
     );
   });
 

--- a/assistant/src/persistence/slow-query-log.ts
+++ b/assistant/src/persistence/slow-query-log.ts
@@ -19,11 +19,16 @@
  * Drizzle or {@link ./raw-query}.
  *
  * Attribution: raw-query callers attach a curated `.label()` (e.g.
- * `"schedule:claimDue"`). Drizzle's fluent API has no chokepoint to label, so
- * for any query without an explicit label the reporter derives a `caller` from
- * the stack — `path:function:line` of the application frame that issued it —
- * captured only on the slow path. Between the two, every slow query is
- * attributable to its call site with no per-query annotation of Drizzle code.
+ * `"schedule:claimDue"`). Wrappers that know the operation they run publish an
+ * ambient label ({@link ../util/sqlite-query-label} — e.g. `withSqliteRetry`
+ * publishes its `op`), picked up here when no statement label is set. Drizzle's
+ * fluent API has no chokepoint to label, so for any query without a label the
+ * reporter derives a `caller` from the stack — `path:function:line` of the
+ * nearest *named* application frame, so a query issued inside an anonymous
+ * transaction callback is attributed to the enclosing function rather than
+ * `<anonymous>` — captured only on the slow path. Between the three, every
+ * slow query is attributable to its call site with no per-query annotation of
+ * Drizzle code.
  *
  * The same per-statement chokepoint also surfaces *failed* executions: when a
  * statement throws, the error is handed to {@link observeSqliteStatementError}
@@ -42,6 +47,7 @@ import type { Database, Statement } from "bun:sqlite";
 
 import { observeSqliteStatementError } from "../daemon/sqlite-corruption-watchdog.js";
 import { getLogger } from "../util/logger.js";
+import { getAmbientSqliteQueryLabel } from "../util/sqlite-query-label.js";
 
 const log = getLogger("slow-query");
 
@@ -75,12 +81,19 @@ export interface SlowQueryEvent {
   sql: string;
   /** Number of rows returned, when the execution produced an array result. */
   rowCount?: number;
-  /** Caller-supplied attribution tag, when the query was issued via `.label()`. */
+  /**
+   * Caller-supplied attribution tag: the statement's `.label()` when set,
+   * otherwise the ambient label published by an enclosing wrapper (e.g.
+   * `withSqliteRetry`'s `op` — see {@link ../util/sqlite-query-label}).
+   */
   label?: string;
   /**
-   * Auto-derived call site (`path:function:line`) for queries with no explicit
-   * `.label()` — notably every Drizzle query, which has no chokepoint to attach
-   * a label to. Captured from the stack only on the slow path.
+   * Auto-derived call site (`path:function:line` of the nearest named
+   * application frame) for queries with no explicit `.label()` — notably every
+   * Drizzle query, which has no chokepoint to attach a label to. Captured from
+   * the stack only on the slow path. Present alongside an *ambient* label
+   * (which marks an outer boundary, not the statement's own call site) but
+   * suppressed by an explicit `.label()`.
    */
   caller?: string;
 }
@@ -127,13 +140,26 @@ function shortenStackFile(file: string): string {
   return file.split("/").pop() ?? file;
 }
 
+/** Function names Bun uses for frames with no name of their own. */
+function isAnonymousFunctionName(name: string): boolean {
+  return name === "<anonymous>" || name === "anonymous";
+}
+
 /**
- * Best-effort attribution for a query with no explicit label: the first stack
- * frame outside this module, dependencies, and the runtime — i.e. the
- * application code that issued the query. Returns e.g.
- * `persistence/conversation-crud.ts:insertMessageCore:474`. Only called on the
- * slow path (a query already past the threshold), so the `Error().stack` cost is
- * incurred rarely. Accepts an explicit `stack` for testing.
+ * Best-effort attribution for a query with no explicit label: the nearest
+ * *named* stack frame outside this module, dependencies, and the runtime —
+ * i.e. the application function accountable for the query. Returns e.g.
+ * `persistence/conversation-crud.ts:insertMessageCore:474`.
+ *
+ * Anonymous application frames are skipped in favor of a named frame further
+ * up: a statement run inside `db.transaction((tx) => …)` sits in an anonymous
+ * callback, and attributing it there (`file:<anonymous>:line`) hides which
+ * operation issued it. The innermost anonymous frame is kept as a fallback for
+ * stacks with no named application frame at all.
+ *
+ * Only called on the slow path (a query already past the threshold), so the
+ * `Error().stack` cost is incurred rarely. Accepts an explicit `stack` for
+ * testing.
  *
  * @internal exported only for unit tests.
  */
@@ -142,6 +168,7 @@ export function callerFromStack(
 ): string | undefined {
   if (!stack) return undefined;
   const lines = stack.split("\n");
+  let anonymousFallback: string | undefined;
   for (let i = 1; i < lines.length; i++) {
     const line = lines[i];
     if (!line.includes("at ")) continue;
@@ -152,14 +179,19 @@ export function callerFromStack(
       /at (?:async )?([^\s(]+) \((.+?):(\d+)(?::\d+)?\)/,
     );
     if (withFn) {
-      return `${shortenStackFile(withFn[2])}:${withFn[1]}:${withFn[3]}`;
+      const caller = `${shortenStackFile(withFn[2])}:${withFn[1]}:${withFn[3]}`;
+      if (isAnonymousFunctionName(withFn[1])) {
+        anonymousFallback ??= caller;
+        continue;
+      }
+      return caller;
     }
     const noFn = line.match(/at (?:async )?(.+?):(\d+)(?::\d+)?$/);
     if (noFn) {
-      return `${shortenStackFile(noFn[1])}:${noFn[2]}`;
+      anonymousFallback ??= `${shortenStackFile(noFn[1])}:${noFn[2]}`;
     }
   }
-  return undefined;
+  return anonymousFallback;
 }
 
 /** Log a slow statement execution at WARN with its SQL and duration. */
@@ -251,14 +283,19 @@ export function wrapSqliteForSlowQueryLogging(
     durationMs: number,
     result: unknown,
   ): void => {
-    // Only ever called on the slow path, so building the payload — including the
-    // stack walk for unlabeled (Drizzle) queries — is fine.
+    // Only ever called on the slow path, so building the payload — including
+    // the ambient-label read and the stack walk for unlabeled (Drizzle)
+    // queries — is fine. An explicit `.label()` marks the statement's own
+    // call site, so the stack adds nothing; an ambient label marks an outer
+    // boundary (e.g. a `withSqliteRetry` op), so the call site is still
+    // derived alongside it.
+    const effectiveLabel = label ?? getAmbientSqliteQueryLabel();
     const caller = label === undefined ? callerFromStack() : undefined;
     onSlowQuery({
       durationMs,
       sql: sql.slice(0, SQL_PREVIEW_MAX),
       ...(Array.isArray(result) ? { rowCount: result.length } : {}),
-      ...(label === undefined ? {} : { label }),
+      ...(effectiveLabel === undefined ? {} : { label: effectiveLabel }),
       ...(caller === undefined ? {} : { caller }),
     });
   };

--- a/assistant/src/util/sqlite-query-label.ts
+++ b/assistant/src/util/sqlite-query-label.ts
@@ -1,0 +1,51 @@
+/**
+ * Ambient attribution label for SQLite statements, carried across an async
+ * call tree via `AsyncLocalStorage`.
+ *
+ * The slow-query reporter ({@link ../persistence/slow-query-log}) attributes
+ * an unlabeled statement by walking the stack, but some execution paths leave
+ * no usable application frame: a lazy Drizzle query awaited by a wrapper runs
+ * from a microtask, and a retried statement (after a backoff sleep) runs from
+ * a truncated stack that bottoms out in the retry helper itself. Wrappers that
+ * *do* know what operation they are running — {@link ./sqlite-retry
+ * withSqliteRetry} with its curated `op` — publish that name here, and the
+ * reporter reads it on the slow path as the statement's label.
+ *
+ * This module lives in `util/` (not beside the reporter in `persistence/`)
+ * because `util/` must not import from `persistence/`; both sides depend on
+ * this small shared seam instead.
+ *
+ * Scoping: the label applies to every statement executed inside `fn`'s
+ * synchronous and awaited continuations — exactly the work the wrapper is
+ * accountable for — and evaporates when `fn` settles. Nested scopes shadow
+ * naturally (innermost wins), and an explicit statement-level `.label()`
+ * always takes precedence over an ambient label.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const ambientLabel = new AsyncLocalStorage<string>();
+
+/**
+ * Run `fn` (sync or async) with `label` as the ambient SQLite query label.
+ * Returns `fn`'s result unchanged; for an async `fn` the label stays in
+ * effect across its awaits.
+ *
+ * Caveat: the label covers only work performed *inside* the scope. If `fn`
+ * returns a lazy thenable (a Drizzle QueryPromise executes its statement when
+ * first awaited), the caller's own `await` happens after this scope has
+ * exited — pass `async () => await lazy()` so assimilation, and therefore the
+ * query, runs inside the scope.
+ */
+export function runWithSqliteQueryLabel<T>(label: string, fn: () => T): T {
+  return ambientLabel.run(label, fn);
+}
+
+/**
+ * The innermost ambient label in effect, or `undefined` outside any
+ * {@link runWithSqliteQueryLabel} scope. Read by the slow-query reporter on
+ * its slow path only — never on the per-statement fast path.
+ */
+export function getAmbientSqliteQueryLabel(): string | undefined {
+  return ambientLabel.getStore();
+}

--- a/assistant/src/util/sqlite-retry.ts
+++ b/assistant/src/util/sqlite-retry.ts
@@ -26,6 +26,7 @@
 
 import { getLogger } from "./logger.js";
 import { computeRetryDelay } from "./retry.js";
+import { runWithSqliteQueryLabel } from "./sqlite-query-label.js";
 
 const log = getLogger("sqlite-retry");
 
@@ -34,7 +35,14 @@ const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_BASE_DELAY_MS = 50;
 
 export interface SqliteRetryOptions {
-  /** Short identifier for the wrapped operation, used in retry logs. */
+  /**
+   * Short identifier for the wrapped operation, used in retry logs. Also
+   * published as the ambient SQLite query label while `fn` runs, so any
+   * slow-query WARN emitted for a statement inside it is attributed to this
+   * name instead of an unattributable stack (a lazy Drizzle query awaited
+   * here executes from a microtask; a post-backoff retry runs from a stack
+   * that bottoms out in this helper).
+   */
   op: string;
   /** Maximum retry attempts after the initial try (default 3). */
   maxRetries?: number;
@@ -69,7 +77,11 @@ export async function withSqliteRetry<T>(
   const baseDelayMs = options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
   for (let attempt = 0; ; attempt++) {
     try {
-      return await fn();
+      // The inner await must happen inside the label scope: a lazy thenable
+      // (e.g. a Drizzle QueryPromise) executes its statement only when
+      // awaited, so assimilating it outside the scope would run the query
+      // after the ambient label has already evaporated.
+      return await runWithSqliteQueryLabel(options.op, async () => await fn());
     } catch (err) {
       if (attempt < maxRetries && isRetryableSqliteError(err)) {
         log.warn(


### PR DESCRIPTION
## Prompt / plan

Follow-up to the slow-query WARN log breakdown of a production daemon: after the top telemetry-flush bucket (handled separately), the next two buckets were unattributable — **100× `anonymous`** (statements inside `db.transaction((tx) => …)` callbacks) and **72× `util/sqlite-retry.ts:withSqliteRetry`** (the retry helper attributing queries to itself). The task: de-anonymize and label those two buckets so the log names the operation that issued each slow query.

Root causes, confirmed by capturing real Bun stacks:

- A statement inside a sync transaction callback sits in an anonymous app frame, with the accountable named function above the ORM plumbing — `callerFromStack` stopped at the first (anonymous) app frame.
- A lazy Drizzle `QueryPromise` awaited inside `withSqliteRetry` executes from a microtask (and a post-backoff retry from a truncated stack), so no caller frame outside the helper survives.

Changes:

- `callerFromStack` now prefers the nearest **named** application frame, keeping the innermost anonymous frame only as a fallback.
- New `util/sqlite-query-label.ts`: an `AsyncLocalStorage`-carried ambient query label. `withSqliteRetry` publishes its curated `op` for the duration of each attempt (awaiting inside the scope so lazy thenables are covered), and the slow-query reporter picks it up when no statement-level `.label()` is set. Explicit `.label()` still wins and still suppresses the stack walk; an ambient label additionally keeps the derived caller, since it marks an outer boundary rather than the statement's own call site.

## Test plan

- Unit tests (`slow-query-log.test.ts`, 20 pass): named-frame preference, anonymous fallback, ambient label + caller coexistence, explicit-label precedence, `withSqliteRetry` op labeling on a post-backoff retry and on a lazy thenable.
- Live verification: hatched a local instance from this branch with `VELLUM_SLOW_QUERY_THRESHOLD_MS` lowered so every statement logs, then drove conversation creation and message persistence. Observed in the daemon log: statements inside `getOrCreateConversation`'s transaction callback attribute to `persistence/conversation-key-store.ts:getOrCreateConversation:157` (formerly `<anonymous>`), and the `insert into "messages"` transaction batch carries `label: "insertMessageCore"`; `SELECT changes()` under the processing-flag retry carries `label: "conversation:setProcessing"`. Zero `anonymous` attributions across ~450 captured events.
- `bun run typecheck` clean; eslint reports only the file's pre-existing `curly` warnings (same 9 before/after).

## CLI verb checklist

Deleted — this PR adds no new routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01592BiY7zKCG6cHFqoHscYR

---
_Generated by [Claude Code](https://claude.ai/code/session_01592BiY7zKCG6cHFqoHscYR)_