### PR TITLE
refactor(cli): route memory nodes commands through daemon memory-nodes routes

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -16408,8 +16408,11 @@ paths:
   /v1/memory-nodes/delete:
     post:
       operationId: memorynodes_delete_post
-      summary: Delete a memory graph node by content
-      description: Delete the memory graph node whose content exactly matches the given text.
+      summary: Delete a memory graph node by content match
+      description:
+        "Delete the single memory graph node matching `content`: a case-insensitive exact match takes priority;
+        with no exact match, a substring match is tried. Fails as `{ success: false }` when zero or multiple nodes
+        match."
       tags:
         - memory
       requestBody:
@@ -16442,8 +16445,11 @@ paths:
   /v1/memory-nodes/update:
     post:
       operationId: memorynodes_update_post
-      summary: Update a memory graph node by content
-      description: Replace the content of the memory graph node whose content exactly matches `oldContent`.
+      summary: Update a memory graph node by content match
+      description:
+        "Replace the content of the single memory graph node matching `oldContent`: a case-insensitive exact match
+        takes priority; with no exact match, a substring match is tried. Fails as `{ success: false }` when zero or
+        multiple nodes match, or when another active node already has `newContent`."
       tags:
         - memory
       requestBody:

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -16341,6 +16341,141 @@ paths:
                 additionalProperties: false
         "409":
           description: Another memory item with this content already exists
+  /v1/memory-nodes:
+    get:
+      operationId: memorynodes_get
+      summary: List memory graph nodes
+      description:
+        Return active memory graph nodes ordered by significance. With `search`, all nodes are scanned so the
+        content filter is exhaustive; without it the query is capped at `limit` rows.
+      tags:
+        - memory
+      parameters:
+        - name: search
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter nodes whose content contains the query
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: Max results (default 50, max 200)
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  message:
+                    type: string
+                  nodes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        content:
+                          type: string
+                        type:
+                          type: string
+                        fidelity:
+                          type: string
+                        created:
+                          type: number
+                      required:
+                        - id
+                        - content
+                        - type
+                        - fidelity
+                        - created
+                      additionalProperties: false
+                  total:
+                    type: number
+                required:
+                  - success
+                  - message
+                  - nodes
+                  - total
+                additionalProperties: false
+  /v1/memory-nodes/delete:
+    post:
+      operationId: memorynodes_delete_post
+      summary: Delete a memory graph node by content
+      description: Delete the memory graph node whose content exactly matches the given text.
+      tags:
+        - memory
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                content:
+                  type: string
+              required:
+                - content
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  message:
+                    type: string
+                required:
+                  - success
+                  - message
+                additionalProperties: false
+  /v1/memory-nodes/update:
+    post:
+      operationId: memorynodes_update_post
+      summary: Update a memory graph node by content
+      description: Replace the content of the memory graph node whose content exactly matches `oldContent`.
+      tags:
+        - memory
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                oldContent:
+                  type: string
+                newContent:
+                  type: string
+              required:
+                - oldContent
+                - newContent
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  message:
+                    type: string
+                required:
+                  - success
+                  - message
+                additionalProperties: false
   /v1/memory/eval/run:
     post:
       operationId: memory_eval_run_post

