### PR TITLE
chore(telemetry): remove the GA'd trace-collection feature flag

### DIFF
--- a/assistant/src/platform/consent-cache.ts
+++ b/assistant/src/platform/consent-cache.ts
@@ -4,8 +4,8 @@
  * Three values are cached, all refreshed from the same owner-consent fetch:
  *  - `share_analytics`: gates usage telemetry collection.
  *  - `share_diagnostics`: gates crash diagnostics (read by Sentry `beforeSend`),
- *    and composes the per-turn trace-collection gate alongside the
- *    `trace-collection` feature flag.
+ *    and composes the per-turn trace-collection gate alongside the accepted
+ *    consent version.
  *  - `share_diagnostics_accepted_version`: the consent version the owner
  *    accepted; the disclosing-version half of the trace-collection gate (see
  *    telemetry/trace-collection-policy.ts).

--- a/assistant/src/telemetry/telemetry-event-sources.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.ts
@@ -9,8 +9,6 @@
  * which sources its reporter instance is constructed with.
  */
 
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
-import { getConfig } from "../config/loader.js";
 import { queryUnreportedOnboardingEvents } from "../onboarding/onboarding-events-store.js";
 import { queryUnreportedLifecycleEvents } from "../persistence/lifecycle-events-store.js";
 import { queryUnreportedUsageEvents } from "../persistence/llm-usage-store.js";
