### PR TITLE
feat(web): redesign secure credential card to match Figma spec

### DIFF
--- a/clients/web/src/domains/chat/components/secret-prompt-card.stories.tsx
+++ b/clients/web/src/domains/chat/components/secret-prompt-card.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { SecretPromptCard } from "./secret-prompt-card";
+
+function noop() {}
+
+const meta: Meta<typeof SecretPromptCard> = {
+  title: "Chat/SecretPromptCard",
+  component: SecretPromptCard,
+  parameters: {
+    layout: "padded",
+  },
+  args: {
+    isSubmitting: false,
+    saved: false,
+    onSave: noop,
+    onSendOnce: noop,
+    onCancel: noop,
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-2xl">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof SecretPromptCard>;
+
+const hubspotSecret = {
+  requestId: "req-1",
+  service: "hubspot",
+  field: "app_token",
+  description:
+    "Instructions on where to find the token/key shall be written here so the user can easily find it.",
+  placeholder: "xapp-",
+  purpose: "Access HubSpot CRM contacts and deals",
+  allowedDomains: ["api.hubspot.com"],
+};
+
+export const Default: Story = {
+  args: {
+    secret: hubspotSecret,
+  },
+};
+
+export const Minimal: Story = {
+  args: {
+    secret: {
+      requestId: "req-2",
+      label: "API Key",
+    },
+  },
+};
+
+export const WithToolsAndSendOnce: Story = {
+  args: {
+    secret: {
+      ...hubspotSecret,
+      requestId: "req-3",
+      allowedTools: ["crm_search", "crm_update"],
+      allowOneTimeSend: true,
+    },
+  },
+};
+
+export const Submitting: Story = {
+  args: {
+    secret: hubspotSecret,
+    isSubmitting: true,
+  },
+};
+
+export const Saved: Story = {
+  args: {
+    secret: hubspotSecret,
+    saved: true,
+  },
+};

--- a/clients/web/src/domains/chat/components/secret-prompt-card.tsx
+++ b/clients/web/src/domains/chat/components/secret-prompt-card.tsx
@@ -1,8 +1,7 @@
+import { AlertTriangle, CheckCircle, Globe, Info, Loader2, Lock, Wrench, type LucideIcon } from "lucide-react";
+import { type FormEvent, type ReactNode, useState } from "react";
 
-import { AlertTriangle, CheckCircle, EyeOff, Globe, Info, KeyRound, Loader2, Shield, Wrench } from "lucide-react";
-import { type FormEvent, useState } from "react";
-
-import { Card, Input } from "@vellumai/design-library";
+import { Button, Card, Input } from "@vellumai/design-library";
 
 /**
  * Mechanically humanize a structured identifier like `slack_channel` or
@@ -40,6 +39,15 @@ export interface SecretPromptCardProps {
   onCancel: () => void;
 }
 
+function ContextChip({ icon: IconGlyph, children }: { icon: LucideIcon; children: ReactNode }) {
+  return (
+    <div className="flex items-center gap-1.5 rounded-lg bg-[var(--surface-base)] px-2 py-1.5">
+      <IconGlyph className="h-3.5 w-3.5 shrink-0 text-[var(--content-tertiary)]" />
+      <span className="text-body-small-default text-[var(--content-tertiary)]">{children}</span>
+    </div>
+  );
+}
+
 export function SecretPromptCard({
   secret,
   isSubmitting,
@@ -59,6 +67,8 @@ export function SecretPromptCard({
     .filter(Boolean)
     .join(" · ");
 
+  const inputLabel = secret.label || credentialIdentity || "Secret value";
+
   const handleSave = (e: FormEvent) => {
     e.preventDefault();
     if (!canSubmit) {
@@ -68,86 +78,53 @@ export function SecretPromptCard({
   };
 
   return (
-    <Card padding="lg">
+    <Card.Root padding="md" className="flex flex-col gap-3">
       {/* Header */}
-      <div className="mb-4 flex items-center gap-3">
-        <Shield className="h-5 w-5 text-[var(--primary-base)] dark:text-[var(--content-secondary)]" />
-        <div className="flex flex-col">
-          <span className="text-body-medium-default text-[var(--content-default)]">
-            Secure Credential
-          </span>
-          <span className="text-body-small-default text-[var(--content-tertiary)]">
-            {secret.label || "Secret required"}
-          </span>
-          {credentialIdentity && (
-            <span className="text-body-small-default text-[var(--content-tertiary)]">
-              {credentialIdentity}
-            </span>
-          )}
+      <div className="flex items-center gap-2">
+        <div className="rounded-md bg-[var(--surface-active)] p-1.5">
+          <Lock className="h-3 w-3 text-[var(--content-emphasised)]" />
         </div>
+        <span className="text-title-small text-[var(--content-emphasised)]">
+          Secure Credential
+        </span>
       </div>
 
-      {/* Description */}
-      {secret.description && (
-        <p className="mb-4 text-body-small-default text-[var(--content-tertiary)]">
-          {secret.description}
-        </p>
-      )}
+      <div className="h-px w-full bg-[var(--border-base)]" />
 
       {/* Usage context */}
       {!!(secret.purpose || secret.allowedTools?.length || secret.allowedDomains?.length) && (
-        <div className="mb-4 rounded-lg bg-[var(--surface-base)] p-3 flex flex-col gap-2">
-          {secret.purpose && (
-            <div className="flex items-start gap-2">
-              <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--content-tertiary)]" />
-              <span className="text-body-small-default text-[var(--content-tertiary)]">{secret.purpose}</span>
-            </div>
-          )}
+        <div className="flex flex-col items-start gap-1">
+          {secret.purpose && <ContextChip icon={Info}>{secret.purpose}</ContextChip>}
           {secret.allowedTools?.length ? (
-            <div className="flex items-start gap-2">
-              <Wrench className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--content-tertiary)]" />
-              <span className="text-body-small-default text-[var(--content-tertiary)]">
-                <span className="text-[var(--content-secondary)]">Tools:</span> {secret.allowedTools.join(", ")}
-              </span>
-            </div>
+            <ContextChip icon={Wrench}>Tools: {secret.allowedTools.join(", ")}</ContextChip>
           ) : null}
           {secret.allowedDomains?.length ? (
-            <div className="flex items-start gap-2">
-              <Globe className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--content-tertiary)]" />
-              <span className="text-body-small-default text-[var(--content-tertiary)]">
-                <span className="text-[var(--content-secondary)]">Domains:</span> {secret.allowedDomains.join(", ")}
-              </span>
-            </div>
+            <ContextChip icon={Globe}>Domains: {secret.allowedDomains.join(", ")}</ContextChip>
           ) : null}
         </div>
       )}
 
