### PR TITLE
fix(slack): validate assistant-side backfill downloads against declared MIME

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -120,6 +120,7 @@ COPY --from=builder /app /app
 COPY packages/ces-client /app/packages/ces-client
 COPY packages/service-contracts /app/packages/service-contracts
 COPY packages/credential-storage /app/packages/credential-storage
+COPY packages/download-validation /app/packages/download-validation
 COPY packages/egress-proxy /app/packages/egress-proxy
 COPY packages/environments /app/packages/environments
 COPY packages/gateway-client /app/packages/gateway-client

--- a/assistant/knip.json
+++ b/assistant/knip.json
@@ -14,6 +14,7 @@
     "@microsoft/api-extractor",
     "@vellumai/ces-client",
     "@vellumai/credential-storage",
+    "@vellumai/download-validation",
     "@vellumai/egress-proxy",
     "@vellumai/environments",
     "@vellumai/gateway-client",

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -43,6 +43,7 @@
     "@slack/types": "2.21.1",
     "@vellumai/ces-client": "workspace:*",
     "@vellumai/credential-storage": "workspace:*",
+    "@vellumai/download-validation": "workspace:*",
     "@vellumai/egress-proxy": "workspace:*",
     "@vellumai/environments": "workspace:*",
     "@vellumai/gateway-client": "workspace:*",
@@ -85,6 +86,7 @@
   "bundledDependencies": [
     "@vellumai/ces-client",
     "@vellumai/credential-storage",
+    "@vellumai/download-validation",
     "@vellumai/service-contracts",
     "@vellumai/egress-proxy",
     "@vellumai/environments",

--- a/assistant/src/messaging/providers/slack/__tests__/download.test.ts
+++ b/assistant/src/messaging/providers/slack/__tests__/download.test.ts
@@ -13,7 +13,18 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import { ContentMismatchError } from "@vellumai/download-validation";
+
 import { downloadSlackFile } from "../download.js";
+
+/** Minimal valid PNG buffer that file-type can detect as `image/png`. */
+function makePngBuffer(): Uint8Array {
+  return new Uint8Array([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+    0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+    0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde,
+  ]);
+}
 
 interface CapturedFetchCall {
   url: string;
@@ -220,5 +231,51 @@ describe("downloadSlackFile", () => {
       "xoxb-test",
     );
     expect(result?.mimeType).toBe("image/webp");
+  });
+
+  test("throws ContentMismatchError when an HTML page is returned as image/png", async () => {
+    responses.push(
+      new Response(
+        new TextEncoder().encode(
+          "<!DOCTYPE html><html><body>Sign in to continue</body></html>",
+        ).buffer as ArrayBuffer,
+        {
+          status: 200,
+          headers: { "Content-Type": "text/html" },
+        },
+      ),
+    );
+    await expect(
+      downloadSlackFile(
+        {
+          id: "F1",
+          name: "screenshot.png",
+          mimetype: "image/png",
+          urlPrivate: "https://files.slack.com/files-pri/T/F1/inline",
+        },
+        "xoxb-test",
+      ),
+    ).rejects.toThrow(ContentMismatchError);
+  });
+
+  test("returns a valid PNG declared as image/png without throwing", async () => {
+    const png = makePngBuffer();
+    responses.push(
+      new Response(png.buffer as ArrayBuffer, {
+        status: 200,
+        headers: { "Content-Type": "image/png" },
+      }),
+    );
+    const result = await downloadSlackFile(
+      {
+        id: "F1",
+        name: "shot.png",
+        mimetype: "image/png",
+        urlPrivate: "https://files.slack.com/files-pri/T/F1/inline",
+      },
+      "xoxb-test",
+    );
+    expect(result?.mimeType).toBe("image/png");
+    expect(result?.data).toBe(Buffer.from(png).toString("base64"));
   });
 });

--- a/assistant/src/messaging/providers/slack/download.ts
+++ b/assistant/src/messaging/providers/slack/download.ts
@@ -13,7 +13,13 @@
  *    where the signed redirect URL is self-authenticating; the WHATWG fetch
  *    spec strips `Authorization` on cross-origin redirects, so we manually
  *    follow the redirect without re-sending the bot token.
