### PR TITLE
feat(telemetry): relocate onboarding_events into assistant-telemetry.db

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-activation-emit.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-activation-emit.test.ts
@@ -28,7 +28,7 @@ const { createSurfaceMutex, handleSurfaceAction, surfaceProxyResolver } =
 import type { SurfaceConversationContext } from "../daemon/conversation-surfaces.js";
 import type { SurfaceType, UiSurfaceShow } from "../daemon/message-protocol.js";
 import { queryUnreportedOnboardingEvents } from "../onboarding/onboarding-events-store.js";
-import { getDb } from "../persistence/db-connection.js";
+import { getDb, getTelemetryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import {
   activationSessions,
@@ -84,7 +84,7 @@ function makeContext(
 }
 
 function resetTables(): void {
-  getDb().delete(onboardingEvents).run();
+  getTelemetryDb()!.delete(onboardingEvents).run();
   getDb().delete(activationSessions).run();
 }
 

--- a/assistant/src/onboarding/__tests__/onboarding-events-store.test.ts
+++ b/assistant/src/onboarding/__tests__/onboarding-events-store.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 
 // Mutable consent gate, flipped per-test.
 let shareAnalytics = true;
@@ -6,18 +6,33 @@ mock.module("../../platform/consent-cache.js", () => ({
   getCachedShareAnalytics: () => shareAnalytics,
 }));
 
-import { getDb } from "../../persistence/db-connection.js";
+import * as dbConnection from "../../persistence/db-connection.js";
+import {
+  getTelemetryDb,
+  getTelemetrySqlite,
+} from "../../persistence/db-connection.js";
 import { initializeDb } from "../../persistence/db-init.js";
 import { onboardingEvents } from "../../persistence/schema/index.js";
 import {
   queryUnreportedOnboardingEvents,
   recordActivationEvent,
+  recordOnboardingEvent,
 } from "../onboarding-events-store.js";
 
 await initializeDb();
 
 function resetTable(): void {
-  getDb().delete(onboardingEvents).run();
+  getTelemetryDb()!.delete(onboardingEvents).run();
+}
+
+/** Run `fn` with the dedicated telemetry connection reported as unavailable. */
+function withTelemetryDbUnavailable(fn: () => void): void {
+  const spy = spyOn(dbConnection, "getTelemetryDb").mockReturnValue(null);
+  try {
+    fn();
+  } finally {
+    spy.mockRestore();
+  }
 }
 
 describe("onboarding-events-store: recordActivationEvent", () => {
@@ -45,6 +60,19 @@ describe("onboarding-events-store: recordActivationEvent", () => {
     expect(row.completedAt).toBe(new Date(row.createdAt).toISOString());
   });
 
+  test("writes the row into the dedicated telemetry database", () => {
+    const event = recordActivationEvent({
+      stepName: "activation_moment_1_complete",
+      sessionId: "conv-telemetry",
+    });
+    expect(event).not.toBeNull();
+
+    const raw = getTelemetrySqlite()!
+      .query(`SELECT id, session_id FROM onboarding_events`)
+      .all() as Array<{ id: string; session_id: string }>;
+    expect(raw).toEqual([{ id: event!.id, session_id: "conv-telemetry" }]);
+  });
+
   test("honors an explicit abVariant override", () => {
     recordActivationEvent({
       stepName: "activation_moment_2_complete",
@@ -68,5 +96,61 @@ describe("onboarding-events-store: recordActivationEvent", () => {
 
     const rows = queryUnreportedOnboardingEvents(0, undefined, 10);
     expect(rows).toHaveLength(0);
+  });
+
+  test("returns null when the telemetry database is unavailable", () => {
+    withTelemetryDbUnavailable(() => {
+      const event = recordActivationEvent({
+        stepName: "activation_moment_1_complete",
+        sessionId: "conv-4",
+      });
+      expect(event).toBeNull();
+      expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+    });
+
+    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+  });
+});
+
+describe("onboarding-events-store: recordOnboardingEvent", () => {
+  beforeEach(() => {
+    shareAnalytics = true;
+    resetTable();
+  });
+
+  test("persists a pre-chat onboarding event into the telemetry database", () => {
+    const event = recordOnboardingEvent({
+      screen: "tools",
+      tools: ["gmail", "calendar"],
+      tone: "warm",
+      googleConnected: true,
+    });
+    expect(event).not.toBeNull();
+
+    const rows = queryUnreportedOnboardingEvents(0, undefined, 10);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.screen).toBe("tools");
+    expect(rows[0]!.toolsJson).toBe(JSON.stringify(["gmail", "calendar"]));
+    expect(rows[0]!.tone).toBe("warm");
+    expect(rows[0]!.googleConnected).toBe(true);
+
+    const raw = getTelemetrySqlite()!
+      .query(`SELECT id FROM onboarding_events`)
+      .all() as Array<{ id: string }>;
+    expect(raw).toEqual([{ id: event!.id }]);
+  });
+
+  test("returns null and writes no row when share_analytics is disabled", () => {
+    shareAnalytics = false;
+    expect(recordOnboardingEvent({ screen: "tools" })).toBeNull();
+    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+  });
+
+  test("returns null when the telemetry database is unavailable", () => {
+    withTelemetryDbUnavailable(() => {
+      expect(recordOnboardingEvent({ screen: "tools" })).toBeNull();
+    });
+
+    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
   });
 });

--- a/assistant/src/onboarding/onboarding-events-store.ts
+++ b/assistant/src/onboarding/onboarding-events-store.ts
@@ -1,7 +1,7 @@
 import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getDb } from "../persistence/db-connection.js";
+import { getTelemetryDb } from "../persistence/db-connection.js";
 import { onboardingEvents } from "../persistence/schema/index.js";
 import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import {
@@ -45,15 +45,22 @@ export interface RecordOnboardingEventParams {
   funnelVersion?: string | null;
 }
 
-/** Insert a fully-built event row. Shared by all record* entry points. */
-function insertOnboardingEvent(event: OnboardingEvent): OnboardingEvent {
-  getDb().insert(onboardingEvents).values(event).run();
+/**
+ * Insert a fully-built event row. Shared by all record* entry points.
+ * Returns null when the telemetry database is unavailable — the event is
+ * dropped, matching the degraded-mode behavior of the other telemetry stores.
+ */
+function insertOnboardingEvent(event: OnboardingEvent): OnboardingEvent | null {
+  const db = getTelemetryDb();
+  if (!db) return null;
+  db.insert(onboardingEvents).values(event).run();
   return event;
 }
 
 /**
  * Record an onboarding event (pre-chat selections and Google connect status).
- * Returns null when usage data collection is disabled.
+ * Returns null when usage data collection is disabled or the telemetry
+ * database is unavailable.
  */
 export function recordOnboardingEvent(
   params: RecordOnboardingEventParams,
@@ -85,7 +92,8 @@ export function recordOnboardingEvent(
 /**
  * Record an activation-funnel milestone event. Reuses the onboarding telemetry
  * substrate (`screen` carries the step name to satisfy the NOT NULL column).
- * Returns null when usage data collection is disabled.
+ * Returns null when usage data collection is disabled or the telemetry
+ * database is unavailable.
  */
 export function recordActivationEvent(params: {
   stepName: ActivationStepName;
@@ -123,7 +131,8 @@ export function queryUnreportedOnboardingEvents(
   afterId: string | undefined,
   limit: number,
 ): OnboardingEvent[] {
-  const db = getDb();
+  const db = getTelemetryDb();
+  if (!db) return [];
   const rows = db
     .select({
       id: onboardingEvents.id,

--- a/assistant/src/persistence/migrations/327-move-onboarding-events-to-telemetry-db.test.ts
+++ b/assistant/src/persistence/migrations/327-move-onboarding-events-to-telemetry-db.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for migration 327: relocating `onboarding_events` from the main DB
+ * into the dedicated telemetry database (`assistant-telemetry.db`).
+ *
+ * Runs against real workspace databases (`initializeDb()`) because the drain
+ * engine dispatches batches via `runAsyncSqlite` against the workspace's main
+ * DB file. `initializeDb()` already ran migration 327 once (dropping the empty
+ * main-side table created by migration 248), so each test recreates the
+ * pre-move source table in `main` to simulate an upgrading install.
+ */
+import { describe, expect, test } from "bun:test";
+
+const { getDb, getSqlite, getTelemetrySqlite } =
+  await import("../db-connection.js");
+const { initializeDb } = await import("../db-init.js");
+const { queryUnreportedOnboardingEvents } =
+  await import("../../onboarding/onboarding-events-store.js");
+const { migrateMoveOnboardingEventsToTelemetryDb } =
+  await import("./327-move-onboarding-events-to-telemetry-db.js");
+
+await initializeDb();
+
+const SOURCE_COLUMNS = `
+  id TEXT PRIMARY KEY, created_at INTEGER NOT NULL, screen TEXT NOT NULL,
+  tools_json TEXT, tasks_json TEXT, tone TEXT, google_connected INTEGER,
+  google_scopes_json TEXT, prior_assistants_json TEXT, ab_variant TEXT,
+  session_id TEXT, step_name TEXT, step_index INTEGER, completed_at TEXT,
+  funnel_version TEXT`;
+
+function existsInMain(name: string): boolean {
+  return (
+    getSqlite()
+      .query(
+        `SELECT name FROM main.sqlite_master WHERE type='table' AND name = ?`,
+      )
+      .get(name) != null
+  );
+}
+
+function resetState(): void {
+  getTelemetrySqlite()!.exec(`DELETE FROM onboarding_events`);
+  getSqlite().exec(`DROP TABLE IF EXISTS main.onboarding_events`);
+  getSqlite().exec(`DROP TABLE IF EXISTS main."onboarding_events__relocating"`);
+}
+
+function seedSourceTable(): void {
+  const sqlite = getSqlite();
+  sqlite.exec(`CREATE TABLE main.onboarding_events (${SOURCE_COLUMNS})`);
+  const insert = sqlite.prepare(
+    `INSERT INTO main.onboarding_events
+       (id, created_at, screen, session_id, step_name, step_index)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  );
+  insert.run("seed-1", 1000, "tools", "conv-1", null, null);
+  insert.run(
+    "seed-2",
+    2000,
+    "activation_moment_1_complete",
+    "conv-2",
+    "activation_moment_1_complete",
+    1,
+  );
+  insert.run("seed-dupe", 3000, "tasks", "conv-3", null, null);
+}
+
+describe("migration 327: move onboarding_events to the telemetry DB", () => {
+  test("drains pre-move rows into the telemetry DB and drops the main-side table", async () => {
+    resetState();
+    seedSourceTable();
+
+    await migrateMoveOnboardingEventsToTelemetryDb(getDb());
+
+    expect(existsInMain("onboarding_events")).toBe(false);
+    expect(existsInMain("onboarding_events__relocating")).toBe(false);
+
+    const moved = getTelemetrySqlite()!
+      .query(`SELECT id, screen FROM onboarding_events ORDER BY id`)
+      .all();
+    expect(moved).toEqual([
+      { id: "seed-1", screen: "tools" },
+      { id: "seed-2", screen: "activation_moment_1_complete" },
+      { id: "seed-dupe", screen: "tasks" },
+    ]);
+
+    // The relocated rows are readable through the store's reporter query.
+    const rows = queryUnreportedOnboardingEvents(0, undefined, 10);
+    expect(rows.map((r) => r.id)).toEqual(["seed-1", "seed-2", "seed-dupe"]);
+    expect(rows[1]!.stepName).toBe("activation_moment_1_complete");
+    expect(rows[1]!.stepIndex).toBe(1);
+  });
+
+  test("re-running after a completed move is a no-op", async () => {
+    resetState();
+    seedSourceTable();
+
+    await migrateMoveOnboardingEventsToTelemetryDb(getDb());
+    await migrateMoveOnboardingEventsToTelemetryDb(getDb());
+
+    expect(existsInMain("onboarding_events")).toBe(false);
+    expect(existsInMain("onboarding_events__relocating")).toBe(false);
+    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(3);
+  });
+
+  test("a pre-existing duplicate id in the telemetry copy does not fail the drain", async () => {
+    resetState();
+    seedSourceTable();
+
+    // A crash between a drain batch's copy and delete re-copies the same rows
+    // next boot; INSERT OR IGNORE must keep the already-copied row and finish.
+    getTelemetrySqlite()!.exec(
+      `INSERT INTO onboarding_events (id, created_at, screen)
+       VALUES ('seed-dupe', 3000, 'already-copied')`,
+    );
+
+    await migrateMoveOnboardingEventsToTelemetryDb(getDb());
+
+    expect(existsInMain("onboarding_events")).toBe(false);
+    expect(existsInMain("onboarding_events__relocating")).toBe(false);
+    const dupe = getTelemetrySqlite()!
+      .query(`SELECT screen FROM onboarding_events WHERE id = 'seed-dupe'`)
+      .get() as { screen: string };
+    expect(dupe.screen).toBe("already-copied");
+    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(3);
+  });
+
+  test("an empty main-side table (fresh install) is dropped without a drain", async () => {
+    resetState();
+    getSqlite().exec(`CREATE TABLE main.onboarding_events (${SOURCE_COLUMNS})`);
+
+    await migrateMoveOnboardingEventsToTelemetryDb(getDb());
+
+    expect(existsInMain("onboarding_events")).toBe(false);
+    expect(existsInMain("onboarding_events__relocating")).toBe(false);
+    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+  });
+
+  test("telemetry-side schema has the reporter's compound cursor index", () => {
+    const indexes = (
+      getTelemetrySqlite()!
+        .query(`PRAGMA index_list(onboarding_events)`)
+        .all() as Array<{ name: string }>
+    ).map((i) => i.name);
+    expect(indexes).toContain("idx_onboarding_events_created_at_id");
+  });
+});

--- a/assistant/src/persistence/migrations/327-move-onboarding-events-to-telemetry-db.ts
+++ b/assistant/src/persistence/migrations/327-move-onboarding-events-to-telemetry-db.ts
@@ -1,0 +1,119 @@
+import type { Database } from "bun:sqlite";
+
+import { getTelemetryDbPath } from "../../util/telemetry-db-path.js";
+import {
+  type DrizzleDb,
+  getSqliteFrom,
+  getTelemetrySqlite,
+} from "../db-connection.js";
+import {
+  drainStagedTable,
+  type RelocationSpec,
+  stageTableForRelocation,
+} from "./helpers/relocation.js";
+
+/**
+ * How to drain `onboarding_events` from `main` into the telemetry DB. The
+ * table is a pure telemetry outbox — every row is worth keeping until the
+ * usage telemetry reporter flushes it — so all rows are copied verbatim.
+ */
+export const ONBOARDING_EVENTS_RELOCATION: RelocationSpec = {
+  table: "onboarding_events",
+  targetDbPath: getTelemetryDbPath,
+  columns: [
+    "id",
+    "created_at",
+    "screen",
+    "tools_json",
+    "tasks_json",
+    "tone",
+    "google_connected",
+    "google_scopes_json",
+    "prior_assistants_json",
+    "ab_variant",
+    "session_id",
+    "step_name",
+    "step_index",
+    "completed_at",
+    "funnel_version",
+  ],
+};
+
+const CREATE_TABLE = /*sql*/ `
+  CREATE TABLE IF NOT EXISTS onboarding_events (
+    id TEXT PRIMARY KEY,
+    created_at INTEGER NOT NULL,
+    screen TEXT NOT NULL,
+    tools_json TEXT,
+    tasks_json TEXT,
+    tone TEXT,
+    google_connected INTEGER,
+    google_scopes_json TEXT,
+    prior_assistants_json TEXT,
+    ab_variant TEXT,
+    session_id TEXT,
+    step_name TEXT,
+    step_index INTEGER,
+    completed_at TEXT,
+    funnel_version TEXT
+  )
+`;
+
+/**
+ * Create the `onboarding_events` table and its cursor index on the telemetry
+ * connection. Idempotent (`IF NOT EXISTS`) — the dedicated connection itself
+ * performs no DDL on open, so this migration owns the schema. The index backs
+ * the telemetry reporter's compound `(created_at, id)` watermark cursor,
+ * matching `watchdog_events` (migration 301).
+ */
+function ensureOnboardingEventsSchema(telemetryRaw: Database): void {
+  telemetryRaw.exec(CREATE_TABLE);
+  telemetryRaw.exec(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_onboarding_events_created_at_id ON onboarding_events (created_at, id)`,
+  );
+}
+
+/**
+ * Move `onboarding_events` — the onboarding/activation-funnel telemetry
+ * outbox — into the dedicated telemetry database (`assistant-telemetry.db`),
+ * alongside `watchdog_events` (migration 301) and `config_setting_events`
+ * (migration 325). Rows are inserted at emit time and read only by the usage
+ * telemetry reporter's flush; housing them with the other telemetry tables
+ * keeps the main DB and its WAL out of that write path. The store in
+ * `onboarding/onboarding-events-store.ts` reads/writes it over the dedicated
+ * telemetry connection (see `getTelemetryDb()`), and the reporter's
+ * `(createdAt, id)` watermark in the main DB's checkpoints store survives the
+ * move unchanged.
+ *
+ * Like migrations 297/298/326 the move is incremental: create the table (and
+ * index) on the telemetry connection, rename any populated
+ * `main.onboarding_events` aside to `onboarding_events__relocating`, then
+ * drain it in awaited batches (see `helpers/relocation.ts`) per
+ * {@link ONBOARDING_EVENTS_RELOCATION}. On a fresh install the main-side
+ * table created by migration 248 is empty, so staging just drops it.
+ *
+ * Throws (rather than returning) if the telemetry database cannot be opened,
+ * so the runner records the step as failed instead of applied and retries it
+ * on a later boot — never renaming the source aside without a target to write
+ * to. The throw is caught per-step by the runner, so startup is not aborted.
+ */
+export async function migrateMoveOnboardingEventsToTelemetryDb(
+  database: DrizzleDb,
+): Promise<void> {
+  const telemetryRaw = getTelemetrySqlite();
+  if (!telemetryRaw) {
+    throw new Error(
+      "telemetry database unavailable — deferring onboarding_events relocation",
+    );
+  }
+
+  ensureOnboardingEventsSchema(telemetryRaw);
+
+  const raw = getSqliteFrom(database);
+  const needsDrain = stageTableForRelocation(
+    raw,
+    ONBOARDING_EVENTS_RELOCATION.table,
+  );
+
+  if (needsDrain) await drainStagedTable(raw, ONBOARDING_EVENTS_RELOCATION);
+}

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -434,6 +434,7 @@ import { migrateDeleteNonDefaultMemoryScopes } from "./migrations/323-delete-non
 import { migrateMessageFinalizedColumn } from "./migrations/324-message-finalized-column.js";
 import { createConfigSettingEventsTable } from "./migrations/325-create-config-setting-events.js";
 import { migrateMoveInjectionEventsToMemoryDb } from "./migrations/326-move-injection-events-to-memory-db.js";
+import { migrateMoveOnboardingEventsToTelemetryDb } from "./migrations/327-move-onboarding-events-to-telemetry-db.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1339,4 +1340,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateMessageFinalizedColumn,
   createConfigSettingEventsTable,
   migrateMoveInjectionEventsToMemoryDb,
+  migrateMoveOnboardingEventsToTelemetryDb,
 ];


### PR DESCRIPTION
## Summary
- Migration 327 relocates onboarding_events from the main DB into assistant-telemetry.db using the staged-drain relocation engine
- Onboarding events store now reads/writes the dedicated telemetry connection with degraded-mode null guards

Part of plan: telemetry-db-move.md (PR 2 of 6)