### PR TITLE
fix(assistant): route all llm_request_logs writers through a pluggable writer backend

### DIFF
--- a/assistant/src/__tests__/llm-request-log-clickhouse-routing.test.ts
+++ b/assistant/src/__tests__/llm-request-log-clickhouse-routing.test.ts
@@ -18,7 +18,8 @@ mock.module("../config/loader.js", () => ({
   getConfigReadOnly: () => ({ llmRequestLogs: { readSource: "local" } }),
 }));
 
-// Mutable fake sink: when non-null, the store must route to it.
+// Mutable fake sink: when non-null, the store must route to it. Mirrors the
+// `LlmRequestLogWriter` surface the store dispatches through.
 interface CapturedRow {
   id: string;
   conversationId: string;
@@ -30,9 +31,13 @@ mock.module("../persistence/llm-request-log-sink-clickhouse.js", () => ({
   getClickHouseLlmRequestLogSink: () =>
     sinkActive
       ? {
-          recordBestEffort: (row: CapturedRow) => {
+          insertRequestLog: (row: CapturedRow) => {
             capturedRows.push(row);
           },
+          setAgentLoopExitReasonOnLatestLog: () => {},
+          backfillMessageIdOnLogs: () => {},
+          relinkLlmRequestLogs: () => {},
+          backfillMessageIdOnRecoveredLogs: () => {},
         }
       : null,
 }));

--- a/assistant/src/__tests__/llm-request-log-clickhouse-writer-guards.test.ts
+++ b/assistant/src/__tests__/llm-request-log-clickhouse-writer-guards.test.ts
@@ -1,0 +1,104 @@
+/**
+ * When ClickHouse owns LLM-request-log writes, the store's SQLite row mutators
+ * must skip — otherwise they mutate stale local rows left over from earlier
+ * local-mode turns (e.g. `setAgentLoopExitReasonOnLatestLog` would stamp this
+ * turn's reason onto an unrelated prior call). These tests seed a local row in
+ * local mode, flip `readSource` to `clickhouse`, and assert each mutator leaves
+ * the local row untouched.
+ */
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+// Mutable read source drives both the write routing and the mutator guards.
+let readSource: "local" | "clickhouse" = "local";
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({ llmRequestLogs: { readSource } }),
+  getConfigReadOnly: () => ({ llmRequestLogs: { readSource } }),
+}));
+
+afterAll(() => {
+  readSource = "local";
+});
+
+import { getLogsDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import {
+  backfillMessageIdOnLogs,
+  getRequestLogById,
+  recordRequestLog,
+  relinkLlmRequestLogs,
+  setAgentLoopExitReasonOnLatestLog,
+} from "../persistence/llm-request-log-store.js";
+import { llmRequestLogs } from "../persistence/schema/index.js";
+
+await initializeDb();
+
+function resetLogs(): void {
+  getLogsDb()!.delete(llmRequestLogs).run();
+}
+
+/** Seed one local SQLite row in local-write mode and return its id. */
+function seedLocalRow(
+  conversationId: string,
+  opts: { messageId?: string } = {},
+): string {
+  readSource = "local";
+  const id = recordRequestLog(
+    conversationId,
+    '{"req":1}',
+    '{"res":1}',
+    opts.messageId,
+    "anthropic",
+    "mainAgent",
+  );
+  expect(id).not.toBeNull();
+  return id!;
+}
+
+describe("SQLite mutators skip when ClickHouse owns writes", () => {
+  beforeEach(() => {
+    resetLogs();
+    readSource = "local";
+  });
+
+  test("setAgentLoopExitReasonOnLatestLog stamps in local mode", () => {
+    const id = seedLocalRow("conv-1");
+    setAgentLoopExitReasonOnLatestLog("conv-1", "no_tool_calls");
+    expect(getRequestLogById(id)?.agentLoopExitReason).toBe("no_tool_calls");
+  });
+
+  test("setAgentLoopExitReasonOnLatestLog leaves stale local rows untouched in ClickHouse mode", () => {
+    // An older local-mode row with a NULL exit reason (a normal intermediate
+    // call). A later ClickHouse-mode turn must NOT stamp it.
+    const staleId = seedLocalRow("conv-1");
+    readSource = "clickhouse";
+    setAgentLoopExitReasonOnLatestLog("conv-1", "yield_to_user");
+    expect(getRequestLogById(staleId)?.agentLoopExitReason).toBeNull();
+  });
+
+  test("backfillMessageIdOnLogs leaves stale local rows untouched in ClickHouse mode", () => {
+    const staleId = seedLocalRow("conv-2"); // messageId NULL
+    expect(getRequestLogById(staleId)?.messageId).toBeNull();
+    readSource = "clickhouse";
+    backfillMessageIdOnLogs("conv-2", "msg-new");
+    expect(getRequestLogById(staleId)?.messageId).toBeNull();
+  });
+
+  test("relinkLlmRequestLogs leaves stale local rows untouched in ClickHouse mode", () => {
+    const staleId = seedLocalRow("conv-3", { messageId: "m1" });
+    expect(getRequestLogById(staleId)?.messageId).toBe("m1");
+    readSource = "clickhouse";
+    relinkLlmRequestLogs(["m1"], "m2");
+    expect(getRequestLogById(staleId)?.messageId).toBe("m1");
+  });
+
+  test("backfillMessageIdOnLogs still works in local mode", () => {
+    const id = seedLocalRow("conv-4");
+    backfillMessageIdOnLogs("conv-4", "msg-local");
+    expect(getRequestLogById(id)?.messageId).toBe("msg-local");
+  });
+});

--- a/assistant/src/__tests__/llm-request-log-clickhouse-writer-guards.test.ts
+++ b/assistant/src/__tests__/llm-request-log-clickhouse-writer-guards.test.ts
@@ -1,10 +1,11 @@
 /**
- * When ClickHouse owns LLM-request-log writes, the store's SQLite row mutators
- * must skip — otherwise they mutate stale local rows left over from earlier
- * local-mode turns (e.g. `setAgentLoopExitReasonOnLatestLog` would stamp this
- * turn's reason onto an unrelated prior call). These tests seed a local row in
- * local mode, flip `readSource` to `clickhouse`, and assert each mutator leaves
- * the local row untouched.
+ * When ClickHouse owns LLM-request-log writes, the store's post-hoc mutators
+ * dispatch to the ClickHouse writer, whose mutation methods are no-ops
+ * (INSERT-only backend) — so stale local SQLite rows from earlier local-mode
+ * turns are never touched (e.g. `setAgentLoopExitReasonOnLatestLog` must not
+ * stamp this turn's reason onto an unrelated prior call). These tests seed a
+ * local row in local mode, flip `readSource` to `clickhouse`, and assert each
+ * mutator leaves the local row untouched.
  */
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -13,11 +14,21 @@ mock.module("../util/logger.js", () => ({
     new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
 }));
 
-// Mutable read source drives both the write routing and the mutator guards.
+// Mutable read source drives the writer resolution: local SQLite writer vs
+// the ClickHouse sink (whose mutators are no-ops).
 let readSource: "local" | "clickhouse" = "local";
+const CLICKHOUSE_CONFIG = {
+  database: "default",
+  table: "llm_request_logs",
+  user: "default",
+};
 mock.module("../config/loader.js", () => ({
-  getConfig: () => ({ llmRequestLogs: { readSource } }),
-  getConfigReadOnly: () => ({ llmRequestLogs: { readSource } }),
+  getConfig: () => ({
+    llmRequestLogs: { readSource, clickhouse: CLICKHOUSE_CONFIG },
+  }),
+  getConfigReadOnly: () => ({
+    llmRequestLogs: { readSource, clickhouse: CLICKHOUSE_CONFIG },
+  }),
 }));
 
 afterAll(() => {

--- a/assistant/src/__tests__/llm-request-log-sink-clickhouse.test.ts
+++ b/assistant/src/__tests__/llm-request-log-sink-clickhouse.test.ts
@@ -163,11 +163,11 @@ describe("ClickHouseLlmRequestLogSink.insert", () => {
     ).rejects.toThrow(/ClickHouse llm-request-log write failed/);
   });
 
-  test("recordBestEffort never throws synchronously on a failing backend", () => {
+  test("insertRequestLog never throws synchronously on a failing backend", () => {
     const calls: FakeFetchCall[] = [];
     const sink = makeSink(calls, 500);
     expect(() =>
-      sink.recordBestEffort({
+      sink.insertRequestLog({
         id: "log-4",
         conversationId: "conv-4",
         messageId: null,
@@ -179,6 +179,19 @@ describe("ClickHouseLlmRequestLogSink.insert", () => {
         callSite: null,
       }),
     ).not.toThrow();
+  });
+
+  test("the post-hoc mutators are no-ops that never touch the backend", () => {
+    // INSERT-only backend: the LlmRequestLogWriter mutation methods must not
+    // issue any request (and must not throw) — the store relies on this to
+    // keep stale local rows untouched while ClickHouse owns writes.
+    const calls: FakeFetchCall[] = [];
+    const sink = makeSink(calls);
+    sink.setAgentLoopExitReasonOnLatestLog("conv-1", "no_tool_calls");
+    sink.backfillMessageIdOnLogs("conv-1", "msg-1");
+    sink.relinkLlmRequestLogs(["m1"], "m2");
+    sink.backfillMessageIdOnRecoveredLogs(["log-1"], "msg-1");
+    expect(calls).toHaveLength(0);
   });
 });
 

--- a/assistant/src/persistence/llm-request-log-sink-clickhouse.ts
+++ b/assistant/src/persistence/llm-request-log-sink-clickhouse.ts
@@ -40,25 +40,12 @@ import type { LlmRequestLogsClickHouseConfig } from "../config/schemas/llm-reque
 import { credentialKey } from "../security/credential-key.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
+import type {
+  LlmRequestLogWriter,
+  LlmRequestLogWriteRow,
+} from "./llm-request-log-writer-types.js";
 
 const log = getLogger("clickhouse-llm-request-log-sink");
-
-/**
- * A request-log row to insert, in the store's domain shape. `null` string
- * fields are written as the `''` sentinel; `assistant_id` is resolved
- * internally from the credential store, so callers never supply it.
- */
-export interface LlmRequestLogSinkRow {
-  id: string;
-  conversationId: string;
-  messageId: string | null;
-  provider: string | null;
-  requestPayload: string;
-  responsePayload: string;
-  createdAt: number;
-  agentLoopExitReason: string | null;
-  callSite: string | null;
-}
 
 /** Wire row written as one JSONEachRow line. */
 interface ClickHouseInsertRow {
@@ -96,7 +83,7 @@ export interface ClickHouseLlmRequestLogSinkDeps {
   fetchImpl?: ClickHouseSinkFetch;
 }
 
-export class ClickHouseLlmRequestLogSink {
+export class ClickHouseLlmRequestLogSink implements LlmRequestLogWriter {
   private cachedUrl: string | null = null;
   private cachedPassword: string | null = null;
   private cachedAssistantId: string | null = null;
@@ -123,12 +110,16 @@ export class ClickHouseLlmRequestLogSink {
   }
 
   /**
-   * Fire-and-forget insert. Returns immediately; the write runs on a detached
-   * promise whose rejection is logged and swallowed so a ClickHouse outage
-   * never propagates into the turn. Mirrors the compaction-log store's
-   * best-effort recording contract.
+   * `LlmRequestLogWriter` insert. Fire-and-forget: returns immediately; the
+   * write runs on a detached promise whose rejection is logged and swallowed
+   * so a ClickHouse outage never propagates into the turn. Mirrors the
+   * compaction-log store's best-effort recording contract.
+   *
+   * `latencyBreakdown` on the row is intentionally dropped — the ClickHouse
+   * table doesn't carry that column, and the read source already treats
+   * ClickHouse-sourced rows as having no latency waterfall.
    */
-  recordBestEffort(row: LlmRequestLogSinkRow): void {
+  insertRequestLog(row: LlmRequestLogWriteRow): void {
     this.insert(row).catch((err: unknown) => {
       log.warn(
         { err, conversationId: row.conversationId, callSite: row.callSite },
@@ -137,7 +128,35 @@ export class ClickHouseLlmRequestLogSink {
     });
   }
 
-  async insert(row: LlmRequestLogSinkRow): Promise<void> {
+  /**
+   * No-op: this backend is INSERT-only, so a row's exit reason is whatever
+   * was known at insert time (synthetic rows carry theirs; real calls stay
+   * unstamped). Deliberately does NOT fall through to SQLite — the newest
+   * NULL-reason local row would be a stale one from an earlier local-mode
+   * turn, and stamping it would corrupt local history.
+   */
+  setAgentLoopExitReasonOnLatestLog(
+    _conversationId: string,
+    _reason: string,
+  ): void {}
+
+  /**
+   * No-op: INSERT-only. The NULL-`message_id`-scoped backfill is a heuristic
+   * over the write backend's own rows; running it against SQLite in
+   * ClickHouse mode would stamp stale local rows with the wrong message.
+   */
+  backfillMessageIdOnLogs(_conversationId: string, _messageId: string): void {}
+
+  /** No-op: INSERT-only — rows cannot be re-linked after the fact. */
+  relinkLlmRequestLogs(_fromMessageIds: string[], _toMessageId: string): void {}
+
+  /** No-op: INSERT-only — recovered-row backfill only applies to local rows. */
+  backfillMessageIdOnRecoveredLogs(
+    _logIds: string[],
+    _messageId: string,
+  ): void {}
+
+  async insert(row: LlmRequestLogWriteRow): Promise<void> {
     const assistantId = await this.assistantId();
     await this.ensureTable();
     const wire: ClickHouseInsertRow = {
@@ -304,31 +323,6 @@ export function getClickHouseLlmRequestLogSink(): ClickHouseLlmRequestLogSink | 
     cachedSink = { key, sink: new ClickHouseLlmRequestLogSink(cfg.clickhouse) };
   }
   return cachedSink.sink;
-}
-
-/**
- * Whether ClickHouse owns LLM-request-log writes (`readSource === "clickhouse"`).
- *
- * When this is true the local SQLite `llm_request_logs` table is NOT the write
- * target, so the store's SQLite row mutators — the exit-reason stamp, the
- * message-id backfills, and the relink — must skip. Running them against SQLite
- * in ClickHouse mode would mutate stale rows left over from earlier local-mode
- * turns (e.g. the exit-reason stamp would land on an unrelated prior call),
- * corrupting local history and any later fallback/switch-back to local reads.
- *
- * Cheaper than {@link getClickHouseLlmRequestLogSink} for a boolean check (no
- * sink instantiation). Read-only config access; `false` on any resolution
- * error so a config hiccup keeps writes on SQLite.
- */
-export function clickHouseOwnsLlmRequestLogWrites(): boolean {
-  try {
-    return (
-      configLoader.getConfigReadOnly().llmRequestLogs?.readSource ===
-      "clickhouse"
-    );
-  } catch {
-    return false;
-  }
 }
 
 /** Test hook: drop the memoized sink so config/dep changes are picked up. */

--- a/assistant/src/persistence/llm-request-log-sink-clickhouse.ts
+++ b/assistant/src/persistence/llm-request-log-sink-clickhouse.ts
@@ -306,6 +306,31 @@ export function getClickHouseLlmRequestLogSink(): ClickHouseLlmRequestLogSink | 
   return cachedSink.sink;
 }
 
+/**
+ * Whether ClickHouse owns LLM-request-log writes (`readSource === "clickhouse"`).
+ *
+ * When this is true the local SQLite `llm_request_logs` table is NOT the write
+ * target, so the store's SQLite row mutators — the exit-reason stamp, the
+ * message-id backfills, and the relink — must skip. Running them against SQLite
+ * in ClickHouse mode would mutate stale rows left over from earlier local-mode
+ * turns (e.g. the exit-reason stamp would land on an unrelated prior call),
+ * corrupting local history and any later fallback/switch-back to local reads.
+ *
+ * Cheaper than {@link getClickHouseLlmRequestLogSink} for a boolean check (no
+ * sink instantiation). Read-only config access; `false` on any resolution
+ * error so a config hiccup keeps writes on SQLite.
+ */
+export function clickHouseOwnsLlmRequestLogWrites(): boolean {
+  try {
+    return (
+      configLoader.getConfigReadOnly().llmRequestLogs?.readSource ===
+      "clickhouse"
+    );
+  } catch {
+    return false;
+  }
+}
+
 /** Test hook: drop the memoized sink so config/dep changes are picked up. */
 export function resetClickHouseLlmRequestLogSinkForTests(): void {
   cachedSink = null;

--- a/assistant/src/persistence/llm-request-log-store.ts
+++ b/assistant/src/persistence/llm-request-log-store.ts
@@ -32,10 +32,11 @@ import {
   messageMetadataSchema,
 } from "./conversation-crud.js";
 import { type DrizzleDb, getDb, getLogsDb } from "./db-connection.js";
-import {
-  clickHouseOwnsLlmRequestLogWrites,
-  getClickHouseLlmRequestLogSink,
-} from "./llm-request-log-sink-clickhouse.js";
+import { getClickHouseLlmRequestLogSink } from "./llm-request-log-sink-clickhouse.js";
+import type {
+  LlmRequestLogWriter,
+  LlmRequestLogWriteRow,
+} from "./llm-request-log-writer-types.js";
 import { llmRequestLogs, messages } from "./schema/index.js";
 import { timeSyncSection } from "./slow-sync-log.js";
 
@@ -184,6 +185,127 @@ function parseRawBody(rawBody: string): unknown {
   }
 }
 
+/**
+ * The local SQLite write backend for `llm_request_logs` — the
+ * `LlmRequestLogWriter` implementation behind the default
+ * `readSource: "local"` config. Holds the actual SQL for the insert and
+ * every post-hoc mutation; the exported store functions dispatch here (or
+ * to the ClickHouse sink) via {@link resolveLlmRequestLogWriter}.
+ */
+class LocalLlmRequestLogWriter implements LlmRequestLogWriter {
+  insertRequestLog(row: LlmRequestLogWriteRow): void {
+    const db = logsDb();
+    // Synchronous insert of the full request/response payloads (an entire
+    // context window for main-agent calls) into the append-only logs DB, on
+    // the per-LLM-call critical path. Timed so an event-loop freeze the
+    // watchdog detects can be attributed to this write (see slow-sync-log).
+    timeSyncSection(
+      "llm-request-log:write",
+      () =>
+        db
+          .insert(llmRequestLogs)
+          .values({
+            id: row.id,
+            conversationId: row.conversationId,
+            messageId: row.messageId,
+            provider: row.provider,
+            requestPayload: row.requestPayload,
+            responsePayload: row.responsePayload,
+            createdAt: row.createdAt,
+            agentLoopExitReason: row.agentLoopExitReason,
+            callSite: row.callSite,
+            latencyBreakdown: row.latencyBreakdown ?? null,
+          })
+          .run(),
+      () => ({
+        conversationId: row.conversationId,
+        callSite: row.callSite,
+        requestBytes: row.requestPayload.length,
+        responseBytes: row.responsePayload.length,
+      }),
+    );
+  }
+
+  setAgentLoopExitReasonOnLatestLog(
+    conversationId: string,
+    reason: string,
+  ): void {
+    const db = logsDb();
+    const latest = db
+      .select({ id: llmRequestLogs.id })
+      .from(llmRequestLogs)
+      .where(
+        and(
+          eq(llmRequestLogs.conversationId, conversationId),
+          isNull(llmRequestLogs.agentLoopExitReason),
+        ),
+      )
+      .orderBy(desc(llmRequestLogs.createdAt))
+      .limit(1)
+      .get();
+    if (!latest) {
+      return;
+    }
+    db.update(llmRequestLogs)
+      .set({ agentLoopExitReason: reason })
+      .where(eq(llmRequestLogs.id, latest.id))
+      .run();
+  }
+
+  backfillMessageIdOnLogs(conversationId: string, messageId: string): void {
+    const db = logsDb();
+    db.update(llmRequestLogs)
+      .set({ messageId })
+      .where(
+        and(
+          eq(llmRequestLogs.conversationId, conversationId),
+          isNull(llmRequestLogs.messageId),
+        ),
+      )
+      .run();
+  }
+
+  relinkLlmRequestLogs(fromMessageIds: string[], toMessageId: string): void {
+    const db = logsDb();
+    db.update(llmRequestLogs)
+      .set({ messageId: toMessageId })
+      .where(inArray(llmRequestLogs.messageId, fromMessageIds))
+      .run();
+  }
+
+  backfillMessageIdOnRecoveredLogs(logIds: string[], messageId: string): void {
+    const db = logsDb();
+    // Guard with isNull so this recovery path never overwrites a messageId
+    // already set by an authoritative caller (e.g. watch-notifier).
+    db.update(llmRequestLogs)
+      .set({ messageId })
+      .where(
+        and(
+          inArray(llmRequestLogs.id, logIds),
+          isNull(llmRequestLogs.messageId),
+        ),
+      )
+      .run();
+  }
+}
+
+const LOCAL_LLM_REQUEST_LOG_WRITER = new LocalLlmRequestLogWriter();
+
+/**
+ * Resolve the write backend that currently owns `llm_request_logs` writes:
+ * the ClickHouse sink when `llmRequestLogs.readSource === "clickhouse"`,
+ * local SQLite otherwise. Every writer of the table — inserts AND the
+ * post-hoc mutators — dispatches through this, so a backend that can't
+ * support an operation expresses that as a method no-op rather than the
+ * store branching per backend. Resolved fresh per call so config edits take
+ * effect without a restart (same contract as the read-source factory); a
+ * future third-party backend implements `LlmRequestLogWriter` and slots in
+ * here.
+ */
+function resolveLlmRequestLogWriter(): LlmRequestLogWriter {
+  return getClickHouseLlmRequestLogSink() ?? LOCAL_LLM_REQUEST_LOG_WRITER;
+}
+
 export function recordRequestLog(
   conversationId: string,
   requestPayload: string,
@@ -200,62 +322,26 @@ export function recordRequestLog(
     return null;
   }
   const id = uuid();
-  // When ClickHouse is the configured source, it is also the write target:
-  // send the row there instead of local SQLite (fire-and-forget). The id is
-  // still returned for signature parity, though no local row exists for the
-  // post-loop stamping helpers to update — an accepted ClickHouse limitation.
-  const clickHouseSink = getClickHouseLlmRequestLogSink();
-  if (clickHouseSink) {
-    clickHouseSink.recordBestEffort({
-      id,
-      conversationId,
-      messageId: messageId ?? null,
-      provider: provider ?? null,
-      requestPayload,
-      responsePayload,
-      createdAt: Date.now(),
-      agentLoopExitReason: null,
-      callSite: callSite ?? null,
-    });
-    return id;
-  }
-  const db = logsDb();
-  // Synchronous insert of the full request/response payloads (an entire
-  // context window for main-agent calls) into the append-only logs DB, on the
-  // per-LLM-call critical path. Timed so an event-loop freeze the watchdog
-  // detects can be attributed to this write (see slow-sync-log).
-  timeSyncSection(
-    "llm-request-log:write",
-    () =>
-      db
-        .insert(llmRequestLogs)
-        .values({
-          id,
-          conversationId,
-          messageId: messageId ?? null,
-          provider: provider ?? null,
-          requestPayload,
-          responsePayload,
-          createdAt: Date.now(),
-          // Stamped later via setAgentLoopExitReasonOnLatestLog, once the
-          // agent loop body actually exits. Intermediate rows stay NULL.
-          agentLoopExitReason: null,
-          // Logical call site (`mainAgent`, `compactionAgent`, …). NULL when
-          // a caller hasn't been updated yet — preserves backward compat
-          // while we plumb call sites through one site at a time.
-          callSite: callSite ?? null,
-          // JSON first-token latency waterfall, supplied by `handleUsage` for
-          // main-agent calls. NULL for failed/non-instrumented call paths.
-          latencyBreakdown: latencyBreakdown ?? null,
-        })
-        .run(),
-    () => ({
-      conversationId,
-      callSite: callSite ?? null,
-      requestBytes: requestPayload.length,
-      responseBytes: responsePayload.length,
-    }),
-  );
+  resolveLlmRequestLogWriter().insertRequestLog({
+    id,
+    conversationId,
+    messageId: messageId ?? null,
+    provider: provider ?? null,
+    requestPayload,
+    responsePayload,
+    createdAt: Date.now(),
+    // Stamped later via setAgentLoopExitReasonOnLatestLog, once the agent
+    // loop body actually exits. Intermediate rows stay NULL. (INSERT-only
+    // backends never stamp — their rows keep the insert-time value.)
+    agentLoopExitReason: null,
+    // Logical call site (`mainAgent`, `compactionAgent`, …). NULL when a
+    // caller hasn't been updated yet — preserves backward compat while we
+    // plumb call sites through one site at a time.
+    callSite: callSite ?? null,
+    // JSON first-token latency waterfall, supplied by `handleUsage` for
+    // main-agent calls. NULL for failed/non-instrumented call paths.
+    latencyBreakdown: latencyBreakdown ?? null,
+  });
   return id;
 }
 
@@ -321,38 +407,21 @@ export function recordSyntheticAgentErrorMessageLog(args: {
       noticeText: args.noticeText,
     },
   });
-  // Route to ClickHouse when it is the configured target. The exit reason is
-  // already known here, so it is carried on the row directly (unlike real
-  // calls, which stamp it post-loop against a local row that ClickHouse lacks).
-  const clickHouseSink = getClickHouseLlmRequestLogSink();
-  if (clickHouseSink) {
-    clickHouseSink.recordBestEffort({
-      id,
-      conversationId: args.conversationId,
-      messageId: args.messageId,
-      provider: null,
-      requestPayload,
-      responsePayload,
-      createdAt: args.createdAt,
-      agentLoopExitReason: args.exitReason,
-      callSite: CALL_SITE_SYNTHETIC_AGENT_ERROR_MESSAGE,
-    });
-    return id;
-  }
-  const db = logsDb();
-  db.insert(llmRequestLogs)
-    .values({
-      id,
-      conversationId: args.conversationId,
-      messageId: args.messageId,
-      provider: null,
-      requestPayload,
-      responsePayload,
-      createdAt: args.createdAt,
-      agentLoopExitReason: args.exitReason,
-      callSite: CALL_SITE_SYNTHETIC_AGENT_ERROR_MESSAGE,
-    })
-    .run();
+  // The exit reason is already known here, so it is carried on the row at
+  // insert time — which also makes synthetic rows complete on INSERT-only
+  // backends that can never stamp it afterwards.
+  resolveLlmRequestLogWriter().insertRequestLog({
+    id,
+    conversationId: args.conversationId,
+    messageId: args.messageId,
+    provider: null,
+    requestPayload,
+    responsePayload,
+    createdAt: args.createdAt,
+    agentLoopExitReason: args.exitReason,
+    callSite: CALL_SITE_SYNTHETIC_AGENT_ERROR_MESSAGE,
+    latencyBreakdown: null,
+  });
   return id;
 }
 
@@ -373,48 +442,20 @@ export function setAgentLoopExitReasonOnLatestLog(
   conversationId: string,
   reason: string,
 ): void {
-  // When ClickHouse owns writes there is no current-turn SQLite row to stamp;
-  // stamping would land this turn's reason on a stale local row from an earlier
-  // local-mode turn (the newest with a NULL reason), corrupting local history.
-  if (clickHouseOwnsLlmRequestLogWrites()) return;
-  const db = logsDb();
-  const latest = db
-    .select({ id: llmRequestLogs.id })
-    .from(llmRequestLogs)
-    .where(
-      and(
-        eq(llmRequestLogs.conversationId, conversationId),
-        isNull(llmRequestLogs.agentLoopExitReason),
-      ),
-    )
-    .orderBy(desc(llmRequestLogs.createdAt))
-    .limit(1)
-    .get();
-  if (!latest) return;
-  db.update(llmRequestLogs)
-    .set({ agentLoopExitReason: reason })
-    .where(eq(llmRequestLogs.id, latest.id))
-    .run();
+  resolveLlmRequestLogWriter().setAgentLoopExitReasonOnLatestLog(
+    conversationId,
+    reason,
+  );
 }
 
 export function backfillMessageIdOnLogs(
   conversationId: string,
   messageId: string,
 ): void {
-  // In ClickHouse-write mode the current turn's rows live in ClickHouse, not
-  // SQLite. Backfilling here would stamp this messageId onto unrelated
-  // NULL-messageId rows left over from earlier local-mode turns.
-  if (clickHouseOwnsLlmRequestLogWrites()) return;
-  const db = logsDb();
-  db.update(llmRequestLogs)
-    .set({ messageId })
-    .where(
-      and(
-        eq(llmRequestLogs.conversationId, conversationId),
-        isNull(llmRequestLogs.messageId),
-      ),
-    )
-    .run();
+  resolveLlmRequestLogWriter().backfillMessageIdOnLogs(
+    conversationId,
+    messageId,
+  );
 }
 
 /**
@@ -427,15 +468,13 @@ export function relinkLlmRequestLogs(
   fromMessageIds: string[],
   toMessageId: string,
 ): void {
-  if (fromMessageIds.length === 0) return;
-  // ClickHouse-owned rows aren't in SQLite; a relink here can only touch stale
-  // local rows, so skip when ClickHouse owns writes.
-  if (clickHouseOwnsLlmRequestLogWrites()) return;
-  const db = logsDb();
-  db.update(llmRequestLogs)
-    .set({ messageId: toMessageId })
-    .where(inArray(llmRequestLogs.messageId, fromMessageIds))
-    .run();
+  if (fromMessageIds.length === 0) {
+    return;
+  }
+  resolveLlmRequestLogWriter().relinkLlmRequestLogs(
+    fromMessageIds,
+    toMessageId,
+  );
 }
 
 /**
@@ -786,28 +825,17 @@ export function getRequestLogsByMessageId(messageId: string): LogRow[] {
         );
 
         // Opportunistically backfill recovered unlinked logs so future queries
-        // hit the fast indexed-by-messageId path.  Guard with isNull so this
-        // recovery path never overwrites a messageId already set by an
-        // authoritative caller (e.g. watch-notifier). Skipped when ClickHouse
-        // owns writes — the SQLite rows aren't the source of truth then.
-        if (
-          unlinkedLogs.length > 0 &&
-          turnMessageIds.length > 0 &&
-          !clickHouseOwnsLlmRequestLogWrites()
-        ) {
+        // hit the fast indexed-by-messageId path. Dispatched through the
+        // active write backend like every other table writer — INSERT-only
+        // backends no-op.
+        if (unlinkedLogs.length > 0 && turnMessageIds.length > 0) {
           try {
-            const db = logsDb();
             const ids = unlinkedLogs.map((l) => l.id);
             const targetMessageId = turnMessageIds[turnMessageIds.length - 1]!;
-            db.update(llmRequestLogs)
-              .set({ messageId: targetMessageId })
-              .where(
-                and(
-                  inArray(llmRequestLogs.id, ids),
-                  isNull(llmRequestLogs.messageId),
-                ),
-              )
-              .run();
+            resolveLlmRequestLogWriter().backfillMessageIdOnRecoveredLogs(
+              ids,
+              targetMessageId,
+            );
           } catch {
             // non-fatal — the recovery already returned the right data
           }

--- a/assistant/src/persistence/llm-request-log-store.ts
+++ b/assistant/src/persistence/llm-request-log-store.ts
@@ -32,7 +32,10 @@ import {
   messageMetadataSchema,
 } from "./conversation-crud.js";
 import { type DrizzleDb, getDb, getLogsDb } from "./db-connection.js";
-import { getClickHouseLlmRequestLogSink } from "./llm-request-log-sink-clickhouse.js";
+import {
+  clickHouseOwnsLlmRequestLogWrites,
+  getClickHouseLlmRequestLogSink,
+} from "./llm-request-log-sink-clickhouse.js";
 import { llmRequestLogs, messages } from "./schema/index.js";
 import { timeSyncSection } from "./slow-sync-log.js";
 
@@ -370,6 +373,10 @@ export function setAgentLoopExitReasonOnLatestLog(
   conversationId: string,
   reason: string,
 ): void {
+  // When ClickHouse owns writes there is no current-turn SQLite row to stamp;
+  // stamping would land this turn's reason on a stale local row from an earlier
+  // local-mode turn (the newest with a NULL reason), corrupting local history.
+  if (clickHouseOwnsLlmRequestLogWrites()) return;
   const db = logsDb();
   const latest = db
     .select({ id: llmRequestLogs.id })
@@ -394,6 +401,10 @@ export function backfillMessageIdOnLogs(
   conversationId: string,
   messageId: string,
 ): void {
+  // In ClickHouse-write mode the current turn's rows live in ClickHouse, not
+  // SQLite. Backfilling here would stamp this messageId onto unrelated
+  // NULL-messageId rows left over from earlier local-mode turns.
+  if (clickHouseOwnsLlmRequestLogWrites()) return;
   const db = logsDb();
   db.update(llmRequestLogs)
     .set({ messageId })
@@ -417,6 +428,9 @@ export function relinkLlmRequestLogs(
   toMessageId: string,
 ): void {
   if (fromMessageIds.length === 0) return;
+  // ClickHouse-owned rows aren't in SQLite; a relink here can only touch stale
+  // local rows, so skip when ClickHouse owns writes.
+  if (clickHouseOwnsLlmRequestLogWrites()) return;
   const db = logsDb();
   db.update(llmRequestLogs)
     .set({ messageId: toMessageId })
@@ -774,8 +788,13 @@ export function getRequestLogsByMessageId(messageId: string): LogRow[] {
         // Opportunistically backfill recovered unlinked logs so future queries
         // hit the fast indexed-by-messageId path.  Guard with isNull so this
         // recovery path never overwrites a messageId already set by an
-        // authoritative caller (e.g. watch-notifier).
-        if (unlinkedLogs.length > 0 && turnMessageIds.length > 0) {
+        // authoritative caller (e.g. watch-notifier). Skipped when ClickHouse
+        // owns writes — the SQLite rows aren't the source of truth then.
+        if (
+          unlinkedLogs.length > 0 &&
+          turnMessageIds.length > 0 &&
+          !clickHouseOwnsLlmRequestLogWrites()
+        ) {
           try {
             const db = logsDb();
             const ids = unlinkedLogs.map((l) => l.id);

--- a/assistant/src/persistence/llm-request-log-writer-types.ts
+++ b/assistant/src/persistence/llm-request-log-writer-types.ts
@@ -1,0 +1,80 @@
+/**
+ * Type-only contract for the pluggable LLM request log WRITE backend — the
+ * write-side counterpart to `llm-request-log-source-types.ts` (reads).
+ *
+ * One implementation per backend:
+ *  - `LocalLlmRequestLogWriter` (in `llm-request-log-store.ts`) — the SQLite
+ *    `llm_request_logs` table, with full post-hoc mutation support.
+ *  - `ClickHouseLlmRequestLogSink` (`llm-request-log-sink-clickhouse.ts`) —
+ *    INSERT-only; the post-hoc mutators are documented no-ops.
+ *
+ * The store's exported write functions resolve the active backend per call
+ * (`readSource` config) and dispatch through this interface, so EVERY writer
+ * of the table goes through the same resolution — a future third-party
+ * backend implements this interface and slots into the resolver without the
+ * store growing per-backend branching.
+ *
+ * Methods are synchronous from the caller's point of view: the local backend
+ * writes synchronously on the per-LLM-call critical path (deliberate — see
+ * the store's slow-sync-log instrumentation), and remote backends are
+ * fire-and-forget (errors logged, never thrown into the turn).
+ */
+
+/** A fully-formed `llm_request_logs` row to insert. */
+export interface LlmRequestLogWriteRow {
+  id: string;
+  conversationId: string;
+  messageId: string | null;
+  provider: string | null;
+  requestPayload: string;
+  responsePayload: string;
+  createdAt: number;
+  agentLoopExitReason: string | null;
+  callSite: string | null;
+  /**
+   * JSON first-token latency waterfall. Persisted by the local backend only —
+   * remote INSERT-only backends drop it (their table schema doesn't carry it,
+   * matching the read source, which treats remote rows as having no latency).
+   */
+  latencyBreakdown?: string | null;
+}
+
+export interface LlmRequestLogWriter {
+  /**
+   * Insert one request-log row. Local: synchronous SQLite insert. Remote:
+   * fire-and-forget — a backend outage must never abort the turn.
+   */
+  insertRequestLog(row: LlmRequestLogWriteRow): void;
+
+  /**
+   * Stamp an `agent_loop_exit_reason` onto the backend's most-recent
+   * unstamped row for the conversation. INSERT-only backends no-op: their
+   * rows can't be updated after the fact, and mutating the OTHER backend's
+   * rows would corrupt history (e.g. stamping this turn's reason onto a
+   * stale local row from an earlier local-mode turn).
+   */
+  setAgentLoopExitReasonOnLatestLog(
+    conversationId: string,
+    reason: string,
+  ): void;
+
+  /**
+   * Backfill `message_id` onto the conversation's rows that don't have one
+   * yet. INSERT-only backends no-op (same reasoning as the exit-reason
+   * stamp — the NULL-scoped predicate is a heuristic over this backend's
+   * own rows).
+   */
+  backfillMessageIdOnLogs(conversationId: string, messageId: string): void;
+
+  /**
+   * Re-link rows from a set of source message IDs to a target message
+   * (message consolidation). INSERT-only backends no-op.
+   */
+  relinkLlmRequestLogs(fromMessageIds: string[], toMessageId: string): void;
+
+  /**
+   * Backfill `message_id` onto specific recovered rows (by row id) found
+   * unlinked on the read path. INSERT-only backends no-op.
+   */
+  backfillMessageIdOnRecoveredLogs(logIds: string[], messageId: string): void;
+}


### PR DESCRIPTION
Follow-up to #37788, addressing codex's P2 there and the review feedback on this PR.

## Prompt / plan

> Update the other writers to the `llm_request_logs` table to also go through the ClickHouse resolver.

Codex flagged on #37788 that when `readSource === "clickhouse"`, `recordRequestLog` returns without creating a local SQLite row, but the turn-completion path still calls `setAgentLoopExitReasonOnLatestLog()` against SQLite — stamping **this** turn's exit reason onto a **stale** local row from an earlier local-mode turn, corrupting local history. The message-id backfills and relink shared the flaw.

Review feedback on the first cut of this PR: don't gate the mutators on a `clickHouseOwnsLlmRequestLogWrites()` boolean — use public methods on the shared per-backend class, since we may have other third-party data sources over time.

## What this does (current design)

- **New `llm-request-log-writer-types.ts`** — `LlmRequestLogWriter`, the write-side counterpart to the existing `LlmRequestLogSource` read interface: `insertRequestLog` plus the four post-hoc mutators (`setAgentLoopExitReasonOnLatestLog`, `backfillMessageIdOnLogs`, `relinkLlmRequestLogs`, `backfillMessageIdOnRecoveredLogs`).
- **`ClickHouseLlmRequestLogSink implements LlmRequestLogWriter`** — insert is the existing fire-and-forget path; the mutators are documented **no-ops** (INSERT-only backend, and deliberately not falling through to SQLite where they could only corrupt stale local-mode rows). The boolean is gone.
- **New `LocalLlmRequestLogWriter`** in the store holds the SQLite SQL. The store's exported functions resolve the active backend per call (`resolveLlmRequestLogWriter()` → ClickHouse sink or local writer) and dispatch — so **every** writer of the table, inserts and mutators alike, goes through the same resolution. A future backend implements the interface and slots into the resolver; the store never grows per-backend branching.

### Notes on the other codex P2s

- **Braces**: the braceless guard returns are gone with the redesign (guards became polymorphic no-ops); all new control flow is braced.
- **Config-flip timing** (mutation skip should follow the row's write target, not config-at-mutation-time): the resolver is intentionally resolved fresh per call, matching the read-source factory's "config edits take effect on the next call" contract. Tying each mutation to the originating row's backend would require threading row identity through the agent-loop event dispatch; the flip window is a single in-flight turn during a manual config edit. Called out as a known trade-off rather than handled.

### Out of scope (noted for later)

Conversation deletion still issues a SQLite `DELETE` on `llm_request_logs` (`conversation-crud.ts`); removing ClickHouse rows needs a real MergeTree mutation and belongs with broader ClickHouse-retention work.

## Test plan

- `llm-request-log-clickhouse-writer-guards.test.ts`: seeds a local row in local mode, flips `readSource` to `clickhouse`, asserts each mutator leaves the stale local row untouched — and still mutates in local mode.
- `llm-request-log-sink-clickhouse.test.ts`: adds coverage that the sink's mutator methods are no-ops that never touch the backend.
- `llm-request-log-clickhouse-routing.test.ts`: updated to the writer surface.
- `bunx tsgo --noEmit` clean; eslint clean (0 errors).

## CLI verb checklist

No new routes — internal persistence change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5EQ7hFW26ndg21csTCZJq