### PR TITLE
refactor(persistence): typed MessageRow.content (ContentBlock[]) resolved at the row mapper

### DIFF
--- a/assistant/src/__tests__/add-message-preassigned-id.test.ts
+++ b/assistant/src/__tests__/add-message-preassigned-id.test.ts
@@ -40,7 +40,7 @@ describe("addMessage pre-assigned id", () => {
     const msgs = getMessages("conv-preassigned-id");
     const found = msgs.find((m) => m.id === customId);
     expect(found).toBeDefined();
-    expect(found?.content).toBe("hello");
+    expect(found?.content).toEqual([{ type: "text", text: "hello" }]);
   });
 
   test("generates a uuid when no id is provided", async () => {

--- a/assistant/src/__tests__/annotate-activity-metadata.test.ts
+++ b/assistant/src/__tests__/annotate-activity-metadata.test.ts
@@ -59,7 +59,7 @@ mock.module("../persistence/conversation-crud.js", () => ({
   isConversationProcessing: () => false,
   addMessage: () => ({ id: "mock-msg-id" }),
   getMessageById: (id: string) =>
-    mockedRowContent ? { id, content: mockedRowContent } : null,
+    mockedRowContent ? { id, content: JSON.parse(mockedRowContent) } : null,
   updateMessageContent: (id: string, content: string) => {
     updates.push({ id, content });
   },
@@ -129,7 +129,9 @@ function findBlockById(
 ): Record<string, unknown> {
   const parsed = JSON.parse(rawContent) as Array<Record<string, unknown>>;
   const block = parsed.find((b) => b.id === id);
-  if (!block) throw new Error(`block ${id} not found`);
+  if (!block) {
+    throw new Error(`block ${id} not found`);
+  }
   return block;
 }
 

--- a/assistant/src/__tests__/annotate-risk-options.test.ts
+++ b/assistant/src/__tests__/annotate-risk-options.test.ts
@@ -54,7 +54,7 @@ mock.module("../persistence/conversation-crud.js", () => ({
   isConversationProcessing: () => false,
   addMessage: () => ({ id: "mock-msg-id" }),
   getMessageById: (id: string) =>
-    mockedRowContent ? { id, content: mockedRowContent } : null,
+    mockedRowContent ? { id, content: JSON.parse(mockedRowContent) } : null,
   updateMessageContent: (id: string, content: string) => {
     updates.push({ id, content });
   },
@@ -123,7 +123,9 @@ function findPersistedToolUse(
 ): Record<string, unknown> {
   const parsed = JSON.parse(rawContent) as Array<Record<string, unknown>>;
   const block = parsed.find((b) => b.type === "tool_use" && b.id === toolUseId);
-  if (!block) throw new Error(`tool_use block ${toolUseId} not found`);
+  if (!block) {
+    throw new Error(`tool_use block ${toolUseId} not found`);
+  }
   return block;
 }
 

--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -149,7 +149,9 @@ function createMockVoiceTurn(tokens: string[]) {
 
     // Emit text deltas
     for (const token of tokens) {
-      if (opts.signal?.aborted) break;
+      if (opts.signal?.aborted) {
+        break;
+      }
       opts.onTextDelta(token);
     }
 
@@ -394,8 +396,9 @@ async function pollUntil(
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (!predicate()) {
-    if (Date.now() > deadline)
+    if (Date.now() > deadline) {
       throw new Error(`pollUntil timed out after ${timeoutMs}ms`);
+    }
     await new Promise((r) => setTimeout(r, intervalMs));
   }
 }
@@ -438,23 +441,13 @@ function getLatestAssistantText(conversationId: string): string | null {
   );
   if (msgs.length === 0) return null;
   const latest = msgs[msgs.length - 1];
-  try {
-    const parsed = JSON.parse(latest.content) as unknown;
-    if (Array.isArray(parsed)) {
-      return parsed
-        .filter(
-          (b): b is { type: string; text?: string } =>
-            typeof b === "object" && b != null,
-        )
-        .filter((b) => b.type === "text")
-        .map((b) => b.text ?? "")
-        .join("");
-    }
-    if (typeof parsed === "string") return parsed;
-  } catch {
-    /* fall through */
-  }
-  return latest.content;
+  return latest.content
+    .filter(
+      (b): b is { type: "text"; text: string } =>
+        b.type === "text" && typeof (b as { text?: unknown }).text === "string",
+    )
+    .map((b) => b.text)
+    .join("");
 }
 
 function setupControllerWithOrigin(task?: string) {
@@ -3913,7 +3906,9 @@ describe("call-controller", () => {
       const turnPromise = controller.handleCallerUtterance("Hello");
 
       // Wait for microtasks to settle
-      for (let i = 0; i < 5; i++) await Promise.resolve();
+      for (let i = 0; i < 5; i++) {
+        await Promise.resolve();
+      }
 
       // No outbound audio/tokens yet → still processing.
       expect(controller.getState()).toBe("processing");
@@ -3969,7 +3964,9 @@ describe("call-controller", () => {
 
       const { controller } = setupController();
       const turnPromise = controller.handleCallerUtterance("Hi");
-      for (let i = 0; i < 5; i++) await Promise.resolve();
+      for (let i = 0; i < 5; i++) {
+        await Promise.resolve();
+      }
 
       // Before any token: processing, barge-in ignored (turn not aborted).
       expect(controller.getState()).toBe("processing");
@@ -3978,7 +3975,9 @@ describe("call-controller", () => {
 
       // Release the first token → controller flips to speaking.
       emitFirstToken();
-      for (let i = 0; i < 5; i++) await Promise.resolve();
+      for (let i = 0; i < 5; i++) {
+        await Promise.resolve();
+      }
       expect(controller.getState()).toBe("speaking");
 
       // Now barge-in is accepted and interrupts the turn.
@@ -4021,7 +4020,9 @@ describe("call-controller", () => {
       };
 
       const turnPromise = controller.handleCallerUtterance("Hi");
-      for (let i = 0; i < 10; i++) await Promise.resolve();
+      for (let i = 0; i < 10; i++) {
+        await Promise.resolve();
+      }
 
       // Tokens were emitted (buffered by the transport) but no audio has
       // started — the controller must still be processing.
@@ -4077,7 +4078,9 @@ describe("call-controller", () => {
       };
 
       const turnPromise = controller.handleCallerUtterance("Hi");
-      for (let i = 0; i < 10; i++) await Promise.resolve();
+      for (let i = 0; i < 10; i++) {
+        await Promise.resolve();
+      }
       expect(controller.getState()).toBe("processing");
 
       // Transport reports real outbound audio started → speaking.
@@ -4130,7 +4133,9 @@ describe("call-controller", () => {
       };
 
       const turn1 = controller.handleCallerUtterance("Hi");
-      for (let i = 0; i < 10; i++) await Promise.resolve();
+      for (let i = 0; i < 10; i++) {
+        await Promise.resolve();
+      }
       expect(controller.getState()).toBe("processing");
       expect(cancelledPendingSpeech).toBe(0);
 
@@ -4171,7 +4176,9 @@ describe("call-controller", () => {
       };
 
       const turnPromise = controller.handleCallerUtterance("Hi");
-      for (let i = 0; i < 10; i++) await Promise.resolve();
+      for (let i = 0; i < 10; i++) {
+        await Promise.resolve();
+      }
       const staleCallback = audioStartCallback!;
 
       // Supersede the run (hard interrupt), then fire the stale signal.
@@ -4213,7 +4220,9 @@ describe("call-controller", () => {
       const turnPromise = controller.handleCallerUtterance("Hi");
 
       // Let microtasks settle so onTextDelta runs
-      for (let i = 0; i < 10; i++) await Promise.resolve();
+      for (let i = 0; i < 10; i++) {
+        await Promise.resolve();
+      }
 
       expect(controller.getState()).toBe("speaking");
 

--- a/assistant/src/__tests__/call-conversation-messages.test.ts
+++ b/assistant/src/__tests__/call-conversation-messages.test.ts
@@ -51,7 +51,7 @@ function getLatestAssistantText(conversationId: string): string {
   );
   expect(rows.length).toBeGreaterThan(0);
   const latest = rows[rows.length - 1];
-  const parsed = JSON.parse(latest.content) as Array<{
+  const parsed = latest.content as unknown as Array<{
     type: string;
     text?: string;
     surfaceType?: string;

--- a/assistant/src/__tests__/call-domain.test.ts
+++ b/assistant/src/__tests__/call-domain.test.ts
@@ -171,23 +171,13 @@ function getLatestAssistantText(conversationId: string): string | null {
   );
   if (msgs.length === 0) return null;
   const latest = msgs[msgs.length - 1];
-  try {
-    const parsed = JSON.parse(latest.content) as unknown;
-    if (Array.isArray(parsed)) {
-      return parsed
-        .filter(
-          (b): b is { type: string; text?: string } =>
-            typeof b === "object" && b != null,
-        )
-        .filter((b) => b.type === "text")
-        .map((b) => b.text ?? "")
-        .join("");
-    }
-    if (typeof parsed === "string") return parsed;
-  } catch {
-    /* fall through */
-  }
-  return latest.content;
+  return latest.content
+    .filter(
+      (b): b is { type: "text"; text: string } =>
+        b.type === "text" && typeof (b as { text?: unknown }).text === "string",
+    )
+    .map((b) => b.text)
+    .join("");
 }
 
 function makeConfig(

--- a/assistant/src/__tests__/call-pointer-messages.test.ts
+++ b/assistant/src/__tests__/call-pointer-messages.test.ts
@@ -80,7 +80,7 @@ function getLatestAssistantText(conversationId: string): string {
   );
   expect(rows.length).toBeGreaterThan(0);
   const latest = rows[rows.length - 1];
-  const parsed = JSON.parse(latest.content) as Array<{
+  const parsed = latest.content as unknown as Array<{
     type: string;
     text?: string;
   }>;

--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
+import { resolveMessageContentBlocks } from "../persistence/message-content-file.js";
 import type { RuntimeAttachmentMetadata } from "../runtime/http-types.js";
 
 type DeliveryCall = {
@@ -104,16 +105,26 @@ mock.module("../persistence/conversation-crud.js", () => ({
   }),
   getConversationOriginInterface: () => null,
   getConversationOriginChannel: () => null,
-  getMessages: () => conversationMessages,
+  getMessages: () =>
+    conversationMessages.map((m) => ({
+      ...m,
+      content: resolveMessageContentBlocks(m.content),
+    })),
   getMessagesAfter: (
     _conversationId: string,
     afterMessageId: string | null,
   ) => {
-    if (!afterMessageId) return conversationMessages;
-    const index = conversationMessages.findIndex(
+    const resolved = conversationMessages.map((m) => ({
+      ...m,
+      content: resolveMessageContentBlocks(m.content),
+    }));
+    if (!afterMessageId) {
+      return resolved;
+    }
+    const index = resolved.findIndex(
       (message) => message.id === afterMessageId,
     );
-    return index === -1 ? [] : conversationMessages.slice(index + 1);
+    return index === -1 ? [] : resolved.slice(index + 1);
   },
   getMessageById: (messageId: string) =>
     conversationMessages.find((m) => m.id === messageId) ?? null,
@@ -123,7 +134,9 @@ mock.module("../persistence/conversation-crud.js", () => ({
   ) => {
     updateMessageMetadataCalls.push({ messageId, updates });
     const row = conversationMessages.find((m) => m.id === messageId);
-    if (!row) return;
+    if (!row) {
+      return;
+    }
     const existing =
       row.metadata && typeof row.metadata === "string"
         ? (JSON.parse(row.metadata) as Record<string, unknown>)

--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -41,6 +41,7 @@ import { getConversationDirPath } from "../persistence/conversation-disk-view.js
 import { getDb, getLogsDb, getMemoryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { getRequestLogsByMessageId } from "../persistence/llm-request-log-store.js";
+import { stringifyMessageContent } from "../persistence/message-content.js";
 import { rawGet, rawRun } from "../persistence/raw-query.js";
 import {
   activationState,
@@ -175,10 +176,9 @@ describe("forkConversation", () => {
     const fork = forkConversation({ conversationId: source.id });
     const forkMessages = getMessages(fork.id);
 
-    expect(sourceMessages.map((message) => message.content)).toEqual([
-      "first",
-      "second",
-    ]);
+    expect(
+      sourceMessages.map((message) => stringifyMessageContent(message.content)),
+    ).toEqual(["first", "second"]);
     expect(forkMessages.map((message) => message.content)).toEqual(
       sourceMessages.map((message) => message.content),
     );
@@ -209,10 +209,11 @@ describe("forkConversation", () => {
 
     expect(fork.forkParentConversationId).toBe(source.id);
     expect(fork.forkParentMessageId).toBe(branchPoint.id);
-    expect(getMessages(fork.id).map((message) => message.content)).toEqual([
-      "Message 1",
-      "Message 2",
-    ]);
+    expect(
+      getMessages(fork.id).map((message) =>
+        stringifyMessageContent(message.content),
+      ),
+    ).toEqual(["Message 1", "Message 2"]);
   });
 
   test("pinned fork through a (createdAt, id) cutoff matches the cursor slice for same-timestamp rows", () => {
@@ -242,11 +243,11 @@ describe("forkConversation", () => {
       throughMessageId: "msg-c",
     });
 
-    expect(getMessages(fork.id).map((message) => message.content)).toEqual([
-      "msg-a",
-      "msg-b",
-      "msg-c",
-    ]);
+    expect(
+      getMessages(fork.id).map((message) =>
+        stringifyMessageContent(message.content),
+      ),
+    ).toEqual(["msg-a", "msg-b", "msg-c"]);
   });
 
   test("advances fork boundary through consecutive assistant rows after the requested message", async () => {
@@ -283,7 +284,11 @@ describe("forkConversation", () => {
 
     // Boundary advances past the entire consecutive-assistant cluster, so the
     // full turn is preserved in the fork — not just the anchor row.
-    expect(getMessages(fork.id).map((message) => message.content)).toEqual([
+    expect(
+      getMessages(fork.id).map((message) =>
+        stringifyMessageContent(message.content),
+      ),
+    ).toEqual([
       "Message 1",
       "Assistant text segment",
       "Tool turn row",
@@ -339,12 +344,14 @@ describe("forkConversation", () => {
 
     // All three DB rows of the assistant display turn — including the
     // suppressed tool-result user row in the middle — land in the fork.
-    const forkedContent = getMessages(fork.id).map((m) => m.content);
+    const forkedContent = getMessages(fork.id).map((m) =>
+      JSON.stringify(m.content),
+    );
     expect(forkedContent).toHaveLength(4);
-    expect(forkedContent[0]).toBe("Find the latest sales numbers");
+    expect(forkedContent[0]).toContain("Find the latest sales numbers");
     expect(forkedContent[1]).toContain("tool_use");
     expect(forkedContent[2]).toContain("tool_result");
-    expect(forkedContent[3]).toBe("Here are the numbers.");
+    expect(forkedContent[3]).toContain("Here are the numbers.");
     expect(fork.forkParentMessageId).toBe(tailAssistantRow.id);
     expect(toolResultUserRow.id).not.toBe(anchor.id);
   });
@@ -460,12 +467,11 @@ describe("forkConversation", () => {
     expect(fork.contextSummary).toBeNull();
     expect(fork.contextCompactedMessageCount).toBe(0);
     expect(fork.contextCompactedAt).toBeNull();
-    expect(getMessages(fork.id).map((message) => message.content)).toEqual([
-      "Message 1",
-      "Message 2",
-      "Message 3",
-      "Message 4",
-    ]);
+    expect(
+      getMessages(fork.id).map((message) =>
+        stringifyMessageContent(message.content),
+      ),
+    ).toEqual(["Message 1", "Message 2", "Message 3", "Message 4"]);
   });
 
   test("forks from the compacted-away prefix without inheriting source compaction state", async () => {
@@ -522,9 +528,11 @@ describe("forkConversation", () => {
     expect(fork.contextCompactedAt).toBeNull();
     expect(fork.forkParentConversationId).toBe(source.id);
     expect(fork.forkParentMessageId).toBe(compactedBranchPoint.id);
-    expect(getMessages(fork.id).map((message) => message.content)).toEqual([
-      "Message 1",
-    ]);
+    expect(
+      getMessages(fork.id).map((message) =>
+        stringifyMessageContent(message.content),
+      ),
+    ).toEqual(["Message 1"]);
   });
 
   test("inherits historyStrippedAt when forking past the clean event", async () => {

--- a/assistant/src/__tests__/conversation-fork-retrospective.test.ts
+++ b/assistant/src/__tests__/conversation-fork-retrospective.test.ts
@@ -93,7 +93,7 @@ function resetTables(): void {
 /** Strip per-row identity so two forks of the same source compare equal. */
 function normalize(message: {
   role: string;
-  content: string;
+  content: unknown;
   createdAt: number;
   metadata: string | null;
 }) {
@@ -331,7 +331,7 @@ describe("forkConversationForRetrospective — compacted source", () => {
     return { id: source.id, summary, compactedAt, compactedCount: 4, base };
   }
 
-  function contentOf(m: { role: string; content: string; createdAt: number }) {
+  function contentOf(m: { role: string; content: unknown; createdAt: number }) {
     return { role: m.role, content: m.content, createdAt: m.createdAt };
   }
 
@@ -368,7 +368,7 @@ describe("forkConversationForRetrospective — compacted source", () => {
     // `loadFromDb` does — is identical to the source's.
     const render = (
       summary: string | null,
-      rows: Array<{ role: string; content: string; createdAt: number }>,
+      rows: Array<{ role: string; content: unknown; createdAt: number }>,
       count: number,
     ) => [summary, ...rows.slice(Math.min(count, rows.length)).map(contentOf)];
     expect(
@@ -665,8 +665,8 @@ describe("forkConversationForRetrospective — compacted source", () => {
     // The source renders ["still visible", "fresh tail"] after its slice;
     // the fork must carry exactly those rows.
     expect(getMessages(fork.id).map((m) => m.content)).toEqual([
-      "still visible",
-      "fresh tail",
+      [{ type: "text", text: "still visible" }],
+      [{ type: "text", text: "fresh tail" }],
     ]);
   });
 
@@ -715,7 +715,9 @@ describe("forkConversationForRetrospective — compacted source", () => {
       source: MEMORY_RETROSPECTIVE_FORK_SOURCE,
     });
 
-    expect(getMessages(fork.id).map((m) => m.content)).toEqual(["visible"]);
+    expect(getMessages(fork.id).map((m) => m.content)).toEqual([
+      [{ type: "text", text: "visible" }],
+    ]);
     expect(fork.contextSummary).toBe("Tie summary");
     expect(fork.contextCompactedMessageCount).toBe(0);
     const forkEvents = getDb()

--- a/assistant/src/__tests__/conversation-history-web-search.test.ts
+++ b/assistant/src/__tests__/conversation-history-web-search.test.ts
@@ -27,7 +27,7 @@ let dbMessages: Array<{
   id: string;
   conversationId: string;
   role: string;
-  content: string;
+  content: ContentBlock[];
   createdAt: number;
   metadata: string | null;
 }> = [];
@@ -48,7 +48,9 @@ mock.module("../persistence/conversation-crud.js", () => ({
   updateMessageContent: (messageId: string, content: string) => {
     updatedMessages.push({ id: messageId, content });
     const msg = dbMessages.find((m) => m.id === messageId);
-    if (msg) msg.content = content;
+    if (msg) {
+      msg.content = JSON.parse(content) as ContentBlock[];
+    }
   },
   relinkAttachments: () => 0,
   deleteLastExchange: () => 0,
@@ -98,7 +100,7 @@ function makeDbMessage(
     id,
     conversationId,
     role,
-    content: JSON.stringify(content),
+    content,
     createdAt,
     metadata: null,
   };
@@ -809,7 +811,9 @@ describe("web_search_tool_result structural guard", () => {
       const hasRawCheck =
         /[=!]==?\s*["']tool_result["']/.test(line) ||
         /["']tool_result["']\s*[=!]==?/.test(line);
-      if (!hasRawCheck) continue;
+      if (!hasRawCheck) {
+        continue;
+      }
 
       // Allow lines that reference web_search_tool_result nearby (paired check).
       // Multi-line patterns like `block.type === "tool_result" ||\n  block.type === "web_search_tool_result"`
@@ -821,7 +825,9 @@ describe("web_search_tool_result structural guard", () => {
       const windowEnd = Math.min(lines.length - 1, i + 3);
       let pairedOrSuppressed = false;
       for (let j = windowStart; j <= windowEnd; j++) {
-        if (consumedSuppressions.has(j)) continue;
+        if (consumedSuppressions.has(j)) {
+          continue;
+        }
         if (
           /web_search_tool_result/.test(lines[j]) ||
           /guard:allow-tool-result-only/.test(lines[j])
@@ -831,10 +837,14 @@ describe("web_search_tool_result structural guard", () => {
           break;
         }
       }
-      if (pairedOrSuppressed) continue;
+      if (pairedOrSuppressed) {
+        continue;
+      }
 
       // Allow comment-only lines
-      if (/^\s*\/\//.test(line) || /^\s*\*/.test(line)) continue;
+      if (/^\s*\/\//.test(line) || /^\s*\*/.test(line)) {
+        continue;
+      }
 
       violations.push({
         file: filePath,
@@ -889,7 +899,9 @@ describe("web_search_tool_result structural guard", () => {
       const relPath = filePath.slice(SRC_DIR.length + 1);
 
       // Skip allowlisted files
-      if (ALLOWLISTED_FILES.has(relPath)) continue;
+      if (ALLOWLISTED_FILES.has(relPath)) {
+        continue;
+      }
 
       const source = readFileSync(filePath, "utf-8");
       const violations = findRawToolResultChecks(source, relPath);

--- a/assistant/src/__tests__/conversation-lifecycle.test.ts
+++ b/assistant/src/__tests__/conversation-lifecycle.test.ts
@@ -65,7 +65,7 @@ mock.module("../security/secret-allowlist.js", () => ({
 let mockDbMessages: Array<{
   id: string;
   role: string;
-  content: string;
+  content: unknown;
   metadata?: string | null;
 }> = [];
 let mockConversation: Record<string, unknown> | null = null;
@@ -88,7 +88,7 @@ mock.module("../persistence/conversation-crud.js", () => ({
   addMessage: async (
     _conversationId: string,
     role: string,
-    content: string,
+    content: unknown,
     options?: { metadata?: Record<string, unknown> },
   ) => {
     const metadata = options?.metadata;
@@ -206,13 +206,13 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "Hi" }]),
+        content: [{ type: "text", text: "Hi" }],
         metadata: JSON.stringify({ memoryInjectedBlock: "remember: alice" }),
       },
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Hello" }]),
+        content: [{ type: "text", text: "Hello" }],
       },
       // Ensure m1 is historical (not the tail) so memory rehydration triggers
       // on a non-tail user row. Memory applies to all rows either way, but a
@@ -240,7 +240,7 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "First turn" }]),
+        content: [{ type: "text", text: "First turn" }],
         metadata: JSON.stringify({
           memoryInjectedBlock: "mem payload",
           turnContextBlock: "<turn_context>\nctx payload\n</turn_context>",
@@ -251,12 +251,12 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+        content: [{ type: "text", text: "Reply" }],
       },
       {
         id: "m3",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "Second turn (tail)" }]),
+        content: [{ type: "text", text: "Second turn (tail)" }],
       },
     ];
 
@@ -291,17 +291,17 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "First" }]),
+        content: [{ type: "text", text: "First" }],
       },
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+        content: [{ type: "text", text: "Reply" }],
       },
       {
         id: "m3",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "Tail turn" }]),
+        content: [{ type: "text", text: "Tail turn" }],
         metadata: JSON.stringify({
           memoryInjectedBlock: "mem payload",
           turnContextBlock: "<turn_context>\nctx\n</turn_context>",
@@ -334,18 +334,18 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "First" }]),
+        content: [{ type: "text", text: "First" }],
         metadata: JSON.stringify({}),
       },
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+        content: [{ type: "text", text: "Reply" }],
       },
       {
         id: "m3",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "Second" }]),
+        content: [{ type: "text", text: "Second" }],
         metadata: JSON.stringify({ userMessageChannel: "desktop" }),
       },
     ];
@@ -369,7 +369,7 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "Hi" }]),
+        content: [{ type: "text", text: "Hi" }],
         metadata: JSON.stringify({
           memoryInjectedBlock: "<memory>\nremember: alice\n</memory>",
         }),
@@ -377,7 +377,7 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Hello" }]),
+        content: [{ type: "text", text: "Hello" }],
       },
     ];
 
@@ -391,7 +391,9 @@ describe("loadFromDb metadata injection rehydration", () => {
       type: "text",
       text: "<memory>\nremember: alice\n</memory>",
     });
-    if (firstBlock.type !== "text") throw new Error("unexpected block type");
+    if (firstBlock.type !== "text") {
+      throw new Error("unexpected block type");
+    }
     expect(firstBlock.text.match(/<memory>/g)?.length).toBe(1);
   });
 
@@ -405,7 +407,7 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "First turn" }]),
+        content: [{ type: "text", text: "First turn" }],
         metadata: JSON.stringify({
           memoryV3InjectedBlock:
             "header line\n\n# memory/concepts/page-a.md\nhead a",
@@ -414,12 +416,12 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+        content: [{ type: "text", text: "Reply" }],
       },
       {
         id: "m3",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "Tail turn" }]),
+        content: [{ type: "text", text: "Tail turn" }],
         metadata: JSON.stringify({
           memoryV3InjectedBlock: "# memory/concepts/page-b.md\nhead b",
         }),
@@ -458,7 +460,7 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "First turn" }]),
+        content: [{ type: "text", text: "First turn" }],
         metadata: JSON.stringify({
           memoryV3InjectedBlock:
             "header line\n\n# memory/concepts/page-a.md\nhead a\n\n# memory/concepts/page-b.md\nhead b",
@@ -467,7 +469,7 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+        content: [{ type: "text", text: "Reply" }],
       },
     ];
 
@@ -491,7 +493,7 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "First turn" }]),
+        content: [{ type: "text", text: "First turn" }],
         metadata: JSON.stringify({
           memoryV3InjectedBlock:
             "header line\n\n# memory/concepts/page-a.md\nhead a",
@@ -500,7 +502,7 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+        content: [{ type: "text", text: "Reply" }],
       },
     ];
 
@@ -519,7 +521,7 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "Hi" }]),
+        content: [{ type: "text", text: "Hi" }],
         metadata: JSON.stringify({
           memoryV3InjectedBlock:
             "<memory>\n# memory/concepts/page-a.md\nhead a\n</memory>",
@@ -528,7 +530,7 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Hello" }]),
+        content: [{ type: "text", text: "Hello" }],
       },
     ];
 
@@ -541,7 +543,9 @@ describe("loadFromDb metadata injection rehydration", () => {
       type: "text",
       text: "<memory>\n# memory/concepts/page-a.md\nhead a\n</memory>",
     });
-    if (firstBlock.type !== "text") throw new Error("unexpected block type");
+    if (firstBlock.type !== "text") {
+      throw new Error("unexpected block type");
+    }
     expect(firstBlock.text.match(/<memory>/g)?.length).toBe(1);
   });
 
@@ -551,13 +555,13 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "First" }]),
+        content: [{ type: "text", text: "First" }],
         metadata: "not-json",
       },
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+        content: [{ type: "text", text: "Reply" }],
       },
     ];
 
@@ -576,7 +580,7 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "First turn" }]),
+        content: [{ type: "text", text: "First turn" }],
         metadata: JSON.stringify({
           memoryInjectedBlock: "mem payload",
           memoryV2StaticBlock:
@@ -588,12 +592,12 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+        content: [{ type: "text", text: "Reply" }],
       },
       {
         id: "m3",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "Tail turn" }]),
+        content: [{ type: "text", text: "Tail turn" }],
       },
     ];
 
@@ -627,7 +631,7 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "First turn" }]),
+        content: [{ type: "text", text: "First turn" }],
         metadata: JSON.stringify({
           memoryV2StaticBlock:
             "<memory>\n## Essentials\n\nAlice prefers VS Code.\n</memory>",
@@ -636,12 +640,12 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+        content: [{ type: "text", text: "Reply" }],
       },
       {
         id: "m3",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "Tail turn" }]),
+        content: [{ type: "text", text: "Tail turn" }],
       },
     ];
 
@@ -664,17 +668,17 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "First" }]),
+        content: [{ type: "text", text: "First" }],
       },
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+        content: [{ type: "text", text: "Reply" }],
       },
       {
         id: "m3",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "Tail" }]),
+        content: [{ type: "text", text: "Tail" }],
         metadata: JSON.stringify({
           memoryV2StaticBlock: "<info>\n## Essentials\n\nleak\n</info>",
         }),
@@ -705,7 +709,7 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "First" }]),
+        content: [{ type: "text", text: "First" }],
         metadata: JSON.stringify({
           // Rows must carry `trusted_contact` / `unknown` provenance to
           // survive the row-level filter for non-guardian views.
@@ -717,13 +721,13 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+        content: [{ type: "text", text: "Reply" }],
         metadata: JSON.stringify({ provenanceTrustClass: "trusted_contact" }),
       },
       {
         id: "m3",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "Tail" }]),
