### PR TITLE
test: await async loadRetrospectiveRunMessages in fork-retrospective test

### DIFF
--- a/assistant/src/__tests__/conversation-fork-retrospective.test.ts
+++ b/assistant/src/__tests__/conversation-fork-retrospective.test.ts
@@ -549,7 +549,7 @@ describe("forkConversationForRetrospective — compacted source", () => {
       .set({ createdAt: tip.createdAt + 100 })
       .where(eq(messages.id, runMessage.id))
       .run();
-    const runRows = loadRetrospectiveRunMessages(
+    const runRows = await loadRetrospectiveRunMessages(
       fork.id,
       MEMORY_RETROSPECTIVE_FORK_SOURCE,
     );
@@ -602,7 +602,7 @@ describe("forkConversationForRetrospective — compacted source", () => {
       },
       skipIndexing: true,
     });
-    const runRows = loadRetrospectiveRunMessages(
+    const runRows = await loadRetrospectiveRunMessages(
       fork.id,
       MEMORY_RETROSPECTIVE_FORK_SOURCE,
     );


### PR DESCRIPTION
Two call sites in `conversation-fork-retrospective.test.ts` missed their `await` when `loadRetrospectiveRunMessages` became async, calling `.map` on the returned promise. This fails `tsc`/`tsgo` and therefore blocks every commit repo-wide via the pre-commit hook's type-check step.

Mechanical fix: add the two missing `await`s. Test file passes (14/14) and `typecheck:fast` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)