### PR TITLE
feat(macos): host_ui_snapshot executor — offscreen staged-view capture

### DIFF
--- a/clients/macos/src/main/executors/host-ui-snapshot-executor.test.ts
+++ b/clients/macos/src/main/executors/host-ui-snapshot-executor.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, mock, test } from "bun:test";
+
+// Avoid pulling the electron-log file backend into the test process.
+mock.module("electron-log/main", () => {
+  const noop = () => {};
+  return {
+    default: {
+      info: noop,
+      warn: noop,
+      error: noop,
+      debug: noop,
+      initialize: noop,
+      transports: {
+        file: { maxSize: 0, fileName: "", format: "", getFile: () => ({ path: "" }) },
+      },
+    },
+  };
+});
+
+import { createHostUiSnapshotExecutor } from "./host-ui-snapshot-executor";
+import type { StagedCaptureFn } from "./host-ui-snapshot-executor";
+import type { HostProxyPoster } from "../host-proxy-poster";
+import type { HostProxySseMessage } from "../host-proxy-sse";
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function makePoster() {
+  const postUiSnapshotResult = mock(async (_payload: unknown) => true);
+  return {
+    poster: { postUiSnapshotResult } as unknown as HostProxyPoster,
+    postUiSnapshotResult,
+  };
+}
+
+function request(overrides: Partial<HostProxySseMessage> = {}): HostProxySseMessage {
+  return {
+    type: "host_ui_snapshot_request",
+    requestId: "req-1",
+    view: "sampler",
+    tokens: { accent: "#e8a04c" },
+    ...overrides,
+  };
+}
+
+describe("hostUiSnapshotExecutor", () => {
+  test("captures the requested view and posts the PNG result", async () => {
+    const seen: Array<{ view: string; tokens: unknown }> = [];
+    const capture: StagedCaptureFn = async (view, tokens) => {
+      seen.push({ view, tokens });
+      return { pngBase64: "cGluZw==", widthPx: 1440, heightPx: 2160 };
+    };
+    const executor = createHostUiSnapshotExecutor({ capture });
+    const { poster, postUiSnapshotResult } = makePoster();
+
+    executor.handleRequest(request({ view: "chat" }), poster);
+    await tick();
+
+    expect(seen).toEqual([{ view: "chat", tokens: { accent: "#e8a04c" } }]);
+    expect(postUiSnapshotResult.mock.calls[0]?.[0]).toEqual({
+      requestId: "req-1",
+      pngBase64: "cGluZw==",
+      widthPx: 1440,
+      heightPx: 2160,
+    });
+  });
+
+  test("posts an error result when the capture fails", async () => {
+    const capture: StagedCaptureFn = async () => {
+      throw new Error("render exploded");
+    };
+    const executor = createHostUiSnapshotExecutor({ capture });
+    const { poster, postUiSnapshotResult } = makePoster();
+
+    executor.handleRequest(request(), poster);
+    await tick();
+
+    expect(postUiSnapshotResult.mock.calls[0]?.[0]).toEqual({
+      requestId: "req-1",
+      isError: true,
+      errorMessage: "render exploded",
+    });
+  });
+
+  test("posts an error result for an invalid view", async () => {
+    const executor = createHostUiSnapshotExecutor({
+      capture: async () => {
+        throw new Error("should not run");
+      },
+    });
+    const { poster, postUiSnapshotResult } = makePoster();
+
+    executor.handleRequest(request({ view: "desktop" }), poster);
+    await tick();
+
+    const payload = postUiSnapshotResult.mock.calls[0]?.[0] as {
+      requestId: string;
+      isError?: boolean;
+    };
+    expect(payload.requestId).toBe("req-1");
+    expect(payload.isError).toBe(true);
+  });
+
+  test("cancel aborts the in-flight capture and suppresses the post", async () => {
+    let releaseCapture: (() => void) | undefined;
+    let observedSignal: AbortSignal | undefined;
+    const capture: StagedCaptureFn = (_view, _tokens, signal) => {
+      observedSignal = signal;
+      return new Promise((_resolve, reject) => {
+        releaseCapture = () => reject(new Error("Snapshot cancelled"));
+        signal.addEventListener("abort", () => {
+          releaseCapture?.();
+        });
+      });
+    };
+    const executor = createHostUiSnapshotExecutor({ capture });
+    const { poster, postUiSnapshotResult } = makePoster();
+
+    executor.handleRequest(request(), poster);
+    await tick();
+    executor.handleCancel(
+      { type: "host_ui_snapshot_cancel", requestId: "req-1" },
+      poster,
+    );
+    await tick();
+
+    expect(observedSignal?.aborted).toBe(true);
+    expect(postUiSnapshotResult).not.toHaveBeenCalled();
+  });
+
+  test("ignores a duplicate request for the same requestId", async () => {
+    let captures = 0;
+    const capture: StagedCaptureFn = async () => {
+      captures += 1;
+      return { pngBase64: "cGluZw==", widthPx: 10, heightPx: 10 };
+    };
+    const executor = createHostUiSnapshotExecutor({ capture });
+    const { poster, postUiSnapshotResult } = makePoster();
+
+    executor.handleRequest(request(), poster);
+    executor.handleRequest(request(), poster);
+    await tick();
+
+    expect(captures).toBe(1);
+    expect(postUiSnapshotResult).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/macos/src/main/executors/host-ui-snapshot-executor.ts
+++ b/clients/macos/src/main/executors/host-ui-snapshot-executor.ts
@@ -1,0 +1,228 @@
+/**
+ * Host UI-snapshot executor — handles `host_ui_snapshot_request` by rendering
+ * a staged view of the app's own UI (`/assistant/theme-stage/:view`) in a
+ * hidden offscreen BrowserWindow, capturing it with
+ * `webContents.capturePage()`, and posting the PNG back to the daemon.
+ *
+ * The staged views contain only fixed generic content — never user data —
+ * with the workspace-theme tokens from the request applied. The stage page
+ * signals paint-settled readiness by setting `document.title` to the ready
+ * sentinel after fonts load and two frames paint; capture waits for that
+ * sentinel (bounded by a watchdog) so screenshots are deterministic.
+ *
+ * The capture pipeline is dependency-injected so tests exercise the
+ * dispatch/cancel/post lifecycle without a real BrowserWindow.
+ */
+
+import { app } from "electron";
+import { z } from "zod";
+
+import { getDevRendererBase, RENDERER_BASE_PROD } from "../app-config";
+import type { HostProxyExecutor } from "../host-proxy-router";
+import type {
+  HostProxyPoster,
+  HostUiSnapshotResultPayload,
+} from "../host-proxy-poster";
+import type { HostProxySseMessage } from "../host-proxy-sse";
+import { createWindow } from "../windows";
+import log from "../logger";
+
+/** Must match THEME_STAGE_READY_TITLE in the web client's theme-stage page. */
+const READY_TITLE = "__THEME_STAGE_READY__";
+
+/** Watchdog for load + fonts + paint of the staged view. */
+const READY_TIMEOUT_MS = 10_000;
+
+/** Settle delay before the recapture fallback when the first frame is empty. */
+const EMPTY_CAPTURE_RETRY_DELAY_MS = 150;
+
+/** Logical window sizes per staged view (capture is at device scale). */
+const VIEW_SIZES: Record<"sampler" | "chat", { width: number; height: number }> = {
+  sampler: { width: 720, height: 1080 },
+  chat: { width: 720, height: 760 },
+};
+
+const REQUEST_SCHEMA = z.object({
+  requestId: z.string().min(1),
+  view: z.enum(["sampler", "chat"]),
+  tokens: z.record(z.string(), z.string()).optional(),
+});
+
+export interface StagedCaptureResult {
+  pngBase64: string;
+  widthPx: number;
+  heightPx: number;
+}
+
+export type StagedCaptureFn = (
+  view: "sampler" | "chat",
+  tokens: Record<string, string> | undefined,
+  signal: AbortSignal,
+) => Promise<StagedCaptureResult>;
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Production capture: hidden offscreen window → staged route → ready
+ * sentinel → capturePage → PNG. The window is destroyed on every path,
+ * including abort (cancel from the daemon).
+ */
+async function captureStagedView(
+  view: "sampler" | "chat",
+  tokens: Record<string, string> | undefined,
+  signal: AbortSignal,
+): Promise<StagedCaptureResult> {
+  const base = app.isPackaged ? RENDERER_BASE_PROD : getDevRendererBase();
+  const query = tokens ? `?tokens=${encodeURIComponent(JSON.stringify(tokens))}` : "";
+  const url = `${base}/theme-stage/${view}${query}`;
+  const { width, height } = VIEW_SIZES[view];
+
+  const win = createWindow({
+    browserWindow: {
+      width,
+      height,
+      x: -10_000,
+      y: -10_000,
+      show: false,
+      frame: false,
+      resizable: false,
+      skipTaskbar: true,
+    },
+    navigation: "deny-all",
+  });
+
+  try {
+    // A hidden window throttles timers and rAF by default, which would stall
+    // the stage's double-rAF ready signal.
+    win.webContents.setBackgroundThrottling(false);
+
+    const ready = new Promise<void>((resolve, reject) => {
+      const cleanup = () => {
+        clearTimeout(watchdog);
+        win.webContents.removeListener("page-title-updated", onTitle);
+        signal.removeEventListener("abort", onAbort);
+      };
+      const watchdog = setTimeout(() => {
+        cleanup();
+        reject(new Error(`Staged view did not become ready within ${READY_TIMEOUT_MS}ms`));
+      }, READY_TIMEOUT_MS);
+      const onTitle = (_event: unknown, title: string) => {
+        if (title === READY_TITLE) {
+          cleanup();
+          resolve();
+        }
+      };
+      const onAbort = () => {
+        cleanup();
+        reject(new Error("Snapshot cancelled"));
+      };
+      signal.addEventListener("abort", onAbort);
+      win.webContents.on("page-title-updated", onTitle);
+
+      win.webContents.once("did-fail-load", (_event, code, description) => {
+        cleanup();
+        reject(new Error(`Staged view failed to load: ${description} (${code})`));
+      });
+
+      void win.loadURL(url).catch((err: unknown) => {
+        cleanup();
+        reject(err instanceof Error ? err : new Error(String(err)));
+      });
+    });
+    await ready;
+
+    let image = await win.webContents.capturePage();
+    if (image.isEmpty()) {
+      // `paintWhenInitiallyHidden` should composite hidden windows, but if
+      // the platform returned a blank frame, show it offscreen and retry.
+      win.showInactive();
+      await delay(EMPTY_CAPTURE_RETRY_DELAY_MS);
+      image = await win.webContents.capturePage();
+    }
+    if (image.isEmpty()) {
+      throw new Error("Capture produced an empty image");
+    }
+
+    const size = image.getSize();
+    return {
+      pngBase64: image.toPNG().toString("base64"),
+      widthPx: size.width,
+      heightPx: size.height,
+    };
+  } finally {
+    if (!win.isDestroyed()) {
+      win.destroy();
+    }
+  }
+}
+
+export interface HostUiSnapshotExecutorDeps {
+  capture?: StagedCaptureFn;
+}
+
+export function createHostUiSnapshotExecutor(
+  deps: HostUiSnapshotExecutorDeps = {},
+): HostProxyExecutor {
+  const capture = deps.capture ?? captureStagedView;
+  const inFlight = new Map<string, AbortController>();
+
+  return {
+    handleRequest(message: HostProxySseMessage, poster: HostProxyPoster): void {
+      const parsed = REQUEST_SCHEMA.safeParse(message);
+      if (!parsed.success) {
+        const requestId =
+          typeof message.requestId === "string" ? message.requestId : undefined;
+        log.warn("[host-ui-snapshot] invalid request", { issues: parsed.error.issues });
+        if (requestId) {
+          void poster.postUiSnapshotResult({
+            requestId,
+            isError: true,
+            errorMessage: `Invalid snapshot request: ${parsed.error.issues.map((i) => i.message).join("; ")}`,
+          });
+        }
+        return;
+      }
+
+      const { requestId, view, tokens } = parsed.data;
+      if (inFlight.has(requestId)) {
+        log.warn("[host-ui-snapshot] duplicate request, ignoring", { requestId });
+        return;
+      }
+
+      const controller = new AbortController();
+      inFlight.set(requestId, controller);
+
+      void (async () => {
+        let payload: HostUiSnapshotResultPayload;
+        try {
+          const result = await capture(view, tokens, controller.signal);
+          payload = { requestId, ...result };
+        } catch (err) {
+          payload = {
+            requestId,
+            isError: true,
+            errorMessage: err instanceof Error ? err.message : String(err),
+          };
+        } finally {
+          inFlight.delete(requestId);
+        }
+        // A cancelled request has no consumer; the daemon already resolved it.
+        if (!controller.signal.aborted) {
+          void poster.postUiSnapshotResult(payload);
+        }
+      })();
+    },
+
+    handleCancel(message: HostProxySseMessage): void {
+      const requestId =
+        typeof message.requestId === "string" ? message.requestId : undefined;
+      if (!requestId) {
+        return;
+      }
+      inFlight.get(requestId)?.abort();
+      inFlight.delete(requestId);
+    },
+  };
+}
+
+export const hostUiSnapshotExecutor = createHostUiSnapshotExecutor();

--- a/clients/macos/src/main/host-proxy-poster.ts
+++ b/clients/macos/src/main/host-proxy-poster.ts
@@ -49,6 +49,16 @@ export interface HostBrowserResultPayload {
   isError?: boolean;
 }
 
+export interface HostUiSnapshotResultPayload {
+  requestId: string;
+  /** Base64 PNG capture of the staged view (device-scale pixels). */
+  pngBase64?: string;
+  widthPx?: number;
+  heightPx?: number;
+  isError?: boolean;
+  errorMessage?: string;
+}
+
 export interface HostCuResultPayload {
   requestId: string;
   axTree?: string;
@@ -154,6 +164,12 @@ export class HostProxyPoster {
     result: HostAppControlResultPayload,
   ): Promise<boolean> {
     return this.postJson("/host-app-control-result", result);
+  }
+
+  async postUiSnapshotResult(
+    result: HostUiSnapshotResultPayload,
+  ): Promise<boolean> {
+    return this.postJson("/host-ui-snapshot-result", result);
   }
 
   // -----------------------------------------------------------------------

--- a/clients/macos/src/main/host-proxy-router.ts
+++ b/clients/macos/src/main/host-proxy-router.ts
@@ -26,6 +26,7 @@ import { onLockfileChange, getWatchedLockfile } from "./lockfile-watcher";
 import { HostBrowserExecutor } from "./executors/host-browser-executor";
 import { hostCuExecutor } from "./executors/host-cu-executor";
 import { hostAppControlExecutor } from "./executors/host-app-control-executor";
+import { hostUiSnapshotExecutor } from "./executors/host-ui-snapshot-executor";
 import { shutdownSharedCuHelper } from "./sidecar/shared-cu-helper";
 import { getSessionToken } from "./session-token-store";
 import log from "./logger";
@@ -77,7 +78,7 @@ export function removeExecutor(kind: string): void {
 // Message dispatch
 // ---------------------------------------------------------------------------
 
-const EXECUTOR_KINDS = ["host_bash", "host_file", "host_transfer", "host_browser", "host_cu", "host_app_control"] as const;
+const EXECUTOR_KINDS = ["host_bash", "host_file", "host_transfer", "host_browser", "host_cu", "host_app_control", "host_ui_snapshot"] as const;
 
 /** Route type → executor kind. Returns null for unknown types. */
 function executorKindForType(type: string): { kind: string; action: "request" | "cancel" } | null {
@@ -158,6 +159,13 @@ function dispatchMessage(message: HostProxySseMessage, poster: HostProxyPoster):
         requestId,
         state: "missing",
         executionError: "Executor not yet implemented",
+      });
+      break;
+    case "host_ui_snapshot":
+      void poster.postUiSnapshotResult({
+        requestId,
+        isError: true,
+        errorMessage: "Executor not yet implemented",
       });
       break;
   }
@@ -395,6 +403,7 @@ export function installHostProxyBridge(
   setExecutor("host_transfer", hostTransferExecutor);
   setExecutor("host_cu", hostCuExecutor);
   setExecutor("host_app_control", hostAppControlExecutor);
+  setExecutor("host_ui_snapshot", hostUiSnapshotExecutor);
   unsubscribe = onLockfileChange(handleLockfileChange);
 
   // Seed from any assistants already present in the lockfile

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -310,7 +310,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-10T10:29:14.000Z"
+      "updatedAt": "2026-07-10T11:09:04.000Z"
     },
     {
       "id": "google-calendar",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1199,7 +1199,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-10T05:05:47.000Z"
+      "updatedAt": "2026-07-11T00:41:02.000Z"
     },
     {
       "id": "vercel-token-setup",

--- a/skills/vellum-workspace-theme/SKILL.md
+++ b/skills/vellum-workspace-theme/SKILL.md
@@ -89,7 +89,23 @@ The runtime tells you exactly what it accepted or why it refused. Fetch `GET /v1
 - `source: "invalid"` — rejected; `issues` lists human-readable reasons (e.g. `"incomplete override group: setting tokens.background also requires tokens.text, …"` or `"tokens.text on tokens.background has contrast 1.02:1 — minimum is 3:1"`). Fix and re-check.
 - `source: "none"` — no theme file exists.
 
-To see the result visually, take a browser screenshot of the app, or ask the user — the change is already on their screen.
+## Seeing your work
+
+You do not need the user to screenshot the app for you. The desktop app can render a **staged view** of its own UI — fixed generic content, never real conversation data — with your current theme applied, capture it offscreen, and hand you the PNG:
+
+```bash
+assistant ui snapshot --view sampler --out /tmp/theme-sampler.png
+assistant ui snapshot --view chat --out /tmp/theme-chat.png
+```
+
+Then view the image file. Two views:
+
+- **`sampler`** — a dense style sheet: the text ramp, accent, buttons, a raised card, inputs, borders, and both chat bubbles in one frame. Use it while iterating — it answers "does the palette read".
+- **`chat`** — a staged conversation with a composer. Use it to judge the finished feel — it answers "does it look like home".
+
+The capture reflects `ui/theme.json` as it is on disk at that moment, so edit → snapshot → look → adjust is a tight private loop. If the theme file is invalid, the command prints the validation issues and the capture shows the built-in theme. The framing is fixed, so before/after snapshots align exactly.
+
+This requires the desktop app to be running; if the command times out or reports no connected client, fall back to taking a browser screenshot of the app or asking the user — the change is already on their screen.
 
 ## Removing the theme
 


### PR DESCRIPTION
## Summary

- New `host-ui-snapshot-executor` in the Electron main process: answers `host_ui_snapshot_request` by loading `/assistant/theme-stage/:view` (merged in #37860) in a **hidden offscreen BrowserWindow** — hardened `createWindow` seam, deny-all navigation, `setBackgroundThrottling(false)` — waiting for the stage's `__THEME_STAGE_READY__` title sentinel (10s watchdog), then `capturePage()` → PNG → `POST /v1/host-ui-snapshot-result`.
- Robustness: one `showInactive()`-offscreen recapture if the hidden compositor returns an empty frame; `did-fail-load`/load errors post error results (the daemon never waits out its timeout when the client can answer); cancel aborts the in-flight capture and suppresses the post; the window is destroyed on every path; duplicate requestIds are ignored.
- Router: `host_ui_snapshot` added to `EXECUTOR_KINDS`, executor installed alongside the other host proxies, and the executor-missing stub posts an error result (pattern-complete with the rest of the switch).
- Skill: `vellum-workspace-theme` gains a **"Seeing your work"** section — the edit → `assistant ui snapshot` → look loop (sampler = *does it read*, chat = *does it feel like home*), with the browser-screenshot/ask-the-user fallback when no desktop client is connected. Catalog regenerated via the generator.
- 5 executor tests via a deps-injected capture fn (no BrowserWindow in tests); router tests, `tsc`, and `electron-vite build` green.

## Original prompt

Part 3 of 3 of "the mirror" (user-approved plan): the assistant authors `ui/theme.json` but iterated blind, with the user hand-screenshotting the app. With #37860 (render target) and #37861 (daemon request/result plumbing + CLI verb), this PR lights the flow up end-to-end: `assistant ui snapshot --view sampler --out /tmp/s.png` returns a deterministic, generic-content PNG of the themed UI without a human in the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)