+        content: [{ type: "text", text: "Tail" }],
         metadata: JSON.stringify({ provenanceTrustClass: "trusted_contact" }),
       },
     ];
@@ -759,7 +763,7 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "First turn" }]),
+        content: [{ type: "text", text: "First turn" }],
         metadata: JSON.stringify({
           memoryInjectedBlock: "mem payload",
           memoryV2StaticBlock:
@@ -773,12 +777,12 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+        content: [{ type: "text", text: "Reply" }],
       },
       {
         id: "m3",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "Tail" }]),
+        content: [{ type: "text", text: "Tail" }],
       },
     ];
 
@@ -825,7 +829,7 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "First turn" }]),
+        content: [{ type: "text", text: "First turn" }],
         metadata: JSON.stringify({
           workspaceBlock: "<workspace>\nworkspace body\n</workspace>",
           turnContextBlock: "<turn_context>\nctx payload\n</turn_context>",
@@ -843,12 +847,12 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+        content: [{ type: "text", text: "Reply" }],
       },
       {
         id: "m3",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "Tail" }]),
+        content: [{ type: "text", text: "Tail" }],
       },
     ];
 
@@ -901,7 +905,7 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "First turn" }]),
+        content: [{ type: "text", text: "First turn" }],
         metadata: JSON.stringify({
           workspaceBlock: "<workspace>\nworkspace body\n</workspace>",
           backgroundTurnBlock: "<background_turn>\nbg body\n</background_turn>",
@@ -924,12 +928,12 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+        content: [{ type: "text", text: "Reply" }],
       },
       {
         id: "m3",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "Tail" }]),
+        content: [{ type: "text", text: "Tail" }],
       },
     ];
 
@@ -977,7 +981,7 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "Tail" }]),
+        content: [{ type: "text", text: "Tail" }],
         metadata: JSON.stringify({
           backgroundTurnBlock: "<background_turn>\nbg body\n</background_turn>",
           channelCapabilitiesBlock:
@@ -1004,7 +1008,7 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "First" }]),
+        content: [{ type: "text", text: "First" }],
         metadata: JSON.stringify({
           provenanceTrustClass: "trusted_contact",
           memoryV2StaticBlock:
@@ -1014,13 +1018,13 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+        content: [{ type: "text", text: "Reply" }],
         metadata: JSON.stringify({ provenanceTrustClass: "unknown" }),
       },
       {
         id: "m3",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "Tail" }]),
+        content: [{ type: "text", text: "Tail" }],
         metadata: JSON.stringify({ provenanceTrustClass: "trusted_contact" }),
       },
     ];
@@ -1049,7 +1053,7 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "First" }]),
+        content: [{ type: "text", text: "First" }],
         metadata: JSON.stringify({
           provenanceTrustClass: "trusted_contact",
           memoryV3InjectedBlock:
@@ -1059,13 +1063,13 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+        content: [{ type: "text", text: "Reply" }],
         metadata: JSON.stringify({ provenanceTrustClass: "unknown" }),
       },
       {
         id: "m3",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "Tail" }]),
+        content: [{ type: "text", text: "Tail" }],
         metadata: JSON.stringify({
           provenanceTrustClass: "trusted_contact",
           memoryV3InjectedBlock: "# memory/concepts/page-b.md\nhead b",
@@ -1098,7 +1102,7 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "First" }]),
+        content: [{ type: "text", text: "First" }],
         metadata: JSON.stringify({
           provenanceTrustClass: "trusted_contact",
           memoryV2StaticBlock:
@@ -1108,13 +1112,13 @@ describe("loadFromDb metadata injection rehydration", () => {
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+        content: [{ type: "text", text: "Reply" }],
         metadata: JSON.stringify({ provenanceTrustClass: "trusted_contact" }),
       },
       {
         id: "m3",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "Tail" }]),
+        content: [{ type: "text", text: "Tail" }],
         metadata: JSON.stringify({ provenanceTrustClass: "trusted_contact" }),
       },
     ];

--- a/assistant/src/__tests__/conversation-load-history-repair.test.ts
+++ b/assistant/src/__tests__/conversation-load-history-repair.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { resolveMessageContentBlocks } from "../persistence/message-content-file.js";
 import type { Message } from "../providers/types.js";
 
 // Stub out heavy dependencies before importing Conversation
@@ -67,7 +68,7 @@ mock.module("../security/secret-allowlist.js", () => ({
 let mockDbMessages: Array<{
   id: string;
   role: string;
-  content: string;
+  content: unknown;
   metadata?: string | null;
 }> = [];
 let mockConversation: Record<string, unknown> | null = null;
@@ -86,13 +87,20 @@ mock.module("../persistence/conversation-crud.js", () => ({
   }),
   getConversationOriginInterface: () => null,
   getConversationOriginChannel: () => null,
-  getMessages: () => mockDbMessages,
+  getMessages: () =>
+    mockDbMessages.map((m) => ({
+      ...m,
+      content:
+        typeof m.content === "string"
+          ? resolveMessageContentBlocks(m.content)
+          : m.content,
+    })),
   getConversation: () => mockConversation,
   createConversation: () => ({ id: "conv-1" }),
   addMessage: async (
     _conversationId: string,
     role: string,
-    content: string,
+    content: unknown,
     options?: { metadata?: Record<string, unknown> },
   ) => {
     const metadata = options?.metadata;
@@ -158,20 +166,20 @@ describe("loadFromDb history repair", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "Hello" }]),
+        content: [{ type: "text", text: "Hello" }],
       },
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([
+        content: [
           { type: "tool_use", id: "tu_1", name: "bash", input: { cmd: "ls" } },
-        ]),
+        ],
       },
       // Missing user message with tool_result for tu_1
       {
         id: "m3",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Done" }]),
+        content: [{ type: "text", text: "Done" }],
       },
     ];
 
@@ -242,7 +250,7 @@ describe("loadFromDb history repair", () => {
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Hi" }]),
+        content: [{ type: "text", text: "Hi" }],
       },
     ];
 
@@ -275,7 +283,7 @@ describe("loadFromDb history repair", () => {
       {
         id: "m4",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Done" }]),
+        content: [{ type: "text", text: "Done" }],
       },
     ];
 
@@ -284,8 +292,8 @@ describe("loadFromDb history repair", () => {
     const messages = conversation.getMessages();
 
     expect(messages).toHaveLength(4);
-    // String JSON should be wrapped
-    expect(messages[0].content).toEqual([{ type: "text", text: '"hello"' }]);
+    // String JSON unwraps to its parsed value (uniform resolver semantics)
+    expect(messages[0].content).toEqual([{ type: "text", text: "hello" }]);
     // Number JSON should be wrapped
     expect(messages[1].content).toEqual([{ type: "text", text: "42" }]);
     // Object JSON should be wrapped
@@ -307,15 +315,15 @@ describe("loadFromDb history repair", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "Hello" }]),
+        content: [{ type: "text", text: "Hello" }],
       },
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([
+        content: [
           { type: "text", text: "Sure" },
           { type: "tool_result", tool_use_id: "tu_x", content: "stale" },
-        ]),
+        ],
       },
     ];
 
