### PR TITLE
fix(memory): failure-aware backoff for v2 consolidation scheduling

### DIFF
--- a/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-v2-schedule.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-v2-schedule.test.ts
@@ -68,7 +68,10 @@ const { memoryJobs } = await import("../../../../persistence/schema/index.js");
 const { applyNestedDefaults } = await import("../../../../config/loader.js");
 const { getMemoryCheckpoint, setMemoryCheckpoint, deleteMemoryCheckpoint } =
   await import("../../../../persistence/checkpoints.js");
-const { maybeEnqueueGraphMaintenanceJobs } = await import("../jobs-worker.js");
+const { maybeEnqueueGraphMaintenanceJobs, consolidationFailureBackoffMs } =
+  await import("../jobs-worker.js");
+const { CONSOLIDATION_FAILURE_CHECKPOINT_KEY } =
+  await import("../v2/consolidation-job.js");
 const CONSOLIDATE_CHECKPOINT_KEY = "memory_v2_consolidate_last_run";
 
 function buildConfig(overrides: {
@@ -426,6 +429,146 @@ describe("maybeEnqueueGraphMaintenanceJobs — buffer-size trigger", () => {
     maybeEnqueueGraphMaintenanceJobs(config, Date.now());
 
     expect(countPendingJobs("memory_v2_consolidate")).toBe(0);
+  });
+});
+
+describe("maybeEnqueueGraphMaintenanceJobs — consolidation failure backoff", () => {
+  const MINUTE_MS = 60 * 1000;
+  const HOUR_MS = 60 * MINUTE_MS;
+
+  function seedFailureState(
+    consecutiveFailures: number,
+    lastFailureAt: number,
+  ): void {
+    setMemoryCheckpoint(
+      CONSOLIDATION_FAILURE_CHECKPOINT_KEY,
+      JSON.stringify({ consecutiveFailures, lastFailureAt }),
+    );
+  }
+
+  test("interval trigger is skipped inside the backoff window and the checkpoint does not advance", () => {
+    const config = buildConfig({ v2Enabled: true, intervalHours: 1 });
+    const now = Date.now();
+    const staleCheckpoint = String(now - 2 * HOUR_MS);
+    setMemoryCheckpoint(CONSOLIDATE_CHECKPOINT_KEY, staleCheckpoint);
+    writeBuffer(15);
+    // One failure a minute ago → 5min backoff, 4min remaining.
+    seedFailureState(1, now - MINUTE_MS);
+
+    maybeEnqueueGraphMaintenanceJobs(config, now);
+
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(0);
+    expect(getMemoryCheckpoint(CONSOLIDATE_CHECKPOINT_KEY)).toBe(
+      staleCheckpoint,
+    );
+  });
+
+  test("size trigger is skipped inside the backoff window and the checkpoint does not advance", () => {
+    const config = buildConfig({
+      v2Enabled: true,
+      intervalHours: 1,
+      maxBufferLines: 5,
+    });
+    const now = Date.now();
+    const recentCheckpoint = String(now - MINUTE_MS);
+    setMemoryCheckpoint(CONSOLIDATE_CHECKPOINT_KEY, recentCheckpoint);
+    writeBuffer(10);
+    seedFailureState(1, now - MINUTE_MS);
+
+    maybeEnqueueGraphMaintenanceJobs(config, now);
+
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(0);
+    expect(getMemoryCheckpoint(CONSOLIDATE_CHECKPOINT_KEY)).toBe(
+      recentCheckpoint,
+    );
+  });
+
+  test("enqueue resumes on the first tick after the backoff elapses", () => {
+    const config = buildConfig({
+      v2Enabled: true,
+      intervalHours: 1,
+      maxBufferLines: 5,
+    });
+    const now = Date.now();
+    setMemoryCheckpoint(CONSOLIDATE_CHECKPOINT_KEY, String(now - MINUTE_MS));
+    writeBuffer(10);
+    seedFailureState(1, now - MINUTE_MS);
+
+    // Inside the 5min window: skipped.
+    maybeEnqueueGraphMaintenanceJobs(config, now);
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(0);
+
+    // Past the window: the size trigger fires.
+    maybeEnqueueGraphMaintenanceJobs(config, now + 6 * MINUTE_MS);
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(1);
+  });
+
+  test("interval trigger resumes after the backoff elapses without waiting a full interval", () => {
+    const config = buildConfig({ v2Enabled: true, intervalHours: 1 });
+    const now = Date.now();
+    setMemoryCheckpoint(CONSOLIDATE_CHECKPOINT_KEY, String(now - 2 * HOUR_MS));
+    writeBuffer(15);
+    // 5min backoff already elapsed.
+    seedFailureState(1, now - 6 * MINUTE_MS);
+
+    maybeEnqueueGraphMaintenanceJobs(config, now);
+
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(1);
+  });
+
+  test("backoff grows with the failure count", () => {
+    const config = buildConfig({
+      v2Enabled: true,
+      intervalHours: 1,
+      maxBufferLines: 5,
+    });
+    const now = Date.now();
+    setMemoryCheckpoint(CONSOLIDATE_CHECKPOINT_KEY, String(now - MINUTE_MS));
+    writeBuffer(10);
+    // Three failures → 20min backoff; 6min elapsed (past the single-failure
+    // 5min window) must still skip.
+    seedFailureState(3, now - 6 * MINUTE_MS);
+
+    maybeEnqueueGraphMaintenanceJobs(config, now);
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(0);
+
+    // 21min elapsed → the 20min window is over.
+    seedFailureState(3, now - 21 * MINUTE_MS);
+    maybeEnqueueGraphMaintenanceJobs(config, now);
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(1);
+  });
+
+  test("a corrupt failure-state payload does not gate enqueues", () => {
+    const config = buildConfig({ v2Enabled: true, intervalHours: 1 });
+    const now = Date.now();
+    setMemoryCheckpoint(CONSOLIDATE_CHECKPOINT_KEY, String(now - 2 * HOUR_MS));
+    writeBuffer(15);
+    setMemoryCheckpoint(CONSOLIDATION_FAILURE_CHECKPOINT_KEY, "not-json");
+
+    maybeEnqueueGraphMaintenanceJobs(config, now);
+
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(1);
+  });
+});
+
+describe("consolidationFailureBackoffMs", () => {
+  const MINUTE_MS = 60 * 1000;
+  const HOUR_MS = 60 * MINUTE_MS;
+
+  test("doubles from a 5-minute base per consecutive failure", () => {
+    expect(consolidationFailureBackoffMs(1, HOUR_MS)).toBe(5 * MINUTE_MS);
+    expect(consolidationFailureBackoffMs(2, HOUR_MS)).toBe(10 * MINUTE_MS);
+    expect(consolidationFailureBackoffMs(3, HOUR_MS)).toBe(20 * MINUTE_MS);
+    expect(consolidationFailureBackoffMs(5, HOUR_MS)).toBe(80 * MINUTE_MS);
+  });
+
+  test("caps at 6 hours for a shorter configured interval", () => {
+    expect(consolidationFailureBackoffMs(10, HOUR_MS)).toBe(6 * HOUR_MS);
+    expect(consolidationFailureBackoffMs(1000, HOUR_MS)).toBe(6 * HOUR_MS);
+  });
+
+  test("cap rises to the configured interval when it exceeds 6 hours", () => {
+    expect(consolidationFailureBackoffMs(10, 12 * HOUR_MS)).toBe(12 * HOUR_MS);
   });
 });
 

