### PR TITLE
feat(daemon): ui_snapshot — staged UI capture plumbing + CLI verb

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -13688,6 +13688,57 @@ paths:
           description:
             Submitting client does not match the targeted client, or the submitting actor's principal does not match
             the target client's actor.
+  /v1/host-ui-snapshot-result:
+    post:
+      operationId: hostuisnapshotresult_post
+      summary: Submit host UI-snapshot result
+      description:
+        Resolve a pending UI-snapshot request by requestId. Returns 200 even when no pending interaction matches
+        (late delivery is tolerated).
+      tags:
+        - host
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                requestId:
+                  type: string
+                  description: Pending UI-snapshot request ID
+                pngBase64:
+                  type: string
+                  description: Base64 PNG capture of the staged view
+                widthPx:
+                  type: number
+                heightPx:
+                  type: number
+                isError:
+                  type: boolean
+                errorMessage:
+                  type: string
+              required:
+                - requestId
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accepted:
+                    type: boolean
+                required:
+                  - accepted
+                additionalProperties: false
+        "400":
+          description: x-vellum-client-id header is missing for a targeted UI-snapshot request.
+        "403":
+          description:
+            Submitting client does not match the targeted client, or the submitting actor's principal does not match
+            the target client's actor.
   /v1/identity:
     get:
       operationId: identity_get
@@ -29952,6 +30003,71 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/ui/snapshot:
+    post:
+      operationId: ui_snapshot_post
+      summary: Capture a staged UI snapshot
+      description:
+        Ask the connected desktop client to render a staged view of the app (sampler or chat) with the current
+        workspace-theme tokens applied and return a PNG capture. The staged views contain only fixed generic content.
+        Blocks until the client responds or the timeout elapses.
+      tags:
+        - host
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                view:
+                  default: sampler
+                  description: Which staged composition to capture
+                  type: string
+                  enum:
+                    - sampler
+                    - chat
+                timeoutMs:
+                  description: How long to wait for the client capture
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 120000
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  pngBase64:
+                    type: string
+                    description: Base64 PNG capture of the staged view
+                  widthPx:
+                    type: number
+                  heightPx:
+                    type: number
+                  themeSource:
+                    type: string
+                    enum:
+                      - workspace
+                      - invalid
+                      - none
+                  themeIssues:
+                    type: array
+                    items:
+                      type: string
+                  timedOut:
+                    type: boolean
+                  error:
+                    type: string
+                required:
+                  - ok
+                  - themeSource
+                  - themeIssues
+                additionalProperties: false
   /v1/usage/breakdown:
     get:
       operationId: usage_breakdown_get

