### PR TITLE
chore(assistant): restore named getConfigReadOnly imports; drop the config mock they dodged

### DIFF
--- a/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
+++ b/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
@@ -16,32 +16,11 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ── Shared mock setup ────────────────────────────────────────────────────────
-// Config mock must be declared before importing tool modules so that the
-// mock.module calls are hoisted above the dynamic imports.
-
-mock.module("../config/loader.js", () => ({
-  getConfig: () => ({
-    ui: {},
-
-    provider: "anthropic",
-    model: "test",
-    maxTokens: 4096,
-    dataDir: "/tmp",
-    timeouts: {
-      shellDefaultTimeoutSec: 120,
-      shellMaxTimeoutSec: 600,
-      permissionTimeoutSec: 300,
-    },
-    rateLimit: { maxRequestsPerMinute: 0 },
-    secretDetection: {
-      enabled: false,
-    },
-  }),
-  loadConfig: () => ({}),
-  invalidateConfigCache: () => {},
-  loadRawConfig: () => ({}),
-  saveRawConfig: () => {},
-}));
+// The real config loader serves these tests: it reads from the per-test temp
+// workspace and returns schema defaults (the timeout values the shell tool
+// needs are the documented defaults). Mocking `config/loader` here would force
+// the mock to mirror the loader's full export surface — modules under test
+// import it by name, and a partial mock fails to link.
 
 // shell.ts uses the script proxy — stub it to avoid network side-effects.
 mock.module("../tools/network/script-proxy/index.js", () => ({

--- a/assistant/src/persistence/llm-request-log-sink-clickhouse.ts
+++ b/assistant/src/persistence/llm-request-log-sink-clickhouse.ts
@@ -29,13 +29,7 @@
  * Writes are best-effort: a ClickHouse outage logs and is swallowed so it
  * can never abort a turn.
  */
-// Namespace import (not a named `getConfigReadOnly` import) on purpose: the
-// store imports this module, so it is reached transitively by the large set of
-// tests that stub `config/loader` with a partial mock exposing only
-// `getConfig`. A named import would fail to link against those mocks; a
-// namespace access degrades to `undefined` at call time instead, which the
-// factory's try/catch treats as "no sink" (→ local SQLite). Matches the store.
-import * as configLoader from "../config/loader.js";
+import { getConfigReadOnly } from "../config/loader.js";
 import type { LlmRequestLogsClickHouseConfig } from "../config/schemas/llm-request-logs.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
@@ -313,7 +307,7 @@ let cachedSink: { key: string; sink: ClickHouseLlmRequestLogSink } | null =
 export function getClickHouseLlmRequestLogSink(): ClickHouseLlmRequestLogSink | null {
   let cfg;
   try {
-    cfg = configLoader.getConfigReadOnly().llmRequestLogs;
+    cfg = getConfigReadOnly().llmRequestLogs;
   } catch {
     return null;
   }

--- a/assistant/src/persistence/llm-request-log-store.ts
+++ b/assistant/src/persistence/llm-request-log-store.ts
@@ -16,13 +16,7 @@ import {
 import { v4 as uuid } from "uuid";
 
 import { CALL_SITE_SYNTHETIC_AGENT_ERROR_MESSAGE } from "../api/constants/call-sites.js";
-// Namespace import (not a named `getConfigReadOnly` import) on purpose: the
-// store is reached transitively by a large number of tests that stub
-// `config/loader` with a partial mock exposing only `getConfig`. A named
-// import would fail to link against those mocks ("Export … not found"); a
-// namespace access degrades to `undefined` at call time instead, which the
-// try/catch in `llmRequestLoggingEnabled` treats as "enabled".
-import * as configLoader from "../config/loader.js";
+import { getConfigReadOnly } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { AssistantError, ProviderError } from "../util/errors.js";
 import {
@@ -64,7 +58,7 @@ function logsDb(): DrizzleDb {
  */
 export function llmRequestLoggingEnabled(): boolean {
   try {
-    return configLoader.getConfigReadOnly().llmRequestLogs?.enabled !== false;
+    return getConfigReadOnly().llmRequestLogs?.enabled !== false;
   } catch {
     return true;
   }


### PR DESCRIPTION
**PR 4** of the LLM request logging series — the cleanup requested in [this review comment on #37649](https://github.com/vellum-ai/vellum-assistant/pull/37649#discussion_r3558337150).

## Prompt / plan

> We should not make concessions in source code due to tests. We want to restore the previous import, and remove the mock.module on config loading on all relevant tests.

The LLM request log store (and later the ClickHouse sink) used a namespace `import * as configLoader` for `config/loader` so they could link against test files that stub the loader with a partial mock exposing only `getConfig`. That was a test-driven concession in production code.

## What this does

- **Restores the plain named `import { getConfigReadOnly }`** in `llm-request-log-store.ts` and `llm-request-log-sink-clickhouse.ts`, removing the namespace-import workaround and its comments.
- **Removes the `mock.module("config/loader")` stub from `tool-execution-abort-cleanup.test.ts`** — the one file whose partial mock actually broke the named import (it dynamic-imports the tool modules *after* registering the mock, so the store linked against the mock's incomplete export map; files with static imports link against the real loader before their mock lands, which is why they never broke). The real loader now serves that test from the per-test temp workspace, and the timeout values its shell tests rely on are the schema defaults the mock was duplicating anyway.

## Test plan

- Reproduced the original CI failure (`Export named 'getConfigReadOnly' not found`) on `tool-execution-abort-cleanup.test.ts` after restoring the import, then verified all 20 of its tests pass with the mock removed.
- Ran the **full assistant suite** on this branch: zero `getConfigReadOnly` link errors anywhere, confirming this was the only test needing the mock removed. The 8 files that failed in the run (`script-proxy-*`, `sandbox-escape`, `avatar-state-routes`, `audit-log-rotation`, `secret-routes-platform-proxy`, `provider-commit-message-generator`) fail identically on a clean `origin/main` worktree in this environment — pre-existing/environmental (read-only-workspace and sandbox-timeout cases), unrelated to this change.
- `bunx tsgo --noEmit` clean; eslint clean (0 errors).

## CLI verb checklist

No new routes — import/test hygiene only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5EQ7hFW26ndg21csTCZJq

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5EQ7hFW26ndg21csTCZJq)_