### PR TITLE
docs(telemetry): telemetry DB now houses all telemetry-only event tables

### DIFF
--- a/assistant/src/persistence/db-connection.ts
+++ b/assistant/src/persistence/db-connection.ts
@@ -236,7 +236,8 @@ export function getMemorySqlite(): Database | null {
 
 /**
  * The telemetry database (`assistant-telemetry.db`), opened lazily as its own
- * connection. Houses telemetry event tables (starting with `watchdog_events`).
+ * connection. Houses the telemetry-only event tables (see
+ * `util/telemetry-db-path.ts` for the list).
  * Returns `null` if the file cannot be opened (logged; the daemon stays up).
  */
 export function getTelemetryDb(): DrizzleDb | null {

--- a/assistant/src/util/telemetry-db-path.ts
+++ b/assistant/src/util/telemetry-db-path.ts
@@ -3,13 +3,14 @@ import { join } from "node:path";
 import { getDataDir } from "./platform.js";
 
 /**
- * Path to the dedicated SQLite file that houses telemetry event tables
- * (starting with `watchdog_events`). It lives in the same `data/db` directory
- * as the main DB and is opened on its own connection (see `getTelemetryDb()`
- * in `memory/db-connection.ts`). Splitting telemetry tables into their own
- * file keeps the main DB — and its WAL — small and lets the two files
- * VACUUM/checkpoint independently, so a burst of watchdog events can no longer
- * bloat the main database.
+ * Path to the dedicated SQLite file that houses the telemetry-only event
+ * tables: `watchdog_events`, `config_setting_events`, `onboarding_events`,
+ * `auth_fallback_events`, `lifecycle_events`, and `skill_loaded_events`. It
+ * lives in the same `data/db` directory as the main DB and is opened on its
+ * own connection (see `getTelemetryDb()` in `persistence/db-connection.ts`).
+ * Splitting telemetry tables into their own file keeps the main DB — and its
+ * WAL — small and lets the two files VACUUM/checkpoint independently, so a
+ * burst of telemetry events cannot bloat the main database.
  *
  * Kept in its own leaf module rather than alongside `getDbPath()` in
  * `platform.ts`: `platform.ts` is imported very early and widely, and adding an


### PR DESCRIPTION
## Summary
- Updates the telemetry-db-path and db-connection doc comments: the telemetry DB now houses all six telemetry-only event tables, not just watchdog_events

Part of plan: telemetry-db-move.md (PR 6 of 6)