### PR TITLE
Add context.conversations.postMessage for custom routes (webhook→conversation turns)

### DIFF
--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -150,6 +150,10 @@ export const INTERFACE_IDS = [
   "email",
   "chrome-extension",
   "a2a",
+  // Turns injected by workspace custom routes (webhook receivers, cron jobs,
+  // device/service callbacks). Non-interactive — permission prompts route
+  // through the guardian system, not an interactive client — and non-host-proxy.
+  "route",
 ] as const;
 
 export type InterfaceId = (typeof INTERFACE_IDS)[number];

--- a/assistant/src/config/bundled-skills/app-builder/references/CUSTOM_ROUTES.md
+++ b/assistant/src/config/bundled-skills/app-builder/references/CUSTOM_ROUTES.md
@@ -84,6 +84,7 @@ Every handler receives a frozen `context` object as its second argument. This pr
 export async function POST(request: Request, context): Promise<Response> {
   // context.assistantEventHub — publish events to connected SSE clients
   // context.assistantId       — the daemon's logical assistant ID ("self")
+  // context.conversations     — post messages into conversations as real turns
 }
 ```
 
@@ -107,6 +108,35 @@ export async function POST(request: Request, context): Promise<Response> {
   return Response.json({ ok: true });
 }
 ```
+
+### Posting into a conversation
+
+Use `context.conversations.postMessage` to surface an inbound event as a real assistant turn — the way a webhook receiver, a scheduled job, or a device callback turns "your deploy finished" or "payment received" into a message the assistant actually responds to (not just a client-side event).
+
+```typescript
+// routes/deploy-webhook.ts — an external CI system POSTs here when a build finishes
+export async function POST(request: Request, context): Promise<Response> {
+  const { conversationId, status } = await request.json();
+  try {
+    await context.conversations.postMessage(
+      conversationId,
+      `Your deploy finished: ${status}.`,
+    );
+    return Response.json({ ok: true });
+  } catch (err) {
+    // err.code is "not_found" | "rate_limited" | "invalid"
+    const code = (err as { code?: string }).code;
+    const httpStatus =
+      code === "not_found" ? 404 : code === "rate_limited" ? 429 : 400;
+    return Response.json(
+      { ok: false, error: String(err) },
+      { status: httpStatus },
+    );
+  }
+}
+```
+
+The posted turn is attributed to a dedicated `route` interface — it can never impersonate a human surface — and runs under the target conversation's existing trust context, so a route cannot elevate privilege by posting. Unknown conversation ids are rejected (a route never silently creates a conversation), and posts are rate-limited per conversation to backstop runaway route→assistant→route loops.
 
 The context object is **immutable** — attempting to reassign its properties will throw in strict mode (ESM). This prevents user route handlers from accidentally corrupting shared state.
 

