### PR TITLE
feat(cli): first-class inference model & profile CLI primitives

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -14016,6 +14016,55 @@ paths:
                   - images
                   - resolvedModel
                 additionalProperties: false
+  /v1/inference/callsites:
+    get:
+      operationId: inference_callsites_get
+      summary: List call-site resolutions
+      description:
+        "Return the effective resolution for every LLM call site: the winning profile, its source (override /
+        active / call-site pin / shipped default), and the resolved provider/model plus notable tuning."
+      tags:
+        - inference
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  callSites:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/CallSiteResolutionSummary"
+                required:
+                  - callSites
+                additionalProperties: false
+  /v1/inference/callsites/{site}:
+    get:
+      operationId: inference_callsites_by_site_get
+      summary: Get a call-site resolution detail
+      description:
+        "Return the full resolution for one call site: the winner, the resolution chain (rungs considered and
+        skipped), the shipped default fragment, the user's pin fragment, and a preflight-derived resolution error when
+        dispatch would provably fail."
+      tags:
+        - inference
+      parameters:
+        - name: site
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CallSiteResolutionDetail"
+        "400":
+          description: Unknown call site
   /v1/inference/chatgpt-subscription/auth:
     post:
       operationId: inference_chatgptsubscription_auth_post
@@ -14077,6 +14126,237 @@ paths:
                 required:
                   - ok
                 additionalProperties: false
+  /v1/inference/models:
+    get:
+      operationId: inference_models_get
+      summary: List inference catalog models
+      description:
+        Return every model in the code-owned provider catalog, each tagged with its provider. Optionally filter by
+        provider with ?provider=<id>.
+      tags:
+        - inference
+      parameters:
+        - name: provider
+          in: query
+          required: false
+          schema:
+            type: string
+          description:
+            "Filter by provider id. One of: anthropic, openai, gemini, ollama, fireworks, together, openrouter,
+            vercel-ai-gateway, openai-compatible, minimax, atlascloud"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  models:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/CatalogModel"
+                required:
+                  - models
+                additionalProperties: false
+        "400":
+          description: Unknown provider filter
+  /v1/inference/profiles:
+    get:
+      operationId: inference_profiles_get
+      summary: List effective inference profiles
+      description:
+        "Return the effective profile catalog: code-defined managed defaults merged with user profiles, each
+        annotated with source and (when it has a connection) availability."
+      tags:
+        - inference
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  profiles:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/InferenceProfileSummary"
+                required:
+                  - profiles
+                additionalProperties: false
+    post:
+      operationId: inference_profiles_post
+      summary: Create an inference profile
+      description:
+        Create a validated custom profile. The provider must be a known LLM provider, the model must be in the
+        catalog (unless allowUnlisted), and a referenced connection must exist. Managed default names cannot be created.
+      tags:
+        - inference
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  minLength: 1
+                provider:
+                  type: string
+                  minLength: 1
+                model:
+                  type: string
+                  minLength: 1
+                connection:
+                  type: string
+                  minLength: 1
+                label:
+                  type: string
+                  minLength: 1
+                effort:
+                  type: string
+                maxTokens:
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 9007199254740991
+                temperature:
+                  type: number
+                thinking:
+                  type: boolean
+                description:
+                  type: string
+                allowUnlisted:
+                  type: boolean
+              required:
+                - name
+                - provider
+                - model
+      responses:
+        "201":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InferenceProfileWriteResult"
+        "400":
+          description: Invalid provider, uncataloged model, or missing connection
+        "409":
+          description: A profile with this name already exists
+  /v1/inference/profiles/{name}:
+    delete:
+      operationId: inference_profiles_by_name_delete
+      summary: Delete an inference profile
+      description: Delete a custom profile. Managed default profiles cannot be deleted (they are re-seeded on boot).
+      tags:
+        - inference
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    const: true
+                  name:
+                    type: string
+                required:
+                  - ok
+                  - name
+                additionalProperties: false
+        "400":
+          description: Attempt to delete a managed profile
+        "404":
+          description: Profile not found
+    get:
+      operationId: inference_profiles_by_name_get
+      summary: Get an effective inference profile
+      description: Return a single effective profile by name, with availability.
+      tags:
+        - inference
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InferenceProfileDetail"
+        "404":
+          description: Profile not found
+    patch:
+      operationId: inference_profiles_by_name_patch
+      summary: Update an inference profile
+      description:
+        Partial update of a custom profile with the same write-time validation as create. Managed default profiles
+        are read-only.
+      tags:
+        - inference
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                provider:
+                  type: string
+                  minLength: 1
+                model:
+                  type: string
+                  minLength: 1
+                connection:
+                  type: string
+                  minLength: 1
+                label:
+                  type: string
+                  minLength: 1
+                effort:
+                  type: string
+                maxTokens:
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 9007199254740991
+                temperature:
+                  type: number
+                thinking:
+                  type: boolean
+                description:
+                  type: string
+                allowUnlisted:
+                  type: boolean
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InferenceProfileWriteResult"
+        "400":
+          description: Invalid fields, or attempt to edit a managed profile
+        "404":
+          description: Profile not found
   /v1/inference/provider-connections:
     get:
       operationId: inference_providerconnections_get
@@ -32664,6 +32944,274 @@ components:
       required:
         - provider
         - resolvedConnectionName
+        - availability
+      additionalProperties: false
+    CallSiteResolutionSummary:
+      type: object
+      properties:
+        callSite:
+          type: string
+        profile:
+          anyOf:
+            - type: string
+            - type: "null"
+        label:
+          anyOf:
+            - type: string
+            - type: "null"
+        source:
+          type: string
+          enum:
+            - override
+            - active
+            - call_site
+            - default
+        provider:
+          type: string
+        model:
+          type: string
+        effort:
+          type: string
+        maxTokens:
+          type: number
+        maxInputTokens:
+          type: number
+      required:
+        - callSite
+        - profile
+        - label
+        - source
+        - provider
+        - model
+        - effort
+        - maxTokens
+      additionalProperties: false
+    CallSiteResolutionDetail:
+      type: object
+      properties:
+        callSite:
+          type: string
+        winner:
+          type: object
+          properties:
+            profile:
+              anyOf:
+                - type: string
+                - type: "null"
+            label:
+              anyOf:
+                - type: string
+                - type: "null"
+            source:
+              type: string
+              enum:
+                - override
+                - active
+                - call_site
+                - default
+          required:
+            - profile
+            - label
+            - source
+          additionalProperties: false
+        resolved:
+          type: object
+          properties:
+            provider:
+              type: string
+            model:
+              type: string
+            maxTokens:
+              type: number
+            effort:
+              type: string
+            temperature:
+              anyOf:
+                - type: number
+                - type: "null"
+            maxInputTokens:
+              type: number
+          required:
+            - provider
+            - model
+            - maxTokens
+            - effort
+            - temperature
+          additionalProperties: false
+        resolutionChain:
+          type: array
+          items:
+            type: object
+            properties:
+              requested:
+                type: string
+              reason:
+                type: string
+                enum:
+                  - missing
+                  - disabled
+                  - incomplete
+            required:
+              - requested
+              - reason
+            additionalProperties: false
+        shippedDefault:
+          type: object
+          propertyNames:
+            type: string
+          additionalProperties: {}
+        userPin:
+          anyOf:
+            - type: object
+              propertyNames:
+                type: string
+              additionalProperties: {}
+            - type: "null"
+        resolutionError:
+          type: object
+          properties:
+            reason:
+              type: string
+            message:
+              type: string
+          required:
+            - reason
+            - message
+          additionalProperties: false
+      required:
+        - callSite
+        - winner
+        - resolved
+        - resolutionChain
+        - shippedDefault
+        - userPin
+      additionalProperties: false
+    CatalogModel:
+      type: object
+      properties:
+        provider:
+          type: string
+        id:
+          type: string
+        displayName:
+          type: string
+        contextWindowTokens:
+          type: number
+        maxOutputTokens:
+          type: number
+        supportsThinking:
+          type: boolean
+        supportsVision:
+          type: boolean
+        supportsToolUse:
+          type: boolean
+        featureFlag:
+          type: string
+      required:
+        - provider
+        - id
+        - displayName
+      additionalProperties: false
+    InferenceProfileSummary:
+      type: object
+      properties:
+        name:
+          type: string
+        label:
+          anyOf:
+            - type: string
+            - type: "null"
+        provider:
+          anyOf:
+            - type: string
+            - type: "null"
+        model:
+          anyOf:
+            - type: string
+            - type: "null"
+        status:
+          type: string
+          enum:
+            - active
+            - disabled
+        source:
+          type: string
+          enum:
+            - managed
+            - user
+        provider_connection:
+          type: string
+        availability:
+          anyOf:
+            - $ref: "#/components/schemas/ProfileConnectionAvailability"
+            - type: "null"
+      required:
+        - name
+        - label
+        - provider
+        - model
+        - status
+        - source
+        - availability
+      additionalProperties: false
+    ProfileConnectionAvailability:
+      type: object
+      properties:
+        status:
+          type: string
+          enum:
+            - ok
+            - missing_connection
+            - missing_credential
+            - provider_mismatch
+            - unsupported_auth
+            - vellum_unauthenticated
+            - unknown
+        message:
+          type: string
+      required:
+        - status
+      additionalProperties: false
+    InferenceProfileWriteResult:
+      type: object
+      properties:
+        ok:
+          type: boolean
+          const: true
+        name:
+          type: string
+        entry:
+          type: object
+          propertyNames:
+            type: string
+          additionalProperties: {}
+        warnings:
+          type: array
+          items:
+            type: string
+      required:
+        - ok
+        - name
+        - entry
+        - warnings
+      additionalProperties: false
+    InferenceProfileDetail:
+      type: object
+      properties:
+        name:
+          type: string
+        entry:
+          type: object
+          propertyNames:
+            type: string
+          additionalProperties: {}
+        availability:
+          anyOf:
+            - $ref: "#/components/schemas/ProfileConnectionAvailability"
+            - type: "null"
+      required:
+        - name
+        - entry
         - availability
       additionalProperties: false
     ProviderConnection:

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -234,7 +234,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "tools/executor.ts", // CES approval bridge resolves the CES RPC client via getCesClient
       "tools/network/web-fetch.ts", // Firecrawl /scrape BYOK fetch provider API key lookup (firecrawl provider key)
       "workspace/default-provider-ensure.ts", // legacy anthropic echo disambiguation (vault key presence check)
-      "runtime/routes/default-provider-routes.ts", // default-provider availability status (credential presence check only; value never leaves the handler)
+      "providers/inference/connection-availability.ts", // shared (provider, connection) availability status (credential presence check only; value never leaves the helper)
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));

--- a/assistant/src/cli/commands/__tests__/inference-models.test.ts
+++ b/assistant/src/cli/commands/__tests__/inference-models.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for `assistant inference models list` CLI arg parsing / IPC wiring.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+let lastIpcCall: { method: string; params?: any } | null = null;
+let mockIpcResult: { ok: boolean; result?: unknown; error?: string } = {
+  ok: true,
+  result: { models: [] },
+};
+
+mock.module("../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (method: string, params?: Record<string, unknown>) => {
+    lastIpcCall = { method, params };
+    return mockIpcResult;
+  },
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+  getCliLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+const { attachModelsSubcommand } = await import("../inference-models.js");
+
+beforeEach(() => {
+  lastIpcCall = null;
+  mockIpcResult = { ok: true, result: { models: [] } };
+  process.exitCode = 0;
+});
+
+async function run(args: string[]): Promise<string> {
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  const chunks: string[] = [];
+  process.stdout.write = ((chunk: unknown) => {
+    chunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    const program = new Command();
+    program.exitOverride();
+    const inference = program.command("inference");
+    attachModelsSubcommand(inference);
+    await program.parseAsync(["node", "assistant", "inference", ...args]);
+  } catch {
+    // swallow commander exits
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+  return chunks.join("");
+}
+
+describe("models list", () => {
+  test("no filter → empty queryParams", async () => {
+    await run(["models", "list"]);
+    expect(lastIpcCall?.method).toBe("inference_models_list");
+    expect(lastIpcCall?.params).toEqual({ queryParams: {} });
+  });
+
+  test("--provider forwards the filter", async () => {
+    await run(["models", "list", "--provider", "anthropic"]);
+    expect(lastIpcCall?.params).toEqual({
+      queryParams: { provider: "anthropic" },
+    });
+  });
+
+  test("--json emits structured output", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        models: [
+          { provider: "anthropic", id: "claude-opus-4-8", displayName: "X" },
+        ],
+      },
+    };
+    const out = await run(["models", "list", "--json"]);
+    const parsed = JSON.parse(out.trim());
+    expect(parsed.ok).toBe(true);
+    expect(parsed.models[0].id).toBe("claude-opus-4-8");
+  });
+});

