### PR TITLE
feat(assistant): write LLM request logs to ClickHouse when it's the configured source

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -208,6 +208,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "media/image-credentials.ts", // shared image-gen credential resolver (provider API key lookup)
       "persistence/embeddings/embedding-backend.ts", // embedding backend API key lookup
       "persistence/llm-request-log-source-clickhouse.ts", // ClickHouse read source — lazy lookup of clickhouse:url + clickhouse:password + vellum:platform_assistant_id for self-scoped mirror reads
+      "persistence/llm-request-log-sink-clickhouse.ts", // ClickHouse write sink — lazy lookup of clickhouse:url + clickhouse:password + vellum:platform_assistant_id for self-scoped log writes
       "persistence/compaction-log-store-clickhouse.ts", // ClickHouse compaction log writer — lazy lookup of clickhouse:url + clickhouse:password + vellum:platform_assistant_id for self-scoped event writes
       "daemon/providers-setup.ts", // provider initialization API key lookup
       "workspace/migrations/006-services-config.ts", // services config migration reads provider API keys

--- a/assistant/src/__tests__/llm-request-log-clickhouse-routing.test.ts
+++ b/assistant/src/__tests__/llm-request-log-clickhouse-routing.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests that the store's write path routes to ClickHouse instead of local
+ * SQLite when a ClickHouse sink is configured — and stays on SQLite
+ * otherwise. The sink module is mocked so the routing decision is observable
+ * without a live ClickHouse.
+ */
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+// Logging stays enabled; `getConfigReadOnly` is only consulted by the store.s
+// disabled gate here (the sink factory itself is mocked below).
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({ llmRequestLogs: { readSource: "local" } }),
+  getConfigReadOnly: () => ({ llmRequestLogs: { readSource: "local" } }),
+}));
+
+// Mutable fake sink: when non-null, the store must route to it.
+interface CapturedRow {
+  id: string;
+  conversationId: string;
+  callSite: string | null;
+}
+let capturedRows: CapturedRow[] = [];
+let sinkActive = false;
+mock.module("../persistence/llm-request-log-sink-clickhouse.js", () => ({
+  getClickHouseLlmRequestLogSink: () =>
+    sinkActive
+      ? {
+          recordBestEffort: (row: CapturedRow) => {
+            capturedRows.push(row);
+          },
+        }
+      : null,
+}));
+
+afterAll(() => {
+  sinkActive = false;
+});
+
+import { getLogsDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import {
+  getRequestLogsByConversationId,
+  recordRequestLog,
+  recordSyntheticAgentErrorMessageLog,
+} from "../persistence/llm-request-log-store.js";
+import { llmRequestLogs } from "../persistence/schema/index.js";
+
+await initializeDb();
+
+function resetLogs(): void {
+  getLogsDb()!.delete(llmRequestLogs).run();
+}
+
+describe("write routing between SQLite and ClickHouse", () => {
+  beforeEach(() => {
+    resetLogs();
+    capturedRows = [];
+    sinkActive = false;
+  });
+
+  test("writes to local SQLite when no ClickHouse sink is configured", () => {
+    const id = recordRequestLog(
+      "conv-local",
+      '{"req":1}',
+      '{"res":1}',
+      undefined,
+      "anthropic",
+      "mainAgent",
+    );
+    expect(id).not.toBeNull();
+    expect(capturedRows).toHaveLength(0);
+    const rows = getRequestLogsByConversationId("conv-local");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.provider).toBe("anthropic");
+  });
+
+  test("routes to ClickHouse and skips SQLite when a sink is configured", () => {
+    sinkActive = true;
+    const id = recordRequestLog(
+      "conv-ch",
+      '{"req":1}',
+      '{"res":1}',
+      "msg-ch",
+      "openai",
+      "mainAgent",
+    );
+    expect(id).not.toBeNull();
+    // Nothing landed in the local table.
+    expect(getRequestLogsByConversationId("conv-ch")).toEqual([]);
+    // The row went to the sink, carrying the same id and call site.
+    expect(capturedRows).toHaveLength(1);
+    expect(capturedRows[0]!.id).toBe(id!);
+    expect(capturedRows[0]!.conversationId).toBe("conv-ch");
+    expect(capturedRows[0]!.callSite).toBe("mainAgent");
+  });
+
+  test("routes synthetic error rows to ClickHouse too", () => {
+    sinkActive = true;
+    const id = recordSyntheticAgentErrorMessageLog({
+      conversationId: "conv-ch-2",
+      messageId: "msg-ch-2",
+      exitReason: "budget_yield_unrecovered",
+      noticeText: "Out of budget.",
+      preparedRequest: null,
+      createdAt: 1_700_000_000_000,
+    });
+    expect(id).not.toBeNull();
+    expect(getRequestLogsByConversationId("conv-ch-2")).toEqual([]);
+    expect(capturedRows).toHaveLength(1);
+    expect(capturedRows[0]!.callSite).toBe("syntheticAgentErrorMessage");
+  });
+});

