### PR TITLE
feat(telemetry): relocate lifecycle_events into assistant-telemetry.db

### DIFF
--- a/assistant/src/__tests__/conversation-clear-safety.test.ts
+++ b/assistant/src/__tests__/conversation-clear-safety.test.ts
@@ -34,7 +34,7 @@ import {
   createConversation,
   getConversation,
 } from "../persistence/conversation-crud.js";
-import { getDb } from "../persistence/db-connection.js";
+import { getTelemetrySqlite } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { enforcePolicy } from "../runtime/auth/route-policy.js";
 import type { AuthContext, Scope } from "../runtime/auth/types.js";
@@ -177,12 +177,8 @@ describe("DELETE /v1/conversations — route handler", () => {
       headers: { "x-confirm-destructive": "clear-all-conversations" },
     });
 
-    const raw = (
-      getDb() as unknown as {
-        $client: import("bun:sqlite").Database;
-      }
-    ).$client;
-    const rows = raw
+    // The audit row lives in the dedicated telemetry DB (migration 329).
+    const rows = getTelemetrySqlite()!
       .query(
         "SELECT event_name FROM lifecycle_events WHERE event_name = 'conversations_clear_all'",
       )

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -2970,13 +2970,20 @@ export async function clearAll(): Promise<{
 
   // Record audit event — lifecycle_events lives in the telemetry DB and is
   // NOT deleted by clearAll(), so this survives the wipe as a permanent trail.
-  rawTelemetryRun(
-    "conversation:clearAll:auditEvent",
-    `INSERT INTO lifecycle_events (id, event_name, created_at) VALUES (?, ?, ?)`,
-    uuid(),
-    "conversations_clear_all",
-    Date.now(),
-  );
+  // Best-effort: the destructive deletes above already completed, so telemetry
+  // degradation must not turn a finished wipe into a failure or skip the
+  // cleanup below.
+  try {
+    rawTelemetryRun(
+      "conversation:clearAll:auditEvent",
+      `INSERT INTO lifecycle_events (id, event_name, created_at) VALUES (?, ?, ?)`,
+      uuid(),
+      "conversations_clear_all",
+      Date.now(),
+    );
+  } catch (err) {
+    log.warn({ err }, "clearAll: failed to record audit event");
+  }
 
   // Drop the whole lexical (Qdrant) collection — a "delete all" leaves no ids
   // to key per-message cleanup on. AWAITED so the drop completes before

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -97,6 +97,7 @@ import {
   rawLogsRun,
   rawMemoryRun,
   rawRun,
+  rawTelemetryRun,
 } from "./raw-query.js";
 import {
   channelInboundEvents,
@@ -2967,9 +2968,9 @@ export async function clearAll(): Promise<{
   await runOrThrow("DELETE FROM messages");
   await runOrThrow("DELETE FROM conversations");
 
-  // Record audit event — lifecycle_events is NOT deleted by clearAll(),
-  // so this survives the wipe and provides a permanent trail.
-  rawRun(
+  // Record audit event — lifecycle_events lives in the telemetry DB and is
+  // NOT deleted by clearAll(), so this survives the wipe as a permanent trail.
+  rawTelemetryRun(
     "conversation:clearAll:auditEvent",
     `INSERT INTO lifecycle_events (id, event_name, created_at) VALUES (?, ?, ?)`,
     uuid(),

--- a/assistant/src/persistence/lifecycle-events-store.test.ts
+++ b/assistant/src/persistence/lifecycle-events-store.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+
+// Mutable consent gate, flipped per-test.
+let shareAnalytics = true;
+mock.module("../platform/consent-cache.js", () => ({
+  getCachedShareAnalytics: () => shareAnalytics,
+}));
+
+import * as dbConnection from "./db-connection.js";
+import { getTelemetryDb, getTelemetrySqlite } from "./db-connection.js";
+import { initializeDb } from "./db-init.js";
+import {
+  queryUnreportedLifecycleEvents,
+  recordLifecycleEvent,
+} from "./lifecycle-events-store.js";
+import { lifecycleEvents } from "./schema.js";
+
+await initializeDb();
+
+function insertEvent(id: string, createdAt: number, eventName = "hatch"): void {
+  getTelemetryDb()!
+    .insert(lifecycleEvents)
+    .values({ id, eventName, createdAt })
+    .run();
+}
+
+/** Run `fn` with the dedicated telemetry connection reported as unavailable. */
+function withTelemetryDbUnavailable(fn: () => void): void {
+  const spy = spyOn(dbConnection, "getTelemetryDb").mockReturnValue(null);
+  try {
+    fn();
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+describe("lifecycle-events-store", () => {
+  beforeEach(() => {
+    shareAnalytics = true;
+    getTelemetryDb()!.delete(lifecycleEvents).run();
+  });
+
+  test("record + query round-trips and writes into the telemetry database", () => {
+    const event = recordLifecycleEvent("app_open");
+    expect(event).not.toBeNull();
+    expect(event!.eventName).toBe("app_open");
+    expect(event!.createdAt).toBeGreaterThan(0);
+
+    const rows = queryUnreportedLifecycleEvents(0, undefined, 10);
+    expect(rows).toEqual([event!]);
+
+    const raw = getTelemetrySqlite()!
+      .query(`SELECT id, event_name FROM lifecycle_events`)
+      .all() as Array<{ id: string; event_name: string }>;
+    expect(raw).toEqual([{ id: event!.id, event_name: "app_open" }]);
+  });
+
+  test("returns null and writes no row when share_analytics is disabled", () => {
+    shareAnalytics = false;
+    expect(recordLifecycleEvent("app_open")).toBeNull();
+    expect(queryUnreportedLifecycleEvents(0, undefined, 10)).toHaveLength(0);
+  });
+
+  test("degrades when the telemetry database is unavailable", () => {
+    withTelemetryDbUnavailable(() => {
+      expect(recordLifecycleEvent("app_open")).toBeNull();
+      expect(queryUnreportedLifecycleEvents(0, undefined, 10)).toEqual([]);
+    });
+
+    expect(queryUnreportedLifecycleEvents(0, undefined, 10)).toHaveLength(0);
+  });
+
+  test("returns rows in (createdAt, id) order", () => {
+    insertEvent("le-b", 2000);
+    insertEvent("le-a", 1000);
+
+    const rows = queryUnreportedLifecycleEvents(0, undefined, 100);
+    expect(rows.map((r) => r.id)).toEqual(["le-a", "le-b"]);
+  });
+
+  test("query advances past the compound (createdAt, id) cursor", () => {
+    // Two rows in the same millisecond: pagination must use the id
+    // tiebreaker to make forward progress, not loop.
+    insertEvent("le-1", 5000);
+    insertEvent("le-2", 5000);
+    insertEvent("le-3", 6000);
+
+    const first = queryUnreportedLifecycleEvents(0, undefined, 1);
+    expect(first.map((r) => r.id)).toEqual(["le-1"]);
+
+    const second = queryUnreportedLifecycleEvents(
+      first[0]!.createdAt,
+      first[0]!.id,
+      100,
+    );
+    expect(second.map((r) => r.id)).toEqual(["le-2", "le-3"]);
+
+    // Without an id cursor the timestamp-only branch is used.
+    expect(
+      queryUnreportedLifecycleEvents(5000, undefined, 100).map((r) => r.id),
+    ).toEqual(["le-3"]);
+
+    // Cursor past the last row returns nothing.
+    const last = second[second.length - 1]!;
+    expect(
+      queryUnreportedLifecycleEvents(last.createdAt, last.id, 100).length,
+    ).toBe(0);
+  });
+
+  test("honors the limit", () => {
+    insertEvent("le-l1", 1000);
+    insertEvent("le-l2", 2000);
+    insertEvent("le-l3", 3000);
+
+    const rows = queryUnreportedLifecycleEvents(0, undefined, 2);
+    expect(rows.map((r) => r.id)).toEqual(["le-l1", "le-l2"]);
+  });
+});

--- a/assistant/src/persistence/lifecycle-events-store.ts
+++ b/assistant/src/persistence/lifecycle-events-store.ts
@@ -2,7 +2,7 @@ import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getCachedShareAnalytics } from "../platform/consent-cache.js";
-import { getDb } from "./db-connection.js";
+import { getTelemetryDb } from "./db-connection.js";
 import { lifecycleEvents } from "./schema.js";
 
 export interface LifecycleEvent {
@@ -11,10 +11,19 @@ export interface LifecycleEvent {
   createdAt: number;
 }
 
-/** Record a lifecycle event (e.g. app_open, hatch). Returns null when usage data collection is disabled. */
+/**
+ * Record a lifecycle event (e.g. app_open, hatch). Returns null when usage
+ * data collection is disabled or the telemetry database is unavailable
+ * (degraded mode).
+ */
 export function recordLifecycleEvent(eventName: string): LifecycleEvent | null {
-  if (!getCachedShareAnalytics()) return null;
-  const db = getDb();
+  if (!getCachedShareAnalytics()) {
+    return null;
+  }
+  const db = getTelemetryDb();
+  if (!db) {
+    return null;
+  }
   const event: LifecycleEvent = {
     id: uuid(),
     eventName,
@@ -39,7 +48,10 @@ export function queryUnreportedLifecycleEvents(
   afterId: string | undefined,
   limit: number,
 ): LifecycleEvent[] {
-  const db = getDb();
+  const db = getTelemetryDb();
+  if (!db) {
+    return [];
+  }
   const rows = db
     .select({
       id: lifecycleEvents.id,

--- a/assistant/src/persistence/migrations/329-move-lifecycle-events-to-telemetry-db.test.ts
+++ b/assistant/src/persistence/migrations/329-move-lifecycle-events-to-telemetry-db.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for migration 329: relocating `lifecycle_events` from the main DB
+ * into the dedicated telemetry database (`assistant-telemetry.db`).
+ *
+ * Runs against real workspace databases (`initializeDb()`) because the drain
+ * engine dispatches batches via `runAsyncSqlite` against the workspace's main
+ * DB file. `initializeDb()` already ran migration 329 once (dropping the empty
+ * main-side table created by migration 175), so each test recreates the
+ * pre-move source table in `main` to simulate an upgrading install.
+ */
+import { describe, expect, test } from "bun:test";
+
+const { getDb, getSqlite, getTelemetrySqlite } =
+  await import("../db-connection.js");
+const { initializeDb } = await import("../db-init.js");
+const { queryUnreportedLifecycleEvents } =
+  await import("../lifecycle-events-store.js");
+const { migrateMoveLifecycleEventsToTelemetryDb } =
+  await import("./329-move-lifecycle-events-to-telemetry-db.js");
+
+await initializeDb();
+
+const SOURCE_COLUMNS = `
+  id TEXT PRIMARY KEY, event_name TEXT NOT NULL, created_at INTEGER NOT NULL`;
+
+function existsInMain(name: string): boolean {
+  return (
+    getSqlite()
+      .query(
+        `SELECT name FROM main.sqlite_master WHERE type='table' AND name = ?`,
+      )
+      .get(name) != null
+  );
+}
+
+function resetState(): void {
+  getTelemetrySqlite()!.exec(`DELETE FROM lifecycle_events`);
+  getSqlite().exec(`DROP TABLE IF EXISTS main.lifecycle_events`);
+  getSqlite().exec(`DROP TABLE IF EXISTS main."lifecycle_events__relocating"`);
+}
+
+function seedSourceTable(): void {
+  const sqlite = getSqlite();
+  sqlite.exec(`CREATE TABLE main.lifecycle_events (${SOURCE_COLUMNS})`);
+  const insert = sqlite.prepare(
+    `INSERT INTO main.lifecycle_events (id, event_name, created_at)
+     VALUES (?, ?, ?)`,
+  );
+  insert.run("seed-1", "app_open", 1000);
+  insert.run("seed-2", "hatch", 2000);
+  insert.run("seed-dupe", "conversations_clear_all", 3000);
+}
+
+describe("migration 329: move lifecycle_events to the telemetry DB", () => {
+  test("drains pre-move rows into the telemetry DB and drops the main-side table", async () => {
+    resetState();
+    seedSourceTable();
+
+    await migrateMoveLifecycleEventsToTelemetryDb(getDb());
+
+    expect(existsInMain("lifecycle_events")).toBe(false);
+    expect(existsInMain("lifecycle_events__relocating")).toBe(false);
+
+    const moved = getTelemetrySqlite()!
+      .query(`SELECT id, event_name FROM lifecycle_events ORDER BY id`)
+      .all();
+    expect(moved).toEqual([
+      { id: "seed-1", event_name: "app_open" },
+      { id: "seed-2", event_name: "hatch" },
+      { id: "seed-dupe", event_name: "conversations_clear_all" },
+    ]);
+
+    // The relocated rows are readable through the store's reporter query.
+    const rows = queryUnreportedLifecycleEvents(0, undefined, 10);
+    expect(rows).toEqual([
+      { id: "seed-1", eventName: "app_open", createdAt: 1000 },
+      { id: "seed-2", eventName: "hatch", createdAt: 2000 },
+      {
+        id: "seed-dupe",
+        eventName: "conversations_clear_all",
+        createdAt: 3000,
+      },
+    ]);
+  });
+
+  test("re-running after a completed move is a no-op", async () => {
+    resetState();
+    seedSourceTable();
+
+    await migrateMoveLifecycleEventsToTelemetryDb(getDb());
+    await migrateMoveLifecycleEventsToTelemetryDb(getDb());
+
+    expect(existsInMain("lifecycle_events")).toBe(false);
+    expect(existsInMain("lifecycle_events__relocating")).toBe(false);
+    expect(queryUnreportedLifecycleEvents(0, undefined, 10)).toHaveLength(3);
+  });
+
+  test("a pre-existing duplicate id in the telemetry copy does not fail the drain", async () => {
+    resetState();
+    seedSourceTable();
+
+    // A crash between a drain batch's copy and delete re-copies the same rows
+    // next boot; INSERT OR IGNORE must keep the already-copied row and finish.
+    getTelemetrySqlite()!.exec(
+      `INSERT INTO lifecycle_events (id, event_name, created_at)
+       VALUES ('seed-dupe', 'already-copied', 3000)`,
+    );
+
+    await migrateMoveLifecycleEventsToTelemetryDb(getDb());
+
+    expect(existsInMain("lifecycle_events")).toBe(false);
+    expect(existsInMain("lifecycle_events__relocating")).toBe(false);
+    const dupe = getTelemetrySqlite()!
+      .query(`SELECT event_name FROM lifecycle_events WHERE id = 'seed-dupe'`)
+      .get() as { event_name: string };
+    expect(dupe.event_name).toBe("already-copied");
+    expect(queryUnreportedLifecycleEvents(0, undefined, 10)).toHaveLength(3);
+  });
+
+  test("an empty main-side table (fresh install) is dropped without a drain", async () => {
+    resetState();
+    getSqlite().exec(`CREATE TABLE main.lifecycle_events (${SOURCE_COLUMNS})`);
+
+    await migrateMoveLifecycleEventsToTelemetryDb(getDb());
+
+    expect(existsInMain("lifecycle_events")).toBe(false);
+    expect(existsInMain("lifecycle_events__relocating")).toBe(false);
+    expect(queryUnreportedLifecycleEvents(0, undefined, 10)).toHaveLength(0);
+  });
+
+  test("telemetry-side schema has the reporter's compound cursor index", () => {
+    const indexes = (
+      getTelemetrySqlite()!
+        .query(`PRAGMA index_list(lifecycle_events)`)
+        .all() as Array<{ name: string }>
+    ).map((i) => i.name);
+    expect(indexes).toContain("idx_lifecycle_events_created_at_id");
+  });
+});

--- a/assistant/src/persistence/migrations/329-move-lifecycle-events-to-telemetry-db.ts
+++ b/assistant/src/persistence/migrations/329-move-lifecycle-events-to-telemetry-db.ts
@@ -1,0 +1,97 @@
+import type { Database } from "bun:sqlite";
+
+import { getTelemetryDbPath } from "../../util/telemetry-db-path.js";
+import {
+  type DrizzleDb,
+  getSqliteFrom,
+  getTelemetrySqlite,
+} from "../db-connection.js";
+import {
+  drainStagedTable,
+  type RelocationSpec,
+  stageTableForRelocation,
+} from "./helpers/relocation.js";
+
+/**
+ * How to drain `lifecycle_events` from `main` into the telemetry DB. The
+ * table is a pure telemetry outbox — every row is worth keeping until the
+ * usage telemetry reporter flushes it (and, by design, forever after: the
+ * table is never deleted from) — so all rows are copied verbatim.
+ */
+export const LIFECYCLE_EVENTS_RELOCATION: RelocationSpec = {
+  table: "lifecycle_events",
+  targetDbPath: getTelemetryDbPath,
+  columns: ["id", "event_name", "created_at"],
+};
+
+const CREATE_TABLE = /*sql*/ `
+  CREATE TABLE IF NOT EXISTS lifecycle_events (
+    id TEXT PRIMARY KEY,
+    event_name TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+  )
+`;
+
+/**
+ * Create the `lifecycle_events` table and its cursor index on the telemetry
+ * connection. Idempotent (`IF NOT EXISTS`) — the dedicated connection itself
+ * performs no DDL on open, so this migration owns the schema. The index backs
+ * the telemetry reporter's compound `(created_at, id)` watermark cursor,
+ * matching `watchdog_events` (migration 301).
+ */
+function ensureLifecycleEventsSchema(telemetryRaw: Database): void {
+  telemetryRaw.exec(CREATE_TABLE);
+  telemetryRaw.exec(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_lifecycle_events_created_at_id ON lifecycle_events (created_at, id)`,
+  );
+}
+
+/**
+ * Move `lifecycle_events` — the app-lifecycle telemetry outbox (app_open,
+ * hatch, permission prompts, watcher breadcrumbs, and the permanent
+ * `conversations_clear_all` audit trail) — into the dedicated telemetry
+ * database (`assistant-telemetry.db`), alongside `watchdog_events`
+ * (migration 301), `config_setting_events` (migration 325),
+ * `onboarding_events` (migration 327), and `auth_fallback_events`
+ * (migration 328). Rows are inserted at emit time and read only by the usage
+ * telemetry reporter's flush; housing them with the other telemetry tables
+ * keeps the main DB and its WAL out of that write path. The store in
+ * `persistence/lifecycle-events-store.ts` reads/writes it over the dedicated
+ * telemetry connection (see `getTelemetryDb()`), and the reporter's
+ * `(createdAt, id)` watermark in the main DB's checkpoints store survives the
+ * move unchanged.
+ *
+ * Like migrations 297/298/326/327/328 the move is incremental: create the
+ * table (and index) on the telemetry connection, rename any populated
+ * `main.lifecycle_events` aside to `lifecycle_events__relocating`, then drain
+ * it in awaited batches (see `helpers/relocation.ts`) per
+ * {@link LIFECYCLE_EVENTS_RELOCATION}. On a fresh install the main-side table
+ * created by migration 175 is empty, so staging just drops it.
+ *
+ * Throws (rather than returning) if the telemetry database cannot be opened,
+ * so the runner records the step as failed instead of applied and retries it
+ * on a later boot — never renaming the source aside without a target to write
+ * to. The throw is caught per-step by the runner, so startup is not aborted.
+ */
+export async function migrateMoveLifecycleEventsToTelemetryDb(
+  database: DrizzleDb,
+): Promise<void> {
+  const telemetryRaw = getTelemetrySqlite();
+  if (!telemetryRaw) {
+    throw new Error(
+      "telemetry database unavailable — deferring lifecycle_events relocation",
+    );
+  }
+
+  ensureLifecycleEventsSchema(telemetryRaw);
+
+  const raw = getSqliteFrom(database);
+  const needsDrain = stageTableForRelocation(
+    raw,
+    LIFECYCLE_EVENTS_RELOCATION.table,
+  );
+
+  if (needsDrain) {
+    await drainStagedTable(raw, LIFECYCLE_EVENTS_RELOCATION);
+  }
+}

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -436,6 +436,7 @@ import { createConfigSettingEventsTable } from "./migrations/325-create-config-s
 import { migrateMoveInjectionEventsToMemoryDb } from "./migrations/326-move-injection-events-to-memory-db.js";
 import { migrateMoveOnboardingEventsToTelemetryDb } from "./migrations/327-move-onboarding-events-to-telemetry-db.js";
 import { migrateMoveAuthFallbackEventsToTelemetryDb } from "./migrations/328-move-auth-fallback-events-to-telemetry-db.js";
+import { migrateMoveLifecycleEventsToTelemetryDb } from "./migrations/329-move-lifecycle-events-to-telemetry-db.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1343,4 +1344,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateMoveInjectionEventsToMemoryDb,
   migrateMoveOnboardingEventsToTelemetryDb,
   migrateMoveAuthFallbackEventsToTelemetryDb,
+  migrateMoveLifecycleEventsToTelemetryDb,
 ];


### PR DESCRIPTION
## Summary
- Migration 329 relocates lifecycle_events from the main DB into assistant-telemetry.db using the staged-drain relocation engine
- Lifecycle events store now reads/writes the dedicated telemetry connection; clearAll's audit insert goes through rawTelemetryRun

Part of plan: telemetry-db-move.md (PR 4 of 6)