### PR TITLE
Add window.vellum.subscribe — push sync updates into sandboxed apps

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -282,6 +282,17 @@ return src ? <video src={src} controls /> : null;
 
 Paths are validated server-side (no traversal, no `records/`); the file is served only from this app's own directory.
 
+**Live updates — `window.vellum.subscribe({ tags }, cb)`.** Instead of polling on a timer, subscribe to your own invalidation tags and refresh when the data actually changes. After a route mutates data it publishes a `sync_changed` event (`context.assistantEventHub.publish({ …, message: { type: "sync_changed", tags: ["my-app:items"] } })`); the app subscribes to that tag and re-fetches when it fires. Returns an unsubscribe function — call it on cleanup. Only your own custom tags are delivered (host namespaces like `conversation:`/`assistant:` are never forwarded), and the payload is just the changed tags — re-fetch through `window.vellum.fetch` for the data.
+
+```tsx
+useEffect(() => {
+  const off = window.vellum.subscribe({ tags: ["my-app:items"] }, () => {
+    void loadItems(); // re-fetch on change — no polling
+  });
+  return off;
+}, []);
+```
+
 **Writing a route handler.** Routes are `.ts`/`.js` files in `{workspaceDir}/routes/`, served at `/v1/x/<filename>` (`routes/items.ts` → `/v1/x/items`; `routes/bar/index.ts` → `/v1/x/bar`). Write them with `file_write` **before** `app_refresh`. Each exports named functions per HTTP method (`GET`/`POST`/`PUT`/`PATCH`/`DELETE`), receiving the Web `Request` and an optional `context`. Full Node API access (`fs`, `path`, `crypto`), 30s timeout, hot-reloaded on change. No `[id].ts` dynamic segments — use query params.
 
 ```typescript

--- a/clients/web/src/hooks/use-sandbox-fetch-proxy.ts
+++ b/clients/web/src/hooks/use-sandbox-fetch-proxy.ts
@@ -13,7 +13,7 @@
  * @see {@link @/utils/sandbox-bridge} for the in-iframe bridge that sends these messages
  */
 
-import { type RefObject, useEffect } from "react";
+import { type RefObject, useEffect, useRef } from "react";
 
 import { client } from "@/generated/api/client.gen";
 import { subscribe as busSubscribe } from "@/lib/event-bus";
@@ -64,10 +64,16 @@ export function useSandboxFetchProxy(
     onOpenVellumLink,
   } = options;
 
+  // subId → the sync tags the sandboxed app asked to hear about. Held in a ref,
+  // not effect-local state, so it survives effect restarts: a dependency change
+  // (e.g. assistantId resolving, or a new callback identity) re-runs the effect
+  // while the iframe stays mounted and never re-sends vellum_subscribe — a local
+  // map would be wiped and later matching events silently dropped. The ref is
+  // discarded with the component on unmount.
+  const subscriptionsRef = useRef<Map<string, Set<string>>>(new Map());
+
   useEffect(() => {
-    // subId → the sync tags the sandboxed app asked to hear about. Populated
-    // by vellum_subscribe messages, read by the bus forwarder below.
-    const subscriptions = new Map<string, Set<string>>();
+    const subscriptions = subscriptionsRef.current;
 
     const handler = async (event: MessageEvent) => {
       const msg = event.data;
@@ -303,7 +309,9 @@ export function useSandboxFetchProxy(
     return () => {
       window.removeEventListener("message", handler);
       busUnsubscribe();
-      subscriptions.clear();
+      // Deliberately not clearing `subscriptions`: it must survive effect
+      // re-runs so subscriptions registered before a dependency change keep
+      // receiving events. It is discarded with the component on unmount.
     };
   }, [
     frameId,

--- a/clients/web/src/hooks/use-sandbox-fetch-proxy.ts
+++ b/clients/web/src/hooks/use-sandbox-fetch-proxy.ts
@@ -16,7 +16,9 @@
 import { type RefObject, useEffect } from "react";
 
 import { client } from "@/generated/api/client.gen";
+import { subscribe as busSubscribe } from "@/lib/event-bus";
 import { FETCH_PROXY_PATH_RE } from "@/utils/sandbox-bridge";
+import { forwardableSyncTags } from "@/utils/sandbox-sync-filter";
 
 export interface SandboxFetchProxyOptions {
   /** Unique identifier matching the bridge's `frameId`. */
@@ -63,10 +65,34 @@ export function useSandboxFetchProxy(
   } = options;
 
   useEffect(() => {
+    // subId → the sync tags the sandboxed app asked to hear about. Populated
+    // by vellum_subscribe messages, read by the bus forwarder below.
+    const subscriptions = new Map<string, Set<string>>();
+
     const handler = async (event: MessageEvent) => {
       const msg = event.data;
       if (!msg || msg.frameId !== frameId) {return;}
       if (event.source !== iframeRef.current?.contentWindow) {return;}
+
+      if (msg.type === "vellum_subscribe") {
+        if (!enabled) {return;}
+        const { subId, tags } = msg as { subId: string; tags: unknown };
+        if (typeof subId === "string" && Array.isArray(tags)) {
+          subscriptions.set(
+            subId,
+            new Set(tags.filter((t): t is string => typeof t === "string")),
+          );
+        }
+        return;
+      }
+
+      if (msg.type === "vellum_unsubscribe") {
+        const { subId } = msg as { subId: string };
+        if (typeof subId === "string") {
+          subscriptions.delete(subId);
+        }
+        return;
+      }
 
       if (msg.type === "vellum_surface_action") {
         onAction?.(msg.actionId, msg.data);
@@ -235,7 +261,50 @@ export function useSandboxFetchProxy(
     };
 
     window.addEventListener("message", handler);
-    return () => window.removeEventListener("message", handler);
+
+    // Forward host `sync_changed` invalidations to any sandbox subscription
+    // whose tags match, scoped by `forwardableSyncTags` (reserved host
+    // namespaces are never delivered). Only `sync_changed` is forwarded — no
+    // event carrying a payload crosses into the sandbox.
+    const busUnsubscribe = busSubscribe("sse.event", (envelope) => {
+      const message = envelope.message as
+        | { type?: string; tags?: unknown }
+        | undefined;
+      if (
+        !message ||
+        message.type !== "sync_changed" ||
+        !Array.isArray(message.tags)
+      ) {
+        return;
+      }
+      const contentWindow = iframeRef.current?.contentWindow;
+      if (!contentWindow || subscriptions.size === 0) {
+        return;
+      }
+      const eventTags = message.tags.filter(
+        (t): t is string => typeof t === "string",
+      );
+      for (const [subId, wanted] of subscriptions) {
+        const tags = forwardableSyncTags([...wanted], eventTags);
+        if (tags.length > 0) {
+          contentWindow.postMessage(
+            {
+              type: "vellum_event",
+              frameId,
+              subId,
+              event: { type: "sync_changed", tags },
+            },
+            "*",
+          );
+        }
+      }
+    });
+
+    return () => {
+      window.removeEventListener("message", handler);
+      busUnsubscribe();
+      subscriptions.clear();
+    };
   }, [
     frameId,
     assistantId,

--- a/clients/web/src/utils/sandbox-bridge.ts
+++ b/clients/web/src/utils/sandbox-bridge.ts
@@ -13,6 +13,9 @@
  *    `window.vellum.asset(path)` is the binary sibling: it fetches a bundled
  *    app file through the parent and resolves to a `blob:` object URL the
  *    sandbox can load in `<img>` / `<video>` / `<audio>`.
+ *    `window.vellum.subscribe(filter, cb)` completes the trio with server→app
+ *    push: the parent forwards scoped `sync_changed` invalidations so an app
+ *    refreshes on demand instead of polling.
  * 4. **Link interceptor** — catches clicks on `<a>` elements and opens them in
  *    new tabs via `window.open()`, which the `allow-popups` sandbox token
  *    permits. Without this, links inside sandboxed iframes are non-interactive
@@ -235,6 +238,8 @@ function buildBridgeLogicScript(
   window.vellum._pendingAssets = {};
   window.vellum._assetNextId = 1;
   window.vellum._assetCache = {};
+  window.vellum._subs = {};
+  window.vellum._subNextId = 1;
   window.addEventListener('message', function(event) {
     var d = event.data;
     if (!d) return;
@@ -256,6 +261,12 @@ function buildBridgeLogicScript(
         window.vellum._assetCache[pa.path] = url;
         pa.resolve(url);
       } catch (e) { pa.reject(e); }
+    }
+    if (d.type === 'vellum_event' && d.subId) {
+      var s = window.vellum._subs[d.subId];
+      if (s && typeof s.cb === 'function') {
+        try { s.cb(d.event); } catch (e) { /* a subscriber throwing is not the host's problem */ }
+      }
     }
   });
   window.vellum.fetch = function(path, options) {
@@ -288,6 +299,26 @@ function buildBridgeLogicScript(
         path: path
       }, '*');
     });
+  };
+  window.vellum.subscribe = function(filter, cb) {
+    var subId = 's' + (window.vellum._subNextId++);
+    var tags = (filter && Array.isArray(filter.tags)) ? filter.tags : [];
+    window.vellum._subs[subId] = { cb: cb, tags: tags };
+    window.parent.postMessage({
+      type: 'vellum_subscribe',
+      frameId: ${jsonForScript(frameId)},
+      subId: subId,
+      tags: tags
+    }, '*');
+    return function() {
+      if (!window.vellum._subs[subId]) return;
+      delete window.vellum._subs[subId];
+      window.parent.postMessage({
+        type: 'vellum_unsubscribe',
+        frameId: ${jsonForScript(frameId)},
+        subId: subId
+      }, '*');
+    };
   };`
     : "";
 

