### PR TITLE
refactor(plugins): stop the internal plugin contract importing memory internals

### DIFF
--- a/assistant/src/__tests__/plugin-import-boundary-reverse-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-reverse-guard.test.ts
@@ -104,7 +104,6 @@ const BASELINE: Record<string, readonly string[]> = {
     "src/persistence/conversation-crud.ts",
     "src/persistence/steps.ts",
     "src/persistence/worker-control.ts",
-    "src/plugins/types.ts",
     "src/prompts/system-prompt.ts",
     "src/runtime/routes/consolidation-routes.ts",
     "src/runtime/routes/conversation-query-routes.ts",

--- a/assistant/src/plugins/defaults/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/plugins/defaults/memory/graph/conversation-graph-memory.ts
@@ -85,6 +85,16 @@ export function getLiveGraphMemory(
 }
 
 /**
+ * Full output of a single memory-graph retrieval — the object returned by
+ * {@link ConversationGraphMemory.prepareMemory} (injected messages, query
+ * vectors, metrics). The plugin's user-prompt-submit hook consumes these
+ * fields to drive PKB hint search and runtime injection.
+ */
+export type GraphMemoryResult = Awaited<
+  ReturnType<ConversationGraphMemory["prepareMemory"]>
+>;
+
+/**
  * Manages memory graph state for a single conversation.
  * Create one per Conversation instance. Persists across turns.
  */

--- a/assistant/src/plugins/defaults/memory/hooks/user-prompt-submit.ts
+++ b/assistant/src/plugins/defaults/memory/hooks/user-prompt-submit.ts
@@ -45,7 +45,7 @@ import {
 import type { MemoryRecalled } from "../../../../daemon/message-types/memory.js";
 import { resolveTrustClass } from "../../../../daemon/trust-context.js";
 import { broadcastMessage } from "../../../../runtime/assistant-event-hub.js";
-import type { GraphMemoryResult } from "../../../types.js";
+import type { GraphMemoryResult } from "../graph/conversation-graph-memory.js";
 import { recordMemoryRecallLog } from "../memory-recall-log-store.js";
 import { MEMORY_V3_INJECTED_BLOCK_METADATA_KEY } from "../v3/ever-injected-store.js";
 

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -53,6 +53,7 @@ import {
   SLOW_LLM_JOB_TYPES,
 } from "../../../persistence/jobs-store.js";
 import { spawnMemoryWorkerProcess } from "../../../persistence/worker-control.js";
+import type { JobHandler } from "../../types.js";
 import { getLogger } from "./logging.js";
 import { sweepOrphanMemoryRetrospectiveConversations } from "./memory-retrospective-startup-cleanup.js";
 import { getWorkspaceDir } from "./paths.js";
@@ -60,14 +61,6 @@ import { hasPkbBufferContent } from "./pkb-schedule.js";
 import { countBufferLines } from "./v2/consolidation-job.js";
 
 const log = getLogger("memory-jobs-worker");
-
-/**
- * A per-job-type handler. The owning feature (e.g. memory) registers handlers
- * via {@link registerJobHandler}; the worker dispatches each claimed job to its
- * registered handler. Decoupling registration from the worker keeps the queue
- * mechanics generic and free of feature-specific handler imports.
- */
-export type JobHandler = (job: MemoryJob, config: AssistantConfig) => unknown;
 
 const jobHandlers = new Map<string, JobHandler>();
 

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -13,19 +13,19 @@ import type { CompactionCircuitClosedEvent } from "../api/events/compaction-circ
 import type { CompactionCircuitOpenEvent } from "../api/events/compaction-circuit-open.js";
 import type { HookEventOwner } from "../api/events/hook-event.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
+import type { AssistantConfig } from "../config/types.js";
 import type {
   ChannelCapabilities,
   InboundActorContext,
   InjectionMode,
 } from "../daemon/conversation-runtime-assembly.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
+import type { MemoryJob } from "../persistence/jobs-store.js";
 import type { HookFunction } from "../plugin-api/types.js";
 import type { Message } from "../providers/types.js";
 import type { SkillRoute } from "../runtime/skill-route-registry.js";
 import type { Tool } from "../tools/types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
-import type { ConversationGraphMemory } from "./defaults/memory/graph/conversation-graph-memory.js";
-import type { JobHandler } from "./defaults/memory/jobs-worker.js";
 
 // ─── Manifest ────────────────────────────────────────────────────────────────
 
@@ -67,18 +67,6 @@ export type {
   ShutdownContext,
   ShutdownReason,
 } from "../plugin-api/types.js";
-
-// ─── Memory-graph result ─────────────────────────────────────────────────────
-
-/**
- * Full output of a single memory-graph retrieval — the object returned by
- * {@link ConversationGraphMemory.prepareMemory} (injected messages, query
- * vectors, metrics). The agent loop consumes these fields directly to drive
- * PKB hint search and runtime injection.
- */
-export type GraphMemoryResult = Awaited<
-  ReturnType<ConversationGraphMemory["prepareMemory"]>
->;
 
 /**
  * The complete set of compaction circuit-breaker transition events:
@@ -335,6 +323,13 @@ export interface Injector {
  * happen to register the same regex from evicting each other's routes.
  */
 export type PluginRouteRegistration = SkillRoute;
+
+/**
+ * Processes one claimed background job: receives the claimed job row and the
+ * live assistant config. The return value is ignored — a handler signals
+ * failure by throwing, which the worker records against the job.
+ */
+export type JobHandler = (job: MemoryJob, config: AssistantConfig) => unknown;
 
 /**
  * A single background-job-handler entry: a job `type` string paired with the


### PR DESCRIPTION
## Summary
- `plugins/types.ts` — the internal plugin contract — no longer imports anything from `plugins/defaults/memory/`. It previously pulled two types from the plugin it is supposed to sit above:
  - **`JobHandler` moves INTO the contract** (defined beside `JobHandlerEntry`, which is its only contract consumer). Its constituents are host types (`MemoryJob` from `persistence/jobs-store`, `AssistantConfig` from `config/types`), so the contribution type now lives where contribution types belong; the plugin's `jobs-worker.ts` imports it from `../../types.js` like every other contract type.
  - **`GraphMemoryResult` moves OUT to the plugin** (`graph/conversation-graph-memory.ts`, beside the class it derives from). Its only consumer is the memory plugin's own `user-prompt-submit` hook — the contract docstring claiming "the agent loop consumes these fields" predated the hook migration and is stale; nothing outside the plugin references it.
- Reverse boundary baseline shrinks by exactly one entry: `src/plugins/types.ts` drops out of memory's host-importer list (49 → 48). Forward baseline unchanged.
- Type-only moves; zero runtime change; zero `@vellumai/plugin-api` changes.

Part of the BYO-memory effort — the contract file importing one plugin's internals was the most symbolically backwards edge in the reverse-guard inventory (#37747).

Full local gate: `typecheck:fast`, `lint` (0 errors), `lint:unused`, prettier, both boundary guards (reverse regenerated); jobs-worker and conversation-graph-memory suites run individually — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)