### PR TITLE
Route OpenRouter GPT-5.6 models onto the Responses transport for explicit prompt caching

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -970,6 +970,17 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     ).toBeUndefined();
   });
 
+  test("promptCacheKey is not forwarded to the Anthropic API", async () => {
+    // Reaches this client on OpenRouter's anthropic/* delegation path;
+    // Anthropic rejects unknown fields with "Extra inputs are not permitted".
+    await provider.sendMessage([userMsg("Hi")], {
+      config: { promptCacheKey: "conv-1" },
+    });
+    expect(
+      (lastStreamParams as Record<string, unknown>).promptCacheKey,
+    ).toBeUndefined();
+  });
+
   // -----------------------------------------------------------------------
   // Negative: assistant messages never get cache_control
   // -----------------------------------------------------------------------

--- a/assistant/src/__tests__/openrouter-responses-transport.test.ts
+++ b/assistant/src/__tests__/openrouter-responses-transport.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Routing of OpenRouter `openai/*` models with explicit prompt caching onto
+ * the Responses transport: flagged models hit `/responses` with cache params,
+ * attribution headers, and `provider.only` pass-through; unflagged and
+ * native-web-search traffic stays on chat completions.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock openai module — must be before importing the provider. Captures both
+// the chat-completions and Responses surfaces so routing is observable.
+// ---------------------------------------------------------------------------
+
+let chatCalls: Array<Record<string, unknown>> = [];
+let responsesCalls: Array<Record<string, unknown>> = [];
+let lastResponsesOptions: Record<string, unknown> | null = null;
+let lastConstructorOptions: Record<string, unknown> | null = null;
+
+mock.module("openai", () => ({
+  default: class MockOpenAI {
+    constructor(opts: Record<string, unknown>) {
+      lastConstructorOptions = opts;
+    }
+    chat = {
+      completions: {
+        create: async (params: Record<string, unknown>) => {
+          chatCalls.push(params);
+          return {
+            [Symbol.asyncIterator]: async function* () {
+              yield {
+                choices: [{ delta: { content: "ok" }, finish_reason: "stop" }],
+                model: String(params.model),
+                usage: { prompt_tokens: 1, completion_tokens: 1 },
+              };
+            },
+          };
+        },
+      },
+    };
+    responses = {
+      create: async (
+        params: Record<string, unknown>,
+        options?: Record<string, unknown>,
+      ) => {
+        responsesCalls.push(params);
+        lastResponsesOptions = options ?? null;
+        return {
+          [Symbol.asyncIterator]: async function* () {
+            yield { type: "response.output_text.delta", delta: "ok" };
+            yield {
+              type: "response.completed",
+              response: {
+                model: String(params.model),
+                status: "completed",
+                output: [],
+                usage: { input_tokens: 1, output_tokens: 1 },
+              },
+            };
+          },
+        };
+      },
+    };
+  },
+}));
+
+// Import after mocking
+import { OpenRouterProvider } from "../providers/openrouter/client.js";
+import type { Message } from "../providers/types.js";
+
+function userMsg(text: string): Message {
+  return { role: "user", content: [{ type: "text", text }] };
+}
+
+beforeEach(() => {
+  chatCalls = [];
+  responsesCalls = [];
+  lastResponsesOptions = null;
+  lastConstructorOptions = null;
+});
+
+describe("OpenRouter Responses transport routing", () => {
+  test("flagged openai/* model routes to /responses with cache params", async () => {
+    const provider = new OpenRouterProvider("sk-or-test", "openai/gpt-5.6-sol");
+    await provider.sendMessage([userMsg("hi")], {
+      config: { promptCacheKey: "conv-1" },
+    });
+
+    expect(chatCalls).toHaveLength(0);
+    expect(responsesCalls).toHaveLength(1);
+    const params = responsesCalls[0];
+    expect(params.model).toBe("openai/gpt-5.6-sol");
+    expect(params.prompt_cache_options).toEqual({ mode: "explicit" });
+    expect(params.prompt_cache_key).toBe("conv-1");
+    expect(JSON.stringify(params.input)).toContain("prompt_cache_breakpoint");
+    // The delegate targets OpenRouter, not api.openai.com.
+    expect(lastConstructorOptions?.baseURL).toBe(
+      "https://openrouter.ai/api/v1",
+    );
+  });
+
+  test("sends OpenRouter app-attribution headers on /responses requests", async () => {
+    const provider = new OpenRouterProvider(
+      "sk-or-test",
+      "openai/gpt-5.6-luna",
+    );
+    await provider.sendMessage([userMsg("hi")]);
+
+    expect(responsesCalls).toHaveLength(1);
+    expect(lastResponsesOptions?.headers).toEqual(
+      expect.objectContaining({
+        "HTTP-Referer": "https://www.vellum.ai",
+        "X-OpenRouter-Title": "Vellum Assistant",
+      }),
+    );
+  });
+
+  test("openrouter.only becomes provider.only on the /responses body", async () => {
+    const provider = new OpenRouterProvider(
+      "sk-or-test",
+      "openai/gpt-5.6-terra",
+    );
+    await provider.sendMessage([userMsg("hi")], {
+      config: { openrouter: { only: ["OpenAI"] } },
+    });
+
+    expect(responsesCalls).toHaveLength(1);
+    expect(responsesCalls[0].provider).toEqual({ only: ["OpenAI"] });
+  });
+
+  test("model override onto a flagged model routes to /responses", async () => {
+    const provider = new OpenRouterProvider("sk-or-test", "x-ai/grok-4.20");
+    await provider.sendMessage([userMsg("hi")], {
+      config: { model: "openai/gpt-5.6-luna" },
+    });
+
+    expect(chatCalls).toHaveLength(0);
+    expect(responsesCalls).toHaveLength(1);
+    expect(responsesCalls[0].model).toBe("openai/gpt-5.6-luna");
+  });
+
+  test("unflagged models stay on chat completions", async () => {
+    const provider = new OpenRouterProvider("sk-or-test", "x-ai/grok-4.20");
+    await provider.sendMessage([userMsg("hi")]);
+
+    expect(responsesCalls).toHaveLength(0);
+    expect(chatCalls).toHaveLength(1);
+    expect(chatCalls[0].model).toBe("x-ai/grok-4.20");
+  });
+
+  test("unflagged openai/* models stay on chat completions", async () => {
+    const provider = new OpenRouterProvider("sk-or-test", "openai/gpt-5.5");
+    await provider.sendMessage([userMsg("hi")]);
+
+    expect(responsesCalls).toHaveLength(0);
+    expect(chatCalls).toHaveLength(1);
+  });
+
+  test("native web search keeps flagged models on chat completions", async () => {
+    const provider = new OpenRouterProvider(
+      "sk-or-test",
+      "openai/gpt-5.6-sol",
+      { useNativeWebSearch: true },
+    );
+    await provider.sendMessage([userMsg("hi")]);
+
+    expect(responsesCalls).toHaveLength(0);
+    expect(chatCalls).toHaveLength(1);
+  });
+});

