### PR TITLE
cli: adopt static-help split for audit and auth

### DIFF
--- a/assistant/src/cli/commands/audit.help.ts
+++ b/assistant/src/cli/commands/audit.help.ts
@@ -1,0 +1,40 @@
+/**
+ * Declarative help for the `assistant audit` command.
+ *
+ * Plain data (no action handlers, imports only the help contract type) so the
+ * memory capability indexer can read it without pulling in the daemon/IPC action
+ * graph. The handler lives in `audit.ts`, which applies this via
+ * `applyCommandHelp` and attaches it.
+ */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const auditHelp: CliCommandHelp = {
+  name: "audit",
+  description: "Show recent tool invocations",
+  options: [
+    {
+      flags: "-l, --limit <n>",
+      description: "Number of entries to show",
+      defaultValue: "20",
+    },
+    { flags: "--json", description: "Output raw JSON" },
+  ],
+  helpText: `
+Reads from the tool invocation audit log via the daemon. Each row
+represents one tool call the assistant made, including what was invoked,
+how the approval system classified it, and how long it took.
+
+Table columns:
+  Timestamp   When the tool was invoked (UTC, YYYY-MM-DD HH:MM:SS)
+  Tool        Tool name (e.g. bash, read_file, write_file, browser)
+  Input       Truncated summary of the tool input (command, path, etc.)
+  Decision    Approval decision: allow, deny, or ask
+  Risk        Risk classification: none, low, medium, high
+  Duration    Wall-clock execution time (e.g. 120ms, 1.3s)
+
+Examples:
+  $ assistant audit
+  $ assistant audit --limit 50
+  $ assistant audit --json`,
+};

