### PR TITLE
perf(persistence): WAL hygiene — size limit, ungated passive checkpoints, human-quiet gate

### DIFF
--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -14,6 +14,7 @@ import {
   like,
   lt,
   lte,
+  notInArray,
   or,
   sql,
 } from "drizzle-orm";
@@ -67,7 +68,10 @@ import {
 import { ensureDisplayOrderMigration } from "./conversation-display-order-migration.js";
 import { ensureGroupMigration } from "./conversation-group-migration.js";
 import { deleteConversationRowsInBatches } from "./conversation-row-batch-delete.js";
-import type { ConversationCreateType } from "./conversation-types.js";
+import {
+  BACKGROUND_CONVERSATION_TYPES,
+  type ConversationCreateType,
+} from "./conversation-types.js";
 import { runAsyncSqlite } from "./db-async-query.js";
 import {
   type DrizzleDb,
@@ -2239,12 +2243,29 @@ export function getLastUserTimestampBefore(
  * newest `role = "user"` row rather than a scan of the whole (potentially
  * multi-GB) table.
  */
-export function getLastUserMessageTimestamp(): number {
+/**
+ * Timestamp of the newest user-role message in an interactive
+ * (non-background) conversation, or 0 when none exists. Background machinery
+ * writes user-role rows of its own — the memory-retrospective instruction
+ * message, scheduled/heartbeat wake hints — inside background/scheduled
+ * conversations, so an unfiltered max would keep an always-on install
+ * permanently "active" for consumers gating on human quiet (the
+ * db-maintenance quiet period).
+ */
+export function getLastInteractiveUserMessageTimestamp(): number {
   const db = getDb();
   const row = db
     .select({ createdAt: messages.createdAt })
     .from(messages)
-    .where(eq(messages.role, "user"))
+    .innerJoin(conversations, eq(messages.conversationId, conversations.id))
+    .where(
+      and(
+        eq(messages.role, "user"),
+        notInArray(conversations.conversationType, [
+          ...BACKGROUND_CONVERSATION_TYPES,
+        ]),
+      ),
+    )
     .orderBy(desc(messages.createdAt))
     .limit(1)
     .get();

--- a/assistant/src/persistence/conversation-types.ts
+++ b/assistant/src/persistence/conversation-types.ts
@@ -11,10 +11,21 @@ export type ConversationCreateType = "standard" | "background" | "scheduled";
 /** Read-side alias of {@link ConversationCreateType}. */
 export type ConversationType = ConversationCreateType;
 
+/**
+ * Conversation types created by background machinery (heartbeat runs,
+ * scheduled runs, retrospective forks) rather than by a person. Exported as a
+ * list so SQL filters (e.g. `notInArray`) share the same set as the predicate
+ * below.
+ */
+export const BACKGROUND_CONVERSATION_TYPES = [
+  "background",
+  "scheduled",
+] as const satisfies readonly ConversationType[];
+
 // Tolerant of null/undefined/unknown strings so it can be called directly on
 // raw DB column values without pre-validation.
 export function isBackgroundConversationType(
   t: ConversationType | string | null | undefined,
 ): boolean {
-  return t === "background" || t === "scheduled";
+  return (BACKGROUND_CONVERSATION_TYPES as readonly string[]).includes(t ?? "");
 }

--- a/assistant/src/persistence/db-connection.ts
+++ b/assistant/src/persistence/db-connection.ts
@@ -104,11 +104,21 @@ function applyConnectionPragmas(sqlite: Database): void {
   sqlite.exec("PRAGMA foreign_keys = ON");
   sqlite.exec("PRAGMA cache_size=-256000");
   sqlite.exec("PRAGMA temp_store=MEMORY");
+  // Checkpointing alone never shrinks the WAL file — a fully-backfilled WAL
+  // is reused from offset 0 at its high-water size, so a single write burst
+  // otherwise leaves a permanently huge file (disk cost, plus a long recovery
+  // scan on the first open after a hard crash). With a size limit, any WAL
+  // reset also truncates the file to at most this many bytes. 64 MB
+  // comfortably exceeds the WAL's steady-state hover (the ~4 MB autocheckpoint
+  // threshold), so normal writes never pay file re-extension.
+  sqlite.exec("PRAGMA journal_size_limit=67108864");
 }
 
 export function getDb(): DrizzleDb {
   const existing = getStoredDb<DrizzleDb>("main");
-  if (existing) return existing;
+  if (existing) {
+    return existing;
+  }
 
   assertTestDbIsIsolated();
   ensureDataDir();
@@ -193,7 +203,9 @@ function openDedicatedDb(
  */
 export function getLogsDb(): DrizzleDb | null {
   const existing = getStoredDb<DrizzleDb>("logs");
-  if (existing) return existing;
+  if (existing) {
+    return existing;
+  }
   return openDedicatedDb("logs", getLogsDbPath());
 }
 
@@ -210,7 +222,9 @@ export function getLogsSqlite(): Database | null {
  */
 export function getMemoryDb(): DrizzleDb | null {
   const existing = getStoredDb<DrizzleDb>("memory");
-  if (existing) return existing;
+  if (existing) {
+    return existing;
+  }
   return openDedicatedDb("memory", getMemoryDbPath());
 }
 
@@ -227,7 +241,9 @@ export function getMemorySqlite(): Database | null {
  */
 export function getTelemetryDb(): DrizzleDb | null {
   const existing = getStoredDb<DrizzleDb>("telemetry");
-  if (existing) return existing;
+  if (existing) {
+    return existing;
+  }
   return openDedicatedDb("telemetry", getTelemetryDbPath());
 }
 

--- a/assistant/src/persistence/db-maintenance.ts
+++ b/assistant/src/persistence/db-maintenance.ts
@@ -5,13 +5,22 @@ import { getLogger } from "../util/logger.js";
 import { getDbPath } from "../util/platform.js";
 import { pruneRuns } from "../workflows/journal-store.js";
 import { getMemoryCheckpoint, setMemoryCheckpoint } from "./checkpoints.js";
-import { getLastUserMessageTimestamp } from "./conversation-crud.js";
+import { getLastInteractiveUserMessageTimestamp } from "./conversation-crud.js";
 import { runAsyncSqlite } from "./db-async-query.js";
 import { getSqlite } from "./db-connection.js";
 
 const log = getLogger("db-maintenance");
 
 const DB_MAINTENANCE_CHECKPOINT_KEY = "db_maintenance:last_run";
+const DB_PASSIVE_CHECKPOINT_KEY = "db_maintenance:last_passive_checkpoint";
+
+/**
+ * Cadence for the ungated PASSIVE WAL checkpoint. Frequent enough that the
+ * WAL backlog stays near zero on an always-active instance (so the per-commit
+ * autocheckpoints every writer runs stay cheap), infrequent enough that the
+ * subprocess spawn is noise.
+ */
+export const PASSIVE_CHECKPOINT_INTERVAL_MS = 15 * 60 * 1000;
 
 interface DbStats {
   pageSize: number;
@@ -134,15 +143,22 @@ export async function maybeRunDbMaintenance(nowMs = Date.now()): Promise<void> {
     getMemoryCheckpoint(DB_MAINTENANCE_CHECKPOINT_KEY) ?? "0",
     10,
   );
-  if (nowMs - lastRun < intervalMs) return;
+  if (nowMs - lastRun < intervalMs) {
+    return;
+  }
 
   // Maintenance still takes brief write locks (PRAGMA optimize and the
   // truncating WAL checkpoint), so defer it until the user has been quiet for
-  // `quietPeriodMs` and those locks never land mid-conversation. The checkpoint
-  // below is only written once maintenance actually runs, so a deferred run is
-  // simply retried on a later (still-idle) worker tick.
+  // `quietPeriodMs` and those locks never land mid-conversation. "Quiet"
+  // means HUMAN quiet — the newest user-role message in an interactive
+  // conversation. Background machinery writes user-role rows of its own
+  // (retrospective instructions, scheduled/heartbeat wake hints) inside
+  // background/scheduled conversations; counting those would keep an
+  // always-on install permanently "active" and starve this pass forever. The
+  // checkpoint below is only written once maintenance actually runs, so a
+  // deferred run is simply retried on a later (still-idle) worker tick.
   if (quietPeriodMs > 0) {
-    const lastUserMessageAt = getLastUserMessageTimestamp();
+    const lastUserMessageAt = getLastInteractiveUserMessageTimestamp();
     if (lastUserMessageAt > 0 && nowMs - lastUserMessageAt < quietPeriodMs) {
       return;
     }
@@ -155,4 +171,60 @@ export async function maybeRunDbMaintenance(nowMs = Date.now()): Promise<void> {
   }
   // Always set checkpoint — even on failure — to avoid retry-hammering every tick.
   setMemoryCheckpoint(DB_MAINTENANCE_CHECKPOINT_KEY, String(nowMs));
+}
+
+/**
+ * Ungated PASSIVE WAL checkpoint on a short cadence (see
+ * {@link PASSIVE_CHECKPOINT_INTERVAL_MS}).
+ *
+ * PASSIVE never blocks anyone: it gives up instantly if another checkpointer
+ * holds the checkpointer lock and backfills only up to the oldest live
+ * reader's mark — so unlike the truncating maintenance checkpoint it needs no
+ * quiet-period gate and is safe mid-conversation. Running it continuously
+ * keeps the WAL backlog near zero on always-active instances, which keeps
+ * every writer's per-commit autocheckpoint cheap (a large standing backlog
+ * otherwise amortizes multi-second backfill work into commits while they hold
+ * the write lock).
+ *
+ * The `busy|log|checkpointed` triple is logged like the truncate path's: a
+ * persistently large gap between `log` and `checkpointed` frames means a
+ * pinned reader is starving checkpoints — the diagnostic that matters when a
+ * WAL balloons anyway.
+ */
+export async function maybeRunPassiveWalCheckpoint(
+  nowMs = Date.now(),
+): Promise<void> {
+  const lastRun = parseInt(
+    getMemoryCheckpoint(DB_PASSIVE_CHECKPOINT_KEY) ?? "0",
+    10,
+  );
+  if (nowMs - lastRun < PASSIVE_CHECKPOINT_INTERVAL_MS) {
+    return;
+  }
+
+  try {
+    const result = await runAsyncSqlite(
+      "PRAGMA wal_checkpoint(PASSIVE)",
+      "db-maintenance:wal-checkpoint-passive",
+    );
+    if (result.ok) {
+      log.info(
+        {
+          backend: result.backend,
+          checkpointResult: result.stdout?.trim(),
+          elapsedMs: result.elapsedMs,
+        },
+        "Passive WAL checkpoint complete",
+      );
+    } else {
+      log.warn(
+        { error: result.error, backend: result.backend },
+        "Passive WAL checkpoint failed (non-fatal)",
+      );
+    }
+  } catch (err) {
+    log.warn({ err }, "Passive WAL checkpoint threw (non-fatal)");
+  }
+  // Always set checkpoint — even on failure — to avoid retry-hammering every tick.
+  setMemoryCheckpoint(DB_PASSIVE_CHECKPOINT_KEY, String(nowMs));
 }

--- a/assistant/src/plugins/defaults/memory/__tests__/db-maintenance.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/db-maintenance.test.ts
@@ -22,38 +22,50 @@ const { getSqlite } = await import("../../../../persistence/db-connection.js");
 const { initializeDb } = await import("../../../../persistence/db-init.js");
 const { deleteMemoryCheckpoint, getMemoryCheckpoint } =
   await import("../../../../persistence/checkpoints.js");
-const { maybeRunDbMaintenance } =
+const { maybeRunDbMaintenance, maybeRunPassiveWalCheckpoint } =
   await import("../../../../persistence/db-maintenance.js");
-const { getLastUserMessageTimestamp } =
+const { getLastInteractiveUserMessageTimestamp } =
   await import("../../../../persistence/conversation-crud.js");
 const { getDbPath } = await import("../../../../util/platform.js");
 
 await initializeDb();
 
 const MAINTENANCE_CHECKPOINT_KEY = "db_maintenance:last_run";
+const PASSIVE_CHECKPOINT_KEY = "db_maintenance:last_passive_checkpoint";
 const QUIET_PERIOD_MS = 3 * 60 * 60 * 1000;
 
 beforeEach(() => {
   deleteMemoryCheckpoint(MAINTENANCE_CHECKPOINT_KEY);
+  deleteMemoryCheckpoint(PASSIVE_CHECKPOINT_KEY);
   const sqlite = getSqlite();
   sqlite.exec("DELETE FROM messages");
   sqlite.exec("DELETE FROM conversations");
 });
 
 /** Insert a message row directly, bypassing indexing/job side effects. */
-function insertMessage(role: "user" | "assistant", createdAt: number): void {
+function insertMessage(
+  role: "user" | "assistant",
+  createdAt: number,
+  conversationType: "standard" | "background" | "scheduled" = "standard",
+): void {
   const sqlite = getSqlite();
-  const convId = `conv-${createdAt}-${role}`;
+  const convId = `conv-${createdAt}-${role}-${conversationType}`;
   sqlite
     .prepare(
-      "INSERT OR IGNORE INTO conversations (id, created_at, updated_at) VALUES (?, ?, ?)",
+      "INSERT OR IGNORE INTO conversations (id, created_at, updated_at, conversation_type) VALUES (?, ?, ?, ?)",
     )
-    .run(convId, createdAt, createdAt);
+    .run(convId, createdAt, createdAt, conversationType);
   sqlite
     .prepare(
       "INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES (?, ?, ?, ?, ?)",
     )
-    .run(`msg-${createdAt}-${role}`, convId, role, "[]", createdAt);
+    .run(
+      `msg-${createdAt}-${role}-${conversationType}`,
+      convId,
+      role,
+      "[]",
+      createdAt,
+    );
 }
 
 /** Pile writes into the WAL (without checkpointing) so a truncating
@@ -186,16 +198,79 @@ describe("maybeRunDbMaintenance", () => {
     // THEN it still runs, since only user activity gates it
     expect(getMemoryCheckpoint(MAINTENANCE_CHECKPOINT_KEY)).toBe(String(now));
   });
+
+  test("a recent user-role message in a background conversation does not keep maintenance deferred", async () => {
+    /** Background machinery persists user-role rows of its own — the
+     *  memory-retrospective instruction message lands as `role: "user"` in a
+     *  `background` conversation, and scheduled wake hints land in
+     *  `scheduled` ones. On an always-on install those arrive around the
+     *  clock, so counting them would starve maintenance forever. */
+    // GIVEN the human has been quiet past the quiet period
+    const now = Date.now();
+    insertMessage("user", now - (QUIET_PERIOD_MS + 60_000));
+    // AND background machinery wrote user-role rows just now
+    insertMessage("user", now - 60_000, "background");
+    insertMessage("user", now - 30_000, "scheduled");
+
+    // WHEN maintenance is considered
+    await maybeRunDbMaintenance(now);
+
+    // THEN it still runs — only interactive-conversation activity gates it
+    expect(getMemoryCheckpoint(MAINTENANCE_CHECKPOINT_KEY)).toBe(String(now));
+  });
 });
 
-describe("getLastUserMessageTimestamp", () => {
+describe("maybeRunPassiveWalCheckpoint", () => {
+  test("runs despite recent user activity — the passive pass has no quiet gate", async () => {
+    /** PASSIVE checkpoints block no readers or writers, so they must not be
+     *  deferred by user activity; deferring them is what lets the WAL
+     *  backlog grow on always-active installs. */
+    // GIVEN the user is active right now
+    const now = Date.now();
+    insertMessage("user", now - 1_000);
+
+    // WHEN the passive pass is considered
+    await maybeRunPassiveWalCheckpoint(now);
+
+    // THEN it runs and stamps its own checkpoint key
+    expect(getMemoryCheckpoint(PASSIVE_CHECKPOINT_KEY)).toBe(String(now));
+    // AND the truncating-maintenance key is untouched
+    expect(getMemoryCheckpoint(MAINTENANCE_CHECKPOINT_KEY)).toBeNull();
+  });
+
+  test("respects its own interval and skips when the last pass was recent", async () => {
+    const now = Date.now();
+    const recent = now - 60_000;
+    const { setMemoryCheckpoint } =
+      await import("../../../../persistence/checkpoints.js");
+    setMemoryCheckpoint(PASSIVE_CHECKPOINT_KEY, String(recent));
+
+    await maybeRunPassiveWalCheckpoint(now);
+
+    expect(getMemoryCheckpoint(PASSIVE_CHECKPOINT_KEY)).toBe(String(recent));
+  });
+});
+
+describe("applyConnectionPragmas", () => {
+  test("sets journal_size_limit so WAL resets shrink the file", () => {
+    /** Checkpointing alone never shrinks the WAL file; the size limit is what
+     *  truncates it back after a burst. Pin that every connection carries it. */
+    const sqlite = getSqlite();
+    const row = sqlite.query("PRAGMA journal_size_limit").get() as {
+      journal_size_limit: number;
+    };
+    expect(row.journal_size_limit).toBe(67108864);
+  });
+});
+
+describe("getLastInteractiveUserMessageTimestamp", () => {
   test("returns 0 when no user message exists", () => {
     /** With only non-user rows present, there is no user activity to report. */
     // GIVEN only an assistant message exists
     insertMessage("assistant", Date.now());
 
     // WHEN the last user message timestamp is read
-    const result = getLastUserMessageTimestamp();
+    const result = getLastInteractiveUserMessageTimestamp();
 
     // THEN it reports 0 (no user activity)
     expect(result).toBe(0);
@@ -211,7 +286,7 @@ describe("getLastUserMessageTimestamp", () => {
     insertMessage("assistant", base);
 
     // WHEN the last user message timestamp is read
-    const result = getLastUserMessageTimestamp();
+    const result = getLastInteractiveUserMessageTimestamp();
 
     // THEN it returns the most recent user message, not the assistant row
     expect(result).toBe(base - 5_000);
@@ -230,9 +305,28 @@ describe("getLastUserMessageTimestamp", () => {
     insertMessage("user", base - 60 * 60 * 1000);
 
     // WHEN the last user message timestamp is read
-    const result = getLastUserMessageTimestamp();
+    const result = getLastInteractiveUserMessageTimestamp();
 
     // THEN it reports the genuinely most recent turn, not the last-inserted one
     expect(result).toBe(base - 5_000);
+  });
+
+  test("ignores user-role rows in background and scheduled conversations", () => {
+    /** The memory-retrospective instruction message is persisted as
+     *  `role: "user"` inside a `background` fork, and scheduled/heartbeat
+     *  wake hints land in `scheduled`/`background` conversations — machine
+     *  writes, not human activity. */
+    // GIVEN an older interactive user message
+    const base = Date.now();
+    insertMessage("user", base - 10_000);
+    // AND newer user-role rows written by background machinery
+    insertMessage("user", base - 5_000, "background");
+    insertMessage("user", base - 1_000, "scheduled");
+
+    // WHEN the last interactive user message timestamp is read
+    const result = getLastInteractiveUserMessageTimestamp();
+
+    // THEN only the interactive conversation's message counts
+    expect(result).toBe(base - 10_000);
   });
 });

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -17,7 +17,10 @@ import {
   getLastScheduledCleanupEnqueueMs,
   markScheduledCleanupEnqueued,
 } from "../../../persistence/cleanup-schedule-state.js";
-import { maybeRunDbMaintenance } from "../../../persistence/db-maintenance.js";
+import {
+  maybeRunDbMaintenance,
+  maybeRunPassiveWalCheckpoint,
+} from "../../../persistence/db-maintenance.js";
 import {
   EmbeddingBillingBlockError,
   extractHttpStatus,
@@ -411,6 +414,7 @@ export async function runMemoryJobsOnce(
     maybeEnqueueGraphMaintenanceJobs(config);
     if (memoryEnabled) {
       await maybeRunDbMaintenance();
+      await maybeRunPassiveWalCheckpoint();
     }
     return 0;
   }
@@ -478,6 +482,7 @@ export async function runMemoryJobsOnce(
   }
   maybeEnqueueGraphMaintenanceJobs(config);
   await maybeRunDbMaintenance();
+  await maybeRunPassiveWalCheckpoint();
   return slowProcessed + fastProcessed + embedProcessed;
 }
 
@@ -871,7 +876,9 @@ function isWithinPkbActiveHours(
   start: number | null,
   end: number | null,
 ): boolean {
-  if (start == null || end == null) return true;
+  if (start == null || end == null) {
+    return true;
+  }
   if (start <= end) {
     return hour >= start && hour < end;
   }


### PR DESCRIPTION
## Summary
- `applyConnectionPragmas` sets `journal_size_limit=67108864` (64MB) so any WAL reset — including passive checkpoints between maintenance passes — truncates the file instead of leaving it at burst high-water forever; pinned by a pragma test.
- New `maybeRunPassiveWalCheckpoint` runs `wal_checkpoint(PASSIVE)` via the async subprocess every 15 minutes with no quiet gate (PASSIVE blocks no readers/writers and yields instantly to a concurrent checkpointer), wired into both jobs-worker tick paths next to `maybeRunDbMaintenance`; the `busy|log|checkpointed` triple is logged as the pinned-reader diagnostic. The optimize + TRUNCATE pass keeps its 24h + quiet gating.
- The quiet gate now measures *human* quiet: `getLastInteractiveUserMessageTimestamp` (renamed from `getLastUserMessageTimestamp`; db-maintenance was its only consumer) excludes `background`/`scheduled` conversations via a new `BACKGROUND_CONVERSATION_TYPES` list shared with `isBackgroundConversationType`. Verified against the actual creation sites: heartbeat → `background`, scheduler → `scheduled`, retrospective forks → `background`; `conversation_type` is NOT NULL DEFAULT 'standard' so the SQL `NOT IN` filter is null-safe. Regression tests cover the retro-instruction case, the passive tick's gating, and the pragma.

## Original prompt
Closes out the WAL-size investigation: the existing machinery (startup fold, shutdown fold, idle-gated TRUNCATE) fails on always-on instances because background jobs perpetually re-arm the 3h quiet gate — the retrospective instruction itself is a user-role row — so the truncating checkpoint never runs, and nothing between maintenance passes ever shrinks a ballooned WAL file. The ask: (a) journal_size_limit on every connection, (b) split cadences so a PASSIVE checkpoint runs ungated every ~15min while TRUNCATE stays idle-gated, (c) fix the quiet signal to count only interactive-conversation user messages, verifying the real conversationType values in the tree. Fourth of four fixes from this investigation (#37752 bulk-write gate, #37753 phase-3 immediate transaction, #37754 subprocess synchronous=NORMAL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)