### PR TITLE
feat(theme): validated workspace theme overrides with live sync invalidation

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -30982,6 +30982,93 @@ paths:
                   - oldPath
                   - newPath
                 additionalProperties: false
+  /v1/workspace/theme:
+    get:
+      operationId: workspace_theme_get
+      summary: Get workspace theme
+      description:
+        "Return validated design-token overrides from the workspace ui/theme.json. Absent or rejected files yield
+        theme: null with the rejection reasons in issues; clients fall back to built-in theme defaults."
+      tags:
+        - workspace
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  theme:
+                    anyOf:
+                      - type: object
+                        properties:
+                          version:
+                            type: number
+                            const: 1
+                          base:
+                            type: string
+                            enum:
+                              - light
+                              - dark
+                              - velvet
+                              - system
+                          tokens:
+                            type: object
+                            properties:
+                              accent:
+                                type: string
+                                pattern: ^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$
+                              background:
+                                type: string
+                                pattern: ^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$
+                              surface:
+                                type: string
+                                pattern: ^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$
+                              surfaceRaised:
+                                type: string
+                                pattern: ^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$
+                              border:
+                                type: string
+                                pattern: ^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$
+                              text:
+                                type: string
+                                pattern: ^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$
+                              textMuted:
+                                type: string
+                                pattern: ^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$
+                              assistantBubbleBackground:
+                                type: string
+                                pattern: ^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$
+                              assistantBubbleText:
+                                type: string
+                                pattern: ^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$
+                              userBubbleBackground:
+                                type: string
+                                pattern: ^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$
+                              userBubbleText:
+                                type: string
+                                pattern: ^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$
+                            additionalProperties: false
+                        required:
+                          - version
+                        additionalProperties: false
+                      - type: "null"
+                  source:
+                    type: string
+                    enum:
+                      - workspace
+                      - invalid
+                      - none
+                  issues:
+                    type: array
+                    items:
+                      type: string
+                required:
+                  - theme
+                  - source
+                  - issues
+                additionalProperties: false
   /v1/workspace/tree:
     get:
       operationId: workspace_tree_get

