### PR TITLE
feat(cli): per-schedule usage visibility + connection verification hints

### DIFF
--- a/assistant/src/cli/commands/__tests__/schedules.test.ts
+++ b/assistant/src/cli/commands/__tests__/schedules.test.ts
@@ -471,7 +471,7 @@ describe("schedules runs", () => {
     expect(logLines.join("\n")).toContain("conversation-1");
   });
 
-  test("renders a COST column with formatted USD run cost", async () => {
+  test("renders a COST column with the shared variable-precision USD format", async () => {
     mockIpcResult = {
       ok: true,
       result: {
@@ -489,6 +489,19 @@ describe("schedules runs", () => {
             estimatedCostUsd: 0.0123,
             createdAt: 1_778_799_000_000,
           },
+          {
+            id: "run-subcent",
+            jobId: "schedule-1",
+            status: "ok",
+            startedAt: 1_778_799_000_000,
+            finishedAt: 1_778_799_002_500,
+            durationMs: 2_500,
+            output: "done",
+            error: null,
+            conversationId: "conversation-1",
+            estimatedCostUsd: 0.0042,
+            createdAt: 1_778_799_000_000,
+          },
         ],
       },
     };
@@ -496,8 +509,11 @@ describe("schedules runs", () => {
     const { exitCode } = await runCommand(["schedules", "runs", "schedule-1"]);
 
     expect(exitCode).toBe(0);
-    expect(logLines.join("\n")).toContain("COST");
-    expect(logLines.join("\n")).toContain("$0.0123");
+    const output = logLines.join("\n");
+    expect(output).toContain("COST");
+    // Matches usage totals/daily/breakdown: 2dp at a cent or more, 6dp sub-cent.
+    expect(output).toContain("$0.01");
+    expect(output).toContain("$0.004200");
   });
 
   test("renders — for zero or unpriced run cost", async () => {

--- a/assistant/src/cli/commands/__tests__/schedules.test.ts
+++ b/assistant/src/cli/commands/__tests__/schedules.test.ts
@@ -64,7 +64,9 @@ async function runCommand(
     registerSchedulesCommand(program);
     await program.parseAsync(["node", "assistant", ...args]);
   } catch {
-    if (process.exitCode === 0) process.exitCode = 1;
+    if (process.exitCode === 0) {
+      process.exitCode = 1;
+    }
   } finally {
     process.stdout.write = originalStdoutWrite;
   }
@@ -467,6 +469,120 @@ describe("schedules runs", () => {
     expect(logLines.join("\n")).toContain("run-1");
     expect(logLines.join("\n")).toContain("2.5s");
     expect(logLines.join("\n")).toContain("conversation-1");
+  });
+
+  test("renders a COST column with formatted USD run cost", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        runs: [
+          {
+            id: "run-1",
+            jobId: "schedule-1",
+            status: "ok",
+            startedAt: 1_778_799_000_000,
+            finishedAt: 1_778_799_002_500,
+            durationMs: 2_500,
+            output: "done",
+            error: null,
+            conversationId: "conversation-1",
+            estimatedCostUsd: 0.0123,
+            createdAt: 1_778_799_000_000,
+          },
+        ],
+      },
+    };
+
+    const { exitCode } = await runCommand(["schedules", "runs", "schedule-1"]);
+
+    expect(exitCode).toBe(0);
+    expect(logLines.join("\n")).toContain("COST");
+    expect(logLines.join("\n")).toContain("$0.0123");
+  });
+
+  test("renders — for zero or unpriced run cost", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        runs: [
+          {
+            id: "run-zero",
+            jobId: "schedule-1",
+            status: "ok",
+            startedAt: 1_778_799_000_000,
+            finishedAt: 1_778_799_002_500,
+            durationMs: 2_500,
+            output: "done",
+            error: null,
+            conversationId: "conversation-1",
+            estimatedCostUsd: 0,
+            createdAt: 1_778_799_000_000,
+          },
+          {
+            id: "run-unpriced",
+            jobId: "schedule-1",
+            status: "ok",
+            startedAt: 1_778_799_000_000,
+            finishedAt: 1_778_799_002_500,
+            durationMs: 2_500,
+            output: "done",
+            error: null,
+            conversationId: "conversation-1",
+            createdAt: 1_778_799_000_000,
+          },
+        ],
+      },
+    };
+
+    const { exitCode } = await runCommand(["schedules", "runs", "schedule-1"]);
+
+    expect(exitCode).toBe(0);
+    const output = logLines.join("\n");
+    expect(output).toContain("COST");
+    expect(output).not.toContain("$");
+    const runZeroLine = logLines.find((line) => line.includes("run-zero"));
+    const runUnpricedLine = logLines.find((line) =>
+      line.includes("run-unpriced"),
+    );
+    expect(runZeroLine).toContain("—");
+    expect(runUnpricedLine).toContain("—");
+  });
+
+  test("includes estimatedCostUsd in --json output", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        runs: [
+          {
+            id: "run-1",
+            jobId: "schedule-1",
+            status: "ok",
+            startedAt: 1_778_799_000_000,
+            finishedAt: 1_778_799_002_500,
+            durationMs: 2_500,
+            output: "done",
+            error: null,
+            conversationId: "conversation-1",
+            estimatedCostUsd: 0.0123,
+            createdAt: 1_778_799_000_000,
+          },
+        ],
+      },
+    };
+
+    const { stdout, exitCode } = await runCommand([
+      "schedules",
+      "runs",
+      "schedule-1",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout)).toEqual({
+      runs: [
+        expect.objectContaining({ id: "run-1", estimatedCostUsd: 0.0123 }),
+      ],
+    });
   });
 
   test("formats run durations into human-friendly units", async () => {

--- a/assistant/src/cli/commands/__tests__/usage.test.ts
+++ b/assistant/src/cli/commands/__tests__/usage.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+let ipcCalls: Array<{ method: string; params?: Record<string, unknown> }> = [];
+let mockIpcResult: {
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+} = { ok: true, result: {} };
+let exitFromIpcResultCalls: unknown[] = [];
+
+mock.module("../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (method: string, params?: Record<string, unknown>) => {
+    ipcCalls.push({ method, params });
+    return mockIpcResult;
+  },
+  exitFromIpcResult: (result: unknown) => {
+    exitFromIpcResultCalls.push(result);
+    process.exitCode = 10;
+    throw new Error("exitFromIpcResult called");
+  },
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+const { registerUsageCommand } = await import("../usage.js");
+
+async function runCommand(args: string[]): Promise<{ exitCode: number }> {
+  process.exitCode = 0;
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: () => {},
+    });
+    registerUsageCommand(program);
+    await program.parseAsync(["node", "assistant", "usage", ...args]);
+  } catch {
+    if (process.exitCode === 0) {
+      process.exitCode = 1;
+    }
+  }
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+  return { exitCode };
+}
+
+function lastQueryParams(): Record<string, unknown> {
+  const call = ipcCalls.at(-1);
+  return (call?.params?.queryParams ?? {}) as Record<string, unknown>;
+}
+
+describe("usage --schedule option", () => {
+  beforeEach(() => {
+    ipcCalls = [];
+    exitFromIpcResultCalls = [];
+    mockIpcResult = { ok: true, result: {} };
+  });
+
+  test("totals forwards --schedule as scheduleId", async () => {
+    mockIpcResult = { ok: true, result: { buckets: [] } };
+    await runCommand([
+      "totals",
+      "--range",
+      "all",
+      "--schedule",
+      "sched-abc123",
+    ]);
+    expect(ipcCalls.at(-1)?.method).toBe("usage_totals");
+    expect(lastQueryParams().scheduleId).toBe("sched-abc123");
+  });
+
+  test("totals omits scheduleId when --schedule absent", async () => {
+    await runCommand(["totals", "--range", "all"]);
+    expect(ipcCalls.at(-1)?.method).toBe("usage_totals");
+    expect(lastQueryParams()).not.toHaveProperty("scheduleId");
+  });
+
+  test("daily forwards --schedule as scheduleId", async () => {
+    mockIpcResult = { ok: true, result: { buckets: [] } };
+    await runCommand(["daily", "--range", "all", "--schedule", "sched-abc123"]);
+    expect(ipcCalls.at(-1)?.method).toBe("usage_daily");
+    expect(lastQueryParams().scheduleId).toBe("sched-abc123");
+  });
+
+  test("daily omits scheduleId when --schedule absent", async () => {
+    mockIpcResult = { ok: true, result: { buckets: [] } };
+    await runCommand(["daily", "--range", "all"]);
+    expect(ipcCalls.at(-1)?.method).toBe("usage_daily");
+    expect(lastQueryParams()).not.toHaveProperty("scheduleId");
+  });
+
+  test("breakdown forwards --schedule as scheduleId alongside groupBy", async () => {
+    mockIpcResult = { ok: true, result: { breakdown: [] } };
+    await runCommand([
+      "breakdown",
+      "--range",
+      "all",
+      "--group-by",
+      "provider",
+      "--schedule",
+      "sched-abc123",
+    ]);
+    expect(ipcCalls.at(-1)?.method).toBe("usage_breakdown");
+    const qp = lastQueryParams();
+    expect(qp.scheduleId).toBe("sched-abc123");
+    expect(qp.groupBy).toBe("provider");
+  });
+
+  test("breakdown omits scheduleId when --schedule absent", async () => {
+    mockIpcResult = { ok: true, result: { breakdown: [] } };
+    await runCommand(["breakdown", "--range", "all", "--group-by", "provider"]);
+    expect(ipcCalls.at(-1)?.method).toBe("usage_breakdown");
+    expect(lastQueryParams()).not.toHaveProperty("scheduleId");
+  });
+});