--- a/clients/web/src/utils/sandbox-sync-filter.test.ts
+++ b/clients/web/src/utils/sandbox-sync-filter.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+
+import { forwardableSyncTags, isReservedSyncTag } from "./sandbox-sync-filter";
+
+describe("forwardableSyncTags", () => {
+  test("delivers a custom tag the app subscribed to", () => {
+    expect(forwardableSyncTags(["show:state"], ["show:state"])).toEqual([
+      "show:state",
+    ]);
+  });
+
+  test("delivers only the intersection of subscribed and event tags", () => {
+    expect(forwardableSyncTags(["a", "b"], ["b", "c"])).toEqual(["b"]);
+  });
+
+  test("an empty subscription receives nothing (default-deny)", () => {
+    expect(forwardableSyncTags([], ["show:state"])).toEqual([]);
+  });
+
+  test("never forwards reserved host namespaces, even if explicitly subscribed", () => {
+    const reserved = [
+      "assistant:self:theme",
+      "conversation:conv-1:messages",
+      "conversations:list",
+      "apps:list",
+      "plugins:list",
+      "feature-flags:client",
+    ];
+    expect(forwardableSyncTags(reserved, reserved)).toEqual([]);
+    for (const tag of reserved) {
+      expect(isReservedSyncTag(tag)).toBe(true);
+    }
+  });
+
+  test("keeps custom tags while dropping reserved ones in the same event", () => {
+    expect(
+      forwardableSyncTags(
+        ["show:state", "apps:list"],
+        ["show:state", "apps:list"],
+      ),
+    ).toEqual(["show:state"]);
+  });
+
+  test("custom app tags are not reserved", () => {
+    expect(isReservedSyncTag("show:state")).toBe(false);
+    expect(isReservedSyncTag("my-app:data")).toBe(false);
+  });
+});

