### PR TITLE
fix(oauth): list available accounts when connection resolution misses

### DIFF
--- a/assistant/src/oauth/connection-resolver.test.ts
+++ b/assistant/src/oauth/connection-resolver.test.ts
@@ -576,6 +576,104 @@ describe("resolveOAuthConnectionWithMeta multi-account visibility", () => {
   });
 });
 
+describe("resolveOAuthConnection account-mismatch error listing", () => {
+  function clientReturning(results: unknown[]) {
+    return {
+      ...makeMockClient(),
+      fetch: mock(
+        async () => new Response(JSON.stringify({ results }), { status: 200 }),
+      ),
+    };
+  }
+
+  beforeEach(() => {
+    setupDefaults();
+  });
+
+  test("managed: account mismatch lists other active connections", async () => {
+    mockProvider!.managedServiceConfigKey = "google-oauth";
+    mockPlatformClient = {
+      ...makeMockClient(),
+      fetch: mock(async (path: string) => {
+        // The account-identifier-filtered lookup matches nothing…
+        if (path.includes("account_identifier=")) {
+          return new Response(JSON.stringify({ results: [] }), { status: 200 });
+        }
+        // …but the provider still has active connections.
+        return new Response(
+          JSON.stringify({
+            results: [
+              { id: "conn-1", account_label: "user@example.com" },
+              { id: "conn-2", account_label: "alice@example.org" },
+            ],
+          }),
+          { status: 200 },
+        );
+      }),
+    };
+
+    await expect(
+      resolveOAuthConnection("google", { account: "typo@example.com" }),
+    ).rejects.toThrow(
+      'No active OAuth connection found for provider "google" with account ' +
+        '"typo@example.com". Active google connections: user@example.com, ' +
+        "alice@example.org.",
+    );
+  });
+
+  test("managed: zero connections keeps the connect-me message", async () => {
+    mockProvider!.managedServiceConfigKey = "google-oauth";
+    mockPlatformClient = clientReturning([]);
+
+    await expect(
+      resolveOAuthConnection("google", { account: "typo@example.com" }),
+    ).rejects.toThrow(
+      'No active OAuth connection found for provider "google" with account ' +
+        '"typo@example.com". The google service needs to be connected.',
+    );
+  });
+
+  test("BYO: account mismatch lists other active connections", async () => {
+    mockConnections = [
+      {
+        id: "conn-personal",
+        provider: "google",
+        accountInfo: "user@example.com",
+        grantedScopes: JSON.stringify([]),
+        status: "active",
+      },
+      {
+        id: "conn-work",
+        provider: "google",
+        accountInfo: "alice@example.org",
+        grantedScopes: JSON.stringify([]),
+        status: "active",
+      },
+    ];
+
+    await expect(
+      resolveOAuthConnection("google", { account: "typo@example.com" }),
+    ).rejects.toThrow(
+      'No active OAuth connection found for "google" matching account ' +
+        '"typo@example.com". Active google connections: user@example.com, ' +
+        "alice@example.org.",
+    );
+  });
+
+  test("BYO: zero connections keeps the connect-me message", async () => {
+    mockConnection = undefined;
+    mockConnections = [];
+
+    await expect(
+      resolveOAuthConnection("google", { account: "typo@example.com" }),
+    ).rejects.toThrow(
+      'No active OAuth connection found for "google" matching account ' +
+        '"typo@example.com". The google service needs to be connected before ' +
+        "it can be used.",
+    );
+  });
+});
+
 describe("resolveEffectiveBaseUrl", () => {
   const fallback = "https://login.salesforce.com";
 

--- a/assistant/src/oauth/connection-resolver.test.ts
+++ b/assistant/src/oauth/connection-resolver.test.ts
@@ -660,6 +660,38 @@ describe("resolveOAuthConnection account-mismatch error listing", () => {
     );
   });
 
+  test("BYO: clientId + mistyped account lists only that app's accounts", async () => {
+    mockConnections = [
+      {
+        id: "conn-app1",
+        provider: "google",
+        accountInfo: "user@example.com",
+        grantedScopes: JSON.stringify([]),
+        status: "active",
+        clientId: "client-1",
+      },
+      {
+        id: "conn-app2",
+        provider: "google",
+        accountInfo: "alice@example.org",
+        grantedScopes: JSON.stringify([]),
+        status: "active",
+        clientId: "client-2",
+      },
+    ];
+
+    await expect(
+      resolveOAuthConnection("google", {
+        clientId: "client-1",
+        account: "typo@example.com",
+      }),
+    ).rejects.toThrow(
+      'No active OAuth connection found for "google" matching account ' +
+        '"typo@example.com" and client ID "client-1". Active google ' +
+        "connections: user@example.com.",
+    );
+  });
+
   test("BYO: zero connections keeps the connect-me message", async () => {
     mockConnection = undefined;
     mockConnections = [];

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -154,10 +154,12 @@ export async function resolveOAuthConnectionWithMeta(
     const qualifier = filters.length
       ? ` matching ${filters.join(" and ")}`
       : "";
-    // When a filter (account/clientId) matched nothing but the provider still
-    // has active connections, list their labels so the caller can self-correct
-    // a mistyped account instead of misreading this as a disconnected service.
-    const otherLabels = getActiveConnections(provider).map(
+    // When a filter matched nothing but active connections still exist, list
+    // their labels so the caller can self-correct a mistyped account instead
+    // of misreading this as a disconnected service. Only the account filter is
+    // dropped: clientId narrows to a specific OAuth app, and accounts under
+    // other apps cannot serve a retry that pins the same clientId.
+    const otherLabels = getActiveConnections(provider, { clientId }).map(
       (row) => (row.accountInfo as string | null) ?? (row.id as string),
     );
     throw new Error(

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -154,8 +154,19 @@ export async function resolveOAuthConnectionWithMeta(
     const qualifier = filters.length
       ? ` matching ${filters.join(" and ")}`
       : "";
+    // When a filter (account/clientId) matched nothing but the provider still
+    // has active connections, list their labels so the caller can self-correct
+    // a mistyped account instead of misreading this as a disconnected service.
+    const otherLabels = getActiveConnections(provider).map(
+      (row) => (row.accountInfo as string | null) ?? (row.id as string),
+    );
     throw new Error(
-      `No active OAuth connection found for "${provider}"${qualifier}. The ${provider} service needs to be connected before it can be used.`,
+      noConnectionFoundMessage({
+        base: `No active OAuth connection found for "${provider}"${qualifier}.`,
+        provider,
+        otherLabels,
+        connectHint: `The ${provider} service needs to be connected before it can be used.`,
+      }),
     );
   }
 
@@ -365,8 +376,11 @@ async function resolvePlatformConnectionId(
     accountIdentifier: account,
   });
 
+  // Holds all active connections for the provider when the account-filtered
+  // lookup came up empty — reused below to list available accounts on failure.
+  let unfilteredConnections: PlatformConnectionEntry[] | undefined;
   if (account && connections.length === 0) {
-    const unfilteredConnections = await fetchPlatformConnections({
+    unfilteredConnections = await fetchPlatformConnections({
       client,
       provider,
     });
@@ -377,10 +391,22 @@ async function resolvePlatformConnectionId(
   }
 
   if (connections.length === 0) {
+    // Reuse the already-fetched unfiltered connections (no extra network call)
+    // to list the user's real accounts so the caller can correct a mistyped
+    // account rather than misreading this as a disconnected service.
+    const otherLabels = (unfilteredConnections ?? []).map(
+      platformConnectionLabel,
+    );
     throw new Error(
-      `No active OAuth connection found for provider "${provider}"` +
-        (account ? ` with account "${account}"` : "") +
-        `. The ${provider} service needs to be connected.`,
+      noConnectionFoundMessage({
+        base:
+          `No active OAuth connection found for provider "${provider}"` +
+          (account ? ` with account "${account}"` : "") +
+          `.`,
+        provider,
+        otherLabels,
+        connectHint: `The ${provider} service needs to be connected.`,
+      }),
     );
   }
 
@@ -485,6 +511,29 @@ function parseGrantedScopes(raw: string | null | undefined): string[] {
   } catch {
     return [];
   }
+}
+
+/**
+ * Build the "no connection found" error. When the provider still has other
+ * active connections, list their account labels so the caller (usually the
+ * model) can self-correct a mistyped account instead of reading the failure as
+ * "the service is disconnected". Falls back to the connect-me hint only when
+ * the provider genuinely has zero active connections.
+ *
+ * `base` is the leading sentence ending in a period. The labels shown are the
+ * user's own connected accounts surfaced back to the same user's assistant.
+ */
+function noConnectionFoundMessage(options: {
+  base: string;
+  provider: string;
+  otherLabels: string[];
+  connectHint: string;
+}): string {
+  const { base, provider, otherLabels, connectHint } = options;
+  if (otherLabels.length > 0) {
+    return `${base} Active ${provider} connections: ${otherLabels.join(", ")}.`;
+  }
+  return `${base} ${connectHint}`;
 }
 
 /** Actionable error shown when a connection is missing required scopes. */


### PR DESCRIPTION
## Why

Feedback investigation follow-up: with multiple connected accounts per provider, a mistyped `--account` value (e.g. a transposed letter in a domain) resolves to `No active OAuth connection found` — indistinguishable from a genuinely disconnected service. In the incident that prompted this, the assistant then told the user they had a connection error while every connection was healthy, feeding a "it keeps telling me connection error" churn complaint.

## What

When account/clientId-filtered resolution misses but the provider still has active connections, both resolution paths now append the available account labels:

```
No active OAuth connection found for provider "google" with account "typo@example.com". Active google connections: user@example.com, alice@example.org.
```

so the caller (usually the model) can self-correct instead of reporting a false outage. The zero-connection wording is unchanged. A shared `noConnectionFoundMessage()` helper keeps the two paths consistent.

- Platform path reuses the already-fetched unfiltered connection list — no extra network call.
- Local/BYO path adds one local SQLite query, only in the error branch.
- Labels appear only in the thrown error message; the `log.warn` telemetry surface is untouched.

## Tests

4 new tests (managed + BYO × mismatch-lists-labels / zero-connections-unchanged). Each test file passes individually (38 + 19); a combined-run `mock.module` cross-contamination failure predates this change (verified against a stashed baseline). `typecheck:fast` clean.

Part of a three-PR set from this feedback investigation (#37775 is the messaging-skill guidance; watcher pause notifications are in a sibling PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->