--- a/assistant/src/__tests__/plugin-import-boundary-reverse-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-reverse-guard.test.ts
@@ -81,7 +81,6 @@ const BASELINE: Record<string, readonly string[]> = {
     "src/cli/commands/memory/memory-v2-compare-render.ts",
     "src/cli/commands/memory/memory-v2.ts",
     "src/cli/commands/memory/memory-v3.ts",
-    "src/cli/commands/memory/nodes.ts",
     "src/config/bundled-skills/messaging/tools/messaging-analyze-style.ts",
     "src/config/bundled-skills/playbooks/tools/playbook-create.ts",
     "src/config/bundled-skills/playbooks/tools/playbook-delete.ts",

--- a/assistant/src/cli/commands/memory/nodes.ts
+++ b/assistant/src/cli/commands/memory/nodes.ts
@@ -1,14 +1,12 @@
 /**
  * `assistant memory nodes` CLI subgroup.
  *
- * Content-based CRUD over the memory v2 graph nodes. Handlers are invoked
- * directly in-process (no IPC, no daemon dependency) — exactly the same
- * functions the daemon would call, but run here without routing through the
- * main thread:
+ * Content-based CRUD over the memory v2 graph nodes, routed through the
+ * daemon's memory-nodes routes via IPC:
  *
- *   - `list`   → handleListMemory
- *   - `delete` → handleDeleteMemory
- *   - `update` → handleUpdateMemory
+ *   - `list`   → `listMemoryNodes`
+ *   - `delete` → `deleteMemoryNode`
+ *   - `update` → `updateMemoryNode`
  *
  * Unlike `memory items`, which addresses nodes by UUID, these commands address
  * nodes by content text — matching the way an operator or agent naturally
@@ -17,20 +15,36 @@
 
 import type { Command } from "commander";
 
-import { getConfig } from "../../../config/loader.js";
-import {
-  handleDeleteMemory,
-  handleListMemory,
-  handleUpdateMemory,
-} from "../../../plugins/defaults/memory/graph/tool-handlers.js";
+import { cliIpcCall } from "../../../ipc/cli-client.js";
 import { registerCommand } from "../../lib/register-command.js";
 import { log } from "../../logger.js";
 import { writeOutput } from "../../output.js";
 
+/** Wire shapes of the daemon's memory-nodes route responses. */
+interface MemoryNodeEntry {
+  id: string;
+  content: string;
+  type: string;
+  fidelity: string;
+  created: number;
+}
+
+interface ListMemoryNodesResult {
+  success: boolean;
+  message: string;
+  nodes: MemoryNodeEntry[];
+  total: number;
+}
+
+interface MemoryNodeMutationResult {
+  success: boolean;
+  message: string;
+}
+
 export function registerMemoryNodesCommand(memory: Command): void {
   registerCommand(memory, {
     name: "nodes",
-    transport: "local",
+    transport: "ipc",
     description: "Content-based list, delete, and update of memory graph nodes",
     build: (nodes) => {
       nodes.addHelpText(
@@ -41,7 +55,7 @@ memory v2 subsystem. Unlike 'memory items', which addresses nodes by UUID, these
 commands address nodes by content text — matching the way an operator refers to
 a remembered fact without first looking up its ID.
 
-All subcommands require memory v2 to be enabled on the assistant.
+All subcommands require memory v2 to be enabled and the assistant to be running.
 
 Examples:
   $ assistant memory nodes list
@@ -77,17 +91,27 @@ Examples:
   $ assistant memory nodes list --json`,
         )
         .action(
-          (
+          async (
             opts: { search?: string; limit?: string; json?: boolean },
             cmd: Command,
           ) => {
-            const result = handleListMemory(
-              {
-                search: opts.search,
-                limit: opts.limit ? parseInt(opts.limit, 10) : undefined,
-              },
-              getConfig(),
+            const queryParams: Record<string, string> = {};
+            if (opts.search) {
+              queryParams.search = opts.search;
+            }
+            if (opts.limit) {
+              queryParams.limit = opts.limit;
+            }
+            const r = await cliIpcCall<ListMemoryNodesResult>(
+              "listMemoryNodes",
+              { queryParams },
             );
+            if (!r.ok) {
+              log.error(r.error ?? "Failed to list memory nodes");
+              process.exitCode = 1;
+              return;
+            }
+            const result = r.result!;
 
             if (!result.success) {
               log.error(result.message);
@@ -125,7 +149,9 @@ Examples:
             );
 
             console.log(
-              `${"CONTENT".padEnd(CONTENT_WIDTH)}  ${"TYPE".padEnd(typeWidth)}  ${"FIDELITY".padEnd(fidelityWidth)}  CREATED`,
+              `${"CONTENT".padEnd(CONTENT_WIDTH)}  ${"TYPE".padEnd(
+                typeWidth,
+              )}  ${"FIDELITY".padEnd(fidelityWidth)}  CREATED`,
             );
 
             for (const n of result.nodes) {
@@ -136,12 +162,16 @@ Examples:
                 minute: "2-digit",
               });
               console.log(
-                `${truncate(n.content).padEnd(CONTENT_WIDTH)}  ${n.type.padEnd(typeWidth)}  ${n.fidelity.padEnd(fidelityWidth)}  ${created}`,
+                `${truncate(n.content).padEnd(CONTENT_WIDTH)}  ${n.type.padEnd(
+                  typeWidth,
+                )}  ${n.fidelity.padEnd(fidelityWidth)}  ${created}`,
               );
             }
 
             console.log(
-              `\n${result.total} node${result.total === 1 ? "" : "s"}${opts.search ? ` matching "${opts.search}"` : ""}`,
+              `\n${result.total} node${result.total === 1 ? "" : "s"}${
+                opts.search ? ` matching "${opts.search}"` : ""
+              }`,
             );
           },
         );
@@ -171,30 +201,41 @@ Examples:
   $ assistant memory nodes delete "User prefers TypeScript"
   $ assistant memory nodes delete "User prefers TypeScript" --json`,
         )
-        .action((content: string, opts: { json?: boolean }, cmd: Command) => {
-          if (!content.trim()) {
-            log.error(
-              "content is required. Run 'assistant memory nodes list' to find the exact text.",
+        .action(
+          async (content: string, opts: { json?: boolean }, cmd: Command) => {
+            if (!content.trim()) {
+              log.error(
+                "content is required. Run 'assistant memory nodes list' to find the exact text.",
+              );
+              process.exitCode = 1;
+              return;
+            }
+
+            const r = await cliIpcCall<MemoryNodeMutationResult>(
+              "deleteMemoryNode",
+              { body: { content } },
             );
-            process.exitCode = 1;
-            return;
-          }
+            if (!r.ok) {
+              log.error(r.error ?? "Failed to delete the memory node");
+              process.exitCode = 1;
+              return;
+            }
+            const result = r.result!;
 
-          const result = handleDeleteMemory({ content }, getConfig());
+            if (!result.success) {
+              log.error(result.message);
+              process.exitCode = 1;
+              return;
+            }
 
-          if (!result.success) {
-            log.error(result.message);
-            process.exitCode = 1;
-            return;
-          }
+            if (opts.json) {
+              writeOutput(cmd, result);
+              return;
+            }
 
-          if (opts.json) {
-            writeOutput(cmd, result);
-            return;
-          }
-
-          log.info(result.message);
-        });
+            log.info(result.message);
+          },
+        );
 
       // ── update ────────────────────────────────────────────────────────────
 
@@ -222,7 +263,7 @@ Examples:
   $ assistant memory nodes update "old fact" "corrected fact" --json`,
         )
         .action(
-          (
+          async (
             oldContent: string,
             newContent: string,
             opts: { json?: boolean },
@@ -236,11 +277,16 @@ Examples:
               return;
             }
 
-            const result = handleUpdateMemory(
-              { old_content: oldContent, new_content: newContent },
-              "cli",
-              getConfig(),
+            const r = await cliIpcCall<MemoryNodeMutationResult>(
+              "updateMemoryNode",
+              { body: { oldContent, newContent } },
             );
+            if (!r.ok) {
+              log.error(r.error ?? "Failed to update the memory node");
+              process.exitCode = 1;
+              return;
+            }
+            const result = r.result!;
 
             if (!result.success) {
               log.error(result.message);

--- a/assistant/src/cli/commands/memory/nodes.ts
+++ b/assistant/src/cli/commands/memory/nodes.ts
@@ -15,7 +15,7 @@
 
 import type { Command } from "commander";
 
-import { cliIpcCall } from "../../../ipc/cli-client.js";
+import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
 import { registerCommand } from "../../lib/register-command.js";
 import { log } from "../../logger.js";
 import { writeOutput } from "../../output.js";
@@ -107,9 +107,7 @@ Examples:
               { queryParams },
             );
             if (!r.ok) {
-              log.error(r.error ?? "Failed to list memory nodes");
-              process.exitCode = 1;
-              return;
+              exitFromIpcResult(r, cmd);
             }
             const result = r.result!;
 
@@ -216,9 +214,7 @@ Examples:
               { body: { content } },
             );
             if (!r.ok) {
-              log.error(r.error ?? "Failed to delete the memory node");
-              process.exitCode = 1;
-              return;
+              exitFromIpcResult(r, cmd);
             }
             const result = r.result!;
 
@@ -282,9 +278,7 @@ Examples:
               { body: { oldContent, newContent } },
             );
             if (!r.ok) {
-              log.error(r.error ?? "Failed to update the memory node");
-              process.exitCode = 1;
-              return;
+              exitFromIpcResult(r, cmd);
             }
             const result = r.result!;
 

--- a/assistant/src/plugins/defaults/memory/routes/memory-item-routes.test.ts
+++ b/assistant/src/plugins/defaults/memory/routes/memory-item-routes.test.ts
@@ -1010,6 +1010,13 @@ describe("Memory Item Routes", () => {
       expect(after.nodes.map((n) => n.id)).not.toContain("n1");
     });
 
+    test("listMemoryNodes rejects a non-numeric limit as 400", async () => {
+      const res = await callHandler(getRoute("memory-nodes", "GET"), {
+        queryParams: { limit: "abc" },
+      });
+      expect(res.status).toBe(400);
+    });
+
     test("deleteMemoryNode rejects a missing content body as 400", async () => {
       const res = await callHandler(getRoute("memory-nodes/delete", "POST"), {
         body: {},

--- a/assistant/src/plugins/defaults/memory/routes/memory-item-routes.test.ts
+++ b/assistant/src/plugins/defaults/memory/routes/memory-item-routes.test.ts
@@ -4,7 +4,15 @@
  * Covers: list with filters, get by ID, create + duplicate rejection,
  * update + fingerprint collision, delete + 404.
  */
-import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 
 mock.module("../../../../util/logger.js", () => ({
   getLogger: () =>
@@ -916,6 +924,125 @@ describe("Memory Item Routes", () => {
       const payload = JSON.parse(deleteJobs[0].payload);
       expect(payload.targetType).toBe("graph_node");
       expect(payload.targetId).toBe("i1");
+    });
+  });
+  // ── Memory nodes (content-addressed) ──────────────────────────────────────
+
+  describe("memory nodes routes", () => {
+    const cfg = mockConfig as { memory: { v2: { enabled: boolean } } };
+
+    beforeEach(() => {
+      cfg.memory.v2.enabled = true;
+    });
+
+    afterEach(() => {
+      cfg.memory.v2.enabled = false;
+    });
+
+    interface NodesListBody {
+      success: boolean;
+      message: string;
+      nodes: Array<{ id: string; content: string }>;
+      total: number;
+    }
+
+    interface NodesMutationBody {
+      success: boolean;
+      message: string;
+    }
+
+    test("listMemoryNodes lists seeded nodes and filters by search", async () => {
+      insertItem({
+        id: "n1",
+        type: "semantic",
+        content: "User prefers TypeScript",
+        significance: 0.9,
+      });
+      insertItem({
+        id: "n2",
+        type: "episodic",
+        content: "User visited Springfield",
+        significance: 0.5,
+      });
+
+      const route = getRoute("memory-nodes", "GET");
+      const all = (await (
+        await callHandler(route, { queryParams: {} })
+      ).json()) as NodesListBody;
+      expect(all.success).toBe(true);
+      expect(all.total).toBe(2);
+
+      const filtered = (await (
+        await callHandler(route, {
+          queryParams: { search: "TypeScript", limit: "10" },
+        })
+      ).json()) as NodesListBody;
+      expect(filtered.success).toBe(true);
+      expect(filtered.nodes.map((n) => n.id)).toEqual(["n1"]);
+    });
+
+    test("listMemoryNodes reports memory v2 disabled as a business failure", async () => {
+      cfg.memory.v2.enabled = false;
+      const body = (await (
+        await callHandler(getRoute("memory-nodes", "GET"), { queryParams: {} })
+      ).json()) as NodesListBody;
+      expect(body.success).toBe(false);
+      expect(body.message.length).toBeGreaterThan(0);
+    });
+
+    test("deleteMemoryNode deletes the node matching exact content", async () => {
+      insertItem({
+        id: "n1",
+        type: "semantic",
+        content: "User prefers TypeScript",
+      });
+
+      const body = (await (
+        await callHandler(getRoute("memory-nodes/delete", "POST"), {
+          body: { content: "User prefers TypeScript" },
+        })
+      ).json()) as NodesMutationBody;
+      expect(body.success).toBe(true);
+
+      const after = (await (
+        await callHandler(getRoute("memory-nodes", "GET"), { queryParams: {} })
+      ).json()) as NodesListBody;
+      expect(after.nodes.map((n) => n.id)).not.toContain("n1");
+    });
+
+    test("deleteMemoryNode fails as data when nothing matches", async () => {
+      const body = (await (
+        await callHandler(getRoute("memory-nodes/delete", "POST"), {
+          body: { content: "does not exist anywhere" },
+        })
+      ).json()) as NodesMutationBody;
+      expect(body.success).toBe(false);
+      expect(body.message.length).toBeGreaterThan(0);
+    });
+
+    test("updateMemoryNode replaces content on the exact-match node", async () => {
+      insertItem({
+        id: "n1",
+        type: "semantic",
+        content: "User prefers TypeScript",
+      });
+
+      const body = (await (
+        await callHandler(getRoute("memory-nodes/update", "POST"), {
+          body: {
+            oldContent: "User prefers TypeScript",
+            newContent: "User prefers TypeScript and Bun",
+          },
+        })
+      ).json()) as NodesMutationBody;
+      expect(body.success).toBe(true);
+
+      const after = (await (
+        await callHandler(getRoute("memory-nodes", "GET"), { queryParams: {} })
+      ).json()) as NodesListBody;
+      expect(after.nodes.map((n) => n.content)).toContain(
+        "User prefers TypeScript and Bun",
+      );
     });
   });
 });

--- a/assistant/src/plugins/defaults/memory/routes/memory-item-routes.test.ts
+++ b/assistant/src/plugins/defaults/memory/routes/memory-item-routes.test.ts
@@ -1010,6 +1010,20 @@ describe("Memory Item Routes", () => {
       expect(after.nodes.map((n) => n.id)).not.toContain("n1");
     });
 
+    test("deleteMemoryNode rejects a missing content body as 400", async () => {
+      const res = await callHandler(getRoute("memory-nodes/delete", "POST"), {
+        body: {},
+      });
+      expect(res.status).toBe(400);
+    });
+
+    test("updateMemoryNode rejects a non-string body field as 400", async () => {
+      const res = await callHandler(getRoute("memory-nodes/update", "POST"), {
+        body: { oldContent: "x", newContent: 42 },
+      });
+      expect(res.status).toBe(400);
+    });
+
     test("deleteMemoryNode fails as data when nothing matches", async () => {
       const body = (await (
         await callHandler(getRoute("memory-nodes/delete", "POST"), {

--- a/assistant/src/plugins/defaults/memory/routes/memory-item-routes.ts
+++ b/assistant/src/plugins/defaults/memory/routes/memory-item-routes.ts
@@ -14,8 +14,8 @@
  * graph (see the section in ROUTES):
  *
  * GET    /v1/memory-nodes        — list nodes (significance-ordered, content search)
- * POST   /v1/memory-nodes/delete — delete the node matching exact content
- * POST   /v1/memory-nodes/update — replace content on the node matching exact content
+ * POST   /v1/memory-nodes/delete — delete the single node matching content
+ * POST   /v1/memory-nodes/update — replace content on the single node matching content
  */
 
 import {
@@ -881,9 +881,9 @@ export const ROUTES: RouteDefinition[] = [
       requiredScopes: ["settings.write"],
       allowedPrincipalTypes: ACTOR_PRINCIPALS,
     },
-    summary: "Delete a memory graph node by content",
+    summary: "Delete a memory graph node by content match",
     description:
-      "Delete the memory graph node whose content exactly matches the given text.",
+      "Delete the single memory graph node matching `content`: a case-insensitive exact match takes priority; with no exact match, a substring match is tried. Fails as `{ success: false }` when zero or multiple nodes match.",
     tags: ["memory"],
     requestBody: z.object({
       content: z.string(),
@@ -906,9 +906,9 @@ export const ROUTES: RouteDefinition[] = [
       requiredScopes: ["settings.write"],
       allowedPrincipalTypes: ACTOR_PRINCIPALS,
     },
-    summary: "Update a memory graph node by content",
+    summary: "Update a memory graph node by content match",
     description:
-      "Replace the content of the memory graph node whose content exactly matches `oldContent`.",
+      "Replace the content of the single memory graph node matching `oldContent`: a case-insensitive exact match takes priority; with no exact match, a substring match is tried. Fails as `{ success: false }` when zero or multiple nodes match, or when another active node already has `newContent`.",
     tags: ["memory"],
     requestBody: z.object({
       oldContent: z.string(),

--- a/assistant/src/plugins/defaults/memory/routes/memory-item-routes.ts
+++ b/assistant/src/plugins/defaults/memory/routes/memory-item-routes.ts
@@ -865,7 +865,13 @@ export const ROUTES: RouteDefinition[] = [
     }),
     handler: ({ queryParams }) => {
       const limitRaw = queryParams?.limit;
-      const limit = limitRaw ? Number.parseInt(limitRaw, 10) : undefined;
+      let limit: number | undefined;
+      if (limitRaw) {
+        limit = Number.parseInt(limitRaw, 10);
+        if (!Number.isFinite(limit)) {
+          throw new BadRequestError("limit must be an integer");
+        }
+      }
       return handleListMemory(
         { search: queryParams?.search, limit },
         getConfig(),

--- a/assistant/src/plugins/defaults/memory/routes/memory-item-routes.ts
+++ b/assistant/src/plugins/defaults/memory/routes/memory-item-routes.ts
@@ -9,6 +9,13 @@
  * POST   /v1/memory-items        — create a new memory item
  * PATCH  /v1/memory-items/:id    — update an existing memory item
  * DELETE /v1/memory-items/:id    — delete a memory item and its embeddings
+ *
+ * Plus the content-addressed "memory nodes" operator surface over the same
+ * graph (see the section in ROUTES):
+ *
+ * GET    /v1/memory-nodes        — list nodes (significance-ordered, content search)
+ * POST   /v1/memory-nodes/delete — delete the node matching exact content
+ * POST   /v1/memory-nodes/update — replace content on the node matching exact content
  */
 
 import {
@@ -46,6 +53,11 @@ import {
 import type { RouteDefinition } from "../../../../runtime/routes/types.js";
 import { embedWithBackend } from "../embeddings.js";
 import { createNode, deleteNode, getNode, updateNode } from "../graph/store.js";
+import {
+  handleDeleteMemory,
+  handleListMemory,
+  handleUpdateMemory,
+} from "../graph/tool-handlers.js";
 import type {
   Fidelity,
   ImageRef,
@@ -272,7 +284,9 @@ async function handleListMemoryItems(queryParams: Record<string, string>) {
 
   if (!isValidSortField(sortParam)) {
     throw new BadRequestError(
-      `Invalid sort "${sortParam}". Must be one of: ${VALID_SORT_FIELDS.join(", ")}`,
+      `Invalid sort "${sortParam}". Must be one of: ${VALID_SORT_FIELDS.join(
+        ", ",
+      )}`,
     );
   }
 
@@ -802,5 +816,117 @@ export const ROUTES: RouteDefinition[] = [
     description: "Delete a memory graph node and its embeddings.",
     tags: ["memory"],
     handler: ({ pathParams }) => handleDeleteMemoryItem(pathParams!.id),
+  },
+
+  // ── Memory nodes (content-addressed) ───────────────────────────────────────
+  // Operator surface over raw graph nodes addressed by content text rather
+  // than UUID, mirroring how the model-facing memory tools address them. The
+  // handlers return business failures ({ success: false, message }) as data —
+  // the same shape the memory tools hand the model — so callers branch on
+  // `success` instead of catching transport errors.
+
+  {
+    operationId: "listMemoryNodes",
+    endpoint: "memory-nodes",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "List memory graph nodes",
+    description:
+      "Return active memory graph nodes ordered by significance. With `search`, all nodes are scanned so the content filter is exhaustive; without it the query is capped at `limit` rows.",
+    tags: ["memory"],
+    queryParams: [
+      {
+        name: "search",
+        schema: { type: "string" },
+        description: "Filter nodes whose content contains the query",
+      },
+      {
+        name: "limit",
+        schema: { type: "integer" },
+        description: "Max results (default 50, max 200)",
+      },
+    ],
+    responseBody: z.object({
+      success: z.boolean(),
+      message: z.string(),
+      nodes: z.array(
+        z.object({
+          id: z.string(),
+          content: z.string(),
+          type: z.string(),
+          fidelity: z.string(),
+          created: z.number(),
+        }),
+      ),
+      total: z.number(),
+    }),
+    handler: ({ queryParams }) => {
+      const limitRaw = queryParams?.limit;
+      const limit = limitRaw ? Number.parseInt(limitRaw, 10) : undefined;
+      return handleListMemory(
+        { search: queryParams?.search, limit },
+        getConfig(),
+      );
+    },
+  },
+
+  {
+    operationId: "deleteMemoryNode",
+    endpoint: "memory-nodes/delete",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Delete a memory graph node by content",
+    description:
+      "Delete the memory graph node whose content exactly matches the given text.",
+    tags: ["memory"],
+    requestBody: z.object({
+      content: z.string(),
+    }),
+    responseBody: z.object({
+      success: z.boolean(),
+      message: z.string(),
+    }),
+    handler: ({ body }) => {
+      const { content } = z.object({ content: z.string() }).parse(body ?? {});
+      return handleDeleteMemory({ content }, getConfig());
+    },
+  },
+
+  {
+    operationId: "updateMemoryNode",
+    endpoint: "memory-nodes/update",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Update a memory graph node by content",
+    description:
+      "Replace the content of the memory graph node whose content exactly matches `oldContent`.",
+    tags: ["memory"],
+    requestBody: z.object({
+      oldContent: z.string(),
+      newContent: z.string(),
+    }),
+    responseBody: z.object({
+      success: z.boolean(),
+      message: z.string(),
+    }),
+    handler: ({ body }) => {
+      const { oldContent, newContent } = z
+        .object({ oldContent: z.string(), newContent: z.string() })
+        .parse(body ?? {});
+      return handleUpdateMemory(
+        { old_content: oldContent, new_content: newContent },
+        "cli",
+        getConfig(),
+      );
+    },
   },
 ];

--- a/assistant/src/plugins/defaults/memory/routes/memory-item-routes.ts
+++ b/assistant/src/plugins/defaults/memory/routes/memory-item-routes.ts
@@ -893,8 +893,11 @@ export const ROUTES: RouteDefinition[] = [
       message: z.string(),
     }),
     handler: ({ body }) => {
-      const { content } = z.object({ content: z.string() }).parse(body ?? {});
-      return handleDeleteMemory({ content }, getConfig());
+      const parsed = z.object({ content: z.string() }).safeParse(body ?? {});
+      if (!parsed.success) {
+        throw new BadRequestError("content (string) is required");
+      }
+      return handleDeleteMemory({ content: parsed.data.content }, getConfig());
     },
   },
 
@@ -919,11 +922,19 @@ export const ROUTES: RouteDefinition[] = [
       message: z.string(),
     }),
     handler: ({ body }) => {
-      const { oldContent, newContent } = z
+      const parsed = z
         .object({ oldContent: z.string(), newContent: z.string() })
-        .parse(body ?? {});
+        .safeParse(body ?? {});
+      if (!parsed.success) {
+        throw new BadRequestError(
+          "oldContent and newContent (strings) are required",
+        );
+      }
       return handleUpdateMemory(
-        { old_content: oldContent, new_content: newContent },
+        {
+          old_content: parsed.data.oldContent,
+          new_content: parsed.data.newContent,
+        },
         "cli",
         getConfig(),
       );


### PR DESCRIPTION
## Summary
- `assistant memory nodes list|delete|update` now call the daemon over IPC instead of importing the memory plugin's `graph/tool-handlers` and running them in-process against the DB from the CLI process.
- Adds a content-addressed **memory-nodes** route section to the plugin's `memory-item-routes.ts` (`GET /v1/memory-nodes`, `POST /v1/memory-nodes/delete`, `POST /v1/memory-nodes/update`; operationIds `listMemoryNodes`/`deleteMemoryNode`/`updateMemoryNode`) wrapping those same handlers. Business failures stay data (`{ success: false, message }`), matching what the model-facing memory tools return, so CLI output is unchanged.
- The CLI keeps its exact rendering and messages; response shapes are typed locally in `nodes.ts` (the established CLI wire-type convention). `transport: "local"` → `"ipc"`.
- OpenAPI spec regenerated (+135 lines, the three new paths). Reverse boundary baseline: `src/cli/commands/memory/nodes.ts` drops out (memory 48 → 47).
- Tests: five new cases in `memory-item-routes.test.ts` covering list/search, the v2-disabled business failure, delete by exact content, no-match failure, and update-in-place.

## Behavior change
These subcommands now require a **running assistant** (previously they opened the DB directly in the CLI process). That aligns them with the repo direction — CLI→daemon interactions go through `cliIpcCall`, and direct CLI DB access is the pattern being phased out — and avoids CLI-process writes racing the live daemon's DB connection.

Part of the BYO-memory effort (reverse host→plugin coupling burn-down; #37747/#37763/#37766/#37767/#37769).

Full local gate: `typecheck:fast`, `lint` (0 errors), `lint:unused`, prettier, both boundary guards (reverse regenerated), `generate:openapi`; item-routes suite 39/39 and tool-handlers suite 19/19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)