### PR TITLE
feat(telemetry): relocate skill_loaded_events into assistant-telemetry.db

### DIFF
--- a/assistant/src/__tests__/conversation-store.test.ts
+++ b/assistant/src/__tests__/conversation-store.test.ts
@@ -16,7 +16,7 @@ import {
   getMessages,
 } from "../persistence/conversation-crud.js";
 import { isLastUserMessageToolResult } from "../persistence/conversation-queries.js";
-import { getDb } from "../persistence/db-connection.js";
+import { getDb, getTelemetryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { skillLoadedEvents } from "../persistence/schema/index.js";
 // Initialize db once before all tests
@@ -354,9 +354,9 @@ describe("attachment orphan cleanup", () => {
     // Privacy posture: Clear All wins over unflushed telemetry — the
     // skill_loaded_events rows (conversation id, skill name, model
     // attribution) must not survive the wipe and ship later.
-    getDb().delete(skillLoadedEvents).run();
+    getTelemetryDb()!.delete(skillLoadedEvents).run();
     const conv = createConversation("test");
-    getDb()
+    getTelemetryDb()!
       .insert(skillLoadedEvents)
       .values([
         {
@@ -372,15 +372,17 @@ describe("attachment orphan cleanup", () => {
 
     await clearAll();
 
-    expect(getDb().select().from(skillLoadedEvents).all()).toHaveLength(0);
+    expect(
+      getTelemetryDb()!.select().from(skillLoadedEvents).all(),
+    ).toHaveLength(0);
   });
 
   test("deleteConversation removes that conversation's skill_loaded_events", async () => {
-    getDb().delete(skillLoadedEvents).run();
+    getTelemetryDb()!.delete(skillLoadedEvents).run();
     const conv = createConversation("doomed");
     await addMessage(conv.id, "user", "hello");
     const other = createConversation("kept");
-    getDb()
+    getTelemetryDb()!
       .insert(skillLoadedEvents)
       .values([
         {
@@ -400,14 +402,14 @@ describe("attachment orphan cleanup", () => {
 
     deleteConversation(conv.id);
 
-    const remaining = getDb().select().from(skillLoadedEvents).all();
+    const remaining = getTelemetryDb()!.select().from(skillLoadedEvents).all();
     expect(remaining.map((r) => r.id)).toEqual(["sle-del-2"]);
   });
 
   test("deleteConversation removes skill_loaded_events when the conversation has no messages", () => {
-    getDb().delete(skillLoadedEvents).run();
+    getTelemetryDb()!.delete(skillLoadedEvents).run();
     const conv = createConversation("empty");
-    getDb()
+    getTelemetryDb()!
       .insert(skillLoadedEvents)
       .values({
         id: "sle-del-empty",
@@ -419,7 +421,9 @@ describe("attachment orphan cleanup", () => {
 
     deleteConversation(conv.id);
 
-    expect(getDb().select().from(skillLoadedEvents).all()).toHaveLength(0);
+    expect(
+      getTelemetryDb()!.select().from(skillLoadedEvents).all(),
+    ).toHaveLength(0);
   });
 
   test("deleteLastExchange does not delete unlinked user uploads", async () => {

--- a/assistant/src/__tests__/prune-old-conversations-job.test.ts
+++ b/assistant/src/__tests__/prune-old-conversations-job.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import type { AssistantConfig } from "../config/schema.js";
-import { getDb } from "../persistence/db-connection.js";
+import { getDb, getTelemetryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { pruneOldConversationsJob } from "../persistence/job-handlers/cleanup.js";
 import type { MemoryJob } from "../persistence/jobs-store.js";
@@ -39,7 +39,9 @@ function seedConversation(id: string, updatedAt: number): void {
       createdAt: updatedAt,
     })
     .run();
-  db.insert(skillLoadedEvents)
+  // skill_loaded_events lives in the dedicated telemetry DB.
+  getTelemetryDb()!
+    .insert(skillLoadedEvents)
     .values({
       id: `sl-${id}`,
       createdAt: updatedAt,
@@ -60,7 +62,7 @@ function countRows(conversationId: string): {
       .from(toolInvocations)
       .all()
       .filter((r) => r.conversationId === conversationId).length,
-    skillLoads: db
+    skillLoads: getTelemetryDb()!
       .select()
       .from(skillLoadedEvents)
       .all()
@@ -71,7 +73,7 @@ function countRows(conversationId: string): {
 describe("pruneOldConversationsJob", () => {
   beforeEach(() => {
     const db = getDb();
-    db.delete(skillLoadedEvents).run();
+    getTelemetryDb()!.delete(skillLoadedEvents).run();
     db.delete(toolInvocations).run();
     db.delete(conversations).run();
   });

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -78,6 +78,7 @@ import {
   getDb,
   getLogsDb,
   getSqliteFrom,
+  getTelemetryDb,
 } from "./db-connection.js";
 import {
   copyForkMessagesViaSubprocess,
@@ -123,6 +124,20 @@ function logsDb(): DrizzleDb {
   const db = getLogsDb();
   if (!db) {
     throw new Error("logs database unavailable");
+  }
+  return db;
+}
+
+/**
+ * The telemetry connection (`assistant-telemetry.db`), where
+ * `skill_loaded_events` lives. Throws if the file cannot be opened — the
+ * conversation-delete call sites must not report success while unshipped
+ * skill events referencing the deleted conversation survive to be flushed.
+ */
+function telemetryDb(): DrizzleDb {
+  const db = getTelemetryDb();
+  if (!db) {
+    throw new Error("telemetry database unavailable");
   }
   return db;
 }
@@ -1630,11 +1645,17 @@ export function deleteConversation(id: string): DeletedMemoryIds {
   const convBeforeDelete = getConversation(id);
   const createdAtForDiskCleanup = convBeforeDelete?.createdAt;
 
-  // llm_request_logs lives in the dedicated logs connection, so it is deleted
-  // there — separately from the main-DB transaction below.
+  // llm_request_logs and skill_loaded_events live in the dedicated logs and
+  // telemetry connections, so they are deleted there — separately from (and
+  // before) the main-DB transaction below, so a failure leaves the
+  // conversation intact for a retried delete.
   logsDb()
     .delete(llmRequestLogs)
     .where(eq(llmRequestLogs.conversationId, id))
+    .run();
+  telemetryDb()
+    .delete(skillLoadedEvents)
+    .where(eq(skillLoadedEvents.conversationId, id))
     .run();
 
   db.transaction((tx) => {
@@ -1659,9 +1680,6 @@ export function deleteConversation(id: string): DeletedMemoryIds {
       tx.delete(toolInvocations)
         .where(eq(toolInvocations.conversationId, id))
         .run();
-      tx.delete(skillLoadedEvents)
-        .where(eq(skillLoadedEvents.conversationId, id))
-        .run();
       // Cascade deletes memory_segments, message_attachments.
       tx.delete(messages).where(eq(messages.conversationId, id)).run();
 
@@ -1680,9 +1698,6 @@ export function deleteConversation(id: string): DeletedMemoryIds {
       // No messages — just clean up non-message tables.
       tx.delete(toolInvocations)
         .where(eq(toolInvocations.conversationId, id))
-        .run();
-      tx.delete(skillLoadedEvents)
-        .where(eq(skillLoadedEvents.conversationId, id))
         .run();
     }
 
@@ -1785,14 +1800,19 @@ export async function deleteConversationGently(
     );
   }
 
+  // skill_loaded_events lives in the dedicated telemetry connection; delete
+  // it there before the main-DB transaction so a failure leaves the
+  // conversation intact for a retried delete.
+  telemetryDb()
+    .delete(skillLoadedEvents)
+    .where(eq(skillLoadedEvents.conversationId, id))
+    .run();
+
   // Remaining cleanup is cheap (bounded, non-message tables) so it stays a
   // single in-process transaction.
   db.transaction((tx) => {
     tx.delete(toolInvocations)
       .where(eq(toolInvocations.conversationId, id))
-      .run();
-    tx.delete(skillLoadedEvents)
-      .where(eq(skillLoadedEvents.conversationId, id))
       .run();
 
     // Clean up segment embeddings (not FK-linked to segments, so the message
@@ -2951,20 +2971,26 @@ export async function clearAll(): Promise<{
   await runOrThrow("DELETE FROM memory_segments");
   await runOrThrow("DELETE FROM memory_summaries");
   await runOrThrow("DELETE FROM memory_embeddings");
-  // memory_jobs and llm_request_logs each live in their own dedicated
-  // connection; clear them directly on those connections rather than through a
-  // sqlite3 subprocess.
+  // memory_jobs, llm_request_logs, and skill_loaded_events each live in their
+  // own dedicated connection; clear them directly on those connections rather
+  // than through a sqlite3 subprocess. Throw-on-failure like the main-DB
+  // deletes: unshipped skill events reference conversations this wipe must
+  // redact, so a failed delete must fail the clear-all rather than let them
+  // flush later.
   rawMemoryRun("conversation:clearAll:memoryJobs", "DELETE FROM memory_jobs");
   await runOrThrow("DELETE FROM memory_checkpoints");
   rawLogsRun(
     "conversation:clearAll:requestLogs",
     "DELETE FROM llm_request_logs",
   );
+  rawTelemetryRun(
+    "conversation:clearAll:skillLoadedEvents",
+    "DELETE FROM skill_loaded_events",
+  );
   await runOrThrow("DELETE FROM llm_usage_events");
   await runOrThrow("DELETE FROM message_attachments");
   await runOrThrow("DELETE FROM attachments");
   await runOrThrow("DELETE FROM tool_invocations");
-  await runOrThrow("DELETE FROM skill_loaded_events");
   await runOrThrow("DELETE FROM messages");
   await runOrThrow("DELETE FROM conversations");
 

--- a/assistant/src/persistence/job-handlers/cleanup.ts
+++ b/assistant/src/persistence/job-handlers/cleanup.ts
@@ -5,7 +5,7 @@ import { getLogsDbPath } from "../../util/logs-db-path.js";
 import { runAsyncSqlite } from "../db-async-query.js";
 import { getDb } from "../db-connection.js";
 import { enqueueMemoryJob, type MemoryJob } from "../jobs-store.js";
-import { rawAll, rawLogsRun, rawRun } from "../raw-query.js";
+import { rawAll, rawLogsRun, rawRun, rawTelemetryRun } from "../raw-query.js";
 
 const log = getLogger("memory-jobs-worker");
 
@@ -143,8 +143,9 @@ function parseDeletedCount(stdout: string | undefined): number {
  * Tables with onDelete cascade on conversation FK (memory_segments,
  * conversation_keys, channel_inbound_events, message_runs, call_sessions,
  * external_conversation_bindings) are handled automatically. Tables without
- * cascade (messages, tool_invocations, llm_request_logs, skill_loaded_events)
- * are deleted explicitly before removing the conversation row.
+ * cascade (messages, tool_invocations, plus llm_request_logs and
+ * skill_loaded_events on their dedicated connections) are deleted explicitly
+ * before removing the conversation row.
  */
 export function pruneOldConversationsJob(
   job: MemoryJob,
@@ -184,11 +185,20 @@ export function pruneOldConversationsJob(
       );
       if (still.length === 0) return;
 
-      // Non-cascading tables. llm_request_logs lives in the dedicated logs
-      // connection, so it is deleted there (outside this main-DB transaction).
+      // Non-cascading tables. llm_request_logs and skill_loaded_events live in
+      // the dedicated logs/telemetry connections, so they are deleted there
+      // (outside this main-DB transaction). Both run before the main-DB
+      // deletes: a failure leaves the conversation row in place so the prune
+      // retries — unshipped skill events must never outlive their pruned
+      // conversation and flush later.
       rawLogsRun(
         "cleanup:pruneOldConversations:logs",
         `DELETE FROM llm_request_logs WHERE conversation_id = ?`,
+        id,
+      );
+      rawTelemetryRun(
+        "cleanup:pruneOldConversations:skills",
+        `DELETE FROM skill_loaded_events WHERE conversation_id = ?`,
         id,
       );
       rawRun(
@@ -199,11 +209,6 @@ export function pruneOldConversationsJob(
       rawRun(
         "cleanup:pruneOldConversations:messages",
         `DELETE FROM messages WHERE conversation_id = ?`,
-        id,
-      );
-      rawRun(
-        "cleanup:pruneOldConversations:skills",
-        `DELETE FROM skill_loaded_events WHERE conversation_id = ?`,
         id,
       );
       // Conversation row deletion cascades to remaining dependent tables

--- a/assistant/src/persistence/migrations/330-move-skill-loaded-events-to-telemetry-db.test.ts
+++ b/assistant/src/persistence/migrations/330-move-skill-loaded-events-to-telemetry-db.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for migration 330: relocating `skill_loaded_events` from the main DB
+ * into the dedicated telemetry database (`assistant-telemetry.db`).
+ *
+ * Runs against real workspace databases (`initializeDb()`) because the drain
+ * engine dispatches batches via `runAsyncSqlite` against the workspace's main
+ * DB file. `initializeDb()` already ran migration 330 once (dropping the empty
+ * main-side table created by migration 279), so each test recreates the
+ * pre-move source table in `main` to simulate an upgrading install.
+ */
+import { describe, expect, test } from "bun:test";
+
+const { getDb, getSqlite, getTelemetrySqlite } =
+  await import("../db-connection.js");
+const { initializeDb } = await import("../db-init.js");
+const { queryUnreportedSkillLoadedEvents } =
+  await import("../../telemetry/skill-loaded-events-store.js");
+const { migrateMoveSkillLoadedEventsToTelemetryDb } =
+  await import("./330-move-skill-loaded-events-to-telemetry-db.js");
+const { rawTelemetryRun } = await import("../raw-query.js");
+
+await initializeDb();
+
+const SOURCE_COLUMNS = `
+  id TEXT PRIMARY KEY, created_at INTEGER NOT NULL, conversation_id TEXT,
+  skill_name TEXT NOT NULL, skill_updated_at TEXT, provider TEXT, model TEXT,
+  inference_profile TEXT, inference_profile_source TEXT`;
+
+function existsInMain(name: string): boolean {
+  return (
+    getSqlite()
+      .query(
+        `SELECT name FROM main.sqlite_master WHERE type='table' AND name = ?`,
+      )
+      .get(name) != null
+  );
+}
+
+function resetState(): void {
+  getTelemetrySqlite()!.exec(`DELETE FROM skill_loaded_events`);
+  getSqlite().exec(`DROP TABLE IF EXISTS main.skill_loaded_events`);
+  getSqlite().exec(
+    `DROP TABLE IF EXISTS main."skill_loaded_events__relocating"`,
+  );
+}
+
+function seedSourceTable(): void {
+  const sqlite = getSqlite();
+  sqlite.exec(`CREATE TABLE main.skill_loaded_events (${SOURCE_COLUMNS})`);
+  const insert = sqlite.prepare(
+    `INSERT INTO main.skill_loaded_events (id, created_at, conversation_id, skill_name)
+     VALUES (?, ?, ?, ?)`,
+  );
+  insert.run("seed-1", 1000, "conv-a", "web-research");
+  insert.run("seed-2", 2000, null, "tasks");
+  insert.run("seed-dupe", 3000, "conv-b", "calendar");
+}
+
+describe("migration 330: move skill_loaded_events to the telemetry DB", () => {
+  test("drains pre-move rows into the telemetry DB and drops the main-side table", async () => {
+    resetState();
+    seedSourceTable();
+
+    await migrateMoveSkillLoadedEventsToTelemetryDb(getDb());
+
+    expect(existsInMain("skill_loaded_events")).toBe(false);
+    expect(existsInMain("skill_loaded_events__relocating")).toBe(false);
+
+    const moved = getTelemetrySqlite()!
+      .query(
+        `SELECT id, skill_name, conversation_id FROM skill_loaded_events ORDER BY id`,
+      )
+      .all();
+    expect(moved).toEqual([
+      { id: "seed-1", skill_name: "web-research", conversation_id: "conv-a" },
+      { id: "seed-2", skill_name: "tasks", conversation_id: null },
+      { id: "seed-dupe", skill_name: "calendar", conversation_id: "conv-b" },
+    ]);
+
+    // The relocated rows are readable through the store's reporter query.
+    const rows = queryUnreportedSkillLoadedEvents(0, undefined, 10);
+    expect(rows.map((r) => r.id)).toEqual(["seed-1", "seed-2", "seed-dupe"]);
+    expect(rows[0]).toEqual({
+      id: "seed-1",
+      createdAt: 1000,
+      conversationId: "conv-a",
+      skillName: "web-research",
+      skillUpdatedAt: null,
+      provider: null,
+      model: null,
+      inferenceProfile: null,
+      inferenceProfileSource: null,
+    });
+  });
+
+  test("re-running after a completed move is a no-op", async () => {
+    resetState();
+    seedSourceTable();
+
+    await migrateMoveSkillLoadedEventsToTelemetryDb(getDb());
+    await migrateMoveSkillLoadedEventsToTelemetryDb(getDb());
+
+    expect(existsInMain("skill_loaded_events")).toBe(false);
+    expect(existsInMain("skill_loaded_events__relocating")).toBe(false);
+    expect(queryUnreportedSkillLoadedEvents(0, undefined, 10)).toHaveLength(3);
+  });
+
+  test("a pre-existing duplicate id in the telemetry copy does not fail the drain", async () => {
+    resetState();
+    seedSourceTable();
+
+    // A crash between a drain batch's copy and delete re-copies the same rows
+    // next boot; INSERT OR IGNORE must keep the already-copied row and finish.
+    getTelemetrySqlite()!.exec(
+      `INSERT INTO skill_loaded_events (id, created_at, skill_name)
+       VALUES ('seed-dupe', 3000, 'already-copied')`,
+    );
+
+    await migrateMoveSkillLoadedEventsToTelemetryDb(getDb());
+
+    expect(existsInMain("skill_loaded_events")).toBe(false);
+    expect(existsInMain("skill_loaded_events__relocating")).toBe(false);
+    const dupe = getTelemetrySqlite()!
+      .query(
+        `SELECT skill_name FROM skill_loaded_events WHERE id = 'seed-dupe'`,
+      )
+      .get() as { skill_name: string };
+    expect(dupe.skill_name).toBe("already-copied");
+    expect(queryUnreportedSkillLoadedEvents(0, undefined, 10)).toHaveLength(3);
+  });
+
+  test("an empty main-side table (fresh install) is dropped without a drain", async () => {
+    resetState();
+    getSqlite().exec(
+      `CREATE TABLE main.skill_loaded_events (${SOURCE_COLUMNS})`,
+    );
+
+    await migrateMoveSkillLoadedEventsToTelemetryDb(getDb());
+
+    expect(existsInMain("skill_loaded_events")).toBe(false);
+    expect(existsInMain("skill_loaded_events__relocating")).toBe(false);
+    expect(queryUnreportedSkillLoadedEvents(0, undefined, 10)).toHaveLength(0);
+  });
+
+  test("per-conversation redaction deletes rows on the telemetry connection", () => {
+    resetState();
+    getTelemetrySqlite()!.exec(
+      `INSERT INTO skill_loaded_events (id, created_at, conversation_id, skill_name)
+       VALUES ('red-1', 1000, 'conv-pruned', 'web-research'),
+              ('red-2', 2000, 'conv-kept', 'tasks')`,
+    );
+
+    // The exact delete the conversation prune runs (job-handlers/cleanup.ts).
+    rawTelemetryRun(
+      "test:prune-redaction",
+      `DELETE FROM skill_loaded_events WHERE conversation_id = ?`,
+      "conv-pruned",
+    );
+
+    const remaining = queryUnreportedSkillLoadedEvents(0, undefined, 10);
+    expect(remaining.map((r) => r.id)).toEqual(["red-2"]);
+  });
+
+  test("telemetry-side schema has the reporter's compound cursor index", () => {
+    const indexes = (
+      getTelemetrySqlite()!
+        .query(`PRAGMA index_list(skill_loaded_events)`)
+        .all() as Array<{ name: string }>
+    ).map((i) => i.name);
+    expect(indexes).toContain("idx_skill_loaded_events_created_at_id");
+  });
+});

--- a/assistant/src/persistence/migrations/330-move-skill-loaded-events-to-telemetry-db.ts
+++ b/assistant/src/persistence/migrations/330-move-skill-loaded-events-to-telemetry-db.ts
@@ -1,0 +1,116 @@
+import type { Database } from "bun:sqlite";
+
+import { getTelemetryDbPath } from "../../util/telemetry-db-path.js";
+import {
+  type DrizzleDb,
+  getSqliteFrom,
+  getTelemetrySqlite,
+} from "../db-connection.js";
+import {
+  drainStagedTable,
+  type RelocationSpec,
+  stageTableForRelocation,
+} from "./helpers/relocation.js";
+
+/**
+ * How to drain `skill_loaded_events` from `main` into the telemetry DB. The
+ * table is a telemetry outbox — every unflushed row is worth keeping until
+ * the usage telemetry reporter ships it — so all rows are copied verbatim.
+ */
+export const SKILL_LOADED_EVENTS_RELOCATION: RelocationSpec = {
+  table: "skill_loaded_events",
+  targetDbPath: getTelemetryDbPath,
+  columns: [
+    "id",
+    "created_at",
+    "conversation_id",
+    "skill_name",
+    "skill_updated_at",
+    "provider",
+    "model",
+    "inference_profile",
+    "inference_profile_source",
+  ],
+};
+
+const CREATE_TABLE = /*sql*/ `
+  CREATE TABLE IF NOT EXISTS skill_loaded_events (
+    id TEXT PRIMARY KEY,
+    created_at INTEGER NOT NULL,
+    conversation_id TEXT,
+    skill_name TEXT NOT NULL,
+    skill_updated_at TEXT,
+    provider TEXT,
+    model TEXT,
+    inference_profile TEXT,
+    inference_profile_source TEXT
+  )
+`;
+
+/**
+ * Create the `skill_loaded_events` table and its cursor index on the telemetry
+ * connection. Idempotent (`IF NOT EXISTS`) — the dedicated connection itself
+ * performs no DDL on open, so this migration owns the schema. The index backs
+ * the telemetry reporter's compound `(created_at, id)` watermark cursor,
+ * matching the main-DB original (migration 279).
+ */
+function ensureSkillLoadedEventsSchema(telemetryRaw: Database): void {
+  telemetryRaw.exec(CREATE_TABLE);
+  telemetryRaw.exec(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_skill_loaded_events_created_at_id ON skill_loaded_events (created_at, id)`,
+  );
+}
+
+/**
+ * Move `skill_loaded_events` — the `skill_loaded` telemetry outbox (one row
+ * per Vellum-skill activation, metadata only) — into the dedicated telemetry
+ * database (`assistant-telemetry.db`), alongside `watchdog_events`
+ * (migration 301), `config_setting_events` (325), `onboarding_events` (327),
+ * `auth_fallback_events` (328), and `lifecycle_events` (329). Rows are
+ * inserted at activation time and read only by the usage telemetry reporter's
+ * flush; housing them with the other telemetry tables keeps the main DB and
+ * its WAL out of that write path. The store in
+ * `telemetry/skill-loaded-events-store.ts` reads/writes it over the dedicated
+ * telemetry connection (see `getTelemetryDb()`), and the reporter's
+ * `(createdAt, id)` watermark in the main DB's checkpoints store survives the
+ * move unchanged.
+ *
+ * Unlike the other moved outboxes this table has per-conversation redaction
+ * semantics: deleting a conversation (or clearing all) must delete its
+ * unshipped rows. Those cleanup paths (`conversation-crud.ts`,
+ * `job-handlers/cleanup.ts`) delete over the telemetry connection too.
+ *
+ * Like migrations 297/298/326/327/328/329 the move is incremental: create the
+ * table (and index) on the telemetry connection, rename any populated
+ * `main.skill_loaded_events` aside to `skill_loaded_events__relocating`, then
+ * drain it in awaited batches (see `helpers/relocation.ts`) per
+ * {@link SKILL_LOADED_EVENTS_RELOCATION}. On a fresh install the main-side
+ * table created by migration 279 is empty, so staging just drops it.
+ *
+ * Throws (rather than returning) if the telemetry database cannot be opened,
+ * so the runner records the step as failed instead of applied and retries it
+ * on a later boot — never renaming the source aside without a target to write
+ * to. The throw is caught per-step by the runner, so startup is not aborted.
+ */
+export async function migrateMoveSkillLoadedEventsToTelemetryDb(
+  database: DrizzleDb,
+): Promise<void> {
+  const telemetryRaw = getTelemetrySqlite();
+  if (!telemetryRaw) {
+    throw new Error(
+      "telemetry database unavailable — deferring skill_loaded_events relocation",
+    );
+  }
+
+  ensureSkillLoadedEventsSchema(telemetryRaw);
+
+  const raw = getSqliteFrom(database);
+  const needsDrain = stageTableForRelocation(
+    raw,
+    SKILL_LOADED_EVENTS_RELOCATION.table,
+  );
+
+  if (needsDrain) {
+    await drainStagedTable(raw, SKILL_LOADED_EVENTS_RELOCATION);
+  }
+}

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -437,6 +437,7 @@ import { migrateMoveInjectionEventsToMemoryDb } from "./migrations/326-move-inje
 import { migrateMoveOnboardingEventsToTelemetryDb } from "./migrations/327-move-onboarding-events-to-telemetry-db.js";
 import { migrateMoveAuthFallbackEventsToTelemetryDb } from "./migrations/328-move-auth-fallback-events-to-telemetry-db.js";
 import { migrateMoveLifecycleEventsToTelemetryDb } from "./migrations/329-move-lifecycle-events-to-telemetry-db.js";
+import { migrateMoveSkillLoadedEventsToTelemetryDb } from "./migrations/330-move-skill-loaded-events-to-telemetry-db.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1345,4 +1346,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateMoveOnboardingEventsToTelemetryDb,
   migrateMoveAuthFallbackEventsToTelemetryDb,
   migrateMoveLifecycleEventsToTelemetryDb,
+  migrateMoveSkillLoadedEventsToTelemetryDb,
 ];

--- a/assistant/src/telemetry/skill-loaded-events-store.test.ts
+++ b/assistant/src/telemetry/skill-loaded-events-store.test.ts
@@ -6,7 +6,7 @@ mock.module("../platform/consent-cache.js", () => ({
   getCachedShareAnalytics: () => shareAnalytics,
 }));
 
-import { getDb } from "../persistence/db-connection.js";
+import { getTelemetryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { skillLoadedEvents } from "../persistence/schema/index.js";
 import {
@@ -21,13 +21,16 @@ function insertEvent(
   createdAt: number,
   skillName = "web-research",
 ): void {
-  getDb().insert(skillLoadedEvents).values({ id, createdAt, skillName }).run();
+  getTelemetryDb()!
+    .insert(skillLoadedEvents)
+    .values({ id, createdAt, skillName })
+    .run();
 }
 
 describe("skill-loaded-events-store", () => {
   beforeEach(() => {
     shareAnalytics = true;
-    getDb().delete(skillLoadedEvents).run();
+    getTelemetryDb()!.delete(skillLoadedEvents).run();
   });
 
   test("honors the share_analytics opt-out (records nothing)", () => {

--- a/assistant/src/telemetry/skill-loaded-events-store.ts
+++ b/assistant/src/telemetry/skill-loaded-events-store.ts
@@ -1,7 +1,7 @@
 import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getDb } from "../persistence/db-connection.js";
+import { getTelemetryDb } from "../persistence/db-connection.js";
 import { skillLoadedEvents } from "../persistence/schema/index.js";
 import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import type { UsageAttributionColumns } from "../usage/attribution.js";
@@ -39,7 +39,8 @@ export interface SkillLoadedEvent {
  */
 export function recordSkillLoadedEvent(record: SkillLoadedEventRecord): void {
   if (!getCachedShareAnalytics()) return;
-  const db = getDb();
+  const db = getTelemetryDb();
+  if (!db) return;
   db.insert(skillLoadedEvents)
     .values({
       id: uuid(),
@@ -64,7 +65,8 @@ export function queryUnreportedSkillLoadedEvents(
   afterId: string | undefined,
   limit: number,
 ): SkillLoadedEvent[] {
-  const db = getDb();
+  const db = getTelemetryDb();
+  if (!db) return [];
   return db
     .select({
       id: skillLoadedEvents.id,

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -399,7 +399,7 @@ beforeEach(() => {
   mockQueryUnreportedOnboardingEvents.mockReset();
   mockQueryUnreportedOnboardingEvents.mockReturnValue([]);
   getDb().delete(toolInvocations).run();
-  getDb().delete(skillLoadedEvents).run();
+  getTelemetryDb()?.delete(skillLoadedEvents).run();
   getTelemetryDb()?.delete(authFallbackEvents).run();
   getTelemetryDb()?.delete(configSettingEvents).run();
   delete process.env.VELLUM_DISABLE_PLATFORM;
@@ -2507,7 +2507,7 @@ describe("UsageTelemetryReporter", () => {
 
     // The last row by the reporter's (createdAt, id) cursor order is the one
     // whose watermark should be persisted after a successful upload.
-    const rows = getDb()
+    const rows = getTelemetryDb()!
       .select()
       .from(skillLoadedEvents)
       .orderBy(skillLoadedEvents.createdAt, skillLoadedEvents.id)
@@ -2541,7 +2541,7 @@ describe("UsageTelemetryReporter", () => {
       createdAt: 1700000000000 + i,
       skillName: "web-research",
     }));
-    getDb().insert(skillLoadedEvents).values(fullBatch).run();
+    getTelemetryDb()!.insert(skillLoadedEvents).values(fullBatch).run();
     mockFetch.mockImplementation(() =>
       Promise.resolve(new Response('{"accepted":500}', { status: 200 })),
     );


### PR DESCRIPTION
## Summary
- Migration 330 relocates skill_loaded_events from the main DB into assistant-telemetry.db using the staged-drain relocation engine
- Skill-loaded events store, clearAll, the conversation prune, and both deleteConversation variants now use the dedicated telemetry connection; per-conversation redaction holds across the connection boundary (telemetry-side deletes run before the main-DB deletes so a failure leaves the conversation intact for retry)

Part of plan: telemetry-db-move.md (PR 5 of 6)