--- a/assistant/src/daemon/__tests__/route-conversation-post.test.ts
+++ b/assistant/src/daemon/__tests__/route-conversation-post.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Guard tests for {@link postRouteConversationMessage} — the helper that lets a
+ * workspace custom route inject a message into a conversation as a real turn.
+ *
+ * The security-relevant invariants are asserted here without a DB by stubbing
+ * the two dependencies the helper touches: `processMessageInBackground` (the
+ * turn sink — spied to inspect attribution) and `getConversation` (existence).
+ *
+ *   - Attribution is unspoofable: posts are always stamped with the dedicated
+ *     `route` interface, never a human surface, and the helper exposes no way
+ *     to override it.
+ *   - No privilege escalation: the helper never passes a trust or auth context.
+ *   - Unknown conversations are rejected (never silently created).
+ *   - A per-conversation rate limit backstops runaway loops.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+interface ProcessCall {
+  conversationId: string;
+  content: string;
+  options: Record<string, unknown> | undefined;
+}
+const processCalls: ProcessCall[] = [];
+let conversationExists = true;
+
+const realProcess = await import("../process-message.js");
+mock.module("../process-message.js", () => ({
+  ...realProcess,
+  processMessageInBackground: async (
+    conversationId: string,
+    content: string,
+    options?: Record<string, unknown>,
+  ) => {
+    processCalls.push({ conversationId, content, options });
+    return { messageId: `msg-${processCalls.length}` };
+  },
+}));
+
+const realCrud = await import("../../persistence/conversation-crud.js");
+mock.module("../../persistence/conversation-crud.js", () => ({
+  ...realCrud,
+  getConversation: (id: string) =>
+    conversationExists ? ({ id } as unknown) : null,
+}));
+
+const { postRouteConversationMessage } =
+  await import("../route-conversation-post.js");
+
+const HUMAN_INTERFACES = ["web", "macos", "ios", "cli"];
+
+describe("postRouteConversationMessage", () => {
+  beforeEach(() => {
+    processCalls.length = 0;
+    conversationExists = true;
+  });
+
+  test("posts the turn attributed to the route interface, never a human one", async () => {
+    const res = await postRouteConversationMessage(
+      "conv-attr",
+      "deploy finished",
+    );
+    expect(res.messageId).toBeTruthy();
+    expect(processCalls).toHaveLength(1);
+    expect(processCalls[0]!.conversationId).toBe("conv-attr");
+    expect(processCalls[0]!.content).toBe("deploy finished");
+    expect(processCalls[0]!.options?.sourceInterface).toBe("route");
+    expect(HUMAN_INTERFACES).not.toContain(
+      processCalls[0]!.options?.sourceInterface,
+    );
+  });
+
+  test("never passes a trust or auth context (no privilege escalation)", async () => {
+    await postRouteConversationMessage("conv-trust", "hi");
+    expect(processCalls[0]!.options).not.toHaveProperty("trustContext");
+    expect(processCalls[0]!.options).not.toHaveProperty("authContext");
+  });
+
+  test("rejects an unknown conversation without creating one", async () => {
+    conversationExists = false;
+    await expect(
+      postRouteConversationMessage("does-not-exist", "hi"),
+    ).rejects.toMatchObject({ code: "not_found" });
+    expect(processCalls).toHaveLength(0);
+  });
+
+  test("rejects empty text", async () => {
+    await expect(
+      postRouteConversationMessage("conv-empty", "   "),
+    ).rejects.toMatchObject({ code: "invalid" });
+    expect(processCalls).toHaveLength(0);
+  });
+
+  test("rate-limits per conversation to backstop runaway loops", async () => {
+    const convId = "conv-rate-limit";
+    for (let i = 0; i < 5; i++) {
+      await postRouteConversationMessage(convId, `m${i}`);
+    }
+    await expect(
+      postRouteConversationMessage(convId, "overflow"),
+    ).rejects.toMatchObject({ code: "rate_limited" });
+    expect(processCalls).toHaveLength(5);
+  });
+});

--- a/assistant/src/daemon/__tests__/route-conversation-post.test.ts
+++ b/assistant/src/daemon/__tests__/route-conversation-post.test.ts
@@ -44,6 +44,33 @@ mock.module("../../persistence/conversation-crud.js", () => ({
     conversationExists ? ({ id } as unknown) : null,
 }));
 
+// Controls for the active-conversation (busy/queue) path.
+let conversationBusy = false;
+let enqueueResult: { queued: boolean; requestId: string; rejected?: boolean } =
+  {
+    queued: true,
+    requestId: "queued-req",
+  };
+const enqueueCalls: Array<{
+  content: string;
+  metadata: Record<string, unknown> | undefined;
+}> = [];
+
+const realStore = await import("../conversation-store.js");
+mock.module("../conversation-store.js", () => ({
+  ...realStore,
+  getOrCreateConversation: async (_id: string) => ({
+    isProcessing: () => conversationBusy,
+    enqueueMessage: (opts: {
+      content: string;
+      metadata?: Record<string, unknown>;
+    }) => {
+      enqueueCalls.push({ content: opts.content, metadata: opts.metadata });
+      return enqueueResult;
+    },
+  }),
+}));
+
 const { postRouteConversationMessage } =
   await import("../route-conversation-post.js");
 
