### PR TITLE
refactor: finish ContentBlock typing — drop unknown[]/casts, redundant helpers, local block type

### DIFF
--- a/assistant/src/conversations/message-consolidation.ts
+++ b/assistant/src/conversations/message-consolidation.ts
@@ -43,13 +43,11 @@ function isToolResultType(type: string): boolean {
   return type === "tool_result" || type === "web_search_tool_result";
 }
 
-function isSystemNoticeText(block: Record<string, unknown>): boolean {
-  if (block.type !== "text") {
-    return false;
-  }
-  const text = typeof block.text === "string" ? block.text : "";
+function isSystemNoticeText(block: ContentBlock): boolean {
   return (
-    text.startsWith("<system_notice>") && text.endsWith("</system_notice>")
+    block.type === "text" &&
+    block.text.startsWith("<system_notice>") &&
+    block.text.endsWith("</system_notice>")
   );
 }
 
@@ -65,23 +63,13 @@ export function isToolResultOnlyUserMessage(msg: MessageRow): boolean {
   if (msg.role !== "user") {
     return false;
   }
-  const blocks: unknown[] = msg.content;
-
   let sawToolResult = false;
-  for (const block of blocks) {
-    if (
-      typeof block !== "object" ||
-      block === null ||
-      typeof (block as Record<string, unknown>).type !== "string"
-    ) {
-      return false;
-    }
-    const rec = block as Record<string, unknown>;
-    if (isToolResultType(rec.type as string)) {
+  for (const block of msg.content) {
+    if (isToolResultType(block.type)) {
       sawToolResult = true;
       continue;
     }
-    if (isSystemNoticeText(rec)) {
+    if (isSystemNoticeText(block)) {
       continue;
     }
     return false;
@@ -175,27 +163,12 @@ export function mergeToolResultsIntoAssistantMessages(
       continue;
     }
 
-    const blocks: unknown[] = msg.content;
-
     // Separate tool-result blocks from real user content.
-    const toolResultBlocks: unknown[] = [];
-    const otherBlocks: unknown[] = [];
-    for (const block of blocks) {
-      if (
-        typeof block === "object" &&
-        block !== null &&
-        typeof (block as Record<string, unknown>).type === "string"
-      ) {
-        const rec = block as Record<string, unknown>;
-        if (isToolResultType(rec.type as string)) {
-          toolResultBlocks.push(block);
-        } else if (isSystemNoticeText(rec)) {
-          // System notices don't count as user content — drop them when
-          // the message is otherwise tool-result-only.
-          otherBlocks.push(block);
-        } else {
-          otherBlocks.push(block);
-        }
+    const toolResultBlocks: ContentBlock[] = [];
+    const otherBlocks: ContentBlock[] = [];
+    for (const block of msg.content) {
+      if (isToolResultType(block.type)) {
+        toolResultBlocks.push(block);
       } else {
         otherBlocks.push(block);
       }
@@ -220,21 +193,16 @@ export function mergeToolResultsIntoAssistantMessages(
         assistantContent = [...assistant.content];
         parsedAssistantContent.set(lastAssistantIdx, assistantContent);
       }
-      assistantContent.push(...(toolResultBlocks as ContentBlock[]));
+      assistantContent.push(...toolResultBlocks);
     }
 
     // If the user message had only tool_result (+ system_notice) blocks,
     // suppress it entirely. Otherwise keep the non-tool-result content.
-    const realUserContent = otherBlocks.filter(
-      (b) =>
-        !(
-          typeof b === "object" &&
-          b !== null &&
-          isSystemNoticeText(b as Record<string, unknown>)
-        ),
-    );
+    // System notices don't count as real user content — they are only
+    // injected alongside tool results in the agent loop.
+    const realUserContent = otherBlocks.filter((b) => !isSystemNoticeText(b));
     if (realUserContent.length > 0) {
-      result.push({ ...msg, content: otherBlocks as ContentBlock[] });
+      result.push({ ...msg, content: otherBlocks });
     }
     // else: tool-result-only → suppressed
   }
@@ -248,22 +216,6 @@ export function mergeToolResultsIntoAssistantMessages(
 }
 
 // ── Pass 2: consecutive-assistant merging ───────────────────────────
-
-/** Parse a message's JSON content into an array of content blocks. */
-function parseContentBlocks(content: ContentBlock[]): ContentBlock[] {
-  return [...content];
-}
-
-/**
- * Append content blocks from a donor message onto a target block array.
- * Parses the donor's JSON content and pushes each block into `target`.
- */
-function appendContentBlocks(
-  target: ContentBlock[],
-  donorContent: ContentBlock[],
-): void {
-  target.push(...donorContent);
-}
 
 /**
  * Promote metadata fields from a donor message to the surviving message
@@ -351,11 +303,11 @@ export function mergeConsecutiveAssistantMessages(messages: MessageRow[]): {
     // Lazily parse the target's content on first merge.
     let targetContent = pendingMerges.get(lastIdx);
     if (!targetContent) {
-      targetContent = parseContentBlocks(result[lastIdx].content);
+      targetContent = [...result[lastIdx].content];
       pendingMerges.set(lastIdx, targetContent);
     }
 
-    appendContentBlocks(targetContent, msg.content);
+    targetContent.push(...msg.content);
     result[lastIdx] = promoteMetadata(result[lastIdx], msg);
   }
 

--- a/assistant/src/export/formatter.ts
+++ b/assistant/src/export/formatter.ts
@@ -2,17 +2,8 @@
  * Conversation export formatters for markdown and JSON.
  */
 
+import type { ContentBlock } from "../providers/types.js";
 import { truncate } from "../util/truncate.js";
-
-interface ContentBlock {
-  type: string;
-  text?: string;
-  name?: string;
-  input?: Record<string, unknown>;
-  content?: unknown;
-  tool_use_id?: string;
-  is_error?: boolean;
-}
 
 interface ExportMessage {
   role: string;
@@ -42,19 +33,17 @@ function extractText(blocks: ContentBlock[]): string {
         }
         break;
       case "tool_use":
-        parts.push(
-          `[Tool: ${block.name}] ${JSON.stringify(block.input ?? {})}`,
-        );
+        parts.push(`[Tool: ${block.name}] ${JSON.stringify(block.input)}`);
         break;
       case "tool_result":
         if (block.is_error) {
-          parts.push(`[Error: ${String(block.content ?? "")}]`);
+          parts.push(`[Error: ${block.content}]`);
         } else {
-          parts.push(`[Result: ${truncate(String(block.content ?? ""), 500)}]`);
+          parts.push(`[Result: ${truncate(block.content, 500)}]`);
         }
         break;
       case "server_tool_use":
-        parts.push(`[Web search: ${block.name ?? "web_search"}]`);
+        parts.push(`[Web search: ${block.name}]`);
         break;
       case "web_search_tool_result":
         parts.push("[Web search results]");

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -477,10 +477,7 @@ const parseMessage = createRowMapper<typeof messages.$inferSelect, MessageRow>({
   id: "id",
   conversationId: "conversationId",
   role: "role",
-  content: {
-    from: "content",
-    transform: (v) => resolveMessageContentBlocks(String(v)),
-  },
+  content: { from: "content", transform: resolveMessageContentBlocks },
   createdAt: "createdAt",
   metadata: "metadata",
   clientMessageId: "clientMessageId",

--- a/assistant/src/persistence/message-content-file.ts
+++ b/assistant/src/persistence/message-content-file.ts
@@ -194,7 +194,14 @@ function resolveRefToBlocks(ref: MessageContentRef): ContentBlock[] {
  *
  * Never throws — content reads must not take down read paths.
  */
-export function resolveMessageContentBlocks(raw: string): ContentBlock[] {
+export function resolveMessageContentBlocks(raw: unknown): ContentBlock[] {
+  if (typeof raw !== "string") {
+    log.warn(
+      { rawType: typeof raw },
+      "Non-string stored message content; resolving as empty",
+    );
+    return [];
+  }
   const ref = parseContentRef(raw);
   if (ref) {
     return resolveRefToBlocks(ref);


### PR DESCRIPTION
## Prompt / plan

Follow-up to the review feedback on #37794 — finishing the typing the `MessageRow.content: ContentBlock[]` migration enabled:

- **No `unknown[]`** ([comment](https://github.com/vellum-ai/vellum-assistant/pull/37794#discussion_r3560947049)): `isToolResultOnlyUserMessage` and the tool-result separation in `mergeToolResultsIntoAssistantMessages` iterate `msg.content` as typed `ContentBlock`s. `isSystemNoticeText` takes a `ContentBlock` and narrows via `block.type === "text"` — the `Record<string, unknown>` shape checks are gone.
- **No `as` casts** ([comment](https://github.com/vellum-ai/vellum-assistant/pull/37794#discussion_r3560950152)): `toolResultBlocks`/`otherBlocks` are declared `ContentBlock[]` from the start, so the push and write-back sites need no casts.
- **Redundant helper deleted** ([comment](https://github.com/vellum-ai/vellum-assistant/pull/37794#discussion_r3560953078)): `parseContentBlocks` (reduced to a spread copy by the migration) is inlined at its only call site and removed; same for `appendContentBlocks`, which had become a one-line spread push with a doc comment describing parsing it no longer did.
- **Local block type deleted** ([comment](https://github.com/vellum-ai/vellum-assistant/pull/37794#discussion_r3560973939)): `export/formatter.ts` now imports the providers `ContentBlock` union instead of its own structural interface. The switch in `extractText` narrows per variant, which also let the `String()`/`?? {}` fallbacks (needed only because the loose type made every field optional) drop away.
- **Resolver accepts `unknown`** ([comment](https://github.com/vellum-ai/vellum-assistant/pull/37794#discussion_r3560980878)): `resolveMessageContentBlocks(raw: unknown)` handles non-string values (warn + empty), so the row mapper is now `content: { from: "content", transform: resolveMessageContentBlocks }` — no `String(v)` coercion at the call site.

## Test plan

- `message-consolidation.test.ts` (25), `message-content-file.test.ts` (17), `transcript-formatter.test.ts`, `conversation-runtime-assembly.test.ts` (196), `conversation-agent-loop.test.ts` (66) all pass.
- `tsc --noEmit`, eslint, prettier clean via the pre-commit hook. The typecheck doubles as the proof that the formatter switch narrows correctly against the real union (e.g. `tool_result.content: string`, `tool_use.input` required).

## CLI verb checklist

No new routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMnmq1rr4uffg1MgFdgb9h

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMnmq1rr4uffg1MgFdgb9h)_