### PR TITLE
perf(persistence): serialize bulk subprocess writers behind a FIFO gate

### DIFF
--- a/assistant/src/persistence/__tests__/bulk-write-gate.test.ts
+++ b/assistant/src/persistence/__tests__/bulk-write-gate.test.ts
@@ -1,0 +1,165 @@
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, mock, test } from "bun:test";
+
+import { assertNotLiveDb } from "../../__tests__/assert-not-live-db.js";
+import { makeMockLogger } from "../../__tests__/helpers/mock-logger.js";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+import { bulkWriteGateHolder, withBulkWriteGate } from "../bulk-write-gate.js";
+import { deleteConversationRowsInBatches } from "../conversation-row-batch-delete.js";
+import { copyForkMessagesViaSubprocess } from "../fork-message-copy.js";
+
+/** A promise whose resolution the test controls. */
+function deferred(): { promise: Promise<void>; release: () => void } {
+  let release!: () => void;
+  const promise = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return { promise, release };
+}
+
+describe("withBulkWriteGate", () => {
+  test("runs callers FIFO, one at a time", async () => {
+    const events: string[] = [];
+    const first = deferred();
+
+    const run = (id: string, block?: Promise<void>) =>
+      withBulkWriteGate(id, async () => {
+        events.push(`${id}:start`);
+        if (block) {
+          await block;
+        }
+        events.push(`${id}:end`);
+      });
+
+    const p1 = run("a", first.promise);
+    const p2 = run("b");
+    const p3 = run("c");
+
+    await Bun.sleep(20);
+    expect(events).toEqual(["a:start"]);
+
+    first.release();
+    await Promise.all([p1, p2, p3]);
+    expect(events).toEqual([
+      "a:start",
+      "a:end",
+      "b:start",
+      "b:end",
+      "c:start",
+      "c:end",
+    ]);
+  });
+
+  test("releases on throw and propagates the error", async () => {
+    const failing = withBulkWriteGate("boom", async () => {
+      throw new Error("kaput");
+    });
+    await expect(failing).rejects.toThrow("kaput");
+
+    const after = await withBulkWriteGate("after", async () => 42);
+    expect(after).toBe(42);
+  });
+
+  test("returns the wrapped value and reports the holder label", async () => {
+    const holdersWhileRunning: Array<string | null> = [];
+    const value = await withBulkWriteGate("labelled", async () => {
+      holdersWhileRunning.push(bulkWriteGateHolder());
+      return "ok";
+    });
+    expect(value).toBe("ok");
+    expect(holdersWhileRunning).toEqual(["labelled"]);
+    expect(bulkWriteGateHolder()).toBeNull();
+  });
+});
+
+describe("gated bulk writers", () => {
+  test("fork message-copy queues behind a held gate", async () => {
+    const holder = deferred();
+    const holding = withBulkWriteGate("holder", () => holder.promise);
+
+    let copySettled = false;
+    const copy = copyForkMessagesViaSubprocess({
+      forkConversationId: "fork-1",
+      idPairs: [{ oldId: "old-1", newId: "new-1" }],
+      forceInProcess: true,
+    }).then((result) => {
+      copySettled = true;
+      return result;
+    });
+
+    await Bun.sleep(20);
+    expect(copySettled).toBe(false);
+
+    holder.release();
+    await holding;
+    await copy;
+    expect(copySettled).toBe(true);
+  });
+
+  test("empty fork message-copy skips the gate entirely", async () => {
+    const holder = deferred();
+    const holding = withBulkWriteGate("holder", () => holder.promise);
+
+    const result = await copyForkMessagesViaSubprocess({
+      forkConversationId: "fork-1",
+      idPairs: [],
+    });
+    expect(result.ok).toBe(true);
+
+    holder.release();
+    await holding;
+  });
+
+  test("main-DB batched delete queues behind a held gate", async () => {
+    const holder = deferred();
+    const holding = withBulkWriteGate("holder", () => holder.promise);
+
+    let deleteSettled = false;
+    const del = deleteConversationRowsInBatches({
+      conversationId: "conv-1",
+      table: "messages",
+      forceInProcess: true,
+    }).then((result) => {
+      deleteSettled = true;
+      return result;
+    });
+
+    await Bun.sleep(20);
+    expect(deleteSettled).toBe(false);
+
+    holder.release();
+    await holding;
+    await del;
+    expect(deleteSettled).toBe(true);
+  });
+
+  test("dedicated-file batched delete bypasses the gate", async () => {
+    const dbPath = join(tmpdir(), `bulk-write-gate-test-${Date.now()}.db`);
+    const holder = deferred();
+    const holding = withBulkWriteGate("holder", () => holder.promise);
+
+    try {
+      // Must settle while the gate is still held — a dedicated file has its
+      // own write lock, so its drain never queues behind main-DB streams.
+      const result = await deleteConversationRowsInBatches({
+        conversationId: "conv-1",
+        table: "some_table",
+        dbPath,
+        forceInProcess: true,
+      });
+      expect(bulkWriteGateHolder()).toBe("holder");
+      expect(result.backend).toBe("in-process-blocking");
+    } finally {
+      holder.release();
+      await holding;
+      assertNotLiveDb(dbPath);
+      rmSync(dbPath, { force: true });
+    }
+  });
+});

