### PR TITLE
fix(plugins): correct offline adapter-stub ref docs + guard; source-agnostic catalog wording

### DIFF
--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -548,7 +548,7 @@ Examples:
       plugins
         .command("search <query>")
         .description(
-          "Search the plugins/marketplace.json catalog for plugin names matching <query> (case-insensitive regex)",
+          "Search the installable plugin catalog for plugin names matching <query> (case-insensitive regex)",
         )
         .option("--json", "Emit machine-readable JSON instead of a table")
         .action(async (query: string, opts: { json?: boolean }) => {

--- a/assistant/src/cli/lib/__tests__/install-from-github.test.ts
+++ b/assistant/src/cli/lib/__tests__/install-from-github.test.ts
@@ -732,6 +732,68 @@ describe("installPlugin — marketplace resolution", () => {
     expect(hook).toContain("CAVEMAN MODE. Drop filler words.");
   });
 
+  test("fetches the offline adapter stub at the canonical ref, not the external content commit", async () => {
+    // GIVEN caveman's pin already resolved (offline bundled catalog) with the
+    // real curated stub. `trustedSource` names the EXTERNAL content repo, and
+    // its `ref` is caveman's content commit — which does NOT exist in this repo,
+    // where the stub lives. Model production: the canonical repo resolves the
+    // stub only at `main` (DEFAULT_PLUGIN_REF) and 404s any other ref.
+    const base = makeContentsFetch({ tree: readRealCavemanStub() });
+    const stubRefs: string[] = [];
+    const stubContentsPrefix = `https://api.github.com/repos/${CANON_REPO}/contents/plugins/caveman`;
+    const fetch: FetchLike = async (input, init) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.startsWith(stubContentsPrefix)) {
+        const ref = new URL(url).searchParams.get("ref") ?? "";
+        stubRefs.push(ref);
+        if (ref !== "main") {
+          return new Response("No commit found for the ref", { status: 404 });
+        }
+      }
+      return base(url, init);
+    };
+    const runGit = fakeGitRunner({
+      tree: {
+        "package.json": JSON.stringify({
+          name: "caveman-installer",
+          version: "0.1.0",
+        }),
+        "skills/caveman/SKILL.md":
+          "---\nname: caveman\n---\n\nCAVEMAN MODE. Drop filler words.",
+      },
+      commit: CAVEMAN_SHA,
+    });
+
+    // WHEN we install from trusted pre-resolved (external) coordinates
+    await installPlugin(
+      {
+        name: "caveman",
+        trustedSource: {
+          owner: "JuliusBrussee",
+          repo: "caveman",
+          rootPath: "",
+          ref: CAVEMAN_SHA,
+        },
+      },
+      { fetch, runGit, workspacePluginsDir: pluginsDir },
+    );
+
+    // THEN the stub was fetched from the canonical repo at `main`, never at the
+    // external content commit (they live in different repos, so the content SHA
+    // would 404 against this repo and silently skip the overlay)
+    expect(stubRefs.length).toBeGreaterThan(0);
+    expect(stubRefs).not.toContain(CAVEMAN_SHA);
+    for (const ref of stubRefs) {
+      expect(ref).toBe("main");
+    }
+    // AND because the stub resolved, the adapter overlay still ran
+    const pkg = JSON.parse(
+      readFileSync(join(pluginsDir, "caveman", "package.json"), "utf-8"),
+    );
+    expect(pkg.name).toBe("caveman");
+    expect(pkg.peerDependencies["@vellumai/plugin-api"]).toBeString();
+  });
+
   test("falls back to the stub manifest when the upstream ships no package.json", async () => {
     // GIVEN caveman is whitelisted with the real curated adapter stub
     const fetch = makeContentsFetch({

--- a/assistant/src/cli/lib/install-from-github.ts
+++ b/assistant/src/cli/lib/install-from-github.ts
@@ -138,11 +138,13 @@ export interface InstallPluginOptions {
    * analogue of a marketplace install: the pin came from the reviewed bundled
    * catalog instead of a live marketplace fetch, so — unlike
    * {@link InstallPluginOptions.directSource} — the source is trusted and the
-   * adapter stub is kept. The stub is fetched from the canonical repo at
-   * {@link InstallPluginOptions.ref} (default {@link DEFAULT_PLUGIN_REF}), the
-   * same ref the online trusted path uses. When set, marketplace resolution and
-   * {@link InstallPluginOptions.commitOverride} are skipped; `trustedSource.ref`
-   * selects the commit to clone (the reviewed pin).
+   * adapter stub is kept. `trustedSource` names the EXTERNAL plugin repo, so
+   * `trustedSource.ref` (its immutable content commit) cannot address the stub,
+   * which lives in this repo; the stub is fetched from the canonical repo at
+   * {@link InstallPluginOptions.ref} (default {@link DEFAULT_PLUGIN_REF}) — the
+   * bundled catalog records no canonical-repo pin. When set, marketplace
+   * resolution and {@link InstallPluginOptions.commitOverride} are skipped;
+   * `trustedSource.ref` selects the commit to clone (the reviewed pin).
    */
   readonly trustedSource?: PluginFetchSource;
 }
@@ -406,9 +408,12 @@ export async function installPlugin(
     effectiveSource = opts.directSource;
     stubRef = null;
   } else if (opts.trustedSource) {
-    // Trusted, pre-resolved coordinates: keep the curated adapter overlay,
-    // fetched from the canonical repo at `marketplaceRef` exactly as the online
-    // trusted path does.
+    // Offline bundled-catalog install: clone the external content verbatim but
+    // keep the curated adapter overlay (like the marketplace-git trusted path).
+    // The stub lives in this repo, not in `trustedSource` (the external plugin),
+    // so `trustedSource.ref` can't address it; with no canonical-repo pin
+    // recorded offline, the stub is fetched at `marketplaceRef` (its default,
+    // DEFAULT_PLUGIN_REF).
     effectiveSource = opts.trustedSource;
     stubRef = marketplaceRef;
   } else {

--- a/assistant/src/cli/lib/plugin-catalog-platform.ts
+++ b/assistant/src/cli/lib/plugin-catalog-platform.ts
@@ -2,9 +2,10 @@
  * Fetch the installable plugin catalog from the Vellum platform.
  *
  * The platform serves a flattened view of the curated marketplace at
- * `GET {PLATFORM}/v1/plugins/`. Each row is projected onto the shared
- * {@link PluginSearchMatch} shape via {@link marketplaceMatch}, so a catalog
- * sourced from the platform is indistinguishable from one read off GitHub.
+ * `GET {PLATFORM}/v1/plugins/`. Rows are normalized to {@link MarketplaceEntry}
+ * and projected via the shared {@link projectMarketplaceEntries} helper, so a
+ * catalog sourced from the platform is indistinguishable from one read off
+ * GitHub.
  *
  * Every failure mode (non-2xx, unreachable/aborted, malformed body) throws
  * {@link PluginCatalogUnavailableError} — the fetcher never returns a partial


### PR DESCRIPTION
## Summary
Plan re-review remediation (plugins-catalog-platform-first.md). The requested MAIN fix — deriving the offline adapter-stub ref from `trustedSource.ref` so it pins to the bundled source ref instead of `main` — turns out to be a **regression**, so it is intentionally NOT implemented. See the finding below.

### Finding: `trustedSource.ref` is the wrong repo for the stub
- The adapter stub lives in **this** repo: `applyAdapterStub` fetches `vellum-ai/vellum-assistant/plugins/<name>` at `stubRef` via the GitHub Contents API.
- `trustedSource` (offline bundled-catalog install) describes the **external plugin repo** — for `caveman`, `owner=JuliusBrussee, repo=caveman, ref=63a91ec…`. That ref is an immutable commit in the *caveman* repo, not in `vellum-assistant`.
- Setting `stubRef = trustedSource.ref` would request `vellum-ai/vellum-assistant/plugins/caveman?ref=63a91ec…` → GitHub 404 → `copyDir` returns 0 → overlay silently skipped → the adapter never runs → `caveman` (and every adapter-stub plugin) installs broken offline.
- The bundled manifest is a verbatim copy of `plugins/marketplace.json` (see `meta/feature-flags/sync-bundled-copies.ts`) and records **no** canonical-repo commit, so there is no pinned vellum-assistant ref available offline. Fixing reproducibility properly requires a new pinning mechanism — out of scope per the task's "do not invent a pinning mechanism that doesn't exist."

### What this PR does instead
- **Corrects the inaccurate comment** claiming the trusted path fetches the stub "exactly as the online trusted path does," and the `trustedSource` docstring claiming it uses "the same ref the online trusted path uses." The online path's ref is a vellum-assistant ref; the offline path has none, so the stub falls back to `DEFAULT_PLUGIN_REF` (main). Behavior unchanged.
- **Adds a regression-guard test** with a ref-aware fetch fake proving the offline stub is fetched at the canonical ref (main), **not** at the external content commit. The pre-existing trusted-source test could not catch this — its fetch mock ignored `?ref=`. Verified: flipping to `stubRef = trustedSource.ref` makes the new test fail.
- **Gap 2 (cosmetic):** `plugins search` help text is now source-agnostic.
- **Gap 3 (cosmetic):** `plugin-catalog-platform.ts` header references the shared `projectMarketplaceEntries` helper.

## Recommended follow-up
To actually pin the offline stub reproducibly, record the vellum-assistant bundle commit in `bundled-marketplace.json` at sync time and thread it through the offline branch as the stub ref.

## Validation
- offline + install-from-github tests → 40 pass
- `bun run lint` → 0 errors; `bun run lint:unused` → exit 0; `bunx tsc --noEmit` → clean (only known symlink error)