### PR TITLE
feat(persistence): add rawTelemetryRun helper for the dedicated telemetry connection

### DIFF
--- a/assistant/src/persistence/__tests__/raw-query-telemetry.test.ts
+++ b/assistant/src/persistence/__tests__/raw-query-telemetry.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for {@link rawTelemetryRun} — the raw-write helper for the dedicated
+ * telemetry connection (`assistant-telemetry.db`), mirroring
+ * `rawMemoryRun`/`rawLogsRun`. Writes must land on the telemetry connection,
+ * not the main DB, and return the changed-row count.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { getSqlite, getTelemetrySqlite } from "../db-connection.js";
+import { initializeDb } from "../db-init.js";
+import { rawTelemetryRun } from "../raw-query.js";
+
+await initializeDb();
+
+const telemetry = getTelemetrySqlite();
+if (!telemetry) throw new Error("telemetry database unavailable in test");
+
+telemetry.exec(/*sql*/ `
+  CREATE TABLE IF NOT EXISTS raw_telemetry_run_test (
+    id TEXT PRIMARY KEY,
+    value INTEGER NOT NULL
+  )
+`);
+
+describe("rawTelemetryRun", () => {
+  test("inserts on the telemetry connection and returns the changed-row count", () => {
+    const changes = rawTelemetryRun(
+      "test:insert",
+      "INSERT INTO raw_telemetry_run_test (id, value) VALUES (?, ?)",
+      "row-1",
+      42,
+    );
+    expect(changes).toBe(1);
+
+    // The row is visible through the telemetry connection…
+    const row = telemetry
+      .query("SELECT id, value FROM raw_telemetry_run_test WHERE id = ?")
+      .get("row-1");
+    expect(row).toEqual({ id: "row-1", value: 42 });
+
+    // …and the table does not exist on the main connection at all.
+    const onMain = getSqlite()
+      .query("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+      .get("raw_telemetry_run_test");
+    expect(onMain).toBeNull();
+  });
+
+  test("delete returns the changed-row count", () => {
+    rawTelemetryRun(
+      "test:insert",
+      "INSERT INTO raw_telemetry_run_test (id, value) VALUES (?, ?), (?, ?)",
+      "row-2",
+      1,
+      "row-3",
+      2,
+    );
+
+    const deleted = rawTelemetryRun(
+      "test:delete",
+      "DELETE FROM raw_telemetry_run_test WHERE id IN (?, ?)",
+      "row-2",
+      "row-3",
+    );
+    expect(deleted).toBe(2);
+
+    const noMatch = rawTelemetryRun(
+      "test:delete",
+      "DELETE FROM raw_telemetry_run_test WHERE id = ?",
+      "missing",
+    );
+    expect(noMatch).toBe(0);
+  });
+});

--- a/assistant/src/persistence/raw-query.ts
+++ b/assistant/src/persistence/raw-query.ts
@@ -29,7 +29,12 @@
 
 import type { Database, SQLQueryBindings } from "bun:sqlite";
 
-import { getLogsSqlite, getMemorySqlite, getSqlite } from "./db-connection.js";
+import {
+  getLogsSqlite,
+  getMemorySqlite,
+  getSqlite,
+  getTelemetrySqlite,
+} from "./db-connection.js";
 
 type SqlParam = SQLQueryBindings;
 
@@ -120,6 +125,13 @@ function logsSqlite(): Database {
   return sqlite;
 }
 
+/** The telemetry connection, or a thrown error when it cannot be opened. */
+function telemetrySqlite(): Database {
+  const sqlite = getTelemetrySqlite();
+  if (!sqlite) throw new Error("telemetry database unavailable");
+  return sqlite;
+}
+
 /** {@link rawAll} against the memory connection. */
 export function rawMemoryAll<T>(
   label: string,
@@ -159,6 +171,20 @@ export function rawLogsRun(
   ...params: SqlParam[]
 ): number {
   const sqlite = logsSqlite();
+  sqlite
+    .label(label)
+    .query(sql)
+    .run(...params);
+  return (sqlite.query("SELECT changes() AS c").get() as { c: number }).c;
+}
+
+/** {@link rawRun} against the telemetry connection. */
+export function rawTelemetryRun(
+  label: string,
+  sql: string,
+  ...params: SqlParam[]
+): number {
+  const sqlite = telemetrySqlite();
   sqlite
     .label(label)
     .query(sql)

--- a/assistant/src/plugins/defaults/memory/routes/__tests__/memory-v2-simulate-route.test.ts
+++ b/assistant/src/plugins/defaults/memory/routes/__tests__/memory-v2-simulate-route.test.ts
@@ -71,6 +71,8 @@ mock.module("../../../../../persistence/db-connection.js", () => ({
   getMemorySqlite: () => ({ __stub: true }),
   getLogsDb: () => ({ __stub: true }),
   getLogsSqlite: () => ({ __stub: true }),
+  getTelemetryDb: () => ({ __stub: true }),
+  getTelemetrySqlite: () => ({ __stub: true }),
   resetDb: () => {},
 }));
 


### PR DESCRIPTION
## Summary
- Adds a rawTelemetryRun helper mirroring rawMemoryRun/rawLogsRun for the dedicated assistant-telemetry.db connection
- Needed by upcoming telemetry-table relocations for cross-connection cleanup writes

Part of plan: telemetry-db-move.md (PR 1 of 6)