### PR TITLE
refactor(persistence): move memory_v2_injection_events to assistant-memory.db

### DIFF
--- a/assistant/src/persistence/migrations/326-move-injection-events-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/326-move-injection-events-to-memory-db.ts
@@ -1,0 +1,104 @@
+import type { Database } from "bun:sqlite";
+
+import { getMemoryDbPath } from "../../util/memory-db-path.js";
+import {
+  type DrizzleDb,
+  getMemorySqlite,
+  getSqliteFrom,
+} from "../db-connection.js";
+import {
+  drainStagedTable,
+  type RelocationSpec,
+  stageTableForRelocation,
+} from "./helpers/relocation.js";
+
+/**
+ * Readers of `memory_v2_injection_events` bound their scans to the last
+ * 6 half-lives (6 × 3 days) — events past that window contribute <1.6% each
+ * to the decayed score and are never queried. Mirrors `READ_WINDOW_MS` in
+ * `plugins/defaults/memory/v2/injection-events.ts` (duplicated by design:
+ * persistence migrations do not import plugin code).
+ */
+const READ_WINDOW_MS = 6 * 3 * 24 * 60 * 60 * 1000;
+
+/**
+ * How to drain `memory_v2_injection_events` from `main` into the memory DB.
+ * Rows older than the score read window are purged without copying — no
+ * reader ever looks at them, so carrying them over would only re-seed dead
+ * weight in the new file.
+ */
+export const INJECTION_EVENTS_RELOCATION: RelocationSpec = {
+  table: "memory_v2_injection_events",
+  targetDbPath: getMemoryDbPath,
+  columns: ["id", "slug", "injected_at"],
+  copyWhere: `injected_at >= strftime('%s','now') * 1000 - ${READ_WINDOW_MS}`,
+};
+
+const CREATE_TABLE = /*sql*/ `
+  CREATE TABLE IF NOT EXISTS memory_v2_injection_events (
+    id INTEGER PRIMARY KEY,
+    slug TEXT NOT NULL,
+    injected_at INTEGER NOT NULL
+  )
+`;
+
+/**
+ * Create the `memory_v2_injection_events` table and its indexes on the memory
+ * connection. Idempotent (`IF NOT EXISTS`) — the dedicated connection itself
+ * performs no DDL on open, so this migration owns the schema. Exported so
+ * tests can stand up the memory-side schema without running the full drain.
+ */
+export function ensureInjectionEventsSchema(memoryRaw: Database): void {
+  memoryRaw.exec(CREATE_TABLE);
+  memoryRaw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_v2_injection_events_slug_time
+      ON memory_v2_injection_events (slug, injected_at)
+  `);
+  memoryRaw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_v2_injection_events_time
+      ON memory_v2_injection_events (injected_at)
+  `);
+}
+
+/**
+ * Move `memory_v2_injection_events` — the append-only EMA event log behind
+ * memory router tier-2 scoring — into the dedicated memory database
+ * (`assistant-memory.db`), alongside `memory_jobs` (migration 298). The log
+ * grows with every router selection; housing it with the other high-churn
+ * memory state keeps the main DB and its WAL out of that write path, and the
+ * accessors in `plugins/defaults/memory/v2/injection-events.ts` read/write it
+ * over the dedicated memory connection (see `getMemoryDb()`).
+ *
+ * Like migrations 297/298 the move is incremental: create the table (and
+ * indexes) on the memory connection, rename any populated
+ * `main.memory_v2_injection_events` aside to
+ * `memory_v2_injection_events__relocating`, then drain it in awaited batches
+ * (see `helpers/relocation.ts`) per {@link INJECTION_EVENTS_RELOCATION}. On a
+ * fresh install the main-side table created by migration 256 is empty, so
+ * staging just drops it.
+ *
+ * Throws (rather than returning) if the memory database cannot be opened, so
+ * the runner records the step as failed instead of applied and retries it on
+ * a later boot — never renaming the source aside without a target to write
+ * to. The throw is caught per-step by the runner, so startup is not aborted.
+ */
+export async function migrateMoveInjectionEventsToMemoryDb(
+  database: DrizzleDb,
+): Promise<void> {
+  const memoryRaw = getMemorySqlite();
+  if (!memoryRaw) {
+    throw new Error(
+      "memory database unavailable — deferring memory_v2_injection_events relocation",
+    );
+  }
+
+  ensureInjectionEventsSchema(memoryRaw);
+
+  const raw = getSqliteFrom(database);
+  const needsDrain = stageTableForRelocation(
+    raw,
+    INJECTION_EVENTS_RELOCATION.table,
+  );
+
+  if (needsDrain) await drainStagedTable(raw, INJECTION_EVENTS_RELOCATION);
+}

--- a/assistant/src/persistence/schema/memory-injection.ts
+++ b/assistant/src/persistence/schema/memory-injection.ts
@@ -7,7 +7,9 @@ import {
 } from "drizzle-orm/sqlite-core";
 
 // Time-series of memory-v2 card injections, used by the router to decay a
