### PR TITLE
test: drop stale scopeId assertion from conversation-agent-loop test

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -2254,7 +2254,6 @@ describe("session-agent-loop", () => {
           role: string;
           content: string;
           createdAt: number;
-          scopeId: string;
         },
         unknown,
       ];
@@ -2264,7 +2263,6 @@ describe("session-agent-loop", () => {
         conversationId: "test-conv",
         role: "assistant",
         createdAt: 1234567,
-        scopeId: "default",
       });
       expect(indexCall.content).toContain("indexed reply");
 


### PR DESCRIPTION
## Summary
- Removes the `scopeId: "default"` expectation (and the matching field in the inline mock-call type cast) from the B3 pre-allocation indexing test in `assistant/src/__tests__/conversation-agent-loop.test.ts`.
- #37755 removed `scope_id` from the SQL/v1 memory layer, dropping `scopeId` from `IndexMessageInput` and the `indexMessageNow` call site — the test assertion was left behind, failing the CI Main Assistant Checks Test job on every main commit since 77894833b9.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/29062473099/job/86267081850