### PR TITLE
refactor(memory): plugin-owned memory-db accessor, drop dead v3 edge tables

### DIFF
--- a/assistant/src/persistence/migrations/328-drop-memory-v3-learned-edge-tables.ts
+++ b/assistant/src/persistence/migrations/328-drop-memory-v3-learned-edge-tables.ts
@@ -1,0 +1,16 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+/**
+ * Drops `memory_v3_coactivation` and `memory_v3_auto_edges`. No current code
+ * reads or writes either table — `memory_v3_edge_learning` is a retired job
+ * type whose rows the jobs worker drops without a handler — so the tables
+ * only grow the main DB with rows nothing consults.
+ *
+ * Idempotent: DROP TABLE IF EXISTS (indexes are dropped with the tables).
+ */
+export function migrateDropMemoryV3LearnedEdgeTables(
+  database: DrizzleDb,
+): void {
+  database.run(/*sql*/ `DROP TABLE IF EXISTS memory_v3_coactivation`);
+  database.run(/*sql*/ `DROP TABLE IF EXISTS memory_v3_auto_edges`);
+}

--- a/assistant/src/persistence/schema/conversation-starters.ts
+++ b/assistant/src/persistence/schema/conversation-starters.ts
@@ -1,0 +1,31 @@
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+// Proactive conversation-starter suggestions (home-surface chips/cards),
+// regenerated in batches by the home job handler
+// (`home/job-handlers/conversation-starters.ts`) and served by
+// `runtime/routes/conversation-starter-routes.ts`. Product state owned by the
+// home surface — the generator draws on memory content, but the table is not
+// part of the memory plugin's storage.
+export const conversationStarters = sqliteTable(
+  "conversation_starters",
+  {
+    id: text("id").primaryKey(),
+    label: text("label").notNull(),
+    prompt: text("prompt").notNull(),
+    generationBatch: integer("generation_batch").notNull(),
+    sourceMemoryKinds: text("source_memory_kinds"),
+    category: text("category"),
+    icon: text("icon"),
+    description: text("description"),
+    tags: text("tags"),
+    cardType: text("card_type").notNull().default("chip"),
+    createdAt: integer("created_at").notNull(),
+  },
+  (table) => [
+    index("idx_conversation_starters_batch").on(
+      table.generationBatch,
+      table.createdAt,
+    ),
+    index("idx_conversation_starters_card_type").on(table.cardType),
+  ],
+);

--- a/assistant/src/persistence/schema/index.ts
+++ b/assistant/src/persistence/schema/index.ts
@@ -4,6 +4,7 @@ export * from "./bookmarks.js";
 export * from "./calls.js";
 export * from "./contacts.js";
 export * from "./conversation-groups.js";
+export * from "./conversation-starters.js";
 export * from "./conversations.js";
 export * from "./documents.js";
 export * from "./guardian.js";

--- a/assistant/src/persistence/schema/memory-core.ts
+++ b/assistant/src/persistence/schema/memory-core.ts
@@ -1,6 +1,5 @@
 import {
   blob,
-  index,
   integer,
   sqliteTable,
   text,
@@ -104,28 +103,4 @@ export const memoryRetrospectiveState = sqliteTable(
     // NULL for rows that predate migration 281 or have no saves yet.
     rememberedLog: text("remembered_log"),
   },
-);
-
-export const conversationStarters = sqliteTable(
-  "conversation_starters",
-  {
-    id: text("id").primaryKey(),
-    label: text("label").notNull(),
-    prompt: text("prompt").notNull(),
-    generationBatch: integer("generation_batch").notNull(),
-    sourceMemoryKinds: text("source_memory_kinds"),
-    category: text("category"),
-    icon: text("icon"),
-    description: text("description"),
-    tags: text("tags"),
-    cardType: text("card_type").notNull().default("chip"),
-    createdAt: integer("created_at").notNull(),
-  },
-  (table) => [
-    index("idx_conversation_starters_batch").on(
-      table.generationBatch,
-      table.createdAt,
-    ),
-    index("idx_conversation_starters_card_type").on(table.cardType),
-  ],
 );

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -435,6 +435,7 @@ import { migrateMessageFinalizedColumn } from "./migrations/324-message-finalize
 import { createConfigSettingEventsTable } from "./migrations/325-create-config-setting-events.js";
 import { migrateMoveInjectionEventsToMemoryDb } from "./migrations/326-move-injection-events-to-memory-db.js";
 import { createFlushCheckpointsTable } from "./migrations/327-create-flush-checkpoints.js";
