### PR TITLE
refactor(plugins): registry pulls user-plugin tools; mtime-cache stops pushing

### DIFF
--- a/assistant/docs/workspace-tools.md
+++ b/assistant/docs/workspace-tools.md
@@ -130,14 +130,17 @@ on the incoming tool.
 initializeTools()             # core tools register
   → loadWorkspaceTools()      # initial workspace tool reconcile
     → MCP tool registration
-    → loadUserPlugins()
+    → loadUserPlugins()       # populates the plugin mtime-cache (no registry writes)
+    → loadPluginTools()       # registry pulls the active user-plugin tool set
     → bootstrapPlugins()
 
 # on every conversation turn (createResolveToolsCallback):
 resolveTools(history)
   → loadWorkspaceTools()                # reconcile registry against disk (fire-and-forget)
+  → loadPluginTools()                   # pull user-plugin tools from the mtime-cache (same pattern)
   → getWorkspaceToolDefinitions()       # re-read workspace tools from the registry
   → getMcpToolDefinitions()             # re-read MCP tools (same pattern)
+  → getPluginToolDefinitions()          # re-read plugin tools from the registry
 ```
 
 Workspace tools register _after_ core tools and _before_ every other

--- a/assistant/src/__tests__/mtime-cache.test.ts
+++ b/assistant/src/__tests__/mtime-cache.test.ts
@@ -43,9 +43,11 @@ import {
 } from "../plugins/mtime-cache.js";
 import { getSourceVersionsPath } from "../plugins/source-versions.js";
 import {
+  __resetRegistryForTesting,
   getAllToolDefinitions,
   getPluginToolDefinitions,
   getToolOwner,
+  loadPluginTools,
 } from "../tools/registry.js";
 
 // ─── Test fixtures ───────────────────────────────────────────────────────────
@@ -171,6 +173,9 @@ beforeEach(() => {
   watchState = null;
   sentinelTouchSeq = 0;
   resetPluginCacheForTests();
+  // The registry pulls plugin tools via loadPluginTools(); clear its side
+  // (tools + pulled fingerprints) so registrations never leak across tests.
+  __resetRegistryForTesting();
 });
 
 afterAll(() => {
@@ -357,9 +362,11 @@ describe("plugin mtime cache (per-surface)", () => {
     touchFile(toolFile);
     publishSourceChanges();
     await getUserHooksFor("user-prompt-submit");
+    await loadPluginTools();
 
     // Both the cache and the global registry serve the fresh definition —
-    // the redeploy unregistered the old tool and registered the new one.
+    // the moved source mtime changed the plugin's fingerprint, so the pull
+    // reconcile re-registered its tool set.
     expect(getCachedUserTools()[0]?.description).toBe("v2");
     expect(
       getAllToolDefinitions().find((t) => t.name === "edited-tool")
@@ -632,11 +639,13 @@ const TOOL_SRC = (name: string) =>
  * production sequence: the monitor's pass rewrites the sentinel, and the
  * next hook dispatch's one-stat gate applies the diff. The hook name is
  * irrelevant — the reconcile runs regardless of whether a plugin defines
- * that hook.
+ * that hook. Finish with the registry pull the per-turn tool resolver
+ * fires, so registry-facing assertions see the reconciled tool set.
  */
 async function publishAndDispatch(): Promise<void> {
   publishSourceChanges();
   await getUserHooksFor("user-prompt-submit");
+  await loadPluginTools();
 }
 
 describe("plugin runtime activation", () => {
@@ -701,6 +710,7 @@ describe("plugin runtime activation", () => {
     writeMarkerHook(dir, "shutdown", shutdownMarker, "bye");
 
     await populateCacheAtBoot();
+    await loadPluginTools(); // boot pull (initializePlugins does this)
     expect(getToolOwner("temp-tool")?.kind).toBe("plugin");
 
     rmSync(dir, { recursive: true, force: true });
@@ -740,6 +750,7 @@ describe("plugin runtime activation", () => {
     writeMarkerHook(dir, "shutdown", shutdownMarker, "disabled");
 
     await populateCacheAtBoot();
+    await loadPluginTools(); // boot pull (initializePlugins does this)
     expect(getToolOwner("disable-tool")?.kind).toBe("plugin");
 
     writeFileSync(join(dir, ".disabled"), "");

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -30,6 +30,7 @@ import {
   getToolOwner,
   getWorkspaceToolDefinitions,
   getWorkspaceToolNames,
+  loadPluginTools,
 } from "../tools/registry.js";
 import {
   ACTIVITY_SKIP_SET,
@@ -834,11 +835,15 @@ export function createResolveToolsCallback(
     // serialized, so the registry settles for a subsequent turn to read.
     void loadWorkspaceTools();
 
-    // Re-read plugin tool definitions from the registry each turn so a plugin
-    // installed/removed at runtime (activated by the per-turn scan in
-    // `plugins/mtime-cache.ts`) is picked up without recreating the
-    // conversation. Plugin tools share core's context filter + allowlist path,
-    // so combine them with the core snapshot before filtering.
+    // Same treatment for user-plugin tools: pull the plugin mtime-cache's
+    // active tool set into the registry (a no-op costs one sentinel stat +
+    // fingerprint compares), so a plugin installed/removed/edited at runtime
+    // is picked up without recreating the conversation.
+    void loadPluginTools();
+
+    // Re-read plugin tool definitions from the registry each turn. Plugin
+    // tools share core's context filter + allowlist path, so combine them
+    // with the core snapshot before filtering.
     const currentPluginDefs = getPluginToolDefinitions();
 
     // Scope plugin tools to the conversation's per-chat plugin set. `null`

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -73,6 +73,7 @@ import {
   unregisterSkillRoute,
 } from "../runtime/skill-route-registry.js";
 import {
+  loadPluginTools,
   registerPluginTools,
   unregisterPluginTools,
 } from "../tools/registry.js";
@@ -152,6 +153,12 @@ function ensurePluginStorageDir(pluginName: string): string {
 export async function initializePlugins(): Promise<void> {
   registerDefaultPlugins();
   await loadUserPlugins();
+  // Pull the user-plugin tool set the cache scan above discovered into the
+  // tool registry. Kept in the same slot registration used to occupy (after
+  // the user-plugin scan, before the default plugins' `init()` registers
+  // their Plugin-object tools) so name-conflict precedence is unchanged.
+  // `loadPluginTools` never rejects — a failed pull logs and boots degraded.
+  await loadPluginTools();
   try {
     await bootstrapPlugins();
   } catch (err) {

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -51,10 +51,6 @@ import {
   WORKSPACE_HOOKS_OWNER,
 } from "../hooks/hook-loader.js";
 import type { HookFunction, ShutdownReason } from "../plugin-api/types.js";
-import {
-  registerPluginTools,
-  unregisterPluginTools,
-} from "../tools/registry.js";
 import { finalizeTool } from "../tools/tool-defaults.js";
 import type { Tool, ToolDefinition } from "../tools/types.js";
 import { getLogger } from "../util/logger.js";
@@ -164,8 +160,9 @@ function getInstallDate(pluginDir: string): number {
 
 /**
  * A cached tool plus the mtime of its source file. When the on-disk mtime
- * changes, the tool is re-imported, the old tool is unregistered from the
- * global tool registry, and the new one is registered.
+ * changes, the tool is re-imported and the cache entry replaced; the tool
+ * registry picks the new version up on its next pull reconcile (the mtime is
+ * part of the {@link ActivePluginTools} fingerprint).
  */
 interface CachedTool {
   readonly tool: Tool;
@@ -561,10 +558,11 @@ function toolKey(pluginName: string, toolName: string): string {
 
 /**
  * Reconcile the tool cache for a single plugin directory. Re-imports
- * changed tool files, unregisters deleted tools, and registers new ones.
+ * changed tool files, evicts cache entries for deleted files, and caches
+ * newly appeared ones.
  *
- * Called during `scanPlugins()` so that by the time any consumer reads
- * the tool registry, the cache is fresh.
+ * Called during `scanPlugins()` so that by the time the tool registry pulls
+ * via {@link getActiveUserPluginTools}, the cache is fresh.
  */
 async function reconcilePluginTools(
   pluginDir: string,
@@ -632,11 +630,75 @@ async function reconcilePluginTools(
 }
 
 /**
- * Get all cached tools from user plugins. Called by the tool registry
- * to supplement the core + default plugin tools.
+ * Get all cached tools from user plugins, active or not. Test/diagnostic
+ * read; production consumers go through {@link getActiveUserPluginTools}.
  */
 export function getCachedUserTools(): Tool[] {
   return Array.from(toolCache.values()).map((c) => c.tool);
+}
+
+/**
+ * A single active plugin's tool contribution, as pulled by the tool
+ * registry's plugin reconcile (`loadPluginTools` in `tools/registry.ts`).
+ */
+export interface ActivePluginTools {
+  /**
+   * Change stamp for this plugin's tool set: tool names paired with their
+   * source-file mtimes. The registry reconcile re-registers a plugin's tools
+   * only when this moves, so an unchanged plugin costs a string compare.
+   */
+  fingerprint: string;
+  tools: Tool[];
+}
+
+/**
+ * Sync the plugin caches with the source-versions sentinel, then return the
+ * tool contributions of every *active* (discovered, enabled, activated)
+ * user plugin, keyed by plugin name in install-date order.
+ *
+ * This is the pull half of the tool-registry relationship: the registry's
+ * `loadPluginTools()` reconcile calls this and diffs the result into its own
+ * maps — this module never writes to the registry. Mirrors how hook reads
+ * pull through {@link getUserHookEntriesFor}.
+ */
+export async function getActiveUserPluginTools(): Promise<
+  Map<string, ActivePluginTools>
+> {
+  await maybeReconcileFromSentinel();
+
+  const byPlugin = new Map<string, CachedTool[]>();
+  for (const cached of toolCache.values()) {
+    if (!activatedNames.has(cached.pluginName)) {
+      continue;
+    }
+    const list = byPlugin.get(cached.pluginName);
+    if (list) {
+      list.push(cached);
+    } else {
+      byPlugin.set(cached.pluginName, [cached]);
+    }
+  }
+
+  // Emit in install-date order (discoveredPluginDirs is kept sorted), so the
+  // registry registers plugin tools in the same deterministic order the push
+  // model used. Plugins activated but no longer discovered (mid-teardown)
+  // simply don't appear.
+  const result = new Map<string, ActivePluginTools>();
+  for (const pluginName of discoveredPluginDirs.values()) {
+    const cachedTools = byPlugin.get(pluginName);
+    if (cachedTools === undefined || result.has(pluginName)) {
+      continue;
+    }
+    const fingerprint = cachedTools
+      .map((c) => `${c.tool.name}:${c.sourceMtime}`)
+      .sort()
+      .join("\n");
+    result.set(pluginName, {
+      fingerprint,
+      tools: cachedTools.map((c) => c.tool),
+    });
+  }
+  return result;
 }
 
 // ─── Plugin discovery ────────────────────────────────────────────────────────
@@ -739,8 +801,8 @@ async function scanPlugins(): Promise<void> {
   // Activate any plugin not yet brought up. Idempotent: already-active plugins
   // are skipped by the `activatedNames` guard, so steady-state scans (one per
   // hook dispatch) cost only a membership check per plugin. Tools were imported
-  // into `toolCache` by `reconcilePluginTools` above, so they are ready to
-  // register here.
+  // into `toolCache` by `reconcilePluginTools` above, so they are visible to
+  // the registry's pull reconcile as soon as activation flips.
   for (const [dir, name] of discoveredPluginDirs) {
     await activatePlugin(dir, name);
   }
@@ -834,8 +896,9 @@ const activatedPlugins: Array<{ kind: HookOwnerKind; name: string }> = [];
 const activatedNames = new Set<string>();
 
 /**
- * Activate a single discovered plugin: register its tools into the global tool
- * registry and run its `init` hook. Running `init` also resolves the owner's
+ * Activate a single discovered plugin: mark its cached tools live (the tool
+ * registry pulls them via {@link getActiveUserPluginTools} on its next
+ * reconcile) and run its `init` hook. Running `init` also resolves the owner's
  * `shutdown` (caching it for teardown), so no separate pre-import step is
  * needed; dispatch hooks resolve on their first read. Idempotent — a plugin
  * already activated (or mid-activation) is skipped. Never throws; per-surface
@@ -854,29 +917,9 @@ async function activatePlugin(
     return;
   }
   // Reserve synchronously, before any await, so a re-entrant or concurrent
-  // scan observes this plugin as already handled.
+  // scan observes this plugin as already handled. From this point the
+  // plugin's cached tools are visible to the registry's pull reconcile.
   activatedNames.add(pluginName);
-
-  // Register this plugin's tools into the global tool registry so
-  // `getAllTools()` and `getTool()` can find them. Tools were already imported
-  // and cached by `reconcilePluginTools` during the scan.
-  const pluginTools = Array.from(toolCache.values())
-    .filter((c) => c.pluginName === pluginName)
-    .map((c) => c.tool);
-  if (pluginTools.length > 0) {
-    try {
-      registerPluginTools(pluginName, pluginTools);
-      log.info(
-        { plugin: pluginName, count: pluginTools.length },
-        "user plugin tools registered",
-      );
-    } catch (err) {
-      log.error(
-        { err, plugin: pluginName },
-        `Failed to register tools for user plugin ${pluginName}`,
-      );
-    }
-  }
 
   // Run the `init` hook if present.
   await runInitHook(pluginName, pluginDir);
@@ -886,9 +929,11 @@ async function activatePlugin(
 
 /**
  * Deactivate a plugin that was disabled (`disable`), removed (`uninstall`), or
- * is being redeployed (`reload`) at runtime: unregister its tools and run its
- * `shutdown` hook. Must run *before* `evictPlugin` / `evictHooksForOwner` clear
- * the owner's cache. Idempotent — a plugin that was never activated is a no-op.
+ * is being redeployed (`reload`) at runtime: drop it from the active set (the
+ * tool registry's pull reconcile removes its tools on its next pass) and run
+ * its `shutdown` hook. Must run *before* `evictPlugin` / `evictHooksForOwner`
+ * clear the owner's cache. Idempotent — a plugin that was never activated is a
+ * no-op.
  *
  * `disable` and `reload` keep the directory present, so {@link runShutdownHook}
  * resolves and runs the on-disk `shutdown` (via the same resolution the dispatch
@@ -911,17 +956,6 @@ async function deactivatePlugin(
     activatedPlugins.splice(idx, 1);
   }
 
-  // Unregister tools before running shutdown so the model-visible surface is
-  // clean before teardown.
-  try {
-    unregisterPluginTools(pluginName);
-  } catch (err) {
-    log.warn(
-      { err, plugin: pluginName },
-      "user plugin tool unregister failed (continuing)",
-    );
-  }
-
   if (reason !== "uninstall") {
     await runShutdownHook("plugin", pluginName, reason);
   }
@@ -931,7 +965,7 @@ async function deactivatePlugin(
 
 /**
  * Populate the caches at boot by scanning the plugins directory once (which
- * imports surfaces, registers tools, and runs `init` hooks via `activatePlugin`
+ * imports surfaces into the caches and runs `init` hooks via `activatePlugin`
  * inside `scanPlugins`) and activating standalone workspace hooks. At daemon
  * shutdown these owners' `shutdown` hooks fire through the unified
  * `runHook(HOOKS.SHUTDOWN)` pipeline; a runtime uninstall/disable tears a single
@@ -939,13 +973,15 @@ async function deactivatePlugin(
  *
  * This replaces the old `loadExternalPlugin` → `registerPlugin` →
  * `bootstrapPlugins` path for user plugins. Instead of registering whole
- * `Plugin` objects into the plugin registry, we register individual tools into
- * the tool registry and cache hooks by mtime.
+ * `Plugin` objects into the plugin registry, we cache individual surfaces by
+ * mtime; the tool registry pulls the active tool set through
+ * {@link getActiveUserPluginTools}.
  *
  * Called by `loadUserPlugins()` during daemon startup. After boot, the same
- * `scanPlugins` → `activatePlugin`/`deactivatePlugin` reconciliation runs on
- * every turn via `getUserHooksFor` (plugin hook dispatch), so plugins whose
- * files appear or disappear at runtime are picked up without a restart.
+ * `activatePlugin`/`deactivatePlugin` reconciliation runs via the
+ * source-versions sentinel on every hook dispatch and registry pull, so
+ * plugins whose files appear or disappear at runtime are picked up without a
+ * restart.
  */
 export async function populateCacheAtBoot(
   opts: { importTimeoutMs?: number } = {},

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -115,6 +115,17 @@ const skillRefCount = new Map<string, number>();
 // separate and covers the case of two extensions choosing the same tool name.
 const pluginRefCount = new Map<string, number>();
 
+// Fingerprints of the user-plugin tool sets `loadPluginTools` last pulled
+// from the plugin mtime-cache, keyed by plugin name. The pull reconcile diffs
+// the cache's current fingerprints against this map, so it only ever touches
+// registrations it created itself — plugin-owned tools registered by other
+// callers (the in-process default-plugin bootstrap) are never disturbed.
+const pulledPluginFingerprints = new Map<string, string>();
+
+// In-flight plugin pull — concurrent `loadPluginTools` callers coalesce onto
+// a single reconcile (mirrors `loadWorkspaceTools`).
+let pluginToolsReconcileInFlight: Promise<void> | null = null;
+
 /**
  * Format an owner for log messages and error strings. Returns a stable
  * human-readable description (e.g. `skill "deploy"`, `plugin "weather"`,
@@ -493,6 +504,92 @@ export function unregisterPluginTools(pluginName: string): void {
       tools.delete(name);
       ownersByName.delete(name);
       log.info({ name, ownerPluginId: pluginName }, "Plugin tool unregistered");
+    }
+  }
+}
+
+/**
+ * Pull the active user-plugin tool set from the plugin mtime-cache into the
+ * registry. This is the pull half of the plugin-tool relationship — the
+ * mtime-cache never writes to the registry; instead this reconcile reads
+ * {@link import("../plugins/mtime-cache.js").getActiveUserPluginTools} (which
+ * syncs against the source-versions sentinel first) and diffs the result into
+ * the registry: plugins that vanished are unregistered, new plugins register,
+ * and a plugin whose per-tool source mtimes moved is re-registered. Mirrors
+ * how hooks resolve through `getUserHookEntriesFor`.
+ *
+ * Idempotent, cheap when nothing changed (one sentinel stat + fingerprint
+ * compares), and concurrency-safe (concurrent callers coalesce onto one
+ * in-flight reconcile). Called at boot after `loadUserPlugins()` populates
+ * the cache, and fire-and-forget from the per-turn conversation tool
+ * resolver — the same cadence `loadWorkspaceTools` runs on.
+ */
+export function loadPluginTools(): Promise<void> {
+  if (pluginToolsReconcileInFlight) {
+    return pluginToolsReconcileInFlight;
+  }
+  // `reconcilePluginToolsFromCache` never rejects (failures are caught and
+  // logged); `.finally` clears the slot either way so the next caller pulls
+  // fresh.
+  pluginToolsReconcileInFlight = reconcilePluginToolsFromCache().finally(() => {
+    pluginToolsReconcileInFlight = null;
+  });
+  return pluginToolsReconcileInFlight;
+}
+
+async function reconcilePluginToolsFromCache(): Promise<void> {
+  // Dynamic import: the mtime-cache pulls the plugin-loader subtree in with
+  // it, which must stay out of this module's eager import graph — the
+  // registry is a widely-imported leaf.
+  let active: Map<string, { fingerprint: string; tools: Tool[] }>;
+  try {
+    const { getActiveUserPluginTools } =
+      await import("../plugins/mtime-cache.js");
+    active = await getActiveUserPluginTools();
+  } catch (err) {
+    log.warn(
+      { err },
+      "loadPluginTools: plugin cache pull failed — keeping current registrations",
+    );
+    return;
+  }
+
+  // Tear down plugins this reconcile registered that are no longer active
+  // (uninstalled, disabled, or their last tool file was deleted).
+  for (const pluginName of pulledPluginFingerprints.keys()) {
+    if (!active.has(pluginName)) {
+      unregisterPluginTools(pluginName);
+      pulledPluginFingerprints.delete(pluginName);
+    }
+  }
+
+  // Register new plugins; re-register ones whose tool set changed. Per-plugin
+  // isolation: one plugin's conflict/failure never blocks the others.
+  for (const [pluginName, { fingerprint, tools: pluginTools }] of active) {
+    const prev = pulledPluginFingerprints.get(pluginName);
+    if (prev === fingerprint) {
+      continue;
+    }
+    try {
+      if (prev !== undefined) {
+        // Changed tool set: drop the previous registration first so tools
+        // removed in the new set don't linger (re-registering alone would
+        // only overwrite the survivors).
+        unregisterPluginTools(pluginName);
+      }
+      registerPluginTools(pluginName, pluginTools);
+      pulledPluginFingerprints.set(pluginName, fingerprint);
+      log.info(
+        { plugin: pluginName, count: pluginTools.length },
+        "user plugin tools registered",
+      );
+    } catch (err) {
+      // Leave no fingerprint so the next reconcile retries this plugin.
+      pulledPluginFingerprints.delete(pluginName);
+      log.error(
+        { err, plugin: pluginName },
+        `Failed to register tools for user plugin ${pluginName}`,
+      );
     }
   }
 }
@@ -1150,6 +1247,7 @@ export function __resetRegistryForTesting(): void {
   ownersByName.clear();
   skillRefCount.clear();
   pluginRefCount.clear();
+  pulledPluginFingerprints.clear();
   // Drop the override stash too — the snapshot already represents the
   // pre-override baseline, so leaving stashed entries here would let a
   // later registerWorkspaceTools() falsely report "overridesCore: true"
@@ -1177,6 +1275,7 @@ export function __clearRegistryForTesting(): void {
   ownersByName.clear();
   skillRefCount.clear();
   pluginRefCount.clear();
+  pulledPluginFingerprints.clear();
   coreToolOverrides.clear();
   toolsInitPromise = null;
 }


### PR DESCRIPTION
## Prompt / plan

Step 3 of the initialize-tools removal plan (#37595 → #37694 → #37783 → this): user-plugin tools move to the same **file-backed, cached, pulled** resolution strategy hooks use, and `registerPluginTools`/`unregisterPluginTools` come **out of the mtime-cache**.

Today the mtime-cache *pushes*: `activatePlugin`/`deactivatePlugin` statically import the tool registry and imperatively register/unregister. Hooks are the inverse — reads pull through `getUserHookEntriesFor`, which syncs against the source-versions sentinel first. This PR makes plugin tools work the same way.

Note: the two models can't coexist even transitionally — `registerPluginTools` refcounts per registration, so a push+pull overlap would inflate the refcount to 2 and unregister would stop removing tools. Hence one atomic inversion rather than a two-step migration.

## Changes

**`plugins/mtime-cache.ts`** — no longer imports the tool registry at all:
- `activatePlugin` / `deactivatePlugin` stop calling `registerPluginTools` / `unregisterPluginTools`; activation now just flips the active set (and runs `init`/`shutdown` hooks as before).
- New pull surface: `getActiveUserPluginTools()` — syncs against the source-versions sentinel (`maybeReconcileFromSentinel`, shared singleflight with hook reads), then returns the active plugins' cached tools keyed by plugin name in install-date order, each with a fingerprint built from tool names + source mtimes.

**`tools/registry.ts`** — new `loadPluginTools()`:
- Singleflight reconcile (mirrors `loadWorkspaceTools`): dynamic-imports the mtime-cache (keeping the plugin-loader subtree out of the registry's eager module graph), pulls the active set, and diffs per-plugin fingerprints against what it last registered — new plugins register, vanished/disabled ones unregister, a moved fingerprint re-registers (unregister-then-register so removed tools don't linger).
- Tracks only its own registrations (`pulledPluginFingerprints`), so plugin-owned tools registered by the in-process default-plugin bootstrap (`external-plugins-bootstrap.ts`, which keeps using the push API) are never disturbed.
- Per-plugin failure isolation; a failed pull logs and keeps current registrations. Test-reset helpers clear the new state.

**Wiring (timing preserved):**
- Boot: `initializePlugins()` awaits `loadPluginTools()` in the exact slot registration used to occupy — after `loadUserPlugins()` populates the cache, before `bootstrapPlugins()` — so name-conflict precedence (core → workspace → MCP → user plugins → default plugins) is unchanged.
- Per turn: the conversation tool resolver fires `void loadPluginTools()` beside `void loadWorkspaceTools()` — the established fire-and-forget reconcile cadence — before re-reading `getPluginToolDefinitions()`.

**Dependency direction after this PR:** `plugins/mtime-cache → tools/registry` (static) is gone; the only edge is `tools/registry → plugins/mtime-cache` (dynamic, inside the reconcile) — the same shape as hooks. This is what lets a later PR fold plugin resolution into the `initializeTools`/`resolveTool` ensure and start removing the eager startup registration entirely.

**Behavior notes:** disable already takes effect at read time (`isPluginDisabled` filtering in `getPluginToolDefinitions`/`getEnabledTools`, unchanged). Uninstall/reload registry cleanup now lands on the next reconcile (boot or next turn's pull) instead of inline in the sentinel apply — the same one-turn settling the workspace-tools loader documents.

## Test plan

- `bunx tsc --noEmit` clean; eslint clean (pre-commit + pre-push enforced).
- `mtime-cache.test.ts` exercises the pull end-to-end: boot pull, install-after-boot, idempotent republish (no refcount inflation), out-of-band removal, runtime disable, and live-reload of an edited tool — the test helper now finishes dispatch with the same registry pull the per-turn resolver fires, and the registry side is reset per test.
- Full suite green: `plugin-tool-contribution`, `plugin-bootstrap`, `plugin-registry`, `plugin-config-data-migration`, `external-plugin-loader`, `user-plugin-loader`, `registry`, `conversation-tool-setup-*`, `uninstall-plugin`, `plugins-routes`, and both plugin import-boundary guards all pass. Only the known pre-existing environmental failures remain (script-proxy ×3, secret-routes proxy, avatar read-only workspace, sandbox-escape timeout, audit-log-rotation, provider-commit-message-generator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014ok5MKKrM4ZnmqG3AeXWtc)_