--- a/assistant/src/cli/commands/inference-providers.ts
+++ b/assistant/src/cli/commands/inference-providers.ts
@@ -290,7 +290,8 @@ function attachCreateSubcommand(connections: Command): void {
           );
         } else {
           process.stdout.write(
-            `Created connection "${conn.name}" (provider=${conn.provider}, auth=${formatAuth(conn.auth)})\n`,
+            `Created connection "${conn.name}" (provider=${conn.provider}, auth=${formatAuth(conn.auth)})\n` +
+              `Verify it works: point a profile's provider_connection at "${conn.name}", then run: assistant inference send --profile <profile> "Reply with OK"\n`,
           );
         }
       },
@@ -359,7 +360,8 @@ function attachUpdateSubcommand(connections: Command): void {
           );
         } else {
           process.stdout.write(
-            `Updated connection "${name}" auth to ${formatAuth(conn.auth)}\n`,
+            `Updated connection "${name}" auth to ${formatAuth(conn.auth)}\n` +
+              `Verify it works: assistant inference send --profile <profile-using-this-connection> "Reply with OK"\n`,
           );
         }
       },
@@ -563,7 +565,11 @@ Examples:
       --provider openai-compatible --auth none \\
       --base-url http://localhost:1234/v1 --model my-model
   $ assistant inference providers connections update anthropic-personal --auth platform