+import { migrateDropMemoryV3LearnedEdgeTables } from "./migrations/328-drop-memory-v3-learned-edge-tables.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1341,4 +1342,5 @@ export const migrationSteps: MigrationStep[] = [
   createConfigSettingEventsTable,
   migrateMoveInjectionEventsToMemoryDb,
   createFlushCheckpointsTable,
+  migrateDropMemoryV3LearnedEdgeTables,
 ];

--- a/assistant/src/plugins/defaults/memory/memory-db.ts
+++ b/assistant/src/plugins/defaults/memory/memory-db.ts
@@ -1,0 +1,27 @@
+import { getMemorySqlite } from "../../../persistence/db-connection.js";
+import { getLogger } from "./logging.js";
+
+const log = getLogger("memory-db");
+
+/**
+ * The plugin's accessor for the dedicated memory database
+ * (`assistant-memory.db`), where the memory plugin's relocated tables live
+ * (`memory_v2_injection_events`, with more to follow).
+ *
+ * Fail-soft: returns `null` when the file cannot be opened, logging a warn
+ * tagged with the calling context. Callers degrade rather than throw — the
+ * memory database holds scoring signal and derived state, and losing it must
+ * never break routing or a turn. This is the single place plugin code
+ * resolves the memory connection; new plugin modules should import it from
+ * here rather than reaching into `persistence/db-connection` directly.
+ */
+export function memorySqliteOrNull(context: string) {
+  const sqlite = getMemorySqlite();
+  if (!sqlite) {
+    log.warn(
+      { context },
+      "memory database unavailable; memory-db reads/writes degraded",
+    );
+  }
+  return sqlite;
+}

--- a/assistant/src/plugins/defaults/memory/v2/injection-events.ts
+++ b/assistant/src/plugins/defaults/memory/v2/injection-events.ts
@@ -1,5 +1,5 @@
-import { getMemorySqlite } from "../../../../persistence/db-connection.js";
 import { getLogger } from "../logging.js";
+import { memorySqliteOrNull } from "../memory-db.js";
 
 const log = getLogger("memory-v2-injection-events");
 
@@ -22,23 +22,6 @@ const READ_WINDOW_MS = 6 * INJECTION_SCORE_HALF_LIFE_MS;
 
 function decayContribution(elapsedMs: number): number {
   return Math.exp(-INJECTION_SCORE_LAMBDA * elapsedMs);
-}
-
-/**
- * The dedicated memory connection (`assistant-memory.db`), where
- * `memory_v2_injection_events` lives. `null` when the file cannot be opened
- * — every caller here degrades rather than throwing: the event log is a
- * scoring signal, and losing it must never break routing or a turn.
- */
-function memorySqliteOrNull(context: string) {
-  const sqlite = getMemorySqlite();
-  if (!sqlite) {
-    log.warn(
-      { context },
-      "memory database unavailable; injection events degraded",
-    );
-  }
-  return sqlite;
 }
 
 /**


### PR DESCRIPTION
## Prompt / plan

Follow-up to #37798, per review feedback there and the memory-DB cutover plan:

- **Plugin-owned accessor** (review comment on #37798): the fail-soft memory-connection accessor moves out of `injection-events.ts` into `plugins/defaults/memory/memory-db.ts` (`memorySqliteOrNull(context)`) as the single place plugin code resolves `assistant-memory.db`. The upcoming table relocations all consume it instead of importing `persistence/db-connection` per call site.
- **Migration 328** drops `memory_v3_coactivation` and `memory_v3_auto_edges`. No current code reads or writes either table — `memory_v3_edge_learning` is a retired job type whose rows the jobs worker drops without a handler — so they only grew the main DB with rows nothing consults. Dropped rather than relocated.
- **`conversation_starters`** schema def moves from `schema/memory-core.ts` to its own `schema/conversation-starters.ts`: it's home-surface product state (generated by `home/job-handlers/conversation-starters.ts`, served by `conversation-starter-routes.ts`), not memory-plugin storage. Consumers import via the schema index, so no call-site changes; the table itself stays in the main DB.

(Rebased on main; the drop migration was renumbered 327 → 328 after `327-create-flush-checkpoints` landed.)

## Test plan

- `tsc --noEmit`, eslint, prettier clean; pre-commit hooks green.
- Affected suites pass per-file: `plugin-import-boundary-guard` (validates the new plugin module stays in baseline), `injection-events`, `db-init-migrations-ok`, `db-migration-rollback`, `plugin-state-boundary-guard` — re-run after the rebase.
- Ran the full migration chain against a fresh workspace via `initializeDb()`: `memory_v3_coactivation` and `memory_v3_auto_edges` are absent afterward, `conversation_starters` intact.

## CLI verb checklist

No new routes added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSVMN8d9JNNh6JEWuvN3Gv