### PR TITLE
Track and price OpenAI GPT-5.6 cache writes

### DIFF
--- a/assistant/src/__tests__/openai-responses-provider.test.ts
+++ b/assistant/src/__tests__/openai-responses-provider.test.ts
@@ -149,6 +149,7 @@ function completedEvent(
   opts?: {
     reasoningTokens?: number;
     cachedTokens?: number;
+    cacheWriteTokens?: number;
     model?: string;
     status?: string;
     output?: unknown[];
@@ -171,8 +172,17 @@ function completedEvent(
         output_tokens_details: {
           reasoning_tokens: opts?.reasoningTokens ?? 0,
         },
-        ...(opts?.cachedTokens
-          ? { input_tokens_details: { cached_tokens: opts.cachedTokens } }
+        ...(opts?.cachedTokens || opts?.cacheWriteTokens
+          ? {
+              input_tokens_details: {
+                ...(opts?.cachedTokens
+                  ? { cached_tokens: opts.cachedTokens }
+                  : {}),
+                ...(opts?.cacheWriteTokens
+                  ? { cache_write_tokens: opts.cacheWriteTokens }
+                  : {}),
+              },
+            }
           : {}),
       },
     },
@@ -576,6 +586,30 @@ describe("OpenAIResponsesProvider", () => {
     });
   });
 
