### PR TITLE
feat(voice): triage-and-escalate weak→strong routing to cut perceived latency (Phase 1)

### DIFF
--- a/assistant/src/calls/__tests__/voice-control-protocol.test.ts
+++ b/assistant/src/calls/__tests__/voice-control-protocol.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  couldBeControlMarker,
+  ESCALATE_MARKER,
+  stripInternalSpeechMarkers,
+} from "../voice-control-protocol.js";
+
+describe("[ESCALATE] control marker", () => {
+  test("marker constant is the expected token", () => {
+    expect(ESCALATE_MARKER).toBe("[ESCALATE]");
+  });
+
+  test("stripInternalSpeechMarkers removes [ESCALATE] so it is never spoken", () => {
+    expect(
+      stripInternalSpeechMarkers("Let me think about that. [ESCALATE]").trim(),
+    ).toBe("Let me think about that.");
+  });
+
+  test("stripping removes every [ESCALATE] occurrence", () => {
+    expect(
+      stripInternalSpeechMarkers("[ESCALATE] one [ESCALATE] two").replace(
+        /\s+/g,
+        " ",
+      ),
+    ).toBe(" one two");
+  });
+
+  test("couldBeControlMarker holds the complete marker (not flushed to TTS)", () => {
+    expect(couldBeControlMarker("[ESCALATE]")).toBe(true);
+  });
+
+  test("couldBeControlMarker holds a partial marker still streaming", () => {
+    // Any prefix of the marker must be held so a streamed "[ESCA" does not
+    // leak to the TTS engine before the full marker arrives.
+    for (const partial of ["[", "[ES", "[ESCAL", "[ESCALATE"]) {
+      expect(couldBeControlMarker(partial)).toBe(true);
+    }
+  });
+
+  test("ordinary text is not mistaken for the marker", () => {
+    expect(couldBeControlMarker("Sure, one moment")).toBe(false);
+    expect(stripInternalSpeechMarkers("Sure, one moment")).toBe(
+      "Sure, one moment",
+    );
+  });
+});

