### PR TITLE
refactor(memory): remove conversations/task_runs scope columns + dead ToolContext field

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -857,11 +857,10 @@ graph LR
 
     subgraph "$VELLUM_WORKSPACE_DIR/data/db/assistant.db (SQLite + WAL)"
         direction TB
-        CONV["conversations<br/>───────────────<br/>id, title, timestamps<br/>token counts, estimated cost<br/>context_summary (compaction)<br/>conversation_type: 'standard' | 'background' | 'scheduled'<br/>memory_scope_id: 'default' | '_pkb_workspace' | 'subagent:&lt;id&gt;'"]
+        CONV["conversations<br/>───────────────<br/>id, title, timestamps<br/>token counts, estimated cost<br/>context_summary (compaction)<br/>conversation_type: 'standard' | 'background' | 'scheduled'"]
         MSG["messages<br/>───────────────<br/>id, conversation_id (FK)<br/>role: user | assistant<br/>content: JSON array<br/>created_at"]
         TOOL["tool_invocations<br/>───────────────<br/>tool_name, input, result<br/>decision, risk_level<br/>duration_ms"]
         SEG["memory_segments<br/>───────────────<br/>Text chunks for retrieval<br/>Linked to messages<br/>token_estimate per segment"]
-        ITEMS["memory_items<br/>───────────────<br/>Extracted facts/entities<br/>kind, subject, statement<br/>confidence, fingerprint (dedup)<br/>verification_state, scope_id<br/>first/last seen timestamps"]
         SUM["memory_summaries<br/>───────────────<br/>scope: conversation | weekly<br/>Compressed history for context<br/>window management"]
         EMB["memory_embeddings<br/>───────────────<br/>target: segment | item | summary<br/>provider + model metadata<br/>vector_json (float array)<br/>Powers semantic search"]
         JOBS["memory_jobs<br/>───────────────<br/>Async task queue<br/>Types: embed, extract,<br/>summarize, backfill, cleanup<br/>Status: pending → running →<br/>completed | failed"]

--- a/assistant/docs/architecture/memory.md
+++ b/assistant/docs/architecture/memory.md
@@ -155,7 +155,6 @@ graph TB
         EMBED_Q["Generate dense + sparse<br/>query embeddings"]
         HYBRID["Hybrid Search<br/>dense + sparse RRF on Qdrant"]
         MERGE["Merge + Deduplicate<br/>weighted score combination"]
-        SCOPE["Scope Filter<br/>scope_id filtering<br/>(strict | global_fallback)<br/>Subagents: own scope + 'default'"]
         TIER["Tier Classification<br/>score > 0.8 → tier 1<br/>score > 0.6 → tier 2<br/>below → dropped"]
         STALE["Staleness Computation<br/>kind-specific lifetimes<br/>+ reinforcement from<br/>source conversation count"]
         DEMOTE["Stale Demotion<br/>very_stale tier 1 → tier 2"]
@@ -215,8 +214,7 @@ graph TB
     EMBED_Q --> SPARSE_GEN
     EMBED_Q --> HYBRID
     HYBRID --> RRF
-    HYBRID --> SCOPE
-    SCOPE --> MERGE
+    HYBRID --> MERGE
     MERGE --> TIER
     TIER --> STALE
     STALE --> DEMOTE

