### PR TITLE
fix(web): workspace Files search doesn't surface matching folders

### DIFF
--- a/clients/web/src/domains/workspace/components/workspace-tree.test.tsx
+++ b/clients/web/src/domains/workspace/components/workspace-tree.test.tsx
@@ -1,15 +1,20 @@
 /**
- * Tests for `WorkspaceTreeCreateMenu`.
+ * Tests for `WorkspaceTreeCreateMenu` and `searchWorkspaceTree`.
  *
- * Verifies the mobile vs desktop branch — desktop renders a Radix dropdown
- * Menu with the New File / New Folder rows; mobile renders a BottomSheet
- * (Radix Dialog). Selecting either row forwards `onSelectKind(kind)` to the
- * parent.
+ * Menu tests verify the mobile vs desktop branch — desktop renders a Radix
+ * dropdown Menu with the New File / New Folder rows; mobile renders a
+ * BottomSheet (Radix Dialog). Selecting either row forwards
+ * `onSelectKind(kind)` to the parent.
+ *
+ * Search tests drive the recursive tree walk against a fake directory
+ * listing, verifying that matches and their ancestors are surfaced and that
+ * matched directories are not descended into.
  *
  * Uses `renderToStaticMarkup` + `mock.module` for design library compounds
  * (same pattern as conversation-actions-menu.test.tsx).
  */
 