--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -227,7 +227,7 @@ export function isInteractiveInterface(id: InterfaceId): boolean {
 
 /**
  * Host proxy capabilities that an interface can support. The macOS client
- * supports all five; the chrome-extension interface only supports
+ * supports all of them; the chrome-extension interface only supports
  * host_browser (via the Chrome DevTools Protocol proxy).
  */
 export type HostProxyCapability =
@@ -235,11 +235,12 @@ export type HostProxyCapability =
   | "host_file"
   | "host_cu"
   | "host_browser"
-  | "host_app_control";
+  | "host_app_control"
+  | "host_ui_snapshot";
 
 /**
- * Interfaces that support the full desktop host-proxy set (all five
- * `HostProxyCapability` values). This is the capability-level identity used
+ * Interfaces that support the full desktop host-proxy set (every
+ * `HostProxyCapability` value). This is the capability-level identity used
  * by the discriminated transport metadata union and by the
  * `supportsHostProxy(id)` type predicate.
  *
@@ -272,7 +273,7 @@ export function supportsHostProxy(
   id: InterfaceId,
   capability?: HostProxyCapability,
 ): boolean {
-  // macOS supports all five host proxy capabilities including host_browser
+  // macOS supports every host proxy capability including host_browser
   // and host_app_control. The host_browser proxy is provisioned via the
   // assistant event hub. When no extension is connected, browser tools fall
   // through to cdp-inspect/local via the CDP factory's candidate chain.

--- a/assistant/src/cli/commands/__tests__/ui.test.ts
+++ b/assistant/src/cli/commands/__tests__/ui.test.ts
@@ -200,13 +200,13 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("subcommand registration", () => {
-  test("registers request and confirm subcommands under ui", () => {
+  test("registers request, confirm, and snapshot subcommands under ui", () => {
     const program = new Command();
     registerUiCommand(program);
     const ui = program.commands.find((c) => c.name() === "ui");
     expect(ui).toBeDefined();
     const subcommandNames = ui!.commands.map((c) => c.name()).sort();
-    expect(subcommandNames).toEqual(["confirm", "request"]);
+    expect(subcommandNames).toEqual(["confirm", "request", "snapshot"]);
   });
 });
 

--- a/assistant/src/cli/commands/ui.ts
+++ b/assistant/src/cli/commands/ui.ts
@@ -7,10 +7,15 @@
  *     describing the surface (via `--payload` or stdin).
  *   - `assistant ui confirm`  — Convenience wrapper that presents a yes/no
  *     confirmation prompt and exits 0 on confirm, 1 on deny/cancel/timeout.
+ *   - `assistant ui snapshot` — Capture a PNG of a staged app view (via the
+ *     desktop client) with the current workspace theme applied.
  *
- * Both commands delegate to the daemon's `ui_request` IPC method, which
- * manages the surface lifecycle on the active conversation.
+ * `request` and `confirm` delegate to the daemon's `ui_request` IPC method,
+ * which manages the surface lifecycle on the active conversation; `snapshot`
+ * delegates to `ui_snapshot`, which is conversation-agnostic.
  */
+
+import { writeFileSync } from "node:fs";
 
 import type { Command } from "commander";
 
@@ -19,6 +24,7 @@ import type {
   InteractiveUiAction,
   InteractiveUiResult,
 } from "../../runtime/interactive-ui-types.js";
+import type { UiSnapshotResult } from "../../runtime/routes/ui-snapshot-routes.js";
 import { readStdinSync } from "../../util/read-stdin.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
@@ -39,6 +45,12 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 5 * 60 * 1000; // 5m
  * surface and send the response.
  */
 const IPC_TIMEOUT_BUFFER_MS = 10_000; // 10s
+
+/**
+ * Default timeout for `ui snapshot` (30s). Sized for a hidden-window render
+ * and capture, not a human response.
+ */
+const DEFAULT_SNAPSHOT_TIMEOUT_MS = 30_000;
 
 const CONV_ID_HELP =
   "No conversation ID available.\n" +
@@ -656,6 +668,157 @@ Examples:
 
             if (!confirmed) {
               process.exitCode = 1;
+            }
+          },
+        );
+
+      // ── ui snapshot ─────────────────────────────────────────────────
+
+      ui.command("snapshot")
+        .description(
+          "Capture a PNG of a staged app view with the current workspace theme applied",
+        )
+        .option(
+          "--view <view>",
+          'Staged composition to capture: "sampler" or "chat"',
+          "sampler",
+        )
+        .option("--out <path>", "File path to write the PNG to")
+        .option(
+          "--timeout <ms>",
+          "How long to wait for the desktop client capture",
+          String(DEFAULT_SNAPSHOT_TIMEOUT_MS),
+        )
+        .option(
+          "--json",
+          "Output result as machine-readable JSON (PNG inline as base64)",
+        )
+        .addHelpText(
+          "after",
+          `
+Asks the connected desktop app to render a staged view of its own UI —
+fixed generic content, no user data — with the workspace theme from
+ui/theme.json applied, capture it offscreen, and return the PNG. Use it
+to see theming work without asking the user for screenshots.
+
+Views:
+  sampler  Dense style sheet: text ramp, accent, buttons, card, inputs,
+           borders, chat bubbles. Answers "does the palette read".
+  chat     A staged conversation with a composer. Answers "does it feel
+           like the app".
+
+Requires the desktop app to be running. If the workspace theme file is
+invalid, the capture shows the built-in theme and the validation issues
+are printed.
+
+Examples:
+  $ assistant ui snapshot --view sampler --out /tmp/theme-sampler.png
+  $ assistant ui snapshot --view chat --out /tmp/theme-chat.png`,
+        )
+        .action(
+          async (opts: {
+            view?: string;
+            out?: string;
+            timeout?: string;
+            json?: boolean;
+          }) => {
+            const emitError = (msg: string): void => {
+              if (opts.json) {
+                process.stdout.write(
+                  JSON.stringify({ ok: false, error: msg }) + "\n",
+                );
+              } else {
+                log.error(msg);
+              }
+              process.exitCode = 1;
+            };
+
+            const view = opts.view ?? "sampler";
+            if (view !== "sampler" && view !== "chat") {
+              emitError(
+                `Invalid --view value "${view}". Must be "sampler" or "chat".`,
+              );
+              return;
+            }
+
+            if (!opts.out && !opts.json) {
+              emitError(
+                "Provide --out <path> to write the PNG (or --json for inline base64 output).",
+              );
+              return;
+            }
+
+            const rawTimeout =
+              opts.timeout ?? String(DEFAULT_SNAPSHOT_TIMEOUT_MS);
+            const requestTimeoutMs = parseStrictPositiveInt(rawTimeout);
+            if (isNaN(requestTimeoutMs) || requestTimeoutMs <= 0) {
+              emitError(
+                `Invalid --timeout value "${opts.timeout}". Must be a positive integer (milliseconds).`,
+              );
+              return;
+            }
+
+            const result = await cliIpcCall<UiSnapshotResult>(
+              "ui_snapshot",
+              { body: { view, timeoutMs: requestTimeoutMs } },
+              { timeoutMs: requestTimeoutMs + IPC_TIMEOUT_BUFFER_MS },
+            );
+
+            if (!result.ok) {
+              emitError(`Error: ${result.error}`);
+              return;
+            }
+
+            const snapshot = result.result!;
+
+            if (snapshot.themeSource === "invalid" && !opts.json) {
+              log.warn(
+                "The workspace theme file is invalid — the capture shows the built-in theme.",
+              );
+              for (const issue of snapshot.themeIssues) {
+                log.warn(`  - ${issue}`);
+              }
+            }
+
+            if (!snapshot.ok || !snapshot.pngBase64) {
+              emitError(snapshot.error ?? "The capture returned no image.");
+              return;
+            }
+
+            if (opts.out) {
+              try {
+                writeFileSync(
+                  String(opts.out),
+                  Buffer.from(snapshot.pngBase64, "base64"),
+                );
+              } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                emitError(`Failed to write PNG to ${opts.out}: ${msg}`);
+                return;
+              }
+            }
+
+            if (opts.json) {
+              const jsonOut: Record<string, unknown> = {
+                ok: true,
+                view,
+                widthPx: snapshot.widthPx,
+                heightPx: snapshot.heightPx,
+                themeSource: snapshot.themeSource,
+                themeIssues: snapshot.themeIssues,
+              };
+              if (opts.out) {
+                jsonOut.out = opts.out;
+              } else {
+                jsonOut.pngBase64 = snapshot.pngBase64;
+              }
+              process.stdout.write(JSON.stringify(jsonOut) + "\n");
+            } else {
+              const dims =
+                snapshot.widthPx && snapshot.heightPx
+                  ? ` (${snapshot.widthPx}x${snapshot.heightPx})`
+                  : "";
+              log.info(`Snapshot saved to ${opts.out}${dims}`);
             }
           },
         );