--- a/assistant/src/__tests__/approval-routes-http.test.ts
+++ b/assistant/src/__tests__/approval-routes-http.test.ts
@@ -162,10 +162,6 @@ function makeIdleSession(opts?: {
       processing = true;
       return { id: options.requestId ?? "msg-1", deduplicated: false };
     },
-    memoryPolicy: {
-      scopeId: "default",
-      includeDefaultFallback: false,
-    },
     setChannelCapabilities: () => {},
     setAssistantId: () => {},
     setTrustContext: () => {},
@@ -228,10 +224,6 @@ function makeConfirmationEmittingSession(opts?: {
     persistUserMessage: (options: { requestId?: string }) => {
       processing = true;
       return { id: options.requestId ?? "msg-1", deduplicated: false };
-    },
-    memoryPolicy: {
-      scopeId: "default",
-      includeDefaultFallback: false,
     },
     setChannelCapabilities: () => {},
     setAssistantId: () => {},

--- a/assistant/src/__tests__/conversation-agent-loop-disk-pressure.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-disk-pressure.test.ts
@@ -139,7 +139,6 @@ function makeCtx(overrides: Partial<Context> = {}): Conversation {
     contextCompactedAt: null,
     conversationType: "background",
     source: "memory",
-    memoryPolicy: { scopeId: "default", includeDefaultFallback: true },
     currentActiveSurfaceId: undefined,
     currentPage: undefined,
     surfaceState: new Map(),

--- a/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
@@ -452,8 +452,6 @@ function makeCtx(
     contextCompactedMessageCount: 0,
     contextCompactedAt: null,
 
-    memoryPolicy: { scopeId: "default", includeDefaultFallback: true },
-
     currentActiveSurfaceId: undefined,
     currentPage: undefined,
     surfaceState: new Map(),

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -620,8 +620,6 @@ function makeCtx(
     contextCompactedMessageCount: 0,
     contextCompactedAt: null,
 
-    memoryPolicy: { scopeId: "default", includeDefaultFallback: true },
-
     currentActiveSurfaceId: undefined,
     currentPage: undefined,
     surfaceState: new Map(),

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -755,8 +755,6 @@ function makeCtx(
       mockConversationRow?.lastNotifiedInferenceProfile ?? null,
     processingStartedAt: mockConversationRow?.processingStartedAt ?? null,
 
-    memoryPolicy: { scopeId: "default", includeDefaultFallback: true },
-
     currentActiveSurfaceId: undefined,
     currentPage: undefined,
     surfaceState: new Map(),

--- a/assistant/src/__tests__/conversation-routes-disk-view.test.ts
+++ b/assistant/src/__tests__/conversation-routes-disk-view.test.ts
@@ -146,10 +146,6 @@ function createFakeConversation(conversationId: string): Conversation {
     messages: [] as Array<unknown>,
     hostCuProxy: undefined as unknown,
     usageStats: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
-    memoryPolicy: {
-      scopeId: "default",
-      includeDefaultFallback: false,
-    },
     isProcessing(this: { processing: boolean }) {
       return this.processing;
     },

--- a/assistant/src/__tests__/conversation-store.test.ts
+++ b/assistant/src/__tests__/conversation-store.test.ts
@@ -467,17 +467,11 @@ describe("conversation metadata defaults", () => {
     expect(conv.conversationType).toBe("standard");
   });
 
-  test("new conversation has memoryScopeId defaulting to default", () => {
-    const conv = createConversation("test");
-    expect(conv.memoryScopeId).toBe("default");
-  });
-
   test("defaults are persisted and retrievable from DB", () => {
     const conv = createConversation("test");
     const loaded = getConversation(conv.id);
     expect(loaded).not.toBeNull();
     expect(loaded!.conversationType).toBe("standard");
-    expect(loaded!.memoryScopeId).toBe("default");
   });
 
   test("existing conversations without explicit values get defaults via migration", () => {
@@ -493,7 +487,6 @@ describe("conversation metadata defaults", () => {
     const loaded = getConversation(id);
     expect(loaded).not.toBeNull();
     expect(loaded!.conversationType).toBe("standard");
-    expect(loaded!.memoryScopeId).toBe("default");
   });
 });
 
@@ -508,7 +501,6 @@ describe("createConversation with conversation type option", () => {
     const conv = createConversation("hello");
     expect(conv.title).toBe("hello");
     expect(conv.conversationType).toBe("standard");
-    expect(conv.memoryScopeId).toBe("default");
   });
 
   test("standard create with options object uses defaults", () => {
@@ -517,13 +509,11 @@ describe("createConversation with conversation type option", () => {
       conversationType: "standard",
     });
     expect(conv.conversationType).toBe("standard");
-    expect(conv.memoryScopeId).toBe("default");
   });
 
   test("no-arg create uses defaults", () => {
     const conv = createConversation();
     expect(conv.conversationType).toBe("standard");
-    expect(conv.memoryScopeId).toBe("default");
   });
 });
 

--- a/assistant/src/__tests__/messages-after-tiebreaker.test.ts
+++ b/assistant/src/__tests__/messages-after-tiebreaker.test.ts
@@ -35,7 +35,6 @@ function seedConversation(): void {
       updatedAt: now,
       source: "test",
       conversationType: "default",
-      memoryScopeId: "default",
     })
     .run();
 }

--- a/assistant/src/__tests__/proxy-approval-callback.test.ts
+++ b/assistant/src/__tests__/proxy-approval-callback.test.ts
@@ -49,7 +49,6 @@ function makeContext(overrides?: Partial<ToolSetupContext>): ToolSetupContext {
     conversationId: "conv-test",
     workingDir: "/tmp/test-project",
     abortController: null,
-    memoryPolicy: { scopeId: "default" },
     sendToClient: () => {},
     surfacesByAppId: new Map(),
     ...overrides,

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -164,10 +164,6 @@ function makeCompletingConversation(): Conversation {
       processing = true;
       return { id: options.requestId ?? "msg-1", deduplicated: false };
     },
-    memoryPolicy: {
-      scopeId: "default",
-      includeDefaultFallback: false,
-    },
     setChannelCapabilities: () => {},
     setAssistantId: () => {},
     setTrustContext: () => {},
@@ -217,10 +213,6 @@ function makeHangingConversation(): Conversation {
     persistUserMessage: (options: { requestId?: string }) => {
       processing = true;
       return { id: options.requestId ?? "msg-1", deduplicated: false };
-    },
-    memoryPolicy: {
-      scopeId: "default",
-      includeDefaultFallback: false,
     },
     setChannelCapabilities: () => {},
     setAssistantId: () => {},
@@ -300,10 +292,6 @@ function makePendingApprovalConversation(
       id: options.requestId ?? "msg-1",
       deduplicated: false,
     }),
-    memoryPolicy: {
-      scopeId: "default",
-      includeDefaultFallback: false,
-    },
     setChannelCapabilities: () => {},
     setAssistantId: () => {},
     trustContext: undefined as unknown,

--- a/assistant/src/__tests__/subagent-fork-spawn.test.ts
+++ b/assistant/src/__tests__/subagent-fork-spawn.test.ts
@@ -236,43 +236,6 @@ describe("SubagentManager fork spawn", () => {
     expect(resolvedSendResultToUser).toBeUndefined();
   });
 
-  test("fork uses default memory scope, not isolated subagent scope", () => {
-    // Validate the fork memory policy shape matches what spawn() produces.
-    const isFork = true;
-    const subagentId = "sub-fork-mem";
-
-    const memoryPolicy = isFork
-      ? {
-          scopeId: "default",
-          includeDefaultFallback: false,
-        }
-      : {
-          scopeId: `subagent:${subagentId}`,
-          includeDefaultFallback: true,
-        };
-
-    expect(memoryPolicy.scopeId).toBe("default");
-    expect(memoryPolicy.includeDefaultFallback).toBe(false);
-  });
-
-  test("non-fork uses isolated subagent memory scope", () => {
-    const isFork = false;
-    const subagentId = "sub-normal-mem";
-
-    const memoryPolicy = isFork
-      ? {
-          scopeId: "default",
-          includeDefaultFallback: false,
-        }
-      : {
-          scopeId: `subagent:${subagentId}`,
-          includeDefaultFallback: true,
-        };
-
-    expect(memoryPolicy.scopeId).toBe(`subagent:${subagentId}`);
-    expect(memoryPolicy.includeDefaultFallback).toBe(true);
-  });
-
   test("fork defaults to general role (which has no tool allowlist)", async () => {
     const manager = new SubagentManager();
     const subagentId = "sub-fork-role";

--- a/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
+++ b/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
@@ -139,7 +139,6 @@ function createMockSession(opts?: {
 
   const session = {
     isProcessing: () => false,
-    memoryPolicy: {},
     setAssistantId: () => {},
     setTrustContext: () => {},
     setCommandIntent: () => {},

--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -69,10 +69,6 @@ function makeStreamingSession(events: ServerMessage[]): Conversation {
       id: "test-msg-id",
       deduplicated: false,
     }),
-    memoryPolicy: {
-      scopeId: "default",
-      includeDefaultFallback: false,
-    },
     setChannelCapabilities: () => {},
     setAssistantId: () => {},
     setTrustContext: () => {},
@@ -113,10 +109,6 @@ function makePersistingStreamingSession(
     currentRequestId: undefined,
     queue: {} as never,
     trustContext: undefined,
-    memoryPolicy: {
-      scopeId: "default",
-      includeDefaultFallback: false,
-    },
     isProcessing: () => processing,
     setProcessing: (value: boolean) => {
       processing = value;
@@ -280,10 +272,6 @@ describe("voice-session-bridge", () => {
         session.currentRequestId = options.requestId;
         return { id: "test-msg-id", deduplicated: false };
       },
-      memoryPolicy: {
-        scopeId: "default",
-        includeDefaultFallback: false,
-      },
       setChannelCapabilities: () => {},
       setAssistantId: () => {},
       setTrustContext: () => {},
@@ -368,10 +356,6 @@ describe("voice-session-bridge", () => {
       persistUserMessage: (options: { requestId?: string }) => {
         session.currentRequestId = options.requestId;
         return { id: "test-msg-id", deduplicated: false };
-      },
-      memoryPolicy: {
-        scopeId: "default",
-        includeDefaultFallback: false,
       },
       setChannelCapabilities: () => {},
       setAssistantId: () => {},
@@ -744,10 +728,6 @@ describe("voice-session-bridge", () => {
         id: "test-msg-id",
         deduplicated: false,
       }),
-      memoryPolicy: {
-        scopeId: "default",
-        includeDefaultFallback: false,
-      },
       setChannelCapabilities: () => {},
       setAssistantId: () => {},
       setTrustContext: () => {},
@@ -834,10 +814,6 @@ describe("voice-session-bridge", () => {
         id: "test-msg-id",
         deduplicated: false,
       }),
-      memoryPolicy: {
-        scopeId: "default",
-        includeDefaultFallback: false,
-      },
       setChannelCapabilities: () => {},
       setAssistantId: () => {},
       setTrustContext: () => {},
@@ -905,10 +881,6 @@ describe("voice-session-bridge", () => {
         id: "test-msg-id",
         deduplicated: false,
       }),
-      memoryPolicy: {
-        scopeId: "default",
-        includeDefaultFallback: false,
-      },
       setChannelCapabilities: () => {},
       setAssistantId: () => {},
       setTrustContext: () => {},
@@ -982,10 +954,6 @@ describe("voice-session-bridge", () => {
         id: "test-msg-id",
         deduplicated: false,
       }),
-      memoryPolicy: {
-        scopeId: "default",
-        includeDefaultFallback: false,
-      },
       setChannelCapabilities: () => {},
       setAssistantId: () => {},
       setTrustContext: () => {},
@@ -1075,10 +1043,6 @@ describe("voice-session-bridge", () => {
         id: "test-msg-id",
         deduplicated: false,
       }),
-      memoryPolicy: {
-        scopeId: "default",
-        includeDefaultFallback: false,
-      },
       setChannelCapabilities: () => {},
       setAssistantId: () => {},
       setTrustContext: () => {},
@@ -1151,10 +1115,6 @@ describe("voice-session-bridge", () => {
         id: "test-msg-id",
         deduplicated: false,
       }),
-      memoryPolicy: {
-        scopeId: "default",
-        includeDefaultFallback: false,
-      },
       setChannelCapabilities: () => {},
       setAssistantId: () => {},
       setTrustContext: () => {},
@@ -1223,10 +1183,6 @@ describe("voice-session-bridge", () => {
       persistUserMessage: async () => {
         throw new Error("simulated persistence failure");
       },
-      memoryPolicy: {
-        scopeId: "default",
-        includeDefaultFallback: false,
-      },
       setChannelCapabilities: () => {},
       setAssistantId: () => {},
       setTrustContext: () => {},
@@ -1285,10 +1241,6 @@ describe("voice-session-bridge", () => {
       callSessionId: undefined as string | undefined,
       persistUserMessage: async () => {
         throw new Error("simulated persistence failure");
-      },
-      memoryPolicy: {
-        scopeId: "default",
-        includeDefaultFallback: false,
       },
       setChannelCapabilities: recordLast("setChannelCapabilities"),
       setAssistantId: recordLast("setAssistantId"),
@@ -1356,10 +1308,6 @@ describe("voice-session-bridge", () => {
       persistUserMessage: async () => {
         throw new Error("persist failed before bridge installed callback");
       },
-      memoryPolicy: {
-        scopeId: "default",
-        includeDefaultFallback: false,
-      },
       setChannelCapabilities: () => {},
       setAssistantId: () => {},
       setTrustContext: () => {},
@@ -1419,10 +1367,6 @@ describe("voice-session-bridge", () => {
       persistUserMessage: (options: { requestId?: string }) => {
         session.currentRequestId = options.requestId;
         return { id: "test-msg-id", deduplicated: false };
-      },
-      memoryPolicy: {
-        scopeId: "default",
-        includeDefaultFallback: false,
       },
       setChannelCapabilities: () => {},
       setAssistantId: () => {},

--- a/assistant/src/__tests__/workspace-migration-009-backfill-conversation-disk-view.test.ts
+++ b/assistant/src/__tests__/workspace-migration-009-backfill-conversation-disk-view.test.ts
@@ -86,7 +86,6 @@ function seedConversationRows(): {
       updatedAt: conversationUpdatedAt,
       conversationType: "standard",
       source: "user",
-      memoryScopeId: "default",
       originChannel: "desktop",
     })
     .run();

--- a/assistant/src/__tests__/workspace-migration-013-repair-conversation-disk-view.test.ts
+++ b/assistant/src/__tests__/workspace-migration-013-repair-conversation-disk-view.test.ts
@@ -88,7 +88,6 @@ function seedConversationRows(): {
       updatedAt: conversationUpdatedAt,
       conversationType: "standard",
       source: "user",
-      memoryScopeId: "default",
       originChannel: "desktop",
     })
     .run();

--- a/assistant/src/__tests__/workspace-migration-028-recover-conversations-from-disk-view.test.ts
+++ b/assistant/src/__tests__/workspace-migration-028-recover-conversations-from-disk-view.test.ts
@@ -252,7 +252,6 @@ describe("028-recover-conversations-from-disk-view migration", () => {
         updatedAt: createdAtMs,
         conversationType: "standard",
         source: "user",
-        memoryScopeId: "default",
       })
       .run();
 

--- a/assistant/src/cli/commands/db/repair-step-conversation-backfill.ts
+++ b/assistant/src/cli/commands/db/repair-step-conversation-backfill.ts
@@ -261,7 +261,6 @@ async function runConversationBackfill(
                 conversationType: meta.type ?? "standard",
                 originChannel: meta.channel ?? null,
                 source: "user",
-                memoryScopeId: "default",
                 isAutoTitle: 1,
                 totalInputTokens: 0,
                 totalOutputTokens: 0,

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -379,7 +379,6 @@ export interface ConversationRow {
   slackContextCompactionWatermarkAt: number | null;
   conversationType: string;
   source: string;
-  memoryScopeId: string;
   originChannel: string | null;
   originInterface: string | null;
   forkParentConversationId: string | null;
@@ -417,7 +416,6 @@ export const parseConversation = createRowMapper<
   slackContextCompactionWatermarkAt: "slackContextCompactionWatermarkAt",
   conversationType: "conversationType",
   source: "source",
-  memoryScopeId: "memoryScopeId",
   originChannel: "originChannel",
   originInterface: "originInterface",
   forkParentConversationId: "forkParentConversationId",
@@ -707,7 +705,6 @@ export function createConversation(
   const groupId = opts.groupId;
   // Time-ordered UUIDv7 for server-minted conversation ids (see message id).
   const id = opts.id ?? uuidv7();
-  const memoryScopeId = "default";
 
   // Ensure group_id column exists for deterministic schema readiness,
   // even when this conversation has no groupId (a subsequent query or
@@ -732,7 +729,6 @@ export function createConversation(
     slackContextCompactionWatermarkAt: null as number | null,
     conversationType,
     source,
-    memoryScopeId,
     scheduleJobId: opts.scheduleJobId ?? null,
     forkParentConversationId: opts.forkParentConversationId ?? null,
     // Snapshot↔stream alignment baseline, captured at the creation instant.

--- a/assistant/src/persistence/conversation-key-store.ts
+++ b/assistant/src/persistence/conversation-key-store.ts
@@ -217,7 +217,6 @@ export function getOrCreateConversation(
     const conversationId = uuid();
     const customTitle = opts?.title?.trim();
     const title = customTitle || GENERATING_TITLE;
-    const memoryScopeId = "default";
     // Snapshot↔stream alignment baseline, captured at the creation instant
     // (same seed as `createConversation`; 0 is stored as NULL).
     const initialSeq = getCurrentSeq();
@@ -241,7 +240,6 @@ export function getOrCreateConversation(
         contextCompactedMessageCount: 0,
         contextCompactedAt: null,
         conversationType,
-        memoryScopeId,
       })
       .run();
 

--- a/assistant/src/persistence/schema/conversations.ts
+++ b/assistant/src/persistence/schema/conversations.ts
@@ -32,7 +32,6 @@ export const conversations = sqliteTable(
     ),
     conversationType: text("conversation_type").notNull().default("standard"),
     source: text("source").notNull().default("user"),
-    memoryScopeId: text("memory_scope_id").notNull().default("default"),
     originChannel: text("origin_channel"),
     originInterface: text("origin_interface"),
     forkParentConversationId: text("fork_parent_conversation_id"),

--- a/assistant/src/persistence/schema/tasks.ts
+++ b/assistant/src/persistence/schema/tasks.ts
@@ -26,7 +26,6 @@ export const taskRuns = sqliteTable("task_runs", {
   finishedAt: integer("finished_at"),
   error: text("error"),
   principalId: text("principal_id"),
-  memoryScopeId: text("memory_scope_id"),
   createdAt: integer("created_at").notNull(),
 });
 

--- a/assistant/src/runtime/routes/__tests__/bookmark-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/bookmark-routes.test.ts
@@ -80,7 +80,6 @@ function seedConversationAndMessage(opts: {
       updatedAt: now,
       source: "test",
       conversationType: "standard",
-      memoryScopeId: "default",
     })
     .run();
   db.insert(messages)

--- a/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
@@ -109,7 +109,6 @@ function seedConversation(id: string): void {
       updatedAt: now,
       source: "test",
       conversationType: "standard",
-      memoryScopeId: "default",
     })
     .run();
 }

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -134,7 +134,6 @@ function seedConversationAndMessage(args: {
       updatedAt: now,
       source: args.source,
       conversationType: args.conversationType,
-      memoryScopeId: "default",
       ...(args.totalEstimatedCost != null
         ? { totalEstimatedCost: args.totalEstimatedCost }
         : {}),

--- a/assistant/src/runtime/services/__tests__/conversation-serializer.test.ts
+++ b/assistant/src/runtime/services/__tests__/conversation-serializer.test.ts
@@ -34,7 +34,6 @@ function makeConversationRow(
     slackContextCompactionWatermarkAt: null,
     conversationType: "background",
     source: "task",
-    memoryScopeId: "default",
     originChannel: null,
     originInterface: null,
     forkParentConversationId: null,

--- a/assistant/src/tasks/SPEC.md
+++ b/assistant/src/tasks/SPEC.md
@@ -57,27 +57,20 @@ room to extend later (e.g., multi-step chains, tool-enabled tasks).
 
 ---
 
-## 2. Memory Isolation Policy
+## 2. Memory Policy
 
-Each task's memory is scoped by its task ID:
-
-```
-scope_id = "task:{task_id}"
-```
+Task runs share the single workspace memory pool — the same memory the user's
+main conversations read and write. There is no per-task memory isolation.
 
 This means:
 
-- **Cross-run learning**: All runs of the same task share the same memory
-  scope. The LLM can accumulate knowledge about the task across invocations
-  (e.g., learning the user's preferred summary style over time).
-- **Isolation from default scope**: Task memory is completely separate from the
-  user's main conversation memory (`scope_id = "default"`). A task cannot read
-  or pollute the user's chat history, and vice versa.
-- **Per-task boundaries**: Different tasks have different scopes and cannot see
-  each other's memory.
-
-This follows the same explicit `scope_id` isolation model used by workspace
-memory (`default`, `_pkb_workspace`) and subagent memory (`subagent:{id}`).
+- **Cross-run learning**: All runs of a task draw from and contribute to the
+  shared workspace memory, so the assistant can accumulate knowledge relevant
+  to a task across invocations (e.g., learning the user's preferred summary
+  style over time).
+- **Shared context**: A run can use what the assistant already knows from the
+  user's chat history, and what a run records is available to later
+  conversations and other tasks.
 
 ---
 

--- a/assistant/src/tools/tool-types.ts
+++ b/assistant/src/tools/tool-types.ts
@@ -232,8 +232,6 @@ export interface ToolContext {
   sendToClient?: (msg: { type: string; [key: string]: unknown }) => void;
   /** True when an interactive client is connected (not just a no-op callback). */
   isInteractive?: boolean;
-  /** Memory scope ID from the conversation's memory policy, so memory tools can target the correct scope. */
-  memoryScopeId?: string;
   /** When true, tools with side effects should always prompt for confirmation. */
   forcePromptSideEffects?: boolean;
   /**

--- a/assistant/src/workspace/migrations/028-recover-conversations-from-disk-view.ts
+++ b/assistant/src/workspace/migrations/028-recover-conversations-from-disk-view.ts
@@ -207,7 +207,6 @@ export const recoverConversationsFromDiskViewMigration: WorkspaceMigration = {
               conversationType: meta.type ?? "standard",
               originChannel: meta.channel ?? null,
               source: "user",
-              memoryScopeId: "default",
               isAutoTitle: 1,
               totalInputTokens: 0,
               totalOutputTokens: 0,

--- a/clients/web/src/domains/intelligence/memories/types.ts
+++ b/clients/web/src/domains/intelligence/memories/types.ts
@@ -43,8 +43,6 @@ export interface MemoryItem {
 
   accessCount?: number | null;
   verificationState?: string | null;
-  scopeId?: string | null;
-  scopeLabel?: string | null;
   lastUsedAt?: number | null;
   supersedes?: string | null;
   supersededBy?: string | null;


### PR DESCRIPTION
## Summary
- Drop the `memory_scope_id` Drizzle definitions on `conversations`/`task_runs` and every write-site (createConversation, conversation-key-store, one-line compile-forced edits in workspace migration 028 + the CLI repair-step) — the column was written as `'default'` and never read; physical columns keep their defaults so old and new binaries stay write-compatible.
- Delete the never-populated internal `ToolContext.memoryScopeId` (a #36707 relocation fossil; the public plugin-api ToolContext never had it) and the dead `scopeId`/`scopeLabel` web type fields; strip `memoryPolicy` test fossils from the system deleted in #29607.
- Docs: ARCHITECTURE.md conversations box loses the scope line and the stale `memory_items` box (table dropped by migration 203); the memory-pipeline diagram loses its Scope Filter node; tasks/SPEC.md now states task runs share the single workspace memory pool.

Note for review: the exported `ConversationRow` type (plugin-api, inferred from the Drizzle schema) loses the never-meaningful `memoryScopeId` field — technically a public-type change with no known consumer.

## Original prompt
Final excision PR of the memory-scope cleanup series Sidd requested (PR 1/4 Qdrant layer #37743, PR 2/4 SQL layer + hygiene migration #37755, PR 4/4 v2 gate #37746). Removes the remaining dormant columns, dead fields, and stale docs.