### PR TITLE
fix(macos): re-float shared CLI install after an app update

### DIFF
--- a/clients/macos/src/main/cli-installer.test.ts
+++ b/clients/macos/src/main/cli-installer.test.ts
@@ -9,6 +9,7 @@ import { FakeChild } from "./test-helpers";
 
 const userDataPath = "/mock/userData";
 const mockResourcesPath = "/mock/resources";
+const mockAppVersion = "1.2.3";
 
 // Baked from .tool-versions by electron.vite.config.ts in a real build; set here
 // (before the module import below reads it) so the packageManager stamp is live.
@@ -25,6 +26,7 @@ mock.module("electron", () => ({
       if (name === "userData") return userDataPath;
       return "/tmp";
     },
+    getVersion: () => mockAppVersion,
     isPackaged: true,
   },
 }));
@@ -42,6 +44,9 @@ let readdirSyncError: Error | null = null;
 let writeFileSyncError: Error | null = null;
 // Contents returned by readFileSync (the install package.json stampPackageManager reads).
 let readFileSyncReturn = '{"dependencies":{"vellum":"latest"}}';
+// Per-path readFileSync overrides (e.g. the .app-version marker). Falls back to
+// readFileSyncReturn.
+const readFileSyncByPath: Record<string, string> = {};
 let readFileSyncError: Error | null = null;
 let renameSyncError: Error | null = null;
 const chmodSyncCalls: Array<[string, number]> = [];
