### PR TITLE
feat(flags): GA skill-creation-card (default on)

### DIFF
--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -407,8 +407,8 @@
       "scope": "both",
       "key": "skill-creation-card",
       "label": "Skill creation card",
-      "description": "Insert an in-chat card into the source conversation when the memory retrospective authors a new skill, and render it in the web client.",
-      "defaultEnabled": false
+      "description": "Insert an in-chat card into the source conversation when the memory retrospective authors a new skill, and render it in the web client. GA (default on); the flag remains only as an emergency kill-switch.",
+      "defaultEnabled": true
     },
     {
       "id": "override-or-default-resolution",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -407,8 +407,8 @@
       "scope": "both",
       "key": "skill-creation-card",
       "label": "Skill creation card",
-      "description": "Insert an in-chat card into the source conversation when the memory retrospective authors a new skill, and render it in the web client.",
-      "defaultEnabled": false
+      "description": "Insert an in-chat card into the source conversation when the memory retrospective authors a new skill, and render it in the web client. GA (default on); the flag remains only as an emergency kill-switch.",
+      "defaultEnabled": true
     },
     {
       "id": "override-or-default-resolution",


### PR DESCRIPTION
## Summary
- Flips `skill-creation-card` to `defaultEnabled: true` in the canonical and web registries (hand-edited both per the sync-script drift gotcha)
- The gate code stays as an emergency kill-switch, but no environment needs a toggle for cards to work: with the flag absent from remote (LD archived in the companion platform PR) every deployment resolves to the registry default — on
- Context: three environments' worth of flag-delivery friction (LD env targeting, flags-panel persisted override not sticking, no LD locally) blocked field testing of an already-GA-quality feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)