### PR TITLE
feat(mcp): verified setup feedback loop (add verification, reload --wait, non-blocking auth)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -15513,6 +15513,8 @@ paths:
                   type: string
                 authPrefix:
                   type: string
+                verify:
+                  type: boolean
               required:
                 - name
                 - transportType
@@ -15654,9 +15656,20 @@ paths:
     post:
       operationId: internal_mcp_reload_post
       summary: Trigger MCP server reload
-      description: Kicks off reloadMcpServers() async on the daemon. Returns immediately.
+      description:
+        "Reloads MCP servers on the daemon. Returns immediately by default; with { wait: true } it awaits the
+        reload and returns per-server connection status."
       tags:
         - internal
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                wait:
+                  type: boolean
       responses:
         "200":
           description: Successful response
@@ -15788,6 +15801,8 @@ paths:
                   type: string
                 authPrefix:
                   type: string
+                verify:
+                  type: boolean
               required:
                 - name
       responses:

--- a/assistant/src/__tests__/mcp-auth-routes-credential-headers.test.ts
+++ b/assistant/src/__tests__/mcp-auth-routes-credential-headers.test.ts
@@ -130,7 +130,7 @@ describe("mcp add — credential-reference headers", () => {
       },
     });
 
-    expect(result).toEqual({ added: true });
+    expect(result).toMatchObject({ added: true });
     expect(storedEnvelope("reducto")).toEqual({
       version: 2,
       literals: {},

--- a/assistant/src/__tests__/mcp-auth-routes-feedback.test.ts
+++ b/assistant/src/__tests__/mcp-auth-routes-feedback.test.ts
@@ -1,0 +1,310 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Module mocks (must precede imports that pull them in) ──────────────────────
+
+let rawConfig: { mcp: { servers: Record<string, Record<string, unknown>> } };
+
+mock.module("../config/loader.js", () => ({
+  loadRawConfig: () => rawConfig,
+  saveRawConfig: (c: typeof rawConfig) => {
+    rawConfig = c;
+  },
+  getConfig: () => rawConfig,
+  getConfigReadOnly: () => rawConfig,
+}));
+
+let reloadResult: {
+  success: boolean;
+  servers?: Array<Record<string, unknown>>;
+  error?: string;
+};
+const mockReload = mock(async () => reloadResult);
+
+mock.module("../daemon/mcp-reload-service.js", () => ({
+  reloadMcpServers: () => mockReload(),
+}));
+
+mock.module("../mcp/mcp-auth-orchestrator.js", () => ({
+  orchestrateMcpOAuthConnect: async () => ({ auth_url: "https://x" }),
+}));
+
+mock.module("../mcp/mcp-auth-state.js", () => ({
+  getMcpAuthState: () => null,
+}));
+
+mock.module("../mcp/mcp-oauth-provider.js", () => ({
+  hasMcpOAuthTokens: async () => false,
+  deleteMcpOAuthCredentials: async () => ({ ok: true, failedKeys: [] }),
+}));
+
+let clientConnected = true;
+let clientLastError: Error | null = null;
+const connectCalls: string[] = [];
+
+mock.module("../mcp/client.js", () => ({
+  McpClient: class {
+    constructor(public id: string) {}
+    async connect() {
+      connectCalls.push(this.id);
+    }
+    get isConnected() {
+      return clientConnected;
+    }
+    get lastError() {
+      return clientLastError;
+    }
+    async disconnect() {}
+  },
+}));
+
+let connectedServers: Set<string>;
+
+mock.module("../mcp/manager.js", () => ({
+  getMcpServerManager: () => ({
+    isServerConnected: (id: string) => connectedServers.has(id),
+  }),
+}));
+
+const secureStore = new Map<string, string>();
+const realSecureKeys = await import("../security/secure-keys.js");
+
+mock.module("../security/secure-keys.js", () => ({
+  ...realSecureKeys,
+  getSecureKeyAsync: async (k: string) => secureStore.get(k),
+  setSecureKeyAsync: async (k: string, v: string) => {
+    secureStore.set(k, v);
+    return true;
+  },
+  deleteSecureKeyAsync: async (k: string) => {
+    secureStore.delete(k);
+    return "deleted";
+  },
+  getSecureKeyResultAsync: async (k: string) => ({
+    value: secureStore.get(k),
+    unreachable: false,
+  }),
+}));
+
+// ── Import SUT after mocks ─────────────────────────────────────────────────────
+
+const { ROUTES } = await import("../runtime/routes/mcp-auth-routes.js");
+
+function findRoute(operationId: string) {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) {
+    throw new Error(`Route ${operationId} not found`);
+  }
+  return route;
+}
+
+const httpServer = {
+  transport: { type: "streamable-http", url: "https://srv.example.com/mcp" },
+  enabled: true,
+  defaultRiskLevel: "high",
+};
+
+beforeEach(() => {
+  rawConfig = { mcp: { servers: {} } };
+  reloadResult = { success: true, servers: [] };
+  clientConnected = true;
+  clientLastError = null;
+  connectCalls.length = 0;
+  connectedServers = new Set<string>();
+  secureStore.clear();
+  mockReload.mockClear();
+});
+
+describe("internal_mcp_reload — wait", () => {
+  test("wait=true awaits reload and returns per-server status", async () => {
+    reloadResult = {
+      success: true,
+      servers: [
+        { id: "a", connected: true, toolCount: 2, tools: ["x", "y"] },
+        { id: "b", connected: false, needsAuth: true, toolCount: 0, tools: [] },
+        { id: "c", connected: false, error: "boom", toolCount: 0, tools: [] },
+        { id: "d", connected: false, disabled: true, toolCount: 0, tools: [] },
+      ],
+    };
+
+    const reload = findRoute("internal_mcp_reload");
+    const result = await reload.handler({ body: { wait: true } });
+
+    expect(mockReload).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      ok: true,
+      servers: [
+        { serverId: "a", connected: true },
+        { serverId: "b", connected: false, needsAuth: true },
+        { serverId: "c", connected: false, error: "boom" },
+        { serverId: "d", connected: false, disabled: true },
+      ],
+    });
+  });
+
+  test("without wait it stays fire-and-forget", async () => {
+    const reload = findRoute("internal_mcp_reload");
+    const result = await reload.handler({ body: {} });
+
+    expect(result).toEqual({ ok: true });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockReload).toHaveBeenCalledTimes(1);
+  });
+
+  test("wait=true surfaces a top-level reload error", async () => {
+    reloadResult = { success: false, error: "config broken", servers: [] };
+
+    const reload = findRoute("internal_mcp_reload");
+    const result = await reload.handler({ body: { wait: true } });
+
+    expect(result).toEqual({ ok: true, servers: [], error: "config broken" });
+  });
+});
+
+describe("internal_mcp_add — verification", () => {
+  test("reports connected when the probe connects", async () => {
+    clientConnected = true;
+    const add = findRoute("internal_mcp_add");
+    const result = await add.handler({
+      body: {
+        name: "srv",
+        transportType: "streamable-http",
+        url: "https://srv.example.com/mcp",
+      },
+    });
+
+    expect(result).toEqual({ added: true, status: "connected" });
+    expect(connectCalls).toEqual(["srv"]);
+  });
+
+  test("reports needs-auth when the probe is unauthenticated", async () => {
+    clientConnected = false;
+    clientLastError = null;
+    const add = findRoute("internal_mcp_add");
+    const result = await add.handler({
+      body: {
+        name: "srv",
+        transportType: "streamable-http",
+        url: "https://srv.example.com/mcp",
+      },
+    });
+
+    expect(result).toEqual({ added: true, status: "needs-auth" });
+  });
+
+  test("reports error with the failure message", async () => {
+    clientConnected = false;
+    clientLastError = new Error("dns fail");
+    const add = findRoute("internal_mcp_add");
+    const result = await add.handler({
+      body: {
+        name: "srv",
+        transportType: "streamable-http",
+        url: "https://srv.example.com/mcp",
+      },
+    });
+
+    expect(result).toEqual({ added: true, status: "error", error: "dns fail" });
+  });
+
+  test("verify:false skips the probe entirely", async () => {
+    const add = findRoute("internal_mcp_add");
+    const result = await add.handler({
+      body: {
+        name: "srv",
+        transportType: "streamable-http",
+        url: "https://srv.example.com/mcp",
+        verify: false,
+      },
+    });
+
+    expect(result).toEqual({ added: true });
+    expect(connectCalls).toEqual([]);
+  });
+
+  test("a disabled server is not probed", async () => {
+    const add = findRoute("internal_mcp_add");
+    const result = await add.handler({
+      body: {
+        name: "srv",
+        transportType: "streamable-http",
+        url: "https://srv.example.com/mcp",
+        disabled: true,
+      },
+    });
+
+    expect(result).toEqual({ added: true });
+    expect(connectCalls).toEqual([]);
+  });
+});
+
+describe("internal_mcp_update — verification", () => {
+  test("probes and reports status by default", async () => {
+    rawConfig.mcp.servers.srv = { ...httpServer };
+    clientConnected = false;
+    clientLastError = null;
+
+    const update = findRoute("internal_mcp_update");
+    const result = await update.handler({
+      body: { name: "srv", defaultRiskLevel: "medium" },
+    });
+
+    expect(result).toEqual({ updated: true, status: "needs-auth" });
+    expect(connectCalls).toEqual(["srv"]);
+  });
+
+  test("verify:false skips the probe", async () => {
+    rawConfig.mcp.servers.srv = { ...httpServer };
+
+    const update = findRoute("internal_mcp_update");
+    const result = await update.handler({
+      body: { name: "srv", verify: false },
+    });
+
+    expect(result).toEqual({ updated: true });
+    expect(connectCalls).toEqual([]);
+  });
+
+  test("a server disabled by the update is not probed", async () => {
+    rawConfig.mcp.servers.srv = { ...httpServer };
+
+    const update = findRoute("internal_mcp_update");
+    const result = await update.handler({
+      body: { name: "srv", enabled: false },
+    });
+
+    expect(result).toEqual({ updated: true });
+    expect(connectCalls).toEqual([]);
+  });
+});
+
+describe("internal_mcp_list — live manager state", () => {
+  test("a live-connected server reports connected without a probe", async () => {
+    rawConfig.mcp.servers.live = { ...httpServer };
+    connectedServers.add("live");
+    // A probe, if it ran, would report a non-connected status.
+    clientConnected = false;
+    clientLastError = new Error("would-be error");
+
+    const list = findRoute("internal_mcp_list");
+    const { servers } = (await list.handler({})) as {
+      servers: Array<{ id: string; status: string }>;
+    };
+
+    expect(servers.find((s) => s.id === "live")?.status).toBe("connected");
+    expect(connectCalls).toEqual([]);
+  });
+
+  test("a server without a live connection falls back to the probe", async () => {
+    rawConfig.mcp.servers.dead = { ...httpServer };
+    clientConnected = false;
+    clientLastError = new Error("refused");
+
+    const list = findRoute("internal_mcp_list");
+    const { servers } = (await list.handler({})) as {
+      servers: Array<{ id: string; status: string }>;
+    };
+
+    expect(servers.find((s) => s.id === "dead")?.status).toBe("error");
+    expect(connectCalls).toEqual(["dead"]);
+  });
+});

