### PR TITLE
fix(web): resolve local gateway URLs for docker assistants

### DIFF
--- a/clients/web/src/domains/settings/teleport/teleport-gateway-client.ts
+++ b/clients/web/src/domains/settings/teleport/teleport-gateway-client.ts
@@ -23,11 +23,10 @@ import { readArrayBufferWithProgress } from "./bundle-stream";
 import { TeleportError } from "./teleport-types";
 
 /**
- * Resolve the absolute local gateway base URL for a local assistant. Only
- * `cloud === "local"` assistants are reachable this way (`getLocalGatewayUrl`
- * resolves the `/assistant/__gateway/<port>` proxy for them); Docker and other
- * hosting kinds never reach here because `resolveDestination` doesn't offer
- * teleport for them.
+ * Resolve the absolute local gateway base URL for a local or docker assistant
+ * (`getLocalGatewayUrl` resolves the `/assistant/__gateway/<port>` proxy for
+ * both); other hosting kinds never reach here because `resolveDestination`
+ * doesn't offer teleport for them.
  */
 function localGatewayBase(assistant: LockfileAssistant): string {
   const path = getLocalGatewayUrl(assistant);

--- a/clients/web/src/lib/local-mode.test.ts
+++ b/clients/web/src/lib/local-mode.test.ts
@@ -33,6 +33,7 @@ import {
   getSelectedAssistant,
   isCliWakeableAssistant,
   isLocalAssistant,
+  isLocalGatewayAssistant,
   isPlatformAssistant,
   isRemoteGatewayMode,
   loadLockfile,
@@ -214,9 +215,10 @@ describe("assistant classification", () => {
   });
 
   test("externally-managed container runtimes are not web-client local", () => {
-    // Docker and apple-container have no `resources` in the web lockfile and are
-    // managed by the CLI / macOS app, not the web client's local flows — so
-    // restart/retire/logout routing must keep treating them as non-local.
+    // Docker and apple-container are managed by the CLI / macOS app, not the
+    // web client's lifecycle flows — so restart/retire/logout routing must keep
+    // treating them as non-local. (Docker is still gateway-reachable; see the
+    // isLocalGatewayAssistant tests.)
     const docker = { assistantId: "d", cloud: "docker" } as LockfileAssistant;
     const appleContainer = {
       assistantId: "a",
@@ -224,6 +226,16 @@ describe("assistant classification", () => {
     } as LockfileAssistant;
     expect(isLocalAssistant(docker)).toBe(false);
     expect(isLocalAssistant(appleContainer)).toBe(false);
+  });
+
+  test("local and docker assistants are local-gateway assistants; others are not", () => {
+    const docker = { assistantId: "d", cloud: "docker" } as LockfileAssistant;
+    expect(isLocalGatewayAssistant(localA)).toBe(true);
+    expect(isLocalGatewayAssistant(docker)).toBe(true);
+    for (const cloud of ["apple-container", "vellum", "paired", "gcp"]) {
+      const other = { assistantId: `o-${cloud}`, cloud } as LockfileAssistant;
+      expect(isLocalGatewayAssistant(other)).toBe(false);
+    }
   });
 
   test("a legacy entry with no cloud normalizes to local at the parse seam", () => {
@@ -269,6 +281,55 @@ describe("getLocalGatewayUrl", () => {
     enableLocalMode();
     const portless = { assistantId: "x", cloud: "local" } as LockfileAssistant;
     expect(getLocalGatewayUrl(portless)).toBeUndefined();
+  });
+
+  test("resolves a docker assistant's gateway from its loopback runtimeUrl", () => {
+    // Docker entries record the published gateway as a loopback runtimeUrl and
+    // carry no `resources` block.
+    enableLocalMode();
+    const docker = {
+      assistantId: "dk",
+      cloud: "docker",
+      runtimeUrl: "http://localhost:7930",
+    } as LockfileAssistant;
+    expect(getLocalGatewayUrl(docker)).toBe("/assistant/__gateway/7930");
+  });
+
+  test("accepts 127.0.0.1 as a loopback runtimeUrl host", () => {
+    enableLocalMode();
+    const docker = {
+      assistantId: "dk",
+      cloud: "docker",
+      runtimeUrl: "http://127.0.0.1:7931",
+    } as LockfileAssistant;
+    expect(getLocalGatewayUrl(docker)).toBe("/assistant/__gateway/7931");
+  });
+
+  test("prefers a recorded resources.gatewayPort over the runtimeUrl port", () => {
+    enableLocalMode();
+    const entry = {
+      assistantId: "x",
+      cloud: "local",
+      runtimeUrl: "http://localhost:9999",
+      resources: { gatewayPort: 7830 },
+    } as LockfileAssistant;
+    expect(getLocalGatewayUrl(entry)).toBe("/assistant/__gateway/7830");
+  });
+
+  test("never resolves a gateway from a non-loopback runtimeUrl", () => {
+    enableLocalMode();
+    const docker = {
+      assistantId: "dk",
+      cloud: "docker",
+      runtimeUrl: "http://assistant.example.com:7930",
+    } as LockfileAssistant;
+    expect(getLocalGatewayUrl(docker)).toBeUndefined();
+  });
+
+  test("is undefined for a docker assistant with no runtimeUrl or port", () => {
+    enableLocalMode();
+    const bare = { assistantId: "dk", cloud: "docker" } as LockfileAssistant;
+    expect(getLocalGatewayUrl(bare)).toBeUndefined();
   });
 
   test("is undefined for a platform assistant", () => {
@@ -335,6 +396,14 @@ describe("primeLocalGatewayConnection", () => {
       cloud: "local",
     } as LockfileAssistant;
     await expect(primeLocalGatewayConnection(portless)).rejects.toBeInstanceOf(
+      UnresolvedLocalGatewayError,
+    );
+  });
+
+  test("throws UnresolvedLocalGatewayError for a docker assistant with no resolvable gateway", async () => {
+    enableLocalMode();
+    const bare = { assistantId: "dk", cloud: "docker" } as LockfileAssistant;
+    await expect(primeLocalGatewayConnection(bare)).rejects.toBeInstanceOf(
       UnresolvedLocalGatewayError,
     );
   });

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -337,20 +337,40 @@ export function hasAssistants(): boolean {
 
 /**
  * A local-kind assistant, by origin: a plain on-machine assistant the web client
- * drives through its local flows (gateway connect, wake, local retire) — cloud
- * `"local"`. (Legacy entries that predate the `cloud` field are normalized to
- * `"local"` at the parse seam, so `cloud` is always set by the time it reaches
- * here.) Identity only — whether it currently has a reachable gateway is a
- * separate, connect-time question (see `getLocalGatewayUrl`).
+ * drives through its full set of local lifecycle flows (wake, local retire) —
+ * cloud `"local"`. (Legacy entries that predate the `cloud` field are normalized
+ * to `"local"` at the parse seam, so `cloud` is always set by the time it
+ * reaches here.) Identity only — whether it currently has a reachable gateway is
+ * a separate, connect-time question (see `getLocalGatewayUrl`).
  *
  * Deliberately excludes the externally-managed container runtimes (`docker`,
  * `apple-container`) and remote self-hosted clouds (`paired`/`gcp`/`aws`/
  * `custom`, reached at their own `runtimeUrl`), along with platform (`vellum`):
- * the web client manages none of those through its local flows. See the
- * `KNOWN_CLOUDS` taxonomy in `@vellumai/local-mode/contract`.
+ * the web client manages none of those through its lifecycle flows. Docker
+ * instances ARE still reachable over the local gateway proxy — that broader,
+ * connect-only set is {@link isLocalGatewayAssistant}. See the `KNOWN_CLOUDS`
+ * taxonomy in `@vellumai/local-mode/contract`.
  */
 export function isLocalAssistant(a: LockfileAssistant): boolean {
   return a.cloud === "local";
+}
+
+/**
+ * An assistant this runtime connects to over the local gateway proxy
+ * (`/assistant/__gateway/<port>`) with gateway auth: a plain on-machine
+ * assistant (`local`) or a local Docker instance (`docker`). Both run their
+ * gateway on a loopback port of this machine and lease guardian tokens under
+ * the CLI config dir, so the SPA can mint a gateway token for them without a
+ * platform session.
+ *
+ * Connect-only — a superset of {@link isLocalAssistant} that does NOT extend to
+ * the lifecycle flows (wake, local retire), which stay `cloud === "local"`.
+ * Excludes `apple-container` (its entries are managed by the macOS app and
+ * record no renderer-resolvable loopback gateway), the remote self-hosted
+ * clouds, and platform (`vellum`).
+ */
+export function isLocalGatewayAssistant(a: LockfileAssistant): boolean {
+  return a.cloud === "local" || a.cloud === "docker";
 }
 
 export function isPlatformAssistant(a: LockfileAssistant): boolean {
@@ -440,9 +460,9 @@ export function gatewayProxyUrl(port: number): string {
 
 /**
  * Whether this runtime should reach `assistant` over a local gateway: a
- * local-kind assistant, in local (non-remote-gateway) mode. Whether that gateway
- * is currently resolvable — a recorded port — is a separate question answered by
- * `getLocalGatewayUrl`.
+ * local-gateway assistant ({@link isLocalGatewayAssistant}), in local
+ * (non-remote-gateway) mode. Whether that gateway is currently resolvable — a
+ * recorded port — is a separate question answered by `getLocalGatewayUrl`.
  */
 function expectsLocalGateway(
   assistant: LockfileAssistant | undefined,
@@ -451,8 +471,37 @@ function expectsLocalGateway(
     !!assistant &&
     isLocalMode() &&
     !isRemoteGatewayMode() &&
-    isLocalAssistant(assistant)
+    isLocalGatewayAssistant(assistant)
   );
+}
+
+/**
+ * The loopback gateway port recorded for an assistant. Plain local entries
+ * record it as `resources.gatewayPort`; Docker entries record the published
+ * gateway address as a loopback `runtimeUrl` (`http://localhost:<port>`) with
+ * no `resources` block, so the port is recovered from that URL. A non-loopback
+ * `runtimeUrl` never yields a port — a remote address is not a local gateway.
+ */
+function getRecordedGatewayPort(
+  assistant: LockfileAssistant,
+): number | undefined {
+  const recorded = assistant.resources?.gatewayPort;
+  if (recorded != null) {
+    return recorded;
+  }
+  if (!assistant.runtimeUrl) {
+    return undefined;
+  }
+  try {
+    const url = new URL(assistant.runtimeUrl);
+    if (url.hostname !== "localhost" && url.hostname !== "127.0.0.1") {
+      return undefined;
+    }
+    const port = Number(url.port);
+    return Number.isInteger(port) && port > 0 ? port : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 /**
@@ -464,7 +513,7 @@ export function getLocalGatewayUrl(
   assistant: LockfileAssistant | undefined = getSelectedAssistant(),
 ): string | undefined {
   if (!expectsLocalGateway(assistant)) return undefined;
-  const gatewayPort = assistant.resources?.gatewayPort;
+  const gatewayPort = getRecordedGatewayPort(assistant);
   if (gatewayPort == null) return undefined;
   return gatewayProxyUrl(gatewayPort);
 }

--- a/packages/local-mode/src/__tests__/gateway-proxy.test.ts
+++ b/packages/local-mode/src/__tests__/gateway-proxy.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
-import { resolveGatewayProxyTarget } from "../gateway-proxy";
+import {
+  readAllowedGatewayPorts,
+  resolveGatewayProxyTarget,
+} from "../gateway-proxy";
 
 const allow =
   (...ports: number[]) =>
@@ -62,6 +68,41 @@ describe("resolveGatewayProxyTarget", () => {
       kind: "forbidden-port",
       port: 8080,
     });
+  });
+
+  test("allowlists ports from resources, loopback URLs, and docker runtimeUrls — never remote URLs", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gateway-proxy-test-"));
+    const lockfilePath = path.join(dir, "assistants.json");
+    try {
+      fs.writeFileSync(
+        lockfilePath,
+        JSON.stringify({
+          assistants: [
+            { assistantId: "local-a", resources: { gatewayPort: 7830 } },
+            { assistantId: "local-b", localUrl: "http://127.0.0.1:7831" },
+            // Docker entries record their published gateway only as a
+            // loopback runtimeUrl.
+            {
+              assistantId: "docker-a",
+              cloud: "docker",
+              runtimeUrl: "http://localhost:7930",
+            },
+            // Remote runtimeUrls (managed / gcp / paired) must never widen
+            // the allowlist.
+            {
+              assistantId: "remote-a",
+              cloud: "gcp",
+              runtimeUrl: "https://assistant.example.com:8443",
+            },
+          ],
+        }),
+      );
+      expect(readAllowedGatewayPorts([lockfilePath])).toEqual(
+        new Set([7830, 7831, 7930]),
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test("never reads the allowlist for non-gateway or invalid-port paths", () => {

--- a/packages/local-mode/src/gateway-proxy.ts
+++ b/packages/local-mode/src/gateway-proxy.ts
@@ -87,6 +87,7 @@ export function readAllowedGatewayPorts(lockfilePaths: string[]): Set<number> {
         assistants?: Array<{
           gatewayUrl?: unknown;
           localUrl?: unknown;
+          runtimeUrl?: unknown;
           resources?: { gatewayPort?: unknown };
         }>;
       };
@@ -95,6 +96,10 @@ export function readAllowedGatewayPorts(lockfilePaths: string[]): Set<number> {
         if (!assistant) continue;
         addPortFromUrl(assistant.gatewayUrl, ports);
         addPortFromUrl(assistant.localUrl, ports);
+        // Docker entries record their published gateway as a loopback
+        // `runtimeUrl` with no `resources` block; the loopback-hostname filter
+        // in addPortFromUrl keeps remote runtimeUrls out of the allowlist.
+        addPortFromUrl(assistant.runtimeUrl, ports);
         const gp = assistant.resources?.gatewayPort;
         if (typeof gp === "number" && Number.isInteger(gp) && gp >= 1024 && gp <= 65535) {
           ports.add(gp);


### PR DESCRIPTION
## Prompt / plan

QA feedback: a bare-metal local hatch had to be used instead of Docker because the web client's local-mode auth flow (`getLocalGatewayUrl`) only resolves gateways for `cloud === "local"` assistants — Docker instances (`cloud === "docker"`) get no local gateway URL resolution in the SPA, so the UI can't connect to them without platform auth.

Docker instances already have everything the gateway-auth flow needs: their gateway listens on a loopback port (recorded as `runtimeUrl: http://localhost:<port>` in the lockfile) and `vellum hatch --docker` leases a guardian token under the same CLI config dir the hosts read (`fetchGuardianTokenHost` / `vellum gateway token refresh` are cloud-agnostic). The only blockers were the SPA's `cloud === "local"` predicate, the port lookup (Docker entries have no `resources.gatewayPort`), and the host proxy's port allowlist.

- **`clients/web/src/lib/local-mode.ts`** — new `isLocalGatewayAssistant` (`local` + `docker`) used by the `expectsLocalGateway` connect gate; `getLocalGatewayUrl` falls back to the loopback `runtimeUrl` port when `resources.gatewayPort` is absent (non-loopback hostnames never resolve). Lifecycle affordances (wake, local retire, restart banner) keep the local-only `isLocalAssistant` set — `vellum wake` refuses containers.
- **`packages/local-mode/src/gateway-proxy.ts`** — `readAllowedGatewayPorts` also allowlists loopback `runtimeUrl` ports, so all three gateway-proxy hosts (Vite dev middleware, Electron main, `vellum client`) forward `/assistant/__gateway/<port>` to Docker gateways. The existing loopback-hostname filter keeps remote `runtimeUrl`s (`vellum`/`gcp`/`aws`/`paired`) out of the allowlist.
- Fixes a latent teleport bug as a side effect: `teleport-gateway-client.ts` already documents local **and docker** assistants as reachable over the gateway proxy, but `localGatewayBase` threw for Docker targets because `getLocalGatewayUrl` refused them.
- `apple-container` stays excluded everywhere — its entries are macOS-app-managed and record no renderer-resolvable loopback gateway.

## Test plan

- New unit tests: `isLocalGatewayAssistant` classification; Docker gateway URL resolution from loopback `runtimeUrl` (localhost + 127.0.0.1), `resources.gatewayPort` precedence, non-loopback and missing-URL refusals; `primeLocalGatewayConnection` throws `UnresolvedLocalGatewayError` for an unresolvable Docker entry; `readAllowedGatewayPorts` allowlists resources/localUrl/docker-runtimeUrl ports and never remote URLs.
- `bun test` green: `clients/web` local-mode, gateway-session, teleport, local-platform-identity, api-interceptors, lifecycle-service, auth-middleware, onboarding-lifecycle-sync; full `packages/local-mode` suite; `clients/macos` gateway-forward.
- `bunx tsc --noEmit` clean in `clients/web` and `packages/local-mode`; eslint has no errors on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaaaqC2hWjCKYHPJDyEBMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PaaaqC2hWjCKYHPJDyEBMf)_