--- a/clients/web/src/utils/sandbox-sync-filter.ts
+++ b/clients/web/src/utils/sandbox-sync-filter.ts
@@ -1,0 +1,47 @@
+/**
+ * Scoping for `window.vellum.subscribe` (see `sandbox-bridge.ts` /
+ * `use-sandbox-fetch-proxy.ts`).
+ *
+ * A sandboxed app may only receive `sync_changed` invalidations for the tags
+ * it explicitly subscribed to, and never for the host's reserved sync
+ * namespaces — forwarding those would leak host activity (conversation
+ * traffic, config/theme/schedule changes, the apps/plugins lists) into
+ * untrusted app code. Custom tags an app's own routes emit pass through, so an
+ * app can drive live refreshes off its own `publishSyncInvalidation` without
+ * polling.
+ *
+ * `sync_changed` carries no payload — only which resource went stale — and the
+ * authenticated fetch proxy remains the real access gate; this filter is
+ * defense-in-depth on top of that.
+ */
+
+/** Sync-tag namespaces reserved for the host — never forwarded to sandboxed apps. */
+export const RESERVED_SYNC_TAG_PREFIXES = [
+  "assistant:",
+  "conversation:",
+  "conversations:",
+  "apps:",
+  "plugins:",
+  "feature-flags:",
+] as const;
+
+export function isReservedSyncTag(tag: string): boolean {
+  return RESERVED_SYNC_TAG_PREFIXES.some((prefix) => tag.startsWith(prefix));
+}
+
+/**
+ * The tags from a `sync_changed` event that are safe to deliver to an app that
+ * subscribed to `subscribedTags`: the intersection, minus any reserved host
+ * namespace. An empty subscription (no tags) receives nothing — an app must
+ * name the tags it wants (default-deny).
+ */
+export function forwardableSyncTags(
+  subscribedTags: readonly string[],
+  eventTags: readonly string[],
+): string[] {
+  if (subscribedTags.length === 0) {
+    return [];
+  }
+  const wanted = new Set(subscribedTags);
+  return eventTags.filter((tag) => wanted.has(tag) && !isReservedSyncTag(tag));
+}

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -7,7 +7,7 @@
     },
     "app-builder": {
       "docsSlug": "app-builder",
-      "sha256": "37fc43298c1687d0fd9eace22a383bdb18e287f7506a6f330d050d933d2f415b"
+      "sha256": "71e9052908ef1647b11f32b5bfa70b93c3d2d51cb060ab92df7c25109ca92cf6"
     },
     "computer-use": {
       "docsSlug": "computer-use",


### PR DESCRIPTION
## Summary
- Adds `window.vellum.subscribe({ tags }, cb)` to the sandbox bridge — the server→app-push leg the bridge was missing (it already had `fetch` and `asset`). An app subscribes to its own invalidation tags and refreshes when they fire, instead of polling on a timer.
- The parent (`use-sandbox-fetch-proxy`) forwards host `sync_changed` events to matching subscriptions, scoped by `forwardableSyncTags`: only the tags the app explicitly subscribed to, and **never** reserved host namespaces (`assistant:`, `conversation:`, `apps:`, `plugins:`, `feature-flags:`). Default-deny — an empty subscription receives nothing.
- Only `sync_changed` (a payload-free invalidation signal) is forwarded; no event carrying data crosses into the sandbox, and the authenticated fetch proxy remains the real access gate.
- Unit test for the scoping filter; the app-builder SKILL.md documents the API.

## Original prompt
Complete the sandbox bridge with server→app push. Live/dashboard apps currently fake it by polling `window.vellum.fetch` on a timer; the parent already holds the assistant event stream, so forwarding scoped invalidations to the iframe is the natural completion. The crux is event scoping — this forwards only `sync_changed` invalidations for tags the app named, with reserved host namespaces filtered out, so an untrusted sandboxed app can't observe host activity.