### PR TITLE
refactor(memory): retrospective sweep + fork-boundary reads via the blessed conversation facade

### DIFF
--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-startup-cleanup.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-startup-cleanup.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
 
 mock.module("../../../../util/logger.js", () => ({
   getLogger: () =>
@@ -127,19 +135,11 @@ mock.module("../config.js", () => ({
   }),
 }));
 
-mock.module("../../../../persistence/conversation-crud.js", () => ({
-  deleteConversation: (id: string) => {
-    deletedIds.push(id);
-    mockConversations = mockConversations.filter((c) => c.id !== id);
-  },
-  deleteConversationGently: async (id: string) => {
-    deletedIds.push(id);
-    mockConversations = mockConversations.filter((c) => c.id !== id);
-    return { segmentIds: [], deletedSummaryIds: [] };
-  },
-  getMessages: (conversationId: string) => mockMessages[conversationId] ?? [],
-  reserveMessage: mock(async () => ({ id: "msg-reserve" })),
-}));
+// The contract fns the code under test calls are stubbed per-test with spyOn
+// (restored in afterEach) rather than mock.module — a module mock here would
+// replace the plugin-api registry for every other test file sharing the
+// process.
+import * as pluginApi from "@vellumai/plugin-api";
 
 import { sweepOrphanMemoryRetrospectiveConversations } from "../memory-retrospective-startup-cleanup.js";
 
@@ -174,15 +174,28 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
     activeJobSourceConvIds = new Set();
     injectedNowMinusOrphanAgeMs = 0;
     mockKeepSupersededRuns = false;
+    spyOn(pluginApi, "deleteConversation").mockImplementation(
+      async (id: string) => {
+        deletedIds.push(id);
+        mockConversations = mockConversations.filter((c) => c.id !== id);
+      },
+    );
+    spyOn(pluginApi, "getMessages").mockImplementation(
+      async (conversationId: string) =>
+        (mockMessages[conversationId] ?? []) as Awaited<
+          ReturnType<typeof pluginApi.getMessages>
+        >,
+    );
   });
 
   afterEach(() => {
+    mock.restore();
     mockConversations = [];
     mockJobs = [];
     mockMessages = {};
   });
 