--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -94,6 +94,7 @@ import type {
 import type { _HostCuServerMessages } from "./message-types/host-cu.js";
 import type { _HostFileServerMessages } from "./message-types/host-file.js";
 import type { _HostTransferServerMessages } from "./message-types/host-transfer.js";
+import type { _HostUiSnapshotServerMessages } from "./message-types/host-ui-snapshot.js";
 import type {
   _InboxClientMessages,
   _InboxServerMessages,
@@ -200,6 +201,7 @@ export type ServerMessage =
   | _HostCuServerMessages
   | _HostFileServerMessages
   | _HostTransferServerMessages
+  | _HostUiSnapshotServerMessages
   | _MemoryServerMessages
   | _WorkspaceServerMessages
   | _SchedulesServerMessages

--- a/assistant/src/daemon/message-types/host-ui-snapshot.ts
+++ b/assistant/src/daemon/message-types/host-ui-snapshot.ts
@@ -1,0 +1,44 @@
+// Host UI-snapshot proxy types.
+// Asks the desktop client to render a staged view of the app's own UI
+// (`/assistant/theme-stage/:view`) in a hidden window with the current
+// workspace-theme tokens applied, capture it, and post the PNG back. The
+// stage contains only fixed generic content — never user data — so the
+// assistant can check its theming work without a human screenshotting the
+// app. Distinct from host-app-control's `observe` (which captures OTHER
+// applications' windows via the native helper).
+
+/** Staged compositions the web client can render for capture. */
+export type HostUiSnapshotView = "sampler" | "chat";
+
+export interface HostUiSnapshotRequestMessage {
+  type: "host_ui_snapshot_request";
+  requestId: string;
+  view: HostUiSnapshotView;
+  /**
+   * Validated workspace-theme tokens to apply on the stage. The daemon reads
+   * them from ui/theme.json at request time so the capture reflects the
+   * current file even before connected clients refetch. Absent when no valid
+   * theme exists — the stage renders the built-in base theme.
+   */
+  tokens?: Record<string, string>;
+}
+
+export interface HostUiSnapshotCancelMessage {
+  type: "host_ui_snapshot_cancel";
+  requestId: string;
+}
+
+export type _HostUiSnapshotServerMessages =
+  | HostUiSnapshotRequestMessage
+  | HostUiSnapshotCancelMessage;
+
+/** Body the desktop client POSTs to /v1/host-ui-snapshot-result. */
+export interface HostUiSnapshotResultPayload {
+  requestId: string;
+  /** Base64 PNG capture of the staged view (device-scale pixels). */
+  pngBase64?: string;
+  widthPx?: number;
+  heightPx?: number;
+  isError?: boolean;
+  errorMessage?: string;
+}

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -26,6 +26,7 @@ const HOST_PREFIX_TO_CAPABILITY: Record<string, HostProxyCapability> = {
   host_cu: "host_cu",
   host_browser: "host_browser",
   host_app_control: "host_app_control",
+  host_ui_snapshot: "host_ui_snapshot",
 };
 
 /**

--- a/assistant/src/runtime/auth/same-actor.ts
+++ b/assistant/src/runtime/auth/same-actor.ts
@@ -47,7 +47,8 @@ export type SameActorOp =
   | "host_cu"
   | "host_browser"
   | "host_app_control"
-  | "host_transfer";
+  | "host_transfer"
+  | "host_ui_snapshot";
 
 /**
  * Args for the live-lookup variant: caller supplies the hub + target client

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -98,6 +98,7 @@ export interface PendingInteraction {
     | "host_browser"
     | "host_app_control"
     | "host_transfer"
+    | "host_ui_snapshot"
     | "acp_confirmation";
   confirmationDetails?: ConfirmationDetails;
   /** For a pending `question`: the full batched entries, so a history-load render can rehydrate the question card. */

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -58,6 +58,7 @@ const ALL_CAPABILITIES: HostProxyCapability[] = [
   "host_cu",
   "host_app_control",
   "host_browser",
+  "host_ui_snapshot",
 ];
 
 /**

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -144,6 +144,7 @@ import { ROUTES as TRUST_RULES_ROUTES } from "./trust-rules-routes.js";
 import { ROUTES as TTS_ROUTES } from "./tts-routes.js";
 import type { RouteDefinition } from "./types.js";
 import { ROUTES as UI_REQUEST_ROUTES } from "./ui-request-routes.js";
+import { ROUTES as UI_SNAPSHOT_ROUTES } from "./ui-snapshot-routes.js";
 import { ROUTES as UPGRADE_BROADCAST_ROUTES } from "./upgrade-broadcast-routes.js";
 import { ROUTES as USAGE_ROUTES } from "./usage-routes.js";
 import { ROUTES as USER_ROUTES } from "./user-routes.js";
@@ -289,6 +290,7 @@ export const ROUTES: RouteDefinition[] = [
   ...TRUST_RULES_ROUTES,
   ...TTS_ROUTES,
   ...UI_REQUEST_ROUTES,
+  ...UI_SNAPSHOT_ROUTES,
   ...UPGRADE_BROADCAST_ROUTES,
   ...USAGE_ROUTES,
   ...VERCEL_ROUTES,

--- a/assistant/src/runtime/routes/ui-snapshot-routes.test.ts
+++ b/assistant/src/runtime/routes/ui-snapshot-routes.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for the staged UI-snapshot routes.
+ *
+ * Covers the full daemon-side round trip with a mocked event hub:
+ * - no capable client → clean error (no pending interaction left behind)
+ * - happy path: request broadcast to the targeted client, result POST
+ *   resolves the blocked request with the PNG and theme context
+ * - same-actor binding: a result from the wrong client is rejected
+ * - timeout: cancel broadcast + timed_out error shape
+ * - late delivery: a result for an unknown requestId is tolerated
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+interface FakeClient {
+  clientId: string;
+  actorPrincipalId?: string;
+}
+
+let fakeClient: FakeClient | undefined;
+const broadcasts: Array<{
+  msg: Record<string, unknown>;
+  targetClientId?: string;
+}> = [];
+
+mock.module("../assistant-event-hub.js", () => ({
+  assistantEventHub: {
+    getMostRecentClientByCapability: () => fakeClient,
+    getActorPrincipalIdForClient: (clientId: string) =>
+      fakeClient?.clientId === clientId
+        ? fakeClient.actorPrincipalId
+        : undefined,
+  },
+  broadcastMessage: (
+    msg: Record<string, unknown>,
+    _conversationId?: string,
+    options?: { targetClientId?: string },
+  ) => {
+    broadcasts.push({ msg, targetClientId: options?.targetClientId });
+  },
+}));
+
+const { ROUTES } = await import("./ui-snapshot-routes.js");
+
+const snapshotRoute = ROUTES.find((r) => r.operationId === "ui_snapshot")!;
+const resultRoute = ROUTES.find(
+  (r) => r.operationId === "host_ui_snapshot_result",
+)!;
+
+const PNG_BASE64 = Buffer.from("fake-png-bytes").toString("base64");
+
+let workspaceDir: string;
+let originalWorkspaceDir: string | undefined;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "ui-snapshot-test-"));
+  originalWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+  fakeClient = undefined;
+  broadcasts.length = 0;
+});
+
+afterEach(() => {
+  if (originalWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = originalWorkspaceDir;
+  }
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+function writeTheme(content: string): void {
+  mkdirSync(join(workspaceDir, "ui"), { recursive: true });
+  writeFileSync(join(workspaceDir, "ui", "theme.json"), content);
+}
+
+describe("ui_snapshot", () => {
+  test("fails cleanly when no capable client is connected", async () => {
+    const result = (await snapshotRoute.handler({
+      body: { view: "sampler" },
+    })) as { ok: boolean; error?: string; themeSource: string };
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("desktop client");
+    expect(result.themeSource).toBe("none");
+    expect(broadcasts.length).toBe(0);
+  });
+
+  test("round trip: broadcasts the targeted request and resolves with the client's PNG", async () => {
+    fakeClient = { clientId: "client-1", actorPrincipalId: "actor-1" };
+    writeTheme(JSON.stringify({ version: 1, tokens: { accent: "#e8a04c" } }));
+
+    const pending = snapshotRoute.handler({
+      body: { view: "chat", timeoutMs: 5_000 },
+    }) as Promise<{
+      ok: boolean;
+      pngBase64?: string;
+      widthPx?: number;
+      themeSource: string;
+    }>;
+
+    // The request event is broadcast synchronously at dispatch.
+    expect(broadcasts.length).toBe(1);
+    const request = broadcasts[0]!;
+    expect(request.targetClientId).toBe("client-1");
+    expect(request.msg.type).toBe("host_ui_snapshot_request");
+    expect(request.msg.view).toBe("chat");
+    expect(request.msg.tokens).toEqual({ accent: "#e8a04c" });
+
+    const accepted = (await resultRoute.handler({
+      body: {
+        requestId: request.msg.requestId,
+        pngBase64: PNG_BASE64,
+        widthPx: 1440,
+        heightPx: 1520,
+      },
+      headers: {
+        "x-vellum-client-id": "client-1",
+        "x-vellum-actor-principal-id": "actor-1",
+      },
+    })) as { accepted: boolean };
+    expect(accepted.accepted).toBe(true);
+
+    const result = await pending;
+    expect(result.ok).toBe(true);
+    expect(result.pngBase64).toBe(PNG_BASE64);
+    expect(result.widthPx).toBe(1440);
+    expect(result.themeSource).toBe("workspace");
+  });
+
+  test("rejects a result posted by a client other than the target", async () => {
+    fakeClient = { clientId: "client-1", actorPrincipalId: "actor-1" };
+
+    const pending = snapshotRoute.handler({
+      body: { view: "sampler", timeoutMs: 5_000 },
+    }) as Promise<{ ok: boolean }>;
+    const requestId = broadcasts[0]!.msg.requestId;
+
+    await expect(
+      resultRoute.handler({
+        body: { requestId, pngBase64: PNG_BASE64 },
+        headers: {
+          "x-vellum-client-id": "client-2",
+          "x-vellum-actor-principal-id": "actor-2",
+        },
+      }),
+    ).rejects.toThrow(/not the target/);
+
+    // The legitimate client can still resolve it.
+    await resultRoute.handler({
+      body: { requestId, pngBase64: PNG_BASE64 },
+      headers: {
+        "x-vellum-client-id": "client-1",
+        "x-vellum-actor-principal-id": "actor-1",
+      },
+    });
+    const result = await pending;
+    expect(result.ok).toBe(true);
+  });
+
+  test("times out with a cancel broadcast when the client never responds", async () => {
+    fakeClient = { clientId: "client-1", actorPrincipalId: "actor-1" };
+
+    const result = (await snapshotRoute.handler({
+      body: { view: "sampler", timeoutMs: 50 },
+    })) as { ok: boolean; timedOut?: boolean; error?: string };
+
+    expect(result.ok).toBe(false);
+    expect(result.timedOut).toBe(true);
+    expect(result.error).toContain("Timed out");
+    const cancel = broadcasts.find(
+      (b) => b.msg.type === "host_ui_snapshot_cancel",
+    );
+    expect(cancel).toBeDefined();
+    expect(cancel!.targetClientId).toBe("client-1");
+  });
+
+  test("surfaces an invalid theme as themeSource invalid with issues, and omits tokens", async () => {
+    fakeClient = { clientId: "client-1", actorPrincipalId: "actor-1" };
+    writeTheme(JSON.stringify({ version: 1, tokens: { accent: "magenta" } }));
+
+    const pending = snapshotRoute.handler({
+      body: { view: "sampler", timeoutMs: 5_000 },
+    }) as Promise<{ themeSource: string; themeIssues: string[] }>;
+
+    const request = broadcasts[0]!;
+    expect(request.msg.tokens).toBeUndefined();
+
+    await resultRoute.handler({
+      body: { requestId: request.msg.requestId, pngBase64: PNG_BASE64 },
+      headers: {
+        "x-vellum-client-id": "client-1",
+        "x-vellum-actor-principal-id": "actor-1",
+      },
+    });
+
+    const result = await pending;
+    expect(result.themeSource).toBe("invalid");
+    expect(result.themeIssues.length).toBeGreaterThan(0);
+  });
+});
+
+describe("host_ui_snapshot_result", () => {
+  test("tolerates late delivery for an unknown requestId", async () => {
+    const result = (await resultRoute.handler({
+      body: { requestId: "gone", pngBase64: PNG_BASE64 },
+      headers: { "x-vellum-client-id": "client-1" },
+    })) as { accepted: boolean };
+    expect(result.accepted).toBe(true);
+  });
+
+  test("rejects a missing requestId", async () => {
+    await expect(
+      resultRoute.handler({ body: { pngBase64: PNG_BASE64 } }),
+    ).rejects.toThrow(/requestId/);
+  });
+});

--- a/assistant/src/runtime/routes/ui-snapshot-routes.ts
+++ b/assistant/src/runtime/routes/ui-snapshot-routes.ts
@@ -1,0 +1,313 @@
+/**
+ * Routes for the staged UI-snapshot flow (`assistant ui snapshot`).
+ *
+ * `ui_snapshot` (IPC-eligible, CLI-facing) asks the most recent connected
+ * desktop client to render a staged view of the app with the current
+ * validated workspace-theme tokens and return a PNG capture. The request is
+ * conversation-agnostic: it registers a pending interaction that resolves
+ * via `rpcResolve` when the client POSTs to `host_ui_snapshot_result`
+ * (HTTP-only, like the other host result routes).
+ *
+ * The staged views contain only fixed generic content — never user data —
+ * so no permission gate applies; an unavailable or outdated client degrades
+ * to a clean error the CLI can explain.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import { z } from "zod";
+
+import type {
+  HostUiSnapshotResultPayload,
+  HostUiSnapshotView,
+} from "../../daemon/message-types/host-ui-snapshot.js";
+import { readWorkspaceTheme } from "../../theme/workspace-theme.js";
+import { assistantEventHub, broadcastMessage } from "../assistant-event-hub.js";
+import { ACTOR_PRINCIPALS, LOCAL_PRINCIPALS } from "../auth/route-policy.js";
+import {
+  enforceSameActorOrThrow,
+  SAME_ACTOR_FORBIDDEN_DESCRIPTION,
+} from "../auth/same-actor.js";
+import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
+import * as pendingInteractions from "../pending-interactions.js";
+import { BadRequestError, ForbiddenError } from "./errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+const DEFAULT_SNAPSHOT_TIMEOUT_MS = 30_000;
+const MAX_SNAPSHOT_TIMEOUT_MS = 120_000;
+
+const SnapshotRequestParams = z.object({
+  view: z.enum(["sampler", "chat"]).default("sampler"),
+  timeoutMs: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_SNAPSHOT_TIMEOUT_MS)
+    .optional(),
+});
+
+export interface UiSnapshotResult {
+  ok: boolean;
+  pngBase64?: string;
+  widthPx?: number;
+  heightPx?: number;
+  /** Where the embedded theme came from: the validated file, an invalid file, or no file. */
+  themeSource: "workspace" | "invalid" | "none";
+  /** Validation issues when the theme file exists but was rejected. */
+  themeIssues: string[];
+  timedOut?: boolean;
+  error?: string;
+}
+
+async function handleUiSnapshot({
+  body = {},
+}: RouteHandlerArgs): Promise<UiSnapshotResult> {
+  const { view, timeoutMs } = SnapshotRequestParams.parse(body);
+
+  const theme = readWorkspaceTheme();
+  const themeContext = {
+    themeSource: theme.source,
+    themeIssues: theme.issues,
+  } as const;
+
+  const client =
+    assistantEventHub.getMostRecentClientByCapability("host_ui_snapshot");
+  if (!client) {
+    return {
+      ok: false,
+      ...themeContext,
+      error:
+        "No connected desktop client supports UI snapshots. Make sure the desktop app is running and up to date.",
+    };
+  }
+
+  const requestId = randomUUID();
+  const effectiveTimeoutMs = timeoutMs ?? DEFAULT_SNAPSHOT_TIMEOUT_MS;
+
+  const payload = await new Promise<HostUiSnapshotResultPayload>(
+    (resolvePromise) => {
+      const timer = setTimeout(() => {
+        // Resolve the tracker first so a late client POST is tolerated as a
+        // no-op instead of double-resolving this promise.
+        const entry = pendingInteractions.resolve(requestId, "cancelled");
+        if (!entry) {
+          return;
+        }
+        broadcastMessage(
+          { type: "host_ui_snapshot_cancel", requestId },
+          undefined,
+          { targetClientId: client.clientId },
+        );
+        resolvePromise({
+          requestId,
+          isError: true,
+          errorMessage: `Timed out after ${effectiveTimeoutMs}ms waiting for the desktop client. It may be busy, outdated, or disconnected.`,
+        });
+      }, effectiveTimeoutMs);
+
+      // Arm the same-actor result check only when the target client has a
+      // verified actor principal; a legacy/service connection would otherwise
+      // fail `missing_target` on its own legitimate result.
+      const targetActorPrincipalId =
+        assistantEventHub.getActorPrincipalIdForClient(client.clientId);
+      pendingInteractions.register(requestId, {
+        kind: "host_ui_snapshot",
+        rpcResolve: resolvePromise as (value: unknown) => void,
+        timer,
+        ...(targetActorPrincipalId
+          ? { targetClientId: client.clientId, targetActorPrincipalId }
+          : {}),
+        metadata: { view },
+      });
+
+      broadcastMessage(
+        {
+          type: "host_ui_snapshot_request",
+          requestId,
+          view: view as HostUiSnapshotView,
+          ...(theme.theme?.tokens ? { tokens: theme.theme.tokens } : {}),
+        },
+        undefined,
+        { targetClientId: client.clientId },
+      );
+    },
+  );
+
+  if (payload.isError || !payload.pngBase64) {
+    return {
+      ok: false,
+      ...themeContext,
+      timedOut: payload.errorMessage?.startsWith("Timed out") || undefined,
+      error: payload.errorMessage ?? "The desktop client returned no capture.",
+    };
+  }
+
+  return {
+    ok: true,
+    pngBase64: payload.pngBase64,
+    widthPx: payload.widthPx,
+    heightPx: payload.heightPx,
+    ...themeContext,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/host-ui-snapshot-result
+// ---------------------------------------------------------------------------
+
+async function handleHostUiSnapshotResult({ body, headers }: RouteHandlerArgs) {
+  if (!body || typeof body !== "object") {
+    throw new BadRequestError("Request body is required");
+  }
+
+  const { requestId, pngBase64, widthPx, heightPx, isError, errorMessage } =
+    body as {
+      requestId?: string;
+      pngBase64?: string;
+      widthPx?: number;
+      heightPx?: number;
+      isError?: boolean;
+      errorMessage?: string;
+    };
+
+  if (!requestId || typeof requestId !== "string") {
+    throw new BadRequestError("requestId is required");
+  }
+
+  // Late-delivery tolerance: if the pending interaction is already gone (the
+  // request timed out), accept the post and move on — mirrors the other host
+  // result routes.
+  const peeked = pendingInteractions.get(requestId);
+  if (!peeked || peeked.kind !== "host_ui_snapshot") {
+    return { accepted: true };
+  }
+
+  // Same-actor binding: the targeted client must be the one submitting.
+  if (peeked.targetClientId != null) {
+    const headerMap = headers ?? {};
+    const submittingClientId =
+      headerMap["x-vellum-client-id"]?.trim() || undefined;
+    if (!submittingClientId) {
+      throw new BadRequestError(
+        "x-vellum-client-id header is missing for a targeted UI-snapshot request.",
+      );
+    }
+    if (submittingClientId !== peeked.targetClientId) {
+      throw new ForbiddenError(
+        `Client "${submittingClientId}" is not the target for this request (expected "${peeked.targetClientId}"). The targeted client must submit the result.`,
+      );
+    }
+    const submittingActorPrincipalId =
+      await resolveActorPrincipalIdForLocalGuardian(
+        headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+      );
+    enforceSameActorOrThrow({
+      sourceActorPrincipalId: submittingActorPrincipalId,
+      targetActorPrincipalId: peeked.targetActorPrincipalId,
+      targetClientId: peeked.targetClientId,
+      op: "host_ui_snapshot",
+    });
+  }
+
+  const interaction = pendingInteractions.resolve(requestId, "answered");
+  const payload: HostUiSnapshotResultPayload = {
+    requestId,
+    ...(pngBase64 !== undefined ? { pngBase64 } : {}),
+    ...(widthPx !== undefined ? { widthPx } : {}),
+    ...(heightPx !== undefined ? { heightPx } : {}),
+    ...(isError !== undefined ? { isError } : {}),
+    ...(errorMessage !== undefined ? { errorMessage } : {}),
+  };
+  interaction?.rpcResolve?.(payload);
+
+  return { accepted: true };
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions (shared HTTP + IPC)
+// ---------------------------------------------------------------------------
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "ui_snapshot",
+    endpoint: "ui/snapshot",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: LOCAL_PRINCIPALS,
+    },
+    summary: "Capture a staged UI snapshot",
+    description:
+      "Ask the connected desktop client to render a staged view of the app " +
+      "(sampler or chat) with the current workspace-theme tokens applied and " +
+      "return a PNG capture. The staged views contain only fixed generic " +
+      "content. Blocks until the client responds or the timeout elapses.",
+    tags: ["host"],
+    requestBody: z.object({
+      view: z
+        .enum(["sampler", "chat"])
+        .default("sampler")
+        .describe("Which staged composition to capture"),
+      timeoutMs: z
+        .number()
+        .int()
+        .positive()
+        .max(MAX_SNAPSHOT_TIMEOUT_MS)
+        .optional()
+        .describe("How long to wait for the client capture"),
+    }),
+    responseBody: z.object({
+      ok: z.boolean(),
+      pngBase64: z
+        .string()
+        .describe("Base64 PNG capture of the staged view")
+        .optional(),
+      widthPx: z.number().optional(),
+      heightPx: z.number().optional(),
+      themeSource: z.enum(["workspace", "invalid", "none"]),
+      themeIssues: z.array(z.string()),
+      timedOut: z.boolean().optional(),
+      error: z.string().optional(),
+    }),
+    handler: handleUiSnapshot,
+  },
+  {
+    operationId: "host_ui_snapshot_result",
+    endpoint: "host-ui-snapshot-result",
+    method: "POST",
+    policy: {
+      requiredScopes: ["approval.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    requireGuardian: true,
+    summary: "Submit host UI-snapshot result",
+    description:
+      "Resolve a pending UI-snapshot request by requestId. Returns 200 even " +
+      "when no pending interaction matches (late delivery is tolerated).",
+    tags: ["host"],
+    requestBody: z.object({
+      requestId: z.string().describe("Pending UI-snapshot request ID"),
+      pngBase64: z
+        .string()
+        .describe("Base64 PNG capture of the staged view")
+        .optional(),
+      widthPx: z.number().optional(),
+      heightPx: z.number().optional(),
+      isError: z.boolean().optional(),
+      errorMessage: z.string().optional(),
+    }),
+    responseBody: z.object({
+      accepted: z.boolean(),
+    }),
+    additionalResponses: {
+      "400": {
+        description:
+          "x-vellum-client-id header is missing for a targeted UI-snapshot request.",
+      },
+      "403": {
+        description: SAME_ACTOR_FORBIDDEN_DESCRIPTION,
+      },
+    },
+    handler: handleHostUiSnapshotResult,
+  },
+];

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -275,6 +275,7 @@ const ASSISTANT_SUPPORTED_COMMAND_PATHS = [
   "ui",
   "ui request",
   "ui confirm",
+  "ui snapshot",
   "usage",
   "usage totals",
   "usage daily",


### PR DESCRIPTION
## Summary

- **`assistant ui snapshot --view sampler|chat --out <path>`**: asks the most recently active desktop client to render a staged view of the app with the current validated workspace-theme tokens and return a PNG. Conversation-agnostic — a pending interaction resolved via `rpcResolve` (credentials-prompt precedent), not a conversation surface.
- New `host_ui_snapshot` capability wired through the lock-step registries (`HostProxyCapability`, `ALL_CAPABILITIES`, `HOST_PREFIX_TO_CAPABILITY`, pending-interaction kinds, `SameActorOp`) + `host_ui_snapshot_request/_cancel` message types in the `ServerMessage` union.
- `ui_snapshot` route (IPC-eligible, `LOCAL_PRINCIPALS`, `settings.write`): embeds tokens from `readWorkspaceTheme()` at request time, targets the capture at one client, 30s default timeout with a targeted cancel broadcast, and reports `themeSource`/`themeIssues` alongside the image (the CLI prints validation issues when the theme file is invalid).
- `host-ui-snapshot-result` route (HTTP-only, `requireGuardian`, `approval.write`, `ACTOR_PRINCIPALS`): same-actor binding mirroring the host result-route family; late delivery tolerated. The same-actor check is armed only when the target client has a verified actor principal (legacy/service connections would otherwise 403 their own legitimate results).
- 7 route tests covering the full round trip with a mocked hub: no-client fail-fast, targeted broadcast + result resolution, wrong-client rejection, timeout + cancel, invalid-theme reporting, late delivery, missing requestId.

Compat: old desktop clients ignore the unknown request kind → the CLI reports a clean timeout with an update hint. New clients + old daemons receive no requests. No version gates.

## Original prompt

Part 2 of 3 of "the mirror" (user-approved plan): the workspace-theme pipeline lets the assistant author `ui/theme.json` but it iterates blind. This PR is the daemon transport half — request/result plumbing modeled on the host-proxy family plus the CLI verb. The render target (web theme-stage route, #37860) and the Electron capture executor land separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)