### PR TITLE
cli: adopt static-help split for avatar, backup, bash, and browser

### DIFF
--- a/assistant/src/cli/AGENTS.md
+++ b/assistant/src/cli/AGENTS.md
@@ -123,9 +123,10 @@ registerFooCommand(program);
    _synchronously_ at command registration (so it can't be a lazy
    `import()`) may stay hoisted behind a scoped
    `// eslint-disable-next-line cli/no-daemon-internals` with a comment
-   explaining why. The only current case is `browser/operation-meta` in
+   explaining why. The only current case is `browser/operation-meta`, in
    `commands/browser.ts` (it drives synchronous subcommand generation and
-   deliberately pulls no Playwright graph).
+   deliberately pulls no Playwright graph) and `commands/browser.help.ts`
+   (which derives the declarative help from the same contract).
 
 2. **Lazy-import daemon functionality inside the action.** Running daemon
    logic in-process is encouraged where it avoids an IPC round-trip (which

--- a/assistant/src/cli/commands/avatar.help.ts
+++ b/assistant/src/cli/commands/avatar.help.ts
@@ -1,0 +1,236 @@
+/**
+ * Declarative help for the `assistant avatar` command.
+ *
+ * Plain data (no action handlers, imports only the help contract type) so the
+ * memory capability indexer can read it without pulling in the daemon/IPC action
+ * graph. The handlers live in `avatar.ts`, which applies this via
+ * `applyCommandHelp` and attaches them.
+ */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const avatarHelp: CliCommandHelp = {
+  name: "avatar",
+  description: "Manage the assistant's avatar",
+  helpText: `
+The avatar system supports two modes:
+
+  1. Native character — a procedurally generated character with configurable
+     body shape, eye style, and color. The character is rendered as both a
+     PNG image and ASCII art. Use the "character" subcommand group to manage
+     native character avatars.
+
+  2. Custom image — an externally provided image file set via the "set"
+     subcommand, or generated via "generate".
+
+Files are stored in $VELLUM_WORKSPACE_DIR/data/avatar/:
+  character-traits.json   Current trait selection (bodyShape, eyeStyle, color)
+  avatar-image.png        Rendered PNG of the character
+  character-ascii.txt     ASCII art representation (best-effort; may not be written)
+
+Examples:
+  $ assistant avatar set --image /path/to/photo.png
+  $ assistant avatar remove
+  $ assistant avatar get --format base64
+  $ assistant avatar character update --body-shape blob --eye-style curious --color green
+  $ assistant avatar generate --description "a cute blue cat"`,
+  subcommands: [
+    {
+      name: "generate",
+      description: "Generate an AI avatar from a text description",
+      options: [
+        {
+          flags: "--description <text>",
+          description: "Description of the avatar to generate",
+          required: true,
+        },
+      ],
+      helpText: `
+Generates an avatar image using AI based on the provided text description
+and saves it as the assistant's avatar PNG. This replaces any existing
+native character avatar — the character traits and ASCII files are removed.
+
+On success, writes avatar-image.png to $VELLUM_WORKSPACE_DIR/data/avatar/
+and removes character-traits.json and character-ascii.txt if they exist.
+
+Examples:
+  $ assistant avatar generate --description "a cute blue cat"
+  $ assistant avatar generate --description "a friendly robot with green eyes"`,
+    },
+    {
+      name: "set",
+      description:
+        "Set the assistant's avatar from an image file (removes any native character)",
+      options: [
+        {
+          flags: "--image <path>",
+          description: "Path to image file (absolute or relative to workspace)",
+          required: true,
+        },
+      ],
+      helpText: `
+Sets the assistant's avatar by copying the provided image file to the
+canonical avatar location. This REPLACES any existing avatar and removes
+any configured native character: character-traits.json (and character-ascii.txt)
+are deleted, so a previously configured character is NOT preserved and cannot
+be restored. Rebuild the character with "assistant avatar character update"
+to reconfigure one.
+
+The --image path can be absolute or relative to the workspace directory.
+
+Examples:
+  $ assistant avatar set --image /path/to/photo.png
+  $ assistant avatar set --image conversations/abc123/attachments/Dropped\\ Image.png`,
+    },
+    {
+      name: "remove",
+      description: "Reset the avatar to none (clears image and character)",
+      helpText: `
+Resets the avatar to its empty state. This deletes ALL avatar artifacts —
+the custom image (avatar-image.png) AND any configured native character
+(character-traits.json / character-ascii.txt) — and marks the avatar as
+"none".
+
+This is destructive: a previously configured native character is NOT
+preserved and will not be restored. Rebuild the character (or set a new
+image) to configure an avatar again.
+
+Examples:
+  $ assistant avatar remove`,
+    },
+    {
+      name: "get",
+      description: "Retrieve the current avatar",
+      options: [
+        {
+          flags: "--format <format>",
+          description: "Output format: path or base64",
+          defaultValue: "path",
+        },
+      ],
+      helpText: `
+Retrieves the current avatar. By default prints the absolute file path;
+with --format base64, prints the base64-encoded image content.
+
+If no avatar image exists but character-traits.json is present, the PNG
+is regenerated from the saved traits before output.
+
+Examples:
+  $ assistant avatar get
+  $ assistant avatar get --format path
+  $ assistant avatar get --format base64`,
+    },
+    {
+      name: "character",
+      description: "Manage the native character avatar",
+      helpText: `
+A native character avatar is composed of three traits:
+  - body shape: the silhouette of the character (e.g. blob, cloud, star)
+  - eye style: the expression of the character's eyes (e.g. curious, gentle)
+  - color: the body fill color (e.g. green, purple, teal)
+
+Use "character components" to list all available values for each trait.
+Use "character update" to set traits and regenerate the avatar files.
+Use "character ascii" to preview the current character in the terminal.
+
+Examples:
+  $ assistant avatar character update --body-shape blob --eye-style curious --color green
+  $ assistant avatar character components --json
+  $ assistant avatar character ascii --width 40`,
+      subcommands: [
+        {
+          name: "update",
+          description: "Set character traits and regenerate avatar",
+          options: [
+            {
+              flags: "--body-shape <shape>",
+              description: "Body shape (e.g. blob, cloud, star)",
+              required: true,
+            },
+            {
+              flags: "--eye-style <style>",
+              description: "Eye style (e.g. curious, gentle, goofy)",
+              required: true,
+            },
+            {
+              flags: "--color <color>",
+              description: "Body color (e.g. green, purple, teal)",
+              required: true,
+            },
+          ],
+          helpText: `
+Sets the three character traits and regenerates avatar files (PNG image,
+traits JSON, and optionally ASCII art). Each trait value must be a valid ID from the
+component set — use "assistant avatar character components" to list valid IDs.
+
+The --body-shape flag sets the character silhouette. Valid values:
+  blob, cloud, sprout, star, ghost, urchin, stack, flower, burst, ninja
+
+The --eye-style flag sets the eye expression. Valid values:
+  grumpy, angry, curious, goofy, surprised, bashful, gentle, quirky, dazed
+
+The --color flag sets the body fill color. Valid values:
+  green, orange, pink, purple, teal, yellow
+
+On success, writes character-traits.json and avatar-image.png to
+$VELLUM_WORKSPACE_DIR/data/avatar/. character-ascii.txt is written on a
+best-effort basis and may be skipped if ASCII rendering fails.
+
+Examples:
+  $ assistant avatar character update --body-shape blob --eye-style curious --color green
+  $ assistant avatar character update --body-shape star --eye-style goofy --color purple
+  $ assistant avatar character update --body-shape ghost --eye-style gentle --color teal`,
+        },
+        {
+          name: "components",
+          description: "List available character traits",
+          options: [
+            { flags: "--json", description: "Machine-readable JSON output" },
+          ],
+          helpText: `
+Lists all available values for each character trait: body shapes, eye styles,
+and colors. Each value is shown with its ID (the string you pass to
+"character update").
+
+With --json, outputs the full components object including SVG path data,
+viewBox dimensions, and face-center coordinates — useful for programmatic
+consumption.
+
+Without --json, prints a human-readable summary of IDs only.
+
+Examples:
+  $ assistant avatar character components
+  $ assistant avatar character components --json`,
+        },
+        {
+          name: "ascii",
+          description: "Print the current character as ASCII art",
+          options: [
+            {
+              flags: "--width <n>",
+              description: "Output width in characters",
+              defaultValue: "60",
+            },
+          ],
+          helpText: `
+Reads the current character traits from character-traits.json and renders
+the character as ASCII art to stdout. The output uses a brightness ramp
+optimized for dark terminal backgrounds.
+
+The --width flag controls the number of characters per line (default: 60).
+Terminal cells are roughly twice as tall as they are wide, so the renderer
+compensates automatically — a 60-character-wide output will look correctly
+proportioned in most terminals.
+
+If no character has been set yet, prints an error and suggests using
+"assistant avatar character update" first.
+
+Examples:
+  $ assistant avatar character ascii
+  $ assistant avatar character ascii --width 40
+  $ assistant avatar character ascii --width 80`,
+        },
+      ],
+    },
+  ],
+};

--- a/assistant/src/cli/commands/avatar.ts
+++ b/assistant/src/cli/commands/avatar.ts
@@ -1,3 +1,11 @@
+/**
+ * `assistant avatar` CLI namespace.
+ *
+ * The command's help structure lives in `avatar.help.ts` (import-safe for
+ * the memory capability indexer); this module applies it and attaches the
+ * action handlers.
+ */
+
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, join } from "node:path";
@@ -5,9 +13,11 @@ import { isAbsolute, join } from "node:path";
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
 import { writeOutput } from "../output.js";
