### PR TITLE
Add platform managed-speech client for STT and TTS

### DIFF
--- a/assistant/src/platform/managed-speech.test.ts
+++ b/assistant/src/platform/managed-speech.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+interface MockPlatformClient {
+  platformAssistantId: string;
+  fetch: ReturnType<typeof mock>;
+}
+
+let mockClient: MockPlatformClient | null = null;
+
+mock.module("./client.js", () => ({
+  VellumPlatformClient: {
+    create: async () => mockClient,
+  },
+}));
+
+import {
+  managedSpeechSynthesize,
+  managedSpeechTranscribe,
+} from "./managed-speech.js";
+
+const AUDIO = Buffer.from([0x01, 0x02, 0x03, 0xff]);
+
+describe("managedSpeechTranscribe", () => {
+  beforeEach(() => {
+    mockClient = {
+      platformAssistantId: "asst-123",
+      fetch: mock(
+        async () =>
+          new Response(
+            JSON.stringify({
+              text: "hello world",
+              providerId: "deepgram",
+              model: "nova-3",
+              durationSeconds: 12.5,
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      ),
+    };
+  });
+
+  afterEach(() => {
+    mockClient = null;
+  });
+
+  test("posts base64 audio to the assistant's transcribe endpoint", async () => {
+    const result = await managedSpeechTranscribe({
+      audio: AUDIO,
+      mimeType: "audio/wav",
+      source: "dictation",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      value: { text: "hello world", durationSeconds: 12.5 },
+    });
+    const [path, init] = mockClient!.fetch.mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    expect(path).toBe("/v1/assistants/asst-123/managed-speech/stt/transcribe/");
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body as string);
+    expect(body).toEqual({
+      audioBase64: AUDIO.toString("base64"),
+      mimeType: "audio/wav",
+      source: "dictation",
+    });
+  });
+
+  test("omits source when not provided", async () => {
+    await managedSpeechTranscribe({ audio: AUDIO, mimeType: "audio/wav" });
+    const [, init] = mockClient!.fetch.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).not.toHaveProperty("source");
+  });
+
+  test("returns unavailable when no platform client resolves", async () => {
+    mockClient = null;
+    const result = await managedSpeechTranscribe({
+      audio: AUDIO,
+      mimeType: "audio/wav",
+    });
+    expect(result).toMatchObject({ ok: false, kind: "unavailable" });
+  });
+
+  test("returns unavailable when the assistant ID is missing", async () => {
+    mockClient!.platformAssistantId = "";
+    const result = await managedSpeechTranscribe({
+      audio: AUDIO,
+      mimeType: "audio/wav",
+    });
+    expect(result).toMatchObject({ ok: false, kind: "unavailable" });
+  });
+
+  test("surfaces the platform error code on 402", async () => {
+    mockClient!.fetch = mock(
+      async () =>
+        new Response(
+          JSON.stringify({
+            code: "insufficient_balance",
+            detail: "Insufficient balance. Please add funds to continue.",
+          }),
+          { status: 402, headers: { "content-type": "application/json" } },
+        ),
+    );
+    const result = await managedSpeechTranscribe({
+      audio: AUDIO,
+      mimeType: "audio/wav",
+    });
+    expect(result).toMatchObject({
+      ok: false,
+      kind: "platform-error",
+      status: 402,
+      code: "insufficient_balance",
+      message: "Insufficient balance. Please add funds to continue.",
+    });
+  });
+
+  test("treats a malformed 200 body as a platform error", async () => {
+    mockClient!.fetch = mock(
+      async () =>
+        new Response(JSON.stringify({ unexpected: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const result = await managedSpeechTranscribe({
+      audio: AUDIO,
+      mimeType: "audio/wav",
+    });
+    expect(result).toMatchObject({ ok: false, kind: "platform-error" });
+  });
+});
+
+describe("managedSpeechSynthesize", () => {
+  const MP3_BYTES = Buffer.from([0x49, 0x44, 0x33, 0x04, 0x00]);
+
+  beforeEach(() => {
+    mockClient = {
+      platformAssistantId: "asst-123",
+      fetch: mock(
+        async () =>
+          new Response(new Uint8Array(MP3_BYTES), {
+            status: 200,
+            headers: { "content-type": "audio/mpeg" },
+          }),
+      ),
+    };
+  });
+
+  afterEach(() => {
+    mockClient = null;
+  });
+
+  test("posts text and format, round-trips binary audio and content type", async () => {
+    const result = await managedSpeechSynthesize({
+      text: "hello",
+      format: "pcm_16000",
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(Buffer.compare(result.value.audio, MP3_BYTES)).toBe(0);
+      expect(result.value.contentType).toBe("audio/mpeg");
+    }
+    const [path, init] = mockClient!.fetch.mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    expect(path).toBe("/v1/assistants/asst-123/managed-speech/tts/synthesize/");
+    expect(JSON.parse(init.body as string)).toEqual({
+      text: "hello",
+      format: "pcm_16000",
+    });
+  });
+
+  test("falls back to audio/mpeg when no content type is returned", async () => {
+    mockClient!.fetch = mock(
+      async () => new Response(new Uint8Array(MP3_BYTES), { status: 200 }),
+    );
+    const result = await managedSpeechSynthesize({
+      text: "hello",
+      format: "mp3",
+    });
+    expect(result.ok && result.value.contentType).toBe("audio/mpeg");
+  });
+
+  test("treats empty audio as a platform error", async () => {
+    mockClient!.fetch = mock(
+      async () => new Response(new Uint8Array(0), { status: 200 }),
+    );
+    const result = await managedSpeechSynthesize({
+      text: "hello",
+      format: "mp3",
+    });
+    expect(result).toMatchObject({ ok: false, kind: "platform-error" });
+  });
+
+  test("surfaces insufficient_balance on 402", async () => {
+    mockClient!.fetch = mock(
+      async () =>
+        new Response(
+          JSON.stringify({ code: "insufficient_balance", detail: "Top up." }),
+          { status: 402, headers: { "content-type": "application/json" } },
+        ),
+    );
+    const result = await managedSpeechSynthesize({
+      text: "hello",
+      format: "mp3",
+    });
+    expect(result).toMatchObject({
+      ok: false,
+      kind: "platform-error",
+      status: 402,
+      code: "insufficient_balance",
+    });
+  });
+});

--- a/assistant/src/platform/managed-speech.ts
+++ b/assistant/src/platform/managed-speech.ts
@@ -1,0 +1,195 @@
+/**
+ * Client for the platform's managed speech endpoints: Vellum-held Deepgram
+ * key, billed to the org's credits. The daemon sends complete audio (STT) or
+ * text (TTS) and the platform does the provider call — no speech credentials
+ * ever live on this machine.
+ *
+ * Contract (mirrors `vellum-assistant-platform` — do not change unilaterally):
+ * - `POST /v1/assistants/{id}/managed-speech/stt/transcribe/`
+ *   `{audioBase64, mimeType, source?}` → 200 `{text, providerId, model,
+ *   durationSeconds}`.
+ * - `POST /v1/assistants/{id}/managed-speech/tts/synthesize/`
+ *   `{text, format?}` → 200 binary audio, `Content-Type` from upstream.
+ * - Errors: `{code, detail}`; notable codes: `insufficient_balance` (402),
+ *   `missing_price` (400), `provider_configuration_error` (500).
+ *
+ * Pure platform HTTP client: no provider-catalog, config-schema, or resolver
+ * imports — the vellum STT/TTS providers build on top of it.
+ */
+
+import { VellumPlatformClient } from "./client.js";
+
+export type ManagedSpeechResult<T> =
+  | { ok: true; value: T }
+  | {
+      ok: false;
+      kind: "unavailable" | "platform-error";
+      status?: number;
+      /** Platform error code (e.g. `insufficient_balance`) when the body carried one. */
+      code?: string;
+      message: string;
+    };
+
+export interface ManagedSpeechTranscription {
+  text: string;
+  durationSeconds: number;
+}
+
+export interface ManagedSpeechSynthesis {
+  audio: Buffer;
+  contentType: string;
+}
+
+export type ManagedSpeechTtsFormat = "mp3" | "wav_8000" | "pcm_16000";
+
+async function resolveClient(): Promise<
+  { client: VellumPlatformClient } | { error: ManagedSpeechResult<never> }
+> {
+  const client = await VellumPlatformClient.create();
+  if (!client) {
+    return {
+      error: {
+        ok: false,
+        kind: "unavailable",
+        message:
+          "Managed speech is unavailable: no Vellum platform connection.",
+      },
+    };
+  }
+  if (!client.platformAssistantId) {
+    return {
+      error: {
+        ok: false,
+        kind: "unavailable",
+        message:
+          "Managed speech is unavailable: platform assistant ID is missing.",
+      },
+    };
+  }
+  return { client };
+}
+
+export async function managedSpeechTranscribe(input: {
+  audio: Buffer;
+  mimeType: string;
+  source?: string;
+  signal?: AbortSignal;
+}): Promise<ManagedSpeechResult<ManagedSpeechTranscription>> {
+  const resolved = await resolveClient();
+  if ("error" in resolved) {
+    return resolved.error;
+  }
+  const { client } = resolved;
+
+  const response = await client.fetch(
+    `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/managed-speech/stt/transcribe/`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        audioBase64: input.audio.toString("base64"),
+        mimeType: input.mimeType,
+        ...(input.source !== undefined ? { source: input.source } : {}),
+      }),
+      signal: input.signal,
+    },
+  );
+
+  if (!response.ok) {
+    return await platformError(response, "transcription");
+  }
+
+  const body: unknown = await response.json().catch(() => null);
+  if (
+    !body ||
+    typeof body !== "object" ||
+    typeof (body as { text?: unknown }).text !== "string" ||
+    typeof (body as { durationSeconds?: unknown }).durationSeconds !== "number"
+  ) {
+    return {
+      ok: false,
+      kind: "platform-error",
+      status: response.status,
+      message: "Managed speech transcription returned a malformed response.",
+    };
+  }
+  const parsed = body as { text: string; durationSeconds: number };
+  return {
+    ok: true,
+    value: { text: parsed.text, durationSeconds: parsed.durationSeconds },
+  };
+}
+
+export async function managedSpeechSynthesize(input: {
+  text: string;
+  format: ManagedSpeechTtsFormat;
+  signal?: AbortSignal;
+}): Promise<ManagedSpeechResult<ManagedSpeechSynthesis>> {
+  const resolved = await resolveClient();
+  if ("error" in resolved) {
+    return resolved.error;
+  }
+  const { client } = resolved;
+
+  const response = await client.fetch(
+    `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/managed-speech/tts/synthesize/`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: input.text, format: input.format }),
+      signal: input.signal,
+    },
+  );
+
+  if (!response.ok) {
+    return await platformError(response, "synthesis");
+  }
+
+  const audio = Buffer.from(await response.arrayBuffer());
+  if (audio.length === 0) {
+    return {
+      ok: false,
+      kind: "platform-error",
+      status: response.status,
+      message: "Managed speech synthesis returned empty audio.",
+    };
+  }
+  return {
+    ok: true,
+    value: {
+      audio,
+      contentType: response.headers.get("content-type") ?? "audio/mpeg",
+    },
+  };
+}
+
+async function platformError(
+  response: Response,
+  operation: string,
+): Promise<ManagedSpeechResult<never>> {
+  let code: string | undefined;
+  let detail: string | undefined;
+  try {
+    const body = (await response.json()) as {
+      code?: unknown;
+      detail?: unknown;
+    };
+    if (typeof body?.code === "string") {
+      code = body.code;
+    }
+    if (typeof body?.detail === "string") {
+      detail = body.detail;
+    }
+  } catch {
+    // Non-JSON error body; status alone will have to do.
+  }
+  return {
+    ok: false,
+    kind: "platform-error",
+    status: response.status,
+    code,
+    message:
+      detail ??
+      `Managed speech ${operation} failed (platform returned ${response.status}).`,
+  };
+}


