### PR TITLE
refactor(persistence): zod-validate content refs/deltas, reserve ref paths, expressive resolver

### DIFF
--- a/assistant/src/persistence/__tests__/message-content-file.test.ts
+++ b/assistant/src/persistence/__tests__/message-content-file.test.ts
@@ -1,8 +1,9 @@
 /**
  * Tests for the file-backed message content module: the JSONL delta fold
- * semantics, the append/fold roundtrip, and `resolveStoredMessageContent`'s
- * union handling (inline passthrough, ref resolution, missing-file and
- * workspace-escape fallbacks).
+ * semantics, the append/fold roundtrip, the reserved-path ref discriminator,
+ * and both resolver forms (expressive `ContentBlock[]` and the row-mapper
+ * string shim) across inline passthrough, ref resolution, missing-file and
+ * workspace-escape fallbacks.
  */
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
@@ -15,6 +16,7 @@ import {
   foldContentDeltas,
   foldContentFile,
   isMessageContentRef,
+  resolveMessageContentBlocks,
   resolveStoredMessageContent,
 } from "../message-content-file.js";
 
@@ -44,6 +46,8 @@ describe("foldContentDeltas", () => {
       "\n" +
       "not json\n" +
       JSON.stringify({ seq: 2, block: textBlock("missing index") }) +
+      "\n" +
+      JSON.stringify({ i: 2, seq: 4, block: { typo: "no type field" } }) +
       "\n" +
       '{"i": 1, "seq": 3, "block": {"type": "text", "te'; // truncated
     expect(foldContentDeltas(text)).toEqual([textBlock("kept")]);
@@ -82,20 +86,46 @@ describe("appendContentDeltas + foldContentFile", () => {
 });
 
 describe("isMessageContentRef", () => {
-  test("accepts exactly { ref: string }", () => {
-    expect(isMessageContentRef({ ref: "a/b.jsonl" })).toBe(true);
+  test("accepts exactly { ref } naming a reserved conversations/ .jsonl path", () => {
+    expect(
+      isMessageContentRef({ ref: "conversations/a/inflight/b.jsonl" }),
+    ).toBe(true);
+  });
+
+  test("rejects non-reserved paths — the legacy-text discriminator", () => {
+    expect(isMessageContentRef({ ref: "a/b.jsonl" })).toBe(false);
+    expect(isMessageContentRef({ ref: "conversations/a/b.txt" })).toBe(false);
+    expect(isMessageContentRef({ ref: "/etc/passwd" })).toBe(false);
+    expect(isMessageContentRef({ ref: "../../../etc/passwd" })).toBe(false);
   });
 
   test("rejects arrays, extra keys, empty and non-string refs", () => {
     expect(isMessageContentRef([textBlock("x")])).toBe(false);
-    expect(isMessageContentRef({ ref: "a", other: 1 })).toBe(false);
+    expect(
+      isMessageContentRef({ ref: "conversations/a/b.jsonl", other: 1 }),
+    ).toBe(false);
     expect(isMessageContentRef({ ref: "" })).toBe(false);
     expect(isMessageContentRef({ ref: 42 })).toBe(false);
     expect(isMessageContentRef(null)).toBe(false);
   });
 });
 
-describe("resolveStoredMessageContent", () => {
+function writeRefFixture(dir: string, file: string): string {
+  const rel = join("conversations", dir, "inflight", file);
+  mkdirSync(join(getWorkspaceDir(), "conversations", dir, "inflight"), {
+    recursive: true,
+  });
+  writeFileSync(
+    join(getWorkspaceDir(), rel),
+    [
+      JSON.stringify({ i: 0, seq: 1, block: textBlock("partial") }),
+      JSON.stringify({ i: 0, seq: 2, block: textBlock("final") }),
+    ].join("\n") + "\n",
+  );
+  return rel;
+}
+
+describe("resolveStoredMessageContent (row-mapper string shim)", () => {
   test("passes inline ContentBlock[] JSON through by identity", () => {
     const inline = JSON.stringify([textBlock("hello")]);
     expect(resolveStoredMessageContent(inline)).toBe(inline);
@@ -110,41 +140,66 @@ describe("resolveStoredMessageContent", () => {
     expect(resolveStoredMessageContent(objectButNotRef)).toBe(objectButNotRef);
   });
 
-  test("resolves a ref to the folded file content", () => {
-    const rel = join("conversations", "test-resolve", "inflight", "m.jsonl");
-    const abs = join(getWorkspaceDir(), rel);
-    mkdirSync(
-      join(getWorkspaceDir(), "conversations", "test-resolve", "inflight"),
-      {
-        recursive: true,
-      },
+  test("passes legacy text shaped like a ref to a NON-reserved path through untouched", () => {
+    const legacyRefLikeText = JSON.stringify({ ref: "missing.jsonl" });
+    expect(resolveStoredMessageContent(legacyRefLikeText)).toBe(
+      legacyRefLikeText,
     );
-    writeFileSync(
-      abs,
-      [
-        JSON.stringify({ i: 0, seq: 1, block: textBlock("partial") }),
-        JSON.stringify({ i: 0, seq: 2, block: textBlock("final") }),
-      ].join("\n") + "\n",
-    );
+  });
+
+  test("resolves a reserved-path ref to the folded file content", () => {
+    const rel = writeRefFixture("test-resolve", "m.jsonl");
     expect(resolveStoredMessageContent(JSON.stringify({ ref: rel }))).toBe(
       JSON.stringify([textBlock("final")]),
     );
   });
 
-  test("resolves a ref to a missing file as empty content", () => {
+  test("resolves a reserved-path ref to a missing file as empty content", () => {
     expect(
-      resolveStoredMessageContent(JSON.stringify({ ref: "gone/m.jsonl" })),
+      resolveStoredMessageContent(
+        JSON.stringify({ ref: "conversations/gone/inflight/m.jsonl" }),
+      ),
     ).toBe("[]");
   });
 
-  test("rejects refs that escape the workspace directory", () => {
+  test("resolves a reserved-prefix ref that escapes the workspace as empty content", () => {
     expect(
       resolveStoredMessageContent(
-        JSON.stringify({ ref: "../../../etc/passwd" }),
+        JSON.stringify({ ref: "conversations/../../../etc/evil.jsonl" }),
       ),
     ).toBe("[]");
+  });
+});
+
+describe("resolveMessageContentBlocks (expressive form)", () => {
+  test("parses inline ContentBlock[] JSON to blocks", () => {
     expect(
-      resolveStoredMessageContent(JSON.stringify({ ref: "/etc/passwd" })),
-    ).toBe("[]");
+      resolveMessageContentBlocks(JSON.stringify([textBlock("hello")])),
+    ).toEqual([textBlock("hello")]);
+  });
+
+  test("folds a reserved-path ref to blocks", () => {
+    const rel = writeRefFixture("test-resolve-blocks", "m.jsonl");
+    expect(resolveMessageContentBlocks(JSON.stringify({ ref: rel }))).toEqual([
+      textBlock("final"),
+    ]);
+  });
+
+  test("wraps legacy plain strings in a single text block", () => {
+    expect(resolveMessageContentBlocks("plain old text")).toEqual([
+      textBlock("plain old text"),
+    ]);
+    const legacyRefLikeText = JSON.stringify({ ref: "missing.jsonl" });
+    expect(resolveMessageContentBlocks(legacyRefLikeText)).toEqual([
+      textBlock(legacyRefLikeText),
+    ]);
+  });
+
+  test("resolves a missing ref file to empty blocks", () => {
+    expect(
+      resolveMessageContentBlocks(
+        JSON.stringify({ ref: "conversations/gone/inflight/m.jsonl" }),
+      ),
+    ).toEqual([]);
   });
 });

--- a/assistant/src/persistence/__tests__/message-content-file.test.ts
+++ b/assistant/src/persistence/__tests__/message-content-file.test.ts
@@ -15,13 +15,13 @@ import {
   appendContentDeltas,
   foldContentDeltas,
   foldContentFile,
-  isMessageContentRef,
+  messageContentRefSchema,
   resolveMessageContentBlocks,
   resolveStoredMessageContent,
 } from "../message-content-file.js";
 
 function textBlock(text: string): ContentBlock {
-  return { type: "text", text } as ContentBlock;
+  return { type: "text", text };
 }
 
 describe("foldContentDeltas", () => {
@@ -51,6 +51,19 @@ describe("foldContentDeltas", () => {
       "\n" +
       '{"i": 1, "seq": 3, "block": {"type": "text", "te'; // truncated
     expect(foldContentDeltas(text)).toEqual([textBlock("kept")]);
+  });
+
+  test("preserves internal rider fields on blocks (passthrough, not strip)", () => {
+    // Timing stamps like _startedAt ride inside persisted thinking blocks;
+    // the fold must round-trip them, not strip them as unknown keys.
+    const stamped = {
+      type: "thinking",
+      thinking: "hmm",
+      signature: "sig",
+      _startedAt: 123,
+    };
+    const text = JSON.stringify({ i: 0, seq: 1, block: stamped });
+    expect(foldContentDeltas(text)).toEqual([stamped as ContentBlock]);
   });
 
   test("empty input folds to empty content", () => {
@@ -85,28 +98,36 @@ describe("appendContentDeltas + foldContentFile", () => {
   });
 });
 
-describe("isMessageContentRef", () => {
+describe("messageContentRefSchema", () => {
   test("accepts exactly { ref } naming a reserved conversations/ .jsonl path", () => {
     expect(
-      isMessageContentRef({ ref: "conversations/a/inflight/b.jsonl" }),
+      messageContentRefSchema.safeParse({
+        ref: "conversations/a/inflight/b.jsonl",
+      }).success,
     ).toBe(true);
   });
 
   test("rejects non-reserved paths — the legacy-text discriminator", () => {
-    expect(isMessageContentRef({ ref: "a/b.jsonl" })).toBe(false);
-    expect(isMessageContentRef({ ref: "conversations/a/b.txt" })).toBe(false);
-    expect(isMessageContentRef({ ref: "/etc/passwd" })).toBe(false);
-    expect(isMessageContentRef({ ref: "../../../etc/passwd" })).toBe(false);
+    for (const ref of [
+      "a/b.jsonl",
+      "conversations/a/b.txt",
+      "/etc/passwd",
+      "../../../etc/passwd",
+    ]) {
+      expect(messageContentRefSchema.safeParse({ ref }).success).toBe(false);
+    }
   });
 
   test("rejects arrays, extra keys, empty and non-string refs", () => {
-    expect(isMessageContentRef([textBlock("x")])).toBe(false);
-    expect(
-      isMessageContentRef({ ref: "conversations/a/b.jsonl", other: 1 }),
-    ).toBe(false);
-    expect(isMessageContentRef({ ref: "" })).toBe(false);
-    expect(isMessageContentRef({ ref: 42 })).toBe(false);
-    expect(isMessageContentRef(null)).toBe(false);
+    for (const value of [
+      [textBlock("x")],
+      { ref: "conversations/a/b.jsonl", other: 1 },
+      { ref: "" },
+      { ref: 42 },
+      null,
+    ]) {
+      expect(messageContentRefSchema.safeParse(value).success).toBe(false);
+    }
   });
 });
 
@@ -176,6 +197,25 @@ describe("resolveMessageContentBlocks (expressive form)", () => {
     expect(
       resolveMessageContentBlocks(JSON.stringify([textBlock("hello")])),
     ).toEqual([textBlock("hello")]);
+  });
+
+  test("parses a nested tool_result with contentBlocks (recursive schema)", () => {
+    const blocks: ContentBlock[] = [
+      {
+        type: "tool_result",
+        tool_use_id: "tu-1",
+        content: "done",
+        contentBlocks: [textBlock("nested")],
+      },
+    ];
+    expect(resolveMessageContentBlocks(JSON.stringify(blocks))).toEqual(blocks);
+  });
+
+  test("passes historical arrays with unrecognized block shapes through", () => {
+    const historical = [{ type: "some_retired_block_kind", payload: 1 }];
+    expect(resolveMessageContentBlocks(JSON.stringify(historical))).toEqual(
+      historical as unknown as ContentBlock[],
+    );
   });
 
   test("folds a reserved-path ref to blocks", () => {

--- a/assistant/src/persistence/message-content-file.ts
+++ b/assistant/src/persistence/message-content-file.ts
@@ -3,8 +3,15 @@
  *
  * A `messages.content` value is a union of two shapes:
  *   - Inline: a JSON-serialized `ContentBlock[]` (or a legacy plain string).
- *   - Ref:    `{ "ref": "<workspace-relative path>" }` pointing at a JSONL
- *             delta file that folds to a `ContentBlock[]`.
+ *   - Ref:    `{ "ref": "conversations/<dir>/…/<messageId>.jsonl" }` pointing
+ *             at a JSONL delta file that folds to a `ContentBlock[]`.
+ *
+ * The ref path is workspace-relative and MUST live under the reserved
+ * `conversations/` prefix with a `.jsonl` extension — the schema rejects
+ * anything else. This is the migration-safe discriminator against legacy
+ * plain-string rows: a legacy message whose entire text happens to parse as
+ * `{ "ref": … }` is only misread if it also names a reserved content path,
+ * which no organic legacy text does.
  *
  * The delta file is append-only. Each line is `{ i, seq, block }` where `i`
  * is the block index in the final array and `seq` is a monotonically
@@ -13,13 +20,16 @@
  * crash-truncated file still folds to the newest complete snapshot of each
  * block.
  *
- * All content reads must go through {@link resolveStoredMessageContent}
- * (wired into the message row mapper) — downstream consumers never see a
- * raw `{ ref }` value.
+ * All content reads must go through {@link resolveMessageContentBlocks}
+ * (expressive form) or {@link resolveStoredMessageContent} (the string shim
+ * wired into the message row mapper) — downstream consumers never see a raw
+ * `{ ref }` value.
  */
 
 import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname, resolve, sep } from "node:path";
+
+import { z } from "zod";
 
 import type { ContentBlock } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
@@ -27,42 +37,73 @@ import { getWorkspaceDir } from "../util/platform.js";
 
 const log = getLogger("message-content-file");
 
-/** Ref-shaped `messages.content` value pointing at a delta file. */
-export interface MessageContentRef {
-  /** Path of the JSONL delta file, relative to the workspace directory. */
-  ref: string;
-}
+/**
+ * Ref-shaped `messages.content` value. Strict (no extra keys) and
+ * reserved-path constrained so legacy plain-string rows that parse as
+ * arbitrary JSON objects can never be mistaken for a ref.
+ */
+const messageContentRefSchema = z
+  .object({
+    ref: z
+      .string()
+      .regex(
+        /^conversations\/.+\.jsonl$/,
+        "content refs must be workspace-relative paths under conversations/ ending in .jsonl",
+      ),
+  })
+  .strict();
+
+export type MessageContentRef = z.infer<typeof messageContentRefSchema>;
 
 /** One line of the append-only content delta file. */
+const contentDeltaLineSchema = z
+  .object({
+    /** Index of `block` in the folded `ContentBlock[]`. */
+    i: z.number(),
+    /** Monotonic write sequence; the highest `seq` per `i` wins the fold. */
+    seq: z.number(),
+    /** Minimal ContentBlock shape — every block variant has a string type. */
+    block: z.object({ type: z.string() }).passthrough(),
+  })
+  .strict();
+
 export interface ContentDeltaLine {
-  /** Index of `block` in the folded `ContentBlock[]`. */
   i: number;
-  /** Monotonic write sequence; the highest `seq` per `i` wins the fold. */
   seq: number;
   block: ContentBlock;
 }
 
-/**
- * Narrow a parsed `messages.content` value to the ref shape. Strict on
- * purpose (exactly one key) so a legacy plain-string message that happens
- * to parse as an object can never be mistaken for a ref.
- */
+/** Narrow a parsed `messages.content` value to the ref shape. */
 export function isMessageContentRef(
   value: unknown,
 ): value is MessageContentRef {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    !Array.isArray(value) &&
-    Object.keys(value).length === 1 &&
-    typeof (value as { ref?: unknown }).ref === "string" &&
-    (value as { ref: string }).ref.length > 0
-  );
+  return messageContentRefSchema.safeParse(value).success;
+}
+
+/**
+ * Parse a raw `messages.content` string to a ref, or null when the value is
+ * inline content. The charCode fast path keeps the overwhelmingly common
+ * inline-array case to a single character check.
+ */
+function parseContentRef(raw: string): MessageContentRef | null {
+  if (typeof raw !== "string" || raw.charCodeAt(0) !== 0x7b /* '{' */) {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  const result = messageContentRefSchema.safeParse(parsed);
+  return result.success ? result.data : null;
 }
 
 /**
  * Resolve a workspace-relative content ref to an absolute path, rejecting
- * anything that escapes the workspace directory. Returns null on escape.
+ * anything that escapes the workspace directory (e.g. a ref containing
+ * `..` segments that still matched the reserved-prefix schema). Returns
+ * null on escape.
  */
 export function resolveContentRefPath(ref: string): string | null {
   const workspaceDir = resolve(getWorkspaceDir());
@@ -106,21 +147,14 @@ export function foldContentDeltas(text: string): ContentBlock[] {
     } catch {
       continue;
     }
-    if (typeof parsed !== "object" || parsed === null) {
+    const result = contentDeltaLineSchema.safeParse(parsed);
+    if (!result.success) {
       continue;
     }
-    const { i, seq, block } = parsed as Partial<ContentDeltaLine>;
-    if (
-      typeof i !== "number" ||
-      typeof seq !== "number" ||
-      typeof block !== "object" ||
-      block === null
-    ) {
-      continue;
-    }
+    const { i, seq, block } = result.data;
     const existing = byIndex.get(i);
     if (!existing || seq > existing.seq) {
-      byIndex.set(i, { seq, block });
+      byIndex.set(i, { seq, block: block as unknown as ContentBlock });
     }
   }
   return [...byIndex.entries()]
@@ -142,49 +176,68 @@ export function foldContentFile(absPath: string): ContentBlock[] | null {
   return foldContentDeltas(text);
 }
 
-/**
- * Resolve a stored `messages.content` value to its inline JSON form.
- *
- * Inline values (JSON `ContentBlock[]` or legacy plain strings) pass
- * through untouched — the common case costs one character check. Ref
- * values are resolved by folding the delta file and returning the folded
- * blocks as a JSON string, so every consumer downstream of the row mapper
- * sees the same shape it always has.
- *
- * Never throws. A missing/unreadable file or an escaping ref resolves to
- * `"[]"` (empty content) with a warning — content reads must not take
- * down read paths.
- */
-export function resolveStoredMessageContent(raw: string): string {
-  // Inline arrays start with '[', legacy plain strings rarely start with
-  // '{' — and when one does, the parse/shape checks below reject it.
-  if (typeof raw !== "string" || raw.charCodeAt(0) !== 0x7b /* '{' */) {
-    return raw;
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return raw;
-  }
-  if (!isMessageContentRef(parsed)) {
-    return raw;
-  }
-  const absPath = resolveContentRefPath(parsed.ref);
+/** Fold a validated ref to blocks; empty content on missing/escaping refs. */
+function resolveRefToBlocks(ref: MessageContentRef): ContentBlock[] {
+  const absPath = resolveContentRefPath(ref.ref);
   if (!absPath) {
     log.warn(
-      { ref: parsed.ref },
+      { ref: ref.ref },
       "Content ref escapes the workspace directory; resolving as empty",
     );
-    return "[]";
+    return [];
   }
   const blocks = foldContentFile(absPath);
   if (blocks === null) {
     log.warn(
-      { ref: parsed.ref },
+      { ref: ref.ref },
       "Content ref file missing or unreadable; resolving as empty",
     );
-    return "[]";
+    return [];
   }
-  return JSON.stringify(blocks);
+  return blocks;
+}
+
+/**
+ * Resolve a stored `messages.content` value to a `ContentBlock[]`.
+ *
+ * This is the expressive form of the resolver:
+ *   - Inline `ContentBlock[]` JSON parses to its blocks.
+ *   - A `{ ref }` folds its delta file (empty on missing/escaping refs).
+ *   - A legacy plain string (or any non-array, non-ref JSON) becomes a
+ *     single text block carrying the raw value.
+ *
+ * Never throws — content reads must not take down read paths.
+ */
+export function resolveMessageContentBlocks(raw: string): ContentBlock[] {
+  const ref = parseContentRef(raw);
+  if (ref) {
+    return resolveRefToBlocks(ref);
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed as ContentBlock[];
+    }
+  } catch {
+    // legacy plain string — fall through
+  }
+  return [{ type: "text", text: raw } as ContentBlock];
+}
+
+/**
+ * Resolve a stored `messages.content` value to its inline JSON string form.
+ *
+ * String shim over the resolver for call sites whose contract is the raw
+ * stored string — today that is `MessageRow.content` via the row mapper.
+ * Inline values (JSON `ContentBlock[]` or legacy plain strings) pass
+ * through by identity — the common case costs one character check — so
+ * legacy-string handling stays byte-identical for existing consumers.
+ * Prefer {@link resolveMessageContentBlocks} in new code.
+ */
+export function resolveStoredMessageContent(raw: string): string {
+  const ref = parseContentRef(raw);
+  if (!ref) {
+    return raw;
+  }
+  return JSON.stringify(resolveRefToBlocks(ref));
 }

--- a/assistant/src/persistence/message-content-file.ts
+++ b/assistant/src/persistence/message-content-file.ts
@@ -31,6 +31,7 @@ import { dirname, resolve, sep } from "node:path";
 
 import { z } from "zod";
 
+import { contentBlockSchema } from "../providers/content-block-schema.js";
 import type { ContentBlock } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir } from "../util/platform.js";
@@ -42,7 +43,7 @@ const log = getLogger("message-content-file");
  * reserved-path constrained so legacy plain-string rows that parse as
  * arbitrary JSON objects can never be mistaken for a ref.
  */
-const messageContentRefSchema = z
+export const messageContentRefSchema = z
   .object({
     ref: z
       .string()
@@ -62,23 +63,11 @@ const contentDeltaLineSchema = z
     i: z.number(),
     /** Monotonic write sequence; the highest `seq` per `i` wins the fold. */
     seq: z.number(),
-    /** Minimal ContentBlock shape — every block variant has a string type. */
-    block: z.object({ type: z.string() }).passthrough(),
+    block: contentBlockSchema,
   })
   .strict();
 
-export interface ContentDeltaLine {
-  i: number;
-  seq: number;
-  block: ContentBlock;
-}
-
-/** Narrow a parsed `messages.content` value to the ref shape. */
-export function isMessageContentRef(
-  value: unknown,
-): value is MessageContentRef {
-  return messageContentRefSchema.safeParse(value).success;
-}
+export type ContentDeltaLine = z.infer<typeof contentDeltaLineSchema>;
 
 /**
  * Parse a raw `messages.content` string to a ref, or null when the value is
@@ -154,7 +143,7 @@ export function foldContentDeltas(text: string): ContentBlock[] {
     const { i, seq, block } = result.data;
     const existing = byIndex.get(i);
     if (!existing || seq > existing.seq) {
-      byIndex.set(i, { seq, block: block as unknown as ContentBlock });
+      byIndex.set(i, { seq, block });
     }
   }
   return [...byIndex.entries()]
@@ -213,15 +202,29 @@ export function resolveMessageContentBlocks(raw: string): ContentBlock[] {
   if (ref) {
     return resolveRefToBlocks(ref);
   }
+  let parsed: unknown;
   try {
-    const parsed: unknown = JSON.parse(raw);
-    if (Array.isArray(parsed)) {
-      return parsed as ContentBlock[];
-    }
+    parsed = JSON.parse(raw);
   } catch {
-    // legacy plain string — fall through
+    // legacy plain string
+    return [{ type: "text", text: raw }];
   }
-  return [{ type: "text", text: raw } as ContentBlock];
+  if (Array.isArray(parsed)) {
+    const result = z.array(contentBlockSchema).safeParse(parsed);
+    if (result.success) {
+      return result.data;
+    }
+    // Historical rows may carry block variants that predate the current
+    // union (the renderer tolerates unknown types in its default case).
+    // Pass them through rather than mangling stored content into a text
+    // wrap; this is the one legacy boundary the schema cannot close.
+    log.warn(
+      { issueCount: result.error.issues.length },
+      "Inline content array has unrecognized block shapes; passing through unvalidated",
+    );
+    return parsed as ContentBlock[];
+  }
+  return [{ type: "text", text: raw }];
 }
 
 /**

--- a/assistant/src/providers/content-block-schema.ts
+++ b/assistant/src/providers/content-block-schema.ts
@@ -1,0 +1,149 @@
+/**
+ * Canonical zod schema for the raw model-loop {@link ContentBlock} union in
+ * `providers/types.ts` — the shape PERSISTED into `messages.content` and
+ * consumed by plugins/hooks.
+ *
+ * This is deliberately distinct from `ConversationContentBlockSchema`
+ * (`api/responses/conversation-message.ts`), which is the cleaned wire/display
+ * projection: that form merges tool results into their calls and drops
+ * internal fields, so it cannot validate raw persisted content.
+ *
+ * Every variant uses `.passthrough()` rather than zod's default key-stripping:
+ * persisted blocks carry internal riders (e.g. `_startedAt` /
+ * `_previewStartedAt` timing stamps on thinking and tool_use blocks) that
+ * must survive a parse→serialize round trip byte-for-byte.
+ *
+ * The export is typed `z.ZodType<ContentBlock>`, so the compiler enforces
+ * that the schema's output stays assignable to the hand-written union —
+ * drifting the schema away from `providers/types.ts` is a type error here.
+ */
+
+import { z } from "zod";
+
+import type { ContentBlock } from "./types.js";
+
+const base64MediaSourceSchema = z
+  .object({
+    type: z.literal("base64"),
+    media_type: z.string(),
+    data: z.string(),
+    filename: z.string().optional(),
+  })
+  .passthrough();
+
+const workspaceRefMediaSourceSchema = z
+  .object({
+    type: z.literal("workspace_ref"),
+    media_type: z.string(),
+    attachmentId: z.string(),
+    sizeBytes: z.number(),
+    filename: z.string().optional(),
+    width: z.number().optional(),
+    height: z.number().optional(),
+  })
+  .passthrough();
+
+export const mediaSourceSchema = z.discriminatedUnion("type", [
+  base64MediaSourceSchema,
+  workspaceRefMediaSourceSchema,
+]);
+
+const textContentSchema = z
+  .object({
+    type: z.literal("text"),
+    text: z.string(),
+  })
+  .passthrough();
+
+const thinkingContentSchema = z
+  .object({
+    type: z.literal("thinking"),
+    thinking: z.string(),
+    signature: z.string(),
+  })
+  .passthrough();
+
+const redactedThinkingContentSchema = z
+  .object({
+    type: z.literal("redacted_thinking"),
+    data: z.string(),
+  })
+  .passthrough();
+
+const imageContentSchema = z
+  .object({
+    type: z.literal("image"),
+    source: mediaSourceSchema,
+  })
+  .passthrough();
+
+const fileContentSchema = z
+  .object({
+    type: z.literal("file"),
+    source: mediaSourceSchema,
+    extracted_text: z.string().optional(),
+    _attachmentId: z.string().optional(),
+  })
+  .passthrough();
+
+const toolUseContentSchema = z
+  .object({
+    type: z.literal("tool_use"),
+    id: z.string(),
+    name: z.string(),
+    input: z.record(z.string(), z.unknown()),
+    providerMetadata: z
+      .object({
+        gemini: z
+          .object({ thoughtSignature: z.string().optional() })
+          .passthrough()
+          .optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+const toolResultContentSchema = z
+  .object({
+    type: z.literal("tool_result"),
+    tool_use_id: z.string(),
+    content: z.string(),
+    is_error: z.boolean().optional(),
+    contentBlocks: z.lazy(() => z.array(contentBlockSchema)).optional(),
+  })
+  .passthrough();
+
+const serverToolUseContentSchema = z
+  .object({
+    type: z.literal("server_tool_use"),
+    id: z.string(),
+    name: z.string(),
+    input: z.record(z.string(), z.unknown()),
+  })
+  .passthrough();
+
+const webSearchToolResultContentSchema = z
+  .object({
+    type: z.literal("web_search_tool_result"),
+    tool_use_id: z.string(),
+    content: z.unknown(),
+  })
+  .passthrough();
+
+export const contentBlockSchema: z.ZodType<ContentBlock> = z.discriminatedUnion(
+  "type",
+  [
+    textContentSchema,
+    thinkingContentSchema,
+    redactedThinkingContentSchema,
+    imageContentSchema,
+    fileContentSchema,
+    toolUseContentSchema,
+    toolResultContentSchema,
+    serverToolUseContentSchema,
+    webSearchToolResultContentSchema,
+  ],
+);
+
+export const contentBlockArraySchema = z.array(contentBlockSchema);


### PR DESCRIPTION
## Prompt / plan

Follow-up addressing the review feedback on #37739 (Message Content Scalability, PR 1), before starting PR 2 (streaming write-path cutover):

- **Zod validation** ([comment](https://github.com/vellum-ai/vellum-assistant/pull/37739#discussion_r3557807817), [comment](https://github.com/vellum-ai/vellum-assistant/pull/37739#discussion_r3557809967)): the `{ ref }` shape and delta-file lines are now validated by `zod` schemas (`messageContentRefSchema`, `contentDeltaLineSchema`) instead of hand-rolled type checks. Delta lines additionally require `block.type: string` — every `ContentBlock` variant carries one — so a malformed block is skipped at the line level.
- **Expressive resolver** ([comment](https://github.com/vellum-ai/vellum-assistant/pull/37739#discussion_r3557819809)): new `resolveMessageContentBlocks(raw): ContentBlock[]` is the primary resolver — inline arrays parse, refs fold, legacy plain strings wrap into a single text block. `resolveStoredMessageContent` remains as a thin string shim for the row mapper, whose `MessageRow.content` contract is the raw stored string today (changing that type ripples across every `MessageRow` consumer — out of scope here); new code should prefer the blocks form.
- **Legacy-text discriminator** (Codex P2, [comment](https://github.com/vellum-ai/vellum-assistant/pull/37739#discussion_r3555336498)): refs are now constrained to reserved workspace-relative paths (`conversations/**.jsonl`) in the schema. A legacy plain-string row whose entire text parses as `{ "ref": … }` with a non-reserved path now passes through as inline content instead of resolving to empty. The workspace-escape path guard stays as the second layer for reserved-prefix refs containing `..` segments.

## Test plan

- `message-content-file.test.ts` extended to 18 tests: reserved-path acceptance/rejection (the discriminator cases, including the exact legacy `{"ref":"missing.jsonl"}` scenario from the P2), delta-line rejection of blocks missing `type`, and coverage of both resolver forms (inline, ref fold, legacy wrap, missing file, escape).
- Regression: `db-init-migrations-ok.test.ts` and `conversation-runtime-assembly.test.ts` (196 tests) pass; `tsc --noEmit`, eslint, prettier clean via pre-commit hook.

## CLI verb checklist

No new routes — persistence-layer only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMnmq1rr4uffg1MgFdgb9h

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMnmq1rr4uffg1MgFdgb9h)_