+  test("maps cache write tokens to cacheCreationInputTokens (GPT-5.6+)", async () => {
+    // GPT-5.6+ bills prompt tokens written to the cache at 1.25x input and
+    // reports them in input_tokens_details.cache_write_tokens; input_tokens
+    // includes them, mirroring the cached-read accounting above.
+    fakeStreamEvents = [
+      textDeltaEvent("Cached reply"),
+      completedEvent(50_648, 114, {
+        cachedTokens: 40_000,
+        cacheWriteTokens: 9_536,
+      }),
+    ];
+
+    const result = await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "Hi" }] },
+    ]);
+
+    expect(result.usage).toEqual({
+      inputTokens: 50_648,
+      outputTokens: 114,
+      cacheReadInputTokens: 40_000,
+      cacheCreationInputTokens: 9_536,
+    });
+  });
+
   test("omits cacheReadInputTokens when no cached tokens", async () => {
     fakeStreamEvents = [textDeltaEvent("Fresh reply"), completedEvent(10, 5)];
 
@@ -584,6 +618,7 @@ describe("OpenAIResponsesProvider", () => {
     ]);
 
     expect(result.usage).not.toHaveProperty("cacheReadInputTokens");
+    expect(result.usage).not.toHaveProperty("cacheCreationInputTokens");
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/__tests__/pricing.test.ts
+++ b/assistant/src/__tests__/pricing.test.ts
@@ -91,6 +91,36 @@ describe("resolvePricing", () => {
       }
     });
 
+    test("bills GPT-5.6 cache writes at the catalog write rate", () => {
+      // Total prompt tokens (150k) stay under the 272k tier threshold.
+      const result = resolvePricingForUsage("openai", "gpt-5.6-sol", {
+        directInputTokens: 50_000,
+        outputTokens: 0,
+        cacheCreationInputTokens: 50_000,
+        cacheReadInputTokens: 50_000,
+        anthropicCacheCreation: null,
+      });
+
+      expect(result.pricingStatus).toBe("priced");
+      // 0.05M x $5 direct + 0.05M x $6.25 write + 0.05M x $0.5 read
+      expect(result.estimatedCostUsd).toBeCloseTo(0.25 + 0.3125 + 0.025, 10);
+    });
+
+    test("bills GPT-5.6 cache writes at the tier write rate above 272k", () => {
+      const result = resolvePricingForUsage("openai", "gpt-5.6-sol", {
+        directInputTokens: 500_000,
+        outputTokens: 1_000_000,
+        cacheCreationInputTokens: 500_000,
+        cacheReadInputTokens: 1_000_000,
+        anthropicCacheCreation: null,
+      });
+
+      expect(result.pricingStatus).toBe("priced");
+      // Tier rates: 0.5M x $10 direct + 0.5M x $12.5 write + 1M x $1 read
+      // + 1M x $45 output.
+      expect(result.estimatedCostUsd).toBeCloseTo(5 + 6.25 + 1 + 45, 10);
+    });
+
     test("uses OpenAI short-context tiers through 272k prompt tokens", () => {
       const result = resolvePricingForUsage("openai", "gpt-5.4", {
         directInputTokens: 272_000,
@@ -791,6 +821,21 @@ describe("Anthropic models on OpenRouter", () => {
     );
     expect(result.pricingStatus).toBe("priced");
     expect(result.estimatedCostUsd).toBe(1.25 + 2.5);
+  });
+
+  test("bills OpenRouter GPT-5.6 cache writes at the catalog write rate", () => {
+    // Total prompt tokens (150k) stay under the 272k tier threshold.
+    const result = resolvePricingForUsage("openrouter", "openai/gpt-5.6-luna", {
+      directInputTokens: 50_000,
+      outputTokens: 0,
+      cacheCreationInputTokens: 50_000,
+      cacheReadInputTokens: 50_000,
+      anthropicCacheCreation: null,
+    });
+
+    expect(result.pricingStatus).toBe("priced");
+    // 0.05M x $1 direct + 0.05M x $1.25 write + 0.05M x $0.1 read
+    expect(result.estimatedCostUsd).toBeCloseTo(0.05 + 0.0625 + 0.005, 10);
   });
 
   test("returns unpriced for unknown non-Anthropic OpenRouter model", () => {

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -326,11 +326,11 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     },
     models: [
       // GPT-5.6 family (Sol / Terra / Luna). cacheRead is the 90% cached-read
-      // discount; long-context (>272K input) is 2x input / 1.5x output / 2x
-      // cache-read for the whole request, per OpenAI's model cards. GPT-5.6+
-      // also bills cache *writes* at 1.25x input, but that isn't represented
-      // here — the managed proxy's OpenAI billing path emits no cache-write
-      // token class (Anthropic-only today).
+      // discount; cacheWrite is the 1.25x-input rate GPT-5.6+ bills for
+      // prompt tokens written to the cache (reported as `cache_write_tokens`
+      // in usage, tracked as `cacheCreationInputTokens`). Long-context
+      // (>272K input) is 2x input / 1.5x output / 2x cache-read+write for
+      // the whole request, per OpenAI's model cards.
       {
         id: "gpt-5.6-sol",
         displayName: "GPT-5.6 Sol",
@@ -345,12 +345,14 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         pricing: {
           inputPer1mTokens: 5.0,
           outputPer1mTokens: 30.0,
+          cacheWritePer1mTokens: 6.25,
           cacheReadPer1mTokens: 0.5,
           tiers: [
             {
               inputTokenThreshold: OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
               inputPer1mTokens: 10,
               outputPer1mTokens: 45,
+              cacheWritePer1mTokens: 12.5,
               cacheReadPer1mTokens: 1,
             },
           ],
@@ -370,12 +372,14 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         pricing: {
           inputPer1mTokens: 2.5,
           outputPer1mTokens: 15.0,
+          cacheWritePer1mTokens: 3.125,
           cacheReadPer1mTokens: 0.25,
           tiers: [
             {
               inputTokenThreshold: OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
               inputPer1mTokens: 5,
               outputPer1mTokens: 22.5,
+              cacheWritePer1mTokens: 6.25,
               cacheReadPer1mTokens: 0.5,
             },
           ],
@@ -395,12 +399,14 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         pricing: {
           inputPer1mTokens: 1.0,
           outputPer1mTokens: 6.0,
+          cacheWritePer1mTokens: 1.25,
           cacheReadPer1mTokens: 0.1,
           tiers: [
             {
               inputTokenThreshold: OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
               inputPer1mTokens: 2,
               outputPer1mTokens: 9,
+              cacheWritePer1mTokens: 2.5,
               cacheReadPer1mTokens: 0.2,
             },
           ],
@@ -1091,11 +1097,12 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
       // OpenAI
       // GPT-5.6 family (Sol / Terra / Luna). The `*-pro` slugs are the same
       // underlying models served with `reasoning.mode: pro` at identical
-      // rates. Long-context (>272K input) is 2x input / 1.5x output / 2x
-      // cache-read for the whole request, per OpenAI's model cards. GPT-5.6+
-      // also bills cache *writes* at 1.25x input, but that isn't represented
-      // here — the chat-completions usage path reports no cache-write token
-      // class, only cached (read) tokens.
+      // rates. cacheWrite is the 1.25x-input rate GPT-5.6+ bills for prompt
+      // tokens written to the cache (reported as `cache_write_tokens` in
+      // usage when the route forwards it, tracked as
+      // `cacheCreationInputTokens`). Long-context (>272K input) is 2x input
+      // / 1.5x output / 2x cache-read+write for the whole request, per
+      // OpenAI's model cards.
       {
         id: "openai/gpt-5.6-sol",
         displayName: "GPT-5.6 Sol",
@@ -1110,12 +1117,14 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         pricing: {
           inputPer1mTokens: 5.0,
           outputPer1mTokens: 30.0,
+          cacheWritePer1mTokens: 6.25,
           cacheReadPer1mTokens: 0.5,
           tiers: [
             {
               inputTokenThreshold: OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
               inputPer1mTokens: 10,
               outputPer1mTokens: 45,
+              cacheWritePer1mTokens: 12.5,
               cacheReadPer1mTokens: 1,
             },
           ],
@@ -1135,12 +1144,14 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         pricing: {
           inputPer1mTokens: 5.0,
           outputPer1mTokens: 30.0,
+          cacheWritePer1mTokens: 6.25,
           cacheReadPer1mTokens: 0.5,
           tiers: [
             {
               inputTokenThreshold: OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
               inputPer1mTokens: 10,
               outputPer1mTokens: 45,
+              cacheWritePer1mTokens: 12.5,
               cacheReadPer1mTokens: 1,
             },
           ],
@@ -1160,12 +1171,14 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         pricing: {
           inputPer1mTokens: 2.5,
           outputPer1mTokens: 15.0,
+          cacheWritePer1mTokens: 3.125,
           cacheReadPer1mTokens: 0.25,
           tiers: [
             {
               inputTokenThreshold: OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
               inputPer1mTokens: 5,
               outputPer1mTokens: 22.5,
+              cacheWritePer1mTokens: 6.25,
               cacheReadPer1mTokens: 0.5,
             },
           ],
@@ -1185,12 +1198,14 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         pricing: {
           inputPer1mTokens: 2.5,
           outputPer1mTokens: 15.0,
+          cacheWritePer1mTokens: 3.125,
           cacheReadPer1mTokens: 0.25,
           tiers: [
             {
               inputTokenThreshold: OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
               inputPer1mTokens: 5,
               outputPer1mTokens: 22.5,
+              cacheWritePer1mTokens: 6.25,
               cacheReadPer1mTokens: 0.5,
             },
           ],
@@ -1210,12 +1225,14 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         pricing: {
           inputPer1mTokens: 1.0,
           outputPer1mTokens: 6.0,
+          cacheWritePer1mTokens: 1.25,
           cacheReadPer1mTokens: 0.1,
           tiers: [
             {
               inputTokenThreshold: OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
               inputPer1mTokens: 2,
               outputPer1mTokens: 9,
+              cacheWritePer1mTokens: 2.5,
               cacheReadPer1mTokens: 0.2,
             },
           ],
@@ -1235,12 +1252,14 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         pricing: {
           inputPer1mTokens: 1.0,
           outputPer1mTokens: 6.0,
+          cacheWritePer1mTokens: 1.25,
           cacheReadPer1mTokens: 0.1,
           tiers: [
             {
               inputTokenThreshold: OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
               inputPer1mTokens: 2,
               outputPer1mTokens: 9,
+              cacheWritePer1mTokens: 2.5,
               cacheReadPer1mTokens: 0.2,
             },
           ],

--- a/assistant/src/providers/openai/__tests__/chat-completions-provider-reasoning.test.ts
+++ b/assistant/src/providers/openai/__tests__/chat-completions-provider-reasoning.test.ts
@@ -26,6 +26,10 @@ type MockChunk = {
   usage?: {
     prompt_tokens: number;
     completion_tokens: number;
+    prompt_tokens_details?: {
+      cached_tokens?: number;
+      cache_write_tokens?: number;
+    };
   };
 };
 
@@ -638,5 +642,55 @@ describe("reasoning opt-out rejection fallback", () => {
       ),
     ).rejects.toThrow();
     expect(requests).toHaveLength(1);
+  });
+});
+
+describe("OpenAIChatCompletionsProvider cache usage parsing", () => {
+  test("maps prompt_tokens_details cache fields into usage", async () => {
+    // prompt_tokens is the inclusive total; the cached subset surfaces as
+    // cacheReadInputTokens and the written subset (GPT-5.6+
+    // cache_write_tokens, billed at 1.25x input) as cacheCreationInputTokens.
+    const { provider } = stubProvider([
+      { choices: [{ delta: { content: "ok" } }] },
+      {
+        choices: [{ delta: {}, finish_reason: "stop" }],
+        usage: {
+          prompt_tokens: 2_006,
+          completion_tokens: 300,
+          prompt_tokens_details: {
+            cached_tokens: 1_920,
+            cache_write_tokens: 64,
+          },
+        },
+      },
+    ]);
+
+    const response = await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+    ]);
+
+    expect(response.usage).toEqual({
+      inputTokens: 2_006,
+      outputTokens: 300,
+      cacheReadInputTokens: 1_920,
+      cacheCreationInputTokens: 64,
+    });
+  });
+
+  test("omits cache fields when prompt_tokens_details is absent", async () => {
+    const { provider } = stubProvider([
+      { choices: [{ delta: { content: "ok" } }] },
+      {
+        choices: [{ delta: {}, finish_reason: "stop" }],
+        usage: { prompt_tokens: 10, completion_tokens: 2 },
+      },
+    ]);
+
+    const response = await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+    ]);
+
+    expect(response.usage).not.toHaveProperty("cacheReadInputTokens");
+    expect(response.usage).not.toHaveProperty("cacheCreationInputTokens");
   });
 });

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -503,6 +503,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
       let completionTokens = 0;
       let reasoningTokens = 0;
       let cachedPromptTokens = 0;
+      let cacheWritePromptTokens = 0;
 
       try {
         const requestHeaders = {
@@ -634,10 +635,14 @@ export class OpenAIChatCompletionsProvider implements Provider {
             reasoningTokens = completionDetails?.reasoning_tokens ?? 0;
             const promptDetails = (
               chunk.usage as {
-                prompt_tokens_details?: { cached_tokens?: number };
+                prompt_tokens_details?: {
+                  cached_tokens?: number;
+                  cache_write_tokens?: number;
+                };
               }
             ).prompt_tokens_details;
             cachedPromptTokens = promptDetails?.cached_tokens ?? 0;
+            cacheWritePromptTokens = promptDetails?.cache_write_tokens ?? 0;
           }
 
           responseModel = chunk.model;
@@ -723,10 +728,13 @@ export class OpenAIChatCompletionsProvider implements Provider {
                 },
               }
             : {}),
-          ...(cachedPromptTokens > 0
+          ...(cachedPromptTokens > 0 || cacheWritePromptTokens > 0
             ? {
                 prompt_tokens_details: {
                   cached_tokens: cachedPromptTokens,
+                  ...(cacheWritePromptTokens > 0
+                    ? { cache_write_tokens: cacheWritePromptTokens }
+                    : {}),
                 },
               }
             : {}),
@@ -742,6 +750,9 @@ export class OpenAIChatCompletionsProvider implements Provider {
           ...(reasoningTokens > 0 ? { reasoningTokens } : {}),
           ...(cachedPromptTokens > 0
             ? { cacheReadInputTokens: cachedPromptTokens }
+            : {}),
+          ...(cacheWritePromptTokens > 0
+            ? { cacheCreationInputTokens: cacheWritePromptTokens }
             : {}),
         },
         stopReason: finishReason,

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -128,7 +128,11 @@ interface ResponsesStreamEvent {
       input_tokens?: number;
       output_tokens?: number;
       output_tokens_details?: { reasoning_tokens?: number };
-      input_tokens_details?: { cached_tokens?: number };
+      input_tokens_details?: {
+        cached_tokens?: number;
+        /** GPT-5.6+: prompt tokens written to the cache, billed at 1.25x input. */
+        cache_write_tokens?: number;
+      };
     };
   };
 }
@@ -304,6 +308,7 @@ export class OpenAIResponsesProvider implements Provider {
       let outputTokens = 0;
       let reasoningTokens = 0;
       let cachedInputTokens = 0;
+      let cacheWriteInputTokens = 0;
       let rawFinalResponse: unknown = undefined;
 
       try {
@@ -426,6 +431,9 @@ export class OpenAIResponsesProvider implements Provider {
                     response.usage.output_tokens_details?.reasoning_tokens ?? 0;
                   cachedInputTokens =
                     response.usage.input_tokens_details?.cached_tokens ?? 0;
+                  cacheWriteInputTokens =
+                    response.usage.input_tokens_details?.cache_write_tokens ??
+                    0;
                 }
                 finishReason =
                   response.incomplete_details?.reason ??
@@ -507,6 +515,9 @@ export class OpenAIResponsesProvider implements Provider {
           ...(reasoningTokens > 0 ? { reasoningTokens } : {}),
           ...(cachedInputTokens > 0
             ? { cacheReadInputTokens: cachedInputTokens }
+            : {}),
+          ...(cacheWriteInputTokens > 0
+            ? { cacheCreationInputTokens: cacheWriteInputTokens }
             : {}),
         },
         stopReason,

--- a/assistant/src/util/pricing.ts
+++ b/assistant/src/util/pricing.ts
@@ -12,6 +12,7 @@ interface ModelPricing {
   inputPer1M: number; // USD per 1M input tokens
   outputPer1M: number; // USD per 1M output tokens
   cacheReadPer1M?: number; // USD per 1M cache-read input tokens
+  cacheWritePer1M?: number; // USD per 1M cache-write input tokens
   tiers?: ModelPricingTier[];
 }
 
@@ -20,6 +21,7 @@ interface ModelPricingTier {
   inputPer1M: number;
   outputPer1M: number;
   cacheReadPer1M?: number;
+  cacheWritePer1M?: number;
 }
 
 const ANTHROPIC_PROMPT_CACHE_MULTIPLIERS = {
@@ -69,6 +71,7 @@ function catalogPricingToInternal(p: CatalogModelPricing): ModelPricing {
     inputPer1M: p.inputPer1mTokens,
     outputPer1M: p.outputPer1mTokens,
     cacheReadPer1M: p.cacheReadPer1mTokens,
+    cacheWritePer1M: p.cacheWritePer1mTokens,
     tiers: p.tiers?.map(catalogTierToInternal),
   };
 }
@@ -81,6 +84,7 @@ function catalogTierToInternal(
     inputPer1M: tier.inputPer1mTokens,
     outputPer1M: tier.outputPer1mTokens,
     cacheReadPer1M: tier.cacheReadPer1mTokens,
+    cacheWritePer1M: tier.cacheWritePer1mTokens,
   };
 }
 
@@ -260,6 +264,7 @@ function selectPricingTier(
     inputPer1M: selectedTier.inputPer1M,
     outputPer1M: selectedTier.outputPer1M,
     cacheReadPer1M: selectedTier.cacheReadPer1M ?? pricing.cacheReadPer1M,
+    cacheWritePer1M: selectedTier.cacheWritePer1M ?? pricing.cacheWritePer1M,
   };
 }
 
@@ -318,6 +323,10 @@ function calculateUsageCost(
       tieredPricing.cacheReadPer1M == null
         ? undefined
         : tieredPricing.cacheReadPer1M * speedMultiplier,
+    cacheWritePer1M:
+      tieredPricing.cacheWritePer1M == null
+        ? undefined
+        : tieredPricing.cacheWritePer1M * speedMultiplier,
   };
 
   const directInputCost = calculateTokenCost(
@@ -334,7 +343,7 @@ function calculateUsageCost(
       directInputCost +
       outputCost +
       calculateTokenCost(
-        effectivePricing.inputPer1M,
+        effectivePricing.cacheWritePer1M ?? effectivePricing.inputPer1M,
         usage.cacheCreationInputTokens,
       ) +
       calculateTokenCost(

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -219,12 +219,14 @@
           "pricing": {
             "inputPer1mTokens": 5,
             "outputPer1mTokens": 30,
+            "cacheWritePer1mTokens": 6.25,
             "cacheReadPer1mTokens": 0.5,
             "tiers": [
               {
                 "inputTokenThreshold": 272000,
                 "inputPer1mTokens": 10,
                 "outputPer1mTokens": 45,
+                "cacheWritePer1mTokens": 12.5,
                 "cacheReadPer1mTokens": 1
               }
             ]
@@ -245,12 +247,14 @@
           "pricing": {
             "inputPer1mTokens": 2.5,
             "outputPer1mTokens": 15,
+            "cacheWritePer1mTokens": 3.125,
             "cacheReadPer1mTokens": 0.25,
             "tiers": [
               {
                 "inputTokenThreshold": 272000,
                 "inputPer1mTokens": 5,
                 "outputPer1mTokens": 22.5,
+                "cacheWritePer1mTokens": 6.25,
                 "cacheReadPer1mTokens": 0.5
               }
             ]
@@ -271,12 +275,14 @@
           "pricing": {
             "inputPer1mTokens": 1,
             "outputPer1mTokens": 6,
+            "cacheWritePer1mTokens": 1.25,
             "cacheReadPer1mTokens": 0.1,
             "tiers": [
               {
                 "inputTokenThreshold": 272000,
                 "inputPer1mTokens": 2,
                 "outputPer1mTokens": 9,
+                "cacheWritePer1mTokens": 2.5,
                 "cacheReadPer1mTokens": 0.2
               }
             ]
@@ -1034,12 +1040,14 @@
           "pricing": {
             "inputPer1mTokens": 5,
             "outputPer1mTokens": 30,
+            "cacheWritePer1mTokens": 6.25,
             "cacheReadPer1mTokens": 0.5,
             "tiers": [
               {
                 "inputTokenThreshold": 272000,
                 "inputPer1mTokens": 10,
                 "outputPer1mTokens": 45,
+                "cacheWritePer1mTokens": 12.5,
                 "cacheReadPer1mTokens": 1
               }
             ]
@@ -1060,12 +1068,14 @@
           "pricing": {
             "inputPer1mTokens": 5,
             "outputPer1mTokens": 30,
+            "cacheWritePer1mTokens": 6.25,
             "cacheReadPer1mTokens": 0.5,
             "tiers": [
               {
                 "inputTokenThreshold": 272000,
                 "inputPer1mTokens": 10,
                 "outputPer1mTokens": 45,
+                "cacheWritePer1mTokens": 12.5,
                 "cacheReadPer1mTokens": 1
               }
             ]
@@ -1086,12 +1096,14 @@
           "pricing": {
             "inputPer1mTokens": 2.5,
             "outputPer1mTokens": 15,
+            "cacheWritePer1mTokens": 3.125,
             "cacheReadPer1mTokens": 0.25,
             "tiers": [
               {
                 "inputTokenThreshold": 272000,
                 "inputPer1mTokens": 5,
                 "outputPer1mTokens": 22.5,
+                "cacheWritePer1mTokens": 6.25,
                 "cacheReadPer1mTokens": 0.5
               }
             ]
@@ -1112,12 +1124,14 @@
           "pricing": {
             "inputPer1mTokens": 2.5,
             "outputPer1mTokens": 15,
+            "cacheWritePer1mTokens": 3.125,
             "cacheReadPer1mTokens": 0.25,
             "tiers": [
               {
                 "inputTokenThreshold": 272000,
                 "inputPer1mTokens": 5,
                 "outputPer1mTokens": 22.5,
+                "cacheWritePer1mTokens": 6.25,
                 "cacheReadPer1mTokens": 0.5
               }
             ]
@@ -1138,12 +1152,14 @@
           "pricing": {
             "inputPer1mTokens": 1,
             "outputPer1mTokens": 6,
+            "cacheWritePer1mTokens": 1.25,
             "cacheReadPer1mTokens": 0.1,
             "tiers": [
               {
                 "inputTokenThreshold": 272000,
                 "inputPer1mTokens": 2,
                 "outputPer1mTokens": 9,
+                "cacheWritePer1mTokens": 2.5,
                 "cacheReadPer1mTokens": 0.2
               }
             ]
@@ -1164,12 +1180,14 @@
           "pricing": {
             "inputPer1mTokens": 1,
             "outputPer1mTokens": 6,
+            "cacheWritePer1mTokens": 1.25,
             "cacheReadPer1mTokens": 0.1,
             "tiers": [
               {
                 "inputTokenThreshold": 272000,
                 "inputPer1mTokens": 2,
                 "outputPer1mTokens": 9,
+                "cacheWritePer1mTokens": 2.5,
                 "cacheReadPer1mTokens": 0.2
               }
             ]


### PR DESCRIPTION
## Summary
- Parse `usage.input_tokens_details.cache_write_tokens` (Responses API) and `usage.prompt_tokens_details.cache_write_tokens` (chat completions) into `cacheCreationInputTokens` — GPT-5.6+ bills prompt tokens written to the cache at 1.25x input, a token class that was previously invisible to cost tracking
- Thread `cacheWritePer1mTokens` through `util/pricing.ts` (`ModelPricing`/`ModelPricingTier`, catalog converters, tier selection, and the non-Anthropic cost branch, which previously billed cache-creation tokens at the plain input rate); models without the field keep the input-rate fallback, so existing pricing is unchanged
- Add the write rates to all nine GPT-5.6 catalog rows (direct `openai` + OpenRouter `openai/gpt-5.6-*`): Sol $6.25, Terra $3.125, Luna $1.25 per 1M, doubling at the >272K long-context tier; regenerate `meta/llm-provider-catalog.json` and fix the stale section comments that claimed the token class wasn't reported

## Original prompt
While investigating how GPT-5.6 prompt caching behaves (OpenAI switched the series to breakpoint-anchored caching with paid cache writes), we found Vellum's OpenAI usage path never parses the new cache-write token class and the pricing math drops the catalog's write rate for non-Anthropic providers, undercounting 5.6 spend. This is PR 1 of the approved two-PR plan; PR 2 adds explicit cache breakpoints + `prompt_cache_key` to the Responses provider so 5.6 caching actually hits despite the volatile latest-message injections.