### PR TITLE
fix(image-recovery): recover conversations poisoned by non-image bytes stored as images

### DIFF
--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -396,6 +396,22 @@ describe("classifyConversationError", () => {
       expect(result.userMessage.toLowerCase()).toContain("image");
     });
 
+    it("classifies Anthropic 400 'does not match the provided media type' as image_unprocessable", () => {
+      // Bytes whose format disagrees with the declared media_type (e.g. an HTML
+      // page stored as image/png). Must route to the image-recovery
+      // classification, staying in lockstep with what the recovery hook acts on.
+      const err = new ProviderError(
+        'Anthropic API error (400): 400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.0.content.1.image.source.base64: image does not match the provided media type image/png"}}',
+        "anthropic",
+        400,
+      );
+      const result = classifyConversationError(err, baseCtx);
+      expect(result.code).toBe("IMAGE_TOO_LARGE");
+      expect(result.errorCategory).toBe("image_unprocessable");
+      expect(result.retryable).toBe(false);
+      expect(result.userMessage).not.toContain("invalid_request_error");
+    });
+
     it("does not steal generic 400s that happen to mention 'image'", () => {
       const err = new ProviderError(
         "invalid request: image source is missing",

--- a/assistant/src/__tests__/image-recovery-hook.test.ts
+++ b/assistant/src/__tests__/image-recovery-hook.test.ts
@@ -241,6 +241,57 @@ describe("image-recovery post-model-call hook — direct", () => {
     });
   });
 
+  test("'Could not process image' on non-image bytes (HTML) → replaces with note, continues, one-shot", async () => {
+    // GIVEN a provider rejection for an image block whose bytes are actually an
+    // HTML page (a Slack auth interstitial stored as image/png), the field
+    // incident shape — Anthropic returns 400 "Could not process image".
+    const htmlAsImageData = Buffer.from(
+      "<!DOCTYPE html><html><body>Sign in to continue</body></html>",
+    ).toString("base64");
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "read this thread" },
+          imageBlock(htmlAsImageData),
+        ],
+      },
+    ];
+    const ctx = makePostModelCallCtx({
+      conversationId: "conv-html",
+      messages,
+      error: new Error(
+        'Anthropic API error (400): 400 {"type":"error","error":{"type":"invalid_request_error","message":"Could not process image"},"request_id":"req_011CcsLvPnYo5Xnvhs5edSS2"}',
+      ),
+    });
+
+    // WHEN the hook runs.
+    await postModelCall(ctx);
+
+    // THEN it retries with the HTML payload gone, replaced by a text note, and
+    // marks the one-shot bound.
+    expect(ctx.decision).toBe("continue");
+    expect(isImageRecoveryAttempted(ctx.conversationId)).toBe(true);
+    expect(JSON.stringify(ctx.messages)).not.toContain(htmlAsImageData);
+    expect(ctx.messages[0].content.some((b) => b.type === "image")).toBe(false);
+    expect(ctx.messages[0].content).toContainEqual({
+      type: "text",
+      text: "read this thread",
+    });
+
+    // AND a second consecutive rejection this turn is left to surface — the
+    // recovery is one-shot per turn (the bound is already marked).
+    const secondCtx = makePostModelCallCtx({
+      conversationId: "conv-html",
+      messages,
+      error: new Error(
+        'Anthropic API error (400): 400 {"type":"error","error":{"type":"invalid_request_error","message":"Could not process image"}}',
+      ),
+    });
+    await postModelCall(secondCtx);
+    expect(secondCtx.decision).toBe("stop");
+  });
+
   test("durably persists the downgrade so the image cannot resurface", async () => {
     // GIVEN a conversation whose stored history holds an oversized image.
     const conv = createConversation();

--- a/assistant/src/__tests__/persist-unsendable-image-downscale.test.ts
+++ b/assistant/src/__tests__/persist-unsendable-image-downscale.test.ts
@@ -3,7 +3,7 @@
  * recovery (JARVIS-1041 review follow-up).
  *
  * When an oversized stored image *can* be shrunk on this host (the common macOS
- * path where `sips` is available), `persistUnsendableImageDowngrades` must write
+ * path where `sips` is available), `persistImageDowngrades` must write
  * the downscaled bytes back to the DB — not leave the original in place. The
  * latest tool-result media is intentionally kept in context, so leaving the
  * full-size block would rehydrate and re-reject on every later turn instead of
@@ -42,7 +42,10 @@ import {
 } from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
-import { persistUnsendableImageDowngrades } from "../plugins/defaults/image-recovery/recover.js";
+import {
+  persistImageDowngrades,
+  unsendableImageReplacement,
+} from "../plugins/defaults/image-recovery/recover.js";
 import { base64Source } from "../providers/media-resolve.js";
 import type { ContentBlock } from "../providers/types.js";
 
@@ -115,7 +118,7 @@ function storedContent(conversationId: string): ContentBlock[][] {
   return getMessages(conversationId).map((row) => row.content);
 }
 
-describe("persistUnsendableImageDowngrades (downscalable host)", () => {
+describe("persistImageDowngrades (downscalable host)", () => {
   beforeEach(() => {
     resetTables();
   });
@@ -133,7 +136,10 @@ describe("persistUnsendableImageDowngrades (downscalable host)", () => {
     );
 
     // WHEN the downgrade is persisted
-    const rewritten = persistUnsendableImageDowngrades(conv.id);
+    const rewritten = persistImageDowngrades(
+      conv.id,
+      unsendableImageReplacement,
+    );
 
     // THEN the nested block stays an image, rewritten to the downscaled payload
     expect(rewritten).toBe(1);
@@ -159,10 +165,13 @@ describe("persistUnsendableImageDowngrades (downscalable host)", () => {
       JSON.stringify([toolResultWithImage(oversizedPngBase64())]),
       { skipIndexing: true },
     );
-    expect(persistUnsendableImageDowngrades(conv.id)).toBe(1);
+    expect(persistImageDowngrades(conv.id, unsendableImageReplacement)).toBe(1);
 
     // WHEN the downgrade runs again
-    const secondRun = persistUnsendableImageDowngrades(conv.id);
+    const secondRun = persistImageDowngrades(
+      conv.id,
+      unsendableImageReplacement,
+    );
 
     // THEN nothing further is rewritten
     expect(secondRun).toBe(0);

--- a/assistant/src/__tests__/persist-unsendable-image.test.ts
+++ b/assistant/src/__tests__/persist-unsendable-image.test.ts
@@ -5,7 +5,7 @@
  * per-image byte cap, and not shrinkable on this host — must be durably swapped
  * for a text note in its stored message. If it stays in the stored content,
  * every later turn rehydrates it from the DB and the model reports seeing both
- * the rejected image and any smaller re-upload. `persistUnsendableImageDowngrades`
+ * the rejected image and any smaller re-upload. `persistImageDowngrades`
  * makes the swap durable so the rejected upload cannot resurface.
  *
  * Uses the real SQLite DB wired up via `test-preload.ts` (per-file temp
@@ -22,10 +22,14 @@ import {
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import {
-  persistUnsendableImageDowngrades,
+  INVALID_IMAGE_NOTE,
+  invalidImageReplacement,
+  persistImageDowngrades,
+  recoverImages,
+  unprocessableImageReplacement,
   unsendableImageReplacement,
 } from "../plugins/defaults/image-recovery/recover.js";
-import type { ContentBlock } from "../providers/types.js";
+import type { ContentBlock, Message } from "../providers/types.js";
 
 await initializeDb();
 
@@ -110,7 +114,7 @@ function storedContent(conversationId: string): ContentBlock[][] {
 
 const PROVIDER_MAX_IMAGE_DIMENSION = 8000;
 
-describe("persistUnsendableImageDowngrades", () => {
+describe("persistImageDowngrades", () => {
   beforeEach(() => {
     resetTables();
   });
@@ -131,7 +135,10 @@ describe("persistUnsendableImageDowngrades", () => {
     );
 
     // WHEN the downgrade is persisted
-    const rewritten = persistUnsendableImageDowngrades(conv.id);
+    const rewritten = persistImageDowngrades(
+      conv.id,
+      unsendableImageReplacement,
+    );
 
     // THEN one message is rewritten with no image block left
     expect(rewritten).toBe(1);
@@ -161,7 +168,10 @@ describe("persistUnsendableImageDowngrades", () => {
     );
 
     // WHEN the downgrade is persisted
-    const rewritten = persistUnsendableImageDowngrades(conv.id);
+    const rewritten = persistImageDowngrades(
+      conv.id,
+      unsendableImageReplacement,
+    );
 
     // THEN only the rejected original is removed
     expect(rewritten).toBe(1);
@@ -183,7 +193,10 @@ describe("persistUnsendableImageDowngrades", () => {
     );
 
     // WHEN the downgrade is persisted
-    const rewritten = persistUnsendableImageDowngrades(conv.id);
+    const rewritten = persistImageDowngrades(
+      conv.id,
+      unsendableImageReplacement,
+    );
 
     // THEN nothing is rewritten and the image remains
     expect(rewritten).toBe(0);
@@ -201,7 +214,10 @@ describe("persistUnsendableImageDowngrades", () => {
     });
 
     // WHEN the downgrade is persisted
-    const rewritten = persistUnsendableImageDowngrades(conv.id);
+    const rewritten = persistImageDowngrades(
+      conv.id,
+      unsendableImageReplacement,
+    );
 
     // THEN the oversized-payload image is removed
     expect(rewritten).toBe(1);
@@ -223,7 +239,10 @@ describe("persistUnsendableImageDowngrades", () => {
     );
 
     // WHEN the downgrade is persisted
-    const rewritten = persistUnsendableImageDowngrades(conv.id);
+    const rewritten = persistImageDowngrades(
+      conv.id,
+      unsendableImageReplacement,
+    );
 
     // THEN the undersized image is removed (upscale is a no-op on this host)
     expect(rewritten).toBe(1);
@@ -247,7 +266,10 @@ describe("persistUnsendableImageDowngrades", () => {
     );
 
     // WHEN the downgrade is persisted
-    const rewritten = persistUnsendableImageDowngrades(conv.id);
+    const rewritten = persistImageDowngrades(
+      conv.id,
+      unsendableImageReplacement,
+    );
 
     // THEN the message is rewritten with the nested image swapped for a note
     expect(rewritten).toBe(1);
@@ -273,7 +295,10 @@ describe("persistUnsendableImageDowngrades", () => {
     );
 
     // WHEN the downgrade is persisted
-    const rewritten = persistUnsendableImageDowngrades(conv.id);
+    const rewritten = persistImageDowngrades(
+      conv.id,
+      unsendableImageReplacement,
+    );
 
     // THEN nothing is rewritten and the nested image remains
     expect(rewritten).toBe(0);
@@ -296,10 +321,13 @@ describe("persistUnsendableImageDowngrades", () => {
       JSON.stringify([imageBlock(makePngBase64(10000, 10000))]),
       { skipIndexing: true },
     );
-    expect(persistUnsendableImageDowngrades(conv.id)).toBe(1);
+    expect(persistImageDowngrades(conv.id, unsendableImageReplacement)).toBe(1);
 
     // WHEN the downgrade runs a second time
-    const secondRun = persistUnsendableImageDowngrades(conv.id);
+    const secondRun = persistImageDowngrades(
+      conv.id,
+      unsendableImageReplacement,
+    );
 
     // THEN nothing further is rewritten
     expect(secondRun).toBe(0);
@@ -339,5 +367,120 @@ describe("unsendableImageReplacement", () => {
     >;
     const replacement = unsendableImageReplacement(undersized);
     expect(replacement?.type).toBe("text");
+  });
+});
+
+/** Base64 payload for a page of HTML (a Slack auth interstitial), the exact
+ *  shape that was stored under an image media type in the field incident. */
+const HTML_AS_IMAGE_DATA = Buffer.from(
+  "<!DOCTYPE html><html><head><title>Sign in</title></head><body>Redirecting…</body></html>",
+).toString("base64");
+
+/** Base64 payload whose magic bytes are a JPEG (SOI + APP0 marker). */
+const JPEG_BYTES_DATA = Buffer.from(
+  Uint8Array.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46]),
+).toString("base64");
+
+function asImage(data: string): Extract<ContentBlock, { type: "image" }> {
+  return imageBlock(data) as Extract<ContentBlock, { type: "image" }>;
+}
+
+describe("invalidImageReplacement", () => {
+  /** Non-image bytes (HTML) stored under image/png can never decode — no
+   *  relabeling helps, so the block collapses to the invalid-image note. */
+  test("replaces non-image bytes (HTML) with the invalid-image note", () => {
+    const replacement = invalidImageReplacement(asImage(HTML_AS_IMAGE_DATA));
+    expect(replacement).toEqual({ type: "text", text: INVALID_IMAGE_NOTE });
+  });
+
+  /** A real image whose declared media type already agrees is left untouched
+   *  so the caller can fall through to the size rule. */
+  test("returns null for a valid PNG whose media type already agrees", () => {
+    expect(invalidImageReplacement(asImage(makePngBase64(64, 64)))).toBeNull();
+  });
+
+  /** JPEG bytes mislabeled image/png have their media type corrected in place,
+   *  keeping the same payload. */
+  test("corrects the media type when the bytes disagree with the label", () => {
+    const replacement = invalidImageReplacement(asImage(JPEG_BYTES_DATA));
+    expect(replacement).toEqual({
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: "image/jpeg",
+        data: JPEG_BYTES_DATA,
+      },
+    });
+  });
+});
+
+describe("unprocessable-image recovery (invalid bytes)", () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  /** HTML-as-image/png is swapped for the note both in the working history and
+   *  in the stored row, so it cannot rehydrate and re-reject on later turns. */
+  test("replaces HTML-as-image with the note in-memory and durably", async () => {
+    // GIVEN a stored turn whose image block is actually an HTML page.
+    const conv = createConversation();
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([
+        { type: "text", text: "what is this?" },
+        imageBlock(HTML_AS_IMAGE_DATA),
+      ]),
+      { skipIndexing: true },
+    );
+
+    // WHEN the working history is recovered in-memory
+    const history: Message[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "what is this?" },
+          imageBlock(HTML_AS_IMAGE_DATA),
+        ],
+      },
+    ];
+    const recovered = recoverImages(history, unprocessableImageReplacement);
+
+    // THEN the HTML payload is gone, replaced with the invalid-image note
+    expect(JSON.stringify(recovered)).not.toContain(HTML_AS_IMAGE_DATA);
+    expect(recovered[0].content).toContainEqual({
+      type: "text",
+      text: INVALID_IMAGE_NOTE,
+    });
+
+    // AND the durable rewrite removes it from the stored row too
+    const rewritten = persistImageDowngrades(
+      conv.id,
+      unprocessableImageReplacement,
+    );
+    expect(rewritten).toBe(1);
+    const [content] = storedContent(conv.id);
+    expect(content.some((b) => b.type === "image")).toBe(false);
+    expect(content).toContainEqual({ type: "text", text: INVALID_IMAGE_NOTE });
+  });
+
+  /** A valid PNG is never disturbed by the unprocessable rule. */
+  test("leaves a valid PNG untouched", async () => {
+    const conv = createConversation();
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([imageBlock(makePngBase64(1024, 768))]),
+      { skipIndexing: true },
+    );
+
+    const rewritten = persistImageDowngrades(
+      conv.id,
+      unprocessableImageReplacement,
+    );
+
+    expect(rewritten).toBe(0);
+    const [content] = storedContent(conv.id);
+    expect(content.some((b) => b.type === "image")).toBe(true);
   });
 });

--- a/assistant/src/__tests__/persist-unsendable-image.test.ts
+++ b/assistant/src/__tests__/persist-unsendable-image.test.ts
@@ -27,6 +27,7 @@ import {
   persistImageDowngrades,
   recoverImages,
   unprocessableImageReplacement,
+  UNSENDABLE_IMAGE_NOTE,
   unsendableImageReplacement,
 } from "../plugins/defaults/image-recovery/recover.js";
 import type { ContentBlock, Message } from "../providers/types.js";
@@ -411,6 +412,23 @@ describe("invalidImageReplacement", () => {
         data: JPEG_BYTES_DATA,
       },
     });
+  });
+
+  /** A mislabeled image that also violates a size cap must not survive as a
+   *  relabeled-but-oversized image: recovery is one-shot per turn, so the size
+   *  rule runs on the corrected image in the same pass (here the fake PNG
+   *  cannot be resized, so it collapses to the unsendable note). */
+  test("applies the size rule to a media-type-corrected image in the same pass", () => {
+    const block: Extract<ContentBlock, { type: "image" }> = {
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: "image/jpeg",
+        data: makePngBase64(PROVIDER_MAX_IMAGE_DIMENSION + 1000, 4000),
+      },
+    };
+    const replacement = unprocessableImageReplacement(block);
+    expect(replacement).toEqual({ type: "text", text: UNSENDABLE_IMAGE_NOTE });
   });
 });
 

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -456,7 +456,7 @@ function classifyCore(
         return {
           code: "IMAGE_TOO_LARGE",
           userMessage:
-            "An image in this conversation could not be processed by the AI provider — it may be below the provider's minimum image size. It was automatically adjusted where possible; send your message again to continue.",
+            "An image in this conversation could not be processed by the AI provider — it may be corrupted or below the provider's minimum image size. It was automatically adjusted where possible; send your message again to continue.",
           retryable: false,
           errorCategory: "image_unprocessable",
         };

--- a/assistant/src/plugins/defaults/image-recovery/detect.ts
+++ b/assistant/src/plugins/defaults/image-recovery/detect.ts
@@ -5,10 +5,12 @@
  * violates a hard limit. The too-large patterns match the per-side pixel cap
  * ("image dimensions exceed max allowed size") and the base64 payload cap
  * ("image exceeds 5 MB maximum: 7465044 bytes > 5242880 bytes"). The
- * unprocessable pattern matches "Could not process image", which Anthropic
- * returns for images below its (undocumented) minimum size and for payloads
- * it cannot decode. Distinct classification matters because retrying with the
- * same image is futile — the recovery path must resize or note it instead.
+ * unprocessable patterns match "Could not process image" (images below the
+ * provider's undocumented minimum size, and payloads the provider cannot
+ * decode) and "image does not match the provided media type" (bytes whose
+ * format disagrees with the declared `media_type`, e.g. an HTML page stored as
+ * image/png). Distinct classification matters because retrying with the same
+ * image is futile — the recovery path must resize, relabel, or note it instead.
  *
  * Exported as the single source of truth: the image-recovery hook reads these
  * to recognize the rejections it can recover, and `daemon/conversation-error`
@@ -23,6 +25,7 @@ export const IMAGE_DIMENSIONS_TOO_LARGE_PATTERNS: readonly RegExp[] = [
 
 export const IMAGE_UNPROCESSABLE_PATTERNS: readonly RegExp[] = [
   /could not process image/i,
+  /image does not match the provided media type/i,
 ];
 
 /** Whether an error message indicates an image-input dimension/payload failure. */
@@ -31,8 +34,9 @@ export function isImageDimensionsTooLargeError(message: string): boolean {
 }
 
 /**
- * Whether an error message indicates the provider could not process an image
- * at all — an image below the minimum size floor, or undecodable bytes.
+ * Whether an error message indicates the provider could not process an image at
+ * all — an image below the minimum size floor, undecodable bytes, or bytes
+ * whose format does not match the declared media type.
  */
 export function isImageUnprocessableError(message: string): boolean {
   return IMAGE_UNPROCESSABLE_PATTERNS.some((p) => p.test(message));

--- a/assistant/src/plugins/defaults/image-recovery/hooks/post-model-call.ts
+++ b/assistant/src/plugins/defaults/image-recovery/hooks/post-model-call.ts
@@ -4,14 +4,16 @@
  *
  * A provider rejects the call when an attached image violates a hard limit —
  * its longest side exceeds the per-side pixel cap, its base64 payload exceeds
- * the size cap, or it falls below the minimum size floor ("Could not process
- * image"). That rejection is a model-call outcome — the loop runs the
- * `post-model-call` chain with the rejection attached. This hook recognizes
- * the image-rejection class, resizes the unsendable image blocks in the
- * working history via {@link recoverUnsendableImages}, and asks the loop to
- * retry the call. It also persists the same rewrite durably via {@link
- * persistUnsendableImageDowngrades} so the rejected image cannot rehydrate from
- * the stored row and re-reject on every later turn.
+ * the size cap, it falls below the minimum size floor, or its bytes cannot be
+ * decoded ("Could not process image" / "image does not match the provided
+ * media type"). That rejection is a model-call outcome — the loop runs the
+ * `post-model-call` chain with the rejection attached. This hook recognizes the
+ * image-rejection class, selects the matching replacement rule (size vs.
+ * unprocessable), rewrites the offending image blocks in the working history
+ * via {@link recoverImages}, and asks the loop to retry the call. It also
+ * persists the same rewrite durably via {@link persistImageDowngrades} so the
+ * rejected image cannot rehydrate from the stored row and re-reject on every
+ * later turn.
  *
  * Bounded to one pass per turn via the per-conversation recovery state: a
  * second consecutive image rejection means the resize could not bring the
@@ -28,14 +30,19 @@
 
 import type { HookFunction, PostModelCallContext } from "@vellumai/plugin-api";
 
-import { isRecoverableImageError } from "../detect.js";
+import {
+  isImageUnprocessableError,
+  isRecoverableImageError,
+} from "../detect.js";
 import {
   isImageRecoveryAttempted,
   markImageRecoveryAttempted,
 } from "../image-recovery-state-store.js";
 import {
-  persistUnsendableImageDowngrades,
-  recoverUnsendableImages,
+  persistImageDowngrades,
+  recoverImages,
+  unprocessableImageReplacement,
+  unsendableImageReplacement,
 } from "../recover.js";
 
 const postModelCall: HookFunction<PostModelCallContext> = async (ctx) => {
@@ -45,13 +52,16 @@ const postModelCall: HookFunction<PostModelCallContext> = async (ctx) => {
     !isImageRecoveryAttempted(ctx.conversationId)
   ) {
     markImageRecoveryAttempted(ctx.conversationId);
-    ctx.messages = recoverUnsendableImages(ctx.messages);
+    const rule = isImageUnprocessableError(ctx.error.message)
+      ? unprocessableImageReplacement
+      : unsendableImageReplacement;
+    ctx.messages = recoverImages(ctx.messages, rule);
     // Make the downgrade durable so the rejected image can't rehydrate from the
     // stored row and re-reject on later turns. This is cleanup for future
     // turns, so a persistence failure must never abort the retry that is about
     // to run — log it and continue with the in-memory recovery.
     try {
-      const rewritten = persistUnsendableImageDowngrades(ctx.conversationId);
+      const rewritten = persistImageDowngrades(ctx.conversationId, rule);
       if (rewritten > 0) {
         ctx.logger.info(
           { plugin: "image-recovery", rewritten },

--- a/assistant/src/plugins/defaults/image-recovery/hooks/stop.ts
+++ b/assistant/src/plugins/defaults/image-recovery/hooks/stop.ts
@@ -3,7 +3,7 @@
  * turn terminates.
  *
  * The `post-model-call` hook (see `./post-model-call.ts`) marks the bound when
- * it downscales an oversized image and asks the loop to retry. `stop` is the
+ * it rewrites a rejected image and asks the loop to retry. `stop` is the
  * definitive terminal hook — it fires exactly once when the turn is truly
  * ending, after every retry decision has been made — so clearing the bound here
  * unconditionally guarantees the next turn always recovers afresh, no matter how

--- a/assistant/src/plugins/defaults/image-recovery/recover.ts
+++ b/assistant/src/plugins/defaults/image-recovery/recover.ts
@@ -2,16 +2,25 @@
  * Image-rejection recovery transforms for the image-recovery plugin.
  *
  * When the provider rejects a turn because an attached image violates its
- * limits — too large on a side, over the payload cap, or below the minimum
- * size floor — the `post-model-call` hook rewrites the offending image blocks
- * in the working history and asks the loop to retry. {@link
- * recoverUnsendableImages} performs that in-memory transform for the immediate
- * retry; {@link persistUnsendableImageDowngrades} makes the same rewrite
- * durable, because the stored message row otherwise keeps the rejected image
- * block and it rehydrates on every later turn and keeps re-entering the
- * model's context. The durable rewrite replaces the unsendable block with its
- * resized form, or with a text note when it cannot be resized on this host,
- * so a rejected image cannot resurface and re-reject on every later turn.
+ * limits, the `post-model-call` hook rewrites the offending image blocks in the
+ * working history and asks the loop to retry. Two rejection classes each have
+ * their own replacement rule:
+ *
+ * - Size rejections ({@link unsendableImageReplacement}) — too large on a side,
+ *   over the payload cap, or below the minimum-size floor — are resized, or
+ *   noted when this host cannot resize.
+ * - Unprocessable rejections ({@link unprocessableImageReplacement}) — bytes
+ *   the provider cannot decode or whose format disagrees with the declared
+ *   media type — have their media type corrected when the bytes are a real
+ *   image, are noted when the bytes are not an image at all (e.g. an HTML page
+ *   stored as image/png), and otherwise fall through to the size rule.
+ *
+ * {@link recoverImages} applies a rule in-memory for the immediate retry;
+ * {@link persistImageDowngrades} applies the same rule durably, because the
+ * stored message row otherwise keeps the rejected image block and it rehydrates
+ * on every later turn and keeps re-rejecting. The durable rewrite is what heals
+ * an already-poisoned conversation — a rejected image cannot resurface and
+ * re-reject once its stored row is downgraded.
  */
 
 import {
@@ -44,13 +53,114 @@ const PROVIDER_MAX_IMAGE_DIMENSION = 8000;
 // https://docs.anthropic.com/en/docs/build-with-claude/vision#image-size
 const PROVIDER_MAX_IMAGE_PAYLOAD_BYTES = 5 * 1024 * 1024;
 
+/** An inline or referenced image content block. */
+type ImageBlock = Extract<ContentBlock, { type: "image" }>;
+
 /**
- * Note left in place of an image that cannot be sent to the provider. Shared
+ * A per-image replacement rule: given a rejected image block, return the block
+ * to substitute (a rewritten image or a text note) or `null` to leave it
+ * untouched. Shared by the in-memory recovery transform and the durable persist
+ * pass so both apply an identical rewrite.
+ */
+export type ImageReplacementRule = (block: ImageBlock) => ContentBlock | null;
+
+/**
+ * Note left in place of an image that cannot be sent to the provider because it
+ * exceeds the provider's size limits and this host cannot resize it. Shared
  * with the in-memory recovery path so the persisted history matches what the
  * model saw on the turn the image was rejected.
  */
 export const UNSENDABLE_IMAGE_NOTE =
   "(An image was attached but could not be sent — it does not meet the provider's image size limits and automatic resizing was not available. Please resize the image and try again.)";
+
+/**
+ * Note left in place of an attachment whose bytes are not a valid image (e.g.
+ * an HTML page stored under an image media type), so it cannot rehydrate and
+ * re-reject on later turns.
+ */
+export const INVALID_IMAGE_NOTE =
+  "(An image was attached but its data was not a valid image and could not be sent — it may have been corrupted when it was received. Please re-send the image.)";
+
+/**
+ * Detect the true image format of a base64 payload from its magic bytes, or
+ * `null` when it matches none of the formats the provider accepts. Only the
+ * first ~24 base64 chars (18 bytes) are decoded — enough for every signature,
+ * including WebP's `RIFF....WEBP` at offset 8 — so a large payload is never
+ * fully decoded just to sniff its head.
+ */
+function sniffImageMediaType(base64Data: string): string | null {
+  const head = Buffer.from(base64Data.slice(0, 24), "base64");
+  if (
+    head.length >= 4 &&
+    head[0] === 0x89 &&
+    head[1] === 0x50 &&
+    head[2] === 0x4e &&
+    head[3] === 0x47
+  ) {
+    return "image/png";
+  }
+  if (
+    head.length >= 3 &&
+    head[0] === 0xff &&
+    head[1] === 0xd8 &&
+    head[2] === 0xff
+  ) {
+    return "image/jpeg";
+  }
+  if (
+    head.length >= 4 &&
+    head[0] === 0x47 &&
+    head[1] === 0x49 &&
+    head[2] === 0x46 &&
+    head[3] === 0x38
+  ) {
+    return "image/gif";
+  }
+  if (
+    head.length >= 12 &&
+    head.toString("ascii", 0, 4) === "RIFF" &&
+    head.toString("ascii", 8, 12) === "WEBP"
+  ) {
+    return "image/webp";
+  }
+  return null;
+}
+
+/**
+ * Replacement for an image the provider rejected as unprocessable. Sniffs the
+ * decoded bytes for a real image format:
+ *
+ * - Bytes match no known image format (e.g. an HTML interstitial saved as
+ *   image/png): replaced with {@link INVALID_IMAGE_NOTE} — no relabeling can
+ *   make non-image bytes decode.
+ * - Bytes match a format that disagrees with the declared `media_type` (e.g.
+ *   JPEG bytes labeled image/png): the same image with its `media_type`
+ *   corrected to the detected type.
+ * - Bytes match and the declared type already agrees: `null` (untouched) so the
+ *   caller can fall through to the size rule.
+ *
+ * Returns `null` when the source cannot be resolved, leaving the block
+ * untouched.
+ */
+export function invalidImageReplacement(
+  block: ImageBlock,
+): ContentBlock | null {
+  const resolved = resolveMediaSourceData(block.source);
+  if (!resolved) {
+    return null;
+  }
+  const detected = sniffImageMediaType(resolved.data);
+  if (!detected) {
+    return { type: "text", text: INVALID_IMAGE_NOTE };
+  }
+  if (detected === resolved.media_type) {
+    return null;
+  }
+  return {
+    type: "image",
+    source: { type: "base64", media_type: detected, data: resolved.data },
+  };
+}
 
 /**
  * Replacement for an image that violates a provider hard limit (per-side pixel
@@ -64,14 +174,12 @@ export const UNSENDABLE_IMAGE_NOTE =
  * one that cannot be resized on this host (resize is a no-op, e.g. `sips` is
  * absent off macOS or the format is unsupported) is replaced with a text note.
  *
- * Shared by the in-memory recovery transform and the durable persist pass so
- * both apply the identical rule. Persisting the resized form is what lets a
- * poisoned conversation durably self-heal — the latest tool-result media is kept
- * in context, so without it the original rejected block rehydrates and
- * re-rejects on every later turn.
+ * Persisting the resized form is what lets a poisoned conversation durably
+ * self-heal — the latest tool-result media is kept in context, so without it the
+ * original rejected block rehydrates and re-rejects on every later turn.
  */
 export function unsendableImageReplacement(
-  block: Extract<ContentBlock, { type: "image" }>,
+  block: ImageBlock,
 ): ContentBlock | null {
   // Resolve reference sources to their bytes so a reloaded (referenced) image
   // is gated on the same payload/dimension caps as an inline one. When the
@@ -112,81 +220,15 @@ export function unsendableImageReplacement(
 }
 
 /**
- * Rewrite every stored message in a conversation that holds an image the
- * provider rejects — whether a top-level block or one nested in a
- * tool_result's contentBlocks — replacing it with its resized form, or with
- * {@link UNSENDABLE_IMAGE_NOTE} when it cannot be resized on this host. Reads
- * stored content directly (not the in-memory, injection-enriched copy) so
- * injected prefixes and hydrated source paths are never written back.
- *
- * Idempotent: a resized image is within limits and a note is no longer an
- * image, so neither matches on a second run. Returns the number of rewritten
- * messages.
+ * Replacement rule for the "unprocessable image" rejection class. Sniffs the
+ * bytes first ({@link invalidImageReplacement}) so corrupt/non-image data
+ * becomes a note and a mislabeled media type is corrected; when the bytes are a
+ * valid image whose media type already agrees, falls back to the size rule
+ * ({@link unsendableImageReplacement}) so an image below the provider's
+ * minimum-size floor is still upscaled.
  */
-export function persistUnsendableImageDowngrades(
-  conversationId: string,
-): number {
-  let rewritten = 0;
-  for (const row of getMessages(conversationId)) {
-    const hasImageBlock = row.content.some(
-      (b) =>
-        b.type === "image" ||
-        (b.type === "tool_result" &&
-          b.contentBlocks?.some((cb) => cb.type === "image")),
-    );
-    if (!hasImageBlock) {
-      continue;
-    }
-
-    const parsed = row.content;
-
-    let changed = false;
-    const next = (parsed as ContentBlock[]).map((block): ContentBlock => {
-      if (block.type === "image") {
-        const replacement = unsendableImageReplacement(block);
-        if (!replacement) {
-          return block;
-        }
-        changed = true;
-        return replacement;
-      }
-      // Images returned by a tool (e.g. browser_screenshot) live inside the
-      // tool_result's contentBlocks, not as top-level blocks. Downgrade them
-      // in place so the tool_use/tool_result pairing stays intact.
-      if (block.type === "tool_result" && block.contentBlocks?.length) {
-        let nestedChanged = false;
-        const contentBlocks = block.contentBlocks.map((cb): ContentBlock => {
-          if (cb.type !== "image") {
-            return cb;
-          }
-          const replacement = unsendableImageReplacement(cb);
-          if (!replacement) {
-            return cb;
-          }
-          nestedChanged = true;
-          return replacement;
-        });
-        if (!nestedChanged) {
-          return block;
-        }
-        changed = true;
-        return { ...block, contentBlocks };
-      }
-      return block;
-    });
-    if (!changed) {
-      continue;
-    }
-
-    updateMessageContent(row.id, JSON.stringify(next));
-    rewritten++;
-    log.info(
-      { conversationId, messageId: row.id },
-      "Persisted unsendable-image downgrade so it cannot resurface on later turns",
-    );
-  }
-  return rewritten;
-}
+export const unprocessableImageReplacement: ImageReplacementRule = (block) =>
+  invalidImageReplacement(block) ?? unsendableImageReplacement(block);
 
 /**
  * True when a message's content holds an image the provider may have rejected
@@ -203,16 +245,51 @@ function messageHasImageBlock(content: ReadonlyArray<ContentBlock>): boolean {
 }
 
 /**
- * Resize every unsendable image in the working history for an immediate
- * retry, leaving still-sendable images untouched. Recovers both top-level image
- * blocks (user uploads) and images nested inside a tool_result's contentBlocks
- * (e.g. a browser screenshot) in place, so the tool_use/tool_result pairing
- * stays intact rather than dropping the whole tool_result. Applies the same
- * provider-cap gate as {@link persistUnsendableImageDowngrades} so the in-memory
- * retry and the durable rewrite agree on which images are unsendable.
+ * Apply an {@link ImageReplacementRule} to a single content block, recovering
+ * both a top-level image block and images nested inside a tool_result's
+ * contentBlocks in place — the latter so the tool_use/tool_result pairing stays
+ * intact rather than dropping the whole tool_result. Returns the (possibly
+ * rewritten) block and whether it changed.
  */
-export function recoverUnsendableImages(
+function applyRuleToBlock(
+  block: ContentBlock,
+  rule: ImageReplacementRule,
+): { block: ContentBlock; changed: boolean } {
+  if (block.type === "image") {
+    const replacement = rule(block);
+    if (!replacement) {
+      return { block, changed: false };
+    }
+    return { block: replacement, changed: true };
+  }
+  if (block.type === "tool_result" && block.contentBlocks?.length) {
+    let nestedChanged = false;
+    const contentBlocks = block.contentBlocks.map((cb): ContentBlock => {
+      if (cb.type !== "image") {
+        return cb;
+      }
+      const replacement = rule(cb);
+      if (!replacement) {
+        return cb;
+      }
+      nestedChanged = true;
+      return replacement;
+    });
+    if (!nestedChanged) {
+      return { block, changed: false };
+    }
+    return { block: { ...block, contentBlocks }, changed: true };
+  }
+  return { block, changed: false };
+}
+
+/**
+ * Apply `rule` to every image in the working history for an immediate retry,
+ * leaving blocks the rule declines (returns null for) untouched.
+ */
+export function recoverImages(
   messages: ReadonlyArray<Message>,
+  rule: ImageReplacementRule,
 ): Message[] {
   return messages.map((msg) => {
     if (!Array.isArray(msg.content)) {
@@ -223,24 +300,51 @@ export function recoverUnsendableImages(
     }
     return {
       ...msg,
-      content: msg.content.flatMap((b): ContentBlock[] => {
-        if (b.type === "image") {
-          return [unsendableImageReplacement(b) ?? b];
-        }
-        if (b.type === "tool_result" && b.contentBlocks?.length) {
-          return [
-            {
-              ...b,
-              contentBlocks: b.contentBlocks.map((cb) =>
-                cb.type === "image"
-                  ? (unsendableImageReplacement(cb) ?? cb)
-                  : cb,
-              ),
-            },
-          ];
-        }
-        return [b];
-      }),
+      content: msg.content.map((b) => applyRuleToBlock(b, rule).block),
     };
   });
+}
+
+/**
+ * Apply `rule` durably to every stored message in a conversation that holds a
+ * rejected image — whether a top-level block or one nested in a tool_result's
+ * contentBlocks — so the rejected block cannot rehydrate from the DB row and
+ * re-reject on a later turn. Reads stored content directly (not the in-memory,
+ * injection-enriched copy) so injected prefixes and hydrated source paths are
+ * never written back.
+ *
+ * Idempotent: a rewritten image no longer trips the rule and a note is no
+ * longer an image, so neither matches on a second run. Returns the number of
+ * rewritten messages.
+ */
+export function persistImageDowngrades(
+  conversationId: string,
+  rule: ImageReplacementRule,
+): number {
+  let rewritten = 0;
+  for (const row of getMessages(conversationId)) {
+    if (!messageHasImageBlock(row.content)) {
+      continue;
+    }
+
+    let changed = false;
+    const next = (row.content as ContentBlock[]).map((block): ContentBlock => {
+      const result = applyRuleToBlock(block, rule);
+      if (result.changed) {
+        changed = true;
+      }
+      return result.block;
+    });
+    if (!changed) {
+      continue;
+    }
+
+    updateMessageContent(row.id, JSON.stringify(next));
+    rewritten++;
+    log.info(
+      { conversationId, messageId: row.id },
+      "Persisted image-rejection downgrade so it cannot resurface on later turns",
+    );
+  }
+  return rewritten;
 }

--- a/assistant/src/plugins/defaults/image-recovery/recover.ts
+++ b/assistant/src/plugins/defaults/image-recovery/recover.ts
@@ -222,13 +222,22 @@ export function unsendableImageReplacement(
 /**
  * Replacement rule for the "unprocessable image" rejection class. Sniffs the
  * bytes first ({@link invalidImageReplacement}) so corrupt/non-image data
- * becomes a note and a mislabeled media type is corrected; when the bytes are a
- * valid image whose media type already agrees, falls back to the size rule
- * ({@link unsendableImageReplacement}) so an image below the provider's
- * minimum-size floor is still upscaled.
+ * becomes a note and a mislabeled media type is corrected; the size rule
+ * ({@link unsendableImageReplacement}) then runs on the surviving image —
+ * whether untouched or relabeled — so an image below the provider's
+ * minimum-size floor is still upscaled and a relabeled image that also
+ * violates a size cap is resized in the same pass (recovery is one-shot per
+ * turn, so a size violation left behind here would surface instead of
+ * recovering).
  */
-export const unprocessableImageReplacement: ImageReplacementRule = (block) =>
-  invalidImageReplacement(block) ?? unsendableImageReplacement(block);
+export const unprocessableImageReplacement: ImageReplacementRule = (block) => {
+  const relabeled = invalidImageReplacement(block);
+  if (relabeled != null && relabeled.type !== "image") {
+    return relabeled;
+  }
+  const survivor = relabeled ?? block;
+  return unsendableImageReplacement(survivor) ?? relabeled;
+};
 
 /**
  * True when a message's content holds an image the provider may have rejected


### PR DESCRIPTION
## Problem

A Slack thread-backfill stored two HTML interstitial pages (Slack auth pages returned with HTTP 200) as `image/png` conversation attachments. Every subsequent turn sent those blocks to Anthropic, which rejected the request with 400 `invalid_request_error: "Could not process image"`. No recovery rule rewrote the poisoned blocks, so the conversation hard-failed on every turn indefinitely — upgrading didn't help because the corruption is persisted in message history. (Field incident: feedback bundle `019f4def-8757-738e-aa48-9ae155149009`.)

The image-recovery plugin already classified "Could not process image" as the unprocessable class, but its only replacement rule was size-based (resize/upscale), which leaves non-image bytes untouched — recovery ran once, changed nothing, and the rejection resurfaced every turn.

## Fix

- `invalidImageReplacement`: sniff the decoded byte head (first 18 bytes) for the formats Anthropic accepts (PNG/JPEG/GIF/WebP). Non-image bytes → replaced with a text note; valid image mislabeled (e.g. JPEG bytes declared `image/png`) → `media_type` corrected; valid + correctly labeled → fall through to the existing size rule (preserves the below-min-floor upscale).
- The in-memory and durable walkers are generalized into a single rule-parameterized pass (`recoverImages` / `persistImageDowngrades`). The durable rewrite is what heals already-poisoned conversations in the field: on the first turn after upgrade, the stored rows are downgraded so the corrupt block can never rehydrate and re-reject.
- `detect.ts` adds Anthropic's second corruption phrasing (`image does not match the provided media type`) to `IMAGE_UNPROCESSABLE_PATTERNS`; daemon classification stays in lockstep.

## Tests

- HTML-as-`image/png` block → post-model-call sets `continue`, replaces with note in-memory and durably; one-shot per turn.
- Valid PNG untouched; JPEG-bytes-as-png relabeled; below-min-floor upscale preserved.
- `bun test` on the four touched test files: 180 pass, 0 fail. `bun run typecheck:fast` clean.

Root-cause companion (validating Slack backfill downloads so HTML never gets stored as an image) is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37846" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->