### PR TITLE
fix(oauth): scope available-account listing to the requested clientId

### DIFF
--- a/assistant/src/oauth/connection-resolver.test.ts
+++ b/assistant/src/oauth/connection-resolver.test.ts
@@ -633,6 +633,41 @@ describe("no-match error lists available accounts", () => {
     expect(message).toContain("Check the account spelling.");
   });
 
+  test("BYO: clientId + mistyped account lists only that app's accounts", async () => {
+    mockConnections = [
+      {
+        id: "conn-app1",
+        provider: "google",
+        accountInfo: "user@example.com",
+        grantedScopes: JSON.stringify([]),
+        status: "active",
+        clientId: "client-1",
+      },
+      {
+        id: "conn-app2",
+        provider: "google",
+        accountInfo: "other@example.org",
+        grantedScopes: JSON.stringify([]),
+        status: "active",
+        clientId: "client-2",
+      },
+    ];
+
+    let message = "";
+    try {
+      await resolveOAuthConnection("google", {
+        clientId: "client-1",
+        account: "missing@example.com",
+      });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+
+    expect(message).toContain('account "missing@example.com"');
+    expect(message).toContain("Active google connections: user@example.com.");
+    expect(message).not.toContain("other@example.org");
+  });
+
   test("BYO: zero connections keeps the plain 'needs to be connected' shape", async () => {
     mockConnections = [];
 

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -150,10 +150,12 @@ export async function resolveOAuthConnectionWithMeta(
     // When a filter produced zero matches, enumerate the provider's other
     // active connections so the error can name the accounts that DO exist —
     // a one-letter account typo should be self-correctable, not read as a
-    // disconnection.
+    // disconnection. Only the account filter is dropped: clientId narrows to
+    // a specific OAuth app, and accounts under other apps cannot serve a
+    // retry that pins the same clientId, so suggesting them would mislead.
     const availableLabels =
       account || clientId
-        ? getActiveConnections(provider).map(
+        ? getActiveConnections(provider, { clientId }).map(
             (row) => (row.accountInfo as string | null) ?? (row.id as string),
           )
         : [];


### PR DESCRIPTION
## Why

Follow-up to #37627. When a BYO caller pins both `clientId` and `account` and the account misses, the no-match error enumerates active connections **across all OAuth apps** for the provider. Accounts under a different app cannot serve a retry that pins the same `clientId`, so the error can suggest accounts that are unresolvable for this request.

## What

The fallback enumeration keeps the `clientId` filter and drops only the `account` filter: `getActiveConnections(provider, { clientId })`. When no `clientId` was supplied, behavior is unchanged (the option is only applied when truthy). Added a two-app regression test asserting only the pinned app's accounts are listed.

Tests: `connection-resolver.test.ts` 41 pass / 0 fail; `typecheck:fast` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->