### PR TITLE
docs(messaging): require live per-account connection checks

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -38,7 +38,8 @@ When a platform is connected (auth test succeeds), always use the messaging API 
 
 Connection and auth state changes without warning: OAuth tokens expire and connections drop between one message and the next. Prior conversation state, memory files, and recall are minutes-to-days stale and must never stand in for a live check.
 
-- **Before asserting anything about whether accounts are connected, working, or being monitored, run a live check.** Call `messaging_auth_test` for each relevant `platform` instead of answering from memory or prior state.
+- **Before asserting anything about whether accounts are connected or working, run a live check.** Call `messaging_auth_test` for each relevant `platform` instead of answering from memory or prior state.
+- **"Being monitored / watched" is a separate claim.** `messaging_auth_test` only proves auth. Before claiming an account is monitored, also check watcher state live with `assistant watchers list` and read each watcher's status — not just enabled/disabled, since a watcher can be enabled yet paused pending re-authorization. A valid connection with a missing, disabled, or paused watcher is not being monitored.
 - **Check per account, report per account.** With multiple accounts on a platform, enumerate them (`assistant oauth status <provider>`) and call `messaging_auth_test` once per account with its `account` address — omitting `account` defaults to the most recently connected one, so a bare call proves only that single account. Report status per account; never generalize one account's success to the rest. If an account fails, name it and tell the user to reconnect that one, without hiding the healthy accounts.
 - **On a connection error mid-task, keep going.** Tell the user which specific account failed and continue with the remaining accounts instead of aborting the whole task.
 

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -34,6 +34,14 @@ When a platform is connected (auth test succeeds), always use the messaging API 
 
 **Exception: Slack.** Slack messaging should use the Slack Web API directly via CLI, not messaging tools. See the **slack** skill for details.
 
+## Connection Health Is Volatile — Check Live, Never From Memory
+
+Connection and auth state changes without warning: OAuth tokens expire and connections drop between one message and the next. Prior conversation state, memory files, and recall are minutes-to-days stale and must never stand in for a live check.
+
+- **Before asserting anything about whether accounts are connected, working, or being monitored, run a live check.** Call `messaging_auth_test` for each relevant `platform` instead of answering from memory or prior state.
+- **Check per account, report per account.** With multiple accounts on a platform, enumerate them (`assistant oauth status <provider>`) and call `messaging_auth_test` once per account with its `account` address — omitting `account` defaults to the most recently connected one, so a bare call proves only that single account. Report status per account; never generalize one account's success to the rest. If an account fails, name it and tell the user to reconnect that one, without hiding the healthy accounts.
+- **On a connection error mid-task, keep going.** Tell the user which specific account failed and continue with the remaining accounts instead of aborting the whole task.
+
 ## Connection Setup
 
 Before using any messaging tool, verify that the platform is connected by calling `messaging_auth_test` with the appropriate `platform` parameter. If the call fails with a token/authorization error, follow the steps below.

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -35,7 +35,7 @@
     },
     "messaging": {
       "docsSlug": "messaging",
-      "sha256": "bbe48449dc1d19d176ba0bf16988107a8b92eea74dac37e9d05e433947727315"
+      "sha256": "cddd7f31be0106af283f4046eac6e76a4950942347bc79f1733e0f9e40fac75d"
     },
     "phone-calls": {
       "docsSlug": "phone-calls",

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -35,7 +35,7 @@
     },
     "messaging": {
       "docsSlug": "messaging",
-      "sha256": "cddd7f31be0106af283f4046eac6e76a4950942347bc79f1733e0f9e40fac75d"
+      "sha256": "eae727d19ba1360738a3553c063f4e09adb2e3b07ed5e30771beb74ea6ff8a0e"
     },
     "phone-calls": {
       "docsSlug": "phone-calls",


### PR DESCRIPTION
## Why

Feedback from a paying user: the assistant told them all their email accounts were connected and monitored, then a live read minutes later failed with an OAuth connection error — "it will tell me one minute all my email accounts are connected and working and the next minute … it has had a connection error."

Root behavior: the assistant answered a connection-health question from recall/memory instead of a live check, and generalized one account's state to all five connected accounts. `messaging_auth_test` without an `account` param silently tests only the most-recently-connected account, which compounds the problem.

## What

Adds a section to the bundled messaging SKILL.md establishing:

- Connection health is volatile — never assert connected/monitored state from memory, recall, or prior conversation state; run a live `messaging_auth_test`.
- Check and report **per account**: enumerate accounts and pass `account` explicitly, since a bare call proves only one account.
- On a mid-task connection error, name the failing account and continue with the healthy ones.

Also re-records the messaging skill docs-sync fingerprint (`skill-docs-sync-guard.test.ts` passes).

Part of a three-PR set from this feedback investigation (silent watcher pause notifications and connection-resolver error improvements are in sibling PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->