-// concept's recent injection pressure.
+// concept's recent injection pressure. Lives in the dedicated memory database
+// (`assistant-memory.db`), not main — access it via the memory connection
+// (`getMemoryDb()` / `getMemorySqlite()`).
 export const memoryV2InjectionEvents = sqliteTable(
   "memory_v2_injection_events",
   {

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -433,6 +433,7 @@ import { migrateAddProcessingResumeAttempts } from "./migrations/322-add-process
 import { migrateDeleteNonDefaultMemoryScopes } from "./migrations/323-delete-non-default-memory-scopes.js";
 import { migrateMessageFinalizedColumn } from "./migrations/324-message-finalized-column.js";
 import { createConfigSettingEventsTable } from "./migrations/325-create-config-setting-events.js";
+import { migrateMoveInjectionEventsToMemoryDb } from "./migrations/326-move-injection-events-to-memory-db.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1337,4 +1338,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateDeleteNonDefaultMemoryScopes,
   migrateMessageFinalizedColumn,
   createConfigSettingEventsTable,
+  migrateMoveInjectionEventsToMemoryDb,
 ];

--- a/assistant/src/plugins/defaults/memory/__tests__/db-memory-attach.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/db-memory-attach.test.ts
@@ -8,8 +8,9 @@
  *      the *main* WAL is exactly what this split exists to prevent.
  *   2. The main connection no longer ATTACHes the memory file: there is no
  *      `memory` schema on its `database_list`.
- *   3. `memory_jobs` lives in the dedicated memory connection, not in the main
- *      connection — proving the physical split.
+ *   3. The relocated memory tables (`memory_jobs`, `memory_v2_injection_events`)
+ *      live in the dedicated memory connection, not in the main connection —
+ *      proving the physical split.
  *   4. `runAsyncSqlite({ dbPath })` targets the given file via the sqlite3
  *      CLI backend, leaving the main DB untouched.
  */
@@ -51,23 +52,26 @@ describe("memory database connection", () => {
     expect(attached.some((e) => e.name === "memory")).toBe(false);
   });
 
-  test("memory_jobs lives in the memory connection, not main", () => {
-    const inMemory = getMemorySqlite()!
-      .query<
-        { name: string },
-        []
-      >(`SELECT name FROM sqlite_master WHERE type='table' AND name='memory_jobs'`)
-      .get();
-    expect(inMemory?.name).toBe("memory_jobs");
+  test.each(["memory_jobs", "memory_v2_injection_events"])(
+    "%s lives in the memory connection, not main",
+    (table) => {
+      const inMemory = getMemorySqlite()!
+        .query<
+          { name: string },
+          [string]
+        >(`SELECT name FROM sqlite_master WHERE type='table' AND name = ?`)
+        .get(table);
+      expect(inMemory?.name).toBe(table);
 
-    const inMain = getSqlite()
-      .query<
-        { name: string },
-        []
-      >(`SELECT name FROM main.sqlite_master WHERE name='memory_jobs'`)
-      .get();
-    expect(inMain).toBeNull();
-  });
+      const inMain = getSqlite()
+        .query<
+          { name: string },
+          [string]
+        >(`SELECT name FROM main.sqlite_master WHERE name = ?`)
+        .get(table);
+      expect(inMain).toBeNull();
+    },
+  );
 
   test.if(sqlite3Available)(
     "runAsyncSqlite({ dbPath }) targets the given file, not the main DB",

--- a/assistant/src/plugins/defaults/memory/__tests__/table-relocation.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/table-relocation.test.ts
@@ -26,6 +26,8 @@ const { drainStagedTable, stageTableForRelocation } =
   await import("../../../../persistence/migrations/helpers/relocation.js");
 const { MEMORY_JOBS_RELOCATION } =
   await import("../../../../persistence/migrations/298-move-memory-jobs-to-memory-db.js");
+const { INJECTION_EVENTS_RELOCATION } =
+  await import("../../../../persistence/migrations/326-move-injection-events-to-memory-db.js");
 
 await initializeDb();
 
@@ -125,6 +127,53 @@ describe("memory_jobs drain", () => {
       { id: "seed-keep-1", status: "pending" },
       { id: "seed-keep-2", status: "pending" },
       { id: "seed-keep-3", status: "pending" },
+    ]);
+  });
+});
+
+describe("memory_v2_injection_events drain", () => {
+  test("copies in-window rows, purges rows older than the read window, drops staging", async () => {
+    const sqlite = getSqlite();
+    const memory = getMemorySqlite()!;
+
+    // Clean slate: empty live table, fresh populated staging table.
+    memory.exec(`DELETE FROM memory_v2_injection_events`);
+    sqlite.exec(
+      `DROP TABLE IF EXISTS main."memory_v2_injection_events__relocating"`,
+    );
+    sqlite.exec(/*sql*/ `
+      CREATE TABLE main."memory_v2_injection_events__relocating" (
+        id INTEGER PRIMARY KEY, slug TEXT NOT NULL, injected_at INTEGER NOT NULL
+      )
+    `);
+
+    const now = Date.now();
+    const readWindowMs = 18 * 24 * 60 * 60 * 1000; // 6 half-lives of 3 days
+    const insert = sqlite.prepare(
+      `INSERT INTO main."memory_v2_injection_events__relocating"
+         (id, slug, injected_at) VALUES (?, ?, ?)`,
+    );
+    insert.run(1, "fresh-a", now - 1000);
+    insert.run(2, "fresh-b", now - readWindowMs / 2);
+    insert.run(3, "stale-a", now - readWindowMs - 24 * 60 * 60 * 1000);
+    insert.run(4, "stale-b", now - 2 * readWindowMs);
+
+    await drainStagedTable(sqlite, INJECTION_EVENTS_RELOCATION);
+
+    // Staging dropped.
+    expect(existsInMain("memory_v2_injection_events__relocating")).toBe(false);
+
+    // Only the in-window rows landed in the memory database, ids preserved;
+    // rows past the score read window were purged without being copied.
+    const kept = memory
+      .query<
+        { id: number; slug: string },
+        []
+      >(`SELECT id, slug FROM memory_v2_injection_events ORDER BY id`)
+      .all();
+    expect(kept).toEqual([
+      { id: 1, slug: "fresh-a" },
+      { id: 2, slug: "fresh-b" },
     ]);
   });
 });

