### PR TITLE
docs(mcp): teach the credential-ref + non-blocking auth setup flow; add credentials get alias

### DIFF
--- a/assistant/src/cli/commands/__tests__/credentials.test.ts
+++ b/assistant/src/cli/commands/__tests__/credentials.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+let ipcCalls: Array<{ method: string; params?: Record<string, unknown> }> = [];
+let mockIpcResult: {
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+} = { ok: true, result: {} };
+let logLines: string[] = [];
+let errorLines: string[] = [];
+
+mock.module("../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (method: string, params?: Record<string, unknown>) => {
+    ipcCalls.push({ method, params });
+    return mockIpcResult;
+  },
+  exitFromIpcResult: (result: { error?: string }) => {
+    process.exitCode = 10;
+    errorLines.push(result.error ?? "");
+  },
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: (message: string) => logLines.push(message),
+    warn: () => {},
+    error: (message: string) => errorLines.push(message),
+    debug: () => {},
+  }),
+}));
+
+const { registerCredentialsCommand } = await import("../credentials.js");
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = (() => true) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerCredentialsCommand(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) {
+      process.exitCode = 1;
+    }
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return { exitCode, stdout: stdoutChunks.join("") };
+}
+
+beforeEach(() => {
+  ipcCalls = [];
+  logLines = [];
+  errorLines = [];
+  mockIpcResult = { ok: true, result: {} };
+  process.exitCode = 0;
+});
+
+describe("credentials command", () => {
+  test("registers inspect with a get alias", () => {
+    const program = new Command();
+    registerCredentialsCommand(program);
+
+    const credentials = program.commands.find(
+      (command) => command.name() === "credentials",
+    );
+    expect(credentials).toBeDefined();
+
+    const inspect = credentials!.commands.find(
+      (command) => command.name() === "inspect",
+    );
+    expect(inspect).toBeDefined();
+    expect(inspect!.aliases()).toContain("get");
+  });
+});
+
+describe("credentials inspect / get", () => {
+  const credentialFixture = {
+    service: "twilio",
+    field: "account_sid",
+    credentialId: "cred-1",
+    scrubbedValue: "****c123",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    injectionTemplateCount: 0,
+  };
+
+  test("inspect calls credentials_inspect with service/field", async () => {
+    mockIpcResult = { ok: true, result: credentialFixture };
+
+    const { exitCode } = await runCommand([
+      "credentials",
+      "inspect",
+      "--service",
+      "twilio",
+      "--field",
+      "account_sid",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(ipcCalls).toEqual([
+      {
+        method: "credentials_inspect",
+        params: {
+          body: { service: "twilio", field: "account_sid", id: undefined },
+        },
+      },
+    ]);
+  });
+
+  test("get alias resolves to the same credentials_inspect handler", async () => {
+    // GIVEN the assistant returns a masked credential for the requested lookup
+    mockIpcResult = { ok: true, result: credentialFixture };
+
+    // WHEN the user invokes the `get` alias instead of `inspect`
+    const { exitCode } = await runCommand([
+      "credentials",
+      "get",
+      "--service",
+      "twilio",
+      "--field",
+      "account_sid",
+    ]);
+
+    // THEN it calls the same credentials_inspect IPC method with the same body
+    expect(exitCode).toBe(0);
+    expect(ipcCalls).toEqual([
+      {
+        method: "credentials_inspect",
+        params: {
+          body: { service: "twilio", field: "account_sid", id: undefined },
+        },
+      },
+    ]);
+    // AND it renders the same masked human-readable view
+    expect(logLines.join("\n")).toContain("****c123");
+  });
+});

--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -423,8 +423,9 @@ Examples:
 
       credential
         .command("inspect [id]")
+        .alias("get")
         .description(
-          "Show metadata and a masked preview of a stored credential",
+          "Show metadata and a masked preview of a stored credential (alias: get)",
         )
         .option("--service <service>", "Service namespace")
         .option("--field <field>", "Field name")
@@ -435,7 +436,10 @@ Arguments:
   id   (optional) Credential UUID for lookup by ID
 
 Shows everything known about a credential without revealing the secret value.
-The secret is masked to show only the last 4 characters (e.g. ****c123).
+The secret is masked to show only the last 4 characters (e.g. ****c123). To
+print the plaintext value instead, use "assistant credentials reveal".
+
+Also invokable as "assistant credentials get".
 
 Displayed fields include: label, creation/update timestamps, allowed tools,
 allowed domains, OAuth2 scopes, account info, and injection template count.
@@ -445,6 +449,7 @@ positional argument. One of the two forms is required.
 
 Examples:
   $ assistant credentials inspect --service twilio --field account_sid
+  $ assistant credentials get --service twilio --field account_sid
   $ assistant credentials inspect 7a3b1c2d-4e5f-6789-abcd-ef0123456789
   $ assistant credentials inspect --json --service slack_channel --field bot_token`,
         )

--- a/assistant/src/config/bundled-skills/_shared/CLI_RETRIEVAL_PATTERN.md
+++ b/assistant/src/config/bundled-skills/_shared/CLI_RETRIEVAL_PATTERN.md
@@ -8,7 +8,7 @@ any generic account registry:
 - `assistant credentials list` for discovering stored credential handles
 - `assistant oauth status <provider>` for discovering OAuth connection handles
 - `assistant credentials set ...` for storing new credentials
-- `assistant mcp auth <name>` when an MCP server needs browser login
+- `assistant mcp auth <name> --no-wait` when an MCP server needs browser login — start the flow, relay the printed authorization URL to the user, then poll `assistant mcp auth <name> --status`. Do not run a blocking `assistant mcp auth <name>`, which ties up the turn for up to 2.5 minutes.
 - `assistant platform status` for platform-linked deployment/auth context
 
 If a bundled skill documents a service-specific `assistant <service>` auth or

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -115,6 +115,7 @@ const ASSISTANT_SUPPORTED_COMMAND_PATHS = [
   "credentials set",
   "credentials delete",
   "credentials inspect",
+  "credentials get",
   "credentials reveal",
   "credentials status",
   "db",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -533,7 +533,7 @@
         }
       },
       "compatibility": "Works on both the Vellum desktop app (local daemon) and the Vellum web app (platform-hosted). Auth flow differs by environment.",
-      "updatedAt": "2026-07-10T22:57:21.000Z"
+      "updatedAt": "2026-07-10T23:05:18.000Z"
     },
     {
       "id": "meme-generator",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -533,7 +533,7 @@
         }
       },
       "compatibility": "Works on both the Vellum desktop app (local daemon) and the Vellum web app (platform-hosted). Auth flow differs by environment.",
-      "updatedAt": "2026-07-10T22:51:17.000Z"
+      "updatedAt": "2026-07-10T22:57:21.000Z"
     },
     {
       "id": "meme-generator",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -310,7 +310,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-10T10:29:14.000Z"
+      "updatedAt": "2026-07-10T11:09:04.000Z"
     },
     {
       "id": "google-calendar",
@@ -533,7 +533,7 @@
         }
       },
       "compatibility": "Works on both the Vellum desktop app (local daemon) and the Vellum web app (platform-hosted). Auth flow differs by environment.",
-      "updatedAt": "2026-06-12T18:05:36.000Z"
+      "updatedAt": "2026-07-10T22:51:17.000Z"
     },
     {
       "id": "meme-generator",

--- a/skills/mcp-setup/SKILL.md
+++ b/skills/mcp-setup/SKILL.md
@@ -19,7 +19,7 @@ USE THIS SKILL WHEN:
 
 - User asks to connect any external tool or service via MCP
 - User asks "what MCP servers / integrations do I have?"
-- An MCP tool returns an auth error → run `assistant mcp auth <name>`
+- An MCP tool returns an auth error → start OAuth with `assistant mcp auth <name> --no-wait` and relay the URL (see "Authenticate (OAuth)")
 - User wants to disconnect an integration
 
 ## Prefer Native OAuth Integration (check this first)
@@ -61,32 +61,50 @@ Both environments fully support MCP. The only difference is which tool runs the 
 
 **Check this table before doing anything else.** If the service is listed, run the command shown and do nothing else — no exploration, no checking available commands, no looking up documentation.
 
-| Service         | Command                                                                                | After?                          |
-| --------------- | -------------------------------------------------------------------------------------- | ------------------------------- |
-| Context7 (docs) | `assistant mcp add context7 -t streamable-http -u https://mcp.context7.com/mcp -r low` | Done — no auth needed           |
-| Linear          | `assistant mcp add linear -t streamable-http -u https://mcp.linear.app/mcp`            | Run `assistant mcp auth linear` |
-| Figma           | `assistant mcp add figma -t streamable-http -u https://mcp.figma.com/mcp`              | Run `assistant mcp auth figma`  |
+| Service         | Command                                                                                | After?                                          |
+| --------------- | -------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| Context7 (docs) | `assistant mcp add context7 -t streamable-http -u https://mcp.context7.com/mcp -r low` | Done — `add` reports `connected`, no auth needed |
+| Linear          | `assistant mcp add linear -t streamable-http -u https://mcp.linear.app/mcp`            | `add` reports `needs-auth` → do the OAuth flow  |
+| Figma           | `assistant mcp add figma -t streamable-http -u https://mcp.figma.com/mcp`              | `add` reports `needs-auth` → do the OAuth flow  |
+
+`assistant mcp add` verifies the connection and prints one of `connected`,
+`needs-auth`, or an error. When it reports `needs-auth`, follow the
+non-blocking OAuth flow in "Authenticate (OAuth)" below — never run a blocking
+`assistant mcp auth` from your shell tool.
 
 If the service is not in this table, go to Step 3.
 
 ## Step 3 — Unknown service
 
-Find the MCP endpoint URL in the service's documentation, then run:
+Find the MCP endpoint URL in the service's documentation, then decide how the
+server authenticates:
 
-```
-assistant mcp add <name> -t streamable-http -u <url>
-```
+- **OAuth** (login in a browser) → add it, then follow the OAuth flow:
 
-Then run `assistant mcp list`. If it shows `! Needs authentication`, run `assistant mcp auth <name>`.
+  ```
+  assistant mcp add <name> -t streamable-http -u <url>
+  ```
 
-- On **desktop** → run via `host_bash` (opens the local browser).
-- On **web app** → run via `bash` (the platform handles the browser redirect).
+  `add` verifies and prints the status. If it reports `needs-auth`, do the
+  non-blocking OAuth flow in "Authenticate (OAuth)" below.
+
+- **API key / bearer token** (the service gives you a static key) → collect the
+  key through the secure prompt, then reference it — the key never touches the
+  shell or the conversation:
+
+  ```
+  assistant credentials prompt --service <name> --field api_key --label "<Service> API key"
+  assistant mcp add <name> -t streamable-http -u <url> --auth-credential <name>/api_key
+  ```
+
+  See "Add a server" for `--auth-header` / `--auth-prefix` when the service
+  uses a custom header instead of `Authorization: Bearer`.
 
 ---
 
 ## Reference: All Commands
 
-Run `list`, `add`, `remove`, and `reload` via `bash` on both environments. Run `auth` via `host_bash` on desktop, or via `bash` on the web app.
+Run all `mcp` commands — `list`, `add`, `remove`, `reload`, and `auth` — via `bash` on both environments. The non-blocking OAuth flow (below) relays the authorization URL to the user, so no local browser tool is needed.
 
 ### List servers
 
@@ -104,7 +122,7 @@ Shows each server's connection status, transport, URL/command, and risk level. S
 ### Add a server
 
 ```
-assistant mcp add <name> -t <transport> -u <url> [-r low|medium|high] [--disabled]
+assistant mcp add <name> -t <transport> -u <url> [-r low|medium|high] [--disabled] [--no-verify]
 ```
 
 Transport types:
@@ -115,6 +133,10 @@ Transport types:
 
 Risk level (`-r`) controls approval prompts per tool call — `low` auto-approves, `high` always prompts (default: `high`).
 
+After writing the config, `add` verifies the server with a bounded connection
+and prints `connected`, `needs-auth` (do the OAuth flow), or an error. Pass
+`--no-verify` to skip the check and return immediately.
+
 Examples:
 
 ```
@@ -123,20 +145,87 @@ assistant mcp add context7 -t streamable-http -u https://mcp.context7.com/mcp -r
 assistant mcp add local-db -t stdio -c npx -a -y @my/mcp-server
 ```
 
+#### API-key / bearer auth (recommended for static keys)
+
+For servers that authenticate with a static API key or bearer token, store the
+secret in the encrypted vault first, then reference it with
+`--auth-credential <service>/<field>`. The key is resolved on connect (and on
+reconnect, so rotations are picked up) and **never** passes through the shell or
+the conversation:
+
+```
+assistant credentials prompt --service reducto --field api_key --label "Reducto API key"
+assistant mcp add reducto -t streamable-http -u https://mcp.reducto.ai/mcp \
+    --auth-credential reducto/api_key
+```
+
+`--auth-header` defaults to `Authorization` and `--auth-prefix` defaults to
+`"Bearer "`. For a custom API-key header, set both — e.g. a server that expects
+`X-API-Key: <key>` with no prefix:
+
+```
+assistant mcp add acme -t streamable-http -u https://mcp.acme.com/mcp \
+    --auth-credential acme/api_key --auth-header X-API-Key --auth-prefix ''
+```
+
+**Never** do these — they silently produce a broken, unauthenticated server:
+
+- Never put a secret in a `${ENV_VAR}` shell expansion in `-H`/`--header`. The
+  assistant strips environment variables before running, so the header is
+  stored empty (and `add` rejects `${...}` and empty header values).
+- Never `assistant credentials reveal` a secret into an `mcp add` command line.
+  That leaks the plaintext into the conversation and command history — use
+  `--auth-credential` so the value stays in the vault.
+
+To inject a stored credential from a raw `-H`/`--header`, use the placeholder
+syntax instead of a shell variable:
+
+```
+assistant mcp add srv -t streamable-http -u https://srv.example.com/mcp \
+    -H 'Authorization: Bearer {{credential:srv/api_key}}'
+```
+
 ### Authenticate (OAuth)
 
+Use the **non-blocking** flow. A plain `assistant mcp auth <name>` blocks for up
+to 2.5 minutes waiting for the browser login — running that from your shell tool
+wedges the whole conversation turn. Instead:
+
+1. Start the flow and print the authorization URL without waiting:
+
+   ```
+   assistant mcp auth <name> --no-wait
+   ```
+
+2. Relay the printed authorization URL to the user as a clickable link and ask
+   them to complete the login in their browser.
+
+3. Poll for completion (do not block):
+
+   ```
+   assistant mcp auth <name> --status
+   ```
+
+   Repeat every few seconds until it reports the flow is complete, or check
+   `assistant mcp list` for `✓ Connected`. Once complete, the running assistant
+   picks up the change automatically.
+
+Once authenticated, tokens are cached and **refresh automatically** — the user
+does not need to re-auth on expiry. If a server's client registration goes stale
+or the token flow breaks, force a fresh registration with:
+
 ```
-assistant mcp auth <name>
+assistant mcp auth <name> --reset
 ```
 
-- On **desktop** → run via `host_bash` (opens the user's local browser for OAuth login).
-- On **web app** → run via `bash` (the platform handles the browser redirect and saves tokens).
+Use the OAuth flow when:
 
-Tokens are saved automatically. Use when:
-
-- `assistant mcp list` shows `! Needs authentication`
+- `assistant mcp add` or `assistant mcp list` reports `needs-auth`
 - An MCP tool call fails with an auth/token error
 - Setting up a new OAuth-protected server for the first time
+
+Run these via `bash` on both environments — the running assistant handles the
+browser redirect and token exchange.
 
 ### Remove a server
 
@@ -149,20 +238,27 @@ Removes config and cleans up stored OAuth credentials.
 ### Reload
 
 ```
-assistant mcp reload
+assistant mcp reload           # fire-and-forget
+assistant mcp reload --wait     # block and print each server's connection status
 ```
 
-Manually signals the assistant to reconnect all MCP servers from disk. Normally not needed — the assistant detects changes automatically after `add`, `remove`, and `auth`. Use this only if a server's tools aren't appearing after ~10 seconds.
+Signals the assistant to reconnect all MCP servers from disk. Normally not needed — the assistant detects changes automatically after `add`, `remove`, and `auth`. Use `--wait` to confirm a server reconnected (it prints `connected` / `needs-auth` / `disabled` / `error` per server) instead of adding a sleep and re-running `assistant mcp list`.
 
 ## Advanced Configuration
 
-`mcp add` covers the common cases. For advanced options, edit `$VELLUM_WORKSPACE_DIR/config.json` directly under `mcp.servers.<name>`:
+`mcp add` covers the common cases, including auth headers via `--auth-credential`
+(see "Add a server"). For remaining advanced options, edit
+`$VELLUM_WORKSPACE_DIR/config.json` directly under `mcp.servers.<name>`:
 
 - `env` — environment variables for stdio servers
-- `headers` — custom HTTP headers for remote servers
 - `maxTools` — per-server tool cap (default: 20)
 - `allowedTools` / `blockedTools` — tool name filters
 - `globalMaxTools` — total cap across all servers (default: 50)
+
+Do **not** hand-edit auth headers into `mcp.servers.<name>`. Use
+`--auth-credential` (or the `{{credential:service/field}}` placeholder in
+`-H`/`--header`) so the secret is stored in the encrypted vault and resolved on
+connect — config-level header secrets are not the supported path.
 
 ## SKILL COMPLETE WHEN
 

--- a/skills/mcp-setup/SKILL.md
+++ b/skills/mcp-setup/SKILL.md
@@ -61,11 +61,11 @@ Both environments fully support MCP. The only difference is which tool runs the 
 
 **Check this table before doing anything else.** If the service is listed, run the command shown and do nothing else — no exploration, no checking available commands, no looking up documentation.
 
-| Service         | Command                                                                                | After?                                          |
-| --------------- | -------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| Service         | Command                                                                                | After?                                           |
+| --------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------ |
 | Context7 (docs) | `assistant mcp add context7 -t streamable-http -u https://mcp.context7.com/mcp -r low` | Done — `add` reports `connected`, no auth needed |
-| Linear          | `assistant mcp add linear -t streamable-http -u https://mcp.linear.app/mcp`            | `add` reports `needs-auth` → do the OAuth flow  |
-| Figma           | `assistant mcp add figma -t streamable-http -u https://mcp.figma.com/mcp`              | `add` reports `needs-auth` → do the OAuth flow  |
+| Linear          | `assistant mcp add linear -t streamable-http -u https://mcp.linear.app/mcp`            | `add` reports `needs-auth` → do the OAuth flow   |
+| Figma           | `assistant mcp add figma -t streamable-http -u https://mcp.figma.com/mcp`              | `add` reports `needs-auth` → do the OAuth flow   |
 
 `assistant mcp add` verifies the connection and prints one of `connected`,
 `needs-auth`, or an error. When it reports `needs-auth`, follow the

--- a/skills/mcp-setup/SKILL.md
+++ b/skills/mcp-setup/SKILL.md
@@ -52,10 +52,10 @@ Try `host_bash`:
 echo "desktop ok"
 ```
 
-- If it succeeds → you are on the **desktop app**. Use `host_bash` for all commands, including `auth` (opens a local browser).
-- If it is unavailable → you are on the **web app** (or a cloud-hosted session). Use `bash` for all commands, including `auth` (the platform handles the browser redirect).
+- If it succeeds → you are on the **desktop app**. Use `host_bash` for all commands so they run against the host-installed CLI.
+- If it is unavailable → you are on the **web app** (or a cloud-hosted session). Use `bash` for all commands.
 
-Both environments fully support MCP. The only difference is which tool runs the commands.
+Both environments fully support MCP, including OAuth: the non-blocking `auth --no-wait` flow (see "Authenticate (OAuth)") relays the authorization URL to the user, so neither environment needs a local browser tool. The only difference is which shell tool runs the commands.
 
 ## Step 2 — Check the recipe table
 
@@ -104,7 +104,7 @@ server authenticates:
 
 ## Reference: All Commands
 
-Run all `mcp` commands — `list`, `add`, `remove`, `reload`, and `auth` — via `bash` on both environments. The non-blocking OAuth flow (below) relays the authorization URL to the user, so no local browser tool is needed.
+Run all `mcp` commands — `list`, `add`, `remove`, `reload`, and `auth` — via the shell tool from Step 1 (`host_bash` on desktop, `bash` on web). The non-blocking OAuth flow (below) relays the authorization URL to the user, so no local browser tool is needed.
 
 ### List servers
 


### PR DESCRIPTION
## Problem

Feedback session `019f4e08` (2026-07-10): the assistant guessed `credentials get` (doesn't exist), and the `mcp-setup` SKILL.md taught a stale flow — hand-editing `config.json` headers (never consulted by the add path), no mention of `-H`, and blocking `mcp auth` runs that wedged a conversation turn for 2 minutes.

## Changes

- `credentials inspect` gains a `get` alias (masked view, same risk class); help points to `reveal` for plaintext. Gateway command registry updated; registry guard test passes.
- `skills/mcp-setup/SKILL.md` rewritten for the new surface: API-key servers use `credentials prompt` → `mcp add --auth-credential service/field` (with explicit warnings against `${ENV_VAR}` headers and revealing secrets into command lines); OAuth uses `mcp auth --no-wait` → relay URL → poll `--status`; `mcp add` verification and `mcp reload --wait` replace sleep-and-list polling; stale config.json header editing removed.
- `bundled-skills/_shared/CLI_RETRIEVAL_PATTERN.md` aligned with the non-blocking auth flow.

## Tests

New `credentials.test.ts` (alias → same IPC handler, masked render); gateway `command-registry.test.ts` (52 pass); typecheck clean in both packages.

Final PR of the MCP setup-friction remediation: stacked on #37854 (base `mcp-setup-feedback-loop`), with #37851 / #37852.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37855" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

**Merge order**: merge #37851 before this PR — the SKILL.md documents its `mcp auth --reset` flag.