+import { avatarHelp } from "./avatar.help.js";
 
 // Types returned by IPC routes
 interface CharacterComponents {
@@ -18,58 +28,15 @@ interface CharacterComponents {
 
 export function registerAvatarCommand(program: Command): void {
   registerCommand(program, {
-    name: "avatar",
+    name: avatarHelp.name,
     transport: "ipc",
-    description: "Manage the assistant's avatar",
+    description: avatarHelp.description,
     build: (avatar) => {
-      avatar.addHelpText(
-        "after",
-        `
-The avatar system supports two modes:
+      applyCommandHelp(avatar, avatarHelp);
 
-  1. Native character — a procedurally generated character with configurable
-     body shape, eye style, and color. The character is rendered as both a
-     PNG image and ASCII art. Use the "character" subcommand group to manage
-     native character avatars.
-
-  2. Custom image — an externally provided image file set via the "set"
-     subcommand, or generated via "generate".
-
-Files are stored in $VELLUM_WORKSPACE_DIR/data/avatar/:
-  character-traits.json   Current trait selection (bodyShape, eyeStyle, color)
-  avatar-image.png        Rendered PNG of the character
-  character-ascii.txt     ASCII art representation (best-effort; may not be written)
-
-Examples:
-  $ assistant avatar set --image /path/to/photo.png
-  $ assistant avatar remove
-  $ assistant avatar get --format base64
-  $ assistant avatar character update --body-shape blob --eye-style curious --color green
-  $ assistant avatar generate --description "a cute blue cat"`,
-      );
-
-      avatar
-        .command("generate")
-        .description("Generate an AI avatar from a text description")
-        .requiredOption(
-          "--description <text>",
-          "Description of the avatar to generate",
-        )
-        .addHelpText(
-          "after",
-          `
-Generates an avatar image using AI based on the provided text description
-and saves it as the assistant's avatar PNG. This replaces any existing
-native character avatar — the character traits and ASCII files are removed.
-
-On success, writes avatar-image.png to $VELLUM_WORKSPACE_DIR/data/avatar/
-and removes character-traits.json and character-ascii.txt if they exist.
-
-Examples:
-  $ assistant avatar generate --description "a cute blue cat"
-  $ assistant avatar generate --description "a friendly robot with green eyes"`,
-        )
-        .action(async (opts: { description: string }, cmd: Command) => {
+      // ── generate ─────────────────────────────────────────────────────
+      subcommand(avatar, "generate").action(
+        async (opts: { description: string }, cmd: Command) => {
           const r = await cliIpcCall<{ ok: boolean; message: string }>(
             "avatar_generate",
             { body: { description: opts.description } },
@@ -80,34 +47,12 @@ Examples:
               cmd,
             );
           log.info(r.result!.message);
-        });
+        },
+      );
 
-      avatar
-        .command("set")
-        .description(
-          "Set the assistant's avatar from an image file (removes any native character)",
-        )
-        .requiredOption(
-          "--image <path>",
-          "Path to image file (absolute or relative to workspace)",
-        )
-        .addHelpText(
-          "after",
-          `
-Sets the assistant's avatar by copying the provided image file to the
-canonical avatar location. This REPLACES any existing avatar and removes
-any configured native character: character-traits.json (and character-ascii.txt)
-are deleted, so a previously configured character is NOT preserved and cannot
-be restored. Rebuild the character with "assistant avatar character update"
-to reconfigure one.
-
-The --image path can be absolute or relative to the workspace directory.
-
-Examples:
-  $ assistant avatar set --image /path/to/photo.png
-  $ assistant avatar set --image conversations/abc123/attachments/Dropped\\ Image.png`,
-        )
-        .action(async (opts: { image: string }, cmd: Command) => {
+      // ── set ──────────────────────────────────────────────────────────
+      subcommand(avatar, "set").action(
+        async (opts: { image: string }, cmd: Command) => {
           const resolvedSource = isAbsolute(opts.image)
             ? opts.image
             : join(
@@ -131,27 +76,12 @@ Examples:
               cmd,
             );
           log.info(`Avatar set from: ${resolvedSource}`);
-        });
+        },
+      );
 
-      avatar
-        .command("remove")
-        .description("Reset the avatar to none (clears image and character)")
-        .addHelpText(
-          "after",
-          `
-Resets the avatar to its empty state. This deletes ALL avatar artifacts —
-the custom image (avatar-image.png) AND any configured native character
-(character-traits.json / character-ascii.txt) — and marks the avatar as
-"none".
-
-This is destructive: a previously configured native character is NOT
-preserved and will not be restored. Rebuild the character (or set a new
-image) to configure an avatar again.
-
-Examples:
-  $ assistant avatar remove`,
-        )
-        .action(async (_opts: object, cmd: Command) => {
+      // ── remove ───────────────────────────────────────────────────────
+      subcommand(avatar, "remove").action(
+        async (_opts: object, cmd: Command) => {
           const r = await cliIpcCall<{ ok: boolean; hadAvatar: boolean }>(
             "avatar_remove",
           );
@@ -165,27 +95,12 @@ Examples:
           } else {
             log.info("Custom avatar removed.");
           }
-        });
+        },
+      );
 
-      avatar
-        .command("get")
-        .description("Retrieve the current avatar")
-        .option("--format <format>", "Output format: path or base64", "path")
-        .addHelpText(
-          "after",
-          `
-Retrieves the current avatar. By default prints the absolute file path;
-with --format base64, prints the base64-encoded image content.
-
-If no avatar image exists but character-traits.json is present, the PNG
-is regenerated from the saved traits before output.
-
-Examples:
-  $ assistant avatar get
-  $ assistant avatar get --format path
-  $ assistant avatar get --format base64`,
-        )
-        .action(async (opts: { format: string }, cmd: Command) => {
+      // ── get ──────────────────────────────────────────────────────────
+      subcommand(avatar, "get").action(
+        async (opts: { format: string }, cmd: Command) => {
           if (opts.format !== "path" && opts.format !== "base64") {
             log.error(
               `Invalid format: "${opts.format}". Must be "path" or "base64".`,
@@ -217,118 +132,40 @@ Examples:
           } else {
             process.stdout.write(r.result!.base64! + "\n");
           }
-        });
-
-      const character = avatar
-        .command("character")
-        .description("Manage the native character avatar");
-
-      character.addHelpText(
-        "after",
-        `
-A native character avatar is composed of three traits:
-  - body shape: the silhouette of the character (e.g. blob, cloud, star)
-  - eye style: the expression of the character's eyes (e.g. curious, gentle)
-  - color: the body fill color (e.g. green, purple, teal)
-
-Use "character components" to list all available values for each trait.
-Use "character update" to set traits and regenerate the avatar files.
-Use "character ascii" to preview the current character in the terminal.
-
-Examples:
-  $ assistant avatar character update --body-shape blob --eye-style curious --color green
-  $ assistant avatar character components --json
-  $ assistant avatar character ascii --width 40`,
+        },
       );
 
-      character
-        .command("update")
-        .description("Set character traits and regenerate avatar")
-        .requiredOption(
-          "--body-shape <shape>",
-          "Body shape (e.g. blob, cloud, star)",
-        )
-        .requiredOption(
-          "--eye-style <style>",
-          "Eye style (e.g. curious, gentle, goofy)",
-        )
-        .requiredOption(
-          "--color <color>",
-          "Body color (e.g. green, purple, teal)",
-        )
-        .addHelpText(
-          "after",
-          `
-Sets the three character traits and regenerates avatar files (PNG image,
-traits JSON, and optionally ASCII art). Each trait value must be a valid ID from the
-component set — use "assistant avatar character components" to list valid IDs.
+      // ── character ────────────────────────────────────────────────────
+      const character = subcommand(avatar, "character");
 
-The --body-shape flag sets the character silhouette. Valid values:
-  blob, cloud, sprout, star, ghost, urchin, stack, flower, burst, ninja
-
-The --eye-style flag sets the eye expression. Valid values:
-  grumpy, angry, curious, goofy, surprised, bashful, gentle, quirky, dazed
-
-The --color flag sets the body fill color. Valid values:
-  green, orange, pink, purple, teal, yellow
-
-On success, writes character-traits.json and avatar-image.png to
-$VELLUM_WORKSPACE_DIR/data/avatar/. character-ascii.txt is written on a
-best-effort basis and may be skipped if ASCII rendering fails.
-
-Examples:
-  $ assistant avatar character update --body-shape blob --eye-style curious --color green
-  $ assistant avatar character update --body-shape star --eye-style goofy --color purple
-  $ assistant avatar character update --body-shape ghost --eye-style gentle --color teal`,
-        )
-        .action(
-          async (
-            opts: { bodyShape: string; eyeStyle: string; color: string },
-            cmd: Command,
-          ) => {
-            const r = await cliIpcCall<{ ok: boolean }>(
-              "avatar_render_from_traits",
-              {
-                body: {
-                  bodyShape: opts.bodyShape,
-                  eyeStyle: opts.eyeStyle,
-                  color: opts.color,
-                },
+      subcommand(character, "update").action(
+        async (
+          opts: { bodyShape: string; eyeStyle: string; color: string },
+          cmd: Command,
+        ) => {
+          const r = await cliIpcCall<{ ok: boolean }>(
+            "avatar_render_from_traits",
+            {
+              body: {
+                bodyShape: opts.bodyShape,
+                eyeStyle: opts.eyeStyle,
+                color: opts.color,
               },
+            },
+          );
+          if (!r.ok)
+            return exitFromIpcResult(
+              r as { ok: false; error?: string; statusCode?: number },
+              cmd,
             );
-            if (!r.ok)
-              return exitFromIpcResult(
-                r as { ok: false; error?: string; statusCode?: number },
-                cmd,
-              );
-            log.info(
-              `Avatar updated: ${opts.bodyShape} body, ${opts.eyeStyle} eyes, ${opts.color} color`,
-            );
-          },
-        );
+          log.info(
+            `Avatar updated: ${opts.bodyShape} body, ${opts.eyeStyle} eyes, ${opts.color} color`,
+          );
+        },
+      );
 
-      character
-        .command("components")
-        .description("List available character traits")
-        .option("--json", "Machine-readable JSON output")
-        .addHelpText(
-          "after",
-          `
-Lists all available values for each character trait: body shapes, eye styles,
-and colors. Each value is shown with its ID (the string you pass to
-"character update").
-
-With --json, outputs the full components object including SVG path data,
-viewBox dimensions, and face-center coordinates — useful for programmatic
-consumption.
-
-Without --json, prints a human-readable summary of IDs only.
-
-Examples:
-  $ assistant avatar character components
-  $ assistant avatar character components --json`,
-        )
-        .action(async (opts: { json?: boolean }, cmd: Command) => {
+      subcommand(character, "components").action(
+        async (opts: { json?: boolean }, cmd: Command) => {
           const r = await cliIpcCall<CharacterComponents>(
             "avatar_character_components",
           );
@@ -360,33 +197,11 @@ Examples:
           for (const color of components.colors) {
             log.info(`  ${color.id} (${color.hex})`);
           }
-        });
+        },
+      );
 
-      character
-        .command("ascii")
-        .description("Print the current character as ASCII art")
-        .option("--width <n>", "Output width in characters", "60")
-        .addHelpText(
-          "after",
-          `
-Reads the current character traits from character-traits.json and renders
-the character as ASCII art to stdout. The output uses a brightness ramp
-optimized for dark terminal backgrounds.
-
-The --width flag controls the number of characters per line (default: 60).
-Terminal cells are roughly twice as tall as they are wide, so the renderer
-compensates automatically — a 60-character-wide output will look correctly
-proportioned in most terminals.
-
-If no character has been set yet, prints an error and suggests using
-"assistant avatar character update" first.
-
-Examples:
-  $ assistant avatar character ascii
-  $ assistant avatar character ascii --width 40
-  $ assistant avatar character ascii --width 80`,
-        )
-        .action(async (opts: { width: string }, cmd: Command) => {
+      subcommand(character, "ascii").action(
+        async (opts: { width: string }, cmd: Command) => {
           if (!/^\d+$/.test(opts.width)) {
             log.error(
               `Invalid width: "${opts.width}". Must be a positive integer.`,
@@ -413,7 +228,8 @@ Examples:
               cmd,
             );
           process.stdout.write(r.result!.ascii + "\n");
-        });
+        },
+      );
     },
   });
 }

--- a/assistant/src/cli/commands/backup.help.ts
+++ b/assistant/src/cli/commands/backup.help.ts
@@ -1,0 +1,190 @@
+/**
+ * Declarative help for the `assistant backup` command.
+ *
+ * Plain data (no action handlers, imports only the help contract type) so the
+ * memory capability indexer can read it without pulling in the daemon/IPC action
+ * graph. The handlers live in `backup.ts`, which applies this via
+ * `applyCommandHelp` and attaches them.
+ */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const backupHelp: CliCommandHelp = {
+  name: "backup",
+  description: "Manage automated backup configuration and list snapshots",
+  helpText: `
+Backups capture a snapshot of the assistant workspace (config, conversations,
+trust rules, hooks, the SQLite database) as a .vbundle file. Credentials are
+NOT included — they live in the OS keychain / CES and users re-authenticate
+integrations after a restore (via the gateway). The automated worker runs on a configurable
+interval and writes to a local pool under ~/.vellum/backups/local/, optionally
+mirroring each snapshot to one or more offsite destinations (iCloud Drive by
+default).
+
+Offsite destinations can be per-destination encrypted (AES-256-GCM) or
+plaintext — plaintext only makes sense when the user owns physical access to
+the medium (e.g. an external SSD).
+
+Examples:
+  $ assistant backup enable --interval 6 --retention 3
+  $ assistant backup destinations add /Volumes/BackupSSD/vellum --plaintext
+  $ assistant backup status
+  $ assistant backup list`,
+  subcommands: [
+    {
+      name: "enable",
+      description: "Enable automated backups",
+      options: [
+        {
+          flags: "--interval <hours>",
+          description:
+            "Hours between automated backups (1-168). Defaults to 6.",
+        },
+        {
+          flags: "--retention <n>",
+          description:
+            "Snapshots to retain per destination (1-100). Defaults to 3.",
+        },
+        {
+          flags: "--no-offsite",
+          description:
+            "Disable offsite backup (local only). Does not touch the destinations list.",
+        },
+      ],
+      helpText: `
+Sets backup.enabled = true in config.json. Optionally overrides intervalHours,
+retention, and the offsite.enabled flag. Does NOT modify
+backup.offsite.destinations — use 'assistant backup destinations add/remove' to
+manage those.
+
+Examples:
+  $ assistant backup enable
+  $ assistant backup enable --interval 12 --retention 14
+  $ assistant backup enable --no-offsite`,
+    },
+    {
+      name: "disable",
+      description: "Disable automated backups",
+      helpText: `
+Sets backup.enabled = false in config.json. Existing snapshots are untouched;
+only the automated worker stops creating new ones.
+
+Examples:
+  $ assistant backup disable`,
+    },
+    {
+      name: "destinations",
+      description: "Manage offsite backup destinations",
+      helpText: `
+Offsite destinations are absolute paths the backup worker writes a copy of
+each snapshot to after the local write succeeds. The default destination is
+the iCloud Drive VellumAssistant folder, and it is used implicitly until an
+explicit destinations array is configured. The first 'destinations add' or
+'destinations remove' materializes the iCloud default before applying the
+change, so the default is never lost on an accidental "clear all".
+
+Each destination has an 'encrypt' flag. When true (the default), snapshots
+are written as .vbundle.enc (AES-256-GCM). When false, snapshots are copied
+as plaintext .vbundle — only use this for media you control physically.
+
+Examples:
+  $ assistant backup destinations list
+  $ assistant backup destinations add /Volumes/BackupSSD/vellum --plaintext
+  $ assistant backup destinations remove /Volumes/BackupSSD/vellum
+  $ assistant backup destinations set-encrypt /Volumes/BackupSSD/vellum false`,
+      subcommands: [
+        {
+          name: "list",
+          description: "List configured offsite destinations",
+          helpText: `
+Resolves the current destinations array (materializing the iCloud default if
+no explicit array is configured) and prints a table with the path and
+encryption flag per row.
+
+Examples:
+  $ assistant backup destinations list`,
+        },
+        {
+          name: "add",
+          args: "<path>",
+          description: "Add an offsite backup destination",
+          options: [
+            {
+              flags: "--plaintext",
+              description:
+                "Write snapshots as plaintext .vbundle (default is AES-256-GCM encrypted .vbundle.enc)",
+            },
+          ],
+          helpText: `
+Arguments:
+  path   Absolute path to the destination directory. Must be on a mount the
+         caller controls; the backup worker writes files inside this
+         directory, not the directory itself.
+
+If backup.offsite.destinations is currently null (the implicit iCloud default),
+the iCloud default is materialized first so the new entry appends to a
+2-element array rather than replacing the default.
+
+Examples:
+  $ assistant backup destinations add /Volumes/BackupSSD/vellum --plaintext
+  $ assistant backup destinations add ~/Dropbox/VellumAssistant/backups`,
+        },
+        {
+          name: "remove",
+          args: "<path>",
+          description: "Remove an offsite backup destination by path",
+          helpText: `
+Arguments:
+  path   Exact path match of the destination to remove. Run
+         'assistant backup destinations list' to see configured paths.
+
+Errors if no destination with the given path exists.
+
+Examples:
+  $ assistant backup destinations remove /Volumes/BackupSSD/vellum`,
+        },
+        {
+          name: "set-encrypt",
+          args: "<path> <value>",
+          description: "Toggle encryption for an existing destination",
+          helpText: `
+Arguments:
+  path    Exact path match of an existing destination. Run
+          'assistant backup destinations list' to see configured paths.
+  value   "true" to encrypt, "false" for plaintext writes.
+
+Errors if no destination with the given path exists. Existing snapshot files
+are not modified; only future writes honour the new setting.
+
+Examples:
+  $ assistant backup destinations set-encrypt /Volumes/BackupSSD/vellum false
+  $ assistant backup destinations set-encrypt /Volumes/BackupSSD/vellum true`,
+        },
+      ],
+    },
+    {
+      name: "status",
+      description: "Show backup status and next-run timing",
+      helpText: `
+Reports enabled/disabled state, interval and retention, last-run and next-run
+timing (from the backup:last_run_at memory checkpoint), and a per-destination
+reachability probe. Unreachable destinations (parent directory missing, e.g.
+iCloud Drive not enabled or external volume unplugged) are flagged
+[unreachable] and skipped by the worker.
+
+Examples:
+  $ assistant backup status`,
+    },
+    {
+      name: "list",
+      description: "List all backup snapshots, grouped by destination",
+      helpText: `
+Prints a per-destination table of snapshots with timestamp, size, and
+encryption flag. Local destination is listed first, followed by each offsite
+destination. Unreachable destinations are listed with an empty snapshot set.
+
+Examples:
+  $ assistant backup list`,
+    },
+  ],
+};

--- a/assistant/src/cli/commands/backup.ts
+++ b/assistant/src/cli/commands/backup.ts
@@ -2,14 +2,18 @@
  * `assistant backup` — manage automated backup configuration and list snapshots.
  *
  * Thin IPC wrapper: each subcommand forwards its request to the daemon via
- * cliIpcCall and never imports daemon-internal modules.
+ * cliIpcCall. The command's help structure lives in `backup.help.ts`
+ * (import-safe for the memory capability indexer); this module applies it and
+ * attaches the action handlers.
  */
 
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
+import { backupHelp } from "./backup.help.js";
 
 // ---------------------------------------------------------------------------
 // Small formatting helpers
@@ -59,105 +63,48 @@ function formatDurationShort(ms: number): string {
 
 export function registerBackupCommand(program: Command): void {
   registerCommand(program, {
-    name: "backup",
+    name: backupHelp.name,
     transport: "ipc",
-    description: "Manage automated backup configuration and list snapshots",
+    description: backupHelp.description,
     build: (backup) => {
-      backup.addHelpText(
-        "after",
-        `
-Backups capture a snapshot of the assistant workspace (config, conversations,
-trust rules, hooks, the SQLite database) as a .vbundle file. Credentials are
-NOT included — they live in the OS keychain / CES and users re-authenticate
-integrations after a restore (via the gateway). The automated worker runs on a configurable
-interval and writes to a local pool under ~/.vellum/backups/local/, optionally
-mirroring each snapshot to one or more offsite destinations (iCloud Drive by
-default).
+      applyCommandHelp(backup, backupHelp);
 
-Offsite destinations can be per-destination encrypted (AES-256-GCM) or
-plaintext — plaintext only makes sense when the user owns physical access to
-the medium (e.g. an external SSD).
-
-Examples:
-  $ assistant backup enable --interval 6 --retention 3
-  $ assistant backup destinations add /Volumes/BackupSSD/vellum --plaintext
-  $ assistant backup status
-  $ assistant backup list`,
+      // ── enable ───────────────────────────────────────────────────────
+      subcommand(backup, "enable").action(
+        async (
+          opts: { interval?: string; retention?: string; offsite?: boolean },
+          cmd: Command,
+        ) => {
+          const r = await cliIpcCall("backup_enable", {
+            body: {
+              ...(opts.interval !== undefined && {
+                intervalHours: Number.parseInt(opts.interval, 10),
+              }),
+              ...(opts.retention !== undefined && {
+                retention: Number.parseInt(opts.retention, 10),
+              }),
+              ...(opts.offsite === false && { offsiteEnabled: false }),
+            },
+          });
+          if (!r.ok)
+            return exitFromIpcResult(
+              { ok: false, error: r.error, statusCode: r.statusCode },
+              cmd,
+            );
+          const cfg = r.result as {
+            intervalHours: number;
+            retention: number;
+            offsite: { enabled: boolean };
+          };
+          log.info(
+            `Automatic backups enabled (interval=${cfg.intervalHours}h, retention=${cfg.retention}, offsite=${cfg.offsite.enabled ? "on" : "off"})`,
+          );
+        },
       );
 
-      backup
-        .command("enable")
-        .description("Enable automated backups")
-        .option(
-          "--interval <hours>",
-          "Hours between automated backups (1-168). Defaults to 6.",
-        )
-        .option(
-          "--retention <n>",
-          "Snapshots to retain per destination (1-100). Defaults to 3.",
-        )
-        .option(
-          "--no-offsite",
-          "Disable offsite backup (local only). Does not touch the destinations list.",
-        )
-        .addHelpText(
-          "after",
-          `
-Sets backup.enabled = true in config.json. Optionally overrides intervalHours,
-retention, and the offsite.enabled flag. Does NOT modify
-backup.offsite.destinations — use 'assistant backup destinations add/remove' to
-manage those.
-
-Examples:
-  $ assistant backup enable
-  $ assistant backup enable --interval 12 --retention 14
-  $ assistant backup enable --no-offsite`,
-        )
-        .action(
-          async (
-            opts: { interval?: string; retention?: string; offsite?: boolean },
-            cmd: Command,
-          ) => {
-            const r = await cliIpcCall("backup_enable", {
-              body: {
-                ...(opts.interval !== undefined && {
-                  intervalHours: Number.parseInt(opts.interval, 10),
-                }),
-                ...(opts.retention !== undefined && {
-                  retention: Number.parseInt(opts.retention, 10),
-                }),
-                ...(opts.offsite === false && { offsiteEnabled: false }),
-              },
-            });
-            if (!r.ok)
-              return exitFromIpcResult(
-                { ok: false, error: r.error, statusCode: r.statusCode },
-                cmd,
-              );
-            const cfg = r.result as {
-              intervalHours: number;
-              retention: number;
-              offsite: { enabled: boolean };
-            };
-            log.info(
-              `Automatic backups enabled (interval=${cfg.intervalHours}h, retention=${cfg.retention}, offsite=${cfg.offsite.enabled ? "on" : "off"})`,
-            );
-          },
-        );
-
-      backup
-        .command("disable")
-        .description("Disable automated backups")
-        .addHelpText(
-          "after",
-          `
-Sets backup.enabled = false in config.json. Existing snapshots are untouched;
-only the automated worker stops creating new ones.
-
-Examples:
-  $ assistant backup disable`,
-        )
-        .action(async (_opts: unknown, cmd: Command) => {
+      // ── disable ──────────────────────────────────────────────────────
+      subcommand(backup, "disable").action(
+        async (_opts: unknown, cmd: Command) => {
           const r = await cliIpcCall("backup_disable");
           if (!r.ok)
             return exitFromIpcResult(
@@ -165,51 +112,14 @@ Examples:
               cmd,
             );
           log.info("Automatic backups disabled");
-        });
-
-      // -----------------------------------------------------------------------
-      // destinations — subgroup
-      // -----------------------------------------------------------------------
-
-      const destinations = backup
-        .command("destinations")
-        .description("Manage offsite backup destinations");
-
-      destinations.addHelpText(
-        "after",
-        `
-Offsite destinations are absolute paths the backup worker writes a copy of
-each snapshot to after the local write succeeds. The default destination is
-the iCloud Drive VellumAssistant folder, and it is used implicitly until an
-explicit destinations array is configured. The first 'destinations add' or
-'destinations remove' materializes the iCloud default before applying the
-change, so the default is never lost on an accidental "clear all".
-
-Each destination has an 'encrypt' flag. When true (the default), snapshots
-are written as .vbundle.enc (AES-256-GCM). When false, snapshots are copied
-as plaintext .vbundle — only use this for media you control physically.
-
-Examples:
-  $ assistant backup destinations list
-  $ assistant backup destinations add /Volumes/BackupSSD/vellum --plaintext
-  $ assistant backup destinations remove /Volumes/BackupSSD/vellum
-  $ assistant backup destinations set-encrypt /Volumes/BackupSSD/vellum false`,
+        },
       );
 
-      destinations
-        .command("list")
-        .description("List configured offsite destinations")
-        .addHelpText(
-          "after",
-          `
-Resolves the current destinations array (materializing the iCloud default if
-no explicit array is configured) and prints a table with the path and
-encryption flag per row.
+      // ── destinations ─────────────────────────────────────────────────
+      const destinations = subcommand(backup, "destinations");
 
-Examples:
-  $ assistant backup destinations list`,
-        )
-        .action(async (_opts: unknown, cmd: Command) => {
+      subcommand(destinations, "list").action(
+        async (_opts: unknown, cmd: Command) => {
           const r = await cliIpcCall<{
             destinations: Array<{ path: string; encrypt: boolean }>;
           }>("backup_destinations_list");
@@ -229,139 +139,71 @@ Examples:
           for (const d of dests) {
             log.info(d.path.padEnd(pathW) + "  " + (d.encrypt ? "yes" : "no"));
           }
-        });
+        },
+      );
 
-      destinations
-        .command("add <path>")
-        .description("Add an offsite backup destination")
-        .option(
-          "--plaintext",
-          "Write snapshots as plaintext .vbundle (default is AES-256-GCM encrypted .vbundle.enc)",
-        )
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  path   Absolute path to the destination directory. Must be on a mount the
-         caller controls; the backup worker writes files inside this
-         directory, not the directory itself.
-
-If backup.offsite.destinations is currently null (the implicit iCloud default),
-the iCloud default is materialized first so the new entry appends to a
-2-element array rather than replacing the default.
-
-Examples:
-  $ assistant backup destinations add /Volumes/BackupSSD/vellum --plaintext
-  $ assistant backup destinations add ~/Dropbox/VellumAssistant/backups`,
-        )
-        .action(
-          async (path: string, opts: { plaintext?: boolean }, cmd: Command) => {
-            const r = await cliIpcCall("backup_destinations_add", {
-              body: {
-                path,
-                encrypt: !opts.plaintext,
-              },
-            });
-            if (!r.ok)
-              return exitFromIpcResult(
-                { ok: false, error: r.error, statusCode: r.statusCode },
-                cmd,
-              );
-            log.info(
-              `Added destination ${path} (${opts.plaintext ? "plaintext" : "encrypted"})`,
+      subcommand(destinations, "add").action(
+        async (path: string, opts: { plaintext?: boolean }, cmd: Command) => {
+          const r = await cliIpcCall("backup_destinations_add", {
+            body: {
+              path,
+              encrypt: !opts.plaintext,
+            },
+          });
+          if (!r.ok)
+            return exitFromIpcResult(
+              { ok: false, error: r.error, statusCode: r.statusCode },
+              cmd,
             );
-          },
-        );
+          log.info(
+            `Added destination ${path} (${opts.plaintext ? "plaintext" : "encrypted"})`,
+          );
+        },
+      );
 
-      destinations
-        .command("remove <path>")
-        .description("Remove an offsite backup destination by path")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  path   Exact path match of the destination to remove. Run
-         'assistant backup destinations list' to see configured paths.
-
-Errors if no destination with the given path exists.
-
-Examples:
-  $ assistant backup destinations remove /Volumes/BackupSSD/vellum`,
-        )
-        .action(async (path: string, _opts: unknown, cmd: Command) => {
-          const r = await cliIpcCall("backup_destinations_remove", { body: { path } });
+      subcommand(destinations, "remove").action(
+        async (path: string, _opts: unknown, cmd: Command) => {
+          const r = await cliIpcCall("backup_destinations_remove", {
+            body: { path },
+          });
           if (!r.ok)
             return exitFromIpcResult(
               { ok: false, error: r.error, statusCode: r.statusCode },
               cmd,
             );
           log.info(`Removed destination ${path}`);
-        });
+        },
+      );
 
-      destinations
-        .command("set-encrypt <path> <value>")
-        .description("Toggle encryption for an existing destination")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  path    Exact path match of an existing destination. Run
-          'assistant backup destinations list' to see configured paths.
-  value   "true" to encrypt, "false" for plaintext writes.
+      subcommand(destinations, "set-encrypt").action(
+        async (path: string, value: string, _opts: unknown, cmd: Command) => {
+          const normalized = value.toLowerCase();
+          if (normalized !== "true" && normalized !== "false") {
+            log.error(
+              `Invalid encrypt value "${value}". Must be "true" or "false". ` +
+                `Run 'assistant backup destinations set-encrypt --help' for usage.`,
+            );
+            process.exitCode = 1;
+            return;
+          }
+          const r = await cliIpcCall("backup_destinations_set_encrypt", {
+            body: {
+              path,
+              encrypt: normalized === "true",
+            },
+          });
+          if (!r.ok)
+            return exitFromIpcResult(
+              { ok: false, error: r.error, statusCode: r.statusCode },
+              cmd,
+            );
+          log.info(`Set ${path} encrypt=${normalized}`);
+        },
+      );
 
-Errors if no destination with the given path exists. Existing snapshot files
-are not modified; only future writes honour the new setting.
-
-Examples:
-  $ assistant backup destinations set-encrypt /Volumes/BackupSSD/vellum false
-  $ assistant backup destinations set-encrypt /Volumes/BackupSSD/vellum true`,
-        )
-        .action(
-          async (path: string, value: string, _opts: unknown, cmd: Command) => {
-            const normalized = value.toLowerCase();
-            if (normalized !== "true" && normalized !== "false") {
-              log.error(
-                `Invalid encrypt value "${value}". Must be "true" or "false". ` +
-                  `Run 'assistant backup destinations set-encrypt --help' for usage.`,
-              );
-              process.exitCode = 1;
-              return;
-            }
-            const r = await cliIpcCall("backup_destinations_set_encrypt", {
-              body: {
-                path,
-                encrypt: normalized === "true",
-              },
-            });
-            if (!r.ok)
-              return exitFromIpcResult(
-                { ok: false, error: r.error, statusCode: r.statusCode },
-                cmd,
-              );
-            log.info(`Set ${path} encrypt=${normalized}`);
-          },
-        );
-
-      // -----------------------------------------------------------------------
-      // status / list
-      // -----------------------------------------------------------------------
-
-      backup
-        .command("status")
-        .description("Show backup status and next-run timing")
-        .addHelpText(
-          "after",
-          `
-Reports enabled/disabled state, interval and retention, last-run and next-run
-timing (from the backup:last_run_at memory checkpoint), and a per-destination
-reachability probe. Unreachable destinations (parent directory missing, e.g.
-iCloud Drive not enabled or external volume unplugged) are flagged
-[unreachable] and skipped by the worker.
-
-Examples:
-  $ assistant backup status`,
-        )
-        .action(async (_opts: unknown, cmd: Command) => {
+      // ── status ───────────────────────────────────────────────────────
+      subcommand(backup, "status").action(
+        async (_opts: unknown, cmd: Command) => {
           const r = await cliIpcCall<{
             enabled: boolean;
             intervalHours: number;
@@ -437,22 +279,12 @@ Examples:
               `  ${tag} ${dest.path}  (${enc}, ${dest.snapshotCount} snapshots)${suffix}`,
             );
           }
-        });
+        },
+      );
 
-      backup
-        .command("list")
-        .description("List all backup snapshots, grouped by destination")
-        .addHelpText(
-          "after",
-          `
-Prints a per-destination table of snapshots with timestamp, size, and
-encryption flag. Local destination is listed first, followed by each offsite
-destination. Unreachable destinations are listed with an empty snapshot set.
-
-Examples:
-  $ assistant backup list`,
-        )
-        .action(async (_opts: unknown, cmd: Command) => {
+      // ── list ─────────────────────────────────────────────────────────
+      subcommand(backup, "list").action(
+        async (_opts: unknown, cmd: Command) => {
           const r = await cliIpcCall<{
             local: Array<{
               filename: string;
@@ -491,7 +323,8 @@ Examples:
               dest.snapshots,
             );
           }
-        });
+        },
+      );
     },
   });
 }

--- a/assistant/src/cli/commands/bash.help.ts
+++ b/assistant/src/cli/commands/bash.help.ts
@@ -1,0 +1,45 @@
+/**
+ * Declarative help for the `assistant bash` command.
+ *
+ * Plain data (no action handlers, imports only the help contract type) so the
+ * memory capability indexer can read it without pulling in the daemon/IPC action
+ * graph. The handler lives in `bash.ts`, which applies this via
+ * `applyCommandHelp` and attaches it.
+ */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const bashHelp: CliCommandHelp = {
+  name: "bash",
+  args: "<command>",
+  description:
+    "Execute a shell command through the assistant process for debugging",
+  options: [
+    {
+      flags: "-t, --timeout <ms>",
+      description: "Timeout in milliseconds for command execution",
+      defaultValue: "30000",
+    },
+  ],
+  helpText: `
+Sends a shell command to the running assistant for execution via the IPC
+socket. The assistant spawns the command in its own process environment and
+returns stdout, stderr, and the exit code.
+
+This is a developer debugging tool for inspecting how the assistant invokes and
+observes shell commands. The command runs with the assistant's environment, working
+directory, and process context — not the caller's shell.
+
+Requires the assistant to be running with VELLUM_DEBUG=1. When debug mode is off
+(the default), the assistant returns an error immediately.
+
+Arguments:
+  command   The shell command string to execute (e.g. "echo hello", "ls -la").
+            Runs in bash via \`bash -c\` in the assistant's process environment.
+
+Examples:
+  $ assistant bash "echo hello"
+  $ assistant bash "which node"
+  $ assistant bash "env | grep PATH" --timeout 10000
+  $ assistant bash "ls -la"`,
+};

--- a/assistant/src/cli/commands/bash.ts
+++ b/assistant/src/cli/commands/bash.ts
@@ -1,10 +1,19 @@
+/**
+ * `assistant bash` — run a shell command in the assistant's process
+ * environment (debug tool, requires VELLUM_DEBUG=1 on the daemon).
+ *
+ * The command's help structure lives in `bash.help.ts` (import-safe for
+ * the memory capability indexer); this module applies it and attaches the
+ * action handler.
+ */
+
 import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
+import { applyCommandHelp, commandSpec } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
-
-const DEFAULT_TIMEOUT_MS = 30_000;
+import { bashHelp } from "./bash.help.js";
 
 interface DebugBashResult {
   stdout: string;
@@ -16,92 +25,63 @@ interface DebugBashResult {
 
 export function registerBashCommand(program: Command): void {
   registerCommand(program, {
-    name: "bash <command>",
+    name: commandSpec(bashHelp),
     transport: "ipc",
-    description: "Execute a shell command through the assistant process for debugging",
+    description: bashHelp.description,
     build: (cmd) => {
-      cmd
-    .option(
-      "-t, --timeout <ms>",
-      "Timeout in milliseconds for command execution",
-      String(DEFAULT_TIMEOUT_MS),
-    )
-    .addHelpText(
-      "after",
-      `
-Sends a shell command to the running assistant for execution via the IPC
-socket. The assistant spawns the command in its own process environment and
-returns stdout, stderr, and the exit code.
-
-This is a developer debugging tool for inspecting how the assistant invokes and
-observes shell commands. The command runs with the assistant's environment, working
-directory, and process context — not the caller's shell.
-
-Requires the assistant to be running with VELLUM_DEBUG=1. When debug mode is off
-(the default), the assistant returns an error immediately.
-
-Arguments:
-  command   The shell command string to execute (e.g. "echo hello", "ls -la").
-            Runs in bash via \`bash -c\` in the assistant's process environment.
-
-Examples:
-  $ assistant bash "echo hello"
-  $ assistant bash "which node"
-  $ assistant bash "env | grep PATH" --timeout 10000
-  $ assistant bash "ls -la"`,
-    )
-    .action(async (command: string, opts: { timeout: string }) => {
-      const timeoutMs = parseInt(opts.timeout, 10);
-      if (!Number.isFinite(timeoutMs) || timeoutMs < 1) {
-        log.error("Invalid timeout value. Must be a positive integer.");
-        process.exitCode = 1;
-        return;
-      }
-
-      const result = await cliIpcCall<DebugBashResult>(
-        "debug_bash",
-        { body: { command, timeoutMs } },
-        { timeoutMs: timeoutMs + 10_000 },
-      );
-
-      if (!result.ok) {
-        log.error(result.error ?? "Failed to reach the assistant.");
-        process.exitCode = 1;
-        return;
-      }
-
-      const data = result.result!;
-
-      if (data.error) {
-        log.error(data.error);
-        process.exitCode = 1;
-        return;
-      }
-
-      if (data.stdout) {
-        process.stdout.write(data.stdout);
-        if (!data.stdout.endsWith("\n")) {
-          process.stdout.write("\n");
+      applyCommandHelp(cmd, bashHelp);
+      cmd.action(async (command: string, opts: { timeout: string }) => {
+        const timeoutMs = parseInt(opts.timeout, 10);
+        if (!Number.isFinite(timeoutMs) || timeoutMs < 1) {
+          log.error("Invalid timeout value. Must be a positive integer.");
+          process.exitCode = 1;
+          return;
         }
-      }
 
-      if (data.stderr) {
-        process.stderr.write(data.stderr);
-        if (!data.stderr.endsWith("\n")) {
-          process.stderr.write("\n");
+        const result = await cliIpcCall<DebugBashResult>(
+          "debug_bash",
+          { body: { command, timeoutMs } },
+          { timeoutMs: timeoutMs + 10_000 },
+        );
+
+        if (!result.ok) {
+          log.error(result.error ?? "Failed to reach the assistant.");
+          process.exitCode = 1;
+          return;
         }
-      }
 
-      if (data.timedOut) {
-        log.info(`Command timed out in assistant.`);
-      }
+        const data = result.result!;
 
-      if (data.exitCode != null && data.exitCode !== 0) {
-        log.info(`Exit code: ${data.exitCode}`);
-      }
+        if (data.error) {
+          log.error(data.error);
+          process.exitCode = 1;
+          return;
+        }
 
-      process.exitCode = data.exitCode ?? 1;
-    });
+        if (data.stdout) {
+          process.stdout.write(data.stdout);
+          if (!data.stdout.endsWith("\n")) {
+            process.stdout.write("\n");
+          }
+        }
+
+        if (data.stderr) {
+          process.stderr.write(data.stderr);
+          if (!data.stderr.endsWith("\n")) {
+            process.stderr.write("\n");
+          }
+        }
+
+        if (data.timedOut) {
+          log.info(`Command timed out in assistant.`);
+        }
+
+        if (data.exitCode != null && data.exitCode !== 0) {
+          log.info(`Exit code: ${data.exitCode}`);
+        }
+
+        process.exitCode = data.exitCode ?? 1;
+      });
     },
   });
 }

--- a/assistant/src/cli/commands/browser.help.ts
+++ b/assistant/src/cli/commands/browser.help.ts
@@ -1,0 +1,196 @@
+/**
+ * Declarative help for the `assistant browser` command.
+ *
+ * Import-safe for the memory capability indexer: no action handlers and no
+ * daemon/IPC action graph. Unlike the hand-written `.help.ts` modules, the
+ * per-operation subcommands are derived from {@link BROWSER_OPERATION_META} —
+ * the browser operations contract is the single source of truth for their
+ * names, flags, and help text, so the derived help can never drift from the
+ * operations the daemon actually supports. The handlers live in `browser.ts`,
+ * which applies this via `applyCommandHelp` and attaches them.
+ */
+
+// operation-meta is an execution-free data leaf (no Playwright imports),
+// consumed synchronously to derive this module's constant — pure data from
+// pure data, so a lazy `import()` has nothing to defer. Kept out of the
+// heavier `browser/operations` barrel on purpose.
+// eslint-disable-next-line cli/no-daemon-internals
+import { BROWSER_OPERATION_META } from "../../browser/operation-meta.js";
+import type {
+  BrowserOperationMeta,
+  OperationField,
+} from "../../browser/types.js";
+import type {
+  CliCommandHelp,
+  CliOptionHelp,
+  CliSubcommandHelp,
+} from "../lib/cli-command-help.js";
+
+// ── Naming helpers ───────────────────────────────────────────────────
+
+/**
+ * Convert a snake_case operation name to kebab-case for CLI subcommand
+ * names (e.g. `press_key` -> `press-key`).
+ */
+export function toKebab(snakeCase: string): string {
+  return snakeCase.replace(/_/g, "-");
+}
+
+/**
+ * Convert a snake_case field name to a kebab-case CLI option flag
+ * (e.g. `allow_private_network` -> `--allow-private-network`).
+ *
+ * Boolean fields declare only `--flag`; Commander 13 auto-generates
+ * the `--no-flag` negation variant. Declaring both in a single spec
+ * string (e.g. `--flag, --no-flag`) breaks in Commander 13 because
+ * `--flag` still parses to `false`.
+ */
+function fieldToFlag(field: OperationField): string {
+  const kebab = toKebab(field.name);
+  if (field.type === "boolean") {
+    return `--${kebab}`;
+  }
+  return `--${kebab} <${field.type === "number" ? "number" : "value"}>`;
+}
+
+/**
+ * Valid browser mode values for the --browser-mode option.
+ * Includes canonical values and compatibility aliases accepted by
+ * `normalizeBrowserMode` (cdp-debugger → cdp-inspect, playwright → local).
+ */
+const BROWSER_MODES = [
+  "auto",
+  "extension",
+  "cdp-inspect",
+  "cdp-debugger",
+  "local",
+  "playwright",
+] as const;
+
+// ── Per-operation subcommand derivation ──────────────────────────────
+
+function operationToSubcommand(meta: BrowserOperationMeta): CliSubcommandHelp {
+  const options: CliOptionHelp[] = meta.fields.map((field) => ({
+    flags: fieldToFlag(field),
+    description: field.description,
+    ...(field.required ? { required: true } : {}),
+    ...(field.enum ? { choices: [...field.enum] } : {}),
+  }));
+
+  // screenshot gets an --output <path> option for writing JPEG to disk
+  if (meta.operation === "screenshot") {
+    options.push({
+      flags: "--output <path>",
+      description: "Write the screenshot JPEG to a file path on disk.",
+    });
+  }
+
+  return {
+    name: toKebab(meta.operation),
+    description: meta.description,
+    ...(options.length > 0 ? { options } : {}),
+    ...(meta.helpText ? { helpText: `\n${meta.helpText}` } : {}),
+  };
+}
+
+// ── Command help ─────────────────────────────────────────────────────
+
+export const browserHelp: CliCommandHelp = {
+  name: "browser",
+  description: "Control the browser via the running assistant.",
+  options: [
+    {
+      flags: "--session <id>",
+      description: "Session ID to preserve browser state across invocations.",
+      defaultValue: "default",
+    },
+    {
+      flags: "--json",
+      description: "Output results as machine-readable JSON.",
+    },
+    {
+      flags: "--browser-mode <mode>",
+      description: "Browser backend to use. Overrides automatic selection.",
+      choices: BROWSER_MODES,
+    },
+    {
+      flags: "--target-client-id <id>",
+      description:
+        "Route browser operations to a specific client. Obtain IDs from `assistant clients list --capability host_browser`.",
+    },
+  ],
+  helpText: `
+Browser operations are executed through the running assistant.
+Each subcommand maps to a browser operation and communicates
+with the assistant process.
+
+The --session flag groups sequential commands so they share browser
+state (same page, cookies, etc.). Different session IDs create
+independent browser contexts.
+
+The --browser-mode flag pins the browser backend for all operations
+in the invocation. Valid modes: auto (default), extension, cdp-inspect,
+local. Useful for debugging or when deterministic backend selection
+is required.
+
+Examples:
+  $ assistant browser navigate --url https://example.com
+  $ assistant browser snapshot
+  $ assistant browser click --selector "#login"
+  $ assistant browser type --text "hello" --element-id e14
+  $ assistant browser screenshot --output page.jpg
+  $ assistant browser --session myflow navigate --url https://example.com
+  $ assistant browser --browser-mode local navigate --url http://localhost:3000
+  $ assistant browser --json screenshot`,
+  subcommands: [
+    ...BROWSER_OPERATION_META.map(operationToSubcommand),
+    {
+      name: "tabs",
+      description: "Manage browser tabs",
+      subcommands: [
+        {
+          name: "list",
+          description: "List all open browser tabs",
+          options: [
+            {
+              flags: "--pretty",
+              description: "Human-readable table output instead of JSON",
+            },
+          ],
+        },
+        {
+          name: "select",
+          description: "Select (activate) a browser tab by ID",
+          options: [
+            {
+              flags: "--tab-id <id>",
+              description: "Tab ID to select",
+              required: true,
+            },
+          ],
+        },
+        {
+          name: "new",
+          description: "Open a new browser tab",
+          options: [
+            {
+              flags: "--url <url>",
+              description: "URL to navigate the new tab to",
+            },
+          ],
+        },
+        {
+          name: "close",
+          description: "Close a browser tab by ID",
+          options: [
+            {
+              flags: "--tab-id <id>",
+              description: "Tab ID to close",
+              required: true,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/assistant/src/cli/commands/browser.ts
+++ b/assistant/src/cli/commands/browser.ts
@@ -5,11 +5,15 @@
  * browser operations contract ({@link BROWSER_OPERATION_META}).
  * Each subcommand maps CLI kebab-case flags into snake_case input
  * keys and calls `browser_execute` over the CLI IPC socket.
+ *
+ * The command's help structure lives in `browser.help.ts` (import-safe for
+ * the memory capability indexer, derived from the same operations contract);
+ * this module applies it and attaches the action handlers.
  */
 
 import { writeFileSync } from "node:fs";
 
-import { type Command, Option } from "commander";
+import type { Command } from "commander";
 
 // operation-meta is an execution-free data leaf (no Playwright imports),
 // consumed synchronously while building the `browser` subcommand tree — the
@@ -23,35 +27,12 @@ import type {
   OperationField,
 } from "../../browser/types.js";
 import { cliIpcCall } from "../../ipc/cli-client.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
+import { browserHelp, toKebab } from "./browser.help.js";
 
 // ── Naming helpers ───────────────────────────────────────────────────
-
-/**
- * Convert a snake_case operation name to kebab-case for CLI subcommand
- * names (e.g. `press_key` -> `press-key`).
- */
-function toKebab(snakeCase: string): string {
-  return snakeCase.replace(/_/g, "-");
-}
-
-/**
- * Convert a snake_case field name to a kebab-case CLI option flag
- * (e.g. `allow_private_network` -> `--allow-private-network`).
- *
- * Boolean fields declare only `--flag`; Commander 13 auto-generates
- * the `--no-flag` negation variant. Declaring both in a single spec
- * string (e.g. `--flag, --no-flag`) breaks in Commander 13 because
- * `--flag` still parses to `false`.
- */
-function fieldToFlag(field: OperationField): string {
-  const kebab = toKebab(field.name);
-  if (field.type === "boolean") {
-    return `--${kebab}`;
-  }
-  return `--${kebab} <${field.type === "number" ? "number" : "value"}>`;
-}
 
 /**
  * Convert a kebab-case option key back to snake_case for the IPC
@@ -125,51 +106,20 @@ interface BrowserExecuteResult {
   screenshots?: Array<{ mediaType: string; data: string }>;
 }
 
-// ── Subcommand builder ───────────────────────────────────────────────
+// ── Operation action wiring ──────────────────────────────────────────
 
 /**
- * Build a Commander subcommand for a single browser operation.
+ * Attach the `browser_execute` action for a single browser operation to its
+ * (already help-declared) subcommand.
  */
-function buildSubcommand(parent: Command, meta: BrowserOperationMeta): void {
-  const subcmd = parent
-    .command(toKebab(meta.operation))
-    .description(meta.description);
-
-  // Add per-operation field options
-  for (const field of meta.fields) {
-    const flag = fieldToFlag(field);
-
-    if (field.enum) {
-      // Use Commander's Option class with .choices() for enum-constrained
-      // fields so invalid values are rejected at the CLI level and
-      // --help lists the allowed values.
-      const opt = new Option(flag, field.description).choices([...field.enum]);
-      if (field.required) {
-        opt.makeOptionMandatory(true);
-      }
-      subcmd.addOption(opt);
-    } else if (field.required) {
-      subcmd.requiredOption(flag, field.description);
-    } else {
-      subcmd.option(flag, field.description);
-    }
-  }
-
-  // Append per-operation help text with behavioral notes and examples
-  if (meta.helpText) {
-    subcmd.addHelpText("after", `\n${meta.helpText}`);
-  }
-
-  // screenshot gets an --output <path> option for writing JPEG to disk
-  if (meta.operation === "screenshot") {
-    subcmd.option(
-      "--output <path>",
-      "Write the screenshot JPEG to a file path on disk.",
-    );
-  }
+function attachOperationAction(
+  browser: Command,
+  meta: BrowserOperationMeta,
+): void {
+  const subcmd = subcommand(browser, toKebab(meta.operation));
 
   subcmd.action(async (opts: Record<string, unknown>) => {
-    const parentOpts = parent.opts() as {
+    const parentOpts = browser.opts() as {
       session?: string;
       json?: boolean;
       browserMode?: string;
@@ -355,320 +305,249 @@ function formatBrowserStatus(content: string): void {
 
 // ── Registration ─────────────────────────────────────────────────────
 
-/**
- * Valid browser mode values for the --browser-mode option.
- * Includes canonical values and compatibility aliases accepted by
- * `normalizeBrowserMode` (cdp-debugger → cdp-inspect, playwright → local).
- */
-const BROWSER_MODES = [
-  "auto",
-  "extension",
-  "cdp-inspect",
-  "cdp-debugger",
-  "local",
-  "playwright",
-] as const;
-
 export function registerBrowserCommand(program: Command): void {
   registerCommand(program, {
-    name: "browser",
+    name: browserHelp.name,
     transport: "ipc",
-    description: "Control the browser via the running assistant.",
+    description: browserHelp.description,
     build: (browser) => {
-      browser
-        .option(
-          "--session <id>",
-          "Session ID to preserve browser state across invocations.",
-          "default",
-        )
-        .option("--json", "Output results as machine-readable JSON.")
-        .addOption(
-          new Option(
-            "--browser-mode <mode>",
-            "Browser backend to use. Overrides automatic selection.",
-          ).choices([...BROWSER_MODES]),
-        )
-        .option(
-          "--target-client-id <id>",
-          "Route browser operations to a specific client. Obtain IDs from `assistant clients list --capability host_browser`.",
-        );
+      applyCommandHelp(browser, browserHelp);
 
-      browser.addHelpText(
-        "after",
-        `
-Browser operations are executed through the running assistant.
-Each subcommand maps to a browser operation and communicates
-with the assistant process.
-
-The --session flag groups sequential commands so they share browser
-state (same page, cookies, etc.). Different session IDs create
-independent browser contexts.
-
-The --browser-mode flag pins the browser backend for all operations
-in the invocation. Valid modes: auto (default), extension, cdp-inspect,
-local. Useful for debugging or when deterministic backend selection
-is required.
-
-Examples:
-  $ assistant browser navigate --url https://example.com
-  $ assistant browser snapshot
-  $ assistant browser click --selector "#login"
-  $ assistant browser type --text "hello" --element-id e14
-  $ assistant browser screenshot --output page.jpg
-  $ assistant browser --session myflow navigate --url https://example.com
-  $ assistant browser --browser-mode local navigate --url http://localhost:3000
-  $ assistant browser --json screenshot`,
-      );
-
-      // Register one subcommand per browser operation
+      // Attach one action per browser operation
       for (const meta of BROWSER_OPERATION_META) {
-        buildSubcommand(browser, meta);
+        attachOperationAction(browser, meta);
       }
 
       // -- tabs subcommand group
-      const tabs = browser.command("tabs").description("Manage browser tabs");
+      const tabs = subcommand(browser, "tabs");
 
-      tabs
-        .command("list")
-        .description("List all open browser tabs")
-        .option("--pretty", "Human-readable table output instead of JSON")
-        .action(async (opts: { pretty?: boolean }) => {
-          const parentOpts = browser.opts() as {
-            session?: string;
-            json?: boolean;
-            targetClientId?: string;
-          };
-          const sessionId = parentOpts.session ?? "default";
-          const jsonMode = parentOpts.json ?? false;
-          const conversationId = resolveContextConversationId();
-          const targetClientId = parentOpts.targetClientId;
+      subcommand(tabs, "list").action(async (opts: { pretty?: boolean }) => {
+        const parentOpts = browser.opts() as {
+          session?: string;
+          json?: boolean;
+          targetClientId?: string;
+        };
+        const sessionId = parentOpts.session ?? "default";
+        const jsonMode = parentOpts.json ?? false;
+        const conversationId = resolveContextConversationId();
+        const targetClientId = parentOpts.targetClientId;
 
-          const ipcResult = await cliIpcCall<{
-            ok: boolean;
-            tabs?: Array<{
-              tabId?: number;
-              windowId?: number;
-              url?: string;
-              title?: string;
-              active: boolean;
-              pinned: boolean;
-            }>;
-          }>(
-            "browser_tabs",
-            {
-              body: {
-                command: "list",
-                sessionId,
-                ...(conversationId ? { conversationId } : {}),
-                ...(targetClientId ? { targetClientId } : {}),
-              },
-            },
-            { timeoutMs: 30_000 },
-          );
-
-          if (!ipcResult.ok) {
-            if (jsonMode) {
-              process.stdout.write(
-                JSON.stringify({ ok: false, error: ipcResult.error }) + "\n",
-              );
-            } else {
-              log.error(`Error: ${ipcResult.error}`);
-            }
-            process.exitCode = 1;
-            return;
-          }
-
-          const tabList = ipcResult.result?.tabs ?? [];
-
-          if (jsonMode || !opts.pretty) {
-            process.stdout.write(JSON.stringify(tabList) + "\n");
-          } else {
-            if (tabList.length === 0) {
-              log.info("No tabs found.");
-              return;
-            }
-            log.info(
-              `${"ID".padEnd(8)} ${"WIN".padEnd(5)} ${"ACT".padEnd(4)} ${"PIN".padEnd(4)} URL/Title`,
-            );
-            log.info("-".repeat(80));
-            for (const tab of tabList) {
-              const id = String(tab.tabId ?? "?").padEnd(8);
-              const win = String(tab.windowId ?? "?").padEnd(5);
-              const act = (tab.active ? "yes" : "no").padEnd(4);
-              const pin = (tab.pinned ? "yes" : "no").padEnd(4);
-              const label = tab.url ?? tab.title ?? "(untitled)";
-              log.info(`${id} ${win} ${act} ${pin} ${label}`);
-            }
-          }
-        });
-
-      tabs
-        .command("select")
-        .description("Select (activate) a browser tab by ID")
-        .requiredOption("--tab-id <id>", "Tab ID to select", Number)
-        .action(async (opts: { tabId: number }) => {
-          const parentOpts = browser.opts() as {
-            session?: string;
-            json?: boolean;
-            targetClientId?: string;
-          };
-          const sessionId = parentOpts.session ?? "default";
-          const jsonMode = parentOpts.json ?? false;
-          const conversationId = resolveContextConversationId();
-          const targetClientId = parentOpts.targetClientId;
-
-          const ipcResult = await cliIpcCall<{ ok: boolean; tab?: unknown }>(
-            "browser_tabs",
-            {
-              body: {
-                command: "select",
-                sessionId,
-                tabId: opts.tabId,
-                ...(conversationId ? { conversationId } : {}),
-                ...(targetClientId ? { targetClientId } : {}),
-              },
-            },
-            { timeoutMs: 30_000 },
-          );
-
-          if (!ipcResult.ok) {
-            if (jsonMode) {
-              process.stdout.write(
-                JSON.stringify({ ok: false, error: ipcResult.error }) + "\n",
-              );
-            } else {
-              log.error(`Error: ${ipcResult.error}`);
-            }
-            process.exitCode = 1;
-            return;
-          }
-
-          if (jsonMode) {
-            process.stdout.write(
-              JSON.stringify({ ok: true, tab: ipcResult.result?.tab }) + "\n",
-            );
-          } else {
-            log.info(`Selected tab ${opts.tabId}`);
-          }
-        });
-
-      tabs
-        .command("new")
-        .description("Open a new browser tab")
-        .option("--url <url>", "URL to navigate the new tab to")
-        .action(async (opts: { url?: string }) => {
-          const parentOpts = browser.opts() as {
-            session?: string;
-            json?: boolean;
-            targetClientId?: string;
-          };
-          const sessionId = parentOpts.session ?? "default";
-          const jsonMode = parentOpts.json ?? false;
-          const conversationId = resolveContextConversationId();
-          const targetClientId = parentOpts.targetClientId;
-
-          const ipcResult = await cliIpcCall<{
-            ok: boolean;
-            tabId?: string;
-            clientId?: string;
-          }>(
-            "browser_tabs",
-            {
-              body: {
-                command: "new",
-                sessionId,
-                ...(opts.url ? { url: opts.url } : {}),
-                ...(conversationId ? { conversationId } : {}),
-                ...(targetClientId ? { targetClientId } : {}),
-              },
-            },
-            { timeoutMs: 30_000 },
-          );
-
-          if (!ipcResult.ok) {
-            if (jsonMode) {
-              process.stdout.write(
-                JSON.stringify({ ok: false, error: ipcResult.error }) + "\n",
-              );
-            } else {
-              log.error(`Error: ${ipcResult.error}`);
-            }
-            process.exitCode = 1;
-            return;
-          }
-
-          if (jsonMode) {
-            process.stdout.write(
-              JSON.stringify({
-                ok: true,
-                tabId: ipcResult.result?.tabId,
-                clientId: ipcResult.result?.clientId,
-              }) + "\n",
-            );
-          } else {
-            log.info(
-              `Opened new tab${ipcResult.result?.tabId ? ` (ID: ${ipcResult.result.tabId})` : ""}`,
-            );
-          }
-        });
-
-      tabs
-        .command("close")
-        .description("Close a browser tab by ID")
-        .requiredOption("--tab-id <id>", "Tab ID to close", Number)
-        .action(async (opts: { tabId: number }) => {
-          const parentOpts = browser.opts() as {
-            session?: string;
-            json?: boolean;
-            targetClientId?: string;
-          };
-          const sessionId = parentOpts.session ?? "default";
-          const jsonMode = parentOpts.json ?? false;
-          const conversationId = resolveContextConversationId();
-          const targetClientId = parentOpts.targetClientId;
-
-          const ipcResult = await cliIpcCall<{
-            ok: boolean;
-            closed?: boolean;
+        const ipcResult = await cliIpcCall<{
+          ok: boolean;
+          tabs?: Array<{
             tabId?: number;
-          }>(
-            "browser_tabs",
-            {
-              body: {
-                command: "close",
-                sessionId,
-                tabId: opts.tabId,
-                ...(conversationId ? { conversationId } : {}),
-                ...(targetClientId ? { targetClientId } : {}),
-              },
+            windowId?: number;
+            url?: string;
+            title?: string;
+            active: boolean;
+            pinned: boolean;
+          }>;
+        }>(
+          "browser_tabs",
+          {
+            body: {
+              command: "list",
+              sessionId,
+              ...(conversationId ? { conversationId } : {}),
+              ...(targetClientId ? { targetClientId } : {}),
             },
-            { timeoutMs: 30_000 },
-          );
+          },
+          { timeoutMs: 30_000 },
+        );
 
-          if (!ipcResult.ok) {
-            if (jsonMode) {
-              process.stdout.write(
-                JSON.stringify({ ok: false, error: ipcResult.error }) + "\n",
-              );
-            } else {
-              log.error(`Error: ${ipcResult.error}`);
-            }
-            process.exitCode = 1;
-            return;
-          }
-
+        if (!ipcResult.ok) {
           if (jsonMode) {
             process.stdout.write(
-              JSON.stringify({
-                ok: true,
-                closed: ipcResult.result?.closed,
-                tabId: opts.tabId,
-              }) + "\n",
+              JSON.stringify({ ok: false, error: ipcResult.error }) + "\n",
             );
           } else {
-            log.info(`Closed tab ${opts.tabId}`);
+            log.error(`Error: ${ipcResult.error}`);
           }
-        });
+          process.exitCode = 1;
+          return;
+        }
+
+        const tabList = ipcResult.result?.tabs ?? [];
+
+        if (jsonMode || !opts.pretty) {
+          process.stdout.write(JSON.stringify(tabList) + "\n");
+        } else {
+          if (tabList.length === 0) {
+            log.info("No tabs found.");
+            return;
+          }
+          log.info(
+            `${"ID".padEnd(8)} ${"WIN".padEnd(5)} ${"ACT".padEnd(4)} ${"PIN".padEnd(4)} URL/Title`,
+          );
+          log.info("-".repeat(80));
+          for (const tab of tabList) {
+            const id = String(tab.tabId ?? "?").padEnd(8);
+            const win = String(tab.windowId ?? "?").padEnd(5);
+            const act = (tab.active ? "yes" : "no").padEnd(4);
+            const pin = (tab.pinned ? "yes" : "no").padEnd(4);
+            const label = tab.url ?? tab.title ?? "(untitled)";
+            log.info(`${id} ${win} ${act} ${pin} ${label}`);
+          }
+        }
+      });
+
+      subcommand(tabs, "select").action(async (opts: { tabId: string }) => {
+        const parentOpts = browser.opts() as {
+          session?: string;
+          json?: boolean;
+          targetClientId?: string;
+        };
+        const sessionId = parentOpts.session ?? "default";
+        const jsonMode = parentOpts.json ?? false;
+        const conversationId = resolveContextConversationId();
+        const targetClientId = parentOpts.targetClientId;
+        const tabId = Number(opts.tabId);
+
+        const ipcResult = await cliIpcCall<{ ok: boolean; tab?: unknown }>(
+          "browser_tabs",
+          {
+            body: {
+              command: "select",
+              sessionId,
+              tabId,
+              ...(conversationId ? { conversationId } : {}),
+              ...(targetClientId ? { targetClientId } : {}),
+            },
+          },
+          { timeoutMs: 30_000 },
+        );
+
+        if (!ipcResult.ok) {
+          if (jsonMode) {
+            process.stdout.write(
+              JSON.stringify({ ok: false, error: ipcResult.error }) + "\n",
+            );
+          } else {
+            log.error(`Error: ${ipcResult.error}`);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        if (jsonMode) {
+          process.stdout.write(
+            JSON.stringify({ ok: true, tab: ipcResult.result?.tab }) + "\n",
+          );
+        } else {
+          log.info(`Selected tab ${tabId}`);
+        }
+      });
+
+      subcommand(tabs, "new").action(async (opts: { url?: string }) => {
+        const parentOpts = browser.opts() as {
+          session?: string;
+          json?: boolean;
+          targetClientId?: string;
+        };
+        const sessionId = parentOpts.session ?? "default";
+        const jsonMode = parentOpts.json ?? false;
+        const conversationId = resolveContextConversationId();
+        const targetClientId = parentOpts.targetClientId;
+
+        const ipcResult = await cliIpcCall<{
+          ok: boolean;
+          tabId?: string;
+          clientId?: string;
+        }>(
+          "browser_tabs",
+          {
+            body: {
+              command: "new",
+              sessionId,
+              ...(opts.url ? { url: opts.url } : {}),
+              ...(conversationId ? { conversationId } : {}),
+              ...(targetClientId ? { targetClientId } : {}),
+            },
+          },
+          { timeoutMs: 30_000 },
+        );
+
+        if (!ipcResult.ok) {
+          if (jsonMode) {
+            process.stdout.write(
+              JSON.stringify({ ok: false, error: ipcResult.error }) + "\n",
+            );
+          } else {
+            log.error(`Error: ${ipcResult.error}`);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        if (jsonMode) {
+          process.stdout.write(
+            JSON.stringify({
+              ok: true,
+              tabId: ipcResult.result?.tabId,
+              clientId: ipcResult.result?.clientId,
+            }) + "\n",
+          );
+        } else {
+          log.info(
+            `Opened new tab${ipcResult.result?.tabId ? ` (ID: ${ipcResult.result.tabId})` : ""}`,
+          );
+        }
+      });
+
+      subcommand(tabs, "close").action(async (opts: { tabId: string }) => {
+        const parentOpts = browser.opts() as {
+          session?: string;
+          json?: boolean;
+          targetClientId?: string;
+        };
+        const sessionId = parentOpts.session ?? "default";
+        const jsonMode = parentOpts.json ?? false;
+        const conversationId = resolveContextConversationId();
+        const targetClientId = parentOpts.targetClientId;
+        const tabId = Number(opts.tabId);
+
+        const ipcResult = await cliIpcCall<{
+          ok: boolean;
+          closed?: boolean;
+          tabId?: number;
+        }>(
+          "browser_tabs",
+          {
+            body: {
+              command: "close",
+              sessionId,
+              tabId,
+              ...(conversationId ? { conversationId } : {}),
+              ...(targetClientId ? { targetClientId } : {}),
+            },
+          },
+          { timeoutMs: 30_000 },
+        );
+
+        if (!ipcResult.ok) {
+          if (jsonMode) {
+            process.stdout.write(
+              JSON.stringify({ ok: false, error: ipcResult.error }) + "\n",
+            );
+          } else {
+            log.error(`Error: ${ipcResult.error}`);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        if (jsonMode) {
+          process.stdout.write(
+            JSON.stringify({
+              ok: true,
+              closed: ipcResult.result?.closed,
+              tabId,
+            }) + "\n",
+          );
+        } else {
+          log.info(`Closed tab ${tabId}`);
+        }
+      });
     },
   });
 }

--- a/assistant/src/cli/index.help.ts
+++ b/assistant/src/cli/index.help.ts
@@ -14,10 +14,18 @@
 import { attachmentHelp } from "./commands/attachment.help.js";
 import { auditHelp } from "./commands/audit.help.js";
 import { authHelp } from "./commands/auth.help.js";
+import { avatarHelp } from "./commands/avatar.help.js";
+import { backupHelp } from "./commands/backup.help.js";
+import { bashHelp } from "./commands/bash.help.js";
+import { browserHelp } from "./commands/browser.help.js";
 import type { CliCommandHelp } from "./lib/cli-command-help.js";
 
 export const CLI_COMMAND_HELP: readonly CliCommandHelp[] = [
   attachmentHelp,
   auditHelp,
   authHelp,
+  avatarHelp,
+  backupHelp,
+  bashHelp,
+  browserHelp,
 ];

--- a/assistant/src/cli/lib/cli-command-help.ts
+++ b/assistant/src/cli/lib/cli-command-help.ts
@@ -1,4 +1,4 @@
-import type { Command } from "commander";
+import { type Command, Option } from "commander";
 
 /**
  * Fully declarative description of a top-level `assistant` CLI command and its
@@ -9,6 +9,13 @@ import type { Command } from "commander";
  */
 export interface CliCommandHelp {
   name: string;
+  /**
+   * Positional-argument spec appended to the name at registration, e.g.
+   * `"<command>"`. Use {@link commandSpec} to build the Commander registration
+   * string; `name` stays the bare command name so consumers (dedup, slugs,
+   * rendering) never parse argument syntax out of it.
+   */
+  args?: string;
   description: string;
   /** Options declared directly on the top-level command. */
   options?: CliOptionHelp[];
@@ -19,10 +26,14 @@ export interface CliCommandHelp {
 
 export interface CliSubcommandHelp {
   name: string;
+  /** Positional-argument spec, e.g. `"<path>"` — see {@link CliCommandHelp.args}. */
+  args?: string;
   description: string;
   options?: CliOptionHelp[];
   /** Extra help appended after the option list (`addHelpText("after", …)`). */
   helpText?: string;
+  /** Nested subcommand groups (e.g. `avatar character update`). */
+  subcommands?: CliSubcommandHelp[];
 }
 
 export interface CliOptionHelp {
@@ -33,11 +44,24 @@ export interface CliOptionHelp {
   required?: boolean;
   /** Default value passed to `option(flags, description, defaultValue)`. */
   defaultValue?: string;
+  /** Allowed values, applied via Commander's `Option.choices()` (invalid → error). */
+  choices?: readonly string[];
 }
 
 function applyOptions(command: Command, options?: CliOptionHelp[]): void {
   for (const option of options ?? []) {
-    if (option.required) {
+    if (option.choices) {
+      const built = new Option(option.flags, option.description).choices([
+        ...option.choices,
+      ]);
+      if (option.required) {
+        built.makeOptionMandatory(true);
+      }
+      if (option.defaultValue !== undefined) {
+        built.default(option.defaultValue);
+      }
+      command.addOption(built);
+    } else if (option.required) {
       command.requiredOption(option.flags, option.description);
     } else if (option.defaultValue !== undefined) {
       command.option(option.flags, option.description, option.defaultValue);
@@ -49,23 +73,38 @@ function applyOptions(command: Command, options?: CliOptionHelp[]): void {
 
 /**
  * Configure a Commander command from its declarative {@link CliCommandHelp}:
- * top-level options, appended help text, and subcommands (with their options).
- * Does not set the top-level name/description — `registerCommand` owns those —
- * and does not attach action handlers; the command module attaches those to the
- * command or its subcommands.
+ * top-level options, appended help text, and subcommands (with their options,
+ * recursively). Does not set the top-level name/description — `registerCommand`
+ * owns those — and does not attach action handlers; the command module attaches
+ * those to the command or its subcommands.
  */
 export function applyCommandHelp(command: Command, help: CliCommandHelp): void {
   applyOptions(command, help.options);
   if (help.helpText) {
     command.addHelpText("after", help.helpText);
   }
-  for (const sub of help.subcommands ?? []) {
-    const child = command.command(sub.name).description(sub.description);
+  applySubcommands(command, help.subcommands);
+}
+
+function applySubcommands(parent: Command, subs?: CliSubcommandHelp[]): void {
+  for (const sub of subs ?? []) {
+    const child = parent.command(commandSpec(sub)).description(sub.description);
     applyOptions(child, sub.options);
     if (sub.helpText) {
       child.addHelpText("after", sub.helpText);
     }
+    applySubcommands(child, sub.subcommands);
   }
+}
+
+/**
+ * Commander registration spec for a command: the bare name plus its
+ * positional-argument spec, if any (`"bash <command>"`, `"add <path>"`).
+ */
+export function commandSpec(
+  help: Pick<CliCommandHelp, "name" | "args">,
+): string {
+  return help.args ? `${help.name} ${help.args}` : help.name;
 }
 
 /** Return a subcommand by name, throwing if absent. */

--- a/assistant/src/plugins/defaults/memory/v2/cli-command-content.ts
+++ b/assistant/src/plugins/defaults/memory/v2/cli-command-content.ts
@@ -15,6 +15,8 @@ import type { CLI_COMMAND_HELP } from "@vellumai/plugin-api";
 
 /** Element type of the plugin-api's declarative CLI help constant. */
 type CliCommandHelp = (typeof CLI_COMMAND_HELP)[number];
+/** Subcommand element type — recursive via its own `subcommands` field. */
+type CliSubcommandHelp = NonNullable<CliCommandHelp["subcommands"]>[number];
 
 export function buildCliCommandContent(
   name: string,
@@ -40,8 +42,28 @@ export function buildCliCommandHelpContent(help: CliCommandHelp): string {
   if (help.helpText) {
     sections.push(help.helpText.trim());
   }
-  for (const sub of help.subcommands ?? []) {
-    const lines = [`${help.name} ${sub.name} — ${sub.description}`];
+  collectSubcommandSections(help.name, help.subcommands, sections);
+  return buildCliCommandContent(
+    help.name,
+    help.description,
+    sections.join("\n\n"),
+  );
+}
+
+/**
+ * Walk the subcommand tree depth-first, emitting one section per subcommand
+ * headed by its full command path (`backup destinations add <path> — …`) so
+ * nested groups index under the phrase a user would actually type.
+ */
+function collectSubcommandSections(
+  path: string,
+  subs: readonly CliSubcommandHelp[] | undefined,
+  sections: string[],
+): void {
+  for (const sub of subs ?? []) {
+    const subPath = `${path} ${sub.name}`;
+    const heading = `${subPath}${sub.args ? ` ${sub.args}` : ""} — ${sub.description}`;
+    const lines = [heading];
     const options = renderOptionLines(sub.options);
     if (options) {
       lines.push(options);
@@ -50,12 +72,8 @@ export function buildCliCommandHelpContent(help: CliCommandHelp): string {
       lines.push(sub.helpText.trim());
     }
     sections.push(lines.join("\n"));
+    collectSubcommandSections(subPath, sub.subcommands, sections);
   }
-  return buildCliCommandContent(
-    help.name,
-    help.description,
-    sections.join("\n\n"),
-  );
 }
 
 function renderOptionLines(options: CliCommandHelp["options"]): string | null {
@@ -63,9 +81,17 @@ function renderOptionLines(options: CliCommandHelp["options"]): string | null {
     return null;
   }
   return options
-    .map(
-      (option) =>
-        `  ${option.flags}${option.required ? " (required)" : ""}  ${option.description}`,
-    )
+    .map((option) => {
+      const qualifiers = [
+        option.required ? " (required)" : "",
+        option.choices?.length
+          ? ` (choices: ${option.choices.join(", ")})`
+          : "",
+        option.defaultValue !== undefined
+          ? ` (default: ${option.defaultValue})`
+          : "",
+      ].join("");
+      return `  ${option.flags}${qualifiers}  ${option.description}`;
+    })
     .join("\n");
 }


### PR DESCRIPTION
## Prompt / plan

Third batch of the static-help migration (after attachment in #37732 and audit/auth in #37785), continuing alphabetically: **avatar, backup, bash, browser**. Registry now covers 7 commands.

These four are the first commands whose shape exceeded the original contract, so `CliCommandHelp` grows three capabilities (all still pure data):

- **Nested subcommand groups** — `CliSubcommandHelp` gains a recursive `subcommands` field, applied recursively by `applyCommandHelp`. Covers avatar `character …`, backup `destinations …`, browser `tabs …`.
- **Positional arguments** — new `args` field on commands and subcommands. `name` stays the bare command name (so store dedup, slugs, and rendering never parse argument syntax out of it); the new `commandSpec()` helper builds the Commander registration string (`bash <command>`, `destinations add <path>`, `set-encrypt <path> <value>`).
- **Enum options** — `choices` on `CliOptionHelp`, applied via Commander's `Option.choices()` (browser `--browser-mode`).

The memory renderer (`cli-command-content.ts`) walks the subcommand tree depth-first, heading each section with the full command path a user would actually type (`backup destinations add <path> — …`), and annotates option lines with `(required)` / `(choices: …)` / `(default: …)`.

### browser: derived, not hand-written

`browser.help.ts` derives its ~17 per-operation subcommands from `BROWSER_OPERATION_META` instead of duplicating them as literals — the operations contract remains the single source of truth, so the declarative help cannot drift from the operations the daemon supports. It's still import-safe (operation-meta is the execution-free data leaf, no Playwright graph) and carries the same sanctioned `cli/no-daemon-internals` disable as `browser.ts`; the AGENTS.md exception note now names both files.

One handler-side adjustment: `tabs select/close` previously coerced `--tab-id` with a Commander parser fn (`Number`). A parser fn is behavior, not data, so the coercion moves into the actions (`Number(opts.tabId)` — same NaN semantics on invalid input).

## Test plan

- **Byte-for-byte identical `--help` output** across all 29 command/subcommand screens (`avatar`×9, `backup`×10, `bash`, `browser`×9), diffed against a pre-split baseline captured from `bun src/index.ts <cmd> --help`.
- Functional spot checks without a daemon: avatar `--format` validation, missing positional on `destinations add`, missing required `--url` on `browser navigate`, invalid `--browser-mode` choice, invalid `bash --timeout` — all error identically to before.
- Rendered memory content verified for the nested/derived cases (full-path headings, args, choices/defaults).
- `tsc` clean, `eslint` 0 errors, `prettier` + `knip` clean; related tests green run individually as CI does (`cli-command-store` 13, `injection` 39, `lifecycle-memory-v2-seed` 13, `memory-v2-startup` 9, `shadow-plugin` 29, browser parity guards 3, plugin import-boundary guard 5). The `cli-command-store`+`injection` pair fails when run in one process on unmodified main too — pre-existing `mock.module` cross-contamination that `scripts/test.ts` isolates.

## CLI verb checklist

Help/registration restructure only — no verbs added/removed/renamed, no routes touched, byte-identical help output. Section N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWL4FYZVRGkJkMwL46PY3m)_