-      {/* Secure input */}
-      <form onSubmit={handleSave}>
-        <Input
-          type="password"
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-          placeholder={secret.placeholder || "Enter secret value..."}
-          disabled={isSubmitting || saved}
-          fullWidth
-          wrapperClassName="mb-4"
-        />
-
-        {/* Safety explainer */}
-        <div className="mb-4 flex flex-col gap-1.5">
-          <div className="flex items-center gap-2">
-            <KeyRound className="h-3 w-3 shrink-0 text-[var(--system-positive-strong)]" />
-            <span className="text-body-small-default text-[var(--content-tertiary)]">
-              Stored securely on your device, not sent to any server
-            </span>
-          </div>
-          <div className="flex items-center gap-2">
-            <EyeOff className="h-3 w-3 shrink-0 text-[var(--system-positive-strong)]" />
-            <span className="text-body-small-default text-[var(--content-tertiary)]">
-              The AI never sees this value — only your device can read it
-            </span>
-          </div>
+      <form onSubmit={handleSave} className="flex flex-col gap-3">
+        {/* Credential entry */}
+        <div className="flex flex-col gap-4 rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] p-4">
+          {secret.description && (
+            <p className="text-body-medium-default text-[var(--content-default)]">
+              {secret.description}
+            </p>
+          )}
+          <Input
+            label={inputLabel}
+            type="password"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder={secret.placeholder || "Enter secret value..."}
+            disabled={isSubmitting || saved}
+            fullWidth
+          />
+          <p className="text-body-small-default text-[var(--content-disabled)]">
+            This information is stored securely on your device and not sent to any server. AI
+            never sees this value.
+          </p>
         </div>
 
         {saved ? (
@@ -160,30 +137,23 @@ export function SecretPromptCard({
         ) : (
           <>
             {/* Buttons */}
-            <div className="flex items-center justify-end gap-2">
-              <button
-                type="button"
-                onClick={onCancel}
-                disabled={isSubmitting}
-                className="rounded-md border border-[var(--border-base)] bg-white px-3 py-1.5 text-body-small-default text-[var(--content-default)] transition-colors hover:bg-[var(--surface-base)] disabled:opacity-50 dark:border-[var(--border-base)] dark:bg-[var(--surface-lift)] dark:text-[var(--content-default)] dark:hover:bg-[var(--ghost-hover)]"
-              >
+            <div className="flex items-center justify-between">
+              <Button variant="danger" onClick={onCancel} disabled={isSubmitting}>
                 Cancel
-              </button>
-              <button
+              </Button>
+              <Button
                 type="submit"
+                variant="primary"
                 disabled={!canSubmit}
-                className="flex items-center gap-1.5 rounded-md bg-[var(--primary-base)] px-3 py-1.5 text-body-small-default text-[var(--content-inset)] transition-colors hover:bg-[var(--primary-hover)] disabled:opacity-50"
+                leftIcon={isSubmitting ? <Loader2 className="animate-spin" /> : undefined}
               >
-                {isSubmitting ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                ) : null}
                 {isSubmitting ? "Saving..." : "Save"}
-              </button>
+              </Button>
             </div>
 
             {/* Send Once option */}
             {secret.allowOneTimeSend && (
-              <div className="mt-2 flex items-center justify-end gap-1.5">
+              <div className="flex items-center justify-end gap-1.5">
                 <AlertTriangle className="h-3 w-3 text-[var(--system-mid-strong)]" />
                 <button
                   type="button"
@@ -203,6 +173,6 @@ export function SecretPromptCard({
           </>
         )}
       </form>
-    </Card>
+    </Card.Root>
   );
 }


### PR DESCRIPTION
## Summary
- Redesign `SecretPromptCard` to match the new Figma spec (node 6405-122204): icon-chip header with divider, muted context chips for purpose/tools/domains, a bordered inner panel containing the description, labeled credential input and storage disclaimer, and a Cancel (danger) / Save (primary) footer using the design-library `Button`.
- The credential label / humanized `service · field` identity now renders as the input label (matching the Figma "App Token" label) instead of a header subtitle; existing tests pass unchanged.
- Add `secret-prompt-card.stories.tsx` with Default, Minimal, WithToolsAndSendOnce, Submitting, and Saved stories.

## Original prompt
Update the secure credential card to match the new Figma design (https://www.figma.com/design/cCGBcpVDbn22kj3OPU58W8/New-App?node-id=6405-122204) — the current card uses a plain shield header, inline safety bullets, and hand-rolled buttons. Restyle it to the new card layout and add it to Storybook. Branch from main.