### PR TITLE
refactor(web): remove analyze-conversation UI wiring

### DIFF
--- a/clients/web/docs/CONVENTIONS.md
+++ b/clients/web/docs/CONVENTIONS.md
@@ -85,7 +85,7 @@ structured data (`ChatHeaderSupplements`) that `ChatLayout` renders
 directly. This keeps conversation-action callbacks in `ChatLayout`
 (which owns `useConversationActions`) instead of duplicating them in
 `ActiveChatView`. The supplements carry only the few chat-specific
-values the header menu needs (fork, analyze, inspect callbacks, slack
+values the header menu needs (fork, inspect callbacks, slack
 label, `hasPersistedMessage`).
 
 A Zustand store rather than outlet context because `ActiveAssistantGate`

--- a/clients/web/src/components/layout/chat-layout-slots-store.ts
+++ b/clients/web/src/components/layout/chat-layout-slots-store.ts
@@ -41,7 +41,6 @@ export interface ChatHeaderSupplements {
   channelHeaderChannelId: string | null;
   /** Secondary action callbacks — ChatPage-specific because they need
    *  access to the message list, active stream, or ChatPage-local state. */
-  onAnalyze: ((conversation: Conversation) => void) | null;
   onForkConversation: (() => void) | null;
   onOpenInNewWindow: ((conversation: Conversation) => void) | null;
   onInspect: ((conversation: Conversation) => void) | null;

--- a/clients/web/src/domains/chat/active-chat-view.tsx
+++ b/clients/web/src/domains/chat/active-chat-view.tsx
@@ -227,7 +227,6 @@ export function ActiveChatView() {
   // -------------------------------------------------------------------------
   const {
     refreshConversations,
-    switchConversation,
     startNewConversation,
     conversationExistsOnServer,
     historyResult,
@@ -383,7 +382,7 @@ export function ActiveChatView() {
   });
 
   // -------------------------------------------------------------------------
-  // Conversation secondary actions (fork, analyze, inspect, copy, etc.)
+  // Conversation secondary actions (fork, inspect, copy, etc.)
   // Primary actions (archive, pin, rename, mark-read) are owned by
   // ChatConversationHeader in chat-layout.tsx.
   // -------------------------------------------------------------------------
@@ -391,7 +390,6 @@ export function ActiveChatView() {
     handleForkConversation,
     handleForkConversationFromMenu,
     handleSummarizeUpToMessage,
-    handleAnalyzeConversation,
     handleOpenInNewWindow,
     handleInspectConversation,
     handleInspectMessage,
@@ -399,7 +397,6 @@ export function ActiveChatView() {
   } = useConversationSecondaryActions({
     activeConversation: activeConversation ?? null,
     refreshConversations,
-    switchConversation,
   });
 
   // "Summarize up to here" confirm dialog. The hover action only records the
@@ -443,7 +440,6 @@ export function ActiveChatView() {
   // -------------------------------------------------------------------------
   useChatHeaderRegistration({
     assetsRefreshKey,
-    handleAnalyzeConversation,
     handleForkConversationFromMenu,
     handleOpenInNewWindow,
     handleInspectConversation,

--- a/clients/web/src/domains/chat/chat-conversation-header.tsx
+++ b/clients/web/src/domains/chat/chat-conversation-header.tsx
@@ -61,11 +61,6 @@ export function ChatConversationHeader({
       onRename={() => onRename(activeConversation)}
       onArchive={() => onArchive(activeConversation)}
       onUnarchive={() => onUnarchive(activeConversation)}
-      onAnalyze={
-        !isReadonly && headerSupplements?.onAnalyze && activeConversation.conversationId
-          ? () => headerSupplements.onAnalyze!(activeConversation)
-          : undefined
-      }
       onForkConversation={
         !isReadonly && headerSupplements?.hasPersistedMessage && headerSupplements?.onForkConversation
           ? headerSupplements.onForkConversation

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -80,7 +80,6 @@ export interface AssistantSideMenuProps extends UseSidebarStateParams {
   onArchiveAllInGroup?: (groupName: string, conversations: Conversation[]) => void;
   processingConversationIds?: Set<string>;
   activeConversationProcessing?: boolean;
-  onAnalyze?: (conversation: Conversation) => void;
   onOpenInNewWindow?: (conversation: Conversation) => void;
   onShareFeedback?: () => void;
   onInspect?: (conversation: Conversation) => void;
@@ -166,7 +165,6 @@ export function AssistantSideMenu({
   processingConversationIds,
   attentionConversationIds,
   activeConversationProcessing,
-  onAnalyze,
   onOpenInNewWindow,
   onShareFeedback,
   onInspect,
@@ -237,7 +235,6 @@ export function AssistantSideMenu({
     onUnarchive: onUnarchiveConversation,
     onMarkRead: onMarkConversationRead,
     onMarkUnread: onMarkConversationUnread,
-    onAnalyze,
     onOpenInNewWindow,
     onShareFeedback,
     onInspect,

--- a/clients/web/src/domains/chat/components/conversation-actions-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-actions-menu.test.tsx
@@ -155,19 +155,17 @@ describe("renderConversationMenuItems", () => {
     expect(html).toContain("Unarchive");
   });
 
-  test("hides Mark as unread and Analyze when isReadonly", () => {
+  test("hides Mark as unread when isReadonly", () => {
     const html = renderToStaticMarkup(
       <>{renderConversationMenuItems({
         Primitive: Menu as unknown as ConversationMenuPrimitive,
         isReadonly: true,
         onArchive: () => {},
-        onAnalyze: () => {},
         onMarkUnread: () => {},
       })}</>,
     );
     expect(html).toContain("Archive");
     expect(html).not.toContain("Mark as unread");
-    expect(html).not.toContain("Analyze");
   });
 
   test("renders header variant with correct item order", () => {
@@ -177,14 +175,12 @@ describe("renderConversationMenuItems", () => {
         variant: "header",
         onCopyConversation: () => {},
         onForkConversation: () => {},
-        onAnalyze: () => {},
         onPinToggle: () => {},
         onRename: () => {},
       })}</>,
     );
     expect(html).toContain("Copy full conversation");
     expect(html).toContain("Fork conversation");
-    expect(html).toContain("Analyze conversation");
     expect(html).toContain("Pin");
     expect(html).toContain("Rename");
   });
@@ -310,14 +306,12 @@ describe("ConversationActionsMenu — mobile panel details", () => {
         variant="header"
         onCopyConversation={() => {}}
         onForkConversation={() => {}}
-        onAnalyze={() => {}}
         onPinToggle={() => {}}
         onRename={() => {}}
       />,
     );
     expect(html).toContain("Copy full conversation");
     expect(html).toContain("Fork conversation");
-    expect(html).toContain("Analyze conversation");
     expect(html).toContain("Pin");
     expect(html).toContain("Rename");
   });
@@ -330,13 +324,11 @@ describe("ConversationActionsMenu — read-only conversations", () => {
       <ConversationActionsMenu
         isReadonly
         onArchive={() => {}}
-        onAnalyze={() => {}}
         onMarkUnread={() => {}}
       />,
     );
     expect(html).toContain("Archive");
     expect(html).not.toContain("Mark as unread");
-    expect(html).not.toContain("Analyze");
   });
 
   test("Unarchive renders when archived and read-only", () => {

--- a/clients/web/src/domains/chat/components/conversation-actions-menu.tsx
+++ b/clients/web/src/domains/chat/components/conversation-actions-menu.tsx
@@ -13,7 +13,6 @@ import {
     Pin,
     PinOff,
     RefreshCw,
-    Sparkles,
     type LucideIcon,
 } from "lucide-react";
 import { useState, type ReactNode } from "react";
@@ -91,7 +90,7 @@ export interface ConversationMenuItemsProps {
    */
   onMarkRead?: () => void;
   /**
-   * Hide write-affording menu items (Mark-as-read/unread, Analyze) when
+   * Hide write-affording menu items (Mark-as-read/unread) when
    * the conversation is read-only. Items are hidden entirely, not
    * disabled. Today this fires for channel-bound conversations (Slack,
    * Telegram, voice) where outbound writes aren't mirrored back to the
@@ -105,8 +104,6 @@ export interface ConversationMenuItemsProps {
    * to be able to tidy them up.
    */
   isReadonly?: boolean;
-  /** Trigger an analysis of this conversation via the daemon. */
-  onAnalyze?: () => void;
   /** Open this conversation in a new browser tab. */
   onOpenInNewWindow?: () => void;
   /** Fork the conversation through the latest persisted message. */
@@ -146,7 +143,6 @@ export function renderConversationMenuItems({
   isMarkUnreadDisabled = false,
   onMarkRead,
   isReadonly = false,
-  onAnalyze,
   onForkConversation,
   onOpenInNewWindow,
   onShareFeedback,
@@ -204,13 +200,6 @@ export function renderConversationMenuItems({
       </Primitive.Item>
     ) : null;
 
-  const analyzeItem =
-    !isReadonly && onAnalyze ? (
-      <Primitive.Item leftIcon={<Sparkles size={14} />} onSelect={onAnalyze}>
-        {variant === "header" ? "Analyze conversation" : "Analyze"}
-      </Primitive.Item>
-    ) : null;
-
   const openInNewWindowItem =
     onOpenInNewWindow ? (
       <Primitive.Item
@@ -248,7 +237,6 @@ export function renderConversationMenuItems({
           </Primitive.Item>
         ) : null}
 
-        {analyzeItem}
         {openInNewWindowItem}
 
         {onRefresh ? (
@@ -275,7 +263,6 @@ export function renderConversationMenuItems({
       {archiveItem}
 
       {markReadUnreadItem}
-      {analyzeItem}
       {openInNewWindowItem}
 
       {onShareFeedback ? (
@@ -378,7 +365,6 @@ function renderConversationMenuItemsAsPanelItems({
   isMarkUnreadDisabled = false,
   onMarkRead,
   isReadonly = false,
-  onAnalyze,
   onForkConversation,
   onOpenInNewWindow,
   onShareFeedback,
@@ -451,17 +437,6 @@ function renderConversationMenuItemsAsPanelItems({
           })
         : null;
 
-  const analyzeItem =
-    !isReadonly && onAnalyze
-      ? buildPanelItem({
-          key: "analyze",
-          icon: Sparkles,
-          label: variant === "header" ? "Analyze conversation" : "Analyze",
-          run: onAnalyze,
-          onClose,
-        })
-      : null;
-
   const openInNewWindowItem =
     onOpenInNewWindow && !isNativePlatform
       ? buildPanelItem({
@@ -507,7 +482,6 @@ function renderConversationMenuItemsAsPanelItems({
             })
           : null}
 
-        {analyzeItem}
         {openInNewWindowItem}
 
         {onRefresh
@@ -534,7 +508,6 @@ function renderConversationMenuItemsAsPanelItems({
       {renameItem}
       {archiveItem}
       {markReadUnreadItem}
-      {analyzeItem}
       {openInNewWindowItem}
 
       {onShareFeedback ? (

--- a/clients/web/src/domains/chat/components/conversation-list-context.tsx
+++ b/clients/web/src/domains/chat/components/conversation-list-context.tsx
@@ -32,7 +32,6 @@ export interface ConversationListContextValue {
   onUnarchive?: (conversation: Conversation) => void;
   onMarkRead?: (conversation: Conversation) => void;
   onMarkUnread?: (conversation: Conversation) => void;
-  onAnalyze?: (conversation: Conversation) => void;
   onOpenInNewWindow?: (conversation: Conversation) => void;
   onShareFeedback?: () => void;
   onInspect?: (conversation: Conversation) => void;

--- a/clients/web/src/domains/chat/components/conversation-row.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-row.test.tsx
@@ -37,22 +37,12 @@ function conv(overrides: Partial<Conversation> = {}): Conversation {
 }
 
 describe("buildMenuProps", () => {
-  test("marks channel conversations read-only and omits analyze", () => {
-    const props = buildMenuProps(
-      makeCtx({ onAnalyze: () => {} }),
-      conv({ originChannel: "telegram" }),
-    );
-    expect(props.isReadonly).toBe(true);
-    expect(props.onAnalyze).toBeUndefined();
-  });
+  test("marks channel conversations read-only", () => {
+    const channel = buildMenuProps(makeCtx(), conv({ originChannel: "telegram" }));
+    expect(channel.isReadonly).toBe(true);
 
-  test("wires analyze for native conversations", () => {
-    const props = buildMenuProps(
-      makeCtx({ onAnalyze: () => {} }),
-      conv({ originChannel: "vellum" }),
-    );
-    expect(props.isReadonly).toBe(false);
-    expect(typeof props.onAnalyze).toBe("function");
+    const native = buildMenuProps(makeCtx(), conv({ originChannel: "vellum" }));
+    expect(native.isReadonly).toBe(false);
   });
 
   test("only wires callbacks the context provides", () => {

--- a/clients/web/src/domains/chat/components/conversation-row.tsx
+++ b/clients/web/src/domains/chat/components/conversation-row.tsx
@@ -76,10 +76,6 @@ export function buildMenuProps(
         ? () => ctx.onMarkUnread?.(conversation)
         : undefined,
     isMarkUnreadDisabled: !canMarkUnread(conversation),
-    onAnalyze:
-      ctx.onAnalyze && hasId && !isChannel
-        ? () => ctx.onAnalyze?.(conversation)
-        : undefined,
     onOpenInNewWindow:
       ctx.onOpenInNewWindow && hasId
         ? () => ctx.onOpenInNewWindow?.(conversation)

--- a/clients/web/src/domains/chat/hooks/use-chat-header-registration.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-header-registration.test.tsx
@@ -84,7 +84,6 @@ function renderRegistration() {
   return renderHook(() =>
     useChatHeaderRegistration({
       assetsRefreshKey: 0,
-      handleAnalyzeConversation: async () => {},
       handleForkConversationFromMenu: () => {},
       handleOpenInNewWindow: () => {},
       handleInspectConversation: () => {},

--- a/clients/web/src/domains/chat/hooks/use-chat-header-registration.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-header-registration.tsx
@@ -38,7 +38,6 @@ import type { Conversation } from "@/types/conversation-types";
 
 export interface UseChatHeaderRegistrationOptions {
   assetsRefreshKey: number;
-  handleAnalyzeConversation: (conversation: Conversation) => Promise<void>;
   handleForkConversationFromMenu: () => void;
   handleOpenInNewWindow: (conversation: Conversation) => void;
   handleInspectConversation: (conversation: Conversation) => void;
@@ -48,7 +47,6 @@ export interface UseChatHeaderRegistrationOptions {
 
 export function useChatHeaderRegistration({
   assetsRefreshKey,
-  handleAnalyzeConversation,
   handleForkConversationFromMenu,
   handleOpenInNewWindow,
   handleInspectConversation,
@@ -116,7 +114,6 @@ export function useChatHeaderRegistration({
     hasPersistedMessage,
     channelHeaderLabel,
     channelHeaderChannelId,
-    onAnalyze: handleAnalyzeConversation,
     onForkConversation: handleForkConversationFromMenu,
     onOpenInNewWindow: handleOpenInNewWindow,
     onInspect: handleInspectConversation,
@@ -126,7 +123,6 @@ export function useChatHeaderRegistration({
     hasPersistedMessage,
     channelHeaderLabel,
     channelHeaderChannelId,
-    handleAnalyzeConversation,
     handleForkConversationFromMenu,
     handleOpenInNewWindow,
     handleInspectConversation,

--- a/clients/web/src/domains/chat/hooks/use-conversation-secondary-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-secondary-actions.ts
@@ -1,5 +1,5 @@
 /**
- * Conversation secondary actions — fork, analyze, inspect, open-in-new-window,
+ * Conversation secondary actions — fork, inspect, open-in-new-window,
  * copy transcript, and share-feedback modal state.
  *
  * These are the "utility" actions surfaced in the conversation header chevron
@@ -19,7 +19,6 @@ import { toast } from "@vellumai/design-library";
 
 import type { Conversation } from "@/types/conversation-types";
 import {
-  conversationsByIdAnalyzePost,
   conversationsForkPost,
   conversationsSummarizePost,
 } from "@/generated/daemon/sdk.gen";
@@ -29,7 +28,6 @@ import { openPopoutWindow } from "@/runtime/popout-window";
 import { routes } from "@/utils/routes";
 import { haptic } from "@/utils/haptics";
 import { messagePlainText } from "@/domains/chat/utils/message-plain-text";
-import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
@@ -43,7 +41,6 @@ import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 export interface UseConversationSecondaryActionsParams {
   activeConversation: Conversation | null | undefined;
   refreshConversations: () => void;
-  switchConversation: (key: string) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -54,7 +51,6 @@ export interface UseConversationSecondaryActionsReturn {
   handleForkConversation: (throughMessageId: string) => Promise<void>;
   handleForkConversationFromMenu: () => void;
   handleSummarizeUpToMessage: (beforeMessageId: string) => Promise<void>;
-  handleAnalyzeConversation: (conversation: Conversation) => Promise<void>;
   handleOpenInNewWindow: (conversation: Conversation) => void;
   handleInspectConversation: (conversation: Conversation) => void;
   handleInspectMessage: (messageId: string) => void;
@@ -93,7 +89,6 @@ function turnHeadMessageId(
 export function useConversationSecondaryActions({
   activeConversation,
   refreshConversations,
-  switchConversation,
 }: UseConversationSecondaryActionsParams): UseConversationSecondaryActionsReturn {
   const navigate = useNavigate();
 
@@ -172,27 +167,6 @@ export function useConversationSecondaryActions({
     void handleForkConversation(throughMessageId);
   }, [handleForkConversation]);
 
-  const handleAnalyzeConversation = useCallback(
-    async (conversation: Conversation) => {
-      const assistantId = useResolvedAssistantsStore.getState().activeAssistantId;
-      if (!assistantId) return;
-      try {
-        const { data } = await conversationsByIdAnalyzePost({
-          path: { assistant_id: assistantId, id: conversation.conversationId },
-          throwOnError: true,
-        });
-        await refreshConversations();
-        switchConversation(data.conversation.id);
-      } catch (err) {
-        const message =
-          err instanceof Error ? err.message : "Failed to analyze conversation.";
-        useChatSessionStore.getState().setError({ message });
-        captureError(err, { context: "analyzeConversation" });
-      }
-    },
-    [refreshConversations, switchConversation],
-  );
-
   const handleOpenInNewWindow = useCallback(
     (conversation: Conversation) => {
       if (isElectron()) {
@@ -268,7 +242,6 @@ export function useConversationSecondaryActions({
     handleForkConversation,
     handleForkConversationFromMenu,
     handleSummarizeUpToMessage,
-    handleAnalyzeConversation,
     handleOpenInNewWindow,
     handleInspectConversation,
     handleInspectMessage,


### PR DESCRIPTION
## Summary
- Remove the "Analyze conversation" / "Analyze" menu item from the conversation header dropdown, sidebar row menu, and mobile bottom sheet (`conversation-actions-menu.tsx`), plus the dormant `onAnalyze` plumbing through `conversation-list-context`, `assistant-side-menu`, `conversation-row`, and the header-supplements slot store.
- Remove `handleAnalyzeConversation` from `use-conversation-secondary-actions` (and the now-unused `switchConversation` param) and its registration in `use-chat-header-registration` / `active-chat-view`.
- The analyze-conversation feature never GA'd and is superseded by memory retrospectives. This PR de-references the generated `conversationsByIdAnalyzePost` SDK call so the backend route + LLM call site + feature flags can be removed in a follow-up PR without breaking the web typecheck.

## Original prompt
Clean up the deprecated analyze-conversation feature (never GA'd, superseded by adding features to memory retrospectives). Plan: PR 1 removes the clients/web UI wiring; PR 2 removes the backend service/route/job/LLM call site + both feature flags + a workspace config migration; a companion vellum-assistant-platform PR removes the flags from Terraform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)