### PR TITLE
feat(web): apply workspace theme overrides live

### DIFF
--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -313,9 +313,9 @@ describe("TranscriptMessageBody", () => {
     expect(markdown).not.toBeNull();
     expect(markdown!.textContent).toBe("line one\nline two");
     expect(markdown!.getAttribute("data-hard-line-breaks")).toBe("true");
-    // The text run is wrapped in the surface-lift user bubble.
+    // The text run is wrapped in the user bubble.
     expect(
-      container.querySelector(".bg-\\[var\\(--surface-lift\\)\\]"),
+      container.querySelector("[class*='user-bubble-bg']"),
     ).not.toBeNull();
   });
 
@@ -1001,9 +1001,9 @@ describe("TranscriptMessageBody", () => {
     );
 
     const bubbles = container.querySelectorAll(
-      "[class*='bg-[var(--surface-lift)]']",
+      "[class*='user-bubble-bg']",
     );
-    // Exactly one bubble container carries the surface-lift background.
+    // Exactly one bubble container carries the user-bubble background.
     expect(bubbles.length).toBe(1);
 
     const bubble = bubbles[0]!;
@@ -1042,7 +1042,7 @@ describe("TranscriptMessageBody", () => {
     );
 
     const bubbles = container.querySelectorAll(
-      "[class*='bg-[var(--surface-lift)]']",
+      "[class*='user-bubble-bg']",
     );
     expect(bubbles.length).toBe(1);
     expect(bubbles[0]!.querySelector("img")?.getAttribute("src")).toBe(
@@ -1227,16 +1227,16 @@ describe("TranscriptMessageBody", () => {
       />,
     );
 
-    // Assistant path: separate strip renders, no surface-lift bubble.
+    // Assistant path: separate strip renders, no user bubble.
     expect(
       container.querySelector("[data-testid='attachments']"),
     ).not.toBeNull();
     expect(
-      container.querySelector("[class*='bg-[var(--surface-lift)]']"),
+      container.querySelector("[class*='user-bubble-bg']"),
     ).toBeNull();
   });
 
-  test("renders a user-message surface outside the surface-lift bubble", () => {
+  test("renders a user-message surface outside the user bubble", () => {
     const { container } = render(
       <TranscriptMessageBody
         message={{
@@ -1249,7 +1249,7 @@ describe("TranscriptMessageBody", () => {
     );
 
     const bubble = container.querySelector(
-      "[class*='bg-[var(--surface-lift)]']",
+      "[class*='user-bubble-bg']",
     );
     expect(bubble).not.toBeNull();
     // Text lives inside the bubble.
@@ -1285,9 +1285,9 @@ describe("TranscriptMessageBody", () => {
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
 
-    // The surface is NOT inside a surface-lift bubble; the text IS.
+    // The surface is NOT inside a user bubble; the text IS.
     const bubble = container.querySelector(
-      "[class*='bg-[var(--surface-lift)]']",
+      "[class*='user-bubble-bg']",
     );
     expect(bubble).not.toBeNull();
     expect(bubble!.contains(surface)).toBe(false);
@@ -1335,10 +1335,10 @@ describe("TranscriptMessageBody", () => {
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
 
-    // The tool chip is never wrapped inside a surface-lift text bubble — the
+    // The tool chip is never wrapped inside a user text bubble — the
     // text runs render inline and the chip sits between them.
     const bubbles = container.querySelectorAll(
-      "[class*='bg-[var(--surface-lift)]']",
+      "[class*='user-bubble-bg']",
     );
     for (const bubble of bubbles) {
       expect(bubble.contains(toolChip)).toBe(false);
@@ -1364,10 +1364,10 @@ describe("TranscriptMessageBody", () => {
       />,
     );
 
-    // No visible text and no attachments: the empty surface-lift bubble must
+    // No visible text and no attachments: the empty user bubble must
     // not render.
     expect(
-      container.querySelector("[class*='bg-[var(--surface-lift)]']"),
+      container.querySelector("[class*='user-bubble-bg']"),
     ).toBeNull();
     // The lone tool still renders as the inline chip.
     expect(

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -109,7 +109,7 @@ export function TranscriptMessageBody({
   const textBubbleClass = isSlackMessage
     ? "max-w-[80%] text-[var(--content-default)] sm:max-w-[640px]"
     : "w-full text-[var(--content-default)]";
-  const userBubbleClass = `max-w-[80%] rounded-lg bg-[var(--surface-lift)] px-4 py-3 text-[var(--content-default)] flex flex-col gap-2 ${
+  const userBubbleClass = `max-w-[80%] rounded-lg bg-[var(--user-bubble-bg,var(--surface-lift))] px-4 py-3 text-[var(--user-bubble-text,var(--content-default))] flex flex-col gap-2 ${
     isSlackMessage ? "sm:max-w-[420px]" : ""
   }`;
   const segmentClass = isUser

--- a/clients/web/src/domains/settings/utils/workspace-theme-tokens.test.ts
+++ b/clients/web/src/domains/settings/utils/workspace-theme-tokens.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 
 import {
   applyWorkspaceThemeTokens,
+  readableOnColor,
   resolveThemeCssVars,
   WORKSPACE_THEME_CSS_VARS,
 } from "./workspace-theme-tokens";
@@ -47,6 +48,31 @@ describe("resolveThemeCssVars", () => {
     const vars = resolveThemeCssVars({ accent: "", background: "#000000" });
     expect(vars["--primary-base"]).toBeUndefined();
     expect(vars["--background"]).toBe("#000000");
+  });
+
+  test("derives a legible on-primary text color for a light accent", () => {
+    const vars = resolveThemeCssVars({ accent: "#ffffff" });
+    expect(vars["--primary-base"]).toBe("#ffffff");
+    expect(vars["--content-inset"]).toBe("#17191c");
+  });
+
+  test("derives a legible on-primary text color for a dark accent", () => {
+    const vars = resolveThemeCssVars({ accent: "#1a1a1a" });
+    expect(vars["--content-inset"]).toBe("#fdfdfc");
+  });
+
+  test("does not touch on-primary text when accent is unset", () => {
+    const vars = resolveThemeCssVars({ background: "#000000" });
+    expect(vars["--content-inset"]).toBeUndefined();
+  });
+});
+
+describe("readableOnColor", () => {
+  test("returns dark text on light fills and light text on dark fills", () => {
+    expect(readableOnColor("#ffffff")).toBe("#17191c");
+    expect(readableOnColor("#000000")).toBe("#fdfdfc");
+    expect(readableOnColor("#ffd700")).toBe("#17191c");
+    expect(readableOnColor("#4b0082")).toBe("#fdfdfc");
   });
 });
 

--- a/clients/web/src/domains/settings/utils/workspace-theme-tokens.test.ts
+++ b/clients/web/src/domains/settings/utils/workspace-theme-tokens.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  applyWorkspaceThemeTokens,
+  resolveThemeCssVars,
+  WORKSPACE_THEME_CSS_VARS,
+} from "./workspace-theme-tokens";
+
+describe("resolveThemeCssVars", () => {
+  test("returns no vars for undefined tokens", () => {
+    expect(resolveThemeCssVars(undefined)).toEqual({});
+  });
+
+  test("fans a single token out to its full css-var group", () => {
+    const vars = resolveThemeCssVars({ text: "#f2e4d4" });
+    expect(vars["--foreground"]).toBe("#f2e4d4");
+    expect(vars["--content-default"]).toBe("#f2e4d4");
+    expect(vars["--content-emphasised"]).toBe("#f2e4d4");
+    expect(vars["--content-strong"]).toBe("#f2e4d4");
+  });
+
+  test("maps background across the base surface group", () => {
+    const vars = resolveThemeCssVars({ background: "#1c1512" });
+    expect(vars["--background"]).toBe("#1c1512");
+    expect(vars["--surface-base"]).toBe("#1c1512");
+    expect(vars["--surface-sunken"]).toBe("#1c1512");
+  });
+
+  test("maps the user bubble tokens to dedicated vars", () => {
+    const vars = resolveThemeCssVars({
+      userBubbleBackground: "#26201a",
+      userBubbleText: "#efe3d2",
+    });
+    expect(vars["--user-bubble-bg"]).toBe("#26201a");
+    expect(vars["--user-bubble-text"]).toBe("#efe3d2");
+  });
+
+  test("assistant bubble tokens are accepted but not applied (deferred)", () => {
+    const vars = resolveThemeCssVars({
+      assistantBubbleBackground: "#33202a",
+      assistantBubbleText: "#ffd7e4",
+    });
+    expect(vars).toEqual({});
+  });
+
+  test("ignores empty-string token values", () => {
+    const vars = resolveThemeCssVars({ accent: "", background: "#000000" });
+    expect(vars["--primary-base"]).toBeUndefined();
+    expect(vars["--background"]).toBe("#000000");
+  });
+});
+
+describe("applyWorkspaceThemeTokens", () => {
+  afterEach(() => {
+    for (const cssVar of WORKSPACE_THEME_CSS_VARS) {
+      document.documentElement.style.removeProperty(cssVar);
+    }
+  });
+
+  test("sets the resolved vars on the document root", () => {
+    applyWorkspaceThemeTokens({ accent: "#e8a04c" });
+    expect(
+      document.documentElement.style.getPropertyValue("--primary-base"),
+    ).toBe("#e8a04c");
+  });
+
+  test("clears a previously-set var when the token is removed", () => {
+    applyWorkspaceThemeTokens({ accent: "#e8a04c" });
+    applyWorkspaceThemeTokens({ background: "#111111" });
+    expect(
+      document.documentElement.style.getPropertyValue("--primary-base"),
+    ).toBe("");
+    expect(
+      document.documentElement.style.getPropertyValue("--background"),
+    ).toBe("#111111");
+  });
+
+  test("clears all overrides when passed undefined", () => {
+    applyWorkspaceThemeTokens({ text: "#ffffff", background: "#000000" });
+    applyWorkspaceThemeTokens(undefined);
+    for (const cssVar of WORKSPACE_THEME_CSS_VARS) {
+      expect(document.documentElement.style.getPropertyValue(cssVar)).toBe("");
+    }
+  });
+});

--- a/clients/web/src/domains/settings/utils/workspace-theme-tokens.ts
+++ b/clients/web/src/domains/settings/utils/workspace-theme-tokens.ts
@@ -72,10 +72,42 @@ const TOKEN_TO_CSS_VARS: Record<
   assistantBubbleText: [],
 };
 
+/**
+ * The design-library text color that renders on top of `--primary-base`
+ * (e.g. the Button primary label, via `--content-inset`). When `accent`
+ * recolors the primary fill, this is re-derived to stay legible — the daemon
+ * does not contrast-check `accent` against the fixed on-primary text.
+ */
+const ON_ACCENT_VAR = "--content-inset";
+const ON_ACCENT_DARK = "#17191c";
+const ON_ACCENT_LIGHT = "#fdfdfc";
+
 /** The full set of CSS variables this layer may set — used to clear cleanly. */
-export const WORKSPACE_THEME_CSS_VARS: readonly string[] = Object.values(
-  TOKEN_TO_CSS_VARS,
-).flat();
+export const WORKSPACE_THEME_CSS_VARS: readonly string[] = [
+  ...Object.values(TOKEN_TO_CSS_VARS).flat(),
+  ON_ACCENT_VAR,
+];
+
+/** Perceived luminance (0–1) of a 3- or 6-digit hex color, sRGB-weighted. */
+function hexLuminance(hex: string): number {
+  const raw = hex.replace("#", "");
+  const full =
+    raw.length === 3
+      ? raw
+          .split("")
+          .map((c) => c + c)
+          .join("")
+      : raw;
+  const [r, g, b] = [0, 2, 4].map(
+    (offset) => parseInt(full.slice(offset, offset + 2), 16) / 255,
+  );
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/** Near-black or near-white, whichever reads better on the given fill. */
+export function readableOnColor(hex: string): string {
+  return hexLuminance(hex) > 0.5 ? ON_ACCENT_DARK : ON_ACCENT_LIGHT;
+}
 
 /**
  * Resolve a theme's tokens into the flat `{ cssVar: value }` overrides to
@@ -96,6 +128,11 @@ export function resolveThemeCssVars(
     for (const cssVar of cssVars ?? []) {
       vars[cssVar] = value;
     }
+  }
+  // `accent` recolors the primary fill; keep on-primary text legible against
+  // it since the daemon does not contrast-check `accent`.
+  if (tokens.accent) {
+    vars[ON_ACCENT_VAR] = readableOnColor(tokens.accent);
   }
   return vars;
 }

--- a/clients/web/src/domains/settings/utils/workspace-theme-tokens.ts
+++ b/clients/web/src/domains/settings/utils/workspace-theme-tokens.ts
@@ -1,0 +1,123 @@
+/**
+ * Maps the daemon's semantic workspace-theme tokens onto the concrete
+ * design-library CSS variables the app consumes, and applies them as inline
+ * custom properties on the document root (layered over the active
+ * light/dark/velvet base theme).
+ *
+ * The mapping is intentionally comprehensive per token: setting `text` writes
+ * the whole content-color ramp, not just `--content-default`, so a base-theme
+ * text shade can never survive alongside an authored background and clash.
+ * The daemon has already validated contrast for text/background/surface pairs
+ * (see assistant `theme/workspace-theme.ts`), so a fanned-out override is safe.
+ *
+ * The assistant-message bubble pair is intentionally not mapped here: assistant
+ * messages render as full-width text with no themeable container today, and
+ * applying bubble text without a matching background would reintroduce the
+ * readability hole the daemon's pair-contrast check cannot see across the page
+ * background. Those tokens still validate server-side; their client
+ * application waits on a dedicated assistant-bubble surface.
+ */
+
+/** The token names served by `GET /v1/workspace/theme`. */
+export interface WorkspaceThemeTokens {
+  accent?: string;
+  background?: string;
+  surface?: string;
+  surfaceRaised?: string;
+  border?: string;
+  text?: string;
+  textMuted?: string;
+  assistantBubbleBackground?: string;
+  assistantBubbleText?: string;
+  userBubbleBackground?: string;
+  userBubbleText?: string;
+}
+
+export interface WorkspaceTheme {
+  version: 1;
+  base?: "light" | "dark" | "velvet" | "system";
+  tokens?: WorkspaceThemeTokens;
+}
+
+/**
+ * Each semantic token fans out to the design-library variables it should
+ * control. Grouped so no base-theme color in the same visual role leaks
+ * through a partial override.
+ */
+const TOKEN_TO_CSS_VARS: Record<
+  keyof WorkspaceThemeTokens,
+  readonly string[]
+> = {
+  accent: ["--primary-base", "--primary-hover", "--primary-active"],
+  background: ["--background", "--surface-base", "--surface-sunken"],
+  surface: ["--surface-overlay", "--surface-active"],
+  surfaceRaised: ["--surface-lift"],
+  border: ["--border-base", "--border-element", "--border-subtle"],
+  text: [
+    "--foreground",
+    "--content-default",
+    "--content-emphasised",
+    "--content-strong",
+  ],
+  textMuted: [
+    "--content-secondary",
+    "--content-tertiary",
+    "--content-quiet",
+    "--content-faint",
+  ],
+  userBubbleBackground: ["--user-bubble-bg"],
+  userBubbleText: ["--user-bubble-text"],
+  // Deferred until assistant messages have a themeable surface (see docstring).
+  assistantBubbleBackground: [],
+  assistantBubbleText: [],
+};
+
+/** The full set of CSS variables this layer may set — used to clear cleanly. */
+export const WORKSPACE_THEME_CSS_VARS: readonly string[] = Object.values(
+  TOKEN_TO_CSS_VARS,
+).flat();
+
+/**
+ * Resolve a theme's tokens into the flat `{ cssVar: value }` overrides to
+ * apply. Unset tokens contribute nothing.
+ */
+export function resolveThemeCssVars(
+  tokens: WorkspaceThemeTokens | undefined,
+): Record<string, string> {
+  const vars: Record<string, string> = {};
+  if (!tokens) {
+    return vars;
+  }
+  for (const [token, value] of Object.entries(tokens)) {
+    if (!value) {
+      continue;
+    }
+    const cssVars = TOKEN_TO_CSS_VARS[token as keyof WorkspaceThemeTokens];
+    for (const cssVar of cssVars ?? []) {
+      vars[cssVar] = value;
+    }
+  }
+  return vars;
+}
+
+/**
+ * Apply a validated workspace theme's token overrides to the document root,
+ * clearing any previously-applied overrides first so a demoted token reverts
+ * to its base-theme value. Idempotent; safe to call on every theme change.
+ */
+export function applyWorkspaceThemeTokens(
+  tokens: WorkspaceThemeTokens | undefined,
+): void {
+  if (typeof document === "undefined") {
+    return;
+  }
+  const root = document.documentElement;
+  const next = resolveThemeCssVars(tokens);
+  for (const cssVar of WORKSPACE_THEME_CSS_VARS) {
+    if (cssVar in next) {
+      root.style.setProperty(cssVar, next[cssVar]);
+    } else {
+      root.style.removeProperty(cssVar);
+    }
+  }
+}

--- a/clients/web/src/hooks/use-workspace-theme.ts
+++ b/clients/web/src/hooks/use-workspace-theme.ts
@@ -55,13 +55,13 @@ export function useWorkspaceTheme(
 
   const theme = (data?.theme ?? null) as WorkspaceTheme | null;
 
-  // Apply on every resolved theme; clearing when the theme is removed reverts
-  // to the base-theme values. This hook is the sole writer of these vars.
+  // Apply on every resolved theme; clearing when the theme is removed, or when
+  // the hook is disabled (assistant inactive / unsupported / switched away),
+  // reverts to the base-theme values. These vars live outside React on
+  // <html>, so a disabled hook must actively clear a prior assistant's theme
+  // rather than leave it applied. This hook is the sole writer of these vars.
   useEffect(() => {
-    if (!enabled) {
-      return;
-    }
-    applyWorkspaceThemeTokens(theme?.tokens);
+    applyWorkspaceThemeTokens(enabled ? theme?.tokens : undefined);
   }, [enabled, theme]);
 
   const invalidate = () => {

--- a/clients/web/src/hooks/use-workspace-theme.ts
+++ b/clients/web/src/hooks/use-workspace-theme.ts
@@ -1,0 +1,104 @@
+/**
+ * Applies the assistant's workspace theme (design-token overrides authored in
+ * `ui/theme.json`) on top of the active light/dark/velvet base theme, and
+ * keeps it live across multi-client edits.
+ *
+ * Mounted once from the root layout. Three responsibilities:
+ *
+ *  1. Fetch the validated theme from `GET /v1/workspace/theme` (version-gated;
+ *     older assistants that lack the route apply nothing) and push its token
+ *     overrides onto the document root.
+ *  2. Refetch on the `assistant:self:theme` sync tag and on non-fresh SSE
+ *     reconnect, so a theme the assistant (or another client) writes shows up
+ *     without a reload — the daemon's config watcher emits the invalidation.
+ *  3. Surface a change made elsewhere as a small toast, the way an avatar or
+ *     identity change is announced.
+ *
+ * References:
+ * - EVENT_BUS.md — bus subscription contract
+ * - BACKWARDS_COMPAT.md — version gating
+ */
+
+import { useEffect } from "react";
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { toast } from "@vellumai/design-library/components/toast";
+
+import {
+  workspaceThemeGetOptions,
+  workspaceThemeGetQueryKey,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import { useBusSubscription } from "@/hooks/use-bus-subscription";
+import { useSupportsWorkspaceTheme } from "@/lib/backwards-compat/workspace-theme";
+import { SYNC_TAGS } from "@/lib/sync/types";
+import { getClientId } from "@/lib/telemetry/client-identity";
+import {
+  applyWorkspaceThemeTokens,
+  type WorkspaceTheme,
+} from "@/domains/settings/utils/workspace-theme-tokens";
+
+export function useWorkspaceTheme(
+  assistantId: string | null,
+  isAssistantActive: boolean,
+): void {
+  const queryClient = useQueryClient();
+  const supportsWorkspaceTheme = useSupportsWorkspaceTheme();
+  const enabled = isAssistantActive && !!assistantId && supportsWorkspaceTheme;
+
+  const { data } = useQuery({
+    ...workspaceThemeGetOptions({
+      path: { assistant_id: assistantId ?? "" },
+    }),
+    enabled,
+  });
+
+  const theme = (data?.theme ?? null) as WorkspaceTheme | null;
+
+  // Apply on every resolved theme; clearing when the theme is removed reverts
+  // to the base-theme values. This hook is the sole writer of these vars.
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    applyWorkspaceThemeTokens(theme?.tokens);
+  }, [enabled, theme]);
+
+  const invalidate = () => {
+    void queryClient.invalidateQueries({
+      queryKey: workspaceThemeGetQueryKey({
+        path: { assistant_id: assistantId ?? "" },
+      }),
+    });
+  };
+
+  useBusSubscription("sse.event", (envelope) => {
+    if (!enabled) {
+      return;
+    }
+    const event = envelope.message;
+    if (event.type !== "sync_changed") {
+      return;
+    }
+    if (!event.tags.includes(SYNC_TAGS.assistantTheme)) {
+      return;
+    }
+    invalidate();
+    // A change from another client (or the assistant itself) is worth
+    // announcing; a self-originated write already updated locally.
+    if (event.originClientId && event.originClientId === getClientId()) {
+      return;
+    }
+    toast.info("Theme updated");
+  });
+
+  useBusSubscription("sse.opened", ({ cause }) => {
+    if (!enabled) {
+      return;
+    }
+    if (cause === "fresh") {
+      return;
+    }
+    invalidate();
+  });
+}

--- a/clients/web/src/lib/backwards-compat/workspace-theme.ts
+++ b/clients/web/src/lib/backwards-compat/workspace-theme.ts
@@ -1,0 +1,16 @@
+/**
+ * Backwards-compat gate: workspace theme overrides.
+ *
+ * Vellum Assistant 0.10.8 added `GET /v1/workspace/theme`, which serves
+ * validated design-token overrides authored in the workspace
+ * `ui/theme.json`. Older assistants 404 the route, so the web app skips
+ * the theme query and applies no overrides — the built-in light/dark/velvet
+ * themes render exactly as they did before the feature.
+ */
+import { useAssistantSupports } from "@/lib/backwards-compat/utils";
+
+const MIN_VERSION = "0.10.8";
+
+export function useSupportsWorkspaceTheme(): boolean {
+  return useAssistantSupports(MIN_VERSION);
+}

--- a/clients/web/src/lib/sync/types.ts
+++ b/clients/web/src/lib/sync/types.ts
@@ -4,6 +4,7 @@ export const SYNC_TAGS = {
   assistantConfig: "assistant:self:config",
   assistantSounds: "assistant:self:sounds",
   assistantSchedules: "assistant:self:schedules",
+  assistantTheme: "assistant:self:theme",
   appsList: "apps:list",
   pluginsList: "plugins:list",
   conversationsList: "conversations:list",

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -38,6 +38,7 @@ import { useSoundEffects } from "@/hooks/use-sound-effects";
 import { useOnboardingWindowSize } from "@/hooks/use-onboarding-window-size";
 import { useConversationSync } from "@/hooks/use-conversation-sync";
 import { useFeatureFlagBusSync } from "@/hooks/use-feature-flag-bus-sync";
+import { useWorkspaceTheme } from "@/hooks/use-workspace-theme";
 import { useClientFeatureFlagSync } from "@/hooks/use-client-feature-flag-sync";
 import { useAssistantFeatureFlagSync } from "@/hooks/use-assistant-feature-flag-sync";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
@@ -136,6 +137,7 @@ export function RootLayout() {
   useAssistantResourceSync(assistantId, isAssistantActive);
   useConversationSync(assistantId, isAssistantActive);
   useFeatureFlagBusSync(assistantId, isAssistantActive);
+  useWorkspaceTheme(assistantId, isAssistantActive);
   useNotificationIntentSync(assistantId);
   usePushRegistration(assistantId);
   useNotificationTapNavigation();


### PR DESCRIPTION
PR 3 of the workspace-theming series — the client half. Consumes `GET /v1/workspace/theme` (daemon route + validation from #37765, read-guard from #37768) and applies the assistant's authored design-token overrides on top of the active light/dark/velvet base theme, live across multi-client edits.

## What's here

- **`useWorkspaceTheme`** (mounted once in `root-layout`, alongside the other resource-sync hooks): version-gated query (`MIN_VERSION 0.10.8`), refetch on the `assistant:self:theme` sync tag and on non-fresh SSE reconnect, and a "Theme updated" toast when the change originates from another client / the assistant itself (self-originated writes are suppressed via `originClientId`).
- **`workspace-theme-tokens`**: the mapping layer. Each semantic token (`accent`, `background`, `surface`, `surfaceRaised`, `border`, `text`, `textMuted`, `userBubble*`) fans out to the concrete design-library CSS variables it controls — the whole content-color ramp for `text`, the surface group for `background`, etc. — so a base-theme color in the same role can't survive alongside an authored one and clash. Applied as inline custom properties on `document.documentElement`; a demoted token is cleared back to its base value.
- **User message bubble** now reads `--user-bubble-bg` / `--user-bubble-text` with fallback to the current `--surface-lift` / `--content-default` — **zero visual change when unthemed.**
- **Backwards-compat gate** (`workspace-theme.ts`, `MIN_VERSION 0.10.8`): older assistants that 404 the route apply nothing and render exactly as before.

## Deliberate scope note

The **assistant-bubble token pair is not applied on the client** (it still validates server-side). Assistant messages render as full-width text with no themeable container today; applying bubble *text* without a matching *background* would reintroduce the exact readability hole the daemon's pair-contrast check can't see across the page background. That waits on a dedicated assistant-bubble surface — flagged here so it isn't mistaken for an omission.

## Testing

`workspace-theme-tokens.test.ts` — token→CSS-var fan-out, empty-value handling, the deferred assistant pair, apply/clear/revert on the document root. `tsc --noEmit` and `bun run lint` clean. The generated daemon SDK (gitignored) is regenerated by CI's `openapi-ts` step from the committed spec.

## Not in this PR

Revert-from-the-client (needs a workspace write endpoint) and the assistant-authored `corner.md` card (PR 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)