@@ -70,8 +75,9 @@ mock.module("node:fs", () => ({
     if (readdirSyncError) throw readdirSyncError;
     return readdirSyncReturn;
   },
-  readFileSync: (_p: string, _enc?: string) => {
+  readFileSync: (p: string, _enc?: string) => {
     if (readFileSyncError) throw readFileSyncError;
+    if (p in readFileSyncByPath) return readFileSyncByPath[p];
     return readFileSyncReturn;
   },
   renameSync: (src: string, dst: string) => {
@@ -130,6 +136,9 @@ const cliBinPath = `${latestInstallDir}/node_modules/.bin/vellum`;
 /** Bin path for an install dir under `cli/`. */
 const binPathFor = (name: string) =>
   `${userDataPath}/cli/${name}/node_modules/.bin/vellum`;
+/** `.app-version` marker path for an install dir under `cli/`. */
+const markerPathFor = (name: string) =>
+  `${userDataPath}/cli/${name}/.app-version`;
 
 afterEach(() => {
   existsSyncDefault = false;
@@ -138,6 +147,7 @@ afterEach(() => {
   readdirSyncError = null;
   writeFileSyncError = null;
   readFileSyncReturn = '{"dependencies":{"vellum":"latest"}}';
+  for (const key of Object.keys(readFileSyncByPath)) delete readFileSyncByPath[key];
   readFileSyncError = null;
   renameSyncError = null;
   chmodSyncCalls.length = 0;
@@ -348,6 +358,7 @@ describe("isCliInstalled", () => {
 describe("ensureCliInstalled", () => {
   test("skips install but refreshes the locator when already installed", async () => {
     existsSyncDefault = true;
+    readFileSyncByPath[markerPathFor("latest")] = mockAppVersion;
 
     await ensureCliInstalled();
 
@@ -361,6 +372,7 @@ describe("ensureCliInstalled", () => {
     // installs predating the field (or on an older bun) don't drift (LUM-2649).
     existsSyncDefault = true;
     readFileSyncReturn = '{"dependencies":{"vellum":"latest"}}';
+    readFileSyncByPath[markerPathFor("latest")] = mockAppVersion;
 
     await ensureCliInstalled();
 
@@ -375,6 +387,7 @@ describe("ensureCliInstalled", () => {
   test("does not rewrite an already-stamped install on the upgrade path", async () => {
     existsSyncDefault = true;
     readFileSyncReturn = `{"packageManager":"bun@${mockBunVersion}","dependencies":{"vellum":"latest"}}`;
+    readFileSyncByPath[markerPathFor("latest")] = mockAppVersion;
 
     await ensureCliInstalled();
 
@@ -386,6 +399,7 @@ describe("ensureCliInstalled", () => {
 
   test("a throwing locator write does not reject", async () => {
     existsSyncDefault = true;
+    readFileSyncByPath[markerPathFor("latest")] = mockAppVersion;
     writeFileSyncError = new Error("EROFS: read-only file system");
 
     await expect(ensureCliInstalled()).resolves.toBeUndefined();
@@ -395,6 +409,7 @@ describe("ensureCliInstalled", () => {
     existsSyncDefault = false;
     readdirSyncReturn = [dirEntry("0.9.0")];
     existsSyncByPath[binPathFor("0.9.0")] = true;
+    readFileSyncByPath[markerPathFor("0.9.0")] = mockAppVersion;
 
     await ensureCliInstalled();
 
@@ -408,6 +423,55 @@ describe("ensureCliInstalled", () => {
     ]);
     // ...and the locator is still refreshed.
     expect(renameSyncCalls).toContainEqual([`${locatorPath}.tmp`, locatorPath]);
+  });
+
+  test("re-floats a stale install seeded by an older app version", async () => {
+    existsSyncByPath[cliBinPath] = true;
+    readFileSyncByPath[markerPathFor("latest")] = "0.0.1";
+
+    const promise = ensureCliInstalled();
+    lastChild.emit("close", 0);
+    await promise;
+
+    // The stale tree is wiped so the reinstall re-resolves the dist-tag...
+    expect(rmSyncCalls).toContainEqual([
+      `${latestInstallDir}/node_modules`,
+      { recursive: true, force: true },
+    ]);
+    // ...and bun re-floats to the environment's tag.
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0][1]).toEqual(["add", "vellum@latest", "--ignore-scripts"]);
+    // The running app version is recorded so it won't refresh again next launch.
+    expect(writeFileSyncCalls).toContainEqual([
+      `${latestInstallDir}/.app-version.tmp`,
+      `${mockAppVersion}\n`,
+    ]);
+  });
+
+  test("re-floats a markerless install on first launch of the fixed app", async () => {
+    // An install written before the marker existed reads as a non-matching
+    // version, so it heals exactly once.
+    existsSyncByPath[cliBinPath] = true;
+
+    const promise = ensureCliInstalled();
+    lastChild.emit("close", 0);
+    await promise;
+
+    expect(rmSyncCalls).toContainEqual([
+      `${latestInstallDir}/node_modules`,
+      { recursive: true, force: true },
+    ]);
+    expect(spawnCalls).toHaveLength(1);
+  });
+
+  test("does not refresh when the install matches the running app version", async () => {
+    existsSyncByPath[cliBinPath] = true;
+    readFileSyncByPath[markerPathFor("latest")] = mockAppVersion;
+
+    await ensureCliInstalled();
+
+    expect(spawnCalls).toHaveLength(0);
+    expect(rmSyncCalls).toHaveLength(0);
   });
 
   test("fresh unpinned install spawns bun add vellum@latest", async () => {

--- a/clients/macos/src/main/cli-installer.ts
+++ b/clients/macos/src/main/cli-installer.ts
@@ -23,6 +23,11 @@ export const PINNED_CLI_VERSION = "";
 // Install dir for fresh, unpinned installs.
 const LATEST_INSTALL_DIR = "latest";
 
+// Records the app version that seeded an unpinned install so a later app
+// update can tell its shared CLI is stale and re-float it. See
+// clearStaleInstallForAppUpdate.
+const INSTALL_APP_VERSION_MARKER = ".app-version";
+
 // Injected by `electron.vite.config.ts` at build time.
 declare const __VELLUM_ENVIRONMENT__: string;
 const VELLUM_ENVIRONMENT =
@@ -372,6 +377,71 @@ function runBun(args: string[], cwd: string): Promise<void> {
   });
 }
 
+/** Path to the app-version marker inside an install dir. */
+function installAppVersionMarkerPath(installDir: string): string {
+  return path.join(installDir, INSTALL_APP_VERSION_MARKER);
+}
+
+/** App version that seeded `installDir`, or null when unmarked/unreadable. */
+function readInstalledAppVersion(installDir: string): string | null {
+  try {
+    return readFileSync(installAppVersionMarkerPath(installDir), "utf8").trim();
+  } catch {
+    return null;
+  }
+}
+
+/** Stamp the running app version into `installDir`. Non-fatal. */
+function writeInstalledAppVersion(installDir: string): void {
+  try {
+    writeFileAtomicSync(
+      installAppVersionMarkerPath(installDir),
+      `${app.getVersion()}\n`,
+    );
+  } catch (err) {
+    log.warn("[cli-installer] failed to record CLI app-version marker:", err);
+  }
+}
+
+/**
+ * Re-float a stale unpinned install after an app update.
+ *
+ * `isCliInstalled()` only checks that the bin exists, so a shared `cli/latest`
+ * seeded by an older app build stays pinned to that old runtime version across
+ * every later app update — and the in-app "new version available" banner (which
+ * compares the platform release against the running daemon) can never land
+ * (LUM-2733). Record the app version that seeded the install and, when the
+ * running app differs, wipe the tree so the reinstall below re-floats to the
+ * current dist-tag. Fires at most once per app update (the marker is rewritten
+ * after each install); a markerless install from before this field one-time
+ * heals on first launch of the fixed app.
+ *
+ * Skipped for pinned builds (their dir name already changes on a bump, so
+ * isCliInstalled goes false on its own) and local builds (they run the repo CLI
+ * source, not an install). Returns true when a stale install was cleared and a
+ * reinstall is needed.
+ */
+function clearStaleInstallForAppUpdate(): boolean {
+  if (PINNED_CLI_VERSION) return false;
+  if (getLocalCliEntry() !== null) return false;
+
+  const installDir = getCliInstallDir();
+  if (!existsSync(binPathIn(installDir))) return false;
+
+  const seededBy = readInstalledAppVersion(installDir);
+  if (seededBy === app.getVersion()) return false;
+
+  log.info(
+    `[cli-installer] app ${seededBy ?? "unknown"} -> ${app.getVersion()}: refreshing CLI install`,
+  );
+  rmSync(path.join(installDir, "node_modules"), {
+    recursive: true,
+    force: true,
+  });
+  rmSync(path.join(installDir, "bun.lock"), { force: true });
+  return true;
+}
+
 async function bunInstallCli(): Promise<void> {
   const installDir = getCliInstallDir();
   mkdirSync(installDir, { recursive: true });
@@ -423,6 +493,10 @@ async function bunInstallCli(): Promise<void> {
   // Mark the freshly written install bun-only so manual recovery doesn't drift
   // it to npm. Both bun add and the seeded package.json omit the field.
   stampPackageManager(installDir);
+
+  // Record which app build seeded this install so a later update knows to
+  // re-float it (clearStaleInstallForAppUpdate).
+  writeInstalledAppVersion(installDir);
 }
 
 // Singleton promise prevents concurrent installs from corrupting node_modules.
@@ -441,7 +515,7 @@ export function _resetInstallLock(): void {
  * lifecycle scripts are always suppressed via `--ignore-scripts`.
  */
 export async function ensureCliInstalled(): Promise<void> {
-  if (isCliInstalled()) {
+  if (isCliInstalled() && !clearStaleInstallForAppUpdate()) {
     writeCliLocator();
     // Heal installs written before this field existed (or before a bun bump):
     // the upgrade path returns here without reinstalling, so an existing user's

--- a/clients/macos/src/main/cli-installer.ts
+++ b/clients/macos/src/main/cli-installer.ts
@@ -407,29 +407,32 @@ function writeInstalledAppVersion(installDir: string): void {
  * Re-float a stale unpinned install after an app update.
  *
  * `isCliInstalled()` only checks that the bin exists, so a shared `cli/latest`
- * seeded by an older app build stays pinned to that old runtime version across
- * every later app update — and the in-app "new version available" banner (which
- * compares the platform release against the running daemon) can never land
- * (LUM-2733). Record the app version that seeded the install and, when the
- * running app differs, wipe the tree so the reinstall below re-floats to the
- * current dist-tag. Fires at most once per app update (the marker is rewritten
- * after each install); a markerless install from before this field one-time
- * heals on first launch of the fixed app.
+ * seeded by an older app build would otherwise stay on that build's runtime
+ * version across every later app update. A markerless install (from builds
+ * that predate the marker) reads as stale on purpose, one-time healing on the
+ * first launch of a build that writes markers.
  *
- * Skipped for pinned builds (their dir name already changes on a bump, so
- * isCliInstalled goes false on its own) and local builds (they run the repo CLI
- * source, not an install). Returns true when a stale install was cleared and a
- * reinstall is needed.
+ * Pinned builds don't need this (a version bump changes the install dir, so
+ * `isCliInstalled` goes false on its own); local builds run the repo CLI
+ * source, not an install. Returns true when a reinstall is needed.
  */
 function clearStaleInstallForAppUpdate(): boolean {
-  if (PINNED_CLI_VERSION) return false;
-  if (getLocalCliEntry() !== null) return false;
+  if (PINNED_CLI_VERSION) {
+    return false;
+  }
+  if (getLocalCliEntry() !== null) {
+    return false;
+  }
 
   const installDir = getCliInstallDir();
-  if (!existsSync(binPathIn(installDir))) return false;
+  if (!existsSync(binPathIn(installDir))) {
+    return false;
+  }
 
   const seededBy = readInstalledAppVersion(installDir);
-  if (seededBy === app.getVersion()) return false;
+  if (seededBy === app.getVersion()) {
+    return false;
+  }
 
   log.info(
     `[cli-installer] app ${seededBy ?? "unknown"} -> ${app.getVersion()}: refreshing CLI install`,


### PR DESCRIPTION
## Problem

A freshly-hatched local assistant can be permanently stranded on an old runtime version, with the in-app **"New assistant version available"** banner nagging forever and clicking **UPDATE** never landing.

Root cause: instances whose daemon launches from the app-managed **shared** CLI (`~/Library/Application Support/@vellumai/<env>/cli/latest`) are pinned to whatever version first created that directory. `ensureCliInstalled()` gates only on `isCliInstalled()` — *does the `vellum` bin exist* — with **no version comparison**. So on an app update the pre-existing `cli/latest` is never re-floated:

- App updates `0.10.7-staging.3 → 0.10.8-staging.1`
- `cli/latest` still holds `0.10.7-staging.3`; the daemon reports `0.10.7-staging.3`
- The banner reads "latest" from the platform releases DB (`0.10.8-staging.1`) and compares against the daemon → shows an update that can never apply

(Instances hatched through the *per-instance* runtime path — `.vellum/runtime/<version>/` — are unaffected; this is specific to the shared `cli/latest`.)

## Fix

Record the app version that seeded each unpinned install in a `.app-version` marker. On launch, if the running app differs from the marker, wipe the tree so the reinstall re-floats to the current dist-tag — at most once per app update (the marker is rewritten after each install). A markerless install from before this field heals once on first launch of the fixed app.

Skipped for pinned builds (their dir name already changes on a bump, so `isCliInstalled` goes false on its own) and local builds (they run the repo CLI source, not an install).

## Test

`bun test src/main/cli-installer.test.ts` — 57 pass. New cases: stale-version refresh, markerless heal, and matching-version no-op; existing "already installed" cases updated to carry a matching marker. Typecheck clean.

## Notes for reviewers

- The refresh uses the **app** version as the trigger, not runtime==app equality — the runtime legitimately floats to a dist-tag independent of the shell version. The marker just answers "did the app that seeded this install change."
- Every existing user gets one CLI reinstall (a ~2s `bun add`) on first launch of the fixed app; that's the intended heal.
- Field bug that surfaced this: manually deleting `cli/latest` to force a refresh nukes the CLI out from under a running app (every shelled CLI command then fails until relaunch). This fix removes the need for that workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)