### PR TITLE
fix(theme): guard theme-file reads; contrast-check muted text on surfaces

### DIFF
--- a/assistant/src/theme/workspace-theme.test.ts
+++ b/assistant/src/theme/workspace-theme.test.ts
@@ -1,10 +1,18 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { execSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import {
   contrastRatio,
+  MAX_THEME_FILE_BYTES,
   MIN_TEXT_CONTRAST_RATIO,
   readWorkspaceTheme,
   WORKSPACE_THEME_RELATIVE_PATH,
@@ -186,6 +194,52 @@ describe("readWorkspaceTheme", () => {
     const result = readWorkspaceTheme();
     expect(result.source).toBe("invalid");
     expect(result.issues[0]).toContain("contrast");
+  });
+
+  test("muted text is contrast-checked against surfaces, not just background", () => {
+    writeTheme(
+      JSON.stringify({
+        version: 1,
+        tokens: {
+          background: "#0a0a0a",
+          surface: "#6b6b6b",
+          surfaceRaised: "#6f6f6f",
+          text: "#ffffff",
+          textMuted: "#777777",
+        },
+      }),
+    );
+    const result = readWorkspaceTheme();
+    expect(result.source).toBe("invalid");
+    expect(result.issues.join("\n")).toContain("textMuted on tokens.surface");
+  });
+
+  test("symlinked theme file is rejected without following it", () => {
+    const target = join(workspaceDir, "elsewhere.json");
+    writeFileSync(target, JSON.stringify({ version: 1 }));
+    mkdirSync(join(workspaceDir, "ui"), { recursive: true });
+    symlinkSync(target, join(workspaceDir, WORKSPACE_THEME_RELATIVE_PATH));
+    const result = readWorkspaceTheme();
+    expect(result.source).toBe("invalid");
+    expect(result.theme).toBeNull();
+    expect(result.issues[0]).toContain("symbolic link");
+  });
+
+  test("oversized theme file is rejected before parsing", () => {
+    writeTheme(`{"version":1}${" ".repeat(MAX_THEME_FILE_BYTES)}`);
+    const result = readWorkspaceTheme();
+    expect(result.source).toBe("invalid");
+    expect(result.issues[0]).toContain("maximum");
+  });
+
+  test("FIFO at the theme path is rejected without blocking", () => {
+    const fifoPath = join(workspaceDir, WORKSPACE_THEME_RELATIVE_PATH);
+    mkdirSync(join(workspaceDir, "ui"), { recursive: true });
+    execSync(`mkfifo "${fifoPath}"`);
+    const result = readWorkspaceTheme();
+    expect(result.source).toBe("invalid");
+    expect(result.theme).toBeNull();
+    expect(result.issues[0]).toContain("regular file");
   });
 });
 

--- a/assistant/src/theme/workspace-theme.ts
+++ b/assistant/src/theme/workspace-theme.ts
@@ -11,12 +11,21 @@
  *   group, so a partial override can never pair an authored color with an
  *   unknown base-theme color,
  * - text/background pairs must clear a minimum contrast ratio so an
- *   authored theme can never render core copy illegible.
+ *   authored theme can never render core copy illegible,
+ * - the file itself is read through a no-follow, non-blocking, size-capped
+ *   guard so a symlink, FIFO, or oversized file cannot stall the event
+ *   loop or escape the workspace.
  *
  * Trust-critical chrome (permission prompts, credential entry) does not
  * consume these tokens; this module only governs the expressive surface.
  */
-import { existsSync, readFileSync } from "node:fs";
+import {
+  closeSync,
+  constants,
+  fstatSync,
+  openSync,
+  readFileSync,
+} from "node:fs";
 import { join } from "node:path";
 
 import { z } from "zod";
@@ -80,6 +89,8 @@ const CONTRAST_PAIRS: readonly [
   ["text", "surface"],
   ["text", "surfaceRaised"],
   ["textMuted", "background"],
+  ["textMuted", "surface"],
+  ["textMuted", "surfaceRaised"],
   ["assistantBubbleText", "assistantBubbleBackground"],
   ["userBubbleText", "userBubbleBackground"],
 ];