-  $ assistant inference providers connections delete anthropic-personal`,
+  $ assistant inference providers connections delete anthropic-personal
+
+After creating or updating a connection, validate it with a live call through
+a profile that uses it:
+  $ assistant inference send --profile <profile> "Reply with OK"`,
   );
 
   attachListSubcommand(connections);

--- a/assistant/src/cli/commands/schedules.ts
+++ b/assistant/src/cli/commands/schedules.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import { formatCostUsd } from "../lib/cli-output.js";
 import { confirmPrompt } from "../lib/confirm-prompt.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
@@ -1175,11 +1176,12 @@ function formatNullableTimestamp(value: number | null): string {
   return value == null ? "—" : formatTimestamp(value);
 }
 
+/** Run costs render "—" when absent or zero; positive values use the shared USD formatter. */
 function formatRunCost(value: number | null | undefined): string {
   if (value == null || !Number.isFinite(value) || value <= 0) {
     return "—";
   }
-  return `$${value.toFixed(4)}`;
+  return formatCostUsd(value);
 }
 
 function formatDuration(value: number | null): string {

--- a/assistant/src/cli/commands/schedules.ts
+++ b/assistant/src/cli/commands/schedules.ts
@@ -54,6 +54,7 @@ interface ScheduleRunRecord {
   output: string | null;
   error: string | null;
   conversationId: string | null;
+  estimatedCostUsd: number;
   createdAt: number;
 }
 
@@ -360,6 +361,7 @@ Examples:
               startedAt: formatTimestamp(run.startedAt),
               finishedAt: formatNullableTimestamp(run.finishedAt),
               duration: formatDuration(run.durationMs),
+              cost: formatRunCost(run.estimatedCostUsd),
               conversation: run.conversationId ?? "—",
               error: run.error ?? "—",
             }));
