### PR TITLE
Add explicit prompt-cache breakpoints for GPT-5.6 on the OpenAI Responses transport

### DIFF
--- a/assistant/src/__tests__/openai-responses-prompt-cache.test.ts
+++ b/assistant/src/__tests__/openai-responses-prompt-cache.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Explicit prompt-cache breakpoint placement for GPT-5.6+ on the OpenAI
+ * Responses transport: request-wide `prompt_cache_options`/`prompt_cache_key`
+ * emission, block-level `prompt_cache_breakpoint` anchor placement (turn-start
+ * / previous-turn / advancing tail, mirroring the Anthropic client), the
+ * `disableCache` explicit-mode-with-zero-markers opt-out, and the unflagged-
+ * model regression guard.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { Message } from "../providers/types.js";
+
+// ---------------------------------------------------------------------------
+// Mock openai module — must be before importing the provider
+// ---------------------------------------------------------------------------
+
+interface FakeStreamEvent {
+  type: string;
+  [key: string]: unknown;
+}
+
+let fakeStreamEvents: FakeStreamEvent[] = [];
+let lastStreamParams: Record<string, unknown> | null = null;
+
+mock.module("openai", () => ({
+  default: class MockOpenAI {
+    responses = {
+      create: async (params: Record<string, unknown>) => {
+        lastStreamParams = params;
+        return {
+          [Symbol.asyncIterator]: async function* () {
+            for (const event of fakeStreamEvents) {
+              yield event;
+            }
+          },
+        };
+      },
+    };
+  },
+}));
+
+// Import after mocking
+import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
+import { OpenAIResponsesProvider } from "../providers/openai/responses-provider.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function textDeltaEvent(delta: string): FakeStreamEvent {
+  return { type: "response.output_text.delta", delta };
+}
+
+function completedEvent(): FakeStreamEvent {
+  return {
+    type: "response.completed",
+    response: {
+      model: "gpt-5.6-sol",
+      status: "completed",
+      output: [],
+      usage: { input_tokens: 10, output_tokens: 5 },
+    },
+  };
+}
+
+function userMsg(text: string): Message {
+  return { role: "user", content: [{ type: "text", text }] };
+}
+
+function assistantMsg(text: string): Message {
+  return { role: "assistant", content: [{ type: "text", text }] };
+}
+
+function toolUseMsg(id: string, name: string): Message {
+  return {
+    role: "assistant",
+    content: [{ type: "tool_use", id, name, input: {} }],
+  };
+}
+
+function toolResultMsg(toolUseId: string, content: string): Message {
+  return {
+    role: "user",
+    content: [{ type: "tool_result", tool_use_id: toolUseId, content }],
+  };
+}
+
+type WireItem = {
+  type?: string;
+  role?: string;
+  content?: Array<Record<string, unknown>>;
+};
+
+/** Indexes of wire input items carrying a `prompt_cache_breakpoint` marker. */
+function breakpointedItemIndexes(): number[] {
+  const input = (lastStreamParams?.input ?? []) as WireItem[];
+  const marked: number[] = [];
+  input.forEach((item, idx) => {
+    if (item.content?.some((p) => p.prompt_cache_breakpoint !== undefined)) {
+      marked.push(idx);
+    }
+  });
+  return marked;
+}
+
+function makeProvider(model: string, codexSubscription = false) {
+  return new OpenAIResponsesProvider("sk-test", model, { codexSubscription });
+}
+
+beforeEach(() => {
+  fakeStreamEvents = [textDeltaEvent("ok"), completedEvent()];
+  lastStreamParams = null;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("OpenAIResponsesProvider explicit prompt caching (GPT-5.6+)", () => {
+  test("first turn: explicit mode, key, and a turn-start anchor", async () => {
+    const provider = makeProvider("gpt-5.6-sol");
+    await provider.sendMessage([userMsg("hi")], {
+      config: { promptCacheKey: "conv-1" },
+    });
+
+    expect(lastStreamParams?.prompt_cache_options).toEqual({
+      mode: "explicit",
+    });
+    expect(lastStreamParams?.prompt_cache_key).toBe("conv-1");
+    expect(breakpointedItemIndexes()).toEqual([0]);
+  });
+
+  test("multi-turn first-of-turn: turn-start and previous-turn anchors", async () => {
+    const provider = makeProvider("gpt-5.6-sol");
+    await provider.sendMessage(
+      [userMsg("t1"), assistantMsg("r1"), userMsg("t2")],
+      { config: { promptCacheKey: "conv-1" } },
+    );
+
+    // Wire items: [user t1, assistant r1, user t2].
+    expect(breakpointedItemIndexes()).toEqual([0, 2]);
+  });
+
+  test("volatile latest message: anchor moves to the previous stable user message, tail covers the latest", async () => {
+    const provider = makeProvider("gpt-5.6-sol");
+    await provider.sendMessage(
+      [userMsg("t1"), assistantMsg("r1"), userMsg("t2 + <memory>")],
+      { config: { mutableLatestUserMessage: true, promptCacheKey: "conv-1" } },
+    );
+
+    // Previous-turn anchor on item 0; the advancing tail prepays the volatile
+    // latest item so in-turn tool iterations can read it.
+    expect(breakpointedItemIndexes()).toEqual([0, 2]);
+  });
+
+  test("volatile single-message first turn: no markers (nothing stable to anchor)", async () => {
+    const provider = makeProvider("gpt-5.6-sol");
+    await provider.sendMessage([userMsg("hi")], {
+      config: { mutableLatestUserMessage: true, promptCacheKey: "conv-1" },
+    });
+
+    expect(lastStreamParams?.prompt_cache_options).toEqual({
+      mode: "explicit",
+    });
+    expect(breakpointedItemIndexes()).toEqual([]);
+  });
+
+  test("tool loop: single fixed anchor on the turn-start user item, none on function_call_output", async () => {
+    const provider = makeProvider("gpt-5.6-sol");
+    await provider.sendMessage(
+      [
+        userMsg("read the file"),
+        toolUseMsg("call_1", "read"),
+        toolResultMsg("call_1", "contents"),
+      ],
+      { config: { promptCacheKey: "conv-1" } },
+    );
+
+    // Wire items: [user message, function_call, function_call_output]. The
+    // tail walk cannot land on the tool output (no stampable parts) and
+    // dedupes onto the turn-start item.
+    const input = (lastStreamParams?.input ?? []) as WireItem[];
+    expect(input.map((i) => i.type)).toEqual([
+      "message",
+      "function_call",
+      "function_call_output",
+    ]);
+    expect(breakpointedItemIndexes()).toEqual([0]);
+    expect(JSON.stringify(input[2])).not.toContain("prompt_cache_breakpoint");
+  });
+
+  test("tool loop with trailing user text: advancing tail lands on the latest user-text item", async () => {
+    const provider = makeProvider("gpt-5.6-sol");
+    const reminderTurn: Message = {
+      role: "user",
+      content: [
+        { type: "tool_result", tool_use_id: "call_1", content: "contents" },
+        { type: "text", text: "[System reminder]" },
+      ],
+    };
+    await provider.sendMessage(
+      [userMsg("read the file"), toolUseMsg("call_1", "read"), reminderTurn],
+      { config: { promptCacheKey: "conv-1" } },
+    );
+
+    // Wire items: [message, function_call, function_call_output,
+    // message(reminder)] — the reminder is the latest user-text item and
+    // becomes the turn-start anchor; item 0 gets the previous-turn anchor.
+    expect(breakpointedItemIndexes()).toEqual([0, 3]);
+  });
+
+  test("disableCache: explicit mode with zero markers", async () => {
+    const provider = makeProvider("gpt-5.6-sol");
+    await provider.sendMessage(
+      [userMsg("t1"), assistantMsg("r1"), userMsg("t2")],
+      { config: { disableCache: true, promptCacheKey: "conv-1" } },
+    );
+
+    // Explicit mode with no breakpoints = no cache use and no write charges.
+    // Omitting prompt_cache_options would re-enable implicit mode instead.
+    expect(lastStreamParams?.prompt_cache_options).toEqual({
+      mode: "explicit",
+    });
+    expect(breakpointedItemIndexes()).toEqual([]);
+  });
+
+  test("disableTurnStartCache one-shot: no markers", async () => {
+    const provider = makeProvider("gpt-5.6-sol");
+    await provider.sendMessage([userMsg("one-shot")], {
+      config: { disableTurnStartCache: true, promptCacheKey: "conv-1" },
+    });
+
+    expect(lastStreamParams?.prompt_cache_options).toEqual({
+      mode: "explicit",
+    });
+    expect(breakpointedItemIndexes()).toEqual([]);
+  });
+
+  test("prompt_cache_key omitted when absent; markers still stamped", async () => {
+    const provider = makeProvider("gpt-5.6-sol");
+    await provider.sendMessage([userMsg("hi")]);
+
+    expect(lastStreamParams?.prompt_cache_options).toEqual({
+      mode: "explicit",
+    });
+    expect(lastStreamParams?.prompt_cache_key).toBeUndefined();
+    expect(breakpointedItemIndexes()).toEqual([0]);
+  });
+
+  test("unflagged model sends no cache params at all", async () => {
+    const provider = makeProvider("gpt-5.5");
+    await provider.sendMessage(
+      [userMsg("t1"), assistantMsg("r1"), userMsg("t2")],
+      { config: { mutableLatestUserMessage: true, promptCacheKey: "conv-1" } },
+    );
+
+    expect(lastStreamParams?.prompt_cache_options).toBeUndefined();
+    expect(lastStreamParams?.prompt_cache_key).toBeUndefined();
+    expect(JSON.stringify(lastStreamParams?.input)).not.toContain(
+      "prompt_cache_breakpoint",
+    );
+  });
+
+  test("model override gates on the effective model, not the constructor model", async () => {
+    const provider = makeProvider("gpt-5.5");
+    await provider.sendMessage([userMsg("hi")], {
+      config: { model: "gpt-5.6-terra", promptCacheKey: "conv-1" },
+    });
+
+    expect(lastStreamParams?.model).toBe("gpt-5.6-terra");
+    expect(lastStreamParams?.prompt_cache_options).toEqual({
+      mode: "explicit",
+    });
+    expect(breakpointedItemIndexes()).toEqual([0]);
+  });
+
+  test("codex subscription endpoint gets no cache params", async () => {
+    const provider = makeProvider("gpt-5.6-sol", true);
+    await provider.sendMessage([userMsg("hi")], {
+      config: { promptCacheKey: "conv-1" },
+    });
+
+    expect(lastStreamParams?.prompt_cache_options).toBeUndefined();
+    expect(lastStreamParams?.prompt_cache_key).toBeUndefined();
+    expect(JSON.stringify(lastStreamParams?.input)).not.toContain(
+      "prompt_cache_breakpoint",
+    );
+  });
+
+  test("never mutates the caller's messages", async () => {
+    const provider = makeProvider("gpt-5.6-sol");
+    const messages = [userMsg("t1"), assistantMsg("r1"), userMsg("t2")];
+    await provider.sendMessage(messages, {
+      config: { promptCacheKey: "conv-1" },
+    });
+
+    expect(JSON.stringify(messages)).not.toContain("prompt_cache_breakpoint");
+  });
+
+  test("catalog flags exactly the GPT-5.6 direct-openai rows", () => {
+    const openai = PROVIDER_CATALOG.find((p) => p.id === "openai");
+    const flagged = (openai?.models ?? [])
+      .filter((m) => m.supportsPromptCacheBreakpoints)
+      .map((m) => m.id)
+      .sort();
+    expect(flagged).toEqual(["gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra"]);
+  });
+});

--- a/assistant/src/__tests__/retry-prompt-cache-key.test.ts
+++ b/assistant/src/__tests__/retry-prompt-cache-key.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Verifies that `RetryProvider.normalizeSendMessageOptions` copies
+ * `selectionSeed` (the durable conversation id) into `promptCacheKey` for the
+ * `openai` provider only — and never for providers whose clients spread config
+ * into wire request bodies (Anthropic 400s unknown fields).
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let mockLlmConfig: Record<string, unknown> = {};
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({ llm: mockLlmConfig }),
+}));
+
+import { LLMSchema } from "../config/schemas/llm.js";
+import { RetryProvider } from "../providers/retry.js";
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+} from "../providers/types.js";
+
+beforeEach(() => {
+  mockLlmConfig = LLMSchema.parse({}) as Record<string, unknown>;
+});
+
+function makePipeline(providerName: string): {
+  provider: Provider;
+  lastConfig: () => Record<string, unknown> | undefined;
+} {
+  let captured: Record<string, unknown> | undefined;
+  const inner: Provider = {
+    name: providerName,
+    async sendMessage(
+      _messages: Message[],
+      options?: SendMessageOptions,
+    ): Promise<ProviderResponse> {
+      captured = options?.config as Record<string, unknown> | undefined;
+      return {
+        content: [],
+        model: "test",
+        usage: { inputTokens: 0, outputTokens: 0 },
+        stopReason: "stop",
+      };
+    },
+  };
+  return {
+    provider: new RetryProvider(inner),
+    lastConfig: () => captured,
+  };
+}
+
+const userMessage: Message = {
+  role: "user",
+  content: [{ type: "text", text: "hi" }],
+};
+
+describe("retry normalization for promptCacheKey", () => {
+  test("copies selectionSeed into promptCacheKey for openai and strips the seed", async () => {
+    const { provider, lastConfig } = makePipeline("openai");
+    await provider.sendMessage([userMessage], {
+      config: { selectionSeed: "conv-1" },
+    });
+
+    expect(lastConfig()?.promptCacheKey).toBe("conv-1");
+    expect(lastConfig()?.selectionSeed).toBeUndefined();
+  });
+
+  test("does not create promptCacheKey for anthropic", async () => {
+    const { provider, lastConfig } = makePipeline("anthropic");
+    await provider.sendMessage([userMessage], {
+      config: { selectionSeed: "conv-1" },
+    });
+
+    expect(lastConfig()?.promptCacheKey).toBeUndefined();
+    expect(lastConfig()?.selectionSeed).toBeUndefined();
+  });
+
+  test("does not create promptCacheKey for openrouter", async () => {
+    // OpenRouter delegates anthropic/* models into AnthropicProvider with the
+    // config intact, so the key must not be created there either.
+    const { provider, lastConfig } = makePipeline("openrouter");
+    await provider.sendMessage([userMessage], {
+      config: { selectionSeed: "conv-1" },
+    });
+
+    expect(lastConfig()?.promptCacheKey).toBeUndefined();
+  });
+
+  test("no selectionSeed → no promptCacheKey", async () => {
+    const { provider, lastConfig } = makePipeline("openai");
+    await provider.sendMessage([userMessage], { config: {} });
+
+    expect(lastConfig()?.promptCacheKey).toBeUndefined();
+  });
+
+  test("an explicit caller-set promptCacheKey wins over the seed copy", async () => {
+    const { provider, lastConfig } = makePipeline("openai");
+    await provider.sendMessage([userMessage], {
+      config: { selectionSeed: "conv-1", promptCacheKey: "explicit-key" },
+    });
+
+    expect(lastConfig()?.promptCacheKey).toBe("explicit-key");
+  });
+
+  test("callSite resolution still runs and the key survives it", async () => {
+    mockLlmConfig = LLMSchema.parse({
+      default: { provider: "openai", model: "gpt-5.6-sol" },
+    }) as Record<string, unknown>;
+    const { provider, lastConfig } = makePipeline("openai");
+    await provider.sendMessage([userMessage], {
+      config: { callSite: "mainAgent", selectionSeed: "conv-1" },
+    });
+
+    // The resolver populated wire fields (exact model depends on the active
+    // resolution cascade — not this test's concern) and the routing keys were
+    // consumed, while the copied prompt-cache key survived normalization.
+    expect(typeof lastConfig()?.model).toBe("string");
+    expect((lastConfig()?.model as string).length).toBeGreaterThan(0);
+    expect(lastConfig()?.promptCacheKey).toBe("conv-1");
+    expect(lastConfig()?.callSite).toBeUndefined();
+    expect(lastConfig()?.selectionSeed).toBeUndefined();
+  });
+});

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -61,6 +61,14 @@ export interface CatalogModel {
    * default.
    */
   maxEffort?: "high" | "xhigh" | "max";
+  /**
+   * Daemon-only: when true, the direct-OpenAI Responses transport sends
+   * explicit prompt-cache breakpoints for this model (GPT-5.6+ semantics:
+   * request-wide `prompt_cache_options: { mode: "explicit" }` plus
+   * block-level `prompt_cache_breakpoint` markers and `prompt_cache_key`).
+   * Not projected into the client catalog (see scripts/sync-llm-catalog.ts).
+   */
+  supportsPromptCacheBreakpoints?: boolean;
   /** When set, this model is only visible when the named feature flag is enabled. */
   featureFlag?: string;
 }
