### PR TITLE
fix: repair gateway tests and version-gate trust-floor queries after channel-trust-floors default-on

### DIFF
--- a/clients/web/src/domains/channels/hooks/use-channel-trust-floors.ts
+++ b/clients/web/src/domains/channels/hooks/use-channel-trust-floors.ts
@@ -15,6 +15,7 @@ import {
   toChannelPolicyViews,
 } from "@/lib/channel-admission-policy/api";
 import type { AdmissionPolicy } from "@/lib/channel-admission-policy/types";
+import { useSupportsChannelTrustFloors } from "@/lib/backwards-compat/channel-trust-floors";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { toastOnError } from "@/utils/mutation-error";
 
@@ -36,12 +37,15 @@ export interface ChannelTrustFloors {
 /**
  * Per-channel admission floor (trust floor) wiring for the assistant's
  * channel list (the Channels tab and the Contacts assistant detail). Reads
- * the `channelTrustFloors` flag itself; when off it returns no policies and
- * no `onChange`, which hides the inline control entirely.
+ * the `channelTrustFloors` flag and the gateway-version gate itself; when
+ * either is off it returns no policies and no `onChange`, which hides the
+ * inline control entirely.
  */
 export function useChannelTrustFloors(assistantId: string): ChannelTrustFloors {
   const queryClient = useQueryClient();
-  const enabled = useAssistantFeatureFlagStore.use.channelTrustFloors();
+  const flagOn = useAssistantFeatureFlagStore.use.channelTrustFloors();
+  const supported = useSupportsChannelTrustFloors();
+  const enabled = flagOn && supported;
 
   const pathOptions = useMemo(
     () => ({ path: { assistant_id: assistantId } }),

--- a/clients/web/src/domains/contacts/hooks/use-channel-provenance.ts
+++ b/clients/web/src/domains/contacts/hooks/use-channel-provenance.ts
@@ -9,6 +9,7 @@ import {
   type ChannelPolicyView,
 } from "@/lib/channel-admission-policy/types";
 import { toChannelPolicyViews } from "@/lib/channel-admission-policy/api";
+import { useSupportsChannelTrustFloors } from "@/lib/backwards-compat/channel-trust-floors";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 export type ChannelProvenanceMap = Partial<
@@ -52,8 +53,8 @@ function selectChannelProvenance(
  * whether each setup channel's admission floor comes from the global default
  * or a channel-level default set on the Channels tab (see
  * {@link deriveChannelProvenance} for the decision rule). Reads the
- * `channelTrustFloors` flag itself; when off it returns `undefined`, which
- * hides the provenance pill entirely.
+ * `channelTrustFloors` flag and the gateway-version gate itself; when either
+ * is off it returns `undefined`, which hides the provenance pill entirely.
  *
  * Spreads the generated `assistantChannelAdmissionPolicyListOptions` so it
  * shares the generated query key — and one raw cache entry — with
@@ -62,7 +63,9 @@ function selectChannelProvenance(
 export function useChannelProvenance(
   assistantId: string,
 ): ChannelProvenanceMap | undefined {
-  const enabled = useAssistantFeatureFlagStore.use.channelTrustFloors();
+  const flagOn = useAssistantFeatureFlagStore.use.channelTrustFloors();
+  const supported = useSupportsChannelTrustFloors();
+  const enabled = flagOn && supported;
 
   const query = useQuery({
     ...assistantChannelAdmissionPolicyListOptions({

--- a/clients/web/src/lib/backwards-compat/channel-trust-floors.ts
+++ b/clients/web/src/lib/backwards-compat/channel-trust-floors.ts
@@ -1,0 +1,21 @@
+/**
+ * Backwards-compat gate: per-channel admission floors (trust floors).
+ *
+ * The admission-policy list/set routes behind `useChannelTrustFloors`
+ * and `useChannelProvenance` shipped with 0.10.0 (PR #35150) — the
+ * pinned version below. Now that the `channel-trust-floors` flag
+ * defaults on, an older gateway that omits the flag from
+ * `/feature-flags` leaves the registry default (`true`) in place, so
+ * without this gate the queries would fire against a gateway that
+ * lacks the routes and render a dead error state. When unsupported,
+ * the channel list renders without floor controls or provenance pills
+ * (read-path degrade), matching `channel-access-controls.ts`.
+ */
+import { useAssistantSupports } from "./utils";
+
+export const MIN_VERSION = "0.10.0";
+
+/** Render-path gate for the per-channel admission-floor queries. */
+export function useSupportsChannelTrustFloors(): boolean {
+  return useAssistantSupports(MIN_VERSION);
+}

--- a/clients/web/src/lib/backwards-compat/channel-trust-floors.ts
+++ b/clients/web/src/lib/backwards-compat/channel-trust-floors.ts
@@ -1,14 +1,13 @@
 /**
  * Backwards-compat gate: per-channel admission floors (trust floors).
  *
- * The admission-policy list/set routes behind `useChannelTrustFloors`
- * and `useChannelProvenance` shipped with 0.10.0 (PR #35150) — the
- * pinned version below. Now that the `channel-trust-floors` flag
- * defaults on, an older gateway that omits the flag from
- * `/feature-flags` leaves the registry default (`true`) in place, so
- * without this gate the queries would fire against a gateway that
- * lacks the routes and render a dead error state. When unsupported,
- * the channel list renders without floor controls or provenance pills
+ * Gateways below the pinned version lack the admission-policy list/set
+ * routes behind `useChannelTrustFloors` and `useChannelProvenance`.
+ * Such a gateway also omits the `channel-trust-floors` flag from
+ * `/feature-flags`, leaving the registry default (`true`) in place, so
+ * the flag alone cannot keep the queries from firing against a gateway
+ * that 404s them into a dead error state. When unsupported, the
+ * channel list renders without floor controls or provenance pills
  * (read-path degrade), matching `channel-access-controls.ts`.
  */
 import { useAssistantSupports } from "./utils";

--- a/gateway/src/__tests__/twilio-webhooks.test.ts
+++ b/gateway/src/__tests__/twilio-webhooks.test.ts
@@ -1,10 +1,15 @@
-import { describe, test, expect, mock, afterEach } from "bun:test";
+import { describe, test, expect, mock, afterEach, beforeEach } from "bun:test";
 import { createHmac } from "node:crypto";
 import type { GatewayConfig } from "../config.js";
 import type { CredentialCache } from "../credential-cache.js";
 import type { ConfigFileCache } from "../config-file-cache.js";
 import { credentialKey } from "../credential-key.js";
 import { initSigningKey } from "../auth/token-service.js";
+import {
+  initAdmissionPolicyCache,
+  resetAdmissionPolicyCache,
+} from "../risk/admission-policy-cache.js";
+import { initGatewayDb, resetGatewayDb } from "../db/connection.js";
 
 const TEST_SIGNING_KEY = Buffer.from("test-signing-key-at-least-32-bytes-long");
 initSigningKey(TEST_SIGNING_KEY);
@@ -52,9 +57,21 @@ const { createTwilioStatusWebhookHandler } =
 
 const AUTH_TOKEN = "test-twilio-auth-token";
 
+beforeEach(async () => {
+  // The voice webhook resolves the phone admission floor (channel-trust-floors
+  // is on by default); init the cache fresh per test like the other webhook
+  // handler tests.
+  resetGatewayDb();
+  resetAdmissionPolicyCache();
+  await initGatewayDb();
+  initAdmissionPolicyCache();
+});
+
 afterEach(() => {
   fetchMock = mock(async () => new Response());
   logCalls.length = 0;
+  resetAdmissionPolicyCache();
+  resetGatewayDb();
 });
 
 function findLogCall(message: string): {


### PR DESCRIPTION
## Summary
- Fixes the `Lint, Type Check & Test` gateway CI failure introduced on main by #37831: `twilio-webhooks.test.ts` now reaches the admission-policy cache (the `channel-trust-floors` flag defaults on), so init the gateway DB + admission-policy cache per test, matching the sibling webhook handler tests.
- Addresses Codex's P2 on #37831: adds a `lib/backwards-compat/channel-trust-floors.ts` gate (MIN_VERSION 0.10.0, where the admission-policy routes shipped in #35150) and composes it into `useChannelTrustFloors` / `useChannelProvenance`, so older gateways that omit the flag from `/feature-flags` degrade to a channel list without floor controls instead of rendering a dead 404 error state.

## Original prompt
Follow-up to #37831 (make the `channel-trust-floors` feature flag default on), which was merged while its CI fix was still in flight. This PR carries the two follow-ups: the gateway test initialization the new default requires, and the gateway-version gate Codex requested so pre-0.10.0 gateways fail soft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)