@@ -180,6 +191,65 @@ function formatZodIssues(error: z.ZodError): string[] {
   });
 }
 
+/** Generous ceiling for a token-override file; anything larger is not a theme. */
+export const MAX_THEME_FILE_BYTES = 64 * 1024;
+
+/**
+ * Open the theme file without following a final-component symlink and
+ * without blocking (opening a FIFO read-only would otherwise suspend the
+ * event loop until a writer appears), then require a bounded regular file
+ * before reading. Returns the file content or a rejection issue.
+ */
+function readThemeFileGuarded(
+  themePath: string,
+): { raw: string } | { missing: true } | { issue: string } {
+  let fd: number;
+  try {
+    fd = openSync(
+      themePath,
+      constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+    );
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      return { missing: true };
+    }
+    if (code === "ELOOP" || code === "EMLINK") {
+      return {
+        issue: `${WORKSPACE_THEME_RELATIVE_PATH} must be a regular file, not a symbolic link`,
+      };
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      issue: `failed to open ${WORKSPACE_THEME_RELATIVE_PATH}: ${message}`,
+    };
+  }
+
+  try {
+    const stat = fstatSync(fd);
+    if (!stat.isFile()) {
+      return {
+        issue: `${WORKSPACE_THEME_RELATIVE_PATH} must be a regular file`,
+      };
+    }
+    if (stat.size > MAX_THEME_FILE_BYTES) {
+      return {
+        issue:
+          `${WORKSPACE_THEME_RELATIVE_PATH} is ${stat.size} bytes — ` +
+          `maximum is ${MAX_THEME_FILE_BYTES}`,
+      };
+    }
+    return { raw: readFileSync(fd, "utf-8") };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      issue: `failed to read ${WORKSPACE_THEME_RELATIVE_PATH}: ${message}`,
+    };
+  } finally {
+    closeSync(fd);
+  }
+}
+
 /**
  * Read and validate the workspace theme file. Never throws: an unreadable,
  * unparsable, or out-of-policy file yields `source: "invalid"` with
@@ -188,21 +258,15 @@ function formatZodIssues(error: z.ZodError): string[] {
  */
 export function readWorkspaceTheme(): WorkspaceThemeReadResult {
   const themePath = join(getWorkspaceDir(), WORKSPACE_THEME_RELATIVE_PATH);
-  if (!existsSync(themePath)) {
+
+  const file = readThemeFileGuarded(themePath);
+  if ("missing" in file) {
     return { theme: null, source: "none", issues: [] };
   }
-
-  let raw: string;
-  try {
-    raw = readFileSync(themePath, "utf-8");
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return {
-      theme: null,
-      source: "invalid",
-      issues: [`failed to read ${WORKSPACE_THEME_RELATIVE_PATH}: ${message}`],
-    };
+  if ("issue" in file) {
+    return { theme: null, source: "invalid", issues: [file.issue] };
   }
+  const raw = file.raw;
 
   let parsed: unknown;
   try {


### PR DESCRIPTION
Follow-up to #37765, addressing the second Codex review pass:

1. **Theme-file read guard.** `readWorkspaceTheme` previously ran `readFileSync` directly, which follows symlinks and blocks on FIFOs (a read-only FIFO open suspends until a writer appears — an event-loop stall on a route clients hit at startup and on every sync invalidation). Reads now go through `openSync(O_RDONLY | O_NOFOLLOW | O_NONBLOCK)` → `fstat` regular-file check → 64KB size cap → `readFileSync(fd)`. Symlinks, FIFOs, devices, and oversized files all yield `source: "invalid"` with a readable issue. Checking the fd (not the path) closes the check-then-read race.
2. **Muted-text contrast on surfaces.** `textMuted` was only checked against `background`; it renders on cards and raised panels too. Added `textMuted/surface` and `textMuted/surfaceRaised` pairs — group completeness already guarantees both sides are present.

Tests: symlink rejection, FIFO rejection (via `mkfifo`), oversize rejection, muted-on-surface contrast case. 25 tests across the theme files pass; typecheck and lint clean. No API shape change — `openapi.yaml` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)