### PR TITLE
feat(telemetry): relocate auth_fallback_events into assistant-telemetry.db

### DIFF
--- a/assistant/src/__tests__/auth-fallback-events-store.test.ts
+++ b/assistant/src/__tests__/auth-fallback-events-store.test.ts
@@ -6,7 +6,7 @@ mock.module("../platform/consent-cache.js", () => ({
   getCachedShareAnalytics: () => shareAnalytics,
 }));
 
-import { getDb } from "../persistence/db-connection.js";
+import { getTelemetryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { authFallbackEvents } from "../persistence/schema/index.js";
 import {
@@ -18,7 +18,7 @@ import {
 await initializeDb();
 
 function resetTable(): void {
-  getDb().delete(authFallbackEvents).run();
+  getTelemetryDb()!.delete(authFallbackEvents).run();
 }
 
 const SAMPLE: AuthFallbackCount[] = [

--- a/assistant/src/__tests__/internal-telemetry-routes.test.ts
+++ b/assistant/src/__tests__/internal-telemetry-routes.test.ts
@@ -28,7 +28,7 @@ mock.module("../telemetry/watchdog-direct-emit.js", () => ({
   },
 }));
 
-import { getDb } from "../persistence/db-connection.js";
+import { getTelemetryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { authFallbackEvents } from "../persistence/schema/index.js";
 import { GATEWAY_PRINCIPALS } from "../runtime/auth/route-policy.js";
@@ -64,7 +64,7 @@ const VALID_BODY = {
 describe("internal-telemetry-routes: auth-fallback", () => {
   beforeEach(() => {
     shareAnalytics = true;
-    getDb().delete(authFallbackEvents).run();
+    getTelemetryDb()!.delete(authFallbackEvents).run();
   });
 
   test("route is locked to service-token callers (GATEWAY_PRINCIPALS + internal.write)", () => {

--- a/assistant/src/persistence/migrations/328-move-auth-fallback-events-to-telemetry-db.test.ts
+++ b/assistant/src/persistence/migrations/328-move-auth-fallback-events-to-telemetry-db.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for migration 328: relocating `auth_fallback_events` from the main DB
+ * into the dedicated telemetry database (`assistant-telemetry.db`).
+ *
+ * Runs against real workspace databases (`initializeDb()`) because the drain
+ * engine dispatches batches via `runAsyncSqlite` against the workspace's main
+ * DB file. `initializeDb()` already ran migration 328 once (dropping the empty
+ * main-side table created by migration 271), so each test recreates the
+ * pre-move source table in `main` to simulate an upgrading install.
+ */
+import { describe, expect, test } from "bun:test";
+
+const { getDb, getSqlite, getTelemetrySqlite } =
+  await import("../db-connection.js");
+const { initializeDb } = await import("../db-init.js");
+const { queryUnreportedAuthFallbackEvents } =
+  await import("../../security/auth-fallback-events-store.js");
+const { migrateMoveAuthFallbackEventsToTelemetryDb } =
+  await import("./328-move-auth-fallback-events-to-telemetry-db.js");
+
+await initializeDb();
+
+const SOURCE_COLUMNS = `
+  id TEXT PRIMARY KEY, created_at INTEGER NOT NULL, guard TEXT NOT NULL,
+  path TEXT NOT NULL, failure_kind TEXT NOT NULL, count INTEGER NOT NULL,
+  window_start INTEGER NOT NULL, window_end INTEGER NOT NULL`;
+
+function existsInMain(name: string): boolean {
+  return (
+    getSqlite()
+      .query(
+        `SELECT name FROM main.sqlite_master WHERE type='table' AND name = ?`,
+      )
+      .get(name) != null
+  );
+}
+
+function resetState(): void {
+  getTelemetrySqlite()!.exec(`DELETE FROM auth_fallback_events`);
+  getSqlite().exec(`DROP TABLE IF EXISTS main.auth_fallback_events`);
+  getSqlite().exec(
+    `DROP TABLE IF EXISTS main."auth_fallback_events__relocating"`,
+  );
+}
+
+function seedSourceTable(): void {
+  const sqlite = getSqlite();
+  sqlite.exec(`CREATE TABLE main.auth_fallback_events (${SOURCE_COLUMNS})`);
+  const insert = sqlite.prepare(
+    `INSERT INTO main.auth_fallback_events
+       (id, created_at, guard, path, failure_kind, count, window_start, window_end)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+  insert.run(
+    "seed-1",
+    1000,
+    "edge",
+    "/v1/messages",
+    "missing_authorization",
+    7,
+    900,
+    1000,
+  );
+  insert.run(
+    "seed-2",
+    2000,
+    "edge-scoped",
+    "/v1/files",
+    "insufficient_scope",
+    2,
+    1900,
+    2000,
+  );
+  insert.run(
+    "seed-dupe",
+    3000,
+    "edge-guardian",
+    "/v1/pair",
+    "guardian_mismatch",
+    1,
+    2900,
+    3000,
+  );
+}
+
+describe("migration 328: move auth_fallback_events to the telemetry DB", () => {
+  test("drains pre-move rows into the telemetry DB and drops the main-side table", async () => {
+    resetState();
+    seedSourceTable();
+
+    await migrateMoveAuthFallbackEventsToTelemetryDb(getDb());
+
+    expect(existsInMain("auth_fallback_events")).toBe(false);
+    expect(existsInMain("auth_fallback_events__relocating")).toBe(false);
+
+    const moved = getTelemetrySqlite()!
+      .query(`SELECT id, guard FROM auth_fallback_events ORDER BY id`)
+      .all();
+    expect(moved).toEqual([
+      { id: "seed-1", guard: "edge" },
+      { id: "seed-2", guard: "edge-scoped" },
+      { id: "seed-dupe", guard: "edge-guardian" },
+    ]);
+
+    // The relocated rows are readable through the store's reporter query.
+    const rows = queryUnreportedAuthFallbackEvents(0, undefined, 10);
+    expect(rows.map((r) => r.id)).toEqual(["seed-1", "seed-2", "seed-dupe"]);
+    expect(rows[0]!).toMatchObject({
+      guard: "edge",
+      path: "/v1/messages",
+      failureKind: "missing_authorization",
+      count: 7,
+      windowStart: 900,
+      windowEnd: 1000,
+    });
+  });
+
+  test("re-running after a completed move is a no-op", async () => {
+    resetState();
+    seedSourceTable();
+
+    await migrateMoveAuthFallbackEventsToTelemetryDb(getDb());
+    await migrateMoveAuthFallbackEventsToTelemetryDb(getDb());
+
+    expect(existsInMain("auth_fallback_events")).toBe(false);
+    expect(existsInMain("auth_fallback_events__relocating")).toBe(false);
+    expect(queryUnreportedAuthFallbackEvents(0, undefined, 10)).toHaveLength(3);
+  });
+
+  test("a pre-existing duplicate id in the telemetry copy does not fail the drain", async () => {
+    resetState();
+    seedSourceTable();
+
+    // A crash between a drain batch's copy and delete re-copies the same rows
+    // next boot; INSERT OR IGNORE must keep the already-copied row and finish.
+    getTelemetrySqlite()!.exec(
+      `INSERT INTO auth_fallback_events
+         (id, created_at, guard, path, failure_kind, count, window_start, window_end)
+       VALUES ('seed-dupe', 3000, 'already-copied', '/v1/pair', 'guardian_mismatch', 1, 2900, 3000)`,
+    );
+
+    await migrateMoveAuthFallbackEventsToTelemetryDb(getDb());
+
+    expect(existsInMain("auth_fallback_events")).toBe(false);
+    expect(existsInMain("auth_fallback_events__relocating")).toBe(false);
+    const dupe = getTelemetrySqlite()!
+      .query(`SELECT guard FROM auth_fallback_events WHERE id = 'seed-dupe'`)
+      .get() as { guard: string };
+    expect(dupe.guard).toBe("already-copied");
+    expect(queryUnreportedAuthFallbackEvents(0, undefined, 10)).toHaveLength(3);
+  });
+
+  test("an empty main-side table (fresh install) is dropped without a drain", async () => {
+    resetState();
+    getSqlite().exec(
+      `CREATE TABLE main.auth_fallback_events (${SOURCE_COLUMNS})`,
+    );
+
+    await migrateMoveAuthFallbackEventsToTelemetryDb(getDb());
+
+    expect(existsInMain("auth_fallback_events")).toBe(false);
+    expect(existsInMain("auth_fallback_events__relocating")).toBe(false);
+    expect(queryUnreportedAuthFallbackEvents(0, undefined, 10)).toHaveLength(0);
+  });
+
+  test("telemetry-side schema has the reporter's compound cursor index", () => {
+    const indexes = (
+      getTelemetrySqlite()!
+        .query(`PRAGMA index_list(auth_fallback_events)`)
+        .all() as Array<{ name: string }>
+    ).map((i) => i.name);
+    expect(indexes).toContain("idx_auth_fallback_events_created_at_id");
+  });
+});

--- a/assistant/src/persistence/migrations/328-move-auth-fallback-events-to-telemetry-db.ts
+++ b/assistant/src/persistence/migrations/328-move-auth-fallback-events-to-telemetry-db.ts
@@ -1,0 +1,108 @@
+import type { Database } from "bun:sqlite";
+
+import { getTelemetryDbPath } from "../../util/telemetry-db-path.js";
+import {
+  type DrizzleDb,
+  getSqliteFrom,
+  getTelemetrySqlite,
+} from "../db-connection.js";
+import {
+  drainStagedTable,
+  type RelocationSpec,
+  stageTableForRelocation,
+} from "./helpers/relocation.js";
+
+/**
+ * How to drain `auth_fallback_events` from `main` into the telemetry DB. The
+ * table is a pure telemetry outbox — every row is worth keeping until the
+ * usage telemetry reporter flushes it — so all rows are copied verbatim.
+ */
+export const AUTH_FALLBACK_EVENTS_RELOCATION: RelocationSpec = {
+  table: "auth_fallback_events",
+  targetDbPath: getTelemetryDbPath,
+  columns: [
+    "id",
+    "created_at",
+    "guard",
+    "path",
+    "failure_kind",
+    "count",
+    "window_start",
+    "window_end",
+  ],
+};
+
+const CREATE_TABLE = /*sql*/ `
+  CREATE TABLE IF NOT EXISTS auth_fallback_events (
+    id TEXT PRIMARY KEY,
+    created_at INTEGER NOT NULL,
+    guard TEXT NOT NULL,
+    path TEXT NOT NULL,
+    failure_kind TEXT NOT NULL,
+    count INTEGER NOT NULL,
+    window_start INTEGER NOT NULL,
+    window_end INTEGER NOT NULL
+  )
+`;
+
+/**
+ * Create the `auth_fallback_events` table and its cursor index on the
+ * telemetry connection. Idempotent (`IF NOT EXISTS`) — the dedicated
+ * connection itself performs no DDL on open, so this migration owns the
+ * schema. The index backs the telemetry reporter's compound `(created_at, id)`
+ * watermark cursor, matching `watchdog_events` (migration 301).
+ */
+function ensureAuthFallbackEventsSchema(telemetryRaw: Database): void {
+  telemetryRaw.exec(CREATE_TABLE);
+  telemetryRaw.exec(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_auth_fallback_events_created_at_id ON auth_fallback_events (created_at, id)`,
+  );
+}
+
+/**
+ * Move `auth_fallback_events` — the aggregated legacy-loopback auth-fallback
+ * telemetry outbox — into the dedicated telemetry database
+ * (`assistant-telemetry.db`), alongside `watchdog_events` (migration 301),
+ * `config_setting_events` (migration 325), and `onboarding_events`
+ * (migration 327). Rows are inserted at emit time (counts forwarded by the
+ * gateway) and read only by the usage telemetry reporter's flush; housing
+ * them with the other telemetry tables keeps the main DB and its WAL out of
+ * that write path. The store in `security/auth-fallback-events-store.ts`
+ * reads/writes it over the dedicated telemetry connection (see
+ * `getTelemetryDb()`), and the reporter's `(createdAt, id)` watermark in the
+ * main DB's checkpoints store survives the move unchanged.
+ *
+ * Like migrations 297/298/326/327 the move is incremental: create the table
+ * (and index) on the telemetry connection, rename any populated
+ * `main.auth_fallback_events` aside to `auth_fallback_events__relocating`,
+ * then drain it in awaited batches (see `helpers/relocation.ts`) per
+ * {@link AUTH_FALLBACK_EVENTS_RELOCATION}. On a fresh install the main-side
+ * table created by migration 271 is empty, so staging just drops it.
+ *
+ * Throws (rather than returning) if the telemetry database cannot be opened,
+ * so the runner records the step as failed instead of applied and retries it
+ * on a later boot — never renaming the source aside without a target to write
+ * to. The throw is caught per-step by the runner, so startup is not aborted.
+ */
+export async function migrateMoveAuthFallbackEventsToTelemetryDb(
+  database: DrizzleDb,
+): Promise<void> {
+  const telemetryRaw = getTelemetrySqlite();
+  if (!telemetryRaw) {
+    throw new Error(
+      "telemetry database unavailable — deferring auth_fallback_events relocation",
+    );
+  }
+
+  ensureAuthFallbackEventsSchema(telemetryRaw);
+
+  const raw = getSqliteFrom(database);
+  const needsDrain = stageTableForRelocation(
+    raw,
+    AUTH_FALLBACK_EVENTS_RELOCATION.table,
+  );
+
+  if (needsDrain) {
+    await drainStagedTable(raw, AUTH_FALLBACK_EVENTS_RELOCATION);
+  }
+}

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -435,6 +435,7 @@ import { migrateMessageFinalizedColumn } from "./migrations/324-message-finalize
 import { createConfigSettingEventsTable } from "./migrations/325-create-config-setting-events.js";
 import { migrateMoveInjectionEventsToMemoryDb } from "./migrations/326-move-injection-events-to-memory-db.js";
 import { migrateMoveOnboardingEventsToTelemetryDb } from "./migrations/327-move-onboarding-events-to-telemetry-db.js";
+import { migrateMoveAuthFallbackEventsToTelemetryDb } from "./migrations/328-move-auth-fallback-events-to-telemetry-db.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1341,4 +1342,5 @@ export const migrationSteps: MigrationStep[] = [
   createConfigSettingEventsTable,
   migrateMoveInjectionEventsToMemoryDb,
   migrateMoveOnboardingEventsToTelemetryDb,
+  migrateMoveAuthFallbackEventsToTelemetryDb,
 ];

--- a/assistant/src/security/auth-fallback-events-store.ts
+++ b/assistant/src/security/auth-fallback-events-store.ts
@@ -1,7 +1,7 @@
 import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getDb } from "../persistence/db-connection.js";
+import { getTelemetryDb } from "../persistence/db-connection.js";
 import { authFallbackEvents } from "../persistence/schema/index.js";
 import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 
@@ -29,16 +29,24 @@ export interface AuthFallbackEvent {
  * Record a batch of aggregated auth-fallback counts forwarded by the gateway —
  * one row per count entry, all sharing the same flush window. Returns the
  * number of rows recorded, or 0 when usage data collection is disabled (the
- * counts are dropped to honor the opt-out, matching the rest of telemetry).
+ * counts are dropped to honor the opt-out, matching the rest of telemetry) or
+ * the telemetry database is unavailable (degraded mode).
  */
 export function recordAuthFallbackCounts(
   windowStart: number,
   windowEnd: number,
   counts: AuthFallbackCount[],
 ): number {
-  if (!getCachedShareAnalytics()) return 0;
-  if (counts.length === 0) return 0;
-  const db = getDb();
+  if (!getCachedShareAnalytics()) {
+    return 0;
+  }
+  if (counts.length === 0) {
+    return 0;
+  }
+  const db = getTelemetryDb();
+  if (!db) {
+    return 0;
+  }
   const createdAt = Date.now();
   const rows = counts.map((c) => ({
     id: uuid(),
@@ -63,7 +71,10 @@ export function queryUnreportedAuthFallbackEvents(
   afterId: string | undefined,
   limit: number,
 ): AuthFallbackEvent[] {
-  const db = getDb();
+  const db = getTelemetryDb();
+  if (!db) {
+    return [];
+  }
   const rows = db
     .select({
       id: authFallbackEvents.id,

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -398,9 +398,9 @@ beforeEach(() => {
   mockQueryUnreportedLifecycleEvents.mockReturnValue([]);
   mockQueryUnreportedOnboardingEvents.mockReset();
   mockQueryUnreportedOnboardingEvents.mockReturnValue([]);
-  getDb().delete(authFallbackEvents).run();
   getDb().delete(toolInvocations).run();
   getDb().delete(skillLoadedEvents).run();
+  getTelemetryDb()?.delete(authFallbackEvents).run();
   getTelemetryDb()?.delete(configSettingEvents).run();
   delete process.env.VELLUM_DISABLE_PLATFORM;
   delete process.env.IS_PLATFORM;
@@ -1938,7 +1938,11 @@ describe("UsageTelemetryReporter", () => {
 
     // The last row by the reporter's (createdAt, id) cursor order is the one
     // whose watermark should be persisted after a successful upload.
-    const rows = getDb()
+    const telemetryDb = getTelemetryDb();
+    if (!telemetryDb) {
+      throw new Error("telemetry DB unavailable in test");
+    }
+    const rows = telemetryDb
       .select()
       .from(authFallbackEvents)
       .orderBy(authFallbackEvents.createdAt, authFallbackEvents.id)


### PR DESCRIPTION
## Summary
- Migration 328 relocates auth_fallback_events from the main DB into assistant-telemetry.db using the staged-drain relocation engine
- Auth-fallback events store now reads/writes the dedicated telemetry connection with degraded-mode null guards

Part of plan: telemetry-db-move.md (PR 3 of 6)