--- a/assistant/src/__tests__/config-watcher-skill-reseed.test.ts
+++ b/assistant/src/__tests__/config-watcher-skill-reseed.test.ts
@@ -136,6 +136,7 @@ mock.module("../runtime/sync/resource-sync-events.js", () => ({
   publishConfigChanged: () => {},
   publishSoundsConfigUpdated: () => {},
   publishAvatarChanged: () => {},
+  publishWorkspaceThemeChanged: () => {},
 }));
 
 mock.module("../platform/sync-identity.js", () => ({

--- a/assistant/src/__tests__/config-watcher.test.ts
+++ b/assistant/src/__tests__/config-watcher.test.ts
@@ -147,6 +147,7 @@ mock.module("../signals/cancel.js", () => ({
 // or client broadcasts.
 let evictCallCount = 0;
 let identityCallCount = 0;
+let themeCallCount = 0;
 
 mock.module("../daemon/conversation-store.js", () => ({
   evictConversationsForReload: () => {
@@ -161,6 +162,9 @@ mock.module("../runtime/sync/resource-sync-events.js", () => ({
   publishConfigChanged: () => {},
   publishSoundsConfigUpdated: () => {},
   publishAvatarChanged: () => {},
+  publishWorkspaceThemeChanged: () => {
+    themeCallCount++;
+  },
 }));
 
 mock.module("../daemon/skill-memory-refresh.js", () => ({
@@ -190,7 +194,12 @@ function findFileWatch(filePath: string): CapturedFileWatch | undefined {
   return capturedFileWatches.find((w) => w.filePath === filePath);
 }
 
-const WORKSPACE_FILES = new Set(["config.json", "SOUL.md", "IDENTITY.md"]);
+const WORKSPACE_FILES = new Set([
+  "config.json",
+  "SOUL.md",
+  "IDENTITY.md",
+  "ui/theme.json",
+]);
 
 // Each call advances the inode + mtime so the listener's early-return guard
 // (curr.ino === prev.ino && curr.mtimeMs === prev.mtimeMs) doesn't fire.
@@ -242,6 +251,7 @@ beforeEach(() => {
   inoMap.clear();
   evictCallCount = 0;
   identityCallCount = 0;
+  themeCallCount = 0;
   watcher = new ConfigWatcher(undefined, TEST_DEBOUNCE_MS);
 });
 
@@ -273,11 +283,19 @@ describe("ConfigWatcher workspace file handlers", () => {
 
   test("unregistered workspace files are not subscribed (only the registered handler set is)", () => {
     watcher.start();
-    // Per-file watching only registers config.json, SOUL.md, IDENTITY.md.
-    // The whole workspace dir must not be watched either — that was the
-    // ENXIO-on-Unix-sockets bug.
+    // Per-file watching only registers config.json, SOUL.md, IDENTITY.md,
+    // and ui/theme.json. The whole workspace dir must not be watched
+    // either — that was the ENXIO-on-Unix-sockets bug.
     expect(findFileWatch(join(WORKSPACE_DIR, "OTHER.md"))).toBeUndefined();
     expect(findWatcher(WORKSPACE_DIR)).toBeUndefined();
+  });
+
+  test("ui/theme.json change publishes the workspace-theme invalidation", async () => {
+    watcher.start();
+    simulateFileChange(WORKSPACE_DIR, "ui/theme.json");
+    await new Promise((r) => setTimeout(r, WAIT_MS));
+    expect(themeCallCount).toBe(1);
+    expect(evictCallCount).toBe(0);
   });
 
   test("config.json change calls refreshConfigFromSources", async () => {

--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -27,11 +27,13 @@ import {
   publishConfigChanged,
   publishIdentityChanged,
   publishSoundsConfigUpdated,
+  publishWorkspaceThemeChanged,
 } from "../runtime/sync/resource-sync-events.js";
 import { handleCancelSignal } from "../signals/cancel.js";
 import { handleConversationUndoSignal } from "../signals/conversation-undo.js";
 import { handleEmitEventSignal } from "../signals/emit-event.js";
 import { handleUserMessageSignal } from "../signals/user-message.js";
+import { WORKSPACE_THEME_RELATIVE_PATH } from "../theme/workspace-theme.js";
 import { DebouncerMap } from "../util/debounce.js";
 import { getLogger } from "../util/logger.js";
 import {
@@ -63,7 +65,9 @@ const SKILL_WATCH_SKIPPED_DIRS = new Set([
 ]);
 
 function isSkippedSkillWatchPath(relativePath: string): boolean {
-  if (relativePath === "(unknown)") return false;
+  if (relativePath === "(unknown)") {
+    return false;
+  }
 
   const segments = relativePath.split(/[\\/]+/).filter(Boolean);
   return segments.some((segment) => SKILL_WATCH_SKIPPED_DIRS.has(segment));
@@ -204,7 +208,9 @@ export class ConfigWatcher {
 
     const workspaceHandlers: Record<string, () => void> = {
       "config.json": async () => {
-        if (this.suppressReload) return;
+        if (this.suppressReload) {
+          return;
+        }
         try {
           const prevMcpFingerprint = JSON.stringify(this.lastConfig?.mcp ?? {});
           const changed = await this.refreshConfigFromSources();
@@ -232,6 +238,9 @@ export class ConfigWatcher {
       "IDENTITY.md": () => {
         evictConversationsForReload();
         broadcastIdentityChange();
+      },
+      [WORKSPACE_THEME_RELATIVE_PATH]: () => {
+        publishWorkspaceThemeChanged();
       },
     };
 
@@ -272,8 +281,12 @@ export class ConfigWatcher {
     // edge case must not propagate up to DaemonServer.start().
     try {
       watchFile(filePath, { interval: this.pollIntervalMs }, (curr, prev) => {
-        if (this.stopped) return;
-        if (curr.ino === prev.ino && curr.mtimeMs === prev.mtimeMs) return;
+        if (this.stopped) {
+          return;
+        }
+        if (curr.ino === prev.ino && curr.mtimeMs === prev.mtimeMs) {
+          return;
+        }
         this.debounceTimers.schedule(`file:${filePath}`, () => {
           log.info({ file: filePath }, "File changed, reloading");
           handler();
@@ -301,7 +314,9 @@ export class ConfigWatcher {
 
     try {
       const watcher = watch(soundsDir, (_eventType, filename) => {
-        if (!filename) return;
+        if (!filename) {
+          return;
+        }
         this.debounceTimers.schedule("file:sounds", () => {
           log.info(
             { file: String(filename) },
@@ -333,9 +348,13 @@ export class ConfigWatcher {
 
     try {
       const watcher = watch(usersDir, (_eventType, filename) => {
-        if (!filename) return;
+        if (!filename) {
+          return;
+        }
         const file = String(filename);
-        if (!file.endsWith(".md")) return;
+        if (!file.endsWith(".md")) {
+          return;
+        }
         this.debounceTimers.schedule(`file:users/${file}`, () => {
           log.info({ file }, "Users persona file changed, reloading");
           evictConversationsForReload();
@@ -367,8 +386,12 @@ export class ConfigWatcher {
 
     try {
       const watcher = watch(avatarDir, (_eventType, filename) => {
-        if (!filename) return;
-        if (String(filename) !== AVATAR_IMAGE_FILENAME) return;
+        if (!filename) {
+          return;
+        }
+        if (String(filename) !== AVATAR_IMAGE_FILENAME) {
+          return;
+        }
         this.debounceTimers.schedule("file:avatar", () => {
           log.info(
             { file: String(filename) },
@@ -413,7 +436,9 @@ export class ConfigWatcher {
 
     try {
       const watcher = watch(signalsDir, (_eventType, filename) => {
-        if (!filename) return;
+        if (!filename) {
+          return;
+        }
         const file = String(filename);
 
         if (exactSignalHandlers[file]) {
@@ -447,10 +472,14 @@ export class ConfigWatcher {
 
   private startSkillsWatchers(): void {
     const skillsDir = getWorkspaceSkillsDir();
-    if (!existsSync(skillsDir)) return;
+    if (!existsSync(skillsDir)) {
+      return;
+    }
 
     const scheduleSkillsReload = (file: string): void => {
-      if (isSkippedSkillWatchPath(file)) return;
+      if (isSkippedSkillWatchPath(file)) {
+        return;
+      }
 
       this.debounceTimers.schedule("skills:catalog", () => {
         log.info({ file }, "Skill file changed, reloading");
@@ -529,8 +558,12 @@ export class ConfigWatcher {
       }
 
       for (const entry of entries) {
-        if (!entry.isDirectory()) continue;
-        if (SKILL_WATCH_SKIPPED_DIRS.has(entry.name)) continue;
+        if (!entry.isDirectory()) {
+          continue;
+        }
+        if (SKILL_WATCH_SKIPPED_DIRS.has(entry.name)) {
+          continue;
+        }
         const childDir = join(dirPath, entry.name);
         acc.add(childDir);
         enumerateSkillSubdirectories(childDir, acc);
@@ -554,16 +587,22 @@ export class ConfigWatcher {
       }
 
       for (const [childDir, watcher] of childWatchers.entries()) {
-        if (nextChildDirs.has(childDir)) continue;
+        if (nextChildDirs.has(childDir)) {
+          continue;
+        }
         closeChildWatcher(childDir, watcher);
       }
 
       for (const childDir of nextChildDirs) {
-        if (childWatchers.has(childDir)) continue;
+        if (childWatchers.has(childDir)) {
+          continue;
+        }
 
         const watcher = watchDir(childDir, (filename) => {
           const file = formatSkillChangeLabel(childDir, filename);
-          if (isSkippedSkillWatchPath(file)) return;
+          if (isSkippedSkillWatchPath(file)) {
+            return;
+          }
 
           scheduleSkillsReload(file);
           refreshChildWatchers();
@@ -575,13 +614,17 @@ export class ConfigWatcher {
     };
 
     const rootWatcher = watchDir(skillsDir, (filename) => {
-      if (isSkippedSkillWatchPath(filename)) return;
+      if (isSkippedSkillWatchPath(filename)) {
+        return;
+      }
 
       scheduleSkillsReload(filename);
       refreshChildWatchers();
     });
 
-    if (!rootWatcher) return;
+    if (!rootWatcher) {
+      return;
+    }
 
     refreshChildWatchers();
     log.info(
@@ -645,7 +688,9 @@ export function cleanupSettingsChanged(
   prev: MemoryCleanupConfig | undefined,
   next: MemoryCleanupConfig | undefined,
 ): boolean {
-  if (!prev || !next) return false;
+  if (!prev || !next) {
+    return false;
+  }
   return (
     prev.llmRequestLogRetentionMs !== next.llmRequestLogRetentionMs ||
     prev.conversationRetentionDays !== next.conversationRetentionDays ||

--- a/assistant/src/daemon/message-types/sync.ts
+++ b/assistant/src/daemon/message-types/sync.ts
@@ -13,6 +13,7 @@ export const SYNC_TAGS = {
   assistantConfig: "assistant:self:config",
   assistantSounds: "assistant:self:sounds",
   assistantSchedules: "assistant:self:schedules",
+  assistantTheme: "assistant:self:theme",
   appsList: "apps:list",
   pluginsList: "plugins:list",
   conversationsList: "conversations:list",

--- a/assistant/src/runtime/routes/__tests__/theme-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/theme-routes.test.ts
@@ -1,0 +1,66 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { WorkspaceThemeReadResult } from "../../../theme/workspace-theme.js";
+import { ROUTES } from "../theme-routes.js";
+
+function getThemeHandler() {
+  const route = ROUTES.find((r) => r.operationId === "workspace_theme_get");
+  if (!route) {
+    throw new Error("workspace_theme_get route not registered");
+  }
+  expect(route.endpoint).toBe("workspace/theme");
+  expect(route.method).toBe("GET");
+  return route.handler as () => WorkspaceThemeReadResult;
+}
+
+describe("GET /workspace/theme", () => {
+  let workspaceDir: string;
+  let prevWorkspaceDir: string | undefined;
+
+  beforeEach(() => {
+    workspaceDir = mkdtempSync(join(tmpdir(), "theme-route-test-"));
+    prevWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+    process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+  });
+
+  afterEach(() => {
+    if (prevWorkspaceDir === undefined) {
+      delete process.env.VELLUM_WORKSPACE_DIR;
+    } else {
+      process.env.VELLUM_WORKSPACE_DIR = prevWorkspaceDir;
+    }
+    rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  test("returns source none when no theme file exists", () => {
+    const result = getThemeHandler()();
+    expect(result).toEqual({ theme: null, source: "none", issues: [] });
+  });
+
+  test("returns the validated theme when the file is valid", () => {
+    mkdirSync(join(workspaceDir, "ui"), { recursive: true });
+    writeFileSync(
+      join(workspaceDir, "ui", "theme.json"),
+      JSON.stringify({ version: 1, base: "velvet" }),
+    );
+    const result = getThemeHandler()();
+    expect(result.source).toBe("workspace");
+    expect(result.theme).toEqual({ version: 1, base: "velvet" });
+    expect(result.issues).toEqual([]);
+  });
+
+  test("returns null theme plus issues when the file is rejected", () => {
+    mkdirSync(join(workspaceDir, "ui"), { recursive: true });
+    writeFileSync(
+      join(workspaceDir, "ui", "theme.json"),
+      JSON.stringify({ version: 1, tokens: { accent: "not-a-color" } }),
+    );
+    const result = getThemeHandler()();
+    expect(result.source).toBe("invalid");
+    expect(result.theme).toBeNull();
+    expect(result.issues.length).toBeGreaterThan(0);
+  });
+});

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -136,6 +136,7 @@ import { ROUTES as SURFACE_ACTION_ROUTES } from "./surface-action-routes.js";
 import { ROUTES as SURFACE_CONTENT_ROUTES } from "./surface-content-routes.js";
 import { ROUTES as TASK_ROUTES } from "./task-routes.js";
 import { ROUTES as TELEMETRY_ROUTES } from "./telemetry-routes.js";
+import { ROUTES as THEME_ROUTES } from "./theme-routes.js";
 import { ROUTES as TRUST_RULES_ROUTES } from "./trust-rules-routes.js";
 import { ROUTES as TTS_ROUTES } from "./tts-routes.js";
 import type { RouteDefinition } from "./types.js";
@@ -279,6 +280,7 @@ export const ROUTES: RouteDefinition[] = [
   ...TWILIO_ROUTES,
   ...TASK_ROUTES,
   ...TELEMETRY_ROUTES,
+  ...THEME_ROUTES,
   ...TRUST_RULES_ROUTES,
   ...TTS_ROUTES,
   ...UI_REQUEST_ROUTES,

--- a/assistant/src/runtime/routes/theme-routes.ts
+++ b/assistant/src/runtime/routes/theme-routes.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+import {
+  readWorkspaceTheme,
+  WorkspaceThemeSchema,
+} from "../../theme/workspace-theme.js";
+import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import type { RouteDefinition } from "./types.js";
+
+function handleGetWorkspaceTheme() {
+  return readWorkspaceTheme();
+}
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "workspace_theme_get",
+    endpoint: "workspace/theme",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    handler: handleGetWorkspaceTheme,
+    summary: "Get workspace theme",
+    description:
+      "Return validated design-token overrides from the workspace ui/theme.json. " +
+      "Absent or rejected files yield theme: null with the rejection reasons in issues; " +
+      "clients fall back to built-in theme defaults.",
+    tags: ["workspace"],
+    responseBody: z.object({
+      theme: WorkspaceThemeSchema.nullable(),
+      source: z.enum(["workspace", "invalid", "none"]),
+      issues: z.array(z.string()),
+    }),
+  },
+];

--- a/assistant/src/runtime/sync/resource-sync-events.ts
+++ b/assistant/src/runtime/sync/resource-sync-events.ts
@@ -57,6 +57,10 @@ export function publishSchedulesChanged(originClientId?: string): void {
   void publishSyncInvalidation([SYNC_TAGS.assistantSchedules], originClientId);
 }
 
+export function publishWorkspaceThemeChanged(originClientId?: string): void {
+  void publishSyncInvalidation([SYNC_TAGS.assistantTheme], originClientId);
+}
+
 export function publishAppsChanged(originClientId?: string): void {
   void publishSyncInvalidation([SYNC_TAGS.appsList], originClientId);
 }

--- a/assistant/src/theme/workspace-theme.test.ts
+++ b/assistant/src/theme/workspace-theme.test.ts
@@ -1,0 +1,179 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  contrastRatio,
+  MIN_TEXT_CONTRAST_RATIO,
+  readWorkspaceTheme,
+  WORKSPACE_THEME_RELATIVE_PATH,
+} from "./workspace-theme.js";
+
+describe("readWorkspaceTheme", () => {
+  let workspaceDir: string;
+  let prevWorkspaceDir: string | undefined;
+
+  beforeEach(() => {
+    workspaceDir = mkdtempSync(join(tmpdir(), "workspace-theme-test-"));
+    prevWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+    process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+  });
+
+  afterEach(() => {
+    if (prevWorkspaceDir === undefined) {
+      delete process.env.VELLUM_WORKSPACE_DIR;
+    } else {
+      process.env.VELLUM_WORKSPACE_DIR = prevWorkspaceDir;
+    }
+    rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  function writeTheme(content: string): void {
+    const themePath = join(workspaceDir, WORKSPACE_THEME_RELATIVE_PATH);
+    mkdirSync(join(workspaceDir, "ui"), { recursive: true });
+    writeFileSync(themePath, content);
+  }
+
+  test("absent file yields source none with no issues", () => {
+    const result = readWorkspaceTheme();
+    expect(result).toEqual({ theme: null, source: "none", issues: [] });
+  });
+
+  test("valid theme parses with all token slots", () => {
+    writeTheme(
+      JSON.stringify({
+        version: 1,
+        base: "dark",
+        tokens: {
+          accent: "#e8a04c",
+          background: "#1c1512",
+          surface: "#2b2018",
+          surfaceRaised: "#332619",
+          border: "#43301f",
+          text: "#f2e4d4",
+          textMuted: "#a68d75",
+          assistantBubbleBackground: "#33202a",
+          assistantBubbleText: "#ffd7e4",
+          userBubbleBackground: "#26201a",
+          userBubbleText: "#efe3d2",
+        },
+      }),
+    );
+    const result = readWorkspaceTheme();
+    expect(result.source).toBe("workspace");
+    expect(result.issues).toEqual([]);
+    expect(result.theme?.base).toBe("dark");
+    expect(result.theme?.tokens?.accent).toBe("#e8a04c");
+  });
+
+  test("minimal theme (version only) is valid", () => {
+    writeTheme(JSON.stringify({ version: 1 }));
+    const result = readWorkspaceTheme();
+    expect(result.source).toBe("workspace");
+    expect(result.theme).toEqual({ version: 1 });
+  });
+
+  test("3-digit hex colors are accepted", () => {
+    writeTheme(JSON.stringify({ version: 1, tokens: { accent: "#f0a" } }));
+    const result = readWorkspaceTheme();
+    expect(result.source).toBe("workspace");
+  });
+
+  test("unknown top-level keys are rejected", () => {
+    writeTheme(JSON.stringify({ version: 1, css: "body { display: none }" }));
+    const result = readWorkspaceTheme();
+    expect(result.source).toBe("invalid");
+    expect(result.theme).toBeNull();
+    expect(result.issues.length).toBeGreaterThan(0);
+  });
+
+  test("unknown token slots are rejected", () => {
+    writeTheme(
+      JSON.stringify({ version: 1, tokens: { zIndexOverlay: "#000000" } }),
+    );
+    const result = readWorkspaceTheme();
+    expect(result.source).toBe("invalid");
+    expect(result.theme).toBeNull();
+  });
+
+  test("non-hex values are rejected, including alpha hex and CSS functions", () => {
+    for (const value of ["#aabbccdd", "red", "url(http://evil)", "#12"]) {
+      writeTheme(JSON.stringify({ version: 1, tokens: { accent: value } }));
+      const result = readWorkspaceTheme();
+      expect(result.source).toBe("invalid");
+      expect(result.theme).toBeNull();
+    }
+  });
+
+  test("unsupported version is rejected", () => {
+    writeTheme(JSON.stringify({ version: 2 }));
+    const result = readWorkspaceTheme();
+    expect(result.source).toBe("invalid");
+  });
+
+  test("malformed JSON is rejected with a readable issue", () => {
+    writeTheme("{ version: 1 ");
+    const result = readWorkspaceTheme();
+    expect(result.source).toBe("invalid");
+    expect(result.issues[0]).toContain("not valid JSON");
+  });
+
+  test("illegible text/background pair is rejected by the contrast floor", () => {
+    writeTheme(
+      JSON.stringify({
+        version: 1,
+        tokens: { text: "#fefefe", background: "#ffffff" },
+      }),
+    );
+    const result = readWorkspaceTheme();
+    expect(result.source).toBe("invalid");
+    expect(result.theme).toBeNull();
+    expect(result.issues[0]).toContain("contrast");
+  });
+
+  test("contrast floor is skipped when only one side of a pair is set", () => {
+    writeTheme(JSON.stringify({ version: 1, tokens: { text: "#ffffff" } }));
+    const result = readWorkspaceTheme();
+    expect(result.source).toBe("workspace");
+  });
+
+  test("bubble text/background pairs are contrast-checked", () => {
+    writeTheme(
+      JSON.stringify({
+        version: 1,
+        tokens: {
+          assistantBubbleText: "#111111",
+          assistantBubbleBackground: "#141414",
+        },
+      }),
+    );
+    const result = readWorkspaceTheme();
+    expect(result.source).toBe("invalid");
+  });
+});
+
+describe("contrastRatio", () => {
+  test("black on white is the maximum 21:1", () => {
+    expect(contrastRatio("#000000", "#ffffff")).toBeCloseTo(21, 0);
+  });
+
+  test("identical colors are 1:1", () => {
+    expect(contrastRatio("#336699", "#336699")).toBeCloseTo(1, 5);
+  });
+
+  test("is order-independent", () => {
+    expect(contrastRatio("#000000", "#ffffff")).toBe(
+      contrastRatio("#ffffff", "#000000"),
+    );
+  });
+
+  test("floor constant catches near-invisible text", () => {
+    expect(contrastRatio("#fefefe", "#ffffff")).toBeLessThan(
+      MIN_TEXT_CONTRAST_RATIO,
+    );
+    expect(contrastRatio("#f2e4d4", "#1c1512")).toBeGreaterThan(
+      MIN_TEXT_CONTRAST_RATIO,
+    );
+  });
+});

--- a/assistant/src/theme/workspace-theme.test.ts
+++ b/assistant/src/theme/workspace-theme.test.ts
@@ -123,7 +123,13 @@ describe("readWorkspaceTheme", () => {
     writeTheme(
       JSON.stringify({
         version: 1,
-        tokens: { text: "#fefefe", background: "#ffffff" },
+        tokens: {
+          text: "#fefefe",
+          textMuted: "#555555",
+          background: "#ffffff",
+          surface: "#f2f2f2",
+          surfaceRaised: "#e8e8e8",
+        },
       }),
     );
     const result = readWorkspaceTheme();
@@ -132,10 +138,39 @@ describe("readWorkspaceTheme", () => {
     expect(result.issues[0]).toContain("contrast");
   });
 
-  test("contrast floor is skipped when only one side of a pair is set", () => {
-    writeTheme(JSON.stringify({ version: 1, tokens: { text: "#ffffff" } }));
+  test("partial core override group is rejected, naming the missing tokens", () => {
+    writeTheme(
+      JSON.stringify({ version: 1, tokens: { background: "#000000" } }),
+    );
+    const result = readWorkspaceTheme();
+    expect(result.source).toBe("invalid");
+    expect(result.theme).toBeNull();
+    expect(result.issues[0]).toContain("incomplete override group");
+    expect(result.issues[0]).toContain("tokens.text");
+  });
+
+  test("partial bubble pair is rejected", () => {
+    writeTheme(
+      JSON.stringify({
+        version: 1,
+        tokens: { assistantBubbleBackground: "#33202a" },
+      }),
+    );
+    const result = readWorkspaceTheme();
+    expect(result.source).toBe("invalid");
+    expect(result.issues[0]).toContain("incomplete override group");
+  });
+
+  test("group-exempt tokens (accent, border) are valid alone", () => {
+    writeTheme(
+      JSON.stringify({
+        version: 1,
+        tokens: { accent: "#e8a04c", border: "#43301f" },
+      }),
+    );
     const result = readWorkspaceTheme();
     expect(result.source).toBe("workspace");
+    expect(result.issues).toEqual([]);
   });
 
   test("bubble text/background pairs are contrast-checked", () => {
@@ -150,6 +185,7 @@ describe("readWorkspaceTheme", () => {
     );
     const result = readWorkspaceTheme();
     expect(result.source).toBe("invalid");
+    expect(result.issues[0]).toContain("contrast");
   });
 });
 

--- a/assistant/src/theme/workspace-theme.ts
+++ b/assistant/src/theme/workspace-theme.ts
@@ -7,6 +7,9 @@
  * - only the semantic token slots below are accepted (unknown keys reject),
  * - values must be plain 3- or 6-digit hex colors (no alpha, so the
  *   contrast floor stays meaningful),
+ * - tokens that resolve against each other are all-or-none per override
+ *   group, so a partial override can never pair an authored color with an
+ *   unknown base-theme color,
  * - text/background pairs must clear a minimum contrast ratio so an
  *   authored theme can never render core copy illegible.
  *
@@ -65,8 +68,9 @@ export type WorkspaceTheme = z.infer<typeof WorkspaceThemeSchema>;
 export const MIN_TEXT_CONTRAST_RATIO = 3;
 
 /**
- * Token pairs that must clear the contrast floor when both sides are
- * present: [foreground, background].
+ * Token pairs that must clear the contrast floor: [foreground, background].
+ * Group completeness (below) guarantees both sides are present whenever
+ * either is, so every pair is always checkable.
  */
 const CONTRAST_PAIRS: readonly [
   keyof WorkspaceThemeTokens,
@@ -74,10 +78,41 @@ const CONTRAST_PAIRS: readonly [
 ][] = [
   ["text", "background"],
   ["text", "surface"],
+  ["text", "surfaceRaised"],
   ["textMuted", "background"],
   ["assistantBubbleText", "assistantBubbleBackground"],
   ["userBubbleText", "userBubbleBackground"],
 ];
+
+/**
+ * Tokens that resolve against each other must be overridden together.
+ * Clients layer these tokens over a base theme whose palette the daemon
+ * does not know, so a half-overridden pairing (e.g. a dark `background`
+ * with the base's dark `text` inherited) would bypass the contrast floor.
+ * `accent` and `border` are exempt: no body copy resolves against them.
+ */
+const OVERRIDE_GROUPS: readonly (keyof WorkspaceThemeTokens)[][] = [
+  ["background", "surface", "surfaceRaised", "text", "textMuted"],
+  ["assistantBubbleBackground", "assistantBubbleText"],
+  ["userBubbleBackground", "userBubbleText"],
+];
+
+function groupCompletenessIssues(tokens: WorkspaceThemeTokens): string[] {
+  const issues: string[] = [];
+  for (const group of OVERRIDE_GROUPS) {
+    const set = group.filter((key) => tokens[key] !== undefined);
+    if (set.length === 0 || set.length === group.length) {
+      continue;
+    }
+    const missing = group.filter((key) => tokens[key] === undefined);
+    issues.push(
+      `incomplete override group: setting ${set.map((k) => `tokens.${k}`).join(", ")} also requires ` +
+        `${missing.map((k) => `tokens.${k}`).join(", ")} — a partial override mixes with unknown ` +
+        `base-theme colors, which would bypass the contrast floor`,
+    );
+  }
+  return issues;
+}
 
 function expandHex(hex: string): string {
   const raw = hex.slice(1);
@@ -190,11 +225,15 @@ export function readWorkspaceTheme(): WorkspaceThemeReadResult {
     };
   }
 
-  const legibility = result.data.tokens
-    ? contrastIssues(result.data.tokens)
-    : [];
-  if (legibility.length > 0) {
-    return { theme: null, source: "invalid", issues: legibility };
+  if (result.data.tokens) {
+    const completeness = groupCompletenessIssues(result.data.tokens);
+    if (completeness.length > 0) {
+      return { theme: null, source: "invalid", issues: completeness };
+    }
+    const legibility = contrastIssues(result.data.tokens);
+    if (legibility.length > 0) {
+      return { theme: null, source: "invalid", issues: legibility };
+    }
   }
 
   return { theme: result.data, source: "workspace", issues: [] };

--- a/assistant/src/theme/workspace-theme.ts
+++ b/assistant/src/theme/workspace-theme.ts
@@ -1,0 +1,201 @@
+/**
+ * Workspace theme: user- or assistant-authored design-token overrides read
+ * from `ui/theme.json` in the workspace. Clients apply the validated tokens
+ * on top of the built-in themes (light/dark/velvet).
+ *
+ * Security posture is a strict whitelist:
+ * - only the semantic token slots below are accepted (unknown keys reject),
+ * - values must be plain 3- or 6-digit hex colors (no alpha, so the
+ *   contrast floor stays meaningful),
+ * - text/background pairs must clear a minimum contrast ratio so an
+ *   authored theme can never render core copy illegible.
+ *
+ * Trust-critical chrome (permission prompts, credential entry) does not
+ * consume these tokens; this module only governs the expressive surface.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { z } from "zod";
+
+import { getWorkspaceDir } from "../util/platform.js";
+
+/** Workspace-relative path clients and the config watcher both key on. */
+export const WORKSPACE_THEME_RELATIVE_PATH = "ui/theme.json";
+
+const HEX_COLOR_RE = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
+const hexColor = z
+  .string()
+  .regex(HEX_COLOR_RE, "must be a 3- or 6-digit hex color like #1a2b3c");
+
+const ThemeTokensSchema = z
+  .object({
+    accent: hexColor,
+    background: hexColor,
+    surface: hexColor,
+    surfaceRaised: hexColor,
+    border: hexColor,
+    text: hexColor,
+    textMuted: hexColor,
+    assistantBubbleBackground: hexColor,
+    assistantBubbleText: hexColor,
+    userBubbleBackground: hexColor,
+    userBubbleText: hexColor,
+  })
+  .partial()
+  .strict();
+
+export type WorkspaceThemeTokens = z.infer<typeof ThemeTokensSchema>;
+
+export const WorkspaceThemeSchema = z
+  .object({
+    version: z.literal(1),
+    base: z.enum(["light", "dark", "velvet", "system"]).optional(),
+    tokens: ThemeTokensSchema.optional(),
+  })
+  .strict();
+
+export type WorkspaceTheme = z.infer<typeof WorkspaceThemeSchema>;
+
+/**
+ * Readability floor, not an accessibility certification: blocks themes whose
+ * core text would be effectively invisible against its own background.
+ */
+export const MIN_TEXT_CONTRAST_RATIO = 3;
+
+/**
+ * Token pairs that must clear the contrast floor when both sides are
+ * present: [foreground, background].
+ */
+const CONTRAST_PAIRS: readonly [
+  keyof WorkspaceThemeTokens,
+  keyof WorkspaceThemeTokens,
+][] = [
+  ["text", "background"],
+  ["text", "surface"],
+  ["textMuted", "background"],
+  ["assistantBubbleText", "assistantBubbleBackground"],
+  ["userBubbleText", "userBubbleBackground"],
+];
+
+function expandHex(hex: string): string {
+  const raw = hex.slice(1);
+  if (raw.length === 6) {
+    return raw;
+  }
+  return raw
+    .split("")
+    .map((c) => c + c)
+    .join("");
+}
+
+function relativeLuminance(hex: string): number {
+  const expanded = expandHex(hex);
+  const channels = [0, 2, 4].map((offset) => {
+    const value = parseInt(expanded.slice(offset, offset + 2), 16) / 255;
+    return value <= 0.04045
+      ? value / 12.92
+      : Math.pow((value + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+/** WCAG contrast ratio between two hex colors (order-independent). */
+export function contrastRatio(a: string, b: string): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const [lighter, darker] = la >= lb ? [la, lb] : [lb, la];
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function contrastIssues(tokens: WorkspaceThemeTokens): string[] {
+  const issues: string[] = [];
+  for (const [fgKey, bgKey] of CONTRAST_PAIRS) {
+    const fg = tokens[fgKey];
+    const bg = tokens[bgKey];
+    if (!fg || !bg) {
+      continue;
+    }
+    const ratio = contrastRatio(fg, bg);
+    if (ratio < MIN_TEXT_CONTRAST_RATIO) {
+      issues.push(
+        `tokens.${fgKey} on tokens.${bgKey} has contrast ${ratio.toFixed(2)}:1 — minimum is ${MIN_TEXT_CONTRAST_RATIO}:1`,
+      );
+    }
+  }
+  return issues;
+}
+
+export interface WorkspaceThemeReadResult {
+  /** Validated theme, or null when the file is absent or rejected. */
+  theme: WorkspaceTheme | null;
+  /**
+   * "workspace" = valid file applied; "invalid" = file present but rejected
+   * (see issues); "none" = no theme file in the workspace.
+   */
+  source: "workspace" | "invalid" | "none";
+  issues: string[];
+}
+
+function formatZodIssues(error: z.ZodError): string[] {
+  return error.issues.map((issue) => {
+    const path = issue.path.join(".");
+    return path ? `${path}: ${issue.message}` : issue.message;
+  });
+}
+
+/**
+ * Read and validate the workspace theme file. Never throws: an unreadable,
+ * unparsable, or out-of-policy file yields `source: "invalid"` with
+ * human-readable issues so callers (and the authoring assistant) can surface
+ * exactly what was rejected.
+ */
+export function readWorkspaceTheme(): WorkspaceThemeReadResult {
+  const themePath = join(getWorkspaceDir(), WORKSPACE_THEME_RELATIVE_PATH);
+  if (!existsSync(themePath)) {
+    return { theme: null, source: "none", issues: [] };
+  }
+
+  let raw: string;
+  try {
+    raw = readFileSync(themePath, "utf-8");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      theme: null,
+      source: "invalid",
+      issues: [`failed to read ${WORKSPACE_THEME_RELATIVE_PATH}: ${message}`],
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      theme: null,
+      source: "invalid",
+      issues: [`not valid JSON: ${message}`],
+    };
+  }
+
+  const result = WorkspaceThemeSchema.safeParse(parsed);
+  if (!result.success) {
+    return {
+      theme: null,
+      source: "invalid",
+      issues: formatZodIssues(result.error),
+    };
+  }
+
+  const legibility = result.data.tokens
+    ? contrastIssues(result.data.tokens)
+    : [];
+  if (legibility.length > 0) {
+    return { theme: null, source: "invalid", issues: legibility };
+  }
+
+  return { theme: result.data, source: "workspace", issues: [] };
+}


### PR DESCRIPTION
## Summary

Daemon-side foundation for workspace theming: a `ui/theme.json` file in the workspace that clients apply as design-token overrides on top of the built-in themes (light/dark/velvet). The file is authorable by the user or by the assistant through its normal file tools — the write path is the existing permission-gated workspace surface; this PR adds only read, validate, serve, and invalidate.

## Design

- **Strict whitelist schema** (`src/theme/workspace-theme.ts`): eleven semantic token slots (`accent`, `background`, `surface`, `text`, bubble colors, …), values restricted to 3/6-digit hex (no alpha, no CSS functions, no `url()`), unknown keys rejected via `.strict()`.
- **Contrast floor**: text/background token pairs must clear 3:1 (WCAG relative luminance) so an authored theme can never render core copy illegible. Readability floor, not an accessibility certification.
- **Trust boundary**: trust-critical chrome (permission prompts, credential entry) does not consume these tokens — this feature governs only the expressive surface, and the schema exposes no positioning/z-index/visibility levers.
- **`GET /v1/workspace/theme`**: returns `{ theme, source: "workspace" | "invalid" | "none", issues }`. Rejected files yield `theme: null` plus human-readable issues, so the authoring side can see exactly what was rejected and why. Read-only, no side effects.
- **Live invalidation**: new `assistant:self:theme` sync tag; `ConfigWatcher` registers `ui/theme.json` alongside `config.json`/`SOUL.md`/`IDENTITY.md` and publishes `sync_changed` on change, per the multi-client sync contract. No new bespoke server message.

## Out of scope (follow-up PR)

Client-side token application in `clients/web` (mapping validated tokens onto the design-library CSS variables + a change toast).

## Testing

- `src/theme/workspace-theme.test.ts` — schema accept/reject matrix (unknown keys, alpha hex, CSS functions, version gate), contrast-floor cases, contrast math sanity.
- `src/runtime/routes/__tests__/theme-routes.test.ts` — route behavior for absent/valid/invalid files.
- `src/__tests__/config-watcher.test.ts` — extended: `ui/theme.json` change publishes the invalidation; registered-file set assertion updated.

40 tests across the three files pass; `typecheck:fast` and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)