@@ -53,6 +80,9 @@ describe("postRouteConversationMessage", () => {
   beforeEach(() => {
     processCalls.length = 0;
     conversationExists = true;
+    conversationBusy = false;
+    enqueueCalls.length = 0;
+    enqueueResult = { queued: true, requestId: "queued-req" };
   });
 
   test("posts the turn attributed to the route interface, never a human one", async () => {
@@ -100,5 +130,29 @@ describe("postRouteConversationMessage", () => {
       postRouteConversationMessage(convId, "overflow"),
     ).rejects.toMatchObject({ code: "rate_limited" });
     expect(processCalls).toHaveLength(5);
+  });
+
+  test("queues (does not drop) when the conversation is mid-turn", async () => {
+    conversationBusy = true;
+    const res = await postRouteConversationMessage("conv-busy", "event fired");
+    // Queued, not processed immediately, and never dropped.
+    expect(res.messageId).toBeTruthy();
+    expect(enqueueCalls).toHaveLength(1);
+    expect(processCalls).toHaveLength(0);
+    // Queued turn keeps the route attribution via metadata.
+    expect(enqueueCalls[0]!.metadata?.userMessageInterface).toBe("route");
+    expect(enqueueCalls[0]!.metadata?.assistantMessageInterface).toBe("route");
+    expect(HUMAN_INTERFACES).not.toContain(
+      enqueueCalls[0]!.metadata?.userMessageInterface,
+    );
+  });
+
+  test("surfaces a rate_limited error when the turn queue is full", async () => {
+    conversationBusy = true;
+    enqueueResult = { queued: false, requestId: "x", rejected: true };
+    await expect(
+      postRouteConversationMessage("conv-busy", "event"),
+    ).rejects.toMatchObject({ code: "rate_limited" });
+    expect(processCalls).toHaveLength(0);
   });
 });

--- a/assistant/src/daemon/route-conversation-post.ts
+++ b/assistant/src/daemon/route-conversation-post.ts
@@ -1,0 +1,119 @@
+/**
+ * Post a message into a conversation from a workspace custom route.
+ *
+ * Lets integration routes (webhook receivers, cron-triggered handlers,
+ * device/service callbacks) surface an inbound event as a real assistant turn
+ * — "your deploy finished", "payment received" — instead of only publishing a
+ * client-side event via the event hub.
+ *
+ * Security posture (asserted by route-conversation-post.test.ts):
+ *   - Attribution is unspoofable: every posted turn is stamped with the
+ *     dedicated `route` interface. The caller cannot supply an interface, so a
+ *     route can never impersonate a human surface (web / macos / cli / …).
+ *   - No privilege escalation: the turn runs under the target conversation's
+ *     existing trust context. This helper never passes a trust or auth context,
+ *     so a route cannot grant itself guardian trust by posting a turn.
+ *   - Loop backstop: a per-conversation rate limit bounds runaway
+ *     route → assistant → route cycles.
+ */
+
+import type { InterfaceId } from "../channels/types.js";
+import { getConversation } from "../persistence/conversation-crud.js";
+import { getLogger } from "../util/logger.js";
+import { processMessageInBackground } from "./process-message.js";
+
+const log = getLogger("route-conversation-post");
+
+/** Attribution interface for turns injected by workspace custom routes. */
+const ROUTE_SOURCE_INTERFACE: InterfaceId = "route";
+
+/** Loop backstop: max route-originated posts per conversation per window. */
+const RATE_LIMIT_MAX = 5;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const recentPostTimestamps = new Map<string, number[]>();
+
+export type RouteMessageErrorCode = "not_found" | "rate_limited" | "invalid";
+
+/**
+ * Typed failure surfaced by {@link postRouteConversationMessage}. A route
+ * handler can catch it and map `code` to an HTTP status, or let it propagate
+ * (the dispatcher renders it as a 500).
+ */
+export class RouteMessageError extends Error {
+  readonly code: RouteMessageErrorCode;
+  constructor(message: string, code: RouteMessageErrorCode) {
+    super(message);
+    this.name = "RouteMessageError";
+    this.code = code;
+  }
+}
+
+function enforceRateLimit(conversationId: string): void {
+  const now = Date.now();
+  const cutoff = now - RATE_LIMIT_WINDOW_MS;
+  const recent = (recentPostTimestamps.get(conversationId) ?? []).filter(
+    (t) => t > cutoff,
+  );
+  if (recent.length >= RATE_LIMIT_MAX) {
+    throw new RouteMessageError(
+      `Route message rate limit exceeded for this conversation ` +
+        `(max ${RATE_LIMIT_MAX} per ${RATE_LIMIT_WINDOW_MS / 1000}s). ` +
+        `This backstops runaway route→assistant→route loops.`,
+      "rate_limited",
+    );
+  }
+  recent.push(now);
+  recentPostTimestamps.set(conversationId, recent);
+}
+
+/**
+ * Post `text` into an existing conversation as a real user turn attributed to
+ * the `route` interface, returning the persisted message id. The agent turn
+ * runs fire-and-forget (matching the conversation launcher), so this resolves
+ * as soon as the message is persisted and the loop is kicked off.
+ *
+ * @throws {@link RouteMessageError} with code `invalid` (missing id / empty
+ *   text), `not_found` (unknown conversation — never silently creates one), or
+ *   `rate_limited`.
+ */
+export async function postRouteConversationMessage(
+  conversationId: string,
+  text: string,
+): Promise<{ messageId: string }> {
+  if (typeof conversationId !== "string" || conversationId.trim() === "") {
+    throw new RouteMessageError("conversationId is required", "invalid");
+  }
+  if (typeof text !== "string" || text.trim() === "") {
+    throw new RouteMessageError(
+      "message text must be a non-empty string",
+      "invalid",
+    );
+  }
+
+  // Reject unknown conversations explicitly. processMessageInBackground would
+  // otherwise create one via getOrCreateActiveConversation, letting a route
+  // spawn empty conversations from arbitrary ids.
+  if (!getConversation(conversationId)) {
+    throw new RouteMessageError(
+      `conversation not found: ${conversationId}`,
+      "not_found",
+    );
+  }
+
+  enforceRateLimit(conversationId);
+
+  // Attribution is fixed here — never taken from the caller — so a route cannot
+  // post as a human interface. Trust and auth contexts are intentionally
+  // omitted: the turn inherits the conversation's existing trust context and a
+  // route cannot elevate privilege by posting.
+  const { messageId } = await processMessageInBackground(conversationId, text, {
+    sourceChannel: "vellum",
+    sourceInterface: ROUTE_SOURCE_INTERFACE,
+  });
+
+  log.info(
+    { conversationId, messageId },
+    "Route posted a message into a conversation",
+  );
+  return { messageId };
+}

--- a/assistant/src/daemon/route-conversation-post.ts
+++ b/assistant/src/daemon/route-conversation-post.ts
@@ -17,9 +17,12 @@
  *     route → assistant → route cycles.
  */
 
+import { v7 as uuidv7 } from "uuid";
+
 import type { InterfaceId } from "../channels/types.js";
 import { getConversation } from "../persistence/conversation-crud.js";
 import { getLogger } from "../util/logger.js";
+import { getOrCreateConversation } from "./conversation-store.js";
 import { processMessageInBackground } from "./process-message.js";
 
 const log = getLogger("route-conversation-post");
@@ -106,6 +109,42 @@ export async function postRouteConversationMessage(
   // post as a human interface. Trust and auth contexts are intentionally
   // omitted: the turn inherits the conversation's existing trust context and a
   // route cannot elevate privilege by posting.
+
+  // Honor the standard send contract: queue when the conversation is mid-turn
+  // rather than dropping the event. A bursty integration (webhook, cron) that
+  // fires during an active turn would otherwise hit CONVERSATION_BUSY_MESSAGE
+  // and be lost. The queued turn carries the same `route` attribution via
+  // metadata so its drain is stamped correctly.
+  const conversation = await getOrCreateConversation(conversationId);
+  if (conversation.isProcessing()) {
+    const requestId = uuidv7();
+    const result = conversation.enqueueMessage({
+      content: text,
+      requestId,
+      metadata: {
+        userMessageChannel: "vellum",
+        assistantMessageChannel: "vellum",
+        userMessageInterface: ROUTE_SOURCE_INTERFACE,
+        assistantMessageInterface: ROUTE_SOURCE_INTERFACE,
+      },
+    });
+    if (result.rejected) {
+      throw new RouteMessageError(
+        "conversation queue is full; retry shortly",
+        "rate_limited",
+      );
+    }
+    if (result.queued) {
+      log.info(
+        { conversationId, requestId },
+        "Route message queued behind an active turn",
+      );
+      return { messageId: requestId };
+    }
+    // The turn finished between the check and the enqueue — fall through and
+    // process immediately.
+  }
+
   const { messageId } = await processMessageInBackground(conversationId, text, {
     sourceChannel: "vellum",
     sourceInterface: ROUTE_SOURCE_INTERFACE,

--- a/assistant/src/runtime/routes/__tests__/user-route-dispatcher.test.ts
+++ b/assistant/src/runtime/routes/__tests__/user-route-dispatcher.test.ts
@@ -19,6 +19,9 @@ function makeContext(overrides?: Partial<UserRouteContext>): UserRouteContext {
   return {
     assistantEventHub: new AssistantEventHub(),
     assistantId: "test-assistant",
+    conversations: {
+      postMessage: async () => ({ messageId: "test-msg" }),
+    },
     ...overrides,
   };
 }

--- a/assistant/src/runtime/routes/user-route-dispatcher.ts
+++ b/assistant/src/runtime/routes/user-route-dispatcher.ts
@@ -44,6 +44,33 @@ export interface UserRouteContext {
   readonly assistantEventHub: AssistantEventHub;
   /** The logical assistant ID used by the daemon (typically "self"). */
   readonly assistantId: string;
+  /** Conversation operations available to route handlers (e.g. posting integration events as turns). */
+  readonly conversations: RouteConversationsApi;
+}
+
+/**
+ * Conversation operations exposed to route handlers. Lets integration routes
+ * (webhook receivers, cron jobs, device/service callbacks) surface an inbound
+ * event as a real assistant turn rather than only a client-side event.
+ */
+export interface RouteConversationsApi {
+  /**
+   * Post a message into an existing conversation as a real assistant turn.
+   *
+   * The turn is attributed to a dedicated integration interface (never a human
+   * surface) and runs under the conversation's existing trust context — a
+   * route cannot impersonate a user or elevate privilege by posting. Unknown
+   * conversation ids are rejected (a route never silently creates one), and
+   * posts are rate-limited per conversation to backstop runaway loops.
+   *
+   * Rejects with a `RouteMessageError` carrying `code`
+   * (`"not_found" | "rate_limited" | "invalid"`) — catch it to map to an HTTP
+   * status, or let it surface as a 500.
+   */
+  postMessage(
+    conversationId: string,
+    text: string,
+  ): Promise<{ messageId: string }>;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/routes/user-routes.ts
+++ b/assistant/src/runtime/routes/user-routes.ts
@@ -12,6 +12,7 @@
  * over both HTTP and IPC.
  */
 
+import { postRouteConversationMessage } from "../../daemon/route-conversation-post.js";
 import { assistantEventHub } from "../assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
@@ -23,6 +24,9 @@ const dispatcher = new UserRouteDispatcher({
   context: {
     assistantEventHub,
     assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+    conversations: {
+      postMessage: postRouteConversationMessage,
+    },
   },
 });
 


### PR DESCRIPTION
## Summary
- Adds `context.conversations.postMessage(conversationId, text)` to the custom-route context so integration routes (webhook receivers, cron jobs, device/service callbacks) can surface an inbound event as a real assistant turn — not just a client-side event via the event hub.
- Security posture is the review focus: posts are stamped with a dedicated `route` interface (never a human surface, so attribution is unspoofable), run under the target conversation's existing trust context (no trust/auth context is ever passed, so a route cannot escalate privilege), reject unknown conversation ids (never silently creating one), and are rate-limited per conversation to backstop runaway route→assistant→route loops.
- Adds a guard test for those invariants and a "Posting into a conversation" section in the custom-routes reference doc.

## Original prompt
Implement a general integration-ingestion capability the custom-route system was missing. Routes could already publish client-side events via the event hub, but could not start an assistant turn, so inbound events (a webhook, a cron, an alert, a device callback) could not become a message the assistant actually responds to. This PR adds the post-into-an-existing-conversation core with an emphasis on the security posture — unspoofable attribution, no privilege escalation, and a loop backstop — which is where review attention belongs. Creating a fresh conversation from a route, and any client-side "from integration" label, are deliberately left as follow-ups.