### PR TITLE
feat(mcp): credential-referenced auth headers for MCP servers

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -15507,6 +15507,12 @@ paths:
                     type: string
                   additionalProperties:
                     type: string
+                authCredential:
+                  type: string
+                authHeader:
+                  type: string
+                authPrefix:
+                  type: string
               required:
                 - name
                 - transportType
@@ -15776,6 +15782,12 @@ paths:
                       additionalProperties:
                         type: string
                     - type: "null"
+                authCredential:
+                  type: string
+                authHeader:
+                  type: string
+                authPrefix:
+                  type: string
               required:
                 - name
       responses:

--- a/assistant/src/__tests__/mcp-abort-signal.test.ts
+++ b/assistant/src/__tests__/mcp-abort-signal.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, jest, mock, test } from "bun:test";
 
 // Mock secure-keys so McpOAuthProvider doesn't try to access the credential store
+// mock.module applies process-wide; provide every export of the real module
+// so other test files importing it in the same run don't hit missing names.
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: jest.fn().mockResolvedValue(null),
   setSecureKeyAsync: jest.fn().mockResolvedValue(true),
   deleteSecureKeyAsync: jest.fn().mockResolvedValue("deleted"),
+  getSecureKeyResultAsync: jest
+    .fn()
+    .mockResolvedValue({ value: null, backend: "encrypted-store" }),
 }));
 
 mock.module("../config/env-registry.js", () => ({

--- a/assistant/src/__tests__/mcp-auth-routes-credential-headers.test.ts
+++ b/assistant/src/__tests__/mcp-auth-routes-credential-headers.test.ts
@@ -1,0 +1,317 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Module mocks (must precede imports) ───────────────────────────────────────
+
+let rawConfig: {
+  mcp: { servers: Record<string, Record<string, unknown>> };
+};
+
+mock.module("../config/loader.js", () => ({
+  loadRawConfig: () => rawConfig,
+  saveRawConfig: (c: typeof rawConfig) => {
+    rawConfig = c;
+  },
+  getConfig: () => rawConfig,
+  getConfigReadOnly: () => rawConfig,
+}));
+
+mock.module("../daemon/mcp-reload-service.js", () => ({
+  reloadMcpServers: async () => {},
+}));
+
+mock.module("../mcp/mcp-auth-orchestrator.js", () => ({
+  orchestrateMcpOAuthConnect: async () => ({ auth_url: "https://x" }),
+}));
+
+mock.module("../mcp/mcp-auth-state.js", () => ({
+  getMcpAuthState: () => null,
+}));
+
+mock.module("../mcp/mcp-oauth-provider.js", () => ({
+  hasMcpOAuthTokens: async () => false,
+  deleteMcpOAuthCredentials: async () => ({ ok: true, failedKeys: [] }),
+}));
+
+mock.module("../mcp/client.js", () => ({
+  McpClient: class {
+    constructor(_id: string) {}
+    async connect() {}
+    get isConnected() {
+      return true;
+    }
+    get lastError() {
+      return null;
+    }
+    async disconnect() {}
+  },
+}));
+
+// In-memory secure key backend. Spread the real module so exports consumed
+// elsewhere in the route graph (e.g. getProviderKeyAsync) stay intact.
+const secureStore = new Map<string, string>();
+const realSecureKeys = await import("../security/secure-keys.js");
+
+mock.module("../security/secure-keys.js", () => ({
+  ...realSecureKeys,
+  getSecureKeyAsync: async (k: string) => secureStore.get(k),
+  setSecureKeyAsync: async (k: string, v: string) => {
+    secureStore.set(k, v);
+    return true;
+  },
+  deleteSecureKeyAsync: async (k: string) => {
+    secureStore.delete(k);
+    return "deleted";
+  },
+  getSecureKeyResultAsync: async (k: string) => ({
+    value: secureStore.get(k),
+    unreachable: false,
+  }),
+}));
+
+// Credentials that "exist" in the vault, keyed by "service/field".
+const existingCredentials = new Map<string, string>();
+const realResolve = await import("../tools/credentials/resolve.js");
+
+mock.module("../tools/credentials/resolve.js", () => ({
+  ...realResolve,
+  resolveCredentialRef: (ref: string) => {
+    const storageKey = existingCredentials.get(ref);
+    if (!storageKey) {
+      return undefined;
+    }
+    const [service, field] = ref.split("/");
+    return {
+      credentialId: ref,
+      service,
+      field,
+      storageKey,
+      injectionTemplates: [],
+      metadata: {},
+    };
+  },
+}));
+
+// ── Import SUT after mocks ────────────────────────────────────────────────────
+
+const { ROUTES } = await import("../runtime/routes/mcp-auth-routes.js");
+
+function findRoute(operationId: string) {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) {
+    throw new Error(`Route ${operationId} not found`);
+  }
+  return route;
+}
+
+function storedEnvelope(serverId: string) {
+  const raw = secureStore.get(`mcp:${serverId}:headers`);
+  return raw ? JSON.parse(raw) : undefined;
+}
+
+beforeEach(() => {
+  rawConfig = { mcp: { servers: {} } };
+  secureStore.clear();
+  existingCredentials.clear();
+});
+
+describe("mcp add — credential-reference headers", () => {
+  test("stores --auth-credential as a ref, never a literal", async () => {
+    existingCredentials.set("reducto/api_key", "credkey-1");
+    const add = findRoute("internal_mcp_add");
+
+    const result = await add.handler({
+      body: {
+        name: "reducto",
+        transportType: "streamable-http",
+        url: "https://mcp.reducto.ai/mcp",
+        authCredential: "reducto/api_key",
+        authHeader: "Authorization",
+        authPrefix: "Bearer ",
+      },
+    });
+
+    expect(result).toEqual({ added: true });
+    expect(storedEnvelope("reducto")).toEqual({
+      version: 2,
+      literals: {},
+      refs: [
+        {
+          headerName: "Authorization",
+          service: "reducto",
+          field: "api_key",
+          prefix: "Bearer ",
+        },
+      ],
+    });
+  });
+
+  test("parses {{credential:...}} placeholder in -H into a ref with prefix", async () => {
+    existingCredentials.set("reducto/api_key", "credkey-1");
+    const add = findRoute("internal_mcp_add");
+
+    await add.handler({
+      body: {
+        name: "reducto",
+        transportType: "streamable-http",
+        url: "https://mcp.reducto.ai/mcp",
+        headers: { Authorization: "Bearer {{credential:reducto/api_key}}" },
+      },
+    });
+
+    expect(storedEnvelope("reducto")).toEqual({
+      version: 2,
+      literals: {},
+      refs: [
+        {
+          headerName: "Authorization",
+          service: "reducto",
+          field: "api_key",
+          prefix: "Bearer ",
+        },
+      ],
+    });
+  });
+
+  test("rejects an empty header value", async () => {
+    const add = findRoute("internal_mcp_add");
+    await expect(
+      add.handler({
+        body: {
+          name: "srv",
+          transportType: "streamable-http",
+          url: "https://srv.example.com/mcp",
+          headers: { "X-API-Key": "" },
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: "BadRequestError",
+      message: expect.stringContaining("empty"),
+    });
+  });
+
+  test("rejects a header containing a shell env var and points to --auth-credential", async () => {
+    const add = findRoute("internal_mcp_add");
+    await expect(
+      add.handler({
+        body: {
+          name: "srv",
+          transportType: "streamable-http",
+          url: "https://srv.example.com/mcp",
+          headers: { Authorization: "Bearer ${REDUCTO_API_KEY}" },
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: "BadRequestError",
+      message: expect.stringContaining("--auth-credential"),
+    });
+  });
+
+  test("missing credential error includes the exact prompt command", async () => {
+    const add = findRoute("internal_mcp_add");
+    await expect(
+      add.handler({
+        body: {
+          name: "reducto",
+          transportType: "streamable-http",
+          url: "https://mcp.reducto.ai/mcp",
+          authCredential: "reducto/api_key",
+          authHeader: "Authorization",
+          authPrefix: "Bearer ",
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: "BadRequestError",
+      message: expect.stringContaining(
+        "assistant credentials prompt --service reducto --field api_key",
+      ),
+    });
+    // Server must not be half-written when the credential is missing.
+    expect(rawConfig.mcp.servers.reducto).toBeUndefined();
+  });
+
+  test("rejects static auth on stdio transports", async () => {
+    const add = findRoute("internal_mcp_add");
+    await expect(
+      add.handler({
+        body: {
+          name: "local",
+          transportType: "stdio",
+          command: "npx",
+          authCredential: "reducto/api_key",
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: "BadRequestError",
+      message: expect.stringContaining("sse/streamable-http"),
+    });
+  });
+});
+
+describe("mcp list — authType with refs", () => {
+  test("reports bearer auth for an Authorization ref without leaking values", async () => {
+    rawConfig.mcp.servers.reducto = {
+      transport: { type: "streamable-http", url: "https://mcp.reducto.ai/mcp" },
+      enabled: true,
+      defaultRiskLevel: "high",
+    };
+    secureStore.set(
+      "mcp:reducto:headers",
+      JSON.stringify({
+        version: 2,
+        literals: {},
+        refs: [
+          {
+            headerName: "Authorization",
+            service: "reducto",
+            field: "api_key",
+            prefix: "Bearer ",
+          },
+        ],
+      }),
+    );
+
+    const list = findRoute("internal_mcp_list");
+    const { servers } = (await list.handler({})) as {
+      servers: Array<Record<string, unknown>>;
+    };
+    const entry = servers.find((s) => s.id === "reducto");
+
+    expect(entry).toMatchObject({
+      hasStaticAuth: true,
+      authType: "bearer",
+    });
+    expect(entry?.authHeaderName).toBeUndefined();
+    expect(JSON.stringify(entry?.transport)).not.toContain("Authorization");
+  });
+
+  test("reports api-key auth and the header name for a non-Authorization ref", async () => {
+    rawConfig.mcp.servers.acme = {
+      transport: {
+        type: "streamable-http",
+        url: "https://acme.example.com/mcp",
+      },
+      enabled: true,
+      defaultRiskLevel: "high",
+    };
+    secureStore.set(
+      "mcp:acme:headers",
+      JSON.stringify({
+        version: 2,
+        literals: {},
+        refs: [{ headerName: "X-API-Key", service: "acme", field: "key" }],
+      }),
+    );
+
+    const list = findRoute("internal_mcp_list");
+    const { servers } = (await list.handler({})) as {
+      servers: Array<Record<string, unknown>>;
+    };
+    const entry = servers.find((s) => s.id === "acme");
+
+    expect(entry).toMatchObject({
+      hasStaticAuth: true,
+      authType: "api-key",
+      authHeaderName: "X-API-Key",
+    });
+  });
+});

--- a/assistant/src/__tests__/mcp-client-auth.test.ts
+++ b/assistant/src/__tests__/mcp-client-auth.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, jest, mock, test } from "bun:test";
 
 // Mock secure-keys so McpOAuthProvider doesn't try to access the credential store
+// mock.module applies process-wide; provide every export of the real module
+// so other test files importing it in the same run don't hit missing names.
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: jest.fn().mockResolvedValue(null),
   setSecureKeyAsync: jest.fn().mockResolvedValue(true),
   deleteSecureKeyAsync: jest.fn().mockResolvedValue("deleted"),
+  getSecureKeyResultAsync: jest
+    .fn()
+    .mockResolvedValue({ value: null, backend: "encrypted-store" }),
 }));
 
 mock.module("../config/env-registry.js", () => ({

--- a/assistant/src/cli/commands/mcp.ts
+++ b/assistant/src/cli/commands/mcp.ts
@@ -239,12 +239,26 @@ Examples:
         )
         .option(
           "-H, --header <key:value>",
-          "Custom HTTP header (repeatable, for sse/streamable-http). E.g. -H 'Authorization: Bearer tok123'",
+          "Custom HTTP header (repeatable, for sse/streamable-http). Prefer --auth-credential for secrets. E.g. -H 'X-Trace: on' or -H 'Authorization: Bearer {{credential:service/field}}'",
           (val: string, acc: string[]) => {
             acc.push(val);
             return acc;
           },
           [] as string[],
+        )
+        .option(
+          "--auth-credential <service/field>",
+          "Reference a stored vault credential for auth (recommended for API-key servers). Store it first with 'assistant credentials prompt --service <s> --field <f>'.",
+        )
+        .option(
+          "--auth-header <name>",
+          "Header name for --auth-credential",
+          "Authorization",
+        )
+        .option(
+          "--auth-prefix <prefix>",
+          "Value prefix prepended to the resolved credential for --auth-credential",
+          "Bearer ",
         )
         .option("--disabled", "Add as disabled")
         .addHelpText(
@@ -262,9 +276,23 @@ The --risk flag sets the default risk level for all tools from this server
 (defaults to "high" if not specified). The server starts enabled unless
 --disabled is passed.
 
+Auth for API-key / Bearer servers (recommended): store the secret in the
+vault, then reference it — the key never passes through the shell or the
+conversation, and rotation is picked up on reconnect:
+
+  $ assistant credentials prompt --service reducto --field api_key --label "Reducto API key"
+  $ assistant mcp add reducto -t streamable-http -u https://mcp.reducto.ai/mcp \\
+      --auth-credential reducto/api_key
+
+--auth-header defaults to "Authorization" and --auth-prefix defaults to
+"Bearer ". For a custom API-key header, pass both, e.g.
+--auth-credential acme/key --auth-header X-API-Key --auth-prefix ''.
+
 The --header (-H) flag adds custom HTTP headers to sse/streamable-http
-transports. Use it for Bearer Token or API Key authentication. The flag
-is repeatable — pass multiple -H flags for multiple headers.
+transports and is repeatable. Do NOT put a raw secret or a $VAR shell
+expansion in -H (the assistant strips env vars, so the header would be
+stored empty). To inject a stored credential from -H, use the placeholder
+syntax: -H 'Authorization: Bearer {{credential:service/field}}'.
 
 If a server with the same name already exists, the command fails. Remove the
 existing server first with "assistant mcp remove <name>".
@@ -273,8 +301,8 @@ Examples:
   $ assistant mcp add my-server -t stdio -c npx -a my-mcp-server
   $ assistant mcp add remote-api -t streamable-http -u https://api.example.com/mcp -r medium
   $ assistant mcp add legacy-sse -t sse -u https://old.example.com/events --disabled
-  $ assistant mcp add authed-api -t sse -u https://api.example.com/mcp -H 'Authorization: Bearer tok123'
-  $ assistant mcp add apikey-srv -t streamable-http -u https://srv.example.com/mcp -H 'X-API-Key: sk_live_abc'`,
+  $ assistant mcp add reducto -t streamable-http -u https://mcp.reducto.ai/mcp --auth-credential reducto/api_key
+  $ assistant mcp add apikey-srv -t streamable-http -u https://srv.example.com/mcp --auth-credential acme/key --auth-header X-API-Key --auth-prefix ''`,
         )
         .action(
           async (
@@ -286,6 +314,9 @@ Examples:
               args?: string[];
               risk: string;
               header: string[];
+              authCredential?: string;
+              authHeader?: string;
+              authPrefix?: string;
               disabled?: boolean;
             },
           ) => {
@@ -301,9 +332,23 @@ Examples:
                   process.exitCode = 1;
                   return;
                 }
-                headers[h.slice(0, colonIdx).trim()] = h
-                  .slice(colonIdx + 1)
-                  .trim();
+                const key = h.slice(0, colonIdx).trim();
+                const value = h.slice(colonIdx + 1).trim();
+                if (value.includes("${")) {
+                  log.error(
+                    `Header "${key}" contains a shell variable ("${value}"). Shell environment variables are stripped before the assistant runs, so this header would be stored empty. Use --auth-credential ${key === "Authorization" ? "<service/field>" : `<service/field> --auth-header ${key}`}, or the {{credential:service/field}} placeholder.`,
+                  );
+                  process.exitCode = 1;
+                  return;
+                }
+                if (value.length === 0) {
+                  log.error(
+                    `Header "${key}" has an empty value and would be stored empty. Provide a value or use --auth-credential.`,
+                  );
+                  process.exitCode = 1;
+                  return;
+                }
+                headers[key] = value;
               }
             }
 
@@ -319,6 +364,9 @@ Examples:
                   risk: opts.risk,
                   disabled: opts.disabled,
                   headers,
+                  authCredential: opts.authCredential,
+                  authHeader: opts.authHeader,
+                  authPrefix: opts.authPrefix,
                 },
               },
             );

--- a/assistant/src/mcp/__tests__/mcp-header-store.test.ts
+++ b/assistant/src/mcp/__tests__/mcp-header-store.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Module mocks (must precede imports) ───────────────────────────────────────
+
+// In-memory secure key backend shared by the header blob store and the
+// resolved credential values.
+const secureStore = new Map<string, string>();
+
+mock.module("../../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async (k: string) => secureStore.get(k),
+  setSecureKeyAsync: async (k: string, v: string) => {
+    secureStore.set(k, v);
+    return true;
+  },
+  deleteSecureKeyAsync: async (k: string) => {
+    secureStore.delete(k);
+    return "deleted";
+  },
+  getSecureKeyResultAsync: async (k: string) => ({
+    value: secureStore.get(k),
+    unreachable: false,
+  }),
+}));
+
+// Credentials that "exist" in the vault, keyed by "service/field" → storageKey.
+const existingCredentials = new Map<string, string>();
+
+mock.module("../../tools/credentials/resolve.js", () => ({
+  resolveCredentialRef: (ref: string) => {
+    const storageKey = existingCredentials.get(ref);
+    if (!storageKey) {
+      return undefined;
+    }
+    const [service, field] = ref.split("/");
+    return {
+      credentialId: ref,
+      service,
+      field,
+      storageKey,
+      injectionTemplates: [],
+      metadata: {},
+    };
+  },
+}));
+
+// ── Import SUT after mocks ────────────────────────────────────────────────────
+
+const {
+  buildMissingCredentialCommand,
+  getMcpHeaderEnvelope,
+  McpHeaderResolutionError,
+  resolveMcpHeaders,
+  setMcpHeaderEnvelope,
+  setMcpHeaders,
+} = await import("../mcp-header-store.js");
+
+const HEADERS_KEY = "mcp:srv:headers";
+
+beforeEach(() => {
+  secureStore.clear();
+  existingCredentials.clear();
+});
+
+describe("mcp-header-store", () => {
+  describe("legacy read-compat", () => {
+    test("normalizes a flat Record<string,string> blob into a v2 envelope", async () => {
+      secureStore.set(
+        HEADERS_KEY,
+        JSON.stringify({ Authorization: "Bearer legacy-tok" }),
+      );
+
+      const envelope = await getMcpHeaderEnvelope("srv");
+      expect(envelope).toEqual({
+        version: 2,
+        literals: { Authorization: "Bearer legacy-tok" },
+        refs: [],
+      });
+
+      const resolved = await resolveMcpHeaders("srv");
+      expect(resolved).toEqual({ Authorization: "Bearer legacy-tok" });
+    });
+
+    test("returns undefined when nothing is stored", async () => {
+      expect(await getMcpHeaderEnvelope("srv")).toBeUndefined();
+      expect(await resolveMcpHeaders("srv")).toEqual({});
+    });
+  });
+
+  describe("v2 envelope round-trip", () => {
+    test("persists and reads back literals and refs", async () => {
+      const envelope = {
+        version: 2 as const,
+        literals: { "X-Trace": "on" },
+        refs: [
+          {
+            headerName: "Authorization",
+            service: "reducto",
+            field: "api_key",
+            prefix: "Bearer ",
+          },
+        ],
+      };
+      expect(await setMcpHeaderEnvelope("srv", envelope)).toBe(true);
+      expect(await getMcpHeaderEnvelope("srv")).toEqual(envelope);
+    });
+
+    test("setMcpHeaders stores literal-only envelopes", async () => {
+      await setMcpHeaders("srv", { "X-API-Key": "abc" });
+      expect(await getMcpHeaderEnvelope("srv")).toEqual({
+        version: 2,
+        literals: { "X-API-Key": "abc" },
+        refs: [],
+      });
+    });
+  });
+
+  describe("ref resolution", () => {
+    test("resolves a ref with prefix through the vault", async () => {
+      existingCredentials.set("reducto/api_key", "credkey-1");
+      secureStore.set("credkey-1", "sk-secret-123");
+
+      await setMcpHeaderEnvelope("srv", {
+        version: 2,
+        literals: {},
+        refs: [
+          {
+            headerName: "Authorization",
+            service: "reducto",
+            field: "api_key",
+            prefix: "Bearer ",
+          },
+        ],
+      });
+
+      expect(await resolveMcpHeaders("srv")).toEqual({
+        Authorization: "Bearer sk-secret-123",
+      });
+    });
+
+    test("resolves a ref without a prefix", async () => {
+      existingCredentials.set("acme/key", "credkey-2");
+      secureStore.set("credkey-2", "raw-key");
+
+      await setMcpHeaderEnvelope("srv", {
+        version: 2,
+        literals: {},
+        refs: [{ headerName: "X-API-Key", service: "acme", field: "key" }],
+      });
+
+      expect(await resolveMcpHeaders("srv")).toEqual({
+        "X-API-Key": "raw-key",
+      });
+    });
+
+    test("refs win over literals on header-name collision", async () => {
+      existingCredentials.set("reducto/api_key", "credkey-3");
+      secureStore.set("credkey-3", "fresh-token");
+
+      await setMcpHeaderEnvelope("srv", {
+        version: 2,
+        literals: { Authorization: "Bearer stale-literal" },
+        refs: [
+          {
+            headerName: "Authorization",
+            service: "reducto",
+            field: "api_key",
+            prefix: "Bearer ",
+          },
+        ],
+      });
+
+      expect(await resolveMcpHeaders("srv")).toEqual({
+        Authorization: "Bearer fresh-token",
+      });
+    });
+  });
+
+  describe("missing credential behavior", () => {
+    test("throws McpHeaderResolutionError when a ref is unknown", async () => {
+      await setMcpHeaderEnvelope("srv", {
+        version: 2,
+        literals: {},
+        refs: [{ headerName: "Authorization", service: "gone", field: "key" }],
+      });
+
+      const promise = resolveMcpHeaders("srv");
+      await expect(promise).rejects.toBeInstanceOf(McpHeaderResolutionError);
+      await expect(promise).rejects.toMatchObject({
+        serverId: "srv",
+        missing: [
+          { headerName: "Authorization", service: "gone", field: "key" },
+        ],
+      });
+    });
+
+    test("throws when the credential exists but resolves to an empty value", async () => {
+      existingCredentials.set("empty/key", "credkey-empty");
+      secureStore.set("credkey-empty", "");
+
+      await setMcpHeaderEnvelope("srv", {
+        version: 2,
+        literals: {},
+        refs: [{ headerName: "Authorization", service: "empty", field: "key" }],
+      });
+
+      await expect(resolveMcpHeaders("srv")).rejects.toBeInstanceOf(
+        McpHeaderResolutionError,
+      );
+    });
+  });
+
+  describe("buildMissingCredentialCommand", () => {
+    test("produces the exact credentials prompt command", () => {
+      expect(buildMissingCredentialCommand("reducto", "api_key")).toBe(
+        'assistant credentials prompt --service reducto --field api_key --label "reducto api key"',
+      );
+    });
+  });
+});

--- a/assistant/src/mcp/client.ts
+++ b/assistant/src/mcp/client.ts
@@ -8,7 +8,10 @@ import { getIsPlatform } from "../config/env-registry.js";
 import type { McpTransport } from "../config/schemas/mcp.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
-import { getMcpHeaders } from "./mcp-header-store.js";
+import {
+  McpHeaderResolutionError,
+  resolveMcpHeaders,
+} from "./mcp-header-store.js";
 import { McpOAuthProvider } from "./mcp-oauth-provider.js";
 
 const log = getLogger("mcp-client");
@@ -109,16 +112,31 @@ export class McpClient {
       }
     }
 
