### PR TITLE
refactor(tools): fold host tools into the explicit tool manifest

### DIFF
--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -2,11 +2,6 @@ import { isPluginDisabled } from "../plugins/disabled-state.js";
 import { getLogger } from "../util/logger.js";
 import { coreAppProxyTools } from "./apps/definitions.js";
 import { registerAppTools } from "./apps/registry.js";
-import { hostFileEditTool } from "./host-filesystem/edit.js";
-import { hostFileReadTool } from "./host-filesystem/read.js";
-import { hostFileTransferTool } from "./host-filesystem/transfer.js";
-import { hostFileWriteTool } from "./host-filesystem/write.js";
-import { hostShellTool } from "./host-terminal/host-shell.js";
 import { toProviderSafeToolName } from "./provider-tool-name.js";
 import { registerSystemTools } from "./system/register.js";
 import { finalizeTool } from "./tool-defaults.js";
@@ -1090,19 +1085,6 @@ async function runToolInitialization(): Promise<void> {
     registerTool(tool);
   }
 
-  // Host tools are registered here so host access stays opt-in until this
-  // point in startup.
-  const hostTools = [
-    hostFileReadTool,
-    hostFileWriteTool,
-    hostFileEditTool,
-    hostFileTransferTool,
-    hostShellTool,
-  ];
-  for (const tool of hostTools) {
-    registerTool(tool);
-  }
-
   registerUiSurfaceTools();
   registerAppTools();
   registerSystemTools();
@@ -1112,15 +1094,14 @@ async function runToolInitialization(): Promise<void> {
   // arbitrary test tools that were registered before init.
   //
   // A pre-existing tool is included only if it is a known manifest tool
-  // (declared in explicitTools or hostTools) — e.g. a test registered a
-  // manifest tool directly before its first initializeTools() call.
+  // (declared in explicitTools) — e.g. a test registered a manifest tool
+  // directly before its first initializeTools() call.
   if (!coreToolsSnapshot) {
     // Core tool literals always set `name` (verified by `registerTool` —
     // it throws on missing name). The `!` assertions reflect that
     // invariant at the iteration sites.
     const manifestToolNames = new Set<string>([
       ...explicitTools.map((t) => t.name!),
-      ...hostTools.map((t) => t.name!),
       ...allUiSurfaceTools.map((t) => t.name!),
       ...coreAppProxyTools.map((t) => t.name!),
     ]);

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -13,6 +13,11 @@ import { fileListTool } from "./filesystem/list.js";
 import { fileReadTool } from "./filesystem/read.js";
 import { codeSearchTool } from "./filesystem/search.js";
 import { fileWriteTool } from "./filesystem/write.js";
+import { hostFileEditTool } from "./host-filesystem/edit.js";
+import { hostFileReadTool } from "./host-filesystem/read.js";
+import { hostFileTransferTool } from "./host-filesystem/transfer.js";
+import { hostFileWriteTool } from "./host-filesystem/write.js";
+import { hostShellTool } from "./host-terminal/host-shell.js";
 import { webFetchTool } from "./network/web-fetch.js";
 import { webSearchTool } from "./network/web-search.js";
 import { skillExecuteTool } from "./skills/execute.js";
@@ -50,4 +55,12 @@ export const explicitTools: ToolDefinition[] = [
   recallTool,
   notifyParentTool,
   askQuestionTool,
+  // Host tools — executed on the desktop host via the client proxy rather
+  // than in the daemon's sandbox. Listed after the sandbox tools so
+  // registration order (and thus tools.json ordering) is stable.
+  hostFileReadTool,
+  hostFileWriteTool,
+  hostFileEditTool,
+  hostFileTransferTool,
+  hostShellTool,
 ];


### PR DESCRIPTION
## Prompt / plan

Next step now that the manifest is statically hoisted (#37820): host tools were registered by `runToolInitialization` immediately after the `explicitTools` loop anyway, from a hardcoded array inside the registry — so the two arrays combine into one in the manifest.

## Changes

- `tool-manifest.ts`: the five host tools (`host_file_read`/`write`/`edit`/`transfer`, `host_shell`) join `explicitTools`, appended after the sandbox tools so registration order — and therefore anything derived from it — is unchanged (explicit tools → host tools → ui-surface / app / system groups).
- `registry.ts`: the hardcoded `hostTools` array, its registration loop, its five imports, and its line in the core-snapshot `manifestToolNames` set are gone; the manifest is now the single list of directly-registered core tools.

Net −6 lines; behavior identical.

## Test plan

- Registry-adjacent suites green (200 tests: `registry`, `skill-tool-manifest`, `always-loaded-tools-guard`, `host-file-read-tool`, `host-shell-tool`, `browser-skill-baseline-tool-payload`, `memory-worker-tool-registry-guard`, `computer-use-skill-manifest-regression`).
- Full suite: only the 8 known pre-existing environmental failures. `tsc` + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014ok5MKKrM4ZnmqG3AeXWtc)_