### PR DESCRIPTION
## Summary

B1 of `.private/plans/managed-speech-assistant.md` (managed speech: Vellum-held Deepgram key billed to org credits — platform endpoints are deployed and E2E-verified). A pure platform HTTP client, modeled on `managed-search-proxy.ts`'s result-union style over `VellumPlatformClient`:

- `managedSpeechTranscribe({audio, mimeType, source?})` → POSTs base64 audio to `…/managed-speech/stt/transcribe/`, validates the response shape defensively, returns `{text, durationSeconds}`.
- `managedSpeechSynthesize({text, format})` → POSTs to `…/managed-speech/tts/synthesize/`, returns binary audio + upstream content type (fallback `audio/mpeg`); empty audio is an error, not a success.
- `ManagedSpeechResult<T>` union: `unavailable` (no platform connection / missing assistant ID) vs `platform-error` with the platform's `{code, detail}` surfaced — so B2/B3 can branch on `insufficient_balance` and show a top-up message instead of a generic failure.
- Nothing throws for expected failures; no provider-catalog, config-schema, or resolver imports (acceptance criterion: usable by both later PRs without import cycles).

Next in the plan: B2 (vellum STT provider + `mode: "managed"` unlock) and B3 (vellum TTS provider), which consume this client.

## Testing

`bun test` (10 tests): request construction for both endpoints (URL, method, body shape, base64 correctness, `source` omitted when absent), unavailable paths (null client, missing assistant ID), 402 surfacing `insufficient_balance` + detail, malformed 200 → platform-error, binary round-trip + content-type fallback + empty-audio rejection. `tsc --noEmit`, eslint, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37841" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->