### PR TITLE
web: surface interactive backups panel inline in doctor sessions

### DIFF
--- a/clients/web/src/domains/settings/components/panels/doctor-panel.tsx
+++ b/clients/web/src/domains/settings/components/panels/doctor-panel.tsx
@@ -389,20 +389,35 @@ export function DoctorPanel() {
   // listings are stale once the doctor (or the user) creates or restores one.
   // Persisted history replays of past sessions never get it: a transcript
   // from days ago is no place for live Create/Restore buttons.
-  const latestBackupsListEntryId = useMemo(() => {
+  //
+  // refreshKey remounts the panel (forcing a refetch) when the doctor
+  // completes a backup mutation AFTER the listing — the mounted panel only
+  // fetches on mount and after its own actions, so without this it would
+  // show a stale backup set.
+  const backupsPanel = useMemo(() => {
     const viewingLiveSession = sessionId !== null || storeEntries.length > 0;
     if (!viewingLiveSession) {
       return null;
     }
+    let refreshKey: string | null = null;
     for (let i = entries.length - 1; i >= 0; i--) {
       const candidate = entries[i];
       if (
-        candidate.kind === "tool_call" &&
-        candidate.meta.toolName === "list_assistant_backups" &&
-        candidate.meta.status === "completed" &&
-        !candidate.meta.isError
+        candidate.kind !== "tool_call" ||
+        candidate.meta.status !== "completed" ||
+        candidate.meta.isError
       ) {
-        return candidate.id;
+        continue;
+      }
+      if (candidate.meta.toolName === "list_assistant_backups") {
+        return { entryId: candidate.id, refreshKey: refreshKey ?? candidate.id };
+      }
+      if (
+        refreshKey === null &&
+        (candidate.meta.toolName === "create_doctor_backup" ||
+          candidate.meta.toolName === "restore_assistant_backup")
+      ) {
+        refreshKey = candidate.id;
       }
     }
     return null;
@@ -581,9 +596,12 @@ export function DoctorPanel() {
                       <div key={entry.id} className="flex justify-start">
                         <div className="w-full">
                           <ToolCallBlock entry={entry} />
-                          {entry.id === latestBackupsListEntryId && assistantId && (
+                          {entry.id === backupsPanel?.entryId && assistantId && (
                             <div className="mt-2 rounded-lg border border-[var(--border-base)] bg-[var(--surface-lift)] p-4">
-                              <AssistantBackups assistantId={assistantId} />
+                              <AssistantBackups
+                                key={backupsPanel.refreshKey}
+                                assistantId={assistantId}
+                              />
                             </div>
                           )}
                         </div>

--- a/clients/web/src/domains/settings/components/panels/doctor-panel.tsx
+++ b/clients/web/src/domains/settings/components/panels/doctor-panel.tsx
@@ -387,7 +387,13 @@ export function DoctorPanel() {
   // panel (list + restore) inline so the user can act without leaving the
   // session. Only the most recent completed listing gets the panel — earlier
   // listings are stale once the doctor (or the user) creates or restores one.
+  // Persisted history replays of past sessions never get it: a transcript
+  // from days ago is no place for live Create/Restore buttons.
   const latestBackupsListEntryId = useMemo(() => {
+    const viewingLiveSession = sessionId !== null || storeEntries.length > 0;
+    if (!viewingLiveSession) {
+      return null;
+    }
     for (let i = entries.length - 1; i >= 0; i--) {
       const candidate = entries[i];
       if (
@@ -400,7 +406,7 @@ export function DoctorPanel() {
       }
     }
     return null;
-  }, [entries]);
+  }, [entries, sessionId, storeEntries]);
 
   // Scroll coordinator — auto-follows streaming growth only while the
   // user is pinned to the latest message. Scrolling away (drag on

--- a/clients/web/src/domains/settings/components/panels/doctor-panel.tsx
+++ b/clients/web/src/domains/settings/components/panels/doctor-panel.tsx
@@ -7,6 +7,7 @@ import { Tag } from "@vellumai/design-library/components/tag";
 
 import { ShareFeedbackModal } from "@/components/share-feedback-modal";
 import type { FeedbackReason } from "@/components/share-feedback-types";
+import { AssistantBackups } from "@/domains/settings/components/assistant-backups";
 import {
   ApprovalBlock,
   AssistantMessage,
@@ -382,6 +383,25 @@ export function DoctorPanel() {
     [entries],
   );
 
+  // When the doctor lists platform backups, surface the interactive backups
+  // panel (list + restore) inline so the user can act without leaving the
+  // session. Only the most recent completed listing gets the panel — earlier
+  // listings are stale once the doctor (or the user) creates or restores one.
+  const latestBackupsListEntryId = useMemo(() => {
+    for (let i = entries.length - 1; i >= 0; i--) {
+      const candidate = entries[i];
+      if (
+        candidate.kind === "tool_call" &&
+        candidate.meta.toolName === "list_assistant_backups" &&
+        candidate.meta.status === "completed" &&
+        !candidate.meta.isError
+      ) {
+        return candidate.id;
+      }
+    }
+    return null;
+  }, [entries]);
+
   // Scroll coordinator — auto-follows streaming growth only while the
   // user is pinned to the latest message. Scrolling away (drag on
   // mobile, wheel on desktop) un-pins and surfaces a "Go to Newest"
@@ -555,6 +575,11 @@ export function DoctorPanel() {
                       <div key={entry.id} className="flex justify-start">
                         <div className="w-full">
                           <ToolCallBlock entry={entry} />
+                          {entry.id === latestBackupsListEntryId && assistantId && (
+                            <div className="mt-2 rounded-lg border border-[var(--border-base)] bg-[var(--surface-lift)] p-4">
+                              <AssistantBackups assistantId={assistantId} />
+                            </div>
+                          )}
                         </div>
                       </div>
                     );

--- a/clients/web/src/domains/settings/components/panels/use-doctor-auto-scroll.ts
+++ b/clients/web/src/domains/settings/components/panels/use-doctor-auto-scroll.ts
@@ -133,6 +133,31 @@ export function useDoctorAutoScroll(
     classify();
   }, [entries, classify]);
 
+  // Transcript content can also grow WITHOUT an entries change — e.g. the
+  // inline backups panel loading asynchronously, or a tool block expanding.
+  // Observe the content element's size so pinned users keep following and
+  // un-pinned users get the "Go to Newest" affordance, matching the chat
+  // transcript's content-ResizeObserver re-pins.
+  useEffect(() => {
+    if (!scrollEl || typeof ResizeObserver === "undefined") {
+      return;
+    }
+    const content = scrollEl.firstElementChild;
+    if (!content) {
+      return;
+    }
+    const observer = new ResizeObserver(() => {
+      if (isPinnedRef.current) {
+        scrollEl.scrollTo({ top: scrollEl.scrollHeight, behavior: "auto" });
+      }
+      classify();
+    });
+    observer.observe(content);
+    return () => {
+      observer.disconnect();
+    };
+  }, [scrollEl, classify]);
+
   const scrollToLatest = useCallback(() => {
     if (!scrollEl) {
       return;


### PR DESCRIPTION
## Summary
- When a Doctor session runs `list_assistant_backups` (new tool from vellum-assistant-platform#8896), the doctor panel now renders the existing `AssistantBackups` component (full list + create + restore-with-confirm-dialog) inline under that tool call, so users can see and restore platform backups from within the doctor session instead of reading raw tool output.
- Only the most recent completed listing shows the panel — earlier listings are stale once the doctor or the user creates/restores a backup. The panel reuses `AssistantBackups` unchanged (it is self-contained and already platform-aware), wrapped in the same card styling as the other doctor chat blocks.
- No event-schema or API changes: the new doctor tools already flow through the generic `tool_call`/`approval_required` rendering, and the backups list on the debug page's General tab is untouched.

## Original prompt
Follow-up to the platform-side Doctor backup tools (vellum-assistant-platform#8896): the UI affordances need to exist in this repo's web frontend too, as a second PR — users in a doctor session should get the backups list and restore UI in this client, not just the platform admin app's debug panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->