### PR TITLE
fix(memory): skip PKB index-job enqueue when memory v2 is enabled

### DIFF
--- a/assistant/src/plugins/defaults/memory/jobs/embed-pkb-file.test.ts
+++ b/assistant/src/plugins/defaults/memory/jobs/embed-pkb-file.test.ts
@@ -26,6 +26,14 @@ mock.module("../../../../config/loader.js", () => ({
   invalidateConfigCache: () => {},
 }));
 
+// Controls the enqueue gate: PKB index jobs are v1-only, so the enqueue
+// helper consults memory.v2.enabled.
+let v2Enabled = false;
+
+mock.module("../config.js", () => ({
+  getMemoryConfig: () => ({ v2: { enabled: v2Enabled } }),
+}));
+
 import { DEFAULT_CONFIG } from "../../../../config/defaults.js";
 import type { AssistantConfig } from "../../../../config/types.js";
 import { getMemoryDb } from "../../../../persistence/db-connection.js";
@@ -123,8 +131,23 @@ describe("enqueuePkbIndexJob", () => {
 
   beforeEach(() => {
     indexPkbFileCalls.length = 0;
+    v2Enabled = false;
     const db = getMemoryDb()!;
     db.delete(memoryJobs).run();
+  });
+
+  test("does not enqueue when memory v2 is enabled", () => {
+    v2Enabled = true;
+
+    const id = enqueuePkbIndexJob({
+      pkbRoot: "/pkb/root",
+      absPath: "/pkb/root/note.md",
+    });
+
+    expect(id).toBe("");
+    expect(claimMemoryJobs({ slowLlm: 10, fast: 10, embed: 10 })).toHaveLength(
+      0,
+    );
   });
 
   test("enqueues a pending embed_pkb_file job with payload", () => {

--- a/assistant/src/plugins/defaults/memory/jobs/embed-pkb-file.ts
+++ b/assistant/src/plugins/defaults/memory/jobs/embed-pkb-file.ts
@@ -5,6 +5,7 @@ import {
   isMemoryEnabled,
   type MemoryJob,
 } from "../../../../persistence/jobs-store.js";
+import { getMemoryConfig } from "../config.js";
 import { indexPkbFile } from "../pkb/pkb-index.js";
 
 /**
@@ -46,9 +47,16 @@ export async function embedPkbFileJob(
 
 /**
  * Enqueue an `embed_pkb_file` job (async, fire-and-forget).
+ *
+ * PKB is the v1 storage layer; under v2 nothing reads the PKB index and the
+ * v1 Qdrant collection is not initialized, so processing the job would throw.
+ * Skipping the enqueue here covers every producer (file-write hook, remember,
+ * startup reconcile); a later switch back to v1 rebuilds the index via the
+ * startup reconcile.
  */
 export function enqueuePkbIndexJob(input: EmbedPkbFileJobInput): string {
   if (!isMemoryEnabled()) return "";
+  if (getMemoryConfig().v2.enabled) return "";
   return enqueueMemoryJob("embed_pkb_file", {
     pkbRoot: input.pkbRoot,
     absPath: input.absPath,


### PR DESCRIPTION
## Summary
- Gate `enqueuePkbIndexJob` on `!memory.v2.enabled`: under the default v2 cutover the v1 Qdrant collection is never initialized, so PKB embed jobs from the `file_write` hook throw and pile up as failed rows for an index nothing reads.
- Single choke point — remember() and startup reconcile already run only under v1; a later flip back to v1 rebuilds the index via startup reconcile.
- New test: enqueue is a no-op with v2 enabled.

## Original prompt
Part of the memory-scope cleanup series Sidd requested (remove the vestigial memoryScopeId concept, keep v1 working). This is the one deliberate behavior change in the series, split out so the pure-excision PRs stay provably behavior-preserving: it stops enqueueing v1 PKB index jobs on v2 installs where they can only fail.