### PR TITLE
feat(web): rename tool drawer risk section to "Risk Level", drop trust-rule button

### DIFF
--- a/clients/web/src/domains/chat/components/tool-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.test.tsx
@@ -32,7 +32,6 @@ const { ToolDetailPanel } = await import(
 const { useChatSessionStore } = await import(
   "@/domains/chat/chat-session-store"
 );
-const { useViewerStore } = await import("@/stores/viewer-store");
 import type { ToolDetailPayload } from "@/stores/viewer-store";
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types";
@@ -132,7 +131,7 @@ describe("ToolDetailPanel", () => {
     expect(queryByText("Technical details")).toBeNull();
   });
 
-  test("renders the Reasoning section with the risk badge but not the raw reason", () => {
+  test("renders the Risk Level section with the risk badge but not the raw reason", () => {
     const { getByTestId, getByText, queryByText } = render(
       <ToolDetailPanel
         detail={makeDetail({ riskReason: "File edit (default)" })}
@@ -140,7 +139,7 @@ describe("ToolDetailPanel", () => {
       />,
     );
 
-    expect(getByText("Reasoning")).toBeDefined();
+    expect(getByText("Risk Level")).toBeDefined();
     expect(getByTestId("risk-badge").getAttribute("data-risk-level")).toBe(
       "low",
     );
@@ -150,12 +149,11 @@ describe("ToolDetailPanel", () => {
     ).toBeDefined();
     // The classifier's rule-match string is internal jargon — never shown.
     expect(queryByText("File edit (default)")).toBeNull();
-    // The tool call isn't resolvable in the (empty) transcript, so the
-    // trust-rule affordance stays hidden — the editor would open on nothing.
+    // The trust-rule affordance was removed from the drawer.
     expect(queryByText("Create Trust Rule")).toBeNull();
   });
 
-  test("hides the Reasoning section when the call has no risk level", () => {
+  test("hides the Risk Level section when the call has no risk level", () => {
     const { queryByText, queryByTestId } = render(
       <ToolDetailPanel
         detail={makeDetail({ riskLevel: undefined })}
@@ -163,11 +161,11 @@ describe("ToolDetailPanel", () => {
       />,
     );
 
-    expect(queryByText("Reasoning")).toBeNull();
+    expect(queryByText("Risk Level")).toBeNull();
     expect(queryByTestId("risk-badge")).toBeNull();
   });
 
-  test("Create Trust Rule requests the rule editor for the tool call", () => {
+  test("does not render a Create Trust Rule button even when the call resolves live", () => {
     seedHistory([
       {
         id: "m1",
@@ -177,15 +175,11 @@ describe("ToolDetailPanel", () => {
         ],
       } as DisplayMessage,
     ]);
-    const { getByText } = render(
+    const { queryByText } = render(
       <ToolDetailPanel detail={makeDetail()} onClose={noop} />,
     );
 
-    const before = useViewerStore.getState().ruleEditorRequestSeq;
-    fireEvent.click(getByText("Create Trust Rule"));
-
-    expect(useViewerStore.getState().ruleEditorRequestSeq).toBe(before + 1);
-    expect(useViewerStore.getState().ruleEditorRequestToolCallId).toBe("tc-1");
+    expect(queryByText("Create Trust Rule")).toBeNull();
   });
 
   test("hides the Output section when result is empty", () => {

--- a/clients/web/src/domains/chat/components/tool-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.tsx
@@ -2,7 +2,7 @@
  * Side-drawer body shown when a tool-call step pill is clicked. Mirrors the
  * web `SubagentDetailPanel` shell (outer container, header with leading icon /
  * title / close, scrollable body with sections). The call's risk level lives
- * in the body's "Reasoning" section (badge + trust-rule button), not the
+ * in the body's "Risk Level" section (badge + tolerance hint), not the
  * header.
  *
  * Driven by the `ToolDetailPayload` opened into `viewer-store`. Both variants
@@ -30,12 +30,11 @@ import {
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
-import { Button, Typography } from "@vellumai/design-library";
+import { Typography } from "@vellumai/design-library";
 
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
 import { DetailShell } from "@/domains/chat/components/detail-shell";
 import { RiskBadge } from "@/domains/chat/components/risk-badge";
-import { useViewerStore } from "@/stores/viewer-store";
 import { titleCaseToolName } from "@/domains/chat/components/tool-call-chip/utils";
 import { useLiveThinkingText } from "@/domains/chat/hooks/use-live-thinking-text";
 import { useLiveToolCall } from "@/domains/chat/hooks/use-live-tool-call";
@@ -194,33 +193,14 @@ export function ToolDetailBody({ detail }: { detail: ToolDetailPayload }) {
   // classifier jargon and is deliberately NOT shown.
   const riskLevel = liveTc?.riskLevel ?? detail.riskLevel;
   const riskHint = getRiskToleranceHint(riskLevel);
-  // The trust-rule editor needs the raw tool call (its allowlist ladder /
-  // scope options), which the bridge resolves from the transcript — offer the
-  // button only when the call resolves live, so it never opens on nothing.
-  const canCreateTrustRule = liveTc != null;
 
   return (
     <>
-      {/* Reasoning — the call's risk level and the affordance to persist
-          that judgement as a trust rule. Label row (with the trust-rule
-          button trailing) over the badge in an overlay card. */}
+      {/* Risk Level — the call's risk badge and tolerance hint in an
+          overlay card. */}
       {riskLevel && (
         <div className="mb-5">
-          <div className="mb-1.5 flex items-center justify-between gap-3">
-            <SectionLabel className="mb-0">Reasoning</SectionLabel>
-            {canCreateTrustRule && (
-              <Button
-                variant="outlined"
-                size="compact"
-                className="shrink-0"
-                onClick={() =>
-                  useViewerStore.getState().requestRuleEditor(detail.toolCallId)
-                }
-              >
-                Create Trust Rule
-              </Button>
-            )}
-          </div>
+          <SectionLabel>Risk Level</SectionLabel>
           <div className="rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] p-3">
             <RiskBadge level={riskLevel} />
             {riskHint && (


### PR DESCRIPTION
## Summary
- Rename the tool-detail drawer's risk section label from "Reasoning" to "Risk Level"
- Remove the "Create Trust Rule" button from the drawer (the trust-rule editor remains reachable from the approval/confirmation flow)
- Clean up now-unused `Button` / `useViewerStore` imports and update tests

## Testing
- `bun test src/domains/chat/components/tool-detail-panel.test.tsx` — 16 pass
- `bunx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)