@@ -370,6 +372,7 @@ Examples:
               "STARTED",
               "FINISHED",
               "DURATION",
+              "COST",
               "CONVERSATION",
               "ERROR",
             ];
@@ -381,6 +384,7 @@ Examples:
               headers[4].length,
               headers[5].length,
               headers[6].length,
+              headers[7].length,
             ];
 
             for (const row of rows) {
@@ -389,8 +393,9 @@ Examples:
               widths[2] = Math.max(widths[2], row.startedAt.length);
               widths[3] = Math.max(widths[3], row.finishedAt.length);
               widths[4] = Math.max(widths[4], row.duration.length);
-              widths[5] = Math.max(widths[5], row.conversation.length);
-              widths[6] = Math.max(widths[6], row.error.length);
+              widths[5] = Math.max(widths[5], row.cost.length);
+              widths[6] = Math.max(widths[6], row.conversation.length);
+              widths[7] = Math.max(widths[7], row.error.length);
             }
 
             const pad = (value: string, width: number) => value.padEnd(width);
@@ -408,6 +413,7 @@ Examples:
                   row.startedAt,
                   row.finishedAt,
                   row.duration,
+                  row.cost,
                   row.conversation,
                   row.error,
                 ]
@@ -1167,6 +1173,13 @@ function formatTimestamp(value: number): string {
 
 function formatNullableTimestamp(value: number | null): string {
   return value == null ? "—" : formatTimestamp(value);
+}
+
+function formatRunCost(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value) || value <= 0) {
+    return "—";
+  }
+  return `$${value.toFixed(4)}`;
 }
 
 function formatDuration(value: number | null): string {

--- a/assistant/src/cli/commands/usage.ts
+++ b/assistant/src/cli/commands/usage.ts
@@ -7,14 +7,22 @@ import { log } from "../logger.js";
 // ── Formatting helpers ───────────────────────────────────────────
 
 function formatCost(usd: number): string {
-  if (usd === 0) return "$0.00";
-  if (usd < 0.01) return `$${usd.toFixed(6)}`;
+  if (usd === 0) {
+    return "$0.00";
+  }
+  if (usd < 0.01) {
+    return `$${usd.toFixed(6)}`;
+  }
   return `$${usd.toFixed(2)}`;
 }
 
 function formatTokens(count: number): string {
-  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
-  if (count >= 1_000) return `${(count / 1_000).toFixed(1)}k`;
+  if (count >= 1_000_000) {
+    return `${(count / 1_000_000).toFixed(1)}M`;
+  }
+  if (count >= 1_000) {
+    return `${(count / 1_000).toFixed(1)}k`;
+  }
   return String(count);
 }
 
@@ -232,11 +240,12 @@ Examples:
         "--from <epoch_ms>",
         "Start of range (epoch ms)",
       ] as const;
-      const toOption = [
-        "--to <epoch_ms>",
-        "End of range (epoch ms)",
-      ] as const;
+      const toOption = ["--to <epoch_ms>", "End of range (epoch ms)"] as const;
       const jsonOption = ["--json", "Output raw JSON"] as const;
+      const scheduleOption = [
+        "--schedule <id>",
+        "Filter to a schedule id; attributes usage by that schedule's cron run windows",
+      ] as const;
 
       usage
         .command("totals", { isDefault: true })
@@ -244,6 +253,7 @@ Examples:
         .option(...rangeOption)
         .option(...fromOption)
         .option(...toOption)