--- a/assistant/src/cli/commands/__tests__/inference-profiles.test.ts
+++ b/assistant/src/cli/commands/__tests__/inference-profiles.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Tests for `assistant inference profiles` CLI arg parsing / IPC wiring.
+ *
+ * Validates that flags map onto the correct IPC method + body, that create
+ * requires --provider/--model, that --thinking parses to a boolean, and that
+ * `active` reads via config_get and writes via config_patch.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+let lastIpcCall: { method: string; params?: any } | null = null;
+let mockIpcResult: { ok: boolean; result?: unknown; error?: string } = {
+  ok: true,
+  result: {},
+};
+
+mock.module("../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (method: string, params?: Record<string, unknown>) => {
+    lastIpcCall = { method, params };
+    return mockIpcResult;
+  },
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+  getCliLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+const { attachProfilesSubcommand } = await import("../inference-profiles.js");
+
+beforeEach(() => {
+  lastIpcCall = null;
+  mockIpcResult = { ok: true, result: {} };
+  process.exitCode = 0;
+});
+
+afterEach(() => {
+  process.exitCode = 0;
+});
+
+async function run(
+  args: string[],
+): Promise<{ stdout: string; exitCode: number }> {
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  const chunks: string[] = [];
+  process.stdout.write = ((chunk: unknown) => {
+    chunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  const prevExit = process.exitCode;
+  process.exitCode = 0;
+  try {
+    const program = new Command();
+    program.exitOverride();
+    const inference = program.command("inference");
+    attachProfilesSubcommand(inference);
+    await program.parseAsync(["node", "assistant", "inference", ...args]);
+  } catch (err: unknown) {
+    if (!(err instanceof Error && err.message.startsWith("(outputHelp)"))) {
+      // swallow commander exits
+    }
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+  const stdout = chunks.join("");
+  const exitCode = (process.exitCode as number) ?? 0;
+  process.exitCode = prevExit;
+  return { stdout, exitCode };
+}
+
+describe("profiles list", () => {
+  test("calls inference_profiles_list", async () => {
+    mockIpcResult = { ok: true, result: { profiles: [] } };
+    await run(["profiles", "list"]);
+    expect(lastIpcCall?.method).toBe("inference_profiles_list");
+  });
+});
+
+describe("profiles create", () => {
+  test("requires --provider", async () => {
+    const { exitCode } = await run(["profiles", "create", "p", "--model", "m"]);
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("requires --model", async () => {
+    const { exitCode } = await run([
+      "profiles",
+      "create",
+      "p",
+      "--provider",
+      "anthropic",
+    ]);
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("maps flags onto the create body with thinking→boolean and numeric parse", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: { ok: true, name: "p", entry: {}, warnings: [] },
+    };
+    await run([
+      "profiles",
+      "create",
+      "p",
+      "--provider",
+      "anthropic",
+      "--model",
+      "claude-opus-4-8",
+      "--connection",
+      "anthropic-personal",
+      "--effort",
+      "high",
+      "--max-tokens",
+      "8000",
+      "--temperature",
+      "0.5",
+      "--thinking",
+      "on",
+      "--allow-unlisted",
+    ]);
+    expect(lastIpcCall?.method).toBe("inference_profiles_create");
+    expect(lastIpcCall?.params?.body).toEqual({
+      name: "p",
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      connection: "anthropic-personal",
+      effort: "high",
+      maxTokens: 8000,
+      temperature: 0.5,
+      thinking: true,
+      allowUnlisted: true,
+    });
+  });
+
+  test("prints the verification hint on success", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: { ok: true, name: "p", entry: {}, warnings: [] },
+    };
+    const { stdout } = await run([
+      "profiles",
+      "create",
+      "p",
+      "--provider",
+      "anthropic",
+      "--model",
+      "claude-opus-4-8",
+    ]);
+    expect(stdout).toContain("Verify it works:");
+    expect(stdout).toContain("assistant inference send --profile p");
+  });
+
+  test("rejects a non-numeric --max-tokens before calling the daemon", async () => {
+    const { exitCode } = await run([
+      "profiles",
+      "create",
+      "p",
+      "--provider",
+      "anthropic",
+      "--model",
+      "m",
+      "--max-tokens",
+      "lots",
+    ]);
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+
+  test("rejects an invalid --thinking value", async () => {
+    const { exitCode } = await run([
+      "profiles",
+      "create",
+      "p",
+      "--provider",
+      "anthropic",
+      "--model",
+      "m",
+      "--thinking",
+      "maybe",
+    ]);
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+});
+
+describe("profiles update", () => {
+  test("sends pathParams + partial body", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: { ok: true, name: "p", entry: {}, warnings: [] },
+    };
+    await run(["profiles", "update", "p", "--effort", "low"]);
+    expect(lastIpcCall?.method).toBe("inference_profiles_update");
+    expect(lastIpcCall?.params).toEqual({
+      pathParams: { name: "p" },
+      body: { effort: "low" },
+    });
+  });
+
+  test("refuses an empty update", async () => {
+    const { exitCode } = await run(["profiles", "update", "p"]);
+    expect(exitCode).toBe(1);
+    expect(lastIpcCall).toBeNull();
+  });
+});
+
+describe("profiles delete", () => {
+  test("sends the name as a path param", async () => {
+    mockIpcResult = { ok: true, result: { ok: true, name: "p" } };
+    await run(["profiles", "delete", "p"]);
+    expect(lastIpcCall?.method).toBe("inference_profiles_delete");
+    expect(lastIpcCall?.params).toEqual({ pathParams: { name: "p" } });
+  });
+});
+
+describe("profiles active", () => {
+  test("no arg reads via config_get", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: { llm: { activeProfile: "balanced" } },
+    };
+    const { stdout } = await run(["profiles", "active"]);
+    expect(lastIpcCall?.method).toBe("config_get");
+    expect(stdout).toContain("balanced");
+  });
+
+  test("with a name writes via config_patch deep-merge", async () => {
+    mockIpcResult = { ok: true, result: {} };
+    await run(["profiles", "active", "my-fast"]);
+    expect(lastIpcCall?.method).toBe("config_patch");
+    expect(lastIpcCall?.params).toEqual({
+      body: { llm: { activeProfile: "my-fast" } },
+    });
+  });
+});

--- a/assistant/src/cli/commands/inference-callsites.ts
+++ b/assistant/src/cli/commands/inference-callsites.ts
@@ -13,7 +13,7 @@
 import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
-import { log } from "../logger.js";
+import { renderTable, writeCliError, writeLine } from "../lib/cli-output.js";
 
 type Source = "override" | "active" | "call_site" | "default";
 
@@ -52,34 +52,6 @@ const SOURCE_LABEL: Record<Source, string> = {
   call_site: "pin",
   default: "default",
 };
-
-function writeLine(msg: string): void {
-  process.stdout.write(msg + "\n");
-}
-
-function writeCliError(message: string, json?: boolean): void {
-  if (json) {
-    process.stdout.write(JSON.stringify({ ok: false, error: message }) + "\n");
-  } else {
-    log.error(message);
-  }
-  process.exitCode = 1;
-}
-
-function renderTable(headers: string[], rows: string[][]): void {
-  const widths = headers.map((h, i) =>
-    Math.max(h.length, ...rows.map((r) => (r[i] ?? "").length)),
-  );
-  const fmt = (cells: string[]) =>
-    cells
-      .map((c, i) => (c ?? "").padEnd(widths[i]!))
-      .join("  ")
-      .trimEnd();
-  writeLine(fmt(headers));
-  for (const row of rows) {
-    writeLine(fmt(row));
-  }
-}
 
 function formatCtxIn(tokens: number | undefined): string {
   if (tokens == null) {

--- a/assistant/src/cli/commands/inference-callsites.ts
+++ b/assistant/src/cli/commands/inference-callsites.ts
@@ -1,0 +1,186 @@
+/**
+ * `assistant inference callsites` CLI namespace.
+ *
+ *   callsites list          — effective resolution for every call site
+ *   callsites get <site>    — resolution detail + chain for one call site
+ *
+ * Read-only. Delegates to the daemon (`inference_callsites_*`), which computes
+ * resolution via the shared `resolveCallSiteConfig` / `selectWinningProfile`
+ * machinery. Output is deliberately compact and aligned — it is mostly read by
+ * the assistant itself.
+ */
+
+import type { Command } from "commander";
+
+import { cliIpcCall } from "../../ipc/cli-client.js";
+import { log } from "../logger.js";
+
+type Source = "override" | "active" | "call_site" | "default";
+
+interface CallSiteSummary {
+  callSite: string;
+  profile: string | null;
+  label: string | null;
+  source: Source;
+  provider: string;
+  model: string;
+  effort: string;
+  maxTokens: number;
+  maxInputTokens?: number;
+}
+
+interface CallSiteDetail {
+  callSite: string;
+  winner: { profile: string | null; label: string | null; source: Source };
+  resolved: {
+    provider: string;
+    model: string;
+    maxTokens: number;
+    effort: string;
+    temperature: number | null;
+    maxInputTokens?: number;
+  };
+  resolutionChain: { requested: string; reason: string }[];
+  shippedDefault: Record<string, unknown>;
+  userPin: Record<string, unknown> | null;
+  resolutionError?: { reason: string; message: string };
+}
+
+const SOURCE_LABEL: Record<Source, string> = {
+  override: "override",
+  active: "active",
+  call_site: "pin",
+  default: "default",
+};
+
+function writeLine(msg: string): void {
+  process.stdout.write(msg + "\n");
+}
+
+function writeCliError(message: string, json?: boolean): void {
+  if (json) {
+    process.stdout.write(JSON.stringify({ ok: false, error: message }) + "\n");
+  } else {
+    log.error(message);
+  }
+  process.exitCode = 1;
+}
+
+function renderTable(headers: string[], rows: string[][]): void {
+  const widths = headers.map((h, i) =>
+    Math.max(h.length, ...rows.map((r) => (r[i] ?? "").length)),
+  );
+  const fmt = (cells: string[]) =>
+    cells
+      .map((c, i) => (c ?? "").padEnd(widths[i]!))
+      .join("  ")
+      .trimEnd();
+  writeLine(fmt(headers));
+  for (const row of rows) {
+    writeLine(fmt(row));
+  }
+}
+
+function formatCtxIn(tokens: number | undefined): string {
+  if (tokens == null) {
+    return "-";
+  }
+  if (tokens >= 1_000_000 && tokens % 1_000_000 === 0) {
+    return `${tokens / 1_000_000}M`;
+  }
+  return tokens.toLocaleString();
+}
+
+export function attachCallsitesSubcommand(inference: Command): void {
+  const callsites = inference
+    .command("callsites")
+    .description("Inspect how each LLM call site resolves to a profile");
+
+  callsites
+    .command("list")
+    .description("List the effective resolution for every call site")
+    .option("--json", "Output as machine-readable JSON")
+    .action(async (opts: { json?: boolean }) => {
+      const ipcResult = await cliIpcCall<{ callSites: CallSiteSummary[] }>(
+        "inference_callsites_list",
+        {},
+      );
+      if (!ipcResult.ok) {
+        writeCliError(ipcResult.error ?? "Unknown error", opts.json);
+        return;
+      }
+      const rows = ipcResult.result!.callSites;
+      if (opts.json) {
+        process.stdout.write(
+          JSON.stringify({ ok: true, callSites: rows }) + "\n",
+        );
+        return;
+      }
+      renderTable(
+        [
+          "CALL SITE",
+          "PROFILE",
+          "SRC",
+          "PROVIDER",
+          "MODEL",
+          "EFFORT",
+          "CTX-IN",
+        ],
+        rows.map((r) => [
+          r.callSite,
+          r.profile ?? "(anchor)",
+          SOURCE_LABEL[r.source],
+          r.provider,
+          r.model,
+          r.effort,
+          formatCtxIn(r.maxInputTokens),
+        ]),
+      );
+    });
+
+  callsites
+    .command("get <site>")
+    .description("Show the resolution detail and chain for one call site")
+    .option("--json", "Output as machine-readable JSON")
+    .action(async (site: string, opts: { json?: boolean }) => {
+      const ipcResult = await cliIpcCall<CallSiteDetail>(
+        "inference_callsites_get",
+        { pathParams: { site } },
+      );
+      if (!ipcResult.ok) {
+        writeCliError(ipcResult.error ?? "Unknown error", opts.json);
+        return;
+      }
+      const d = ipcResult.result!;
+      if (opts.json) {
+        process.stdout.write(JSON.stringify({ ok: true, ...d }) + "\n");
+        return;
+      }
+      writeLine(`call site: ${d.callSite}`);
+      writeLine(
+        `  winner: ${d.winner.profile ?? "(anchor)"} [${SOURCE_LABEL[d.winner.source]}]` +
+          (d.winner.label ? ` "${d.winner.label}"` : ""),
+      );
+      writeLine(
+        `  resolved: ${d.resolved.provider}/${d.resolved.model} effort=${d.resolved.effort} maxTokens=${d.resolved.maxTokens}` +
+          (d.resolved.maxInputTokens != null
+            ? ` ctxIn=${formatCtxIn(d.resolved.maxInputTokens)}`
+            : ""),
+      );
+      if (d.resolutionChain.length > 0) {
+        writeLine("  resolution chain (skipped rungs):");
+        for (const step of d.resolutionChain) {
+          writeLine(`    - ${step.requested}: ${step.reason}`);
+        }
+      }
+      writeLine(`  shipped default: ${JSON.stringify(d.shippedDefault)}`);
+      writeLine(
+        `  user pin: ${d.userPin ? JSON.stringify(d.userPin) : "(none)"}`,
+      );
+      if (d.resolutionError) {
+        writeLine(
+          `  resolution error [${d.resolutionError.reason}]: ${d.resolutionError.message}`,
+        );
+      }
+    });
+}

--- a/assistant/src/cli/commands/inference-models.ts
+++ b/assistant/src/cli/commands/inference-models.ts
@@ -1,0 +1,113 @@
+/**
+ * `assistant inference models` CLI namespace.
+ *
+ *   `assistant inference models list [--provider <p>] [--json]`
+ *
+ * Lists the code-owned model catalog so the assistant can discover valid
+ * model ids instead of guessing. Delegates to the daemon via IPC
+ * (`inference_models_list`).
+ */
+
+import type { Command } from "commander";
+
+import { cliIpcCall } from "../../ipc/cli-client.js";
+import { log } from "../logger.js";
+
+interface CatalogModel {
+  provider: string;
+  id: string;
+  displayName: string;
+  contextWindowTokens?: number;
+  maxOutputTokens?: number;
+  supportsThinking?: boolean;
+  supportsVision?: boolean;
+  supportsToolUse?: boolean;
+  featureFlag?: string;
+}
+
+function writeLine(msg: string): void {
+  process.stdout.write(msg + "\n");
+}
+
+function writeCliError(message: string, json?: boolean): void {
+  if (json) {
+    process.stdout.write(JSON.stringify({ ok: false, error: message }) + "\n");
+  } else {
+    log.error(message);
+  }
+  process.exitCode = 1;
+}
+
+/** Render rows as a left-aligned fixed-width table with a header row. */
+function renderTable(headers: string[], rows: string[][]): void {
+  const widths = headers.map((h, i) =>
+    Math.max(h.length, ...rows.map((r) => (r[i] ?? "").length)),
+  );
+  const fmt = (cells: string[]) =>
+    cells
+      .map((c, i) => (c ?? "").padEnd(widths[i]!))
+      .join("  ")
+      .trimEnd();
+  writeLine(fmt(headers));
+  for (const row of rows) {
+    writeLine(fmt(row));
+  }
+}
+
+export function attachModelsSubcommand(inference: Command): void {
+  const models = inference
+    .command("models")
+    .description("Inspect the inference model catalog");
+
+  models
+    .command("list")
+    .description("List catalog models (optionally filtered by provider)")
+    .option("--provider <p>", "Filter by provider id")
+    .option("--json", "Output as machine-readable JSON")
+    .addHelpText(
+      "after",
+      `
+Lists every model in the code-owned provider catalog. Use the ids here
+when creating an inference profile:
+
+Examples:
+  $ assistant inference models list
+  $ assistant inference models list --provider anthropic
+  $ assistant inference models list --json`,
+    )
+    .action(async (opts: { provider?: string; json?: boolean }) => {
+      const ipcResult = await cliIpcCall<{ models: CatalogModel[] }>(
+        "inference_models_list",
+        { queryParams: opts.provider ? { provider: opts.provider } : {} },
+      );
+
+      if (!ipcResult.ok) {
+        writeCliError(ipcResult.error ?? "Unknown error", opts.json);
+        return;
+      }
+
+      const rows = ipcResult.result!.models;
+
+      if (opts.json) {
+        process.stdout.write(JSON.stringify({ ok: true, models: rows }) + "\n");
+        return;
+      }
+
+      if (rows.length === 0) {
+        writeLine("No models found.");
+        return;
+      }
+
+      renderTable(
+        ["PROVIDER", "MODEL ID", "DISPLAY NAME", "CONTEXT"],
+        rows.map((m) => [
+          m.provider,
+          m.id,
+          m.displayName,
+          m.contextWindowTokens != null
+            ? m.contextWindowTokens.toLocaleString()
+            : "-",
+        ]),
+      );
+    });
+}

--- a/assistant/src/cli/commands/inference-models.ts
+++ b/assistant/src/cli/commands/inference-models.ts
@@ -11,7 +11,7 @@
 import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
-import { log } from "../logger.js";
+import { renderTable, writeCliError, writeLine } from "../lib/cli-output.js";
 
 interface CatalogModel {
   provider: string;
@@ -23,35 +23,6 @@ interface CatalogModel {
   supportsVision?: boolean;
   supportsToolUse?: boolean;
   featureFlag?: string;
-}
-
-function writeLine(msg: string): void {
-  process.stdout.write(msg + "\n");
-}
-
-function writeCliError(message: string, json?: boolean): void {
-  if (json) {
-    process.stdout.write(JSON.stringify({ ok: false, error: message }) + "\n");
-  } else {
-    log.error(message);
-  }
-  process.exitCode = 1;
-}
-
-/** Render rows as a left-aligned fixed-width table with a header row. */
-function renderTable(headers: string[], rows: string[][]): void {
-  const widths = headers.map((h, i) =>
-    Math.max(h.length, ...rows.map((r) => (r[i] ?? "").length)),
-  );
-  const fmt = (cells: string[]) =>
-    cells
-      .map((c, i) => (c ?? "").padEnd(widths[i]!))
-      .join("  ")
-      .trimEnd();
-  writeLine(fmt(headers));
-  for (const row of rows) {
-    writeLine(fmt(row));
-  }
 }
 
 export function attachModelsSubcommand(inference: Command): void {

--- a/assistant/src/cli/commands/inference-profiles.ts
+++ b/assistant/src/cli/commands/inference-profiles.ts
@@ -1,0 +1,397 @@
+/**
+ * `assistant inference profiles` CLI namespace.
+ *
+ *   profiles list                 — effective profile catalog (managed + user)
+ *   profiles get <name>           — a single effective profile
+ *   profiles create <name> ...    — create a validated custom profile
+ *   profiles update <name> ...    — partial update of a custom profile
+ *   profiles delete <name>        — delete a custom profile (managed protected)
+ *   profiles active [name]        — read or set the active (chat) profile
+ *
+ * All subcommands delegate to the daemon via IPC. Provider/model/connection
+ * validation is enforced by the daemon (`inference_profiles_*` routes); the
+ * CLI only shape-parses flags.
+ */
+
+import type { Command } from "commander";
+
+import { cliIpcCall } from "../../ipc/cli-client.js";
+import { log } from "../logger.js";
+
+interface ProfileSummary {
+  name: string;
+  label: string | null;
+  provider: string | null;
+  model: string | null;
+  status: "active" | "disabled";
+  source: "managed" | "user";
+  provider_connection?: string;
+  availability: { status: string; message?: string } | null;
+}
+
+interface ProfileWriteResult {
+  ok: true;
+  name: string;
+  entry: Record<string, unknown>;
+  warnings: string[];
+}
+
+type WriteFlags = {
+  provider?: string;
+  model?: string;
+  connection?: string;
+  label?: string;
+  effort?: string;
+  maxTokens?: string;
+  temperature?: string;
+  thinking?: string;
+  description?: string;
+  allowUnlisted?: boolean;
+  json?: boolean;
+};
+
+function writeLine(msg: string): void {
+  process.stdout.write(msg + "\n");
+}
+
+function writeCliError(message: string, json?: boolean): void {
+  if (json) {
+    process.stdout.write(JSON.stringify({ ok: false, error: message }) + "\n");
+  } else {
+    log.error(message);
+  }
+  process.exitCode = 1;
+}
+
+function renderTable(headers: string[], rows: string[][]): void {
+  const widths = headers.map((h, i) =>
+    Math.max(h.length, ...rows.map((r) => (r[i] ?? "").length)),
+  );
+  const fmt = (cells: string[]) =>
+    cells
+      .map((c, i) => (c ?? "").padEnd(widths[i]!))
+      .join("  ")
+      .trimEnd();
+  writeLine(fmt(headers));
+  for (const row of rows) {
+    writeLine(fmt(row));
+  }
+}
+
+/**
+ * Parse the shared write flags into an IPC body. Returns an error string when
+ * a numeric/enum flag is malformed. Only keys the user supplied are included.
+ */
+function buildWriteBody(
+  opts: WriteFlags,
+): { ok: true; body: Record<string, unknown> } | { ok: false; error: string } {
+  const body: Record<string, unknown> = {};
+  if (opts.provider !== undefined) {
+    body.provider = opts.provider;
+  }
+  if (opts.model !== undefined) {
+    body.model = opts.model;
+  }
+  if (opts.connection !== undefined) {
+    body.connection = opts.connection;
+  }
+  if (opts.label !== undefined) {
+    body.label = opts.label;
+  }
+  if (opts.effort !== undefined) {
+    body.effort = opts.effort;
+  }
+  if (opts.description !== undefined) {
+    body.description = opts.description;
+  }
+  if (opts.allowUnlisted) {
+    body.allowUnlisted = true;
+  }
+
+  if (opts.maxTokens !== undefined) {
+    if (!/^\d+$/.test(opts.maxTokens.trim())) {
+      return { ok: false, error: "--max-tokens must be a positive integer." };
+    }
+    body.maxTokens = Number(opts.maxTokens.trim());
+  }
+  if (opts.temperature !== undefined) {
+    const value = Number(opts.temperature.trim());
+    if (!Number.isFinite(value)) {
+      return { ok: false, error: "--temperature must be a number." };
+    }
+    body.temperature = value;
+  }
+  if (opts.thinking !== undefined) {
+    const normalized = opts.thinking.trim().toLowerCase();
+    if (normalized !== "on" && normalized !== "off") {
+      return { ok: false, error: "--thinking must be 'on' or 'off'." };
+    }
+    body.thinking = normalized === "on";
+  }
+
+  return { ok: true, body };
+}
+
+function printWriteResult(
+  verb: string,
+  result: ProfileWriteResult,
+  json?: boolean,
+): void {
+  if (json) {
+    process.stdout.write(JSON.stringify(result) + "\n");
+    return;
+  }
+  for (const warning of result.warnings) {
+    writeLine(`warning: ${warning}`);
+  }
+  writeLine(`profile ${result.name} ${verb}`);
+  writeLine(
+    `Verify it works: assistant inference send --profile ${result.name} "Reply with OK"`,
+  );
+}
+
+function addWriteFlags(cmd: Command): Command {
+  return cmd
+    .option("--provider <p>", "LLM provider (e.g. anthropic, openai)")
+    .option("--model <id>", "Model id (see 'assistant inference models list')")
+    .option("--connection <name>", "Provider connection name to use")
+    .option("--label <text>", "Human-readable label")
+    .option(
+      "--effort <tier>",
+      "Reasoning effort (none|low|medium|high|xhigh|max)",
+    )
+    .option("--max-tokens <n>", "Max response tokens")
+    .option("--temperature <x>", "Sampling temperature")
+    .option("--thinking <on|off>", "Enable or disable thinking")
+    .option("--description <text>", "Profile description")
+    .option("--allow-unlisted", "Allow a model not in the catalog (warns)")
+    .option("--json", "Output as machine-readable JSON");
+}
+
+export function attachProfilesSubcommand(inference: Command): void {
+  const profiles = inference
+    .command("profiles")
+    .description("Manage inference profiles (named model configurations)");
+
+  profiles.addHelpText(
+    "after",
+    `
+Profiles are named model configurations. Managed defaults (balanced,
+quality-optimized, cost-optimized) are read-only; create your own to
+customize provider, model, and tuning.
+
+Examples:
+  $ assistant inference profiles list
+  $ assistant inference profiles create my-fast --provider anthropic \\
+      --model claude-haiku-4-5 --connection anthropic-personal --effort low
+  $ assistant inference profiles update my-fast --effort high
+  $ assistant inference profiles active my-fast
+  $ assistant inference profiles delete my-fast`,
+  );
+
+  // ── list ────────────────────────────────────────────────────────────
+  profiles
+    .command("list")
+    .description("List the effective profile catalog")
+    .option("--json", "Output as machine-readable JSON")
+    .action(async (opts: { json?: boolean }) => {
+      const ipcResult = await cliIpcCall<{ profiles: ProfileSummary[] }>(
+        "inference_profiles_list",
+        {},
+      );
+      if (!ipcResult.ok) {
+        writeCliError(ipcResult.error ?? "Unknown error", opts.json);
+        return;
+      }
+      const rows = ipcResult.result!.profiles;
+      if (opts.json) {
+        process.stdout.write(
+          JSON.stringify({ ok: true, profiles: rows }) + "\n",
+        );
+        return;
+      }
+      if (rows.length === 0) {
+        writeLine("No profiles found.");
+        return;
+      }
+      renderTable(
+        ["NAME", "LABEL", "PROVIDER", "MODEL", "STATUS", "SOURCE", "AVAIL"],
+        rows.map((p) => [
+          p.name,
+          p.label ?? "-",
+          p.provider ?? "-",
+          p.model ?? "-",
+          p.status,
+          p.source,
+          p.availability ? p.availability.status : "-",
+        ]),
+      );
+    });
+
+  // ── get ─────────────────────────────────────────────────────────────
+  profiles
+    .command("get <name>")
+    .description("Show a single effective profile")
+    .option("--json", "Output as machine-readable JSON")
+    .action(async (name: string, opts: { json?: boolean }) => {
+      const ipcResult = await cliIpcCall<{
+        name: string;
+        entry: Record<string, unknown>;
+        availability: { status: string; message?: string } | null;
+      }>("inference_profiles_get", { pathParams: { name } });
+      if (!ipcResult.ok) {
+        writeCliError(ipcResult.error ?? "Unknown error", opts.json);
+        return;
+      }
+      const result = ipcResult.result!;
+      if (opts.json) {
+        process.stdout.write(JSON.stringify({ ok: true, ...result }) + "\n");
+        return;
+      }
+      writeLine(`profile: ${result.name}`);
+      for (const [key, value] of Object.entries(result.entry)) {
+        writeLine(`  ${key}: ${JSON.stringify(value)}`);
+      }
+      if (result.availability) {
+        writeLine(`  availability: ${result.availability.status}`);
+        if (result.availability.message) {
+          writeLine(`    ${result.availability.message}`);
+        }
+      }
+    });
+
+  // ── create ──────────────────────────────────────────────────────────
+  addWriteFlags(
+    profiles
+      .command("create <name>")
+      .description("Create a validated custom profile"),
+  ).action(async (name: string, opts: WriteFlags) => {
+    if (!opts.provider) {
+      writeCliError("--provider is required.", opts.json);
+      return;
+    }
+    if (!opts.model) {
+      writeCliError("--model is required.", opts.json);
+      return;
+    }
+    const built = buildWriteBody(opts);
+    if (!built.ok) {
+      writeCliError(built.error, opts.json);
+      return;
+    }
+    const ipcResult = await cliIpcCall<ProfileWriteResult>(
+      "inference_profiles_create",
+      { body: { ...built.body, name } },
+    );
+    if (!ipcResult.ok) {
+      writeCliError(ipcResult.error ?? "Unknown error", opts.json);
+      return;
+    }
+    printWriteResult("created", ipcResult.result!, opts.json);
+  });
+
+  // ── update ──────────────────────────────────────────────────────────
+  addWriteFlags(
+    profiles
+      .command("update <name>")
+      .description("Partially update a custom profile"),
+  ).action(async (name: string, opts: WriteFlags) => {
+    const built = buildWriteBody(opts);
+    if (!built.ok) {
+      writeCliError(built.error, opts.json);
+      return;
+    }
+    if (Object.keys(built.body).length === 0) {
+      writeCliError(
+        "Nothing to update — pass at least one field flag.",
+        opts.json,
+      );
+      return;
+    }
+    const ipcResult = await cliIpcCall<ProfileWriteResult>(
+      "inference_profiles_update",
+      { pathParams: { name }, body: built.body },
+    );
+    if (!ipcResult.ok) {
+      writeCliError(ipcResult.error ?? "Unknown error", opts.json);
+      return;
+    }
+    printWriteResult("updated", ipcResult.result!, opts.json);
+  });
+
+  // ── delete ──────────────────────────────────────────────────────────
+  profiles
+    .command("delete <name>")
+    .description("Delete a custom profile")
+    .option("--json", "Output as machine-readable JSON")
+    .action(async (name: string, opts: { json?: boolean }) => {
+      const ipcResult = await cliIpcCall<{ ok: true; name: string }>(
+        "inference_profiles_delete",
+        { pathParams: { name } },
+      );
+      if (!ipcResult.ok) {
+        writeCliError(ipcResult.error ?? "Unknown error", opts.json);
+        return;
+      }
+      if (opts.json) {
+        process.stdout.write(
+          JSON.stringify({ ok: true, name: ipcResult.result!.name }) + "\n",
+        );
+        return;
+      }
+      writeLine(`profile ${name} deleted`);
+    });
+
+  // ── active ──────────────────────────────────────────────────────────
+  profiles
+    .command("active [name]")
+    .description("Read or set the active (chat) profile")
+    .option("--json", "Output as machine-readable JSON")
+    .addHelpText(
+      "after",
+      `
+With no argument, prints the active profile. With a name, sets it — the
+same deep-merge write the model picker performs.
+
+Examples:
+  $ assistant inference profiles active
+  $ assistant inference profiles active balanced`,
+    )
+    .action(async (name: string | undefined, opts: { json?: boolean }) => {
+      if (name === undefined) {
+        const ipcResult = await cliIpcCall<{
+          llm?: { activeProfile?: string };
+        }>("config_get");
+        if (!ipcResult.ok) {
+          writeCliError(ipcResult.error ?? "Unknown error", opts.json);
+          return;
+        }
+        const active = ipcResult.result!.llm?.activeProfile ?? null;
+        if (opts.json) {
+          process.stdout.write(
+            JSON.stringify({ ok: true, activeProfile: active }) + "\n",
+          );
+          return;
+        }
+        writeLine(
+          active ? `active profile: ${active}` : "no active profile set",
+        );
+        return;
+      }
+
+      const ipcResult = await cliIpcCall("config_patch", {
+        body: { llm: { activeProfile: name } },
+      });
+      if (!ipcResult.ok) {
+        writeCliError(ipcResult.error ?? "Unknown error", opts.json);
+        return;
+      }
+      if (opts.json) {
+        process.stdout.write(
+          JSON.stringify({ ok: true, activeProfile: name }) + "\n",
+        );
+        return;
+      }
+      writeLine(`active profile set to ${name}`);
+    });
+}

--- a/assistant/src/cli/commands/inference-profiles.ts
+++ b/assistant/src/cli/commands/inference-profiles.ts
@@ -16,7 +16,7 @@
 import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
-import { log } from "../logger.js";
+import { renderTable, writeCliError, writeLine } from "../lib/cli-output.js";
 
 interface ProfileSummary {
   name: string;
@@ -49,34 +49,6 @@ type WriteFlags = {
   allowUnlisted?: boolean;
   json?: boolean;
 };
-
-function writeLine(msg: string): void {
-  process.stdout.write(msg + "\n");
-}
-
-function writeCliError(message: string, json?: boolean): void {
-  if (json) {
-    process.stdout.write(JSON.stringify({ ok: false, error: message }) + "\n");
-  } else {
-    log.error(message);
-  }
-  process.exitCode = 1;
-}
-
-function renderTable(headers: string[], rows: string[][]): void {
-  const widths = headers.map((h, i) =>
-    Math.max(h.length, ...rows.map((r) => (r[i] ?? "").length)),
-  );
-  const fmt = (cells: string[]) =>
-    cells
-      .map((c, i) => (c ?? "").padEnd(widths[i]!))
-      .join("  ")
-      .trimEnd();
-  writeLine(fmt(headers));
-  for (const row of rows) {
-    writeLine(fmt(row));
-  }
-}
 
 /**
  * Parse the shared write flags into an IPC body. Returns an error string when

--- a/assistant/src/cli/commands/inference-providers-default.ts
+++ b/assistant/src/cli/commands/inference-providers-default.ts
@@ -1,0 +1,102 @@
+/**
+ * `assistant inference providers default [name]` — read or set the workspace
+ * default provider (`llm.defaultProvider`), wrapping the daemon's
+ * `llm_default_provider_get` / `llm_default_provider_put` routes. The read
+ * form prints the resolved connection and its availability status.
+ */
+
+import type { Command } from "commander";
+
+import { cliIpcCall } from "../../ipc/cli-client.js";
+import { log } from "../logger.js";
+
+interface DefaultProviderStatus {
+  provider: string | null;
+  connectionName?: string;
+  resolvedConnectionName: string | null;
+  availability: { status: string; message?: string };
+}
+
+function writeLine(msg: string): void {
+  process.stdout.write(msg + "\n");
+}
+
+function writeCliError(message: string, json?: boolean): void {
+  if (json) {
+    process.stdout.write(JSON.stringify({ ok: false, error: message }) + "\n");
+  } else {
+    log.error(message);
+  }
+  process.exitCode = 1;
+}
+
+function printStatus(status: DefaultProviderStatus, json?: boolean): void {
+  if (json) {
+    process.stdout.write(JSON.stringify({ ok: true, ...status }) + "\n");
+    return;
+  }
+  if (!status.provider) {
+    writeLine("no default provider configured");
+  } else {
+    writeLine(`default provider: ${status.provider}`);
+    if (status.resolvedConnectionName) {
+      writeLine(`  connection: ${status.resolvedConnectionName}`);
+    }
+  }
+  writeLine(`  availability: ${status.availability.status}`);
+  if (status.availability.message) {
+    writeLine(`    ${status.availability.message}`);
+  }
+}
+
+export function attachDefaultProviderSubcommand(providers: Command): void {
+  providers
+    .command("default [name]")
+    .description("Read or set the default provider (prints availability)")
+    .option("--connection <name>", "Pin a specific connection when setting")
+    .option("--json", "Output as machine-readable JSON")
+    .addHelpText(
+      "after",
+      `
+With no argument, prints the default provider and whether it is usable.
+With a provider name, sets it (optionally pinning a connection).
+
+Examples:
+  $ assistant inference providers default
+  $ assistant inference providers default anthropic
+  $ assistant inference providers default anthropic --connection anthropic-personal`,
+    )
+    .action(
+      async (
+        name: string | undefined,
+        opts: { connection?: string; json?: boolean },
+      ) => {
+        if (name === undefined) {
+          const ipcResult = await cliIpcCall<DefaultProviderStatus>(
+            "llm_default_provider_get",
+            {},
+          );
+          if (!ipcResult.ok) {
+            writeCliError(ipcResult.error ?? "Unknown error", opts.json);
+            return;
+          }
+          printStatus(ipcResult.result!, opts.json);
+          return;
+        }
+
+        const body: Record<string, unknown> = { provider: name };
+        if (opts.connection !== undefined) {
+          body.connectionName = opts.connection;
+        }
+        const ipcResult = await cliIpcCall<DefaultProviderStatus>(
+          "llm_default_provider_put",
+          { body },
+        );
+        if (!ipcResult.ok) {
+          writeCliError(ipcResult.error ?? "Unknown error", opts.json);
+          return;
+        }
+        printStatus(ipcResult.result!, opts.json);
+      },
+    );
+}

--- a/assistant/src/cli/commands/inference-providers-default.ts
+++ b/assistant/src/cli/commands/inference-providers-default.ts
@@ -8,26 +8,13 @@
 import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
-import { log } from "../logger.js";
+import { writeCliError, writeLine } from "../lib/cli-output.js";
 
 interface DefaultProviderStatus {
   provider: string | null;
   connectionName?: string;
   resolvedConnectionName: string | null;
   availability: { status: string; message?: string };
-}
-
-function writeLine(msg: string): void {
-  process.stdout.write(msg + "\n");
-}
-
-function writeCliError(message: string, json?: boolean): void {
-  if (json) {
-    process.stdout.write(JSON.stringify({ ok: false, error: message }) + "\n");
-  } else {
-    log.error(message);
-  }
-  process.exitCode = 1;
 }
 
 function printStatus(status: DefaultProviderStatus, json?: boolean): void {

--- a/assistant/src/cli/commands/inference-providers.ts
+++ b/assistant/src/cli/commands/inference-providers.ts
@@ -18,7 +18,7 @@ import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
 import type { OAuth2Config } from "../../security/oauth2.js";
-import { log } from "../logger.js";
+import { writeCliError } from "../lib/cli-output.js";
 import { attachDefaultProviderSubcommand } from "./inference-providers-default.js";
 
 // ---------------------------------------------------------------------------
@@ -160,32 +160,30 @@ function buildAuthInput(
   credential?: string,
 ): Record<string, unknown> | string {
   if (authType === "api_key") {
-    if (!credential) return "--credential is required when --auth api_key";
+    if (!credential) {
+      return "--credential is required when --auth api_key";
+    }
     return { type: "api_key", credential };
   }
   if (authType === "platform") {
-    if (credential) return "--credential is not accepted with --auth platform";
+    if (credential) {
+      return "--credential is not accepted with --auth platform";
+    }
     return { type: "platform" };
   }
   if (authType === "none") {
-    if (credential) return "--credential is not accepted with --auth none";
+    if (credential) {
+      return "--credential is not accepted with --auth none";
+    }
     return { type: "none" };
   }
   if (authType === "oauth_subscription") {
-    if (!credential)
+    if (!credential) {
       return "--credential is required when --auth oauth_subscription";
+    }
     return { type: "oauth_subscription", credential };
   }
   return `Unknown auth type "${authType}". Use: api_key, platform, none, oauth_subscription`;
-}
-
-function writeCliError(msg: string, json?: boolean): void {
-  if (json) {
-    process.stdout.write(JSON.stringify({ ok: false, error: msg }) + "\n");
-  } else {
-    log.error(msg);
-  }
-  process.exitCode = 1;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/cli/commands/inference-providers.ts
+++ b/assistant/src/cli/commands/inference-providers.ts
@@ -19,6 +19,7 @@ import type { Command } from "commander";
 import { cliIpcCall } from "../../ipc/cli-client.js";
 import type { OAuth2Config } from "../../security/oauth2.js";
 import { log } from "../logger.js";
+import { attachDefaultProviderSubcommand } from "./inference-providers-default.js";
 
 // ---------------------------------------------------------------------------
 // Response types
@@ -509,4 +510,5 @@ Examples:
   attachDeleteSubcommand(connections);
 
   attachLoginChatgptSubcommand(providers);
+  attachDefaultProviderSubcommand(providers);
 }

--- a/assistant/src/cli/commands/inference.ts
+++ b/assistant/src/cli/commands/inference.ts
@@ -15,6 +15,9 @@ import { cliIpcCall } from "../../ipc/cli-client.js";
 import { readStdinSync } from "../../util/read-stdin.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
+import { attachCallsitesSubcommand } from "./inference-callsites.js";
+import { attachModelsSubcommand } from "./inference-models.js";
+import { attachProfilesSubcommand } from "./inference-profiles.js";
 import { attachProvidersSubcommand } from "./inference-providers.js";
 import { attachSessionSubcommand } from "./inference-session.js";
 
@@ -248,6 +251,9 @@ Examples:
       attachSendSubcommand(inference);
       attachSessionSubcommand(inference);
       attachProvidersSubcommand(inference);
+      attachModelsSubcommand(inference);
+      attachProfilesSubcommand(inference);
+      attachCallsitesSubcommand(inference);
     },
   });
 

--- a/assistant/src/cli/lib/cli-output.ts
+++ b/assistant/src/cli/lib/cli-output.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared stdout/error helpers for CLI subcommands that support a `--json`
+ * mode: plain line output, a JSON-aware error writer that sets the exit
+ * code, and a fixed-width table renderer for human-readable lists.
+ */
+
+import { log } from "../logger.js";
+
+export function writeLine(msg: string): void {
+  process.stdout.write(msg + "\n");
+}
+
+/**
+ * Report a CLI failure and set `process.exitCode = 1`. In `--json` mode the
+ * error is emitted to stdout as `{ ok: false, error }` so machine callers
+ * always get a parseable body; otherwise it goes through the CLI logger.
+ */
+export function writeCliError(message: string, json?: boolean): void {
+  if (json) {
+    process.stdout.write(JSON.stringify({ ok: false, error: message }) + "\n");
+  } else {
+    log.error(message);
+  }
+  process.exitCode = 1;
+}
+
+/** Render rows as a left-aligned fixed-width table with a header row. */
+export function renderTable(headers: string[], rows: string[][]): void {
+  const widths = headers.map((h, i) =>
+    Math.max(h.length, ...rows.map((r) => (r[i] ?? "").length)),
+  );
+  const fmt = (cells: string[]) =>
+    cells
+      .map((c, i) => (c ?? "").padEnd(widths[i]!))
+      .join("  ")
+      .trimEnd();
+  writeLine(fmt(headers));
+  for (const row of rows) {
+    writeLine(fmt(row));
+  }
+}

--- a/assistant/src/providers/inference/connection-availability.ts
+++ b/assistant/src/providers/inference/connection-availability.ts
@@ -13,6 +13,7 @@
 import { getDb } from "../../persistence/db-connection.js";
 import { credentialKey } from "../../security/credential-key.js";
 import { getSecureKeyResultAsync } from "../../security/secure-keys.js";
+import { PROVIDER_CATALOG } from "../model-catalog.js";
 import { resolveManagedProxyContext } from "../platform-proxy/context.js";
 import {
   isVellumManagedConnection,
@@ -172,10 +173,21 @@ export async function computeConnectionAvailability(
         status: "unsupported_auth",
         message: `Connection "${resolvedConnectionName}" uses Vellum platform auth, which cannot serve provider "${provider}". Add an API-key connection for "${provider}" ${SETTINGS_HINT}.`,
       };
-    case "none":
+    case "none": {
+      // Keyless providers (catalog setupMode "keyless", e.g. ollama)
+      // legitimately dispatch with none-auth — mirror
+      // `createAdapterFromConnection`, which only rejects none-auth for
+      // keyed catalog entries.
+      const isKeyless =
+        PROVIDER_CATALOG.find((entry) => entry.id === provider)?.setupMode ===
+        "keyless";
+      if (isKeyless) {
+        return { status: "ok" };
+      }
       return {
         status: "unsupported_auth",
         message: `Connection "${resolvedConnectionName}" has no authentication configured, but provider "${provider}" requires an API key. Add a key ${SETTINGS_HINT}.`,
       };
+    }
   }
 }

--- a/assistant/src/providers/inference/connection-availability.ts
+++ b/assistant/src/providers/inference/connection-availability.ts
@@ -1,0 +1,181 @@
+/**
+ * Shared availability computation for a (provider, connection) pair: whether
+ * the connection exists, carries a usable credential, and can actually serve
+ * the provider. The status is reported, never enforced — a dangling or
+ * uncredentialed connection is a valid persisted state that surfaces an
+ * explainable error at dispatch time.
+ *
+ * Consumed by the default-provider status route (`llm.defaultProvider`) and
+ * the inference-profile list route (per-profile `provider_connection`) so the
+ * two never drift.
+ */
+
+import { getDb } from "../../persistence/db-connection.js";
+import { credentialKey } from "../../security/credential-key.js";
+import { getSecureKeyResultAsync } from "../../security/secure-keys.js";
+import { resolveManagedProxyContext } from "../platform-proxy/context.js";
+import {
+  isVellumManagedConnection,
+  MANAGED_ROUTABLE_PROVIDERS,
+} from "../vellum-model-routing.js";
+import { getConnection } from "./connections.js";
+
+export type ConnectionAvailabilityStatus =
+  | "ok"
+  | "missing_connection"
+  | "missing_credential"
+  | "provider_mismatch"
+  | "unsupported_auth"
+  | "vellum_unauthenticated"
+  | "unknown";
+
+export interface ConnectionAvailability {
+  status: ConnectionAvailabilityStatus;
+  /** Present on every non-`ok` status: names the broken thing and the fix. */
+  message?: string;
+}
+
+const SETTINGS_HINT = "in Settings → Models & Services";
+
+/**
+ * Availability of the Vellum-managed platform proxy: signed in and reachable.
+ */
+export async function vellumConnectionAvailability(): Promise<ConnectionAvailability> {
+  const ctx = await resolveManagedProxyContext();
+  if (ctx.enabled) {
+    return { status: "ok" };
+  }
+  if (!ctx.platformBaseUrl) {
+    return {
+      status: "vellum_unauthenticated",
+      message: "Not signed in to Vellum — the platform URL is not configured.",
+    };
+  }
+  // The context collapses an unreachable credential read into "no key";
+  // re-read reachability-aware so a CES outage isn't reported as logged out.
+  const key = await getSecureKeyResultAsync(
+    credentialKey("vellum", "assistant_api_key"),
+  );
+  if (key.value != null) {
+    return { status: "ok" };
+  }
+  if (key.unreachable) {
+    return {
+      status: "unknown",
+      message:
+        "The credential store is unreachable, so Vellum sign-in could not be verified. Try again shortly.",
+    };
+  }
+  return {
+    status: "vellum_unauthenticated",
+    message:
+      "Not signed in to Vellum — no assistant API key is stored. Log in to use Vellum-managed inference.",
+  };
+}
+
+function vellumManagedMismatch(
+  resolvedConnectionName: string,
+  provider: string,
+): ConnectionAvailability {
+  return {
+    status: "provider_mismatch",
+    message: `Connection "${resolvedConnectionName}" is the Vellum-managed connection, which cannot serve provider "${provider}". Pick a connection for "${provider}" ${SETTINGS_HINT}.`,
+  };
+}
+
+/**
+ * Compute the availability of `resolvedConnectionName` when used to serve
+ * `provider`. Mirrors the dispatch-time resolution checks
+ * (`tryResolveProviderForConnectionName` / `resolveAuth`) so a status of `ok`
+ * means dispatch would succeed.
+ */
+export async function computeConnectionAvailability(
+  provider: string,
+  resolvedConnectionName: string,
+): Promise<ConnectionAvailability> {
+  // Every path loads the row — even the canonical `vellum` name. Boot seeding
+  // (`seedCanonicalConnections`) deliberately leaves a user-owned connection
+  // that claims that name in place, and dispatch reads whatever row is
+  // stored, so availability must judge the actual row, not the name.
+  let connection;
+  try {
+    connection = getConnection(getDb(), resolvedConnectionName);
+  } catch {
+    return {
+      status: "unknown",
+      message: `Connection "${resolvedConnectionName}" could not be looked up. Try again shortly.`,
+    };
+  }
+  if (!connection) {
+    return {
+      status: "missing_connection",
+      message: `No connection named "${resolvedConnectionName}" exists for provider "${provider}". Add one ${SETTINGS_HINT}.`,
+    };
+  }
+
+  // Mirror the dispatch-time provider check (`tryResolveProviderForConnectionName`):
+  // the provider-agnostic Vellum-managed connection routes managed-routable
+  // providers via platform auth; any other provider mismatch fails there, so
+  // usable credentials must not read as ok.
+  if (isVellumManagedConnection(connection)) {
+    if (provider === "vellum" || MANAGED_ROUTABLE_PROVIDERS.has(provider)) {
+      return vellumConnectionAvailability();
+    }
+    return vellumManagedMismatch(resolvedConnectionName, provider);
+  }
+  if (connection.provider !== provider) {
+    return {
+      status: "provider_mismatch",
+      message: `Connection "${resolvedConnectionName}" is for provider "${connection.provider}", but the requested provider is "${provider}". Pick a connection for "${provider}" ${SETTINGS_HINT}.`,
+    };
+  }
+
+  switch (connection.auth.type) {
+    // Schema-accepted but not dispatchable: `resolveAuth` returns
+    // not_implemented for service_account, so a stored credential still
+    // cannot serve inference.
+    case "service_account":
+      return {
+        status: "unsupported_auth",
+        message: `Connection "${resolvedConnectionName}" uses service-account auth, which inference does not support yet. Pick a connection with a different auth type.`,
+      };
+    case "api_key":
+    case "oauth_subscription": {
+      const result = await getSecureKeyResultAsync(connection.auth.credential);
+      if (result.value != null) {
+        return { status: "ok" };
+      }
+      if (result.unreachable) {
+        // Credential store down ≠ credential missing. Reporting
+        // `missing_credential` here would send the user re-entering a key
+        // that is probably still stored.
+        return {
+          status: "unknown",
+          message: `The credential store is unreachable, so the credential for connection "${resolvedConnectionName}" could not be verified. Try again shortly.`,
+        };
+      }
+      const noun =
+        connection.auth.type === "api_key" ? "API key" : "credential";
+      return {
+        status: "missing_credential",
+        message: `Connection "${resolvedConnectionName}" has no ${noun} stored. Add one ${SETTINGS_HINT}.`,
+      };
+    }
+    case "platform":
+      // The managed proxy only serves managed-routable upstreams
+      // (`resolveAuth` → `buildManagedBaseUrl` has no proxy path for the
+      // rest), so platform auth on e.g. openrouter can never dispatch.
+      if (MANAGED_ROUTABLE_PROVIDERS.has(provider)) {
+        return vellumConnectionAvailability();
+      }
+      return {
+        status: "unsupported_auth",
+        message: `Connection "${resolvedConnectionName}" uses Vellum platform auth, which cannot serve provider "${provider}". Add an API-key connection for "${provider}" ${SETTINGS_HINT}.`,
+      };
+    case "none":
+      return {
+        status: "unsupported_auth",
+        message: `Connection "${resolvedConnectionName}" has no authentication configured, but provider "${provider}" requires an API key. Add a key ${SETTINGS_HINT}.`,
+      };
+  }
+}

--- a/assistant/src/runtime/routes/__tests__/inference-callsites-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-callsites-routes.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Smoke tests for the inference call-site resolution routes.
+ *
+ *   GET /v1/inference/callsites        — one row per LLM call site
+ *   GET /v1/inference/callsites/:site  — 400 on an unknown site
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+let fakeLlm: Record<string, unknown> = {};
+mock.module("../../../config/loader.js", () => ({
+  getConfigReadOnly: () => ({ llm: fakeLlm }),
+  getConfig: () => ({ llm: fakeLlm }),
+}));
+
+import { LLMCallSiteEnum, LLMSchema } from "../../../config/schemas/llm.js";
+import { BadRequestError } from "../errors.js";
+import { ROUTES } from "../inference-callsites-routes.js";
+import type { RouteDefinition, RouteHandlerArgs } from "../types.js";
+
+fakeLlm = LLMSchema.parse({});
+
+function handler(operationId: string): RouteDefinition["handler"] {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) {
+    throw new Error(`Route ${operationId} not found`);
+  }
+  return route.handler;
+}
+
+function call(operationId: string, args: RouteHandlerArgs): Promise<unknown> {
+  return Promise.resolve(handler(operationId)(args));
+}
+
+describe("GET inference/callsites", () => {
+  test("returns one summary row per call site", async () => {
+    const result = (await call("inference_callsites_list", {})) as {
+      callSites: { callSite: string; provider: string; model: string }[];
+    };
+    expect(result.callSites.length).toBe(LLMCallSiteEnum.options.length);
+    for (const row of result.callSites) {
+      expect(typeof row.provider).toBe("string");
+      expect(typeof row.model).toBe("string");
+    }
+  });
+});
+
+describe("GET inference/callsites/:site", () => {
+  test("400s on an unknown call site", async () => {
+    await expect(
+      call("inference_callsites_get", { pathParams: { site: "not-a-site" } }),
+    ).rejects.toBeInstanceOf(BadRequestError);
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/inference-models-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-models-routes.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for the inference model-catalog route handler.
+ *
+ *   GET /v1/inference/models  — list all catalog models, optional ?provider=
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { PROVIDER_CATALOG } from "../../../providers/model-catalog.js";
+import { BadRequestError } from "../errors.js";
+import { ROUTES } from "../inference-models-routes.js";
+import type { RouteDefinition, RouteHandlerArgs } from "../types.js";
+
+function handler(operationId: string): RouteDefinition["handler"] {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) {
+    throw new Error(`Route ${operationId} not found`);
+  }
+  return route.handler;
+}
+
+function call(args: RouteHandlerArgs): {
+  models: { provider: string; id: string }[];
+} {
+  return handler("inference_models_list")(args) as {
+    models: { provider: string; id: string }[];
+  };
+}
+
+describe("GET inference/models", () => {
+  test("lists every catalog model tagged with its provider", () => {
+    const { models } = call({});
+    const expected = PROVIDER_CATALOG.reduce(
+      (sum, p) => sum + p.models.length,
+      0,
+    );
+    expect(models.length).toBe(expected);
+    expect(models.every((m) => typeof m.provider === "string")).toBe(true);
+    expect(models.every((m) => typeof m.id === "string")).toBe(true);
+  });
+
+  test("filters by provider", () => {
+    const provider = PROVIDER_CATALOG[0]!.id;
+    const { models } = call({ queryParams: { provider } });
+    expect(models.length).toBe(PROVIDER_CATALOG[0]!.models.length);
+    expect(models.every((m) => m.provider === provider)).toBe(true);
+  });
+
+  test("400s on an unknown provider filter", () => {
+    expect(() => call({ queryParams: { provider: "not-a-provider" } })).toThrow(
+      BadRequestError,
+    );
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Tests for the inference-profile route handlers' write-time validation.
+ *
+ * Covers the guardrails that distinguish these routes from the generic
+ * `config set llm.profiles.*` path:
+ *   - bad provider (not in the LLMProvider enum)
+ *   - uncataloged model without --allow-unlisted
+ *   - missing provider connection
+ *   - managed-profile create / update / delete rejection
+ *
+ * The happy-path write is intentionally not exercised here — it flows through
+ * `commitConfigWrite` (disk write + provider reinit), which is covered by the
+ * config-write tests.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Module mocks (must come before imports) ──────────────────────────────────
+
+let fakeConfig: Record<string, unknown> = { llm: {} };
+mock.module("../../../config/loader.js", () => ({
+  getConfig: () => structuredClone(fakeConfig),
+  getConfigReadOnly: () => structuredClone(fakeConfig),
+  loadRawConfig: () => structuredClone(fakeConfig),
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+// ── Real imports (after mocks) ────────────────────────────────────────────────
+
+import { getDb } from "../../../persistence/db-connection.js";
+import { initializeDb } from "../../../persistence/db-init.js";
+import { providerConnections } from "../../../persistence/schema/inference.js";
+import { BadRequestError, ConflictError, NotFoundError } from "../errors.js";
+import { ROUTES } from "../inference-profiles-routes.js";
+import type { RouteDefinition, RouteHandlerArgs } from "../types.js";
+
+await initializeDb();
+
+function handler(operationId: string): RouteDefinition["handler"] {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) {
+    throw new Error(`Route ${operationId} not found`);
+  }
+  return route.handler;
+}
+
+function call(operationId: string, args: RouteHandlerArgs): Promise<unknown> {
+  return Promise.resolve(handler(operationId)(args));
+}
+
+function seedConnection(name: string, provider: string): void {
+  const now = Date.now();
+  getDb()
+    .insert(providerConnections)
+    .values({
+      name,
+      provider,
+      auth: JSON.stringify({ type: "none" }),
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+beforeEach(() => {
+  getDb().delete(providerConnections).run();
+  fakeConfig = { llm: {} };
+});
+
+// ── create validation ─────────────────────────────────────────────────────────
+
+describe("POST inference/profiles (create) validation", () => {
+  test("rejects an unknown provider", async () => {
+    await expect(
+      call("inference_profiles_create", {
+        body: {
+          name: "my-profile",
+          provider: "bogus",
+          model: "claude-opus-4-8",
+        },
+      }),
+    ).rejects.toBeInstanceOf(BadRequestError);
+  });
+
+  test("rejects an uncataloged model without allowUnlisted", async () => {
+    await expect(
+      call("inference_profiles_create", {
+        body: {
+          name: "my-profile",
+          provider: "anthropic",
+          model: "totally-made-up-model",
+        },
+      }),
+    ).rejects.toThrow(/not in the catalog/);
+  });
+
+  test("rejects a missing provider connection", async () => {
+    await expect(
+      call("inference_profiles_create", {
+        body: {
+          name: "my-profile",
+          provider: "anthropic",
+          model: "claude-opus-4-8",
+          connection: "does-not-exist",
+        },
+      }),
+    ).rejects.toThrow(/does not exist/);
+  });
+
+  test("rejects creating a managed default name", async () => {
+    await expect(
+      call("inference_profiles_create", {
+        body: {
+          name: "balanced",
+          provider: "anthropic",
+          model: "claude-opus-4-8",
+        },
+      }),
+    ).rejects.toThrow(/reserved for a code-defined default/);
+  });
+});
+
+// ── update validation ─────────────────────────────────────────────────────────
+
+describe("PATCH inference/profiles/:name (update) validation", () => {
+  test("rejects editing a managed default profile", async () => {
+    fakeConfig = {
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "fireworks",
+            model: "accounts/fireworks/models/glm-5p2",
+          },
+        },
+      },
+    };
+    await expect(
+      call("inference_profiles_update", {
+        pathParams: { name: "balanced" },
+        body: { effort: "low" },
+      }),
+    ).rejects.toThrow(/managed profile/);
+  });
+
+  test("404s an unknown profile", async () => {
+    await expect(
+      call("inference_profiles_update", {
+        pathParams: { name: "ghost" },
+        body: { effort: "low" },
+      }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+});
+
+// ── delete protection ───────────────────────────────────────────────────────
+
+describe("DELETE inference/profiles/:name protection", () => {
+  test("rejects deleting a managed default profile", async () => {
+    fakeConfig = {
+      llm: { profiles: { balanced: { source: "managed" } } },
+    };
+    await expect(
+      call("inference_profiles_delete", { pathParams: { name: "balanced" } }),
+    ).rejects.toThrow(/managed profile/);
+  });
+
+  test("404s an unknown profile", async () => {
+    fakeConfig = { llm: { profiles: {} } };
+    await expect(
+      call("inference_profiles_delete", { pathParams: { name: "ghost" } }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+});
+
+// ── duplicate create ──────────────────────────────────────────────────────────
+
+describe("POST inference/profiles create conflict", () => {
+  test("409s when a profile with the name already exists", async () => {
+    seedConnection("anthropic-personal", "anthropic");
+    fakeConfig = {
+      llm: {
+        profiles: { existing: { source: "user", provider: "anthropic" } },
+      },
+    };
+    await expect(
+      call("inference_profiles_create", {
+        body: {
+          name: "existing",
+          provider: "anthropic",
+          model: "claude-opus-4-8",
+          connection: "anthropic-personal",
+        },
+      }),
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/inference-routes-registration.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-routes-registration.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Registration guard for the inference model/profile/call-site routes.
+ *
+ * A route module that exports ROUTES but is never spread into the aggregator
+ * (`routes/index.ts`) compiles, unit-tests green, and is silently unreachable
+ * over both HTTP and IPC. This test pins every inference operationId to the
+ * aggregated array and to the IPC method mapping the CLI depends on.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { routeDefinitionsToIpcMethods } from "../../../ipc/routes/route-adapter.js";
+import { ROUTES } from "../index.js";
+
+const EXPECTED_OPERATION_IDS = [
+  "inference_models_list",
+  "inference_profiles_list",
+  "inference_profiles_get",
+  "inference_profiles_create",
+  "inference_profiles_update",
+  "inference_profiles_delete",
+  "inference_callsites_list",
+  "inference_callsites_get",
+] as const;
+
+describe("inference route registration", () => {
+  test("every inference operationId is registered in the aggregated ROUTES array", () => {
+    const registered = new Set(ROUTES.map((r) => r.operationId));
+    for (const operationId of EXPECTED_OPERATION_IDS) {
+      expect(registered.has(operationId)).toBe(true);
+    }
+  });
+
+  test("every inference operationId is exposed as an IPC method (CLI transport)", () => {
+    const ipcMethods = new Set(
+      routeDefinitionsToIpcMethods(ROUTES).map((r) => r.operationId),
+    );
+    for (const operationId of EXPECTED_OPERATION_IDS) {
+      expect(ipcMethods.has(operationId)).toBe(true);
+    }
+  });
+});

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -914,7 +914,7 @@ function stripWireOnlyProfileKeys(patch: unknown): void {
  * `handleSetConfig`'s `raw` write, which shares object references with the
  * inspected patch shape.
  */
-function normalizeManagedProfileWrites(patch: unknown): void {
+export function normalizeManagedProfileWrites(patch: unknown): void {
   const root = readPlainObject(patch);
   const llm = readPlainObject(root?.llm);
   const profiles = readPlainObject(llm?.profiles);
@@ -1086,7 +1086,9 @@ function handleGetConfigSchema({ queryParams = {} }: RouteHandlerArgs) {
   };
 }
 
-function rejectManagedProfileDeletion(body: Record<string, unknown>): void {
+export function rejectManagedProfileDeletion(
+  body: Record<string, unknown>,
+): void {
   const llm = asMutablePlainObject(body.llm);
   if (!llm) {
     return;
@@ -1296,7 +1298,7 @@ function completeChangedCustomProfiles(
  * Shared by `handlePatchConfig` and `handleSetConfig` so both write paths get
  * identical post-write side effects.
  */
-async function commitConfigWrite(
+export async function commitConfigWrite(
   raw: Record<string, unknown>,
   opLabel: string,
 ): Promise<void> {

--- a/assistant/src/runtime/routes/default-provider-routes.ts
+++ b/assistant/src/runtime/routes/default-provider-routes.ts
@@ -22,17 +22,8 @@ import {
   resolveDefaultConnectionName,
 } from "../../config/default-provider-resolution.js";
 import { getConfigReadOnly } from "../../config/loader.js";
-import type { DefaultProviderConfig } from "../../config/schemas/llm.js";
 import { DefaultProviderSchema } from "../../config/schemas/llm.js";
-import { getDb } from "../../persistence/db-connection.js";
-import { getConnection } from "../../providers/inference/connections.js";
-import { resolveManagedProxyContext } from "../../providers/platform-proxy/context.js";
-import {
-  isVellumManagedConnection,
-  MANAGED_ROUTABLE_PROVIDERS,
-} from "../../providers/vellum-model-routing.js";
-import { credentialKey } from "../../security/credential-key.js";
-import { getSecureKeyResultAsync } from "../../security/secure-keys.js";
+import { computeConnectionAvailability } from "../../providers/inference/connection-availability.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
@@ -64,149 +55,8 @@ const defaultProviderStatusSchema = z
   .meta({ id: "DefaultProviderStatus" });
 
 type DefaultProviderStatus = z.infer<typeof defaultProviderStatusSchema>;
-type Availability = z.infer<typeof availabilitySchema>;
 
 const SETTINGS_HINT = "in Settings → Models & Services";
-
-async function vellumAvailability(): Promise<Availability> {
-  const ctx = await resolveManagedProxyContext();
-  if (ctx.enabled) {
-    return { status: "ok" };
-  }
-  if (!ctx.platformBaseUrl) {
-    return {
-      status: "vellum_unauthenticated",
-      message: "Not signed in to Vellum — the platform URL is not configured.",
-    };
-  }
-  // The context collapses an unreachable credential read into "no key";
-  // re-read reachability-aware so a CES outage isn't reported as logged out.
-  const key = await getSecureKeyResultAsync(
-    credentialKey("vellum", "assistant_api_key"),
-  );
-  if (key.value != null) {
-    return { status: "ok" };
-  }
-  if (key.unreachable) {
-    return {
-      status: "unknown",
-      message:
-        "The credential store is unreachable, so Vellum sign-in could not be verified. Try again shortly.",
-    };
-  }
-  return {
-    status: "vellum_unauthenticated",
-    message:
-      "Not signed in to Vellum — no assistant API key is stored. Log in to use Vellum-managed inference.",
-  };
-}
-
-function vellumManagedMismatch(
-  resolvedConnectionName: string,
-  provider: string,
-): Availability {
-  return {
-    status: "provider_mismatch",
-    message: `Connection "${resolvedConnectionName}" is the Vellum-managed connection, which cannot serve provider "${provider}". Pick a connection for "${provider}" ${SETTINGS_HINT}.`,
-  };
-}
-
-async function computeAvailability(
-  dp: DefaultProviderConfig,
-  resolvedConnectionName: string,
-): Promise<Availability> {
-  // Every path loads the row — even the canonical `vellum` name. Boot seeding
-  // (`seedCanonicalConnections`) deliberately leaves a user-owned connection
-  // that claims that name in place, and dispatch reads whatever row is
-  // stored, so availability must judge the actual row, not the name.
-  let connection;
-  try {
-    connection = getConnection(getDb(), resolvedConnectionName);
-  } catch {
-    return {
-      status: "unknown",
-      message: `Connection "${resolvedConnectionName}" could not be looked up. Try again shortly.`,
-    };
-  }
-  if (!connection) {
-    return {
-      status: "missing_connection",
-      message: `No connection named "${resolvedConnectionName}" exists for provider "${dp.provider}". Add one ${SETTINGS_HINT}.`,
-    };
-  }
-
-  // Mirror the dispatch-time provider check (`tryResolveProviderForConnectionName`):
-  // the provider-agnostic Vellum-managed connection routes managed-routable
-  // providers via platform auth; any other provider mismatch fails there, so
-  // usable credentials must not read as ok.
-  if (isVellumManagedConnection(connection)) {
-    if (
-      dp.provider === "vellum" ||
-      MANAGED_ROUTABLE_PROVIDERS.has(dp.provider)
-    ) {
-      return vellumAvailability();
-    }
-    return vellumManagedMismatch(resolvedConnectionName, dp.provider);
-  }
-  if (connection.provider !== dp.provider) {
-    return {
-      status: "provider_mismatch",
-      message: `Connection "${resolvedConnectionName}" is for provider "${connection.provider}", but the default provider is "${dp.provider}". Pick a connection for "${dp.provider}" or update the default ${SETTINGS_HINT}.`,
-    };
-  }
-
-  switch (connection.auth.type) {
-    // Schema-accepted but not dispatchable: `resolveAuth` returns
-    // not_implemented for service_account, so a stored credential still
-    // cannot serve inference.
-    case "service_account":
-      return {
-        status: "unsupported_auth",
-        message: `Connection "${resolvedConnectionName}" uses service-account auth, which inference does not support yet. Pick a connection with a different auth type.`,
-      };
-    case "api_key":
-    case "oauth_subscription": {
-      const result = await getSecureKeyResultAsync(connection.auth.credential);
-      if (result.value != null) {
-        return { status: "ok" };
-      }
-      if (result.unreachable) {
-        // Credential store down ≠ credential missing. Reporting
-        // `missing_credential` here would send the user re-entering a key
-        // that is probably still stored.
-        return {
-          status: "unknown",
-          message: `The credential store is unreachable, so the credential for connection "${resolvedConnectionName}" could not be verified. Try again shortly.`,
-        };
-      }
-      const noun =
-        connection.auth.type === "api_key" ? "API key" : "credential";
-      return {
-        status: "missing_credential",
-        message: `Connection "${resolvedConnectionName}" has no ${noun} stored. Add one ${SETTINGS_HINT}.`,
-      };
-    }
-    case "platform":
-      // The managed proxy only serves managed-routable upstreams
-      // (`resolveAuth` → `buildManagedBaseUrl` has no proxy path for the
-      // rest), so platform auth on e.g. openrouter can never dispatch.
-      if (MANAGED_ROUTABLE_PROVIDERS.has(dp.provider)) {
-        return vellumAvailability();
-      }
-      return {
-        status: "unsupported_auth",
-        message: `Connection "${resolvedConnectionName}" uses Vellum platform auth, which cannot serve provider "${dp.provider}". Add an API-key connection for "${dp.provider}" ${SETTINGS_HINT}.`,
-      };
-    case "none":
-      // Every default-provider candidate except vellum is an API-key
-      // provider; dispatch (`createAdapterFromConnection`) yields no adapter
-      // for keyless auth on them.
-      return {
-        status: "unsupported_auth",
-        message: `Connection "${resolvedConnectionName}" has no authentication configured, but provider "${dp.provider}" requires an API key. Add a key ${SETTINGS_HINT}.`,
-      };
-  }
-}
 
 async function handleGetDefaultProvider(): Promise<DefaultProviderStatus> {
   const dp = getDefaultProviderFromConfig(getConfigReadOnly());
@@ -225,7 +75,10 @@ async function handleGetDefaultProvider(): Promise<DefaultProviderStatus> {
     provider: dp.provider,
     ...(dp.connectionName ? { connectionName: dp.connectionName } : {}),
     resolvedConnectionName,
-    availability: await computeAvailability(dp, resolvedConnectionName),
+    availability: await computeConnectionAvailability(
+      dp.provider,
+      resolvedConnectionName,
+    ),
   };
 }
 

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -82,7 +82,9 @@ import { ROUTES as HOST_FILE_ROUTES } from "./host-file-routes.js";
 import { ROUTES as HOST_TRANSFER_ROUTES } from "./host-transfer-routes.js";
 import { ROUTES as IDENTITY_ROUTES } from "./identity-routes.js";
 import { ROUTES as IMAGE_GENERATION_ROUTES } from "./image-generation-routes.js";
+import { ROUTES as INFERENCE_MODELS_ROUTES } from "./inference-models-routes.js";
 import { ROUTES as INFERENCE_PROFILE_SESSION_ROUTES } from "./inference-profile-session-routes.js";
+import { ROUTES as INFERENCE_PROFILES_ROUTES } from "./inference-profiles-routes.js";
 import { ROUTES as INFERENCE_PROVIDER_CONNECTION_ROUTES } from "./inference-provider-connection-routes.js";
 import { ROUTES as INFERENCE_SEND_ROUTES } from "./inference-send-routes.js";
 import { ROUTES as A2A_ROUTES } from "./integrations/a2a.js";
@@ -223,7 +225,9 @@ export const ROUTES: RouteDefinition[] = [
   ...HOST_FILE_ROUTES,
   ...HOST_TRANSFER_ROUTES,
   ...IDENTITY_ROUTES,
+  ...INFERENCE_MODELS_ROUTES,
   ...INFERENCE_PROFILE_SESSION_ROUTES,
+  ...INFERENCE_PROFILES_ROUTES,
   ...INFERENCE_PROVIDER_CONNECTION_ROUTES,
   ...INFERENCE_SEND_ROUTES,
   ...INTERNAL_OAUTH_ROUTES,

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -82,6 +82,7 @@ import { ROUTES as HOST_FILE_ROUTES } from "./host-file-routes.js";
 import { ROUTES as HOST_TRANSFER_ROUTES } from "./host-transfer-routes.js";
 import { ROUTES as IDENTITY_ROUTES } from "./identity-routes.js";
 import { ROUTES as IMAGE_GENERATION_ROUTES } from "./image-generation-routes.js";
+import { ROUTES as INFERENCE_CALLSITES_ROUTES } from "./inference-callsites-routes.js";
 import { ROUTES as INFERENCE_MODELS_ROUTES } from "./inference-models-routes.js";
 import { ROUTES as INFERENCE_PROFILE_SESSION_ROUTES } from "./inference-profile-session-routes.js";
 import { ROUTES as INFERENCE_PROFILES_ROUTES } from "./inference-profiles-routes.js";
@@ -225,6 +226,7 @@ export const ROUTES: RouteDefinition[] = [
   ...HOST_FILE_ROUTES,
   ...HOST_TRANSFER_ROUTES,
   ...IDENTITY_ROUTES,
+  ...INFERENCE_CALLSITES_ROUTES,
   ...INFERENCE_MODELS_ROUTES,
   ...INFERENCE_PROFILE_SESSION_ROUTES,
   ...INFERENCE_PROFILES_ROUTES,

--- a/assistant/src/runtime/routes/inference-callsites-routes.ts
+++ b/assistant/src/runtime/routes/inference-callsites-routes.ts
@@ -1,0 +1,211 @@
+/**
+ * Route definitions for read-only inference call-site resolution inspection.
+ *
+ * GET /v1/inference/callsites        — effective resolution for every call site
+ * GET /v1/inference/callsites/:site  — resolution detail + chain for one site
+ *
+ * These expose what `resolveCallSiteConfig` / `selectWinningProfile` already
+ * compute so the assistant can inspect which profile wins each call site
+ * without reading raw `llm.callSites.*` config paths. The detail view reuses
+ * the resolver's own fallback reporting (`onResolutionFallback`) for the
+ * resolution chain and the dispatch preflight (`preflightResolvedConfig`) for
+ * the usability check — no explanation logic is duplicated here.
+ */
+
+import { z } from "zod";
+
+import { CALL_SITE_DEFAULTS } from "../../config/call-site-defaults.js";
+import {
+  type ResolutionFallbackReason,
+  resolveCallSiteConfig,
+  selectWinningProfile,
+} from "../../config/llm-resolver.js";
+import { getConfigReadOnly } from "../../config/loader.js";
+import { type LLMCallSite, LLMCallSiteEnum } from "../../config/schemas/llm.js";
+import {
+  ConnectionResolutionError,
+  preflightResolvedConfig,
+} from "../../providers/connection-resolution.js";
+import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { BadRequestError } from "./errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+const sourceEnum = z.enum(["override", "active", "call_site", "default"]);
+
+const callSiteSummarySchema = z
+  .object({
+    callSite: z.string(),
+    profile: z.string().nullable(),
+    label: z.string().nullable(),
+    source: sourceEnum,
+    provider: z.string(),
+    model: z.string(),
+    effort: z.string(),
+    maxTokens: z.number(),
+    /** Notable tuning: the resolved context-window input cap, when set. */
+    maxInputTokens: z.number().optional(),
+  })
+  .meta({ id: "CallSiteResolutionSummary" });
+
+const resolutionChainEntrySchema = z.object({
+  requested: z.string(),
+  reason: z.enum(["missing", "disabled", "incomplete"]),
+});
+
+const callSiteDetailSchema = z
+  .object({
+    callSite: z.string(),
+    winner: z.object({
+      profile: z.string().nullable(),
+      label: z.string().nullable(),
+      source: sourceEnum,
+    }),
+    resolved: z.object({
+      provider: z.string(),
+      model: z.string(),
+      maxTokens: z.number(),
+      effort: z.string(),
+      temperature: z.number().nullable(),
+      maxInputTokens: z.number().optional(),
+    }),
+    /** Rungs the resolver considered and skipped, oldest-first. */
+    resolutionChain: z.array(resolutionChainEntrySchema),
+    /** The shipped default fragment for this call site (code-owned). */
+    shippedDefault: z.record(z.string(), z.unknown()),
+    /** The user's call-site override fragment, if any. */
+    userPin: z.record(z.string(), z.unknown()).nullable(),
+    /** Present when the preflight can statically prove dispatch would fail. */
+    resolutionError: z
+      .object({ reason: z.string(), message: z.string() })
+      .optional(),
+  })
+  .meta({ id: "CallSiteResolutionDetail" });
+
+function summarizeCallSite(
+  callSite: LLMCallSite,
+  llm: Parameters<typeof resolveCallSiteConfig>[1],
+) {
+  const selection = selectWinningProfile(callSite, llm, {});
+  const resolved = resolveCallSiteConfig(callSite, llm, {});
+  const label =
+    typeof selection.entry?.label === "string" ? selection.entry.label : null;
+  const maxInputTokens = resolved.contextWindow?.maxInputTokens;
+  return {
+    callSite,
+    profile: selection.profileName,
+    label,
+    source: selection.source,
+    provider: resolved.provider,
+    model: resolved.model,
+    effort: resolved.effort,
+    maxTokens: resolved.maxTokens,
+    ...(typeof maxInputTokens === "number" ? { maxInputTokens } : {}),
+  };
+}
+
+function handleListCallSites() {
+  const llm = getConfigReadOnly().llm;
+  const callSites = LLMCallSiteEnum.options.map((callSite) =>
+    summarizeCallSite(callSite, llm),
+  );
+  return { callSites };
+}
+
+async function handleGetCallSite({ pathParams = {} }: RouteHandlerArgs) {
+  const site = (pathParams.site ?? "").trim();
+  const parsedSite = LLMCallSiteEnum.safeParse(site);
+  if (!parsedSite.success) {
+    throw new BadRequestError(
+      `Unknown call site "${site}". Valid call sites: ${LLMCallSiteEnum.options.join(", ")}.`,
+    );
+  }
+  const callSite = parsedSite.data;
+  const llm = getConfigReadOnly().llm;
+
+  const resolutionChain: {
+    requested: string;
+    reason: ResolutionFallbackReason;
+  }[] = [];
+  const selection = selectWinningProfile(callSite, llm, {
+    onResolutionFallback: ({ requested, reason }) => {
+      resolutionChain.push({ requested, reason });
+    },
+  });
+  const resolved = resolveCallSiteConfig(callSite, llm, {});
+
+  let resolutionError: { reason: string; message: string } | undefined;
+  try {
+    await preflightResolvedConfig(resolved, {
+      profileName: selection.profileName ?? undefined,
+    });
+  } catch (err) {
+    if (err instanceof ConnectionResolutionError) {
+      resolutionError = { reason: err.reason, message: err.message };
+    } else {
+      throw err;
+    }
+  }
+
+  const maxInputTokens = resolved.contextWindow?.maxInputTokens;
+  return {
+    callSite,
+    winner: {
+      profile: selection.profileName,
+      label:
+        typeof selection.entry?.label === "string"
+          ? selection.entry.label
+          : null,
+      source: selection.source,
+    },
+    resolved: {
+      provider: resolved.provider,
+      model: resolved.model,
+      maxTokens: resolved.maxTokens,
+      effort: resolved.effort,
+      temperature: resolved.temperature ?? null,
+      ...(typeof maxInputTokens === "number" ? { maxInputTokens } : {}),
+    },
+    resolutionChain,
+    shippedDefault: CALL_SITE_DEFAULTS[callSite] as Record<string, unknown>,
+    userPin: (llm.callSites?.[callSite] ?? null) as Record<
+      string,
+      unknown
+    > | null,
+    ...(resolutionError ? { resolutionError } : {}),
+  };
+}
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "inference_callsites_list",
+    endpoint: "inference/callsites",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "List call-site resolutions",
+    description:
+      "Return the effective resolution for every LLM call site: the winning profile, its source (override / active / call-site pin / shipped default), and the resolved provider/model plus notable tuning.",
+    tags: ["inference"],
+    responseBody: z.object({ callSites: z.array(callSiteSummarySchema) }),
+    handler: handleListCallSites,
+  },
+  {
+    operationId: "inference_callsites_get",
+    endpoint: "inference/callsites/:site",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Get a call-site resolution detail",
+    description:
+      "Return the full resolution for one call site: the winner, the resolution chain (rungs considered and skipped), the shipped default fragment, the user's pin fragment, and a preflight-derived resolution error when dispatch would provably fail.",
+    tags: ["inference"],
+    pathParams: [{ name: "site", description: "LLM call-site id" }],
+    responseBody: callSiteDetailSchema,
+    additionalResponses: { "400": { description: "Unknown call site" } },
+    handler: handleGetCallSite,
+  },
+];

--- a/assistant/src/runtime/routes/inference-models-routes.ts
+++ b/assistant/src/runtime/routes/inference-models-routes.ts
@@ -1,0 +1,104 @@
+/**
+ * Route definitions for the inference model catalog.
+ *
+ * GET /v1/inference/models — list catalog models (optional ?provider= filter)
+ *
+ * The catalog (`PROVIDER_CATALOG`) is the code-owned source of truth for which
+ * model ids each provider serves. Exposing it lets clients (and the assistant
+ * itself) discover valid model ids instead of guessing — the same ids
+ * `isModelInCatalog` validates against when a profile is created.
+ */
+
+import { z } from "zod";
+
+import { PROVIDER_CATALOG } from "../../providers/model-catalog.js";
+import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { BadRequestError } from "./errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+const catalogModelSchema = z
+  .object({
+    provider: z.string(),
+    id: z.string(),
+    displayName: z.string(),
+    contextWindowTokens: z.number().optional(),
+    maxOutputTokens: z.number().optional(),
+    supportsThinking: z.boolean().optional(),
+    supportsVision: z.boolean().optional(),
+    supportsToolUse: z.boolean().optional(),
+    /** When set, the model is only visible while the named flag is enabled. */
+    featureFlag: z.string().optional(),
+  })
+  .meta({ id: "CatalogModel" });
+
+function handleListModels({ queryParams = {} }: RouteHandlerArgs) {
+  const providerFilter = queryParams.provider?.trim();
+  if (providerFilter) {
+    const known = PROVIDER_CATALOG.some((p) => p.id === providerFilter);
+    if (!known) {
+      throw new BadRequestError(
+        `Unknown provider "${providerFilter}". Known providers: ${PROVIDER_CATALOG.map(
+          (p) => p.id,
+        ).join(", ")}.`,
+      );
+    }
+  }
+
+  const models = PROVIDER_CATALOG.filter(
+    (entry) => !providerFilter || entry.id === providerFilter,
+  ).flatMap((entry) =>
+    entry.models.map((model) => ({
+      provider: entry.id,
+      id: model.id,
+      displayName: model.displayName,
+      ...(model.contextWindowTokens !== undefined
+        ? { contextWindowTokens: model.contextWindowTokens }
+        : {}),
+      ...(model.maxOutputTokens !== undefined
+        ? { maxOutputTokens: model.maxOutputTokens }
+        : {}),
+      ...(model.supportsThinking !== undefined
+        ? { supportsThinking: model.supportsThinking }
+        : {}),
+      ...(model.supportsVision !== undefined
+        ? { supportsVision: model.supportsVision }
+        : {}),
+      ...(model.supportsToolUse !== undefined
+        ? { supportsToolUse: model.supportsToolUse }
+        : {}),
+      ...(model.featureFlag !== undefined
+        ? { featureFlag: model.featureFlag }
+        : {}),
+    })),
+  );
+
+  return { models };
+}
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "inference_models_list",
+    endpoint: "inference/models",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "List inference catalog models",
+    description:
+      "Return every model in the code-owned provider catalog, each tagged with its provider. Optionally filter by provider with ?provider=<id>.",
+    tags: ["inference"],
+    queryParams: [
+      {
+        name: "provider",
+        schema: { type: "string" },
+        description: `Filter by provider id. One of: ${PROVIDER_CATALOG.map(
+          (p) => p.id,
+        ).join(", ")}`,
+      },
+    ],
+    responseBody: z.object({ models: z.array(catalogModelSchema) }),
+    additionalResponses: { "400": { description: "Unknown provider filter" } },
+    handler: handleListModels,
+  },
+];

--- a/assistant/src/runtime/routes/inference-profiles-routes.ts
+++ b/assistant/src/runtime/routes/inference-profiles-routes.ts
@@ -1,0 +1,574 @@
+/**
+ * Route definitions for inference-profile CRUD with write-time validation.
+ *
+ * GET    /v1/inference/profiles        — effective profile catalog (managed defaults + user profiles)
+ * GET    /v1/inference/profiles/:name  — single effective profile
+ * POST   /v1/inference/profiles        — create a validated custom profile
+ * PATCH  /v1/inference/profiles/:name  — partial update of a custom profile
+ * DELETE /v1/inference/profiles/:name  — delete a custom profile (managed defaults are protected)
+ *
+ * Unlike the generic `config set llm.profiles.<name> '<json>'` path, these
+ * routes validate at write time: the provider must be a known `LLMProvider`,
+ * the model must be in the catalog (unless `allowUnlisted`), and a referenced
+ * connection must exist. Writes reuse the shared config-write plumbing
+ * (`commitConfigWrite` + the managed-profile guards), so a CLI-created profile
+ * is completed/materialized identically to a UI-created one.
+ */
+
+import { z } from "zod";
+
+import {
+  getEffectiveProfile,
+  getEffectiveProfiles,
+  MANAGED_PROFILE_NAMES,
+} from "../../config/default-profile-catalog.js";
+import {
+  getConfig,
+  getConfigReadOnly,
+  loadRawConfig,
+} from "../../config/loader.js";
+import { LLMProvider, ProfileEntry } from "../../config/schemas/llm.js";
+import { getDb } from "../../persistence/db-connection.js";
+import { computeConnectionAvailability } from "../../providers/inference/connection-availability.js";
+import { getConnection } from "../../providers/inference/connections.js";
+import { isModelInCatalog } from "../../providers/model-catalog.js";
+import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import {
+  commitConfigWrite,
+  normalizeManagedProfileWrites,
+  rejectManagedProfileDeletion,
+} from "./conversation-query-routes.js";
+import { BadRequestError, ConflictError, NotFoundError } from "./errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+// Prototype-pollution guards — a profile name may never be one of these.
+const RESERVED_PROFILE_NAMES = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
+
+// ---------------------------------------------------------------------------
+// Wire schemas
+// ---------------------------------------------------------------------------
+
+const availabilitySchema = z
+  .object({
+    status: z.enum([
+      "ok",
+      "missing_connection",
+      "missing_credential",
+      "provider_mismatch",
+      "unsupported_auth",
+      "vellum_unauthenticated",
+      "unknown",
+    ]),
+    message: z.string().optional(),
+  })
+  .meta({ id: "ProfileConnectionAvailability" });
+
+const profileSummarySchema = z
+  .object({
+    name: z.string(),
+    label: z.string().nullable(),
+    provider: z.string().nullable(),
+    model: z.string().nullable(),
+    status: z.enum(["active", "disabled"]),
+    source: z.enum(["managed", "user"]),
+    provider_connection: z.string().optional(),
+    /** Null when the profile has no connection to judge (e.g. mix profiles). */
+    availability: availabilitySchema.nullable(),
+  })
+  .meta({ id: "InferenceProfileSummary" });
+
+const profileDetailSchema = z
+  .object({
+    name: z.string(),
+    entry: z.record(z.string(), z.unknown()),
+    availability: availabilitySchema.nullable(),
+  })
+  .meta({ id: "InferenceProfileDetail" });
+
+const profileWriteResultSchema = z
+  .object({
+    ok: z.literal(true),
+    name: z.string(),
+    entry: z.record(z.string(), z.unknown()),
+    warnings: z.array(z.string()),
+  })
+  .meta({ id: "InferenceProfileWriteResult" });
+
+const createRequestSchema = z.object({
+  name: z.string().min(1),
+  provider: z.string().min(1),
+  model: z.string().min(1),
+  connection: z.string().min(1).optional(),
+  label: z.string().min(1).optional(),
+  effort: z.string().optional(),
+  maxTokens: z.number().int().positive().optional(),
+  temperature: z.number().optional(),
+  thinking: z.boolean().optional(),
+  description: z.string().optional(),
+  allowUnlisted: z.boolean().optional(),
+});
+
+const updateRequestSchema = z.object({
+  provider: z.string().min(1).optional(),
+  model: z.string().min(1).optional(),
+  connection: z.string().min(1).optional(),
+  label: z.string().min(1).optional(),
+  effort: z.string().optional(),
+  maxTokens: z.number().int().positive().optional(),
+  temperature: z.number().optional(),
+  thinking: z.boolean().optional(),
+  description: z.string().optional(),
+  allowUnlisted: z.boolean().optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Validation helpers (daemon is the authority — clients only shape-parse args)
+// ---------------------------------------------------------------------------
+
+function assertValidProvider(provider: string): void {
+  if (!LLMProvider.safeParse(provider).success) {
+    throw new BadRequestError(
+      `Invalid provider "${provider}". Valid providers: ${LLMProvider.options.join(", ")}.`,
+    );
+  }
+}
+
+/**
+ * Validate a (provider, model) pair against the catalog. Returns warnings
+ * (never throws) when `allowUnlisted`; throws otherwise for an uncataloged
+ * model. An uncataloged model always warns, whether or not it is allowed.
+ */
+function validateModel(
+  provider: string,
+  model: string,
+  allowUnlisted: boolean,
+): string[] {
+  if (isModelInCatalog(provider, model)) {
+    return [];
+  }
+  if (!allowUnlisted) {
+    throw new BadRequestError(
+      `Model "${model}" is not in the catalog for provider "${provider}". ` +
+        `Pass allowUnlisted to create it anyway, or run ` +
+        `"assistant inference models list --provider ${provider}" to see valid ids.`,
+    );
+  }
+  return [
+    `Model "${model}" is not in the catalog for provider "${provider}" — created anyway (allowUnlisted).`,
+  ];
+}
+
+function assertConnectionExists(name: string): void {
+  if (!getConnection(getDb(), name)) {
+    throw new BadRequestError(
+      `Connection "${name}" does not exist. Create it first with ` +
+        `"assistant inference providers connections create", or omit --connection.`,
+    );
+  }
+}
+
+function asPlainObject(value: unknown): Record<string, unknown> | null {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+/**
+ * Compute connection availability for an effective profile entry — null when
+ * there is nothing to judge (no connection or no provider, e.g. mix profiles).
+ */
+async function profileAvailability(
+  entry: Record<string, unknown>,
+): Promise<Awaited<ReturnType<typeof computeConnectionAvailability>> | null> {
+  const provider = entry.provider;
+  const connection = entry.provider_connection;
+  if (typeof provider !== "string" || typeof connection !== "string") {
+    return null;
+  }
+  return computeConnectionAvailability(provider, connection);
+}
+
+function ensureRawProfiles(
+  raw: Record<string, unknown>,
+): Record<string, unknown> {
+  const existingLlm = asPlainObject(raw.llm);
+  const llm = existingLlm ?? {};
+  if (!existingLlm) {
+    raw.llm = llm;
+  }
+  const existingProfiles = asPlainObject(llm.profiles);
+  const profiles = existingProfiles ?? {};
+  if (!existingProfiles) {
+    llm.profiles = profiles;
+  }
+  return profiles;
+}
+
+/**
+ * Build the fragment of profile fields carried by the create/update request
+ * body, converting the CLI's flat `thinking` boolean into the schema shape.
+ * Only keys present in `body` are set — absent keys are left for the caller
+ * to merge (update) or default (create).
+ */
+function fragmentFromBody(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
+  const fragment: Record<string, unknown> = {};
+  if (typeof body.label === "string") {
+    fragment.label = body.label;
+  }
+  if (typeof body.effort === "string") {
+    fragment.effort = body.effort;
+  }
+  if (typeof body.maxTokens === "number") {
+    fragment.maxTokens = body.maxTokens;
+  }
+  if (typeof body.temperature === "number") {
+    fragment.temperature = body.temperature;
+  }
+  if (typeof body.thinking === "boolean") {
+    fragment.thinking = { enabled: body.thinking };
+  }
+  if (typeof body.description === "string") {
+    fragment.description = body.description;
+  }
+  if (typeof body.connection === "string") {
+    fragment.provider_connection = body.connection;
+  }
+  return fragment;
+}
+
+function validateProfileEntry(entry: Record<string, unknown>): void {
+  const parsed = ProfileEntry.safeParse(entry);
+  if (!parsed.success) {
+    const detail = parsed.error.issues.map((issue) => issue.message).join("; ");
+    throw new BadRequestError(`Invalid profile: ${detail}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+async function handleListProfiles() {
+  const effective = getEffectiveProfiles(getConfigReadOnly().llm.profiles);
+  const profiles = await Promise.all(
+    Object.entries(effective).map(async ([name, entry]) => {
+      const record = entry as Record<string, unknown>;
+      return {
+        name,
+        label: typeof record.label === "string" ? record.label : null,
+        provider: typeof record.provider === "string" ? record.provider : null,
+        model: typeof record.model === "string" ? record.model : null,
+        status: record.status === "disabled" ? "disabled" : "active",
+        source: record.source === "managed" ? "managed" : "user",
+        ...(typeof record.provider_connection === "string"
+          ? { provider_connection: record.provider_connection }
+          : {}),
+        availability: await profileAvailability(record),
+      };
+    }),
+  );
+  return { profiles };
+}
+
+async function handleGetProfile({ pathParams = {} }: RouteHandlerArgs) {
+  const name = (pathParams.name ?? "").trim();
+  if (!name) {
+    throw new BadRequestError("Profile name must be a non-empty string");
+  }
+  const entry = getEffectiveProfile(getConfigReadOnly().llm.profiles, name);
+  if (!entry) {
+    throw new NotFoundError(`Profile "${name}" not found.`);
+  }
+  const record = entry as Record<string, unknown>;
+  return {
+    name,
+    entry: record,
+    availability: await profileAvailability(record),
+  };
+}
+
+async function handleCreateProfile({ body = {} }: RouteHandlerArgs) {
+  const parsed = createRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new BadRequestError(
+      `Invalid request: ${parsed.error.issues.map((i) => i.message).join("; ")}`,
+    );
+  }
+  const input = parsed.data;
+  const name = input.name.trim();
+  if (!name) {
+    throw new BadRequestError("Profile name must be a non-empty string");
+  }
+  if (RESERVED_PROFILE_NAMES.has(name)) {
+    throw new BadRequestError(`Profile name "${name}" is reserved.`);
+  }
+  if (MANAGED_PROFILE_NAMES.has(name)) {
+    throw new BadRequestError(
+      `Cannot create profile "${name}" — the name is reserved for a code-defined default profile. Pick a different name.`,
+    );
+  }
+
+  assertValidProvider(input.provider);
+  const warnings = validateModel(
+    input.provider,
+    input.model,
+    input.allowUnlisted ?? false,
+  );
+  if (input.connection) {
+    assertConnectionExists(input.connection);
+  }
+
+  const entry: Record<string, unknown> = {
+    ...fragmentFromBody(body as Record<string, unknown>),
+    provider: input.provider,
+    model: input.model,
+    source: "user",
+  };
+  validateProfileEntry(entry);
+
+  const raw = loadRawConfig();
+  const profiles = ensureRawProfiles(raw);
+  if (profiles[name] !== undefined) {
+    throw new ConflictError(
+      `Profile "${name}" already exists. Use update to modify it.`,
+    );
+  }
+  profiles[name] = entry;
+  // Defensive: for a user-owned name this is a no-op; it re-asserts the
+  // managed-name protection at the shared write choke point.
+  normalizeManagedProfileWrites({ llm: { profiles: { [name]: entry } } });
+
+  await commitConfigWrite(raw, "create inference profile");
+
+  return {
+    ok: true as const,
+    name,
+    entry: (getEffectiveProfile(getConfig().llm.profiles, name) ??
+      entry) as Record<string, unknown>,
+    warnings,
+  };
+}
+
+async function handleUpdateProfile({
+  pathParams = {},
+  body = {},
+}: RouteHandlerArgs) {
+  const name = (pathParams.name ?? "").trim();
+  if (!name) {
+    throw new BadRequestError("Profile name must be a non-empty string");
+  }
+  if (RESERVED_PROFILE_NAMES.has(name)) {
+    throw new BadRequestError(`Profile name "${name}" is reserved.`);
+  }
+  const parsed = updateRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new BadRequestError(
+      `Invalid request: ${parsed.error.issues.map((i) => i.message).join("; ")}`,
+    );
+  }
+  const input = parsed.data;
+
+  const raw = loadRawConfig();
+  const profiles = ensureRawProfiles(raw);
+  const existing = asPlainObject(profiles[name]);
+  if (!existing) {
+    if (MANAGED_PROFILE_NAMES.has(name)) {
+      throw new BadRequestError(
+        `Cannot edit managed profile "${name}". Managed profiles are read-only; duplicate to a custom profile to customize.`,
+      );
+    }
+    throw new NotFoundError(`Profile "${name}" not found.`);
+  }
+  if (MANAGED_PROFILE_NAMES.has(name) && existing.source === "managed") {
+    throw new BadRequestError(
+      `Cannot edit managed profile "${name}". Managed profiles are read-only; duplicate to a custom profile to customize.`,
+    );
+  }
+
+  const nextProvider =
+    input.provider ??
+    (typeof existing.provider === "string" ? existing.provider : undefined);
+  const nextModel =
+    input.model ??
+    (typeof existing.model === "string" ? existing.model : undefined);
+
+  if (input.provider) {
+    assertValidProvider(input.provider);
+  }
+  let warnings: string[] = [];
+  if (
+    (input.provider !== undefined || input.model !== undefined) &&
+    typeof nextProvider === "string" &&
+    typeof nextModel === "string"
+  ) {
+    warnings = validateModel(
+      nextProvider,
+      nextModel,
+      input.allowUnlisted ?? false,
+    );
+  }
+  if (input.connection) {
+    assertConnectionExists(input.connection);
+  }
+
+  const merged: Record<string, unknown> = {
+    ...existing,
+    ...fragmentFromBody(body as Record<string, unknown>),
+    ...(input.provider !== undefined ? { provider: input.provider } : {}),
+    ...(input.model !== undefined ? { model: input.model } : {}),
+    source:
+      existing.source === "managed" ? "user" : (existing.source ?? "user"),
+  };
+  validateProfileEntry(merged);
+
+  profiles[name] = merged;
+  normalizeManagedProfileWrites({ llm: { profiles: { [name]: merged } } });
+
+  await commitConfigWrite(raw, "update inference profile");
+
+  return {
+    ok: true as const,
+    name,
+    entry: (getEffectiveProfile(getConfig().llm.profiles, name) ??
+      merged) as Record<string, unknown>,
+    warnings,
+  };
+}
+
+async function handleDeleteProfile({ pathParams = {} }: RouteHandlerArgs) {
+  const name = (pathParams.name ?? "").trim();
+  if (!name) {
+    throw new BadRequestError("Profile name must be a non-empty string");
+  }
+
+  const raw = loadRawConfig();
+  const llm = asPlainObject(raw.llm);
+  const profiles = asPlainObject(llm?.profiles);
+
+  // Reject deletion of a managed default with a clear message before the
+  // existence check, so `delete balanced` explains itself even when the
+  // managed stub is on disk.
+  rejectManagedProfileDeletion({ llm: { profiles: { [name]: null } } });
+
+  if (!profiles || profiles[name] === undefined) {
+    throw new NotFoundError(`Profile "${name}" not found.`);
+  }
+  delete profiles[name];
+
+  await commitConfigWrite(raw, "delete inference profile");
+
+  return { ok: true as const, name };
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "inference_profiles_list",
+    endpoint: "inference/profiles",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "List effective inference profiles",
+    description:
+      "Return the effective profile catalog: code-defined managed defaults merged with user profiles, each annotated with source and (when it has a connection) availability.",
+    tags: ["inference"],
+    responseBody: z.object({ profiles: z.array(profileSummarySchema) }),
+    handler: handleListProfiles,
+  },
+  {
+    operationId: "inference_profiles_get",
+    endpoint: "inference/profiles/:name",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Get an effective inference profile",
+    description:
+      "Return a single effective profile by name, with availability.",
+    tags: ["inference"],
+    pathParams: [{ name: "name", description: "Profile name" }],
+    responseBody: profileDetailSchema,
+    additionalResponses: { "404": { description: "Profile not found" } },
+    handler: handleGetProfile,
+  },
+  {
+    operationId: "inference_profiles_create",
+    endpoint: "inference/profiles",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Create an inference profile",
+    description:
+      "Create a validated custom profile. The provider must be a known LLM provider, the model must be in the catalog (unless allowUnlisted), and a referenced connection must exist. Managed default names cannot be created.",
+    tags: ["inference"],
+    requestBody: createRequestSchema,
+    responseBody: profileWriteResultSchema,
+    responseStatus: "201",
+    additionalResponses: {
+      "400": {
+        description:
+          "Invalid provider, uncataloged model, or missing connection",
+      },
+      "409": { description: "A profile with this name already exists" },
+    },
+    handler: handleCreateProfile,
+  },
+  {
+    operationId: "inference_profiles_update",
+    endpoint: "inference/profiles/:name",
+    method: "PATCH",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Update an inference profile",
+    description:
+      "Partial update of a custom profile with the same write-time validation as create. Managed default profiles are read-only.",
+    tags: ["inference"],
+    pathParams: [{ name: "name", description: "Profile name" }],
+    requestBody: updateRequestSchema,
+    responseBody: profileWriteResultSchema,
+    additionalResponses: {
+      "400": {
+        description: "Invalid fields, or attempt to edit a managed profile",
+      },
+      "404": { description: "Profile not found" },
+    },
+    handler: handleUpdateProfile,
+  },
+  {
+    operationId: "inference_profiles_delete",
+    endpoint: "inference/profiles/:name",
+    method: "DELETE",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Delete an inference profile",
+    description:
+      "Delete a custom profile. Managed default profiles cannot be deleted (they are re-seeded on boot).",
+    tags: ["inference"],
+    pathParams: [{ name: "name", description: "Profile name" }],
+    responseBody: z.object({ ok: z.literal(true), name: z.string() }),
+    additionalResponses: {
+      "400": { description: "Attempt to delete a managed profile" },
+      "404": { description: "Profile not found" },
+    },
+    handler: handleDeleteProfile,
+  },
+];

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -126,6 +126,18 @@ const ASSISTANT_SUPPORTED_COMMAND_PATHS = [
   "image-generation",
   "image-generation generate",
   "inference",
+  "inference callsites",
+  "inference callsites get",
+  "inference callsites list",
+  "inference models",
+  "inference models list",
+  "inference profiles",
+  "inference profiles active",
+  "inference profiles create",
+  "inference profiles delete",
+  "inference profiles get",
+  "inference profiles list",
+  "inference profiles update",
   "inference providers",
   "inference providers connections",
   "inference providers connections create",
@@ -133,6 +145,7 @@ const ASSISTANT_SUPPORTED_COMMAND_PATHS = [
   "inference providers connections get",
   "inference providers connections list",
   "inference providers connections update",
+  "inference providers default",
   "inference send",
   "inference session",
   "inference session open",
@@ -442,6 +455,61 @@ const riskOverrides: AssistantRiskOverride[] = [
   { path: "email send", risk: "high" },
   { path: "image-generation generate", risk: "medium" },
   { path: "inference send", risk: "medium" },
+  {
+    path: "inference models list",
+    risk: "low",
+    reason: "Read-only listing of the code-owned model catalog",
+  },
+  {
+    path: "inference profiles list",
+    risk: "low",
+    reason: "Read-only listing of the effective inference profiles",
+  },
+  {
+    path: "inference profiles get",
+    risk: "low",
+    reason: "Read-only fetch of a single effective profile",
+  },
+  {
+    path: "inference profiles create",
+    risk: "medium",
+    reason:
+      "Writes a validated custom profile to llm.profiles; daemon rejects managed names",
+  },
+  {
+    path: "inference profiles update",
+    risk: "medium",
+    reason:
+      "Mutates a custom profile in llm.profiles; daemon rejects managed profiles",
+  },
+  {
+    path: "inference profiles delete",
+    risk: "medium",
+    reason:
+      "Deletes a custom profile from llm.profiles; daemon rejects managed profiles",
+  },
+  {
+    path: "inference profiles active",
+    risk: "medium",
+    reason:
+      "Reads or switches llm.activeProfile — the user's chat-model selection",
+  },
+  {
+    path: "inference callsites list",
+    risk: "low",
+    reason: "Read-only per-call-site resolution summary",
+  },
+  {
+    path: "inference callsites get",
+    risk: "low",
+    reason: "Read-only resolution detail for one call site",
+  },
+  {
+    path: "inference providers default",
+    risk: "medium",
+    reason:
+      "Reads the default provider, or replaces llm.defaultProvider when a name is passed",
+  },
   {
     path: "inference providers connections list",
     risk: "low",


### PR DESCRIPTION
## Motivation

The assistant self-configures its inference setup, but today it must **guess** model ids and hand-write raw JSON into `llm.profiles` via `assistant config set llm.profiles.<name> '{...}'` — there is **no guardrail** against model-id hallucination or malformed profiles, and no first-class way to discover the model catalog or inspect how each call site resolves. This PR gives the assistant (and other clients) first-class primitives for model discovery, inference-profile management, and call-site resolution inspection, with validation living in the daemon.

Built on the M6/M7 profile-refactor machinery: profile writes flow through the shared `commitConfigWrite` + `completeCustomProfile` completion path, so a CLI-created profile is materialized identically to a UI-created one.

## Command surface

**Part 1 — model discovery**
- `assistant inference models list [--provider <p>] [--json]` — table of catalog models (provider, id, display name, context window).

**Part 2 — profile management**
- `assistant inference profiles list [--json]` — effective catalog (managed defaults + user profiles) with source and per-profile connection availability.
- `assistant inference profiles get <name> [--json]`
- `assistant inference profiles create <name> --provider <p> --model <id> [--connection <name>] [--label] [--effort] [--max-tokens] [--temperature] [--thinking on|off] [--description] [--allow-unlisted]`
- `assistant inference profiles update <name> [same flags]` — partial update.
- `assistant inference profiles delete <name>` — managed defaults protected.
- On create success, prints: `Verify it works: assistant inference send --profile <name> "Reply with OK"`.

**Part 3 — resolution inspection & config wrappers (kills remaining raw `config get/set llm.*` paths)**
- `assistant inference callsites list [--json]` — effective resolution per `LLMCallSite` (winning profile + label + source + provider/model + notable tuning).
- `assistant inference callsites get <site> [--json]` — resolution chain (skipped rungs), shipped default fragment, user pin fragment, and a preflight-derived resolution error when dispatch would provably fail.
- `assistant inference profiles active [name]` — read/set the active chat profile (deep-merge `{llm:{activeProfile}}` via `config_patch`).
- `assistant inference providers default [name] [--connection <name>]` — wraps `GET/PUT /v1/config/llm/default-provider`, printing availability on read.

## Validation — CLI vs daemon

- **CLI** only shape-parses flags: integer `--max-tokens`, numeric `--temperature`, `--thinking on|off` → boolean, and requires `--provider`/`--model` on create.
- **Daemon** (`/v1/inference/profiles` routes) is the authority:
  - provider must be in the `LLMProvider` enum,
  - model must pass `isModelInCatalog(provider, model)` unless `allowUnlisted` (uncataloged always warns; without the flag it's a hard 400),
  - `--connection` must reference an existing provider connection,
  - managed default names cannot be created/edited/deleted — reuses `normalizeManagedProfileWrites` / `rejectManagedProfileDeletion` + `assertInvariantProfilesPreserved` (inside `commitConfigWrite`).

All new routes live in the shared `ROUTES` array (dual HTTP/IPC).

## Reuse / no duplication

- Profile writes reuse `commitConfigWrite` (exported from `conversation-query-routes.ts`) — no parallel write path.
- Availability logic was **extracted** from `default-provider-routes.ts` into a shared `providers/inference/connection-availability.ts` and consumed by both the default-provider status route and `profiles list` (secure-keys importer allowlist updated accordingly).
- `callsites` reuses `selectWinningProfile`, `resolveCallSiteConfig`, and the explainable `preflightResolvedConfig` — no explanation logic is re-implemented.

## Tests / verification
- `bunx tsc --noEmit` clean; `bun run lint` clean (remaining curly warnings are pre-existing).
- New tests: profiles route validation (bad provider / uncataloged model / missing connection / managed create+update+delete rejection / duplicate 409), models route, callsites route smoke, CLI arg-parsing for models + profiles. Refactor-safety confirmed via the existing `default-provider-routes` and `credential-security-invariants` tests.
- `openapi.yaml` regenerated.

## Follow-up
The `skills/llm-cost-optimizer/SKILL.md` doc will be updated to reference these commands in a **separate follow-up**, to avoid conflicting with the in-flight `remove-legacy-llm-default-resolution` PR that also touches that file. No new code references `llm.default`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37745" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->