--- a/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-v2-schedule.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-v2-schedule.test.ts
@@ -439,10 +439,11 @@ describe("maybeEnqueueGraphMaintenanceJobs — consolidation failure backoff", (
   function seedFailureState(
     consecutiveFailures: number,
     lastFailureAt: number,
+    kind: "billing" | "transient" = "transient",
   ): void {
     setMemoryCheckpoint(
       CONSOLIDATION_FAILURE_CHECKPOINT_KEY,
-      JSON.stringify({ consecutiveFailures, lastFailureAt }),
+      JSON.stringify({ consecutiveFailures, lastFailureAt, kind }),
     );
   }
 
@@ -516,7 +517,7 @@ describe("maybeEnqueueGraphMaintenanceJobs — consolidation failure backoff", (
     expect(countPendingJobs("memory_v2_consolidate")).toBe(1);
   });
 
-  test("backoff grows with the failure count", () => {
+  test("transient backoff grows with the failure count", () => {
     const config = buildConfig({
       v2Enabled: true,
       intervalHours: 1,
@@ -525,8 +526,8 @@ describe("maybeEnqueueGraphMaintenanceJobs — consolidation failure backoff", (
     const now = Date.now();
     setMemoryCheckpoint(CONSOLIDATE_CHECKPOINT_KEY, String(now - MINUTE_MS));
     writeBuffer(10);
-    // Three failures → 20min backoff; 6min elapsed (past the single-failure
-    // 5min window) must still skip.
+    // Three transient failures → 20min backoff; 6min elapsed (past the
+    // single-failure 5min window) must still skip.
     seedFailureState(3, now - 6 * MINUTE_MS);
 
     maybeEnqueueGraphMaintenanceJobs(config, now);
@@ -534,6 +535,46 @@ describe("maybeEnqueueGraphMaintenanceJobs — consolidation failure backoff", (
 
     // 21min elapsed → the 20min window is over.
     seedFailureState(3, now - 21 * MINUTE_MS);
+    maybeEnqueueGraphMaintenanceJobs(config, now);
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(1);
+  });
+
+  test("transient backoff never delays more than 30 minutes", () => {
+    const config = buildConfig({
+      v2Enabled: true,
+      intervalHours: 1,
+      maxBufferLines: 5,
+    });
+    const now = Date.now();
+    setMemoryCheckpoint(CONSOLIDATE_CHECKPOINT_KEY, String(now - MINUTE_MS));
+    writeBuffer(10);
+    // Ten transient failures — uncapped doubling would be days, the 30min
+    // cap keeps 31min elapsed enough to resume.
+    seedFailureState(10, now - 31 * MINUTE_MS);
+
+    maybeEnqueueGraphMaintenanceJobs(config, now);
+
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(1);
+  });
+
+  test("a single billing failure already waits the 1-hour base", () => {
+    const config = buildConfig({
+      v2Enabled: true,
+      intervalHours: 1,
+      maxBufferLines: 5,
+    });
+    const now = Date.now();
+    setMemoryCheckpoint(CONSOLIDATE_CHECKPOINT_KEY, String(now - MINUTE_MS));
+    writeBuffer(10);
+    // 30min elapsed — a transient failure would have resumed at 5min, but a
+    // billing failure holds for the full hour.
+    seedFailureState(1, now - 30 * MINUTE_MS, "billing");
+
+    maybeEnqueueGraphMaintenanceJobs(config, now);
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(0);
+
+    // 61min elapsed → the 1h window is over.
+    seedFailureState(1, now - 61 * MINUTE_MS, "billing");
     maybeEnqueueGraphMaintenanceJobs(config, now);
     expect(countPendingJobs("memory_v2_consolidate")).toBe(1);
   });
@@ -555,20 +596,50 @@ describe("consolidationFailureBackoffMs", () => {
   const MINUTE_MS = 60 * 1000;
   const HOUR_MS = 60 * MINUTE_MS;
 
-  test("doubles from a 5-minute base per consecutive failure", () => {
-    expect(consolidationFailureBackoffMs(1, HOUR_MS)).toBe(5 * MINUTE_MS);
-    expect(consolidationFailureBackoffMs(2, HOUR_MS)).toBe(10 * MINUTE_MS);
-    expect(consolidationFailureBackoffMs(3, HOUR_MS)).toBe(20 * MINUTE_MS);
-    expect(consolidationFailureBackoffMs(5, HOUR_MS)).toBe(80 * MINUTE_MS);
+  test("transient: doubles from a 5-minute base per consecutive failure", () => {
+    expect(consolidationFailureBackoffMs("transient", 1, HOUR_MS)).toBe(
+      5 * MINUTE_MS,
+    );
+    expect(consolidationFailureBackoffMs("transient", 2, HOUR_MS)).toBe(
+      10 * MINUTE_MS,
+    );
+    expect(consolidationFailureBackoffMs("transient", 3, HOUR_MS)).toBe(
+      20 * MINUTE_MS,
+    );
   });
 
-  test("caps at 6 hours for a shorter configured interval", () => {
-    expect(consolidationFailureBackoffMs(10, HOUR_MS)).toBe(6 * HOUR_MS);
-    expect(consolidationFailureBackoffMs(1000, HOUR_MS)).toBe(6 * HOUR_MS);
+  test("transient: caps at 30 minutes regardless of the configured interval", () => {
+    expect(consolidationFailureBackoffMs("transient", 4, HOUR_MS)).toBe(
+      30 * MINUTE_MS,
+    );
+    expect(consolidationFailureBackoffMs("transient", 1000, 12 * HOUR_MS)).toBe(
+      30 * MINUTE_MS,
+    );
   });
 
-  test("cap rises to the configured interval when it exceeds 6 hours", () => {
-    expect(consolidationFailureBackoffMs(10, 12 * HOUR_MS)).toBe(12 * HOUR_MS);
+  test("billing: doubles from a 1-hour base per consecutive failure", () => {
+    expect(consolidationFailureBackoffMs("billing", 1, HOUR_MS)).toBe(HOUR_MS);
+    expect(consolidationFailureBackoffMs("billing", 2, HOUR_MS)).toBe(
+      2 * HOUR_MS,
+    );
+    expect(consolidationFailureBackoffMs("billing", 3, HOUR_MS)).toBe(
+      4 * HOUR_MS,
+    );
+  });
+
+  test("billing: caps at 6 hours for a shorter configured interval", () => {
+    expect(consolidationFailureBackoffMs("billing", 4, HOUR_MS)).toBe(
+      6 * HOUR_MS,
+    );
+    expect(consolidationFailureBackoffMs("billing", 1000, HOUR_MS)).toBe(
+      6 * HOUR_MS,
+    );
+  });
+
+  test("billing: cap rises to the configured interval when it exceeds 6 hours", () => {
+    expect(consolidationFailureBackoffMs("billing", 10, 12 * HOUR_MS)).toBe(
+      12 * HOUR_MS,
+    );
   });
 });
 

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -58,6 +58,7 @@ import { sweepOrphanMemoryRetrospectiveConversations } from "./memory-retrospect
 import { getWorkspaceDir } from "./paths.js";
 import { hasPkbBufferContent } from "./pkb-schedule.js";
 import {
+  type ConsolidationFailureKind,
   countBufferLines,
   readConsolidationFailureState,
 } from "./v2/consolidation-job.js";
@@ -821,24 +822,44 @@ function memoryBufferLineCount(): number {
 // Failure backoff for automatic consolidation enqueues. A failed run never
 // trims the buffer, so without backoff the size trigger re-enqueues a
 // fast-failing run on every worker poll (~1.5s), each iteration persisting a
-// full background conversation. Base doubles per consecutive failure, capped
-// at max(6h, the configured interval). Manual "run now" enqueues go through
-// the routes layer, not this schedule, and are never gated.
-const CONSOLIDATION_FAILURE_BACKOFF_BASE_MS = 5 * 60 * 1000;
-const CONSOLIDATION_FAILURE_BACKOFF_MIN_CAP_MS = 6 * 60 * 60 * 1000;
+// full background conversation. Two curves, selected by the most recent
+// failure's kind (see `ConsolidationFailureState`):
+//   - transient (network blip, model hiccup, timeout): 5min doubling,
+//     capped at 30min — transient failures never meaningfully delay
+//     consolidation;
+//   - billing (non-retryable PROVIDER_BILLING): 1h doubling, capped at
+//     max(6h, the configured interval) — retrying can't succeed until the
+//     account is funded.
+// Manual "run now" enqueues go through the routes layer, not this schedule,
+// and are never gated.
+const CONSOLIDATION_TRANSIENT_BACKOFF_BASE_MS = 5 * 60 * 1000;
+const CONSOLIDATION_TRANSIENT_BACKOFF_CAP_MS = 30 * 60 * 1000;
+const CONSOLIDATION_BILLING_BACKOFF_BASE_MS = 60 * 60 * 1000;
+const CONSOLIDATION_BILLING_BACKOFF_MIN_CAP_MS = 6 * 60 * 60 * 1000;
 
 /**
- * Backoff window after `consecutiveFailures` failed consolidation runs:
- * `min(BASE * 2^(n-1), max(6h, intervalMs))`.
+ * Backoff window after `consecutiveFailures` failed consolidation runs.
+ * Billing: `min(1h * 2^(n-1), max(6h, intervalMs))`. Transient:
+ * `min(5min * 2^(n-1), 30min)`.
  */
 export function consolidationFailureBackoffMs(
+  kind: ConsolidationFailureKind,
   consecutiveFailures: number,
   intervalMs: number,
 ): number {
-  const capMs = Math.max(CONSOLIDATION_FAILURE_BACKOFF_MIN_CAP_MS, intervalMs);
+  if (kind === "billing") {
+    const capMs = Math.max(
+      CONSOLIDATION_BILLING_BACKOFF_MIN_CAP_MS,
+      intervalMs,
+    );
+    return Math.min(
+      CONSOLIDATION_BILLING_BACKOFF_BASE_MS * 2 ** (consecutiveFailures - 1),
+      capMs,
+    );
+  }
   return Math.min(
-    CONSOLIDATION_FAILURE_BACKOFF_BASE_MS * 2 ** (consecutiveFailures - 1),
-    capMs,
+    CONSOLIDATION_TRANSIENT_BACKOFF_BASE_MS * 2 ** (consecutiveFailures - 1),
+    CONSOLIDATION_TRANSIENT_BACKOFF_CAP_MS,
   );
 }
 
@@ -855,6 +876,7 @@ function consolidationBackoffRemainingMs(
     return 0;
   }
   const backoffMs = consolidationFailureBackoffMs(
+    state.kind,
     state.consecutiveFailures,
     intervalMs,
   );

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -57,7 +57,10 @@ import { getLogger } from "./logging.js";
 import { sweepOrphanMemoryRetrospectiveConversations } from "./memory-retrospective-startup-cleanup.js";
 import { getWorkspaceDir } from "./paths.js";
 import { hasPkbBufferContent } from "./pkb-schedule.js";
-import { countBufferLines } from "./v2/consolidation-job.js";
+import {
+  countBufferLines,
+  readConsolidationFailureState,
+} from "./v2/consolidation-job.js";
 import { spawnMemoryWorkerProcess } from "./worker-control.js";
 
 const log = getLogger("memory-jobs-worker");
@@ -815,6 +818,49 @@ function memoryBufferLineCount(): number {
   return countBufferLines(join(getWorkspaceDir(), "memory", "buffer.md"));
 }
 
+// Failure backoff for automatic consolidation enqueues. A failed run never
+// trims the buffer, so without backoff the size trigger re-enqueues a
+// fast-failing run on every worker poll (~1.5s), each iteration persisting a
+// full background conversation. Base doubles per consecutive failure, capped
+// at max(6h, the configured interval). Manual "run now" enqueues go through
+// the routes layer, not this schedule, and are never gated.
+const CONSOLIDATION_FAILURE_BACKOFF_BASE_MS = 5 * 60 * 1000;
+const CONSOLIDATION_FAILURE_BACKOFF_MIN_CAP_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * Backoff window after `consecutiveFailures` failed consolidation runs:
+ * `min(BASE * 2^(n-1), max(6h, intervalMs))`.
+ */
+export function consolidationFailureBackoffMs(
+  consecutiveFailures: number,
+  intervalMs: number,
+): number {
+  const capMs = Math.max(CONSOLIDATION_FAILURE_BACKOFF_MIN_CAP_MS, intervalMs);
+  return Math.min(
+    CONSOLIDATION_FAILURE_BACKOFF_BASE_MS * 2 ** (consecutiveFailures - 1),
+    capMs,
+  );
+}
+
+/**
+ * Milliseconds until the consolidation failure backoff expires; `0` when no
+ * failure state is recorded or the window has already elapsed.
+ */
+function consolidationBackoffRemainingMs(
+  intervalMs: number,
+  nowMs: number,
+): number {
+  const state = readConsolidationFailureState();
+  if (state === null) {
+    return 0;
+  }
+  const backoffMs = consolidationFailureBackoffMs(
+    state.consecutiveFailures,
+    intervalMs,
+  );
+  return Math.max(0, state.lastFailureAt + backoffMs - nowMs);
+}
+
 export function maybeEnqueueGraphMaintenanceJobs(
   config: AssistantConfig,
   nowMs = Date.now(),
@@ -888,6 +934,20 @@ export function maybeEnqueueGraphMaintenanceJobs(
       // The checkpoint advances so the next check fires after the regular
       // interval. Manual "Run now" is unaffected (routes layer, not schedule).
       if (jobType === consolidateEntry.jobType) {
+        // Failure backoff: skip WITHOUT advancing the checkpoint so the
+        // enqueue fires on the first tick after the window elapses instead
+        // of a full interval later.
+        const backoffRemainingMs = consolidationBackoffRemainingMs(
+          intervalMs,
+          nowMs,
+        );
+        if (backoffRemainingMs > 0) {
+          log.debug(
+            { backoffRemainingMs },
+            "Scheduled consolidation skipped: failure backoff active",
+          );
+          continue;
+        }
         if (memoryBufferLineCount() < MIN_BUFFER_LINES_FOR_CONSOLIDATION) {
           log.debug(
             "Scheduled consolidation skipped: buffer under minimum line threshold",
@@ -916,6 +976,9 @@ export function maybeEnqueueGraphMaintenanceJobs(
   // interval elapses), so it dedupes against an already-active consolidate job
   // instead — otherwise it would re-enqueue on every worker tick while the
   // buffer stays over threshold, flooding the queue with redundant LLM work.
+  // The failure backoff gates it too: a failed run never trims the buffer, so
+  // the size trigger alone would re-fire a failing run on every tick. A
+  // backoff skip leaves the checkpoint alone.
   const maxLines = config.memory.v2.consolidation_max_buffer_lines;
   if (
     v2Active &&
@@ -924,11 +987,22 @@ export function maybeEnqueueGraphMaintenanceJobs(
     !hasActiveJobOfType(consolidateEntry.jobType)
   ) {
     if (memoryBufferLineCount() >= maxLines) {
-      enqueueMemoryJob(
-        consolidateEntry.jobType,
-        AUTOMATIC_CONSOLIDATION_JOB_PAYLOAD,
+      const backoffRemainingMs = consolidationBackoffRemainingMs(
+        consolidateEntry.intervalMs,
+        nowMs,
       );
-      setMemoryCheckpoint(consolidateEntry.key, String(nowMs));
+      if (backoffRemainingMs > 0) {
+        log.debug(
+          { backoffRemainingMs },
+          "Size-triggered consolidation skipped: failure backoff active",
+        );
+      } else {
+        enqueueMemoryJob(
+          consolidateEntry.jobType,
+          AUTOMATIC_CONSOLIDATION_JOB_PAYLOAD,
+        );
+        setMemoryCheckpoint(consolidateEntry.key, String(nowMs));
+      }
     }
   }
 

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/consolidation-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/consolidation-job.test.ts
@@ -16,7 +16,9 @@
  *   - Follow-up coalescing: a pending job of a follow-up type suppresses
  *     that enqueue (the pending row already covers it).
  *   - Consecutive-failure state: failed runs increment the durable
- *     checkpoint, success clears it, pre-runner bail paths leave it alone.
+ *     checkpoint, success clears it, pre-runner bail paths leave it alone,
+ *     and the recorded kind (billing vs transient) tracks the most recent
+ *     failure's classification.
  *
  * Tests use temp workspaces (mkdtemp) and never touch `~/.vellum/`. Sample
  * content uses generic placeholders (Alice).
@@ -66,6 +68,7 @@ let runnerImpl: () => Promise<{
   ok: boolean;
   error?: Error;
   errorKind?: string;
+  failureCode?: string;
 }> = runnerTrimsBuffer;
 
 mock.module("../../../../../runtime/background-job-runner.js", () => ({
@@ -884,6 +887,7 @@ describe("memoryV2ConsolidateJob — consecutive-failure state", () => {
   function readFailureState(): {
     consecutiveFailures: number;
     lastFailureAt: number;
+    kind: string;
   } | null {
     const raw = checkpointStore.get(CONSOLIDATION_FAILURE_CHECKPOINT_KEY);
     return raw === undefined
@@ -891,17 +895,29 @@ describe("memoryV2ConsolidateJob — consecutive-failure state", () => {
       : (JSON.parse(raw) as {
           consecutiveFailures: number;
           lastFailureAt: number;
+          kind: string;
         });
   }
 
   function seedFailureState(
     consecutiveFailures: number,
     lastFailureAt: number,
+    kind: "billing" | "transient" = "transient",
   ): void {
     checkpointStore.set(
       CONSOLIDATION_FAILURE_CHECKPOINT_KEY,
-      JSON.stringify({ consecutiveFailures, lastFailureAt }),
+      JSON.stringify({ consecutiveFailures, lastFailureAt, kind }),
     );
+  }
+
+  function failingRunner(failureCode?: string): typeof runnerImpl {
+    return async () => ({
+      conversationId: "conv-1",
+      ok: false,
+      error: new Error("provider refused"),
+      errorKind: "model_provider",
+      ...(failureCode !== undefined ? { failureCode } : {}),
+    });
   }
 
   beforeEach(() => {
@@ -909,12 +925,7 @@ describe("memoryV2ConsolidateJob — consecutive-failure state", () => {
   });
 
   test("a failed run records consecutiveFailures=1 with a failure timestamp", async () => {
-    runnerImpl = async () => ({
-      conversationId: "conv-1",
-      ok: false,
-      error: new Error("provider refused"),
-      errorKind: "model_provider",
-    });
+    runnerImpl = failingRunner();
 
     const before = Date.now();
     const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
@@ -929,12 +940,7 @@ describe("memoryV2ConsolidateJob — consecutive-failure state", () => {
   });
 
   test("consecutive failed runs increment the count", async () => {
-    runnerImpl = async () => ({
-      conversationId: "conv-1",
-      ok: false,
-      error: new Error("provider refused"),
-      errorKind: "model_provider",
-    });
+    runnerImpl = failingRunner();
 
     await memoryV2ConsolidateJob(makeJob(), CONFIG);
     await memoryV2ConsolidateJob(makeJob(), CONFIG);
@@ -943,8 +949,52 @@ describe("memoryV2ConsolidateJob — consecutive-failure state", () => {
     expect(readFailureState()!.consecutiveFailures).toBe(3);
   });
 
+  test("a PROVIDER_BILLING turn failure records kind=billing", async () => {
+    runnerImpl = failingRunner("PROVIDER_BILLING");
+
+    await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(readFailureState()!.kind).toBe("billing");
+  });
+
+  test("a failure without a failureCode records kind=transient", async () => {
+    runnerImpl = failingRunner();
+
+    await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(readFailureState()!.kind).toBe("transient");
+  });
+
+  test("a non-billing failureCode records kind=transient", async () => {
+    runnerImpl = failingRunner("PROVIDER_RATE_LIMIT");
+
+    await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(readFailureState()!.kind).toBe("transient");
+  });
+
+  test("the most recent failure's kind wins while the count keeps accruing", async () => {
+    // transient → billing: kind flips to billing at count 2.
+    runnerImpl = failingRunner();
+    await memoryV2ConsolidateJob(makeJob(), CONFIG);
+    runnerImpl = failingRunner("PROVIDER_BILLING");
+    await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    let state = readFailureState()!;
+    expect(state.consecutiveFailures).toBe(2);
+    expect(state.kind).toBe("billing");
+
+    // billing → transient: kind flips back at count 3.
+    runnerImpl = failingRunner();
+    await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    state = readFailureState()!;
+    expect(state.consecutiveFailures).toBe(3);
+    expect(state.kind).toBe("transient");
+  });
+
   test("a successful run clears the failure state", async () => {
-    seedFailureState(4, Date.now() - 60_000);
+    seedFailureState(4, Date.now() - 60_000, "billing");
 
     const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
 
@@ -962,6 +1012,7 @@ describe("memoryV2ConsolidateJob — consecutive-failure state", () => {
     expect(readFailureState()).toEqual({
       consecutiveFailures: 2,
       lastFailureAt,
+      kind: "transient",
     });
   });
 
@@ -976,6 +1027,7 @@ describe("memoryV2ConsolidateJob — consecutive-failure state", () => {
     expect(readFailureState()).toEqual({
       consecutiveFailures: 2,
       lastFailureAt,
+      kind: "transient",
     });
   });
 
@@ -991,21 +1043,36 @@ describe("memoryV2ConsolidateJob — consecutive-failure state", () => {
     expect(readFailureState()).toEqual({
       consecutiveFailures: 2,
       lastFailureAt,
+      kind: "transient",
     });
   });
 
   test("a corrupt failure-state payload restarts the count at 1 on the next failure", async () => {
     checkpointStore.set(CONSOLIDATION_FAILURE_CHECKPOINT_KEY, "not-json");
-    runnerImpl = async () => ({
-      conversationId: "conv-1",
-      ok: false,
-      error: new Error("provider refused"),
-      errorKind: "model_provider",
-    });
+    runnerImpl = failingRunner();
 
     await memoryV2ConsolidateJob(makeJob(), CONFIG);
 
     expect(readFailureState()!.consecutiveFailures).toBe(1);
+  });
+
+  test("a payload with an unknown kind restarts the count at 1 on the next failure", async () => {
+    checkpointStore.set(
+      CONSOLIDATION_FAILURE_CHECKPOINT_KEY,
+      JSON.stringify({
+        consecutiveFailures: 7,
+        lastFailureAt: Date.now(),
+        kind: "mystery",
+      }),
+    );
+    runnerImpl = failingRunner();
+
+    await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(readFailureState()).toMatchObject({
+      consecutiveFailures: 1,
+      kind: "transient",
+    });
   });
 });
 

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/consolidation-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/consolidation-job.test.ts
@@ -16,9 +16,10 @@
  *   - Follow-up coalescing: a pending job of a follow-up type suppresses
  *     that enqueue (the pending row already covers it).
  *   - Consecutive-failure state: failed runs increment the durable
- *     checkpoint, success clears it, pre-runner bail paths leave it alone,
- *     and the recorded kind (billing vs transient) tracks the most recent
- *     failure's classification.
+ *     checkpoint, progressing success clears it, no-progress completions
+ *     record a transient failure, skipped runs and pre-runner bail paths
+ *     leave it alone, and the recorded kind (billing vs transient) tracks
+ *     the most recent failure's classification.
  *
  * Tests use temp workspaces (mkdtemp) and never touch `~/.vellum/`. Sample
  * content uses generic placeholders (Alice).
@@ -69,6 +70,7 @@ let runnerImpl: () => Promise<{
   error?: Error;
   errorKind?: string;
   failureCode?: string;
+  skipReason?: string;
 }> = runnerTrimsBuffer;
 
 mock.module("../../../../../runtime/background-job-runner.js", () => ({
@@ -999,6 +1001,54 @@ describe("memoryV2ConsolidateJob — consecutive-failure state", () => {
     const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
 
     expect(result.kind).toBe("invoked");
+    expect(readFailureState()).toBeNull();
+  });
+
+  test("a completed run with no progress records a transient failure instead of clearing", async () => {
+    seedFailureState(2, Date.now() - 60_000, "billing");
+    // Completes ok but never touches buffer.md — the stuck-agent shape.
+    runnerImpl = async () => ({ conversationId: "conv-1", ok: true });
+
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(result.kind).toBe("invoked");
+    if (result.kind !== "invoked") {
+      throw new Error("unreachable");
+    }
+    expect(result.noProgress).toBe(true);
+    expect(readFailureState()).toMatchObject({
+      consecutiveFailures: 3,
+      kind: "transient",
+    });
+  });
+
+  test("a skipped run neither clears nor records failure state", async () => {
+    const lastFailureAt = Date.now() - 60_000;
+    seedFailureState(2, lastFailureAt, "billing");
+    runnerImpl = async () => ({
+      conversationId: "",
+      ok: true,
+      skipReason: "pre_first_user_message",
+    });
+
+    await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(readFailureState()).toEqual({
+      consecutiveFailures: 2,
+      lastFailureAt,
+      kind: "billing",
+    });
+  });
+
+  test("a skipped run creates no failure state when none exists", async () => {
+    runnerImpl = async () => ({
+      conversationId: "",
+      ok: true,
+      skipReason: "pre_first_user_message",
+    });
+
+    await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
     expect(readFailureState()).toBeNull();
   });
 

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/consolidation-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/consolidation-job.test.ts
@@ -15,6 +15,8 @@
  *     `invoked` with `noProgress: true` and enqueues no follow-ups.
  *   - Follow-up coalescing: a pending job of a follow-up type suppresses
  *     that enqueue (the pending row already covers it).
+ *   - Consecutive-failure state: failed runs increment the durable
+ *     checkpoint, success clears it, pre-runner bail paths leave it alone.
  *
  * Tests use temp workspaces (mkdtemp) and never touch `~/.vellum/`. Sample
  * content uses generic placeholders (Alice).
@@ -119,6 +121,24 @@ mock.module("../../../../../persistence/jobs-store.js", () => ({
   isMemoryEnabled: () => true,
 }));
 
+// ── checkpoints mock ────────────────────────────────────────────────
+//
+// The handler persists consecutive-failure state through the durable
+// checkpoint helpers. An in-memory map stands in for the DB so the tests
+// can assert what the handler wrote without initializing sqlite.
+const checkpointStore = new Map<string, string>();
+
+mock.module("../../../../../persistence/checkpoints.js", () => ({
+  getMemoryCheckpoint: (key: string): string | null =>
+    checkpointStore.get(key) ?? null,
+  setMemoryCheckpoint: (key: string, value: string): void => {
+    checkpointStore.set(key, value);
+  },
+  deleteMemoryCheckpoint: (key: string): void => {
+    checkpointStore.delete(key);
+  },
+}));
+
 // ── v3 live gate mock ───────────────────────────────────────────────
 //
 // `memory.v3.live` being on appends `memory_v3_maintain` to the
@@ -158,7 +178,8 @@ afterAll(() => {
   rmSync(tmpWorkspace, { recursive: true, force: true });
 });
 
-const { memoryV2ConsolidateJob } = await import("../consolidation-job.js");
+const { memoryV2ConsolidateJob, CONSOLIDATION_FAILURE_CHECKPOINT_KEY } =
+  await import("../consolidation-job.js");
 const { CUTOFF_PLACEHOLDER, CONSOLIDATION_PROMPT } =
   await import("../prompts/consolidation.js");
 
@@ -238,6 +259,7 @@ beforeEach(() => {
   enqueuedJobs.length = 0;
   nextJobIdCounter = 0;
   pendingJobTypes = new Set();
+  checkpointStore.clear();
 
   // v3 follow-up flag default: off.
   v3FlagOn = false;
@@ -855,6 +877,135 @@ describe("memoryV2ConsolidateJob — concurrent invocations", () => {
     expect(result.kind).toBe("invoked");
     expect(runnerCalls).toBe(1);
     expect(existsSync(lockPath())).toBe(false);
+  });
+});
+
+describe("memoryV2ConsolidateJob — consecutive-failure state", () => {
+  function readFailureState(): {
+    consecutiveFailures: number;
+    lastFailureAt: number;
+  } | null {
+    const raw = checkpointStore.get(CONSOLIDATION_FAILURE_CHECKPOINT_KEY);
+    return raw === undefined
+      ? null
+      : (JSON.parse(raw) as {
+          consecutiveFailures: number;
+          lastFailureAt: number;
+        });
+  }
+
+  function seedFailureState(
+    consecutiveFailures: number,
+    lastFailureAt: number,
+  ): void {
+    checkpointStore.set(
+      CONSOLIDATION_FAILURE_CHECKPOINT_KEY,
+      JSON.stringify({ consecutiveFailures, lastFailureAt }),
+    );
+  }
+
+  beforeEach(() => {
+    writeFileSync(bufferPath(), "- [Apr 27, 9:00 AM] Alice prefers VS Code.\n");
+  });
+
+  test("a failed run records consecutiveFailures=1 with a failure timestamp", async () => {
+    runnerImpl = async () => ({
+      conversationId: "conv-1",
+      ok: false,
+      error: new Error("provider refused"),
+      errorKind: "model_provider",
+    });
+
+    const before = Date.now();
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+    const after = Date.now();
+
+    expect(result.kind).toBe("run_failed");
+    const state = readFailureState();
+    expect(state).not.toBeNull();
+    expect(state!.consecutiveFailures).toBe(1);
+    expect(state!.lastFailureAt).toBeGreaterThanOrEqual(before);
+    expect(state!.lastFailureAt).toBeLessThanOrEqual(after);
+  });
+
+  test("consecutive failed runs increment the count", async () => {
+    runnerImpl = async () => ({
+      conversationId: "conv-1",
+      ok: false,
+      error: new Error("provider refused"),
+      errorKind: "model_provider",
+    });
+
+    await memoryV2ConsolidateJob(makeJob(), CONFIG);
+    await memoryV2ConsolidateJob(makeJob(), CONFIG);
+    await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(readFailureState()!.consecutiveFailures).toBe(3);
+  });
+
+  test("a successful run clears the failure state", async () => {
+    seedFailureState(4, Date.now() - 60_000);
+
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(result.kind).toBe("invoked");
+    expect(readFailureState()).toBeNull();
+  });
+
+  test("the disabled bail path leaves the failure state untouched", async () => {
+    const lastFailureAt = Date.now() - 60_000;
+    seedFailureState(2, lastFailureAt);
+
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG_DISABLED);
+
+    expect(result.kind).toBe("disabled");
+    expect(readFailureState()).toEqual({
+      consecutiveFailures: 2,
+      lastFailureAt,
+    });
+  });
+
+  test("the empty-buffer bail path leaves the failure state untouched", async () => {
+    rmSync(bufferPath(), { force: true });
+    const lastFailureAt = Date.now() - 60_000;
+    seedFailureState(2, lastFailureAt);
+
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(result.kind).toBe("empty_buffer");
+    expect(readFailureState()).toEqual({
+      consecutiveFailures: 2,
+      lastFailureAt,
+    });
+  });
+
+  test("the locked bail path leaves the failure state untouched", async () => {
+    mkdirSync(join(memoryDir(), ".v2-state"), { recursive: true });
+    writeFileSync(lockPath(), `${process.pid} ${Date.now()}\n`);
+    const lastFailureAt = Date.now() - 60_000;
+    seedFailureState(2, lastFailureAt);
+
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(result.kind).toBe("locked");
+    expect(readFailureState()).toEqual({
+      consecutiveFailures: 2,
+      lastFailureAt,
+    });
+  });
+
+  test("a corrupt failure-state payload restarts the count at 1 on the next failure", async () => {
+    checkpointStore.set(CONSOLIDATION_FAILURE_CHECKPOINT_KEY, "not-json");
+    runnerImpl = async () => ({
+      conversationId: "conv-1",
+      ok: false,
+      error: new Error("provider refused"),
+      errorKind: "model_provider",
+    });
+
+    await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(readFailureState()!.consecutiveFailures).toBe(1);
   });
 });
 

--- a/assistant/src/plugins/defaults/memory/v2/consolidation-job.ts
+++ b/assistant/src/plugins/defaults/memory/v2/consolidation-job.ts
@@ -174,14 +174,23 @@ const STALE_LOCK_TTL_MS = 4 * CONSOLIDATION_TIMEOUT_MS;
  * buffer never trims re-fires the size trigger on every worker poll. Manual
  * "run now" enqueues are not gated.
  *
- * Value is JSON: `{ consecutiveFailures, lastFailureAt }`.
+ * `kind` reflects the MOST RECENT failure and selects the scheduler's backoff
+ * curve: `billing` (non-retryable `PROVIDER_BILLING` turn failures) backs off
+ * toward the long cap, `transient` (everything else) stays short so a network
+ * blip or model hiccup never meaningfully delays consolidation. The
+ * consecutive count spans both kinds.
+ *
+ * Value is JSON: `{ consecutiveFailures, lastFailureAt, kind }`.
  */
 export const CONSOLIDATION_FAILURE_CHECKPOINT_KEY =
   "memory_v2_consolidate_failure_state";
 
+export type ConsolidationFailureKind = "billing" | "transient";
+
 export interface ConsolidationFailureState {
   consecutiveFailures: number;
   lastFailureAt: number;
+  kind: ConsolidationFailureKind;
 }
 
 /**
@@ -201,13 +210,15 @@ export function readConsolidationFailureState(): ConsolidationFailureState | nul
       !Number.isFinite(parsed.consecutiveFailures) ||
       parsed.consecutiveFailures < 1 ||
       typeof parsed.lastFailureAt !== "number" ||
-      !Number.isFinite(parsed.lastFailureAt)
+      !Number.isFinite(parsed.lastFailureAt) ||
+      (parsed.kind !== "billing" && parsed.kind !== "transient")
     ) {
       return null;
     }
     return {
       consecutiveFailures: parsed.consecutiveFailures,
       lastFailureAt: parsed.lastFailureAt,
+      kind: parsed.kind,
     };
   } catch {
     return null;
@@ -215,15 +226,20 @@ export function readConsolidationFailureState(): ConsolidationFailureState | nul
 }
 
 /**
- * Increment the consecutive-failure count and stamp the failure time.
+ * Increment the consecutive-failure count, stamp the failure time, and set
+ * the kind to this (most recent) failure's classification.
  * Best-effort: failure bookkeeping must never change the handler's outcome.
  */
-function recordConsolidationFailure(nowMs: number): void {
+function recordConsolidationFailure(
+  nowMs: number,
+  kind: ConsolidationFailureKind,
+): void {
   try {
     const prior = readConsolidationFailureState();
     const state: ConsolidationFailureState = {
       consecutiveFailures: (prior?.consecutiveFailures ?? 0) + 1,
       lastFailureAt: nowMs,
+      kind,
     };
     setMemoryCheckpoint(
       CONSOLIDATION_FAILURE_CHECKPOINT_KEY,
@@ -435,15 +451,24 @@ export async function memoryV2ConsolidateJob(
     });
 
     if (!runResult.ok) {
+      // Billing turn failures (`PROVIDER_BILLING` covers both exhausted
+      // managed credits and BYOK provider-account credits) are
+      // non-retryable and select the scheduler's long backoff curve;
+      // everything else (network blip, model hiccup, timeout) is transient
+      // and stays on the short curve.
+      const failureKind: ConsolidationFailureKind =
+        runResult.failureCode === "PROVIDER_BILLING" ? "billing" : "transient";
       log.error(
         {
           conversationId: runResult.conversationId,
           errorKind: runResult.errorKind,
+          failureCode: runResult.failureCode,
+          failureKind,
           err: runResult.error?.message,
         },
         "consolidation run failed; follow-ups skipped",
       );
-      recordConsolidationFailure(Date.now());
+      recordConsolidationFailure(Date.now(), failureKind);
       return runResult.error?.message !== undefined
         ? { kind: "run_failed", reason: runResult.error.message }
         : { kind: "run_failed" };

--- a/assistant/src/plugins/defaults/memory/v2/consolidation-job.ts
+++ b/assistant/src/plugins/defaults/memory/v2/consolidation-job.ts
@@ -51,9 +51,10 @@
  *      are enqueued — the agent's writes may be partial and re-embedding
  *      partial state would be misleading. Run outcome also drives the durable
  *      consecutive-failure state (see
- *      {@link CONSOLIDATION_FAILURE_CHECKPOINT_KEY}): failure increments it,
- *      success clears it, and the scheduler backs off automatic re-enqueues
- *      while it is set.
+ *      {@link CONSOLIDATION_FAILURE_CHECKPOINT_KEY}): a failed or
+ *      no-progress run increments it, a progressing run clears it, a skipped
+ *      run leaves it untouched, and the scheduler backs off automatic
+ *      re-enqueues while it is set.
  *   8. Release the lock. A stale lock is taken over automatically on the next
  *      run (single-writer per workspace): when the holder's PID is no longer
  *      running, or — because the daemon runs as PID 1 in containers and a
@@ -166,9 +167,10 @@ const STALE_LOCK_TTL_MS = 4 * CONSOLIDATION_TIMEOUT_MS;
 /**
  * Durable checkpoint tracking consecutive consolidation run failures.
  *
- * Written by this handler: incremented when `runBackgroundJob` reports
- * failure, cleared on a successful run. Paths that bail before invoking the
- * runner (disabled, locked, empty buffer) leave it untouched. The scheduler
+ * Written by this handler: incremented when the run fails or completes
+ * without draining the buffer, cleared when a run makes progress. Paths that
+ * bail before invoking the runner (disabled, locked, empty buffer) and
+ * skipped runs (`skipReason`) leave it untouched. The scheduler
  * (`maybeEnqueueGraphMaintenanceJobs`) reads it to back off automatic
  * re-enqueues while runs keep failing — without it, a fast-failing run whose
  * buffer never trims re-fires the size trigger on every worker poll. Manual
@@ -253,7 +255,7 @@ function recordConsolidationFailure(
   }
 }
 
-/** Clear the failure state after a successful run. Best-effort. */
+/** Clear the failure state after a progressing run. Best-effort. */
 function clearConsolidationFailureState(): void {
   try {
     deleteMemoryCheckpoint(CONSOLIDATION_FAILURE_CHECKPOINT_KEY);
@@ -474,8 +476,6 @@ export async function memoryV2ConsolidateJob(
         : { kind: "run_failed" };
     }
 
-    clearConsolidationFailureState();
-
     // Step 5: verify the run drained the buffer. `runResult.ok` only means
     // the background run completed — the trim itself is delegated to the
     // agent, and nothing above checks that it happened. A run that completes
@@ -486,7 +486,22 @@ export async function memoryV2ConsolidateJob(
     // after-count into a false "no progress"; that is benign — the next
     // progressing run enqueues the same follow-ups.
     const bufferLinesAfter = countBufferLines(bufferPath);
-    if (bufferLinesAfter >= bufferLinesBefore) {
+    const noProgress = bufferLinesAfter >= bufferLinesBefore;
+
+    // Failure-state bookkeeping. A skipped run (`skipReason`) never invoked
+    // the agent, so it neither clears nor records. A completed run that made
+    // no progress behaves like a failure for scheduling — the size trigger
+    // stays armed — so it records on the transient curve rather than
+    // re-firing every worker poll; only a progressing run clears the backoff.
+    if (runResult.skipReason === undefined) {
+      if (noProgress) {
+        recordConsolidationFailure(Date.now(), "transient");
+      } else {
+        clearConsolidationFailureState();
+      }
+    }
+
+    if (noProgress) {
       log.warn(
         {
           conversationId: runResult.conversationId,

--- a/assistant/src/plugins/defaults/memory/v2/consolidation-job.ts
+++ b/assistant/src/plugins/defaults/memory/v2/consolidation-job.ts
@@ -49,7 +49,11 @@
  *      a conservative full-reembed effectively free. Each follow-up coalesces
  *      with an already-pending job of the same type. On failure no follow-ups
  *      are enqueued — the agent's writes may be partial and re-embedding
- *      partial state would be misleading.
+ *      partial state would be misleading. Run outcome also drives the durable
+ *      consecutive-failure state (see
+ *      {@link CONSOLIDATION_FAILURE_CHECKPOINT_KEY}): failure increments it,
+ *      success clears it, and the scheduler backs off automatic re-enqueues
+ *      while it is set.
  *   8. Release the lock. A stale lock is taken over automatically on the next
  *      run (single-writer per workspace): when the holder's PID is no longer
  *      running, or — because the daemon runs as PID 1 in containers and a
@@ -74,6 +78,11 @@ import { dirname, join } from "node:path";
 
 import { isMemoryV3Live } from "../../../../config/memory-v3-gate.js";
 import type { AssistantConfig } from "../../../../config/types.js";
+import {
+  deleteMemoryCheckpoint,
+  getMemoryCheckpoint,
+  setMemoryCheckpoint,
+} from "../../../../persistence/checkpoints.js";
 import {
   enqueueMemoryJob,
   hasPendingJobOfType,
@@ -153,6 +162,92 @@ const CONSOLIDATION_TIMEOUT_MS = 15 * 60 * 1000;
  * within a couple of scheduled passes.
  */
 const STALE_LOCK_TTL_MS = 4 * CONSOLIDATION_TIMEOUT_MS;
+
+/**
+ * Durable checkpoint tracking consecutive consolidation run failures.
+ *
+ * Written by this handler: incremented when `runBackgroundJob` reports
+ * failure, cleared on a successful run. Paths that bail before invoking the
+ * runner (disabled, locked, empty buffer) leave it untouched. The scheduler
+ * (`maybeEnqueueGraphMaintenanceJobs`) reads it to back off automatic
+ * re-enqueues while runs keep failing — without it, a fast-failing run whose
+ * buffer never trims re-fires the size trigger on every worker poll. Manual
+ * "run now" enqueues are not gated.
+ *
+ * Value is JSON: `{ consecutiveFailures, lastFailureAt }`.
+ */
+export const CONSOLIDATION_FAILURE_CHECKPOINT_KEY =
+  "memory_v2_consolidate_failure_state";
+
+export interface ConsolidationFailureState {
+  consecutiveFailures: number;
+  lastFailureAt: number;
+}
+
+/**
+ * Read the persisted failure state. Missing, malformed, or out-of-range
+ * payloads read as `null` (no failures on record) — corruption self-heals on
+ * the next record/clear.
+ */
+export function readConsolidationFailureState(): ConsolidationFailureState | null {
+  const raw = getMemoryCheckpoint(CONSOLIDATION_FAILURE_CHECKPOINT_KEY);
+  if (raw === null) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<ConsolidationFailureState>;
+    if (
+      typeof parsed.consecutiveFailures !== "number" ||
+      !Number.isFinite(parsed.consecutiveFailures) ||
+      parsed.consecutiveFailures < 1 ||
+      typeof parsed.lastFailureAt !== "number" ||
+      !Number.isFinite(parsed.lastFailureAt)
+    ) {
+      return null;
+    }
+    return {
+      consecutiveFailures: parsed.consecutiveFailures,
+      lastFailureAt: parsed.lastFailureAt,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Increment the consecutive-failure count and stamp the failure time.
+ * Best-effort: failure bookkeeping must never change the handler's outcome.
+ */
+function recordConsolidationFailure(nowMs: number): void {
+  try {
+    const prior = readConsolidationFailureState();
+    const state: ConsolidationFailureState = {
+      consecutiveFailures: (prior?.consecutiveFailures ?? 0) + 1,
+      lastFailureAt: nowMs,
+    };
+    setMemoryCheckpoint(
+      CONSOLIDATION_FAILURE_CHECKPOINT_KEY,
+      JSON.stringify(state),
+    );
+  } catch (err) {
+    log.warn(
+      { err },
+      "consolidation: failed to record failure state (best-effort)",
+    );
+  }
+}
+
+/** Clear the failure state after a successful run. Best-effort. */
+function clearConsolidationFailureState(): void {
+  try {
+    deleteMemoryCheckpoint(CONSOLIDATION_FAILURE_CHECKPOINT_KEY);
+  } catch (err) {
+    log.warn(
+      { err },
+      "consolidation: failed to clear failure state (best-effort)",
+    );
+  }
+}
 
 /**
  * Follow-up jobs to fan out after a successful consolidation.
@@ -348,10 +443,13 @@ export async function memoryV2ConsolidateJob(
         },
         "consolidation run failed; follow-ups skipped",
       );
+      recordConsolidationFailure(Date.now());
       return runResult.error?.message !== undefined
         ? { kind: "run_failed", reason: runResult.error.message }
         : { kind: "run_failed" };
     }
+
+    clearConsolidationFailureState();
 
     // Step 5: verify the run drained the buffer. `runResult.ok` only means
     // the background run completed — the trim itself is delegated to the

--- a/assistant/src/runtime/__tests__/background-job-runner.test.ts
+++ b/assistant/src/runtime/__tests__/background-job-runner.test.ts
@@ -260,6 +260,9 @@ describe("runBackgroundJob", () => {
     expect(result.errorKind).toBe("model_provider");
     expect(result.error?.message).toContain("provider_error");
     expect(result.conversationId).toBe(STUB_CONVERSATION_ID);
+    // The stable classified code rides the result so callers can branch on
+    // the failure class without parsing the error message.
+    expect(result.failureCode).toBe("provider_error");
 
     expect(emitCalls).toHaveLength(1);
     expect(emitCalls[0].sourceEventName).toBe("activity.failed");

--- a/assistant/src/runtime/background-job-runner.ts
+++ b/assistant/src/runtime/background-job-runner.ts
@@ -201,6 +201,14 @@ export interface RunBackgroundJobResult {
   error?: Error;
   errorKind?: BackgroundJobErrorKind;
   /**
+   * Stable classified error code (`ConversationErrorCode`, e.g.
+   * `"PROVIDER_BILLING"`) when the turn failed without throwing. Absent for
+   * timeouts and thrown exceptions. Lets callers branch on the failure class
+   * (e.g. billing vs transient) without depending on error identity or
+   * message text.
+   */
+  failureCode?: string;
+  /**
    * Set when the runner declined to execute. Callers can distinguish a
    * skipped job from a successful one even though both report `ok: true`.
    *
@@ -380,6 +388,10 @@ export async function runBackgroundJob(
   } catch (err) {
     const errorKind = classifyError(err);
     const error = err instanceof Error ? err : new Error(String(err));
+    const failureCode =
+      err instanceof BackgroundJobTurnFailureError
+        ? err.failureCode
+        : undefined;
     // Bootstrap can fail before `conversation` is assigned; fall back to ""
     // so the structured failure result still flows to the caller.
     const conversationId = conversation?.id ?? "";
@@ -439,6 +451,7 @@ export async function runBackgroundJob(
       ok: false,
       error,
       errorKind,
+      ...(failureCode !== undefined ? { failureCode } : {}),
     };
   } finally {
     if (timer) clearTimeout(timer);


### PR DESCRIPTION
ref ATL-1028

## Problem

When a `memory_v2_consolidate` background run fails, the failure is absorbed by the job handler (documented contract of `runBackgroundJob`) and the job row completes. A failed run never trims `memory/buffer.md`, so while the buffer is over `consolidation_max_buffer_lines`, the size-based trigger in `maybeEnqueueGraphMaintenanceJobs` re-enqueues consolidation on the next worker poll — minimum poll interval 1.5s. A fast-failing run (e.g. account out of credits: classified `PROVIDER_BILLING`, `retryable: false`) therefore loops every ~1.5 seconds while the pod is awake. Each iteration bootstraps a background conversation and persists a ~30KB prompt plus memory segments and embeddings.

Observed in production: ~9,600 junk consolidation conversations in two days on one assistant (~350MB+ across messages/segments/vector store/disk view), filling the machine's volume and taking the pod down.

## Fix

Durable consecutive-failure backoff for the *automatic* consolidation enqueues, with two curves selected by the most recent failure's classification:

- **Billing** (`failureCode === "PROVIDER_BILLING"`, non-retryable): `min(1h × 2^(n−1), max(6h, configured interval))` — no point probing a drained account every few minutes.
- **Transient** (timeout, provider hiccup, anything else): `min(5min × 2^(n−1), 30min)` — a transient failure never delays consolidation by more than 30 minutes.

Mechanics:
- Failure state `{consecutiveFailures, lastFailureAt, kind}` persisted via the existing durable checkpoint store; incremented on `run_failed`, cleared on success; pre-run bails (empty buffer, lock held, memory disabled) never touch it.
- Both the interval branch and the size-trigger branch skip enqueue while the window is open, **without advancing the interval checkpoint** — the first tick after expiry runs immediately.
- Manual "run now" (consolidation routes) bypasses the gate structurally (it never passes through the scheduler).
- `RunBackgroundJobResult` gains optional `failureCode` (populated for non-throwing turn failures) so the handler can classify without depending on error class identity.

## Tests

- Failure-state transitions: increment, reset on success, kind recording (billing / no-code / non-billing), most-recent-kind-wins, corrupt-payload self-heal.
- Scheduler: both branches gated inside the window (checkpoint unchanged), resume on first tick after expiry, billing waits 1h immediately, transient caps at 30min, cap rises with a >6h configured interval.
- Runner: `failureCode` surfaces on the result.

`bun test` (scoped per AGENTS.md): 77 + 21 + 23 pass, 0 fail. `bun run typecheck:fast` clean. Lint 0 errors on touched files.

## Follow-ups (deliberately out of scope)

- Don't persist the bootstrap conversation/prompt for runs that fail before first assistant output (compensating delete in `runBackgroundJob`'s failure path).
- Skip memory-indexing for background-job prompts (currently every run — including successful ones — segments and embeds its own instruction text).
- User-visible surfacing when consolidation is paused in backoff.

## Rollout

No config/schema/infra changes; constants only. Behavior change is scoped to automatic consolidation scheduling after failed runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)