+ *
+ * Both implementations also share the same byte-level guard from
+ * `@vellumai/download-validation`: a CDN that returns an HTML auth/error page
+ * with a 200 status can never be surfaced as an image attachment.
  */
+
+import { validateDownloadedContent } from "@vellumai/download-validation";
 
 import { getLogger } from "../../../util/logger.js";
 
@@ -48,10 +54,11 @@ const DOWNLOAD_TIMEOUT_MS = 30_000;
  * (`{ id, name, mimetype }`) and have no way to download. This is treated as
  * an expected branch rather than an error.
  *
- * Throws on transport / HTTP errors so the caller can decide whether to log
- * and skip or fail the surrounding operation. The thread-backfill caller
- * logs and proceeds with the text-only message rather than failing the whole
- * backfill.
+ * Throws on transport / HTTP errors, and `ContentMismatchError` when the
+ * downloaded bytes don't match the declared MIME type (e.g. an HTML auth page
+ * served as an image), so the caller can decide whether to log and skip or
+ * fail the surrounding operation. The thread-backfill caller logs and proceeds
+ * with the text-only message rather than failing the whole backfill.
  */
 export async function downloadSlackFile(
   file: SlackFileDownloadInput,
@@ -94,10 +101,17 @@ export async function downloadSlackFile(
   }
 
   const buffer = await response.arrayBuffer();
+  const bytes = new Uint8Array(buffer);
   const mimeType =
     file.mimetype ||
     response.headers.get("Content-Type")?.split(";")[0]?.trim() ||
     "application/octet-stream";
+
+  // Reject an HTML auth/error page masquerading as a binary before it can be
+  // base64-encoded and stored as an image attachment. ContentMismatchError
+  // propagates for the caller to log-and-skip.
+  await validateDownloadedContent(bytes, mimeType, file.id ?? file.name);
+
   const filename = file.name || `slack_file_${file.id ?? "unknown"}`;
   const data = Buffer.from(buffer).toString("base64");
   return { filename, mimeType, data };

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -5,6 +5,7 @@
  * Invite token/code redemption is intercepted at gateway ingress before
  * messages reach this handler.
  */
+import { ContentMismatchError } from "@vellumai/download-validation";
 import type { SourceMetadata } from "@vellumai/gateway-client";
 import {
   ADMISSION_POLICY_DEFAULT,
@@ -1769,6 +1770,18 @@ async function persistBackfilledSlackMessage(params: {
             data: downloaded.data,
           });
         } catch (err) {
+          if (err instanceof ContentMismatchError) {
+            log.warn(
+              {
+                fileId: file.id,
+                filename: file.name,
+                error: err.message,
+                channelTs: message.id,
+              },
+              "Skipping backfilled Slack image: content did not match declared type",
+            );
+            continue;
+          }
           if (err instanceof AttachmentUploadError) {
             log.warn(
               {

--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "@slack/types": "2.21.1",
         "@vellumai/ces-client": "workspace:*",
         "@vellumai/credential-storage": "workspace:*",
+        "@vellumai/download-validation": "workspace:*",
         "@vellumai/egress-proxy": "workspace:*",
         "@vellumai/environments": "workspace:*",
         "@vellumai/gateway-client": "workspace:*",
@@ -275,6 +276,7 @@
         "@slack/types": "2.21.1",
         "@vellumai/assistant-client": "workspace:*",
         "@vellumai/ces-client": "workspace:*",
+        "@vellumai/download-validation": "workspace:*",
         "@vellumai/gateway-client": "workspace:*",
         "@vellumai/ipc-server-utils": "workspace:*",
         "@vellumai/service-contracts": "workspace:*",
@@ -406,6 +408,17 @@
         "tailwind-merge": ">=3.6.0",
         "tailwindcss": ">=4.0.0",
         "unified": ">=11.0.0",
+      },
+    },
+    "packages/download-validation": {
+      "name": "@vellumai/download-validation",
+      "version": "0.0.1",
+      "dependencies": {
+        "file-type": "21.3.0",
+      },
+      "devDependencies": {
+        "@types/bun": "1.3.10",
+        "typescript": "5.9.3",
       },
     },
     "packages/egress-proxy": {
@@ -1558,6 +1571,8 @@
     "@vellumai/credential-storage": ["@vellumai/credential-storage@workspace:packages/credential-storage"],
 
     "@vellumai/design-library": ["@vellumai/design-library@workspace:packages/design-library"],
+
+    "@vellumai/download-validation": ["@vellumai/download-validation@workspace:packages/download-validation"],
 
     "@vellumai/egress-proxy": ["@vellumai/egress-proxy@workspace:packages/egress-proxy"],
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -51,6 +51,7 @@ COPY --from=builder --chown=gateway:gateway /app /app
 # Copy source after installing dependencies for better layer caching.
 COPY --chown=gateway:gateway packages/assistant-client /app/packages/assistant-client
 COPY --chown=gateway:gateway packages/ces-client /app/packages/ces-client
+COPY --chown=gateway:gateway packages/download-validation /app/packages/download-validation
 COPY --chown=gateway:gateway packages/gateway-client /app/packages/gateway-client
 COPY --chown=gateway:gateway packages/ipc-server-utils /app/packages/ipc-server-utils
 COPY --chown=gateway:gateway packages/service-contracts /app/packages/service-contracts

--- a/gateway/knip.json
+++ b/gateway/knip.json
@@ -5,6 +5,7 @@
     "@slack/types",
     "@vellumai/assistant-client",
     "@vellumai/ces-client",
+    "@vellumai/download-validation",
     "@vellumai/gateway-client",
     "@vellumai/ipc-server-utils",
     "@vellumai/service-contracts",

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -28,6 +28,7 @@
     "@slack/types": "2.21.1",
     "@vellumai/assistant-client": "workspace:*",
     "@vellumai/ces-client": "workspace:*",
+    "@vellumai/download-validation": "workspace:*",
     "@vellumai/gateway-client": "workspace:*",
     "@vellumai/ipc-server-utils": "workspace:*",
     "@vellumai/service-contracts": "workspace:*",
@@ -46,6 +47,7 @@
   "bundledDependencies": [
     "@vellumai/assistant-client",
     "@vellumai/ces-client",
+    "@vellumai/download-validation",
     "@vellumai/gateway-client",
     "@vellumai/ipc-server-utils",
     "@vellumai/service-contracts",

--- a/gateway/src/download-validation.test.ts
+++ b/gateway/src/download-validation.test.ts
@@ -2,95 +2,36 @@ import { describe, expect, test } from "bun:test";
 import {
   ContentMismatchError,
   validateDownloadedContent,
-} from "./download-validation.js";
+} from "@vellumai/download-validation";
 
-/** Create a minimal valid PNG buffer that file-type can detect. */
+/**
+ * CI-coverage smoke test for the shared download validation consumed by the
+ * gateway inbound path. The exhaustive behavior matrix lives in the package
+ * itself (`packages/download-validation`); this pins the load-bearing contract
+ * the gateway relies on so gateway CI fails if the guard regresses.
+ */
+
+/** Minimal valid PNG buffer that file-type can detect. */
 function makePngBuffer(): Uint8Array {
   return new Uint8Array([
-    // PNG signature
-    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
-    // IHDR chunk: length (13)
-    0x00, 0x00, 0x00, 0x0d,
-    // IHDR type
-    0x49, 0x48, 0x44, 0x52,
-    // Width: 1
-    0x00, 0x00, 0x00, 0x01,
-    // Height: 1
-    0x00, 0x00, 0x00, 0x01,
-    // Bit depth, color type, compression, filter, interlace
-    0x08, 0x02, 0x00, 0x00, 0x00,
-    // CRC (placeholder)
-    0x90, 0x77, 0x53, 0xde,
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+    0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+    0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde,
   ]);
 }
 
-function htmlBuffer(html: string): Uint8Array {
-  return new TextEncoder().encode(html);
-}
-
-describe("validateDownloadedContent", () => {
+describe("validateDownloadedContent (gateway consumption)", () => {
   test("throws ContentMismatchError when HTML is received instead of image/png", async () => {
-    const buffer = htmlBuffer(
+    const buffer = new TextEncoder().encode(
       "<!DOCTYPE html><html><body><h1>Access Denied</h1></body></html>",
     );
 
     await expect(
       validateDownloadedContent(buffer, "image/png", "F001"),
     ).rejects.toThrow(ContentMismatchError);
-
-    await expect(
-      validateDownloadedContent(buffer, "image/png", "F001"),
-    ).rejects.toThrow(
-      "File F001 declared as image/png but content is HTML (likely an auth/error page)",
-    );
   });
 
-  test("throws ContentMismatchError for HTML with leading whitespace and BOM", async () => {
-    // UTF-8 BOM (EF BB BF) + whitespace + HTML
-    const bom = new Uint8Array([0xef, 0xbb, 0xbf]);
-    const html = new TextEncoder().encode(
-      "  \n  <!DOCTYPE html><html><body>Error</body></html>",
-    );
-    const buffer = new Uint8Array(bom.length + html.length);
-    buffer.set(bom, 0);
-    buffer.set(html, bom.length);
-
-    await expect(
-      validateDownloadedContent(buffer, "image/jpeg", "F002"),
-    ).rejects.toThrow(ContentMismatchError);
-  });
-
-  test("passes for valid PNG buffer with declared image/png", async () => {
-    const buffer = makePngBuffer();
-
-    // Should not throw
-    await validateDownloadedContent(buffer, "image/png", "F003");
-  });
-
-  test("passes for valid PNG buffer with declared image/jpeg (same image family)", async () => {
-    const buffer = makePngBuffer();
-
-    // file-type detects it as image/png, which still starts with "image/"
-    // so it should pass even though declared as image/jpeg
-    await validateDownloadedContent(buffer, "image/jpeg", "F004");
-  });
-
-  test("passes for plain text buffer with declared text/plain (non-binary)", async () => {
-    const buffer = new TextEncoder().encode("hello world");
-
-    // text/plain is not a binary MIME type, so no validation is performed
-    await validateDownloadedContent(
-      new Uint8Array(buffer),
-      "text/plain",
-      "F005",
-    );
-  });
-
-  test("passes for empty buffer with declared image/png", async () => {
-    const buffer = new Uint8Array(0);
-
-    // Empty buffer: looksLikeHtml returns false, fileTypeFromBuffer returns
-    // undefined, so we allow it through and let downstream handle it
-    await validateDownloadedContent(buffer, "image/png", "F006");
+  test("passes for a valid PNG buffer declared as image/png", async () => {
+    await validateDownloadedContent(makePngBuffer(), "image/png", "F002");
   });
 });

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -6,7 +6,7 @@ import { credentialKey } from "../../credential-key.js";
 import { verifySecretWithRefresh } from "../../credential-refresh.js";
 import { recordDenialReplyIfAllowed } from "../../db/denial-reply-rate-limiter.js";
 import { DedupCache } from "../../dedup-cache.js";
-import { ContentMismatchError } from "../../download-validation.js";
+import { ContentMismatchError } from "@vellumai/download-validation";
 import { handleInbound } from "../../handlers/handle-inbound.js";
 import { getLogger } from "../../logger.js";
 import { readLimitedBody } from "../read-limited-body.js";

--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -21,7 +21,7 @@ import {
   AttachmentValidationError,
   uploadAttachment,
 } from "../../runtime/client.js";
-import { ContentMismatchError } from "../../download-validation.js";
+import { ContentMismatchError } from "@vellumai/download-validation";
 import {
   handleCircuitBreakerError,
   handleNewCommand,

--- a/gateway/src/slack/download.test.ts
+++ b/gateway/src/slack/download.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { ContentMismatchError } from "../download-validation.js";
+import { ContentMismatchError } from "@vellumai/download-validation";
 import type { SlackFile } from "./normalize.js";
 
 type FetchFn = (
@@ -142,9 +142,7 @@ describe("downloadSlackFile", () => {
   });
 
   test("throws when redirect has no Location header", async () => {
-    fetchMock = mock(
-      async () => new Response(null, { status: 302 }),
-    );
+    fetchMock = mock(async () => new Response(null, { status: 302 }));
 
     const file = makeSlackFile();
 

--- a/gateway/src/slack/download.ts
+++ b/gateway/src/slack/download.ts
@@ -1,5 +1,5 @@
 import { fileTypeFromBuffer } from "file-type";
-import { validateDownloadedContent } from "../download-validation.js";
+import { validateDownloadedContent } from "@vellumai/download-validation";
 import { fetchImpl } from "../fetch.js";
 import type { SlackFile } from "./normalize.js";
 

--- a/gateway/src/telegram/download.ts
+++ b/gateway/src/telegram/download.ts
@@ -2,7 +2,7 @@ import { fileTypeFromBuffer } from "file-type";
 import type { ConfigFileCache } from "../config-file-cache.js";
 import type { CredentialCache } from "../credential-cache.js";
 import { credentialKey } from "../credential-key.js";
-import { validateDownloadedContent } from "../download-validation.js";
+import { validateDownloadedContent } from "@vellumai/download-validation";
 import { fetchImpl } from "../fetch.js";
 import { callTelegramApi } from "./api.js";
 

--- a/gateway/src/whatsapp/download.ts
+++ b/gateway/src/whatsapp/download.ts
@@ -1,6 +1,6 @@
 import { fileTypeFromBuffer } from "file-type";
 import type { GatewayConfig } from "../config.js";
-import { validateDownloadedContent } from "../download-validation.js";
+import { validateDownloadedContent } from "@vellumai/download-validation";
 import {
   getWhatsAppMediaMetadata,
   downloadWhatsAppMediaBytes,

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "packages/ces-client",
     "packages/credential-storage",
     "packages/design-library",
+    "packages/download-validation",
     "packages/egress-proxy",
     "packages/environments",
     "packages/gateway-client",

--- a/packages/download-validation/package.json
+++ b/packages/download-validation/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@vellumai/download-validation",
+  "version": "0.0.1",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "bunx tsc --noEmit",
+    "test": "bun test src/"
+  },
+  "dependencies": {
+    "file-type": "21.3.0"
+  },
+  "devDependencies": {
+    "@types/bun": "1.3.10",
+    "typescript": "5.9.3"
+  }
+}

--- a/packages/download-validation/src/__tests__/download-validation.test.ts
+++ b/packages/download-validation/src/__tests__/download-validation.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { ContentMismatchError, validateDownloadedContent } from "../index.js";
+
+/** Create a minimal valid PNG buffer that file-type can detect. */
+function makePngBuffer(): Uint8Array {
+  return new Uint8Array([
+    // PNG signature
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    // IHDR chunk: length (13)
+    0x00, 0x00, 0x00, 0x0d,
+    // IHDR type
+    0x49, 0x48, 0x44, 0x52,
+    // Width: 1
+    0x00, 0x00, 0x00, 0x01,
+    // Height: 1
+    0x00, 0x00, 0x00, 0x01,
+    // Bit depth, color type, compression, filter, interlace
+    0x08, 0x02, 0x00, 0x00, 0x00,
+    // CRC (placeholder)
+    0x90, 0x77, 0x53, 0xde,
+  ]);
+}
+
+function htmlBuffer(html: string): Uint8Array {
+  return new TextEncoder().encode(html);
+}
+
+describe("validateDownloadedContent", () => {
+  test("throws ContentMismatchError when HTML is received instead of image/png", async () => {
+    const buffer = htmlBuffer(
+      "<!DOCTYPE html><html><body><h1>Access Denied</h1></body></html>",
+    );
+
+    await expect(
+      validateDownloadedContent(buffer, "image/png", "F001"),
+    ).rejects.toThrow(ContentMismatchError);
+
+    await expect(
+      validateDownloadedContent(buffer, "image/png", "F001"),
+    ).rejects.toThrow(
+      "File F001 declared as image/png but content is HTML (likely an auth/error page)",
+    );
+  });
+
+  test("throws ContentMismatchError for HTML with leading whitespace and BOM", async () => {
+    // UTF-8 BOM (EF BB BF) + whitespace + HTML
+    const bom = new Uint8Array([0xef, 0xbb, 0xbf]);
+    const html = new TextEncoder().encode(
+      "  \n  <!DOCTYPE html><html><body>Error</body></html>",
+    );
+    const buffer = new Uint8Array(bom.length + html.length);
+    buffer.set(bom, 0);
+    buffer.set(html, bom.length);
+
+    await expect(
+      validateDownloadedContent(buffer, "image/jpeg", "F002"),
+    ).rejects.toThrow(ContentMismatchError);
+  });
+
+  test("passes for valid PNG buffer with declared image/png", async () => {
+    const buffer = makePngBuffer();
+
+    // Should not throw
+    await validateDownloadedContent(buffer, "image/png", "F003");
+  });
+
+  test("passes for valid PNG buffer with declared image/jpeg (same image family)", async () => {
+    const buffer = makePngBuffer();
+
+    // file-type detects it as image/png, which still starts with "image/"
+    // so it should pass even though declared as image/jpeg
+    await validateDownloadedContent(buffer, "image/jpeg", "F004");
+  });
+
+  test("passes for plain text buffer with declared text/plain (non-binary)", async () => {
+    const buffer = new TextEncoder().encode("hello world");
+
+    // text/plain is not a binary MIME type, so no validation is performed
+    await validateDownloadedContent(
+      new Uint8Array(buffer),
+      "text/plain",
+      "F005",
+    );
+  });
+
+  test("passes for empty buffer with declared image/png", async () => {
+    const buffer = new Uint8Array(0);
+
+    // Empty buffer: looksLikeHtml returns false, fileTypeFromBuffer returns
+    // undefined, so we allow it through and let downstream handle it
+    await validateDownloadedContent(buffer, "image/png", "F006");
+  });
+});

--- a/packages/download-validation/src/index.ts
+++ b/packages/download-validation/src/index.ts
@@ -1,3 +1,16 @@
+/**
+ * Shared validation for downloaded channel attachments.
+ *
+ * The gateway's live inbound path and the assistant's thread-backfill path
+ * both download files from channel CDNs (Slack, WhatsApp, Telegram) that may
+ * return an HTML auth/error page with an HTTP 200 status instead of the
+ * requested binary. Base64-encoding that HTML and forwarding it to an LLM
+ * provider as e.g. `image/png` causes the provider to reject the request.
+ *
+ * Both packages import this module so the byte-level guard stays identical
+ * across the two download paths.
+ */
+
 import { fileTypeFromBuffer } from "file-type";
 
 export class ContentMismatchError extends Error {

--- a/packages/download-validation/tsconfig.json
+++ b/packages/download-validation/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Problem

The Slack image corruption fix (HTML auth/interstitial pages stored as `image/png`) only covered the gateway's live inbound path (`gateway/src/download-validation.ts`). The assistant-side **thread-backfill** downloader (`assistant/src/messaging/providers/slack/download.ts`) — used to hydrate images from earlier thread messages when the assistant is mentioned mid-thread — had no content validation, so a Slack CDN returning an HTML page with HTTP 200 was still stored as an image attachment and poisoned the conversation (Anthropic 400 "Could not process image" on every turn). This happened in the field on 2026-07-10 (feedback bundle `019f4def-8757-738e-aa48-9ae155149009`).

## Fix

- Extract the validation (`looksLikeHtml`, `validateDownloadedContent`, `ContentMismatchError`) into a shared workspace package `packages/download-validation` (`file-type` pinned exactly to 21.3.0, matching the gateway; MIT).
- Gateway consumes the package; the local module is deleted and all six importers updated (slack/telegram/whatsapp downloaders + webhook routes). A gateway-side smoke test keeps the contract covered by gateway CI; the exhaustive behavior matrix moves package-local.
- The assistant backfill downloader validates the downloaded bytes before base64-encoding; the hydration loop in `inbound-message-handler.ts` logs-and-skips a `ContentMismatchError` attachment so the message is still processed text-only.

## Tests

- Assistant: HTML body declared `image/png` → throws `ContentMismatchError`; valid PNG passes (10 pass).
- Package matrix: 6 pass. Gateway: 16 pass. `tsc --noEmit` clean in assistant, gateway, and the package.

Recovery companion for already-poisoned conversations: #37846.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->