### PR TITLE
refactor(tools): resolve exclusivity + trace tool defs without threading getTool

### DIFF
--- a/assistant/src/agent/loop-exclusive-tool.test.ts
+++ b/assistant/src/agent/loop-exclusive-tool.test.ts
@@ -1,15 +1,40 @@
 /**
- * Verifies the agent loop's exclusive-tool dispatch: when a tool the loop is
- * told is exclusive appears in a multi-call turn, only that tool runs and the
+ * Verifies the agent loop's exclusive-tool dispatch: when a tool the registry
+ * marks exclusive appears in a multi-call turn, only that tool runs and the
  * siblings are deferred un-run with a benign result — so the model incorporates
  * the exclusive tool's output before acting on anything else. Drives the REAL
  * loop, mocking only the provider boundary.
  */
-import { describe, expect, test } from "bun:test";
+import { beforeAll, describe, expect, test } from "bun:test";
 
 import { createMockProvider } from "../__tests__/helpers/mock-provider.js";
+import { RiskLevel } from "../permissions/types.js";
 import type { ContentBlock, ProviderResponse } from "../providers/types.js";
+import { registerTool } from "../tools/registry.js";
+import type { ToolContext, ToolExecutionResult } from "../tools/types.js";
 import { AgentLoop } from "./loop.js";