--- a/assistant/src/persistence/bulk-write-gate.ts
+++ b/assistant/src/persistence/bulk-write-gate.ts
@@ -1,0 +1,82 @@
+// ---------------------------------------------------------------------------
+// Bulk-write gate — process-wide FIFO serialization of bulk main-DB writers.
+// ---------------------------------------------------------------------------
+//
+// The batched bulk writers (fork message-copy, conversation-row batch delete)
+// each hold the main database's write lock only briefly per batch — but SQLite
+// has a single writer, so two bulk streams running concurrently gain no
+// throughput. They only convoy: every batch of each stream contends with the
+// other's (waiting up to `busy_timeout`), and the inter-batch yield each
+// stream inserts for foreground fairness is consumed by the sibling stream
+// instead of the live user turn it was meant for. Concurrent streams are
+// reachable because the memory jobs worker groups jobs by
+// `(type, conversationId)` — retrospectives for two different conversations
+// run in parallel.
+//
+// This gate serializes those streams within the process: one bulk writer runs
+// at a time, the rest queue FIFO, and the write lock (plus the yields) go back
+// to foreground writers. Waiters are bounded by the jobs worker's lane
+// concurrency, and the durable jobs queue upstream coalesces to one pending
+// row per conversation, so the gate cannot accumulate an unbounded backlog.
+//
+// Scope and discipline:
+//   - Per-process. The daemon and each worker process have their own gate;
+//     bulk writers live almost entirely in the memory worker, so cross-process
+//     overlap is rare.
+//   - Main DB only. Dedicated files (e.g. the logs DB) have their own write
+//     locks and must not queue behind main-DB streams.
+//   - Callers wrap only their batch loop — never an LLM call, a wake, or an
+//     open transaction — so the worst-case hold is one bulk pass, itself
+//     bounded by {@link BULK_BATCH_TIMEOUT_MS} per batch.
+
+import { getLogger } from "../util/logger.js";
+import { Mutex } from "../util/mutex.js";
+
+const log = getLogger("bulk-write-gate");
+
+/**
+ * Per-batch subprocess timeout for gated bulk writers. `runAsyncSqlite`'s
+ * default cap (1 h) is sized for legitimately long single statements like
+ * `VACUUM`; a gated bulk batch is a sub-second write, so a batch anywhere near
+ * this bound is wedged (stale lock, dead disk) and must fail rather than hold
+ * the gate — and every queued bulk writer behind it — for the full default.
+ */
+export const BULK_BATCH_TIMEOUT_MS = 5 * 60 * 1000;
+
+/** Gate waits longer than this are logged — the convoy-formation signal. */
+const CONTENTION_LOG_THRESHOLD_MS = 1000;
+
+const gate = new Mutex();
+let heldBy: string | null = null;
+
+/** Label of the bulk writer currently holding the gate, or null when free. */
+export function bulkWriteGateHolder(): string | null {
+  return heldBy;
+}
+
+/**
+ * Run `fn` as the sole bulk main-DB writer in this process. Callers queue
+ * FIFO; the gate is released when `fn` settles (resolve or reject), so a
+ * throwing writer never wedges the queue.
+ */
+export async function withBulkWriteGate<T>(
+  label: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const waitStartMs = Date.now();
+  return await gate.withLock(async () => {
+    const waitedMs = Date.now() - waitStartMs;
+    if (waitedMs >= CONTENTION_LOG_THRESHOLD_MS) {
+      log.info(
+        { label, waitedMs },
+        "bulk-write gate: waited for prior bulk writers",
+      );
+    }
+    heldBy = label;
+    try {
+      return await fn();
+    } finally {
+      heldBy = null;
+    }
+  });
+}

--- a/assistant/src/persistence/conversation-row-batch-delete.ts
+++ b/assistant/src/persistence/conversation-row-batch-delete.ts
@@ -34,6 +34,7 @@
 
 import { setTimeout as sleep } from "node:timers/promises";
 