--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -41,6 +41,7 @@ mock.module("../../daemon/conversation-store.js", () => ({
 import { ABORT_WATCHDOG_MS } from "../../daemon/abort-watchdog.js";
 import { CALL_OPENING_MARKER } from "../voice-control-protocol.js";
 import { startVoiceTurn } from "../voice-session-bridge.js";
+import { ESCALATION_CONTINUATION_CONTENT } from "../voice-triage-escalate.js";
 
 // ---------------------------------------------------------------------------
 // Fake conversation
@@ -69,6 +70,7 @@ interface FakeConversation {
   persistUserMessage: (opts: {
     content: string;
     requestId: string;
+    metadata?: Record<string, unknown>;
   }) => Promise<{ id: string }>;
   updateClient: (cb: unknown, reset?: boolean) => void;
   runAgentLoop: (...args: unknown[]) => Promise<void>;
@@ -87,6 +89,9 @@ function makeFakeConversation(opts: {
 }) {
   const waitForIdleCalls: WaitForIdleCall[] = [];
   let persistCount = 0;
+  let lastPersistOpts:
+    | { content: string; requestId: string; metadata?: Record<string, unknown> }
+    | undefined;
   const conversation: FakeConversation = {
     conversationId: "conv-voice-bridge-test",
     callSessionId: undefined,
@@ -108,8 +113,9 @@ function makeFakeConversation(opts: {
     setTurnInterfaceContext: () => {},
     setChannelCapabilities: () => {},
     setVoiceCallControlPrompt: () => {},
-    persistUserMessage: async () => {
+    persistUserMessage: async (persistOpts) => {
       persistCount += 1;
+      lastPersistOpts = persistOpts;
       // Recorded before `onPersist` so scripted persist FAILURES also
       // appear in the event stream — ordering tests need the losing
       // attempt visible.
@@ -129,6 +135,7 @@ function makeFakeConversation(opts: {
     conversation,
     waitForIdleCalls,
     persistCount: () => persistCount,
+    lastPersistOpts: () => lastPersistOpts,
     setProcessingFlag: (value: boolean) => {
       opts.processing = value;
     },
@@ -262,6 +269,35 @@ const flushMicrotasks = async () => {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+describe("startVoiceTurn escalation-continuation persistence", () => {
+  test("persists the escalation-continuation prompt as a hidden row", async () => {
+    // The continuation is a pure internal instruction — it must be persisted
+    // `hidden` so `/messages` filters it out of the transcript after a reload,
+    // not merely echo-suppressed live.
+    const fake = makeFakeConversation({ processing: false });
+    fakeConversation = fake.conversation;
+
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      content: ESCALATION_CONTINUATION_CONTENT,
+    });
+
+    expect(fake.lastPersistOpts()?.content).toBe(
+      ESCALATION_CONTINUATION_CONTENT,
+    );
+    expect(fake.lastPersistOpts()?.metadata).toEqual({ hidden: true });
+  });
+
+  test("the opener prompt is persisted un-hidden (unchanged)", async () => {
+    const fake = makeFakeConversation({ processing: false });
+    fakeConversation = fake.conversation;
+
+    await startVoiceTurn(makeTurnOptions()); // content: CALL_OPENING_MARKER
+
+    expect(fake.lastPersistOpts()?.metadata).toBeUndefined();
+  });
+});
 
 describe("startVoiceTurn conversation-lock wait", () => {
   test("an idle conversation starts the turn without consulting waitForIdle", async () => {
@@ -553,7 +589,9 @@ describe("startVoiceTurn queued-message drain race", () => {
     };
     conv.setTrustContext = (ctx) => {
       conv.trustContext = ctx ?? undefined;
-      events.push(ctx === null || ctx === undefined ? "trust:clear" : "trust:install");
+      events.push(
+        ctx === null || ctx === undefined ? "trust:clear" : "trust:install",
+      );
     };
     fakeConversation = fake.conversation;
 

--- a/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
+++ b/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
@@ -129,6 +129,18 @@ describe("call-controller escalation orchestration (integration — TODO)", () =
     () => {},
   );
   test.todo(
+    "post-[ESCALATE] front-door text is dropped from the completion text — no spurious [END_CALL]/[ASK_GUARDIAN], no transcript pollution",
+    () => {},
+  );
+  test.todo(
+    "the front-door leg is aborted on [ESCALATE] so a model that keeps generating does not delay the escalated leg",
+    () => {},
+  );
+  test.todo(
+    "an unpunctuated bridge is force-synthesized before the escalated leg so the caller is not left in silence during the strong-model call",
+    () => {},
+  );
+  test.todo(
     "bare [ESCALATE] with no holding phrase injects the fallback bridge before the quality leg so there is no dead air",
     () => {},
   );

--- a/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
+++ b/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
@@ -11,6 +11,7 @@ import {
   FRONT_DOOR_PROFILE,
   frontDoorTriageRule,
   isVoiceTriageEscalateEnabled,
+  needsFallbackBridge,
   VOICE_TRIAGE_ESCALATE_FLAG,
 } from "../voice-triage-escalate.js";
 
@@ -72,6 +73,29 @@ describe("escalated continuation rule", () => {
   test("forbids the quality model from emitting [ESCALATE] again", () => {
     expect(rule).toContain(ESCALATE_MARKER);
     expect(rule.toLowerCase()).toContain("never emit");
+  });
+});
+
+describe("needsFallbackBridge", () => {
+  test("false when the model spoke a real holding phrase before the marker", () => {
+    expect(
+      needsFallbackBridge("Let me think about that for a second. [ESCALATE]"),
+    ).toBe(false);
+  });
+
+  test("true for a bare marker with no holding phrase", () => {
+    expect(needsFallbackBridge("[ESCALATE]")).toBe(true);
+  });
+
+  test("true when only post-marker text exists — that text was never spoken", () => {
+    // Regression: the fallback decision must measure text BEFORE the marker.
+    // Post-marker text is suppressed from TTS, so counting it would skip the
+    // fallback and leave the caller in silence during the hand-off.
+    expect(
+      needsFallbackBridge(
+        "[ESCALATE] here is my weak answer the model kept going",
+      ),
+    ).toBe(true);
   });
 });
 

--- a/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
+++ b/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helpers.js";
+import { clearFeatureFlagOverridesCache } from "../../config/assistant-feature-flags.js";
+import type { AssistantConfig } from "../../config/schema.js";
+import { ESCALATE_MARKER } from "../voice-control-protocol.js";
+import {
+  escalatedContinuationRule,
+  ESCALATION_CONTINUATION_CONTENT,
+  ESCALATION_PROFILE,
+  FRONT_DOOR_PROFILE,
+  frontDoorTriageRule,
+  isVoiceTriageEscalateEnabled,
+  VOICE_TRIAGE_ESCALATE_FLAG,
+} from "../voice-triage-escalate.js";
+
+// The gate ignores the config arg (flags resolve from the override cache +
+// bundled registry), so a bare cast is sufficient.
+const CONFIG = {} as AssistantConfig;
+
+afterEach(() => {
+  clearFeatureFlagOverridesCache();
+});
+
+describe("voice-triage-escalate profiles", () => {
+  test("front door is the fast Speed profile, escalation is the Quality profile", () => {
+    expect(FRONT_DOOR_PROFILE).toBe("cost-optimized");
+    expect(ESCALATION_PROFILE).toBe("quality-optimized");
+  });
+});
+
+describe("isVoiceTriageEscalateEnabled", () => {
+  test("is off by default (registry defaultEnabled: false)", () => {
+    clearFeatureFlagOverridesCache();
+    expect(isVoiceTriageEscalateEnabled(CONFIG)).toBe(false);
+  });
+
+  test("is on when the flag override is set", () => {
+    setOverridesForTesting({ [VOICE_TRIAGE_ESCALATE_FLAG]: true });
+    expect(isVoiceTriageEscalateEnabled(CONFIG)).toBe(true);
+  });
+
+  test("is off when the flag override is explicitly false", () => {
+    setOverridesForTesting({ [VOICE_TRIAGE_ESCALATE_FLAG]: false });
+    expect(isVoiceTriageEscalateEnabled(CONFIG)).toBe(false);
+  });
+});
+
+describe("front-door triage rule", () => {
+  const rule = frontDoorTriageRule();
+
+  test("instructs the model to triage before answering and emit [ESCALATE]", () => {
+    expect(rule).toContain("TRIAGE FIRST");
+    expect(rule).toContain(ESCALATE_MARKER);
+    // Must decide up front — never answer, then bail (spoken audio is final).
+    expect(rule.toLowerCase()).toContain("before you begin answering");
+  });
+
+  test("lists tool uncertainty as an escalate trigger (no fabrication)", () => {
+    expect(rule.toLowerCase()).toContain("tool");
+  });
+});
+
+describe("escalated continuation rule", () => {
+  const rule = escalatedContinuationRule();
+
+  test("tells the quality model to continue without re-greeting or repeating", () => {
+    expect(rule.toLowerCase()).toContain("continue");
+    expect(rule.toLowerCase()).toContain("do not greet again");
+  });
+
+  test("forbids the quality model from emitting [ESCALATE] again", () => {
+    expect(rule).toContain(ESCALATE_MARKER);
+    expect(rule.toLowerCase()).toContain("never emit");
+  });
+});
+
+describe("escalation continuation content", () => {
+  test("is an echo-suppressed synthetic prompt (parenthesized, non-user-speech)", () => {
+    expect(ESCALATION_CONTINUATION_CONTENT.startsWith("(")).toBe(true);
+    expect(ESCALATION_CONTINUATION_CONTENT.endsWith(")")).toBe(true);
+  });
+});
+
+// Controller-level orchestration in CallController.streamTtsTokens is not
+// covered by unit tests here — CallController needs a live transport,
+// conversation, and TTS provider to instantiate. These document the intended
+// integration coverage (a harnessed call-controller test or the manual
+// cli-testing flow) for the two-leg escalation path.
+describe("call-controller escalation orchestration (integration — TODO)", () => {
+  test.todo(
+    "flag OFF: a single leg runs on the call-site default profile, no [ESCALATE] rule in the prompt",
+    () => {},
+  );
+  test.todo(
+    "flag ON, simple turn: the front-door (cost-optimized) leg answers and no escalation leg runs",
+    () => {},
+  );
+  test.todo(
+    "flag ON, tricky turn: [ESCALATE] triggers a second (quality-optimized) leg that shares the TTS stream and end-of-turn signal",
+    () => {},
+  );
+  test.todo(
+    "front-door text after [ESCALATE] is suppressed and never spoken; only the bridge before the marker reaches TTS",
+    () => {},
+  );
+  test.todo(
+    "bare [ESCALATE] with no holding phrase injects the fallback bridge before the quality leg so there is no dead air",
+    () => {},
+  );
+  test.todo(
+    "barge-in during the bridge or hand-off aborts both legs via runSignal",
+    () => {},
+  );
+});

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -894,20 +894,26 @@ export class CallController {
       routingLeg: VoiceRoutingLeg | undefined,
     ): Promise<string> => {
       let legText = "";
-      // Once the front-door leg emits [ESCALATE], nothing more it says is
-      // spoken: only the holding phrase preceding the marker reaches the
-      // caller. Guards against a model that ignores "stop after [ESCALATE]"
-      // and keeps answering — that weak answer must never be heard.
+      // Once the front-door leg emits [ESCALATE], the leg is done as far as
+      // this turn is concerned: only the holding phrase preceding the marker
+      // reaches the caller, and nothing after the marker is spoken, recorded,
+      // or acted on. Guards against a model that ignores "stop after
+      // [ESCALATE]" and keeps answering.
       let legSpeechSuppressed = false;
+      let legHandle: VoiceTurnHandle | null = null;
       const turnComplete = new Promise<void>((resolve, reject) => {
         const onTextDelta = (text: string): void => {
           if (!this.isCurrentRun(runVersion)) return;
           legText += text;
-          fullResponseText += text;
+          // After the marker, drop everything: not spoken, and not appended to
+          // fullResponseText — handleTurnCompletion scans that string for
+          // [END_CALL]/[ASK_GUARDIAN] and records it as the transcript, so an
+          // ignored weak answer must not reach it.
           if (legSpeechSuppressed) return;
+          fullResponseText += text;
           ttsBuffer += text;
           if (routingLeg === "front-door") {
-            // Speak only up to the marker, then suppress the rest of this leg.
+            // Speak only up to the marker, then end this leg immediately.
             const markerIdx = ttsBuffer.indexOf(ESCALATE_MARKER);
             if (markerIdx !== -1) {
               ttsBuffer = stripInternalSpeechMarkers(
@@ -915,7 +921,16 @@ export class CallController {
               );
               flushSafeText();
               ttsBuffer = "";
+              const fullMarkerIdx = fullResponseText.indexOf(ESCALATE_MARKER);
+              if (fullMarkerIdx !== -1) {
+                fullResponseText = fullResponseText.slice(0, fullMarkerIdx);
+              }
               legSpeechSuppressed = true;
+              // Abort the front-door turn and settle the leg now so a model
+              // that keeps generating past the marker doesn't add silent
+              // latency before the escalated leg starts.
+              legHandle?.abort();
+              resolve();
               return;
             }
           }
@@ -949,10 +964,12 @@ export class CallController {
           ...(routingLeg != null ? { routingLeg } : {}),
         })
           .then((handle) => {
-            if (this.isCurrentRun(runVersion)) {
+            legHandle = handle;
+            if (this.isCurrentRun(runVersion) && !legSpeechSuppressed) {
               this.currentTurnHandle = handle;
             } else {
-              // Turn was superseded before handle arrived; abort immediately
+              // Turn was superseded, or the front-door leg already handed off
+              // before the handle arrived — abort immediately.
               handle.abort();
             }
           })
@@ -1010,15 +1027,25 @@ export class CallController {
     }
 
     // Escalation: the front-door model handed off. Its holding phrase already
-    // streamed to TTS and its onTextDelta stopped speaking at the marker, so
-    // nothing it said after [ESCALATE] was spoken. Clear any residual buffer
-    // before the quality leg as a belt-and-suspenders guard.
+    // streamed to TTS and its onTextDelta stopped speaking, dropped the marker,
+    // and aborted the leg. Clear any residual buffer before the quality leg as
+    // a belt-and-suspenders guard.
     if (escalateEnabled && frontDoorText.includes(ESCALATE_MARKER)) {
       ttsBuffer = "";
       // If the front-door model emitted no meaningful holding phrase before the
       // marker, speak a canned bridge so the hand-off has no dead air.
       if (needsFallbackBridge(frontDoorText)) {
         emitSafeChunk(`${FALLBACK_ESCALATION_BRIDGE} `);
+      }
+      // Force-synthesize the bridge now. On the synthesized-TTS path text is
+      // held in pendingSynthText until a sentence boundary, so an unpunctuated
+      // bridge ("Give me one second") would otherwise sit unspoken until the
+      // post-leg drain — leaving the caller in silence during the escalated
+      // model's call, the exact gap the bridge exists to mask.
+      if (synthProvider) {
+        const { segments } = extractSpeakableSegments(pendingSynthText, true);
+        pendingSynthText = "";
+        enqueueSynthesisSegments(synthProvider, segments);
       }
       await runVoiceLeg(
         ESCALATION_CONTINUATION_CONTENT,

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -1030,6 +1030,14 @@ export class CallController {
     // streamed to TTS and its onTextDelta stopped speaking, dropped the marker,
     // and aborted the leg. Clear any residual buffer before the quality leg as
     // a belt-and-suspenders guard.
+    //
+    // KNOWN LIMITATION (issue #37850): this suppression governs the caller's
+    // AUDIO only. The bridge still broadcasts the front-door leg's raw
+    // assistant_text_delta events (marker + any post-marker text) to the
+    // conversation hub and persists them in the assistant message — the same
+    // path [END_CALL]/[ASK_GUARDIAN] already take today, so a web/desktop
+    // observer sees the raw markers on every voice turn. Stripping markers at
+    // the broadcast/persist source is tracked separately.
     if (escalateEnabled && frontDoorText.includes(ESCALATE_MARKER)) {
       ttsBuffer = "";
       // If the front-door model emitted no meaningful holding phrase before the

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -71,6 +71,7 @@ import {
   CALL_VERIFICATION_COMPLETE_MARKER,
   couldBeControlMarker,
   END_CALL_MARKER,
+  ESCALATE_MARKER,
   extractBalancedJson,
   stripInternalSpeechMarkers,
 } from "./voice-control-protocol.js";
@@ -79,6 +80,15 @@ import {
   startVoiceTurn,
   type VoiceTurnHandle,
 } from "./voice-session-bridge.js";
+import {
+  ESCALATION_CONTINUATION_CONTENT,
+  ESCALATION_PROFILE,
+  FALLBACK_ESCALATION_BRIDGE,
+  FRONT_DOOR_PROFILE,
+  isVoiceTriageEscalateEnabled,
+  MIN_SPOKEN_BRIDGE_CHARS,
+  type VoiceRoutingLeg,
+} from "./voice-triage-escalate.js";
 
 const log = getLogger("call-controller");
 
@@ -864,88 +874,162 @@ export class CallController {
       }
     };
 
-    // Use a promise to track completion of the voice turn
-    const turnComplete = new Promise<void>((resolve, reject) => {
-      const onTextDelta = (text: string): void => {
-        if (!this.isCurrentRun(runVersion)) return;
-        fullResponseText += text;
-        ttsBuffer += text;
-        ttsBuffer = stripInternalSpeechMarkers(ttsBuffer);
-        flushSafeText();
-      };
+    // Triage-and-escalate routing (voice-triage-escalate flag). When on, a fast
+    // "front-door" model fronts the turn; if it emits [ESCALATE] we run a second
+    // "escalated" leg on the quality model. Both legs stream through the shared
+    // TTS machinery below and share this turn's single end-of-turn signal, so
+    // the caller never gets a listening window between the spoken bridge and the
+    // answer. When off, exactly one leg runs on the call-site default profile —
+    // identical to the prior behavior.
+    const escalateEnabled = isVoiceTriageEscalateEnabled();
 
-      const onComplete = (): void => {
-        resolve();
-      };
-
-      const onError = (message: string): void => {
-        reject(new Error(message));
-      };
-
-      // Start the voice turn through the session bridge
-      startVoiceTurn({
-        conversationId: this.conversationId,
-        callSessionId: this.callSessionId,
-        content,
-        assistantId: this.assistantId,
-        trustContext: this.trustContext ?? undefined,
-        isInbound: this.isInbound,
-        task: this.task,
-        skipDisclosure: this.skipDisclosure,
-        onTextDelta,
-        onComplete,
-        onError,
-        signal: runSignal,
-      })
-        .then((handle) => {
-          if (this.isCurrentRun(runVersion)) {
-            this.currentTurnHandle = handle;
-          } else {
-            // Turn was superseded before handle arrived; abort immediately
-            handle.abort();
+    // Run a single voice-turn leg through the session bridge, streaming its
+    // deltas through the shared TTS closures above. Resolves with the raw text
+    // this leg produced (used to detect the [ESCALATE] hand-off). Errors cancel
+    // and drain this turn's synthesis before propagating, mirroring the prior
+    // single-leg behavior.
+    const runVoiceLeg = async (
+      legContent: string,
+      overrideProfile: string | undefined,
+      routingLeg: VoiceRoutingLeg | undefined,
+    ): Promise<string> => {
+      let legText = "";
+      // Once the front-door leg emits [ESCALATE], nothing more it says is
+      // spoken: only the holding phrase preceding the marker reaches the
+      // caller. Guards against a model that ignores "stop after [ESCALATE]"
+      // and keeps answering — that weak answer must never be heard.
+      let legSpeechSuppressed = false;
+      const turnComplete = new Promise<void>((resolve, reject) => {
+        const onTextDelta = (text: string): void => {
+          if (!this.isCurrentRun(runVersion)) return;
+          legText += text;
+          fullResponseText += text;
+          if (legSpeechSuppressed) return;
+          ttsBuffer += text;
+          if (routingLeg === "front-door") {
+            // Speak only up to the marker, then suppress the rest of this leg.
+            const markerIdx = ttsBuffer.indexOf(ESCALATE_MARKER);
+            if (markerIdx !== -1) {
+              ttsBuffer = stripInternalSpeechMarkers(
+                ttsBuffer.slice(0, markerIdx),
+              );
+              flushSafeText();
+              ttsBuffer = "";
+              legSpeechSuppressed = true;
+              return;
+            }
           }
-        })
-        .catch((err) => {
-          reject(err);
-        });
+          ttsBuffer = stripInternalSpeechMarkers(ttsBuffer);
+          flushSafeText();
+        };
 
-      // Defensive: if the turn is aborted (e.g. barge-in) and the event
-      // sink callbacks are never invoked, resolve the promise so it
-      // doesn't hang forever.
-      runSignal.addEventListener(
-        "abort",
-        () => {
+        const onComplete = (): void => {
           resolve();
-        },
-        { once: true },
-      );
-    });
+        };
 
-    // Eagerly mark the rejection as handled so runtimes (e.g. bun) don't
-    // flag it as an unhandled rejection when onError fires synchronously
-    // inside the Promise constructor before this await adds its handler.
-    // The await below still re-throws, caught by the outer try-catch.
-    turnComplete.catch(() => {});
-    try {
-      await turnComplete;
-    } catch (err) {
-      // Cancel and settle this turn's synthesis before the error reaches
-      // the outer handler, so no straggling segment plays the partial
-      // answer over the recovery prompt. While this run is current no
-      // newer run's synthesis can be in flight, so the abort is safe.
-      if (this.isCurrentRun(runVersion)) {
-        synthesisCancelled = true;
-        this.abortActiveSynthesis();
+        const onError = (message: string): void => {
+          reject(new Error(message));
+        };
+
+        // Start the voice turn through the session bridge
+        startVoiceTurn({
+          conversationId: this.conversationId,
+          callSessionId: this.callSessionId,
+          content: legContent,
+          assistantId: this.assistantId,
+          trustContext: this.trustContext ?? undefined,
+          isInbound: this.isInbound,
+          task: this.task,
+          skipDisclosure: this.skipDisclosure,
+          onTextDelta,
+          onComplete,
+          onError,
+          signal: runSignal,
+          ...(overrideProfile != null ? { overrideProfile } : {}),
+          ...(routingLeg != null ? { routingLeg } : {}),
+        })
+          .then((handle) => {
+            if (this.isCurrentRun(runVersion)) {
+              this.currentTurnHandle = handle;
+            } else {
+              // Turn was superseded before handle arrived; abort immediately
+              handle.abort();
+            }
+          })
+          .catch((err) => {
+            reject(err);
+          });
+
+        // Defensive: if the turn is aborted (e.g. barge-in) and the event
+        // sink callbacks are never invoked, resolve the promise so it
+        // doesn't hang forever.
+        runSignal.addEventListener(
+          "abort",
+          () => {
+            resolve();
+          },
+          { once: true },
+        );
+      });
+
+      // Eagerly mark the rejection as handled so runtimes (e.g. bun) don't
+      // flag it as an unhandled rejection when onError fires synchronously
+      // inside the Promise constructor before this await adds its handler.
+      // The await below still re-throws, caught by the outer try-catch.
+      turnComplete.catch(() => {});
+      try {
+        await turnComplete;
+      } catch (err) {
+        // Cancel and settle this turn's synthesis before the error reaches
+        // the outer handler, so no straggling segment plays the partial
+        // answer over the recovery prompt. While this run is current no
+        // newer run's synthesis can be in flight, so the abort is safe.
+        if (this.isCurrentRun(runVersion)) {
+          synthesisCancelled = true;
+          this.abortActiveSynthesis();
+        }
+        await synthesisChain.catch(() => {});
+        throw err;
       }
-      await synthesisChain.catch(() => {});
-      throw err;
-    }
+      return legText;
+    };
+
+    // Front-door leg: fast profile + triage rule when routing is on; otherwise
+    // the caller utterance on the call-site default profile (today's behavior).
+    const frontDoorText = await runVoiceLeg(
+      content,
+      escalateEnabled ? FRONT_DOOR_PROFILE : undefined,
+      escalateEnabled ? "front-door" : undefined,
+    );
     if (!this.isCurrentRun(runVersion)) {
       // Superseded mid-stream (barge-in): drain the segment chain — queued
       // links short-circuit on staleness — so this turn's synthesis fully
       // settles instead of racing the next turn.
       await synthesisChain.catch(() => {});
       return fullResponseText;
+    }
+
+    // Escalation: the front-door model handed off. Its holding phrase already
+    // streamed to TTS and its onTextDelta stopped speaking at the marker, so
+    // nothing it said after [ESCALATE] was spoken. Clear any residual buffer
+    // before the quality leg as a belt-and-suspenders guard.
+    if (escalateEnabled && frontDoorText.includes(ESCALATE_MARKER)) {
+      ttsBuffer = "";
+      // If the front-door model emitted no meaningful holding phrase, speak a
+      // canned bridge so the hand-off has no dead air.
+      const spokenBridge = stripInternalSpeechMarkers(frontDoorText).trim();
+      if (spokenBridge.length < MIN_SPOKEN_BRIDGE_CHARS) {
+        emitSafeChunk(`${FALLBACK_ESCALATION_BRIDGE} `);
+      }
+      await runVoiceLeg(
+        ESCALATION_CONTINUATION_CONTENT,
+        ESCALATION_PROFILE,
+        "escalated",
+      );
+      if (!this.isCurrentRun(runVersion)) {
+        await synthesisChain.catch(() => {});
+        return fullResponseText;
+      }
     }
 
     // Final sweep: strip any remaining control markers from the buffer

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -86,7 +86,7 @@ import {
   FALLBACK_ESCALATION_BRIDGE,
   FRONT_DOOR_PROFILE,
   isVoiceTriageEscalateEnabled,
-  MIN_SPOKEN_BRIDGE_CHARS,
+  needsFallbackBridge,
   type VoiceRoutingLeg,
 } from "./voice-triage-escalate.js";
 
@@ -1015,10 +1015,9 @@ export class CallController {
     // before the quality leg as a belt-and-suspenders guard.
     if (escalateEnabled && frontDoorText.includes(ESCALATE_MARKER)) {
       ttsBuffer = "";
-      // If the front-door model emitted no meaningful holding phrase, speak a
-      // canned bridge so the hand-off has no dead air.
-      const spokenBridge = stripInternalSpeechMarkers(frontDoorText).trim();
-      if (spokenBridge.length < MIN_SPOKEN_BRIDGE_CHARS) {
+      // If the front-door model emitted no meaningful holding phrase before the
+      // marker, speak a canned bridge so the hand-off has no dead air.
+      if (needsFallbackBridge(frontDoorText)) {
         emitSafeChunk(`${FALLBACK_ESCALATION_BRIDGE} `);
       }
       await runVoiceLeg(

--- a/assistant/src/calls/voice-control-protocol.ts
+++ b/assistant/src/calls/voice-control-protocol.ts
@@ -14,6 +14,15 @@ export const CALL_OPENING_ACK_MARKER = "[CALL_OPENING_ACK]";
 export const CALL_VERIFICATION_COMPLETE_MARKER = "[CALL_VERIFICATION_COMPLETE]";
 export const END_CALL_MARKER = "[END_CALL]";
 
+/**
+ * Emitted by the fast "front-door" model (triage-and-escalate voice routing)
+ * when a turn is too tricky for it to answer well. The front-door model speaks
+ * a brief holding phrase, appends this marker, and stops; the call controller
+ * then re-runs the turn on the stronger "quality" profile. Like the other
+ * markers, it is swallowed before reaching TTS — never spoken aloud.
+ */
+export const ESCALATE_MARKER = "[ESCALATE]";
+
 // ---------------------------------------------------------------------------
 // Regexes
 // ---------------------------------------------------------------------------
@@ -31,6 +40,7 @@ const USER_INSTRUCTION_MARKER_REGEX = /\[USER_INSTRUCTION:\s*.+?\]/g;
 const CALL_OPENING_MARKER_REGEX = /\[CALL_OPENING\]/g;
 const CALL_OPENING_ACK_MARKER_REGEX = /\[CALL_OPENING_ACK\]/g;
 const END_CALL_MARKER_REGEX = /\[END_CALL\]/g;
+const ESCALATE_MARKER_REGEX = /\[ESCALATE\]/g;
 const GUARDIAN_TIMEOUT_MARKER_REGEX = /\[GUARDIAN_TIMEOUT\]/g;
 const GUARDIAN_UNAVAILABLE_MARKER_REGEX = /\[GUARDIAN_UNAVAILABLE\]/g;
 
@@ -145,6 +155,7 @@ export function stripInternalSpeechMarkers(text: string): string {
     .replace(CALL_OPENING_MARKER_REGEX, "")
     .replace(CALL_OPENING_ACK_MARKER_REGEX, "")
     .replace(END_CALL_MARKER_REGEX, "")
+    .replace(ESCALATE_MARKER_REGEX, "")
     .replace(GUARDIAN_TIMEOUT_MARKER_REGEX, "")
     .replace(GUARDIAN_UNAVAILABLE_MARKER_REGEX, "");
   return result;
@@ -167,6 +178,7 @@ const CONTROL_MARKER_STRINGS = [
   "[CALL_OPENING]",
   "[CALL_OPENING_ACK]",
   "[END_CALL]",
+  "[ESCALATE]",
   "[GUARDIAN_TIMEOUT]",
   "[GUARDIAN_UNAVAILABLE]",
 ];

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -438,6 +438,17 @@ export async function startVoiceTurn(
     opts.content === CALL_VERIFICATION_COMPLETE_MARKER ||
     opts.content === ESCALATION_CONTINUATION_CONTENT;
 
+  // The escalation-continuation prompt is a pure internal instruction ("give
+  // the full answer now"), not a real utterance and not the sort of scaffolding
+  // an opener is — it must never surface as a user message. Unlike the
+  // opener/verification rows (persisted un-hidden), persist it `hidden` so
+  // `/messages` filters it out after a refetch/reload, and flag the turn as a
+  // hidden prompt so prompt-as-user-speech consumers (e.g. title generation)
+  // skip it. The escalated model still sees the row in context — `hidden` only
+  // affects client display.
+  const isHiddenSyntheticPrompt =
+    opts.content === ESCALATION_CONTINUATION_CONTENT;
+
   // Build the call-control protocol prompt so the model knows how to emit
   // control markers (ASK_GUARDIAN, END_CALL, etc.) and recognize opener turns.
   const isCallerGuardian = opts.trustContext?.trustClass === "guardian";
@@ -575,6 +586,7 @@ export async function startVoiceTurn(
     const persistResult = await conversation.persistUserMessage({
       content: persistedContent,
       requestId,
+      ...(isHiddenSyntheticPrompt ? { metadata: { hidden: true } } : {}),
     });
     return persistResult.id;
   };
@@ -965,6 +977,11 @@ export async function startVoiceTurn(
           // Voice only reacts to the definitive tool_use_start event.
         },
         callSite: "callAgent",
+        // The escalation-continuation prompt is a transcript-suppressed machine
+        // signal (persisted `hidden`), so flag the turn to match — keeps
+        // prompt-as-user-speech consumers (e.g. title generation) from treating
+        // it as user speech.
+        ...(isHiddenSyntheticPrompt ? { isHiddenPrompt: true } : {}),
         // Triage-and-escalate routing pins this turn to the fast front-door or
         // strong escalation profile. `forceOverrideProfile` floats it above the
         // callAgent call-site layers (callAgent is not `mainAgent`, so the

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -35,6 +35,12 @@ import {
   CALL_OPENING_MARKER,
   CALL_VERIFICATION_COMPLETE_MARKER,
 } from "./voice-control-protocol.js";
+import {
+  escalatedContinuationRule,
+  ESCALATION_CONTINUATION_CONTENT,
+  frontDoorTriageRule,
+  type VoiceRoutingLeg,
+} from "./voice-triage-escalate.js";
 
 const log = getLogger("voice-session-bridge");
 
@@ -200,6 +206,21 @@ export interface VoiceTurnOptions {
   callbacks?: VoiceTurnCallbacks;
   /** Optional AbortSignal for external cancellation (e.g. barge-in). */
   signal?: AbortSignal;
+  /**
+   * Ad-hoc inference-profile override applied to every LLM call this turn
+   * issues (forwarded to `runAgentLoop` with `forceOverrideProfile`). Used by
+   * triage-and-escalate voice routing to run the front-door leg on the fast
+   * profile and the escalated leg on the quality profile. Undefined = the
+   * call-site default (today's behavior).
+   */
+  overrideProfile?: string;
+  /**
+   * Which leg of a triaged turn this is, so the auto-built phone control prompt
+   * can add the front-door triage rule or the escalated continuation rule.
+   * Undefined = routing off; no routing rules are added. Ignored when a caller
+   * supplies its own `voiceControlPrompt`.
+   */
+  routingLeg?: VoiceRoutingLeg;
 }
 
 export interface VoiceTurnHandle {
@@ -226,6 +247,7 @@ function buildVoiceCallControlPrompt(opts: {
   task?: string | null;
   isCallerGuardian?: boolean;
   skipDisclosure?: boolean;
+  routingLeg?: VoiceRoutingLeg;
 }): string {
   const config = getConfig();
   const disclosureEnabled =
@@ -310,8 +332,18 @@ function buildVoiceCallControlPrompt(opts: {
     "9. After the opening greeting turn, treat the Task field as background context only — do not re-execute its instructions on subsequent turns.",
     '10. Do not make up information. If you are unsure, use [ASK_GUARDIAN: your question] to consult your guardian. For tool permission requests, use [ASK_GUARDIAN_APPROVAL: {"question":"...","toolName":"...","input":{...}}].',
     `11. Your text is sent directly to a text-to-speech engine. Never use markdown formatting (asterisks, headers, backticks, links) or emojis in your spoken responses. Write plain conversational text only. Protocol markers like ${opts.isCallerGuardian ? "[END_CALL]" : "[ASK_GUARDIAN: ...] and [END_CALL]"} are not spoken text and should still be used normally.`,
-    "</voice_call_control>",
   );
+
+  // Triage-and-escalate routing rules (voice-triage-escalate flag). The
+  // front-door leg triages and may hand off; the escalated leg continues the
+  // answer after a holding phrase was already spoken.
+  if (opts.routingLeg === "front-door") {
+    lines.push(`12. ${frontDoorTriageRule()}`);
+  } else if (opts.routingLeg === "escalated") {
+    lines.push(`12. ${escalatedContinuationRule()}`);
+  }
+
+  lines.push("</voice_call_control>");
 
   return lines.join("\n");
 }
@@ -397,13 +429,14 @@ export async function startVoiceTurn(
         ? "(verification completed — transitioning into conversation)"
         : opts.content;
 
-  // Opener / verification prompts are internal scaffolding: they persist a row
-  // so the model wakes, but they are not user speech and must not render as a
-  // live user bubble. Their echo is suppressed below (parity with
-  // `isEchoSuppressedUserMessage` on the text path).
+  // Opener / verification / escalation-continuation prompts are internal
+  // scaffolding: they persist a row so the model wakes, but they are not user
+  // speech and must not render as a live user bubble. Their echo is suppressed
+  // below (parity with `isEchoSuppressedUserMessage` on the text path).
   const isSyntheticVoicePrompt =
     opts.content === CALL_OPENING_MARKER ||
-    opts.content === CALL_VERIFICATION_COMPLETE_MARKER;
+    opts.content === CALL_VERIFICATION_COMPLETE_MARKER ||
+    opts.content === ESCALATION_CONTINUATION_CONTENT;
 
   // Build the call-control protocol prompt so the model knows how to emit
   // control markers (ASK_GUARDIAN, END_CALL, etc.) and recognize opener turns.
@@ -416,6 +449,7 @@ export async function startVoiceTurn(
           task: opts.task,
           isCallerGuardian,
           skipDisclosure: opts.skipDisclosure,
+          routingLeg: opts.routingLeg,
         })
       : opts.voiceControlPrompt;
 
@@ -931,6 +965,16 @@ export async function startVoiceTurn(
           // Voice only reacts to the definitive tool_use_start event.
         },
         callSite: "callAgent",
+        // Triage-and-escalate routing pins this turn to the fast front-door or
+        // strong escalation profile. `forceOverrideProfile` floats it above the
+        // callAgent call-site layers (callAgent is not `mainAgent`, so the
+        // override would otherwise sit below the call-site profile).
+        ...(opts.overrideProfile != null
+          ? {
+              overrideProfile: opts.overrideProfile,
+              forceOverrideProfile: true,
+            }
+          : {}),
       });
       if (lastError) {
         log.error(

--- a/assistant/src/calls/voice-triage-escalate.ts
+++ b/assistant/src/calls/voice-triage-escalate.ts
@@ -23,7 +23,10 @@ import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags
 import type { DefaultProfileKey } from "../config/default-profile-names.js";
 import { getConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/schema.js";
-import { ESCALATE_MARKER } from "./voice-control-protocol.js";
+import {
+  ESCALATE_MARKER,
+  stripInternalSpeechMarkers,
+} from "./voice-control-protocol.js";
 
 /** Feature-flag key gating the whole behavior. Off by default. */
 export const VOICE_TRIAGE_ESCALATE_FLAG = "voice-triage-escalate";
@@ -55,6 +58,25 @@ export const FALLBACK_ESCALATION_BRIDGE =
  * bridge is injected before the quality leg runs.
  */
 export const MIN_SPOKEN_BRIDGE_CHARS = 3;
+
+/**
+ * Whether a canned fallback bridge must be spoken before the escalated leg,
+ * given the front-door leg's full response text.
+ *
+ * Only the text BEFORE `[ESCALATE]` was actually spoken — the controller
+ * suppresses everything after the marker from TTS — so the decision is based on
+ * that slice, not the full response (which may carry ignored post-marker text
+ * the model emitted despite being told to stop). Without this, a bare
+ * `[ESCALATE]` followed by ignored weak text would skip the fallback and leave
+ * the caller in silence while the quality leg spins up.
+ */
+export function needsFallbackBridge(frontDoorText: string): boolean {
+  const markerIdx = frontDoorText.indexOf(ESCALATE_MARKER);
+  const spokenBridge = stripInternalSpeechMarkers(
+    markerIdx === -1 ? frontDoorText : frontDoorText.slice(0, markerIdx),
+  ).trim();
+  return spokenBridge.length < MIN_SPOKEN_BRIDGE_CHARS;
+}
 
 /**
  * The escalated leg runs as its own voice turn. Rather than re-persist the

--- a/assistant/src/calls/voice-triage-escalate.ts
+++ b/assistant/src/calls/voice-triage-escalate.ts
@@ -1,0 +1,114 @@
+/**
+ * Triage-and-escalate voice routing (weak -> strong model) — Phase 1.
+ *
+ * A fast "front-door" model fronts every phone-call turn. It answers simple
+ * turns outright (low first-token latency -> the caller hears audio fast).
+ * When a turn is too tricky, the front-door model speaks a brief natural
+ * holding phrase, appends the `[ESCALATE]` marker, and stops. The call
+ * controller then re-runs the same turn on the stronger "quality" model, whose
+ * answer streams into the same TTS pipe. Because the holding phrase is spoken,
+ * the caller never hears the quality model's think-time as silence.
+ *
+ * This module owns the routing policy in one place: the feature gate, the two
+ * profile keys, the leg-specific prompt fragments, and the fallback bridge.
+ *
+ * Phase 2/3 (not implemented here): fire the quality model the instant the
+ * marker is detected so its prefill overlaps the spoken bridge; model-generated
+ * (rather than canned) fallback bridges; a triage-threshold eval harness; and
+ * extending the orchestration to in-app live voice (`live-voice/`), which drives
+ * `startVoiceTurn` through its own session rather than the call controller.
+ */
+
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import type { DefaultProfileKey } from "../config/default-profile-names.js";
+import { getConfig } from "../config/loader.js";
+import type { AssistantConfig } from "../config/schema.js";
+import { ESCALATE_MARKER } from "./voice-control-protocol.js";
+
+/** Feature-flag key gating the whole behavior. Off by default. */
+export const VOICE_TRIAGE_ESCALATE_FLAG = "voice-triage-escalate";
+
+/** Fast/weak profile that fronts every turn when the flag is on. */
+export const FRONT_DOOR_PROFILE: DefaultProfileKey = "cost-optimized";
+
+/** Strong/quality profile a tricky turn escalates to. */
+export const ESCALATION_PROFILE: DefaultProfileKey = "quality-optimized";
+
+/**
+ * Which leg of a triaged turn a `startVoiceTurn` call represents. Undefined
+ * means routing is off and the turn runs exactly as it does today.
+ */
+export type VoiceRoutingLeg = "front-door" | "escalated";
+
+/**
+ * Spoken when the front-door model emits `[ESCALATE]` without a meaningful
+ * holding phrase of its own — guarantees the caller never hears dead air
+ * across the hand-off. When the model does speak its own bridge, that natural
+ * text is used instead and this is not injected.
+ */
+export const FALLBACK_ESCALATION_BRIDGE =
+  "Let me think about that for a second.";
+
+/**
+ * Minimum length (after marker stripping, trimmed) of the front-door leg's
+ * spoken text for it to count as a real bridge. Below this, the fallback
+ * bridge is injected before the quality leg runs.
+ */
+export const MIN_SPOKEN_BRIDGE_CHARS = 3;
+
+/**
+ * The escalated leg runs as its own voice turn. Rather than re-persist the
+ * caller's utterance (it is already in history from the front-door leg), the
+ * escalated leg is driven by this synthetic, echo-suppressed continuation
+ * prompt — the same pattern the opener/verification synthetic prompts use. The
+ * quality model answers the caller's previous question, which sits in history
+ * just above it.
+ *
+ * Phase 2 could collapse the two legs into a single persisted turn; Phase 1
+ * keeps each leg a normal, independently-understood `startVoiceTurn`.
+ */
+export const ESCALATION_CONTINUATION_CONTENT =
+  "(You just told the caller you needed a moment to think. Now give them your full, careful answer to their previous question — do not repeat the holding phrase.)";
+
+/**
+ * Whether triage-and-escalate routing is active for this workspace.
+ * When false, every voice turn behaves exactly as before.
+ */
+export function isVoiceTriageEscalateEnabled(
+  config: AssistantConfig = getConfig(),
+): boolean {
+  return isAssistantFeatureFlagEnabled(VOICE_TRIAGE_ESCALATE_FLAG, config);
+}
+
+/**
+ * Extra CALL PROTOCOL RULE injected into the front-door leg's control prompt.
+ * The decision must happen up front: the model triages BEFORE it starts
+ * answering so it never speaks half an answer and then bails — spoken audio
+ * cannot be un-said. Escalation triggers include anything needing careful
+ * reasoning, research, or a tool it is unsure of, so the weak model never
+ * fabricates an answer that actually required a tool.
+ */
+export function frontDoorTriageRule(): string {
+  return [
+    "TRIAGE FIRST: Before you begin answering, judge whether this turn is within your reach.",
+    "If it is simple, conversational, or clearly factual, just answer it normally.",
+    "If it needs careful reasoning, research, multi-step work, or a tool you are unsure how to use,",
+    `do NOT attempt the answer. Instead say one short, natural holding phrase out loud (for example "${FALLBACK_ESCALATION_BRIDGE}" or "Give me one second to look into that"), then append ${ESCALATE_MARKER} and stop.`,
+    `Make this decision in your first words. Never start answering and then emit ${ESCALATE_MARKER}. Everything you say before ${ESCALATE_MARKER} is spoken to the caller; everything after it is discarded.`,
+  ].join(" ");
+}
+
+/**
+ * Extra CALL PROTOCOL RULE injected into the escalated (quality) leg's control
+ * prompt. The holding phrase has already been spoken, so the model must
+ * continue straight into the substantive answer.
+ */
+export function escalatedContinuationRule(): string {
+  return [
+    "You have already spoken a brief holding phrase to the caller (something like",
+    `"${FALLBACK_ESCALATION_BRIDGE}").`,
+    "Continue directly into your actual answer now.",
+    'Do NOT greet again, do NOT repeat the holding phrase, and do NOT say things like "as I was saying".',
+    `Never emit ${ESCALATE_MARKER} — you are the model that finishes the answer.`,
+  ].join(" ");
+}

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -123,6 +123,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "voice-triage-escalate",
+      "scope": "assistant",
+      "key": "voice-triage-escalate",
+      "label": "Voice Triage & Escalate",
+      "description": "Front phone-call turns with a fast model that answers simple turns and escalates tricky ones to the quality model, cutting perceived latency",
+      "defaultEnabled": false
+    },
+    {
       "id": "fast-mode",
       "scope": "assistant",
       "key": "fast-mode",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -123,6 +123,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "voice-triage-escalate",
+      "scope": "assistant",
+      "key": "voice-triage-escalate",
+      "label": "Voice Triage & Escalate",
+      "description": "Front phone-call turns with a fast model that answers simple turns and escalates tricky ones to the quality model, cutting perceived latency",
+      "defaultEnabled": false
+    },
+    {
       "id": "fast-mode",
       "scope": "assistant",
       "key": "fast-mode",


### PR DESCRIPTION
## Summary
- Adds an opt-in **triage-and-escalate** voice routing behind a new `voice-triage-escalate` flag (off by default): a fast **front-door** model (`cost-optimized` / Speed) fronts every phone-call turn and answers simple turns outright. When a turn is too tricky, the front-door model speaks a short holding phrase ("Let me think about that for a second"), emits a new `[ESCALATE]` control marker, and stops; the controller then re-runs the turn on the strong `quality-optimized` model, whose answer streams into the same TTS pipe. The spoken bridge masks the strong model's think-time so the caller hears no dead air — cutting **perceived** latency.
- **Reuses existing infra:** `[ESCALATE]` rides the same control-marker rail as `[END_CALL]`/`[ASK_GUARDIAN]` (registered in `voice-control-protocol.ts`, stripped before TTS); the model swap uses `runAgentLoop`'s existing `overrideProfile` + `forceOverrideProfile`. The two legs share one TTS stream and a single end-of-turn signal (no listening window between bridge and answer), and both honor the existing barge-in `runSignal`. The front-door leg hard-stops speaking at the marker, so a weak post-marker answer is never heard.
- **Scope / correctness:** front-door prompt triages *before* answering (never answer-then-bail); tool-uncertainty is an explicit escalate trigger (no fabrication); the escalated leg runs on an echo-suppressed synthetic continuation prompt so the caller's utterance isn't persisted twice; a fallback bridge is spoken if the model emits a bare `[ESCALATE]`. When the flag is **off**, behavior is byte-for-byte today's.
- **Deferred (Phase 2/3, noted in code):** in-app live voice orchestration (this PR is telephony-path only), parallel strong-model warm-up to overlap the bridge, model-generated bridges, and a triage-threshold eval harness.

## Original prompt
Explore, then implement, a weak→strong model-routing strategy to reduce perceived latency in voice mode. The user specified the exact system: a weaker/faster model starts each turn and, if the message is too tricky, acknowledges ("give me a second to think about this") and routes to a stronger model to finish the answer. This PR implements Phase 1 of that design behind a feature flag, on the phone-call path.

## Test plan
- New unit tests: `[ESCALATE]` marker stripping + `couldBeControlMarker` holding (`voice-control-protocol.test.ts`); flag gating on/off/default, prompt-fragment content, and profile keys (`voice-triage-escalate.test.ts`). `test.todo` documents the controller-level integration scenarios.
- `bunx tsc --noEmit` clean; existing `voice-session-bridge` and feature-flag registry tests pass.
- Not yet exercised end-to-end on a live call — see the review-focus comment.