### PR TITLE
refactor(telemetry): source-driven reporter + flush watermarks on the telemetry DB

### DIFF
--- a/assistant/src/persistence/migrations/327-create-flush-checkpoints.ts
+++ b/assistant/src/persistence/migrations/327-create-flush-checkpoints.ts
@@ -1,0 +1,86 @@
+import { Database } from "bun:sqlite";
+
+import { getTelemetryDbPath } from "../../util/telemetry-db-path.js";
+import {
+  type DrizzleDb,
+  getSqliteFrom,
+  getTelemetrySqlite,
+} from "../db-connection.js";
+
+/**
+ * The telemetry flush watermark keys that historically lived in the main
+ * DB's `memory_checkpoints` ledger. Frozen: this is the complete set at the
+ * time `flush_checkpoints` was introduced — event types added later start
+ * their cursors directly in the new table, so this list must never grow.
+ *
+ * Enumerated exactly (rather than pattern-matched) because other
+ * `telemetry:`-prefixed checkpoints exist in `memory_checkpoints` that are
+ * NOT flush watermarks (e.g. `telemetry:installation_id`,
+ * `telemetry:watchers:inventory_last_recorded`) and must stay where they
+ * are.
+ */
+const LEGACY_WATERMARK_KEYS = [
+  "usage",
+  "turns",
+  "lifecycle",
+  "onboarding",
+  "auth_fallback",
+  "tool_executed",
+  "skill_loaded",
+  "watchdog",
+  "config_setting",
+].flatMap((type) => [
+  `telemetry:${type}:last_reported_at`,
+  `telemetry:${type}:last_reported_id`,
+]);
+
+/**
+ * Create the `flush_checkpoints` table on the dedicated telemetry database
+ * (`assistant-telemetry.db`) and move the telemetry reporter's watermark
+ * cursors into it from the main DB's `memory_checkpoints`, which is reserved
+ * for DB-migration checkpoints.
+ *
+ * Idempotent and crash-safe without a cross-DB transaction: the copy uses
+ * `INSERT OR IGNORE` (a re-run never overwrites a value the reporter has
+ * since advanced) and the main-DB delete runs last, so a crash between copy
+ * and delete re-runs both harmlessly.
+ */
+export function createFlushCheckpointsTable(mainDb: DrizzleDb): void {
+  let telemetry: Database | null = getTelemetrySqlite();
+  if (!telemetry) {
+    // The dedicated connection failed to open (logged by openDedicatedDb).
+    // Fall back to opening the file directly so the migration still runs —
+    // the singleton will pick it up on a later access. This mirrors the
+    // fail-soft pattern of the other dedicated-DB migrations.
+    telemetry = new Database(getTelemetryDbPath());
+  }
+  telemetry.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS flush_checkpoints (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  const main = getSqliteFrom(mainDb);
+  const placeholders = LEGACY_WATERMARK_KEYS.map(() => "?").join(", ");
+  const rows = main
+    .query(
+      /*sql*/ `SELECT key, value FROM memory_checkpoints WHERE key IN (${placeholders})`,
+    )
+    .all(...LEGACY_WATERMARK_KEYS) as Array<{ key: string; value: string }>;
+
+  const now = Date.now();
+  const insert = telemetry.prepare(
+    /*sql*/ `INSERT OR IGNORE INTO flush_checkpoints (key, value, updated_at) VALUES (?, ?, ?)`,
+  );
+  for (const row of rows) {
+    insert.run(row.key, row.value, now);
+  }
+
+  main
+    .query(
+      /*sql*/ `DELETE FROM memory_checkpoints WHERE key IN (${placeholders})`,
+    )
+    .run(...LEGACY_WATERMARK_KEYS);
+}

--- a/assistant/src/persistence/migrations/__tests__/327-create-flush-checkpoints.test.ts
+++ b/assistant/src/persistence/migrations/__tests__/327-create-flush-checkpoints.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for migration 327 — the `flush_checkpoints` table on the dedicated
+ * telemetry database, and the one-time move of the telemetry reporter's
+ * watermark cursors out of the main DB's `memory_checkpoints` ledger.
+ *
+ * The step is idempotent, so each test can drive it directly.
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+
+const { getDb, getSqlite, getTelemetrySqlite } =
+  await import("../../db-connection.js");
+const { initializeDb } = await import("../../db-init.js");
+const { createFlushCheckpointsTable } =
+  await import("../327-create-flush-checkpoints.js");
+
+await initializeDb();
+
+function telemetrySqlite() {
+  const db = getTelemetrySqlite();
+  if (!db) {
+    throw new Error("telemetry DB unavailable in test");
+  }
+  return db;
+}
+
+function readTelemetryValue(key: string): string | null {
+  const row = telemetrySqlite()
+    .query(`SELECT value FROM flush_checkpoints WHERE key = ?`)
+    .get(key) as { value: string } | null;
+  return row?.value ?? null;
+}
+
+function readMainValue(key: string): string | null {
+  const row = getSqlite()
+    .query(`SELECT value FROM memory_checkpoints WHERE key = ?`)
+    .get(key) as { value: string } | null;
+  return row?.value ?? null;
+}
+
+function seedMainCheckpoint(key: string, value: string): void {
+  getSqlite()
+    .query(
+      `INSERT OR REPLACE INTO memory_checkpoints (key, value, updated_at) VALUES (?, ?, ?)`,
+    )
+    .run(key, value, Date.now());
+}
+
+describe("migration 327 — flush_checkpoints on the telemetry database", () => {
+  beforeEach(() => {
+    telemetrySqlite().query(`DELETE FROM flush_checkpoints`).run();
+    getSqlite()
+      .query(`DELETE FROM memory_checkpoints WHERE key LIKE 'telemetry:%'`)
+      .run();
+  });
+
+  test("after init, the table exists on the telemetry DB", () => {
+    const row = telemetrySqlite()
+      .query(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name='flush_checkpoints'`,
+      )
+      .get();
+    expect(row).not.toBeNull();
+  });
+
+  test("moves legacy watermark keys from memory_checkpoints", () => {
+    seedMainCheckpoint("telemetry:usage:last_reported_at", "1700000000000");
+    seedMainCheckpoint("telemetry:usage:last_reported_id", "row-abc");
+
+    createFlushCheckpointsTable(getDb());
+
+    expect(readTelemetryValue("telemetry:usage:last_reported_at")).toBe(
+      "1700000000000",
+    );
+    expect(readTelemetryValue("telemetry:usage:last_reported_id")).toBe(
+      "row-abc",
+    );
+    expect(readMainValue("telemetry:usage:last_reported_at")).toBeNull();
+    expect(readMainValue("telemetry:usage:last_reported_id")).toBeNull();
+  });
+
+  test("leaves non-watermark telemetry-prefixed checkpoints in place", () => {
+    seedMainCheckpoint("telemetry:installation_id", "inst-123");
+    seedMainCheckpoint(
+      "telemetry:watchers:inventory_last_recorded",
+      "1700000000000",
+    );
+
+    createFlushCheckpointsTable(getDb());
+
+    expect(readMainValue("telemetry:installation_id")).toBe("inst-123");
+    expect(readMainValue("telemetry:watchers:inventory_last_recorded")).toBe(
+      "1700000000000",
+    );
+    expect(readTelemetryValue("telemetry:installation_id")).toBeNull();
+  });
+
+  test("re-run never overwrites a value the reporter has since advanced", () => {
+    seedMainCheckpoint("telemetry:turns:last_reported_at", "1000");
+    createFlushCheckpointsTable(getDb());
+    expect(readTelemetryValue("telemetry:turns:last_reported_at")).toBe("1000");
+
+    // The reporter advances the moved cursor, then a crash re-runs the
+    // migration with a stale main-DB copy still present (crash between copy
+    // and delete on the first run). INSERT OR IGNORE must keep the advanced
+    // value.
+    telemetrySqlite()
+      .query(`UPDATE flush_checkpoints SET value = '2000' WHERE key = ?`)
+      .run("telemetry:turns:last_reported_at");
+    seedMainCheckpoint("telemetry:turns:last_reported_at", "1000");
+
+    createFlushCheckpointsTable(getDb());
+
+    expect(readTelemetryValue("telemetry:turns:last_reported_at")).toBe("2000");
+    expect(readMainValue("telemetry:turns:last_reported_at")).toBeNull();
+  });
+
+  test("no-op when there are no legacy keys", () => {
+    createFlushCheckpointsTable(getDb());
+    const count = telemetrySqlite()
+      .query(`SELECT COUNT(*) as c FROM flush_checkpoints`)
+      .get() as { c: number };
+    expect(count.c).toBe(0);
+  });
+});

--- a/assistant/src/persistence/schema/infrastructure.ts
+++ b/assistant/src/persistence/schema/infrastructure.ts
@@ -366,6 +366,18 @@ export const watchdogEvents = sqliteTable(
   ],
 );
 
+// Key/value store for telemetry flush state — the per-event-type
+// `(last_reported_at, last_reported_id)` watermark cursors advanced by the
+// usage telemetry reporter after each successful upload. Lives on the
+// dedicated telemetry database (assistant-telemetry.db) so flush state
+// stays with the telemetry pipeline; the main DB's `memory_checkpoints`
+// ledger is reserved for DB-migration checkpoints.
+export const flushCheckpoints = sqliteTable("flush_checkpoints", {
+  key: text("key").primaryKey(),
+  value: text("value").notNull(),
+  updatedAt: integer("updated_at").notNull(),
+});
+
 // One row per `config_setting` telemetry event — a tracked config key's
 // effective value; see config-setting-events-store.ts for the data
 // contract. Lives on the dedicated telemetry database

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -434,6 +434,7 @@ import { migrateDeleteNonDefaultMemoryScopes } from "./migrations/323-delete-non
 import { migrateMessageFinalizedColumn } from "./migrations/324-message-finalized-column.js";
 import { createConfigSettingEventsTable } from "./migrations/325-create-config-setting-events.js";
 import { migrateMoveInjectionEventsToMemoryDb } from "./migrations/326-move-injection-events-to-memory-db.js";
+import { createFlushCheckpointsTable } from "./migrations/327-create-flush-checkpoints.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1339,4 +1340,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateMessageFinalizedColumn,
   createConfigSettingEventsTable,
   migrateMoveInjectionEventsToMemoryDb,
+  createFlushCheckpointsTable,
 ];

--- a/assistant/src/telemetry/__tests__/flush-checkpoints.test.ts
+++ b/assistant/src/telemetry/__tests__/flush-checkpoints.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { getTelemetryDb } from "../../persistence/db-connection.js";
+import { initializeDb } from "../../persistence/db-init.js";
+import { flushCheckpoints } from "../../persistence/schema/index.js";
+import {
+  getFlushCheckpoint,
+  isFlushCheckpointStoreAvailable,
+  setFlushCheckpoint,
+} from "../flush-checkpoints.js";
+
+await initializeDb();
+
+function clearCheckpoints(): void {
+  const db = getTelemetryDb();
+  if (!db) {
+    throw new Error("telemetry DB unavailable in test");
+  }
+  db.delete(flushCheckpoints).run();
+}
+
+describe("flush-checkpoints", () => {
+  beforeEach(() => {
+    clearCheckpoints();
+  });
+
+  test("store is available once the telemetry DB is open", () => {
+    expect(isFlushCheckpointStoreAvailable()).toBe(true);
+  });
+
+  test("get returns null for an absent key", () => {
+    expect(getFlushCheckpoint("telemetry:usage:last_reported_at")).toBeNull();
+  });
+
+  test("set + get round-trips", () => {
+    setFlushCheckpoint("telemetry:usage:last_reported_at", "1700000000000");
+    expect(getFlushCheckpoint("telemetry:usage:last_reported_at")).toBe(
+      "1700000000000",
+    );
+  });
+
+  test("set overwrites an existing value", () => {
+    setFlushCheckpoint("telemetry:turns:last_reported_id", "row-1");
+    setFlushCheckpoint("telemetry:turns:last_reported_id", "row-2");
+    expect(getFlushCheckpoint("telemetry:turns:last_reported_id")).toBe(
+      "row-2",
+    );
+  });
+
+  test("keys are independent", () => {
+    setFlushCheckpoint("telemetry:usage:last_reported_at", "1");
+    setFlushCheckpoint("telemetry:turns:last_reported_at", "2");
+    expect(getFlushCheckpoint("telemetry:usage:last_reported_at")).toBe("1");
+    expect(getFlushCheckpoint("telemetry:turns:last_reported_at")).toBe("2");
+  });
+});

--- a/assistant/src/telemetry/flush-checkpoints.ts
+++ b/assistant/src/telemetry/flush-checkpoints.ts
@@ -1,0 +1,70 @@
+import { eq } from "drizzle-orm";
+
+import { getTelemetryDb } from "../persistence/db-connection.js";
+import { flushCheckpoints } from "../persistence/schema/index.js";
+
+/**
+ * Telemetry flush state — the per-event-type watermark cursors the usage
+ * telemetry reporter advances after each successful upload. Backed by the
+ * `flush_checkpoints` table on the dedicated telemetry database
+ * (`assistant-telemetry.db`); the main DB's `memory_checkpoints` ledger is
+ * reserved for DB-migration checkpoints.
+ *
+ * Reads and writes throw when the table is missing (migrations not yet run)
+ * and are no-op/null when the telemetry DB cannot be opened at all. Callers
+ * that must not mistake an unreadable store for "no watermark" (which would
+ * re-ship history from cursor 0) should gate on
+ * {@link isFlushCheckpointStoreAvailable} first.
+ */
+
+/** True when the telemetry DB connection is open. */
+export function isFlushCheckpointStoreAvailable(): boolean {
+  return getTelemetryDb() != null;
+}
+
+export function getFlushCheckpoint(key: string): string | null {
+  const db = getTelemetryDb();
+  if (!db) {
+    return null;
+  }
+  const row = db
+    .select({ value: flushCheckpoints.value })
+    .from(flushCheckpoints)
+    .where(eq(flushCheckpoints.key, key))
+    .get();
+  return row?.value ?? null;
+}
+
+export function setFlushCheckpoint(key: string, value: string): void {
+  const db = getTelemetryDb();
+  if (!db) {
+    return;
+  }
+  const now = Date.now();
+  db.insert(flushCheckpoints)
+    .values({ key, value, updatedAt: now })
+    .onConflictDoUpdate({
+      target: flushCheckpoints.key,
+      set: { value, updatedAt: now },
+    })
+    .run();
+}
+
+/**
+ * Watermark storage seam for the usage telemetry reporter. The reporter
+ * takes this as a constructor dependency (defaulting to
+ * {@link telemetryDbFlushCheckpointStore}) so tests can substitute an
+ * in-memory fake without process-global module mocking.
+ */
+export interface FlushCheckpointStore {
+  isAvailable(): boolean;
+  get(key: string): string | null;
+  set(key: string, value: string): void;
+}
+
+/** The production store, backed by the telemetry DB's `flush_checkpoints`. */
+export const telemetryDbFlushCheckpointStore: FlushCheckpointStore = {
+  isAvailable: isFlushCheckpointStoreAvailable,
+  get: getFlushCheckpoint,
+  set: setFlushCheckpoint,
+};

--- a/assistant/src/telemetry/telemetry-event-sources.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.ts
@@ -1,0 +1,571 @@
+/**
+ * Per-event-type telemetry sources for the usage telemetry reporter.
+ *
+ * Each {@link TelemetryEventSource} owns one event type end-to-end: querying
+ * unreported rows after a compound `(createdAt, id)` cursor, mapping them to
+ * wire events, and deciding which rows are reportable this cycle (the turn
+ * source defers in-flight turns). The reporter is a generic engine over a
+ * list of sources, so which process flushes which event types is a matter of
+ * which sources its reporter instance is constructed with.
+ */
+
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getConfig } from "../config/loader.js";
+import { queryUnreportedOnboardingEvents } from "../onboarding/onboarding-events-store.js";
+import { queryUnreportedLifecycleEvents } from "../persistence/lifecycle-events-store.js";
+import { queryUnreportedUsageEvents } from "../persistence/llm-usage-store.js";
+import {
+  getCachedShareDiagnostics,
+  getCachedShareDiagnosticsVersion,
+} from "../platform/consent-cache.js";
+import { queryUnreportedAuthFallbackEvents } from "../security/auth-fallback-events-store.js";
+import type { UsageAttributionProfileSource } from "../usage/types.js";
+import { getLogger } from "../util/logger.js";
+import { APP_VERSION } from "../version.js";
+import {
+  type ActivationStepName,
+  buildActivationDaemonEventId,
+} from "./activation-funnel.js";
+import { queryUnreportedConfigSettingEvents } from "./config-setting-events-store.js";
+import { queryUnreportedSkillLoadedEvents } from "./skill-loaded-events-store.js";
+import { queryUnreportedToolExecutedEvents } from "./tool-executed-events-store.js";
+import { isDiagnosticsConsentVersionEligible } from "./trace-collection-policy.js";
+import { queryUnreportedTurnEvents } from "./turn-events-store.js";
+import { assembleBoundedTurnTrace, isTurnSettled } from "./turn-trace-store.js";
+import type { TelemetryEvent, TurnTelemetryClientInfo } from "./types.js";
+import { queryUnreportedWatchdogEvents } from "./watchdog-events-store.js";
+
+const log = getLogger("usage-telemetry");
+
+/** Compound `(createdAt, id)` position of a reported row. */
+export interface TelemetryCursor {
+  createdAt: number;
+  id: string;
+}
+
+/** One flush cycle's worth of reportable events from a single source. */
+export interface TelemetryEventSourceBatch {
+  /** Wire events for the rows reportable this cycle, in cursor order. */
+  events: TelemetryEvent[];
+  /** Cursor of the last reportable row; null when nothing is reportable. */
+  lastCursor: TelemetryCursor | null;
+  /**
+   * True when this source may have more rows immediately behind the batch
+   * (drives the reporter's recurse-after-success). Sources that defer rows
+   * (the turn completeness barrier) key this off the REPORTED count so a
+   * truncated batch waits for a later flush instead of re-querying and
+   * re-deferring in a tight recursion.
+   */
+  fullBatch: boolean;
+}
+
+/** One event type's query + wire mapping, keyed by its watermark namespace. */
+export interface TelemetryEventSource {
+  /**
+   * Stable source id — the watermark key namespace. The reporter persists
+   * this source's cursor under `telemetry:<id>:last_reported_{at,id}` in the
+   * telemetry DB's `flush_checkpoints` table, so ids must never change once
+   * shipped.
+   */
+  id: string;
+  /** Query rows after the compound cursor and map them to wire events. */
+  collect(
+    afterCreatedAt: number,
+    afterId: string | undefined,
+    limit: number,
+  ): TelemetryEventSourceBatch;
+}
+
+/** The `flush_checkpoints` keys holding a source's compound cursor. */
+export function watermarkKeysForSource(sourceId: string): {
+  at: string;
+  id: string;
+} {
+  return {
+    at: `telemetry:${sourceId}:last_reported_at`,
+    id: `telemetry:${sourceId}:last_reported_id`,
+  };
+}
+
+/**
+ * Build a source for the common case: every queried row is reportable, the
+ * cursor advances to the last queried row, and a full query batch signals
+ * more rows behind it.
+ */
+function simpleSource<Row extends { id: string; createdAt: number }>(
+  id: string,
+  query: (
+    afterCreatedAt: number,
+    afterId: string | undefined,
+    limit: number,
+  ) => Row[],
+  toEvent: (row: Row) => TelemetryEvent,
+): TelemetryEventSource {
+  return {
+    id,
+    collect(afterCreatedAt, afterId, limit) {
+      const rows = query(afterCreatedAt, afterId, limit);
+      const last = rows.length > 0 ? rows[rows.length - 1] : null;
+      return {
+        events: rows.map(toEvent),
+        lastCursor: last ? { createdAt: last.createdAt, id: last.id } : null,
+        fullBatch: rows.length === limit,
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Wire-mapping helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a stored `watchdog_events.detail` JSON text column into the object the
+ * platform expects. Returns null for a null column or an unparseable/corrupted
+ * blob (mirroring the turn `client` metadata parse: a bad blob emits null
+ * rather than failing the batch). A non-object (e.g. a bare number or string)
+ * also resolves to null, since the platform serializer treats `detail` as a
+ * JSON object bag.
+ */
+function parseWatchdogDetail(
+  raw: string | null,
+): Record<string, unknown> | null {
+  if (!raw) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    return null;
+  } catch {
+    log.warn(
+      { rawDetail: raw.slice(0, 200) },
+      "Telemetry watchdog: failed to parse detail; emitting null",
+    );
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sources
+// ---------------------------------------------------------------------------
+
+const usageSource = simpleSource(
+  "usage",
+  (afterCreatedAt, afterId, limit) =>
+    queryUnreportedUsageEvents(afterCreatedAt, afterId, limit),
+  (e): TelemetryEvent => ({
+    type: "llm_usage",
+    daemon_event_id: e.id,
+    // Conversation-level metadata for analytics joins. All three
+    // are nullable on the wire: `conversation_id` is null for
+    // LLM calls not tied to a conversation (memory consolidation,
+    // background work), and the other two cascade from that.
+    conversation_id: e.conversationId,
+    conversation_type: e.conversationType,
+    turn_index: e.turnIndex,
+    provider: e.provider,
+    model: e.model,
+    input_tokens: e.inputTokens,
+    output_tokens: e.outputTokens,
+    cache_creation_input_tokens: e.cacheCreationInputTokens ?? null,
+    cache_read_input_tokens: e.cacheReadInputTokens ?? null,
+    llm_call_count: e.llmCallCount,
+    raw_usage: e.rawUsage,
+    actor: e.actor,
+    llm_call_site: e.callSite,
+    inference_profile: e.inferenceProfile,
+    inference_profile_source: e.inferenceProfileSource,
+    cost: e.estimatedCostUsd ?? null,
+    recorded_at: e.createdAt,
+    // Record-time version when present; otherwise the running
+    // binary's `APP_VERSION` (a legacy row from before
+    // migration 267 ran). We deliberately don't emit explicit
+    // `null` — under the platform contract a present-but-null
+    // per-event value would override the envelope, and we'd
+    // rather have a concrete version than no version.
+    assistant_version: e.assistantVersion ?? APP_VERSION,
+  }),
+);
+
+/**
+ * Turn source. Unlike the simple sources it enforces the turn completeness
+ * barrier and attaches consented traces, both of which need the daemon's
+ * live in-memory conversation state (`isProcessing()`, cached system prompt,
+ * registered tool definitions) — so this source must run in the daemon
+ * process.
+ */
+const turnSource: TelemetryEventSource = {
+  id: "turns",
+  collect(afterCreatedAt, afterId, limit) {
+    const turnEvents = queryUnreportedTurnEvents(
+      afterCreatedAt,
+      afterId,
+      limit,
+    );
+
+    // Turn completeness barrier (every turn event).
+    //
+    // A turn event must only be sent once that turn is COMPLETE, for two
+    // reasons sharing the same failure mode (the watermark advances on ship,
+    // so anything captured early is frozen forever):
+    //   - the consented `trace` would capture a partial mid-reply
+    //     transcript, and
+    //   - the `outcome` stamp (`messages.metadata.turnOutcome`, written by
+    //     the agent loop / drainBatch while the conversation is still
+    //     processing) would be missed, permanently mislabeling a
+    //     failed/cancelled/batched turn as normally-replied.
+    // So we report only the leading run of complete turns and STOP at the
+    // first incomplete (in-flight) one: the turn watermark is a single
+    // monotonic `(createdAt, id)` cursor, so a later complete turn cannot be
+    // reported past an earlier deferred one without skipping it. The
+    // deferred turn (and everything after it) is picked up on a later flush
+    // once its response settles.
+    //
+    // Trace eligibility is composed daemon-side to mirror the platform's
+    // authoritative owner-based ingest gate, so traces for ineligible owners
+    // never leave the device. Three parts, fail-closed (all must be true):
+    //   1. the `trace-collection` LaunchDarkly flag (delivered via the
+    //      assistant-tagged flag sync, already evaluated server-side for this
+    //      assistant's owner),
+    //   2. the owner's cached `share_diagnostics` consent, and
+    //   3. the owner's cached `share_diagnostics_accepted_version` being at or
+    //      past the disclosing version — the platform applies the identical
+    //      check, so an old consent never yields a trace here or there.
+    const traceEligible =
+      isAssistantFeatureFlagEnabled("trace-collection", getConfig()) &&
+      getCachedShareDiagnostics() &&
+      isDiagnosticsConsentVersionEligible(getCachedShareDiagnosticsVersion());
+    let reportableTurnEvents = turnEvents;
+    if (turnEvents.length > 0) {
+      let barrier = turnEvents.length;
+      for (let i = 0; i < turnEvents.length; i++) {
+        const t = turnEvents[i];
+        if (
+          !isTurnSettled({
+            conversationId: t.conversationId,
+            userMessageId: t.id,
+            userMessageCreatedAt: t.createdAt,
+          })
+        ) {
+          barrier = i;
+          break;
+        }
+      }
+      if (barrier < turnEvents.length) {
+        reportableTurnEvents = turnEvents.slice(0, barrier);
+        log.debug(
+          {
+            deferredTurnId: turnEvents[barrier].id,
+            deferredConversationId: turnEvents[barrier].conversationId,
+            reportedTurns: barrier,
+            deferredTurns: turnEvents.length - barrier,
+          },
+          "Deferring in-progress turn(s) from telemetry until complete",
+        );
+      }
+    }
+
+    const events = reportableTurnEvents.map((e): TelemetryEvent => {
+      // Per-turn trace collection gate. `traceEligible` (computed above)
+      // requires the `trace-collection` flag AND the owner's cached
+      // `share_diagnostics` consent AND an eligible accepted consent
+      // version. Fail-closed: when any is off the trace is omitted and the
+      // trace-free turn row flushes as before. The
+      // `share_analytics` gate in the reporter already passed, so this is an
+      // additional, independent gate specific to trace PII. Every turn
+      // reaching here is settled (the completeness barrier dropped any
+      // in-flight turns), so the trace is never a partial mid-turn snapshot.
+      const trace = traceEligible
+        ? assembleBoundedTurnTrace({
+            conversationId: e.conversationId,
+            userMessageId: e.id,
+            userMessageCreatedAt: e.createdAt,
+          })
+        : null;
+      // `messages.metadata.client` is a nested JSON object extracted
+      // via `json_extract`; sqlite returns it as a text representation.
+      // Parse defensively — a corrupted blob in the JSON column should
+      // not block the whole batch flush.
+      let client: TurnTelemetryClientInfo | null = null;
+      if (e.clientMetadata) {
+        try {
+          const parsed = JSON.parse(e.clientMetadata) as unknown;
+          if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            client = parsed as TurnTelemetryClientInfo;
+          }
+        } catch {
+          // Malformed client JSON — emit null rather than fail the
+          // batch. Logged once below for visibility.
+          log.warn(
+            { turnId: e.id, conversationId: e.conversationId },
+            "Telemetry turn: failed to parse messages.metadata.client; emitting null",
+          );
+        }
+      }
+      // Narrow the raw metadata projection to the wire union — only
+      // `stampTurnOutcome` writes the key, but the JSON column is
+      // uncontrolled, so an unexpected value is dropped rather than
+      // shipped.
+      const outcome =
+        e.outcome === "batched" ||
+        e.outcome === "failed" ||
+        e.outcome === "cancelled"
+          ? e.outcome
+          : null;
+      return {
+        type: "turn",
+        daemon_event_id: e.id,
+        recorded_at: e.createdAt,
+        conversation_id: e.conversationId,
+        conversation_type: e.conversationType,
+        turn_index: e.turnIndex,
+        interface_id: e.interfaceId,
+        channel_id: e.channelId,
+        client,
+        // Outcome stamps are omit-when-absent: a normally-replied turn's
+        // wire shape is byte-identical to a pre-outcome turn event.
+        ...(outcome ? { outcome } : {}),
+        ...(outcome === "batched" && e.batchedInto
+          ? { batched_into: e.batchedInto }
+          : {}),
+        ...(outcome === "failed" && e.failureCode
+          ? { failure_code: e.failureCode }
+          : {}),
+        // Only attach `trace` when consent is on AND a bounded trace was
+        // assembled. Omitting the key entirely when there's no trace keeps
+        // the wire shape byte-identical to pre-trace turn events for the
+        // common (no-consent) path.
+        ...(trace ? { trace } : {}),
+        // Turn events derive from `messages` + `conversations`
+        // rather than a dedicated table. Adding `assistant_version`
+        // to `messages` is a separate (larger) migration; until
+        // then we stamp the running binary's `APP_VERSION` so the
+        // wire value is concrete (matches what the envelope would
+        // have provided, but per-event so it survives the platform
+        // contract that treats present per-event values as winning
+        // over the envelope).
+        assistant_version: APP_VERSION,
+      };
+    });
+
+    const last =
+      reportableTurnEvents.length > 0
+        ? reportableTurnEvents[reportableTurnEvents.length - 1]
+        : null;
+    return {
+      events,
+      // The cursor advances only to the last REPORTED turn. Deferred
+      // (in-flight) turns sit beyond it and are re-evaluated on a later
+      // flush, so the watermark never skips them.
+      lastCursor: last ? { createdAt: last.createdAt, id: last.id } : null,
+      // Keyed off the REPORTED count: when the completeness barrier
+      // truncates the batch, the deferred turns must wait for a later flush
+      // (by which point they've settled) rather than being re-queried and
+      // re-deferred in a tight recursion.
+      fullBatch: reportableTurnEvents.length === limit,
+    };
+  },
+};
+
+const lifecycleSource = simpleSource(
+  "lifecycle",
+  (afterCreatedAt, afterId, limit) =>
+    queryUnreportedLifecycleEvents(afterCreatedAt, afterId, limit),
+  (e): TelemetryEvent => ({
+    type: "lifecycle",
+    daemon_event_id: e.id,
+    event_name: e.eventName,
+    recorded_at: e.createdAt,
+    // Lifecycle events carry no record-time version column — stamp the
+    // running binary's `APP_VERSION`. Adding the record-time column to
+    // `lifecycle_events` (#18112) is a separate follow-up that mirrors
+    // `llm_usage_events`.
+    assistant_version: APP_VERSION,
+  }),
+);
+
+const onboardingSource = simpleSource(
+  "onboarding",
+  (afterCreatedAt, afterId, limit) =>
+    queryUnreportedOnboardingEvents(afterCreatedAt, afterId, limit),
+  (e): TelemetryEvent => ({
+    type: "onboarding",
+    // Wire-only override for activation rows: a deterministic id keyed
+    // on funnel_version/session/step lets dbt collapse a moment that
+    // fires more than once. Key on the ROW's stored `funnelVersion`
+    // (not the binary's current constant) so rows recorded under an
+    // older version — flushed offline or after an upgrade — keep a
+    // stable id and still collapse with already-ingested rows. The
+    // SQLite watermark cursor still uses `e.id`/`e.createdAt`, so this
+    // override is checkpoint-safe.
+    daemon_event_id:
+      e.sessionId && e.stepName && e.funnelVersion
+        ? buildActivationDaemonEventId(
+            e.sessionId,
+            e.stepName as ActivationStepName,
+            e.funnelVersion,
+          )
+        : e.id,
+    recorded_at: e.createdAt,
+    screen: e.screen,
+    ...(e.toolsJson ? { tools: JSON.parse(e.toolsJson) } : {}),
+    ...(e.tasksJson ? { tasks: JSON.parse(e.tasksJson) } : {}),
+    ...(e.tone ? { tone: e.tone } : {}),
+    ...(e.googleConnected != null
+      ? { google_connected: e.googleConnected }
+      : {}),
+    ...(e.googleScopesJson
+      ? { google_scopes: JSON.parse(e.googleScopesJson) }
+      : {}),
+    ...(e.abVariant ? { ab_variant: e.abVariant } : {}),
+    // Activation funnel fields — only present on activation rows.
+    ...(e.sessionId ? { session_id: e.sessionId } : {}),
+    ...(e.stepName ? { step_name: e.stepName } : {}),
+    ...(e.stepIndex != null ? { step_index: e.stepIndex } : {}),
+    ...(e.completedAt ? { completed_at: e.completedAt } : {}),
+    ...(e.funnelVersion ? { funnel_version: e.funnelVersion } : {}),
+    // Onboarding events carry no record-time version column — stamp the
+    // running binary's `APP_VERSION`. Adding one (mirroring
+    // `llm_usage_events`) is a known follow-up.
+    assistant_version: APP_VERSION,
+  }),
+);
+
+const authFallbackSource = simpleSource(
+  "auth_fallback",
+  (afterCreatedAt, afterId, limit) =>
+    queryUnreportedAuthFallbackEvents(afterCreatedAt, afterId, limit),
+  (e): TelemetryEvent => ({
+    type: "auth_fallback",
+    daemon_event_id: e.id,
+    recorded_at: e.createdAt,
+    guard: e.guard,
+    path: e.path,
+    failure_kind: e.failureKind,
+    count: e.count,
+    window_start: e.windowStart,
+    window_end: e.windowEnd,
+    // Aggregated counts forwarded by the gateway carry no record-time
+    // binary version; stamp the running binary's `APP_VERSION` so the
+    // wire value is concrete rather than an explicit null that would
+    // override the envelope under the platform's per-event-wins
+    // contract.
+    assistant_version: APP_VERSION,
+  }),
+);
+
+const toolExecutedSource = simpleSource(
+  "tool_executed",
+  (afterCreatedAt, afterId, limit) =>
+    queryUnreportedToolExecutedEvents(afterCreatedAt, afterId, limit),
+  (e): TelemetryEvent => ({
+    type: "tool_executed",
+    daemon_event_id: e.id,
+    recorded_at: e.createdAt,
+    tool_name: e.toolName,
+    // The store filters out permission-denied rows, so the only
+    // non-success decision that reaches here is "error".
+    status: e.decision === "error" ? "errored" : "fulfilled",
+    duration_ms: e.durationMs,
+    arg_bytes: e.argBytes,
+    result_bytes: e.resultBytes,
+    conversation_id: e.conversationId,
+    provider: e.provider,
+    model: e.model,
+    inference_profile: e.inferenceProfile,
+    inference_profile_source:
+      e.inferenceProfileSource as UsageAttributionProfileSource | null,
+    // `tool_invocations` has no record-time version column — stamp
+    // the running binary's `APP_VERSION` so the wire value is
+    // concrete rather than an explicit null that would override the
+    // envelope under the platform's per-event-wins contract.
+    assistant_version: APP_VERSION,
+  }),
+);
+
+const skillLoadedSource = simpleSource(
+  "skill_loaded",
+  (afterCreatedAt, afterId, limit) =>
+    queryUnreportedSkillLoadedEvents(afterCreatedAt, afterId, limit),
+  (e): TelemetryEvent => ({
+    type: "skill_loaded",
+    daemon_event_id: e.id,
+    recorded_at: e.createdAt,
+    skill_name: e.skillName,
+    skill_updated_at: e.skillUpdatedAt,
+    conversation_id: e.conversationId,
+    provider: e.provider,
+    model: e.model,
+    inference_profile: e.inferenceProfile,
+    inference_profile_source:
+      e.inferenceProfileSource as UsageAttributionProfileSource | null,
+    // `skill_loaded_events` has no record-time version column — same
+    // upload-time APP_VERSION stamping as the other non-llm_usage
+    // event types.
+    assistant_version: APP_VERSION,
+  }),
+);
+
+const watchdogSource = simpleSource(
+  "watchdog",
+  (afterCreatedAt, afterId, limit) =>
+    queryUnreportedWatchdogEvents(afterCreatedAt, afterId, limit),
+  (e): TelemetryEvent => ({
+    type: "watchdog",
+    daemon_event_id: e.id,
+    recorded_at: e.createdAt,
+    check_name: e.checkName,
+    value: e.value,
+    // `detail` is stored as JSON text; parse defensively so a
+    // corrupted blob never fails the batch flush. A parse failure
+    // emits null rather than dropping the event.
+    detail: parseWatchdogDetail(e.detail),
+    // `watchdog_events` has no record-time version column — same
+    // upload-time APP_VERSION stamping as the other non-llm_usage
+    // event types.
+    assistant_version: APP_VERSION,
+  }),
+);
+
+const configSettingSource = simpleSource(
+  "config_setting",
+  (afterCreatedAt, afterId, limit) =>
+    queryUnreportedConfigSettingEvents(afterCreatedAt, afterId, limit),
+  (e): TelemetryEvent => ({
+    type: "config_setting",
+    daemon_event_id: e.id,
+    recorded_at: e.createdAt,
+    config_key: e.configKey,
+    config_value: e.configValue,
+    // `config_setting_events` has no record-time version column —
+    // same upload-time APP_VERSION stamping as the other
+    // non-llm_usage event types.
+    assistant_version: APP_VERSION,
+  }),
+);
+
+/**
+ * Watermark key namespace of the tool_executed source — referenced by the
+ * reporter's constructor-time absent-watermark init.
+ */
+export const TOOL_EXECUTED_SOURCE_ID = toolExecutedSource.id;
+
+/**
+ * Every telemetry event source, in payload order. The order is part of the
+ * observable wire behavior (events of different types appear in this order
+ * within one batch), so keep it stable.
+ */
+export const ALL_TELEMETRY_EVENT_SOURCES: readonly TelemetryEventSource[] = [
+  usageSource,
+  turnSource,
+  lifecycleSource,
+  onboardingSource,
+  authFallbackSource,
+  toolExecutedSource,
+  skillLoadedSource,
+  watchdogSource,
+  configSettingSource,
+];

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -11,17 +11,20 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 // Module mocks (must precede production imports)
 // ---------------------------------------------------------------------------
 
-const mockGetMemoryCheckpoint = mock<(key: string) => string | null>(
-  () => null,
-);
-const mockSetMemoryCheckpoint = mock<(key: string, value: string) => void>(
+// Watermark storage fake, injected via the reporter's constructor (see
+// `makeReporter` below) — the real store lives on the telemetry DB and has
+// its own DB-backed test, so it is deliberately NOT module-mocked here.
+const mockGetFlushCheckpoint = mock<(key: string) => string | null>(() => null);
+const mockSetFlushCheckpoint = mock<(key: string, value: string) => void>(
   () => {},
 );
+const mockIsFlushCheckpointStoreAvailable = mock<() => boolean>(() => true);
 
-mock.module("../persistence/checkpoints.js", () => ({
-  getMemoryCheckpoint: mockGetMemoryCheckpoint,
-  setMemoryCheckpoint: mockSetMemoryCheckpoint,
-}));
+const fakeFlushCheckpointStore = {
+  isAvailable: () => mockIsFlushCheckpointStoreAvailable(),
+  get: (key: string) => mockGetFlushCheckpoint(key),
+  set: (key: string, value: string) => mockSetFlushCheckpoint(key, value),
+};
 
 const mockQueryUnreportedUsageEvents = mock(
   () =>
@@ -255,6 +258,15 @@ import { recordConfigSettingEvent } from "./config-setting-events-store.js";
 import { recordSkillLoadedEvent } from "./skill-loaded-events-store.js";
 import { UsageTelemetryReporter } from "./usage-telemetry-reporter.js";
 
+/**
+ * Construct a reporter wired to the in-memory checkpoint fake. All tests go
+ * through this so watermark reads/writes stay assertable via the mocks
+ * without process-global module mocking of the real telemetry-DB store.
+ */
+function makeReporter(): UsageTelemetryReporter {
+  return new UsageTelemetryReporter(undefined, fakeFlushCheckpointStore);
+}
+
 await initializeDb();
 
 // ---------------------------------------------------------------------------
@@ -352,10 +364,10 @@ function useStatefulCheckpoints(
   seed: Record<string, string> = {},
 ): Map<string, string> {
   const checkpoints = new Map(Object.entries(seed));
-  mockGetMemoryCheckpoint.mockImplementation(
+  mockGetFlushCheckpoint.mockImplementation(
     (key) => checkpoints.get(key) ?? null,
   );
-  mockSetMemoryCheckpoint.mockImplementation((key, value) => {
+  mockSetFlushCheckpoint.mockImplementation((key, value) => {
     checkpoints.set(key, value);
   });
   return checkpoints;
@@ -389,8 +401,10 @@ beforeEach(() => {
   mockAssembleBoundedTurnTrace.mockImplementation(defaultBoundedTurnTrace);
   mockIsTurnSettled.mockReset();
   mockIsTurnSettled.mockReturnValue(true);
-  mockGetMemoryCheckpoint.mockReset();
-  mockSetMemoryCheckpoint.mockReset();
+  mockGetFlushCheckpoint.mockReset();
+  mockSetFlushCheckpoint.mockReset();
+  mockIsFlushCheckpointStoreAvailable.mockReset();
+  mockIsFlushCheckpointStoreAvailable.mockReturnValue(true);
   mockQueryUnreportedUsageEvents.mockReset();
   mockQueryUnreportedTurnEvents.mockReset();
   mockQueryUnreportedTurnEvents.mockReturnValue([]);
@@ -413,7 +427,7 @@ beforeEach(() => {
   mockGetPlatformUserId.mockReturnValue("");
 
   // Defaults
-  mockGetMemoryCheckpoint.mockReturnValue(null);
+  mockGetFlushCheckpoint.mockReturnValue(null);
   mockGetPlatformBaseUrl.mockReturnValue("https://platform.vellum.ai");
 
   mockFetch = mock(() =>
@@ -457,7 +471,7 @@ describe("UsageTelemetryReporter", () => {
     const events = [makeUsageEvent(), makeUsageEvent()];
     mockQueryUnreportedUsageEvents.mockReturnValue(events);
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(clientFetchMock).toHaveBeenCalledTimes(1);
@@ -475,11 +489,11 @@ describe("UsageTelemetryReporter", () => {
     const events = [makeUsageEvent()];
     mockQueryUnreportedUsageEvents.mockReturnValue(events);
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockFetch).not.toHaveBeenCalled();
-    const watermarkCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+    const watermarkCalls = mockSetFlushCheckpoint.mock.calls.filter(
       (c) => c[0] === "telemetry:usage:last_reported_at",
     );
     expect(watermarkCalls.length).toBe(0);
@@ -494,14 +508,14 @@ describe("UsageTelemetryReporter", () => {
     const events = [makeUsageEvent()];
     mockQueryUnreportedUsageEvents.mockReturnValue(events);
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     // Construction initializes the absent tool_executed watermark; clear that
     // call so the assertion below covers only the flush.
-    mockSetMemoryCheckpoint.mockClear();
+    mockSetFlushCheckpoint.mockClear();
     await reporter.flush();
 
     expect(mockFetch).not.toHaveBeenCalled();
-    expect(mockSetMemoryCheckpoint).not.toHaveBeenCalled();
+    expect(mockSetFlushCheckpoint).not.toHaveBeenCalled();
   });
 
   test("VELLUM_DISABLE_PLATFORM is ignored when IS_PLATFORM is set (managed mode)", async () => {
@@ -514,7 +528,7 @@ describe("UsageTelemetryReporter", () => {
     const events = [makeUsageEvent()];
     mockQueryUnreportedUsageEvents.mockReturnValue(events);
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -530,10 +544,10 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
-    const watermarkCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+    const watermarkCalls = mockSetFlushCheckpoint.mock.calls.filter(
       (c) => c[0] === "telemetry:usage:last_reported_at",
     );
     expect(watermarkCalls.length).toBeGreaterThanOrEqual(1);
@@ -543,7 +557,7 @@ describe("UsageTelemetryReporter", () => {
     );
 
     // The compound cursor ID should also be set to the last event's id
-    const idCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+    const idCalls = mockSetFlushCheckpoint.mock.calls.filter(
       (c) => c[0] === "telemetry:usage:last_reported_id",
     );
     expect(idCalls.length).toBeGreaterThanOrEqual(1);
@@ -557,10 +571,10 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response("error", { status: 500 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
-    const watermarkCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+    const watermarkCalls = mockSetFlushCheckpoint.mock.calls.filter(
       (c) => c[0] === "telemetry:usage:last_reported_at",
     );
     expect(watermarkCalls.length).toBe(0);
@@ -573,7 +587,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
 
     // First flush — should use the per-device ID
     await reporter.flush();
@@ -596,7 +610,7 @@ describe("UsageTelemetryReporter", () => {
   test("empty batch makes no HTTP call", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockFetch).not.toHaveBeenCalled();
@@ -612,7 +626,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":500}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     // MAX_CONSECUTIVE_BATCHES = 10
@@ -626,7 +640,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     reporter.start();
 
     // Wait a tick so start()'s immediate flush settles.
@@ -660,7 +674,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -729,7 +743,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     const body = JSON.parse(
@@ -753,7 +767,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     const body = JSON.parse(
@@ -780,7 +794,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     const body = JSON.parse(
@@ -798,7 +812,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -818,7 +832,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -836,7 +850,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -865,7 +879,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -933,7 +947,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":3}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -1012,7 +1026,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":4}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -1094,7 +1108,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     // The gate consults the `trace-collection` flag.
@@ -1137,7 +1151,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     // Gate off → no assembly at all (no PII touched).
@@ -1167,7 +1181,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     // Version below threshold → no assembly at all (no PII touched).
@@ -1193,7 +1207,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockAssembleBoundedTurnTrace).not.toHaveBeenCalled();
@@ -1213,7 +1227,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     // Flag off → gate closed → no assembly at all (no PII touched).
@@ -1238,7 +1252,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockAssembleBoundedTurnTrace).toHaveBeenCalledTimes(1);
@@ -1258,7 +1272,7 @@ describe("UsageTelemetryReporter", () => {
     mockGetCachedShareDiagnostics.mockReturnValue(true);
     mockQueryUnreportedTurnEvents.mockReturnValue(singleTurnEvent());
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockAssembleBoundedTurnTrace).not.toHaveBeenCalled();
@@ -1302,7 +1316,7 @@ describe("UsageTelemetryReporter", () => {
     // The turn's response is still streaming — not settled.
     mockIsTurnSettled.mockReturnValue(false);
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     // No trace assembled, and the turn is NOT sent (the only event was deferred).
@@ -1323,7 +1337,7 @@ describe("UsageTelemetryReporter", () => {
 
     // Flush 1: turn in progress -> deferred, nothing sent.
     mockIsTurnSettled.mockReturnValue(false);
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
     expect(mockFetch).not.toHaveBeenCalled();
 
@@ -1390,7 +1404,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockAssembleBoundedTurnTrace).toHaveBeenCalledTimes(1);
@@ -1424,7 +1438,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -1461,7 +1475,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockIsTurnSettled).toHaveBeenCalled();
@@ -1482,7 +1496,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -1521,7 +1535,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":4}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -1563,7 +1577,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     const body = JSON.parse(
@@ -1603,7 +1617,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":3}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -1662,10 +1676,10 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     // Construction initializes the absent tool_executed watermark; clear that
     // call so the count below covers only the flush's advancement.
-    mockSetMemoryCheckpoint.mockClear();
+    mockSetFlushCheckpoint.mockClear();
     await reporter.flush();
 
     // No HTTP call should have been made
@@ -1675,9 +1689,9 @@ describe("UsageTelemetryReporter", () => {
     // watermarks pinned to the high-sorting sentinel (a truthy value keeps
     // the compound-cursor branch active while closing its same-millisecond
     // arm against opt-out rows).
-    expect(mockSetMemoryCheckpoint).toHaveBeenCalledTimes(18);
+    expect(mockSetFlushCheckpoint).toHaveBeenCalledTimes(18);
 
-    const calls = mockSetMemoryCheckpoint.mock.calls;
+    const calls = mockSetFlushCheckpoint.mock.calls;
     const keys = calls.map((c) => c[0]);
     const eventTypes = [
       "usage",
@@ -1710,23 +1724,44 @@ describe("UsageTelemetryReporter", () => {
     const events = [makeUsageEvent()];
     mockQueryUnreportedUsageEvents.mockReturnValue(events);
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     // Construction initializes the absent tool_executed watermark; clear that
     // call so the assertion below covers only the flush.
-    mockSetMemoryCheckpoint.mockClear();
+    mockSetFlushCheckpoint.mockClear();
     await reporter.flush();
 
     expect(mockFetch).not.toHaveBeenCalled();
-    expect(mockSetMemoryCheckpoint).not.toHaveBeenCalled();
+    expect(mockSetFlushCheckpoint).not.toHaveBeenCalled();
+  });
+
+  test("flush skipped entirely when the flush-checkpoint store is unavailable", async () => {
+    // An unreadable checkpoint store must not be mistaken for cursor 0 —
+    // that would requery and re-ship history from the beginning. Nothing is
+    // sent and no watermark is touched (not even the opt-out sentinel);
+    // the cycle retries once the store is back.
+    mockIsFlushCheckpointStoreAvailable.mockReturnValue(false);
+    const events = [makeUsageEvent()];
+    mockQueryUnreportedUsageEvents.mockReturnValue(events);
+
+    const reporter = makeReporter();
+    // Construction initializes the absent tool_executed watermark; clear
+    // those calls so the assertions below cover only the flush.
+    mockGetFlushCheckpoint.mockClear();
+    mockSetFlushCheckpoint.mockClear();
+    await reporter.flush();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockGetFlushCheckpoint).not.toHaveBeenCalled();
+    expect(mockSetFlushCheckpoint).not.toHaveBeenCalled();
   });
 
   test("events sent normally after re-granting share_analytics consent", async () => {
     // First flush with opt-out — watermarks advance, nothing sent
     mockGetCachedShareAnalytics.mockReturnValue(false);
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
     expect(mockFetch).not.toHaveBeenCalled();
-    mockSetMemoryCheckpoint.mockReset();
+    mockSetFlushCheckpoint.mockReset();
 
     // Re-grant consent and flush with new events
     mockGetCachedShareAnalytics.mockReturnValue(true);
@@ -1771,7 +1806,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     const body = JSON.parse(
@@ -1795,7 +1830,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     const body = JSON.parse(
@@ -1832,7 +1867,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     const body = JSON.parse(
@@ -1861,7 +1896,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     const body = JSON.parse(
@@ -1893,7 +1928,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -1945,10 +1980,10 @@ describe("UsageTelemetryReporter", () => {
       .all();
     const lastRow = rows[rows.length - 1];
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
-    const watermarkCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+    const watermarkCalls = mockSetFlushCheckpoint.mock.calls.filter(
       (c) => c[0] === "telemetry:auth_fallback:last_reported_at",
     );
     expect(watermarkCalls.length).toBeGreaterThanOrEqual(1);
@@ -1956,7 +1991,7 @@ describe("UsageTelemetryReporter", () => {
       String(lastRow.createdAt),
     );
 
-    const idCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+    const idCalls = mockSetFlushCheckpoint.mock.calls.filter(
       (c) => c[0] === "telemetry:auth_fallback:last_reported_id",
     );
     expect(idCalls.length).toBeGreaterThanOrEqual(1);
@@ -1987,7 +2022,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -2029,7 +2064,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     const body = JSON.parse(
@@ -2062,7 +2097,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -2120,7 +2155,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -2176,10 +2211,10 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
-    const watermarkCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+    const watermarkCalls = mockSetFlushCheckpoint.mock.calls.filter(
       (c) => c[0] === "telemetry:tool_executed:last_reported_at",
     );
     expect(watermarkCalls.length).toBeGreaterThanOrEqual(1);
@@ -2187,7 +2222,7 @@ describe("UsageTelemetryReporter", () => {
       String(1700000002000),
     );
 
-    const idCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+    const idCalls = mockSetFlushCheckpoint.mock.calls.filter(
       (c) => c[0] === "telemetry:tool_executed:last_reported_id",
     );
     expect(idCalls.length).toBeGreaterThanOrEqual(1);
@@ -2199,18 +2234,20 @@ describe("UsageTelemetryReporter", () => {
     seedToolInvocation({ id: "ti-r1", createdAt: 1700000001000 });
     seedToolInvocation({ id: "ti-r2", createdAt: 1700000002000 });
     // A previous flush already reported ti-r1.
-    mockGetMemoryCheckpoint.mockImplementation((key) => {
+    mockGetFlushCheckpoint.mockImplementation((key) => {
       if (key === "telemetry:tool_executed:last_reported_at") {
         return String(1700000001000);
       }
-      if (key === "telemetry:tool_executed:last_reported_id") return "ti-r1";
+      if (key === "telemetry:tool_executed:last_reported_id") {
+        return "ti-r1";
+      }
       return null;
     });
     mockFetch.mockImplementation(() =>
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -2231,7 +2268,7 @@ describe("UsageTelemetryReporter", () => {
     // predating the reporter) stay behind the watermark.
     const checkpoints = useStatefulCheckpoints();
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     const rowCreatedAt =
       Number(checkpoints.get("telemetry:tool_executed:last_reported_at")) +
       1000;
@@ -2270,7 +2307,7 @@ describe("UsageTelemetryReporter", () => {
       createdAt: Date.now() - 60_000,
     });
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
 
     // The checkpoint is persisted immediately at construction so a crash
     // before the first flush can't re-initialize later.
@@ -2315,7 +2352,7 @@ describe("UsageTelemetryReporter", () => {
     // opted-in rows.
     seedToolInvocation({ id: "ti-backlog", createdAt: 1700000002000 });
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     expect(checkpoints.get("telemetry:tool_executed:last_reported_at")).toBe(
       String(1700000001000),
     );
@@ -2349,7 +2386,7 @@ describe("UsageTelemetryReporter", () => {
       id: "ti-opt-out-window",
       createdAt: optOutRowCreatedAt,
     });
-    const optedOutReporter = new UsageTelemetryReporter();
+    const optedOutReporter = makeReporter();
     await optedOutReporter.stop(); // shutdown path: runs the final flush
     expect(mockFetch).not.toHaveBeenCalled();
     const advanced = Number(
@@ -2361,7 +2398,7 @@ describe("UsageTelemetryReporter", () => {
     // after the opt-out epoch ship — the opt-out-window row never does.
     mockGetCachedShareAnalytics.mockReturnValue(true);
     seedToolInvocation({ id: "ti-after-opt-in", createdAt: advanced + 1000 });
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -2385,7 +2422,7 @@ describe("UsageTelemetryReporter", () => {
     // Opted-out flush: advances the timestamp watermark to Date.now() and
     // must also pin the ID watermark to the high-sorting sentinel.
     mockGetCachedShareAnalytics.mockReturnValue(false);
-    const optedOutReporter = new UsageTelemetryReporter();
+    const optedOutReporter = makeReporter();
     await optedOutReporter.flush();
     expect(mockFetch).not.toHaveBeenCalled();
     const watermark = Number(
@@ -2404,7 +2441,7 @@ describe("UsageTelemetryReporter", () => {
     // Re-opt-in: only rows strictly after the opt-out epoch ship.
     mockGetCachedShareAnalytics.mockReturnValue(true);
     seedToolInvocation({ id: "ti-after-opt-in", createdAt: watermark + 1000 });
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -2420,17 +2457,17 @@ describe("UsageTelemetryReporter", () => {
     // initializeDb() failures are tolerated at daemon startup (degraded
     // mode), so the constructor's checkpoint init must never throw out of
     // the constructor and abort the daemon.
-    mockGetMemoryCheckpoint.mockImplementation(() => {
+    mockGetFlushCheckpoint.mockImplementation(() => {
       throw new Error("database disk image is malformed");
     });
-    expect(() => new UsageTelemetryReporter()).not.toThrow();
+    expect(() => makeReporter()).not.toThrow();
 
     // The write path failing is equally non-fatal.
-    mockGetMemoryCheckpoint.mockImplementation(() => null);
-    mockSetMemoryCheckpoint.mockImplementation(() => {
+    mockGetFlushCheckpoint.mockImplementation(() => null);
+    mockSetFlushCheckpoint.mockImplementation(() => {
       throw new Error("database disk image is malformed");
     });
-    expect(() => new UsageTelemetryReporter()).not.toThrow();
+    expect(() => makeReporter()).not.toThrow();
   });
 
   // -------------------------------------------------------------------------
@@ -2454,7 +2491,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -2510,10 +2547,10 @@ describe("UsageTelemetryReporter", () => {
       .all();
     const lastRow = rows[rows.length - 1];
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
-    const watermarkCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+    const watermarkCalls = mockSetFlushCheckpoint.mock.calls.filter(
       (c) => c[0] === "telemetry:skill_loaded:last_reported_at",
     );
     expect(watermarkCalls.length).toBeGreaterThanOrEqual(1);
@@ -2521,7 +2558,7 @@ describe("UsageTelemetryReporter", () => {
       String(lastRow.createdAt),
     );
 
-    const idCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+    const idCalls = mockSetFlushCheckpoint.mock.calls.filter(
       (c) => c[0] === "telemetry:skill_loaded:last_reported_id",
     );
     expect(idCalls.length).toBeGreaterThanOrEqual(1);
@@ -2542,7 +2579,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":500}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     // MAX_CONSECUTIVE_BATCHES = 10
@@ -2567,7 +2604,7 @@ describe("UsageTelemetryReporter", () => {
       Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
     );
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -2613,7 +2650,9 @@ describe("UsageTelemetryReporter", () => {
     // The last row by the reporter's (createdAt, id) cursor order is the one
     // whose watermark should be persisted after a successful upload.
     const telemetryDb = getTelemetryDb();
-    if (!telemetryDb) throw new Error("telemetry DB unavailable in test");
+    if (!telemetryDb) {
+      throw new Error("telemetry DB unavailable in test");
+    }
     const rows = telemetryDb
       .select()
       .from(configSettingEvents)
@@ -2621,10 +2660,10 @@ describe("UsageTelemetryReporter", () => {
       .all();
     const lastRow = rows[rows.length - 1];
 
-    const reporter = new UsageTelemetryReporter();
+    const reporter = makeReporter();
     await reporter.flush();
 
-    const watermarkCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+    const watermarkCalls = mockSetFlushCheckpoint.mock.calls.filter(
       (c) => c[0] === "telemetry:config_setting:last_reported_at",
     );
     expect(watermarkCalls.length).toBeGreaterThanOrEqual(1);
@@ -2632,7 +2671,7 @@ describe("UsageTelemetryReporter", () => {
       String(lastRow.createdAt),
     );
 
-    const idCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+    const idCalls = mockSetFlushCheckpoint.mock.calls.filter(
       (c) => c[0] === "telemetry:config_setting:last_reported_id",
     );
     expect(idCalls.length).toBeGreaterThanOrEqual(1);

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -1,8 +1,13 @@
 /**
  * Usage telemetry reporter.
  *
- * Periodically flushes LLM usage events and turn events (user messages) from
- * the local SQLite database and POSTs them to the platform telemetry endpoint.
+ * Periodically flushes unreported telemetry events (LLM usage, turns,
+ * lifecycle, ...) from the local SQLite databases and POSTs them to the
+ * platform telemetry endpoint. Each event type is a
+ * {@link TelemetryEventSource}; the reporter is a generic engine over the
+ * source list it is constructed with, advancing one compound
+ * `(createdAt, id)` watermark cursor per source in the telemetry DB's
+ * `flush_checkpoints` table after each successful upload.
  *
  * Authenticated-only: events are sent via the managed proxy context
  * (Api-Key header). When no platform credentials are available, or when
@@ -10,40 +15,24 @@
  * flush is skipped and retried next cycle.
  */
 
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getPlatformOrganizationId, getPlatformUserId } from "../config/env.js";
-import { getConfig } from "../config/loader.js";
-import { queryUnreportedOnboardingEvents } from "../onboarding/onboarding-events-store.js";
-import {
-  getMemoryCheckpoint,
-  setMemoryCheckpoint,
-} from "../persistence/checkpoints.js";
-import { queryUnreportedLifecycleEvents } from "../persistence/lifecycle-events-store.js";
-import { queryUnreportedUsageEvents } from "../persistence/llm-usage-store.js";
 import { VellumPlatformClient } from "../platform/client.js";
-import {
-  getCachedShareAnalytics,
-  getCachedShareDiagnostics,
-  getCachedShareDiagnosticsVersion,
-} from "../platform/consent-cache.js";
+import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import { arePlatformFeaturesEnabled } from "../platform/feature-gate.js";
-import { queryUnreportedAuthFallbackEvents } from "../security/auth-fallback-events-store.js";
-import type { UsageAttributionProfileSource } from "../usage/types.js";
 import { getDeviceId } from "../util/device-id.js";
 import { getLogger } from "../util/logger.js";
 import { APP_VERSION } from "../version.js";
 import {
-  type ActivationStepName,
-  buildActivationDaemonEventId,
-} from "./activation-funnel.js";
-import { queryUnreportedConfigSettingEvents } from "./config-setting-events-store.js";
-import { queryUnreportedSkillLoadedEvents } from "./skill-loaded-events-store.js";
-import { queryUnreportedToolExecutedEvents } from "./tool-executed-events-store.js";
-import { isDiagnosticsConsentVersionEligible } from "./trace-collection-policy.js";
-import { queryUnreportedTurnEvents } from "./turn-events-store.js";
-import { assembleBoundedTurnTrace, isTurnSettled } from "./turn-trace-store.js";
-import type { TelemetryEvent, TurnTelemetryClientInfo } from "./types.js";
-import { queryUnreportedWatchdogEvents } from "./watchdog-events-store.js";
+  type FlushCheckpointStore,
+  telemetryDbFlushCheckpointStore,
+} from "./flush-checkpoints.js";
+import {
+  ALL_TELEMETRY_EVENT_SOURCES,
+  type TelemetryEventSource,
+  type TelemetryEventSourceBatch,
+  TOOL_EXECUTED_SOURCE_ID,
+  watermarkKeysForSource,
+} from "./telemetry-event-sources.js";
 
 const log = getLogger("usage-telemetry");
 
@@ -51,67 +40,11 @@ const log = getLogger("usage-telemetry");
 // Constants
 // ---------------------------------------------------------------------------
 
-const CHECKPOINT_KEY_WATERMARK = "telemetry:usage:last_reported_at";
-const CHECKPOINT_KEY_WATERMARK_ID = "telemetry:usage:last_reported_id";
-const CHECKPOINT_KEY_TURN_WATERMARK = "telemetry:turns:last_reported_at";
-const CHECKPOINT_KEY_TURN_WATERMARK_ID = "telemetry:turns:last_reported_id";
-const CHECKPOINT_KEY_LIFECYCLE_WATERMARK =
-  "telemetry:lifecycle:last_reported_at";
-const CHECKPOINT_KEY_LIFECYCLE_WATERMARK_ID =
-  "telemetry:lifecycle:last_reported_id";
-const CHECKPOINT_KEY_ONBOARDING_WATERMARK =
-  "telemetry:onboarding:last_reported_at";
-const CHECKPOINT_KEY_ONBOARDING_WATERMARK_ID =
-  "telemetry:onboarding:last_reported_id";
-const CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK =
-  "telemetry:auth_fallback:last_reported_at";
-const CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK_ID =
-  "telemetry:auth_fallback:last_reported_id";
-const CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK =
-  "telemetry:tool_executed:last_reported_at";
-const CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK_ID =
-  "telemetry:tool_executed:last_reported_id";
-const CHECKPOINT_KEY_SKILL_LOADED_WATERMARK =
-  "telemetry:skill_loaded:last_reported_at";
-const CHECKPOINT_KEY_SKILL_LOADED_WATERMARK_ID =
-  "telemetry:skill_loaded:last_reported_id";
-const CHECKPOINT_KEY_WATCHDOG_WATERMARK = "telemetry:watchdog:last_reported_at";
-const CHECKPOINT_KEY_WATCHDOG_WATERMARK_ID =
-  "telemetry:watchdog:last_reported_id";
-const CHECKPOINT_KEY_CONFIG_SETTING_WATERMARK =
-  "telemetry:config_setting:last_reported_at";
-const CHECKPOINT_KEY_CONFIG_SETTING_WATERMARK_ID =
-  "telemetry:config_setting:last_reported_id";
 // Written into the `*_id` watermark checkpoints by the opt-out flush branch.
 // Sorts lexicographically above every real row ID (all event stores generate
 // lowercase v4 UUIDs), so the compound cursor's same-millisecond arm
 // (`createdAt == watermark AND id > afterId`) can never match an opt-out row.
 const OPT_OUT_WATERMARK_ID_SENTINEL = "ffffffff-ffff-ffff-ffff-ffffffffffff";
-// (timestamp, id) checkpoint-key pairs for every event type's compound
-// cursor — keep in sync when adding an event type.
-const WATERMARK_KEY_PAIRS: ReadonlyArray<readonly [string, string]> = [
-  [CHECKPOINT_KEY_WATERMARK, CHECKPOINT_KEY_WATERMARK_ID],
-  [CHECKPOINT_KEY_TURN_WATERMARK, CHECKPOINT_KEY_TURN_WATERMARK_ID],
-  [CHECKPOINT_KEY_LIFECYCLE_WATERMARK, CHECKPOINT_KEY_LIFECYCLE_WATERMARK_ID],
-  [CHECKPOINT_KEY_ONBOARDING_WATERMARK, CHECKPOINT_KEY_ONBOARDING_WATERMARK_ID],
-  [
-    CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK,
-    CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK_ID,
-  ],
-  [
-    CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK,
-    CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK_ID,
-  ],
-  [
-    CHECKPOINT_KEY_SKILL_LOADED_WATERMARK,
-    CHECKPOINT_KEY_SKILL_LOADED_WATERMARK_ID,
-  ],
-  [CHECKPOINT_KEY_WATCHDOG_WATERMARK, CHECKPOINT_KEY_WATCHDOG_WATERMARK_ID],
-  [
-    CHECKPOINT_KEY_CONFIG_SETTING_WATERMARK,
-    CHECKPOINT_KEY_CONFIG_SETTING_WATERMARK_ID,
-  ],
-];
 const REPORT_INTERVAL_MS = 5 * 60 * 1000;
 const INITIAL_FLUSH_DELAY_MS = 30_000; // Delay first flush to let CES handshake complete
 const BATCH_SIZE = 500;
@@ -146,8 +79,12 @@ export function getUsageTelemetryReporter(): UsageTelemetryReporter | null {
  * degraded-mode safe — its constructor and flush() treat DB errors as non-fatal.
  */
 export function startUsageTelemetryReporter(): void {
-  if (process.env.VELLUM_DEV === "1") return;
-  if (_instance) return;
+  if (process.env.VELLUM_DEV === "1") {
+    return;
+  }
+  if (_instance) {
+    return;
+  }
   _instance = new UsageTelemetryReporter();
   _instance.start();
   log.info("Usage telemetry reporter started");
@@ -158,42 +95,13 @@ export function startUsageTelemetryReporter(): void {
  * and clear it. No-op when the reporter was never started (e.g. dev mode).
  */
 export async function stopUsageTelemetryReporter(): Promise<void> {
-  if (!_instance) return;
+  if (!_instance) {
+    return;
+  }
   try {
     await _instance.stop();
   } finally {
     _instance = null;
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Parse a stored `watchdog_events.detail` JSON text column into the object the
- * platform expects. Returns null for a null column or an unparseable/corrupted
- * blob (mirroring the turn `client` metadata parse: a bad blob emits null
- * rather than failing the batch). A non-object (e.g. a bare number or string)
- * also resolves to null, since the platform serializer treats `detail` as a
- * JSON object bag.
- */
-function parseWatchdogDetail(
-  raw: string | null,
-): Record<string, unknown> | null {
-  if (!raw) return null;
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      return parsed as Record<string, unknown>;
-    }
-    return null;
-  } catch {
-    log.warn(
-      { rawDetail: raw.slice(0, 200) },
-      "Telemetry watchdog: failed to parse detail; emitting null",
-    );
-    return null;
   }
 }
 
@@ -205,8 +113,15 @@ export class UsageTelemetryReporter {
   private initialFlushTimer: ReturnType<typeof setTimeout> | null = null;
   private timer: ReturnType<typeof setInterval> | null = null;
   private activeFlush: Promise<void> | null = null;
+  private readonly sources: readonly TelemetryEventSource[];
+  private readonly checkpoints: FlushCheckpointStore;
 
-  constructor() {
+  constructor(
+    sources: readonly TelemetryEventSource[] = ALL_TELEMETRY_EVENT_SOURCES,
+    checkpoints: FlushCheckpointStore = telemetryDbFlushCheckpointStore,
+  ) {
+    this.sources = sources;
+    this.checkpoints = checkpoints;
     // `tool_invocations` is an always-on audit table that predates this
     // reporter shipping its rows: an absent watermark means no flush (opted
     // in or out) has ever advanced it, so rows recorded before this build —
@@ -226,18 +141,18 @@ export class UsageTelemetryReporter {
     // Best-effort: DB init failures are tolerated at daemon startup (degraded
     // mode), so this must never throw out of the constructor — matching
     // flush(), which treats DB errors as non-fatal.
-    try {
-      if (getMemoryCheckpoint(CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK) == null) {
-        setMemoryCheckpoint(
-          CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK,
-          String(Date.now()),
+    if (this.sources.some((s) => s.id === TOOL_EXECUTED_SOURCE_ID)) {
+      try {
+        const key = watermarkKeysForSource(TOOL_EXECUTED_SOURCE_ID).at;
+        if (this.checkpoints.get(key) == null) {
+          this.checkpoints.set(key, String(Date.now()));
+        }
+      } catch (err) {
+        log.warn(
+          { err },
+          "tool_executed watermark init failed at construction — non-fatal; a later construction with a working DB re-runs the absent-checkpoint init",
         );
       }
-    } catch (err) {
-      log.warn(
-        { err },
-        "tool_executed watermark init failed at construction — non-fatal; a later construction with a working DB re-runs the absent-checkpoint init",
-      );
     }
   }
 
@@ -276,7 +191,9 @@ export class UsageTelemetryReporter {
   }
 
   async flush(): Promise<void> {
-    if (this.activeFlush) return; // overlap guard
+    if (this.activeFlush) {
+      return; // overlap guard
+    }
     this.activeFlush = this._doFlush();
     try {
       await this.activeFlush;
@@ -287,7 +204,9 @@ export class UsageTelemetryReporter {
 
   private async _doFlush(batchCount = 0): Promise<void> {
     try {
-      if (batchCount >= MAX_CONSECUTIVE_BATCHES) return;
+      if (batchCount >= MAX_CONSECUTIVE_BATCHES) {
+        return;
+      }
 
       // Skip when platform features are disabled (VELLUM_DISABLE_PLATFORM in
       // local mode; the flag is ignored when IS_PLATFORM is set, matching
@@ -295,6 +214,17 @@ export class UsageTelemetryReporter {
       // is a deployment/local-mode toggle, not a privacy opt-out, so the unsent
       // backlog ships once the flag is cleared.
       if (!arePlatformFeaturesEnabled()) {
+        return;
+      }
+
+      // Skip when the flush-checkpoint store (telemetry DB) is unreachable.
+      // An unreadable watermark must not be mistaken for cursor 0 — that
+      // would requery and re-ship history from the beginning. Nothing is
+      // advanced or sent; the cycle retries once the store is back.
+      if (!this.checkpoints.isAvailable()) {
+        log.warn(
+          "Telemetry flush: flush-checkpoint store unavailable — skipping, will retry next cycle",
+        );
         return;
       }
 
@@ -324,211 +254,33 @@ export class UsageTelemetryReporter {
         // never ship after a later opt-in. The next opted-in flush that
         // ships events overwrites the sentinel with a real row ID.
         const now = String(Date.now());
-        for (const [timestampKey, idKey] of WATERMARK_KEY_PAIRS) {
-          setMemoryCheckpoint(timestampKey, now);
-          setMemoryCheckpoint(idKey, OPT_OUT_WATERMARK_ID_SENTINEL);
+        for (const source of this.sources) {
+          const keys = watermarkKeysForSource(source.id);
+          this.checkpoints.set(keys.at, now);
+          this.checkpoints.set(keys.id, OPT_OUT_WATERMARK_ID_SENTINEL);
         }
         return;
       }
 
-      // Read usage watermark (compound cursor: createdAt + id)
-      const watermark = Number(
-        getMemoryCheckpoint(CHECKPOINT_KEY_WATERMARK) ?? "0",
-      );
-      const watermarkId =
-        getMemoryCheckpoint(CHECKPOINT_KEY_WATERMARK_ID) ?? undefined;
+      // Read each source's watermark (compound cursor: createdAt + id) and
+      // collect its reportable batch. Absent checkpoints default to cursor 0
+      // — safe for the consent-gated tables (opted-out rows never exist) and
+      // for tool_executed, whose absent watermark was initialized at
+      // construction (see the constructor).
+      const batches: Array<{
+        source: TelemetryEventSource;
+        batch: TelemetryEventSourceBatch;
+      }> = this.sources.map((source) => {
+        const keys = watermarkKeysForSource(source.id);
+        const afterCreatedAt = Number(this.checkpoints.get(keys.at) ?? "0");
+        const afterId = this.checkpoints.get(keys.id) ?? undefined;
+        return {
+          source,
+          batch: source.collect(afterCreatedAt, afterId, BATCH_SIZE),
+        };
+      });
 
-      // Read turn watermark (compound cursor: createdAt + id)
-      const turnWatermark = Number(
-        getMemoryCheckpoint(CHECKPOINT_KEY_TURN_WATERMARK) ?? "0",
-      );
-      const turnWatermarkId =
-        getMemoryCheckpoint(CHECKPOINT_KEY_TURN_WATERMARK_ID) ?? undefined;
-
-      // Read lifecycle watermark (compound cursor: createdAt + id)
-      const lifecycleWatermark = Number(
-        getMemoryCheckpoint(CHECKPOINT_KEY_LIFECYCLE_WATERMARK) ?? "0",
-      );
-      const lifecycleWatermarkId =
-        getMemoryCheckpoint(CHECKPOINT_KEY_LIFECYCLE_WATERMARK_ID) ?? undefined;
-
-      // Read onboarding watermark (compound cursor: createdAt + id)
-      const onboardingWatermark = Number(
-        getMemoryCheckpoint(CHECKPOINT_KEY_ONBOARDING_WATERMARK) ?? "0",
-      );
-      const onboardingWatermarkId =
-        getMemoryCheckpoint(CHECKPOINT_KEY_ONBOARDING_WATERMARK_ID) ??
-        undefined;
-
-      // Read auth-fallback watermark (compound cursor: createdAt + id)
-      const authFallbackWatermark = Number(
-        getMemoryCheckpoint(CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK) ?? "0",
-      );
-      const authFallbackWatermarkId =
-        getMemoryCheckpoint(CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK_ID) ??
-        undefined;
-
-      // Read tool-executed watermark (compound cursor: createdAt + id).
-      // An absent checkpoint was initialized to construction time (see the
-      // constructor), guarding opt-out windows; the 0 fallback here is a
-      // defensive default matching the other event types. Legacy rows are
-      // excluded at the query level (see queryUnreportedToolExecutedEvents).
-      const toolExecutedWatermark = Number(
-        getMemoryCheckpoint(CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK) ?? "0",
-      );
-      const toolExecutedWatermarkId =
-        getMemoryCheckpoint(CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK_ID) ??
-        undefined;
-
-      // Read skill-loaded watermark (compound cursor: createdAt + id).
-      // Writes are gated on share_analytics consent, so opted-out rows
-      // cannot exist and the standard 0 default is safe.
-      const skillLoadedWatermark = Number(
-        getMemoryCheckpoint(CHECKPOINT_KEY_SKILL_LOADED_WATERMARK) ?? "0",
-      );
-      const skillLoadedWatermarkId =
-        getMemoryCheckpoint(CHECKPOINT_KEY_SKILL_LOADED_WATERMARK_ID) ??
-        undefined;
-
-      // Read watchdog watermark (compound cursor: createdAt + id).
-      // Writes are gated on share_analytics consent, so opted-out rows
-      // cannot exist and the standard 0 default is safe.
-      const watchdogWatermark = Number(
-        getMemoryCheckpoint(CHECKPOINT_KEY_WATCHDOG_WATERMARK) ?? "0",
-      );
-      const watchdogWatermarkId =
-        getMemoryCheckpoint(CHECKPOINT_KEY_WATCHDOG_WATERMARK_ID) ?? undefined;
-
-      // Read config-setting watermark (compound cursor: createdAt + id).
-      // Writes are gated on share_analytics consent, so opted-out rows
-      // cannot exist and the standard 0 default is safe.
-      const configSettingWatermark = Number(
-        getMemoryCheckpoint(CHECKPOINT_KEY_CONFIG_SETTING_WATERMARK) ?? "0",
-      );
-      const configSettingWatermarkId =
-        getMemoryCheckpoint(CHECKPOINT_KEY_CONFIG_SETTING_WATERMARK_ID) ??
-        undefined;
-
-      // Query unreported events
-      const events = queryUnreportedUsageEvents(
-        watermark,
-        watermarkId,
-        BATCH_SIZE,
-      );
-      const turnEvents = queryUnreportedTurnEvents(
-        turnWatermark,
-        turnWatermarkId,
-        BATCH_SIZE,
-      );
-      const lifecycleEvents = queryUnreportedLifecycleEvents(
-        lifecycleWatermark,
-        lifecycleWatermarkId,
-        BATCH_SIZE,
-      );
-      const onboardingEvents = queryUnreportedOnboardingEvents(
-        onboardingWatermark,
-        onboardingWatermarkId,
-        BATCH_SIZE,
-      );
-      const authFallbackEvents = queryUnreportedAuthFallbackEvents(
-        authFallbackWatermark,
-        authFallbackWatermarkId,
-        BATCH_SIZE,
-      );
-      const toolExecutedEvents = queryUnreportedToolExecutedEvents(
-        toolExecutedWatermark,
-        toolExecutedWatermarkId,
-        BATCH_SIZE,
-      );
-      const skillLoadedEvents = queryUnreportedSkillLoadedEvents(
-        skillLoadedWatermark,
-        skillLoadedWatermarkId,
-        BATCH_SIZE,
-      );
-      const watchdogEvents = queryUnreportedWatchdogEvents(
-        watchdogWatermark,
-        watchdogWatermarkId,
-        BATCH_SIZE,
-      );
-      const configSettingEvents = queryUnreportedConfigSettingEvents(
-        configSettingWatermark,
-        configSettingWatermarkId,
-        BATCH_SIZE,
-      );
-
-      // Turn completeness barrier (every turn event).
-      //
-      // A turn event must only be sent once that turn is COMPLETE, for two
-      // reasons sharing the same failure mode (the watermark advances on ship,
-      // so anything captured early is frozen forever):
-      //   - the consented `trace` would capture a partial mid-reply
-      //     transcript, and
-      //   - the `outcome` stamp (`messages.metadata.turnOutcome`, written by
-      //     the agent loop / drainBatch while the conversation is still
-      //     processing) would be missed, permanently mislabeling a
-      //     failed/cancelled/batched turn as normally-replied.
-      // So we report only the leading run of complete turns and STOP at the
-      // first incomplete (in-flight) one: the turn watermark is a single
-      // monotonic `(createdAt, id)` cursor, so a later complete turn cannot be
-      // reported past an earlier deferred one without skipping it. The
-      // deferred turn (and everything after it) is picked up on a later flush
-      // once its response settles.
-      //
-      // Trace eligibility is composed daemon-side to mirror the platform's
-      // authoritative owner-based ingest gate, so traces for ineligible owners
-      // never leave the device. Three parts, fail-closed (all must be true):
-      //   1. the `trace-collection` LaunchDarkly flag (delivered via the
-      //      assistant-tagged flag sync, already evaluated server-side for this
-      //      assistant's owner),
-      //   2. the owner's cached `share_diagnostics` consent, and
-      //   3. the owner's cached `share_diagnostics_accepted_version` being at or
-      //      past the disclosing version — the platform applies the identical
-      //      check, so an old consent never yields a trace here or there.
-      const traceEligible =
-        isAssistantFeatureFlagEnabled("trace-collection", getConfig()) &&
-        getCachedShareDiagnostics() &&
-        isDiagnosticsConsentVersionEligible(getCachedShareDiagnosticsVersion());
-      let reportableTurnEvents = turnEvents;
-      if (turnEvents.length > 0) {
-        let barrier = turnEvents.length;
-        for (let i = 0; i < turnEvents.length; i++) {
-          const t = turnEvents[i];
-          if (
-            !isTurnSettled({
-              conversationId: t.conversationId,
-              userMessageId: t.id,
-              userMessageCreatedAt: t.createdAt,
-            })
-          ) {
-            barrier = i;
-            break;
-          }
-        }
-        if (barrier < turnEvents.length) {
-          reportableTurnEvents = turnEvents.slice(0, barrier);
-          log.debug(
-            {
-              deferredTurnId: turnEvents[barrier].id,
-              deferredConversationId: turnEvents[barrier].conversationId,
-              reportedTurns: barrier,
-              deferredTurns: turnEvents.length - barrier,
-            },
-            "Deferring in-progress turn(s) from telemetry until complete",
-          );
-        }
-      }
-
-      if (
-        events.length === 0 &&
-        reportableTurnEvents.length === 0 &&
-        lifecycleEvents.length === 0 &&
-        onboardingEvents.length === 0 &&
-        authFallbackEvents.length === 0 &&
-        toolExecutedEvents.length === 0 &&
-        skillLoadedEvents.length === 0 &&
-        watchdogEvents.length === 0 &&
-        configSettingEvents.length === 0
-      ) {
+      if (batches.every(({ batch }) => batch.events.length === 0)) {
         return;
       }
 
@@ -538,304 +290,31 @@ export class UsageTelemetryReporter {
       const client = await VellumPlatformClient.create();
       if (!client) {
         log.debug(
-          { pendingEventCount: events.length + turnEvents.length },
+          {
+            pendingEventCount: batches.reduce(
+              (total, { batch }) => total + batch.events.length,
+              0,
+            ),
+          },
           "Telemetry flush: no platform credentials — skipping, will retry next cycle",
         );
         return;
       }
       log.debug(
         {
-          usageCount: events.length,
-          turnCount: reportableTurnEvents.length,
-          lifecycleCount: lifecycleEvents.length,
-          onboardingCount: onboardingEvents.length,
-          authFallbackCount: authFallbackEvents.length,
-          toolExecutedCount: toolExecutedEvents.length,
-          skillLoadedCount: skillLoadedEvents.length,
-          watchdogCount: watchdogEvents.length,
-          configSettingCount: configSettingEvents.length,
+          counts: Object.fromEntries(
+            batches.map(({ source, batch }) => [
+              source.id,
+              batch.events.length,
+            ]),
+          ),
         },
         "Telemetry flush: resolved auth context",
       );
 
-      // Build payload
-      const typedEvents: TelemetryEvent[] = [
-        ...events.map(
-          (e): TelemetryEvent => ({
-            type: "llm_usage",
-            daemon_event_id: e.id,
-            // Conversation-level metadata for analytics joins. All three
-            // are nullable on the wire: `conversation_id` is null for
-            // LLM calls not tied to a conversation (memory consolidation,
-            // background work), and the other two cascade from that.
-            conversation_id: e.conversationId,
-            conversation_type: e.conversationType,
-            turn_index: e.turnIndex,
-            provider: e.provider,
-            model: e.model,
-            input_tokens: e.inputTokens,
-            output_tokens: e.outputTokens,
-            cache_creation_input_tokens: e.cacheCreationInputTokens ?? null,
-            cache_read_input_tokens: e.cacheReadInputTokens ?? null,
-            llm_call_count: e.llmCallCount,
-            raw_usage: e.rawUsage,
-            actor: e.actor,
-            llm_call_site: e.callSite,
-            inference_profile: e.inferenceProfile,
-            inference_profile_source: e.inferenceProfileSource,
-            cost: e.estimatedCostUsd ?? null,
-            recorded_at: e.createdAt,
-            // Record-time version when present; otherwise the running
-            // binary's `APP_VERSION` (a legacy row from before
-            // migration 267 ran). We deliberately don't emit explicit
-            // `null` — under the platform contract a present-but-null
-            // per-event value would override the envelope, and we'd
-            // rather have a concrete version than no version.
-            assistant_version: e.assistantVersion ?? APP_VERSION,
-          }),
-        ),
-        ...reportableTurnEvents.map((e): TelemetryEvent => {
-          // Per-turn trace collection gate. `traceEligible` (computed above)
-          // requires the `trace-collection` flag AND the owner's cached
-          // `share_diagnostics` consent AND an eligible accepted consent
-          // version. Fail-closed: when any is off the trace is omitted and the
-          // trace-free turn row flushes as before. The
-          // `share_analytics` gate above already passed, so this is an
-          // additional, independent gate specific to trace PII. Every turn
-          // reaching here is settled (the completeness barrier dropped any
-          // in-flight turns), so the trace is never a partial mid-turn snapshot.
-          const trace = traceEligible
-            ? assembleBoundedTurnTrace({
-                conversationId: e.conversationId,
-                userMessageId: e.id,
-                userMessageCreatedAt: e.createdAt,
-              })
-            : null;
-          // `messages.metadata.client` is a nested JSON object extracted
-          // via `json_extract`; sqlite returns it as a text representation.
-          // Parse defensively — a corrupted blob in the JSON column should
-          // not block the whole batch flush.
-          let client: TurnTelemetryClientInfo | null = null;
-          if (e.clientMetadata) {
-            try {
-              const parsed = JSON.parse(e.clientMetadata) as unknown;
-              if (
-                parsed &&
-                typeof parsed === "object" &&
-                !Array.isArray(parsed)
-              ) {
-                client = parsed as TurnTelemetryClientInfo;
-              }
-            } catch {
-              // Malformed client JSON — emit null rather than fail the
-              // batch. Logged once below for visibility.
-              log.warn(
-                { turnId: e.id, conversationId: e.conversationId },
-                "Telemetry turn: failed to parse messages.metadata.client; emitting null",
-              );
-            }
-          }
-          // Narrow the raw metadata projection to the wire union — only
-          // `stampTurnOutcome` writes the key, but the JSON column is
-          // uncontrolled, so an unexpected value is dropped rather than
-          // shipped.
-          const outcome =
-            e.outcome === "batched" ||
-            e.outcome === "failed" ||
-            e.outcome === "cancelled"
-              ? e.outcome
-              : null;
-          return {
-            type: "turn",
-            daemon_event_id: e.id,
-            recorded_at: e.createdAt,
-            conversation_id: e.conversationId,
-            conversation_type: e.conversationType,
-            turn_index: e.turnIndex,
-            interface_id: e.interfaceId,
-            channel_id: e.channelId,
-            client,
-            // Outcome stamps are omit-when-absent: a normally-replied turn's
-            // wire shape is byte-identical to a pre-outcome turn event.
-            ...(outcome ? { outcome } : {}),
-            ...(outcome === "batched" && e.batchedInto
-              ? { batched_into: e.batchedInto }
-              : {}),
-            ...(outcome === "failed" && e.failureCode
-              ? { failure_code: e.failureCode }
-              : {}),
-            // Only attach `trace` when consent is on AND a bounded trace was
-            // assembled. Omitting the key entirely when there's no trace keeps
-            // the wire shape byte-identical to pre-trace turn events for the
-            // common (no-consent) path.
-            ...(trace ? { trace } : {}),
-            // Turn events derive from `messages` + `conversations`
-            // rather than a dedicated table. Adding `assistant_version`
-            // to `messages` is a separate (larger) migration; until
-            // then we stamp the running binary's `APP_VERSION` so the
-            // wire value is concrete (matches what the envelope would
-            // have provided, but per-event so it survives the platform
-            // contract that treats present per-event values as winning
-            // over the envelope). Same upload-time attribution risk
-            // for turn events as before this PR — lifecycle, onboarding
-            // and turn events all still rely on the envelope; only
-            // llm_usage is record-time accurate in this PR.
-            assistant_version: APP_VERSION,
-          };
-        }),
-        ...lifecycleEvents.map(
-          (e): TelemetryEvent => ({
-            type: "lifecycle",
-            daemon_event_id: e.id,
-            event_name: e.eventName,
-            recorded_at: e.createdAt,
-            // Lifecycle events fall back to the envelope `assistant_version`
-            // — same upload-time attribution risk as before this PR. Adding
-            // the record-time column to `lifecycle_events` (#18112) is a
-            // separate follow-up that mirrors what this PR does for
-            // `llm_usage_events`.
-            assistant_version: APP_VERSION,
-          }),
-        ),
-        ...onboardingEvents.map(
-          (e): TelemetryEvent => ({
-            type: "onboarding",
-            // Wire-only override for activation rows: a deterministic id keyed
-            // on funnel_version/session/step lets dbt collapse a moment that
-            // fires more than once. Key on the ROW's stored `funnelVersion`
-            // (not the binary's current constant) so rows recorded under an
-            // older version — flushed offline or after an upgrade — keep a
-            // stable id and still collapse with already-ingested rows. The
-            // SQLite watermark cursor still uses `e.id`/`e.createdAt`, so this
-            // override is checkpoint-safe.
-            daemon_event_id:
-              e.sessionId && e.stepName && e.funnelVersion
-                ? buildActivationDaemonEventId(
-                    e.sessionId,
-                    e.stepName as ActivationStepName,
-                    e.funnelVersion,
-                  )
-                : e.id,
-            recorded_at: e.createdAt,
-            screen: e.screen,
-            ...(e.toolsJson ? { tools: JSON.parse(e.toolsJson) } : {}),
-            ...(e.tasksJson ? { tasks: JSON.parse(e.tasksJson) } : {}),
-            ...(e.tone ? { tone: e.tone } : {}),
-            ...(e.googleConnected != null
-              ? { google_connected: e.googleConnected }
-              : {}),
-            ...(e.googleScopesJson
-              ? { google_scopes: JSON.parse(e.googleScopesJson) }
-              : {}),
-            ...(e.abVariant ? { ab_variant: e.abVariant } : {}),
-            // Activation funnel fields — only present on activation rows.
-            ...(e.sessionId ? { session_id: e.sessionId } : {}),
-            ...(e.stepName ? { step_name: e.stepName } : {}),
-            ...(e.stepIndex != null ? { step_index: e.stepIndex } : {}),
-            ...(e.completedAt ? { completed_at: e.completedAt } : {}),
-            ...(e.funnelVersion ? { funnel_version: e.funnelVersion } : {}),
-            // Onboarding events fall back to the envelope `assistant_version`,
-            // so events recorded under an older build are attributed to the
-            // version running at upload time. Adding a record-time column to
-            // `onboarding_events` (mirroring `llm_usage_events`) is a known
-            // follow-up.
-            assistant_version: APP_VERSION,
-          }),
-        ),
-        ...authFallbackEvents.map(
-          (e): TelemetryEvent => ({
-            type: "auth_fallback",
-            daemon_event_id: e.id,
-            recorded_at: e.createdAt,
-            guard: e.guard,
-            path: e.path,
-            failure_kind: e.failureKind,
-            count: e.count,
-            window_start: e.windowStart,
-            window_end: e.windowEnd,
-            // Aggregated counts forwarded by the gateway carry no record-time
-            // binary version; stamp the running binary's `APP_VERSION` so the
-            // wire value is concrete rather than an explicit null that would
-            // override the envelope under the platform's per-event-wins
-            // contract.
-            assistant_version: APP_VERSION,
-          }),
-        ),
-        ...toolExecutedEvents.map(
-          (e): TelemetryEvent => ({
-            type: "tool_executed",
-            daemon_event_id: e.id,
-            recorded_at: e.createdAt,
-            tool_name: e.toolName,
-            // The store filters out permission-denied rows, so the only
-            // non-success decision that reaches here is "error".
-            status: e.decision === "error" ? "errored" : "fulfilled",
-            duration_ms: e.durationMs,
-            arg_bytes: e.argBytes,
-            result_bytes: e.resultBytes,
-            conversation_id: e.conversationId,
-            provider: e.provider,
-            model: e.model,
-            inference_profile: e.inferenceProfile,
-            inference_profile_source:
-              e.inferenceProfileSource as UsageAttributionProfileSource | null,
-            // `tool_invocations` has no record-time version column — stamp
-            // the running binary's `APP_VERSION` so the wire value is
-            // concrete rather than an explicit null that would override the
-            // envelope under the platform's per-event-wins contract.
-            assistant_version: APP_VERSION,
-          }),
-        ),
-        ...skillLoadedEvents.map(
-          (e): TelemetryEvent => ({
-            type: "skill_loaded",
-            daemon_event_id: e.id,
-            recorded_at: e.createdAt,
-            skill_name: e.skillName,
-            skill_updated_at: e.skillUpdatedAt,
-            conversation_id: e.conversationId,
-            provider: e.provider,
-            model: e.model,
-            inference_profile: e.inferenceProfile,
-            inference_profile_source:
-              e.inferenceProfileSource as UsageAttributionProfileSource | null,
-            // `skill_loaded_events` has no record-time version column — same
-            // upload-time APP_VERSION stamping as the other non-llm_usage
-            // event types.
-            assistant_version: APP_VERSION,
-          }),
-        ),
-        ...watchdogEvents.map(
-          (e): TelemetryEvent => ({
-            type: "watchdog",
-            daemon_event_id: e.id,
-            recorded_at: e.createdAt,
-            check_name: e.checkName,
-            value: e.value,
-            // `detail` is stored as JSON text; parse defensively so a
-            // corrupted blob never fails the batch flush. A parse failure
-            // emits null rather than dropping the event.
-            detail: parseWatchdogDetail(e.detail),
-            // `watchdog_events` has no record-time version column — same
-            // upload-time APP_VERSION stamping as the other non-llm_usage
-            // event types.
-            assistant_version: APP_VERSION,
-          }),
-        ),
-        ...configSettingEvents.map(
-          (e): TelemetryEvent => ({
-            type: "config_setting",
-            daemon_event_id: e.id,
-            recorded_at: e.createdAt,
-            config_key: e.configKey,
-            config_value: e.configValue,
-            // `config_setting_events` has no record-time version column —
-            // same upload-time APP_VERSION stamping as the other
-            // non-llm_usage event types.
-            assistant_version: APP_VERSION,
-          }),
-        ),
-      ];
+      // Build payload — sources in construction order, each source's events
+      // in cursor order.
+      const typedEvents = batches.flatMap(({ batch }) => batch.events);
 
       const organizationId = getPlatformOrganizationId() || undefined;
       const userId = getPlatformUserId() || undefined;
@@ -868,138 +347,17 @@ export class UsageTelemetryReporter {
       }
       await resp.text(); // consume body to release connection
 
-      // Advance usage watermark (compound cursor)
-      if (events.length > 0) {
-        const lastEvent = events[events.length - 1];
-        setMemoryCheckpoint(
-          CHECKPOINT_KEY_WATERMARK,
-          String(lastEvent.createdAt),
-        );
-        setMemoryCheckpoint(CHECKPOINT_KEY_WATERMARK_ID, lastEvent.id);
+      // Advance each source's watermark to its last reported row.
+      for (const { source, batch } of batches) {
+        if (batch.lastCursor) {
+          const keys = watermarkKeysForSource(source.id);
+          this.checkpoints.set(keys.at, String(batch.lastCursor.createdAt));
+          this.checkpoints.set(keys.id, batch.lastCursor.id);
+        }
       }
 
-      // Advance turn watermark (compound cursor) — only to the last REPORTED
-      // turn. Deferred (in-flight) turns sit beyond this cursor and are
-      // re-evaluated on a later flush, so the watermark never skips them.
-      if (reportableTurnEvents.length > 0) {
-        const lastTurn = reportableTurnEvents[reportableTurnEvents.length - 1];
-        setMemoryCheckpoint(
-          CHECKPOINT_KEY_TURN_WATERMARK,
-          String(lastTurn.createdAt),
-        );
-        setMemoryCheckpoint(CHECKPOINT_KEY_TURN_WATERMARK_ID, lastTurn.id);
-      }
-
-      // Advance lifecycle watermark (compound cursor)
-      if (lifecycleEvents.length > 0) {
-        const lastLifecycle = lifecycleEvents[lifecycleEvents.length - 1];
-        setMemoryCheckpoint(
-          CHECKPOINT_KEY_LIFECYCLE_WATERMARK,
-          String(lastLifecycle.createdAt),
-        );
-        setMemoryCheckpoint(
-          CHECKPOINT_KEY_LIFECYCLE_WATERMARK_ID,
-          lastLifecycle.id,
-        );
-      }
-
-      // Advance onboarding watermark (compound cursor)
-      if (onboardingEvents.length > 0) {
-        const lastOnboarding = onboardingEvents[onboardingEvents.length - 1];
-        setMemoryCheckpoint(
-          CHECKPOINT_KEY_ONBOARDING_WATERMARK,
-          String(lastOnboarding.createdAt),
-        );
-        setMemoryCheckpoint(
-          CHECKPOINT_KEY_ONBOARDING_WATERMARK_ID,
-          lastOnboarding.id,
-        );
-      }
-
-      // Advance auth-fallback watermark (compound cursor)
-      if (authFallbackEvents.length > 0) {
-        const lastAuthFallback =
-          authFallbackEvents[authFallbackEvents.length - 1];
-        setMemoryCheckpoint(
-          CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK,
-          String(lastAuthFallback.createdAt),
-        );
-        setMemoryCheckpoint(
-          CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK_ID,
-          lastAuthFallback.id,
-        );
-      }
-
-      // Advance tool-executed watermark (compound cursor)
-      if (toolExecutedEvents.length > 0) {
-        const lastToolExecuted =
-          toolExecutedEvents[toolExecutedEvents.length - 1];
-        setMemoryCheckpoint(
-          CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK,
-          String(lastToolExecuted.createdAt),
-        );
-        setMemoryCheckpoint(
-          CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK_ID,
-          lastToolExecuted.id,
-        );
-      }
-
-      // Advance skill-loaded watermark (compound cursor)
-      if (skillLoadedEvents.length > 0) {
-        const lastSkillLoaded = skillLoadedEvents[skillLoadedEvents.length - 1];
-        setMemoryCheckpoint(
-          CHECKPOINT_KEY_SKILL_LOADED_WATERMARK,
-          String(lastSkillLoaded.createdAt),
-        );
-        setMemoryCheckpoint(
-          CHECKPOINT_KEY_SKILL_LOADED_WATERMARK_ID,
-          lastSkillLoaded.id,
-        );
-      }
-
-      // Advance watchdog watermark (compound cursor)
-      if (watchdogEvents.length > 0) {
-        const lastWatchdog = watchdogEvents[watchdogEvents.length - 1];
-        setMemoryCheckpoint(
-          CHECKPOINT_KEY_WATCHDOG_WATERMARK,
-          String(lastWatchdog.createdAt),
-        );
-        setMemoryCheckpoint(
-          CHECKPOINT_KEY_WATCHDOG_WATERMARK_ID,
-          lastWatchdog.id,
-        );
-      }
-
-      // Advance config-setting watermark (compound cursor)
-      if (configSettingEvents.length > 0) {
-        const lastConfigSetting =
-          configSettingEvents[configSettingEvents.length - 1];
-        setMemoryCheckpoint(
-          CHECKPOINT_KEY_CONFIG_SETTING_WATERMARK,
-          String(lastConfigSetting.createdAt),
-        );
-        setMemoryCheckpoint(
-          CHECKPOINT_KEY_CONFIG_SETTING_WATERMARK_ID,
-          lastConfigSetting.id,
-        );
-      }
-
-      // If we got a full batch of any type, there may be more — recurse.
-      // Turns use the REPORTED count: when the completeness barrier truncates
-      // the batch, the deferred turns must wait for a later flush (by which
-      // point they've settled) rather than being re-queried and re-deferred in
-      // a tight recursion.
-      if (
-        events.length === BATCH_SIZE ||
-        reportableTurnEvents.length === BATCH_SIZE ||
-        lifecycleEvents.length === BATCH_SIZE ||
-        onboardingEvents.length === BATCH_SIZE ||
-        authFallbackEvents.length === BATCH_SIZE ||
-        toolExecutedEvents.length === BATCH_SIZE ||
-        skillLoadedEvents.length === BATCH_SIZE ||
-        watchdogEvents.length === BATCH_SIZE ||
-        configSettingEvents.length === BATCH_SIZE
-      ) {
+      // If any source produced a full batch, there may be more — recurse.
+      if (batches.some(({ batch }) => batch.fullBatch)) {
         await this._doFlush(batchCount + 1);
       }
     } catch (err) {


### PR DESCRIPTION
## Prompt / plan

PR 1 of the plan to move most telemetry flushing into the resource monitor process while keeping turn-event flushing (traces need the daemon's live conversation state) on the main event loop: make the reporter process-agnostic and move its flush state out of the main DB, without changing wire behavior. PR 2 will instantiate the engine in the monitor with the eight non-turn sources and reduce the daemon's instance to turns; PR 3 adds the `config_setting` emitting side in the monitor.

Two changes:

**Source-driven reporter.** Each event type becomes a `TelemetryEventSource` (`telemetry-event-sources.ts`) owning its query, wire mapping, cursor, and reportable-prefix policy — the turn source keeps the completeness barrier and the trace gate, which are the daemon-only pieces. `UsageTelemetryReporter` is now a generic engine over the source list it is constructed with (default: all nine), so splitting flush responsibilities across processes becomes configuration rather than surgery. Source ids preserve the existing watermark key namespaces (`telemetry:<id>:last_reported_{at,id}`).

**Flush watermarks move to the telemetry DB.** Per review direction, `memory_checkpoints` is reserved for DB-migration checkpoints going forward. Migration `327-create-flush-checkpoints.ts` creates a `flush_checkpoints` table on `assistant-telemetry.db`, copies the eighteen legacy watermark keys over (`INSERT OR IGNORE`, so a crash-rerun never regresses a cursor the reporter has since advanced), and deletes them from `memory_checkpoints`. The keys are enumerated exactly — other `telemetry:`-prefixed checkpoints (`telemetry:installation_id`, `telemetry:watchers:inventory_last_recorded`) are not flush watermarks and stay put. The flush cycle now skips entirely when the telemetry DB is unavailable, because an unreadable watermark must not be mistaken for cursor 0 (which would re-ship history).

Also: the watermark store is injected via the reporter constructor (defaulting to the real telemetry-DB store). The reporter test previously `mock.module`d the checkpoint module, which is process-global and poisoned the store's own DB-backed tests when files share an invocation; the test now passes an in-memory fake instead.

Wire behavior is unchanged: same payload shape and per-type event order, same watermark keys, same opt-out sentinel semantics, same recursion/backpressure.

## Test plan

- All 63 existing reporter tests pass unchanged in their assertions (only the checkpoint mocking seam changed), plus a new test for the telemetry-DB-unavailable skip.
- New DB-backed tests: `flush-checkpoints` store round-trip, and migration 327 (copy + main-DB cleanup, exact-key selection leaving non-watermark `telemetry:*` checkpoints in place, crash-rerun never regressing an advanced cursor, no-op on fresh installs).
- `migration-prefix-guard` and `run-migrations` suites pass; `bunx tsgo --noEmit` clean; ESLint clean on changed files.
- Note: running the full `src/telemetry/` directory in a single bun invocation shows 5 pre-existing failures in `turn-trace-store.test.ts` caused by the reporter test's `turn-trace-store` module mock leaking across files — reproduced on clean `main`, unrelated to this change.

## CLI verb checklist

No new routes — internal telemetry restructuring only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYBzGqULfH9MGTbud4jj1P

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYBzGqULfH9MGTbud4jj1P)_