### PR TITLE
Serve bundled binary assets to sandboxed apps (window.vellum.asset)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -617,6 +617,27 @@ paths:
                 required:
                   - apps
                 additionalProperties: false
+  /v1/apps/{appId}/asset/{path}:
+    get:
+      operationId: apps_by_appId_asset_by_path_get
+      summary: Serve app asset
+      description: Serve a bundled binary asset (image, audio, video, font) from anywhere in an app's directory.
+      tags:
+        - apps
+      parameters:
+        - name: appId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: path
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful response
   /v1/apps/{appId}/dist/{filename}:
     get:
       operationId: apps_by_appId_dist_by_filename_get

--- a/assistant/src/__tests__/app-asset-bytes.test.ts
+++ b/assistant/src/__tests__/app-asset-bytes.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Guard tests for `readAppFileBytes` — the byte-reading helper behind the app
+ * asset endpoint (`GET /v1/apps/:appId/asset/:path*`, served to sandboxed apps
+ * via `window.vellum.asset`).
+ *
+ *   - Bytes round-trip intact (the point of the helper: utf-8 decoding would
+ *     corrupt binary media).
+ *   - Path validation still rejects traversal, absolute paths, and the
+ *     protected `records/` directory.
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  createApp,
+  getAppDirPath,
+  readAppFileBytes,
+} from "../apps/app-store.js";
+
+let testDir: string;
+
+beforeEach(() => {
+  testDir = join(
+    tmpdir(),
+    `vellum-app-asset-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  process.env.VELLUM_WORKSPACE_DIR = testDir;
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+function makeApp(): string {
+  return createApp({
+    name: "Asset Test",
+    schemaJson: "{}",
+    htmlDefinition: "<h1>hi</h1>",
+  }).id;
+}
+
+describe("readAppFileBytes", () => {
+  test("reads binary bytes without utf-8 corruption", () => {
+    const appId = makeApp();
+    // Includes 0xFF/0x80 — bytes that are not valid utf-8 and would be
+    // mangled by a text read.
+    const bytes = Buffer.from([0x00, 0x01, 0xff, 0xfe, 0x80, 0x7f, 0x42]);
+    const abs = join(getAppDirPath(appId), "assets", "clip.bin");
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, bytes);
+
+    const read = readAppFileBytes(appId, "assets/clip.bin");
+    expect(Buffer.compare(read, bytes)).toBe(0);
+  });
+
+  test("rejects traversal, absolute paths, and the records/ directory", () => {
+    const appId = makeApp();
+    expect(() => readAppFileBytes(appId, "../../etc/passwd")).toThrow();
+    expect(() => readAppFileBytes(appId, "/etc/passwd")).toThrow();
+    expect(() => readAppFileBytes(appId, "records/secret.json")).toThrow();
+  });
+
+  test("throws for a missing file", () => {
+    const appId = makeApp();
+    expect(() => readAppFileBytes(appId, "assets/nope.png")).toThrow(
+      /not found/i,
+    );
+  });
+});

--- a/assistant/src/apps/app-store.ts
+++ b/assistant/src/apps/app-store.ts
@@ -866,6 +866,21 @@ export function readAppFile(appId: string, path: string): string {
 }
 
 /**
+ * Read a file from the app directory as raw bytes.
+ * Path is validated to prevent traversal. Use for binary assets (images,
+ * audio, video, fonts) where {@link readAppFile}'s utf-8 decoding corrupts
+ * the data.
+ */
+export function readAppFileBytes(appId: string, path: string): Buffer {
+  validateId(appId);
+  const resolved = validateFilePath(appId, path);
+  if (!existsSync(resolved)) {
+    throw new Error(`File not found: ${path}`);
+  }
+  return readFileSync(resolved);
+}
+
+/**
  * Write a file to the app directory.
  * Auto-creates intermediate directories. Path is validated to prevent traversal.
  */

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -270,6 +270,18 @@ useEffect(() => {
 }, []);
 ```
 
+**Bundled media — `window.vellum.asset(path)`.** For binary assets too big to inline (images, audio, short video, custom fonts), bundle the file under the app directory with `file_write` and load it at runtime via `window.vellum.asset("assets/intro.mp4")`, which resolves to a `blob:` URL the sandbox can use directly. Don't reach for giant base64 data-URIs.
+
+```tsx
+const [src, setSrc] = useState("");
+useEffect(() => {
+  window.vellum.asset("assets/intro.mp4").then(setSrc).catch(() => notifyError("Couldn't load media"));
+}, []);
+return src ? <video src={src} controls /> : null;
+```
+
+Paths are validated server-side (no traversal, no `records/`); the file is served only from this app's own directory.
+
 **Writing a route handler.** Routes are `.ts`/`.js` files in `{workspaceDir}/routes/`, served at `/v1/x/<filename>` (`routes/items.ts` → `/v1/x/items`; `routes/bar/index.ts` → `/v1/x/bar`). Write them with `file_write` **before** `app_refresh`. Each exports named functions per HTTP method (`GET`/`POST`/`PUT`/`PATCH`/`DELETE`), receiving the Web `Request` and an optional `context`. Full Node API access (`fs`, `path`, `crypto`), 30s timeout, hot-reloaded on change. No `[id].ts` dynamic segments — use query params.
 
 ```typescript

--- a/assistant/src/runtime/routes/app-routes.ts
+++ b/assistant/src/runtime/routes/app-routes.ts
@@ -8,7 +8,12 @@ import { extname, join } from "node:path";
 import JSZip from "jszip";
 import { z } from "zod";
 
-import { getApp, getAppDirPath, isMultifileApp } from "../../apps/app-store.js";
+import {
+  getApp,
+  getAppDirPath,
+  isMultifileApp,
+  readAppFileBytes,
+} from "../../apps/app-store.js";
 import {
   createSharedAppLink,
   deleteSharedAppLinkByToken,
@@ -165,8 +170,8 @@ function serveMultifileApp(appId: string, appName: string): string {
   return html;
 }
 
-/** Content-Type map for static dist/ assets. */
-const DIST_CONTENT_TYPES: Record<string, string> = {
+/** Content-Type map for static app files (dist/ assets and bundled media). */
+const STATIC_CONTENT_TYPES: Record<string, string> = {
   ".js": "application/javascript",
   ".css": "text/css",
   ".html": "text/html",
@@ -175,9 +180,31 @@ const DIST_CONTENT_TYPES: Record<string, string> = {
   ".png": "image/png",
   ".jpg": "image/jpeg",
   ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".avif": "image/avif",
+  ".ico": "image/x-icon",
+  ".mp4": "video/mp4",
+  ".webm": "video/webm",
+  ".ogv": "video/ogg",
+  ".mov": "video/quicktime",
+  ".mp3": "audio/mpeg",
+  ".wav": "audio/wav",
+  ".m4a": "audio/mp4",
+  ".aac": "audio/aac",
+  ".oga": "audio/ogg",
   ".woff2": "font/woff2",
   ".woff": "font/woff",
+  ".ttf": "font/ttf",
+  ".otf": "font/otf",
 };
+
+function contentTypeForPath(filePath: string): string {
+  return (
+    STATIC_CONTENT_TYPES[extname(filePath).toLowerCase()] ??
+    "application/octet-stream"
+  );
+}
 
 /**
  * Serve a static file from an app's dist/ directory.
@@ -215,6 +242,55 @@ function handleServeDistFile({ pathParams }: RouteHandlerArgs): Uint8Array {
   }
 
   return new Uint8Array(readFileSync(filePath));
+}
+
+/** 25 MB — generous cap for a single bundled app asset. */
+const MAX_APP_ASSET_BYTES = 25 * 1024 * 1024;
+
+/**
+ * Serve a bundled file from anywhere in an app's directory (e.g.
+ * `assets/intro.mp4`), for binary media an app can't practically inline as a
+ * data-URI. `readAppFileBytes` runs the app-store path validation
+ * (rejects `..`, absolute paths, symlink escapes, and the protected
+ * `records/` directory), so authors bundle assets under the app dir and load
+ * them via `window.vellum.asset(path)`.
+ */
+function handleServeAppAsset({ pathParams }: RouteHandlerArgs): Uint8Array {
+  const appId = pathParams?.appId as string;
+  const assetPath = pathParams?.path as string;
+
+  if (
+    !appId ||
+    appId.includes("..") ||
+    appId.includes("/") ||
+    appId.includes("\\") ||
+    appId !== appId.trim()
+  ) {
+    throw new BadRequestError("Invalid appId");
+  }
+  if (!assetPath || assetPath.trim() === "") {
+    throw new BadRequestError("Invalid asset path");
+  }
+
+  let bytes: Buffer;
+  try {
+    bytes = readAppFileBytes(appId, assetPath);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "";
+    if (message.includes("not found")) {
+      throw new NotFoundError("Asset not found");
+    }
+    // validateFilePath throws on traversal / absolute / records-dir access.
+    throw new BadRequestError("Invalid asset path");
+  }
+
+  if (bytes.byteLength > MAX_APP_ASSET_BYTES) {
+    throw new BadRequestError(
+      `Asset too large (limit: ${MAX_APP_ASSET_BYTES} bytes)`,
+    );
+  }
+
+  return new Uint8Array(bytes);
 }
 
 /** 50 MB — generous cap for zip app bundles. */
@@ -342,12 +418,28 @@ export const ROUTES: RouteDefinition[] = [
     description: "Serve a static asset from an app's compiled dist/ directory.",
     tags: ["apps"],
     responseHeaders: ({ pathParams }) => ({
-      "Content-Type":
-        DIST_CONTENT_TYPES[extname(pathParams?.filename ?? "").toLowerCase()] ??
-        "application/octet-stream",
+      "Content-Type": contentTypeForPath(pathParams?.filename ?? ""),
       "Cache-Control": "no-cache",
     }),
     handler: handleServeDistFile,
+  },
+  {
+    operationId: "apps_asset",
+    endpoint: "apps/:appId/asset/:path*",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Serve app asset",
+    description:
+      "Serve a bundled binary asset (image, audio, video, font) from anywhere in an app's directory.",
+    tags: ["apps"],
+    responseHeaders: ({ pathParams }) => ({
+      "Content-Type": contentTypeForPath(pathParams?.path ?? ""),
+      "Cache-Control": "no-cache",
+    }),
+    handler: handleServeAppAsset,
   },
   {
     operationId: "apps_share",

--- a/clients/web/src/components/app-viewer-container.tsx
+++ b/clients/web/src/components/app-viewer-container.tsx
@@ -62,9 +62,9 @@ export function AppViewerContainer({
 
   // Escape-to-exit handler, active only while fullscreen.
   useEffect(() => {
-    if (!isFullscreen) return;
+    if (!isFullscreen) {return;}
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setIsFullscreen(false);
+      if (e.key === "Escape") {setIsFullscreen(false);}
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
@@ -86,6 +86,7 @@ export function AppViewerContainer({
   useSandboxFetchProxy(iframeRef, {
     frameId: appId,
     assistantId,
+    appId,
     onAction,
   });
 
@@ -116,8 +117,10 @@ export function AppViewerContainer({
           <div
             className="absolute z-10"
             style={{
-              top: "max(0.75rem, var(--safe-area-inset-top, env(safe-area-inset-top, 0px)))",
-              right: "max(0.75rem, var(--safe-area-inset-right, env(safe-area-inset-right, 0px)))",
+              top:
+                "max(0.75rem, var(--safe-area-inset-top, env(safe-area-inset-top, 0px)))",
+              right:
+                "max(0.75rem, var(--safe-area-inset-right, env(safe-area-inset-right, 0px)))",
             }}
           >
             <Button

--- a/clients/web/src/hooks/use-sandbox-fetch-proxy.ts
+++ b/clients/web/src/hooks/use-sandbox-fetch-proxy.ts
@@ -23,6 +23,12 @@ export interface SandboxFetchProxyOptions {
   frameId: string;
   /** Assistant ID for constructing proxy URLs. */
   assistantId: string;
+  /**
+   * The app whose bundled assets `window.vellum.asset()` may read. Scopes
+   * asset requests to this app so a sandboxed frame can only reach its own
+   * files. Omit for non-app sandboxes — asset requests then fail gracefully.
+   */
+  appId?: string;
   /** Whether the fetch proxy is active. Surface actions are always forwarded regardless. Default: true. */
   enabled?: boolean;
   /** Handler for surface action messages from the sandboxed app. */
@@ -47,14 +53,20 @@ export function useSandboxFetchProxy(
   iframeRef: RefObject<HTMLIFrameElement | null>,
   options: SandboxFetchProxyOptions,
 ): void {
-  const { frameId, assistantId, enabled = true, onAction, onOpenVellumLink } =
-    options;
+  const {
+    frameId,
+    assistantId,
+    appId,
+    enabled = true,
+    onAction,
+    onOpenVellumLink,
+  } = options;
 
   useEffect(() => {
     const handler = async (event: MessageEvent) => {
       const msg = event.data;
-      if (!msg || msg.frameId !== frameId) return;
-      if (event.source !== iframeRef.current?.contentWindow) return;
+      if (!msg || msg.frameId !== frameId) {return;}
+      if (event.source !== iframeRef.current?.contentWindow) {return;}
 
       if (msg.type === "vellum_surface_action") {
         onAction?.(msg.actionId, msg.data);
@@ -68,12 +80,72 @@ export function useSandboxFetchProxy(
         // user activation (transient — typically ~5s after a user
         // gesture), so programmatic spam on load or in a loop can't
         // trigger unsolicited downloads.
-        if (!navigator.userActivation?.isActive) return;
+        if (!navigator.userActivation?.isActive) {return;}
         onOpenVellumLink?.(msg.href, msg.linkText);
         return;
       }
 
-      if (!enabled || msg.type !== "vellum_fetch_request") return;
+      if (msg.type === "vellum_asset_request") {
+        const { callId, path } = msg as { callId: string; path: string };
+        const iframe = iframeRef.current;
+        const sendAsset = (
+          response: Record<string, unknown>,
+          transfer?: Transferable[],
+        ) => {
+          iframe?.contentWindow?.postMessage(response, "*", transfer ?? []);
+        };
+        if (!enabled) {
+          sendAsset({ type: "vellum_asset_response", callId, error: "Asset proxy disabled" });
+          return;
+        }
+        if (!appId) {
+          sendAsset({ type: "vellum_asset_response", callId, error: "No app context for assets" });
+          return;
+        }
+        if (typeof path !== "string" || path === "" || path.includes("..")) {
+          sendAsset({ type: "vellum_asset_response", callId, error: "Invalid asset path" });
+          return;
+        }
+        try {
+          const encodedPath = path
+            .split("/")
+            .map(encodeURIComponent)
+            .join("/");
+          const url = `/v1/assistants/${assistantId}/apps/${appId}/asset/${encodedPath}`;
+          const { data: blob, response } = await client.get({
+            url,
+            parseAs: "blob",
+            throwOnError: false,
+          });
+          if (!response?.ok || !(blob instanceof Blob)) {
+            sendAsset({
+              type: "vellum_asset_response",
+              callId,
+              error: `Asset fetch failed (${response?.status ?? 0})`,
+            });
+            return;
+          }
+          const buffer = await blob.arrayBuffer();
+          sendAsset(
+            {
+              type: "vellum_asset_response",
+              callId,
+              buffer,
+              contentType: blob.type || "application/octet-stream",
+            },
+            [buffer],
+          );
+        } catch (err) {
+          sendAsset({
+            type: "vellum_asset_response",
+            callId,
+            error: err instanceof Error ? err.message : "Asset proxy error",
+          });
+        }
+        return;
+      }
+
+      if (!enabled || msg.type !== "vellum_fetch_request") {return;}
 
       const { callId, path, method, headers, body } = msg as {
         callId: string;
@@ -164,5 +236,13 @@ export function useSandboxFetchProxy(
 
     window.addEventListener("message", handler);
     return () => window.removeEventListener("message", handler);
-  }, [frameId, assistantId, enabled, onAction, onOpenVellumLink, iframeRef]);
+  }, [
+    frameId,
+    assistantId,
+    appId,
+    enabled,
+    onAction,
+    onOpenVellumLink,
+    iframeRef,
+  ]);
 }

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -86,6 +86,12 @@ const RUNTIME_PROXIED_FIRST_SEGMENTS = new Set<string>([
   // must be forwarded to the gateway in local / self-hosted mode rather
   // than falling through to the platform proxy.
   "x",
+  // Daemon-owned app-serving routes (`/v1/apps/*`: bundled asset media and
+  // compiled dist files). The sandbox asset proxy in `useSandboxFetchProxy`
+  // fetches `/v1/assistants/{id}/apps/{appId}/asset/...` through the platform
+  // client, so it must be forwarded to the gateway in local / self-hosted
+  // mode rather than falling through to the platform proxy.
+  "apps",
   // Daemon-owned config reached through the platform client via raw
   // `client.*` calls (the background `TimezoneSync` PATCH and the general
   // settings page). Must be forwarded to the gateway in local /

--- a/clients/web/src/utils/sandbox-bridge.ts
+++ b/clients/web/src/utils/sandbox-bridge.ts
@@ -10,6 +10,9 @@
  *    the parent via `postMessage`.
  * 3. **Fetch proxy** — `window.vellum.fetch()` proxies authenticated requests
  *    through the parent, keeping auth tokens out of the sandbox.
+ *    `window.vellum.asset(path)` is the binary sibling: it fetches a bundled
+ *    app file through the parent and resolves to a `blob:` object URL the
+ *    sandbox can load in `<img>` / `<video>` / `<audio>`.
  * 4. **Link interceptor** — catches clicks on `<a>` elements and opens them in
  *    new tabs via `window.open()`, which the `allow-popups` sandbox token
  *    permits. Without this, links inside sandboxed iframes are non-interactive
@@ -48,7 +51,9 @@ export const FETCH_PROXY_PATH_RE = /^\/v1\/x\//;
  * @see https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
  */
 export function jsonForScript(value: unknown): string {
-  return JSON.stringify(value).replace(/<\//g, "<\\/").replace(/<!--/g, "<\\!--");
+  return JSON.stringify(value)
+    .replace(/<\//g, "<\\/")
+    .replace(/<!--/g, "<\\!--");
 }
 
 // ---------------------------------------------------------------------------
@@ -196,7 +201,10 @@ export interface BridgeOptions {
  * storage polyfill is prepended separately via `prependScript` so that it
  * runs before any app code that accesses `localStorage` during parsing.
  */
-function buildBridgeLogicScript(frameId: string, options?: BridgeOptions): string {
+function buildBridgeLogicScript(
+  frameId: string,
+  options?: BridgeOptions,
+): string {
   const enableFetch = options?.fetch ?? false;
   const route = options?.route ?? null;
 
@@ -224,6 +232,9 @@ function buildBridgeLogicScript(frameId: string, options?: BridgeOptions): strin
     delete window.vellum._pendingFetches[callId];
     p.reject(new Error(errorMessage));
   };
+  window.vellum._pendingAssets = {};
+  window.vellum._assetNextId = 1;
+  window.vellum._assetCache = {};
   window.addEventListener('message', function(event) {
     var d = event.data;
     if (!d) return;
@@ -233,6 +244,18 @@ function buildBridgeLogicScript(frameId: string, options?: BridgeOptions): strin
       } else {
         window.vellum._resolveFetch(d.callId, d.status, d.statusText, d.body, d.headers);
       }
+    }
+    if (d.type === 'vellum_asset_response' && d.callId) {
+      var pa = window.vellum._pendingAssets[d.callId];
+      if (!pa) return;
+      delete window.vellum._pendingAssets[d.callId];
+      if (d.error) { pa.reject(new Error(d.error)); return; }
+      try {
+        var blob = new Blob([d.buffer], { type: d.contentType || 'application/octet-stream' });
+        var url = URL.createObjectURL(blob);
+        window.vellum._assetCache[pa.path] = url;
+        pa.resolve(url);
+      } catch (e) { pa.reject(e); }
     }
   });
   window.vellum.fetch = function(path, options) {
@@ -248,6 +271,21 @@ function buildBridgeLogicScript(frameId: string, options?: BridgeOptions): strin
         method: (options.method || 'GET').toUpperCase(),
         headers: options.headers || {},
         body: options.body || null
+      }, '*');
+    });
+  };
+  window.vellum.asset = function(path) {
+    if (window.vellum._assetCache[path]) {
+      return Promise.resolve(window.vellum._assetCache[path]);
+    }
+    return new Promise(function(resolve, reject) {
+      var callId = 'a' + (window.vellum._assetNextId++);
+      window.vellum._pendingAssets[callId] = { resolve: resolve, reject: reject, path: path };
+      window.parent.postMessage({
+        type: 'vellum_asset_request',
+        frameId: ${jsonForScript(frameId)},
+        callId: callId,
+        path: path
       }, '*');
     });
   };`
@@ -277,8 +315,15 @@ function buildBridgeLogicScript(frameId: string, options?: BridgeOptions): strin
  * `injectBridge` is preferred because it places the polyfill and bridge
  * logic at separate positions in the HTML.
  */
-export function buildBridgeScript(frameId: string, options?: BridgeOptions): string {
-  return buildStoragePolyfill() + buildBridgeLogicScript(frameId, options) + buildLinkInterceptorScript(frameId);
+export function buildBridgeScript(
+  frameId: string,
+  options?: BridgeOptions,
+): string {
+  return (
+    buildStoragePolyfill() +
+    buildBridgeLogicScript(frameId, options) +
+    buildLinkInterceptorScript(frameId)
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -341,9 +386,17 @@ export function prependScript(html: string, script: string): string {
  * the bridge logic is appended before `</body>` (app code calls
  * `window.vellum` APIs asynchronously after mount, not during parsing).
  */
-export function injectBridge(html: string, frameId: string, options?: BridgeOptions): string {
+export function injectBridge(
+  html: string,
+  frameId: string,
+  options?: BridgeOptions,
+): string {
   return prependScript(
-    injectScript(html, buildBridgeLogicScript(frameId, options) + buildLinkInterceptorScript(frameId)),
+    injectScript(
+      html,
+      buildBridgeLogicScript(frameId, options) +
+        buildLinkInterceptorScript(frameId),
+    ),
     buildStoragePolyfill(),
   );
 }

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -7,7 +7,7 @@
     },
     "app-builder": {
       "docsSlug": "app-builder",
-      "sha256": "788fdcd4aa29830604d25d9b9f3577bcc5a023a60e9ffad1d2e109a9f326ff8f"
+      "sha256": "37fc43298c1687d0fd9eace22a383bdb18e287f7506a6f330d050d933d2f415b"
     },
     "computer-use": {
       "docsSlug": "computer-use",


### PR DESCRIPTION
## Summary
- Adds `window.vellum.asset(path)` to the sandbox bridge: it fetches a bundled app file through the parent (authenticated) and resolves to a `blob:` object URL the sandboxed iframe can load in `<img>` / `<video>` / `<audio>` / `@font-face` — so apps ship real media instead of inlining giant base64 data-URIs.
- Adds the daemon endpoint `GET /v1/apps/:appId/asset/:path*`, serving any file from an app's own directory via the existing `validateFilePath` guard (rejects traversal, absolute paths, the protected `records/` dir; symlink-safe), with media content-types and a 25 MB cap. Parallels the existing `apps_dist_file` route.
- Binary travels over a **new** postMessage channel (ArrayBuffer transfer), since the existing `window.vellum.fetch` proxy is text-only. Asset requests are scoped to the app the viewer is rendering, so a sandboxed frame can only read its own files.
- Guard test for byte-integrity + path validation; docs in the app-builder SKILL and the bridge reference.

## Original prompt
Close a completeness gap in the app platform. Sandboxed apps render in a no-same-origin `srcDoc` iframe, so every asset must be inlined — fine for JS/CSS, impractical for images, audio, video, or fonts. This adds a proxied, path-validated way for an app to load its own bundled binary files as blob URLs. Scoped to serving from the app directory; no compiler changes, and it reuses the app-store path-validation the existing dist-file route already relies on.