--- a/assistant/src/__tests__/llm-request-log-sink-clickhouse.test.ts
+++ b/assistant/src/__tests__/llm-request-log-sink-clickhouse.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests the ClickHouse WRITE sink for LLM request logs: the wire shape it
+ * POSTs (lazy CREATE TABLE + JSONEachRow INSERT, null → '' sentinels,
+ * assistant_id injected from credentials) and the config-gated factory.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of [
+    "info",
+    "warn",
+    "error",
+    "debug",
+    "trace",
+    "fatal",
+    "silent",
+    "child",
+  ]) {
+    stub[m] = m === "child" ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeLoggerStub(),
+}));
+
+// Mutable config the factory reads via `getConfigReadOnly`.
+let currentConfig: unknown = { llmRequestLogs: { readSource: "local" } };
+mock.module("../config/loader.js", () => ({
+  getConfigReadOnly: () => currentConfig,
+}));
+
+afterEach(() => {
+  currentConfig = { llmRequestLogs: { readSource: "local" } };
+  resetClickHouseLlmRequestLogSinkForTests();
+});
+
+import {
+  ClickHouseLlmRequestLogSink,
+  getClickHouseLlmRequestLogSink,
+  resetClickHouseLlmRequestLogSinkForTests,
+} from "../persistence/llm-request-log-sink-clickhouse.js";
+
+const DEFAULT_CONFIG = {
+  database: "default",
+  table: "llm_request_logs",
+  user: "default",
+};
+
+interface FakeFetchCall {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+function fakeFetch(recorder: FakeFetchCall[], status = 200): typeof fetch {
+  return ((url: string | URL | Request, init?: RequestInit) => {
+    recorder.push({
+      url: typeof url === "string" ? url : url.toString(),
+      init,
+    });
+    return Promise.resolve(new Response("", { status }));
+  }) as typeof fetch;
+}
+
+function makeSink(recorder: FakeFetchCall[], status = 200) {
+  return new ClickHouseLlmRequestLogSink(DEFAULT_CONFIG, {
+    resolveUrl: async () => "https://ch.example.test:8443",
+    resolvePassword: async () => "hunter2",
+    resolveAssistantId: async () => "asst-fixture-001",
+    fetchImpl: fakeFetch(recorder, status),
+  });
+}
+
+describe("ClickHouseLlmRequestLogSink.insert", () => {
+  test("creates the table then inserts the JSONEachRow wire shape", async () => {
+    const calls: FakeFetchCall[] = [];
+    const sink = makeSink(calls);
+
+    await sink.insert({
+      id: "log-1",
+      conversationId: "conv-1",
+      messageId: "msg-1",
+      provider: "anthropic",
+      requestPayload: '{"req":1}',
+      responsePayload: '{"res":1}',
+      createdAt: 1_700_000_000_123,
+      agentLoopExitReason: "no_tool_calls",
+      callSite: "mainAgent",
+    });
+
+    expect(calls).toHaveLength(2);
+    // 1) DDL as the request body, no `query` param.
+    expect(String(calls[0]!.init?.body)).toContain(
+      "CREATE TABLE IF NOT EXISTS",
+    );
+    expect(new URL(calls[0]!.url).searchParams.get("query")).toBeNull();
+
+    // 2) INSERT statement in the `query` param, row JSON in the body.
+    const insertUrl = new URL(calls[1]!.url);
+    expect(insertUrl.searchParams.get("query")).toContain(
+      "INSERT INTO `llm_request_logs` FORMAT JSONEachRow",
+    );
+    expect(insertUrl.searchParams.get("database")).toBe("default");
+    const row = JSON.parse(String(calls[1]!.init?.body));
+    expect(row).toEqual({
+      assistant_id: "asst-fixture-001",
+      id: "log-1",
+      conversation_id: "conv-1",
+      message_id: "msg-1",
+      provider: "anthropic",
+      request_payload: '{"req":1}',
+      response_payload: '{"res":1}',
+      created_at: 1_700_000_000_123,
+      agent_loop_exit_reason: "no_tool_calls",
+      call_site: "mainAgent",
+    });
+    // Basic auth is sent.
+    expect(
+      (calls[1]!.init?.headers as Record<string, string>).Authorization,
+    ).toStartWith("Basic ");
+  });
+
+  test("maps null string fields to the '' sentinel", async () => {
+    const calls: FakeFetchCall[] = [];
+    const sink = makeSink(calls);
+
+    await sink.insert({
+      id: "log-2",
+      conversationId: "conv-2",
+      messageId: null,
+      provider: null,
+      requestPayload: "{}",
+      responsePayload: "{}",
+      createdAt: 1,
+      agentLoopExitReason: null,
+      callSite: null,
+    });
+
+    const row = JSON.parse(String(calls[1]!.init?.body));
+    expect(row.message_id).toBe("");
+    expect(row.provider).toBe("");
+    expect(row.agent_loop_exit_reason).toBe("");
+    expect(row.call_site).toBe("");
+  });
+
+  test("insert rejects on a ClickHouse error status", async () => {
+    const calls: FakeFetchCall[] = [];
+    const sink = makeSink(calls, 500);
+    await expect(
+      sink.insert({
+        id: "log-3",
+        conversationId: "conv-3",
+        messageId: null,
+        provider: null,
+        requestPayload: "{}",
+        responsePayload: "{}",
+        createdAt: 1,
+        agentLoopExitReason: null,
+        callSite: null,
+      }),
+    ).rejects.toThrow(/ClickHouse llm-request-log write failed/);
+  });
+
+  test("recordBestEffort never throws synchronously on a failing backend", () => {
+    const calls: FakeFetchCall[] = [];
+    const sink = makeSink(calls, 500);
+    expect(() =>
+      sink.recordBestEffort({
+        id: "log-4",
+        conversationId: "conv-4",
+        messageId: null,
+        provider: null,
+        requestPayload: "{}",
+        responsePayload: "{}",
+        createdAt: 1,
+        agentLoopExitReason: null,
+        callSite: null,
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("getClickHouseLlmRequestLogSink factory", () => {
+  test("returns null when readSource is 'local'", () => {
+    currentConfig = { llmRequestLogs: { readSource: "local" } };
+    expect(getClickHouseLlmRequestLogSink()).toBeNull();
+  });
+
+  test("returns null when llmRequestLogs is absent", () => {
+    currentConfig = {};
+    expect(getClickHouseLlmRequestLogSink()).toBeNull();
+  });
+
+  test("returns a sink when readSource is 'clickhouse'", () => {
+    currentConfig = {
+      llmRequestLogs: { readSource: "clickhouse", clickhouse: DEFAULT_CONFIG },
+    };
+    expect(getClickHouseLlmRequestLogSink()).toBeInstanceOf(
+      ClickHouseLlmRequestLogSink,
+    );
+  });
+
+  test("re-instantiates when the clickhouse config changes", () => {
+    currentConfig = {
+      llmRequestLogs: { readSource: "clickhouse", clickhouse: DEFAULT_CONFIG },
+    };
+    const first = getClickHouseLlmRequestLogSink();
+    currentConfig = {
+      llmRequestLogs: {
+        readSource: "clickhouse",
+        clickhouse: { ...DEFAULT_CONFIG, table: "other_logs" },
+      },
+    };
+    const second = getClickHouseLlmRequestLogSink();
+    expect(second).not.toBe(first);
+  });
+});

--- a/assistant/src/persistence/llm-request-log-sink-clickhouse.ts
+++ b/assistant/src/persistence/llm-request-log-sink-clickhouse.ts
@@ -1,0 +1,312 @@
+/**
+ * ClickHouse-backed LLM request log WRITE sink.
+ *
+ * The counterpart to `llm-request-log-source-clickhouse.ts` (reads). When
+ * `llmRequestLogs.readSource === "clickhouse"`, `recordRequestLog` writes
+ * request/response rows directly here instead of the local SQLite
+ * `llm_request_logs` table — so ClickHouse is the source of truth for the
+ * write, not a downstream mirror.
+ *
+ * Wire shape matches what the read source expects (see
+ * `llm-request-log-source-clickhouse.ts`): the same columns, scoped to the
+ * running assistant's own `assistant_id`, with `''` string sentinels for
+ * unset `message_id` / `provider` / `agent_loop_exit_reason` / `call_site`
+ * (the read source maps `''` back to `null`). URL and password resolve from
+ * the credential store (`clickhouse:url`, `clickhouse:password`);
+ * database/table/user come from config. The table is created lazily with
+ * `CREATE TABLE IF NOT EXISTS` on first write so opting in needs no
+ * out-of-band DDL, and is a no-op against a table the mirror cron already
+ * created.
+ *
+ * Known limitation, inherited from the ClickHouse mirror design: the sink is
+ * INSERT-only. Post-write stamps that the local store applies to existing
+ * rows — `setAgentLoopExitReasonOnLatestLog`, `backfillMessageIdOnLogs`,
+ * `relinkLlmRequestLogs` — have no ClickHouse equivalent, so a row's
+ * `agent_loop_exit_reason` / `message_id` reflect only what was known at
+ * insert time. `latency_breakdown` is likewise not carried (the read source
+ * already treats ClickHouse-sourced rows as having no latency waterfall).
+ *
+ * Writes are best-effort: a ClickHouse outage logs and is swallowed so it
+ * can never abort a turn.
+ */
+// Namespace import (not a named `getConfigReadOnly` import) on purpose: the
+// store imports this module, so it is reached transitively by the large set of
+// tests that stub `config/loader` with a partial mock exposing only
+// `getConfig`. A named import would fail to link against those mocks; a
+// namespace access degrades to `undefined` at call time instead, which the
+// factory's try/catch treats as "no sink" (→ local SQLite). Matches the store.
+import * as configLoader from "../config/loader.js";
+import type { LlmRequestLogsClickHouseConfig } from "../config/schemas/llm-request-logs.js";
+import { credentialKey } from "../security/credential-key.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("clickhouse-llm-request-log-sink");
+
+/**
+ * A request-log row to insert, in the store's domain shape. `null` string
+ * fields are written as the `''` sentinel; `assistant_id` is resolved
+ * internally from the credential store, so callers never supply it.
+ */
+export interface LlmRequestLogSinkRow {
+  id: string;
+  conversationId: string;
+  messageId: string | null;
+  provider: string | null;
+  requestPayload: string;
+  responsePayload: string;
+  createdAt: number;
+  agentLoopExitReason: string | null;
+  callSite: string | null;
+}
+
+/** Wire row written as one JSONEachRow line. */
+interface ClickHouseInsertRow {
+  assistant_id: string;
+  id: string;
+  conversation_id: string;
+  message_id: string;
+  provider: string;
+  request_payload: string;
+  response_payload: string;
+  created_at: number;
+  agent_loop_exit_reason: string;
+  call_site: string;
+}
+
+async function readCredentialOrNull(
+  service: string,
+  field: string,
+): Promise<string | null> {
+  const value = await getSecureKeyAsync(credentialKey(service, field));
+  return value ?? null;
+}
+
+/** Injectable fetch override for tests. Defaults to globalThis.fetch. */
+export type ClickHouseSinkFetch = typeof fetch;
+
+export interface ClickHouseLlmRequestLogSinkDeps {
+  /** Override the credential read for `clickhouse:url`. */
+  resolveUrl?: () => Promise<string | null>;
+  /** Override the credential read for `clickhouse:password`. */
+  resolvePassword?: () => Promise<string | null>;
+  /** Override the credential read for `vellum:platform_assistant_id`. */
+  resolveAssistantId?: () => Promise<string | null>;
+  /** Override fetch for testing. */
+  fetchImpl?: ClickHouseSinkFetch;
+}
+
+export class ClickHouseLlmRequestLogSink {
+  private cachedUrl: string | null = null;
+  private cachedPassword: string | null = null;
+  private cachedAssistantId: string | null = null;
+  private ensureTablePromise: Promise<void> | null = null;
+
+  private readonly resolveUrl: () => Promise<string | null>;
+  private readonly resolvePassword: () => Promise<string | null>;
+  private readonly resolveAssistantId: () => Promise<string | null>;
+  private readonly fetchImpl: ClickHouseSinkFetch;
+
+  constructor(
+    private readonly config: LlmRequestLogsClickHouseConfig,
+    deps: ClickHouseLlmRequestLogSinkDeps = {},
+  ) {
+    this.resolveUrl =
+      deps.resolveUrl ?? (() => readCredentialOrNull("clickhouse", "url"));
+    this.resolvePassword =
+      deps.resolvePassword ??
+      (() => readCredentialOrNull("clickhouse", "password"));
+    this.resolveAssistantId =
+      deps.resolveAssistantId ??
+      (() => readCredentialOrNull("vellum", "platform_assistant_id"));
+    this.fetchImpl = deps.fetchImpl ?? globalThis.fetch.bind(globalThis);
+  }
+
+  /**
+   * Fire-and-forget insert. Returns immediately; the write runs on a detached
+   * promise whose rejection is logged and swallowed so a ClickHouse outage
+   * never propagates into the turn. Mirrors the compaction-log store's
+   * best-effort recording contract.
+   */
+  recordBestEffort(row: LlmRequestLogSinkRow): void {
+    this.insert(row).catch((err: unknown) => {
+      log.warn(
+        { err, conversationId: row.conversationId, callSite: row.callSite },
+        "Failed to write LLM request log to ClickHouse (non-fatal)",
+      );
+    });
+  }
+
+  async insert(row: LlmRequestLogSinkRow): Promise<void> {
+    const assistantId = await this.assistantId();
+    await this.ensureTable();
+    const wire: ClickHouseInsertRow = {
+      assistant_id: assistantId,
+      id: row.id,
+      conversation_id: row.conversationId,
+      // Non-Nullable columns use `''` for "unset"; the read source maps it back.
+      message_id: row.messageId ?? "",
+      provider: row.provider ?? "",
+      request_payload: row.requestPayload,
+      response_payload: row.responsePayload,
+      created_at: row.createdAt,
+      agent_loop_exit_reason: row.agentLoopExitReason ?? "",
+      call_site: row.callSite ?? "",
+    };
+    await this.exec(
+      `INSERT INTO ${this.tableRef()} FORMAT JSONEachRow`,
+      JSON.stringify(wire),
+    );
+  }
+
+  /**
+   * Create the table on first write so opting in is self-serve. Idempotent
+   * (`IF NOT EXISTS`, so a no-op against the mirror cron's existing table)
+   * and memoized per instance; a rejected attempt clears the memo so the
+   * next write retries.
+   */
+  private ensureTable(): Promise<void> {
+    if (!this.ensureTablePromise) {
+      this.ensureTablePromise = this.exec(
+        `CREATE TABLE IF NOT EXISTS ${this.tableRef()} (
+          assistant_id String,
+          id String,
+          conversation_id String,
+          message_id String,
+          provider String,
+          request_payload String,
+          response_payload String,
+          created_at DateTime64(3),
+          agent_loop_exit_reason String,
+          call_site String
+        ) ENGINE = MergeTree
+        ORDER BY (assistant_id, conversation_id, created_at, id)`,
+      ).then(
+        () => undefined,
+        (err: unknown) => {
+          this.ensureTablePromise = null;
+          throw err;
+        },
+      );
+    }
+    return this.ensureTablePromise;
+  }
+
+  private tableRef(): string {
+    // Database is set via the `database=` URL param in `exec`, so only the
+    // table identifier needs quoting. Backtick-quote to tolerate non-default
+    // names with special characters.
+    return `\`${this.config.table.replace(/`/g, "``")}\``;
+  }
+
+  private async exec(sql: string, body?: string): Promise<string> {
+    const baseUrl = await this.url();
+    const password = await this.password();
+
+    let target: URL;
+    try {
+      target = new URL(baseUrl);
+    } catch (err) {
+      throw new Error(
+        `clickhouse:url is not a valid URL: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    target.searchParams.set("database", this.config.database);
+    // For INSERTs the statement goes in the `query` param and the row data in
+    // the body; DDL ships as the body itself. ClickHouse treats integers
+    // inserted into DateTime64(3) as epoch millis, so `created_at` maps 1:1.
+    if (body !== undefined) {
+      target.searchParams.set("query", sql);
+    }
+
+    const auth =
+      "Basic " +
+      Buffer.from(`${this.config.user}:${password}`, "utf8").toString("base64");
+
+    const res = await this.fetchImpl(target.toString(), {
+      method: "POST",
+      headers: { Authorization: auth, "Content-Type": "text/plain" },
+      body: body ?? sql,
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(
+        `ClickHouse llm-request-log write failed (HTTP ${res.status}): ${text.slice(0, 500)}`,
+      );
+    }
+    return res.text();
+  }
+
+  private async assistantId(): Promise<string> {
+    if (this.cachedAssistantId) return this.cachedAssistantId;
+    const val = await this.resolveAssistantId();
+    if (!val) {
+      throw new Error(
+        "vellum:platform_assistant_id credential is required when readSource=clickhouse",
+      );
+    }
+    this.cachedAssistantId = val;
+    return val;
+  }
+
+  private async url(): Promise<string> {
+    if (this.cachedUrl) return this.cachedUrl;
+    const val = await this.resolveUrl();
+    if (!val) {
+      throw new Error(
+        "clickhouse:url credential is required when readSource=clickhouse",
+      );
+    }
+    this.cachedUrl = val;
+    return val;
+  }
+
+  private async password(): Promise<string> {
+    if (this.cachedPassword) return this.cachedPassword;
+    const val = await this.resolvePassword();
+    if (!val) {
+      throw new Error(
+        "clickhouse:password credential is required when readSource=clickhouse",
+      );
+    }
+    this.cachedPassword = val;
+    return val;
+  }
+}
+
+/**
+ * Sink cache keyed by the serialized connection config so config edits take
+ * effect on the next write without a restart, while steady-state writes reuse
+ * one instance (and its cached credentials / ensured table).
+ */
+let cachedSink: { key: string; sink: ClickHouseLlmRequestLogSink } | null =
+  null;
+
+/**
+ * Resolve the configured ClickHouse write sink, or `null` when
+ * `llmRequestLogs.readSource` is not `"clickhouse"` (i.e. writes stay on
+ * local SQLite). Read-only config access keeps this off the disk-write path,
+ * matching the write hot path's `getConfigReadOnly` usage. Returns `null` on
+ * any config resolution error so a config hiccup falls back to SQLite rather
+ * than dropping the write.
+ */
+export function getClickHouseLlmRequestLogSink(): ClickHouseLlmRequestLogSink | null {
+  let cfg;
+  try {
+    cfg = configLoader.getConfigReadOnly().llmRequestLogs;
+  } catch {
+    return null;
+  }
+  if (!cfg || cfg.readSource !== "clickhouse") return null;
+  const key = JSON.stringify(cfg.clickhouse);
+  if (!cachedSink || cachedSink.key !== key) {
+    cachedSink = { key, sink: new ClickHouseLlmRequestLogSink(cfg.clickhouse) };
+  }
+  return cachedSink.sink;
+}
+
+/** Test hook: drop the memoized sink so config/dep changes are picked up. */
+export function resetClickHouseLlmRequestLogSinkForTests(): void {
+  cachedSink = null;
+}

--- a/assistant/src/persistence/llm-request-log-store.ts
+++ b/assistant/src/persistence/llm-request-log-store.ts
@@ -32,6 +32,7 @@ import {
   messageMetadataSchema,
 } from "./conversation-crud.js";
 import { type DrizzleDb, getDb, getLogsDb } from "./db-connection.js";
+import { getClickHouseLlmRequestLogSink } from "./llm-request-log-sink-clickhouse.js";
 import { llmRequestLogs, messages } from "./schema/index.js";
 import { timeSyncSection } from "./slow-sync-log.js";
 
@@ -195,8 +196,27 @@ export function recordRequestLog(
   if (!llmRequestLoggingEnabled()) {
     return null;
   }
-  const db = logsDb();
   const id = uuid();
+  // When ClickHouse is the configured source, it is also the write target:
+  // send the row there instead of local SQLite (fire-and-forget). The id is
+  // still returned for signature parity, though no local row exists for the
+  // post-loop stamping helpers to update — an accepted ClickHouse limitation.
+  const clickHouseSink = getClickHouseLlmRequestLogSink();
+  if (clickHouseSink) {
+    clickHouseSink.recordBestEffort({
+      id,
+      conversationId,
+      messageId: messageId ?? null,
+      provider: provider ?? null,
+      requestPayload,
+      responsePayload,
+      createdAt: Date.now(),
+      agentLoopExitReason: null,
+      callSite: callSite ?? null,
+    });
+    return id;
+  }
+  const db = logsDb();
   // Synchronous insert of the full request/response payloads (an entire
   // context window for main-agent calls) into the append-only logs DB, on the
   // per-LLM-call critical path. Timed so an event-loop freeze the watchdog
@@ -285,7 +305,6 @@ export function recordSyntheticAgentErrorMessageLog(args: {
   if (!llmRequestLoggingEnabled()) {
     return null;
   }
-  const db = logsDb();
   const id = uuid();
   const requestPayload = JSON.stringify({
     syntheticAgentErrorMessage: {
@@ -299,6 +318,25 @@ export function recordSyntheticAgentErrorMessageLog(args: {
       noticeText: args.noticeText,
     },
   });
+  // Route to ClickHouse when it is the configured target. The exit reason is
+  // already known here, so it is carried on the row directly (unlike real
+  // calls, which stamp it post-loop against a local row that ClickHouse lacks).
+  const clickHouseSink = getClickHouseLlmRequestLogSink();
+  if (clickHouseSink) {
+    clickHouseSink.recordBestEffort({
+      id,
+      conversationId: args.conversationId,
+      messageId: args.messageId,
+      provider: null,
+      requestPayload,
+      responsePayload,
+      createdAt: args.createdAt,
+      agentLoopExitReason: args.exitReason,
+      callSite: CALL_SITE_SYNTHETIC_AGENT_ERROR_MESSAGE,
+    });
+    return id;
+  }
+  const db = logsDb();
   db.insert(llmRequestLogs)
     .values({
       id,


### PR DESCRIPTION
**PR 3 of 3** in the LLM request logging opt-out series (PR #37649 and #37650 are merged). Supersedes #37644, which GitHub auto-closed when the stacked base branch was merged and the branch was rebased onto `main`.

## Prompt / plan

> Update our writes so that if a user has ClickHouse defined it no longer writes to SQLite but writes to ClickHouse instead.

Previously every LLM request log was written to local SQLite, and ClickHouse (when `llmRequestLogs.readSource === "clickhouse"`) was only populated out-of-band by the mirror cron.

## What this does

- New `llm-request-log-sink-clickhouse.ts`: a best-effort write sink mirroring the compaction-log store — lazy `CREATE TABLE IF NOT EXISTS` (a no-op against the mirror's existing table), JSONEachRow INSERT with the same columns the read source expects, `null → ''` sentinels, and `assistant_id` scoping from the credential store. Fire-and-forget: a ClickHouse outage is logged and swallowed so it never aborts a turn. Gated on `readSource === "clickhouse"`, returning null (→ SQLite) otherwise.
- The store routes writes to the sink when configured, so reads and writes share one store.
- Added the sink to the `secure-keys` `ALLOWED_IMPORTERS` allowlist (flagged by the bot review on #37644) — it reads `clickhouse:url` / `clickhouse:password` / `vellum:platform_assistant_id`.
- The sink uses the same namespace `config/loader` import as the store (from #37649) so the partial-mock tests that reach it transitively keep linking. The PR4 follow-up reverts both namespace imports and cleans up those test mocks.

**Known limitation** (consistent with the existing ClickHouse read path): the sink is INSERT-only, so the post-loop stamps — `agent_loop_exit_reason` backfill, `message_id` backfill, relink — have no ClickHouse equivalent; a row reflects only what was known at insert time. Synthetic error rows carry their exit reason at insert.

## Test plan

- `bun test`: `llm-request-log-sink-clickhouse.test.ts` (wire shape — CREATE + JSONEachRow INSERT, `null → ''`, auth, error handling — and factory gating), `llm-request-log-clickhouse-routing.test.ts` (SQLite when no sink; ClickHouse + no SQLite row when a sink is configured; synthetic rows too), and `credential-security-invariants.test.ts` (allowlist). Also verified `tool-execution-abort-cleanup.test.ts` still links.
- `bunx tsgo --noEmit` clean; eslint clean (0 errors).

## CLI verb checklist

No new routes — internal persistence change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5EQ7hFW26ndg21csTCZJq

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5EQ7hFW26ndg21csTCZJq)_