@@ -226,16 +224,12 @@ const turnSource: TelemetryEventSource = {
     //
     // Trace eligibility is composed daemon-side to mirror the platform's
     // authoritative owner-based ingest gate, so traces for ineligible owners
-    // never leave the device. Three parts, fail-closed (all must be true):
-    //   1. the `trace-collection` LaunchDarkly flag (delivered via the
-    //      assistant-tagged flag sync, already evaluated server-side for this
-    //      assistant's owner),
-    //   2. the owner's cached `share_diagnostics` consent, and
-    //   3. the owner's cached `share_diagnostics_accepted_version` being at or
+    // never leave the device. Two parts, fail-closed (both must be true):
+    //   1. the owner's cached `share_diagnostics` consent, and
+    //   2. the owner's cached `share_diagnostics_accepted_version` being at or
     //      past the disclosing version — the platform applies the identical
     //      check, so an old consent never yields a trace here or there.
     const traceEligible =
-      isAssistantFeatureFlagEnabled("trace-collection", getConfig()) &&
       getCachedShareDiagnostics() &&
       isDiagnosticsConsentVersionEligible(getCachedShareDiagnosticsVersion());
     let reportableTurnEvents = turnEvents;
@@ -270,10 +264,9 @@ const turnSource: TelemetryEventSource = {
 
     const events = reportableTurnEvents.map((e): TelemetryEvent => {
       // Per-turn trace collection gate. `traceEligible` (computed above)
-      // requires the `trace-collection` flag AND the owner's cached
-      // `share_diagnostics` consent AND an eligible accepted consent
-      // version. Fail-closed: when any is off the trace is omitted and the
-      // trace-free turn row flushes as before. The
+      // requires the owner's cached `share_diagnostics` consent AND an
+      // eligible accepted consent version. Fail-closed: when either is off
+      // the trace is omitted and the trace-free turn row flushes as before. The
       // `share_analytics` gate in the reporter already passed, so this is an
       // additional, independent gate specific to trace PII. Every turn
       // reaching here is settled (the completeness barrier dropped any

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -208,8 +208,8 @@ export interface TurnTraceToolCall {
  * Full transcript of a single turn — the user message, assistant response
  * message(s), and the tool calls + results that occurred between this user
  * turn and the next real user turn. Attached to the turn telemetry event's
- * `trace` field ONLY when trace collection is enabled — the `trace-collection`
- * feature flag AND the owner's `share_diagnostics` consent must both be true.
+ * `trace` field ONLY when trace collection is enabled — the owner's
+ * `share_diagnostics` consent at an eligible accepted version.
  * The platform stores this verbatim as an opaque JSON column, so the daemon
  * owns the shape.
  *
@@ -348,10 +348,9 @@ export interface TurnTelemetryEvent extends TelemetryEventBase {
   /**
    * Full per-turn transcript (user message + assistant responses + tool
    * calls/results). Present ONLY when trace collection is enabled — the daemon
-   * composes the gate itself from the `trace-collection` feature flag (delivered
-   * via the assistant-tagged flag sync, evaluated server-side for this
-   * assistant's owner) AND the owner's cached `share_diagnostics` consent, both
-   * of which must be true. Fail-closed: when either is off (or unknown) no trace
+   * composes the gate itself from the owner's cached `share_diagnostics`
+   * consent AND the accepted consent version being at or past the disclosing
+   * version. Fail-closed: when either is off (or unknown) no trace
    * is attached. The platform dual-writes consented traces into a separate PII
    * table and keeps the trace-free turn row; downstream consumers that don't
    * read traces ignore this field. Null / absent when the gate is off or the

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -96,7 +96,7 @@ const mockGetCachedShareAnalytics = mock(() => true);
 const mockGetCachedShareDiagnostics = mock(() => false);
 // Owner's accepted diagnostics-consent version — the disclosing-version part of
 // the trace gate. Default to a far-future (unconditionally eligible) version so
-// the consent/flag cases drive eligibility on those axes; the version-specific
+// the consent cases drive eligibility on that axis; the version-specific
 // cases override it with old/empty values.
 const mockGetCachedShareDiagnosticsVersion = mock(() => "2999-01-01");
 
@@ -104,21 +104,6 @@ mock.module("../platform/consent-cache.js", () => ({
   getCachedShareAnalytics: mockGetCachedShareAnalytics,
   getCachedShareDiagnostics: mockGetCachedShareDiagnostics,
   getCachedShareDiagnosticsVersion: mockGetCachedShareDiagnosticsVersion,
-}));
-
-// The `trace-collection` feature flag — the other half of the trace gate.
-const mockIsAssistantFeatureFlagEnabled = mock(
-  (_key: string, _config: unknown): boolean => true,
-);
-
-mock.module("../config/assistant-feature-flags.js", () => ({
-  isAssistantFeatureFlagEnabled: mockIsAssistantFeatureFlagEnabled,
-}));
-
-// Stub config — the flag checker is mocked, so the contents don't matter; this
-// just keeps `getConfig()` from touching the real loader / filesystem.
-mock.module("../config/loader.js", () => ({
-  getConfig: () => ({}),
 }));
 
 interface MockTurnTrace {
@@ -390,13 +375,9 @@ beforeEach(() => {
   mockGetCachedShareDiagnostics.mockReset();
   mockGetCachedShareDiagnostics.mockReturnValue(false);
   // Default the accepted consent version eligible so trace tests drive the gate
-  // via the flag + share_diagnostics knobs; version cases override it.
+  // via the share_diagnostics knob; version cases override it.
   mockGetCachedShareDiagnosticsVersion.mockReset();
   mockGetCachedShareDiagnosticsVersion.mockReturnValue("2999-01-01");
-  // Default the `trace-collection` flag ON so trace tests can drive eligibility
-  // via the consent knob alone; the flag-gating test flips it explicitly.
-  mockIsAssistantFeatureFlagEnabled.mockReset();
-  mockIsAssistantFeatureFlagEnabled.mockReturnValue(true);
   mockAssembleBoundedTurnTrace.mockReset();
   mockAssembleBoundedTurnTrace.mockImplementation(defaultBoundedTurnTrace);
   mockIsTurnSettled.mockReset();
@@ -1080,8 +1061,8 @@ describe("UsageTelemetryReporter", () => {
   });
 
   // -------------------------------------------------------------------------
-  // Per-turn trace collection (gated on the trace-collection flag AND
-  // share_diagnostics consent)
+  // Per-turn trace collection (gated on share_diagnostics consent at an
+  // eligible accepted version)
   // -------------------------------------------------------------------------
 
   function singleTurnEvent() {
@@ -1099,8 +1080,7 @@ describe("UsageTelemetryReporter", () => {
     ];
   }
 
-  test("attaches the assembled trace when the trace-collection flag, share_diagnostics, and an eligible consent version are all true", async () => {
-    mockIsAssistantFeatureFlagEnabled.mockReturnValue(true);
+  test("attaches the assembled trace when share_diagnostics and an eligible consent version are both true", async () => {
     mockGetCachedShareDiagnostics.mockReturnValue(true);
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
     mockQueryUnreportedTurnEvents.mockReturnValue(singleTurnEvent());
@@ -1110,12 +1090,6 @@ describe("UsageTelemetryReporter", () => {
 
     const reporter = makeReporter();
     await reporter.flush();
-
-    // The gate consults the `trace-collection` flag.
-    expect(mockIsAssistantFeatureFlagEnabled).toHaveBeenCalledWith(
-      "trace-collection",
-      expect.anything(),
-    );
 
     // The assembler is called with the turn's (conversationId, id, createdAt)
     // boundary so the window lines up with the turn event.
@@ -1142,8 +1116,7 @@ describe("UsageTelemetryReporter", () => {
     expect(Array.isArray(turn.trace.tool_calls)).toBe(true);
   });
 
-  test("omits the trace when share_diagnostics is false even though the flag is on (and still emits the turn event)", async () => {
-    mockIsAssistantFeatureFlagEnabled.mockReturnValue(true);
+  test("omits the trace when share_diagnostics is false (and still emits the turn event)", async () => {
     mockGetCachedShareDiagnostics.mockReturnValue(false);
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
     mockQueryUnreportedTurnEvents.mockReturnValue(singleTurnEvent());
@@ -1169,8 +1142,7 @@ describe("UsageTelemetryReporter", () => {
     expect("trace" in turn).toBe(false);
   });
 
-  test("omits the trace when the accepted consent version predates the disclosure threshold (flag + share_diagnostics on)", async () => {
-    mockIsAssistantFeatureFlagEnabled.mockReturnValue(true);
+  test("omits the trace when the accepted consent version predates the disclosure threshold (share_diagnostics on)", async () => {
     mockGetCachedShareDiagnostics.mockReturnValue(true);
     // Consent recorded under an older version that never disclosed trace
     // collection → gate closed, mirroring the platform ingest gate.
@@ -1196,7 +1168,6 @@ describe("UsageTelemetryReporter", () => {
   });
 
   test("omits the trace when the owner never accepted a versioned consent (empty version)", async () => {
-    mockIsAssistantFeatureFlagEnabled.mockReturnValue(true);
     mockGetCachedShareDiagnostics.mockReturnValue(true);
     // Empty version (never accepted / no-row default where share_diagnostics is
     // true but unversioned) fails closed.
@@ -1214,30 +1185,6 @@ describe("UsageTelemetryReporter", () => {
     const body = JSON.parse(
       (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
     );
-    expect(body.events.length).toBe(1);
-    expect("trace" in body.events[0]).toBe(false);
-  });
-
-  test("omits the trace when the trace-collection flag is off even though share_diagnostics is true", async () => {
-    mockIsAssistantFeatureFlagEnabled.mockReturnValue(false);
-    mockGetCachedShareDiagnostics.mockReturnValue(true);
-    mockQueryUnreportedUsageEvents.mockReturnValue([]);
-    mockQueryUnreportedTurnEvents.mockReturnValue(singleTurnEvent());
-    mockFetch.mockImplementation(() =>
-      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
-    );
-
-    const reporter = makeReporter();
-    await reporter.flush();
-
-    // Flag off → gate closed → no assembly at all (no PII touched).
-    expect(mockAssembleBoundedTurnTrace).not.toHaveBeenCalled();
-
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    const body = JSON.parse(
-      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
-    );
-    // The single turn event still flushes — just without a trace.
     expect(body.events.length).toBe(1);
     expect("trace" in body.events[0]).toBe(false);
   });
@@ -1266,9 +1213,8 @@ describe("UsageTelemetryReporter", () => {
   test("no trace is assembled or attached when the whole flush is gated off by share_analytics", async () => {
     // The analytics gate short-circuits the entire flush; trace assembly must
     // never run (and nothing is sent) even when the trace gate is fully on
-    // (flag + share_diagnostics both true).
+    // (share_diagnostics true at an eligible version).
     mockGetCachedShareAnalytics.mockReturnValue(false);
-    mockIsAssistantFeatureFlagEnabled.mockReturnValue(true);
     mockGetCachedShareDiagnostics.mockReturnValue(true);
     mockQueryUnreportedTurnEvents.mockReturnValue(singleTurnEvent());
 

--- a/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
+++ b/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
@@ -96,7 +96,7 @@ describe("getEnvFlagOverridesForScope", () => {
         // client-only flag (boolean)
         "home-tab": true,
         // assistant-only flag (boolean) — should be excluded from client scope
-        "trace-collection": true,
+        "settings-developer-nav": true,
         // client-only flag (string)
         "pre-chat-onboarding-experiment-2026-06-06": "variant-a",
       },
@@ -108,7 +108,7 @@ describe("getEnvFlagOverridesForScope", () => {
     expect(result.str).toEqual({
       preChatOnboardingExperiment20260606: "variant-a",
     });
-    expect(result.bool).not.toHaveProperty("traceCollection");
+    expect(result.bool).not.toHaveProperty("settingsDeveloperNav");
   });
 
   test("flags with scope 'both' appear for both client and assistant scopes", () => {

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -51,14 +51,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "trace-collection",
-      "scope": "assistant",
-      "key": "trace-collection",
-      "label": "Trace Collection",
-      "description": "Gate per-turn conversation trace (user/assistant/tool-call/tool-response) collection. The daemon attaches a trace to its turn telemetry only when this flag AND the owner's share_diagnostics consent are both on. Defaults off (fail-closed) \u2014 the live value is delivered from LaunchDarkly.",
-      "defaultEnabled": false
-    },
-    {
       "id": "settings-developer-nav",
       "scope": "assistant",
       "key": "settings-developer-nav",

--- a/gateway/src/__tests__/twilio-webhooks.test.ts
+++ b/gateway/src/__tests__/twilio-webhooks.test.ts
@@ -3,6 +3,7 @@ import { createHmac } from "node:crypto";
 import type { GatewayConfig } from "../config.js";
 import type { CredentialCache } from "../credential-cache.js";
 import type { ConfigFileCache } from "../config-file-cache.js";
+import { AdmissionPolicyStore } from "../db/admission-policy-store.js";
 import { credentialKey } from "../credential-key.js";
 import { initSigningKey } from "../auth/token-service.js";
 import {
@@ -54,7 +55,6 @@ const { createTwilioVoiceWebhookHandler } =
   await import("../http/routes/twilio-voice-webhook.js");
 const { createTwilioStatusWebhookHandler } =
   await import("../http/routes/twilio-status-webhook.js");
-
 const AUTH_TOKEN = "test-twilio-auth-token";
 
 beforeEach(async () => {
@@ -326,6 +326,26 @@ describe("Twilio voice webhook", () => {
     expect(res.status).toBe(200);
     const body = await res.text();
     expect(body).toContain("<Reject");
+  });
+
+  test("hard-denies inbound call with TwiML Reject when the phone admission policy is no_one", async () => {
+    const store = new AdmissionPolicyStore();
+    store.set("phone", "no_one");
+    resetAdmissionPolicyCache();
+    initAdmissionPolicyCache();
+    const handler = createTwilioVoiceWebhookHandler(makeConfig(), makeCaches());
+    const url = "http://localhost:7830/webhooks/twilio/voice";
+    const params = { CallSid: "CA123", From: "+15550100", To: "+15550101" };
+    const req = buildSignedRequest(url, params, AUTH_TOKEN);
+
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("<Reject");
+    // Kill switch fires before any routing — nothing is forwarded, and the
+    // deny is logged as the admission-policy branch, not the unmapped branch.
+    expect(fetchMock).not.toHaveBeenCalled();
+    findLogCall("Inbound voice call hard-denied by admission policy 'no_one'");
   });
 
   test("returns 502 when runtime is unreachable (outbound call)", async () => {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -51,14 +51,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "trace-collection",
-      "scope": "assistant",
-      "key": "trace-collection",
-      "label": "Trace Collection",
-      "description": "Gate per-turn conversation trace (user/assistant/tool-call/tool-response) collection. The daemon attaches a trace to its turn telemetry only when this flag AND the owner's share_diagnostics consent are both on. Defaults off (fail-closed) \u2014 the live value is delivered from LaunchDarkly.",
-      "defaultEnabled": false
-    },
-    {
       "id": "settings-developer-nav",
       "scope": "assistant",
       "key": "settings-developer-nav",


### PR DESCRIPTION
## Prompt / plan

Follow-up from review on #37825: the `trace-collection` flag is GA'd, so remove it. The per-turn trace gate is now composed solely from the owner's `share_diagnostics` consent AND the accepted consent version being at or past the disclosing version (`trace-collection-policy.ts`, unchanged) — both still fail-closed, and the platform ingest continues to apply the identical owner-based gate authoritatively, so this removes a redundant conjunct rather than loosening trace collection for anyone without consent.

- Drop the flag check from the turn source's trace-eligibility gate (`telemetry-event-sources.ts`) and its now-unused `assistant-feature-flags` / config-loader imports.
- Remove the registry entry from `meta/feature-flags/feature-flag-registry.json` and re-run `sync-bundled-copies.ts` (the committed web copy updates; the assistant/gateway copies are gitignored build artifacts).
- Update gate-description comments in `types.ts` and `consent-cache.ts`.
- Reporter tests: delete the flag-off gating test, drop the flag mock and its knobs; the remaining trace tests drive eligibility via consent + version alone. The web catalog test's assistant-only fixture flag switches to `settings-developer-nav`.

Platform-side cleanup (retiring the LaunchDarkly flag in the `vellum-assistant-platform` Terraform) is a companion follow-up — the daemon no longer reads the flag, so ordering doesn't matter.

## Test plan

- `usage-telemetry-reporter.test.ts` (65 tests) and `trace-collection-policy.test.ts` pass; assistant typecheck clean.
- `feature-flag-catalog.test.ts` (web) passes; web typecheck clean.
- ESLint clean on changed files.

## CLI verb checklist

No new routes — flag removal only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYBzGqULfH9MGTbud4jj1P

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYBzGqULfH9MGTbud4jj1P)_