### PR TITLE
fix(persistence): run retrospective-fork phase 3 as an immediate, retried transaction

### DIFF
--- a/assistant/src/persistence/__tests__/immediate-transaction-guard.test.ts
+++ b/assistant/src/persistence/__tests__/immediate-transaction-guard.test.ts
@@ -1,0 +1,70 @@
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { assertNotLiveDb } from "../../__tests__/assert-not-live-db.js";
+
+// Guard for the driver contract `forkConversationForRetrospective`'s phase-3
+// transaction relies on: drizzle's bun-sqlite driver must map
+// `db.transaction(cb, { behavior: "immediate" })` onto BEGIN IMMEDIATE, i.e.
+// acquire the write lock at BEGIN rather than at the first write. If a
+// drizzle upgrade silently dropped the behavior config, the phase-3
+// SQLITE_BUSY_SNAPSHOT fix would regress to a deferred read→write upgrade.
+test("bun-sqlite drizzle transaction honors behavior: 'immediate'", () => {
+  const dbPath = join(tmpdir(), `immediate-txn-guard-${Date.now()}.db`);
+  const writer = new Database(dbPath);
+  const probe = new Database(dbPath);
+  try {
+    writer.exec("PRAGMA journal_mode=WAL");
+    writer.exec("CREATE TABLE t (x INTEGER)");
+    // Fail immediately instead of waiting when the write lock is taken.
+    probe.exec("PRAGMA busy_timeout=0");
+    const probeDb = drizzle(probe);
+
+    writer.exec("BEGIN IMMEDIATE");
+    try {
+      // A DEFERRED empty transaction acquires no locks, so it succeeds even
+      // while the writer holds the write lock — the baseline that proves the
+      // failure below comes from the behavior config, not the environment.
+      const ran: string[] = [];
+      probeDb.transaction(() => {
+        ran.push("deferred");
+      });
+      expect(ran).toEqual(["deferred"]);
+
+      // An IMMEDIATE transaction must take the write lock at BEGIN and fail
+      // fast (busy_timeout=0) while the writer holds it.
+      expect(() =>
+        probeDb.transaction(
+          () => {
+            /* never reached: BEGIN IMMEDIATE itself must throw */
+          },
+          { behavior: "immediate" },
+        ),
+      ).toThrow(/SQLITE_BUSY|database is locked/i);
+    } finally {
+      writer.exec("COMMIT");
+    }
+
+    // With the write lock free, the immediate transaction runs normally.
+    const value = probeDb.transaction(
+      () => {
+        probe.exec("INSERT INTO t (x) VALUES (1)");
+        return "committed";
+      },
+      { behavior: "immediate" },
+    );
+    expect(value).toBe("committed");
+  } finally {
+    writer.close();
+    probe.close();
+    assertNotLiveDb(dbPath);
+    rmSync(dbPath, { force: true });
+    rmSync(`${dbPath}-wal`, { force: true });
+    rmSync(`${dbPath}-shm`, { force: true });
+  }
+});

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -1494,22 +1494,40 @@ export async function forkConversationForRetrospective(params: {
 
     // Phase 3 (in-process): attachments + memory-state seeding, reusing the
     // same helper as the synchronous fork. Disk-view projection is skipped.
+    //
+    // The populate transaction reads (attachment links) before its first
+    // write, so a deferred BEGIN would take its snapshot as a reader and any
+    // concurrent writer committing before the first write fails the
+    // read→write upgrade with SQLITE_BUSY_SNAPSHOT — a hard error
+    // `busy_timeout` cannot wait out, which would discard the entire batch
+    // copy from phase 2. `behavior: "immediate"` acquires the write lock at
+    // BEGIN so the snapshot postdates it, and the retry absorbs residual
+    // contention: the transaction rolls back atomically, so re-running it is
+    // safe.
     const latestForkedAssistant = latestForkedAssistantFrom(
       messagesToCopy,
       forkedMessageIds,
     );
-    db.transaction(() => {
-      populateForkContentsInProcess({
-        fork,
-        sourceConversationId: sourceConversation.id,
-        messagesToCopy,
-        forkedMessageIds,
-        latestForkedAssistant,
-        isFullHistoryFork: copyBoundaryIndex === sourceMessages.length - 1,
-        inheritedCompactedMessageCount:
-          inheritedCompaction?.compactedMessageCount ?? 0,
-      });
-    });
+    await withSqliteRetry(
+      () =>
+        db.transaction(
+          () => {
+            populateForkContentsInProcess({
+              fork,
+              sourceConversationId: sourceConversation.id,
+              messagesToCopy,
+              forkedMessageIds,
+              latestForkedAssistant,
+              isFullHistoryFork:
+                copyBoundaryIndex === sourceMessages.length - 1,
+              inheritedCompactedMessageCount:
+                inheritedCompaction?.compactedMessageCount ?? 0,
+            });
+          },
+          { behavior: "immediate" },
+        ),
+      { op: "forkConversationForRetrospective.populate" },
+    );
 
     const persistedFork = getConversation(fork.id);
     if (!persistedFork) {


### PR DESCRIPTION
## Summary
- Phase 3 (`populateForkContentsInProcess`) now runs under `db.transaction(cb, { behavior: "immediate" })` wrapped in `withSqliteRetry`: the write lock is acquired at BEGIN so a concurrent writer can no longer invalidate the transaction's read snapshot (`SQLITE_BUSY_SNAPSHOT`), and residual contention retries in ~100ms instead of deleting the fork and redoing the whole multi-batch phase-2 copy.
- `forkConversation` and phase 1 are deliberately unchanged — both are write-first transactions (first statement is an INSERT), which never hit the deferred read→write upgrade failure.
- New guard test pins the driver contract (drizzle bun-sqlite maps `behavior: "immediate"` → `BEGIN IMMEDIATE`, verified as write-lock-at-BEGIN against a contending connection), so a drizzle upgrade that dropped the config would fail loudly.

## Original prompt
Daemon-log analysis of memory-retrospective forking found the fork job dying with `SQLITE_BUSY_SNAPSHOT` in phase 3 under write contention, throwing away completed multi-minute batch copies and re-forking — a major amplifier of the bulk-write convoy that starves live user turns. The ask: make phase 3 acquire the write lock up front via drizzle's `behavior: "immediate"` transaction config and wrap it in the existing `withSqliteRetry` helper (already used by phase 1), applying the same treatment to sibling fork transactions only if they share the read-then-write shape (they don't — documented in the PR). Second of four fixes from this investigation; the FIFO bulk-write gate landed as #37752 and the tail-only retrospective fork is in flight separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)