-  test("sweeps an old memory-retrospective orphan that has been superseded by a newer retro for the same source", () => {
+  test("sweeps an old memory-retrospective orphan that has been superseded by a newer retro for the same source", async () => {
     const now = Date.now();
     injectedNowMinusOrphanAgeMs = now - ORPHAN_AGE_MS;
     mockConversations = [
@@ -204,13 +217,13 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
     ];
     rebuildActiveJobSet();
 
-    const result = sweepOrphanMemoryRetrospectiveConversations(now);
+    const result = await sweepOrphanMemoryRetrospectiveConversations(now);
 
     expect(result.swept).toBe(1);
     expect(deletedIds).toEqual(["old-orphan"]);
   });
 
-  test("does NOT sweep recent memory-retrospective conversations", () => {
+  test("does NOT sweep recent memory-retrospective conversations", async () => {
     const now = Date.now();
     injectedNowMinusOrphanAgeMs = now - ORPHAN_AGE_MS;
     mockConversations = [
@@ -224,13 +237,13 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
     ];
     rebuildActiveJobSet();
 
-    const result = sweepOrphanMemoryRetrospectiveConversations(now);
+    const result = await sweepOrphanMemoryRetrospectiveConversations(now);
 
     expect(result.swept).toBe(0);
     expect(deletedIds).toEqual([]);
   });
 
-  test("does NOT sweep conversations of OTHER sources, even when old", () => {
+  test("does NOT sweep conversations of OTHER sources, even when old", async () => {
     const now = Date.now();
     injectedNowMinusOrphanAgeMs = now - ORPHAN_AGE_MS;
     mockConversations = [
@@ -244,7 +257,7 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
     ];
     rebuildActiveJobSet();
 
-    const result = sweepOrphanMemoryRetrospectiveConversations(now);
+    const result = await sweepOrphanMemoryRetrospectiveConversations(now);
 
     expect(result.swept).toBe(0);
   });
@@ -253,7 +266,7 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
   // fix, the predicate compared `conversations.id` (the BACKGROUND-conv id)
   // to source-conv ids extracted from job payloads — two different identifier
   // spaces — so the guard never matched and in-flight retros were swept.
-  test("does NOT sweep a background conversation whose SOURCE has an active job (different identifier spaces)", () => {
+  test("does NOT sweep a background conversation whose SOURCE has an active job (different identifier spaces)", async () => {
     const now = Date.now();
     injectedNowMinusOrphanAgeMs = now - ORPHAN_AGE_MS;
     // The background conv has its own id, distinct from the source it forks
@@ -277,13 +290,13 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
     ];
     rebuildActiveJobSet();
 
-    const result = sweepOrphanMemoryRetrospectiveConversations(now);
+    const result = await sweepOrphanMemoryRetrospectiveConversations(now);
 
     expect(result.swept).toBe(0);
     expect(deletedIds).toEqual([]);
   });
 
-  test("sweeps a superseded background conversation whose source has NO active job, even when another unrelated job is pending", () => {
+  test("sweeps a superseded background conversation whose source has NO active job, even when another unrelated job is pending", async () => {
     const now = Date.now();
     injectedNowMinusOrphanAgeMs = now - ORPHAN_AGE_MS;
     mockConversations = [
@@ -313,7 +326,7 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
     ];
     rebuildActiveJobSet();
 
-    const result = sweepOrphanMemoryRetrospectiveConversations(now);
+    const result = await sweepOrphanMemoryRetrospectiveConversations(now);
 
     expect(result.swept).toBe(1);
     expect(deletedIds).toEqual(["background-A"]);
@@ -324,7 +337,7 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
   // the most-recent successful one per source. That broke
   // `findMostRecentRetrospectiveFor` on the next run — the next retro had
   // no dedup context and could re-save facts the prior pass already captured.
-  test("PRESERVES the most-recent retro per source even when older than the orphan cutoff", () => {
+  test("PRESERVES the most-recent retro per source even when older than the orphan cutoff", async () => {
     const now = Date.now();
     injectedNowMinusOrphanAgeMs = now - ORPHAN_AGE_MS;
     mockConversations = [
@@ -338,19 +351,19 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
     ];
     rebuildActiveJobSet();
 
-    const result = sweepOrphanMemoryRetrospectiveConversations(now);
+    const result = await sweepOrphanMemoryRetrospectiveConversations(now);
 
     expect(result.swept).toBe(0);
     expect(deletedIds).toEqual([]);
   });
 
-  test("running across an empty workspace returns swept=0 without errors", () => {
-    const result = sweepOrphanMemoryRetrospectiveConversations();
+  test("running across an empty workspace returns swept=0 without errors", async () => {
+    const result = await sweepOrphanMemoryRetrospectiveConversations();
     expect(result.swept).toBe(0);
     expect(deletedIds).toEqual([]);
   });
 
-  test("keepSupersededRuns=true skips the sweep entirely — sweepable orphans are retained", () => {
+  test("keepSupersededRuns=true skips the sweep entirely — sweepable orphans are retained", async () => {
     mockKeepSupersededRuns = true;
     const now = Date.now();
     injectedNowMinusOrphanAgeMs = now - ORPHAN_AGE_MS;
@@ -375,7 +388,7 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
     ];
     rebuildActiveJobSet();
 
-    const result = sweepOrphanMemoryRetrospectiveConversations(now);
+    const result = await sweepOrphanMemoryRetrospectiveConversations(now);
 
     expect(result.swept).toBe(0);
     expect(deletedIds).toEqual([]);
@@ -423,7 +436,7 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
     return rows;
   }
 
-  test("sweeps an orphan MOST-RECENT fork-kind row (no post-fork output) and preserves an older row WITH output as the dedup baseline", () => {
+  test("sweeps an orphan MOST-RECENT fork-kind row (no post-fork output) and preserves an older row WITH output as the dedup baseline", async () => {
     const now = Date.now();
     injectedNowMinusOrphanAgeMs = now - ORPHAN_AGE_MS;
     mockConversations = [
@@ -458,13 +471,13 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
     };
     rebuildActiveJobSet();
 
-    const result = sweepOrphanMemoryRetrospectiveConversations(now);
+    const result = await sweepOrphanMemoryRetrospectiveConversations(now);
 
     expect(result.swept).toBe(1);
     expect(deletedIds).toEqual(["fork-orphan"]);
   });
 
-  test("falls back to preserving the plain most-recent row when EVERY row is an orphan", () => {
+  test("falls back to preserving the plain most-recent row when EVERY row is an orphan", async () => {
     const now = Date.now();
     injectedNowMinusOrphanAgeMs = now - ORPHAN_AGE_MS;
     mockConversations = [
@@ -495,7 +508,7 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
     };
     rebuildActiveJobSet();
 
-    const result = sweepOrphanMemoryRetrospectiveConversations(now);
+    const result = await sweepOrphanMemoryRetrospectiveConversations(now);
 
     // Current behavior preserved: the most-recent row survives even though
     // it has no output; the older orphan is swept.
@@ -503,7 +516,7 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
     expect(deletedIds).toEqual(["older-orphan"]);
   });
 
-  test("legacy-kind selection: ANY assistant message counts as output (no fork boundary required)", () => {
+  test("legacy-kind selection: ANY assistant message counts as output (no fork boundary required)", async () => {
     const now = Date.now();
     injectedNowMinusOrphanAgeMs = now - ORPHAN_AGE_MS;
     mockConversations = [
@@ -539,7 +552,7 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
     };
     rebuildActiveJobSet();
 
-    const result = sweepOrphanMemoryRetrospectiveConversations(now);
+    const result = await sweepOrphanMemoryRetrospectiveConversations(now);
 
     expect(result.swept).toBe(1);
     expect(deletedIds).toEqual(["legacy-orphan"]);

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-startup-cleanup.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-startup-cleanup.test.ts
@@ -58,7 +58,7 @@ const makeFakeDb = () => ({
           // requested column shape.
           const colKeys = cols ? Object.keys(cols) : [];
           if (colKeys.includes("conversationId")) {
-            return mockJobs
+            const rows = mockJobs
               .filter(
                 (j) =>
                   j.type === "memory_retrospective" &&
@@ -78,6 +78,15 @@ const makeFakeDb = () => ({
                 }
                 return { conversationId: convId };
               });
+            // Record what the production sweep captured from this query — the
+            // orphan branch filters against it, mirroring how the real orphan
+            // query's notInArray receives the captured id list.
+            capturedActiveJobIds = new Set(
+              rows
+                .map((r) => r.conversationId)
+                .filter((id): id is string => typeof id === "string"),
+            );
+            return rows;
           }
           // The "all retros" query (used to compute the preserved
           // dedup-baseline per source) requests id + source +
@@ -111,7 +120,7 @@ const makeFakeDb = () => ({
             .filter(
               (c) =>
                 c.fork_parent_conversation_id === null ||
-                !activeJobSourceConvIds.has(c.fork_parent_conversation_id),
+                !capturedActiveJobIds.has(c.fork_parent_conversation_id),
             )
             .map((c) => ({ id: c.id }));
         },
@@ -125,7 +134,7 @@ mock.module("../../../../persistence/db-connection.js", () => ({
   getMemoryDb: makeFakeDb,
 }));
 
-let activeJobSourceConvIds = new Set<string>();
+let capturedActiveJobIds = new Set<string>();
 let injectedNowMinusOrphanAgeMs = 0;
 let mockKeepSupersededRuns = false;
 
@@ -145,33 +154,13 @@ import { sweepOrphanMemoryRetrospectiveConversations } from "../memory-retrospec
 
 const ORPHAN_AGE_MS = 60 * 60 * 1000;
 
-function rebuildActiveJobSet(): void {
-  activeJobSourceConvIds = new Set();
-  for (const j of mockJobs) {
-    if (
-      j.type !== "memory_retrospective" ||
-      (j.status !== "pending" && j.status !== "running")
-    ) {
-      continue;
-    }
-    try {
-      const parsed = JSON.parse(j.payload) as { conversationId?: unknown };
-      if (typeof parsed.conversationId === "string") {
-        activeJobSourceConvIds.add(parsed.conversationId);
-      }
-    } catch {
-      // ignore
-    }
-  }
-}
-
 describe("sweepOrphanMemoryRetrospectiveConversations", () => {
   beforeEach(() => {
     mockConversations = [];
     mockJobs = [];
     mockMessages = {};
     deletedIds = [];
-    activeJobSourceConvIds = new Set();
+    capturedActiveJobIds = new Set();
     injectedNowMinusOrphanAgeMs = 0;
     mockKeepSupersededRuns = false;
     spyOn(pluginApi, "deleteConversation").mockImplementation(
@@ -215,7 +204,6 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
         created_at: now - 2 * ORPHAN_AGE_MS,
       },
     ];
-    rebuildActiveJobSet();
 
     const result = await sweepOrphanMemoryRetrospectiveConversations(now);
 
@@ -235,7 +223,6 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
         created_at: now - 60_000,
       },
     ];
-    rebuildActiveJobSet();
 
     const result = await sweepOrphanMemoryRetrospectiveConversations(now);
 
@@ -255,7 +242,6 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
         created_at: now - 2 * ORPHAN_AGE_MS,
       },
     ];
-    rebuildActiveJobSet();
 
     const result = await sweepOrphanMemoryRetrospectiveConversations(now);
 
@@ -288,7 +274,6 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
         payload: JSON.stringify({ conversationId: "source-conv-id" }),
       },
     ];
-    rebuildActiveJobSet();
 
     const result = await sweepOrphanMemoryRetrospectiveConversations(now);
 
@@ -324,7 +309,6 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
         payload: JSON.stringify({ conversationId: "source-B" }),
       },
     ];
-    rebuildActiveJobSet();
 
     const result = await sweepOrphanMemoryRetrospectiveConversations(now);
 
@@ -349,7 +333,6 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
         created_at: now - 2 * ORPHAN_AGE_MS,
       },
     ];
-    rebuildActiveJobSet();
 
     const result = await sweepOrphanMemoryRetrospectiveConversations(now);
 
@@ -386,7 +369,6 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
         created_at: now - 2 * ORPHAN_AGE_MS,
       },
     ];
-    rebuildActiveJobSet();
 
     const result = await sweepOrphanMemoryRetrospectiveConversations(now);
 
@@ -469,7 +451,6 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
         withOutput: false,
       }),
     };
-    rebuildActiveJobSet();
 
     const result = await sweepOrphanMemoryRetrospectiveConversations(now);
 
@@ -506,7 +487,6 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
         withOutput: false,
       }),
     };
-    rebuildActiveJobSet();
 
     const result = await sweepOrphanMemoryRetrospectiveConversations(now);
 
@@ -514,6 +494,77 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
     // it has no output; the older orphan is swept.
     expect(result.swept).toBe(1);
     expect(deletedIds).toEqual(["older-orphan"]);
+  });
+
+  // Regression test for the detached-sweep interleaving: a retrospective
+  // forked while the sweep awaits baseline message loads inherits the copied
+  // source prefix's old lastMessageAt, so only its pending/running job
+  // protects it — the sweep must read the active-job set AFTER the awaited
+  // baseline phase, in the same synchronous block as the orphan query.
+  test("protects a retrospective forked mid-sweep by a concurrent tick (active jobs re-read after the baseline awaits)", async () => {
+    const now = Date.now();
+    injectedNowMinusOrphanAgeMs = now - ORPHAN_AGE_MS;
+    // Source-A has two fork rows with messages so the baseline selector
+    // performs awaited getMessages loads during the sweep.
+    mockConversations = [
+      {
+        id: "fork-with-output",
+        source: "memory-retrospective-fork",
+        last_message_at: now - 3 * ORPHAN_AGE_MS,
+        fork_parent_conversation_id: "source-A",
+        created_at: now - 3 * ORPHAN_AGE_MS,
+      },
+      {
+        id: "fork-orphan",
+        source: "memory-retrospective-fork",
+        last_message_at: now - 2 * ORPHAN_AGE_MS,
+        fork_parent_conversation_id: "source-A",
+        created_at: now - 2 * ORPHAN_AGE_MS,
+      },
+    ];
+    mockMessages = {
+      "fork-with-output": forkKindMessages({
+        boundaryAt: now - 3 * ORPHAN_AGE_MS,
+        withOutput: true,
+      }),
+      "fork-orphan": forkKindMessages({
+        boundaryAt: now - 2 * ORPHAN_AGE_MS,
+        withOutput: false,
+      }),
+    };
+    // On the first awaited baseline load, simulate a concurrent tick claiming
+    // a new job for source-B and bootstrapping its fork: the fork's
+    // lastMessageAt is OLD (inherited from the copied prefix), so the age
+    // cutoff alone would classify it as an orphan.
+    let injected = false;
+    spyOn(pluginApi, "getMessages").mockImplementation(
+      async (conversationId: string) => {
+        if (!injected) {
+          injected = true;
+          mockConversations.push({
+            id: "mid-sweep-fork",
+            source: "memory-retrospective-fork",
+            last_message_at: now - 2 * ORPHAN_AGE_MS,
+            fork_parent_conversation_id: "source-B",
+            created_at: now,
+          });
+          mockJobs.push({
+            type: "memory_retrospective",
+            status: "running",
+            payload: JSON.stringify({ conversationId: "source-B" }),
+          });
+        }
+        return (mockMessages[conversationId] ?? []) as Awaited<
+          ReturnType<typeof pluginApi.getMessages>
+        >;
+      },
+    );
+
+    const result = await sweepOrphanMemoryRetrospectiveConversations(now);
+
+    expect(deletedIds).not.toContain("mid-sweep-fork");
+    expect(result.swept).toBe(1);
+    expect(deletedIds).toEqual(["fork-orphan"]);
   });
 
   test("legacy-kind selection: ANY assistant message counts as output (no fork boundary required)", async () => {
@@ -550,7 +601,6 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
       ],
       "legacy-orphan": [],
     };
-    rebuildActiveJobSet();
 
     const result = await sweepOrphanMemoryRetrospectiveConversations(now);
 

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -258,16 +258,16 @@ export function startInProcessMemoryJobsWorker(
 
   // After running-job recovery (so legitimate in-flight retries aren't
   // swept), clean up orphan memory-retrospective background conversations
-  // left behind by daemon crashes mid-job. Best-effort — never block worker
-  // startup on cleanup failures.
-  try {
-    sweepOrphanMemoryRetrospectiveConversations();
-  } catch (err) {
+  // left behind by daemon crashes mid-job. Best-effort and detached — worker
+  // startup never blocks on the sweep, and failures only log. Concurrent
+  // ticking is safe: the sweep's orphan snapshot predates any job a tick
+  // starts, and fresh conversations are protected by the 1-hour cutoff.
+  void sweepOrphanMemoryRetrospectiveConversations().catch((err: unknown) => {
     log.warn(
       { err },
       "Memory-retrospective startup cleanup failed; continuing worker startup",
     );
-  }
+  });
 
   let stopped = false;
   let tickRunning = false;
@@ -871,7 +871,9 @@ function isWithinPkbActiveHours(
   start: number | null,
   end: number | null,
 ): boolean {
-  if (start == null || end == null) return true;
+  if (start == null || end == null) {
+    return true;
+  }
   if (start <= end) {
     return hour >= start && hour < end;
   }

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -260,8 +260,10 @@ export function startInProcessMemoryJobsWorker(
   // swept), clean up orphan memory-retrospective background conversations
   // left behind by daemon crashes mid-job. Best-effort and detached — worker
   // startup never blocks on the sweep, and failures only log. Concurrent
-  // ticking is safe: the sweep's orphan snapshot predates any job a tick
-  // starts, and fresh conversations are protected by the 1-hour cutoff.
+  // ticking is safe: the sweep reads the active-job set and the orphan
+  // candidates in one synchronous block after its awaited baseline loads, so
+  // a retrospective forked by a mid-sweep tick is protected by its
+  // pending/running job.
   void sweepOrphanMemoryRetrospectiveConversations().catch((err: unknown) => {
     log.warn(
       { err },

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-fork-boundary.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-fork-boundary.ts
@@ -8,7 +8,8 @@
 // next run's dedup baseline). Lives in its own module so the sweep doesn't
 // have to import the job handler's full dependency graph.
 
-import { getMessages } from "../../../persistence/conversation-crud.js";
+import { getMessages } from "@vellumai/plugin-api";
+
 import { getLogger } from "../../../util/logger.js";
 import { MEMORY_RETROSPECTIVE_FORK_SOURCE } from "./memory-retrospective-constants.js";
 
@@ -33,7 +34,9 @@ export function findForkBoundaryCreatedAt(
 ): number | null {
   for (let i = forkMessages.length - 1; i >= 0; i--) {
     const row = forkMessages[i]!;
-    if (!row.metadata) continue;
+    if (!row.metadata) {
+      continue;
+    }
     try {
       const parsed = JSON.parse(row.metadata) as {
         forkSourceMessageId?: unknown;
@@ -63,13 +66,13 @@ export function findForkBoundaryCreatedAt(
  * metadata) — so callers degrade (empty dedup baseline / "no output").
  * Best-effort: failures are logged, never thrown.
  */
-export function loadRetrospectiveRunMessages(
+export async function loadRetrospectiveRunMessages(
   conversationId: string,
   source: string | null | undefined,
-): ReturnType<typeof getMessages> | null {
-  let messages: ReturnType<typeof getMessages>;
+): Promise<Awaited<ReturnType<typeof getMessages>> | null> {
+  let messages: Awaited<ReturnType<typeof getMessages>>;
   try {
-    messages = getMessages(conversationId);
+    messages = await getMessages(conversationId);
   } catch (err) {
     log.warn(
       { err, retrospectiveConversationId: conversationId },

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -920,7 +920,7 @@ async function extractRetrospectiveRunRemembers(
   conversationId: string,
 ): Promise<string[]> {
   const conv = await getConversation(conversationId);
-  const runMessages = loadRetrospectiveRunMessages(
+  const runMessages = await loadRetrospectiveRunMessages(
     conversationId,
     conv?.source ?? null,
   );

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-skill-card.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-skill-card.ts
@@ -79,7 +79,7 @@ export interface AuthoredSkill {
 export async function extractRetrospectiveRunSkillScaffolds(
   retrospectiveConversationId: string,
 ): Promise<AuthoredSkill[]> {
-  const runMessages = loadRetrospectiveRunMessages(
+  const runMessages = await loadRetrospectiveRunMessages(
     retrospectiveConversationId,
     (await getConversation(retrospectiveConversationId))?.source ?? null,
   );

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-startup-cleanup.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-startup-cleanup.ts
@@ -109,28 +109,6 @@ export async function sweepOrphanMemoryRetrospectiveConversations(
     return { swept: 0 };
   }
 
-  // Job payloads encode the SOURCE conversation id (the conversation being
-  // analyzed), not the background-conversation id of the retrospective itself.
-  // The background conversation links back to its source via
-  // `forkParentConversationId` (set when bootstrapped — see
-  // memory-retrospective-job.ts). To protect in-flight jobs we therefore
-  // compare source-id to source-id by filtering on
-  // `conversations.forkParentConversationId`, not `conversations.id`.
-  const activeJobSourceConversationIds = memoryDb
-    .select({
-      conversationId: sql<string>`json_extract(${memoryJobs.payload}, '$.conversationId')`,
-    })
-    .from(memoryJobs)
-    .where(
-      and(
-        eq(memoryJobs.type, "memory_retrospective"),
-        inArray(memoryJobs.status, ["pending", "running"]),
-      ),
-    )
-    .all()
-    .map((row) => row.conversationId)
-    .filter((id): id is string => typeof id === "string" && id.length > 0);
-
   // Compute the preserved dedup baseline per source. Runs whose state row
   // predates the persisted `remembered_log` pull dedup context by scanning
   // the most-recent prior retro (via `findMostRecentRetrospectiveFor`);
@@ -167,6 +145,35 @@ export async function sweepOrphanMemoryRetrospectiveConversations(
   for (const rows of retrosPerSource.values()) {
     preservedIds.add(await selectPreservedBaseline(rows));
   }
+
+  // Job payloads encode the SOURCE conversation id (the conversation being
+  // analyzed), not the background-conversation id of the retrospective itself.
+  // The background conversation links back to its source via
+  // `forkParentConversationId` (set when bootstrapped — see
+  // memory-retrospective-job.ts). To protect in-flight jobs we therefore
+  // compare source-id to source-id by filtering on
+  // `conversations.forkParentConversationId`, not `conversations.id`.
+  //
+  // Read in the same synchronous block as the orphan query below — AFTER the
+  // awaited baseline loads above. The sweep runs concurrently with worker
+  // ticking, and a retrospective forked while baselines were loading inherits
+  // the copied source prefix's old `lastMessageAt`, so the age cutoff alone
+  // does not protect it; its pending/running job must be in this set when the
+  // orphan candidates are classified.
+  const activeJobSourceConversationIds = memoryDb
+    .select({
+      conversationId: sql<string>`json_extract(${memoryJobs.payload}, '$.conversationId')`,
+    })
+    .from(memoryJobs)
+    .where(
+      and(
+        eq(memoryJobs.type, "memory_retrospective"),
+        inArray(memoryJobs.status, ["pending", "running"]),
+      ),
+    )
+    .all()
+    .map((row) => row.conversationId)
+    .filter((id): id is string => typeof id === "string" && id.length > 0);
 
   const orphans = db
     .select({ id: conversations.id })

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-startup-cleanup.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-startup-cleanup.ts
@@ -39,6 +39,7 @@
 // The sweep is skipped entirely when `memory.retrospective.keepSupersededRuns`
 // is true — see the comment inside the function.
 
+import { deleteConversation } from "@vellumai/plugin-api";
 import {
   and,
   eq,
@@ -51,7 +52,6 @@ import {
   sql,
 } from "drizzle-orm";
 
-import { deleteConversation } from "../../../persistence/conversation-crud.js";
 import { getDb, getMemoryDb } from "../../../persistence/db-connection.js";
 import {
   conversations,
@@ -85,9 +85,9 @@ export interface CleanupResult {
  * deleted. Best-effort: errors deleting individual rows are logged and the
  * sweep continues.
  */
-export function sweepOrphanMemoryRetrospectiveConversations(
+export async function sweepOrphanMemoryRetrospectiveConversations(
   now: number = Date.now(),
-): CleanupResult {
+): Promise<CleanupResult> {
   // When the operator opted into retaining superseded retrospective runs
   // (`memory.retrospective.keepSupersededRuns`), skip the sweep entirely —
   // retained runs must survive restarts, and the sweep cannot distinguish a
@@ -153,7 +153,9 @@ export function sweepOrphanMemoryRetrospectiveConversations(
   const retrosPerSource = new Map<string, RetroRow[]>();
   for (const row of allRetros) {
     const parent = row.forkParentConversationId;
-    if (parent === null) continue;
+    if (parent === null) {
+      continue;
+    }
     const rows = retrosPerSource.get(parent);
     if (rows) {
       rows.push(row);
@@ -163,7 +165,7 @@ export function sweepOrphanMemoryRetrospectiveConversations(
   }
   const preservedIds = new Set<string>();
   for (const rows of retrosPerSource.values()) {
-    preservedIds.add(selectPreservedBaseline(rows));
+    preservedIds.add(await selectPreservedBaseline(rows));
   }
 
   const orphans = db
@@ -198,7 +200,7 @@ export function sweepOrphanMemoryRetrospectiveConversations(
   let swept = 0;
   for (const row of orphans) {
     try {
-      deleteConversation(row.id);
+      await deleteConversation(row.id);
       swept++;
     } catch (err) {
       log.warn(
@@ -240,12 +242,14 @@ interface RetroRow {
  * Only loads messages for the newest `MAX_BASELINE_CANDIDATES_PER_SOURCE`
  * rows — never for every retro row.
  */
-function selectPreservedBaseline(rows: RetroRow[]): string {
+async function selectPreservedBaseline(rows: RetroRow[]): Promise<string> {
   const sorted = [...rows].sort((a, b) => b.createdAt - a.createdAt);
-  const withOutput = sorted
-    .slice(0, MAX_BASELINE_CANDIDATES_PER_SOURCE)
-    .find(retrospectiveHasOutput);
-  return (withOutput ?? sorted[0]!).id;
+  for (const row of sorted.slice(0, MAX_BASELINE_CANDIDATES_PER_SOURCE)) {
+    if (await retrospectiveHasOutput(row)) {
+      return row.id;
+    }
+  }
+  return sorted[0]!.id;
 }
 
 /**
@@ -257,8 +261,10 @@ function selectPreservedBaseline(rows: RetroRow[]): string {
  * (`collectPriorRetrospectiveRemembers` treats them as empty), so they don't
  * qualify. Legacy-kind rows start empty, so any assistant message counts.
  */
-function retrospectiveHasOutput(row: RetroRow): boolean {
-  const runMessages = loadRetrospectiveRunMessages(row.id, row.source);
-  if (runMessages == null) return false;
+async function retrospectiveHasOutput(row: RetroRow): Promise<boolean> {
+  const runMessages = await loadRetrospectiveRunMessages(row.id, row.source);
+  if (runMessages == null) {
+    return false;
+  }
   return runMessages.some((m) => m.role === "assistant");
 }


### PR DESCRIPTION
## Summary
- `memory-retrospective-fork-boundary.ts` and `memory-retrospective-startup-cleanup.ts` now use `getMessages` / `deleteConversation` from `@vellumai/plugin-api` instead of importing `persistence/conversation-crud.js` directly. Their call roots (`jobs-worker.ts` startup sweep, retrospective job, skill-card extractor) are all plugin-internal since the worker moved into the plugin (#37134), so the async-ification the lazy facade requires is fully absorbed inside the plugin: `loadRetrospectiveRunMessages`, `sweepOrphanMemoryRetrospectiveConversations`, and the baseline-selection helpers are now async; the two already-async extractor call sites gained awaits.
- **Two deliberate behavior improvements on the orphan sweep's delete path** (previously the sync crud `deleteConversation`): deletes now run through the facade composite, i.e. the off-event-loop batched `deleteConversationGently` (the worker's event loop no longer stalls on bulky `llm_request_logs` drains), and any linked segment/summary ids get `delete_qdrant_vectors` enqueues instead of being silently discarded (a no-op for typical retro rows, which carry no segments).
- The worker startup sweep is now detached (`void …().catch`) — worker startup never blocks on the sweep. Ordering vs. running-job recovery is unchanged (the call still happens after `resetRunningJobsToPending`); the sweep's conservatism (1-hour cutoff + active-job guard) covers concurrent ticking.
- Test: the startup-cleanup suite stubs the two contract fns with per-test `spyOn` on the plugin-api namespace (restored in `afterEach`) instead of a `mock.module` of `conversation-crud` — a module mock there replaces the registry for other test files sharing a process (verified: batched runs with the skill-card suite now match main exactly, both orders).

Part of the memory-as-a-plugin effort (BYO memory north star): burns the retrospective's direct crud coupling down to the modules that genuinely wait on the P2 design round (`enqueue`, `accounting`'s unblessed `getMessagesAfter`/`countMessagesAfter`) or the storage phase (`db-connection`/`schema`). Forward boundary baseline unchanged (the `conversation-crud` specifier survives via those holdouts). Zero `@vellumai/plugin-api` changes.