-    // Resolve static auth headers from credential store, falling back to
-    // any legacy headers in the transport config for backward compatibility.
+    // Resolve static auth headers from credential store, merging literal
+    // headers with vault-backed credential references. Legacy headers in the
+    // transport config remain the fallback for backward compatibility.
     let effectiveConfig = transportConfig;
     if (isHttpTransport) {
-      const storedHeaders = await getMcpHeaders(this.serverId);
-      if (storedHeaders) {
-        effectiveConfig = {
-          ...transportConfig,
-          headers: { ...transportConfig.headers, ...storedHeaders },
-        } as McpTransport;
+      try {
+        const resolvedHeaders = await resolveMcpHeaders(this.serverId);
+        if (Object.keys(resolvedHeaders).length > 0) {
+          effectiveConfig = {
+            ...transportConfig,
+            headers: { ...transportConfig.headers, ...resolvedHeaders },
+          } as McpTransport;
+        }
+      } catch (err) {
+        if (err instanceof McpHeaderResolutionError) {
+          log.warn(
+            {
+              serverId: this.serverId,
+              missing: err.missing.map((m) => `${m.service}/${m.field}`),
+            },
+            "MCP static auth credential unresolvable; connecting without static headers (server will require auth)",
+          );
+        } else {
+          throw err;
+        }
       }
     }
 

--- a/assistant/src/mcp/client.ts
+++ b/assistant/src/mcp/client.ts
@@ -127,16 +127,20 @@ export class McpClient {
         }
       } catch (err) {
         if (err instanceof McpHeaderResolutionError) {
+          // Don't connect without the configured auth header — a server that
+          // tolerates anonymous traffic would silently register unauthenticated
+          // tools. Surface the missing credential as the connection error.
           log.warn(
             {
               serverId: this.serverId,
               missing: err.missing.map((m) => `${m.service}/${m.field}`),
             },
-            "MCP static auth credential unresolvable; connecting without static headers (server will require auth)",
+            "MCP static auth credential unresolvable; not connecting",
           );
-        } else {
-          throw err;
+          this._lastError = err;
+          return;
         }
+        throw err;
       }
     }
 