--- a/assistant/src/__tests__/mcp-cli.test.ts
+++ b/assistant/src/__tests__/mcp-cli.test.ts
@@ -42,7 +42,11 @@ mock.module("../ipc/cli-client.js", () => ({
     params?: Record<string, unknown>,
     opts?: { timeoutMs?: number },
   ) => mockCliIpcCallFn(method, params, opts),
-  exitFromIpcResult: (r: { ok: false; error?: string; statusCode?: number }) => {
+  exitFromIpcResult: (r: {
+    ok: false;
+    error?: string;
+    statusCode?: number;
+  }) => {
     process.stderr.write((r.error ?? "Unknown error") + "\n");
     process.exitCode = 10;
   },
@@ -394,7 +398,8 @@ describe("assistant mcp add", () => {
     mockCliIpcCallFn = mock(() =>
       Promise.resolve({
         ok: false,
-        error: 'MCP server "existing" already exists. Remove it first with: assistant mcp remove existing',
+        error:
+          'MCP server "existing" already exists. Remove it first with: assistant mcp remove existing',
       }),
     );
 
@@ -467,6 +472,66 @@ describe("assistant mcp add", () => {
       (c) => c[0] === "internal_mcp_add",
     );
     expect(addCall).toBeDefined();
+  });
+
+  test("prints needs-auth guidance when verification reports needs-auth", async () => {
+    mockCliIpcCallFn = mock(() =>
+      Promise.resolve({
+        ok: true,
+        result: { added: true, status: "needs-auth" },
+      }),
+    );
+
+    const { stdout, exitCode } = await runMcpAdd("needs-auth-server", [
+      "-t",
+      "streamable-http",
+      "-u",
+      "https://example.com/mcp",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("assistant mcp auth needs-auth-server");
+  });
+
+  test("prints connected when verification reports connected", async () => {
+    mockCliIpcCallFn = mock(() =>
+      Promise.resolve({
+        ok: true,
+        result: { added: true, status: "connected" },
+      }),
+    );
+
+    const { stdout } = await runMcpAdd("ok-server", [
+      "-t",
+      "streamable-http",
+      "-u",
+      "https://example.com/mcp",
+    ]);
+
+    expect(stdout).toContain("Verified: connected");
+  });
+
+  test("--no-verify sends verify:false in the request body", async () => {
+    mockCliIpcCallFn = mock(() =>
+      Promise.resolve({ ok: true, result: { added: true } }),
+    );
+
+    await runMcpAdd("no-verify-server", [
+      "-t",
+      "streamable-http",
+      "-u",
+      "https://example.com/mcp",
+      "--no-verify",
+    ]);
+
+    const addCall = mockCliIpcCallFn.mock.calls.find(
+      (c) => c[0] === "internal_mcp_add",
+    );
+    const body = (addCall![1] as Record<string, unknown>).body as Record<
+      string,
+      unknown
+    >;
+    expect(body.verify).toBe(false);
   });
 });
 
@@ -561,6 +626,32 @@ describe("assistant mcp reload", () => {
 
     expect(exitCode).toBe(0); // best-effort, not fatal
     expect(stderr).toContain("Could not signal reload");
+  });
+
+  test("--wait sends { wait: true } and prints per-server status", async () => {
+    mockCliIpcCallFn = mock(() =>
+      Promise.resolve({
+        ok: true,
+        result: {
+          ok: true,
+          servers: [
+            { serverId: "alpha", connected: true },
+            { serverId: "beta", connected: false, needsAuth: true },
+          ],
+        },
+      }),
+    );
+
+    const { stdout, exitCode } = await runMcp("reload", ["--wait"]);
+
+    expect(exitCode).toBe(0);
+    const reloadCall = mockCliIpcCallFn.mock.calls.find(
+      (c) => c[0] === "internal_mcp_reload",
+    );
+    expect(reloadCall![1]).toEqual({ body: { wait: true } });
+    expect(stdout).toContain("alpha: connected");
+    expect(stdout).toContain("beta: needs-auth");
+    expect(stdout).toContain("assistant mcp auth beta");
   });
 });
 
@@ -771,5 +862,72 @@ describe("assistant mcp auth — IPC path", () => {
     expect(stderr).toMatch(/Internal server error during polling/);
     // Should fail fast — only 1 start call + 1 poll call, not the full timeout
     expect(mockCliIpcCallFn.mock.calls.length).toBe(2);
+  });
+
+  test("--no-wait starts the flow, opens the browser, and exits 0 without polling", async () => {
+    mockCliIpcCallFn = mock((method: string) => {
+      if (method === "internal_mcp_auth_start") {
+        return Promise.resolve({
+          ok: true,
+          result: { auth_url: "https://auth.example.com", state: "srv" },
+        });
+      }
+      return Promise.resolve({ ok: true, result: { status: "pending" } });
+    });
+
+    const { exitCode, stdout } = await runMcp("auth", ["srv", "--no-wait"]);
+
+    expect(exitCode).toBe(0);
+    expect(mockOpenInHostBrowserFn).toHaveBeenCalledWith(
+      "https://auth.example.com",
+    );
+    expect(stdout).toContain("assistant mcp auth srv --status");
+    // Only the start call — the flow does not poll.
+    expect(mockCliIpcCallFn.mock.calls.length).toBe(1);
+    expect(mockCliIpcCallFn.mock.calls[0][0]).toBe("internal_mcp_auth_start");
+  });
+
+  test("--status reports pending with the authorization URL", async () => {
+    mockCliIpcCallFn = mock(() =>
+      Promise.resolve({
+        ok: true,
+        result: { status: "pending", auth_url: "https://auth.example.com" },
+      }),
+    );
+
+    const { exitCode, stdout } = await runMcp("auth", ["srv", "--status"]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("pending");
+    expect(stdout).toContain("https://auth.example.com");
+    // --status never starts a flow.
+    expect(mockCliIpcCallFn.mock.calls.length).toBe(1);
+    expect(mockCliIpcCallFn.mock.calls[0][0]).toBe("internal_mcp_auth_status");
+    expect(mockOpenInHostBrowserFn).not.toHaveBeenCalled();
+  });
+
+  test("--status reports complete", async () => {
+    mockCliIpcCallFn = mock(() =>
+      Promise.resolve({ ok: true, result: { status: "complete" } }),
+    );
+
+    const { exitCode, stdout } = await runMcp("auth", ["srv", "--status"]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("complete");
+  });
+
+  test("--status exits 1 when there is no active flow", async () => {
+    mockCliIpcCallFn = mock(() =>
+      Promise.resolve({
+        ok: false,
+        error: 'No active OAuth flow for server "srv"',
+      }),
+    );
+
+    const { exitCode, stderr } = await runMcp("auth", ["srv", "--status"]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("No active OAuth flow");
   });
 });

--- a/assistant/src/cli/commands/mcp.ts
+++ b/assistant/src/cli/commands/mcp.ts
@@ -24,6 +24,30 @@ interface McpServerEntry {
   blockedTools?: string[];
 }
 
+interface McpReloadServerStatus {
+  serverId: string;
+  connected: boolean;
+  needsAuth?: boolean;
+  disabled?: boolean;
+  error?: string;
+}
+
+function reloadStatusLabel(s: McpReloadServerStatus): string {
+  if (s.disabled) {
+    return "disabled";
+  }
+  if (s.connected) {
+    return "connected";
+  }
+  if (s.needsAuth) {
+    return "needs-auth";
+  }
+  if (s.error) {
+    return `error: ${s.error}`;
+  }
+  return "error";
+}
+
 // ---------------------------------------------------------------------------
 // Auth polling helper
 // ---------------------------------------------------------------------------
@@ -196,6 +220,10 @@ Examples:
       mcp
         .command("reload")
         .description("Reload MCP server connections in the running assistant")
+        .option(
+          "--wait",
+          "Wait for the reload to finish and print per-server connection status",
+        )
         .addHelpText(
           "after",
           `
@@ -203,22 +231,56 @@ Signals the running assistant to disconnect and reconnect all MCP servers
 using the current configuration from disk. Active sessions pick up new tools
 on their next turn automatically. The assistant must be running.
 
+By default the reload is fire-and-forget. Pass --wait to block until the
+reload completes and print each server's status (connected, needs-auth,
+disabled, or error).
+
 Examples:
   $ vellum mcp reload
-  $ vellum mcp reload   # after editing config.json to add a new server
+  $ vellum mcp reload --wait   # block and report per-server status
   $ vellum mcp reload   # after running "vellum mcp auth <server>"`,
         )
-        .action(async () => {
-          const result = await cliIpcCall("internal_mcp_reload", { body: {} });
+        .action(async (opts: { wait?: boolean }) => {
+          const result = await cliIpcCall<{
+            ok: true;
+            servers?: McpReloadServerStatus[];
+            error?: string;
+          }>("internal_mcp_reload", {
+            body: opts.wait ? { wait: true } : {},
+          });
+
           if (!result.ok) {
             log.warn(
               `Could not signal reload: ${result.error}. ` +
                 `Run 'assistant mcp reload' once the assistant is up.`,
             );
-          } else {
+            return;
+          }
+
+          if (!opts.wait) {
             log.info(
               "MCP reload signal sent. The running assistant will reconnect servers shortly.",
             );
+            return;
+          }
+
+          if (result.result?.error) {
+            log.error(`Reload error: ${result.result.error}`);
+            process.exitCode = 1;
+          }
+
+          const servers = result.result?.servers ?? [];
+          if (servers.length === 0) {
+            log.info("Reload complete. No MCP servers configured.");
+            return;
+          }
+
+          log.info("Reload complete:");
+          for (const s of servers) {
+            log.info(`  ${s.serverId}: ${reloadStatusLabel(s)}`);
+            if (s.needsAuth) {
+              log.info(`    Run: assistant mcp auth ${s.serverId}`);
+            }
           }
         });
 
@@ -261,6 +323,10 @@ Examples:
           "Bearer ",
         )
         .option("--disabled", "Add as disabled")
+        .option(
+          "--no-verify",
+          "Skip the post-add connection check (add fire-and-forget without reporting status)",
+        )
         .addHelpText(
           "after",
           `
@@ -275,6 +341,11 @@ Transport-specific requirements:
 The --risk flag sets the default risk level for all tools from this server
 (defaults to "high" if not specified). The server starts enabled unless
 --disabled is passed.
+
+After writing the config the command verifies the server by attempting a
+bounded connection, then reports whether it connected, needs authentication
+(run 'assistant mcp auth <name>'), or errored. Pass --no-verify to skip the
+check and return immediately.
 
 Auth for API-key / Bearer servers (recommended): store the secret in the
 vault, then reference it — the key never passes through the shell or the
@@ -318,6 +389,7 @@ Examples:
               authHeader?: string;
               authPrefix?: string;
               disabled?: boolean;
+              verify?: boolean;
             },
           ) => {
             let headers: Record<string, string> | undefined;
@@ -352,24 +424,26 @@ Examples:
               }
             }
 
-            const result = await cliIpcCall<{ added: true }>(
-              "internal_mcp_add",
-              {
-                body: {
-                  name,
-                  transportType: opts.transportType,
-                  url: opts.url,
-                  command: opts.command,
-                  args: opts.args,
-                  risk: opts.risk,
-                  disabled: opts.disabled,
-                  headers,
-                  authCredential: opts.authCredential,
-                  authHeader: opts.authHeader,
-                  authPrefix: opts.authPrefix,
-                },
+            const result = await cliIpcCall<{
+              added: true;
+              status?: "connected" | "needs-auth" | "error";
+              error?: string;
+            }>("internal_mcp_add", {
+              body: {
+                name,
+                transportType: opts.transportType,
+                url: opts.url,
+                command: opts.command,
+                args: opts.args,
+                risk: opts.risk,
+                disabled: opts.disabled,
+                headers,
+                authCredential: opts.authCredential,
+                authHeader: opts.authHeader,
+                authPrefix: opts.authPrefix,
+                verify: opts.verify,
               },
-            );
+            });
 
             if (!result.ok) {
               log.error(result.error ?? "Failed to add MCP server");
@@ -378,13 +452,36 @@ Examples:
             }
 
             log.info(`Added MCP server "${name}" (${opts.transportType})`);
-            log.info("The running assistant is reloading MCP servers now.");
+
+            const status = result.result?.status;
+            if (!status) {
+              log.info("The running assistant is reloading MCP servers now.");
+              return;
+            }
+            if (status === "connected") {
+              log.info("Verified: connected.");
+            } else if (status === "needs-auth") {
+              log.info(`Needs authentication. Run: assistant mcp auth ${name}`);
+            } else {
+              log.info(
+                `Could not connect: ${result.result?.error ?? "unknown error"}. ` +
+                  "The assistant will keep retrying on reload.",
+              );
+            }
           },
         );
 
       mcp
         .command("auth <name>")
         .description("Authenticate with an MCP server via OAuth")
+        .option(
+          "--no-wait",
+          "Start the OAuth flow, print the authorization URL, and exit without waiting",
+        )
+        .option(
+          "--status",
+          "Print the current OAuth flow status instead of starting a new flow",
+        )
         .addHelpText(
           "after",
           `
@@ -395,83 +492,136 @@ Only works with sse or streamable-http transports (stdio servers do not use
 OAuth). Opens a browser for OAuth authorization with the remote server. The
 running assistant handles the OAuth callback and token exchange.
 
-The command waits up to 2.5 minutes for the user to complete the browser-based
-OAuth flow. If the server already has valid cached tokens, the command succeeds
-immediately without opening a browser. Tokens are cached locally for future use
-by the assistant.
+By default the command waits up to 2.5 minutes for the user to complete the
+browser-based OAuth flow. If the server already has valid cached tokens, it
+succeeds immediately without opening a browser. Tokens are cached locally for
+future use by the assistant.
+
+Pass --no-wait to start the flow, print the authorization URL, and exit
+immediately — then poll with --status until it reports complete. This avoids
+tying up a conversation turn while the browser authorization happens.
 
 After successful authentication, the running assistant detects the change
 automatically. You can also run 'vellum mcp reload' to apply immediately.
 
 Examples:
   $ assistant mcp auth my-server
-  $ assistant mcp auth remote-api`,
+  $ assistant mcp auth my-server --no-wait
+  $ assistant mcp auth my-server --status`,
         )
-        .action(async (name: string) => {
-          // IPC-first path — attempt daemon-orchestrated flow (works on hosted assistants)
-          const startResult = await cliIpcCall<{
-            auth_url: string;
-            state: string;
-            already_authenticated?: boolean;
-          }>("internal_mcp_auth_start", { body: { serverId: name } });
+        .action(
+          async (name: string, opts: { wait?: boolean; status?: boolean }) => {
+            // --status: report the current flow without starting a new one.
+            if (opts.status) {
+              const statusResult = await cliIpcCall<{
+                status: string;
+                auth_url?: string;
+                error?: string;
+              }>("internal_mcp_auth_status", {
+                pathParams: { serverId: name },
+              });
 
-          if (startResult.ok && startResult.result?.already_authenticated) {
-            log.info(`Server "${name}" is already authenticated.`);
-            process.exit(0);
-            return;
-          }
+              if (!statusResult.ok) {
+                log.error(
+                  `No active OAuth flow for "${name}". ` +
+                    `Start one with: assistant mcp auth ${name} --no-wait`,
+                );
+                process.exitCode = 1;
+                return;
+              }
 
-          if (startResult.ok && startResult.result?.auth_url) {
-            const authUrl = startResult.result.auth_url;
-            log.info(`Opening browser for "${name}" OAuth authorization...`);
-            openInHostBrowser(authUrl);
-            log.info(`If the browser did not open, visit:\n${authUrl}`);
-            log.info(
-              "Waiting for authorization in browser... (press Ctrl+C to cancel)",
-            );
+              const state = statusResult.result;
+              if (state?.status === "pending") {
+                log.info(`Authorization pending for "${name}".`);
+                if (state.auth_url) {
+                  log.info(`Authorize at:\n${state.auth_url}`);
+                }
+              } else if (state?.status === "complete") {
+                log.info(`Authentication complete for "${name}".`);
+              } else {
+                log.error(
+                  `OAuth error for "${name}": ${state?.error ?? "unknown error"}`,
+                );
+                process.exitCode = 1;
+              }
+              return;
+            }
 
-            const finalStatus = await pollMcpAuthStatus(name, {
-              intervalMs: 2_000,
-              timeoutMs: 150_000, // matches existing OAUTH_TIMEOUT_MS
-            });
+            // IPC-first path — attempt daemon-orchestrated flow (works on hosted assistants)
+            const startResult = await cliIpcCall<{
+              auth_url: string;
+              state: string;
+              already_authenticated?: boolean;
+            }>("internal_mcp_auth_start", { body: { serverId: name } });
 
-            if (finalStatus.status === "complete") {
-              log.info(`Authentication successful for "${name}".`);
-              log.info(
-                "The running assistant has picked up this change automatically.",
-              );
+            if (startResult.ok && startResult.result?.already_authenticated) {
+              log.info(`Server "${name}" is already authenticated.`);
               process.exit(0);
               return;
             }
 
-            const errMsg = finalStatus.error ?? "Unknown error";
-            if (errMsg.includes("denied") || errMsg.includes("cancelled")) {
-              log.error(`Authorization cancelled for "${name}".`);
-            } else if (errMsg.includes("timed out")) {
+            if (startResult.ok && startResult.result?.auth_url) {
+              const authUrl = startResult.result.auth_url;
+              log.info(`Opening browser for "${name}" OAuth authorization...`);
+              openInHostBrowser(authUrl);
+              log.info(`If the browser did not open, visit:\n${authUrl}`);
+
+              if (opts.wait === false) {
+                log.info(
+                  `Authorization started for "${name}". ` +
+                    `Check status with: assistant mcp auth ${name} --status`,
+                );
+                process.exit(0);
+                return;
+              }
+
+              log.info(
+                "Waiting for authorization in browser... (press Ctrl+C to cancel)",
+              );
+
+              const finalStatus = await pollMcpAuthStatus(name, {
+                intervalMs: 2_000,
+                timeoutMs: 150_000, // matches existing OAUTH_TIMEOUT_MS
+              });
+
+              if (finalStatus.status === "complete") {
+                log.info(`Authentication successful for "${name}".`);
+                log.info(
+                  "The running assistant has picked up this change automatically.",
+                );
+                process.exit(0);
+                return;
+              }
+
+              const errMsg = finalStatus.error ?? "Unknown error";
+              if (errMsg.includes("denied") || errMsg.includes("cancelled")) {
+                log.error(`Authorization cancelled for "${name}".`);
+              } else if (errMsg.includes("timed out")) {
+                log.error(
+                  `Authorization timed out for "${name}". Try again with: assistant mcp auth ${name}`,
+                );
+              } else {
+                log.error(`OAuth failed for "${name}": ${errMsg}`);
+              }
+              process.exitCode = 1;
+              return;
+            }
+
+            // Any !startResult.ok case: surface error and exit 1
+            const ipcErrMsg = startResult.error ?? "Unknown error";
+            if (
+              ipcErrMsg.startsWith("Could not connect to assistant daemon") ||
+              ipcErrMsg.startsWith("Unknown method:")
+            ) {
               log.error(
-                `Authorization timed out for "${name}". Try again with: assistant mcp auth ${name}`,
+                `MCP OAuth requires the assistant to be running. Is it running?`,
               );
             } else {
-              log.error(`OAuth failed for "${name}": ${errMsg}`);
+              log.error(`MCP OAuth failed via assistant: ${ipcErrMsg}`);
             }
             process.exitCode = 1;
-            return;
-          }
-
-          // Any !startResult.ok case: surface error and exit 1
-          const ipcErrMsg = startResult.error ?? "Unknown error";
-          if (
-            ipcErrMsg.startsWith("Could not connect to assistant daemon") ||
-            ipcErrMsg.startsWith("Unknown method:")
-          ) {
-            log.error(
-              `MCP OAuth requires the assistant to be running. Is it running?`,
-            );
-          } else {
-            log.error(`MCP OAuth failed via assistant: ${ipcErrMsg}`);
-          }
-          process.exitCode = 1;
-        });
+          },
+        );
 
       mcp
         .command("remove <name>")

--- a/assistant/src/cli/commands/mcp.ts
+++ b/assistant/src/cli/commands/mcp.ts
@@ -245,9 +245,14 @@ Examples:
             ok: true;
             servers?: McpReloadServerStatus[];
             error?: string;
-          }>("internal_mcp_reload", {
-            body: opts.wait ? { wait: true } : {},
-          });
+          }>(
+            "internal_mcp_reload",
+            { body: opts.wait ? { wait: true } : {} },
+            // A waited reload reconnects servers serially; each slow server
+            // can take the 30s connect timeout, so the default 60s IPC
+            // timeout would cut off multi-server reloads mid-flight.
+            opts.wait ? { timeoutMs: 300_000 } : undefined,
+          );
 
           if (!result.ok) {
             log.warn(

--- a/assistant/src/daemon/mcp-reload-service.ts
+++ b/assistant/src/daemon/mcp-reload-service.ts
@@ -20,6 +20,10 @@ export interface McpReloadServerResult {
   connected: boolean;
   /** True when the server is explicitly disabled in config. */
   disabled?: boolean;
+  /** True when the server did not connect because it requires authentication. */
+  needsAuth?: boolean;
+  /** Transport-level failure message, when the server failed to connect. */
+  error?: string;
   toolCount: number;
   tools: string[];
 }
@@ -85,36 +89,39 @@ async function doReload(): Promise<McpReloadResult> {
 
     if (config.mcp?.servers && Object.keys(config.mcp.servers).length > 0) {
       const serverToolInfos = await manager.start(config.mcp);
-      for (const { serverId, serverConfig, tools } of serverToolInfos) {
-        const mcpTools = createMcpToolsFromServer(
-          tools,
-          serverId,
-          serverConfig,
-          manager,
-        );
-        const accepted = registerMcpTools(serverId, mcpTools);
-        const acceptedNames = accepted.map((t) => t.name);
-        toolCount += accepted.length;
-        servers.push({
-          id: serverId,
-          connected: true,
-          toolCount: accepted.length,
-          tools: acceptedNames,
-        });
-      }
-      // Include servers that were configured but failed to connect or are disabled
+      const infoById = new Map(
+        serverToolInfos.map((info) => [info.serverId, info]),
+      );
+      // Preserve config order so callers see a stable server list.
       for (const id of serverIds) {
-        if (!servers.some((s) => s.id === id)) {
-          const serverConfig = config.mcp!.servers![id];
-          const isDisabled = serverConfig?.enabled === false;
+        const info = infoById.get(id);
+        if (info) {
+          const mcpTools = createMcpToolsFromServer(
+            info.tools,
+            id,
+            info.serverConfig,
+            manager,
+          );
+          const accepted = registerMcpTools(id, mcpTools);
+          toolCount += accepted.length;
           servers.push({
             id,
-            connected: false,
-            disabled: isDisabled || undefined,
-            toolCount: 0,
-            tools: [],
+            connected: true,
+            toolCount: accepted.length,
+            tools: accepted.map((t) => t.name),
           });
+          continue;
         }
+        const state = manager.getConnectionState(id);
+        servers.push({
+          id,
+          connected: false,
+          disabled: state?.status === "disabled" ? true : undefined,
+          needsAuth: state?.status === "needs-auth" ? true : undefined,
+          error: state?.status === "error" ? state.error : undefined,
+          toolCount: 0,
+          tools: [],
+        });
       }
       serverCount = servers.length;
     }

--- a/assistant/src/mcp/manager.ts
+++ b/assistant/src/mcp/manager.ts
@@ -10,12 +10,21 @@ export interface McpServerToolInfo {
   tools: McpToolInfo[];
 }
 
+/** Outcome of the most recent connection attempt for a server. */
+export type McpServerConnectionState =
+  | { status: "connected" }
+  | { status: "needs-auth" }
+  | { status: "error"; error: string }
+  | { status: "disabled" };
+
 export class McpServerManager {
   private clients = new Map<string, McpClient>();
   private serverConfigs = new Map<string, McpServerConfig>();
+  private connectionStates = new Map<string, McpServerConnectionState>();
 
   async start(config: McpConfig): Promise<McpServerToolInfo[]> {
     const results: McpServerToolInfo[] = [];
+    this.connectionStates.clear();
 
     console.log(
       `[MCP] Starting ${Object.keys(config.servers).length} server(s)...`,
@@ -24,6 +33,7 @@ export class McpServerManager {
       if (!serverConfig.enabled) {
         console.log(`[MCP] Server "${serverId}" is disabled, skipping`);
         log.info({ serverId }, "MCP server disabled, skipping");
+        this.connectionStates.set(serverId, { status: "disabled" });
         continue;
       }
 
@@ -44,12 +54,21 @@ export class McpServerManager {
         await client.connect(serverConfig.transport);
 
         if (!client.isConnected) {
-          // Server requires authentication — connect() logged guidance
+          // A recorded lastError means a transport failure; its absence means
+          // the server requires authentication (connect() logged guidance).
+          const err = client.lastError;
+          this.connectionStates.set(
+            serverId,
+            err
+              ? { status: "error", error: err.message }
+              : { status: "needs-auth" },
+          );
           continue;
         }
 
         this.clients.set(serverId, client);
         this.serverConfigs.set(serverId, serverConfig);
+        this.connectionStates.set(serverId, { status: "connected" });
 
         let tools = await client.listTools();
         log.info(
@@ -73,6 +92,10 @@ export class McpServerManager {
       } catch (err) {
         console.error(`[MCP] Failed to connect to server "${serverId}":`, err);
         log.error({ err, serverId }, "Failed to connect to MCP server");
+        this.connectionStates.set(serverId, {
+          status: "error",
+          error: err instanceof Error ? err.message : String(err),
+        });
         // Clean up any partially-connected client
         const staleClient = this.clients.get(serverId);
         if (staleClient) {
@@ -138,6 +161,19 @@ export class McpServerManager {
 
   getClient(serverId: string): McpClient | undefined {
     return this.clients.get(serverId);
+  }
+
+  /** True when the manager holds a live, connected client for the server. */
+  isServerConnected(serverId: string): boolean {
+    return this.clients.get(serverId)?.isConnected ?? false;
+  }
+
+  /**
+   * Outcome of the most recent connection attempt for the server, or undefined
+   * when the server was not part of the last start() cycle.
+   */
+  getConnectionState(serverId: string): McpServerConnectionState | undefined {
+    return this.connectionStates.get(serverId);
   }
 
   private filterTools(

--- a/assistant/src/runtime/routes/mcp-auth-routes.ts
+++ b/assistant/src/runtime/routes/mcp-auth-routes.ts
@@ -17,8 +17,12 @@ import { z } from "zod";
 import { loadRawConfig, saveRawConfig } from "../../config/loader.js";
 import type { McpConfig, McpServerConfig } from "../../config/schemas/mcp.js";
 import { estimateToolDefinitionTokens } from "../../context/token-estimator.js";
-import { reloadMcpServers } from "../../daemon/mcp-reload-service.js";
+import {
+  type McpReloadServerResult,
+  reloadMcpServers,
+} from "../../daemon/mcp-reload-service.js";
 import { McpClient } from "../../mcp/client.js";
+import { getMcpServerManager } from "../../mcp/manager.js";
 import { orchestrateMcpOAuthConnect } from "../../mcp/mcp-auth-orchestrator.js";
 import { getMcpAuthState } from "../../mcp/mcp-auth-state.js";
 import {
@@ -123,11 +127,45 @@ function triggerReload(context: string): void {
   });
 }
 
-function handleMcpReload(_args: { body?: Record<string, unknown> }): {
-  ok: true;
-} {
-  triggerReload("internal_mcp_reload");
-  return { ok: true };
+interface McpReloadRouteServer {
+  serverId: string;
+  connected: boolean;
+  needsAuth?: boolean;
+  disabled?: boolean;
+  error?: string;
+}
+
+function toReloadRouteServers(
+  servers: McpReloadServerResult[],
+): McpReloadRouteServer[] {
+  return servers.map((s) => ({
+    serverId: s.id,
+    connected: s.connected,
+    ...(s.needsAuth ? { needsAuth: true } : {}),
+    ...(s.disabled ? { disabled: true } : {}),
+    ...(s.error ? { error: s.error } : {}),
+  }));
+}
+
+async function handleMcpReload({
+  body,
+}: {
+  body?: Record<string, unknown>;
+}): Promise<
+  { ok: true } | { ok: true; servers: McpReloadRouteServer[]; error?: string }
+> {
+  const wait = (body as { wait?: boolean } | undefined)?.wait === true;
+  if (!wait) {
+    triggerReload("internal_mcp_reload");
+    return { ok: true };
+  }
+
+  const result = await reloadMcpServers();
+  return {
+    ok: true,
+    servers: toReloadRouteServers(result.servers ?? []),
+    ...(result.success ? {} : { error: result.error }),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -136,11 +174,18 @@ function handleMcpReload(_args: { body?: Record<string, unknown> }): {
 
 const HEALTH_CHECK_TIMEOUT_MS = 10_000;
 
+type McpHealthStatus = "connected" | "needs-auth" | "error";
+
+interface McpHealthResult {
+  status: McpHealthStatus;
+  error?: string;
+}
+
 async function checkMachineReadableHealth(
   serverId: string,
   config: McpServerConfig,
   timeoutMs = HEALTH_CHECK_TIMEOUT_MS,
-): Promise<string> {
+): Promise<McpHealthResult> {
   const client = new McpClient(serverId);
   try {
     await Promise.race([
@@ -153,25 +198,25 @@ async function checkMachineReadableHealth(
 
     if (client.isConnected) {
       await client.disconnect();
-      return "connected";
+      return { status: "connected" };
     }
 
     const err = client.lastError;
     if (err) {
-      if (err.message.includes("timeout")) {
-        return "error";
-      }
-      return "error";
+      return { status: "error", error: err.message };
     }
 
-    return "needs-auth";
-  } catch {
+    return { status: "needs-auth" };
+  } catch (err) {
     try {
       await client.disconnect();
     } catch {
       /* ignore */
     }
-    return "error";
+    return {
+      status: "error",
+      error: err instanceof Error ? err.message : String(err),
+    };
   }
 }
 
@@ -259,6 +304,7 @@ async function handleMcpList(_args: {
   const mcpConfig = raw.mcp as Partial<McpConfig> | undefined;
   const servers = mcpConfig?.servers ?? {};
   const entries = Object.entries(servers) as [string, McpServerConfig][];
+  const manager = getMcpServerManager();
 
   const results: McpServerEntry[] = await Promise.all(
     entries
@@ -268,8 +314,12 @@ async function handleMcpList(_args: {
         let status: string;
         if (!enabled) {
           status = "disabled";
+        } else if (manager.isServerConnected(id)) {
+          // The manager holds a live connection — trust it instead of opening
+          // a throwaway probe connection.
+          status = "connected";
         } else {
-          status = await checkMachineReadableHealth(id, config);
+          status = (await checkMachineReadableHealth(id, config)).status;
         }
         const hasOAuth =
           config.transport.type !== "stdio"
@@ -491,7 +541,7 @@ async function handleMcpUpdate({
   body,
 }: {
   body?: Record<string, unknown>;
-}): Promise<{ updated: true }> {
+}): Promise<{ updated: true; status?: McpHealthStatus; error?: string }> {
   const {
     name,
     enabled,
@@ -503,6 +553,7 @@ async function handleMcpUpdate({
     authCredential,
     authHeader,
     authPrefix,
+    verify,
   } = body as {
     name: string;
     enabled?: boolean;
@@ -514,6 +565,7 @@ async function handleMcpUpdate({
     authCredential?: string;
     authHeader?: string;
     authPrefix?: string;
+    verify?: boolean;
   };
 
   const raw = loadRawConfig();
@@ -590,7 +642,20 @@ async function handleMcpUpdate({
   saveRawConfig(raw);
   triggerReload("internal_mcp_update");
 
-  return { updated: true };
+  const isEnabled = server.enabled !== false;
+  if (verify === false || !isEnabled) {
+    return { updated: true };
+  }
+
+  const health = await checkMachineReadableHealth(
+    name,
+    server as unknown as McpServerConfig,
+  );
+  return {
+    updated: true,
+    status: health.status,
+    ...(health.error ? { error: health.error } : {}),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -601,7 +666,7 @@ async function handleMcpAdd({
   body,
 }: {
   body?: Record<string, unknown>;
-}): Promise<{ added: true }> {
+}): Promise<{ added: true; status?: McpHealthStatus; error?: string }> {
   const {
     name,
     transportType,
@@ -614,6 +679,7 @@ async function handleMcpAdd({
     authCredential,
     authHeader,
     authPrefix,
+    verify,
   } = body as {
     name: string;
     transportType: string;
@@ -626,6 +692,7 @@ async function handleMcpAdd({
     authCredential?: string;
     authHeader?: string;
     authPrefix?: string;
+    verify?: boolean;
   };
 
   const riskLevel = risk ?? "high";
@@ -707,7 +774,21 @@ async function handleMcpAdd({
   saveRawConfig(raw);
   triggerReload("internal_mcp_add");
 
-  return { added: true };
+  if (verify === false || disabled) {
+    return { added: true };
+  }
+
+  // Probe the affected server with a bounded health check so the caller learns
+  // whether the first connect will succeed, need auth, or fail.
+  const health = await checkMachineReadableHealth(
+    name,
+    serverMap[name] as unknown as McpServerConfig,
+  );
+  return {
+    added: true,
+    status: health.status,
+    ...(health.error ? { error: health.error } : {}),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -838,8 +919,9 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Trigger MCP server reload",
     description:
-      "Kicks off reloadMcpServers() async on the daemon. Returns immediately.",
+      "Reloads MCP servers on the daemon. Returns immediately by default; with { wait: true } it awaits the reload and returns per-server connection status.",
     tags: ["internal"],
+    requestBody: z.object({ wait: z.boolean().optional() }),
     handler: handleMcpReload,
   },
   {
@@ -929,6 +1011,7 @@ export const ROUTES: RouteDefinition[] = [
       authCredential: z.string().optional(),
       authHeader: z.string().optional(),
       authPrefix: z.string().optional(),
+      verify: z.boolean().optional(),
     }),
     handler: handleMcpUpdate,
   },
@@ -956,6 +1039,7 @@ export const ROUTES: RouteDefinition[] = [
       authCredential: z.string().optional(),
       authHeader: z.string().optional(),
       authPrefix: z.string().optional(),
+      verify: z.boolean().optional(),
     }),
     handler: handleMcpAdd,
   },

--- a/assistant/src/runtime/routes/mcp-auth-routes.ts
+++ b/assistant/src/runtime/routes/mcp-auth-routes.ts
@@ -642,8 +642,11 @@ async function handleMcpUpdate({
   saveRawConfig(raw);
   triggerReload("internal_mcp_update");
 
+  // Probe only HTTP transports: a stdio probe would spawn the server process
+  // a second time alongside the background reload's real connection.
   const isEnabled = server.enabled !== false;
-  if (verify === false || !isEnabled) {
+  const updatedTransport = server.transport as { type?: string } | undefined;
+  if (verify === false || !isEnabled || updatedTransport?.type === "stdio") {
     return { updated: true };
   }
 
@@ -774,7 +777,9 @@ async function handleMcpAdd({
   saveRawConfig(raw);
   triggerReload("internal_mcp_add");
 
-  if (verify === false || disabled) {
+  // Probe only HTTP transports: a stdio probe would spawn the server process
+  // a second time alongside the background reload's real connection.
+  if (verify === false || disabled || transportType === "stdio") {
     return { added: true };
   }
 


### PR DESCRIPTION
## Problem

Feedback session `019f4e08` (2026-07-10): during MCP setup the assistant had no feedback loop. `mcp add` reported success on a server that would 401 on first connect; learning real status required repeated `sleep N && mcp list` dances; `mcp reload` was fire-and-forget; and `mcp auth` blocked a conversation turn for its full 2.5-minute browser-approval poll (one attempt burned 121s and the user thought the assistant hung). `mcp list` also opened a throwaway probe connection per server even while the manager held live connections.

## Changes

- **Awaitable reload**: `internal_mcp_reload` accepts `{wait: true}` and returns per-server `{serverId, connected, needsAuth?, disabled?, error?}`; the manager now records each server's connection outcome. CLI: `mcp reload --wait`.
- **Verified add/update**: after writing config, the affected server is probed with the bounded 10s health check; the response carries `status: connected | needs-auth | error` and the CLI prints next steps (`Run: assistant mcp auth <name>` on needs-auth). `--no-verify` restores fire-and-forget.
- **Non-blocking auth**: `mcp auth --no-wait` starts the flow, prints the authorization URL, and exits 0; `mcp auth <name> --status` polls the flow state. Default blocking behavior unchanged.
- **Churn-free list**: `handleMcpList` trusts a live manager connection; only servers without one get a probe.

## Tests

New `mcp-auth-routes-feedback.test.ts` (13); `mcp-cli.test.ts` extended to 35; PR-base suites re-run green. `bunx tsc --noEmit` clean.

Stacked on #37852 (base branch `mcp-credential-ref-headers`) — part of the MCP setup-friction remediation with #37851.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37854" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->