### PR TITLE
test: mock maybeRunPassiveWalCheckpoint in disk-pressure background-workers test

### DIFF
--- a/assistant/src/__tests__/background-workers-disk-pressure.test.ts
+++ b/assistant/src/__tests__/background-workers-disk-pressure.test.ts
@@ -198,8 +198,10 @@ mock.module("../persistence/jobs-store.js", () => ({
 }));
 
 const mockMaybeRunDbMaintenance = mock(() => {});
+const mockMaybeRunPassiveWalCheckpoint = mock(() => {});
 mock.module("../persistence/db-maintenance.js", () => ({
   maybeRunDbMaintenance: mockMaybeRunDbMaintenance,
+  maybeRunPassiveWalCheckpoint: mockMaybeRunPassiveWalCheckpoint,
 }));
 
 mock.module("../persistence/cleanup-schedule-state.js", () => ({
@@ -219,6 +221,7 @@ describe("background workers disk pressure gate", () => {
     mockFailStalledJobs.mockClear();
     mockClaimMemoryJobs.mockClear();
     mockMaybeRunDbMaintenance.mockClear();
+    mockMaybeRunPassiveWalCheckpoint.mockClear();
   });
 
   test("memory jobs worker skips before claiming or maintenance writes", async () => {
@@ -228,6 +231,7 @@ describe("background workers disk pressure gate", () => {
     expect(mockFailStalledJobs).not.toHaveBeenCalled();
     expect(mockClaimMemoryJobs).not.toHaveBeenCalled();
     expect(mockMaybeRunDbMaintenance).not.toHaveBeenCalled();
+    expect(mockMaybeRunPassiveWalCheckpoint).not.toHaveBeenCalled();
   });
 
   test("workspace heartbeat skips auto-commit checks while locked", async () => {


### PR DESCRIPTION
## Summary
- Fixes the failing `Test` job on `main` ([run 29062903401](https://github.com/vellum-ai/vellum-assistant/actions/runs/29062903401/job/86268376434)): `background-workers-disk-pressure.test.ts` failed with `SyntaxError: Export named 'maybeRunPassiveWalCheckpoint' not found in module .../persistence/db-maintenance.ts`.
- #37759 added a `maybeRunPassiveWalCheckpoint` import to `jobs-worker.ts`, but this test's `mock.module("../persistence/db-maintenance.js", ...)` replacement only exported `maybeRunDbMaintenance`. Because the test dynamically imports `jobs-worker.js` after the mock is registered, ESM linking against the mock fails on the missing named export. (The lanes test mocks the same module but passed — its static imports are hoisted, so the real module links first and gets patched in place.)
- Adds the missing export to the mock and asserts the passive WAL checkpoint is also not called under disk pressure, consistent with the test's purpose (worker skips before any maintenance writes).

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/29062903401/job/86268376434