--- a/assistant/src/__tests__/retry-prompt-cache-key.test.ts
+++ b/assistant/src/__tests__/retry-prompt-cache-key.test.ts
@@ -78,15 +78,18 @@ describe("retry normalization for promptCacheKey", () => {
     expect(lastConfig()?.selectionSeed).toBeUndefined();
   });
 
-  test("does not create promptCacheKey for openrouter", async () => {
-    // OpenRouter delegates anthropic/* models into AnthropicProvider with the
-    // config intact, so the key must not be created there either.
+  test("copies selectionSeed into promptCacheKey for openrouter", async () => {
+    // OpenRouter's openai/* Responses delegate consumes the key. Its
+    // anthropic/* delegation path receives the same config, so the Anthropic
+    // client strips `promptCacheKey` from the wire (see
+    // anthropic-provider.test.ts "promptCacheKey is not forwarded").
     const { provider, lastConfig } = makePipeline("openrouter");
     await provider.sendMessage([userMessage], {
       config: { selectionSeed: "conv-1" },
     });
 
-    expect(lastConfig()?.promptCacheKey).toBeUndefined();
+    expect(lastConfig()?.promptCacheKey).toBe("conv-1");
+    expect(lastConfig()?.selectionSeed).toBeUndefined();
   });
 
   test("no selectionSeed → no promptCacheKey", async () => {

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -76,7 +76,8 @@ function readAnthropicErrorType(
   error: InstanceType<typeof Anthropic.APIError>,
 ): string | undefined {
   const body = error.error as
-    { type?: string; error?: { type?: string; code?: string } } | undefined;
+    | { type?: string; error?: { type?: string; code?: string } }
+    | undefined;
   return body?.error?.type ?? body?.type;
 }
 
@@ -96,7 +97,8 @@ function readAnthropicMessage(
   error: InstanceType<typeof Anthropic.APIError>,
 ): string | undefined {
   const body = error.error as
-    { message?: string; error?: { message?: string } } | undefined;
+    | { message?: string; error?: { message?: string } }
+    | undefined;
   const inner = body?.error?.message ?? body?.message;
   return typeof inner === "string" && inner.length > 0 ? inner : undefined;
 }
@@ -885,7 +887,8 @@ export class AnthropicProvider implements Provider {
     const { tools, systemPrompt, config, onEvent, signal } = options ?? {};
     const cacheTtl: "5m" | "1h" =
       ((config as Record<string, unknown> | undefined)?.cacheTtl as
-        "5m" | "1h") ?? "1h";
+        | "5m"
+        | "1h") ?? "1h";
     // Opt-out for callers (e.g. the memory router) that send a single
     // user message per call with content that changes every time. The
     // turn-start cache breakpoint below is only useful when the same
@@ -924,6 +927,9 @@ export class AnthropicProvider implements Provider {
         disableTurnStartCache: _disableTurnStartCache,
         mutableLatestUserMessage: _mutableLatestUserMessage,
         disableCache: _disableCache,
+        // OpenAI-transport prompt-cache key; reaches this client on
+        // OpenRouter's anthropic/* delegation path and must not hit the wire.
+        promptCacheKey: _promptCacheKey,
         max_tokens: callerMaxTokens,
         usageAttributionHeaders,
         // Pulled out of `restConfig` so they are forwarded conditionally below:

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1125,6 +1125,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: true,
         supportsVision: true,
         supportsToolUse: true,
+        supportsPromptCacheBreakpoints: true,
         pricing: {
           inputPer1mTokens: 5.0,
           outputPer1mTokens: 30.0,
@@ -1152,6 +1153,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: true,
         supportsVision: true,
         supportsToolUse: true,
+        supportsPromptCacheBreakpoints: true,
         pricing: {
           inputPer1mTokens: 5.0,
           outputPer1mTokens: 30.0,
@@ -1179,6 +1181,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: true,
         supportsVision: true,
         supportsToolUse: true,
+        supportsPromptCacheBreakpoints: true,
         pricing: {
           inputPer1mTokens: 2.5,
           outputPer1mTokens: 15.0,
@@ -1206,6 +1209,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: true,
         supportsVision: true,
         supportsToolUse: true,
+        supportsPromptCacheBreakpoints: true,
         pricing: {
           inputPer1mTokens: 2.5,
           outputPer1mTokens: 15.0,
@@ -1233,6 +1237,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: true,
         supportsVision: true,
         supportsToolUse: true,
+        supportsPromptCacheBreakpoints: true,
         pricing: {
           inputPer1mTokens: 1.0,
           outputPer1mTokens: 6.0,
@@ -1260,6 +1265,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: true,
         supportsVision: true,
         supportsToolUse: true,
+        supportsPromptCacheBreakpoints: true,
         pricing: {
           inputPer1mTokens: 1.0,
           outputPer1mTokens: 6.0,
@@ -1957,6 +1963,20 @@ export function isModelInCatalog(provider: string, modelId: string): boolean {
   const entry = PROVIDER_CATALOG.find((p) => p.id === provider);
   return entry?.models.some((m) => m.id === modelId) ?? false;
 }
+
+/**
+ * Model IDs (across all catalog providers) flagged
+ * `supportsPromptCacheBreakpoints`. Consumed by the OpenAI Responses
+ * transport to gate explicit prompt-cache params, and by the OpenRouter
+ * client to route flagged `openai/*` models onto that transport. IDs are
+ * provider-shaped (bare for direct OpenAI, `openai/`-prefixed for
+ * OpenRouter), so a single set serves both consumers without collisions.
+ */
+export const PROMPT_CACHE_BREAKPOINT_MODEL_IDS: ReadonlySet<string> = new Set(
+  PROVIDER_CATALOG.flatMap((p) =>
+    p.models.flatMap((m) => (m.supportsPromptCacheBreakpoints ? [m.id] : [])),
+  ),
+);
 
 /**
  * Return the catalog provider that owns a model ID, if known. When multiple

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -7,7 +7,7 @@ import { getLogger } from "../../util/logger.js";
 import { extractRetryAfterMs } from "../../util/retry.js";
 import { escapeXmlAttr } from "../../util/xml.js";
 import { base64Source, resolveMediaReferences } from "../media-resolve.js";
-import { PROVIDER_CATALOG } from "../model-catalog.js";
+import { PROMPT_CACHE_BREAKPOINT_MODEL_IDS } from "../model-catalog.js";
 import { createStreamTimeout } from "../stream-timeout.js";
 import { createToolProgressEmitter } from "../tool-progress-events.js";
 import type {
@@ -37,6 +37,9 @@ export interface OpenAIResponsesProviderOptions {
   /** When true, target the Codex subscription endpoint and strip fields it
    *  rejects (`max_output_tokens`). */
   codexSubscription?: boolean;
+  /** Static HTTP headers sent with every request (e.g. OpenRouter app
+   *  attribution). Merged under any per-request attribution headers. */
+  requestHeaders?: Record<string, string>;
 }
 
 /** Map our internal effort values to the Responses API reasoning.effort parameter.
@@ -145,15 +148,6 @@ const OPENAI_SUPPORTED_IMAGE_TYPES = new Set([
   "image/webp",
 ]);
 
-/** Direct-OpenAI models that use explicit prompt-cache breakpoints (GPT-5.6+).
- *  Built once from the catalog, mirroring the Fireworks effort-ceiling map
- *  (fireworks/client.ts). */
-const PROMPT_CACHE_BREAKPOINT_MODELS: ReadonlySet<string> = new Set(
-  PROVIDER_CATALOG.find((p) => p.id === "openai")?.models.flatMap((m) =>
-    m.supportsPromptCacheBreakpoints ? [m.id] : [],
-  ) ?? [],
-);
-
 /** Content-part types that accept a `prompt_cache_breakpoint` marker. */
 const STAMPABLE_PART_TYPES = new Set([
   "input_text",
@@ -187,6 +181,7 @@ export class OpenAIResponsesProvider implements Provider {
   private streamTimeoutMs: number;
   private useNativeWebSearch: boolean;
   private codexSubscription: boolean;
+  private readonly requestHeaders: Record<string, string>;
 
   constructor(
     apiKey: string,
@@ -196,6 +191,7 @@ export class OpenAIResponsesProvider implements Provider {
     this.name = options.providerName ?? "openai";
     this.providerLabel = options.providerLabel ?? "OpenAI";
     this.codexSubscription = options.codexSubscription ?? false;
+    this.requestHeaders = options.requestHeaders ?? {};
     this.streamTimeoutMs = options.streamTimeoutMs ?? 1_800_000;
     // Keep the SDK deadline behind our provider stream timeout so
     // createStreamTimeout owns the user-facing timeout error.
@@ -271,7 +267,7 @@ export class OpenAIResponsesProvider implements Provider {
       // rejects extra params, so cache params are skipped entirely there.
       if (
         !this.codexSubscription &&
-        PROMPT_CACHE_BREAKPOINT_MODELS.has(effectiveModel)
+        PROMPT_CACHE_BREAKPOINT_MODEL_IDS.has(effectiveModel)
       ) {
         params.prompt_cache_options = { mode: "explicit" };
         if (promptCacheKey) {
@@ -364,6 +360,8 @@ export class OpenAIResponsesProvider implements Provider {
         }
       }
 
+      Object.assign(params, this.buildExtraCreateParams(options));
+
       const { signal: timeoutSignal, cleanup: cleanupTimeout } =
         createStreamTimeout(this.streamTimeoutMs, signal);
 
@@ -401,12 +399,16 @@ export class OpenAIResponsesProvider implements Provider {
             o?: { signal?: AbortSignal; headers?: Record<string, string> },
           ): Promise<AsyncIterable<ResponsesStreamEvent>>;
         };
+        const requestHeaders = {
+          ...this.requestHeaders,
+          ...(usageAttributionHeaders ?? {}),
+        };
         const stream = await responsesApi.create(
           { ...params, stream: true },
           {
             signal: timeoutSignal,
-            ...(usageAttributionHeaders
-              ? { headers: usageAttributionHeaders }
+            ...(Object.keys(requestHeaders).length > 0
+              ? { headers: requestHeaders }
               : {}),
           },
         );
@@ -704,6 +706,17 @@ export class OpenAIResponsesProvider implements Provider {
         abortReason ? { cause: error, abortReason } : { cause: error },
       );
     }
+  }
+
+  /**
+   * Extra request-body params merged into the create call after the standard
+   * params are assembled (subclass values win). Mirrors the chat-completions
+   * transport's hook of the same name; base implementation adds nothing.
+   */
+  protected buildExtraCreateParams(
+    _options?: SendMessageOptions,
+  ): Record<string, unknown> {
+    return {};
   }
 
   /**

--- a/assistant/src/providers/openrouter/client.ts
+++ b/assistant/src/providers/openrouter/client.ts
@@ -4,11 +4,13 @@ import {
   retagDelegateError,
   toAnthropicMessagesBaseURL,
 } from "../anthropic-gateway-shared.js";
+import { PROMPT_CACHE_BREAKPOINT_MODEL_IDS } from "../model-catalog.js";
 import {
   clampReasoningEffort,
   EFFORT_TO_REASONING_EFFORT,
   OpenAIChatCompletionsProvider,
 } from "../openai/chat-completions-provider.js";
+import { OpenAIResponsesProvider } from "../openai/responses-provider.js";
 import { isThinkingConfigEnabled } from "../thinking-config.js";
 import type {
   Message,
@@ -87,6 +89,28 @@ export function withOpenRouterBodyExtras(
   };
 }
 
+/**
+ * Responses-API delegate for OpenRouter `openai/*` models with explicit
+ * prompt caching. Extends the OpenAI Responses transport with OpenRouter's
+ * `provider: { only: [...] }` body field — the same translation the
+ * chat-completions path performs in `OpenRouterProvider.buildExtraCreateParams`.
+ * Exported for tests.
+ */
+export class OpenRouterResponsesProvider extends OpenAIResponsesProvider {
+  protected override buildExtraCreateParams(
+    options?: SendMessageOptions,
+  ): Record<string, unknown> {
+    const only = extractOnlyList(options?.config);
+    if (only.length === 0) {
+      return {};
+    }
+    const existingProvider = ((
+      options?.config as Record<string, unknown> | undefined
+    )?.provider ?? {}) as Record<string, unknown>;
+    return { provider: { ...existingProvider, only } };
+  }
+}
+
 export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
   private readonly openRouterApiKey: string;
   private readonly defaultModel: string;
@@ -94,6 +118,7 @@ export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
   private readonly providerStreamTimeoutMs: number | undefined;
   private readonly useNativeWebSearch: boolean;
   private anthropicInner: AnthropicProvider | undefined;
+  private responsesInner: OpenRouterResponsesProvider | undefined;
 
   constructor(
     apiKey: string,
@@ -142,6 +167,17 @@ export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
           messages,
           withOpenRouterBodyExtras(options),
         );
+      }
+      // OpenRouter supports OpenAI explicit prompt caching only on its
+      // Responses endpoint, so models flagged for cache breakpoints route
+      // there. Native web search stays on the chat-completions path — the
+      // Responses `web_search_preview` server tool is unverified through
+      // OpenRouter.
+      if (
+        !this.useNativeWebSearch &&
+        PROMPT_CACHE_BREAKPOINT_MODEL_IDS.has(effectiveModel)
+      ) {
+        return await this.getResponsesInner().sendMessage(messages, options);
       }
       return await super.sendMessage(messages, options);
     } catch (error) {
@@ -218,5 +254,22 @@ export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
       );
     }
     return this.anthropicInner;
+  }
+
+  private getResponsesInner(): OpenRouterResponsesProvider {
+    if (!this.responsesInner) {
+      this.responsesInner = new OpenRouterResponsesProvider(
+        this.openRouterApiKey,
+        this.defaultModel,
+        {
+          baseURL: this.resolvedBaseURL,
+          providerName: this.name,
+          providerLabel: "OpenRouter",
+          streamTimeoutMs: this.providerStreamTimeoutMs,
+          requestHeaders: OPENROUTER_APP_ATTRIBUTION_HEADERS,
+        },
+      );
+    }
+    return this.responsesInner;
   }
 }

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -42,6 +42,11 @@ const USAGE_ATTRIBUTION_HEADER_NAMES = {
   resolvedMixArm: "X-Vellum-Resolved-Mix-Arm",
 } as const;
 
+/** Providers whose transports consume `promptCacheKey` (OpenAI Responses
+ *  `prompt_cache_key`); `RetryProvider` derives it from `selectionSeed` for
+ *  these only. */
+const PROMPT_CACHE_KEY_PROVIDERS = new Set(["openai", "openrouter"]);
+
 /** Providers that support the `effort` config (extended thinking / reasoning). */
 const EFFORT_SUPPORTED_PROVIDERS = new Set([
   "anthropic",
@@ -279,13 +284,15 @@ function normalizeSendMessageOptions(
   delete nextConfig.usageTracking;
 
   // Preserve the per-conversation prompt-cache key before `selectionSeed` is
-  // stripped below. Gated to the `openai` provider (the Responses client
-  // consumes it as `prompt_cache_key`); creating it for other providers would
-  // leak a non-wire field through clients that spread config into request
-  // bodies (AnthropicProvider's `...restConfig` → 400 "Extra inputs are not
-  // permitted"). An explicit caller-set value wins.
+  // stripped below. Gated to providers whose Responses transport consumes it
+  // as `prompt_cache_key` (direct OpenAI, and OpenRouter's `openai/*`
+  // Responses delegate); creating it elsewhere would leak a non-wire field
+  // through clients that spread config into request bodies. The Anthropic
+  // client strips `promptCacheKey` from its wire config, which also covers
+  // OpenRouter's `anthropic/*` delegation path. An explicit caller-set value
+  // wins.
   if (
-    providerName === "openai" &&
+    PROMPT_CACHE_KEY_PROVIDERS.has(providerName) &&
     nextConfig.promptCacheKey === undefined &&
     typeof config.selectionSeed === "string" &&
     config.selectionSeed.length > 0

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -250,10 +250,12 @@ export interface SendMessageConfig {
    * Per-conversation prompt-cache key for providers with explicit prompt
    * caching (sent as the OpenAI `prompt_cache_key` request param). Set by
    * `RetryProvider` from `selectionSeed` (the durable conversation id) for
-   * the `openai` provider only — GPT-5.6+ requires the key for reliable
-   * breakpoint matching, and OpenAI's ~15 req/min-per-key routing guidance
-   * is satisfied by per-conversation ids. A non-wire field for every other
-   * provider client; the request param is omitted when absent.
+   * the `openai` and `openrouter` providers — GPT-5.6+ requires the key for
+   * reliable breakpoint matching, and OpenAI's ~15 req/min-per-key routing
+   * guidance is satisfied by per-conversation ids. A non-wire field for
+   * every other provider client (the Anthropic client strips it, covering
+   * OpenRouter's `anthropic/*` delegation); the request param is omitted
+   * when absent.
    */
   promptCacheKey?: string;
   /**


### PR DESCRIPTION
## Summary
- `OpenRouterProvider` now delegates models flagged `supportsPromptCacheBreakpoints` (the six `openai/gpt-5.6-*` rows, newly flagged) to a lazily-constructed `OpenRouterResponsesProvider` — an `OpenAIResponsesProvider` subclass pointed at OpenRouter's base URL with app-attribution headers and OpenRouter's `provider: { only }` body field via a new `buildExtraCreateParams` hook (mirroring the chat-completions hook of the same name). Native-web-search traffic and all unflagged models stay on chat completions
- The breakpoint-model gate is now the catalog-derived `PROMPT_CACHE_BREAKPOINT_MODEL_IDS` set (all providers, provider-shaped IDs), shared by the Responses transport and the OpenRouter router; the flag stays daemon-only (meta JSON unchanged, verified with `sync:llm-catalog --check`)
- `RetryProvider` now derives `promptCacheKey` for `openrouter` as well as `openai`, and the Anthropic client strips the field from its wire config so OpenRouter's `anthropic/*` delegation path can never leak it (Anthropic 400s unknown fields)

## Verification
Live smoke test through the real provider against OpenRouter (`openai/gpt-5.6-luna`, volatile latest message, per-conversation key): turn 1 wrote 1576/1579 tokens (first contact); turn 2 read **1550/1596 tokens (97%) from cache** and wrote only the 43-token delta — vs. the chat-completions path's measured zero reads + full-prompt 1.25x writes every turn. 261 unit tests pass across the transport-routing, retry-plumbing, Anthropic-strip, and existing provider suites.

## Original prompt
Final PR of the sequence Sidd approved after the caching probe: the probe confirmed OpenRouter's chat-completions path can never cache our volatile-latest-message request shape for GPT-5.6 (zero reads, 1.25x full-prompt writes), while OpenRouter's Responses endpoint with explicit breakpoints produces healthy rolling reads. Prior PRs landed the write-rate pricing (#37858), explicit breakpoints (#37859), the probe-verified anchor-ladder fix (#37862), and reasoning-summary visibility (#37863); this one switches the OpenRouter transport so those benefits reach the six GPT-5.6 models we added to the OpenRouter catalog (#37856).