### PR TITLE
fix(watcher): persist credential-pause state and back reconnect dedup durably

### DIFF
--- a/assistant/src/cli/commands/__tests__/watchers.test.ts
+++ b/assistant/src/cli/commands/__tests__/watchers.test.ts
@@ -65,7 +65,8 @@ mock.module("../../../util/logger.js", () => ({
 // Import module under test (after mocks)
 // ---------------------------------------------------------------------------
 
-const { registerWatchersCommand } = await import("../watchers.js");
+const { registerWatchersCommand, formatWatcherStatus } =
+  await import("../watchers.js");
 
 // ---------------------------------------------------------------------------
 // Test helper
@@ -417,6 +418,38 @@ describe("watchers list", () => {
     const { exitCode } = await runCommand(["watchers", "list"]);
 
     expect(exitCode).toBe(1);
+  });
+
+  describe("formatWatcherStatus", () => {
+    test("reports enabled for a healthy, polling watcher", () => {
+      expect(
+        formatWatcherStatus({ enabled: true, credentialPausedAt: null }),
+      ).toBe("enabled");
+    });
+
+    test("reports disabled when the watcher is turned off", () => {
+      expect(
+        formatWatcherStatus({ enabled: false, credentialPausedAt: null }),
+      ).toBe("disabled");
+    });
+
+    test("reports paused with reconnect guidance when the credential is paused", () => {
+      const status = formatWatcherStatus({
+        enabled: true,
+        credentialPausedAt: 1737000000000,
+      });
+      expect(status).toContain("paused");
+      expect(status).toContain("reconnect");
+    });
+
+    test("a disabled watcher reads as disabled even if a stale pause marker lingers", () => {
+      expect(
+        formatWatcherStatus({
+          enabled: false,
+          credentialPausedAt: 1737000000000,
+        }),
+      ).toBe("disabled");
+    });
   });
 
   test("--json outputs error on IPC failure", async () => {

--- a/assistant/src/cli/commands/watchers.ts
+++ b/assistant/src/cli/commands/watchers.ts
@@ -22,9 +22,28 @@ interface WatcherRecord {
   credentialService: string | null;
   pollIntervalMs: number;
   enabled: boolean;
+  credentialPausedAt: number | null;
   configJson: string | null;
   createdAt: number;
   updatedAt: number;
+}
+
+/**
+ * Human-readable status label for a watcher. A watcher whose credential has
+ * gone unhealthy stays `enabled` in the store but is not polling — surface
+ * that as a distinct "paused" state so it doesn't read as normally running.
+ */
+export function formatWatcherStatus(w: {
+  enabled: boolean;
+  credentialPausedAt?: number | null;
+}): string {
+  if (!w.enabled) {
+    return "disabled";
+  }
+  if (w.credentialPausedAt) {
+    return "paused (reconnect account to resume)";
+  }
+  return "enabled";
 }
 
 interface WatcherEvent {
@@ -43,10 +62,9 @@ export function registerWatchersCommand(program: Command): void {
     transport: "ipc",
     description: "Manage polling watchers that monitor external services",
     build: (watchers) => {
-
-  watchers.addHelpText(
-    "after",
-    `
+      watchers.addHelpText(
+        "after",
+        `
 Watchers poll external services (Gmail, Google Calendar, GitHub, Linear,
 Outlook) on a configurable interval and process detected events via an
 action prompt sent to a background conversation. Each watcher targets a
@@ -60,22 +78,22 @@ Examples:
   $ assistant watchers list
   $ assistant watchers list --id <watcherId>
   $ assistant watchers digest --hours 8`,
-  );
+      );
 
-  // ── list ────────────────────────────────────────────────────────────
+      // ── list ────────────────────────────────────────────────────────────
 
-  watchers
-    .command("list")
-    .description("List all watchers or show details for a specific watcher")
-    .option(
-      "--id <watcherId>",
-      "Show details for a specific watcher — run 'assistant watchers list' to find IDs",
-    )
-    .option("--enabled-only", "Only show enabled watchers")
-    .option("--json", "Output result as machine-readable JSON")
-    .addHelpText(
-      "after",
-      `
+      watchers
+        .command("list")
+        .description("List all watchers or show details for a specific watcher")
+        .option(
+          "--id <watcherId>",
+          "Show details for a specific watcher — run 'assistant watchers list' to find IDs",
+        )
+        .option("--enabled-only", "Only show enabled watchers")
+        .option("--json", "Output result as machine-readable JSON")
+        .addHelpText(
+          "after",
+          `
 Arguments:
   --id <watcherId>   UUID of the watcher to inspect. Omit to list all
                      watchers. Run 'assistant watchers list' to discover IDs.
@@ -90,98 +108,107 @@ Examples:
   $ assistant watchers list --enabled-only
   $ assistant watchers list --id abc123-def4-5678-abcd-ef1234567890
   $ assistant watchers list --json`,
-    )
-    .action(
-      async (opts: { id?: string; enabledOnly?: boolean; json?: boolean }) => {
-        const params: Record<string, unknown> = {};
-        if (opts.id) params.watcher_id = opts.id;
-        if (opts.enabledOnly) params.enabled_only = true;
+        )
+        .action(
+          async (opts: {
+            id?: string;
+            enabledOnly?: boolean;
+            json?: boolean;
+          }) => {
+            const params: Record<string, unknown> = {};
+            if (opts.id) params.watcher_id = opts.id;
+            if (opts.enabledOnly) params.enabled_only = true;
 
-        const result = await cliIpcCall<
-          WatcherRecord[] | { watcher: WatcherRecord; events: WatcherEvent[] }
-        >("watcher_list", { body: params });
+            const result = await cliIpcCall<
+              | WatcherRecord[]
+              | { watcher: WatcherRecord; events: WatcherEvent[] }
+            >("watcher_list", { body: params });
 
-        if (!result.ok) {
-          if (opts.json) {
-            process.stdout.write(
-              JSON.stringify({ ok: false, error: result.error }) + "\n",
-            );
-          } else {
-            log.error(`Error: ${result.error}`);
-          }
-          process.exitCode = 1;
-          return;
-        }
+            if (!result.ok) {
+              if (opts.json) {
+                process.stdout.write(
+                  JSON.stringify({ ok: false, error: result.error }) + "\n",
+                );
+              } else {
+                log.error(`Error: ${result.error}`);
+              }
+              process.exitCode = 1;
+              return;
+            }
 
-        if (opts.json) {
-          process.stdout.write(
-            JSON.stringify({ ok: true, data: result.result }) + "\n",
-          );
-          return;
-        }
+            if (opts.json) {
+              process.stdout.write(
+                JSON.stringify({ ok: true, data: result.result }) + "\n",
+              );
+              return;
+            }
 
-        // When --id is provided, the result is a detail object
-        if (opts.id) {
-          const detail = result.result as {
-            watcher: WatcherRecord;
-            events: WatcherEvent[];
-          };
-          const w = detail.watcher;
-          log.info(`Watcher: ${w.name} (${w.id})`);
-          log.info(`  Provider:      ${w.providerId}`);
-          log.info(`  Enabled:       ${w.enabled}`);
-          log.info(`  Poll interval: ${w.pollIntervalMs}ms`);
-          log.info(`  Action prompt: ${w.actionPrompt}`);
-          if (w.configJson) {
-            log.info(`  Config:        ${w.configJson}`);
-          }
-          if (detail.events.length > 0) {
-            log.info(`  Recent events: ${detail.events.length}`);
-            for (const e of detail.events) {
+            // When --id is provided, the result is a detail object
+            if (opts.id) {
+              const detail = result.result as {
+                watcher: WatcherRecord;
+                events: WatcherEvent[];
+              };
+              const w = detail.watcher;
+              log.info(`Watcher: ${w.name} (${w.id})`);
+              log.info(`  Provider:      ${w.providerId}`);
+              log.info(`  Status:        ${formatWatcherStatus(w)}`);
+              log.info(`  Poll interval: ${w.pollIntervalMs}ms`);
+              log.info(`  Action prompt: ${w.actionPrompt}`);
+              if (w.configJson) {
+                log.info(`  Config:        ${w.configJson}`);
+              }
+              if (detail.events.length > 0) {
+                log.info(`  Recent events: ${detail.events.length}`);
+                for (const e of detail.events) {
+                  log.info(
+                    `    [${new Date(e.createdAt).toISOString()}] ${e.eventType}: ${e.summary ?? "(no summary)"}`,
+                  );
+                }
+              }
+              return;
+            }
+
+            // List mode: array of watchers
+            const list = result.result as WatcherRecord[];
+            if (list.length === 0) {
+              log.info("No watchers found.");
+              return;
+            }
+
+            for (const w of list) {
               log.info(
-                `    [${new Date(e.createdAt).toISOString()}] ${e.eventType}: ${e.summary ?? "(no summary)"}`,
+                `  ${w.id}  ${w.name}  ${w.providerId}  ${formatWatcherStatus(w)}`,
               );
             }
-          }
-          return;
-        }
+          },
+        );
 
-        // List mode: array of watchers
-        const list = result.result as WatcherRecord[];
-        if (list.length === 0) {
-          log.info("No watchers found.");
-          return;
-        }
+      // ── create ──────────────────────────────────────────────────────────
 
-        for (const w of list) {
-          const status = w.enabled ? "enabled" : "disabled";
-          log.info(`  ${w.id}  ${w.name}  ${w.providerId}  ${status}`);
-        }
-      },
-    );
-
-  // ── create ──────────────────────────────────────────────────────────
-
-  watchers
-    .command("create")
-    .description("Create a new watcher")
-    .requiredOption("--name <name>", "Watcher name")
-    .requiredOption(
-      "--provider <provider>",
-      "Provider ID (gmail, google-calendar, github, linear, outlook, outlook-calendar)",
-    )
-    .requiredOption("--action-prompt <prompt>", "Action prompt for the watcher")
-    .option(
-      "--poll-interval <ms>",
-      "Poll interval in milliseconds (default: 60000, min: 15000)",
-      parseInt,
-    )
-    .option("--config <json>", "Provider-specific config as JSON string")
-    .option("--credential-service <service>", "Credential service override")
-    .option("--json", "Output result as machine-readable JSON")
-    .addHelpText(
-      "after",
-      `
+      watchers
+        .command("create")
+        .description("Create a new watcher")
+        .requiredOption("--name <name>", "Watcher name")
+        .requiredOption(
+          "--provider <provider>",
+          "Provider ID (gmail, google-calendar, github, linear, outlook, outlook-calendar)",
+        )
+        .requiredOption(
+          "--action-prompt <prompt>",
+          "Action prompt for the watcher",
+        )
+        .option(
+          "--poll-interval <ms>",
+          "Poll interval in milliseconds (default: 60000, min: 15000)",
+          parseInt,
+        )
+        .option("--config <json>", "Provider-specific config as JSON string")
+        .option("--credential-service <service>", "Credential service override")
+        .option("--json", "Output result as machine-readable JSON")
+        .addHelpText(
+          "after",
+          `
 Arguments:
   --name <name>                Human-readable label (e.g. "Work Gmail")
   --provider <provider>        Service to poll: gmail, google-calendar, github,
@@ -201,93 +228,95 @@ Examples:
   $ assistant watchers create --name "My Gmail" --provider gmail --action-prompt "Summarize new emails and notify me if anything is urgent"
   $ assistant watchers create --name "PR Reviews" --provider github --action-prompt "Notify me of new review requests" --poll-interval 30000
   $ assistant watchers create --name "Team Linear" --provider linear --action-prompt "Flag high-priority issues" --config '{"teamId":"TEAM-1"}'`,
-    )
-    .action(
-      async (opts: {
-        name: string;
-        provider: string;
-        actionPrompt: string;
-        pollInterval?: number;
-        config?: string;
-        credentialService?: string;
-        json?: boolean;
-      }) => {
-        const params: Record<string, unknown> = {
-          name: opts.name,
-          provider: opts.provider,
-          action_prompt: opts.actionPrompt,
-        };
+        )
+        .action(
+          async (opts: {
+            name: string;
+            provider: string;
+            actionPrompt: string;
+            pollInterval?: number;
+            config?: string;
+            credentialService?: string;
+            json?: boolean;
+          }) => {
+            const params: Record<string, unknown> = {
+              name: opts.name,
+              provider: opts.provider,
+              action_prompt: opts.actionPrompt,
+            };
 
-        if (opts.pollInterval !== undefined) {
-          params.poll_interval_ms = opts.pollInterval;
-        }
-        if (opts.config !== undefined) {
-          try {
-            params.config = JSON.parse(opts.config);
-          } catch {
-            const msg = `Invalid --config JSON: ${opts.config}`;
+            if (opts.pollInterval !== undefined) {
+              params.poll_interval_ms = opts.pollInterval;
+            }
+            if (opts.config !== undefined) {
+              try {
+                params.config = JSON.parse(opts.config);
+              } catch {
+                const msg = `Invalid --config JSON: ${opts.config}`;
+                if (opts.json) {
+                  process.stdout.write(
+                    JSON.stringify({ ok: false, error: msg }) + "\n",
+                  );
+                } else {
+                  log.error(msg);
+                }
+                process.exitCode = 1;
+                return;
+              }
+            }
+            if (opts.credentialService) {
+              params.credential_service = opts.credentialService;
+            }
+
+            const result = await cliIpcCall<WatcherRecord>("watcher_create", {
+              body: params,
+            });
+
+            if (!result.ok) {
+              if (opts.json) {
+                process.stdout.write(
+                  JSON.stringify({ ok: false, error: result.error }) + "\n",
+                );
+              } else {
+                log.error(`Error: ${result.error}`);
+              }
+              process.exitCode = 1;
+              return;
+            }
+
             if (opts.json) {
               process.stdout.write(
-                JSON.stringify({ ok: false, error: msg }) + "\n",
+                JSON.stringify({ ok: true, data: result.result }) + "\n",
               );
             } else {
-              log.error(msg);
+              const w = result.result!;
+              log.info(`Created watcher: ${w.name} (${w.id})`);
             }
-            process.exitCode = 1;
-            return;
-          }
-        }
-        if (opts.credentialService) {
-          params.credential_service = opts.credentialService;
-        }
-
-        const result = await cliIpcCall<WatcherRecord>(
-          "watcher_create",
-          { body: params },
+          },
         );
 
-        if (!result.ok) {
-          if (opts.json) {
-            process.stdout.write(
-              JSON.stringify({ ok: false, error: result.error }) + "\n",
-            );
-          } else {
-            log.error(`Error: ${result.error}`);
-          }
-          process.exitCode = 1;
-          return;
-        }
+      // ── update ──────────────────────────────────────────────────────────
 
-        if (opts.json) {
-          process.stdout.write(
-            JSON.stringify({ ok: true, data: result.result }) + "\n",
-          );
-        } else {
-          const w = result.result!;
-          log.info(`Created watcher: ${w.name} (${w.id})`);
-        }
-      },
-    );
-
-  // ── update ──────────────────────────────────────────────────────────
-
-  watchers
-    .command("update <watcherId>")
-    .description("Update an existing watcher")
-    .option("--name <name>", "New watcher name")
-    .option("--action-prompt <prompt>", "New action prompt")
-    .option(
-      "--poll-interval <ms>",
-      "New poll interval in milliseconds (min: 15000)",
-      parseInt,
-    )
-    .option("--enabled", "Enable the watcher")
-    .option("--disabled", "Disable the watcher")
-    .option("--config <json>", "New provider-specific config as JSON string")
-    .option("--json", "Output result as machine-readable JSON")
-    .addHelpText(
-      "after",
-      `
+      watchers
+        .command("update <watcherId>")
+        .description("Update an existing watcher")
+        .option("--name <name>", "New watcher name")
+        .option("--action-prompt <prompt>", "New action prompt")
+        .option(
+          "--poll-interval <ms>",
+          "New poll interval in milliseconds (min: 15000)",
+          parseInt,
+        )
+        .option("--enabled", "Enable the watcher")
+        .option("--disabled", "Disable the watcher")
+        .option(
+          "--config <json>",
+          "New provider-specific config as JSON string",
+        )
+        .option("--json", "Output result as machine-readable JSON")
+        .addHelpText(
+          "after",
+          `
 Arguments:
   watcherId              UUID of the watcher to update — run 'assistant
                          watchers list' to find IDs.
@@ -300,85 +329,84 @@ Examples:
   $ assistant watchers update abc123 --action-prompt "Flag urgent emails and ignore newsletters"
   $ assistant watchers update abc123 --disabled
   $ assistant watchers update abc123 --enabled --poll-interval 120000`,
-    )
-    .action(
-      async (
-        watcherId: string,
-        opts: {
-          name?: string;
-          actionPrompt?: string;
-          pollInterval?: number;
-          enabled?: boolean;
-          disabled?: boolean;
-          config?: string;
-          json?: boolean;
-        },
-      ) => {
-        const params: Record<string, unknown> = {
-          watcher_id: watcherId,
-        };
+        )
+        .action(
+          async (
+            watcherId: string,
+            opts: {
+              name?: string;
+              actionPrompt?: string;
+              pollInterval?: number;
+              enabled?: boolean;
+              disabled?: boolean;
+              config?: string;
+              json?: boolean;
+            },
+          ) => {
+            const params: Record<string, unknown> = {
+              watcher_id: watcherId,
+            };
 
-        if (opts.name !== undefined) params.name = opts.name;
-        if (opts.actionPrompt !== undefined)
-          params.action_prompt = opts.actionPrompt;
-        if (opts.pollInterval !== undefined)
-          params.poll_interval_ms = opts.pollInterval;
-        if (opts.enabled) params.enabled = true;
-        if (opts.disabled) params.enabled = false;
-        if (opts.config !== undefined) {
-          try {
-            params.config = JSON.parse(opts.config);
-          } catch {
-            const msg = `Invalid --config JSON: ${opts.config}`;
+            if (opts.name !== undefined) params.name = opts.name;
+            if (opts.actionPrompt !== undefined)
+              params.action_prompt = opts.actionPrompt;
+            if (opts.pollInterval !== undefined)
+              params.poll_interval_ms = opts.pollInterval;
+            if (opts.enabled) params.enabled = true;
+            if (opts.disabled) params.enabled = false;
+            if (opts.config !== undefined) {
+              try {
+                params.config = JSON.parse(opts.config);
+              } catch {
+                const msg = `Invalid --config JSON: ${opts.config}`;
+                if (opts.json) {
+                  process.stdout.write(
+                    JSON.stringify({ ok: false, error: msg }) + "\n",
+                  );
+                } else {
+                  log.error(msg);
+                }
+                process.exitCode = 1;
+                return;
+              }
+            }
+
+            const result = await cliIpcCall<WatcherRecord>("watcher_update", {
+              body: params,
+            });
+
+            if (!result.ok) {
+              if (opts.json) {
+                process.stdout.write(
+                  JSON.stringify({ ok: false, error: result.error }) + "\n",
+                );
+              } else {
+                log.error(`Error: ${result.error}`);
+              }
+              process.exitCode = 1;
+              return;
+            }
+
             if (opts.json) {
               process.stdout.write(
-                JSON.stringify({ ok: false, error: msg }) + "\n",
+                JSON.stringify({ ok: true, data: result.result }) + "\n",
               );
             } else {
-              log.error(msg);
+              const w = result.result!;
+              log.info(`Updated watcher: ${w.name} (${w.id})`);
             }
-            process.exitCode = 1;
-            return;
-          }
-        }
-
-        const result = await cliIpcCall<WatcherRecord>(
-          "watcher_update",
-          { body: params },
+          },
         );
 
-        if (!result.ok) {
-          if (opts.json) {
-            process.stdout.write(
-              JSON.stringify({ ok: false, error: result.error }) + "\n",
-            );
-          } else {
-            log.error(`Error: ${result.error}`);
-          }
-          process.exitCode = 1;
-          return;
-        }
+      // ── delete ──────────────────────────────────────────────────────────
 
-        if (opts.json) {
-          process.stdout.write(
-            JSON.stringify({ ok: true, data: result.result }) + "\n",
-          );
-        } else {
-          const w = result.result!;
-          log.info(`Updated watcher: ${w.name} (${w.id})`);
-        }
-      },
-    );
-
-  // ── delete ──────────────────────────────────────────────────────────
-
-  watchers
-    .command("delete <watcherId>")
-    .description("Delete a watcher and all its event history")
-    .option("--json", "Output result as machine-readable JSON")
-    .addHelpText(
-      "after",
-      `
+      watchers
+        .command("delete <watcherId>")
+        .description("Delete a watcher and all its event history")
+        .option("--json", "Output result as machine-readable JSON")
+        .addHelpText(
+          "after",
+          `
 Arguments:
   watcherId   UUID of the watcher to delete — run 'assistant watchers list'
               to find IDs.
@@ -390,49 +418,53 @@ update <id> --disabled' if you want to pause it instead.
 Examples:
   $ assistant watchers delete abc123-def4-5678-abcd-ef1234567890
   $ assistant watchers delete abc123 --json`,
-    )
-    .action(async (watcherId: string, opts: { json?: boolean }) => {
-      const result = await cliIpcCall<{ deleted: boolean; name: string }>(
-        "watcher_delete",
-        { body: { watcher_id: watcherId } },
-      );
-
-      if (!result.ok) {
-        if (opts.json) {
-          process.stdout.write(
-            JSON.stringify({ ok: false, error: result.error }) + "\n",
+        )
+        .action(async (watcherId: string, opts: { json?: boolean }) => {
+          const result = await cliIpcCall<{ deleted: boolean; name: string }>(
+            "watcher_delete",
+            { body: { watcher_id: watcherId } },
           );
-        } else {
-          log.error(`Error: ${result.error}`);
-        }
-        process.exitCode = 1;
-        return;
-      }
 
-      if (opts.json) {
-        process.stdout.write(
-          JSON.stringify({ ok: true, data: result.result }) + "\n",
-        );
-      } else {
-        log.info(`Deleted watcher: ${result.result!.name}`);
-      }
-    });
+          if (!result.ok) {
+            if (opts.json) {
+              process.stdout.write(
+                JSON.stringify({ ok: false, error: result.error }) + "\n",
+              );
+            } else {
+              log.error(`Error: ${result.error}`);
+            }
+            process.exitCode = 1;
+            return;
+          }
 
-  // ── digest ──────────────────────────────────────────────────────────
+          if (opts.json) {
+            process.stdout.write(
+              JSON.stringify({ ok: true, data: result.result }) + "\n",
+            );
+          } else {
+            log.info(`Deleted watcher: ${result.result!.name}`);
+          }
+        });
 
-  watchers
-    .command("digest")
-    .description("Show recent watcher events grouped by watcher")
-    .option(
-      "--id <watcherId>",
-      "Filter to a single watcher — run 'assistant watchers list' to find IDs",
-    )
-    .option("--hours <n>", "Hours to look back (default: 24)", parseInt)
-    .option("--limit <n>", "Maximum events to return (default: 50)", parseInt)
-    .option("--json", "Output result as machine-readable JSON")
-    .addHelpText(
-      "after",
-      `
+      // ── digest ──────────────────────────────────────────────────────────
+
+      watchers
+        .command("digest")
+        .description("Show recent watcher events grouped by watcher")
+        .option(
+          "--id <watcherId>",
+          "Filter to a single watcher — run 'assistant watchers list' to find IDs",
+        )
+        .option("--hours <n>", "Hours to look back (default: 24)", parseInt)
+        .option(
+          "--limit <n>",
+          "Maximum events to return (default: 50)",
+          parseInt,
+        )
+        .option("--json", "Output result as machine-readable JSON")
+        .addHelpText(
+          "after",
+          `
 Arguments:
   --id <watcherId>   UUID of a watcher to filter by. Omit to show events
                      from all watchers. Run 'assistant watchers list' to
@@ -448,67 +480,67 @@ Examples:
   $ assistant watchers digest --hours 8
   $ assistant watchers digest --id abc123 --hours 4 --limit 10
   $ assistant watchers digest --json`,
-    )
-    .action(
-      async (opts: {
-        id?: string;
-        hours?: number;
-        limit?: number;
-        json?: boolean;
-      }) => {
-        const params: Record<string, unknown> = {};
-        if (opts.id) params.watcher_id = opts.id;
-        if (opts.hours !== undefined) params.hours = opts.hours;
-        if (opts.limit !== undefined) params.limit = opts.limit;
+        )
+        .action(
+          async (opts: {
+            id?: string;
+            hours?: number;
+            limit?: number;
+            json?: boolean;
+          }) => {
+            const params: Record<string, unknown> = {};
+            if (opts.id) params.watcher_id = opts.id;
+            if (opts.hours !== undefined) params.hours = opts.hours;
+            if (opts.limit !== undefined) params.limit = opts.limit;
 
-        const result = await cliIpcCall<{
-          events: WatcherEvent[];
-          watcherNames: Record<string, string>;
-        }>("watcher_digest", { body: params });
+            const result = await cliIpcCall<{
+              events: WatcherEvent[];
+              watcherNames: Record<string, string>;
+            }>("watcher_digest", { body: params });
 
-        if (!result.ok) {
-          if (opts.json) {
-            process.stdout.write(
-              JSON.stringify({ ok: false, error: result.error }) + "\n",
-            );
-          } else {
-            log.error(`Error: ${result.error}`);
-          }
-          process.exitCode = 1;
-          return;
-        }
+            if (!result.ok) {
+              if (opts.json) {
+                process.stdout.write(
+                  JSON.stringify({ ok: false, error: result.error }) + "\n",
+                );
+              } else {
+                log.error(`Error: ${result.error}`);
+              }
+              process.exitCode = 1;
+              return;
+            }
 
-        if (opts.json) {
-          process.stdout.write(
-            JSON.stringify({ ok: true, data: result.result }) + "\n",
-          );
-          return;
-        }
+            if (opts.json) {
+              process.stdout.write(
+                JSON.stringify({ ok: true, data: result.result }) + "\n",
+              );
+              return;
+            }
 
-        const { events, watcherNames } = result.result!;
-        if (events.length === 0) {
-          log.info("No events found.");
-          return;
-        }
+            const { events, watcherNames } = result.result!;
+            if (events.length === 0) {
+              log.info("No events found.");
+              return;
+            }
 
-        // Group events by watcher
-        const grouped: Record<string, WatcherEvent[]> = {};
-        for (const e of events) {
-          if (!grouped[e.watcherId]) grouped[e.watcherId] = [];
-          grouped[e.watcherId].push(e);
-        }
+            // Group events by watcher
+            const grouped: Record<string, WatcherEvent[]> = {};
+            for (const e of events) {
+              if (!grouped[e.watcherId]) grouped[e.watcherId] = [];
+              grouped[e.watcherId].push(e);
+            }
 
-        for (const [watcherId, watcherEvents] of Object.entries(grouped)) {
-          const name = watcherNames[watcherId] ?? watcherId;
-          log.info(`${name} (${watcherId}):`);
-          for (const e of watcherEvents) {
-            log.info(
-              `  [${new Date(e.createdAt).toISOString()}] ${e.eventType}: ${e.summary ?? "(no summary)"}`,
-            );
-          }
-        }
-      },
-    );
+            for (const [watcherId, watcherEvents] of Object.entries(grouped)) {
+              const name = watcherNames[watcherId] ?? watcherId;
+              log.info(`${name} (${watcherId}):`);
+              for (const e of watcherEvents) {
+                log.info(
+                  `  [${new Date(e.createdAt).toISOString()}] ${e.eventType}: ${e.summary ?? "(no summary)"}`,
+                );
+              }
+            }
+          },
+        );
     },
   });
 }

--- a/assistant/src/persistence/migrations/324-watchers-credential-paused-at.test.ts
+++ b/assistant/src/persistence/migrations/324-watchers-credential-paused-at.test.ts
@@ -1,0 +1,107 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "../schema.js";
+import { migrateWatchersCredentialPausedAt } from "./324-watchers-credential-paused-at.js";
+
+const COLUMN = "credential_paused_at";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  // Pre-324 shape: the watchers table without the credential_paused_at column.
+  sqlite.exec(/*sql*/ `
+    CREATE TABLE watchers (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      provider_id TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      poll_interval_ms INTEGER NOT NULL DEFAULT 60000,
+      action_prompt TEXT NOT NULL,
+      watermark TEXT,
+      conversation_id TEXT,
+      status TEXT NOT NULL DEFAULT 'idle',
+      consecutive_errors INTEGER NOT NULL DEFAULT 0,
+      last_error TEXT,
+      last_poll_at INTEGER,
+      next_poll_at INTEGER NOT NULL,
+      config_json TEXT,
+      credential_service TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+function columnNames(sqlite: Database): string[] {
+  return (
+    sqlite.query("PRAGMA table_info(watchers)").all() as Array<{ name: string }>
+  ).map((c) => c.name);
+}
+
+describe("migration 324: watchers.credential_paused_at", () => {
+  test("adds the nullable credential_paused_at column", () => {
+    const { sqlite, db } = createTestDb();
+    expect(columnNames(sqlite)).not.toContain(COLUMN);
+
+    migrateWatchersCredentialPausedAt(db);
+
+    const column = (
+      sqlite.query("PRAGMA table_info(watchers)").all() as Array<{
+        name: string;
+        notnull: number;
+      }>
+    ).find((c) => c.name === COLUMN);
+    expect(column).toBeDefined();
+    expect(column?.notnull).toBe(0);
+  });
+
+  test("existing rows read back with a null marker", () => {
+    const { sqlite, db } = createTestDb();
+    sqlite.exec(/*sql*/ `
+      INSERT INTO watchers
+        (id, name, provider_id, action_prompt, next_poll_at,
+         credential_service, created_at, updated_at)
+      VALUES
+        ('w-1', 'Work Outlook', 'outlook', 'Summarize', 1000,
+         'outlook', 1000, 1000)
+    `);
+
+    migrateWatchersCredentialPausedAt(db);
+
+    const row = sqlite
+      .query(`SELECT ${COLUMN} FROM watchers WHERE id = 'w-1'`)
+      .get() as Record<string, unknown>;
+    expect(row[COLUMN]).toBeNull();
+  });
+
+  test("round-trips a paused timestamp", () => {
+    const { sqlite, db } = createTestDb();
+    migrateWatchersCredentialPausedAt(db);
+
+    sqlite.exec(/*sql*/ `
+      INSERT INTO watchers
+        (id, name, provider_id, action_prompt, next_poll_at,
+         credential_service, created_at, updated_at, credential_paused_at)
+      VALUES
+        ('w-2', 'Work Outlook', 'outlook', 'Summarize', 2000,
+         'outlook', 2000, 2000, 1737000000000)
+    `);
+
+    const row = sqlite
+      .query(`SELECT ${COLUMN} FROM watchers WHERE id = 'w-2'`)
+      .get() as Record<string, unknown>;
+    expect(row[COLUMN]).toBe(1737000000000);
+  });
+
+  test("is idempotent — re-run is a no-op", () => {
+    const { sqlite, db } = createTestDb();
+
+    migrateWatchersCredentialPausedAt(db);
+    expect(() => migrateWatchersCredentialPausedAt(db)).not.toThrow();
+
+    expect(columnNames(sqlite).filter((n) => n === COLUMN)).toHaveLength(1);
+  });
+});

--- a/assistant/src/persistence/migrations/324-watchers-credential-paused-at.ts
+++ b/assistant/src/persistence/migrations/324-watchers-credential-paused-at.ts
@@ -1,0 +1,30 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
+
+const COLUMN_NAME = "credential_paused_at";
+const COLUMN_DEFINITION = "credential_paused_at INTEGER";
+
+/**
+ * Add the nullable `credential_paused_at` column to the `watchers` table.
+ *
+ * Records the epoch-ms instant a watcher's poll was paused because its
+ * credential became unhealthy (revoked, missing, or unrecoverably expired).
+ * The watcher engine's pre-poll credential gate sets it on the
+ * healthy→unhealthy transition and clears it back to null once the credential
+ * recovers, so the value doubles as the dedup marker for the one-shot
+ * "monitoring paused" notification and as the paused indicator surfaced in
+ * `watchers list`.
+ *
+ * No backfill is needed — existing rows default to null (not paused), which is
+ * correct for any watcher whose credential has never been observed unhealthy.
+ *
+ * Idempotent: guarded with `tableHasColumn` so a crash between the `ALTER
+ * TABLE` and the checkpoint write doesn't raise a duplicate-column error on
+ * the next boot.
+ */
+export function migrateWatchersCredentialPausedAt(database: DrizzleDb): void {
+  if (tableHasColumn(database, "watchers", COLUMN_NAME)) {
+    return;
+  }
+  database.run(`ALTER TABLE watchers ADD COLUMN ${COLUMN_DEFINITION}`);
+}

--- a/assistant/src/persistence/schema/infrastructure.ts
+++ b/assistant/src/persistence/schema/infrastructure.ts
@@ -111,6 +111,11 @@ export const watchers = sqliteTable("watchers", {
   status: text("status").notNull().default("idle"), // idle | polling | error | disabled
   consecutiveErrors: integer("consecutive_errors").notNull().default(0),
   lastError: text("last_error"),
+  // Epoch ms at which polling was paused because the watcher's credential
+  // became unhealthy (revoked / missing / unrecoverably expired). Null when
+  // the credential is healthy. Doubles as the healthy→unhealthy transition
+  // marker that dedups the "monitoring paused" notification across ticks.
+  credentialPausedAt: integer("credential_paused_at"),
   lastPollAt: integer("last_poll_at"),
   nextPollAt: integer("next_poll_at").notNull(),
   configJson: text("config_json"),

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -431,6 +431,7 @@ import { migrateDropTraceEventsTable } from "./migrations/320-drop-trace-events-
 import { migrateCanonicalGuardianRequestTrigger } from "./migrations/321-canonical-guardian-request-trigger.js";
 import { migrateAddProcessingResumeAttempts } from "./migrations/322-add-processing-resume-attempts.js";
 import { migrateDeleteNonDefaultMemoryScopes } from "./migrations/323-delete-non-default-memory-scopes.js";
+import { migrateWatchersCredentialPausedAt } from "./migrations/324-watchers-credential-paused-at.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1333,4 +1334,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateCanonicalGuardianRequestTrigger,
   migrateAddProcessingResumeAttempts,
   migrateDeleteNonDefaultMemoryScopes,
+  migrateWatchersCredentialPausedAt,
 ];

--- a/assistant/src/watcher/__tests__/engine-auth-notify.test.ts
+++ b/assistant/src/watcher/__tests__/engine-auth-notify.test.ts
@@ -61,6 +61,11 @@ mock.module("../watcher-store.js", () => ({
   skipWatcherPoll: (watcherId: string, reason: string) => {
     skipCalls.push({ watcherId, reason });
   },
+  // This fake store does not persist credentialPausedAt, so the durable
+  // credential-scoped marker never suppresses — this suite exercises the
+  // in-process episode tracker alone (engine-credential-pause.test.ts covers
+  // the durable layer).
+  hasCredentialPause: () => false,
   disableWatcher: (watcherId: string, reason: string) => {
     disableCalls.push({ watcherId, reason });
     // A disabled watcher is no longer claimed on later ticks.

--- a/assistant/src/watcher/__tests__/engine-credential-pause.test.ts
+++ b/assistant/src/watcher/__tests__/engine-credential-pause.test.ts
@@ -41,10 +41,15 @@ function findWatcher(id: string): FakeWatcher | undefined {
   return fakeWatchers.find((w) => w.id === id);
 }
 
+// Overridable so a test can claim a subset of fakeWatchers (a sibling not
+// yet due) while hasCredentialPause still sees every persisted row.
+let claimDueWatchersImpl: () => FakeWatcher[] = () =>
+  fakeWatchers.map((w) => ({ ...w }));
+
 // A store fake that persists credentialPausedAt exactly like the real store:
 // stamped (coalesced) on skip and on auth-shaped fail, cleared on success.
 mock.module("../watcher-store.js", () => ({
-  claimDueWatchers: () => fakeWatchers.map((w) => ({ ...w })),
+  claimDueWatchers: () => claimDueWatchersImpl(),
   completeWatcherPoll: (id: string) => {
     const w = findWatcher(id);
     if (w) {
@@ -72,6 +77,13 @@ mock.module("../watcher-store.js", () => ({
       w.credentialPausedAt = w.credentialPausedAt ?? Date.now();
     }
   },
+  hasCredentialPause: (credentialService: string) =>
+    fakeWatchers.some(
+      (w) =>
+        w.credentialService === credentialService &&
+        w.enabled &&
+        w.credentialPausedAt !== null,
+    ),
   disableWatcher: (id: string) => {
     fakeWatchers = fakeWatchers.filter((w) => w.id !== id);
   },
@@ -162,6 +174,7 @@ function reconnects(all: Notification[]): Notification[] {
 beforeEach(() => {
   fakeWatchers = [];
   skipCalls.length = 0;
+  claimDueWatchersImpl = () => fakeWatchers.map((w) => ({ ...w }));
   credentialHealthImpl = async () => null;
   providerFetchImpl = async () => ({ items: [], watermark: "wm" });
   _resetAuthNotificationStateForTests();
@@ -191,6 +204,50 @@ describe("runWatchersOnce — durable credential-pause marker", () => {
 
     expect(skipCalls).toEqual(["watcher-1"]);
     expect(reconnects(notes)).toHaveLength(0);
+  });
+
+  test("after a restart, an unstamped sibling on an already-stamped account does not re-notify", async () => {
+    // Watcher A was stamped before the restart; sibling B on the same
+    // account was never due, so its own row is unstamped. The dedup read is
+    // credential-scoped, so A's persisted marker must suppress B's
+    // notification even though the in-process tracker is empty.
+    const watcherA = makeWatcher({
+      id: "watcher-a",
+      name: "Outlook Mail",
+      credentialPausedAt: 1_000,
+      // A is backing off after its earlier skip; only B is due this tick.
+      nextPollAt: Date.now() + 3_600_000,
+    });
+    const watcherB = makeWatcher({
+      id: "watcher-b",
+      name: "Outlook Calendar",
+      credentialPausedAt: null,
+    });
+    fakeWatchers = [watcherA, watcherB];
+    // Only B is claimed this tick (A is not yet due).
+    const claimable = [watcherB];
+    claimDueWatchersImpl = () => claimable.map((w) => ({ ...w }));
+    credentialHealthImpl = async () => revoked;
+    const notes: Notification[] = [];
+
+    await runWatchersOnce((n) => notes.push(n));
+
+    // B is paused but the user is not told again for the same outage.
+    expect(skipCalls).toEqual(["watcher-b"]);
+    expect(reconnects(notes)).toHaveLength(0);
+    expect(watcherB.credentialPausedAt).not.toBeNull();
+
+    // Full recovery: both rows clear their markers.
+    credentialHealthImpl = async () => null;
+    claimDueWatchersImpl = () => fakeWatchers.map((w) => ({ ...w }));
+    await runWatchersOnce((n) => notes.push(n));
+    expect(watcherA.credentialPausedAt).toBeNull();
+    expect(watcherB.credentialPausedAt).toBeNull();
+
+    // A genuinely new outage notifies afresh.
+    credentialHealthImpl = async () => revoked;
+    await runWatchersOnce((n) => notes.push(n));
+    expect(reconnects(notes)).toHaveLength(1);
   });
 
   test("collapses sibling watchers on one dead account to a single notification", async () => {

--- a/assistant/src/watcher/__tests__/engine-credential-pause.test.ts
+++ b/assistant/src/watcher/__tests__/engine-credential-pause.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Tests for the durable `credentialPausedAt` marker that backs the watcher
+ * engine's auth-reconnect notifications (engine-auth-notify.test.ts covers the
+ * in-process once-per-episode semantics with a non-persisting store).
+ *
+ * Here the fake store persists `credentialPausedAt` across ticks like the real
+ * one, so these assert the persistence layer: the marker is stamped on the
+ * credential skip gate and on auth-shaped poll errors, it survives a simulated
+ * restart to suppress re-notification for an ongoing outage, it collapses
+ * sibling watchers on one dead account to a single notification, and it clears
+ * on recovery so a later outage notifies again.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+interface FakeWatcher {
+  id: string;
+  name: string;
+  providerId: string;
+  enabled: boolean;
+  pollIntervalMs: number;
+  actionPrompt: string;
+  watermark: string | null;
+  conversationId: string | null;
+  status: string;
+  consecutiveErrors: number;
+  lastError: string | null;
+  credentialPausedAt: number | null;
+  lastPollAt: number | null;
+  nextPollAt: number;
+  configJson: string | null;
+  credentialService: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+let fakeWatchers: FakeWatcher[] = [];
+const skipCalls: string[] = [];
+
+function findWatcher(id: string): FakeWatcher | undefined {
+  return fakeWatchers.find((w) => w.id === id);
+}
+
+// A store fake that persists credentialPausedAt exactly like the real store:
+// stamped (coalesced) on skip and on auth-shaped fail, cleared on success.
+mock.module("../watcher-store.js", () => ({
+  claimDueWatchers: () => fakeWatchers.map((w) => ({ ...w })),
+  completeWatcherPoll: (id: string) => {
+    const w = findWatcher(id);
+    if (w) {
+      w.consecutiveErrors = 0;
+      w.credentialPausedAt = null;
+    }
+  },
+  failWatcherPoll: (
+    id: string,
+    _error: string,
+    opts?: { credentialPaused?: boolean },
+  ) => {
+    const w = findWatcher(id);
+    if (w) {
+      w.consecutiveErrors += 1;
+      if (opts?.credentialPaused) {
+        w.credentialPausedAt = w.credentialPausedAt ?? Date.now();
+      }
+    }
+  },
+  skipWatcherPoll: (id: string) => {
+    skipCalls.push(id);
+    const w = findWatcher(id);
+    if (w) {
+      w.credentialPausedAt = w.credentialPausedAt ?? Date.now();
+    }
+  },
+  disableWatcher: (id: string) => {
+    fakeWatchers = fakeWatchers.filter((w) => w.id !== id);
+  },
+  insertWatcherEvent: () => true,
+  getPendingEvents: () => [],
+  resetStuckWatchers: () => 0,
+  setWatcherConversationId: () => {},
+  updateEventDisposition: () => {},
+}));
+
+mock.module("../provider-registry.js", () => ({
+  getWatcherProvider: () => ({
+    fetchNew: () => providerFetchImpl(),
+    getInitialWatermark: async () => "wm",
+  }),
+}));
+
+mock.module("../../sequence/reply-matcher.js", () => ({
+  checkForSequenceReplies: () => [],
+}));
+
+let credentialHealthImpl: () => Promise<{
+  status: string;
+  details: string;
+  canAutoRecover: boolean;
+} | null> = async () => null;
+let providerFetchImpl: () => Promise<{
+  items: Array<Record<string, unknown>>;
+  watermark: string;
+}> = async () => ({ items: [], watermark: "wm" });
+
+mock.module("../../credential-health/credential-health-service.js", () => ({
+  checkCredentialForProvider: () => credentialHealthImpl(),
+}));
+
+mock.module("../../runtime/background-job-runner.js", () => ({
+  runBackgroundJob: async () => ({ conversationId: "conv-stub", ok: true }),
+}));
+
+mock.module("../telemetry.js", () => ({
+  recordWatcherInventoryIfDue: () => {},
+  recordWatcherLlmProcessed: () => {},
+}));
+
+const { runWatchersOnce, _resetAuthNotificationStateForTests } =
+  await import("../engine.js");
+
+function makeWatcher(overrides: Partial<FakeWatcher> = {}): FakeWatcher {
+  const now = Date.now();
+  return {
+    id: "watcher-1",
+    name: "Work Outlook",
+    providerId: "outlook",
+    enabled: true,
+    pollIntervalMs: 60_000,
+    actionPrompt: "Summarize new mail.",
+    watermark: "wm",
+    conversationId: null,
+    status: "polling",
+    consecutiveErrors: 0,
+    lastError: null,
+    credentialPausedAt: null,
+    lastPollAt: now,
+    nextPollAt: now + 60_000,
+    configJson: null,
+    credentialService: "outlook",
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+const revoked = {
+  status: "revoked",
+  details: "outlook token was rejected (401/403). Re-authorization required.",
+  canAutoRecover: false,
+};
+
+const authError = new Error(
+  'No active OAuth connection found for "outlook". The outlook service needs to be reconnected.',
+);
+
+type Notification = { title: string; body: string };
+function reconnects(all: Notification[]): Notification[] {
+  return all.filter((n) => n.title.startsWith("Reconnect needed:"));
+}
+
+beforeEach(() => {
+  fakeWatchers = [];
+  skipCalls.length = 0;
+  credentialHealthImpl = async () => null;
+  providerFetchImpl = async () => ({ items: [], watermark: "wm" });
+  _resetAuthNotificationStateForTests();
+});
+
+describe("runWatchersOnce — durable credential-pause marker", () => {
+  test("stamps the marker and notifies once on the first credential skip", async () => {
+    fakeWatchers = [makeWatcher()];
+    credentialHealthImpl = async () => revoked;
+    const notes: Notification[] = [];
+
+    await runWatchersOnce((n) => notes.push(n));
+
+    expect(skipCalls).toEqual(["watcher-1"]);
+    expect(reconnects(notes)).toHaveLength(1);
+    expect(fakeWatchers[0].credentialPausedAt).not.toBeNull();
+  });
+
+  test("a restart mid-outage does not re-notify (durable marker suppresses a fresh process)", async () => {
+    // credentialPausedAt already set simulates a watcher paused before the
+    // restart; the in-process episode tracker was cleared in beforeEach.
+    fakeWatchers = [makeWatcher({ credentialPausedAt: 1_000 })];
+    credentialHealthImpl = async () => revoked;
+    const notes: Notification[] = [];
+
+    await runWatchersOnce((n) => notes.push(n));
+
+    expect(skipCalls).toEqual(["watcher-1"]);
+    expect(reconnects(notes)).toHaveLength(0);
+  });
+
+  test("collapses sibling watchers on one dead account to a single notification", async () => {
+    fakeWatchers = [
+      makeWatcher({ id: "watcher-1", name: "Outlook Mail" }),
+      makeWatcher({ id: "watcher-2", name: "Outlook Calendar" }),
+    ];
+    credentialHealthImpl = async () => revoked;
+    const notes: Notification[] = [];
+
+    await runWatchersOnce((n) => notes.push(n));
+
+    expect(skipCalls.sort()).toEqual(["watcher-1", "watcher-2"]);
+    expect(reconnects(notes)).toHaveLength(1);
+    // Both watchers surface as paused regardless of which one notified.
+    expect(fakeWatchers[0].credentialPausedAt).not.toBeNull();
+    expect(fakeWatchers[1].credentialPausedAt).not.toBeNull();
+  });
+
+  test("marker clears on recovery so a later outage notifies again", async () => {
+    fakeWatchers = [makeWatcher()];
+    const notes: Notification[] = [];
+
+    credentialHealthImpl = async () => revoked;
+    await runWatchersOnce((n) => notes.push(n));
+    expect(reconnects(notes)).toHaveLength(1);
+    expect(fakeWatchers[0].credentialPausedAt).not.toBeNull();
+
+    // Recovery: credential healthy, poll succeeds → marker cleared.
+    credentialHealthImpl = async () => null;
+    await runWatchersOnce((n) => notes.push(n));
+    expect(fakeWatchers[0].credentialPausedAt).toBeNull();
+
+    // Second outage → fresh notification.
+    credentialHealthImpl = async () => revoked;
+    await runWatchersOnce((n) => notes.push(n));
+    expect(reconnects(notes)).toHaveLength(2);
+  });
+
+  test("an auth-shaped poll error stamps the marker for list surfacing", async () => {
+    fakeWatchers = [makeWatcher()];
+    // Health gate passes, but the poll itself fails with an auth-shaped error.
+    credentialHealthImpl = async () => null;
+    providerFetchImpl = async () => {
+      throw authError;
+    };
+    const notes: Notification[] = [];
+
+    await runWatchersOnce((n) => notes.push(n));
+
+    expect(reconnects(notes)).toHaveLength(1);
+    expect(fakeWatchers[0].credentialPausedAt).not.toBeNull();
+  });
+
+  test("a non-auth poll error leaves the marker untouched", async () => {
+    fakeWatchers = [makeWatcher()];
+    credentialHealthImpl = async () => null;
+    providerFetchImpl = async () => {
+      throw new Error("network timeout (ETIMEDOUT)");
+    };
+    const notes: Notification[] = [];
+
+    await runWatchersOnce((n) => notes.push(n));
+
+    expect(reconnects(notes)).toHaveLength(0);
+    expect(fakeWatchers[0].credentialPausedAt).toBeNull();
+  });
+});

--- a/assistant/src/watcher/__tests__/engine.test.ts
+++ b/assistant/src/watcher/__tests__/engine.test.ts
@@ -60,6 +60,7 @@ mock.module("../watcher-store.js", () => ({
   completeWatcherPoll: () => {},
   failWatcherPoll: () => {},
   skipWatcherPoll: () => {},
+  hasCredentialPause: () => false,
   disableWatcher: () => {},
   insertWatcherEvent: () => true,
   getPendingEvents: () => fakePending,

--- a/assistant/src/watcher/__tests__/engine.test.ts
+++ b/assistant/src/watcher/__tests__/engine.test.ts
@@ -24,6 +24,7 @@ interface FakeWatcher {
   status: string;
   consecutiveErrors: number;
   lastError: string | null;
+  credentialPausedAt: number | null;
   lastPollAt: number | null;
   nextPollAt: number;
   configJson: string | null;
@@ -139,6 +140,7 @@ function makeWatcher(overrides: Partial<FakeWatcher> = {}): FakeWatcher {
     status: "polling",
     consecutiveErrors: 0,
     lastError: null,
+    credentialPausedAt: null,
     lastPollAt: now,
     nextPollAt: now + 60_000,
     configJson: null,

--- a/assistant/src/watcher/engine.ts
+++ b/assistant/src/watcher/engine.ts
@@ -22,6 +22,7 @@ import {
   disableWatcher,
   failWatcherPoll,
   getPendingEvents,
+  hasCredentialPause,
   insertWatcherEvent,
   resetStuckWatchers,
   setWatcherConversationId,
@@ -86,11 +87,13 @@ export function _resetAuthNotificationStateForTests(): void {
  * later tick classifies the failure under a different status key or a sibling
  * watcher on the same account trips.
  *
- * `alreadyPausedBeforeTick` reflects the durable `credentialPausedAt` marker
- * observed at claim time. When it is set, the user was already told in an
- * earlier tick — possibly before a restart that emptied the in-process
- * tracker — so this seeds the tracker to keep the current process deduped but
- * stays silent. Returns true if a notification was sent, false if suppressed.
+ * `alreadyPausedBeforeTick` reflects the durable `credentialPausedAt` marker,
+ * read credential-scoped (`hasCredentialPause`) before the current watcher's
+ * row is stamped this tick. When it is set, the user was already told in an
+ * earlier tick — by this watcher or a sibling on the same account, possibly
+ * before a restart that emptied the in-process tracker — so this seeds the
+ * tracker to keep the current process deduped but stays silent. Returns true
+ * if a notification was sent, false if suppressed.
  */
 function notifyAuthEpisodeOnce(
   notify: WatcherNotifier,
@@ -173,10 +176,11 @@ export async function runWatchersOnce(
           health.status === "missing_token" ||
           (health.status === "expired" && !health.canAutoRecover))
       ) {
-        // Capture the durable marker before skipWatcherPoll stamps it, so a
-        // watcher already paused in an earlier tick (or before a restart)
-        // does not re-notify.
-        const alreadyPaused = watcher.credentialPausedAt != null;
+        // Consult the durable marker before skipWatcherPoll stamps this row.
+        // The read is credential-scoped: a sibling watcher on the same
+        // account stamped in an earlier tick (possibly before a restart)
+        // also means the user has already been told about this outage.
+        const alreadyPaused = hasCredentialPause(watcher.credentialService);
         skipWatcherPoll(watcher.id, `Credential unhealthy: ${health.details}`);
         notifyAuthEpisodeOnce(
           notify,
@@ -275,8 +279,10 @@ export async function runWatchersOnce(
       // user to reconnect immediately (once per episode) rather than waiting
       // for the circuit breaker to disable the watcher.
       const authShaped = isAuthConnectionError(err);
-      // Capture the durable marker before failWatcherPoll stamps it.
-      const alreadyPaused = watcher.credentialPausedAt != null;
+      // Consult the credential-scoped durable marker before failWatcherPoll
+      // stamps this row (see the credential gate above for why).
+      const alreadyPaused =
+        authShaped && hasCredentialPause(watcher.credentialService);
       failWatcherPoll(watcher.id, message, { credentialPaused: authShaped });
 
       if (authShaped) {

--- a/assistant/src/watcher/engine.ts
+++ b/assistant/src/watcher/engine.ts
@@ -56,13 +56,20 @@ function isAuthConnectionError(err: unknown): boolean {
 }
 
 /**
- * Per-process record of watchers already notified about an ongoing auth
- * problem, keyed by watcher id. The value is the status key of the tick that
- * first raised the episode ("credential-unhealthy" / "auth-error"), retained
- * for diagnostics only. The presence of an entry — regardless of its value —
- * means the user has been told once for this outage; it is cleared when the
- * watcher's poll succeeds or the circuit breaker disables it, so a later new
- * outage notifies again.
+ * Per-process record of accounts already notified about an ongoing auth
+ * problem, keyed by `credentialService`. Keying by the credential rather than
+ * the watcher collapses multiple watchers that share one dead account into a
+ * single reconnect notification per outage. The value is the status key of
+ * the tick that first raised the episode ("credential-unhealthy" /
+ * "auth-error"), retained for diagnostics only. The presence of an entry —
+ * regardless of its value — means the user has been told once for this
+ * outage; it is cleared when a watcher on the account polls successfully or
+ * the circuit breaker disables the watcher, so a later new outage notifies
+ * again.
+ *
+ * This tracker is only the in-process layer: the durable `credentialPausedAt`
+ * marker on each watcher row backs it so an assistant restart mid-outage does
+ * not re-notify (see `notifyAuthEpisodeOnce`).
  */
 const authNotifiedEpisodes = new Map<string, string>();
 
@@ -72,23 +79,33 @@ export function _resetAuthNotificationStateForTests(): void {
 }
 
 /**
- * Send an auth-reconnect notification for a watcher at most once per
- * outage. Suppression is keyed on watcher id alone: once any auth
- * notification has been sent for an ongoing episode, no more are sent until
- * the episode is cleared (by a successful poll or by circuit-breaker
- * disable), even if a later tick classifies the failure under a different
- * status key. Returns true if a notification was sent, false if suppressed.
+ * Send an auth-reconnect notification for an account at most once per outage.
+ * Suppression is keyed on `credentialService`: once any auth notification has
+ * been sent for an ongoing episode, no more are sent until the episode is
+ * cleared (by a successful poll or by circuit-breaker disable), even if a
+ * later tick classifies the failure under a different status key or a sibling
+ * watcher on the same account trips.
+ *
+ * `alreadyPausedBeforeTick` reflects the durable `credentialPausedAt` marker
+ * observed at claim time. When it is set, the user was already told in an
+ * earlier tick — possibly before a restart that emptied the in-process
+ * tracker — so this seeds the tracker to keep the current process deduped but
+ * stays silent. Returns true if a notification was sent, false if suppressed.
  */
 function notifyAuthEpisodeOnce(
   notify: WatcherNotifier,
-  watcherId: string,
+  episodeKey: string,
+  alreadyPausedBeforeTick: boolean,
   statusKey: string,
   notification: { title: string; body: string },
 ): boolean {
-  if (authNotifiedEpisodes.has(watcherId)) {
+  if (authNotifiedEpisodes.has(episodeKey)) {
     return false;
   }
-  authNotifiedEpisodes.set(watcherId, statusKey);
+  authNotifiedEpisodes.set(episodeKey, statusKey);
+  if (alreadyPausedBeforeTick) {
+    return false;
+  }
   notify(notification);
   return true;
 }
@@ -156,11 +173,21 @@ export async function runWatchersOnce(
           health.status === "missing_token" ||
           (health.status === "expired" && !health.canAutoRecover))
       ) {
+        // Capture the durable marker before skipWatcherPoll stamps it, so a
+        // watcher already paused in an earlier tick (or before a restart)
+        // does not re-notify.
+        const alreadyPaused = watcher.credentialPausedAt != null;
         skipWatcherPoll(watcher.id, `Credential unhealthy: ${health.details}`);
-        notifyAuthEpisodeOnce(notify, watcher.id, "credential-unhealthy", {
-          title: `Reconnect needed: ${watcher.name}`,
-          body: `Your ${watcher.credentialService} account's authorization is no longer valid, so ${watcher.name} is paused. Reconnect the account to resume monitoring. (${health.details})`,
-        });
+        notifyAuthEpisodeOnce(
+          notify,
+          watcher.credentialService,
+          alreadyPaused,
+          "credential-unhealthy",
+          {
+            title: `Reconnect needed: ${watcher.name}`,
+            body: `Your ${watcher.credentialService} account's authorization is no longer valid, so ${watcher.name} is paused. Reconnect the account to resume monitoring. (${health.details})`,
+          },
+        );
         continue;
       }
     } catch {
@@ -233,8 +260,9 @@ export async function runWatchersOnce(
         conversationId: watcher.conversationId ?? undefined,
       });
       // A successful poll ends any active auth-failure episode so a later
-      // new outage notifies the user again.
-      authNotifiedEpisodes.delete(watcher.id);
+      // new outage notifies the user again. completeWatcherPoll clears the
+      // durable credentialPausedAt marker; drop the in-process entry too.
+      authNotifiedEpisodes.delete(watcher.credentialService);
       processed++;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -242,17 +270,26 @@ export async function runWatchersOnce(
         { err, watcherId: watcher.id, name: watcher.name },
         "Watcher poll failed",
       );
-      failWatcherPoll(watcher.id, message);
 
       // Auth-shaped failures point at a broken account connection. Tell the
       // user to reconnect immediately (once per episode) rather than waiting
       // for the circuit breaker to disable the watcher.
       const authShaped = isAuthConnectionError(err);
+      // Capture the durable marker before failWatcherPoll stamps it.
+      const alreadyPaused = watcher.credentialPausedAt != null;
+      failWatcherPoll(watcher.id, message, { credentialPaused: authShaped });
+
       if (authShaped) {
-        notifyAuthEpisodeOnce(notify, watcher.id, "auth-error", {
-          title: `Reconnect needed: ${watcher.name}`,
-          body: `Your ${watcher.credentialService} account's authorization is no longer valid, so ${watcher.name} can't check for updates. Reconnect the account to resume monitoring.`,
-        });
+        notifyAuthEpisodeOnce(
+          notify,
+          watcher.credentialService,
+          alreadyPaused,
+          "auth-error",
+          {
+            title: `Reconnect needed: ${watcher.name}`,
+            body: `Your ${watcher.credentialService} account's authorization is no longer valid, so ${watcher.name} can't check for updates. Reconnect the account to resume monitoring.`,
+          },
+        );
       }
 
       // Circuit breaker: disable after too many consecutive errors
@@ -262,8 +299,9 @@ export async function runWatchersOnce(
         // Close out the auth episode: the disable notification below is the
         // final word for this outage. Clearing lets a fresh episode (and a
         // fresh reconnect notification) start if the user re-enables the
-        // watcher while the account is still broken.
-        authNotifiedEpisodes.delete(watcher.id);
+        // watcher while the account is still broken. disableWatcher clears the
+        // durable credentialPausedAt marker for the same reason.
+        authNotifiedEpisodes.delete(watcher.credentialService);
         // Do NOT call provider.cleanup() here — auto-disable is reversible.
         // If the watcher is re-enabled later, it must diff against the same
         // baseline to avoid missing events that occurred while disabled.

--- a/assistant/src/watcher/watcher-store.ts
+++ b/assistant/src/watcher/watcher-store.ts
@@ -21,6 +21,7 @@ export interface Watcher {
   status: string;
   consecutiveErrors: number;
   lastError: string | null;
+  credentialPausedAt: number | null;
   lastPollAt: number | null;
   nextPollAt: number;
   configJson: string | null;
@@ -71,6 +72,7 @@ export function createWatcher(params: {
     status: "idle",
     consecutiveErrors: 0,
     lastError: null as string | null,
+    credentialPausedAt: null as number | null,
     lastPollAt: null as number | null,
     nextPollAt: enabled ? now : 0,
     configJson: params.configJson ?? null,
@@ -131,11 +133,13 @@ export function updateWatcher(
   if (updates.enabled !== undefined) {
     set.enabled = updates.enabled;
     if (updates.enabled && !existing.enabled) {
-      // Re-enabling: schedule next poll now, reset errors
+      // Re-enabling: schedule next poll now, reset errors and any lingering
+      // credential-pause marker so a still-broken account notifies afresh.
       set.status = "idle";
       set.nextPollAt = now;
       set.consecutiveErrors = 0;
       set.lastError = null;
+      set.credentialPausedAt = null;
     } else if (!updates.enabled) {
       set.status = "disabled";
     }
@@ -212,6 +216,7 @@ export function completeWatcherPoll(
     nextPollAt: now + watcher.pollIntervalMs,
     consecutiveErrors: 0,
     lastError: null,
+    credentialPausedAt: null,
     updatedAt: now,
   };
 
@@ -223,10 +228,15 @@ export function completeWatcherPoll(
 }
 
 /**
- * Skip a watcher poll: apply backoff to nextPollAt without incrementing
- * consecutiveErrors. Used when a poll is skipped for a recoverable reason
- * (e.g. credential health gate) that should NOT count toward the circuit
- * breaker threshold.
+ * Skip a watcher poll because its credential is unhealthy: apply backoff to
+ * nextPollAt without incrementing consecutiveErrors (this is a recoverable
+ * reason that must NOT count toward the circuit breaker threshold), and mark
+ * the watcher as credential-paused.
+ *
+ * `credentialPausedAt` is stamped on the first skip and preserved on
+ * subsequent skips so it reflects when the outage began. It surfaces the
+ * paused state in `watchers list` and backs the engine's once-per-outage
+ * reconnect notification across restarts.
  */
 export function skipWatcherPoll(id: string, reason: string): void {
   const db = getDb();
@@ -245,6 +255,7 @@ export function skipWatcherPoll(id: string, reason: string): void {
     .set({
       status: "idle",
       lastError: truncate(reason, 2000, ""),
+      credentialPausedAt: watcher.credentialPausedAt ?? now,
       lastPollAt: now,
       nextPollAt: now + backoff,
       updatedAt: now,
@@ -255,8 +266,18 @@ export function skipWatcherPoll(id: string, reason: string): void {
 
 /**
  * Record a poll error: increment consecutive errors, apply backoff.
+ *
+ * When `credentialPaused` is set (the error was auth-shaped — a broken
+ * account connection), stamp `credentialPausedAt` so the watcher surfaces as
+ * paused in `watchers list` and the engine's reconnect notification dedups
+ * across restarts. The marker is preserved once set so it reflects when the
+ * outage began.
  */
-export function failWatcherPoll(id: string, error: string): void {
+export function failWatcherPoll(
+  id: string,
+  error: string,
+  opts?: { credentialPaused?: boolean },
+): void {
   const db = getDb();
   const watcher = db.select().from(watchers).where(eq(watchers.id, id)).get();
   if (!watcher) return;
@@ -271,6 +292,9 @@ export function failWatcherPoll(id: string, error: string): void {
       status: "idle",
       consecutiveErrors: errors,
       lastError: truncate(error, 2000, ""),
+      credentialPausedAt: opts?.credentialPaused
+        ? (watcher.credentialPausedAt ?? now)
+        : watcher.credentialPausedAt,
       lastPollAt: now,
       nextPollAt: now + backoff,
       updatedAt: now,
@@ -280,7 +304,9 @@ export function failWatcherPoll(id: string, error: string): void {
 }
 
 /**
- * Disable a watcher (circuit breaker tripped).
+ * Disable a watcher (circuit breaker tripped). Clears the credential-pause
+ * marker so a manual re-enable of a still-broken account starts a fresh
+ * reconnect episode instead of being suppressed by a stale marker.
  */
 export function disableWatcher(id: string, reason: string): void {
   const db = getDb();
@@ -289,6 +315,7 @@ export function disableWatcher(id: string, reason: string): void {
       status: "disabled",
       enabled: false,
       lastError: truncate(reason, 2000, ""),
+      credentialPausedAt: null,
       updatedAt: Date.now(),
     })
     .where(eq(watchers.id, id))
@@ -447,6 +474,7 @@ function parseWatcherRow(row: typeof watchers.$inferSelect): Watcher {
     status: row.status,
     consecutiveErrors: row.consecutiveErrors,
     lastError: row.lastError,
+    credentialPausedAt: row.credentialPausedAt,
     lastPollAt: row.lastPollAt,
     nextPollAt: row.nextPollAt,
     configJson: row.configJson,

--- a/assistant/src/watcher/watcher-store.ts
+++ b/assistant/src/watcher/watcher-store.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gte, lte } from "drizzle-orm";
+import { and, asc, desc, eq, gte, isNotNull, lte } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "../persistence/db-connection.js";
@@ -262,6 +262,29 @@ export function skipWatcherPoll(id: string, reason: string): void {
     })
     .where(eq(watchers.id, id))
     .run();
+}
+
+/**
+ * Whether any enabled watcher on the given credential service is currently
+ * credential-paused. The engine consults this (before stamping the current
+ * watcher's row) to dedupe reconnect notifications per account outage: a
+ * sibling watcher's persisted marker means the user has already been told,
+ * even across a restart that emptied the in-process episode tracker.
+ */
+export function hasCredentialPause(credentialService: string): boolean {
+  const db = getDb();
+  const row = db
+    .select({ id: watchers.id })
+    .from(watchers)
+    .where(
+      and(
+        eq(watchers.credentialService, credentialService),
+        eq(watchers.enabled, true),
+        isNotNull(watchers.credentialPausedAt),
+      ),
+    )
+    .get();
+  return row !== undefined;
 }
 
 /**


### PR DESCRIPTION
## Why

Follow-up to #37625, from the same feedback investigation. #37625 notifies the user when a watcher's account auth breaks, but two gaps remained — both visible in the triaged user's logs:

1. **`watchers list` still shows a credential-paused watcher as normally enabled.** The assistant reads that list and tells the user "all your accounts are monitored" during an outage — the exact trust-destroying flip in the user's complaint ("tells me one minute all my email accounts are connected... the next minute a connection error").
2. **The once-per-episode dedup is an in-memory map keyed by watcher id**, so an assistant restart mid-outage re-notifies, and one dead account with N watchers on it sends N notifications (the affected user runs multiple watchers per account).

## What

- New nullable `credential_paused_at` column on `watchers` (migration `324`, idempotent, no backfill). Stamped on the first credential-unhealthy skip or auth-shaped poll failure (preserving outage-start time on subsequent ticks); cleared on successful poll, circuit-breaker disable, and manual re-enable — so a still-broken account starts a fresh notify episode after re-enable, matching #37625's intent.
- `watchers list` / detail render a stamped enabled watcher as `paused (reconnect account to resume)` via a shared `formatWatcherStatus` helper.
- #37625's `authNotifiedEpisodes` tracker is re-keyed from watcher id to `credentialService` (siblings on one dead account collapse to one notification) and backed by the persisted marker: on restart the marker seeds the tracker silently instead of re-notifying. Notification content and episode semantics are unchanged; `engine-auth-notify.test.ts` passes unmodified.

## Notes for review

- `assistant/src/cli/commands/watchers.ts` carries an incidental full-file Prettier reformat: main's copy was already noncompliant and the pre-commit hook gates the whole file. The logical change there is small (`formatWatcherStatus` + two call sites) — review that file by word-diff.
- Scoped tests: 60 pass, 0 fail (engine-auth-notify, engine-credential-pause, engine, migration 324, watchers CLI). `typecheck:fast` clean.

Part of a three-PR set from this feedback investigation (#37775 messaging-skill live-status guidance, #37776 connection-resolver account listing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->