@@ -342,6 +350,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: true,
         supportsVision: true,
         supportsToolUse: true,
+        supportsPromptCacheBreakpoints: true,
         pricing: {
           inputPer1mTokens: 5.0,
           outputPer1mTokens: 30.0,
@@ -369,6 +378,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: true,
         supportsVision: true,
         supportsToolUse: true,
+        supportsPromptCacheBreakpoints: true,
         pricing: {
           inputPer1mTokens: 2.5,
           outputPer1mTokens: 15.0,
@@ -396,6 +406,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: true,
         supportsVision: true,
         supportsToolUse: true,
+        supportsPromptCacheBreakpoints: true,
         pricing: {
           inputPer1mTokens: 1.0,
           outputPer1mTokens: 6.0,

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -7,6 +7,7 @@ import { getLogger } from "../../util/logger.js";
 import { extractRetryAfterMs } from "../../util/retry.js";
 import { escapeXmlAttr } from "../../util/xml.js";
 import { base64Source, resolveMediaReferences } from "../media-resolve.js";
+import { PROVIDER_CATALOG } from "../model-catalog.js";
 import { createStreamTimeout } from "../stream-timeout.js";
 import { createToolProgressEmitter } from "../tool-progress-events.js";
 import type {
@@ -144,6 +145,29 @@ const OPENAI_SUPPORTED_IMAGE_TYPES = new Set([
   "image/webp",
 ]);
 
+/** Direct-OpenAI models that use explicit prompt-cache breakpoints (GPT-5.6+).
+ *  Built once from the catalog, mirroring the Fireworks effort-ceiling map
+ *  (fireworks/client.ts). */
+const PROMPT_CACHE_BREAKPOINT_MODELS: ReadonlySet<string> = new Set(
+  PROVIDER_CATALOG.find((p) => p.id === "openai")?.models.flatMap((m) =>
+    m.supportsPromptCacheBreakpoints ? [m.id] : [],
+  ) ?? [],
+);
+
+/** Content-part types that accept a `prompt_cache_breakpoint` marker. */
+const STAMPABLE_PART_TYPES = new Set([
+  "input_text",
+  "input_image",
+  "input_file",
+]);
+
+/** Minimal structural view of a Responses `input` message item. */
+interface ResponsesMessageItem {
+  type?: string;
+  role?: string;
+  content?: Array<Record<string, unknown>>;
+}
+
 /**
  * OpenAI Responses API transport.
  *
@@ -203,12 +227,22 @@ export class OpenAIResponsesProvider implements Provider {
     const usageAttributionHeaders = configObj?.usageAttributionHeaders as
       | Record<string, string>
       | undefined;
+    const mutableLatestUserMessage =
+      configObj?.mutableLatestUserMessage === true;
+    const disableCache = configObj?.disableCache === true;
+    const disableTurnStartCache = configObj?.disableTurnStartCache === true;
+    const promptCacheKey =
+      typeof configObj?.promptCacheKey === "string" &&
+      configObj.promptCacheKey.length > 0
+        ? (configObj.promptCacheKey as string)
+        : undefined;
 
     try {
+      const effectiveModel = modelOverride ?? this.model;
       const input = this.toResponsesInput(messages);
 
       const params: Record<string, unknown> = {
-        model: modelOverride ?? this.model,
+        model: effectiveModel,
         input,
         ...(this.codexSubscription ? { store: false } : {}),
       };
@@ -218,6 +252,33 @@ export class OpenAIResponsesProvider implements Provider {
           SYSTEM_PROMPT_CACHE_BOUNDARY,
           "\n\n",
         );
+      }
+
+      // Explicit prompt-cache mode (GPT-5.6+ semantics, direct API only).
+      // Explicit mode disables the implicit latest-message breakpoint — under
+      // implicit mode a volatile latest user message (mutableLatestUserMessage)
+      // makes every cached entry end at content that never recurs: zero reads
+      // plus a full-prompt 1.25x write per turn. With explicit markers we
+      // choose the stable boundaries ourselves. Under `disableCache` we still
+      // send explicit mode but stamp no markers: a request with no explicit
+      // breakpoints neither uses the cache nor incurs cache-write charges,
+      // which is exactly the opt-out `disableCache` wants (omitting the param
+      // would re-enable implicit mode). The Codex subscription endpoint
+      // rejects extra params, so cache params are skipped entirely there.
+      if (
+        !this.codexSubscription &&
+        PROMPT_CACHE_BREAKPOINT_MODELS.has(effectiveModel)
+      ) {
+        params.prompt_cache_options = { mode: "explicit" };
+        if (promptCacheKey) {
+          params.prompt_cache_key = promptCacheKey;
+        }
+        if (!disableCache) {
+          this.applyPromptCacheBreakpoints(input, {
+            mutableLatestUserMessage,
+            disableTurnStartCache,
+          });
+        }
       }
 
       if (maxTokens && !this.codexSubscription) {
@@ -619,6 +680,120 @@ export class OpenAIResponsesProvider implements Provider {
     }
 
     return result;
+  }
+
+  /**
+   * Stamp explicit prompt-cache breakpoints onto the built Responses input
+   * items. Mirrors the Anthropic client's anchor placement
+   * (anthropic/client.ts): a turn-start anchor, a previous-turn anchor on
+   * first-of-turn requests, and an advancing tail — all sharing OpenAI's
+   * fixed 30m TTL (no long-vs-short TTL split, so no `ttl` field is sent).
+   * Operates on the provider-local wire items only; the caller's Message[]
+   * objects are never touched.
+   *
+   * Placement constraints on this API: breakpoints attach only to
+   * input_text / input_image / input_file parts of user message items —
+   * function_call / function_call_output items cannot carry one, so during a
+   * pure tool loop the tail cannot advance past the most recent user item
+   * with parts (the loop delta is re-billed as plain input until a text- or
+   * image-bearing user item appears).
+   *
+   * The system prompt rides the `instructions` request param and cannot
+   * carry a block marker, but it precedes `input` in the cached prefix, so
+   * the first stamped message covers instructions and tools implicitly. Any
+   * instructions/tools change invalidates all previously written prefixes
+   * (exact-prefix matching) — the same blast radius implicit mode has.
+   *
+   * At most 2 positions are marked per request (turn-start + prev-turn, or
+   * prev-turn + tail, or turn-start + tail), within OpenAI's 4 write slots;
+   * positions matching an already-written prefix are reads, not new writes.
+   */
+  private applyPromptCacheBreakpoints(
+    input: unknown[],
+    opts: { mutableLatestUserMessage: boolean; disableTurnStartCache: boolean },
+  ): void {
+    const items = input as ResponsesMessageItem[];
+    const isUserMessageItem = (it: ResponsesMessageItem | undefined): boolean =>
+      it?.type === "message" &&
+      it.role === "user" &&
+      Array.isArray(it.content) &&
+      it.content.length > 0;
+    // Anchor candidates need a real text part (mirror of the Anthropic
+    // client's findUserTextMsgIdx).
+    const findUserTextItemIdx = (startIdx: number): number => {
+      for (let i = startIdx; i >= 0; i--) {
+        const it = items[i];
+        if (!isUserMessageItem(it)) {
+          continue;
+        }
+        const hasText = it.content!.some(
+          (p) =>
+            p.type === "input_text" &&
+            typeof p.text === "string" &&
+            p.text.length > 0,
+        );
+        if (hasText) {
+          return i;
+        }
+      }
+      return -1;
+    };
+    const stampLastPart = (itemIdx: number): void => {
+      const content = items[itemIdx]?.content;
+      if (!Array.isArray(content) || content.length === 0) {
+        return;
+      }
+      const last = content[content.length - 1];
+      if (last && STAMPABLE_PART_TYPES.has(last.type as string)) {
+        last.prompt_cache_breakpoint = { mode: "explicit" };
+      }
+    };
+
+    const turnStartIdx = findUserTextItemIdx(items.length - 1);
+    // Volatile latest user message that is itself the turn start: skip the
+    // anchor — it would write a prefix that never recurs across turns.
+    const skipVolatileTurnStartAnchor =
+      opts.mutableLatestUserMessage && turnStartIdx === items.length - 1;
+
+    // Turn-start anchor: stable within the turn; tool-loop iterations re-send
+    // this exact prefix and read it.
+    if (
+      turnStartIdx >= 0 &&
+      !opts.disableTurnStartCache &&
+      !skipVolatileTurnStartAnchor
+    ) {
+      stampLastPart(turnStartIdx);
+    }
+
+    // Previous-turn anchor (first-of-turn only): the durable cross-turn
+    // boundary. In the volatile flow this is the primary stable breakpoint
+    // (the turn-start anchor above was skipped); in the stable flow it
+    // usually coincides with an already-written prefix and is a read.
+    if (turnStartIdx === items.length - 1 && turnStartIdx > 0) {
+      const prevIdx = findUserTextItemIdx(turnStartIdx - 1);
+      if (prevIdx >= 0) {
+        stampLastPart(prevIdx);
+      }
+    }
+
+    // Advancing tail: the latest stampable user item. Fires during tool
+    // loops and on volatile first-of-turn requests (prepaying the volatile
+    // segment so in-turn tool iterations read it). May resolve to the
+    // turn-start item itself in a pure tool loop — re-stamping is a no-op.
+    if (
+      turnStartIdx >= 0 &&
+      (turnStartIdx < items.length - 1 ||
+        (skipVolatileTurnStartAnchor &&
+          turnStartIdx > 0 &&
+          !opts.disableTurnStartCache))
+    ) {
+      for (let i = items.length - 1; i >= 0; i--) {
+        if (isUserMessageItem(items[i])) {
+          stampLastPart(i);
+          break;
+        }
+      }
+    }
   }
 
   /** Convert an assistant message's content blocks to Responses input items. */

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -278,11 +278,27 @@ function normalizeSendMessageOptions(
   delete nextConfig.usageAttributionHeaders;
   delete nextConfig.usageTracking;
 
+  // Preserve the per-conversation prompt-cache key before `selectionSeed` is
+  // stripped below. Gated to the `openai` provider (the Responses client
+  // consumes it as `prompt_cache_key`); creating it for other providers would
+  // leak a non-wire field through clients that spread config into request
+  // bodies (AnthropicProvider's `...restConfig` → 400 "Extra inputs are not
+  // permitted"). An explicit caller-set value wins.
+  if (
+    providerName === "openai" &&
+    nextConfig.promptCacheKey === undefined &&
+    typeof config.selectionSeed === "string" &&
+    config.selectionSeed.length > 0
+  ) {
+    nextConfig.promptCacheKey = config.selectionSeed;
+  }
+
   // `overrideProfile`, `forceOverrideProfile`, and `selectionSeed` are
   // routing/resolution-time concerns (consumed by the resolver below and
   // `CallSiteRoutingProvider`'s provider selection); none is a wire-format
-  // field. Strip unconditionally so they never leak into provider request
-  // bodies even when callers set them without a `callSite`.
+  // field. Strip unconditionally (after the `openai` promptCacheKey copy
+  // above) so they never leak into provider request bodies even when callers
+  // set them without a `callSite`.
   delete nextConfig.overrideProfile;
   delete nextConfig.forceOverrideProfile;
   delete nextConfig.selectionSeed;

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -247,6 +247,16 @@ export interface SendMessageConfig {
    */
   selectionSeed?: string;
   /**
+   * Per-conversation prompt-cache key for providers with explicit prompt
+   * caching (sent as the OpenAI `prompt_cache_key` request param). Set by
+   * `RetryProvider` from `selectionSeed` (the durable conversation id) for
+   * the `openai` provider only — GPT-5.6+ requires the key for reliable
+   * breakpoint matching, and OpenAI's ~15 req/min-per-key routing guidance
+   * is satisfied by per-conversation ids. A non-wire field for every other
+   * provider client; the request param is omitted when absent.
+   */
+  promptCacheKey?: string;
+  /**
    * Internal per-request HTTP headers for managed-proxy usage attribution.
    * Provider clients may pass these through SDK request options only when the
    * transport is Vellum-managed, and must never include this object in provider


### PR DESCRIPTION
## Summary
- Send `prompt_cache_options: { mode: \"explicit\" }`, block-level `prompt_cache_breakpoint` markers, and `prompt_cache_key` for GPT-5.6 models on the direct-OpenAI Responses transport, gated by a new daemon-only `supportsPromptCacheBreakpoints` catalog flag (set on `gpt-5.6-sol/terra/luna`; not projected to clients, so no generated-JSON churn)
- Breakpoint placement ports the Anthropic client's anchor algorithm to Responses wire items: a turn-start anchor, a previous-turn anchor on first-of-turn requests, and an advancing tail — with the volatile-latest-message skip (`mutableLatestUserMessage`) so per-turn memory injections stay outside every cached prefix. `disableCache` maps to explicit-mode-with-zero-markers (a true opt-out: no cache use, no write charges); Codex-subscription and unflagged models are byte-identical to before
- `RetryProvider.normalizeSendMessageOptions` copies `selectionSeed` (the conversation id) into a new preserved `SendMessageConfig.promptCacheKey` for the `openai` provider only — other providers never see the field (Anthropic spreads config into the wire and 400s unknown fields)

## Why
Under GPT-5.6's implicit caching, the auto-breakpoint lands on the latest message and reads require exact prefix matches at previously-written breakpoints. Vellum's latest user message carries per-turn-volatile injected blocks, so every cached entry ends at content that never recurs: ~zero reads plus a full-prompt 1.25x write per turn — strictly worse than caching off. Explicit breakpoints anchored on stable boundaries restore the rolling read-history/write-delta pattern. OpenRouter GPT-5.6 stays implicit-mode for now (OpenRouter supports explicit caching only via their Responses API; our OpenRouter transport is chat completions).

## Original prompt
Follow-up 2 of 2 from the GPT-5.6 caching investigation (PR 1 was #37858, cache-write usage + pricing). Sidd asked to plan and ship explicit-breakpoint + prompt_cache_key support after we established that our volatile latest-message request shape defeats GPT-5.6 implicit caching.