--- a/assistant/src/mcp/mcp-auth-orchestrator.ts
+++ b/assistant/src/mcp/mcp-auth-orchestrator.ts
@@ -21,7 +21,10 @@ import {
   setMcpAuthError,
   setMcpAuthPending,
 } from "./mcp-auth-state.js";
-import { getMcpHeaders } from "./mcp-header-store.js";
+import {
+  McpHeaderResolutionError,
+  resolveMcpHeaders,
+} from "./mcp-header-store.js";
 import {
   type McpOAuthCallbackTransport,
   McpOAuthProvider,
@@ -81,9 +84,30 @@ export async function orchestrateMcpOAuthConnect(args: {
   // Register the pending callback in the daemon heap
   const { codePromise } = await provider.startCallbackServer();
 
-  // Resolve effective headers: credential store takes precedence, then config
-  const storedHeaders = await getMcpHeaders(serverId);
-  const effectiveHeaders = storedHeaders ?? transport.headers;
+  // Resolve effective headers: credential store (literals + resolved refs)
+  // takes precedence, then config. An unresolvable ref falls back to config
+  // headers so the OAuth discovery attempt still runs.
+  let effectiveHeaders: Record<string, string> | undefined;
+  try {
+    const resolvedHeaders = await resolveMcpHeaders(serverId);
+    effectiveHeaders =
+      Object.keys(resolvedHeaders).length > 0
+        ? resolvedHeaders
+        : transport.headers;
+  } catch (err) {
+    if (err instanceof McpHeaderResolutionError) {
+      log.warn(
+        {
+          serverId,
+          missing: err.missing.map((m) => `${m.service}/${m.field}`),
+        },
+        "MCP static auth credential unresolvable during OAuth discovery; using config headers",
+      );
+      effectiveHeaders = transport.headers;
+    } else {
+      throw err;
+    }
+  }
 
   // Build the MCP transport and client
   const serverUrl = new URL(transport.url);

--- a/assistant/src/mcp/mcp-header-store.ts
+++ b/assistant/src/mcp/mcp-header-store.ts
@@ -5,34 +5,147 @@
  * the secure credential store (CES or encrypted file fallback) rather than
  * in plaintext config.json, keeping secrets out of workspace config files.
  *
- * Key format: mcp:{serverId}:headers — stores JSON-serialized Record<string, string>.
+ * Key format: mcp:{serverId}:headers — stores a JSON-serialized versioned
+ * envelope (McpHeaderEnvelope). Literal header values are stored inline;
+ * credential references point at a stored vault credential (service/field)
+ * and are resolved to a header value at connect time so key rotation is
+ * picked up on reconnect. Legacy flat `Record<string, string>` blobs are
+ * read transparently and treated as literals.
  */
 
 import { loadRawConfig, saveRawConfig } from "../config/loader.js";
 import {
   deleteSecureKeyAsync,
   getSecureKeyAsync,
+  getSecureKeyResultAsync,
   setSecureKeyAsync,
 } from "../security/secure-keys.js";
+import { resolveCredentialRef } from "../tools/credentials/resolve.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("mcp-header-store");
+
+/**
+ * A header whose value is derived from a stored vault credential. The
+ * resolved header value is `${prefix ?? ""}${credentialValue}`.
+ */
+export interface McpHeaderCredentialRef {
+  headerName: string;
+  service: string;
+  field: string;
+  prefix?: string;
+}
+
+/**
+ * Versioned envelope stored in the credential store for an MCP server's
+ * static auth headers. `literals` hold verbatim header values; `refs`
+ * resolve to header values through the vault at read time.
+ */
+export interface McpHeaderEnvelope {
+  version: 2;
+  literals: Record<string, string>;
+  refs: McpHeaderCredentialRef[];
+}
+
+/**
+ * Raised when a stored credential reference cannot be resolved to a value
+ * (the credential was deleted or the store is unreachable). Callers treat
+ * this as a needs-auth state rather than silently dropping the header.
+ */
+export class McpHeaderResolutionError extends Error {
+  readonly serverId: string;
+  readonly missing: McpHeaderCredentialRef[];
+
+  constructor(serverId: string, missing: McpHeaderCredentialRef[]) {
+    const refs = missing.map((m) => `${m.service}/${m.field}`).join(", ");
+    super(
+      `MCP server "${serverId}" references credential(s) that could not be resolved: ${refs}`,
+    );
+    this.name = "McpHeaderResolutionError";
+    this.serverId = serverId;
+    this.missing = missing;
+  }
+}
 
 function headersKey(serverId: string): string {
   return `mcp:${serverId}:headers`;
 }
 
 /**
- * Retrieve stored static auth headers for an MCP server.
- * Returns undefined if none are stored or if the credential store is unreachable.
+ * The exact CLI command that creates a missing vault credential. The prompt
+ * flow collects the secret through the client UI, never the conversation.
  */
-export async function getMcpHeaders(
+export function buildMissingCredentialCommand(
+  service: string,
+  field: string,
+): string {
+  const label = `${service} ${field.replace(/_/g, " ")}`;
+  return `assistant credentials prompt --service ${service} --field ${field} --label "${label}"`;
+}
+
+function normalizeEnvelope(parsed: unknown): McpHeaderEnvelope | undefined {
+  if (!parsed || typeof parsed !== "object") {
+    return undefined;
+  }
+  const obj = parsed as Record<string, unknown>;
+
+  if (obj.version === 2) {
+    const literals: Record<string, string> = {};
+    if (obj.literals && typeof obj.literals === "object") {
+      for (const [k, v] of Object.entries(obj.literals as object)) {
+        if (typeof v === "string") {
+          literals[k] = v;
+        }
+      }
+    }
+    const refs: McpHeaderCredentialRef[] = [];
+    if (Array.isArray(obj.refs)) {
+      for (const entry of obj.refs) {
+        if (!entry || typeof entry !== "object") {
+          continue;
+        }
+        const r = entry as Record<string, unknown>;
+        if (
+          typeof r.headerName === "string" &&
+          typeof r.service === "string" &&
+          typeof r.field === "string"
+        ) {
+          refs.push({
+            headerName: r.headerName,
+            service: r.service,
+            field: r.field,
+            ...(typeof r.prefix === "string" ? { prefix: r.prefix } : {}),
+          });
+        }
+      }
+    }
+    return { version: 2, literals, refs };
+  }
+
+  // Legacy flat Record<string, string> — treat every string entry as a literal.
+  const literals: Record<string, string> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (typeof v === "string") {
+      literals[k] = v;
+    }
+  }
+  return { version: 2, literals, refs: [] };
+}
+
+/**
+ * Retrieve the stored header envelope for an MCP server. Legacy flat blobs
+ * are normalized into a v2 envelope with all entries as literals. Returns
+ * undefined if none are stored or the credential store is unreachable.
+ */
+export async function getMcpHeaderEnvelope(
   serverId: string,
-): Promise<Record<string, string> | undefined> {
+): Promise<McpHeaderEnvelope | undefined> {
   const raw = await getSecureKeyAsync(headersKey(serverId));
-  if (!raw) return undefined;
+  if (!raw) {
+    return undefined;
+  }
   try {
-    return JSON.parse(raw) as Record<string, string>;
+    return normalizeEnvelope(JSON.parse(raw));
   } catch {
     log.warn({ serverId }, "Failed to parse stored MCP headers");
     return undefined;
@@ -40,15 +153,15 @@ export async function getMcpHeaders(
 }
 
 /**
- * Store static auth headers for an MCP server in the credential store.
+ * Persist a header envelope for an MCP server in the credential store.
  */
-export async function setMcpHeaders(
+export async function setMcpHeaderEnvelope(
   serverId: string,
-  headers: Record<string, string>,
+  envelope: McpHeaderEnvelope,
 ): Promise<boolean> {
   const ok = await setSecureKeyAsync(
     headersKey(serverId),
-    JSON.stringify(headers),
+    JSON.stringify(envelope),
   );
   if (!ok) {
     log.warn({ serverId }, "Failed to persist MCP headers to secure storage");
@@ -56,6 +169,66 @@ export async function setMcpHeaders(
   }
   log.info({ serverId }, "MCP static auth headers saved to credential store");
   return true;
+}
+
+/**
+ * Store literal-only static auth headers for an MCP server. Convenience
+ * wrapper over setMcpHeaderEnvelope for callers with no credential refs.
+ */
+export async function setMcpHeaders(
+  serverId: string,
+  headers: Record<string, string>,
+): Promise<boolean> {
+  return setMcpHeaderEnvelope(serverId, {
+    version: 2,
+    literals: { ...headers },
+    refs: [],
+  });
+}
+
+/**
+ * Resolve the effective static auth headers for an MCP server, merging
+ * literal headers with credential-reference headers resolved through the
+ * vault at call time. Refs win over literals on header-name collision.
+ *
+ * Throws McpHeaderResolutionError if any ref cannot be resolved so the
+ * caller can surface a needs-auth state instead of connecting with a
+ * silently missing header.
+ */
+export async function resolveMcpHeaders(
+  serverId: string,
+): Promise<Record<string, string>> {
+  const envelope = await getMcpHeaderEnvelope(serverId);
+  if (!envelope) {
+    return {};
+  }
+
+  const headers: Record<string, string> = { ...envelope.literals };
+  const missing: McpHeaderCredentialRef[] = [];
+
+  for (const ref of envelope.refs) {
+    const resolved = resolveCredentialRef(`${ref.service}/${ref.field}`);
+    if (!resolved) {
+      missing.push(ref);
+      continue;
+    }
+    const { value } = await getSecureKeyResultAsync(resolved.storageKey);
+    if (value == null || value.length === 0) {
+      missing.push(ref);
+      continue;
+    }
+    headers[ref.headerName] = `${ref.prefix ?? ""}${value}`;
+  }
+
+  if (missing.length > 0) {
+    log.error(
+      { serverId, missing: missing.map((m) => `${m.service}/${m.field}`) },
+      "MCP header credential references could not be resolved",
+    );
+    throw new McpHeaderResolutionError(serverId, missing);
+  }
+
+  return headers;
 }
 
 /**
@@ -103,7 +276,7 @@ export async function migrateLegacyMcpHeaders(): Promise<void> {
 
     // Only migrate if credential store doesn't already have headers for
     // this server (idempotent — safe to re-run after partial failure).
-    const existing = await getMcpHeaders(id);
+    const existing = await getMcpHeaderEnvelope(id);
     if (existing) {
       // Credential store already has headers; just strip the config copy.
       delete transport.headers;

--- a/assistant/src/runtime/routes/mcp-auth-routes.ts
+++ b/assistant/src/runtime/routes/mcp-auth-routes.ts
@@ -22,14 +22,18 @@ import { McpClient } from "../../mcp/client.js";
 import { orchestrateMcpOAuthConnect } from "../../mcp/mcp-auth-orchestrator.js";
 import { getMcpAuthState } from "../../mcp/mcp-auth-state.js";
 import {
+  buildMissingCredentialCommand,
   deleteMcpHeaders,
-  getMcpHeaders,
-  setMcpHeaders,
+  getMcpHeaderEnvelope,
+  type McpHeaderCredentialRef,
+  type McpHeaderEnvelope,
+  setMcpHeaderEnvelope,
 } from "../../mcp/mcp-header-store.js";
 import {
   deleteMcpOAuthCredentials,
   hasMcpOAuthTokens,
 } from "../../mcp/mcp-oauth-provider.js";
+import { resolveCredentialRef } from "../../tools/credentials/resolve.js";
 import { getMcpToolsByServer } from "../../tools/registry.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
@@ -189,10 +193,63 @@ interface McpServerEntry {
   blockedTools?: string[];
 }
 
-function detectAuthType(headers: Record<string, string>): "bearer" | "api-key" {
-  const authValue = headers["Authorization"] ?? headers["authorization"];
-  if (authValue?.startsWith("Bearer ")) return "bearer";
-  return "api-key";
+interface StaticAuthEntry {
+  name: string;
+  bearer: boolean;
+}
+
+/**
+ * Derive the auth entries (header name + bearer-ness) for an MCP server from
+ * its stored envelope, falling back to legacy config-level headers. Only the
+ * header name and whether it carries a Bearer prefix are surfaced — resolved
+ * secret values are never read here.
+ */
+function envelopeAuthEntries(
+  envelope: McpHeaderEnvelope | undefined,
+  legacyConfigHeaders: Record<string, string> | undefined,
+): StaticAuthEntry[] {
+  const entries: StaticAuthEntry[] = [];
+  if (envelope) {
+    for (const [name, value] of Object.entries(envelope.literals)) {
+      entries.push({ name, bearer: value.startsWith("Bearer ") });
+    }
+    for (const ref of envelope.refs) {
+      entries.push({
+        name: ref.headerName,
+        bearer: (ref.prefix ?? "").startsWith("Bearer"),
+      });
+    }
+  } else if (legacyConfigHeaders) {
+    for (const [name, value] of Object.entries(legacyConfigHeaders)) {
+      entries.push({ name, bearer: value.startsWith("Bearer ") });
+    }
+  }
+  return entries;
+}
+
+function summarizeStaticAuth(entries: StaticAuthEntry[]): {
+  hasStaticAuth: boolean;
+  authType: "none" | "bearer" | "api-key";
+  authHeaderName?: string;
+} {
+  if (entries.length === 0) {
+    return { hasStaticAuth: false, authType: "none" };
+  }
+  const authorization = entries.find(
+    (e) => e.name.toLowerCase() === "authorization",
+  );
+  const authType: "bearer" | "api-key" = authorization?.bearer
+    ? "bearer"
+    : "api-key";
+  const authHeaderName =
+    authType === "api-key"
+      ? entries.find((e) => e.name.toLowerCase() !== "authorization")?.name
+      : undefined;
+  return {
+    hasStaticAuth: true,
+    authType,
+    ...(authHeaderName ? { authHeaderName } : {}),
+  };
 }
 
 async function handleMcpList(_args: {
@@ -219,25 +276,17 @@ async function handleMcpList(_args: {
             ? await hasMcpOAuthTokens(id)
             : false;
 
-        // Check credential store for stored static auth headers
-        const storedHeaders = await getMcpHeaders(id);
-        // Also check legacy config-level headers
+        // Derive auth shape from the stored envelope (literals + refs),
+        // falling back to legacy config-level headers. Secret values are
+        // never resolved here.
+        const envelope = await getMcpHeaderEnvelope(id);
         const configHeaders =
           config.transport.type !== "stdio"
             ? config.transport.headers
             : undefined;
-        const effectiveHeaders = storedHeaders ?? configHeaders;
-        const hasStaticAuth =
-          !!effectiveHeaders && Object.keys(effectiveHeaders).length > 0;
-        const authType: "none" | "bearer" | "api-key" = hasStaticAuth
-          ? detectAuthType(effectiveHeaders!)
-          : "none";
-        const authHeaderName =
-          authType === "api-key" && effectiveHeaders
-            ? Object.keys(effectiveHeaders).find(
-                (k) => k.toLowerCase() !== "authorization",
-              )
-            : undefined;
+        const { hasStaticAuth, authType, authHeaderName } = summarizeStaticAuth(
+          envelopeAuthEntries(envelope, configHeaders),
+        );
 
         // Strip headers from transport — never return secrets
         const { headers: _stripped, ...safeTransport } =
@@ -317,6 +366,124 @@ function handleMcpToolsSummary(): {
 }
 
 // ---------------------------------------------------------------------------
+// Static auth header inputs (literals + credential references)
+// ---------------------------------------------------------------------------
+
+const CREDENTIAL_PLACEHOLDER = /\{\{\s*credential:([^}]+?)\s*\}\}/;
+
+interface McpAuthHeaderInput {
+  headers?: Record<string, string> | null;
+  authCredential?: string;
+  authHeader?: string;
+  authPrefix?: string;
+}
+
+function parseServiceField(
+  ref: string,
+): { service: string; field: string } | undefined {
+  const trimmed = ref.trim();
+  const slash = trimmed.indexOf("/");
+  if (slash <= 0 || slash >= trimmed.length - 1) {
+    return undefined;
+  }
+  if (trimmed.indexOf("/", slash + 1) !== -1) {
+    return undefined;
+  }
+  return { service: trimmed.slice(0, slash), field: trimmed.slice(slash + 1) };
+}
+
+/**
+ * Build a versioned header envelope from CLI/route inputs, validating each
+ * value and confirming every credential reference resolves to a stored
+ * credential. Returns null when there is nothing to store (the caller clears
+ * any existing headers). Throws BadRequestError for invalid input.
+ */
+function buildMcpHeaderEnvelope(
+  input: McpAuthHeaderInput,
+): McpHeaderEnvelope | null {
+  const literals: Record<string, string> = {};
+  const refs: McpHeaderCredentialRef[] = [];
+
+  if (input.headers) {
+    for (const [name, value] of Object.entries(input.headers)) {
+      if (value.includes("${")) {
+        throw new BadRequestError(
+          `Header "${name}" contains a shell variable (value "${value}"). Shell environment variables are not available when the assistant stores MCP headers, so the header would be saved empty. Reference a stored vault credential instead with --auth-credential service/field (and --auth-header "${name}" if it is not Authorization), or embed {{credential:service/field}} in the header value.`,
+        );
+      }
+
+      const match = value.match(CREDENTIAL_PLACEHOLDER);
+      if (match) {
+        const parsed = parseServiceField(match[1]);
+        if (!parsed) {
+          throw new BadRequestError(
+            `Header "${name}" has an invalid credential placeholder "${match[0]}". Expected {{credential:service/field}}.`,
+          );
+        }
+        const placeholderStart = match.index ?? 0;
+        const prefix = value.slice(0, placeholderStart);
+        const suffix = value.slice(placeholderStart + match[0].length);
+        if (suffix.length > 0) {
+          throw new BadRequestError(
+            `Header "${name}" has text after the {{credential:...}} placeholder. Only a prefix before the placeholder is supported (e.g. "Bearer {{credential:service/field}}").`,
+          );
+        }
+        refs.push({
+          headerName: name,
+          service: parsed.service,
+          field: parsed.field,
+          ...(prefix ? { prefix } : {}),
+        });
+        continue;
+      }
+
+      if (value.trim().length === 0) {
+        throw new BadRequestError(
+          `Header "${name}" has an empty value and would be stored empty, causing auth failures. Provide a value, or reference a stored credential with --auth-credential or {{credential:service/field}}.`,
+        );
+      }
+      literals[name] = value;
+    }
+  }
+
+  const authCredential = input.authCredential?.trim();
+  if (authCredential) {
+    const parsed = parseServiceField(authCredential);
+    if (!parsed) {
+      throw new BadRequestError(
+        `--auth-credential "${input.authCredential}" is invalid. Expected the form service/field, e.g. reducto/api_key.`,
+      );
+    }
+    const headerName =
+      input.authHeader && input.authHeader.length > 0
+        ? input.authHeader
+        : "Authorization";
+    const prefix = input.authPrefix ?? "Bearer ";
+    refs.push({
+      headerName,
+      service: parsed.service,
+      field: parsed.field,
+      ...(prefix ? { prefix } : {}),
+    });
+  }
+
+  if (Object.keys(literals).length === 0 && refs.length === 0) {
+    return null;
+  }
+
+  for (const ref of refs) {
+    const resolved = resolveCredentialRef(`${ref.service}/${ref.field}`);
+    if (!resolved) {
+      throw new BadRequestError(
+        `Credential "${ref.service}/${ref.field}" (for header "${ref.headerName}") is not stored. Create it first with:\n  ${buildMissingCredentialCommand(ref.service, ref.field)}\nThis prompts for the secret through the client UI — never type it into the conversation.`,
+      );
+    }
+  }
+
+  return { version: 2, literals, refs };
+}
+
+// ---------------------------------------------------------------------------
 // Update
 // ---------------------------------------------------------------------------
 
@@ -333,6 +500,9 @@ async function handleMcpUpdate({
     allowedTools,
     blockedTools,
     headers,
+    authCredential,
+    authHeader,
+    authPrefix,
   } = body as {
     name: string;
     enabled?: boolean;
@@ -341,6 +511,9 @@ async function handleMcpUpdate({
     allowedTools?: string[] | null;
     blockedTools?: string[] | null;
     headers?: Record<string, string> | null;
+    authCredential?: string;
+    authHeader?: string;
+    authPrefix?: string;
   };
 
   const raw = loadRawConfig();
@@ -379,7 +552,7 @@ async function handleMcpUpdate({
       server.blockedTools = blockedTools;
     }
   }
-  if (headers !== undefined) {
+  if (headers !== undefined || authCredential !== undefined) {
     const transport = server.transport as Record<string, unknown> | undefined;
     if (
       transport &&
@@ -388,8 +561,15 @@ async function handleMcpUpdate({
       // Migrate any legacy config-level headers away
       delete transport.headers;
 
+      const envelope = buildMcpHeaderEnvelope({
+        headers,
+        authCredential,
+        authHeader,
+        authPrefix,
+      });
+
       // Store in credential store (or delete if clearing)
-      if (headers === null || Object.keys(headers).length === 0) {
+      if (!envelope) {
         const ok = await deleteMcpHeaders(name);
         if (!ok) {
           throw new InternalError(
@@ -397,7 +577,7 @@ async function handleMcpUpdate({
           );
         }
       } else {
-        const ok = await setMcpHeaders(name, headers);
+        const ok = await setMcpHeaderEnvelope(name, envelope);
         if (!ok) {
           throw new InternalError(
             "Failed to persist auth headers to credential store",
@@ -422,17 +602,31 @@ async function handleMcpAdd({
 }: {
   body?: Record<string, unknown>;
 }): Promise<{ added: true }> {
-  const { name, transportType, url, command, args, risk, disabled, headers } =
-    body as {
-      name: string;
-      transportType: string;
-      url?: string;
-      command?: string;
-      args?: string[];
-      risk?: string;
-      disabled?: boolean;
-      headers?: Record<string, string>;
-    };
+  const {
+    name,
+    transportType,
+    url,
+    command,
+    args,
+    risk,
+    disabled,
+    headers,
+    authCredential,
+    authHeader,
+    authPrefix,
+  } = body as {
+    name: string;
+    transportType: string;
+    url?: string;
+    command?: string;
+    args?: string[];
+    risk?: string;
+    disabled?: boolean;
+    headers?: Record<string, string>;
+    authCredential?: string;
+    authHeader?: string;
+    authPrefix?: string;
+  };
 
   const riskLevel = risk ?? "high";
   if (!["low", "medium", "high"].includes(riskLevel)) {
@@ -476,6 +670,24 @@ async function handleMcpAdd({
     );
   }
 
+  const wantsStaticAuth =
+    (headers && Object.keys(headers).length > 0) ||
+    (authCredential !== undefined && authCredential !== "");
+  if (wantsStaticAuth && transportType === "stdio") {
+    throw new BadRequestError(
+      "Static auth headers are only supported for sse/streamable-http transports.",
+    );
+  }
+
+  // Validate and build the header envelope before writing config so an
+  // invalid credential ref never leaves a half-configured server behind.
+  const envelope = buildMcpHeaderEnvelope({
+    headers,
+    authCredential,
+    authHeader,
+    authPrefix,
+  });
+
   serverMap[name] = {
     transport,
     enabled: !disabled,
@@ -483,8 +695,8 @@ async function handleMcpAdd({
   };
 
   // Store auth headers in credential store, not config
-  if (headers && Object.keys(headers).length > 0) {
-    const ok = await setMcpHeaders(name, headers);
+  if (envelope) {
+    const ok = await setMcpHeaderEnvelope(name, envelope);
     if (!ok) {
       throw new InternalError(
         "Failed to persist auth headers to credential store",
@@ -714,6 +926,9 @@ export const ROUTES: RouteDefinition[] = [
       allowedTools: z.array(z.string()).nullable().optional(),
       blockedTools: z.array(z.string()).nullable().optional(),
       headers: z.record(z.string(), z.string()).nullable().optional(),
+      authCredential: z.string().optional(),
+      authHeader: z.string().optional(),
+      authPrefix: z.string().optional(),
     }),
     handler: handleMcpUpdate,
   },
@@ -738,6 +953,9 @@ export const ROUTES: RouteDefinition[] = [
       risk: z.string().optional(),
       disabled: z.boolean().optional(),
       headers: z.record(z.string(), z.string()).optional(),
+      authCredential: z.string().optional(),
+      authHeader: z.string().optional(),
+      authPrefix: z.string().optional(),
     }),
     handler: handleMcpAdd,
   },

--- a/assistant/src/runtime/routes/mcp-auth-routes.ts
+++ b/assistant/src/runtime/routes/mcp-auth-routes.ts
@@ -216,7 +216,7 @@ function envelopeAuthEntries(
     for (const ref of envelope.refs) {
       entries.push({
         name: ref.headerName,
-        bearer: (ref.prefix ?? "").startsWith("Bearer"),
+        bearer: (ref.prefix ?? "").startsWith("Bearer "),
       });
     }
   } else if (legacyConfigHeaders) {


### PR DESCRIPTION
## Problem

Feedback session `019f4e08` (2026-07-10): to connect an API-key MCP server (Reducto), the assistant stored the key in the vault correctly — then had no way to reference it from MCP config. `mcp add --header "Authorization: Bearer ${REDUCTO_API_KEY}"` silently stored an **empty** header (the shell tool strips non-allowlisted env vars) → 401 loop. The only working path was `credentials reveal` piping the **plaintext key through the shell**, defeating the vault.

## Changes

- **Versioned header envelope** in the MCP header store (`mcp:<id>:headers`): literal headers + credential refs `{headerName, service, field, prefix?}`. Legacy flat blobs read transparently as literals. Refs resolve through the existing `resolveCredentialRef` path at connect time (key rotation picked up on reconnect); an unresolvable ref surfaces as needs-auth, never a silently absent header.
- **CLI**: `mcp add --auth-credential service/field` (+ `--auth-header`, default `Authorization`; `--auth-prefix`, default `"Bearer "`), and `{{credential:service/field}}` placeholders inside `-H` values. Help text recommends the credential-ref flow for API-key servers.
- **Validation** (CLI + route as source of truth): empty header values and `${...}` shell vars are rejected with guidance toward `--auth-credential`; a missing credential returns the exact `assistant credentials prompt --service X --field Y --label ...` command to create it (secret collected via client UI, never the conversation). Envelope is validated before the config write, so a bad reference leaves nothing half-written.
- `mcp list` derives `hasStaticAuth`/`authType`/`authHeaderName` from the envelope without resolving secret values.

After this PR the whole Reducto-style flow is: `credentials prompt` → `mcp add reducto -t streamable-http -u <url> --auth-credential reducto/api_key`. No secret ever transits the shell or conversation.

## Tests

`mcp-header-store.test.ts` (10), `mcp-auth-routes-credential-headers.test.ts` (8), plus existing `mcp-auth-routes` / `mcp-health-check` / `mcp-auth-orchestrator` suites; `bunx tsc --noEmit` clean.

Part of the MCP setup-friction remediation with #37851 (OAuth refresh); both touch adjacent `client.ts` lines — whichever merges second rebases. A follow-up PR stacks on this branch adding add-time verification, `mcp reload --wait`, and non-blocking `mcp auth`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->