+import { QueryClient } from "@tanstack/react-query";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { createElement, type ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
@@ -27,7 +32,11 @@ mock.module("@vellumai/design-library/components/bottom-sheet", () => ({
   BottomSheet: {
     Root: passthrough,
     Trigger: ({ children }: Record<string, unknown>) =>
-      createElement("div", { "data-testid": "bs-trigger" }, children as ReactNode),
+      createElement(
+        "div",
+        { "data-testid": "bs-trigger" },
+        children as ReactNode,
+      ),
     Content: passthrough,
     Header: passthrough,
     Title: ({ children }: Record<string, unknown>) =>
@@ -40,11 +49,19 @@ mock.module("@vellumai/design-library/components/menu", () => ({
   Menu: {
     Root: passthrough,
     Trigger: ({ children }: Record<string, unknown>) =>
-      createElement("div", { "data-testid": "menu-trigger" }, children as ReactNode),
+      createElement(
+        "div",
+        { "data-testid": "menu-trigger" },
+        children as ReactNode,
+      ),
     // Mirror the roles the real Radix menu primitives render with.
     Content: ({ children }: Record<string, unknown>) =>
       createElement("div", { role: "menu" }, children as ReactNode),
-    Item: ({ children, onSelect, leftIcon: _leftIcon }: Record<string, unknown>) =>
+    Item: ({
+      children,
+      onSelect,
+      leftIcon: _leftIcon,
+    }: Record<string, unknown>) =>
       createElement(
         "button",
         { role: "menuitem", onClick: onSelect as () => void },
@@ -79,10 +96,101 @@ mock.module("@vellumai/design-library/components/panel-item", () => ({
     ),
 }));
 
-import { WorkspaceTreeCreateMenu } from "./workspace-tree";
+const listedPaths: string[] = [];
+
+const makeEntry = (path: string, type: "directory" | "file") => ({
+  name: path.split("/").pop() ?? "",
+  path,
+  type,
+  size: type === "file" ? 1 : null,
+  mimeType: type === "file" ? "text/plain" : null,
+  modifiedAt: "2026-01-01T00:00:00.000Z",
+});
+
+const FAKE_TREE: Record<string, ReturnType<typeof makeEntry>[]> = {
+  "": [
+    makeEntry("archive", "directory"),
+    makeEntry("bin", "directory"),
+    makeEntry("readme.md", "file"),
+  ],
+  archive: [
+    makeEntry("archive/projects", "directory"),
+    makeEntry("archive/notes.md", "file"),
+  ],
+  "archive/projects": [
+    makeEntry("archive/projects/AgentWatch", "directory"),
+    makeEntry("archive/projects/log.txt", "file"),
+  ],
+  "archive/projects/AgentWatch": [
+    makeEntry("archive/projects/AgentWatch/main.ts", "file"),
+  ],
+  bin: [makeEntry("bin/tool.sh", "file")],
+};
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  workspaceTreeGet: async ({ query }: { query?: { path?: string } }) => {
+    const path = query?.path ?? "";
+    listedPaths.push(path);
+    const entries = FAKE_TREE[path];
+    return entries
+      ? { data: { path, entries }, error: undefined }
+      : { data: undefined, error: "not found" };
+  },
+  workspaceDeletePost: async () => ({}),
+  workspaceMkdirPost: async () => ({}),
+  workspaceRenamePost: async () => ({}),
+  workspaceWritePost: async () => ({}),
+}));
+
+import { searchWorkspaceTree, WorkspaceTreeCreateMenu } from "./workspace-tree";
 
 beforeEach(() => {
   mockIsMobile = false;
+  listedPaths.length = 0;
+});
+
+describe("searchWorkspaceTree", () => {
+  const search = (searchLower: string) =>
+    searchWorkspaceTree(new QueryClient(), {
+      assistantId: "a1",
+      includeDirSizes: false,
+      searchLower,
+      showHidden: false,
+    });
+
+  test("surfaces a nested matching folder and expands its ancestors", async () => {
+    const result = await search("agentwatch");
+    expect([...result.visiblePaths].sort()).toEqual([
+      "archive",
+      "archive/projects",
+      "archive/projects/AgentWatch",
+    ]);
+    expect([...result.expandedPaths].sort()).toEqual([
+      "archive",
+      "archive/projects",
+    ]);
+    expect(result.truncated).toBe(false);
+  });
+
+  test("does not descend into a matched directory", async () => {
+    await search("agentwatch");
+    expect(listedPaths).not.toContain("archive/projects/AgentWatch");
+  });
+
+  test("finds files nested in non-matching directories", async () => {
+    const result = await search("main");
+    expect(result.visiblePaths.has("archive/projects/AgentWatch/main.ts")).toBe(
+      true,
+    );
+    expect(result.expandedPaths.has("archive/projects/AgentWatch")).toBe(true);
+    expect(result.visiblePaths.has("bin")).toBe(false);
+  });
+
+  test("returns empty sets when nothing matches", async () => {
+    const result = await search("zzz-no-such-entry");
+    expect(result.visiblePaths.size).toBe(0);
+    expect(result.expandedPaths.size).toBe(0);
+  });
 });
 
 describe("WorkspaceTreeCreateMenu", () => {

--- a/clients/web/src/domains/workspace/components/workspace-tree.test.tsx
+++ b/clients/web/src/domains/workspace/components/workspace-tree.test.tsx
@@ -125,12 +125,23 @@ const FAKE_TREE: Record<string, ReturnType<typeof makeEntry>[]> = {
     makeEntry("archive/projects/AgentWatch/main.ts", "file"),
   ],
   bin: [makeEntry("bin/tool.sh", "file")],
+  wide: [...Array(20)].map((_, i) => makeEntry(`wide/d${i}`, "directory")),
 };
+for (let i = 0; i < 20; i++) {
+  FAKE_TREE[`wide/d${i}`] = [];
+}
+
+let inFlightLists = 0;
+let maxInFlightLists = 0;
 
 mock.module("@/generated/daemon/sdk.gen", () => ({
   workspaceTreeGet: async ({ query }: { query?: { path?: string } }) => {
     const path = query?.path ?? "";
     listedPaths.push(path);
+    inFlightLists++;
+    maxInFlightLists = Math.max(maxInFlightLists, inFlightLists);
+    await new Promise((resolve) => setTimeout(resolve, 1));
+    inFlightLists--;
     const entries = FAKE_TREE[path];
     return entries
       ? { data: { path, entries }, error: undefined }
@@ -142,11 +153,16 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   workspaceWritePost: async () => ({}),
 }));
 
-import { searchWorkspaceTree, WorkspaceTreeCreateMenu } from "./workspace-tree";
+import {
+  SEARCH_MAX_CONCURRENT_LISTS,
+  searchWorkspaceTree,
+  WorkspaceTreeCreateMenu,
+} from "./workspace-tree";
 
 beforeEach(() => {
   mockIsMobile = false;
   listedPaths.length = 0;
+  maxInFlightLists = 0;
 });
 
 describe("searchWorkspaceTree", () => {
@@ -190,6 +206,13 @@ describe("searchWorkspaceTree", () => {
     const result = await search("zzz-no-such-entry");
     expect(result.visiblePaths.size).toBe(0);
     expect(result.expandedPaths.size).toBe(0);
+  });
+
+  test("bounds concurrent directory listings", async () => {
+    // A no-match search walks every directory, including the 20 under wide/.
+    await search("zzz-no-such-entry");
+    expect(maxInFlightLists).toBeGreaterThan(1);
+    expect(maxInFlightLists).toBeLessThanOrEqual(SEARCH_MAX_CONCURRENT_LISTS);
   });
 });
 

--- a/clients/web/src/domains/workspace/components/workspace-tree.tsx
+++ b/clients/web/src/domains/workspace/components/workspace-tree.tsx
@@ -661,6 +661,17 @@ export function WorkspaceTree({
   // Null until the walk finishes — the tree renders unfiltered in the interim.
   const searchResult = searchLower !== "" ? (searchQuery.data ?? null) : null;
 
+  // Rendered with results and with the no-match empty state alike: a
+  // truncated walk means matches may exist in folders it never reached.
+  const truncationNotice = searchResult?.truncated ? (
+    <p
+      className="px-3 py-2 text-center text-label-medium-default"
+      style={{ color: "var(--content-tertiary)" }}
+    >
+      Workspace too large to search fully — some folders were skipped.
+    </p>
+  ) : null;
+
   const rootEntries = useMemo(
     () => sortEntries(data?.entries ?? [], sortMode),
     [data?.entries, sortMode],
@@ -915,12 +926,15 @@ export function WorkspaceTree({
             No files found
           </p>
         ) : searchResult && searchResult.visiblePaths.size === 0 ? (
-          <p
-            className="px-3 py-4 text-center text-body-medium-lighter"
-            style={{ color: "var(--content-tertiary)" }}
-          >
-            No matching files
-          </p>
+          <>
+            <p
+              className="px-3 py-4 text-center text-body-medium-lighter"
+              style={{ color: "var(--content-tertiary)" }}
+            >
+              No matching files
+            </p>
+            {truncationNotice}
+          </>
         ) : (
           <>
             {rootEntries.map((entry) => (
@@ -942,14 +956,7 @@ export function WorkspaceTree({
                 depth={0}
               />
             ))}
-            {searchResult?.truncated && (
-              <p
-                className="px-3 py-2 text-center text-label-medium-default"
-                style={{ color: "var(--content-tertiary)" }}
-              >
-                Workspace too large to search fully — some folders were skipped.
-              </p>
-            )}
+            {truncationNotice}
           </>
         )}
       </div>

--- a/clients/web/src/domains/workspace/components/workspace-tree.tsx
+++ b/clients/web/src/domains/workspace/components/workspace-tree.tsx
@@ -8,50 +8,45 @@
  */
 
 import {
-    queryOptions,
-    useMutation,
-    useQuery,
-    useQueryClient,
+  type QueryClient,
+  queryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
 } from "@tanstack/react-query";
 import {
-    ArrowDownAZ,
-    ArrowDownWideNarrow,
-    ChevronDown,
-    ChevronRight,
-    Eye,
-    EyeOff,
-    FilePlus,
-    FileText,
-    Folder,
-    FolderPlus,
-    Image as ImageIcon,
-    Pencil,
-    Plus,
-    Search,
-    Trash2,
-    Video,
-    X,
+  ArrowDownAZ,
+  ArrowDownWideNarrow,
+  ChevronDown,
+  ChevronRight,
+  Eye,
+  EyeOff,
+  FilePlus,
+  FileText,
+  Folder,
+  FolderPlus,
+  Image as ImageIcon,
+  Pencil,
+  Plus,
+  Search,
+  Trash2,
+  Video,
+  X,
 } from "lucide-react";
-import {
-    type FormEvent,
-    useCallback,
-    useMemo,
-    useRef,
-    useState,
-} from "react";
+import { type FormEvent, useCallback, useMemo, useRef, useState } from "react";
 
 import { formatFileSize } from "@/domains/workspace/utils/format-file-size";
 import { isHiddenPath } from "@/domains/workspace/utils/is-hidden-path";
 import {
-    sortEntries,
-    type WorkspaceSortMode,
+  sortEntries,
+  type WorkspaceSortMode,
 } from "@/domains/workspace/utils/sort-entries";
 import {
-    workspaceDeletePost,
-    workspaceMkdirPost,
-    workspaceRenamePost,
-    workspaceTreeGet,
-    workspaceWritePost,
+  workspaceDeletePost,
+  workspaceMkdirPost,
+  workspaceRenamePost,
+  workspaceTreeGet,
+  workspaceWritePost,
 } from "@/generated/daemon/sdk.gen";
 import type { WorkspaceTreeGetResponse } from "@/generated/daemon/types.gen";
 import { useIsMobile } from "@/hooks/use-is-mobile";
@@ -106,6 +101,98 @@ function workspaceTreeRetrieveOptions(opts: {
     },
     queryKey: ["assistantsWorkspaceTreeRetrieve", opts],
   });
+}
+
+const SEARCH_MAX_DEPTH = 10;
+const SEARCH_MAX_DIRS = 2000;
+
+export interface WorkspaceSearchResult {
+  /** Entries to render while searching: matches plus their ancestor directories. */
+  visiblePaths: Set<string>;
+  /** Ancestor directories force-expanded so their matching descendants are revealed. */
+  expandedPaths: Set<string>;
+  /** True when the walk hit its depth or directory budget, so matches may be missing. */
+  truncated: boolean;
+}
+
+/**
+ * Recursively walks the workspace tree collecting entries whose name contains
+ * `searchLower`. The daemon lists one directory per request, so the walk fans
+ * out through the query cache (shared with TreeNode's per-directory queries).
+ * Matched directories are not descended into — their contents stay browsable
+ * when the user expands them.
+ */
+export async function searchWorkspaceTree(
+  queryClient: QueryClient,
+  opts: {
+    assistantId: string;
+    includeDirSizes: boolean;
+    searchLower: string;
+    showHidden: boolean;
+  },
+): Promise<WorkspaceSearchResult> {
+  const visiblePaths = new Set<string>();
+  const expandedPaths = new Set<string>();
+  let dirsListed = 0;
+  let truncated = false;
+
+  async function walk(dirPath: string, depth: number): Promise<boolean> {
+    if (depth > SEARCH_MAX_DEPTH || dirsListed >= SEARCH_MAX_DIRS) {
+      truncated = true;
+      return false;
+    }
+    dirsListed++;
+
+    let entries: WorkspaceTreeEntry[];
+    try {
+      const data = await queryClient.fetchQuery({
+        ...workspaceTreeRetrieveOptions({
+          path: { assistant_id: opts.assistantId },
+          query: {
+            ...(dirPath ? { path: dirPath } : {}),
+            showHidden: opts.showHidden,
+            includeDirSizes: opts.includeDirSizes,
+          },
+        }),
+        staleTime: 30_000,
+      });
+      entries = data.entries ?? [];
+    } catch {
+      // An unreadable directory shouldn't sink the whole search.
+      return false;
+    }
+
+    let subtreeHasMatch = false;
+    const unmatchedDirs: string[] = [];
+    for (const entry of entries) {
+      const entryPath = entry.path ?? "";
+      const matches = (entry.name ?? "")
+        .toLowerCase()
+        .includes(opts.searchLower);
+      if (matches) {
+        visiblePaths.add(entryPath);
+        subtreeHasMatch = true;
+      } else if (entry.type === "directory") {
+        unmatchedDirs.push(entryPath);
+      }
+    }
+
+    const childHasMatch = await Promise.all(
+      unmatchedDirs.map((childPath) => walk(childPath, depth + 1)),
+    );
+    childHasMatch.forEach((hasMatch, i) => {
+      if (hasMatch) {
+        visiblePaths.add(unmatchedDirs[i]);
+        expandedPaths.add(unmatchedDirs[i]);
+        subtreeHasMatch = true;
+      }
+    });
+
+    return subtreeHasMatch;
+  }
+
+  await walk("", 0);
+  return { expandedPaths, truncated, visiblePaths };
 }
 
 /**
@@ -181,7 +268,8 @@ function TreeNode({
   selectedPath,
   showHidden,
   sortMode,
-  searchLower,
+  searchResult,
+  ancestorMatched,
   onToggleExpand,
   onSelectPath,
   onRequestDelete,
@@ -195,7 +283,8 @@ function TreeNode({
   selectedPath: string | null;
   showHidden: boolean;
   sortMode: WorkspaceSortMode;
-  searchLower: string;
+  searchResult: WorkspaceSearchResult | null;
+  ancestorMatched: boolean;
   onToggleExpand: (path: string) => void;
   onSelectPath: (path: string) => void;
   onRequestDelete: (target: EntryTarget) => void;
@@ -216,9 +305,11 @@ function TreeNode({
   // segments, so don't offer the context menu for them.
   const hasMenu = !isHiddenPath(entryPath);
 
-  // Expand directories whose names match during search so their children are visible.
+  // During search, force-expand the ancestor directories of matches so the
+  // matches are revealed; everything else keeps its user-driven state.
   const effectivelyExpanded =
-    isDirectory && (isExpanded || searchLower.length > 0);
+    isDirectory &&
+    (isExpanded || (searchResult?.expandedPaths.has(entryPath) ?? false));
 
   const { data } = useQuery({
     ...workspaceTreeRetrieveOptions({
@@ -236,14 +327,21 @@ function TreeNode({
     () => sortEntries(data?.entries ?? [], sortMode),
     [data?.entries, sortMode],
   );
-  const nameMatches =
-    searchLower === "" || entryName.toLowerCase().includes(searchLower);
-
-  // Filter files by name match. Directories stay visible during search so
-  // their children can mount, fetch, and reveal deeply nested matches.
-  if (searchLower !== "" && !isDirectory && !nameMatches) {
+  // While searching, render only matches, their ancestor directories, and
+  // the contents of matched directories the user expands.
+  if (
+    searchResult &&
+    !ancestorMatched &&
+    !searchResult.visiblePaths.has(entryPath)
+  ) {
     return null;
   }
+
+  // A directory rendered as a match (rather than as an ancestor of one) makes
+  // its whole subtree browsable without further filtering.
+  const childAncestorMatched =
+    ancestorMatched ||
+    (searchResult !== null && !searchResult.expandedPaths.has(entryPath));
 
   const handleClick = () => {
     if (isDirectory) {
@@ -329,7 +427,11 @@ function TreeNode({
             <ContextMenu.Item
               leftIcon={<Trash2 className="h-3.5 w-3.5" />}
               onSelect={() =>
-                onRequestDelete({ path: entryPath, name: entryName, isDirectory })
+                onRequestDelete({
+                  path: entryPath,
+                  name: entryName,
+                  isDirectory,
+                })
               }
             >
               Delete
@@ -337,7 +439,11 @@ function TreeNode({
             <ContextMenu.Item
               leftIcon={<Pencil className="h-3.5 w-3.5" />}
               onSelect={() =>
-                onRequestRename({ path: entryPath, name: entryName, isDirectory })
+                onRequestRename({
+                  path: entryPath,
+                  name: entryName,
+                  isDirectory,
+                })
               }
             >
               Rename
@@ -358,7 +464,8 @@ function TreeNode({
               selectedPath={selectedPath}
               showHidden={showHidden}
               sortMode={sortMode}
-              searchLower={searchLower}
+              searchResult={searchResult}
+              ancestorMatched={childAncestorMatched}
               onToggleExpand={onToggleExpand}
               onSelectPath={onSelectPath}
               onRequestDelete={onRequestDelete}
@@ -539,6 +646,21 @@ export function WorkspaceTree({
     }),
   );
 
+  const searchOpts = {
+    assistantId,
+    includeDirSizes: sortMode === "size",
+    searchLower,
+    showHidden,
+  };
+  const searchQuery = useQuery({
+    enabled: searchLower !== "",
+    queryKey: ["assistantsWorkspaceTreeSearch", searchOpts],
+    queryFn: () => searchWorkspaceTree(queryClient, searchOpts),
+    staleTime: 30_000,
+  });
+  // Null until the walk finishes — the tree renders unfiltered in the interim.
+  const searchResult = searchLower !== "" ? (searchQuery.data ?? null) : null;
+
   const rootEntries = useMemo(
     () => sortEntries(data?.entries ?? [], sortMode),
     [data?.entries, sortMode],
@@ -613,7 +735,12 @@ export function WorkspaceTree({
       const newPath = parentPath
         ? `${parentPath}/${input.newName}`
         : input.newName;
-      await assertNameAvailable(assistantId, parentPath, input.newName, oldName);
+      await assertNameAvailable(
+        assistantId,
+        parentPath,
+        input.newName,
+        oldName,
+      );
       const { error, response } = await workspaceRenamePost({
         path: { assistant_id: assistantId },
         body: { oldPath: input.oldPath, newPath },
@@ -786,25 +913,43 @@ export function WorkspaceTree({
           >
             No files found
           </p>
+        ) : searchResult && searchResult.visiblePaths.size === 0 ? (
+          <p
+            className="px-3 py-4 text-center text-body-medium-lighter"
+            style={{ color: "var(--content-tertiary)" }}
+          >
+            No matching files
+          </p>
         ) : (
-          rootEntries.map((entry) => (
-            <TreeNode
-              key={entry.path}
-              entry={entry}
-              assistantId={assistantId}
-              expandedPaths={expandedPaths}
-              selectedPath={selectedPath}
-              showHidden={showHidden}
-              sortMode={sortMode}
-              searchLower={searchLower}
-              onToggleExpand={onToggleExpand}
-              onSelectPath={onSelectPath}
-              onRequestDelete={handleRequestDelete}
-              onRequestRename={handleRequestRename}
-              onRequestCreate={handleRequestCreate}
-              depth={0}
-            />
-          ))
+          <>
+            {rootEntries.map((entry) => (
+              <TreeNode
+                key={entry.path}
+                entry={entry}
+                assistantId={assistantId}
+                expandedPaths={expandedPaths}
+                selectedPath={selectedPath}
+                showHidden={showHidden}
+                sortMode={sortMode}
+                searchResult={searchResult}
+                ancestorMatched={false}
+                onToggleExpand={onToggleExpand}
+                onSelectPath={onSelectPath}
+                onRequestDelete={handleRequestDelete}
+                onRequestRename={handleRequestRename}
+                onRequestCreate={handleRequestCreate}
+                depth={0}
+              />
+            ))}
+            {searchResult?.truncated && (
+              <p
+                className="px-3 py-2 text-center text-label-medium-default"
+                style={{ color: "var(--content-tertiary)" }}
+              >
+                Workspace too large to search fully — some folders were skipped.
+              </p>
+            )}
+          </>
         )}
       </div>
 

--- a/clients/web/src/domains/workspace/components/workspace-tree.tsx
+++ b/clients/web/src/domains/workspace/components/workspace-tree.tsx
@@ -105,6 +105,9 @@ function workspaceTreeRetrieveOptions(opts: {
 
 const SEARCH_MAX_DEPTH = 10;
 const SEARCH_MAX_DIRS = 2000;
+// The daemon lists directories with synchronous filesystem reads, so an
+// unbounded fan-out would stall it (and starve the rest of the Files view).
+export const SEARCH_MAX_CONCURRENT_LISTS = 8;
 
 export interface WorkspaceSearchResult {
   /** Entries to render while searching: matches plus their ancestor directories. */
@@ -136,6 +139,27 @@ export async function searchWorkspaceTree(
   let dirsListed = 0;
   let truncated = false;
 
+  // Counting semaphore over the daemon requests. A slot is held only for the
+  // duration of one directory listing — never across the recursion into
+  // children — so the walk cannot deadlock on its own permits.
+  let activeLists = 0;
+  const waiters: (() => void)[] = [];
+  const acquireListSlot = () => {
+    if (activeLists < SEARCH_MAX_CONCURRENT_LISTS) {
+      activeLists++;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => waiters.push(resolve));
+  };
+  const releaseListSlot = () => {
+    const next = waiters.shift();
+    if (next) {
+      next();
+    } else {
+      activeLists--;
+    }
+  };
+
   async function walk(dirPath: string, depth: number): Promise<boolean> {
     if (depth > SEARCH_MAX_DEPTH || dirsListed >= SEARCH_MAX_DIRS) {
       truncated = true;
@@ -144,6 +168,7 @@ export async function searchWorkspaceTree(
     dirsListed++;
 
     let entries: WorkspaceTreeEntry[];
+    await acquireListSlot();
     try {
       const data = await queryClient.fetchQuery({
         ...workspaceTreeRetrieveOptions({
@@ -160,6 +185,8 @@ export async function searchWorkspaceTree(
     } catch {
       // An unreadable directory shouldn't sink the whole search.
       return false;
+    } finally {
+      releaseListSlot();
     }
 
     let subtreeHasMatch = false;

--- a/clients/web/src/domains/workspace/components/workspace-tree.tsx
+++ b/clients/web/src/domains/workspace/components/workspace-tree.tsx
@@ -672,6 +672,7 @@ export function WorkspaceTree({
   const invalidateWorkspace = useCallback(() => {
     for (const key of [
       "assistantsWorkspaceTreeRetrieve",
+      "assistantsWorkspaceTreeSearch",
       "assistantsWorkspaceFileRetrieve",
       "assistantsWorkspaceFileContentRetrieve",
     ]) {


### PR DESCRIPTION
## Summary
- Workspace **Files** search kept every directory visible and force-expanded while typing — only files were name-filtered — so a matching folder (e.g. `AgentWatch`) was buried inside the fully expanded tree and effectively unfindable.
- Search now runs a bounded recursive walk of the workspace tree (`searchWorkspaceTree`, sharing the TanStack Query cache with the tree's per-directory queries) and renders only matching entries plus their ancestor folders. Ancestors are force-expanded to reveal matches; a matched directory stays collapsed but its contents remain browsable when expanded.
- Adds a "No matching files" empty state, a notice when a very large workspace hits the walk's depth/directory bounds, and unit tests for the walker (ancestor expansion, stop-at-matched-dir, deep file matches).

## Original prompt
Workspace folder search in the web frontend isn't finding a folder named `AgentWatch`: typing "agentwatch" into the Files view search box on the assistant Workspace tab showed the entire folder tree (archive, bin, cache, conversations, …) instead of the matching folder. The ask was to fix search so a nested folder whose name matches the query is actually surfaced.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37843" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->