### PR TITLE
refactor(daemon): replace renderHistoryContent's flat text with surfaceFallbackText

### DIFF
--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -35,7 +35,7 @@ const updateMessageMetadataCalls: UpdateMessageMetadataCall[] = [];
 let nextDeliveryTs: string | null = null;
 
 type RenderedHistoryStub = {
-  text: string;
+  surfaceFallbackText: string;
   textSegments: string[];
   toolCalls: unknown[];
   toolCallsBeforeText: boolean;
@@ -45,7 +45,7 @@ type RenderedHistoryStub = {
 };
 
 let renderedHistoryContent: RenderedHistoryStub = {
-  text: "",
+  surfaceFallbackText: "",
   textSegments: [],
   toolCalls: [],
   toolCallsBeforeText: false,
@@ -160,7 +160,7 @@ describe("channel-reply-delivery", () => {
     nextDeliveryTs = null;
     renderedHistoryContentQueue.length = 0;
     renderedHistoryContent = {
-      text: "",
+      surfaceFallbackText: "",
       textSegments: [],
       toolCalls: [],
       toolCallsBeforeText: false,
@@ -199,7 +199,7 @@ describe("channel-reply-delivery", () => {
       },
     );
     renderedHistoryContentQueue.push({
-      text: "Final reply.",
+      surfaceFallbackText: "Final reply.",
       textSegments: ["Final reply."],
       toolCalls: [],
       toolCallsBeforeText: false,
@@ -257,7 +257,7 @@ describe("channel-reply-delivery", () => {
     });
   });
 
-  it("falls back to rendered.text when no non-empty textSegments exist", async () => {
+  it("falls back to fallbackText when no non-empty textSegments exist", async () => {
     await deliverRenderedReplyViaCallback({
       callbackUrl: "http://gateway/deliver/telegram",
       chatId: "chat-2",
@@ -289,7 +289,7 @@ describe("channel-reply-delivery", () => {
       },
     ]);
     renderedHistoryContent = {
-      text: "Before tool.After tool.",
+      surfaceFallbackText: "Before tool.After tool.",
       textSegments: ["Before tool.", "After tool."],
       toolCalls: [],
       toolCallsBeforeText: false,
@@ -358,7 +358,7 @@ describe("channel-reply-delivery", () => {
     );
     renderedHistoryContentQueue.push(
       {
-        text: "",
+        surfaceFallbackText: "",
         textSegments: [],
         toolCalls: [{ name: "remember", input: {} }],
         toolCallsBeforeText: true,
@@ -367,7 +367,7 @@ describe("channel-reply-delivery", () => {
         thinkingSegments: [],
       },
       {
-        text: "Current answer.",
+        surfaceFallbackText: "Current answer.",
         textSegments: ["Current answer."],
         toolCalls: [],
         toolCallsBeforeText: false,
@@ -376,7 +376,7 @@ describe("channel-reply-delivery", () => {
         thinkingSegments: [],
       },
       {
-        text: "Current answer.",
+        surfaceFallbackText: "Current answer.",
         textSegments: ["Current answer."],
         toolCalls: [],
         toolCallsBeforeText: false,
@@ -415,7 +415,7 @@ describe("channel-reply-delivery", () => {
       },
     );
     renderedHistoryContentQueue.push({
-      text: "",
+      surfaceFallbackText: "",
       textSegments: [],
       toolCalls: [{ name: "remember", input: {} }],
       toolCallsBeforeText: true,
@@ -453,7 +453,7 @@ describe("channel-reply-delivery", () => {
       },
     );
     const silentStub = {
-      text: "<no_response/>",
+      surfaceFallbackText: "<no_response/>",
       textSegments: ["<no_response/>"],
       toolCalls: [],
       toolCallsBeforeText: false,
@@ -462,7 +462,7 @@ describe("channel-reply-delivery", () => {
       thinkingSegments: [],
     };
     const answerStub = {
-      text: "current answer",
+      surfaceFallbackText: "current answer",
       textSegments: ["current answer"],
       toolCalls: [],
       toolCallsBeforeText: false,
@@ -496,7 +496,7 @@ describe("channel-reply-delivery", () => {
       },
     );
     const silentStub = {
-      text: "<no_response/>",
+      surfaceFallbackText: "<no_response/>",
       textSegments: ["<no_response/>"],
       toolCalls: [],
       toolCallsBeforeText: false,
@@ -534,7 +534,7 @@ describe("channel-reply-delivery", () => {
       },
     );
     const silentStub = {
-      text: "<no_response/>",
+      surfaceFallbackText: "<no_response/>",
       textSegments: ["<no_response/>"],
       toolCalls: [],
       toolCallsBeforeText: false,
@@ -543,7 +543,7 @@ describe("channel-reply-delivery", () => {
       thinkingSegments: [],
     };
     const answerStub = {
-      text: "current answer",
+      surfaceFallbackText: "current answer",
       textSegments: ["current answer"],
       toolCalls: [],
       toolCallsBeforeText: false,
@@ -599,7 +599,7 @@ describe("channel-reply-delivery", () => {
       },
     ]);
     const silentStub = {
-      text: "<no_response/>",
+      surfaceFallbackText: "<no_response/>",
       textSegments: ["<no_response/>"],
       toolCalls: [],
       toolCallsBeforeText: false,
@@ -608,7 +608,7 @@ describe("channel-reply-delivery", () => {
       thinkingSegments: [],
     };
     const answerStub = {
-      text: "current answer",
+      surfaceFallbackText: "current answer",
       textSegments: ["current answer"],
       toolCalls: [],
       toolCallsBeforeText: false,
@@ -918,7 +918,7 @@ describe("channel-reply-delivery", () => {
       { id: "msg-a", role: "assistant", content: '"text"' },
     );
     renderedHistoryContent = {
-      text: "Alpha.Beta.Gamma.",
+      surfaceFallbackText: "Alpha.Beta.Gamma.",
       textSegments: ["Alpha.", "Beta.", "Gamma."],
       toolCalls: [],
       toolCallsBeforeText: false,
@@ -971,7 +971,7 @@ describe("channel-reply-delivery", () => {
       },
     ]);
     renderedHistoryContent = {
-      text: "Reply.",
+      surfaceFallbackText: "Reply.",
       textSegments: ["Reply."],
       toolCalls: [],
       toolCallsBeforeText: false,
@@ -1056,7 +1056,7 @@ describe("channel-reply-delivery", () => {
       });
       // Set up renderer to produce one segment so onMessageTs fires once.
       renderedHistoryContent = {
-        text: "hello",
+        surfaceFallbackText: "hello",
         textSegments: ["hello"],
         toolCalls: [],
         toolCallsBeforeText: false,
@@ -1126,7 +1126,7 @@ describe("channel-reply-delivery", () => {
         }),
       });
       renderedHistoryContent = {
-        text: "hi",
+        surfaceFallbackText: "hi",
         textSegments: ["hi"],
         toolCalls: [],
         toolCallsBeforeText: false,
@@ -1166,7 +1166,7 @@ describe("channel-reply-delivery", () => {
         }),
       });
       renderedHistoryContent = {
-        text: "hi",
+        surfaceFallbackText: "hi",
         textSegments: ["hi"],
         toolCalls: [],
         toolCallsBeforeText: false,
@@ -1192,7 +1192,7 @@ describe("channel-reply-delivery", () => {
       // channelTs for the persisted row. Subsequent segments correspond to
       // independent Slack messages.
       renderedHistoryContent = {
-        text: "AlphaBeta",
+        surfaceFallbackText: "AlphaBeta",
         textSegments: ["Alpha", "Beta"],
         toolCalls: [],
         toolCallsBeforeText: false,

--- a/assistant/src/__tests__/server-history-render.test.ts
+++ b/assistant/src/__tests__/server-history-render.test.ts
@@ -7,7 +7,10 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-import { renderHistoryContent } from "../daemon/handlers/shared.js";
+import {
+  renderedPlainText,
+  renderHistoryContent,
+} from "../daemon/handlers/shared.js";
 import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.js";
 import {
   getAttachmentsForMessage,
@@ -28,7 +31,7 @@ describe("renderHistoryContent", () => {
       { type: "text", text: "hello " },
       { type: "text", text: "world" },
     ]);
-    expect(output.text).toBe("hello world");
+    expect(renderedPlainText(output)).toBe("hello world");
     expect(output.toolCalls).toEqual([]);
   });
 
@@ -46,10 +49,10 @@ describe("renderHistoryContent", () => {
       },
     ]);
 
-    expect(output.text).toContain("[File attachment] spec.pdf");
-    expect(output.text).toContain("type=application/pdf");
-    expect(output.text).toContain("size=5 B");
-    expect(output.text).toContain(
+    expect(renderedPlainText(output)).toContain("[File attachment] spec.pdf");
+    expect(renderedPlainText(output)).toContain("type=application/pdf");
+    expect(renderedPlainText(output)).toContain("size=5 B");
+    expect(renderedPlainText(output)).toContain(
       "Attachment text: Important requirement from the attachment.",
     );
   });
@@ -66,7 +69,7 @@ describe("renderHistoryContent", () => {
       },
     ]);
 
-    expect(output.text).toBe("");
+    expect(renderedPlainText(output)).toBe("");
   });
 
   test("appends attachment lines after text content", () => {
@@ -83,7 +86,7 @@ describe("renderHistoryContent", () => {
       },
     ]);
 
-    expect(output.text).toContain(
+    expect(renderedPlainText(output)).toContain(
       "please review the file\n[File attachment] notes.txt",
     );
   });
@@ -165,10 +168,12 @@ describe("renderHistoryContent", () => {
   });
 
   test("falls back to string conversion for non-array content", () => {
-    expect(renderHistoryContent("raw string").text).toBe("raw string");
-    expect(renderHistoryContent(null).text).toBe("");
-    expect(renderHistoryContent(undefined).text).toBe("");
-    expect(renderHistoryContent(42).text).toBe("42");
+    expect(renderedPlainText(renderHistoryContent("raw string"))).toBe(
+      "raw string",
+    );
+    expect(renderedPlainText(renderHistoryContent(null))).toBe("");
+    expect(renderedPlainText(renderHistoryContent(undefined))).toBe("");
+    expect(renderedPlainText(renderHistoryContent(42))).toBe("42");
   });
 
   test("unwraps complete legacy external_content envelopes for plain string content", () => {
@@ -176,7 +181,7 @@ describe("renderHistoryContent", () => {
       '<external_content source="slack">\nVisible Slack text\n</external_content>',
     );
 
-    expect(output.text).toBe("Visible Slack text");
+    expect(renderedPlainText(output)).toBe("Visible Slack text");
     expect(output.textSegments).toEqual(["Visible Slack text"]);
     expect(output.contentOrder).toEqual(["text:0"]);
   });
@@ -190,7 +195,9 @@ describe("renderHistoryContent", () => {
       { type: "text", text: "Plain follow-up." },
     ]);
 
-    expect(output.text).toBe("Visible block text Plain follow-up.");
+    expect(renderedPlainText(output)).toBe(
+      "Visible block text Plain follow-up.",
+    );
     expect(output.textSegments).toEqual([
       "Visible block text Plain follow-up.",
     ]);
@@ -206,16 +213,18 @@ describe("renderHistoryContent", () => {
     const malformedOutput = renderHistoryContent([
       { type: "text", text: malformed },
     ]);
-    expect(malformedOutput.text).toBe(malformed);
+    expect(renderedPlainText(malformedOutput)).toBe(malformed);
     expect(malformedOutput.textSegments).toEqual([malformed]);
 
     const mixedOutput = renderHistoryContent(mixed);
-    expect(mixedOutput.text).toBe(mixed);
+    expect(renderedPlainText(mixedOutput)).toBe(mixed);
     expect(mixedOutput.textSegments).toEqual([mixed]);
   });
 
   test("preserves JSON object content as JSON string", () => {
-    expect(renderHistoryContent({ foo: "bar" }).text).toBe('{"foo":"bar"}');
+    expect(renderedPlainText(renderHistoryContent({ foo: "bar" }))).toBe(
+      '{"foo":"bar"}',
+    );
   });
 
   test("extracts tool_use blocks into toolCalls", () => {
@@ -228,7 +237,7 @@ describe("renderHistoryContent", () => {
       },
     ]);
 
-    expect(output.text).toBe("");
+    expect(renderedPlainText(output)).toBe("");
     expect(output.toolCalls).toEqual([
       { id: "tu_1", name: "web_fetch", input: { url: "https://example.com" } },
     ]);
@@ -618,7 +627,7 @@ describe("renderHistoryContent", () => {
       },
     ]);
 
-    expect(output.text).toBe("Let me look that up.");
+    expect(renderedPlainText(output)).toBe("Let me look that up.");
     expect(output.toolCalls).toHaveLength(1);
     expect(output.toolCalls[0].name).toBe("web_fetch");
     expect(output.toolCalls[0].result).toBe("page content here");
@@ -633,7 +642,7 @@ describe("renderHistoryContent", () => {
     ]);
 
     expect(output.toolCallsBeforeText).toBe(true);
-    expect(output.text).toBe("Here are the files.");
+    expect(renderedPlainText(output)).toBe("Here are the files.");
     expect(output.toolCalls).toHaveLength(1);
   });
 
@@ -651,7 +660,7 @@ describe("renderHistoryContent", () => {
     // Orphans are dropped — without the parent tool_use we can't tell the user
     // what tool ran, so the result is meaningless. See shared.ts comment.
     expect(output.toolCalls).toEqual([]);
-    expect(output.text).toBe("");
+    expect(renderedPlainText(output)).toBe("");
     expect(output.textSegments).toEqual([]);
     expect(output.contentOrder).toEqual([]);
   });
@@ -798,7 +807,9 @@ describe("renderHistoryContent", () => {
       { type: "text", text: "Real response after." },
     ]);
 
-    expect(output.text).toBe("Real response before. Real response after.");
+    expect(renderedPlainText(output)).toBe(
+      "Real response before. Real response after.",
+    );
     expect(output.textSegments).toEqual([
       "Real response before. Real response after.",
     ]);
@@ -810,16 +821,16 @@ describe("renderHistoryContent", () => {
       { type: "text", text: "\x00__PLACEHOLDER__[empty assistant turn]" },
     ]);
 
-    expect(output.text).toBe("");
+    expect(renderedPlainText(output)).toBe("");
     expect(output.textSegments).toEqual([]);
     expect(output.contentOrder).toEqual([]);
   });
 
-  test("keeps a flagged surface-fallback text block in .text but out of blocks/segments", () => {
+  test("routes a flagged surface-fallback text block to surfaceFallbackText, out of blocks/segments", () => {
     // The approval-card builder emits [ui_surface, text(_surfaceFallback)]. The
-    // surface renders the card for rich clients; the flagged fallback must stay
-    // in the flat `.text` body (CLI/search) but NOT appear as a text segment or
-    // content block, or the card would render twice.
+    // surface renders the card for rich clients; the flagged fallback must land
+    // on `surfaceFallbackText` (channel delivery) but NOT appear as a text
+    // segment or content block, or the card would render twice.
     const output = renderHistoryContent([
       {
         type: "ui_surface",
@@ -831,7 +842,7 @@ describe("renderHistoryContent", () => {
       { type: "text", text: "Bob wants to use bash", _surfaceFallback: true },
     ]);
 
-    expect(output.text).toBe("Bob wants to use bash");
+    expect(output.surfaceFallbackText).toBe("Bob wants to use bash");
     expect(output.textSegments).toEqual([]);
     expect(output.surfaces).toHaveLength(1);
     expect(output.contentOrder).toEqual(["surface:0"]);
@@ -851,7 +862,7 @@ describe("renderHistoryContent", () => {
       "surface",
       "text",
     ]);
-    expect(output.text).toBe("legacy fallback");
+    expect(renderedPlainText(output)).toBe("legacy fallback");
   });
 });
 

--- a/assistant/src/__tests__/suggestion-routes.test.ts
+++ b/assistant/src/__tests__/suggestion-routes.test.ts
@@ -79,25 +79,28 @@ mock.module("../daemon/handlers/shared.js", () => ({
         .filter((b: { type: string }) => b.type === "text" && "text" in b)
         .map((b: { text: string }) => b.text);
       return {
-        text: texts.join("\n"),
+        surfaceFallbackText: "",
         toolCalls: [],
         toolCallsBeforeText: false,
-        textSegments: [],
+        textSegments: texts.length > 0 ? [texts.join("\n")] : [],
         contentOrder: [],
         surfaces: [],
         thinkingSegments: [],
       };
     }
+    const text = typeof content === "string" ? content : "";
     return {
-      text: typeof content === "string" ? content : "",
+      surfaceFallbackText: "",
       toolCalls: [],
       toolCallsBeforeText: false,
-      textSegments: [],
+      textSegments: text ? [text] : [],
       contentOrder: [],
       surfaces: [],
       thinkingSegments: [],
     };
   },
+  renderedPlainText: (rendered: { textSegments: string[] }) =>
+    rendered.textSegments.join("\n"),
 }));
 
 // ---------------------------------------------------------------------------
@@ -112,9 +115,12 @@ import { handleGetSuggestion } from "../runtime/routes/conversation-routes.js";
 
 function makeArgs(params: { conversationKey?: string; messageId?: string }) {
   const queryParams: Record<string, string> = {};
-  if (params.conversationKey)
+  if (params.conversationKey) {
     queryParams.conversationKey = params.conversationKey;
-  if (params.messageId) queryParams.messageId = params.messageId;
+  }
+  if (params.messageId) {
+    queryParams.messageId = params.messageId;
+  }
   return { queryParams };
 }
 

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -17,7 +17,10 @@ import {
   updateDaemonText,
   updateStatusText,
 } from "./cli/main-screen.jsx";
-import { renderHistoryContent } from "./daemon/handlers/shared.js";
+import {
+  renderedPlainText,
+  renderHistoryContent,
+} from "./daemon/handlers/shared.js";
 import type { ServerMessage } from "./daemon/message-protocol.js";
 import {
   getConversation,
@@ -675,7 +678,9 @@ export async function startCli(): Promise<void> {
               } catch {
                 parsedContent = msg.content;
               }
-              const text = renderHistoryContent(parsedContent).text;
+              const text = renderedPlainText(
+                renderHistoryContent(parsedContent),
+              );
               const label = msg.role === "user" ? "you" : "assistant";
               const preview = truncate(text, 120);
               process.stdout.write(

--- a/assistant/src/daemon/handlers/conversation-history.ts
+++ b/assistant/src/daemon/handlers/conversation-history.ts
@@ -3,7 +3,7 @@ import {
   listConversations,
   searchConversations,
 } from "../../persistence/conversation-queries.js";
-import { renderHistoryContent } from "./shared.js";
+import { renderedPlainText, renderHistoryContent } from "./shared.js";
 
 // ---------------------------------------------------------------------------
 // Shared business logic (transport-agnostic)
@@ -65,7 +65,7 @@ export function getMessageContent(
   try {
     const content = JSON.parse(dbMessage.content);
     const rendered = renderHistoryContent(content);
-    text = rendered.text || undefined;
+    text = renderedPlainText(rendered) || undefined;
     const parsedToolCalls = rendered.toolCalls;
 
     if (parsedToolCalls.length > 0) {

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -63,7 +63,13 @@ export interface HistoryAttachmentRef {
 }
 
 export interface RenderedHistoryContent {
-  text: string;
+  /**
+   * Prose from `ui_surface` plain-text fallback blocks (`_surfaceFallback`).
+   * Deliberately kept out of `textSegments`/`contentBlocks` so surface-capable
+   * clients don't render the card AND its fallback; channel delivery uses it
+   * as the reply body when a surface-only message has no other text.
+   */
+  surfaceFallbackText: string;
   toolCalls: HistoryToolCall[];
   /** True when the first tool_use block appeared before any text block. */
   toolCallsBeforeText: boolean;
@@ -316,7 +322,7 @@ export function renderHistoryContent(
       text = unwrapExternalContentForDisplay(String(content));
     }
     return {
-      text,
+      surfaceFallbackText: "",
       toolCalls: [],
       toolCallsBeforeText: false,
       textSegments: text ? [text] : [],
@@ -328,7 +334,8 @@ export function renderHistoryContent(
     };
   }
 
-  const textParts: string[] = [];
+  const surfaceFallbackParts: string[] = [];
+  let sawTextPart = false;
   const attachmentParts: string[] = [];
   const attachments: HistoryAttachmentRef[] = [];
   const toolCalls: HistoryToolCall[] = [];
@@ -368,8 +375,8 @@ export function renderHistoryContent(
   // Flush the open text segment into its tracked block and stop tracking it,
   // without closing the segment. Used before folding the synthetic attachment
   // description into the trailing segment: it stays in the legacy
-  // `textSegments`/`text` body but must not pollute the clean contentBlocks,
-  // since `attachment` blocks already carry that metadata.
+  // `textSegments` body but must not pollute the clean contentBlocks, since
+  // `attachment` blocks already carry that metadata.
   function detachTextBlock(): void {
     if (currentTextBlock) {
       currentTextBlock.text = joinWithSpacing(currentSegmentParts);
@@ -378,9 +385,9 @@ export function renderHistoryContent(
   }
 
   // `trackBlock` mirrors the segment into `contentBlocks`. The trailing
-  // attachment-description segment (legacy `message.text` for clients without
-  // attachment UI) sets it false so it isn't duplicated as a text block —
-  // attachments surface as `attachment` blocks instead.
+  // attachment-description segment (shown by clients without attachment UI)
+  // sets it false so it isn't duplicated as a text block — attachments
+  // surface as `attachment` blocks instead.
   function ensureSegment(trackBlock = true): void {
     if (!hasOpenSegment) {
       textSegments.push("");
@@ -461,14 +468,15 @@ export function renderHistoryContent(
       if (isPlaceholderSentinelText(displayText)) {
         continue;
       }
-      textParts.push(displayText);
+      sawTextPart = true;
       // A ui_surface card's plain-text fallback (flagged `_surfaceFallback` by
       // the approval-card builder) is represented by the adjacent surface for
-      // surface-capable clients. Keep it in the flat `.text` body above (CLI,
-      // search, channel replies, non-surface clients) but don't emit it as a
-      // text segment or content block, or those clients would render the card
-      // AND its fallback text.
+      // surface-capable clients. Collect it into `surfaceFallbackText` (used
+      // by channel delivery when a surface-only reply has no other text) but
+      // don't emit it as a text segment or content block, or those clients
+      // would render the card AND its fallback text.
       if (block._surfaceFallback === true) {
+        surfaceFallbackParts.push(displayText);
         continue;
       }
       ensureSegment();
@@ -673,7 +681,9 @@ export function renderHistoryContent(
               continue;
             }
             const resolved = resolveMediaSourceData(source);
-            if (resolved) imageDataList.push(resolved.data);
+            if (resolved) {
+              imageDataList.push(resolved.data);
+            }
           }
         }
       }
@@ -701,13 +711,13 @@ export function renderHistoryContent(
   }
 
   // Include attachment descriptions in textSegments so that clients without
-  // separate attachment UI (e.g. iOS) can display them via `message.text`.
+  // separate attachment UI (e.g. iOS) can display them as message text.
   // The macOS client handles this by selecting the *first* non-empty text
   // segment in interleaved content, so trailing attachment segments are safe.
   if (attachmentParts.length > 0) {
     detachTextBlock();
     const attachmentText = attachmentParts.join("\n");
-    const prefix = textParts.length > 0 ? "\n" : "";
+    const prefix = sawTextPart ? "\n" : "";
     ensureSegment(false);
     currentSegmentParts.push(prefix + attachmentText);
   }
@@ -727,18 +737,8 @@ export function renderHistoryContent(
     });
   }
 
-  const text = joinWithSpacing(textParts);
-  let rendered: string;
-  if (attachmentParts.length === 0) {
-    rendered = text;
-  } else if (text.trim().length === 0) {
-    rendered = attachmentParts.join("\n");
-  } else {
-    rendered = `${text}\n${attachmentParts.join("\n")}`;
-  }
-
   return {
-    text: rendered,
+    surfaceFallbackText: joinWithSpacing(surfaceFallbackParts),
     toolCalls,
     toolCallsBeforeText,
     textSegments,
@@ -748,6 +748,16 @@ export function renderHistoryContent(
     attachments,
     contentBlocks,
   };
+}
+
+/**
+ * Flat plain-text body of a rendered message: its text segments joined (the
+ * trailing segment carries attachment descriptions when the message has file
+ * attachments). Excludes `surfaceFallbackText` — surface prose is a delivery
+ * fallback, not message body text.
+ */
+export function renderedPlainText(rendered: RenderedHistoryContent): string {
+  return joinWithSpacing(rendered.textSegments);
 }
 
 /** Parameters shared by the standalone secret prompt and its link fallback. */

--- a/assistant/src/notifications/approval-card-builder.ts
+++ b/assistant/src/notifications/approval-card-builder.ts
@@ -44,9 +44,9 @@ export const ApprovalCardSurfaceBlockSchema = z.object({
 
 /**
  * The plain-text fallback block, flagged so the display projector
- * (`renderHistoryContent`) keeps it in flat `.text` but omits it from the
- * rendered `contentBlocks` — without it a surface-capable client would render
- * the card AND a duplicate text line.
+ * (`renderHistoryContent`) routes it to `surfaceFallbackText` and omits it
+ * from the rendered `contentBlocks` — without it a surface-capable client
+ * would render the card AND a duplicate text line.
  */
 export const ApprovalCardFallbackBlockSchema = z.object({
   type: z.literal("text"),

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-skill-card.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-skill-card.ts
@@ -398,8 +398,8 @@ async function insertOrDeferSkillCard(
       })),
     },
   };
-  // Plain-text fallback (approval-card pattern): feeds the model, search,
-  // CLI display, and channel replies. Surface-capable clients skip it —
+  // Plain-text fallback (approval-card pattern): feeds the model and channel
+  // replies (via `surfaceFallbackText`). Surface-capable clients skip it —
   // `renderHistoryContent` keeps `_surfaceFallback` text out of the
   // rendered content blocks so the card is never double-rendered.
   const fallbackBlock = {

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -98,7 +98,10 @@ function hasRealDeliverableReply(
   attachments: RuntimeAttachmentMetadata[],
 ): boolean {
   if (
-    toDeliverableTextSegments(rendered.textSegments, rendered.text).length > 0
+    toDeliverableTextSegments(
+      rendered.textSegments,
+      rendered.surfaceFallbackText,
+    ).length > 0
   ) {
     return true;
   }
@@ -374,7 +377,7 @@ async function deliverPersistedAssistantMessageViaCallback(
     callbackUrl,
     chatId: externalChatId,
     textSegments: rendered.textSegments,
-    fallbackText: rendered.text,
+    fallbackText: rendered.surfaceFallbackText,
     attachments: replyAttachments,
     assistantId,
     startFromSegment: options?.startFromSegment,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -70,6 +70,7 @@ import { supersedePendingInteractionsOnEnqueue } from "../../daemon/handlers/con
 import {
   collectAttachmentRefs,
   type HistoryAttachmentRef,
+  renderedPlainText,
   renderHistoryContent,
 } from "../../daemon/handlers/shared.js";
 import { HostAppControlProxy } from "../../daemon/host-app-control-proxy.js";
@@ -2662,7 +2663,7 @@ export async function handleGetSuggestion(
       content = msg.content;
     }
     const rendered = renderHistoryContent(content);
-    const text = rendered.text.trim();
+    const text = renderedPlainText(rendered).trim();
     if (!text) continue;
 
     // If a messageId was requested and the first text-bearing assistant
@@ -2689,7 +2690,9 @@ export async function handleGetSuggestion(
       } catch {
         userContent = rawMessages[j].content;
       }
-      const userText = renderHistoryContent(userContent).text.trim();
+      const userText = renderedPlainText(
+        renderHistoryContent(userContent),
+      ).trim();
       if (userText) {
         priorUserText = userText;
         break;


### PR DESCRIPTION
## Prompt / plan

Follow-up to #37781, from the review comment there: delete `rendered.text` now that the wire no longer carries the flat content string.

Exploration found the flat `text` on `RenderedHistoryContent` couldn't be deleted outright — it had four internal consumers, and one of them depends on content that exists nowhere else: `ui_surface` plain-text fallback prose (`_surfaceFallback` blocks) is deliberately kept out of `textSegments`/`contentBlocks` so surface-capable clients don't render a card twice, and channel delivery (`channel-reply-delivery.ts`) uses the flat text as `fallbackText` so a surface-only reply still delivers something on Slack/Telegram.

So instead of a pure deletion, the field is narrowed to that one remaining role:

- `RenderedHistoryContent.text` → `surfaceFallbackText`, carrying only the `_surfaceFallback` block prose. Channel delivery behavior is preserved: the fallback only ever fired when every text segment was empty, and (attachment descriptions living in a trailing segment) surface-fallback prose was the only content that could make it non-empty in that case.
- The renderer drops the full flat-text assembly (`textParts` + the final join) — the dead weight the review comment pointed at.
- Consumers that wanted the plain-text body derive it from the segments via a new `renderedPlainText()` helper (single definition next to the renderer): reply-suggestion prompts (`conversation-routes.ts`), the `messages/:id/content` route (`conversation-history.ts`), and the dev REPL `/history` preview (`cli.ts`).

Deliberate behavior deltas (both arguably fixes):
- Surface-fallback prose no longer leaks into suggestion prompts or `messages/:id/content` responses.
- A reply consisting solely of stripped vellum links no longer falls back to delivering the unstripped flat text on channels — previously the fallback bypassed `stripVellumLinks`; now such a reply delivers nothing.

Not touched: the `messages_content_get` route itself. It has no in-repo caller (web SDK defines it but nothing invokes it; CLI/tools don't use it) — possible dead API surface, but deleting a published endpoint is a separate decision.

## Test plan

- `bun run typecheck:fast` clean; all changed files prettier-clean and ESLint 0 errors.
- `server-history-render.test.ts` updated: flat-text assertions now go through `renderedPlainText()` (verified equivalent — `joinWithSpacing` joins segments verbatim across existing whitespace boundaries), and the surface-fallback test asserts `surfaceFallbackText`.
- `channel-reply-delivery.test.ts` stubs renamed to the new field; `suggestion-routes.test.ts` module mock updated to provide `renderedPlainText`.
- Full battery green when run per-file: the 3 directly-updated suites (110 tests) plus all 13 suites that mock `daemon/handlers/shared.js`, all 7 `list-messages-*` suites, `annotate-*`, `conversation-attention-telegram`, and `text-spacing`. (The 9-file co-run batch shows 41 failures both with and without this change — pre-existing cross-file DB interference; CI runs isolated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KnwfSEWYCZ8bfjvFD9FwKJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KnwfSEWYCZ8bfjvFD9FwKJ)_