--- a/assistant/src/cli/commands/audit.ts
+++ b/assistant/src/cli/commands/audit.ts
@@ -1,8 +1,10 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import { applyCommandHelp } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
+import { auditHelp } from "./audit.help.js";
 
 interface ToolInvocationRow {
   toolName: string;
@@ -15,100 +17,78 @@ interface ToolInvocationRow {
 
 export function registerAuditCommand(program: Command): void {
   registerCommand(program, {
-    name: "audit",
+    name: auditHelp.name,
     transport: "ipc",
-    description: "Show recent tool invocations",
+    description: auditHelp.description,
     build: (audit) => {
-      audit
-        .option("-l, --limit <n>", "Number of entries to show", "20")
-        .option("--json", "Output raw JSON")
-        .addHelpText(
-          "after",
-          `
-Reads from the tool invocation audit log via the daemon. Each row
-represents one tool call the assistant made, including what was invoked,
-how the approval system classified it, and how long it took.
-
-Table columns:
-  Timestamp   When the tool was invoked (UTC, YYYY-MM-DD HH:MM:SS)
-  Tool        Tool name (e.g. bash, read_file, write_file, browser)
-  Input       Truncated summary of the tool input (command, path, etc.)
-  Decision    Approval decision: allow, deny, or ask
-  Risk        Risk classification: none, low, medium, high
-  Duration    Wall-clock execution time (e.g. 120ms, 1.3s)
-
-Examples:
-  $ assistant audit
-  $ assistant audit --limit 50
-  $ assistant audit --json`,
-        )
-        .action(async (opts: { limit: string; json?: boolean }) => {
-          const limit = parseInt(opts.limit, 10) || 20;
-          const response = await cliIpcCall<{
-            invocations: ToolInvocationRow[];
-          }>("audit_list", {
-            queryParams: { limit: String(limit) },
-          });
-          if (!response.ok) {
-            return exitFromIpcResult(response);
-          }
-          const rows = response.result!.invocations;
-
-          if (opts.json) {
-            console.log(JSON.stringify(rows, null, 2));
-            return;
-          }
-
-          if (rows.length === 0) {
-            log.info("No tool invocations recorded");
-            return;
-          }
-          const tsW = 20;
-          const toolW = 14;
-          const inputW = 30;
-          const decW = 8;
-          const riskW = 8;
-          const durW = 8;
-          log.info(
-            "Timestamp".padEnd(tsW) +
-              "Tool".padEnd(toolW) +
-              "Input".padEnd(inputW) +
-              "Decision".padEnd(decW) +
-              "Risk".padEnd(riskW) +
-              "Duration",
-          );
-          log.info("-".repeat(tsW + toolW + inputW + decW + riskW + durW));
-          for (const r of rows) {
-            const ts = new Date(r.createdAt)
-              .toISOString()
-              .slice(0, 19)
-              .replace("T", " ");
-            let inputSummary = "";
-            try {
-              const parsed = JSON.parse(r.input);
-              if (parsed.command) inputSummary = parsed.command;
-              else if (parsed.path) inputSummary = parsed.path;
-              else inputSummary = r.input;
-            } catch {
-              inputSummary = r.input;
-            }
-            if (inputSummary.length > inputW - 2) {
-              inputSummary = inputSummary.slice(0, inputW - 4) + "..";
-            }
-            const dur =
-              r.durationMs < 1000
-                ? `${r.durationMs}ms`
-                : `${(r.durationMs / 1000).toFixed(1)}s`;
-            log.info(
-              ts.padEnd(tsW) +
-                r.toolName.padEnd(toolW) +
-                inputSummary.padEnd(inputW) +
-                r.decision.padEnd(decW) +
-                r.riskLevel.padEnd(riskW) +
-                dur,
-            );
-          }
+      applyCommandHelp(audit, auditHelp);
+      audit.action(async (opts: { limit: string; json?: boolean }) => {
+        const limit = parseInt(opts.limit, 10) || 20;
+        const response = await cliIpcCall<{
+          invocations: ToolInvocationRow[];
+        }>("audit_list", {
+          queryParams: { limit: String(limit) },
         });
+        if (!response.ok) {
+          return exitFromIpcResult(response);
+        }
+        const rows = response.result!.invocations;
+
+        if (opts.json) {
+          console.log(JSON.stringify(rows, null, 2));
+          return;
+        }
+
+        if (rows.length === 0) {
+          log.info("No tool invocations recorded");
+          return;
+        }
+        const tsW = 20;
+        const toolW = 14;
+        const inputW = 30;
+        const decW = 8;
+        const riskW = 8;
+        const durW = 8;
+        log.info(
+          "Timestamp".padEnd(tsW) +
+            "Tool".padEnd(toolW) +
+            "Input".padEnd(inputW) +
+            "Decision".padEnd(decW) +
+            "Risk".padEnd(riskW) +
+            "Duration",
+        );
+        log.info("-".repeat(tsW + toolW + inputW + decW + riskW + durW));
+        for (const r of rows) {
+          const ts = new Date(r.createdAt)
+            .toISOString()
+            .slice(0, 19)
+            .replace("T", " ");
+          let inputSummary = "";
+          try {
+            const parsed = JSON.parse(r.input);
+            if (parsed.command) inputSummary = parsed.command;
+            else if (parsed.path) inputSummary = parsed.path;
+            else inputSummary = r.input;
+          } catch {
+            inputSummary = r.input;
+          }
+          if (inputSummary.length > inputW - 2) {
+            inputSummary = inputSummary.slice(0, inputW - 4) + "..";
+          }
+          const dur =
+            r.durationMs < 1000
+              ? `${r.durationMs}ms`
+              : `${(r.durationMs / 1000).toFixed(1)}s`;
+          log.info(
+            ts.padEnd(tsW) +
+              r.toolName.padEnd(toolW) +
+              inputSummary.padEnd(inputW) +
+              r.decision.padEnd(decW) +
+              r.riskLevel.padEnd(riskW) +
+              dur,
+          );
+        }
+      });
     },
   });
 }

--- a/assistant/src/cli/commands/auth.help.ts
+++ b/assistant/src/cli/commands/auth.help.ts
@@ -1,0 +1,46 @@
+/**
+ * Declarative help for the `assistant auth` command.
+ *
+ * Plain data (no action handlers, imports only the help contract type) so the
+ * memory capability indexer can read it without pulling in the daemon/IPC action
+ * graph. The handlers live in `auth.ts`, which applies this via `applyCommandHelp`
+ * and attaches them.
+ */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const authHelp: CliCommandHelp = {
+  name: "auth",
+  description: "Manage platform authentication and identity",
+  options: [
+    { flags: "--json", description: "Machine-readable compact JSON output" },
+  ],
+  helpText: `
+The auth namespace manages the assistant's authentication state with the
+Vellum platform. It provides commands to inspect identity and connection
+status, helping diagnose configuration issues.
+
+Examples:
+  $ assistant auth info
+  $ assistant auth info --json`,
+  subcommands: [
+    {
+      name: "info",
+      description: "Show platform identity and authentication status",
+      helpText: `
+Fields:
+  platformUrl         The Vellum platform base URL this assistant connects to
+  assistantId         This assistant's platform UUID
+  organizationId      The organization this assistant belongs to (from PLATFORM_ORGANIZATION_ID)
+  userId              The user who owns this assistant (from PLATFORM_USER_ID)
+  authenticated       Whether all prerequisites for platform authentication are met
+                      (platform URL and assistant API key both present)
+
+When not authenticated, a message field provides guidance on next steps.
+
+Examples:
+  $ assistant auth info
+  $ assistant auth info --json`,
+    },
+  ],
+};

--- a/assistant/src/cli/commands/auth.ts
+++ b/assistant/src/cli/commands/auth.ts
@@ -1,9 +1,11 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
 import { shouldOutputJson, writeOutput } from "../output.js";
+import { authHelp } from "./auth.help.js";
 
 interface AuthInfoResponse {
   platformUrl: string | null;
@@ -16,51 +18,15 @@ interface AuthInfoResponse {
 
 export function registerAuthCommand(program: Command): void {
   registerCommand(program, {
-    name: "auth",
+    name: authHelp.name,
     transport: "ipc",
-    description: "Manage platform authentication and identity",
+    description: authHelp.description,
     build: (auth) => {
-      auth.option("--json", "Machine-readable compact JSON output");
+      applyCommandHelp(auth, authHelp);
 
-      auth.addHelpText(
-        "after",
-        `
-The auth namespace manages the assistant's authentication state with the
-Vellum platform. It provides commands to inspect identity and connection
-status, helping diagnose configuration issues.
-
-Examples:
-  $ assistant auth info
-  $ assistant auth info --json`,
-      );
-
-      // -----------------------------------------------------------------------
-      // info
-      // -----------------------------------------------------------------------
-
-      auth
-        .command("info")
-        .description("Show platform identity and authentication status")
-        .addHelpText(
-          "after",
-          `
-Fields:
-  platformUrl         The Vellum platform base URL this assistant connects to
-  assistantId         This assistant's platform UUID
-  organizationId      The organization this assistant belongs to (from PLATFORM_ORGANIZATION_ID)
-  userId              The user who owns this assistant (from PLATFORM_USER_ID)
-  authenticated       Whether all prerequisites for platform authentication are met
-                      (platform URL and assistant API key both present)
-
-When not authenticated, a message field provides guidance on next steps.
-
-Examples:
-  $ assistant auth info
-  $ assistant auth info --json`,
-        )
-        .action(async (_opts: Record<string, unknown>, cmd: Command) => {
-          const response =
-            await cliIpcCall<AuthInfoResponse>("auth_info");
+      subcommand(auth, "info").action(
+        async (_opts: Record<string, unknown>, cmd: Command) => {
+          const response = await cliIpcCall<AuthInfoResponse>("auth_info");
 
           if (!response.ok) {
             return exitFromIpcResult(response);
@@ -89,7 +55,8 @@ Examples:
               log.info(result.message);
             }
           }
-        });
+        },
+      );
     },
   });
 }

--- a/assistant/src/cli/index.help.ts
+++ b/assistant/src/cli/index.help.ts
@@ -12,6 +12,12 @@
  */
 
 import { attachmentHelp } from "./commands/attachment.help.js";
+import { auditHelp } from "./commands/audit.help.js";
+import { authHelp } from "./commands/auth.help.js";
 import type { CliCommandHelp } from "./lib/cli-command-help.js";
 
-export const CLI_COMMAND_HELP: readonly CliCommandHelp[] = [attachmentHelp];
+export const CLI_COMMAND_HELP: readonly CliCommandHelp[] = [
+  attachmentHelp,
+  auditHelp,
+  authHelp,
+];

--- a/assistant/src/cli/lib/cli-command-help.ts
+++ b/assistant/src/cli/lib/cli-command-help.ts
@@ -10,6 +10,8 @@ import type { Command } from "commander";
 export interface CliCommandHelp {
   name: string;
   description: string;
+  /** Options declared directly on the top-level command. */
+  options?: CliOptionHelp[];
   /** Extra help appended after the option list (`addHelpText("after", …)`). */
   helpText?: string;
   subcommands?: CliSubcommandHelp[];
@@ -24,32 +26,42 @@ export interface CliSubcommandHelp {
 }
 
 export interface CliOptionHelp {
-  /** Commander flag spec, e.g. `"--path <file>"`. */
+  /** Commander flag spec, e.g. `"--path <file>"` or `"-l, --limit <n>"`. */
   flags: string;
   description: string;
   /** When true, applied via `requiredOption` (missing → error) rather than `option`. */
   required?: boolean;
+  /** Default value passed to `option(flags, description, defaultValue)`. */
+  defaultValue?: string;
+}
+
+function applyOptions(command: Command, options?: CliOptionHelp[]): void {
+  for (const option of options ?? []) {
+    if (option.required) {
+      command.requiredOption(option.flags, option.description);
+    } else if (option.defaultValue !== undefined) {
+      command.option(option.flags, option.description, option.defaultValue);
+    } else {
+      command.option(option.flags, option.description);
+    }
+  }
 }
 
 /**
  * Configure a Commander command from its declarative {@link CliCommandHelp}:
- * appended help text and subcommands (with options). Does not set the top-level
- * name/description — `registerCommand` owns those — and does not attach action
- * handlers; the command module attaches those to the created subcommands.
+ * top-level options, appended help text, and subcommands (with their options).
+ * Does not set the top-level name/description — `registerCommand` owns those —
+ * and does not attach action handlers; the command module attaches those to the
+ * command or its subcommands.
  */
 export function applyCommandHelp(command: Command, help: CliCommandHelp): void {
+  applyOptions(command, help.options);
   if (help.helpText) {
     command.addHelpText("after", help.helpText);
   }
   for (const sub of help.subcommands ?? []) {
     const child = command.command(sub.name).description(sub.description);
-    for (const option of sub.options ?? []) {
-      if (option.required) {
-        child.requiredOption(option.flags, option.description);
-      } else {
-        child.option(option.flags, option.description);
-      }
-    }
+    applyOptions(child, sub.options);
     if (sub.helpText) {
       child.addHelpText("after", sub.helpText);
     }

--- a/assistant/src/plugins/defaults/memory/v2/cli-command-content.ts
+++ b/assistant/src/plugins/defaults/memory/v2/cli-command-content.ts
@@ -33,15 +33,18 @@ export function buildCliCommandContent(
  */
 export function buildCliCommandHelpContent(help: CliCommandHelp): string {
   const sections: string[] = [];
+  const topOptions = renderOptionLines(help.options);
+  if (topOptions) {
+    sections.push(topOptions);
+  }
   if (help.helpText) {
     sections.push(help.helpText.trim());
   }
   for (const sub of help.subcommands ?? []) {
     const lines = [`${help.name} ${sub.name} — ${sub.description}`];
-    for (const option of sub.options ?? []) {
-      lines.push(
-        `  ${option.flags}${option.required ? " (required)" : ""}  ${option.description}`,
-      );
+    const options = renderOptionLines(sub.options);
+    if (options) {
+      lines.push(options);
     }
     if (sub.helpText) {
       lines.push(sub.helpText.trim());
@@ -53,4 +56,16 @@ export function buildCliCommandHelpContent(help: CliCommandHelp): string {
     help.description,
     sections.join("\n\n"),
   );
+}
+
+function renderOptionLines(options: CliCommandHelp["options"]): string | null {
+  if (!options?.length) {
+    return null;
+  }
+  return options
+    .map(
+      (option) =>
+        `  ${option.flags}${option.required ? " (required)" : ""}  ${option.description}`,
+    )
+    .join("\n");
 }


### PR DESCRIPTION
## Prompt / plan

Continuing the alphabetical rollout of the static-help split (established for `attachment` in #37732) — the pattern that lets the memory capability indexer read CLI command help from declarative data instead of building the whole Commander tree, so the final command can drop `buildCliProgramTree()` and break the daemon-core cycle.

This migrates the next two commands: **`audit`** and **`auth`**.

- `audit.help.ts` / `auth.help.ts` hold the declarative `CliCommandHelp` data; `audit.ts` / `auth.ts` apply it via `applyCommandHelp` and attach their handlers.
- Both registered in `cli/index.help.ts`, so the memory indexer reads them from the `@vellumai/plugin-api` aggregate (no `buildCliProgramTree` for these).

These two exercised parts of the shape `attachment` didn't, so the shared contract grew to match:

- **`CliCommandHelp` gains top-level `options`** — `audit` and `auth` declare options directly on the command (`--limit`, `--json`), not only on subcommands.
- **`CliOptionHelp` gains `defaultValue`** — `audit`'s `--limit` defaults to `"20"`.
- `applyCommandHelp` applies top-level + subcommand options via one shared helper; the memory content renderer includes top-level options too.
- `audit` has a top-level action (no subcommands); `auth` has a single `info` subcommand — both patterns handled.

Behavior is unchanged: verified the built program's `audit` / `auth` / `auth info` help is structurally identical (options, `--limit` default `"20"`, `info` subcommand) to the originals.

## Test plan

- `bunx tsc --noEmit` clean; prettier + eslint clean (incl. `cli/no-daemon-internals` — the new `../lib/cli-command-help.js` import is an allowed shared CLI helper); knip clean.
- `bun test`: `plugin-import-boundary-guard` (5), `cli-command-store` (13), `attachment` (14) — all pass. No pre-existing tests for `audit`/`auth`.
- Dumped the built program's help for `audit`, `auth`, and `auth info` and confirmed it matches the originals.

## CLI verb checklist

No new routes or verbs — refactor of existing `audit` / `auth` command registration into help modules + handlers. Section N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWL4FYZVRGkJkMwL46PY3m)_