### PR TITLE
refactor(api): remove deprecated flat content field from messages wire format

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -17727,10 +17727,6 @@ paths:
                           enum:
                             - user
                             - assistant
-                        content:
-                          type: string
-                          deprecated: true
-                          description: "Deprecated: superseded by contentBlocks. Flat plain-text body (joined text segments)."
                         timestamp:
                           type: string
                         attachments:

--- a/assistant/src/__tests__/list-messages-queued.test.ts
+++ b/assistant/src/__tests__/list-messages-queued.test.ts
@@ -54,7 +54,7 @@ function resetTables() {
 interface MessagePayload {
   id: string;
   role: string;
-  content?: string;
+  contentBlocks?: Array<{ type: string; text?: string }>;
   clientMessageId?: string;
   queueStatus?: "queued" | "processing";
   queuePosition?: number;
@@ -123,7 +123,10 @@ describe("handleListMessages in-memory queue", () => {
     expect(first.queuePosition).toBe(1);
     expect(first.role).toBe("user");
     expect(first.id).toBe("req-queued-1");
-    expect(first.content).toBe("please also do this");
+    expect(first.contentBlocks?.[0]).toEqual({
+      type: "text",
+      text: "please also do this",
+    });
     expect(first.clientMessageId).toBe("nonce-queued");
 
     const second = body.messages[2];
@@ -148,7 +151,10 @@ describe("handleListMessages in-memory queue", () => {
     const body = response as { messages: MessagePayload[] };
 
     expect(body.messages).toHaveLength(1);
-    expect(body.messages[0].content).toBe("what the user actually typed");
+    expect(body.messages[0].contentBlocks?.[0]).toEqual({
+      type: "text",
+      text: "what the user actually typed",
+    });
   });
 
   test("renders queued attachments with a derived kind", async () => {

--- a/assistant/src/api/responses/conversation-message.ts
+++ b/assistant/src/api/responses/conversation-message.ts
@@ -2,7 +2,6 @@
  * Wire contract for the conversation history / messages endpoints.
  *
  *   - `GET /v1/assistants/:id/messages` → `{ messages: ConversationMessage[] }`
- *   - `POST /v1/messages` send acks echo an `assistantMessage: ConversationMessage`
  *
  * Holds the canonical history-row shape produced by the daemon's
  * `renderHistoryContent` + conversation-routes serializer and consumed by
@@ -480,20 +479,6 @@ export const ConversationMessageSchema = z.object({
    * scaffolding, never a displayed turn.
    */
   role: z.enum(["user", "assistant"]),
-  /**
-   * @deprecated Superseded by `contentBlocks`. Flat plain-text body (joined
-   * text segments). Redundant with `textSegments`/`contentOrder` for clients
-   * that render from the positional arrays (web, CLI). The serializer always
-   * emits it — do not remove without auditing clients that read it directly.
-   */
-  content: z
-    .string()
-    .meta({
-      deprecated: true,
-      description:
-        "Deprecated: superseded by contentBlocks. Flat plain-text body (joined text segments).",
-    })
-    .optional(),
   /** Display timestamp as an ISO-8601 string. */
   timestamp: z.string(),
   /**

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -658,7 +658,6 @@ function buildQueuedMessagePayloads(
         // identifier the queued-message delete/steer endpoints key on.
         id: item.requestId,
         role: "user" as const,
-        content: text,
         timestamp: new Date(item.sentAt).toISOString(),
         attachments,
         ...(contentBlocks.length > 0 ? { contentBlocks } : {}),
@@ -1018,10 +1017,9 @@ export function handleListMessages({
 
     // Strip <no_response/> markers from assistant messages so web/API clients
     // never see the raw sentinel. Only assistant messages produce it; user
-    // messages are untouched. The filter is applied consistently to the flat
-    // text, the segments, the contentOrder text refs, and the text blocks of
+    // messages are untouched. The filter is applied consistently to the
+    // segments, the contentOrder text refs, and the text blocks of
     // contentBlocks.
-    let text = rendered.text;
     let textSegments = rendered.textSegments;
     let contentOrder = rendered.contentOrder;
     let contentBlocks = rendered.contentBlocks;
@@ -1048,7 +1046,6 @@ export function handleListMessages({
         })
         .filter((e): e is string => e !== undefined);
       textSegments = filteredSegments;
-      text = rendered.text.replace(NO_RESPONSE_INLINE_RE, "").trim();
       contentBlocks = rendered.contentBlocks
         .map((block) =>
           block.type === "text"
@@ -1096,9 +1093,6 @@ export function handleListMessages({
       ...(mergedMessageIds.length > 0 ? { mergedMessageIds } : {}),
       ...(m.clientMessageId ? { clientMessageId: m.clientMessageId } : {}),
       role: m.role,
-      // Flat plain-text body; see the `content` field on
-      // ConversationMessageSchema for why this must stay.
-      content: text,
       timestamp: new Date(displayTimestamp).toISOString(),
       attachments: msgAttachments,
       ...(toolCalls.length > 0 ? { toolCalls } : {}),

--- a/clients/web/src/domains/onboarding/apply-personality.ts
+++ b/clients/web/src/domains/onboarding/apply-personality.ts
@@ -27,11 +27,9 @@ import {
   messagesGet,
   messagesPost,
 } from "@/generated/daemon/sdk.gen";
-import type {
-  MessagesGetResponses,
-  MessagesPostData,
-} from "@/generated/daemon/types.gen";
+import type { MessagesPostData } from "@/generated/daemon/types.gen";
 import { captureError } from "@/lib/sentry/capture-error";
+import { latestAssistantText } from "@/domains/onboarding/latest-assistant-text";
 
 /**
  * Axis ids the personality step keys its slider values by. Mirror
@@ -139,27 +137,6 @@ ${nameInstruction}
 
 Each rewritten file must still be complete: SOUL.md keeps everything you operate by — how you use memory, your boundaries, your compliance stance — re-expressed in your new voice rather than dropped. When you finish, both files should read top-to-bottom as this new personality, with nothing left in the generic default voice.
 </system-message>`;
-}
-
-type GetMessage = MessagesGetResponses[200]["messages"][number];
-
-/** Latest assistant reply text (text blocks, then legacy flat content). */
-function latestAssistantText(messages: GetMessage[]): string {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const m = messages[i];
-    if (!m || m.role !== "assistant") continue;
-    const blocks = m.contentBlocks;
-    if (blocks && blocks.length > 0) {
-      const text = blocks
-        .filter((b): b is Extract<typeof b, { type: "text" }> => b.type === "text")
-        .map((b) => b.text)
-        .join("\n")
-        .trim();
-      if (text) return text;
-    }
-    return (m.content ?? "").trim();
-  }
-  return "";
 }
 
 export interface ApplyPersonalityOptions {

--- a/clients/web/src/domains/onboarding/latest-assistant-text.test.ts
+++ b/clients/web/src/domains/onboarding/latest-assistant-text.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ConversationMessage } from "@vellumai/assistant-api";
+
+import { latestAssistantText } from "./latest-assistant-text";
+
+function makeMessage(
+  overrides: Partial<ConversationMessage>,
+): ConversationMessage {
+  return {
+    id: "msg-1",
+    role: "assistant",
+    timestamp: "2026-01-01T00:00:00.000Z",
+    attachments: [],
+    ...overrides,
+  };
+}
+
+describe("latestAssistantText", () => {
+  test("joins the text blocks of the latest assistant message", () => {
+    const messages = [
+      makeMessage({
+        id: "msg-old",
+        contentBlocks: [{ type: "text", text: "older reply" }],
+      }),
+      makeMessage({ id: "msg-user", role: "user" }),
+      makeMessage({
+        id: "msg-new",
+        contentBlocks: [
+          { type: "text", text: "first paragraph" },
+          { type: "thinking", thinking: "hidden reasoning" },
+          { type: "text", text: "second paragraph" },
+        ],
+      }),
+    ];
+
+    expect(latestAssistantText(messages)).toBe(
+      "first paragraph\nsecond paragraph",
+    );
+  });
+
+  test("returns empty string when there is no assistant message", () => {
+    expect(latestAssistantText([])).toBe("");
+    expect(latestAssistantText([makeMessage({ role: "user" })])).toBe("");
+  });
+
+  test("returns empty string for an assistant message with no text blocks", () => {
+    const messages = [
+      makeMessage({
+        contentBlocks: [{ type: "thinking", thinking: "only reasoning" }],
+      }),
+    ];
+
+    expect(latestAssistantText(messages)).toBe("");
+  });
+});

--- a/clients/web/src/domains/onboarding/latest-assistant-text.ts
+++ b/clients/web/src/domains/onboarding/latest-assistant-text.ts
@@ -1,0 +1,25 @@
+import type { ConversationMessage } from "@vellumai/assistant-api";
+
+/**
+ * Latest assistant reply text from a messages list (joined text blocks).
+ *
+ * Reads the wire `contentBlocks` projection directly: onboarding flows only
+ * ever poll a freshly created assistant, so the pre-0.8.8 positional-array
+ * reconstruction in `chat/api/messages.ts` is never needed here.
+ */
+export function latestAssistantText(messages: ConversationMessage[]): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (!m || m.role !== "assistant") {
+      continue;
+    }
+    return (m.contentBlocks ?? [])
+      .filter(
+        (b): b is Extract<typeof b, { type: "text" }> => b.type === "text",
+      )
+      .map((b) => b.text)
+      .join("\n")
+      .trim();
+  }
+  return "";
+}

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -33,11 +33,11 @@ import {
 import { archiveResearchConversation } from "@/domains/onboarding/archive-research-conversation";
 import { invalidateConversationQueries } from "@/utils/conversation-cache";
 import type {
-  MessagesGetResponses,
   MessagesPostData,
   PluginsSearchGetResponses,
 } from "@/generated/daemon/types.gen";
 import { captureError } from "@/lib/sentry/capture-error";
+import { latestAssistantText } from "@/domains/onboarding/latest-assistant-text";
 import { detectClientOs } from "@/runtime/platform-detection";
 import {
   buildResearchPrompt,
@@ -282,8 +282,6 @@ export interface UseResearchRunner extends ResearchRunnerState {
   ) => void;
 }
 
-type GetMessage = MessagesGetResponses[200]["messages"][number];
-
 const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -302,25 +300,6 @@ export function resolveOnboardingPluginInstalls({
       ...modelPlugins.filter((name) => validNames.has(name)),
     ]),
   ];
-}
-
-/** Latest assistant reply text from a messages list (text blocks, then legacy flat content). */
-function latestAssistantText(messages: GetMessage[]): string {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const m = messages[i];
-    if (!m || m.role !== "assistant") continue;
-    const blocks = m.contentBlocks;
-    if (blocks && blocks.length > 0) {
-      const text = blocks
-        .filter((b): b is Extract<typeof b, { type: "text" }> => b.type === "text")
-        .map((b) => b.text)
-        .join("\n")
-        .trim();
-      if (text) return text;
-    }
-    return (m.content ?? "").trim();
-  }
-  return "";
 }
 
 export function useResearchRunner(): UseResearchRunner {


### PR DESCRIPTION
## Prompt / plan

User request: confirm the web client no longer reads the flat `message.content` string now that it has cut over to the `contentBlocks` array, then remove `content` from the daemon messages API.

Approach: audited every consumer of the `ConversationMessage` wire shape before touching the wire, then removed the field from the schema, both serializer emit sites, and the two web fallbacks that still referenced it.

Audit results:
- **web**: the transcript ingest boundary (`mapRuntimeToDisplayMessage`), reconciliation, and inspector all read `contentBlocks` (or reconstruct it from the positional arrays for pre-0.8.8 daemons via `normalizeContentBlocks`); `DisplayMessage` has no `content` field. The only readers were two onboarding pollers (`apply-personality.ts`, `research-runner.ts`) using `m.content ?? ""` as a never-reached fallback after `contentBlocks`. Their duplicated `latestAssistantText` helpers are extracted into a shared `onboarding/latest-assistant-text.ts` that reads text blocks only — onboarding always polls a freshly created (current-version) assistant, so the pre-0.8.8 reconstruction seam isn't needed there (and `chat/api/*` is import-banned from onboarding anyway).
- **CLI**: derives its transcript body from `textSegments`, never the wire `content`. The CLI export route reads raw DB rows (a different shape).
- **gateway / macOS / chrome-extension / skills / scripts / packages**: none consume the messages endpoint's `content` field. The schema docstring's claim that `POST /v1/messages` acks echo an `assistantMessage: ConversationMessage` was stale — no such emit site exists — so that line is removed too.
- **evals** (external repo `vellum-ai/evals`): not verifiable from this repo. The schema docstring listed it as a consumer; if evals reads the flat `content` of history rows it needs a follow-up there. Flagging for reviewer confirmation.

Changes:
- `assistant/src/api/responses/conversation-message.ts`: drop the deprecated `content` field from `ConversationMessageSchema`.
- `assistant/src/runtime/routes/conversation-routes.ts`: stop emitting `content` in the history serializer and `buildQueuedMessagePayloads`; the now-unused flat-text derivation and its `<no_response/>` filtering are removed with it.
- `assistant/openapi.yaml`: regenerated (`bun run generate:openapi`).
- `clients/web`: shared `latestAssistantText` helper + colocated test; both onboarding pollers now use it.

Older daemons that still emit `content` are unaffected — the web client ignores unknown fields (no runtime zod validation of message responses), and the reverse skew (old web bundle, new daemon) doesn't occur since the web always serves the latest bundle.

## Test plan

- `assistant`: `bun run typecheck:fast` clean; all 7 `list-messages-*` serializer test files pass (73 pass, 2 skip), with the queued-message assertions moved from `content` to `contentBlocks`.
- `clients/web`: regenerated the daemon SDK from the new spec (`bun run openapi-ts`), `bunx tsc --noEmit` clean, ESLint 0 errors on touched files, and `latest-assistant-text.test.ts` + `apply-personality.test.ts` + `research-runner.test.ts` + `chat/api/messages.test.ts` pass. Pre-existing failures in the broader onboarding suite (QueryClient/jsdom setup) reproduce identically on the base commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KnwfSEWYCZ8bfjvFD9FwKJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KnwfSEWYCZ8bfjvFD9FwKJ)_