+
+// The loop reads exclusivity straight from the registry (`getTool(name)
+// ?.exclusive`), so seed a registered tool the loop can look up. Other tool
+// names in these turns are absent from the registry, so they read as
+// non-exclusive — exactly the mixed state the deferral logic branches on.
+beforeAll(() => {
+  registerTool({
+    name: "exclusive_tool",
+    description: "Exclusive test tool",
+    category: "test",
+    defaultRiskLevel: RiskLevel.Low,
+    executionTarget: "sandbox",
+    exclusive: true,
+    input_schema: { type: "object", properties: {}, required: [] },
+    async execute(
+      _input: Record<string, unknown>,
+      _context: ToolContext,
+    ): Promise<ToolExecutionResult> {
+      return { content: "ok", isError: false };
+    },
+  });
+});
 
 const endTurn = (text: string): ProviderResponse => ({
   content: [{ type: "text", text }],
@@ -82,7 +107,6 @@ describe("AgentLoop — exclusive tool deferral", () => {
         executed.push(name);
         return { content: `ran ${name}`, isError: false };
       },
-      isExclusiveTool: (name) => name === "exclusive_tool",
     });
 
     const { history } = await loop.run({
@@ -137,7 +161,6 @@ describe("AgentLoop — exclusive tool deferral", () => {
         executed.push(name);
         return { content: `ran ${name}`, isError: false };
       },
-      isExclusiveTool: (name) => name === "exclusive_tool",
     });
 
     const { history } = await loop.run({

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -43,6 +43,7 @@ import type {
   ToolResultContent,
 } from "../providers/types.js";
 import { isContextOverflowError } from "../providers/types.js";
+import { getTool } from "../tools/registry.js";
 import type { SensitiveOutputBinding } from "../tools/sensitive-output-placeholders.js";
 import {
   applyStreamingSubstitution,
@@ -709,14 +710,6 @@ export interface AgentLoopConstructorOptions {
   toolExecutor?: LoopToolExecutor;
   resolveTools?: (history: Message[]) => ToolDefinition[];
   /**
-   * Decide whether a tool runs exclusively in its turn (see
-   * {@link ToolDefinition.exclusive}). When it returns true for a tool present
-   * in a multi-call turn, the loop runs only that tool and defers the siblings
-   * un-run. Injected by the conversation wiring, which can read the tool
-   * registry; lightweight loops that omit it never defer.
-   */
-  isExclusiveTool?: (toolName: string) => boolean;
-  /**
    * Conversation this loop drives. Scopes the loop-held compaction circuit
    * breaker and is the source of truth the loop's pipeline contexts and
    * post-compaction re-injection resolve the live conversation through.
@@ -741,7 +734,6 @@ export class AgentLoop {
   private tools: ToolDefinition[];
   private resolveTools: ((history: Message[]) => ToolDefinition[]) | null;
   private toolExecutor: LoopToolExecutor | null;
-  private isExclusiveTool: ((toolName: string) => boolean) | null;
 
   /**
    * Conversation this loop drives. Source of truth for the `conversationId`
@@ -771,7 +763,6 @@ export class AgentLoop {
       tools,
       toolExecutor,
       resolveTools,
-      isExclusiveTool,
       conversationId,
       resolveConversationDir,
     } = options;
@@ -781,7 +772,6 @@ export class AgentLoop {
     this.tools = tools ?? [];
     this.resolveTools = resolveTools ?? null;
     this.toolExecutor = toolExecutor ?? null;
-    this.isExclusiveTool = isExclusiveTool ?? null;
     this.conversationId = conversationId;
     this.resolveConversationDir = resolveConversationDir ?? null;
     this.compactionCircuit = new CompactionCircuit(this.conversationId);
@@ -2069,9 +2059,9 @@ export class AgentLoop {
         // the siblings with a benign, un-run result so the model re-issues them
         // next turn if still needed. Every tool_use still gets a matching
         // tool_result, so history stays well-formed.
-        const exclusiveBlock = this.isExclusiveTool
-          ? toolUseBlocks.find((block) => this.isExclusiveTool!(block.name))
-          : undefined;
+        const exclusiveBlock = toolUseBlocks.find(
+          (block) => getTool(block.name)?.exclusive === true,
+        );
         const deferSiblings =
           exclusiveBlock !== undefined && toolUseBlocks.length > 1;
         if (deferSiblings) {

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -74,7 +74,7 @@ import {
   type SystemPromptPersonaOverride,
 } from "../prompts/system-prompt.js";
 import type { ContentBlock, Message } from "../providers/types.js";
-import type { Provider } from "../providers/types.js";
+import type { Provider, ToolDefinition } from "../providers/types.js";
 import { type TrustClass } from "../runtime/actor-trust-resolver.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import type { AuthContext } from "../runtime/auth/types.js";
@@ -768,9 +768,6 @@ export class Conversation {
       tools: toolDefs.length > 0 ? toolDefs : undefined,
       toolExecutor: toolDefs.length > 0 ? toolExecutor : undefined,
       resolveTools,
-      // A tool the registry marks exclusive (e.g. `advisor`) runs alone in its
-      // turn; the loop defers any sibling calls until the next turn.
-      isExclusiveTool: (name) => getTool(name)?.exclusive === true,
       resolveConversationDir: () => {
         const conv = getConversation(this.conversationId);
         if (!conv) {
@@ -2377,6 +2374,26 @@ export class Conversation {
    */
   getRegisteredToolNames(): Set<string> {
     return new Set(this.lastResolvedToolNames ?? this.coreToolNames);
+  }
+
+  /**
+   * The {@link getRegisteredToolNames} inventory resolved to full definitions
+   * (name, description, input schema), sorted by name. Resolution reads the
+   * live registry so skill/MCP tools — whose definitions are not in the base
+   * turn snapshot — are included. Consumers (e.g. turn-trace telemetry) read
+   * this instead of reaching into the tool registry themselves.
+   */
+  getRegisteredToolDefinitions(): ToolDefinition[] {
+    return Array.from(this.getRegisteredToolNames())
+      .sort((a, b) => a.localeCompare(b))
+      .map((name) => {
+        const tool = getTool(name);
+        return {
+          name,
+          description: tool?.description ?? "",
+          input_schema: tool?.input_schema ?? {},
+        };
+      });
   }
 
   // ── History ──────────────────────────────────────────────────────

--- a/assistant/src/telemetry/turn-trace-store.test.ts
+++ b/assistant/src/telemetry/turn-trace-store.test.ts
@@ -26,26 +26,15 @@ let mockLiveConversation:
   | {
       isProcessing: () => boolean;
       getCurrentSystemPrompt?: () => string;
-      getRegisteredToolNames?: () => Set<string>;
+      getRegisteredToolDefinitions?: () => Array<{
+        name: string;
+        description: string;
+        input_schema: object;
+      }>;
     }
   | undefined;
 mock.module("../daemon/conversation-registry.js", () => ({
   findConversation: () => mockLiveConversation,
-}));
-
-// Stub the tool registry so trace assembly can resolve descriptions without
-// loading the real tool graph. Returns `undefined` by default; tests override
-// for specific tool names.
-let mockToolDescriptions: Record<string, string> = {};
-mock.module("../tools/registry.js", () => ({
-  getTool: (name: string) =>
-    mockToolDescriptions[name]
-      ? { description: mockToolDescriptions[name], input_schema: {} }
-      : undefined,
-  resolveTool: (name: string) =>
-    mockToolDescriptions[name]
-      ? { description: mockToolDescriptions[name], input_schema: {} }
-      : undefined,
 }));
 
 import { createConversation } from "../persistence/conversation-crud.js";
@@ -72,7 +61,6 @@ function purge(): void {
 beforeEach(() => {
   purge();
   mockLiveConversation = undefined;
-  mockToolDescriptions = {};
 });
 
 interface MessageSeed {
@@ -238,16 +226,16 @@ describe("assembleTurnTrace", () => {
       createdAt: 1100,
     });
 
+    // The conversation resolves + sorts its registered tools; trace assembly
+    // just maps them into the trace, so feed it already-resolved definitions.
     mockLiveConversation = {
       isProcessing: () => false,
       getCurrentSystemPrompt: () => "You are a helpful assistant.",
-      getRegisteredToolNames: () =>
-        new Set(["web_search", "file_read", "notify_parent"]),
-    };
-    mockToolDescriptions = {
-      web_search: "Search the web",
-      file_read: "Read a file",
-      // notify_parent intentionally not in the map — description should be ""
+      getRegisteredToolDefinitions: () => [
+        { name: "file_read", description: "Read a file", input_schema: {} },
+        { name: "notify_parent", description: "", input_schema: {} },
+        { name: "web_search", description: "Search the web", input_schema: {} },
+      ],
     };
 
     const trace = assembleTurnTrace(boundary(conv.id, "m-user-1", 1000));

--- a/assistant/src/telemetry/turn-trace-store.ts
+++ b/assistant/src/telemetry/turn-trace-store.ts
@@ -3,7 +3,6 @@ import { and, asc, eq, gt, lt, lte, or, sql } from "drizzle-orm";
 import { findConversation } from "../daemon/conversation-registry.js";
 import { getDb } from "../persistence/db-connection.js";
 import { messages, toolInvocations } from "../persistence/schema/index.js";
-import { getTool } from "../tools/registry.js";
 import { getLogger } from "../util/logger.js";
 import type {
   TurnTrace,
@@ -315,16 +314,11 @@ export function assembleTurnTrace(boundary: TurnTraceBoundary): TurnTrace {
   const systemPrompt = conversation?.getCurrentSystemPrompt() ?? null;
 
   const toolDefinitions: TurnTraceToolDefinition[] = conversation
-    ? Array.from(conversation.getRegisteredToolNames())
-        .sort((a, b) => a.localeCompare(b))
-        .map((name) => {
-          const tool = getTool(name);
-          return {
-            name,
-            description: tool?.description ?? "",
-            input_schema: (tool?.input_schema ?? {}) as Record<string, unknown>,
-          };
-        })
+    ? conversation.getRegisteredToolDefinitions().map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+        input_schema: tool.input_schema as Record<string, unknown>,
+      }))
     : [];
 
   return {


### PR DESCRIPTION
## Prompt / plan

The two follow-ups left open on PR #37694 (now merged), tracked as `Followup` review comments. Both remove a caller that reached into the tool registry through an indirection, moving the registry read to where it belongs.

## Changes

### 1. Exclusive-tool deferral reads the registry inline (was an AgentLoop parameter)

The agent loop decides whether a tool runs exclusively (e.g. the advisor runs alone, deferring siblings that turn). It did this through an injected `isExclusiveTool?: (name) => boolean` predicate that the conversation wiring built as `(name) => getTool(name)?.exclusive === true`.

- Drop the `isExclusiveTool` option, class field, and constructor plumbing from `AgentLoop`.
- Read `getTool(name)?.exclusive === true` inline where the turn's exclusive block is computed. The loop's own `ToolDefinition` (the wire type: name/description/input_schema) doesn't carry `exclusive`, so this reads the registry directly — the loop already imports from `../tools/`, and the registry has no dependency on the agent loop (no cycle).
- `conversation.ts` no longer passes the predicate and drops its now-unused `getTool` import.
- `loop-exclusive-tool.test.ts` drives exclusivity through the real registry (registers an `exclusive: true` tool) instead of injecting the predicate.

### 2. Turn-trace telemetry consumes tool definitions, not names + registry lookups

`assembleTurnTrace` took the conversation's registered tool **names** and resolved each one to a definition by calling `getTool` on the registry itself.

- Add `Conversation.getRegisteredToolDefinitions()`: the `getRegisteredToolNames()` inventory resolved to name + description + input schema and sorted by name. Resolution reads the live registry (via `getTool`) so skill/MCP tools — whose definitions aren't in the base turn snapshot — are included.
- `turn-trace-store.ts` consumes those definitions and no longer imports the registry.
- The turn-trace test feeds definitions through the conversation mock; the registry stub it needed only for this lookup is gone.

## Test plan

- `bunx tsc --noEmit` — clean; `eslint` on all changed files — 0 errors (both enforced by pre-commit + pre-push hooks).
- Full suite green, including `loop-exclusive-tool`, `turn-trace-store`, `tools-get-route`, `conversation-*`, `agent-loop*`, `registry`, and `checker`. The only failing files are pre-existing environmental/sandbox-limited suites unrelated to this change (script-proxy ×3, secret-routes proxy, avatar read-only-workspace, sandbox-escape host-timeout, audit-log-rotation, provider-commit-message-generator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014ok5MKKrM4ZnmqG3AeXWtc)_