### PR TITLE
fix(cli): only trust execPath-adjacent binaries in compiled CLI builds

### DIFF
--- a/cli/src/lib/__tests__/local-ces.test.ts
+++ b/cli/src/lib/__tests__/local-ces.test.ts
@@ -1,4 +1,10 @@
-import { mkdtempSync, rmSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  existsSync,
+  mkdirSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
@@ -12,7 +18,11 @@ import { startCes } from "../local.js";
 // Capture spawn calls so we can assert on cmd/env.
 let lastSpawnCall: {
   cmd: string[];
-  options: { detached?: boolean; env?: Record<string, string | undefined>; cwd?: string };
+  options: {
+    detached?: boolean;
+    env?: Record<string, string | undefined>;
+    cwd?: string;
+  };
 } | null = null;
 
 mock.module("node:child_process", () => ({
@@ -89,6 +99,12 @@ describe("startCes", () => {
     // Verify spawn was called
     expect(lastSpawnCall).not.toBeNull();
     expect(lastSpawnCall!.options.detached).toBe(true);
+
+    // Under plain bun (source tree / tests), CES must run via `bun run
+    // src/main.ts` — never an adjacent `credential-executor` binary, which in
+    // bun's own bin dir is an unrelated globally-installed package bin.
+    expect(lastSpawnCall!.cmd[0]).toBe(process.execPath);
+    expect(lastSpawnCall!.cmd).toContain("src/main.ts");
 
     // Verify env vars
     const env = lastSpawnCall!.options.env!;

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -94,9 +94,26 @@ function hasLocalRuntimeComponents(installDir: string): boolean {
   );
 }
 
-function resolveBunExecutable(): string {
+/**
+ * True when this process is a compiled standalone binary (desktop app or
+ * `bun build --compile` CLI) rather than a script executed by a plain `bun`
+ * binary (source tree, bunx, npm/global install).
+ *
+ * Only a compiled binary may trust product siblings in
+ * `dirname(process.execPath)`: under plain bun that directory is bun's own
+ * bin dir (e.g. `~/.bun/bin`), where bin links of globally-installed packages
+ * (`assistant`, `credential-executor`) collide with app-bundle binary names
+ * and point at whatever version happens to be installed globally.
+ */
+function isCompiledCli(): boolean {
   const execBase = basename(process.execPath);
-  if (execBase === "bun" || execBase.startsWith("bun-")) {
+  return (
+    execBase !== "bun" && execBase !== "bunx" && !execBase.startsWith("bun-")
+  );
+}
+
+function resolveBunExecutable(): string {
+  if (!isCompiledCli()) {
     return process.execPath;
   }
 
@@ -781,7 +798,7 @@ function resolveGatewayDir(resources?: LocalInstanceResources): string {
 
   // Compiled binary: gateway/ bundled adjacent to the CLI executable.
   const binGateway = join(dirname(process.execPath), "gateway");
-  if (isGatewaySourceDir(binGateway)) {
+  if (isCompiledCli() && isGatewaySourceDir(binGateway)) {
     return binGateway;
   }
 
@@ -897,7 +914,7 @@ export async function startCes(
   let ces;
   const runtimeCesDir = !watch ? localRuntimeCesDir(resources) : undefined;
   const cesBinary = join(dirname(process.execPath), "credential-executor");
-  if (!runtimeCesDir && existsSync(cesBinary) && !watch) {
+  if (!runtimeCesDir && isCompiledCli() && existsSync(cesBinary) && !watch) {
     // Compiled binary alongside the CLI (desktop app / compiled CLI).
     const cesLogFd = openLogFile("hatch.log");
     ces = spawn(cesBinary, [], {
@@ -1253,7 +1270,7 @@ export function isGatewayWatchModeAvailable(): boolean {
  */
 function writeAssistantWrapper(resources: LocalInstanceResources): void {
   const assistantBinary = join(dirname(process.execPath), "assistant");
-  if (!existsSync(assistantBinary)) return;
+  if (!isCompiledCli() || !existsSync(assistantBinary)) return;
 
   const workspaceDir = join(resources.instanceDir, ".vellum", "workspace");
   const protectedDir = join(resources.instanceDir, ".vellum", "protected");
@@ -1315,7 +1332,7 @@ export async function startLocalDaemon(
   // the user runs the compiled CLI directly from the terminal (e.g. via a
   // /usr/local/bin/vellum symlink into the app bundle).
   const daemonBinary = join(dirname(process.execPath), "vellum-daemon");
-  if (existsSync(daemonBinary) && !watch) {
+  if (isCompiledCli() && existsSync(daemonBinary) && !watch) {
     // In watch mode, skip the bundled binary and use source (bun --watch
     // only works with source files, not compiled binaries).
 
@@ -1609,7 +1626,12 @@ export async function startGateway(
     ? localRuntimeGatewayDir(resources)
     : undefined;
   const gatewayBinary = join(dirname(process.execPath), "vellum-gateway");
-  if (!runtimeGatewayDir && existsSync(gatewayBinary) && !watch) {
+  if (
+    !runtimeGatewayDir &&
+    isCompiledCli() &&
+    existsSync(gatewayBinary) &&
+    !watch
+  ) {
     // Use the compiled gateway binary when available (desktop app or compiled
     // CLI invoked from the terminal). In watch mode, skip the bundled binary
     // and use source (bun --watch only works with source files).


### PR DESCRIPTION
## Problem

`vellum wake` run from the source tree (`bun run cli/src/index.ts wake`) crashes:

```
EACCES: permission denied, posix_spawn '~/.bun/bin/credential-executor'
```

Several CLI spawn paths locate compiled product binaries via `join(dirname(process.execPath), <name>)`. That heuristic is only valid when the CLI itself is a compiled standalone binary (desktop app bundle). Under plain bun — source tree, `bunx`, npm global install — `process.execPath` is the bun binary itself, so `dirname(process.execPath)` is **bun's global bin dir** (`~/.bun/bin`), where bin links of globally-installed packages live. A global `vellum` install puts `credential-executor` and `assistant` links right there, colliding with the app-bundle binary names.

Consequences on a machine with a global vellum install:

- **`startCes` crash (this bug):** source-mode wake spawns the *global install's* CES bin link instead of the source-tree CES. Crashes with EACCES when the link target lacks an exec bit (observed after a global package update to 0.10.7 — bun only chmods bin targets at link creation), and silently runs a **version-skewed CES** when the exec bit survives.
- **`writeAssistantWrapper` misfire (silent):** source-mode wakes wrote `<workspace>/bin/assistant` exec-ing the global install's `assistant` bin — wrong version, contradicting the function's own "no-op in source/watch mode" contract.
- **Latent:** the `vellum-daemon` / `vellum-gateway` / bundled `gateway/` lookups have the same shape and would misfire if a global package ever ships bins with those names.

## Fix

New `isCompiledCli()` predicate (execPath basename is not `bun`/`bunx`/`bun-*` — same idiom `resolveBunExecutable` already used, now shared): only a compiled standalone binary may trust siblings of `process.execPath`. All five adjacent-product-file lookups are gated on it. Fallback behavior is unchanged and covers every topology: instance runtime install dir → source sibling → `require.resolve` — none of which depend on a bin link's exec bit.

## Verification

- `cd cli && bunx tsc --noEmit` clean; `bun test` green for `local-ces`, `wake`, `recover`, `upgrade-local` (21 tests).
- `local-ces.test.ts` now pins the spawned command: under plain bun, CES must launch via `bun run src/main.ts` — this assertion fails on pre-fix code on any machine with a global vellum install.
- Live repro on an affected machine: `bun run cli/src/index.ts sleep && … wake` went from the EACCES crash to a full wake (CES running `bun run src/main.ts` with cwd `<repo>/credential-executor`, daemon ready, gateway up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)