+import { BULK_BATCH_TIMEOUT_MS, withBulkWriteGate } from "./bulk-write-gate.js";
 import {
   type AsyncSqliteBackend,
   type AsyncSqliteResult,
@@ -170,9 +171,23 @@ export async function deleteConversationRowsInBatches(
     runOptions.forceBackend = "in-process-blocking";
   }
   if (options.dbPath !== undefined) {
+    // A dedicated file (e.g. the logs DB) has its own write lock, so its
+    // drain must not queue behind — or hold up — main-DB bulk streams.
     runOptions.dbPath = options.dbPath;
+    return await drainBatches(options, batchSize, runOptions);
   }
 
+  return await withBulkWriteGate(
+    `conversation-row-delete:${options.table}:${options.conversationId}`,
+    () => drainBatches(options, batchSize, runOptions),
+  );
+}
+
+async function drainBatches(
+  options: DeleteConversationRowsOptions,
+  batchSize: number,
+  runOptions: RunAsyncSqliteOptions,
+): Promise<AsyncSqliteResult> {
   let totalElapsedMs = 0;
   let backend: AsyncSqliteBackend = "in-process-blocking";
 
@@ -190,7 +205,7 @@ export async function deleteConversationRowsInBatches(
     const result = await runAsyncSqlite(
       sql,
       `conversation-row-delete:${options.table}:${options.conversationId}`,
-      runOptions,
+      { ...runOptions, timeoutMs: BULK_BATCH_TIMEOUT_MS },
     );
     totalElapsedMs += result.elapsedMs;
     backend = result.backend;

--- a/assistant/src/persistence/fork-message-copy.ts
+++ b/assistant/src/persistence/fork-message-copy.ts
@@ -35,6 +35,7 @@
 
 import { setTimeout as sleep } from "node:timers/promises";
 
+import { BULK_BATCH_TIMEOUT_MS, withBulkWriteGate } from "./bulk-write-gate.js";
 import {
   type AsyncSqliteBackend,
   type AsyncSqliteResult,
@@ -164,7 +165,10 @@ FROM messages m JOIN _fork_id_map map ON map.old_id = m.id;`,
  * batches. Each batch runs as its own subprocess call with a brief yield in
  * between (see {@link DEFAULT_FORK_COPY_INTER_BATCH_DELAY_MS}) so foreground
  * writers reliably acquire the write lock between batches instead of losing
- * every race to the copy's greedy lock re-acquisition. Resolves once every
+ * every race to the copy's greedy lock re-acquisition. The whole batch stream
+ * runs under the process-wide {@link withBulkWriteGate} so two copies (or a
+ * copy and a batched delete) never convoy on the write lock — and the yields
+ * go to foreground writers, not a sibling bulk stream. Resolves once every
  * batch has committed (or returns the failing batch's `ok: false` result on
  * subprocess failure — the caller is responsible for cleaning up the
  * partially-built fork).
@@ -183,6 +187,15 @@ export async function copyForkMessagesViaSubprocess(
     };
   }
 
+  return await withBulkWriteGate(
+    `fork-message-copy:${options.forkConversationId}`,
+    () => copyBatches(options),
+  );
+}
+
+async function copyBatches(
+  options: CopyForkMessagesOptions,
+): Promise<AsyncSqliteResult> {
   const batchSize = Math.max(
     1,
     options.batchSize ?? DEFAULT_FORK_COPY_BATCH_SIZE,
@@ -207,7 +220,7 @@ export async function copyForkMessagesViaSubprocess(
     const result = await runAsyncSqlite(
       sql,
       `fork-message-copy:copy-batch:${options.forkConversationId}`,
-      runOptions,
+      { ...runOptions, timeoutMs: BULK_BATCH_TIMEOUT_MS },
     );
     totalElapsedMs += result.elapsedMs;
     backend = result.backend;


### PR DESCRIPTION
## Summary
- Add `bulk-write-gate.ts`: a process-wide FIFO gate (reusing `util/mutex.ts`) with a holder label, contended-wait logging, and a 5-minute per-batch timeout cap (`BULK_BATCH_TIMEOUT_MS`) for gated writers.
- `copyForkMessagesViaSubprocess` and `deleteConversationRowsInBatches` run their batch loops under the gate, so two bulk streams never convoy on SQLite's single write lock and the inter-batch yields reliably go to foreground writers; dedicated-file drains (logs DB) bypass the gate since they contend on a different file's lock.
- Unit tests: FIFO ordering, release-on-throw, holder label, gate routing for both writers, empty-copy fast path, and the dedicated-file bypass.

## Original prompt
While diagnosing why memory-retrospective forking starves live writes (`getOrCreateConversation` hitting `SQLITE_BUSY`, ~5s copy batches), daemon logs showed two retrospective fork copy streams for different conversations running concurrently — the jobs worker's lane pool groups by `(type, conversationId)`, so cross-conversation bulk writers overlap and convoy on the write lock. The ask: serialize the bulk subprocess write streams behind a small FIFO gate acquired around the batch loops only (never across LLM wakes or transactions, released in finally, per-process scope documented), and bound per-batch subprocess timeouts well below the 1h default so a wedged sqlite3 process can't hold the gate. One of four fixes from this investigation; the tail-only retrospective fork is landing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)