@@ -340,9 +348,7 @@ describe("loadFromDb history repair", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([
-          { type: "text", text: "Guardian secret question" },
-        ]),
+        content: [{ type: "text", text: "Guardian secret question" }],
         metadata: JSON.stringify({
           provenanceTrustClass: "guardian",
           provenanceSourceChannel: "telegram",
@@ -351,9 +357,7 @@ describe("loadFromDb history repair", () => {
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([
-          { type: "text", text: "Guardian-only answer" },
-        ]),
+        content: [{ type: "text", text: "Guardian-only answer" }],
         metadata: JSON.stringify({
           provenanceTrustClass: "guardian",
           provenanceSourceChannel: "telegram",
@@ -362,9 +366,7 @@ describe("loadFromDb history repair", () => {
       {
         id: "m3",
         role: "user",
-        content: JSON.stringify([
-          { type: "text", text: "Untrusted follow-up" },
-        ]),
+        content: [{ type: "text", text: "Untrusted follow-up" }],
         metadata: JSON.stringify({
           provenanceTrustClass: "unknown",
           provenanceSourceChannel: "telegram",
@@ -373,9 +375,7 @@ describe("loadFromDb history repair", () => {
       {
         id: "m4",
         role: "assistant",
-        content: JSON.stringify([
-          { type: "text", text: "Untrusted-safe reply" },
-        ]),
+        content: [{ type: "text", text: "Untrusted-safe reply" }],
         metadata: JSON.stringify({
           provenanceTrustClass: "unknown",
           provenanceSourceChannel: "telegram",
@@ -415,7 +415,7 @@ describe("loadFromDb history repair", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "Guardian question" }]),
+        content: [{ type: "text", text: "Guardian question" }],
         metadata: JSON.stringify({
           provenanceTrustClass: "guardian",
           provenanceSourceChannel: "telegram",
@@ -424,7 +424,7 @@ describe("loadFromDb history repair", () => {
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Guardian answer" }]),
+        content: [{ type: "text", text: "Guardian answer" }],
         metadata: JSON.stringify({
           provenanceTrustClass: "guardian",
           provenanceSourceChannel: "telegram",
@@ -433,7 +433,7 @@ describe("loadFromDb history repair", () => {
       {
         id: "m3",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "Unverified ping" }]),
+        content: [{ type: "text", text: "Unverified ping" }],
         metadata: JSON.stringify({
           provenanceTrustClass: "unknown",
           provenanceSourceChannel: "telegram",
@@ -442,7 +442,7 @@ describe("loadFromDb history repair", () => {
       {
         id: "m4",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Unverified reply" }]),
+        content: [{ type: "text", text: "Unverified reply" }],
         metadata: JSON.stringify({
           provenanceTrustClass: "unknown",
           provenanceSourceChannel: "telegram",
@@ -487,9 +487,7 @@ describe("loadFromDb history repair", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([
-          { type: "text", text: "Guardian-only question" },
-        ]),
+        content: [{ type: "text", text: "Guardian-only question" }],
         metadata: JSON.stringify({
           provenanceTrustClass: "guardian",
           provenanceSourceChannel: "telegram",
@@ -498,9 +496,7 @@ describe("loadFromDb history repair", () => {
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([
-          { type: "text", text: "Guardian-only answer" },
-        ]),
+        content: [{ type: "text", text: "Guardian-only answer" }],
         metadata: JSON.stringify({
           provenanceTrustClass: "guardian",
           provenanceSourceChannel: "telegram",
@@ -509,7 +505,7 @@ describe("loadFromDb history repair", () => {
       {
         id: "m3",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "Unverified ping" }]),
+        content: [{ type: "text", text: "Unverified ping" }],
         metadata: JSON.stringify({
           provenanceTrustClass: "unknown",
           provenanceSourceChannel: "telegram",
@@ -518,7 +514,7 @@ describe("loadFromDb history repair", () => {
       {
         id: "m4",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Unverified reply" }]),
+        content: [{ type: "text", text: "Unverified reply" }],
         metadata: JSON.stringify({
           provenanceTrustClass: "unknown",
           provenanceSourceChannel: "telegram",
@@ -570,25 +566,21 @@ describe("loadFromDb turn-count rehydration", () => {
 
   const userText = (text: string) => ({
     role: "user",
-    content: JSON.stringify([{ type: "text", text }]),
+    content: [{ type: "text", text }],
   });
   const assistantText = (text: string) => ({
     role: "assistant",
-    content: JSON.stringify([{ type: "text", text }]),
+    content: [{ type: "text", text }],
   });
   const assistantToolUse = (id: string) => ({
     role: "assistant",
-    content: JSON.stringify([
-      { type: "tool_use", id, name: "bash", input: { cmd: "ls" } },
-    ]),
+    content: [{ type: "tool_use", id, name: "bash", input: { cmd: "ls" } }],
   });
   const toolResult = (id: string) => ({
     role: "user",
-    content: JSON.stringify([
-      { type: "tool_result", tool_use_id: id, content: "ok" },
-    ]),
+    content: [{ type: "tool_result", tool_use_id: id, content: "ok" }],
   });
-  const withIds = (msgs: Array<{ role: string; content: string }>) =>
+  const withIds = (msgs: Array<{ role: string; content: unknown }>) =>
     msgs.map((m, i) => ({ id: `m${i}`, ...m }));
 
   test("restores turnCount from persisted history rather than resetting to 0", async () => {

--- a/assistant/src/__tests__/conversation-load-history-stripped.test.ts
+++ b/assistant/src/__tests__/conversation-load-history-stripped.test.ts
@@ -63,7 +63,7 @@ mock.module("../security/secret-allowlist.js", () => ({
 let mockDbMessages: Array<{
   id: string;
   role: string;
-  content: string;
+  content: unknown;
   createdAt: number;
   metadata?: string | null;
 }> = [];
@@ -147,31 +147,31 @@ describe("loadFromDb with historyStrippedAt", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([
+        content: [
           {
             type: "text",
             text: "<channel_capabilities>old</channel_capabilities>",
           },
           { type: "text", text: "Hello" },
-        ]),
+        ],
         createdAt: 500,
       },
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Hi back" }]),
+        content: [{ type: "text", text: "Hi back" }],
         createdAt: 600,
       },
       {
         id: "m3",
         role: "user",
-        content: JSON.stringify([
+        content: [
           {
             type: "text",
             text: "<channel_capabilities>fresh</channel_capabilities>",
           },
           { type: "text", text: "Second turn" },
-        ]),
+        ],
         createdAt: 1500,
       },
     ];
@@ -204,7 +204,7 @@ describe("loadFromDb with historyStrippedAt", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "Pre-strip turn" }]),
+        content: [{ type: "text", text: "Pre-strip turn" }],
         createdAt: 500,
         metadata: JSON.stringify({
           pkbContextBlock: "<knowledge_base>stale</knowledge_base>",
@@ -213,15 +213,13 @@ describe("loadFromDb with historyStrippedAt", () => {
       {
         id: "m2",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+        content: [{ type: "text", text: "Reply" }],
         createdAt: 600,
       },
       {
         id: "m3",
         role: "user",
-        content: JSON.stringify([
-          { type: "text", text: "Mid post-strip turn" },
-        ]),
+        content: [{ type: "text", text: "Mid post-strip turn" }],
         createdAt: 1500,
         metadata: JSON.stringify({
           pkbContextBlock: "<knowledge_base>kept</knowledge_base>",
@@ -230,7 +228,7 @@ describe("loadFromDb with historyStrippedAt", () => {
       {
         id: "m4",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Tail reply" }]),
+        content: [{ type: "text", text: "Tail reply" }],
         createdAt: 1600,
       },
     ];
@@ -259,13 +257,13 @@ describe("loadFromDb with historyStrippedAt", () => {
       {
         id: "m1",
         role: "user",
-        content: JSON.stringify([
+        content: [
           {
             type: "text",
             text: "<channel_capabilities>kept</channel_capabilities>",
           },
           { type: "text", text: "Hi" },
-        ]),
+        ],
         createdAt: 500,
       },
     ];

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -3216,7 +3216,7 @@ describe("Slack channel chronological rendering — multi-thread", () => {
       id: opts.id,
       conversationId: "conv-1",
       role: "user",
-      content: JSON.stringify([{ type: "text", text: opts.text }]),
+      content: [{ type: "text", text: opts.text }],
       createdAt: opts.createdAt,
       metadata: Object.keys(outer).length > 0 ? JSON.stringify(outer) : null,
       clientMessageId: null,
@@ -3238,7 +3238,7 @@ describe("Slack channel chronological rendering — multi-thread", () => {
       id: opts.id,
       conversationId: "conv-1",
       role: "assistant",
-      content: JSON.stringify([{ type: "text", text: opts.text }]),
+      content: [{ type: "text", text: opts.text }],
       createdAt: opts.createdAt,
       metadata: Object.keys(outer).length > 0 ? JSON.stringify(outer) : null,
       clientMessageId: null,
@@ -4239,7 +4239,10 @@ describe("Slack channel chronological rendering — multi-thread", () => {
             id: r.id,
             conversationId: "runtime-assembly-fallback",
             role: r.role,
-            content: r.content,
+            content:
+              typeof r.content === "string"
+                ? r.content
+                : JSON.stringify(r.content),
             createdAt: r.createdAt,
             metadata: r.metadata,
           })),

--- a/assistant/src/__tests__/conversation-store.test.ts
+++ b/assistant/src/__tests__/conversation-store.test.ts
@@ -49,8 +49,12 @@ describe("deleteLastExchange", () => {
 
     const remaining = getMessages(conv.id);
     expect(remaining).toHaveLength(2);
-    expect(remaining[0].content).toBe("first question");
-    expect(remaining[1].content).toBe("first answer");
+    expect(remaining[0].content).toEqual([
+      { type: "text", text: "first question" },
+    ]);
+    expect(remaining[1].content).toEqual([
+      { type: "text", text: "first answer" },
+    ]);
   });
 
   test("returns 0 when no user messages exist", () => {
@@ -94,8 +98,8 @@ describe("deleteLastExchange", () => {
 
     const remaining = getMessages(conv.id);
     expect(remaining).toHaveLength(2);
-    expect(remaining[0].content).toBe("first");
-    expect(remaining[1].content).toBe("reply1");
+    expect(remaining[0].content).toEqual([{ type: "text", text: "first" }]);
+    expect(remaining[1].content).toEqual([{ type: "text", text: "reply1" }]);
   });
 });
 

--- a/assistant/src/__tests__/conversation-summarize-up-to.test.ts
+++ b/assistant/src/__tests__/conversation-summarize-up-to.test.ts
@@ -124,7 +124,7 @@ interface MockRow {
   id: string;
   conversationId: string;
   role: string;
-  content: string;
+  content: unknown;
   createdAt: number;
   metadata: string | null;
   clientMessageId: string | null;
@@ -330,7 +330,7 @@ function row(id: string, role: string, text: string): MockRow {
     id,
     conversationId: "conv-1",
     role,
-    content: JSON.stringify([{ type: "text", text }]),
+    content: [{ type: "text", text }],
     createdAt: nextCreatedAt++,
     metadata: null,
     clientMessageId: null,
@@ -687,9 +687,9 @@ describe("Conversation.summarizeUpToMessage", () => {
       row("m0", "user", "u1"),
       {
         ...row("m1", "assistant", ""),
-        content: JSON.stringify([
+        content: [
           { type: "tool_use", id: "tu_1", name: "bash", input: { cmd: "ls" } },
-        ]),
+        ],
       },
       row("m2", "assistant", "continued"),
       row("m3", "user", "u2"),

--- a/assistant/src/__tests__/conversation-surfaces-data-persist.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-data-persist.test.ts
@@ -16,7 +16,7 @@ let getMessagesImpl: (conversationId: string) => Array<{
   id: string;
   conversationId: string;
   role: string;
-  content: string;
+  content: unknown;
   createdAt: number;
   metadata: string | null;
 }> = () => [];
@@ -87,7 +87,9 @@ function seedRows(rows: Array<{ id: string; content: unknown }>): void {
       conversationId: "conv-persist-1",
       role: "assistant",
       content:
-        typeof r.content === "string" ? r.content : JSON.stringify(r.content),
+        typeof r.content === "string"
+          ? [{ type: "text", text: r.content }]
+          : r.content,
       createdAt: 0,
       metadata: null,
     }));

--- a/assistant/src/__tests__/persist-unsendable-image-downscale.test.ts
+++ b/assistant/src/__tests__/persist-unsendable-image-downscale.test.ts
@@ -107,9 +107,7 @@ function toolResultWithImage(data: string): ContentBlock {
 }
 
 function storedContent(conversationId: string): ContentBlock[][] {
-  return getMessages(conversationId).map(
-    (row) => JSON.parse(row.content) as ContentBlock[],
-  );
+  return getMessages(conversationId).map((row) => row.content);
 }
 
 describe("persistUnsendableImageDowngrades (downscalable host)", () => {

--- a/assistant/src/__tests__/persist-unsendable-image.test.ts
+++ b/assistant/src/__tests__/persist-unsendable-image.test.ts
@@ -105,9 +105,7 @@ function toolResultWithImage(data: string): ContentBlock {
 }
 
 function storedContent(conversationId: string): ContentBlock[][] {
-  return getMessages(conversationId).map(
-    (row) => JSON.parse(row.content) as ContentBlock[],
-  );
+  return getMessages(conversationId).map((row) => row.content);
 }
 
 const PROVIDER_MAX_IMAGE_DIMENSION = 8000;

--- a/assistant/src/__tests__/subagent-detail.test.ts
+++ b/assistant/src/__tests__/subagent-detail.test.ts
@@ -15,7 +15,7 @@ function msg(role: string, content: unknown[]): MessageRow {
     id: `msg-${msgCounter}`,
     conversationId: "conv-1",
     role,
-    content: JSON.stringify(content),
+    content: content as MessageRow["content"],
     createdAt: Date.now(),
     metadata: null,
     clientMessageId: null,

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, mock, test } from "bun:test";
 // Mock conversation-crud before importing tool executors that depend on it.
 let mockGetMessages: (
   conversationId: string,
-) => Array<{ role: string; content: string }> | null = () => null;
+) => Array<{ role: string; content: unknown }> | null = () => null;
 const mockProfiles = {
   balanced: {},
   "cost-optimized": {},
@@ -79,6 +79,7 @@ mock.module("../persistence/conversation-crud.js", () => ({
   reserveMessage: mock(async () => ({ id: "msg-reserve" })),
 }));
 
+import { resolveMessageContentBlocks } from "../persistence/message-content-file.js";
 import { getSubagentManager } from "../subagent/index.js";
 import { SubagentAbortedError, SubagentManager } from "../subagent/manager.js";
 import type { SubagentState } from "../subagent/types.js";
@@ -848,18 +849,18 @@ describe("Subagent read tool", () => {
     injectSubagent(manager, subagentId, ownerConversation, "completed");
 
     mockGetMessages = (convId: string) => {
-      if (convId !== `conv-${subagentId}`) return null;
+      if (convId !== `conv-${subagentId}`) {
+        return null;
+      }
       return [
         { role: "user", content: "Do the thing" },
         {
           role: "assistant",
-          content: JSON.stringify([
-            { type: "text", text: "Here is the result" },
-          ]),
+          content: [{ type: "text", text: "Here is the result" }],
         },
         {
           role: "assistant",
-          content: JSON.stringify([{ type: "text", text: "And more details" }]),
+          content: [{ type: "text", text: "And more details" }],
         },
       ];
     };
@@ -883,8 +884,15 @@ describe("Subagent read tool", () => {
     injectSubagent(manager, subagentId, ownerConversation, "completed");
 
     mockGetMessages = (convId: string) => {
-      if (convId !== `conv-${subagentId}`) return null;
-      return [{ role: "assistant", content: "Plain text response" }];
+      if (convId !== `conv-${subagentId}`) {
+        return null;
+      }
+      return [
+        {
+          role: "assistant",
+          content: resolveMessageContentBlocks("Plain text response"),
+        },
+      ];
     };
 
     try {
@@ -905,9 +913,16 @@ describe("Subagent read tool", () => {
     injectSubagent(manager, subagentId, ownerConversation, "completed");
 
     mockGetMessages = (convId: string) => {
-      if (convId !== `conv-${subagentId}`) return null;
+      if (convId !== `conv-${subagentId}`) {
+        return null;
+      }
       return [
-        { role: "assistant", content: JSON.stringify("A JSON string value") },
+        {
+          role: "assistant",
+          content: resolveMessageContentBlocks(
+            JSON.stringify("A JSON string value"),
+          ),
+        },
       ];
     };
 
@@ -929,14 +944,16 @@ describe("Subagent read tool", () => {
     injectSubagent(manager, subagentId, ownerConversation, "completed");
 
     mockGetMessages = (convId: string) => {
-      if (convId !== `conv-${subagentId}`) return null;
+      if (convId !== `conv-${subagentId}`) {
+        return null;
+      }
       return [
         {
           role: "assistant",
-          content: JSON.stringify([
+          content: [
             { type: "tool_use", id: "tool-1", name: "bash", input: {} },
             { type: "text", text: "Actual output" },
-          ]),
+          ],
         },
       ];
     };
@@ -960,7 +977,9 @@ describe("Subagent read tool", () => {
     injectSubagent(manager, subagentId, ownerConversation, "completed");
 
     mockGetMessages = (convId: string) => {
-      if (convId !== `conv-${subagentId}`) return null;
+      if (convId !== `conv-${subagentId}`) {
+        return null;
+      }
       return [
         { role: "user", content: "Do something" },
         { role: "tool", content: "tool result" },
@@ -1019,13 +1038,13 @@ describe("Subagent read tool", () => {
     injectSubagent(manager, subagentId, ownerConversation, "failed");
 
     mockGetMessages = (convId: string) => {
-      if (convId !== `conv-${subagentId}`) return null;
+      if (convId !== `conv-${subagentId}`) {
+        return null;
+      }
       return [
         {
           role: "assistant",
-          content: JSON.stringify([
-            { type: "text", text: "Partial output before failure" },
-          ]),
+          content: [{ type: "text", text: "Partial output before failure" }],
         },
       ];
     };
@@ -1048,7 +1067,9 @@ describe("Subagent read tool", () => {
     injectSubagent(manager, subagentId, ownerConversation, "aborted");
 
     mockGetMessages = (convId: string) => {
-      if (convId !== `conv-${subagentId}`) return null;
+      if (convId !== `conv-${subagentId}`) {
+        return null;
+      }
       return [{ role: "assistant", content: "Output before abort" }];
     };
 
@@ -1070,7 +1091,9 @@ describe("Subagent read tool", () => {
     injectSubagent(manager, subagentId, ownerConversation, "completed");
 
     mockGetMessages = (convId: string) => {
-      if (convId !== `conv-${subagentId}`) return null;
+      if (convId !== `conv-${subagentId}`) {
+        return null;
+      }
       return [
         { role: "assistant", content: "First message" },
         { role: "assistant", content: "Second message" },
@@ -1096,7 +1119,9 @@ describe("Subagent read tool", () => {
     injectSubagent(manager, subagentId, ownerConversation, "completed");
 
     mockGetMessages = (convId: string) => {
-      if (convId !== `conv-${subagentId}`) return null;
+      if (convId !== `conv-${subagentId}`) {
+        return null;
+      }
       return [
         { role: "assistant", content: "First message" },
         { role: "assistant", content: "Second message" },
@@ -1122,7 +1147,9 @@ describe("Subagent read tool", () => {
     injectSubagent(manager, subagentId, ownerConversation, "completed");
 
     mockGetMessages = (convId: string) => {
-      if (convId !== `conv-${subagentId}`) return null;
+      if (convId !== `conv-${subagentId}`) {
+        return null;
+      }
       return [
         { role: "assistant", content: "First message" },
         { role: "assistant", content: "Second message" },
@@ -1150,7 +1177,9 @@ describe("Subagent read tool", () => {
     injectSubagent(manager, subagentId, ownerConversation, "completed");
 
     mockGetMessages = (convId: string) => {
-      if (convId !== `conv-${subagentId}`) return null;
+      if (convId !== `conv-${subagentId}`) {
+        return null;
+      }
       return [
         { role: "assistant", content: "First message" },
         { role: "assistant", content: "Second message" },
@@ -1175,7 +1204,9 @@ describe("Subagent read tool", () => {
     injectSubagent(manager, subagentId, ownerConversation, "completed");
 
     mockGetMessages = (convId: string) => {
-      if (convId !== `conv-${subagentId}`) return null;
+      if (convId !== `conv-${subagentId}`) {
+        return null;
+      }
       return [
         { role: "assistant", content: "First response" },
         { role: "user", content: "Follow up question" },
@@ -1208,7 +1239,9 @@ describe("Subagent read tool", () => {
     injectSubagent(manager, subagentId, ownerConversation, "completed");
 
     mockGetMessages = (convId: string) => {
-      if (convId !== `conv-${subagentId}`) return null;
+      if (convId !== `conv-${subagentId}`) {
+        return null;
+      }
       return [
         { role: "assistant", content: "First response" },
         { role: "user", content: "Follow up" },
@@ -1235,7 +1268,9 @@ describe("Subagent read tool", () => {
     injectSubagent(manager, subagentId, ownerConversation, "completed");
 
     mockGetMessages = (convId: string) => {
-      if (convId !== `conv-${subagentId}`) return null;
+      if (convId !== `conv-${subagentId}`) {
+        return null;
+      }
       return [
         { role: "assistant", content: "First response" },
         { role: "user", content: "Follow up" },
@@ -1262,7 +1297,9 @@ describe("Subagent read tool", () => {
     injectSubagent(manager, subagentId, ownerConversation, "completed");
 
     mockGetMessages = (convId: string) => {
-      if (convId !== `conv-${subagentId}`) return null;
+      if (convId !== `conv-${subagentId}`) {
+        return null;
+      }
       return [
         { role: "assistant", content: "First response" },
         { role: "assistant", content: "Second response" },
@@ -1290,7 +1327,9 @@ describe("Subagent read tool", () => {
     injectSubagent(manager, subagentId, ownerConversation, "completed");
 
     mockGetMessages = (convId: string) => {
-      if (convId !== `conv-${subagentId}`) return null;
+      if (convId !== `conv-${subagentId}`) {
+        return null;
+      }
       return [
         { role: "assistant", content: "First response" },
         { role: "assistant", content: "Second response" },
@@ -1428,13 +1467,13 @@ describe("Label-based subagent lookup", () => {
     });
 
     mockGetMessages = (convId: string) => {
-      if (convId !== `conv-${readSubId}`) return null;
+      if (convId !== `conv-${readSubId}`) {
+        return null;
+      }
       return [
         {
           role: "assistant",
-          content: JSON.stringify([
-            { type: "text", text: "Research findings here" },
-          ]),
+          content: [{ type: "text", text: "Research findings here" }],
         },
       ];
     };
@@ -1713,15 +1752,17 @@ describe("Subagent advisor-role consult", () => {
       getCurrentSystemPrompt: () => "SYS",
     });
     mockGetMessages = (convId: string) => {
-      if (convId !== "advisor-sess-3") return null;
+      if (convId !== "advisor-sess-3") {
+        return null;
+      }
       return [
         {
           role: "user",
-          content: JSON.stringify([{ type: "text", text: "Plan the work" }]),
+          content: [{ type: "text", text: "Plan the work" }],
         },
         {
           role: "assistant",
-          content: JSON.stringify([
+          content: [
             { type: "text", text: "My plan: step 1, step 2." },
             {
               type: "tool_use",
@@ -1729,7 +1770,7 @@ describe("Subagent advisor-role consult", () => {
               name: "subagent_spawn",
               input: {},
             },
-          ]),
+          ],
         },
       ];
     };

--- a/assistant/src/__tests__/suggestion-routes.test.ts
+++ b/assistant/src/__tests__/suggestion-routes.test.ts
@@ -33,7 +33,7 @@ const mockGetMessages = mock((_conversationId: string) => [
     id: "msg-user-1",
     conversationId: "conv-test",
     role: "user",
-    content: JSON.stringify([{ type: "text", text: "Hello there" }]),
+    content: [{ type: "text", text: "Hello there" }],
     createdAt: Date.now() - 2000,
     metadata: null,
   },
@@ -41,9 +41,7 @@ const mockGetMessages = mock((_conversationId: string) => [
     id: "msg-asst-1",
     conversationId: "conv-test",
     role: "assistant",
-    content: JSON.stringify([
-      { type: "text", text: "Hi! How can I help you today?" },
-    ]),
+    content: [{ type: "text", text: "Hi! How can I help you today?" }],
     createdAt: Date.now() - 1000,
     metadata: null,
   },
@@ -112,9 +110,12 @@ import { handleGetSuggestion } from "../runtime/routes/conversation-routes.js";
 
 function makeArgs(params: { conversationKey?: string; messageId?: string }) {
   const queryParams: Record<string, string> = {};
-  if (params.conversationKey)
+  if (params.conversationKey) {
     queryParams.conversationKey = params.conversationKey;
-  if (params.messageId) queryParams.messageId = params.messageId;
+  }
+  if (params.messageId) {
+    queryParams.messageId = params.messageId;
+  }
   return { queryParams };
 }
 
@@ -153,7 +154,7 @@ describe("GET /v1/suggestion", () => {
         id: "msg-user-1",
         conversationId: "conv-test",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "Hello" }]),
+        content: [{ type: "text", text: "Hello" }],
         createdAt: Date.now() - 2000,
         metadata: null,
       },
@@ -161,9 +162,7 @@ describe("GET /v1/suggestion", () => {
         id: "msg-asst-1",
         conversationId: "conv-test",
         role: "assistant",
-        content: JSON.stringify([
-          { type: "text", text: "Hi! How can I help you today?" },
-        ]),
+        content: [{ type: "text", text: "Hi! How can I help you today?" }],
         createdAt: Date.now() - 1000,
         metadata: null,
       },
@@ -215,7 +214,7 @@ describe("GET /v1/suggestion", () => {
         id: "msg-asst-1",
         conversationId: "conv-test",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Hello there" }]),
+        content: [{ type: "text", text: "Hello there" }],
         createdAt: Date.now(),
         metadata: null,
       },
@@ -251,7 +250,7 @@ describe("GET /v1/suggestion", () => {
         id: "msg-asst-1",
         conversationId: "conv-test",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Hello there" }]),
+        content: [{ type: "text", text: "Hello there" }],
         createdAt: Date.now(),
         metadata: null,
       },
@@ -277,7 +276,7 @@ describe("GET /v1/suggestion", () => {
         id: "msg-asst-1",
         conversationId: "conv-test",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Hello there" }]),
+        content: [{ type: "text", text: "Hello there" }],
         createdAt: Date.now(),
         metadata: null,
       },
@@ -302,7 +301,7 @@ describe("GET /v1/suggestion", () => {
         id: "msg-asst-1",
         conversationId: "conv-test",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Hello there" }]),
+        content: [{ type: "text", text: "Hello there" }],
         createdAt: Date.now(),
         metadata: null,
       },
@@ -327,7 +326,7 @@ describe("GET /v1/suggestion", () => {
         id: "msg-asst-cache",
         conversationId: "conv-test",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Some response" }]),
+        content: [{ type: "text", text: "Some response" }],
         createdAt: Date.now(),
         metadata: null,
       },
@@ -359,7 +358,7 @@ describe("GET /v1/suggestion", () => {
         id: "msg-asst-latest",
         conversationId: "conv-test",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Latest response" }]),
+        content: [{ type: "text", text: "Latest response" }],
         createdAt: Date.now(),
         metadata: null,
       },
@@ -393,7 +392,7 @@ describe("GET /v1/suggestion", () => {
         id: "msg-asst-1",
         conversationId: "conv-test",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Want to go?" }]),
+        content: [{ type: "text", text: "Want to go?" }],
         createdAt: Date.now(),
         metadata: null,
       },
@@ -418,7 +417,7 @@ describe("GET /v1/suggestion", () => {
         id: "msg-user-1",
         conversationId: "conv-test",
         role: "user",
-        content: JSON.stringify([{ type: "text", text: "heading out" }]),
+        content: [{ type: "text", text: "heading out" }],
         createdAt: Date.now() - 1000,
         metadata: null,
       },
@@ -426,9 +425,7 @@ describe("GET /v1/suggestion", () => {
         id: "msg-asst-shape",
         conversationId: "conv-test",
         role: "assistant",
-        content: JSON.stringify([
-          { type: "text", text: "see you there — which door?" },
-        ]),
+        content: [{ type: "text", text: "see you there — which door?" }],
         createdAt: Date.now(),
         metadata: null,
       },
@@ -470,9 +467,9 @@ describe("GET /v1/suggestion", () => {
         id: "msg-user-1",
         conversationId: "conv-test",
         role: "user",
-        content: JSON.stringify([
+        content: [
           { type: "text", text: "running late, should I grab coffee?" },
-        ]),
+        ],
         createdAt: Date.now() - 1000,
         metadata: null,
       },
@@ -480,9 +477,9 @@ describe("GET /v1/suggestion", () => {
         id: "msg-asst-1",
         conversationId: "conv-test",
         role: "assistant",
-        content: JSON.stringify([
+        content: [
           { type: "text", text: "yes please, an americano would be great" },
-        ]),
+        ],
         createdAt: Date.now(),
         metadata: null,
       },
@@ -516,7 +513,7 @@ describe("GET /v1/suggestion", () => {
         id: "msg-asst-first",
         conversationId: "conv-test",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "hi there!" }]),
+        content: [{ type: "text", text: "hi there!" }],
         createdAt: Date.now(),
         metadata: null,
       },
@@ -547,7 +544,7 @@ describe("GET /v1/suggestion", () => {
         id: "msg-asst-intent",
         conversationId: "conv-test",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Hello!" }]),
+        content: [{ type: "text", text: "Hello!" }],
         createdAt: Date.now(),
         metadata: null,
       },
@@ -585,7 +582,7 @@ describe("GET /v1/suggestion", () => {
         id: "msg-asst-thinking",
         conversationId: "conv-test",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Hello!" }]),
+        content: [{ type: "text", text: "Hello!" }],
         createdAt: Date.now(),
         metadata: null,
       },
@@ -627,9 +624,7 @@ describe("GET /v1/suggestion", () => {
         id: "msg-asst-1",
         conversationId: "conv-test",
         role: "assistant",
-        content: JSON.stringify([
-          { type: "text", text: "Want to meet tomorrow?" },
-        ]),
+        content: [{ type: "text", text: "Want to meet tomorrow?" }],
         createdAt: Date.now(),
         metadata: null,
       },
@@ -665,9 +660,7 @@ describe("GET /v1/suggestion", () => {
         id: "msg-asst-untagged",
         conversationId: "conv-test",
         role: "assistant",
-        content: JSON.stringify([
-          { type: "text", text: "Want to meet tomorrow?" },
-        ]),
+        content: [{ type: "text", text: "Want to meet tomorrow?" }],
         createdAt: Date.now(),
         metadata: null,
       },
@@ -697,7 +690,7 @@ describe("GET /v1/suggestion", () => {
         id: "msg-asst-preamble",
         conversationId: "conv-test",
         role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Ready to ship it?" }]),
+        content: [{ type: "text", text: "Ready to ship it?" }],
         createdAt: Date.now(),
         metadata: null,
       },

--- a/assistant/src/__tests__/summarize-boundary.test.ts
+++ b/assistant/src/__tests__/summarize-boundary.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import { resolveSummarizeBoundary } from "../daemon/summarize-boundary.js";
 import type { MessageRow } from "../persistence/conversation-crud.js";
+import { resolveMessageContentBlocks } from "../persistence/message-content-file.js";
 import { UserError } from "../util/errors.js";
 
 function row(id: string, role: string, content: string): MessageRow {
@@ -9,7 +10,7 @@ function row(id: string, role: string, content: string): MessageRow {
     id,
     conversationId: "conv-xyz",
     role,
-    content,
+    content: resolveMessageContentBlocks(content),
     createdAt: 0,
     metadata: null,
     clientMessageId: null,

--- a/assistant/src/__tests__/tool-start-timestamp.test.ts
+++ b/assistant/src/__tests__/tool-start-timestamp.test.ts
@@ -47,7 +47,7 @@ mock.module("../persistence/conversation-crud.js", () => ({
   isConversationProcessing: () => false,
   addMessage: () => ({ id: "mock-msg-id" }),
   getMessageById: (id: string) =>
-    mockedRowContent ? { id, content: mockedRowContent } : null,
+    mockedRowContent ? { id, content: JSON.parse(mockedRowContent) } : null,
   updateMessageContent: (id: string, content: string) => {
     updates.push({ id, content });
   },
@@ -122,7 +122,9 @@ function findBlockById(
 ): Record<string, unknown> {
   const parsed = JSON.parse(rawContent) as Array<Record<string, unknown>>;
   const block = parsed.find((b) => b.id === id);
-  if (!block) throw new Error(`block ${id} not found`);
+  if (!block) {
+    throw new Error(`block ${id} not found`);
+  }
   return block;
 }
 

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -44,7 +44,9 @@ const CLI_CONVERSATION_KEY = "builtin-cli:default";
 
 export function sanitizeUrlForDisplay(rawUrl: unknown): string {
   const value = typeof rawUrl === "string" ? rawUrl : String(rawUrl ?? "");
-  if (!value) return "";
+  if (!value) {
+    return "";
+  }
 
   try {
     const parsed = new URL(value);
@@ -167,7 +169,9 @@ export async function startCli(): Promise<void> {
           error?: string;
           message?: string;
         }): void => {
-          if (settled) return;
+          if (settled) {
+            return;
+          }
           settled = true;
           watcher.close();
           clearTimeout(timeoutId);
@@ -455,7 +459,9 @@ export async function startCli(): Promise<void> {
         break;
 
       case "tool_result":
-        if (!toolStreaming) spinner.stop();
+        if (!toolStreaming) {
+          spinner.stop();
+        }
         if (toolStreaming) {
           if (msg.status) {
             process.stdout.write(`\n${msg.status}`);
@@ -596,8 +602,12 @@ export async function startCli(): Promise<void> {
 
   function handleLine(line: string): void {
     const content = line.trim();
-    if (!content) return;
-    if (pendingSessionPick) return;
+    if (!content) {
+      return;
+    }
+    if (pendingSessionPick) {
+      return;
+    }
 
     // Persist to history file (ensure parent directory exists)
     try {
@@ -669,12 +679,7 @@ export async function startCli(): Promise<void> {
             process.stdout.write("  No messages in this conversation.\n");
           } else {
             for (const msg of rawMessages) {
-              let parsedContent: unknown;
-              try {
-                parsedContent = JSON.parse(msg.content);
-              } catch {
-                parsedContent = msg.content;
-              }
+              const parsedContent: unknown = msg.content;
               const text = renderHistoryContent(parsedContent).text;
               const label = msg.role === "user" ? "you" : "assistant";
               const preview = truncate(text, 120);
@@ -724,8 +729,12 @@ export async function startCli(): Promise<void> {
               requestId?: string;
               error?: string;
             };
-            if (result.requestId !== requestId) return;
-            if (settled) return;
+            if (result.requestId !== requestId) {
+              return;
+            }
+            if (settled) {
+              return;
+            }
             settled = true;
             undoWatcher.close();
             clearTimeout(undoTimeoutId);

--- a/assistant/src/conversations/__tests__/message-consolidation.test.ts
+++ b/assistant/src/conversations/__tests__/message-consolidation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type { MessageRow } from "../../persistence/conversation-crud.js";
+import { resolveMessageContentBlocks } from "../../persistence/message-content-file.js";
 import {
   findDisplayTurnEndIndex,
   isToolResultOnlyUserMessage,
@@ -17,7 +18,7 @@ function makeMsg(
     id: `msg-${Math.random().toString(36).slice(2, 10)}`,
     conversationId: "conv-1",
     role,
-    content,
+    content: resolveMessageContentBlocks(content),
     createdAt: Date.now(),
     displayOrder: 0,
     seen: 1,
@@ -254,7 +255,7 @@ describe("mergeToolResultsIntoAssistantMessages", () => {
     const merged = mergeToolResultsIntoAssistantMessages(messages);
     expect(merged).toHaveLength(1);
     expect(merged[0].role).toBe("assistant");
-    const blocks = JSON.parse(merged[0].content) as Array<{ type: string }>;
+    const blocks = merged[0].content as Array<{ type: string }>;
     expect(blocks.map((b) => b.type)).toEqual(["tool_use", "tool_result"]);
   });
 
@@ -275,7 +276,7 @@ describe("mergeToolResultsIntoAssistantMessages", () => {
     const merged = mergeToolResultsIntoAssistantMessages(messages);
     expect(merged).toHaveLength(2);
     expect(merged[1].role).toBe("user");
-    const userBlocks = JSON.parse(merged[1].content) as Array<{ type: string }>;
+    const userBlocks = merged[1].content as Array<{ type: string }>;
     expect(userBlocks.map((b) => b.type)).toEqual(["text"]);
   });
 
@@ -283,7 +284,7 @@ describe("mergeToolResultsIntoAssistantMessages", () => {
     const messages = [makeMsg("user", "hi"), makeMsg("assistant", "hello")];
     const merged = mergeToolResultsIntoAssistantMessages(messages);
     expect(merged).toHaveLength(2);
-    expect(merged[0].content).toBe("hi");
+    expect(merged[0].content).toEqual([{ type: "text", text: "hi" }]);
   });
 });
 
@@ -306,7 +307,7 @@ describe("mergeConsecutiveAssistantMessages", () => {
     ]);
     expect(messages).toHaveLength(2);
     expect(messages[1].id).toBe("anchor");
-    const blocks = JSON.parse(messages[1].content) as Array<{ text: string }>;
+    const blocks = messages[1].content as Array<{ text: string }>;
     expect(blocks.map((blk) => blk.text)).toEqual(["part 1", "part 2"]);
     expect(mergedIdMap.get("anchor")).toEqual(["tail"]);
   });

--- a/assistant/src/conversations/message-consolidation.ts
+++ b/assistant/src/conversations/message-consolidation.ts
@@ -32,6 +32,7 @@
  */
 
 import type { MessageRow } from "../persistence/conversation-crud.js";
+import type { ContentBlock } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("message-consolidation");
@@ -43,7 +44,9 @@ function isToolResultType(type: string): boolean {
 }
 
 function isSystemNoticeText(block: Record<string, unknown>): boolean {
-  if (block.type !== "text") return false;
+  if (block.type !== "text") {
+    return false;
+  }
   const text = typeof block.text === "string" ? block.text : "";
   return (
     text.startsWith("<system_notice>") && text.endsWith("</system_notice>")
@@ -59,15 +62,10 @@ function isSystemNoticeText(block: Record<string, unknown>): boolean {
  * must treat them as part of the surrounding assistant turn.
  */
 export function isToolResultOnlyUserMessage(msg: MessageRow): boolean {
-  if (msg.role !== "user") return false;
-  let blocks: unknown[];
-  try {
-    const parsed = JSON.parse(msg.content);
-    if (!Array.isArray(parsed)) return false;
-    blocks = parsed;
-  } catch {
+  if (msg.role !== "user") {
     return false;
   }
+  const blocks: unknown[] = msg.content;
 
   let sawToolResult = false;
   for (const block of blocks) {
@@ -117,13 +115,19 @@ export function findDisplayTurnEndIndex(
   messages: MessageRow[],
   startIdx: number,
 ): number {
-  if (startIdx < 0 || startIdx >= messages.length) return startIdx;
-  if (messages[startIdx]?.role !== "assistant") return startIdx;
+  if (startIdx < 0 || startIdx >= messages.length) {
+    return startIdx;
+  }
+  if (messages[startIdx]?.role !== "assistant") {
+    return startIdx;
+  }
 
   let endIdx = startIdx;
   while (endIdx + 1 < messages.length) {
     const next = messages[endIdx + 1];
-    if (!next) break;
+    if (!next) {
+      break;
+    }
     if (next.role === "assistant") {
       endIdx += 1;
       continue;
@@ -154,7 +158,7 @@ export function mergeToolResultsIntoAssistantMessages(
   // Index of the most recent assistant message in the output array.
   let lastAssistantIdx = -1;
   // Parsed content caches — lazily populated per assistant message.
-  const parsedAssistantContent = new Map<number, unknown[]>();
+  const parsedAssistantContent = new Map<number, ContentBlock[]>();
 
   const result: MessageRow[] = [];
 
@@ -171,18 +175,7 @@ export function mergeToolResultsIntoAssistantMessages(
       continue;
     }
 
-    let blocks: unknown[];
-    try {
-      const parsed = JSON.parse(msg.content);
-      if (!Array.isArray(parsed)) {
-        result.push(msg);
-        continue;
-      }
-      blocks = parsed;
-    } catch {
-      result.push(msg);
-      continue;
-    }
+    const blocks: unknown[] = msg.content;
 
     // Separate tool-result blocks from real user content.
     const toolResultBlocks: unknown[] = [];
@@ -224,15 +217,10 @@ export function mergeToolResultsIntoAssistantMessages(
       const assistant = result[lastAssistantIdx];
       let assistantContent = parsedAssistantContent.get(lastAssistantIdx);
       if (!assistantContent) {
-        try {
-          const parsed = JSON.parse(assistant.content);
-          assistantContent = Array.isArray(parsed) ? parsed : [parsed];
-        } catch {
-          assistantContent = [];
-        }
+        assistantContent = [...assistant.content];
         parsedAssistantContent.set(lastAssistantIdx, assistantContent);
       }
-      assistantContent.push(...toolResultBlocks);
+      assistantContent.push(...(toolResultBlocks as ContentBlock[]));
     }
 
     // If the user message had only tool_result (+ system_notice) blocks,
@@ -246,14 +234,14 @@ export function mergeToolResultsIntoAssistantMessages(
         ),
     );
     if (realUserContent.length > 0) {
-      result.push({ ...msg, content: JSON.stringify(otherBlocks) });
+      result.push({ ...msg, content: otherBlocks as ContentBlock[] });
     }
     // else: tool-result-only → suppressed
   }
 
   // Write back any modified assistant message content.
   for (const [idx, content] of parsedAssistantContent) {
-    result[idx] = { ...result[idx], content: JSON.stringify(content) };
+    result[idx] = { ...result[idx], content };
   }
 
   return result;
@@ -262,37 +250,19 @@ export function mergeToolResultsIntoAssistantMessages(
 // ── Pass 2: consecutive-assistant merging ───────────────────────────
 
 /** Parse a message's JSON content into an array of content blocks. */
-function parseContentBlocks(content: string): unknown[] {
-  try {
-    const parsed = JSON.parse(content);
-    return Array.isArray(parsed) ? parsed : [parsed];
-  } catch (err) {
-    log.warn(
-      { err },
-      "Failed to parse content blocks during assistant message merge",
-    );
-    return [];
-  }
+function parseContentBlocks(content: ContentBlock[]): ContentBlock[] {
+  return [...content];
 }
 
 /**
  * Append content blocks from a donor message onto a target block array.
  * Parses the donor's JSON content and pushes each block into `target`.
  */
-function appendContentBlocks(target: unknown[], donorContent: string): void {
-  try {
-    const parsed = JSON.parse(donorContent);
-    if (Array.isArray(parsed)) {
-      target.push(...parsed);
-    } else {
-      target.push(parsed);
-    }
-  } catch (err) {
-    log.warn(
-      { err },
-      "Failed to parse donor content blocks during assistant message merge",
-    );
-  }
+function appendContentBlocks(
+  target: ContentBlock[],
+  donorContent: ContentBlock[],
+): void {
+  target.push(...donorContent);
 }
 
 /**
@@ -354,7 +324,7 @@ export function mergeConsecutiveAssistantMessages(messages: MessageRow[]): {
 } {
   const result: MessageRow[] = [];
   // Key = index in `result`, value = accumulated content blocks.
-  const pendingMerges = new Map<number, unknown[]>();
+  const pendingMerges = new Map<number, ContentBlock[]>();
   // Key = index in `result`, value = IDs of messages merged into the target.
   const mergedIds = new Map<number, string[]>();
 
@@ -391,7 +361,7 @@ export function mergeConsecutiveAssistantMessages(messages: MessageRow[]): {
 
   // Write back merged content for any messages that were targets.
   for (const [idx, content] of pendingMerges) {
-    result[idx] = { ...result[idx], content: JSON.stringify(content) };
+    result[idx] = { ...result[idx], content };
   }
 
   // Build the merged ID map keyed by surviving message ID.

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -1604,12 +1604,7 @@ function recordToolStartOnPersistedMessage(
     return;
   }
 
-  let content: ContentBlock[];
-  try {
-    content = JSON.parse(row.content) as ContentBlock[];
-  } catch {
-    return;
-  }
+  const content: ContentBlock[] = row.content;
 
   for (const block of content) {
     if (block.type !== "tool_use") {
@@ -1663,12 +1658,7 @@ function recordToolPreviewStartOnPersistedMessage(
     return;
   }
 
-  let content: ContentBlock[];
-  try {
-    content = JSON.parse(row.content) as ContentBlock[];
-  } catch {
-    return;
-  }
+  const content: ContentBlock[] = row.content;
 
   for (const block of content) {
     if (block.type !== "tool_use") {
@@ -1717,12 +1707,7 @@ function annotatePersistedAssistantMessage(
     return;
   }
 
-  let content: ContentBlock[];
-  try {
-    content = JSON.parse(row.content) as ContentBlock[];
-  } catch {
-    return;
-  }
+  const content: ContentBlock[] = row.content;
 
   let modified = false;
   for (const block of content) {

--- a/assistant/src/daemon/conversation-history.ts
+++ b/assistant/src/daemon/conversation-history.ts
@@ -164,12 +164,10 @@ export function consolidateAssistantMessages(
     } else if (msg.role === "user") {
       // Check if this is an internal tool_result message (no text, only tool_result blocks)
       try {
-        const content = JSON.parse(msg.content);
+        const content = msg.content;
         const isToolResultOnly =
           Array.isArray(content) &&
-          content.every((block: Record<string, unknown>) =>
-            isToolResultBlock(block),
-          ) &&
+          content.every((block) => isToolResultBlock(block)) &&
           content.length > 0;
         if (isToolResultOnly) {
           internalToolResultMessages.push(msg);
@@ -223,11 +221,9 @@ export function consolidateAssistantMessages(
   const consolidatedContent: ContentBlock[] = [];
   for (const msg of messagesToConsolidate) {
     try {
-      const content = JSON.parse(msg.content);
+      const content = msg.content;
       if (Array.isArray(content)) {
-        const toolUseBlocks = content.filter(
-          (b: Record<string, unknown>) => b.type === "tool_use",
-        );
+        const toolUseBlocks = content.filter((b) => b.type === "tool_use");
         log.info(
           {
             messageId: msg.id,
@@ -249,11 +245,9 @@ export function consolidateAssistantMessages(
   // Also merge tool_result blocks from internal user messages
   for (const msg of internalToolResultMessages) {
     try {
-      const content = JSON.parse(msg.content);
+      const content = msg.content;
       if (Array.isArray(content)) {
-        const toolResultBlocks = content.filter((b: Record<string, unknown>) =>
-          isToolResultBlock(b),
-        );
+        const toolResultBlocks = content.filter((b) => isToolResultBlock(b));
         log.info(
           {
             messageId: msg.id,

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -319,7 +319,9 @@ export function resolveChannelCapabilities(
  * channel where it is a passive participant.
  */
 export function isGroupChatType(chatType?: string): boolean {
-  if (!chatType) return false;
+  if (!chatType) {
+    return false;
+  }
   switch (chatType) {
     case "group": // Telegram group
     case "supergroup": // Telegram supergroup
@@ -362,10 +364,14 @@ export function buildActiveSurfaceContext(params: {
   >;
 }): ActiveSurfaceContext | null {
   const { currentActiveSurfaceId, currentPage, surfaceState } = params;
-  if (!currentActiveSurfaceId) return null;
+  if (!currentActiveSurfaceId) {
+    return null;
+  }
 
   const stored = surfaceState.get(currentActiveSurfaceId);
-  if (!stored || stored.surfaceType !== "dynamic_page") return null;
+  if (!stored || stored.surfaceType !== "dynamic_page") {
+    return null;
+  }
 
   const data = stored.data as DynamicPageSurfaceData;
   const activeSurface: ActiveSurfaceContext = {
@@ -416,7 +422,9 @@ export function buildActiveDocuments(conversationId: string): Array<{
 const MAX_CONTEXT_LENGTH = 100_000;
 
 function truncateHtml(html: string, budget: number): string {
-  if (html.length <= budget) return html;
+  if (html.length <= budget) {
+    return html;
+  }
   return (
     html.slice(0, budget) +
     `\n<!-- truncated: original is ${html.length} characters -->`
@@ -602,7 +610,9 @@ function escapeXml(str: string): string {
 export function buildSubagentStatusBlock(
   children: SubagentState[] | null | undefined,
 ): string | null {
-  if (!children || children.length === 0) return null;
+  if (!children || children.length === 0) {
+    return null;
+  }
 
   const now = Date.now();
   const lines: string[] = ["<active_subagents>"];
@@ -757,7 +767,9 @@ export function injectChannelCapabilityContext(
   caps: ChannelCapabilities,
 ): Message {
   const block = buildChannelCapabilityBlock(caps);
-  if (block === null) return message;
+  if (block === null) {
+    return message;
+  }
   return {
     ...message,
     content: [{ type: "text", text: block }, ...message.content],
@@ -861,8 +873,8 @@ export function isSlackChannelConversation(
  */
 export interface SlackTranscriptInputRow {
   role: "user" | "assistant";
-  /** Raw persisted content column. JSON-encoded `ContentBlock[]` in production. */
-  content: string;
+  /** Message content — typed blocks in production, plain text in fixtures. */
+  content: string | ContentBlock[];
   /** Epoch ms when the row was created. */
   createdAt: number;
   /** Raw `metadata` column value (JSON string with optional `slackMeta` sub-key). */
@@ -904,11 +916,15 @@ function filterSlackConversationRowsForActor(
   rows: MessageRow[],
   trustClass: TrustClass | undefined,
 ): MessageRow[] {
-  if (resolveCapabilities(trustClass).canAccessMemory) return rows;
+  if (resolveCapabilities(trustClass).canAccessMemory) {
+    return rows;
+  }
   const nonSlackVisibleRows = filterMessagesForUntrustedActor(rows);
   const nonSlackVisibleIds = new Set(nonSlackVisibleRows.map((row) => row.id));
   return rows.filter((row) => {
-    if (hasSlackMetadata(row)) return true;
+    if (hasSlackMetadata(row)) {
+      return true;
+    }
     return nonSlackVisibleIds.has(row.id);
   });
 }
@@ -929,7 +945,9 @@ function extractPlainTextFromBlocks(blocks: ContentBlock[]): string {
   const parts: string[] = [];
   const placeholderLabels: string[] = [];
   for (const block of blocks) {
-    if (!block || typeof block !== "object") continue;
+    if (!block || typeof block !== "object") {
+      continue;
+    }
     if (block.type === "text") {
       parts.push(block.text);
       continue;
@@ -1028,18 +1046,20 @@ function rowToRenderable(row: SlackTranscriptInputRow): RenderableSlackMessage {
   let contentBlocks: ContentBlock[] = [];
   let plainText: string;
   try {
-    const parsed = JSON.parse(row.content);
+    const parsed = Array.isArray(row.content)
+      ? row.content
+      : JSON.parse(row.content);
     if (Array.isArray(parsed)) {
       contentBlocks = parsed as ContentBlock[];
       plainText = extractPlainTextFromBlocks(contentBlocks);
     } else if (typeof parsed === "string") {
       plainText = parsed;
     } else {
-      plainText = row.content;
+      plainText = Array.isArray(row.content) ? "" : row.content;
     }
   } catch {
     // Plain string row (legacy) — no structured blocks to preserve.
-    plainText = row.content;
+    plainText = Array.isArray(row.content) ? "" : row.content;
   }
 
   // Attachment-only rows (images, files) carry no text block, so the
@@ -1077,11 +1097,17 @@ function isSlackAssistantThreadPlaceholder(
   message: RenderableSlackMessage,
   canonicalConfiguredBotUserId: string | null,
 ): boolean {
-  if (!canonicalConfiguredBotUserId) return false;
+  if (!canonicalConfiguredBotUserId) {
+    return false;
+  }
   const metadata = message.metadata;
-  if (!metadata || metadata.eventKind !== "message") return false;
+  if (!metadata || metadata.eventKind !== "message") {
+    return false;
+  }
   const actorExternalUserId = metadata.actorExternalUserId?.trim();
-  if (!actorExternalUserId) return false;
+  if (!actorExternalUserId) {
+    return false;
+  }
 
   const canonicalActor =
     canonicalizeInboundIdentity("slack", actorExternalUserId) ??
@@ -1103,7 +1129,9 @@ function isSlackAssistantThreadPlaceholder(
 
 function getCanonicalConfiguredSlackBotUserId(): string | null {
   const configuredBotUserId = getConfig().slack.botUserId.trim();
-  if (!configuredBotUserId) return null;
+  if (!configuredBotUserId) {
+    return null;
+  }
   return (
     canonicalizeInboundIdentity("slack", configuredBotUserId) ??
     configuredBotUserId
@@ -1152,7 +1180,9 @@ export function assembleSlackChronologicalMessages(
 function maxSlackTs(values: readonly (string | null)[]): string | null {
   let max: string | null = null;
   for (const value of values) {
-    if (value === null) continue;
+    if (value === null) {
+      continue;
+    }
     if (max === null || compareSlackTs(value, max) > 0) {
       max = value;
     }
@@ -1196,13 +1226,17 @@ export function getSlackCompactionWatermarkForPrefix(
   context: SlackChronologicalContext | null,
   compactedRenderedMessages: number,
 ): string | null {
-  if (!context || compactedRenderedMessages <= 0) return null;
+  if (!context || compactedRenderedMessages <= 0) {
+    return null;
+  }
   const start = context.compactableStartIndex;
   const end = Math.min(
     context.renderedMessages.length,
     start + compactedRenderedMessages,
   );
-  if (end <= start) return null;
+  if (end <= start) {
+    return null;
+  }
   return maxSlackTs(
     context.renderedMessages
       .slice(start, end)
@@ -1241,7 +1275,9 @@ export function getSlackWatermarkAdvanceForRowPrefix(
       allowFlatLegacy: true,
     })?.channelTs ?? null;
   const ts = maxSlackTs(rows.slice(0, endExclusive).map(channelTsForRow));
-  if (ts === null) return null;
+  if (ts === null) {
+    return null;
+  }
   if (
     existingWatermarkTs !== null &&
     !isSlackTsAfter(ts, existingWatermarkTs)
@@ -1382,10 +1418,16 @@ export function loadSlackChronologicalContext(
 function detectActiveThreadTs(rows: RenderableSlackMessage[]): string | null {
   for (let i = rows.length - 1; i >= 0; i--) {
     const row = rows[i];
-    if (row.role !== "user") continue;
+    if (row.role !== "user") {
+      continue;
+    }
     const meta = row.metadata;
-    if (!meta) continue;
-    if (meta.eventKind !== "message") continue;
+    if (!meta) {
+      continue;
+    }
+    if (meta.eventKind !== "message") {
+      continue;
+    }
     if (typeof meta.threadTs === "string" && meta.threadTs.length > 0) {
       return meta.threadTs;
     }
@@ -1417,7 +1459,9 @@ function buildActiveThreadBlockFromRenderable(
   const members: RenderableSlackMessage[] = [];
   for (const row of rows) {
     const meta = row.metadata;
-    if (!meta) continue;
+    if (!meta) {
+      continue;
+    }
     if (meta.eventKind === "message") {
       if (
         meta.channelTs === activeThreadTs ||
@@ -1450,14 +1494,20 @@ function buildActiveThreadBlockFromRenderable(
   );
   for (const row of rows) {
     const meta = row.metadata;
-    if (!meta || meta.eventKind !== "reaction" || !meta.reaction) continue;
-    if (meta.reaction.targetChannelTs === activeThreadTs) continue; // already added
+    if (!meta || meta.eventKind !== "reaction" || !meta.reaction) {
+      continue;
+    }
+    if (meta.reaction.targetChannelTs === activeThreadTs) {
+      continue;
+    } // already added
     if (memberChannelTs.has(meta.reaction.targetChannelTs)) {
       members.push(row);
     }
   }
 
-  if (members.length === 0) return null;
+  if (members.length === 0) {
+    return null;
+  }
 
   // The active-thread block is flattened to plain text below. User rows keep
   // explicit Slack attribution through the renderer; assistant rows pass
@@ -1466,13 +1516,19 @@ function buildActiveThreadBlockFromRenderable(
   // here so their tag line carries attribution through the renderer. Labeled
   // user rows and assistant rows pass through unchanged.
   const labeledMembers = members.map((m) => {
-    if (m.role === "assistant") return m;
-    if (m.senderLabel !== null) return m;
+    if (m.role === "assistant") {
+      return m;
+    }
+    if (m.senderLabel !== null) {
+      return m;
+    }
     return { ...m, senderLabel: "@user" };
   });
 
   const rendered = renderSlackTranscriptWithProvenance(labeledMembers);
-  if (rendered.renderedMessages.length === 0) return null;
+  if (rendered.renderedMessages.length === 0) {
+    return null;
+  }
   const lines = rendered.renderedMessages
     .map((entry) => extractTagLineTexts([entry.message])[0] ?? "")
     .join("\n");
@@ -1493,15 +1549,21 @@ export function assembleSlackActiveThreadFocusBlock(
   rows: SlackTranscriptInputRow[],
   capabilities: ChannelCapabilities,
 ): string | null {
-  if (capabilities.channel !== "slack") return null;
+  if (capabilities.channel !== "slack") {
+    return null;
+  }
   // DMs do not have threads, so the focus block is always a no-op.
   // The gateway sets `chatType: "channel"` for every non-DM Slack
   // conversation and omits the field for DMs, so gate the focus block
   // on the positive `"channel"` match.
-  if (capabilities.chatType !== "channel") return null;
+  if (capabilities.chatType !== "channel") {
+    return null;
+  }
   const renderable = rowsToRenderableSlackMessages(rows);
   const activeThreadTs = detectActiveThreadTs(renderable);
-  if (!activeThreadTs) return null;
+  if (!activeThreadTs) {
+    return null;
+  }
   return buildActiveThreadBlockFromRenderable(renderable, activeThreadTs);
 }
 
@@ -1521,8 +1583,12 @@ export function loadSlackActiveThreadFocusBlock(
     slackContextCompactionWatermarkTs?: string | null;
   } = {},
 ): string | null {
-  if (capabilities.channel !== "slack") return null;
-  if (capabilities.chatType !== "channel") return null;
+  if (capabilities.channel !== "slack") {
+    return null;
+  }
+  if (capabilities.chatType !== "channel") {
+    return null;
+  }
   const loader = options.loader ?? defaultGetMessages;
   const allRows = loader(conversationId);
   const scopedRows = filterSlackConversationRowsForActor(
@@ -1652,7 +1718,9 @@ async function collectInjectorBlocks(
   const out: InjectionBlock[] = [];
   for (const injector of getRegisteredInjectors()) {
     const block = await injector.produce(ctx, runMessages);
-    if (block) out.push(block);
+    if (block) {
+      out.push(block);
+    }
   }
   return out;
 }
@@ -1676,7 +1744,9 @@ export async function composeInjectorChain(ctx: TurnContext): Promise<string> {
   const blocks = await collectInjectorBlocks(ctx);
   const pieces: string[] = [];
   for (const block of blocks) {
-    if (block.text.length > 0) pieces.push(block.text);
+    if (block.text.length > 0) {
+      pieces.push(block.text);
+    }
   }
   return pieces.join("\n\n");
 }
@@ -1721,14 +1791,20 @@ function applyInjectionBlock(
   const placement = block.placement ?? DEFAULT_PLACEMENT;
 
   if (placement === "replace-run-messages") {
-    if (!block.messagesOverride) return runMessages;
+    if (!block.messagesOverride) {
+      return runMessages;
+    }
     return block.messagesOverride;
   }
 
-  if (block.text.length === 0) return runMessages;
+  if (block.text.length === 0) {
+    return runMessages;
+  }
 
   const userTail = runMessages[runMessages.length - 1];
-  if (!userTail || userTail.role !== "user") return runMessages;
+  if (!userTail || userTail.role !== "user") {
+    return runMessages;
+  }
 
   const textBlock = { type: "text" as const, text: block.text };
 
@@ -1800,22 +1876,40 @@ function stripTailV2DynamicMemoryPrefix(
   v2WrappedBlock: string | null,
 ): Message[] {
   const last = messages[messages.length - 1];
-  if (!last || last.role !== "user") return messages;
+  if (!last || last.role !== "user") {
+    return messages;
+  }
   const prefixCount = countMemoryPrefixBlocksOnContent(last.content);
-  if (prefixCount === 0) return messages;
+  if (prefixCount === 0) {
+    return messages;
+  }
   const content = last.content.filter((block, i) => {
-    if (i >= prefixCount) return true;
+    if (i >= prefixCount) {
+      return true;
+    }
     // v2's memory-image groups: opener text, injected image, closer text.
-    if (block.type === "image") return false;
-    if (block.type !== "text") return true;
-    if (block.text.startsWith("<memory_image")) return false;
-    if (block.text === "</memory_image>") return false;
+    if (block.type === "image") {
+      return false;
+    }
+    if (block.type !== "text") {
+      return true;
+    }
+    if (block.text.startsWith("<memory_image")) {
+      return false;
+    }
+    if (block.text === "</memory_image>") {
+      return false;
+    }
     // v2's legacy dynamic wrapper.
-    if (block.text.startsWith("<memory __injected>\n")) return false;
+    if (block.text.startsWith("<memory __injected>\n")) {
+      return false;
+    }
     // v2's current dynamic block — identity match only (see doc comment).
     return v2WrappedBlock === null || block.text !== v2WrappedBlock;
   });
-  if (content.length === last.content.length) return messages;
+  if (content.length === last.content.length) {
+    return messages;
+  }
   return [...messages.slice(0, -1), { ...last, content }];
 }
 
@@ -2239,7 +2333,9 @@ export async function applyRuntimeInjections(
   // the turn, including defaults, so downstream observers see the full set.
   const injectorChainPieces: string[] = [];
   for (const block of chainBlocks) {
-    if (block.text.length > 0) injectorChainPieces.push(block.text);
+    if (block.text.length > 0) {
+      injectorChainPieces.push(block.text);
+    }
   }
   const injectorChainBlock =
     injectorChainPieces.length > 0

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -132,15 +132,7 @@ function persistSurfaceData(
   try {
     const rows = getMessages(conversationId);
     for (let r = rows.length - 1; r >= 0; r--) {
-      let parsed: unknown[];
-      try {
-        const result = JSON.parse(rows[r].content);
-        if (!Array.isArray(result)) continue;
-        parsed = result;
-      } catch {
-        // Plain-text content rows — skip and keep scanning.
-        continue;
-      }
+      const parsed: unknown[] = rows[r].content;
       let found = false;
       for (const pb of parsed) {
         const rb = pb as Record<string, unknown>;
@@ -191,7 +183,9 @@ export function scheduleSurfaceDataPersist(
  */
 export function flushSurfaceDataPersist(surfaceId: string): void {
   const pending = pendingSurfacePersists.get(surfaceId);
-  if (!pending) return;
+  if (!pending) {
+    return;
+  }
   clearTimeout(pending.timer);
   pendingSurfacePersists.delete(surfaceId);
   persistSurfaceData(pending.conversationId, surfaceId, pending.data);
@@ -204,7 +198,9 @@ export function flushSurfaceDataPersist(surfaceId: string): void {
  */
 export function cancelSurfaceDataPersist(surfaceId: string): void {
   const pending = pendingSurfacePersists.get(surfaceId);
-  if (!pending) return;
+  if (!pending) {
+    return;
+  }
   clearTimeout(pending.timer);
   pendingSurfacePersists.delete(surfaceId);
 }
@@ -221,7 +217,9 @@ export function cancelPendingSurfaceDataPersists(
   conversationId?: string,
 ): void {
   for (const [surfaceId, pending] of pendingSurfacePersists) {
-    if (conversationId && pending.conversationId !== conversationId) continue;
+    if (conversationId && pending.conversationId !== conversationId) {
+      continue;
+    }
     clearTimeout(pending.timer);
     pendingSurfacePersists.delete(surfaceId);
   }
@@ -236,7 +234,9 @@ export function cancelPendingSurfaceDataPersists(
  */
 export function flushPendingSurfaceDataPersists(conversationId?: string): void {
   for (const [surfaceId, pending] of pendingSurfacePersists) {
-    if (conversationId && pending.conversationId !== conversationId) continue;
+    if (conversationId && pending.conversationId !== conversationId) {
+      continue;
+    }
     clearTimeout(pending.timer);
     pendingSurfacePersists.delete(surfaceId);
     persistSurfaceData(pending.conversationId, surfaceId, pending.data);
@@ -262,7 +262,9 @@ export function markSurfaceCompleted(
   if (ctx.messages) {
     for (let i = ctx.messages.length - 1; i >= 0; i--) {
       const msg = ctx.messages[i];
-      if (!Array.isArray(msg.content)) continue;
+      if (!Array.isArray(msg.content)) {
+        continue;
+      }
       for (const block of msg.content) {
         const b = block as Record<string, unknown>;
         if (b.type === "ui_surface" && b.surfaceId === surfaceId) {
@@ -278,16 +280,7 @@ export function markSurfaceCompleted(
   try {
     const rows = getMessages(ctx.conversationId);
     for (let r = rows.length - 1; r >= 0; r--) {
-      let parsed: unknown[];
-      try {
-        const result = JSON.parse(rows[r].content);
-        if (!Array.isArray(result)) continue;
-        parsed = result;
-      } catch {
-        // Some rows store plain text content (e.g. notification seeding) —
-        // skip them and keep scanning.
-        continue;
-      }
+      const parsed: unknown[] = rows[r].content;
       let found = false;
       for (const pb of parsed) {
         const rb = pb as Record<string, unknown>;
@@ -350,7 +343,9 @@ export function removeSurfaceBlock(
   if (ctx.messages) {
     for (let i = ctx.messages.length - 1; i >= 0; i--) {
       const msg = ctx.messages[i];
-      if (!Array.isArray(msg.content)) continue;
+      if (!Array.isArray(msg.content)) {
+        continue;
+      }
       const idx = msg.content.findIndex((block) => {
         const b = block as Record<string, unknown>;
         return b.type === "ui_surface" && b.surfaceId === surfaceId;
@@ -365,14 +360,7 @@ export function removeSurfaceBlock(
   try {
     const rows = getMessages(ctx.conversationId);
     for (let r = rows.length - 1; r >= 0; r--) {
-      let parsed: unknown[];
-      try {
-        const result = JSON.parse(rows[r].content);
-        if (!Array.isArray(result)) continue;
-        parsed = result;
-      } catch {
-        continue;
-      }
+      const parsed: unknown[] = rows[r].content;
       const idx = parsed.findIndex((pb) => {
         const rb = pb as Record<string, unknown>;
         return rb.type === "ui_surface" && rb.surfaceId === surfaceId;
@@ -410,7 +398,9 @@ const TASK_PROGRESS_STEP_STATUSES = new Set([
 function normalizeTaskProgressSteps(
   value: unknown,
 ): Array<Record<string, unknown>> {
-  if (!Array.isArray(value)) return [];
+  if (!Array.isArray(value)) {
+    return [];
+  }
   return value
     .filter((step): step is Record<string, unknown> => isPlainObject(step))
     .map((step) => {
@@ -568,8 +558,9 @@ function normalizeCardShowData(
     const candidates = allNonEmptyStrings(
       bodyAliasKeys.map((k) => {
         const dataVal = normalized[k];
-        if (typeof dataVal === "string" && dataVal.trim().length > 0)
+        if (typeof dataVal === "string" && dataVal.trim().length > 0) {
           return dataVal;
+        }
         return input[k];
       }),
     );
@@ -740,7 +731,9 @@ function normalizeChoiceShowData(
               : typeof option.label === "string"
                 ? option.label.trim()
                 : "";
-          if (!id || !title) return null;
+          if (!id || !title) {
+            return null;
+          }
           return {
             id,
             title,
@@ -852,20 +845,30 @@ function isSlackTaskProgressUiException(
   toolName: string,
   input: Record<string, unknown>,
 ): boolean {
-  if (ctx.channelCapabilities?.channel !== "slack") return false;
+  if (ctx.channelCapabilities?.channel !== "slack") {
+    return false;
+  }
   if (toolName === "ui_show") {
     const surfaceType = input.surface_type as SurfaceType;
-    if (surfaceType !== "card") return false;
+    if (surfaceType !== "card") {
+      return false;
+    }
     const rawData = isPlainObject(input.data) ? input.data : {};
     const data = normalizeCardShowData(input, rawData);
     return isTaskProgressCardData(data);
   }
   if (toolName === "ui_update") {
     const surfaceId = input.surface_id;
-    if (typeof surfaceId !== "string") return false;
+    if (typeof surfaceId !== "string") {
+      return false;
+    }
     const stored = ctx.surfaceState.get(surfaceId);
-    if (!stored || stored.surfaceType !== "card") return false;
-    if (!isTaskProgressCardData(stored.data)) return false;
+    if (!stored || stored.surfaceType !== "card") {
+      return false;
+    }
+    if (!isTaskProgressCardData(stored.data)) {
+      return false;
+    }
     const rawPatch = isPlainObject(input.data) ? input.data : {};
     const patch = normalizeTaskProgressCardPatch(
       stored.data as CardSurfaceData,
@@ -1062,7 +1065,9 @@ const STANDALONE_TOMBSTONE_TTL_MS = 30_000; // 30 seconds
 export function canShowInteractiveUi(
   ctx: Pick<SurfaceConversationContext, "hasNoClient" | "channelCapabilities">,
 ): boolean {
-  if (ctx.hasNoClient) return false;
+  if (ctx.hasNoClient) {
+    return false;
+  }
   if (ctx.channelCapabilities && !ctx.channelCapabilities.supportsDynamicUi) {
     return false;
   }
@@ -1285,7 +1290,9 @@ export function cleanupStandaloneSurface(
     // Clear any existing tombstone timer for this surfaceId (idempotency).
     const existingTimer =
       ctx.recentlyCompletedStandaloneSurfaces.get(surfaceId);
-    if (existingTimer) clearTimeout(existingTimer);
+    if (existingTimer) {
+      clearTimeout(existingTimer);
+    }
 
     const tombstoneTimer = setTimeout(() => {
       ctx.recentlyCompletedStandaloneSurfaces?.delete(surfaceId);
@@ -1568,9 +1575,13 @@ export function handleSurfaceUndo(
 
     // Update ALL surfaces that share this appId (not just the requesting one)
     for (const [sid, s] of ctx.surfaceState.entries()) {
-      if (s.surfaceType !== "dynamic_page") continue;
+      if (s.surfaceType !== "dynamic_page") {
+        continue;
+      }
       const sData = s.data as DynamicPageSurfaceData;
-      if (sData.appId !== data.appId) continue;
+      if (sData.appId !== data.appId) {
+        continue;
+      }
       const revertedData: DynamicPageSurfaceData = {
         ...sData,
         html: previousHtml,
@@ -1587,10 +1598,16 @@ export function handleSurfaceUndo(
     // Sync sibling undo stacks: pop the top entry if it matches the HTML we
     // just reverted to, preventing phantom no-op undo steps on siblings.
     for (const [sid, s] of ctx.surfaceState.entries()) {
-      if (sid === surfaceId) continue;
-      if (s.surfaceType !== "dynamic_page") continue;
+      if (sid === surfaceId) {
+        continue;
+      }
+      if (s.surfaceType !== "dynamic_page") {
+        continue;
+      }
       const sData = s.data as DynamicPageSurfaceData;
-      if (sData.appId !== data.appId) continue;
+      if (sData.appId !== data.appId) {
+        continue;
+      }
 
       const siblingStack = ctx.surfaceUndoStacks.get(sid);
       if (siblingStack && siblingStack.length > 0) {
@@ -1634,11 +1651,17 @@ export function describeTableRow(
   row: TableRow,
   columns: TableColumn[],
 ): string {
-  if (columns.length === 0) return row.id;
+  if (columns.length === 0) {
+    return row.id;
+  }
   const firstColId = columns[0].id;
   const cell = row.cells[firstColId];
-  if (cell == null) return row.id;
-  if (typeof cell === "string") return cell;
+  if (cell == null) {
+    return row.id;
+  }
+  if (typeof cell === "string") {
+    return cell;
+  }
   return cell.text;
 }
 
@@ -1646,7 +1669,9 @@ const MAX_DESELECTION_ITEMS = 20;
 
 /** Format a list of deselected item labels as a bullet list, capped at MAX_DESELECTION_ITEMS. */
 export function formatDeselectionList(labels: string[]): string {
-  if (labels.length === 0) return "";
+  if (labels.length === 0) {
+    return "";
+  }
   const shown = labels.slice(0, MAX_DESELECTION_ITEMS);
   const lines = shown.map((l) => `- ${l}`);
   if (labels.length > MAX_DESELECTION_ITEMS) {
@@ -1664,19 +1689,25 @@ export function buildDeselectionDescription(
   surfaceState: { surfaceType: SurfaceType; data: SurfaceData } | undefined,
   selectedIds: string[],
 ): string {
-  if (!surfaceState) return "";
+  if (!surfaceState) {
+    return "";
+  }
   const selectedSet = new Set(selectedIds);
 
   if (surfaceType === "table" && surfaceState.surfaceType === "table") {
     const tableData = surfaceState.data as TableSurfaceData;
     const deselectedLabels: string[] = [];
     for (const row of tableData.rows) {
-      if (row.selectable === false) continue;
+      if (row.selectable === false) {
+        continue;
+      }
       if (!selectedSet.has(row.id)) {
         deselectedLabels.push(describeTableRow(row, tableData.columns));
       }
     }
-    if (deselectedLabels.length === 0) return "";
+    if (deselectedLabels.length === 0) {
+      return "";
+    }
     return `\n\nDeselected items (user chose NOT to include):\n${formatDeselectionList(
       deselectedLabels,
     )}`;
@@ -1690,7 +1721,9 @@ export function buildDeselectionDescription(
         deselectedLabels.push(item.title);
       }
     }
-    if (deselectedLabels.length === 0) return "";
+    if (deselectedLabels.length === 0) {
+      return "";
+    }
     return `\n\nDeselected items (user chose NOT to include):\n${formatDeselectionList(
       deselectedLabels,
     )}`;
@@ -1710,7 +1743,9 @@ const SURFACE_COMPLETION_SUMMARY_FIELD = "_completionSummary";
 function getRequestedSurfaceCompletionSummary(
   data?: Record<string, unknown>,
 ): string | null {
-  if (data?.[SURFACE_COMPLETE_FLAG] !== true) return null;
+  if (data?.[SURFACE_COMPLETE_FLAG] !== true) {
+    return null;
+  }
   const summary =
     typeof data[SURFACE_COMPLETION_SUMMARY_FIELD] === "string"
       ? data[SURFACE_COMPLETION_SUMMARY_FIELD].trim()
@@ -1731,7 +1766,9 @@ function recordActivationMoment(
   moment: ActivationMomentParam,
 ): void {
   try {
-    if (!isActivationSession(ctx.conversationId)) return;
+    if (!isActivationSession(ctx.conversationId)) {
+      return;
+    }
     recordActivationEvent({
       stepName: activationStepNameForMomentParam(moment),
       sessionId: ctx.conversationId,
@@ -1765,7 +1802,9 @@ function maybeEmitActivationMoment(
 ): void {
   const stored = ctx.surfaceState.get(surfaceId);
   const moment = stored?.activationMoment;
-  if (!moment) return;
+  if (!moment) {
+    return;
+  }
   // Clear the tag first so this can fire at most once per surface even if the
   // commit path is re-entered.
   stored.activationMoment = undefined;
@@ -2457,13 +2496,19 @@ export function refreshSurfacesForApp(
   opts?: { fileChange?: boolean; status?: string },
 ): boolean {
   const app = getApp(appId);
-  if (!app) return false;
+  if (!app) {
+    return false;
+  }
 
   let refreshed = false;
   for (const [surfaceId, stored] of ctx.surfaceState.entries()) {
-    if (stored.surfaceType !== "dynamic_page") continue;
+    if (stored.surfaceType !== "dynamic_page") {
+      continue;
+    }
     const data = stored.data as DynamicPageSurfaceData;
-    if (data.appId !== appId) continue;
+    if (data.appId !== appId) {
+      continue;
+    }
 
     // Push current HTML onto the undo stack before overwriting
     pushUndoState(ctx.surfaceUndoStacks, surfaceId, data.html);
@@ -2562,9 +2607,12 @@ export function buildCompletionSummary(
   if (surfaceType === "choice" && data) {
     const choiceTitle =
       typeof data.choiceTitle === "string" ? data.choiceTitle : undefined;
-    if (choiceTitle) return `User chose: "${choiceTitle}"`;
-    if (selectedTitles.length === 1)
+    if (choiceTitle) {
+      return `User chose: "${choiceTitle}"`;
+    }
+    if (selectedTitles.length === 1) {
       return `User chose: "${selectedTitles[0]}"`;
+    }
     if (selectedTitles.length > 1) {
       return `User chose ${selectedTitles.length} options: ${selectedTitles
         .map((title) => `"${title}"`)
@@ -2603,17 +2651,22 @@ export function buildCompletionSummary(
   if (surfaceType === "list" && data) {
     const selectedIds = data.selectedIds as string[] | undefined;
     const actionSuffix = actionId ? ` (action: ${actionId})` : "";
-    if (selectedIds?.length === 1)
+    if (selectedIds?.length === 1) {
       return `Selected: ${selectedIds[0]}${actionSuffix}`;
-    if (selectedIds?.length)
+    }
+    if (selectedIds?.length) {
       return `Selected ${selectedIds.length} items${actionSuffix}`;
+    }
   }
   if (surfaceType === "table" && data) {
     const selectedIds = data.selectedIds as string[] | undefined;
     const actionSuffix = actionId ? ` (action: ${actionId})` : "";
-    if (selectedIds?.length === 1) return `Selected 1 row${actionSuffix}`;
-    if (selectedIds?.length)
+    if (selectedIds?.length === 1) {
+      return `Selected 1 row${actionSuffix}`;
+    }
+    if (selectedIds?.length) {
       return `Selected ${selectedIds.length} rows${actionSuffix}`;
+    }
   }
   return actionId.charAt(0).toUpperCase() + actionId.slice(1);
 }
@@ -2660,14 +2713,21 @@ function buildUserFacingLabel(
     }
     return `Selected: ${actionId}`;
   }
-  if (surfaceType === "form") return "Submitted";
+  if (surfaceType === "form") {
+    return "Submitted";
+  }
   if (surfaceType === "choice") {
     const choiceTitle =
       typeof data?.choiceTitle === "string" ? data.choiceTitle : undefined;
-    if (choiceTitle) return choiceTitle;
-    if (selectedTitles.length === 1) return selectedTitles[0];
-    if (selectedTitles.length > 1)
+    if (choiceTitle) {
+      return choiceTitle;
+    }
+    if (selectedTitles.length === 1) {
+      return selectedTitles[0];
+    }
+    if (selectedTitles.length > 1) {
       return `Selected ${selectedTitles.length} options`;
+    }
     return "Selected";
   }
   if (surfaceType === "oauth_connect") {
@@ -2785,7 +2845,9 @@ export async function surfaceProxyResolver(
         targetClientId,
         op: "host_cu",
       });
-      if (rejection) return rejection;
+      if (rejection) {
+        return rejection;
+      }
     }
 
     // Untargeted CU must resolve to exactly one same-user capable client
@@ -2894,7 +2956,9 @@ export async function surfaceProxyResolver(
         targetClientId,
         op: "host_app_control",
       });
-      if (rejection) return rejection;
+      if (rejection) {
+        return rejection;
+      }
     }
 
     if (targetClientId == null) {
@@ -3344,7 +3408,9 @@ export async function surfaceProxyResolver(
       const turnIdx = ctx.currentTurnSurfaces.findIndex(
         (s) => s.surfaceId === surfaceId,
       );
-      if (turnIdx !== -1) ctx.currentTurnSurfaces.splice(turnIdx, 1);
+      if (turnIdx !== -1) {
+        ctx.currentTurnSurfaces.splice(turnIdx, 1);
+      }
       removeSurfaceBlock(ctx, surfaceId);
     }
     ctx.pendingSurfaceActions.delete(surfaceId);

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -184,9 +184,13 @@ const log = getLogger("conversation");
  * no text block. Used to verify the row→history boundary mapping in
  * {@link Conversation.summarizeUpToMessage}.
  */
-function firstPersistedTextBlockText(content: string): string | null {
+function firstPersistedTextBlockText(
+  content: string | ContentBlock[],
+): string | null {
   try {
-    const parsed: unknown = JSON.parse(content);
+    const parsed: unknown = Array.isArray(content)
+      ? content
+      : JSON.parse(content);
     if (Array.isArray(parsed)) {
       const block = parsed.find(
         (b): b is { type: "text"; text: string } =>
@@ -200,7 +204,7 @@ function firstPersistedTextBlockText(content: string): string | null {
   } catch {
     // Non-JSON content loads as a raw text block.
   }
-  return content;
+  return Array.isArray(content) ? null : content;
 }
 
 export interface CleanResult {
@@ -1037,19 +1041,7 @@ export class Conversation {
     const parsedMessages: Message[] = slicedDbMessages.map((m, index, arr) => {
       const isPreStripped = index < preStrippedCount;
       const role = m.role as "user" | "assistant";
-      let content: ContentBlock[];
-      try {
-        const parsed = JSON.parse(m.content);
-        content = Array.isArray(parsed)
-          ? parsed
-          : [{ type: "text", text: m.content }];
-      } catch {
-        log.warn(
-          { conversationId: this.conversationId, messageId: m.id },
-          "Invalid JSON in persisted message content, replacing with safe text block",
-        );
-        content = [{ type: "text", text: m.content }];
-      }
+      let content: ContentBlock[] = m.content;
 
       content = reinjectAttachmentPathAnnotations(content, role, m.metadata);
 

--- a/assistant/src/daemon/handlers/conversation-history.ts
+++ b/assistant/src/daemon/handlers/conversation-history.ts
@@ -3,6 +3,7 @@ import {
   listConversations,
   searchConversations,
 } from "../../persistence/conversation-queries.js";
+import { extractTextFromStoredMessageContent } from "../../persistence/message-content.js";
 import { renderHistoryContent } from "./shared.js";
 
 // ---------------------------------------------------------------------------
@@ -55,7 +56,9 @@ export function getMessageContent(
   conversationId?: string,
 ): MessageContentResult | null {
   const dbMessage = getMessageById(messageId, conversationId);
-  if (!dbMessage) return null;
+  if (!dbMessage) {
+    return null;
+  }
 
   let text: string | undefined;
   let toolCalls:
@@ -63,7 +66,7 @@ export function getMessageContent(
     | undefined;
 
   try {
-    const content = JSON.parse(dbMessage.content);
+    const content = dbMessage.content;
     const rendered = renderHistoryContent(content);
     text = rendered.text || undefined;
     const parsedToolCalls = rendered.toolCalls;
@@ -76,8 +79,7 @@ export function getMessageContent(
       }));
     }
   } catch {
-    // Raw text content (not JSON)
-    text = dbMessage.content || undefined;
+    text = extractTextFromStoredMessageContent(dbMessage.content) || undefined;
   }
 
   return {

--- a/assistant/src/export/__tests__/transcript-formatter.test.ts
+++ b/assistant/src/export/__tests__/transcript-formatter.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, mock, test } from "bun:test";
 
 import { z } from "zod";
 
+import type { ContentBlock } from "../../providers/types.js";
+
 type TestMessage = {
   id: string;
   conversationId: string;
   role: string;
-  content: string;
+  content: ContentBlock[];
   createdAt: number;
   metadata: string | null;
   clientMessageId: string | null;
@@ -18,7 +20,7 @@ const parentMessages: TestMessage[] = [
     id: "msg-parent-1",
     conversationId: "parent-conv",
     role: "user",
-    content: JSON.stringify([{ type: "text", text: "go research foo" }]),
+    content: [{ type: "text", text: "go research foo" }],
     createdAt: 1_700_000_000_000,
     metadata: null,
     clientMessageId: null,
@@ -28,7 +30,7 @@ const parentMessages: TestMessage[] = [
     id: "msg-parent-2",
     conversationId: "parent-conv",
     role: "assistant",
-    content: JSON.stringify([{ type: "text", text: "spawning subagent" }]),
+    content: [{ type: "text", text: "spawning subagent" }],
     createdAt: 1_700_000_001_000,
     metadata: JSON.stringify({
       subagentNotification: {
@@ -48,9 +50,9 @@ const childMessages: TestMessage[] = [
     id: "msg-child-1",
     conversationId: "child-conv-1",
     role: "user",
-    content: JSON.stringify([
+    content: [
       { type: "text", text: "Objective: research foo and report back." },
-    ]),
+    ],
     createdAt: 1_700_000_002_000,
     metadata: null,
     clientMessageId: null,
@@ -60,9 +62,7 @@ const childMessages: TestMessage[] = [
     id: "msg-child-2",
     conversationId: "child-conv-1",
     role: "assistant",
-    content: JSON.stringify([
-      { type: "text", text: "I found that foo is a bar." },
-    ]),
+    content: [{ type: "text", text: "I found that foo is a bar." }],
     createdAt: 1_700_000_003_000,
     metadata: null,
     clientMessageId: null,

--- a/assistant/src/export/formatter.ts
+++ b/assistant/src/export/formatter.ts
@@ -9,7 +9,7 @@ interface ContentBlock {
   text?: string;
   name?: string;
   input?: Record<string, unknown>;
-  content?: string;
+  content?: unknown;
   tool_use_id?: string;
   is_error?: boolean;
 }
@@ -37,7 +37,9 @@ function extractText(blocks: ContentBlock[]): string {
   for (const block of blocks) {
     switch (block.type) {
       case "text":
-        if (block.text) parts.push(block.text);
+        if (block.text) {
+          parts.push(block.text);
+        }
         break;
       case "tool_use":
         parts.push(
@@ -46,9 +48,9 @@ function extractText(blocks: ContentBlock[]): string {
         break;
       case "tool_result":
         if (block.is_error) {
-          parts.push(`[Error: ${block.content ?? ""}]`);
+          parts.push(`[Error: ${String(block.content ?? "")}]`);
         } else {
-          parts.push(`[Result: ${truncate(block.content ?? "", 500)}]`);
+          parts.push(`[Result: ${truncate(String(block.content ?? ""), 500)}]`);
         }
         break;
       case "server_tool_use":

--- a/assistant/src/export/transcript-formatter.ts
+++ b/assistant/src/export/transcript-formatter.ts
@@ -106,7 +106,10 @@ function formatSubagentMessages(
   return lines.join("\n");
 }
 
-function parseContent(raw: string): ContentBlock[] {
+function parseContent(raw: string | unknown[]): ContentBlock[] {
+  if (Array.isArray(raw)) {
+    return raw as ContentBlock[];
+  }
   try {
     return JSON.parse(raw) as ContentBlock[];
   } catch {

--- a/assistant/src/persistence/__tests__/message-content-file.test.ts
+++ b/assistant/src/persistence/__tests__/message-content-file.test.ts
@@ -1,9 +1,9 @@
 /**
  * Tests for the file-backed message content module: the JSONL delta fold
  * semantics, the append/fold roundtrip, the reserved-path ref discriminator,
- * and both resolver forms (expressive `ContentBlock[]` and the row-mapper
- * string shim) across inline passthrough, ref resolution, missing-file and
- * workspace-escape fallbacks.
+ * and the `resolveMessageContentBlocks` resolver across inline content,
+ * ref resolution, legacy plain strings, missing-file and workspace-escape
+ * fallbacks.
  */
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
@@ -17,7 +17,6 @@ import {
   foldContentFile,
   messageContentRefSchema,
   resolveMessageContentBlocks,
-  resolveStoredMessageContent,
 } from "../message-content-file.js";
 
 function textBlock(text: string): ContentBlock {
@@ -118,14 +117,19 @@ describe("messageContentRefSchema", () => {
     }
   });
 
-  test("rejects arrays, extra keys, empty and non-string refs", () => {
-    for (const value of [
-      [textBlock("x")],
-      { ref: "conversations/a/b.jsonl", other: 1 },
-      { ref: "" },
-      { ref: 42 },
-      null,
-    ]) {
+  test("strips unrecognized extra keys rather than rejecting them", () => {
+    const result = messageContentRefSchema.safeParse({
+      ref: "conversations/a/b.jsonl",
+      other: 1,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({ ref: "conversations/a/b.jsonl" });
+    }
+  });
+
+  test("rejects arrays, empty and non-string refs", () => {
+    for (const value of [[textBlock("x")], { ref: "" }, { ref: 42 }, null]) {
       expect(messageContentRefSchema.safeParse(value).success).toBe(false);
     }
   });
@@ -146,53 +150,7 @@ function writeRefFixture(dir: string, file: string): string {
   return rel;
 }
 
-describe("resolveStoredMessageContent (row-mapper string shim)", () => {
-  test("passes inline ContentBlock[] JSON through by identity", () => {
-    const inline = JSON.stringify([textBlock("hello")]);
-    expect(resolveStoredMessageContent(inline)).toBe(inline);
-  });
-
-  test("passes legacy plain strings through, including '{'-prefixed ones", () => {
-    expect(resolveStoredMessageContent("plain old text")).toBe(
-      "plain old text",
-    );
-    expect(resolveStoredMessageContent("{not json")).toBe("{not json");
-    const objectButNotRef = JSON.stringify({ some: "object" });
-    expect(resolveStoredMessageContent(objectButNotRef)).toBe(objectButNotRef);
-  });
-
-  test("passes legacy text shaped like a ref to a NON-reserved path through untouched", () => {
-    const legacyRefLikeText = JSON.stringify({ ref: "missing.jsonl" });
-    expect(resolveStoredMessageContent(legacyRefLikeText)).toBe(
-      legacyRefLikeText,
-    );
-  });
-
-  test("resolves a reserved-path ref to the folded file content", () => {
-    const rel = writeRefFixture("test-resolve", "m.jsonl");
-    expect(resolveStoredMessageContent(JSON.stringify({ ref: rel }))).toBe(
-      JSON.stringify([textBlock("final")]),
-    );
-  });
-
-  test("resolves a reserved-path ref to a missing file as empty content", () => {
-    expect(
-      resolveStoredMessageContent(
-        JSON.stringify({ ref: "conversations/gone/inflight/m.jsonl" }),
-      ),
-    ).toBe("[]");
-  });
-
-  test("resolves a reserved-prefix ref that escapes the workspace as empty content", () => {
-    expect(
-      resolveStoredMessageContent(
-        JSON.stringify({ ref: "conversations/../../../etc/evil.jsonl" }),
-      ),
-    ).toBe("[]");
-  });
-});
-
-describe("resolveMessageContentBlocks (expressive form)", () => {
+describe("resolveMessageContentBlocks", () => {
   test("parses inline ContentBlock[] JSON to blocks", () => {
     expect(
       resolveMessageContentBlocks(JSON.stringify([textBlock("hello")])),
@@ -239,6 +197,14 @@ describe("resolveMessageContentBlocks (expressive form)", () => {
     expect(
       resolveMessageContentBlocks(
         JSON.stringify({ ref: "conversations/gone/inflight/m.jsonl" }),
+      ),
+    ).toEqual([]);
+  });
+
+  test("resolves a reserved-prefix ref that escapes the workspace to empty blocks", () => {
+    expect(
+      resolveMessageContentBlocks(
+        JSON.stringify({ ref: "conversations/../../../etc/evil.jsonl" }),
       ),
     ).toEqual([]);
   });

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -88,7 +88,6 @@ import {
   enqueueLexicalIndexForMessage,
   enqueuePurgeConversationLexical,
 } from "./job-handlers/message-lexical.js";
-import { resolveStoredMessageContent } from "./message-content-file.js";
 import {
   rawAll,
   rawExec,
@@ -447,7 +446,11 @@ export interface MessageRow {
   id: string;
   conversationId: string;
   role: string;
-  /** Resolved content — always inline JSON, never a raw `{ ref }`. */
+  /**
+   * The raw stored value — an inline `ContentBlock[]` JSON string, a legacy
+   * plain string, or (for file-backed rows) a `{ ref }` JSON string. Resolve
+   * to typed blocks with `resolveMessageContentBlocks` before consuming.
+   */
   content: string;
   createdAt: number;
   metadata: string | null;
@@ -460,12 +463,7 @@ const parseMessage = createRowMapper<typeof messages.$inferSelect, MessageRow>({
   id: "id",
   conversationId: "conversationId",
   role: "role",
-  // File-backed `{ ref }` content is resolved here, at the row-fetch
-  // chokepoint, so every consumer of MessageRow sees inline content.
-  content: {
-    from: "content",
-    transform: (v) => resolveStoredMessageContent(v as string),
-  },
+  content: "content",
   createdAt: "createdAt",
   metadata: "metadata",
   clientMessageId: "clientMessageId",

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -35,6 +35,7 @@ import { HOOKS } from "../plugin-api/constants.js";
 import { forkConversationMemory } from "../plugins/defaults/memory/fork-conversation-memory.js";
 import { indexMessageNow } from "../plugins/defaults/memory/indexer.js";
 import { runHook } from "../plugins/pipeline.js";
+import type { ContentBlock } from "../providers/types.js";
 import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
 import { publishSyncInvalidation } from "../runtime/sync/sync-publisher.js";
 import { trustClassSchema } from "../runtime/trust-class.js";
@@ -88,6 +89,7 @@ import {
   enqueueLexicalIndexForMessage,
   enqueuePurgeConversationLexical,
 } from "./job-handlers/message-lexical.js";
+import { resolveMessageContentBlocks } from "./message-content-file.js";
 import {
   rawAll,
   rawExec,
@@ -447,11 +449,12 @@ export interface MessageRow {
   conversationId: string;
   role: string;
   /**
-   * The raw stored value — an inline `ContentBlock[]` JSON string, a legacy
-   * plain string, or (for file-backed rows) a `{ ref }` JSON string. Resolve
-   * to typed blocks with `resolveMessageContentBlocks` before consuming.
+   * Typed content blocks, resolved at the row-fetch chokepoint by
+   * `resolveMessageContentBlocks`: inline JSON parses, file-backed
+   * `{ ref }` rows fold their delta file, and legacy plain strings arrive
+   * wrapped in a single text block.
    */
-  content: string;
+  content: ContentBlock[];
   createdAt: number;
   metadata: string | null;
   clientMessageId: string | null;
@@ -463,7 +466,10 @@ const parseMessage = createRowMapper<typeof messages.$inferSelect, MessageRow>({
   id: "id",
   conversationId: "conversationId",
   role: "role",
-  content: "content",
+  content: {
+    from: "content",
+    transform: (v) => resolveMessageContentBlocks(String(v)),
+  },
   createdAt: "createdAt",
   metadata: "metadata",
   clientMessageId: "clientMessageId",
@@ -1075,7 +1081,7 @@ export function forkConversation(params: {
         id: forkedMessageId,
         conversationId: fc.id,
         role: message.role,
-        content: message.content,
+        content: JSON.stringify(message.content),
         createdAt: message.createdAt,
         metadata: cloneForkMessageMetadata(message.metadata, message.id),
       };

--- a/assistant/src/persistence/conversation-disk-view.ts
+++ b/assistant/src/persistence/conversation-disk-view.ts
@@ -143,7 +143,9 @@ interface FlattenedContent {
  * Parse the message `content` JSON string (ContentBlock[]) and extract
  * text, tool_use, and tool_result blocks into flat fields.
  */
-export function flattenContentBlocks(rawContent: string): FlattenedContent {
+export function flattenContentBlocks(
+  rawContent: string | ContentBlock[],
+): FlattenedContent {
   const result: FlattenedContent = {
     content: "",
     toolCalls: [],
@@ -151,16 +153,20 @@ export function flattenContentBlocks(rawContent: string): FlattenedContent {
   };
 
   let blocks: ContentBlock[];
-  try {
-    const parsed = JSON.parse(rawContent);
-    if (!Array.isArray(parsed)) {
-      // Plain text content (not block array)
+  if (Array.isArray(rawContent)) {
+    blocks = rawContent;
+  } else {
+    try {
+      const parsed = JSON.parse(rawContent);
+      if (!Array.isArray(parsed)) {
+        // Plain text content (not block array)
+        return { ...result, content: rawContent };
+      }
+      blocks = parsed;
+    } catch {
+      // Not valid JSON — treat as plain text
       return { ...result, content: rawContent };
     }
-    blocks = parsed;
-  } catch {
-    // Not valid JSON — treat as plain text
-    return { ...result, content: rawContent };
   }
 
   const textParts: string[] = [];
@@ -198,7 +204,9 @@ export function flattenContentBlocks(rawContent: string): FlattenedContent {
  */
 export function resolveUniqueFilename(dir: string, filename: string): string {
   const sanitized = basename(filename);
-  if (!existsSync(join(dir, sanitized))) return sanitized;
+  if (!existsSync(join(dir, sanitized))) {
+    return sanitized;
+  }
 
   const ext = extname(sanitized);
   const base = basename(sanitized, ext);
@@ -235,7 +243,9 @@ function writeAttachmentFile(
     }
 
     const content = getAttachmentContent(attachmentId);
-    if (!content) return null;
+    if (!content) {
+      return null;
+    }
 
     const resolvedName = resolveUniqueFilename(attachDir, originalFilename);
     writeFileSync(join(attachDir, resolvedName), content);
@@ -301,11 +311,18 @@ export function syncMessageToDisk(
       ts: new Date(message.createdAt).toISOString(),
     };
 
-    if (content) record.content = content;
-    if (toolCalls.length > 0) record.toolCalls = toolCalls;
-    if (toolResults.length > 0) record.toolResults = toolResults;
-    if (attachmentFilenames.length > 0)
+    if (content) {
+      record.content = content;
+    }
+    if (toolCalls.length > 0) {
+      record.toolCalls = toolCalls;
+    }
+    if (toolResults.length > 0) {
+      record.toolResults = toolResults;
+    }
+    if (attachmentFilenames.length > 0) {
       record.attachments = attachmentFilenames;
+    }
     if (message.metadata) {
       try {
         record.metadata = JSON.parse(message.metadata);

--- a/assistant/src/persistence/conversation-title-service.ts
+++ b/assistant/src/persistence/conversation-title-service.ts
@@ -98,7 +98,9 @@ const REPLACEABLE_PATTERNS = [
  * user-provided custom titles.
  */
 export function isReplaceableTitle(title: string | null): boolean {
-  if (title == null || title.trim() === "") return true;
+  if (title == null || title.trim() === "") {
+    return true;
+  }
   return REPLACEABLE_PATTERNS.some((pattern) => pattern.test(title));
 }
 
@@ -467,12 +469,21 @@ function buildTitlePrompt(
 
   if (context) {
     const hints: string[] = [];
-    if (context.sourceChannel) hints.push(`Channel: ${context.sourceChannel}`);
-    if (context.displayName) hints.push(`User: ${context.displayName}`);
-    if (context.systemHint) hints.push(`Context: ${context.systemHint}`);
-    if (context.uxBrief) hints.push(`Brief: ${context.uxBrief}`);
-    if (context.metadataHints?.length)
+    if (context.sourceChannel) {
+      hints.push(`Channel: ${context.sourceChannel}`);
+    }
+    if (context.displayName) {
+      hints.push(`User: ${context.displayName}`);
+    }
+    if (context.systemHint) {
+      hints.push(`Context: ${context.systemHint}`);
+    }
+    if (context.uxBrief) {
+      hints.push(`Brief: ${context.uxBrief}`);
+    }
+    if (context.metadataHints?.length) {
       hints.push(`Hints: ${context.metadataHints.join(", ")}`);
+    }
     if (hints.length > 0) {
       parts.push("Metadata:", ...hints, "");
     }
@@ -513,7 +524,9 @@ function retryableFallbackLogFields(
     reason,
     fallbackSource: params.context ? "context" : "untitled",
   };
-  if (err) fields.err = err;
+  if (err) {
+    fields.err = err;
+  }
   return fields;
 }
 
@@ -546,14 +559,18 @@ const MAX_TITLE_LENGTH = 40;
 const MAX_TITLE_WORDS = 7;
 
 function truncateTitle(title: string): string {
-  if (title.length <= MAX_TITLE_LENGTH) return title;
+  if (title.length <= MAX_TITLE_LENGTH) {
+    return title;
+  }
   const words = title.split(/\s+/);
   if (words.length <= MAX_TITLE_WORDS) {
     // Long words but few of them — truncate to char limit at word boundary
     let result = "";
     for (const word of words) {
       const candidate = result ? result + " " + word : word;
-      if (candidate.length > MAX_TITLE_LENGTH) break;
+      if (candidate.length > MAX_TITLE_LENGTH) {
+        break;
+      }
       result = candidate;
     }
     return result || title.slice(0, MAX_TITLE_LENGTH);
@@ -566,7 +583,9 @@ function normalizeTitle(raw: string): string {
   let title = raw.trim().replace(/^["']|["']$/g, "");
   title = stripMarkdown(title);
   title = stripThinkingTags(title).trim();
-  if (!title) return "";
+  if (!title) {
+    return "";
+  }
   // Reject outputs that are the model reasoning aloud or continuing the
   // conversation instead of naming it (e.g. "I need to generate a…", "I'll
   // work through these files…"). Callers fall back to a deterministic title.
@@ -646,8 +665,12 @@ const LEAKED_PROSE_PREFIXES = [
  * fallback title, while a false accept persists a broken one.
  */
 function looksLikeLeakedProse(title: string): boolean {
-  if (/\n/.test(title)) return true;
-  if (/\b(?:user|assistant)\s*:/i.test(title)) return true;
+  if (/\n/.test(title)) {
+    return true;
+  }
+  if (/\b(?:user|assistant)\s*:/i.test(title)) {
+    return true;
+  }
   const lower = title.toLowerCase();
   if (LEAKED_PROSE_PREFIXES.some((prefix) => lower.startsWith(prefix))) {
     return true;
@@ -688,9 +711,15 @@ function stripMarkdown(text: string): string {
 }
 
 function deriveFallbackTitle(context?: TitleContext): string | null {
-  if (!context) return null;
-  if (context.systemHint) return context.systemHint;
-  if (context.uxBrief) return context.uxBrief;
+  if (!context) {
+    return null;
+  }
+  if (context.systemHint) {
+    return context.systemHint;
+  }
+  if (context.uxBrief) {
+    return context.uxBrief;
+  }
   return null;
 }
 
@@ -705,14 +734,20 @@ function deriveFallbackTitle(context?: TitleContext): string | null {
  * Returns empty string for content-block arrays with no extractable text,
  * preventing raw JSON from polluting the title prompt.
  */
-function extractTextForTitle(raw: string): string {
+function extractTextForTitle(raw: string | Array<{ type: string }>): string {
   try {
-    const parsed = JSON.parse(raw);
-    if (typeof parsed === "string") return parsed;
-    if (!Array.isArray(parsed)) return raw;
+    const parsed = Array.isArray(raw) ? raw : JSON.parse(raw);
+    if (typeof parsed === "string") {
+      return parsed;
+    }
+    if (!Array.isArray(parsed)) {
+      return raw as string;
+    }
     const texts: string[] = [];
     for (const block of parsed) {
-      if (!block || typeof block !== "object") continue;
+      if (!block || typeof block !== "object") {
+        continue;
+      }
       if (block.type === "text" && typeof block.text === "string") {
         texts.push(block.text);
         // guard:allow-tool-result-only — web_search_tool_result has structured
@@ -737,7 +772,7 @@ function extractTextForTitle(raw: string): string {
     }
     return texts.join("\n");
   } catch {
-    return raw;
+    return Array.isArray(raw) ? "" : raw;
   }
 }
 
@@ -746,7 +781,9 @@ function buildRegenerationPrompt(recentMessages: MessageRow[]): string {
 
   for (const msg of recentMessages) {
     const text = extractTextForTitle(msg.content);
-    if (!text) continue;
+    if (!text) {
+      continue;
+    }
     const role = msg.role === "user" ? "User" : "Assistant";
     parts.push(`${role}: ${stripThinkingTags(text)}`);
   }

--- a/assistant/src/persistence/message-content-file.ts
+++ b/assistant/src/persistence/message-content-file.ts
@@ -20,10 +20,10 @@
  * crash-truncated file still folds to the newest complete snapshot of each
  * block.
  *
- * All content reads must go through {@link resolveMessageContentBlocks}
- * (expressive form) or {@link resolveStoredMessageContent} (the string shim
- * wired into the message row mapper) — downstream consumers never see a raw
- * `{ ref }` value.
+ * {@link resolveMessageContentBlocks} is the single resolution seam:
+ * consumers take the raw stored string off the message row and resolve it
+ * to typed blocks here — a raw `{ ref }` value is never interpreted
+ * anywhere else.
  */
 
 import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
@@ -39,33 +39,29 @@ import { getWorkspaceDir } from "../util/platform.js";
 const log = getLogger("message-content-file");
 
 /**
- * Ref-shaped `messages.content` value. Strict (no extra keys) and
- * reserved-path constrained so legacy plain-string rows that parse as
- * arbitrary JSON objects can never be mistaken for a ref.
+ * Ref-shaped `messages.content` value. The reserved-path constraint is the
+ * discriminator that keeps legacy plain-string rows that parse as arbitrary
+ * JSON objects from being mistaken for a ref.
  */
-export const messageContentRefSchema = z
-  .object({
-    ref: z
-      .string()
-      .regex(
-        /^conversations\/.+\.jsonl$/,
-        "content refs must be workspace-relative paths under conversations/ ending in .jsonl",
-      ),
-  })
-  .strict();
+export const messageContentRefSchema = z.object({
+  ref: z
+    .string()
+    .regex(
+      /^conversations\/.+\.jsonl$/,
+      "content refs must be workspace-relative paths under conversations/ ending in .jsonl",
+    ),
+});
 
 export type MessageContentRef = z.infer<typeof messageContentRefSchema>;
 
 /** One line of the append-only content delta file. */
-const contentDeltaLineSchema = z
-  .object({
-    /** Index of `block` in the folded `ContentBlock[]`. */
-    i: z.number(),
-    /** Monotonic write sequence; the highest `seq` per `i` wins the fold. */
-    seq: z.number(),
-    block: contentBlockSchema,
-  })
-  .strict();
+const contentDeltaLineSchema = z.object({
+  /** Index of `block` in the folded `ContentBlock[]`. */
+  i: z.number(),
+  /** Monotonic write sequence; the highest `seq` per `i` wins the fold. */
+  seq: z.number(),
+  block: contentBlockSchema,
+});
 
 export type ContentDeltaLine = z.infer<typeof contentDeltaLineSchema>;
 
@@ -75,7 +71,7 @@ export type ContentDeltaLine = z.infer<typeof contentDeltaLineSchema>;
  * inline-array case to a single character check.
  */
 function parseContentRef(raw: string): MessageContentRef | null {
-  if (typeof raw !== "string" || raw.charCodeAt(0) !== 0x7b /* '{' */) {
+  if (raw.charCodeAt(0) !== 0x7b /* '{' */) {
     return null;
   }
   let parsed: unknown;
@@ -225,22 +221,4 @@ export function resolveMessageContentBlocks(raw: string): ContentBlock[] {
     return parsed as ContentBlock[];
   }
   return [{ type: "text", text: raw }];
-}
-
-/**
- * Resolve a stored `messages.content` value to its inline JSON string form.
- *
- * String shim over the resolver for call sites whose contract is the raw
- * stored string — today that is `MessageRow.content` via the row mapper.
- * Inline values (JSON `ContentBlock[]` or legacy plain strings) pass
- * through by identity — the common case costs one character check — so
- * legacy-string handling stays byte-identical for existing consumers.
- * Prefer {@link resolveMessageContentBlocks} in new code.
- */
-export function resolveStoredMessageContent(raw: string): string {
-  const ref = parseContentRef(raw);
-  if (!ref) {
-    return raw;
-  }
-  return JSON.stringify(resolveRefToBlocks(ref));
 }

--- a/assistant/src/persistence/message-content-file.ts
+++ b/assistant/src/persistence/message-content-file.ts
@@ -188,8 +188,9 @@ function resolveRefToBlocks(ref: MessageContentRef): ContentBlock[] {
  * This is the expressive form of the resolver:
  *   - Inline `ContentBlock[]` JSON parses to its blocks.
  *   - A `{ ref }` folds its delta file (empty on missing/escaping refs).
- *   - A legacy plain string (or any non-array, non-ref JSON) becomes a
- *     single text block carrying the raw value.
+ *   - A JSON string unwraps to its parsed value as a single text block
+ *     (parity with the legacy readers); any other legacy plain string or
+ *     non-array JSON becomes a text block carrying the raw value.
  *
  * Never throws — content reads must not take down read paths.
  */
@@ -204,6 +205,9 @@ export function resolveMessageContentBlocks(raw: string): ContentBlock[] {
   } catch {
     // legacy plain string
     return [{ type: "text", text: raw }];
+  }
+  if (typeof parsed === "string") {
+    return [{ type: "text", text: parsed }];
   }
   if (Array.isArray(parsed)) {
     const result = z.array(contentBlockSchema).safeParse(parsed);

--- a/assistant/src/persistence/message-content.ts
+++ b/assistant/src/persistence/message-content.ts
@@ -1,14 +1,16 @@
 import type { ContentBlock } from "../providers/types.js";
 import { escapeXmlAttr } from "../util/xml.js";
 
-export function extractTextFromStoredMessageContent(raw: string): string {
+export function extractTextFromStoredMessageContent(
+  raw: string | ContentBlock[],
+): string {
   try {
-    const parsed = JSON.parse(raw) as unknown;
+    const parsed = Array.isArray(raw) ? raw : (JSON.parse(raw) as unknown);
     if (typeof parsed === "string") {
       return parsed;
     }
     if (!Array.isArray(parsed)) {
-      return raw;
+      return raw as string;
     }
     const blocks = parsed as ContentBlock[];
     const lines: string[] = [];
@@ -66,7 +68,7 @@ export function extractTextFromStoredMessageContent(raw: string): string {
     }
     return lines.join("\n").trim();
   } catch {
-    return raw;
+    return Array.isArray(raw) ? "" : raw;
   }
 }
 
@@ -93,18 +95,24 @@ function stableJson(value: unknown): string {
  * Parse failures fall back to returning the raw input trimmed (the
  * legacy-string path).
  */
-export function stringifyMessageContent(stored: string): string {
+export function stringifyMessageContent(
+  stored: string | ContentBlock[],
+): string {
   let parsed: unknown;
-  try {
-    parsed = JSON.parse(stored);
-  } catch {
-    return stored.trim();
+  if (Array.isArray(stored)) {
+    parsed = stored;
+  } else {
+    try {
+      parsed = JSON.parse(stored);
+    } catch {
+      return stored.trim();
+    }
   }
   if (typeof parsed === "string") {
     return parsed.trim();
   }
   if (!Array.isArray(parsed)) {
-    return stored.trim();
+    return (stored as string).trim();
   }
   const parts: string[] = [];
   for (const block of parsed) {

--- a/assistant/src/persistence/schema/conversations.ts
+++ b/assistant/src/persistence/schema/conversations.ts
@@ -107,9 +107,9 @@ export const messages = sqliteTable(
     /**
      * Union of two JSON shapes: an inline `ContentBlock[]` (or a legacy
      * plain string), or `{ ref: "<workspace-relative path>" }` pointing at
-     * a file-backed content payload. Always read through the message row
-     * mapper (which applies `resolveStoredMessageContent`) — never parse
-     * this column raw.
+     * a file-backed content payload. Resolve to typed blocks with
+     * `resolveMessageContentBlocks` (message-content-file.ts) — never
+     * interpret this column's shape by hand.
      */
     content: text("content").notNull(),
     createdAt: integer("created_at").notNull(),

--- a/assistant/src/plugins/defaults/image-recovery/recover.ts
+++ b/assistant/src/plugins/defaults/image-recovery/recover.ts
@@ -71,7 +71,9 @@ export function oversizedImageReplacement(
   // is gated on the same payload/dimension caps as an inline one. When the
   // attachment can no longer be read, leave the block untouched.
   const resolved = resolveMediaSourceData(block.source);
-  if (!resolved) return null;
+  if (!resolved) {
+    return null;
+  }
   const payloadBytes = resolved.data.length;
   const dims = parseImageDimensions(block.source);
   const exceedsDimensionCap =
@@ -79,7 +81,9 @@ export function oversizedImageReplacement(
     (dims.width > PROVIDER_MAX_IMAGE_DIMENSION ||
       dims.height > PROVIDER_MAX_IMAGE_DIMENSION);
   const exceedsPayloadCap = payloadBytes > PROVIDER_MAX_IMAGE_PAYLOAD_BYTES;
-  if (!exceedsDimensionCap && !exceedsPayloadCap) return null;
+  if (!exceedsDimensionCap && !exceedsPayloadCap) {
+    return null;
+  }
 
   const optimized = optimizeImageForTransport(
     resolved.data,
@@ -115,23 +119,25 @@ export function persistUnsendableImageDowngrades(
 ): number {
   let rewritten = 0;
   for (const row of getMessages(conversationId)) {
-    // Cheap prefilter — JSON.stringify emits no spaces, so an image block
-    // always serializes with this exact substring.
-    if (!row.content.includes('"type":"image"')) continue;
-
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(row.content);
-    } catch {
+    const hasImageBlock = row.content.some(
+      (b) =>
+        b.type === "image" ||
+        (b.type === "tool_result" &&
+          b.contentBlocks?.some((cb) => cb.type === "image")),
+    );
+    if (!hasImageBlock) {
       continue;
     }
-    if (!Array.isArray(parsed)) continue;
+
+    const parsed = row.content;
 
     let changed = false;
     const next = (parsed as ContentBlock[]).map((block): ContentBlock => {
       if (block.type === "image") {
         const replacement = oversizedImageReplacement(block);
-        if (!replacement) return block;
+        if (!replacement) {
+          return block;
+        }
         changed = true;
         return replacement;
       }
@@ -141,19 +147,27 @@ export function persistUnsendableImageDowngrades(
       if (block.type === "tool_result" && block.contentBlocks?.length) {
         let nestedChanged = false;
         const contentBlocks = block.contentBlocks.map((cb): ContentBlock => {
-          if (cb.type !== "image") return cb;
+          if (cb.type !== "image") {
+            return cb;
+          }
           const replacement = oversizedImageReplacement(cb);
-          if (!replacement) return cb;
+          if (!replacement) {
+            return cb;
+          }
           nestedChanged = true;
           return replacement;
         });
-        if (!nestedChanged) return block;
+        if (!nestedChanged) {
+          return block;
+        }
         changed = true;
         return { ...block, contentBlocks };
       }
       return block;
     });
-    if (!changed) continue;
+    if (!changed) {
+      continue;
+    }
 
     updateMessageContent(row.id, JSON.stringify(next));
     rewritten++;
@@ -192,8 +206,12 @@ export function recoverOversizedImages(
   messages: ReadonlyArray<Message>,
 ): Message[] {
   return messages.map((msg) => {
-    if (!Array.isArray(msg.content)) return msg;
-    if (!messageHasImageBlock(msg.content)) return msg;
+    if (!Array.isArray(msg.content)) {
+      return msg;
+    }
+    if (!messageHasImageBlock(msg.content)) {
+      return msg;
+    }
     return {
       ...msg,
       content: msg.content.flatMap((b): ContentBlock[] => {

--- a/assistant/src/plugins/defaults/memory/indexer.ts
+++ b/assistant/src/plugins/defaults/memory/indexer.ts
@@ -18,6 +18,7 @@ import {
   upsertDebouncedJob,
 } from "../../../persistence/jobs-store.js";
 import { memorySegments } from "../../../persistence/schema/index.js";
+import type { ContentBlock } from "../../../providers/types.js";
 import type { TrustClass } from "../../../runtime/actor-trust-resolver.js";
 import { isAutoAnalysisConversation } from "../../../runtime/services/auto-analysis-guard.js";
 import { getLogger } from "./logging.js";
@@ -35,7 +36,7 @@ export interface IndexMessageInput {
   messageId: string;
   conversationId: string;
   role: string;
-  content: string;
+  content: string | ContentBlock[];
   createdAt: number;
   /**
    * Trust class of the actor who produced this message, captured at

--- a/assistant/src/plugins/defaults/memory/indexer.ts
+++ b/assistant/src/plugins/defaults/memory/indexer.ts
@@ -1,4 +1,5 @@
 import {
+  type ContentBlock,
   extractTextFromStoredMessageContent,
   selectedBackendSupportsMultimodal,
 } from "@vellumai/plugin-api";
@@ -18,7 +19,6 @@ import {
   upsertDebouncedJob,
 } from "../../../persistence/jobs-store.js";
 import { memorySegments } from "../../../persistence/schema/index.js";
-import type { ContentBlock } from "../../../providers/types.js";
 import type { TrustClass } from "../../../runtime/actor-trust-resolver.js";
 import { isAutoAnalysisConversation } from "../../../runtime/services/auto-analysis-guard.js";
 import { getLogger } from "./logging.js";

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -76,6 +76,7 @@ import {
 } from "../../../persistence/jobs-store.js";
 import { resolveUserSlug } from "../../../prompts/persona-resolver.js";
 import type { SystemPromptPersonaOverride } from "../../../prompts/system-prompt.js";
+import type { ContentBlock } from "../../../providers/types.js";
 import { wakeAgentForOpportunity } from "../../../runtime/agent-wake.js";
 import { findMostRecentRetrospectiveFor } from "./find-most-recent-retrospective-for.js";
 import { getLogger } from "./logging.js";
@@ -931,7 +932,7 @@ async function extractRetrospectiveRunRemembers(
 
 interface MessageLike {
   role: string;
-  content: string;
+  content: string | ContentBlock[];
 }
 
 /**
@@ -945,11 +946,13 @@ function extractRememberContents(messages: MessageLike[]): string[] {
     if (msg.role !== "assistant") {
       continue;
     }
-    let blocks: unknown;
-    try {
-      blocks = JSON.parse(msg.content);
-    } catch {
-      continue;
+    let blocks: unknown = msg.content;
+    if (typeof blocks === "string") {
+      try {
+        blocks = JSON.parse(blocks);
+      } catch {
+        continue;
+      }
     }
     if (!Array.isArray(blocks)) {
       continue;

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -42,6 +42,7 @@
 
 import {
   addMessage,
+  type ContentBlock,
   type ConversationRow,
   deleteConversation,
   getConversation,
@@ -76,7 +77,6 @@ import {
 } from "../../../persistence/jobs-store.js";
 import { resolveUserSlug } from "../../../prompts/persona-resolver.js";
 import type { SystemPromptPersonaOverride } from "../../../prompts/system-prompt.js";
-import type { ContentBlock } from "../../../providers/types.js";
 import { wakeAgentForOpportunity } from "../../../runtime/agent-wake.js";
 import { findMostRecentRetrospectiveFor } from "./find-most-recent-retrospective-for.js";
 import { getLogger } from "./logging.js";

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-skill-card.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-skill-card.ts
@@ -39,6 +39,7 @@ import {
   type MemoryJob,
   upsertSkillCardInsertJob,
 } from "../../../persistence/jobs-store.js";
+import type { ContentBlock } from "../../../providers/types.js";
 import { publishConversationMessagesChanged } from "../../../runtime/sync/resource-sync-events.js";
 import { getLogger } from "./logging.js";
 import { SKILL_CARD_MESSAGE_KIND } from "./memory-retrospective-constants.js";
@@ -91,15 +92,17 @@ export async function extractRetrospectiveRunSkillScaffolds(
 
 interface MessageLike {
   role: string;
-  content: string;
+  content: string | ContentBlock[];
 }
 
 function parseBlocks(msg: MessageLike): Array<Record<string, unknown>> {
-  let blocks: unknown;
-  try {
-    blocks = JSON.parse(msg.content);
-  } catch {
-    return [];
+  let blocks: unknown = msg.content;
+  if (typeof blocks === "string") {
+    try {
+      blocks = JSON.parse(blocks);
+    } catch {
+      return [];
+    }
   }
   if (!Array.isArray(blocks)) {
     return [];

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-skill-card.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-skill-card.ts
@@ -30,6 +30,7 @@
 
 import {
   addMessage,
+  type ContentBlock,
   getConversation,
   isConversationProcessing,
   syncMessageToDisk,
@@ -39,7 +40,6 @@ import {
   type MemoryJob,
   upsertSkillCardInsertJob,
 } from "../../../persistence/jobs-store.js";
-import type { ContentBlock } from "../../../providers/types.js";
 import { publishConversationMessagesChanged } from "../../../runtime/sync/resource-sync-events.js";
 import { getLogger } from "./logging.js";
 import { SKILL_CARD_MESSAGE_KIND } from "./memory-retrospective-constants.js";

--- a/assistant/src/plugins/defaults/memory/message-media.ts
+++ b/assistant/src/plugins/defaults/memory/message-media.ts
@@ -59,10 +59,10 @@ export function extractMediaBlocks(raw: string): Array<{
  * metadata without resolving image bytes.
  */
 export function extractMediaBlockMeta(
-  raw: string,
+  raw: string | ContentBlock[],
 ): Array<{ type: "image"; index: number }> {
   try {
-    const parsed = JSON.parse(raw) as unknown;
+    const parsed = Array.isArray(raw) ? raw : (JSON.parse(raw) as unknown);
     if (!Array.isArray(parsed)) {
       return [];
     }

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -75,13 +75,19 @@ function toDeliverableTextSegments(
         : stripped;
     })
     .filter((segment) => segment.trim().length > 0);
-  if (nonEmptySegments.length > 0) return nonEmptySegments;
+  if (nonEmptySegments.length > 0) {
+    return nonEmptySegments;
+  }
   // If the only text was <no_response/>, treat as intentional silence —
   // do not fall back to fallbackText.
-  if (hasNoResponseMarker(textSegments)) return [];
+  if (hasNoResponseMarker(textSegments)) {
+    return [];
+  }
   if (typeof fallbackText === "string") {
     const fallback = stripNoResponseMarkers(fallbackText);
-    if (fallback.length > 0) return [fallback];
+    if (fallback.length > 0) {
+      return [fallback];
+    }
   }
   return [];
 }
@@ -261,12 +267,7 @@ function readPersistedAssistantReply(msg: PersistedMessage): {
   rendered: RenderedHistoryContent;
   replyAttachments: RuntimeAttachmentMetadata[];
 } {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(msg.content);
-  } catch {
-    parsed = msg.content;
-  }
+  const parsed: unknown = msg.content;
   const rendered = renderHistoryContent(parsed);
 
   const linked = getAttachmentMetadataForMessage(msg.id);
@@ -282,9 +283,11 @@ function readPersistedAssistantReply(msg: PersistedMessage): {
 }
 
 function isToolResultUserMessage(msg: PersistedMessage): boolean {
-  if (msg.role !== "user") return false;
+  if (msg.role !== "user") {
+    return false;
+  }
   try {
-    const parsed = JSON.parse(msg.content) as unknown;
+    const parsed = msg.content as unknown;
     return (
       Array.isArray(parsed) &&
       parsed.length > 0 &&
@@ -306,7 +309,9 @@ export function findAssistantReplyMessageIdForTurn(
 ): string | undefined {
   const msgs = getMessages(conversationId);
   const userIndex = msgs.findIndex((msg) => msg.id === userMessageId);
-  if (userIndex === -1) return undefined;
+  if (userIndex === -1) {
+    return undefined;
+  }
 
   let turnEndIndex = msgs.length;
   for (let i = userIndex + 1; i < msgs.length; i++) {
@@ -446,7 +451,9 @@ export async function deliverReplyViaCallback(
 
   const msgs = getMessages(conversationId);
   for (let i = msgs.length - 1; i >= 0; i--) {
-    if (msgs[i].role !== "assistant") continue;
+    if (msgs[i].role !== "assistant") {
+      continue;
+    }
     const delivered = await deliverPersistedAssistantMessageViaCallback(
       msgs[i],
       externalChatId,
@@ -454,7 +461,9 @@ export async function deliverReplyViaCallback(
       assistantId,
       options,
     );
-    if (delivered) break;
+    if (delivered) {
+      break;
+    }
   }
 }
 
@@ -477,9 +486,13 @@ export async function deliverReplyViaCallback(
 function makeChannelTsReconciler(messageId: string): (ts: string) => void {
   let applied = false;
   return (ts: string): void => {
-    if (applied) return;
+    if (applied) {
+      return;
+    }
     applied = true;
-    if (!ts) return;
+    if (!ts) {
+      return;
+    }
     try {
       // Re-read the row's current metadata so a concurrent edit-propagation
       // write (e.g. `editedAt`) is not clobbered. `updateMessageMetadata`
@@ -489,7 +502,9 @@ function makeChannelTsReconciler(messageId: string): (ts: string) => void {
       // `readSlackMetadata` which rejects the partial form for lacking
       // channelTs — exactly the state we are reconciling).
       const row = getMessageById(messageId);
-      if (row === null || row.metadata === null) return;
+      if (row === null || row.metadata === null) {
+        return;
+      }
       let envelope: Record<string, unknown>;
       try {
         envelope = JSON.parse(row.metadata) as Record<string, unknown>;
@@ -498,11 +513,15 @@ function makeChannelTsReconciler(messageId: string): (ts: string) => void {
       }
       const slackMetaRaw =
         typeof envelope.slackMeta === "string" ? envelope.slackMeta : null;
-      if (slackMetaRaw === null) return;
+      if (slackMetaRaw === null) {
+        return;
+      }
       // If the existing slackMeta already parses cleanly via the strict
       // reader, channelTs is already present (a prior reconciliation ran,
       // or backfill stamped the field) — nothing to do.
-      if (readSlackMetadata(slackMetaRaw) !== null) return;
+      if (readSlackMetadata(slackMetaRaw) !== null) {
+        return;
+      }
       // Lenient parse of the partial slackMeta so we can preserve every
       // field already written by `handleMessageComplete` (source,
       // eventKind, channelId, threadTs, ...) while patching channelTs in.

--- a/assistant/src/runtime/routes/conversation-attention-routes.ts
+++ b/assistant/src/runtime/routes/conversation-attention-routes.ts
@@ -75,7 +75,7 @@ function handleListConversationAttention({
       if (msg?.content) {
         snippetMap.set(
           attn.latestAssistantMessageId,
-          truncate(msg.content, 200, ""),
+          truncate(JSON.stringify(msg.content), 200, ""),
         );
       }
     }

--- a/assistant/src/runtime/routes/conversation-cli-routes.ts
+++ b/assistant/src/runtime/routes/conversation-cli-routes.ts
@@ -170,7 +170,7 @@ function handleExportCli({ body = {} }: RouteHandlerArgs) {
     ...conversation,
     messages: msgs.map((m) => ({
       role: m.role,
-      content: JSON.parse(m.content),
+      content: m.content,
       createdAt: m.createdAt,
     })),
   };

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -243,13 +243,19 @@ function alignAttachments(
 
   const byId = new Map<string, number>();
   attachments.forEach((att, idx) => {
-    if (att.id) byId.set(att.id, idx);
+    if (att.id) {
+      byId.set(att.id, idx);
+    }
   });
   const consumed = new Set<number>();
   const orderedRowIdx: Array<number | null> = attachmentRefs.map((ref) => {
-    if (!ref.attachmentId) return null;
+    if (!ref.attachmentId) {
+      return null;
+    }
     const idx = byId.get(ref.attachmentId);
-    if (idx === undefined || consumed.has(idx)) return null;
+    if (idx === undefined || consumed.has(idx)) {
+      return null;
+    }
     consumed.add(idx);
     return idx;
   });
@@ -260,7 +266,9 @@ function alignAttachments(
   if (matchedRows.length > 0) {
     const orphanRows: number[] = [];
     for (let i = 0; i < attachments.length; i++) {
-      if (!consumed.has(i)) orphanRows.push(i);
+      if (!consumed.has(i)) {
+        orphanRows.push(i);
+      }
     }
     const reordered = [
       ...matchedRows.map((i) => attachments[i]),
@@ -279,7 +287,9 @@ function alignAttachments(
       contentOrder
         .map((entry) => {
           const match = entry.match(ATTACHMENT_ENTRY_RE);
-          if (!match) return entry;
+          if (!match) {
+            return entry;
+          }
           const remapped = refToNewIdx.get(Number(match[1]));
           return remapped !== undefined ? `attachment:${remapped}` : undefined;
         })
@@ -332,7 +342,9 @@ function isValidRiskThreshold(value: unknown): value is RiskThreshold {
  * leaving them in the LLM-side context.
  */
 function isHiddenMessage(metadata: string | null): boolean {
-  if (!metadata) return false;
+  if (!metadata) {
+    return false;
+  }
   try {
     return isHiddenMessageMetadata(
       JSON.parse(metadata) as Record<string, unknown>,
@@ -346,7 +358,9 @@ function buildSlackHistoryMessage(
   slackMeta: SlackMessageMetadata | null,
   opts?: { role?: string; assistantDisplayName?: string },
 ): RuntimeMessagePayload["slackMessage"] | undefined {
-  if (!slackMeta) return undefined;
+  if (!slackMeta) {
+    return undefined;
+  }
 
   const slackConfig = getConfig().slack;
   const replyThreadTs =
@@ -443,7 +457,9 @@ function expireOrphanedCanonicalRequests(conversationId: string): void {
   for (const req of sourceScoped) {
     // Skip requests that still have a live in-memory pending interaction —
     // they are not orphaned.
-    if (pendingInteractions.get(req.id)) continue;
+    if (pendingInteractions.get(req.id)) {
+      continue;
+    }
 
     resolveCanonicalGuardianRequest(req.id, "pending", {
       status: "expired",
@@ -622,7 +638,9 @@ function buildQueuedMessagePayloads(
   conversationId: string,
 ): RuntimeMessagePayload[] {
   const conversation = findConversation(conversationId);
-  if (!conversation) return [];
+  if (!conversation) {
+    return [];
+  }
 
   // Hidden sends are suppressed from the transcript at every stage — echo,
   // persisted row, and here the in-memory queue window: a latest-page fetch
@@ -648,7 +666,9 @@ function buildQueuedMessagePayloads(
       );
 
       const contentBlocks: ConversationContentBlock[] = [];
-      if (text.length > 0) contentBlocks.push({ type: "text", text });
+      if (text.length > 0) {
+        contentBlocks.push({ type: "text", text });
+      }
       for (const attachment of attachments) {
         contentBlocks.push({ type: "attachment", attachment });
       }
@@ -823,12 +843,7 @@ export function handleListMessages({
   // alignment, letting renderHistoryContent inline `attachment` blocks during
   // its single content walk.
   const parsed = consolidatedMessages.map((msg) => {
-    let content: unknown;
-    try {
-      content = JSON.parse(msg.content);
-    } catch {
-      content = msg.content;
-    }
+    const content: unknown = msg.content;
 
     // Extract sentAt from metadata for display timestamps. When a message
     // was queued or its persistence was delayed (long assistant generation),
@@ -849,7 +864,9 @@ export function handleListMessages({
     if (msg.metadata) {
       try {
         const meta = JSON.parse(msg.metadata);
-        if (typeof meta.sentAt === "number") sentAt = meta.sentAt;
+        if (typeof meta.sentAt === "number") {
+          sentAt = meta.sentAt;
+        }
         // Every wake persists a `<background_event source="...">` trigger row
         // (see `persistWakeTriggerMessage`) that the LLM reads. Flag any such
         // row so clients hide it from the transcript like a subagent/ACP
@@ -1040,7 +1057,9 @@ export function handleListMessages({
       contentOrder = rendered.contentOrder
         .map((entry) => {
           const tm = entry.match(/^text:(\d+)$/);
-          if (!tm) return entry;
+          if (!tm) {
+            return entry;
+          }
           const newIdx = indexMap.get(Number(tm[1]));
           return newIdx !== undefined ? `text:${newIdx}` : undefined;
         })
@@ -1681,7 +1700,9 @@ export async function handleSendMessage(
           guardianPrincipalId,
           sourceChannel,
         );
-        if (healed) trustCtx = healed;
+        if (healed) {
+          trustCtx = healed;
+        }
       }
       conversation.setTrustContext(trustCtx);
     } else {
@@ -2626,10 +2647,14 @@ export async function handleGetSuggestion(
       resolvedConversationId = conversationKey;
     }
   }
-  if (!resolvedConversationId) return noSuggestion;
+  if (!resolvedConversationId) {
+    return noSuggestion;
+  }
 
   const rawMessages = getMessages(resolvedConversationId);
-  if (rawMessages.length === 0) return noSuggestion;
+  if (rawMessages.length === 0) {
+    return noSuggestion;
+  }
 
   // Staleness check: compare requested messageId against the latest
   // assistant message BEFORE filtering by text content.  This ensures
@@ -2653,17 +2678,16 @@ export async function handleGetSuggestion(
   // Walk backwards to find the last assistant message with text content
   for (let i = rawMessages.length - 1; i >= 0; i--) {
     const msg = rawMessages[i];
-    if (msg.role !== "assistant") continue;
-
-    let content: unknown;
-    try {
-      content = JSON.parse(msg.content);
-    } catch {
-      content = msg.content;
+    if (msg.role !== "assistant") {
+      continue;
     }
+
+    const content: unknown = msg.content;
     const rendered = renderHistoryContent(content);
     const text = rendered.text.trim();
-    if (!text) continue;
+    if (!text) {
+      continue;
+    }
 
     // If a messageId was requested and the first text-bearing assistant
     // message is a *different* message, the request is stale.
@@ -2682,13 +2706,10 @@ export async function handleGetSuggestion(
     // to guess which role it's generating for.
     let priorUserText: string | null = null;
     for (let j = i - 1; j >= 0; j--) {
-      if (rawMessages[j].role !== "user") continue;
-      let userContent: unknown;
-      try {
-        userContent = JSON.parse(rawMessages[j].content);
-      } catch {
-        userContent = rawMessages[j].content;
+      if (rawMessages[j].role !== "user") {
+        continue;
       }
+      const userContent: unknown = rawMessages[j].content;
       const userText = renderHistoryContent(userContent).text.trim();
       if (userText) {
         priorUserText = userText;

--- a/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
@@ -127,7 +127,7 @@ export async function handleEditIntercept(
     // authoritative previous text once the original row is located, so
     // this check lives after the lookup.
     const existingRow = getMessageById(original.messageId);
-    if (existingRow && existingRow.content === newContent) {
+    if (existingRow && JSON.stringify(existingRow.content) === newContent) {
       log.debug(
         {
           assistantId,

--- a/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
@@ -29,6 +29,7 @@ import {
   recordInbound,
 } from "../../../persistence/delivery-crud.js";
 import { enqueueLexicalIndexForMessage } from "../../../persistence/job-handlers/message-lexical.js";
+import { stringifyMessageContent } from "../../../persistence/message-content.js";
 import { safeParseRecord } from "../../../util/json.js";
 import { getLogger } from "../../../util/logger.js";
 
@@ -127,7 +128,10 @@ export async function handleEditIntercept(
     // authoritative previous text once the original row is located, so
     // this check lives after the lookup.
     const existingRow = getMessageById(original.messageId);
-    if (existingRow && JSON.stringify(existingRow.content) === newContent) {
+    if (
+      existingRow &&
+      stringifyMessageContent(existingRow.content) === newContent
+    ) {
       log.debug(
         {
           assistantId,

--- a/assistant/src/runtime/routes/subagents-routes.ts
+++ b/assistant/src/runtime/routes/subagents-routes.ts
@@ -65,14 +65,11 @@ export function parseSubagentMessages(
   const firstUser = messages.find((m) => m.role === "user");
   if (firstUser) {
     try {
-      const parsed = JSON.parse(firstUser.content);
-      if (Array.isArray(parsed)) {
-        const textBlock = parsed.find(
-          (b: Record<string, unknown>) => isRecord(b) && b.type === "text",
-        );
-        if (textBlock && typeof textBlock.text === "string") {
-          objective = stripForkDirectiveFraming(textBlock.text);
-        }
+      const textBlock = firstUser.content.find(
+        (b) => b.type === "text" && typeof b.text === "string",
+      );
+      if (textBlock && "text" in textBlock) {
+        objective = stripForkDirectiveFraming(textBlock.text);
       }
     } catch {
       /* ignore */
@@ -83,17 +80,15 @@ export function parseSubagentMessages(
   const events: SubagentDetailResult["events"] = [];
   const pendingTools = new Map<string, string>();
   for (const m of messages) {
-    if (m.role !== "assistant" && m.role !== "user") continue;
-    let content: unknown[];
-    try {
-      const parsed = JSON.parse(m.content);
-      content = Array.isArray(parsed) ? parsed : [];
-    } catch {
+    if (m.role !== "assistant" && m.role !== "user") {
       continue;
     }
+    const content: unknown[] = m.content;
 
     for (const block of content) {
-      if (!isRecord(block) || typeof block.type !== "string") continue;
+      if (!isRecord(block) || typeof block.type !== "string") {
+        continue;
+      }
       if (
         m.role === "assistant" &&
         block.type === "text" &&
@@ -117,7 +112,9 @@ export function parseSubagentMessages(
           toolUseId: id || undefined,
           input,
         });
-        if (id) pendingTools.set(id, name);
+        if (id) {
+          pendingTools.set(id, name);
+        }
       } else if (
         block.type === "tool_result" ||
         block.type === "web_search_tool_result" ||
@@ -132,13 +129,15 @@ export function parseSubagentMessages(
               ? (block.content as unknown[])
                   .filter((b): b is Record<string, unknown> => isRecord(b))
                   .map((b) => {
-                    if (b.type === "text" && typeof b.text === "string")
+                    if (b.type === "text" && typeof b.text === "string") {
                       return b.text;
+                    }
                     if (
                       b.type === "web_search_result" &&
                       typeof b.title === "string"
-                    )
+                    ) {
                       return `${b.title}\n${typeof b.url === "string" ? b.url : ""}`;
+                    }
                     return null;
                   })
                   .filter((s): s is string => s != null)

--- a/assistant/src/runtime/routes/work-items-routes.ts
+++ b/assistant/src/runtime/routes/work-items-routes.ts
@@ -13,6 +13,7 @@ import { getOrCreateConversation } from "../../daemon/conversation-store.js";
 import type { ServerMessage } from "../../daemon/message-protocol.js";
 import { check, classifyRisk } from "../../permissions/checker.js";
 import { getMessages } from "../../persistence/conversation-crud.js";
+import type { ContentBlock } from "../../providers/types.js";
 import { getSubagentManager } from "../../subagent/index.js";
 import { runTask } from "../../tasks/task-runner.js";
 import { getTask, getTaskRun } from "../../tasks/task-store.js";
@@ -81,15 +82,23 @@ function broadcastWorkItemStatus(id: string): void {
  * Consolidation merges multiple assistant messages into one DB row; scanning
  * from the end keeps task output focused on the final assistant response.
  */
-function extractLatestTextFromContent(content: string): string {
+function extractLatestTextFromContent(
+  content: string | ContentBlock[],
+): string {
   try {
-    const parsed = JSON.parse(content);
+    const parsed = Array.isArray(content) ? content : JSON.parse(content);
     if (Array.isArray(parsed)) {
       for (let i = parsed.length - 1; i >= 0; i--) {
         const block = parsed[i] as { type?: unknown; text?: unknown };
-        if (block.type !== "text") continue;
-        if (typeof block.text !== "string") continue;
-        if (!block.text.trim()) continue;
+        if (block.type !== "text") {
+          continue;
+        }
+        if (typeof block.text !== "string") {
+          continue;
+        }
+        if (!block.text.trim()) {
+          continue;
+        }
         return block.text;
       }
       return "";
@@ -97,15 +106,15 @@ function extractLatestTextFromContent(content: string): string {
   } catch {
     // Plain text content — use as-is
   }
-  return content;
+  return Array.isArray(content) ? "" : content;
 }
 
 /** Extract tool_result blocks from a user message's content. */
 function extractToolResults(
-  content: string,
+  content: string | ContentBlock[],
 ): Array<{ tool_use_id: string; content: string; is_error?: boolean }> {
   try {
-    const parsed = JSON.parse(content);
+    const parsed = Array.isArray(content) ? content : JSON.parse(content);
     if (Array.isArray(parsed)) {
       return parsed
         .filter((b: { type: string }) => b.type === "tool_result")
@@ -144,7 +153,7 @@ function extractToolResults(
  * outcomes like errors, file paths, and URLs.
  */
 function extractToolHighlights(
-  msgs: Array<{ role: string; content: string }>,
+  msgs: Array<{ role: string; content: string | ContentBlock[] }>,
   maxHighlights: number,
 ): string[] {
   const highlights: string[] = [];
@@ -152,9 +161,13 @@ function extractToolHighlights(
   // Build a map of tool_use_id -> tool name from assistant messages
   const toolNameById = new Map<string, string>();
   for (const m of msgs) {
-    if (m.role !== "assistant") continue;
+    if (m.role !== "assistant") {
+      continue;
+    }
     try {
-      const parsed = JSON.parse(m.content);
+      const parsed = Array.isArray(m.content)
+        ? m.content
+        : JSON.parse(m.content);
       if (Array.isArray(parsed)) {
         for (const block of parsed) {
           if (block.type === "tool_use" && block.id && block.name) {
@@ -174,11 +187,15 @@ function extractToolHighlights(
     i--
   ) {
     const m = msgs[i];
-    if (m.role !== "user") continue;
+    if (m.role !== "user") {
+      continue;
+    }
 
     const results = extractToolResults(m.content);
     for (const result of results) {
-      if (highlights.length >= maxHighlights) break;
+      if (highlights.length >= maxHighlights) {
+        break;
+      }
 
       const toolName = toolNameById.get(result.tool_use_id) ?? "tool";
       const resultText = result.content.trim();
@@ -260,10 +277,14 @@ function getWorkItemOutput(id: string): WorkItemOutputResult {
   // Find the last assistant message with text content
   for (let i = msgs.length - 1; i >= 0; i--) {
     const m = msgs[i];
-    if (m.role !== "assistant") continue;
+    if (m.role !== "assistant") {
+      continue;
+    }
 
     const text = extractLatestTextFromContent(m.content);
-    if (!text.trim()) continue;
+    if (!text.trim()) {
+      continue;
+    }
 
     summary = truncate(text, 2000, "");
 
@@ -276,7 +297,9 @@ function getWorkItemOutput(id: string): WorkItemOutputResult {
         trimmed.length > 2
       ) {
         highlights.push(trimmed);
-        if (highlights.length >= 5) break;
+        if (highlights.length >= 5) {
+          break;
+        }
       }
     }
     break;
@@ -508,11 +531,21 @@ export const ROUTES: RouteDefinition[] = [
       }
 
       const updates: Record<string, unknown> = {};
-      if (title !== undefined) updates.title = title;
-      if (notes !== undefined) updates.notes = notes;
-      if (status !== undefined) updates.status = status;
-      if (priorityTier !== undefined) updates.priorityTier = priorityTier;
-      if (sortIndex !== undefined) updates.sortIndex = sortIndex;
+      if (title !== undefined) {
+        updates.title = title;
+      }
+      if (notes !== undefined) {
+        updates.notes = notes;
+      }
+      if (status !== undefined) {
+        updates.status = status;
+      }
+      if (priorityTier !== undefined) {
+        updates.priorityTier = priorityTier;
+      }
+      if (sortIndex !== undefined) {
+        updates.sortIndex = sortIndex;
+      }
 
       const item =
         updateWorkItem(id, updates as Parameters<typeof updateWorkItem>[1]) ??

--- a/assistant/src/sequence/engine.ts
+++ b/assistant/src/sequence/engine.ts
@@ -35,7 +35,9 @@ const STEP_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes per step
 export async function runSequencesOnce(): Promise<number> {
   const now = Date.now();
   const claimed = claimDueEnrollments(now, BATCH_SIZE);
-  if (claimed.length === 0) return 0;
+  if (claimed.length === 0) {
+    return 0;
+  }
 
   let processed = 0;
   for (const enrollment of claimed) {
@@ -202,8 +204,9 @@ async function processEnrollment(
   // null so it won't be re-claimed. The approval/send flow is responsible
   // for advancing the enrollment once the draft is approved.
   if (step.requireApproval) {
-    if (extractedConversationId)
+    if (extractedConversationId) {
       updateEnrollmentConversationId(enrollment.id, extractedConversationId);
+    }
     log.info(
       {
         enrollmentId: enrollment.id,
@@ -322,8 +325,10 @@ function extractThreadIdFromConversation(
     // is the one we want.
     for (let i = msgs.length - 1; i >= 0; i--) {
       const msg = msgs[i];
-      const threadId = extractThreadIdFromContent(msg.content);
-      if (threadId) return threadId;
+      const threadId = extractThreadIdFromContent(JSON.stringify(msg.content));
+      if (threadId) {
+        return threadId;
+      }
     }
   } catch (err) {
     log.warn(
@@ -338,11 +343,15 @@ function extractThreadIdFromConversation(
 function extractThreadIdFromContent(content: string): string | null {
   // Pattern 1: JSON field like "threadId": "..." or "thread_id": "..."
   const jsonMatch = content.match(/"(?:threadId|thread_id)"\s*:\s*"([^"]+)"/);
-  if (jsonMatch) return jsonMatch[1];
+  if (jsonMatch) {
+    return jsonMatch[1];
+  }
 
   // Pattern 2: Prose like "Thread ID: <id>" (from tool result text)
   const proseMatch = content.match(/[Tt]hread\s+(?:ID|id):\s*(\S+)/);
-  if (proseMatch) return proseMatch[1];
+  if (proseMatch) {
+    return proseMatch[1];
+  }
 
   return null;
 }

--- a/assistant/src/tools/subagent/read.ts
+++ b/assistant/src/tools/subagent/read.ts
@@ -1,4 +1,5 @@
 import { getMessages } from "../../persistence/conversation-crud.js";
+import { extractTextFromStoredMessageContent } from "../../persistence/message-content.js";
 import { getSubagentManager, TERMINAL_STATUSES } from "../../subagent/index.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 import { resolveSubagentId } from "./resolve.js";
@@ -58,10 +59,12 @@ export async function executeSubagentRead(
   // Group text blocks by message so last_n slices messages, not blocks.
   const messageTexts: string[] = [];
   for (const msg of dbMessages) {
-    if (msg.role !== "assistant") continue;
+    if (msg.role !== "assistant") {
+      continue;
+    }
     const blocks: string[] = [];
     try {
-      const content = JSON.parse(msg.content);
+      const content = msg.content;
       if (Array.isArray(content)) {
         for (const block of content) {
           if (block.type === "text" && typeof block.text === "string") {
@@ -72,8 +75,7 @@ export async function executeSubagentRead(
         blocks.push(content);
       }
     } catch {
-      // Content might be plain text.
-      blocks.push(msg.content);
+      blocks.push(extractTextFromStoredMessageContent(msg.content));
     }
     if (blocks.length > 0) {
       messageTexts.push(blocks.join("\n\n"));

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -370,7 +370,9 @@ function appendInFlightAssistantTurn(
 ): Message[] {
   // When the snapshot already ends on an assistant turn, the in-flight turn is
   // present (or there is none to add) — appending the latest row would duplicate it.
-  if (messages[messages.length - 1]?.role === "assistant") return messages;
+  if (messages[messages.length - 1]?.role === "assistant") {
+    return messages;
+  }
 
   let rows;
   try {
@@ -378,26 +380,19 @@ function appendInFlightAssistantTurn(
   } catch {
     return messages;
   }
-  if (!rows || rows.length === 0) return messages;
-
-  const lastRow = rows[rows.length - 1];
-  if (lastRow.role !== "assistant") return messages;
-
-  let blocks: ContentBlock[];
-  try {
-    const parsed = JSON.parse(lastRow.content);
-    if (Array.isArray(parsed)) {
-      blocks = parsed as ContentBlock[];
-    } else if (typeof parsed === "string") {
-      blocks = [{ type: "text", text: parsed }];
-    } else {
-      return messages;
-    }
-  } catch {
-    // Plain-text content (no JSON envelope).
-    blocks = [{ type: "text", text: lastRow.content }];
+  if (!rows || rows.length === 0) {
+    return messages;
   }
 
-  if (blocks.length === 0) return messages;
+  const lastRow = rows[rows.length - 1];
+  if (lastRow.role !== "assistant") {
+    return messages;
+  }
+
+  const blocks: ContentBlock[] = lastRow.content;
+
+  if (blocks.length === 0) {
+    return messages;
+  }
   return [...messages, { role: "assistant", content: blocks }];
 }


### PR DESCRIPTION
## Prompt / plan

Third-round review follow-up to #37784, now including the full typed-content migration requested in [this thread](https://github.com/vellum-ai/vellum-assistant/pull/37794#discussion_r3560262278):

- **`MessageRow.content` is `ContentBlock[]`** — `parseMessage` invokes `resolveMessageContentBlocks`, so every `getMessages` / `getMessageById` / `getMessagesAfter` consumer receives typed blocks: inline JSON parses, file-backed `{ ref }` rows fold their delta file, legacy plain strings arrive wrapped in a single text block, and JSON-string content unwraps to its parsed value (previously reader-specific; now uniform).
- **Consumer sweep (~40 files)**: hand-rolled `JSON.parse(msg.content)` try/catch blocks deleted in favor of the typed blocks; shared helpers (`extractTextFromStoredMessageContent`, `stringifyMessageContent`, `extractMediaBlocks/Meta`, `flattenContentBlocks`, memory indexer input, transcript/export formatters, Slack transcript rows) accept `string | ContentBlock[]` for non-row callers. Write paths still serialize. Net **−111 lines** on the consumer sweep.
- **Two real bugs surfaced and fixed by the sweep**:
  - image-recovery's prefilter missed images nested in `tool_result.contentBlocks`;
  - edit-intercept's no-op detection compared serialized blocks against inbound plain text (no-op Slack unfurl edits always rewrote the row) — now compares extracted text.
- **Earlier rounds in this PR**: `.strict()` dropped from the zod schemas per house style; redundant `typeof` guard removed; the string→string resolver shim deleted (`resolveMessageContentBlocks` is the single resolution seam); memory-plugin files import `ContentBlock` from `@vellumai/plugin-api` per the plugin import boundary.

## Spec: aligning `contentBlockSchema` (raw) with `ConversationContentBlockSchema` (wire)

Requested in [this thread](https://github.com/vellum-ai/vellum-assistant/pull/37784#discussion_r3559415462). The two schemas describe different layers on purpose — raw is what's persisted in `messages.content` and consumed by plugins/hooks; wire is the cleaned display projection built by `renderHistoryContent`. Alignment means deriving both from shared parts, not merging them:

1. **Shared variant bases** — extract per-variant field schemas (text, thinking core, media source, tool identifiers) into a shared module; raw variants = base + internal riders, wire variants = base + projection fields via `.omit()`/`.extend()`, so drift becomes a compile error.
2. **Codify the raw→wire transform** — the two structural mismatches can't be schema-merged: tool_use/tool_result pairing (wire merges them) and vellum-only `surface`/`attachment` projections. Formalize `renderHistoryContent`'s merge as one typed transform.
3. **Promote the timing riders** — `_startedAt`/`_previewStartedAt` become schema'd optional fields so wire `startedAt`/`completedAt` derive mechanically.
4. **Size**: medium PR, no data migration, no wire-format change.

## Test plan

- Full assistant suite run; 16 test files whose mocks/fixtures fed string content repaired to pass typed blocks (or resolve at the mock seam, mirroring the row mapper). ~700 tests across the touched suites pass.
- Pre-existing failures confirmed against a main-baseline worktree and left alone: script-proxy (×3), secret-routes-platform-proxy, sandbox-escape, audit-log-rotation, provider-commit-message-generator, avatar-state-routes.
- `tsc --noEmit`, eslint, prettier clean via the pre-commit hook.

## CLI verb checklist

No new routes — persistence-layer only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMnmq1rr4uffg1MgFdgb9h