+        .option(...scheduleOption)
         .option(...jsonOption)
         .addHelpText(
           "after",
@@ -254,9 +264,13 @@ within the time range.
 Columns: estimated cost, LLM call count, input/output tokens, cache
 creation/read tokens, unpriced event count (if any).
 
+Pass --schedule <id> to restrict totals to a single schedule's cron run
+windows.
+
 Examples:
   $ assistant usage totals
   $ assistant usage totals --range all
+  $ assistant usage totals --schedule sched-abc123
   $ assistant usage totals --from 1709856000000 --to 1709942400000`,
         )
         .action(
@@ -264,11 +278,12 @@ Examples:
             range: string;
             from?: string;
             to?: string;
+            schedule?: string;
             json?: boolean;
           }) => {
             const { from, to } = resolveRange(opts);
             const response = await cliIpcCall<UsageTotals>("usage_totals", {
-              queryParams: { from: String(from), to: String(to) },
+              queryParams: buildUsageQueryParams(from, to, opts.schedule),
             });
             if (!response.ok) {
               return exitFromIpcResult(response);
@@ -288,6 +303,7 @@ Examples:
         .option(...rangeOption)
         .option(...fromOption)
         .option(...toOption)
+        .option(...scheduleOption)
         .option(...jsonOption)
         .addHelpText(
           "after",
@@ -295,9 +311,13 @@ Examples:
 Shows one row per day (UTC) with input tokens, output tokens, estimated
 cost, and LLM call count.
 
+Pass --schedule <id> to restrict the breakdown to a single schedule's cron
+run windows.
+
 Examples:
   $ assistant usage daily
   $ assistant usage daily --range week
+  $ assistant usage daily --schedule sched-abc123
   $ assistant usage daily --range month --json`,
         )
         .action(
@@ -305,12 +325,13 @@ Examples:
             range: string;
             from?: string;
             to?: string;
+            schedule?: string;
             json?: boolean;
           }) => {
             const { from, to } = resolveRange(opts);
             const response = await cliIpcCall<{ buckets: UsageDayBucket[] }>(
               "usage_daily",
-              { queryParams: { from: String(from), to: String(to) } },
+              { queryParams: buildUsageQueryParams(from, to, opts.schedule) },
             );
             if (!response.ok) {
               return exitFromIpcResult(response);
@@ -332,6 +353,7 @@ Examples:
         .option(...rangeOption)
         .option(...fromOption)
         .option(...toOption)
+        .option(...scheduleOption)
         .option(...jsonOption)
         .option(
           "-g, --group-by <dimension>",
@@ -354,11 +376,15 @@ Grouping dimensions:
 Shows one row per group with input/output tokens, estimated cost, and
 call count. Rows are sorted by cost descending.
 
+Pass --schedule <id> to restrict the breakdown to a single schedule's cron
+run windows.
+
 Examples:
   $ assistant usage breakdown
   $ assistant usage breakdown --group-by call_site
   $ assistant usage breakdown --group-by inference_profile
   $ assistant usage breakdown --group-by provider
+  $ assistant usage breakdown --schedule sched-abc123
   $ assistant usage breakdown --group-by actor --range week`,
         )
         .action(
@@ -366,6 +392,7 @@ Examples:
             range: string;
             from?: string;
             to?: string;
+            schedule?: string;
             json?: boolean;
             groupBy: string;
           }) => {
@@ -381,8 +408,7 @@ Examples:
               breakdown: UsageGroupBreakdown[];
             }>("usage_breakdown", {
               queryParams: {
-                from: String(from),
-                to: String(to),
+                ...buildUsageQueryParams(from, to, opts.schedule),
                 groupBy: opts.groupBy,
               },
             });
@@ -399,6 +425,25 @@ Examples:
         );
     },
   });
+}
+
+/**
+ * Build the shared usage query params, including scheduleId only when a
+ * schedule filter is provided.
+ */
+function buildUsageQueryParams(
+  from: number,
+  to: number,
+  schedule?: string,
+): Record<string, string> {
+  const queryParams: Record<string, string> = {
+    from: String(from),
+    to: String(to),
+  };
+  if (schedule !== undefined) {
+    queryParams.scheduleId = schedule;
+  }
+  return queryParams;
 }
 
 /** Resolve the time range from commander options. */

--- a/assistant/src/cli/commands/usage.ts
+++ b/assistant/src/cli/commands/usage.ts
@@ -1,20 +1,11 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import { formatCostUsd } from "../lib/cli-output.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
 
 // ── Formatting helpers ───────────────────────────────────────────
-
-function formatCost(usd: number): string {
-  if (usd === 0) {
-    return "$0.00";
-  }
-  if (usd < 0.01) {
-    return `$${usd.toFixed(6)}`;
-  }
-  return `$${usd.toFixed(2)}`;
-}
 
 function formatTokens(count: number): string {
   if (count >= 1_000_000) {
@@ -92,7 +83,9 @@ function printTotalsTable(totals: UsageTotals): void {
   log.info("");
   log.info("  Usage Totals");
   log.info("  ────────────────────────────────────");
-  log.info(`  Estimated Cost     ${formatCost(totals.totalEstimatedCostUsd)}`);
+  log.info(
+    `  Estimated Cost     ${formatCostUsd(totals.totalEstimatedCostUsd)}`,
+  );
   log.info(`  LLM Calls          ${totals.eventCount}`);
   log.info(`  Input Tokens       ${formatTokens(totals.totalInputTokens)}`);
   log.info(`  Output Tokens      ${formatTokens(totals.totalOutputTokens)}`);
@@ -123,7 +116,7 @@ function printDailyTable(buckets: UsageDayBucket[]): void {
   );
   const costW = Math.max(
     "COST".length,
-    ...buckets.map((b) => formatCost(b.totalEstimatedCostUsd).length),
+    ...buckets.map((b) => formatCostUsd(b.totalEstimatedCostUsd).length),
   );
   const callsW = Math.max(
     "CALLS".length,
@@ -140,7 +133,7 @@ function printDailyTable(buckets: UsageDayBucket[]): void {
 
   for (const b of buckets) {
     log.info(
-      `  ${pad(b.date, dateW)}  ${pad(formatTokens(b.totalInputTokens), inputW, "right")}  ${pad(formatTokens(b.totalOutputTokens), outputW, "right")}  ${pad(formatCost(b.totalEstimatedCostUsd), costW, "right")}  ${pad(String(b.eventCount), callsW, "right")}`,
+      `  ${pad(b.date, dateW)}  ${pad(formatTokens(b.totalInputTokens), inputW, "right")}  ${pad(formatTokens(b.totalOutputTokens), outputW, "right")}  ${pad(formatCostUsd(b.totalEstimatedCostUsd), costW, "right")}  ${pad(String(b.eventCount), callsW, "right")}`,
     );
   }
   log.info("");
@@ -175,7 +168,7 @@ function printBreakdownTable(
   );
   const costW = Math.max(
     "COST".length,
-    ...entries.map((e) => formatCost(e.totalEstimatedCostUsd).length),
+    ...entries.map((e) => formatCostUsd(e.totalEstimatedCostUsd).length),
   );
   const callsW = Math.max(
     "CALLS".length,
@@ -192,7 +185,7 @@ function printBreakdownTable(
 
   for (const e of entries) {
     log.info(
-      `  ${pad(e.group, groupW)}  ${pad(formatTokens(e.totalInputTokens), inputW, "right")}  ${pad(formatTokens(e.totalOutputTokens), outputW, "right")}  ${pad(formatCost(e.totalEstimatedCostUsd), costW, "right")}  ${pad(String(e.eventCount), callsW, "right")}`,
+      `  ${pad(e.group, groupW)}  ${pad(formatTokens(e.totalInputTokens), inputW, "right")}  ${pad(formatTokens(e.totalOutputTokens), outputW, "right")}  ${pad(formatCostUsd(e.totalEstimatedCostUsd), costW, "right")}  ${pad(String(e.eventCount), callsW, "right")}`,
     );
   }
   log.info("");
@@ -244,7 +237,7 @@ Examples:
       const jsonOption = ["--json", "Output raw JSON"] as const;
       const scheduleOption = [
         "--schedule <id>",
-        "Filter to a schedule id; attributes usage by that schedule's cron run windows",
+        "Filter to a schedule id — run 'assistant schedules list' to find it; attributes usage by that schedule's cron run windows",
       ] as const;
 
       usage
@@ -265,7 +258,7 @@ Columns: estimated cost, LLM call count, input/output tokens, cache
 creation/read tokens, unpriced event count (if any).
 
 Pass --schedule <id> to restrict totals to a single schedule's cron run
-windows.
+windows. Find schedule ids with 'assistant schedules list'.
 
 Examples:
   $ assistant usage totals
@@ -312,7 +305,7 @@ Shows one row per day (UTC) with input tokens, output tokens, estimated
 cost, and LLM call count.
 
 Pass --schedule <id> to restrict the breakdown to a single schedule's cron
-run windows.
+run windows. Find schedule ids with 'assistant schedules list'.
 
 Examples:
   $ assistant usage daily
@@ -377,7 +370,7 @@ Shows one row per group with input/output tokens, estimated cost, and
 call count. Rows are sorted by cost descending.
 
 Pass --schedule <id> to restrict the breakdown to a single schedule's cron
-run windows.
+run windows. Find schedule ids with 'assistant schedules list'.
 
 Examples:
   $ assistant usage breakdown

--- a/assistant/src/cli/lib/__tests__/cli-output.test.ts
+++ b/assistant/src/cli/lib/__tests__/cli-output.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+
+import { formatCostUsd } from "../cli-output.js";
+
+describe("formatCostUsd", () => {
+  test("renders zero as $0.00", () => {
+    expect(formatCostUsd(0)).toBe("$0.00");
+  });
+
+  test("renders sub-cent amounts with six decimal places", () => {
+    expect(formatCostUsd(0.0042)).toBe("$0.004200");
+    expect(formatCostUsd(0.000001)).toBe("$0.000001");
+  });
+
+  test("renders a cent or more with two decimal places", () => {
+    expect(formatCostUsd(0.0123)).toBe("$0.01");
+    expect(formatCostUsd(1.5)).toBe("$1.50");
+    expect(formatCostUsd(12.345)).toBe("$12.35");
+  });
+});

--- a/assistant/src/cli/lib/cli-output.ts
+++ b/assistant/src/cli/lib/cli-output.ts
@@ -11,6 +11,20 @@ export function writeLine(msg: string): void {
 }
 
 /**
+ * Format a USD cost with variable precision: "$0.00" for zero, six decimal
+ * places for sub-cent amounts, two decimal places otherwise.
+ */
+export function formatCostUsd(usd: number): string {
+  if (usd === 0) {
+    return "$0.00";
+  }
+  if (usd < 0.01) {
+    return `$${usd.toFixed(6)}`;
+  }
+  return `$${usd.toFixed(2)}`;
+}
+
+/**
  * Report a CLI failure and set `process.exitCode = 1`. In `--json` mode the
  * error is emitted to stdout as `{ ok: false, error }` so machine callers
  * always get a parseable body; otherwise it goes through the CLI logger.


### PR DESCRIPTION
## Motivation

Schedule cost was effectively invisible from the CLI: the daemon already
attributes LLM usage to a schedule's cron-run windows and attaches a
per-run cost, but there was no way to slice `usage` by schedule or to see
what a given schedule's runs cost. These CLI surfaces are extracted from
#37740, which is held pending a profile-refactor release bake — pulling
them out lets the schedule/usage visibility ship now instead of riding
that hold.

> Note: the intended base branch `feature/inference-config-cli` (#37748)
> merged into `main` and was deleted, so this PR targets `main` — which
> now contains that exact base state (the `--base-url`/`--model` connection
> flags and the shared `cli-output.ts` helper). The connection breadcrumbs
> here integrate with those.

## What's in it

**`--schedule <id>` on `usage totals` / `daily` / `breakdown`**
Forwards `scheduleId` to the usage routes, which already restrict
attribution to that schedule's cron-run windows. Omitted when the flag
isn't passed.

```
$ assistant usage totals --schedule sched-abc123
$ assistant usage daily --schedule sched-abc123 --range week
$ assistant usage breakdown --group-by provider --schedule sched-abc123
```

**Per-run cost on `schedules runs`**
The `listScheduleRuns` route already attaches `estimatedCostUsd` per run
(via `getUsageCostForRun` — cronRunId primary, conversation+window
fallback). The CLI now renders a `COST` column (USD, `—` when zero or
unpriced) and includes `estimatedCostUsd` in `--json`.

```
$ assistant schedules runs schedule-1
$ assistant schedules runs schedule-1 --json
```

**Verification breadcrumbs on `inference providers connections create` / `update`**
Success output and help text now point at a live validation call:

```
$ assistant inference send --profile <profile> "Reply with OK"
```

## Verification
- `bun run typecheck:fast` — clean
- `bun test` on `usage.test.ts`, `schedules.test.ts`, `inference-providers.test.ts` — all pass
- `eslint` on all touched files — clean

No route response shapes changed (cost plumbing already lives on `main`),
so no OpenAPI regeneration was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->