### PR TITLE
Mark historical anchors so GPT-5.6 explicit cache reads actually hit

### DIFF
--- a/assistant/src/__tests__/openai-responses-prompt-cache.test.ts
+++ b/assistant/src/__tests__/openai-responses-prompt-cache.test.ts
@@ -131,26 +131,63 @@ describe("OpenAIResponsesProvider explicit prompt caching (GPT-5.6+)", () => {
     expect(breakpointedItemIndexes()).toEqual([0]);
   });
 
-  test("multi-turn first-of-turn: turn-start and previous-turn anchors", async () => {
+  test("multi-turn: every user message is marked (the anchor ladder)", async () => {
     const provider = makeProvider("gpt-5.6-sol");
     await provider.sendMessage(
       [userMsg("t1"), assistantMsg("r1"), userMsg("t2")],
       { config: { promptCacheKey: "conv-1" } },
     );
 
-    // Wire items: [user t1, assistant r1, user t2].
+    // Wire items: [user t1, assistant r1, user t2]. Reads only consider
+    // markers in the current request, so historical boundaries must be
+    // re-marked every turn for their cached prefixes to stay reachable.
     expect(breakpointedItemIndexes()).toEqual([0, 2]);
   });
 
-  test("volatile latest message: anchor moves to the previous stable user message, tail covers the latest", async () => {
+  test("longer history: the ladder marks all user messages", async () => {
+    const provider = makeProvider("gpt-5.6-sol");
+    await provider.sendMessage(
+      [
+        userMsg("t1"),
+        assistantMsg("r1"),
+        userMsg("t2"),
+        assistantMsg("r2"),
+        userMsg("t3"),
+      ],
+      { config: { promptCacheKey: "conv-1" } },
+    );
+
+    expect(breakpointedItemIndexes()).toEqual([0, 2, 4]);
+  });
+
+  test("marker ladder caps at 50 boundaries, dropping the oldest", async () => {
+    const provider = makeProvider("gpt-5.6-sol");
+    const messages: Message[] = [];
+    for (let i = 0; i < 55; i++) {
+      messages.push(userMsg(`t${i}`));
+      messages.push(assistantMsg(`r${i}`));
+    }
+    await provider.sendMessage(messages, {
+      config: { promptCacheKey: "conv-1" },
+    });
+
+    const marked = breakpointedItemIndexes();
+    expect(marked).toHaveLength(50);
+    // User items sit at even indexes; the 5 oldest (0..8) fall off the ladder.
+    expect(marked[0]).toBe(10);
+    expect(marked[marked.length - 1]).toBe(108);
+  });
+
+  test("volatile latest message: the previous stable user message stays reachable, the latest is prepaid", async () => {
     const provider = makeProvider("gpt-5.6-sol");
     await provider.sendMessage(
       [userMsg("t1"), assistantMsg("r1"), userMsg("t2 + <memory>")],
       { config: { mutableLatestUserMessage: true, promptCacheKey: "conv-1" } },
     );
 
-    // Previous-turn anchor on item 0; the advancing tail prepays the volatile
-    // latest item so in-turn tool iterations can read it.
+    // Item 0 is the durable cross-turn boundary (next turn re-marks it and
+    // reads its prefix); marking the volatile latest item prepays its write
+    // so in-turn tool iterations read it.
     expect(breakpointedItemIndexes()).toEqual([0, 2]);
   });
 
@@ -177,9 +214,9 @@ describe("OpenAIResponsesProvider explicit prompt caching (GPT-5.6+)", () => {
       { config: { promptCacheKey: "conv-1" } },
     );
 
-    // Wire items: [user message, function_call, function_call_output]. The
-    // tail walk cannot land on the tool output (no stampable parts) and
-    // dedupes onto the turn-start item.
+    // Wire items: [user message, function_call, function_call_output]. Tool
+    // outputs cannot carry markers, so the only user-text item is the sole
+    // rung on the ladder.
     const input = (lastStreamParams?.input ?? []) as WireItem[];
     expect(input.map((i) => i.type)).toEqual([
       "message",
@@ -190,7 +227,7 @@ describe("OpenAIResponsesProvider explicit prompt caching (GPT-5.6+)", () => {
     expect(JSON.stringify(input[2])).not.toContain("prompt_cache_breakpoint");
   });
 
-  test("tool loop with trailing user text: advancing tail lands on the latest user-text item", async () => {
+  test("tool loop with trailing user text: the reminder item joins the ladder", async () => {
     const provider = makeProvider("gpt-5.6-sol");
     const reminderTurn: Message = {
       role: "user",
@@ -205,8 +242,7 @@ describe("OpenAIResponsesProvider explicit prompt caching (GPT-5.6+)", () => {
     );
 
     // Wire items: [message, function_call, function_call_output,
-    // message(reminder)] — the reminder is the latest user-text item and
-    // becomes the turn-start anchor; item 0 gets the previous-turn anchor.
+    // message(reminder)] — both user-text items are marked.
     expect(breakpointedItemIndexes()).toEqual([0, 3]);
   });
 
@@ -223,6 +259,16 @@ describe("OpenAIResponsesProvider explicit prompt caching (GPT-5.6+)", () => {
       mode: "explicit",
     });
     expect(breakpointedItemIndexes()).toEqual([]);
+  });
+
+  test("disableTurnStartCache multi-turn: suppresses only the newest marker", async () => {
+    const provider = makeProvider("gpt-5.6-sol");
+    await provider.sendMessage(
+      [userMsg("t1"), assistantMsg("r1"), userMsg("t2")],
+      { config: { disableTurnStartCache: true, promptCacheKey: "conv-1" } },
+    );
+
+    expect(breakpointedItemIndexes()).toEqual([0]);
   });
 
   test("disableTurnStartCache one-shot: no markers", async () => {

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -161,6 +161,10 @@ const STAMPABLE_PART_TYPES = new Set([
   "input_file",
 ]);
 
+/** OpenAI considers up to the latest 50 breakpoints for cache reads; markers
+ *  beyond that budget are dead weight, so the marker ladder stops there. */
+const PROMPT_CACHE_MAX_BREAKPOINTS = 50;
+
 /** Minimal structural view of a Responses `input` message item. */
 interface ResponsesMessageItem {
   type?: string;
@@ -684,114 +688,96 @@ export class OpenAIResponsesProvider implements Provider {
 
   /**
    * Stamp explicit prompt-cache breakpoints onto the built Responses input
-   * items. Mirrors the Anthropic client's anchor placement
-   * (anthropic/client.ts): a turn-start anchor, a previous-turn anchor on
-   * first-of-turn requests, and an advancing tail — all sharing OpenAI's
-   * fixed 30m TTL (no long-vs-short TTL split, so no `ttl` field is sent).
-   * Operates on the provider-local wire items only; the caller's Message[]
-   * objects are never touched.
+   * items: the last stampable part of every user item carrying real text,
+   * newest first, up to {@link PROMPT_CACHE_MAX_BREAKPOINTS}.
+   *
+   * Cache reads only consider markers present in the *current* request —
+   * boundaries written by earlier requests match only if re-marked here
+   * (verified empirically against gpt-5.6: a previously-written boundary
+   * left unmarked produces zero reads). Marking the full ladder of
+   * historical user-message boundaries makes the newest still-matching one
+   * the read point; in the volatile-latest-message flow that is typically
+   * the previous turn's user message once it re-renders without its
+   * injected block. Marking the volatile latest item itself prepays its
+   * write so in-turn tool-loop iterations read it back. The ladder is
+   * cost-safe: OpenAI writes at most the latest four unmatched marked
+   * boundaries per request and considers up to the latest 50 markers for
+   * reads. All breakpoints share the fixed 30m TTL (no `ttl` field is
+   * sent). Operates on the provider-local wire items only; the caller's
+   * Message[] objects are never touched.
    *
    * Placement constraints on this API: breakpoints attach only to
    * input_text / input_image / input_file parts of user message items —
-   * function_call / function_call_output items cannot carry one, so during a
-   * pure tool loop the tail cannot advance past the most recent user item
-   * with parts (the loop delta is re-billed as plain input until a text- or
-   * image-bearing user item appears).
+   * function_call / function_call_output items cannot carry one, so during
+   * a pure tool loop the newest markable boundary stays at the most recent
+   * user item with parts (the loop delta is re-billed as plain input until
+   * a text-bearing user item appears).
    *
    * The system prompt rides the `instructions` request param and cannot
    * carry a block marker, but it precedes `input` in the cached prefix, so
-   * the first stamped message covers instructions and tools implicitly. Any
+   * every marked boundary covers instructions and tools implicitly. Any
    * instructions/tools change invalidates all previously written prefixes
    * (exact-prefix matching) — the same blast radius implicit mode has.
-   *
-   * At most 2 positions are marked per request (turn-start + prev-turn, or
-   * prev-turn + tail, or turn-start + tail), within OpenAI's 4 write slots;
-   * positions matching an already-written prefix are reads, not new writes.
    */
   private applyPromptCacheBreakpoints(
     input: unknown[],
     opts: { mutableLatestUserMessage: boolean; disableTurnStartCache: boolean },
   ): void {
     const items = input as ResponsesMessageItem[];
-    const isUserMessageItem = (it: ResponsesMessageItem | undefined): boolean =>
+    // Marker candidates need a real text part (mirror of the Anthropic
+    // client's findUserTextMsgIdx).
+    const isUserTextItem = (it: ResponsesMessageItem | undefined): boolean =>
       it?.type === "message" &&
       it.role === "user" &&
       Array.isArray(it.content) &&
-      it.content.length > 0;
-    // Anchor candidates need a real text part (mirror of the Anthropic
-    // client's findUserTextMsgIdx).
-    const findUserTextItemIdx = (startIdx: number): number => {
-      for (let i = startIdx; i >= 0; i--) {
-        const it = items[i];
-        if (!isUserMessageItem(it)) {
-          continue;
-        }
-        const hasText = it.content!.some(
-          (p) =>
-            p.type === "input_text" &&
-            typeof p.text === "string" &&
-            p.text.length > 0,
-        );
-        if (hasText) {
-          return i;
-        }
+      it.content.some(
+        (p) =>
+          p.type === "input_text" &&
+          typeof p.text === "string" &&
+          p.text.length > 0,
+      );
+
+    const candidates: number[] = [];
+    for (
+      let i = items.length - 1;
+      i >= 0 && candidates.length < PROMPT_CACHE_MAX_BREAKPOINTS;
+      i--
+    ) {
+      if (isUserTextItem(items[i])) {
+        candidates.push(i);
       }
-      return -1;
-    };
-    const stampLastPart = (itemIdx: number): void => {
-      const content = items[itemIdx]?.content;
+    }
+    if (candidates.length === 0) {
+      return;
+    }
+
+    // A volatile latest user message with no prior user message to anchor
+    // on: every marker would be a write whose prefix never recurs across
+    // turns — skip caching entirely for this request.
+    if (
+      opts.mutableLatestUserMessage &&
+      candidates.length === 1 &&
+      candidates[0] === items.length - 1
+    ) {
+      return;
+    }
+
+    for (const idx of candidates) {
+      // `disableTurnStartCache` suppresses the marker on the turn-start
+      // (newest user-text) item — one-shot call sites whose prompts never
+      // recur would otherwise pay a write with no future read. Older
+      // boundaries stay marked, matching the Anthropic client's semantics
+      // (its previous-turn anchor is not gated by this flag).
+      if (opts.disableTurnStartCache && idx === candidates[0]) {
+        continue;
+      }
+      const content = items[idx]?.content;
       if (!Array.isArray(content) || content.length === 0) {
-        return;
+        continue;
       }
       const last = content[content.length - 1];
       if (last && STAMPABLE_PART_TYPES.has(last.type as string)) {
         last.prompt_cache_breakpoint = { mode: "explicit" };
-      }
-    };
-
-    const turnStartIdx = findUserTextItemIdx(items.length - 1);
-    // Volatile latest user message that is itself the turn start: skip the
-    // anchor — it would write a prefix that never recurs across turns.
-    const skipVolatileTurnStartAnchor =
-      opts.mutableLatestUserMessage && turnStartIdx === items.length - 1;
-
-    // Turn-start anchor: stable within the turn; tool-loop iterations re-send
-    // this exact prefix and read it.
-    if (
-      turnStartIdx >= 0 &&
-      !opts.disableTurnStartCache &&
-      !skipVolatileTurnStartAnchor
-    ) {
-      stampLastPart(turnStartIdx);
-    }
-
-    // Previous-turn anchor (first-of-turn only): the durable cross-turn
-    // boundary. In the volatile flow this is the primary stable breakpoint
-    // (the turn-start anchor above was skipped); in the stable flow it
-    // usually coincides with an already-written prefix and is a read.
-    if (turnStartIdx === items.length - 1 && turnStartIdx > 0) {
-      const prevIdx = findUserTextItemIdx(turnStartIdx - 1);
-      if (prevIdx >= 0) {
-        stampLastPart(prevIdx);
-      }
-    }
-
-    // Advancing tail: the latest stampable user item. Fires during tool
-    // loops and on volatile first-of-turn requests (prepaying the volatile
-    // segment so in-turn tool iterations read it). May resolve to the
-    // turn-start item itself in a pure tool loop — re-stamping is a no-op.
-    if (
-      turnStartIdx >= 0 &&
-      (turnStartIdx < items.length - 1 ||
-        (skipVolatileTurnStartAnchor &&
-          turnStartIdx > 0 &&
-          !opts.disableTurnStartCache))
-    ) {
-      for (let i = items.length - 1; i >= 0; i--) {
-        if (isUserMessageItem(items[i])) {
-          stampLastPart(i);
-          break;
-        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Rewrite `applyPromptCacheBreakpoints` to mark the last stampable part of every user-text input item (newest first, capped at 50 — OpenAI's read-candidate budget) instead of only the turn-start/previous-turn/tail pair
- Live probing against `gpt-5.6` (via OpenRouter's Responses endpoint) showed reads only consider markers in the *current* request: with the shipped 2-marker placement every turn read 0 tokens and wrote the full prompt; with the full anchor ladder turn 2+ read ~92% of the prompt and wrote only the per-turn delta (probe: 2-marker = cached 0/0/0; ladder = cached 0 → 2039 → 2057 on ~2.2k-token prompts)
- Cost-safe by API contract: only the latest 4 unmatched marked boundaries incur writes; older markers are read candidates only. `disableTurnStartCache` now suppresses just the newest marker (older boundaries stay reachable, matching the Anthropic client's semantics); the volatile single-message skip is unchanged

## Original prompt
Follow-up to #37859 from the probe Sidd approved: before building the OpenRouter Responses transport, verify caching behavior empirically. The probe confirmed the chat-completions volatile-message regression and validated the Responses+explicit approach — but revealed the just-shipped marker placement never produces reads. This PR applies the probe-verified placement.