### PR TITLE
fix(test): await async loadRetrospectiveRunMessages calls from crossed PRs

### DIFF
--- a/assistant/src/__tests__/conversation-fork-retrospective.test.ts
+++ b/assistant/src/__tests__/conversation-fork-retrospective.test.ts
@@ -549,7 +549,7 @@ describe("forkConversationForRetrospective — compacted source", () => {
       .set({ createdAt: tip.createdAt + 100 })
       .where(eq(messages.id, runMessage.id))
       .run();
-    const runRows = loadRetrospectiveRunMessages(
+    const runRows = await loadRetrospectiveRunMessages(
       fork.id,
       MEMORY_RETROSPECTIVE_FORK_SOURCE,
     );
@@ -602,7 +602,7 @@ describe("forkConversationForRetrospective — compacted source", () => {
       },
       skipIndexing: true,
     });
-    const runRows = loadRetrospectiveRunMessages(
+    const runRows = await loadRetrospectiveRunMessages(
       fork.id,
       MEMORY_RETROSPECTIVE_FORK_SOURCE,
     );


### PR DESCRIPTION
## Summary
- #37749 (tail-only retrospective fork copy) added two `loadRetrospectiveRunMessages` call sites written against the pre-#37750 sync signature; the two PRs crossed in flight, so `main` currently fails `typecheck:fast` in `conversation-fork-retrospective.test.ts`.
- Adds `await` at both call sites (their enclosing tests are already `async`). No behavior change beyond restoring the assertions to run against resolved rows.

Verified locally: `bun run typecheck:fast` clean, `bun test src/__tests__/conversation-fork-retrospective.test.ts` 14/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)