--- a/assistant/src/plugins/defaults/memory/routes/__tests__/memory-v2-simulate-route.test.ts
+++ b/assistant/src/plugins/defaults/memory/routes/__tests__/memory-v2-simulate-route.test.ts
@@ -58,15 +58,10 @@ mock.module("../../v2/now-text.js", () => ({
 // zero scores since the test workspace has no event history.
 const recordCalls: Array<{ slugs: readonly string[]; at: number }> = [];
 mock.module("../../v2/injection-events.js", () => ({
-  recordInjectionEvents: (
-    _db: unknown,
-    slugs: readonly string[],
-    at: number,
-  ) => {
+  recordInjectionEvents: (slugs: readonly string[], at: number) => {
     recordCalls.push({ slugs, at });
   },
   computeInjectionScores: (
-    _db: unknown,
     slugs: readonly string[],
     _now: number,
   ): Map<string, number> => new Map(slugs.map((s) => [s, 0])),

--- a/assistant/src/plugins/defaults/memory/routes/memory-v2-routes.ts
+++ b/assistant/src/plugins/defaults/memory/routes/memory-v2-routes.ts
@@ -336,7 +336,7 @@ async function handleEmaScores({
 
   const pageIndex = await getPageIndex(getWorkspaceDir());
   const slugs = pageIndex.entries.map((e) => e.slug);
-  const scores = computeInjectionScores(getDb(), slugs, Date.now());
+  const scores = computeInjectionScores(slugs, Date.now());
 
   const entries: MemoryV2EmaScoresEntry[] = pageIndex.entries.map((entry) => ({
     slug: entry.slug,
@@ -536,7 +536,6 @@ export async function handleSimulateRouter({
     nowText,
     priorEverInjected: [],
     config: mergedConfig,
-    database: getDb(),
     ...(profileOverride !== undefined
       ? { overrideProfile: profileOverride }
       : {}),
@@ -550,11 +549,7 @@ export async function handleSimulateRouter({
   });
 
   const pageIndex = await getPageIndex(workspaceDir);
-  const scores = computeInjectionScores(
-    getDb(),
-    routerResult.selectedSlugs,
-    Date.now(),
-  );
+  const scores = computeInjectionScores(routerResult.selectedSlugs, Date.now());
 
   const sourceBySlug: Record<string, RouterSource> = {};
   for (const [slug, source] of routerResult.sourceBySlug.entries()) {
@@ -660,7 +655,7 @@ export async function handleCompareRetrievers({
 
   // The router is always comparand #1 (the harness self-test against its own
   // logged ground truth).
-  const retrievers: Retriever[] = [createRouterRetriever(db)];
+  const retrievers: Retriever[] = [createRouterRetriever()];
 
   return runComparisonOverHistory({
     db,

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/injection-events.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/injection-events.test.ts
@@ -1,21 +1,25 @@
 /**
- * Tests for `assistant/src/memory/v2/injection-events.ts` and its sibling
- * migration `256-memory-v2-injection-events.ts`.
+ * Tests for `assistant/src/plugins/defaults/memory/v2/injection-events.ts` and
+ * the main-DB migration `256-memory-v2-injection-events.ts`.
  *
  * Coverage matrix:
- *   - Migration creates the table + both indexes; safe to re-run.
+ *   - Migration 256 creates the main-side table + both indexes; safe to
+ *     re-run. (The table is subsequently relocated to the memory DB by
+ *     migration 326 — see table-relocation.test.ts for drain coverage.)
  *   - Backfill replays router-sourced concepts from memory_v2_activation_logs
  *     and is idempotent on a forced re-run with cleared checkpoint.
  *   - Backfill is a no-op when the activation-logs table doesn't exist
  *     (pre-234 DB).
- *   - recordInjectionEvents appends one row per slug per call; empty list
- *     is a no-op.
+ *   - recordInjectionEvents appends one row per slug per call to the memory
+ *     connection; empty list is a no-op.
  *   - computeInjectionScore matches the closed-form decay at known deltas
  *     (0d ≈ 1, 3d ≈ 0.5, 6d ≈ 0.25) and sums multiple events linearly.
  *   - computeInjectionScores returns the same per-slug values in batch and
  *     omits slugs with no events.
  *
- * Uses an in-memory bun:sqlite database — no real workspace DB.
+ * Uses in-memory bun:sqlite databases — the accessor tests install one into
+ * the `memory` singleton slot (where the accessors resolve their connection),
+ * the migration tests drive a plain main-DB handle. No real workspace DB.
  */
 
 import { Database } from "bun:sqlite";
@@ -31,11 +35,16 @@ mock.module("../../../../../util/logger.js", () => ({
 
 import type { DrizzleDb } from "../../../../../persistence/db-connection.js";
 import { getSqliteFrom } from "../../../../../persistence/db-connection.js";
+import {
+  clearStoredDb,
+  setStoredDb,
+} from "../../../../../persistence/db-singleton.js";
 import { migrateMemoryV2ActivationLogs } from "../../../../../persistence/migrations/234-memory-v2-activation-logs.js";
 import {
   downMemoryV2InjectionEvents,
   migrateMemoryV2InjectionEvents,
 } from "../../../../../persistence/migrations/256-memory-v2-injection-events.js";
+import { ensureInjectionEventsSchema } from "../../../../../persistence/migrations/326-move-injection-events-to-memory-db.js";
 import * as schema from "../../../../../persistence/schema/index.js";
 import {
   computeInjectionScore,
@@ -57,14 +66,25 @@ const CHECKPOINTS_DDL = /*sql*/ `
 
 let sqlite: Database;
 let database: DrizzleDb;
+let memorySqlite: Database;
 
 beforeEach(() => {
   sqlite = new Database(":memory:");
   database = drizzle(sqlite, { schema });
   getSqliteFrom(database).exec(CHECKPOINTS_DDL);
+
+  // The accessors resolve the dedicated memory connection through the
+  // `memory` singleton slot — install a fresh in-memory DB there with the
+  // relocated table's schema. `clearStoredDb` in afterEach runs the closer.
+  memorySqlite = new Database(":memory:");
+  ensureInjectionEventsSchema(memorySqlite);
+  setStoredDb("memory", drizzle(memorySqlite, { schema }), () =>
+    memorySqlite.close(),
+  );
 });
 
 afterEach(() => {
+  clearStoredDb("memory");
   sqlite.close();
 });
 
@@ -203,14 +223,10 @@ describe("migrateMemoryV2InjectionEvents", () => {
 });
 
 describe("recordInjectionEvents", () => {
-  beforeEach(() => {
-    migrateMemoryV2InjectionEvents(database);
-  });
-
   test("appends one row per slug at the same timestamp", () => {
     const t = 1_000_000;
-    recordInjectionEvents(database, ["alice", "bob", "alice"], t);
-    const rows = getSqliteFrom(database)
+    recordInjectionEvents(["alice", "bob", "alice"], t);
+    const rows = memorySqlite
       .query(
         `SELECT slug, injected_at FROM memory_v2_injection_events ORDER BY id`,
       )
@@ -222,9 +238,23 @@ describe("recordInjectionEvents", () => {
     ]);
   });
 
+  test("writes land in the memory connection, not the main DB handle", () => {
+    recordInjectionEvents(["alice"], 1_000_000);
+    const inMain = getSqliteFrom(database)
+      .query(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name='memory_v2_injection_events'`,
+      )
+      .get();
+    expect(inMain).toBeFalsy();
+    const { n } = memorySqlite
+      .query(`SELECT COUNT(*) as n FROM memory_v2_injection_events`)
+      .get() as { n: number };
+    expect(n).toBe(1);
+  });
+
   test("empty list is a no-op", () => {
-    recordInjectionEvents(database, [], 1_000_000);
-    const { n } = getSqliteFrom(database)
+    recordInjectionEvents([], 1_000_000);
+    const { n } = memorySqlite
       .query(`SELECT COUNT(*) as n FROM memory_v2_injection_events`)
       .get() as { n: number };
     expect(n).toBe(0);
@@ -232,87 +262,55 @@ describe("recordInjectionEvents", () => {
 });
 
 describe("computeInjectionScore", () => {
-  beforeEach(() => {
-    migrateMemoryV2InjectionEvents(database);
-  });
-
   test("returns 0 for a slug with no events", () => {
-    expect(computeInjectionScore(database, "missing", Date.now())).toBe(0);
+    expect(computeInjectionScore("missing", Date.now())).toBe(0);
   });
 
   test("single event 0 days ago → score ≈ 1", () => {
     const now = 10_000_000_000;
-    recordInjectionEvents(database, ["alice"], now);
-    expect(computeInjectionScore(database, "alice", now)).toBeCloseTo(1, 5);
+    recordInjectionEvents(["alice"], now);
+    expect(computeInjectionScore("alice", now)).toBeCloseTo(1, 5);
   });
 
   test("single event 3 days (one half-life) ago → score ≈ 0.5", () => {
     const now = 10_000_000_000;
-    recordInjectionEvents(
-      database,
-      ["alice"],
-      now - INJECTION_SCORE_HALF_LIFE_MS,
-    );
-    expect(computeInjectionScore(database, "alice", now)).toBeCloseTo(0.5, 5);
+    recordInjectionEvents(["alice"], now - INJECTION_SCORE_HALF_LIFE_MS);
+    expect(computeInjectionScore("alice", now)).toBeCloseTo(0.5, 5);
   });
 
   test("single event 6 days (two half-lives) ago → score ≈ 0.25", () => {
     const now = 10_000_000_000;
-    recordInjectionEvents(
-      database,
-      ["alice"],
-      now - 2 * INJECTION_SCORE_HALF_LIFE_MS,
-    );
-    expect(computeInjectionScore(database, "alice", now)).toBeCloseTo(0.25, 5);
+    recordInjectionEvents(["alice"], now - 2 * INJECTION_SCORE_HALF_LIFE_MS);
+    expect(computeInjectionScore("alice", now)).toBeCloseTo(0.25, 5);
   });
 
   test("multiple events sum independently", () => {
     const now = 10_000_000_000;
-    recordInjectionEvents(database, ["alice"], now);
-    recordInjectionEvents(
-      database,
-      ["alice"],
-      now - INJECTION_SCORE_HALF_LIFE_MS,
-    );
-    recordInjectionEvents(
-      database,
-      ["alice"],
-      now - 2 * INJECTION_SCORE_HALF_LIFE_MS,
-    );
-    expect(computeInjectionScore(database, "alice", now)).toBeCloseTo(1.75, 5);
+    recordInjectionEvents(["alice"], now);
+    recordInjectionEvents(["alice"], now - INJECTION_SCORE_HALF_LIFE_MS);
+    recordInjectionEvents(["alice"], now - 2 * INJECTION_SCORE_HALF_LIFE_MS);
+    expect(computeInjectionScore("alice", now)).toBeCloseTo(1.75, 5);
   });
 });
 
 describe("computeInjectionScores", () => {
-  beforeEach(() => {
-    migrateMemoryV2InjectionEvents(database);
-  });
-
   test("returns the same per-slug values as the single-slug helper", () => {
     const now = 10_000_000_000;
-    recordInjectionEvents(database, ["alice", "bob"], now);
-    recordInjectionEvents(
-      database,
-      ["alice"],
-      now - INJECTION_SCORE_HALF_LIFE_MS,
-    );
+    recordInjectionEvents(["alice", "bob"], now);
+    recordInjectionEvents(["alice"], now - INJECTION_SCORE_HALF_LIFE_MS);
 
-    const scores = computeInjectionScores(
-      database,
-      ["alice", "bob", "ghost"],
-      now,
-    );
+    const scores = computeInjectionScores(["alice", "bob", "ghost"], now);
     expect(scores.get("alice")).toBeCloseTo(1.5, 5);
     expect(scores.get("bob")).toBeCloseTo(1, 5);
     // ghost has no events — omitted from the result, not present as 0.
     expect(scores.has("ghost")).toBe(false);
     expect(scores.get("alice")).toBeCloseTo(
-      computeInjectionScore(database, "alice", now),
+      computeInjectionScore("alice", now),
       5,
     );
   });
 
   test("empty slug list returns empty map", () => {
-    expect(computeInjectionScores(database, [], Date.now()).size).toBe(0);
+    expect(computeInjectionScores([], Date.now()).size).toBe(0);
   });
 });

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/router.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/router.test.ts
@@ -74,13 +74,12 @@ mock.module("../skill-store.js", () => ({
 }));
 
 // Stub `computeInjectionScores` so tier-2 tests can dictate scores
-// without spinning up a real bun:sqlite db. Real production wiring is
-// covered by the splitTier2 unit tests in page-index.test.ts and the
-// score-formula tests in injection-events.test.ts.
+// without spinning up a real bun:sqlite db in the memory singleton slot.
+// Real production wiring is covered by the splitTier2 unit tests in
+// page-index.test.ts and the score-formula tests in injection-events.test.ts.
 const scoresStub = new Map<string, number>();
 mock.module("../injection-events.js", () => ({
   computeInjectionScores: (
-    _db: unknown,
     slugs: readonly string[],
     _now: number,
   ): Map<string, number> => {
@@ -956,10 +955,6 @@ describe("runRouter — tier 1 (recently modified)", () => {
 // ---------------------------------------------------------------------------
 
 describe("runRouter — tier 2 (highest EMA)", () => {
-  // Any non-null value passes the `params.database` check in the orchestrator;
-  // the real db is never touched because computeInjectionScores is mocked.
-  const stubDb = {} as Parameters<typeof runRouter>[0]["database"];
-
   beforeEach(async () => {
     await writePage(workspaceDir, makePage("alpha", { summary: "A" }));
     await writePage(workspaceDir, makePage("bravo", { summary: "B" }));
@@ -974,7 +969,6 @@ describe("runRouter — tier 2 (highest EMA)", () => {
       workspaceDir,
       ...COMMON_PARAMS,
       config: makeConfig(),
-      database: stubDb,
     });
     expect(providerCalls).toHaveLength(1);
   });
@@ -989,7 +983,6 @@ describe("runRouter — tier 2 (highest EMA)", () => {
       workspaceDir,
       ...COMMON_PARAMS,
       config: makeConfig({ tier2Size: 2 }),
-      database: stubDb,
     });
     expect(providerCalls.length).toBe(2);
 
@@ -1025,7 +1018,6 @@ describe("runRouter — tier 2 (highest EMA)", () => {
       workspaceDir,
       ...COMMON_PARAMS,
       config: makeConfig({ tier1Size: 2, tier2Size: 2 }),
-      database: stubDb,
     });
     expect(providerCalls.length).toBe(3);
 
@@ -1054,7 +1046,6 @@ describe("runRouter — tier 2 (highest EMA)", () => {
       workspaceDir,
       ...COMMON_PARAMS,
       config: makeConfig({ tier2Size: 100 }),
-      database: stubDb,
     });
     expect(providerCalls.length).toBe(2);
     const tier2Prompt = providerCalls[0].systemPrompt ?? "";
@@ -1071,7 +1062,6 @@ describe("runRouter — tier 2 (highest EMA)", () => {
       workspaceDir,
       ...COMMON_PARAMS,
       config: makeConfig({ tier1Size: 1, tier2Size: 1 }),
-      database: stubDb,
     });
 
     // Every selected slug should have a tier tag — exactly one of:
@@ -1092,20 +1082,17 @@ describe("runRouter — tier 2 (highest EMA)", () => {
     expect(tags.has("tier2")).toBe(true);
   });
 
-  test("tier2_size set without database logs a warn and skips tier 2", async () => {
-    scoresStub.set("bravo", 5.0);
+  test("tier2_size set with all-zero scores skips tier 2 (degraded memory DB)", async () => {
+    // No scores stubbed — mirrors `computeInjectionScores` returning an
+    // empty map when the memory connection is unavailable. Tier 2 must
+    // select nothing rather than pulling in arbitrary pages.
     providerStub = makeProvider(toolUseResponse([1]));
     await runRouter({
       workspaceDir,
       ...COMMON_PARAMS,
       config: makeConfig({ tier2Size: 2 }),
-      // No database → tier 2 silently skipped.
     });
     expect(providerCalls).toHaveLength(1);
-    const warned = warnLogs.some((l) =>
-      JSON.stringify(l.args).includes("tier2_size set but no database"),
-    );
-    expect(warned).toBe(true);
   });
 });
 

--- a/assistant/src/plugins/defaults/memory/v2/harness/router-retriever.ts
+++ b/assistant/src/plugins/defaults/memory/v2/harness/router-retriever.ts
@@ -7,7 +7,6 @@
  * its own injected ground truth.
  */
 
-import type { DrizzleDb } from "../../../../../persistence/db-connection.js";
 import { runRouter } from "../router.js";
 import type {
   RetrievalInput,
@@ -15,12 +14,7 @@ import type {
   Retriever,
 } from "./retriever.js";
 
-/**
- * @param database optional handle for tier-2 EMA scoring, forwarded to
- * `runRouter`. Omit to exercise only the tier-1 / tier-3 paths (as the router's
- * own tests do).
- */
-export function createRouterRetriever(database?: DrizzleDb): Retriever {
+export function createRouterRetriever(): Retriever {
   return {
     name: "router",
     async retrieve(input: RetrievalInput): Promise<RetrievalOutput> {
@@ -31,7 +25,6 @@ export function createRouterRetriever(database?: DrizzleDb): Retriever {
         priorEverInjected: input.priorEverInjected,
         config: input.config,
         ...(input.signal ? { signal: input.signal } : {}),
-        ...(database ? { database } : {}),
       });
       return {
         selectedSlugs: result.selectedSlugs,

--- a/assistant/src/plugins/defaults/memory/v2/injection-events.ts
+++ b/assistant/src/plugins/defaults/memory/v2/injection-events.ts
@@ -1,5 +1,3 @@
-import type { Database } from "bun:sqlite";
-
 import { getMemorySqlite } from "../../../../persistence/db-connection.js";
 import { getLogger } from "../logging.js";
 
@@ -32,7 +30,7 @@ function decayContribution(elapsedMs: number): number {
  * — every caller here degrades rather than throwing: the event log is a
  * scoring signal, and losing it must never break routing or a turn.
  */
-function memorySqliteOrNull(context: string): Database | null {
+function memorySqliteOrNull(context: string) {
   const sqlite = getMemorySqlite();
   if (!sqlite) {
     log.warn(

--- a/assistant/src/plugins/defaults/memory/v2/injection-events.ts
+++ b/assistant/src/plugins/defaults/memory/v2/injection-events.ts
@@ -1,5 +1,6 @@
-import type { DrizzleDb } from "../../../../persistence/db-connection.js";
-import { getSqliteFrom } from "../../../../persistence/db-connection.js";
+import type { Database } from "bun:sqlite";
+
+import { getMemorySqlite } from "../../../../persistence/db-connection.js";
 import { getLogger } from "../logging.js";
 
 const log = getLogger("memory-v2-injection-events");
@@ -18,10 +19,28 @@ export const INJECTION_SCORE_LAMBDA =
 
 // Events past 6 half-lives contribute <1.6% each. Reads bound the scan to
 // this window so per-slug score computation stays cheap as history grows.
+// Migration 326 uses the same window to purge dead rows during relocation.
 const READ_WINDOW_MS = 6 * INJECTION_SCORE_HALF_LIFE_MS;
 
 function decayContribution(elapsedMs: number): number {
   return Math.exp(-INJECTION_SCORE_LAMBDA * elapsedMs);
+}
+
+/**
+ * The dedicated memory connection (`assistant-memory.db`), where
+ * `memory_v2_injection_events` lives. `null` when the file cannot be opened
+ * — every caller here degrades rather than throwing: the event log is a
+ * scoring signal, and losing it must never break routing or a turn.
+ */
+function memorySqliteOrNull(context: string): Database | null {
+  const sqlite = getMemorySqlite();
+  if (!sqlite) {
+    log.warn(
+      { context },
+      "memory database unavailable; injection events degraded",
+    );
+  }
+  return sqlite;
 }
 
 /**
@@ -30,13 +49,13 @@ function decayContribution(elapsedMs: number): number {
  * caller depends on.
  */
 export function recordInjectionEvents(
-  database: DrizzleDb,
   slugs: readonly string[],
   injectedAt: number,
 ): void {
   if (slugs.length === 0) return;
   try {
-    const raw = getSqliteFrom(database);
+    const raw = memorySqliteOrNull("recordInjectionEvents");
+    if (!raw) return;
     const insert = raw.prepare(
       `INSERT INTO memory_v2_injection_events (slug, injected_at) VALUES (?, ?)`,
     );
@@ -52,14 +71,14 @@ export function recordInjectionEvents(
   }
 }
 
-/** `score(now) = Σᵢ exp(-λ × (now - tᵢ))` over events within READ_WINDOW_MS. */
-export function computeInjectionScore(
-  database: DrizzleDb,
-  slug: string,
-  now: number,
-): number {
+/**
+ * `score(now) = Σᵢ exp(-λ × (now - tᵢ))` over events within READ_WINDOW_MS.
+ * Returns 0 when the memory database is unavailable.
+ */
+export function computeInjectionScore(slug: string, now: number): number {
+  const raw = memorySqliteOrNull("computeInjectionScore");
+  if (!raw) return 0;
   const cutoff = now - READ_WINDOW_MS;
-  const raw = getSqliteFrom(database);
   const rows = raw
     .query(
       `SELECT injected_at FROM memory_v2_injection_events
@@ -75,17 +94,19 @@ export function computeInjectionScore(
  * Batch variant of `computeInjectionScore` — single SQL pass scoped to the
  * requested slugs so tier assignment doesn't issue O(M) queries. Slugs
  * with no events in the read window are omitted from the result; callers
- * should treat a missing entry as score 0.
+ * should treat a missing entry as score 0. Returns an empty map when the
+ * memory database is unavailable, so a degraded connection reads as
+ * all-zero scores (tier 2 simply selects nothing).
  */
 export function computeInjectionScores(
-  database: DrizzleDb,
   slugs: readonly string[],
   now: number,
 ): Map<string, number> {
   const out = new Map<string, number>();
   if (slugs.length === 0) return out;
+  const raw = memorySqliteOrNull("computeInjectionScores");
+  if (!raw) return out;
   const cutoff = now - READ_WINDOW_MS;
-  const raw = getSqliteFrom(database);
   const placeholders = slugs.map(() => "?").join(",");
   const rows = raw
     .query(

--- a/assistant/src/plugins/defaults/memory/v2/injection.ts
+++ b/assistant/src/plugins/defaults/memory/v2/injection.ts
@@ -612,7 +612,6 @@ async function injectViaRouter(args: {
     nowText,
     priorEverInjected,
     config,
-    database,
     ...(signal ? { signal } : {}),
   });
 
@@ -622,7 +621,7 @@ async function injectViaRouter(args: {
   // errors — a SQLite write must not abort the turn on top of a successful
   // routing decision the rest of this function depends on.
   if (routerResult.failureReason === null) {
-    recordInjectionEvents(database, routerResult.selectedSlugs, Date.now());
+    recordInjectionEvents(routerResult.selectedSlugs, Date.now());
   }
 
   if (routerResult.failureReason !== null) {

--- a/assistant/src/plugins/defaults/memory/v2/router.ts
+++ b/assistant/src/plugins/defaults/memory/v2/router.ts
@@ -41,7 +41,6 @@ import {
 import { z } from "zod";
 
 import type { AssistantConfig } from "../../../../config/types.js";
-import type { DrizzleDb } from "../../../../persistence/db-connection.js";
 import {
   cachedTextBlock,
   extractToolUse,
@@ -187,13 +186,6 @@ interface RunRouterParams {
   config: AssistantConfig;
   signal?: AbortSignal;
   /**
-   * Database handle for reading EMA scores when `tier2_size` is set. When
-   * absent, tier 2 is silently skipped (pages flow tier 1 → tier 3). The
-   * production caller (`injectViaRouter`) always passes it; tests that
-   * only exercise tier 1 / tier 3 paths can omit it.
-   */
-  database?: DrizzleDb;
-  /**
    * Per-call profile override forwarded to `getConfiguredProvider`. When
    * set, the `memoryRouter` call site resolves against this profile name
    * instead of the workspace active profile. The simulator route uses
@@ -271,16 +263,14 @@ export async function runRouter(
 
   let tier2: PageIndex | null = null;
   let afterTier2: PageIndex = afterTier1;
-  if (tier2Size !== null && params.database && afterTier1.entries.length > 0) {
+  if (tier2Size !== null && afterTier1.entries.length > 0) {
+    // EMA scores come from the dedicated memory connection; when it is
+    // unavailable the scores read as all-zero and tier 2 selects nothing.
     const slugs = afterTier1.entries.map((e) => e.slug);
-    const scores = computeInjectionScores(params.database, slugs, Date.now());
+    const scores = computeInjectionScores(slugs, Date.now());
     const split = splitTier2(afterTier1, tier2Size, scores);
     tier2 = split.tier2;
     afterTier2 = split.rest;
-  } else if (tier2Size !== null && !params.database) {
-    log.warn(
-      "tier2_size set but no database passed to runRouter; skipping tier 2",
-    );
   }
 
   const tier3Batches = partitionPageIndex(afterTier2, batchSize).filter(


### PR DESCRIPTION
## Prompt / plan

Move `memory_v2_injection_events` (the EMA injection-event log behind memory router tier-2 scoring) out of `assistant.db` into the dedicated memory database, as the first step toward relocating all memory-plugin tables. The table grows with every router selection; housing it with the other high-churn memory state (`memory_jobs`, migration 298) keeps the main DB and its WAL out of that write path.

Approach mirrors migrations 297/298:

- **Migration 326** relocates the table with the incremental stage-and-drain engine (`helpers/relocation.ts`): create table + indexes on the memory connection, rename the main-side table aside, drain in awaited batches. Rows older than the 6-half-life score read window (18 days) are purged during the copy — no reader ever scans past that window, so carrying them over would only re-seed dead weight.
- **Accessors** (`injection-events.ts`) now resolve the dedicated memory connection internally and degrade gracefully when it is unavailable: writes stay best-effort, reads return zero scores (tier 2 then selects nothing, matching `splitTier2`'s `score > 0` filter).
- The `DrizzleDb` parameter on the accessors — and `runRouter`'s `database` param, which existed solely to thread it through — is removed.

(Rebased on main; the migration was renumbered 325 → 326 after `325-create-config-setting-events` landed on main.)

## Test plan

- Unit/integration: reworked `injection-events.test.ts` (accessors now target the `memory` singleton slot), added a drain test for the new relocation spec in `table-relocation.test.ts` (fresh rows copied with ids preserved, stale rows purged, staging dropped), extended `db-memory-attach.test.ts` to assert the table lives in the memory connection and not main. Updated router/simulate-route mocks for the new signatures. All affected test files pass individually (per-file isolation per `scripts/test.ts`); `tsc --noEmit`, eslint, and prettier clean — re-run after the rebase with main's migration 325 ahead of this one in the chain.
- Manual end-to-end against a live daemon (no Docker/LLM needed):
  - Fresh boot: the relocation migration runs, table + both indexes created in `assistant-memory.db`, absent from `assistant.db`.
  - Upgrade path: seeded a main-side table with 2 fresh + 2 stale rows and cleared the `step:` checkpoint; on reboot the drain logged `purged: 2, moved: 2`, staging dropped, main-side table gone, fresh rows in the memory DB with ids preserved.
  - Read surface: `assistant memory v2 ema --json` against the running daemon scored a relocated event ~1 min old at `0.9993` — the expected decay, read via the memory connection.

## CLI verb checklist

No new routes added — existing `memory_v2_ema_scores` route and CLI verb are unchanged apart from the accessor signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSVMN8d9JNNh6JEWuvN3Gv