### PR TITLE
Surface reasoning summaries as visible thinking on the OpenAI Responses transport

### DIFF
--- a/assistant/src/__tests__/openai-responses-provider.test.ts
+++ b/assistant/src/__tests__/openai-responses-provider.test.ts
@@ -638,7 +638,7 @@ describe("OpenAIResponsesProvider", () => {
   // -----------------------------------------------------------------------
   // Effort → reasoning param
   // -----------------------------------------------------------------------
-  test('effort: "high" maps to reasoning: { effort: "high" }', async () => {
+  test('effort: "high" maps to reasoning: { effort: "high", summary: "auto" }', async () => {
     fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
 
     await provider.sendMessage(
@@ -646,10 +646,13 @@ describe("OpenAIResponsesProvider", () => {
       { config: { effort: "high" } },
     );
 
-    expect(lastStreamParams!.reasoning).toEqual({ effort: "high" });
+    expect(lastStreamParams!.reasoning).toEqual({
+      effort: "high",
+      summary: "auto",
+    });
   });
 
-  test('effort: "max" maps to reasoning: { effort: "xhigh" }', async () => {
+  test('effort: "max" maps to reasoning: { effort: "xhigh", summary: "auto" }', async () => {
     fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
 
     await provider.sendMessage(
@@ -657,10 +660,13 @@ describe("OpenAIResponsesProvider", () => {
       { config: { effort: "max" } },
     );
 
-    expect(lastStreamParams!.reasoning).toEqual({ effort: "xhigh" });
+    expect(lastStreamParams!.reasoning).toEqual({
+      effort: "xhigh",
+      summary: "auto",
+    });
   });
 
-  test('effort: "xhigh" maps to reasoning: { effort: "xhigh" }', async () => {
+  test('effort: "xhigh" maps to reasoning: { effort: "xhigh", summary: "auto" }', async () => {
     fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
 
     await provider.sendMessage(
@@ -668,7 +674,10 @@ describe("OpenAIResponsesProvider", () => {
       { config: { effort: "xhigh" } },
     );
 
-    expect(lastStreamParams!.reasoning).toEqual({ effort: "xhigh" });
+    expect(lastStreamParams!.reasoning).toEqual({
+      effort: "xhigh",
+      summary: "auto",
+    });
   });
 
   test("no effort config means no reasoning in params", async () => {
@@ -685,7 +694,8 @@ describe("OpenAIResponsesProvider", () => {
   test('effort: "none" is sent explicitly as reasoning: { effort: "none" }', async () => {
     // The OpenAI Responses API defaults `reasoning.effort` to "medium" when
     // the field is omitted, so the user's opt-out is only honored when we
-    // send the explicit "none" value on the wire.
+    // send the explicit "none" value on the wire. No summary is requested
+    // for a non-reasoning request.
     fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
 
     await provider.sendMessage(
@@ -694,6 +704,50 @@ describe("OpenAIResponsesProvider", () => {
     );
 
     expect(lastStreamParams!.reasoning).toEqual({ effort: "none" });
+  });
+
+  // -----------------------------------------------------------------------
+  // Reasoning summaries → visible thinking
+  // -----------------------------------------------------------------------
+  test("reasoning summary deltas become thinking events and a thinking block", async () => {
+    fakeStreamEvents = [
+      { type: "response.reasoning_summary_text.delta", delta: "Consider " },
+      { type: "response.reasoning_summary_text.delta", delta: "the input." },
+      { type: "response.reasoning_summary_part.done" },
+      { type: "response.reasoning_summary_text.delta", delta: "Then answer." },
+      { type: "response.reasoning_summary_part.done" },
+      textDeltaEvent("Hello"),
+      completedEvent(10, 5),
+    ];
+
+    const events: Array<{ type: string; thinking?: string }> = [];
+    const result = await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      { config: { effort: "high" }, onEvent: (e) => events.push(e) },
+    );
+
+    expect(
+      events
+        .filter((e) => e.type === "thinking_delta")
+        .map((e) => e.thinking)
+        .join(""),
+    ).toBe("Consider the input.Then answer.");
+    expect(result.content[0]).toEqual({
+      type: "thinking",
+      thinking: "Consider the input.\n\nThen answer.",
+      signature: "",
+    });
+    expect(result.content[1]).toEqual({ type: "text", text: "Hello" });
+  });
+
+  test("no thinking block when the stream carries no summary events", async () => {
+    fakeStreamEvents = [textDeltaEvent("Hello"), completedEvent(10, 5)];
+
+    const result = await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "Hi" }] },
+    ]);
+
+    expect(result.content.map((b) => b.type)).toEqual(["text"]);
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -293,7 +293,19 @@ export class OpenAIResponsesProvider implements Provider {
         ? EFFORT_TO_REASONING_EFFORT[effort]
         : undefined;
       if (reasoningEffort) {
-        params.reasoning = { effort: reasoningEffort };
+        // Request a human-readable reasoning summary whenever the model will
+        // reason — without it the Responses API emits no visible thinking at
+        // all. "auto" resolves to the richest level the model supports
+        // (older o-series models reject "concise"/"detailed"). The retry
+        // layer encodes the user's thinking toggle as `effort` for this
+        // provider, so `"none"` is the disabled state and gets no summary.
+        // The Codex subscription endpoint is param-sensitive (it already
+        // forces `store: false` and rejects `max_output_tokens`), so its
+        // wire shape is left untouched.
+        params.reasoning =
+          reasoningEffort === "none" || this.codexSubscription
+            ? { effort: reasoningEffort }
+            : { effort: reasoningEffort, summary: "auto" };
       }
 
       if (
@@ -357,6 +369,7 @@ export class OpenAIResponsesProvider implements Provider {
 
       // Accumulate the response from stream events
       let contentText = "";
+      let reasoningSummaryText = "";
       // Keyed by item_id (from the stream event) to support parallel tool calls.
       const toolCallMap = new Map<
         string,
@@ -406,6 +419,23 @@ export class OpenAIResponsesProvider implements Provider {
                 contentText += delta;
                 onEvent?.({ type: "text_delta", text: delta });
               }
+              break;
+            }
+
+            case "response.reasoning_summary_text.delta": {
+              const delta = event.delta;
+              if (delta) {
+                reasoningSummaryText += delta;
+                onEvent?.({ type: "thinking_delta", thinking: delta });
+              }
+              break;
+            }
+
+            case "response.reasoning_summary_part.done": {
+              // One summary part per reasoning section; separate them the way
+              // the dashboard renders summaries. The trailing separator after
+              // the final part is trimmed when the block is built.
+              reasoningSummaryText += "\n\n";
               break;
             }
 
@@ -534,6 +564,18 @@ export class OpenAIResponsesProvider implements Provider {
       // weaves search results into the text output, so the result content is
       // an empty array — the actual results are in the text block that follows.
       const content: ContentBlock[] = [];
+      const summaryText = reasoningSummaryText.trim();
+      if (summaryText) {
+        // Empty signature: OpenAI reasoning summaries carry no verification
+        // signature (same shape the chat-completions transport produces for
+        // reasoning text). History replay drops thinking blocks on this
+        // transport, so nothing is echoed back to the API.
+        content.push({
+          type: "thinking",
+          thinking: summaryText,
+          signature: "",
+        });
+      }
       for (const toolUseId of webSearchCallIds) {
         content.push({
           type: "server_tool_use",


### PR DESCRIPTION
## Summary
- Send `reasoning: { effort, summary: \"auto\" }` on the direct-OpenAI Responses transport whenever the model will reason (`effort !== \"none\"`; the retry layer encodes the thinking toggle as effort for this provider). \"auto\" resolves to the richest summary level each model supports, so older o-series models keep working
- Handle `response.reasoning_summary_text.delta` → `thinking_delta` events and accumulate summary parts (separated per `reasoning_summary_part.done`) into a leading `thinking` content block — same shape the chat-completions transport produces from reasoning text. History replay already drops thinking blocks on this transport, so nothing is echoed back to the API
- Codex-subscription requests keep their exact previous wire shape (that endpoint is param-sensitive: it already forces `store: false` and rejects `max_output_tokens`)

## Original prompt
Part of the GPT-5.6 caching/Responses work Sidd approved: the direct `openai` provider (Responses API) never requested reasoning summaries, so users saw no thinking for any OpenAI reasoning model — and the upcoming OpenRouter→Responses transport switch would have regressed thinking visibility relative to the chat-completions path, which defaults `reasoning.summary` on. This lands the summary support first.